### PR TITLE
Full review, stages 1–6: races, data safety, update hardening, controls & plotting fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,10 @@ jobs:
         env:
           SPARKLE_PUBLIC_KEY: ${{ secrets.SPARKLE_PUBLIC_KEY }}
         run: |
+          if ([string]::IsNullOrWhiteSpace($env:SPARKLE_PUBLIC_KEY)) {
+            throw "SPARKLE_PUBLIC_KEY repository secret is required: a build without the embedded key cannot verify update signatures."
+          }
+
           $version = "${{ steps.version.outputs.version }}"
           $publishDirectory = Join-Path $env:RUNNER_TEMP "publish-${{ matrix.rid }}"
 
@@ -152,6 +156,10 @@ jobs:
         env:
           SPARKLE_PUBLIC_KEY: ${{ secrets.SPARKLE_PUBLIC_KEY }}
         run: |
+          if ([string]::IsNullOrWhiteSpace($env:SPARKLE_PUBLIC_KEY)) {
+            throw "SPARKLE_PUBLIC_KEY repository secret is required: a build without the embedded key cannot verify update signatures."
+          }
+
           $version = "${{ needs.prepare.outputs.version }}"
           $publishDirectory = Join-Path $env:RUNNER_TEMP "publish-win-x64"
 

--- a/source/Audio/PcmStreamSet.cs
+++ b/source/Audio/PcmStreamSet.cs
@@ -1,0 +1,141 @@
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Packs a mono float signal into PCM playback streams, one per
+/// <see cref="PlaybackChannel"/> routing, built lazily on first request: a
+/// measurement uses exactly one routing, while the previous eager four-way
+/// packing kept four PCM copies of the signal (tens of megabytes for long
+/// sweeps and noise buffers) alive for its whole lifetime.
+/// </summary>
+internal sealed class PcmStreamSet : IDisposable
+{
+    private static readonly int ChannelModeCount =
+        Enum.GetValues<PlaybackChannel>().Length;
+
+    private readonly float[] samples;
+    private readonly int sampleRate;
+    private readonly int bitsPerSample;
+    private readonly MemoryStream?[] memoryStreams = new MemoryStream?[ChannelModeCount];
+    private readonly RawSourceWaveStream?[] sourceStreams =
+        new RawSourceWaveStream?[ChannelModeCount];
+    private bool disposed;
+
+    public PcmStreamSet(float[] samples, int sampleRate, int bitsPerSample)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+        if (bitsPerSample is not (16 or 24))
+        {
+            throw new NotSupportedException(
+                $"Unsupported sample size: {bitsPerSample} bits.");
+        }
+
+        this.samples = samples;
+        this.sampleRate = sampleRate;
+        this.bitsPerSample = bitsPerSample;
+    }
+
+    public RawSourceWaveStream GetStream(PlaybackChannel channel)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        if (!Enum.IsDefined(channel))
+        {
+            throw new ArgumentOutOfRangeException(nameof(channel));
+        }
+
+        int index = (int)channel;
+        if (sourceStreams[index] is { } existing)
+        {
+            return existing;
+        }
+
+        var memory = new MemoryStream(
+            Pack(samples, bitsPerSample, channel),
+            writable: false);
+        int outputChannelCount = channel == PlaybackChannel.Mono ? 1 : 2;
+        var stream = new RawSourceWaveStream(
+            memory,
+            new WaveFormat(sampleRate, bitsPerSample, outputChannelCount));
+        memoryStreams[index] = memory;
+        sourceStreams[index] = stream;
+        return stream;
+    }
+
+    /// <summary>
+    /// Packs normalized floats into little-endian PCM frames for the routing:
+    /// Mono is a single channel; Left/Right are stereo frames with the other
+    /// side silent; Stereo carries the signal on both sides.
+    /// </summary>
+    internal static byte[] Pack(
+        IReadOnlyList<float> samples,
+        int bitsPerSample,
+        PlaybackChannel channel)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        if (bitsPerSample is not (16 or 24))
+        {
+            throw new NotSupportedException(
+                $"Unsupported sample size: {bitsPerSample} bits.");
+        }
+        if (!Enum.IsDefined(channel))
+        {
+            throw new ArgumentOutOfRangeException(nameof(channel));
+        }
+
+        int outputChannelCount = channel == PlaybackChannel.Mono ? 1 : 2;
+        int bytesPerSample = bitsPerSample / 8;
+        int maxValue = int.MaxValue >> (32 - bitsPerSample);
+        var data = new byte[samples.Count * bytesPerSample * outputChannelCount];
+
+        for (int sampleIndex = 0; sampleIndex < samples.Count; sampleIndex++)
+        {
+            int value = (int)(Math.Clamp(samples[sampleIndex], -1.0f, 1.0f) * maxValue);
+            int frameOffset = sampleIndex * bytesPerSample * outputChannelCount;
+            if (channel is PlaybackChannel.Mono or PlaybackChannel.Left or PlaybackChannel.Stereo)
+            {
+                WritePcmSample(data, frameOffset, value, bytesPerSample);
+            }
+            if (channel is PlaybackChannel.Right or PlaybackChannel.Stereo)
+            {
+                WritePcmSample(data, frameOffset + bytesPerSample, value, bytesPerSample);
+            }
+        }
+
+        return data;
+    }
+
+    private static void WritePcmSample(
+        byte[] destination,
+        int offset,
+        int value,
+        int bytesPerSample)
+    {
+        for (int i = 0; i < bytesPerSample; i++)
+        {
+            destination[offset + i] = (byte)(value >> (8 * i));
+        }
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        foreach (RawSourceWaveStream? stream in sourceStreams)
+        {
+            stream?.Dispose();
+        }
+        foreach (MemoryStream? stream in memoryStreams)
+        {
+            stream?.Dispose();
+        }
+    }
+}

--- a/source/History/MeasurementHistoryPersistence.cs
+++ b/source/History/MeasurementHistoryPersistence.cs
@@ -16,18 +16,24 @@ internal sealed class MeasurementHistoryPersistence
         Converters = { new JsonStringEnumConverter() }
     };
 
-    private static string PathOnDisk => Path.Combine(AppContext.BaseDirectory, FileName);
+    private readonly string pathOnDisk;
+
+    public MeasurementHistoryPersistence(string? pathOnDisk = null)
+    {
+        this.pathOnDisk = pathOnDisk
+            ?? Path.Combine(AppContext.BaseDirectory, FileName);
+    }
 
     public IReadOnlyList<MeasurementHistoryEntry> Load()
     {
         try
         {
-            if (!File.Exists(PathOnDisk))
+            if (!File.Exists(pathOnDisk))
             {
                 return Array.Empty<MeasurementHistoryEntry>();
             }
 
-            using FileStream stream = File.OpenRead(PathOnDisk);
+            using FileStream stream = File.OpenRead(pathOnDisk);
             StoreFile? file = JsonSerializer.Deserialize<StoreFile>(stream, SerializerOptions);
             if (file?.SchemaVersion != CurrentSchemaVersion)
             {
@@ -77,8 +83,15 @@ internal sealed class MeasurementHistoryPersistence
                 .ToList()
         };
 
-        using FileStream stream = File.Create(PathOnDisk);
-        JsonSerializer.Serialize(stream, file, SerializerOptions);
+        // Temp file + move keeps the store intact if the write is interrupted;
+        // a corrupted store silently wipes the whole history list on next load.
+        string tempPath = pathOnDisk + ".tmp";
+        using (FileStream stream = File.Create(tempPath))
+        {
+            JsonSerializer.Serialize(stream, file, SerializerOptions);
+        }
+
+        File.Move(tempPath, pathOnDisk, overwrite: true);
     }
 
     private sealed class StoreFile

--- a/source/History/MeasurementHistoryService.cs
+++ b/source/History/MeasurementHistoryService.cs
@@ -6,12 +6,13 @@ internal sealed class MeasurementHistoryService
 {
     public const int MaxInMemoryHistoryEntries = 10;
 
-    private readonly MeasurementHistoryPersistence persistence = new();
+    private readonly MeasurementHistoryPersistence persistence;
     private readonly List<MeasurementHistoryEntry> entries;
 
-    public MeasurementHistoryService()
+    public MeasurementHistoryService(MeasurementHistoryPersistence? persistence = null)
     {
-        entries = persistence.Load().ToList();
+        this.persistence = persistence ?? new MeasurementHistoryPersistence();
+        entries = this.persistence.Load().ToList();
     }
 
     public event Action? Changed;
@@ -62,6 +63,7 @@ internal sealed class MeasurementHistoryService
             MoveToStart(entry);
         }
 
+        RetainSingleFileBackedSnapshot(entry);
         persistence.Save(entries);
         OnChanged();
         return entry.Id;
@@ -106,6 +108,7 @@ internal sealed class MeasurementHistoryService
             MoveToStart(entry);
         }
 
+        RetainSingleFileBackedSnapshot(entry);
         persistence.Save(entries);
         OnChanged();
     }
@@ -147,6 +150,7 @@ internal sealed class MeasurementHistoryService
         entry.Snapshot = CreateSnapshot(file, entry.Session);
         entry.Metadata = MeasurementHistorySnapshotMetadata.FromSnapshot(entry.Snapshot);
         entry.Preview = entry.Snapshot.Preview;
+        RetainSingleFileBackedSnapshot(entry);
         return entry.Snapshot;
     }
 
@@ -282,6 +286,21 @@ internal sealed class MeasurementHistoryService
             }
 
             entries.Remove(oldestUnsaved);
+        }
+    }
+
+    // A snapshot holds the complete impulse responses (tens of megabytes), so at
+    // most one file-backed entry keeps one cached — its file remains the source
+    // of truth and an evicted snapshot is reloaded on demand. Unsaved entries
+    // always keep theirs: memory is their only storage.
+    private void RetainSingleFileBackedSnapshot(MeasurementHistoryEntry keep)
+    {
+        foreach (MeasurementHistoryEntry entry in entries)
+        {
+            if (!ReferenceEquals(entry, keep) && entry.IsFileBacked)
+            {
+                entry.Snapshot = null;
+            }
         }
     }
 

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -438,12 +438,20 @@ internal sealed class LiveSpectrumController : IDisposable
             return;
         }
 
-        owner.BeginInvoke((MethodInvoker)delegate
+        try
         {
-            timer.Stop();
-            updateOverlayAvailability();
-            updateRecordButton();
-            updatePlotLabels();
-        });
+            owner.BeginInvoke((MethodInvoker)delegate
+            {
+                timer.Stop();
+                updateOverlayAvailability();
+                updateRecordButton();
+                updatePlotLabels();
+            });
+        }
+        catch (InvalidOperationException)
+        {
+            // The handle was destroyed between the guard and the call while the
+            // form closes; Dispose stops the timer.
+        }
     }
 }

--- a/source/Measurements/ExponentialSineSweep.cs
+++ b/source/Measurements/ExponentialSineSweep.cs
@@ -15,14 +15,12 @@ public enum PlaybackChannel : byte
 /// </summary>
 public sealed class ExponentialSineSweep : IDisposable
 {
-    private MemoryStream[] memoryStreams = Array.Empty<MemoryStream>();
-    private RawSourceWaveStream[] sourceStreams = Array.Empty<RawSourceWaveStream>();
+    private PcmStreamSet? streamSet;
     private bool disposed;
 
     public float[] SweepData { get; private set; } = Array.Empty<float>();
     public float[] InverseFilter { get; private set; } = Array.Empty<float>();
     public float[] Frequencies { get; private set; } = Array.Empty<float>();
-    public byte[][] SweepByteData { get; private set; } = Array.Empty<byte[]>();
     public int SampleRate { get; private set; }
     public int SweepSamples { get; private set; }
     public int BitsPerSample { get; private set; }
@@ -100,82 +98,19 @@ public sealed class ExponentialSineSweep : IDisposable
                 (float)(SweepData[sampleCount - i - 1] * Math.Pow(perSampleDecay, -i) * inverseScale);
         }
 
-        BuildPlaybackStreams();
+        streamSet?.Dispose();
+        streamSet = new PcmStreamSet(SweepData, sampleRate, bitsPerSample);
     }
 
     public RawSourceWaveStream GetStream(PlaybackChannel channel)
     {
         ThrowIfDisposed();
-        if (!Enum.IsDefined(channel))
+        if (streamSet == null)
         {
-            throw new ArgumentOutOfRangeException(nameof(channel));
+            throw new InvalidOperationException("The sweep is not generated.");
         }
 
-        return sourceStreams[(int)channel];
-    }
-
-    private void BuildPlaybackStreams()
-    {
-        DisposeStreams();
-        int channelModeCount = Enum.GetValues<PlaybackChannel>().Length;
-        SweepByteData = new byte[channelModeCount][];
-        memoryStreams = new MemoryStream[channelModeCount];
-        sourceStreams = new RawSourceWaveStream[channelModeCount];
-
-        foreach (PlaybackChannel channel in Enum.GetValues<PlaybackChannel>())
-        {
-            int outputChannelCount = channel == PlaybackChannel.Mono ? 1 : 2;
-            int bytesPerSample = BitsPerSample / 8;
-            int maxValue = int.MaxValue >> (32 - BitsPerSample);
-            byte[] data = new byte[SweepSamples * bytesPerSample * outputChannelCount];
-
-            for (int sampleIndex = 0; sampleIndex < SweepSamples; sampleIndex++)
-            {
-                int sample = (int)(SweepData[sampleIndex] * maxValue);
-                sample *= (int)Math.Pow(256, 4 - bytesPerSample);
-                byte[] bytes = BitConverter.GetBytes(sample);
-                WriteSample(data, sampleIndex, bytes, bytesPerSample, outputChannelCount, channel);
-            }
-
-            int channelIndex = (int)channel;
-            SweepByteData[channelIndex] = data;
-            memoryStreams[channelIndex] = new MemoryStream(data, writable: false);
-            sourceStreams[channelIndex] = new RawSourceWaveStream(
-                memoryStreams[channelIndex],
-                new WaveFormat(SampleRate, BitsPerSample, outputChannelCount));
-        }
-    }
-
-    private static void WriteSample(
-        byte[] destination,
-        int sampleIndex,
-        byte[] source,
-        int bytesPerSample,
-        int channelCount,
-        PlaybackChannel channel)
-    {
-        int frameOffset = sampleIndex * bytesPerSample * channelCount;
-        int sourceOffset = 4 - bytesPerSample;
-
-        if (channel == PlaybackChannel.Mono)
-        {
-            Array.Copy(source, sourceOffset, destination, frameOffset, bytesPerSample);
-            return;
-        }
-
-        if (channel is PlaybackChannel.Left or PlaybackChannel.Stereo)
-        {
-            Array.Copy(source, sourceOffset, destination, frameOffset, bytesPerSample);
-        }
-        if (channel is PlaybackChannel.Right or PlaybackChannel.Stereo)
-        {
-            Array.Copy(
-                source,
-                sourceOffset,
-                destination,
-                frameOffset + bytesPerSample,
-                bytesPerSample);
-        }
+        return streamSet.GetStream(channel);
     }
 
     private static void ValidateGenerationParameters(
@@ -207,21 +142,6 @@ public sealed class ExponentialSineSweep : IDisposable
         ObjectDisposedException.ThrowIf(disposed, this);
     }
 
-    private void DisposeStreams()
-    {
-        foreach (RawSourceWaveStream stream in sourceStreams)
-        {
-            stream.Dispose();
-        }
-        foreach (MemoryStream stream in memoryStreams)
-        {
-            stream.Dispose();
-        }
-
-        sourceStreams = Array.Empty<RawSourceWaveStream>();
-        memoryStreams = Array.Empty<MemoryStream>();
-    }
-
     public void Dispose()
     {
         if (disposed)
@@ -230,7 +150,8 @@ public sealed class ExponentialSineSweep : IDisposable
         }
 
         disposed = true;
-        DisposeStreams();
+        streamSet?.Dispose();
+        streamSet = null;
         GC.SuppressFinalize(this);
     }
 }

--- a/source/Measurements/ImpulseResponseFile.cs
+++ b/source/Measurements/ImpulseResponseFile.cs
@@ -124,18 +124,48 @@ public sealed class ImpulseResponseFile
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
         Validate();
 
-        await using FileStream stream = new(
-            path,
-            FileMode.Create,
-            FileAccess.Write,
-            FileShare.None,
-            bufferSize: 64 * 1024,
-            useAsync: true);
-        await JsonSerializer.SerializeAsync(
-            stream,
-            this,
-            SerializerOptions,
-            cancellationToken);
+        // Write to a sibling temp file first: creating the target directly would
+        // truncate it before writing, so a failure mid-write (crash, full disk)
+        // destroys the previously saved measurement. The final move is atomic.
+        string tempPath = path + ".tmp";
+        try
+        {
+            await using (FileStream stream = new(
+                tempPath,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 64 * 1024,
+                useAsync: true))
+            {
+                await JsonSerializer.SerializeAsync(
+                    stream,
+                    this,
+                    SerializerOptions,
+                    cancellationToken);
+            }
+
+            File.Move(tempPath, path, overwrite: true);
+        }
+        catch
+        {
+            TryDeleteFile(tempPath);
+            throw;
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 
     public static async Task<ImpulseResponseFile> LoadAsync(

--- a/source/Measurements/NoiseSignal.cs
+++ b/source/Measurements/NoiseSignal.cs
@@ -10,11 +10,9 @@ namespace Resonalyze;
 /// </summary>
 public sealed class NoiseSignal : IDisposable
 {
-    private MemoryStream[] memoryStreams = Array.Empty<MemoryStream>();
-    private RawSourceWaveStream[] sourceStreams = Array.Empty<RawSourceWaveStream>();
+    private PcmStreamSet? streamSet;
     private bool disposed;
 
-    public byte[][] ByteData { get; private set; } = Array.Empty<byte[]>();
     public float[] FloatData { get; private set; } = Array.Empty<float>();
     public int SampleRate { get; private set; }
     public int Samples { get; private set; }
@@ -47,12 +45,7 @@ public sealed class NoiseSignal : IDisposable
         RequestedDuration = requestedDuration;
         Samples = checked((int)(sampleRate * requestedDuration));
 
-        DisposeStreams();
-        int channelModeCount = Enum.GetValues<PlaybackChannel>().Length;
-        ByteData = new byte[channelModeCount][];
         FloatData = new float[Samples];
-        memoryStreams = new MemoryStream[channelModeCount];
-        sourceStreams = new RawSourceWaveStream[channelModeCount];
 
         // A fixed seed keeps measurements reproducible and makes regressions diagnosable.
         var random = new Random(42);
@@ -72,28 +65,8 @@ public sealed class NoiseSignal : IDisposable
                 break;
         }
 
-        foreach (PlaybackChannel channel in Enum.GetValues<PlaybackChannel>())
-        {
-            int outputChannelCount = channel == PlaybackChannel.Mono ? 1 : 2;
-            int bytesPerSample = bitsPerSample / 8;
-            int maxValue = int.MaxValue >> (32 - bitsPerSample);
-            byte[] data = new byte[Samples * bytesPerSample * outputChannelCount];
-
-            for (int sampleIndex = 0; sampleIndex < Samples; sampleIndex++)
-            {
-                int sample = (int)(FloatData[sampleIndex] * maxValue);
-                sample *= (int)Math.Pow(256, 4 - bytesPerSample);
-                byte[] bytes = BitConverter.GetBytes(sample);
-                WriteSample(data, sampleIndex, bytes, bytesPerSample, outputChannelCount, channel);
-            }
-
-            int channelIndex = (int)channel;
-            ByteData[channelIndex] = data;
-            memoryStreams[channelIndex] = new MemoryStream(data, writable: false);
-            sourceStreams[channelIndex] = new RawSourceWaveStream(
-                memoryStreams[channelIndex],
-                new WaveFormat(SampleRate, BitsPerSample, outputChannelCount));
-        }
+        streamSet?.Dispose();
+        streamSet = new PcmStreamSet(FloatData, sampleRate, bitsPerSample);
     }
 
     // Uniform white noise in [-0.5, 0.5): equal energy per hertz.
@@ -225,64 +198,17 @@ public sealed class NoiseSignal : IDisposable
     public RawSourceWaveStream GetStream(PlaybackChannel channel)
     {
         ThrowIfDisposed();
-        if (!Enum.IsDefined(channel))
+        if (streamSet == null)
         {
-            throw new ArgumentOutOfRangeException(nameof(channel));
+            throw new InvalidOperationException("The noise signal is not generated.");
         }
 
-        return sourceStreams[(int)channel];
-    }
-
-    private static void WriteSample(
-        byte[] destination,
-        int sampleIndex,
-        byte[] source,
-        int bytesPerSample,
-        int channelCount,
-        PlaybackChannel channel)
-    {
-        int frameOffset = sampleIndex * bytesPerSample * channelCount;
-        int sourceOffset = 4 - bytesPerSample;
-
-        if (channel == PlaybackChannel.Mono)
-        {
-            Array.Copy(source, sourceOffset, destination, frameOffset, bytesPerSample);
-            return;
-        }
-
-        if (channel is PlaybackChannel.Left or PlaybackChannel.Stereo)
-        {
-            Array.Copy(source, sourceOffset, destination, frameOffset, bytesPerSample);
-        }
-        if (channel is PlaybackChannel.Right or PlaybackChannel.Stereo)
-        {
-            Array.Copy(
-                source,
-                sourceOffset,
-                destination,
-                frameOffset + bytesPerSample,
-                bytesPerSample);
-        }
+        return streamSet.GetStream(channel);
     }
 
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(disposed, this);
-    }
-
-    private void DisposeStreams()
-    {
-        foreach (RawSourceWaveStream stream in sourceStreams)
-        {
-            stream.Dispose();
-        }
-        foreach (MemoryStream stream in memoryStreams)
-        {
-            stream.Dispose();
-        }
-
-        sourceStreams = Array.Empty<RawSourceWaveStream>();
-        memoryStreams = Array.Empty<MemoryStream>();
     }
 
     public void Dispose()
@@ -293,7 +219,8 @@ public sealed class NoiseSignal : IDisposable
         }
 
         disposed = true;
-        DisposeStreams();
+        streamSet?.Dispose();
+        streamSet = null;
         GC.SuppressFinalize(this);
     }
 }

--- a/source/Measurements/SignalFade.cs
+++ b/source/Measurements/SignalFade.cs
@@ -1,0 +1,26 @@
+namespace Resonalyze;
+
+internal static class SignalFade
+{
+    /// <summary>
+    /// Applies a raised-cosine fade-in and fade-out in place, so generated
+    /// signals start and end at zero instead of a step — an abrupt edge is an
+    /// audible (and at high level tweeter-unfriendly) click.
+    /// </summary>
+    public static void ApplyFadeInOut(float[] samples, int fadeSamples)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        if (fadeSamples <= 0 || samples.Length < 2)
+        {
+            return;
+        }
+
+        int fade = Math.Min(fadeSamples, samples.Length / 2);
+        for (int i = 0; i < fade; i++)
+        {
+            float gain = 0.5f * (1.0f - (float)Math.Cos(Math.PI * i / fade));
+            samples[i] *= gain;
+            samples[samples.Length - 1 - i] *= gain;
+        }
+    }
+}

--- a/source/ModeSwitching/ModeController.cs
+++ b/source/ModeSwitching/ModeController.cs
@@ -30,8 +30,29 @@ internal sealed class ModeController
 
     public ModeTab ActiveTab { get; private set; } = ModeTab.Frequency;
 
-    public async Task SelectAsync(ModeTab tab)
+    private Task selectChain = Task.CompletedTask;
+
+    // Switches queue behind each other: a tab click during a slow switch (one
+    // that aborts a running measurement) must not interleave with it, otherwise
+    // ActiveTab and Form1.CurrentMode end up describing different modes.
+    public Task SelectAsync(ModeTab tab)
     {
+        Task current = SelectAfterAsync(selectChain, tab);
+        selectChain = current;
+        return current;
+    }
+
+    private async Task SelectAfterAsync(Task previous, ModeTab tab)
+    {
+        try
+        {
+            await previous;
+        }
+        catch
+        {
+            // The previous switch reported its failure to its own caller.
+        }
+
         await changeModeAsync(getMode(tab));
         ActiveTab = tab;
         activeTabChanged(tab);

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -535,6 +535,7 @@ public sealed class Overlay
     private readonly ToolStripItem exportDeviationMenuItem;
     private readonly ToolStripItem settingsMenuItem;
     private readonly System.Windows.Forms.Timer longPressTimer;
+    private readonly System.Windows.Forms.Timer offsetSaveTimer;
     private int captureMenuOpenedAt;
     private bool captureMenuSpuriousCloseGuard;
     private bool longPressTriggered;
@@ -628,6 +629,12 @@ public sealed class Overlay
         longPressTimer = new System.Windows.Forms.Timer { Interval = 500 };
         longPressTimer.Tick += LongPressTimerTick;
 
+        // Persisting the slot serializes every captured point and flushes to
+        // disk; debounce it so holding the offset spinner arrow doesn't fsync
+        // on each tick. The redraw itself stays immediate.
+        offsetSaveTimer = new System.Windows.Forms.Timer { Interval = 500 };
+        offsetSaveTimer.Tick += OffsetSaveTimerTick;
+
         toolTip.SetToolTip(offsetControl, "Overlay vertical offset (dB)");
         toolTip.SetToolTip(checkBox, "Show / hide this overlay");
         toolTip.SetToolTip(
@@ -657,6 +664,9 @@ public sealed class Overlay
 
     public void Prepare(Mode mode)
     {
+        // A pending debounced offset save must land before the slot state is
+        // replaced from disk, or the last spinner change would be dropped.
+        FlushPendingOffsetSave();
         ResetState();
         if (mode == Mode.None)
         {
@@ -1969,12 +1979,34 @@ public sealed class Overlay
         {
             UpdateDrawPoints();
         }
-        TrySaveCurrentState("Overlay changes could not be saved.");
+        offsetSaveTimer.Stop();
+        offsetSaveTimer.Start();
         if (wasChecked)
         {
             Show();
         }
-        collection.NotifyCapturedOverlayChanged();
+        // Only captured slots feed other overlays (operations consume their
+        // draw points); a target or operation offset cannot change any input.
+        if (kind == OverlayKind.Captured)
+        {
+            collection.NotifyCapturedOverlayChanged();
+        }
+    }
+
+    private void OffsetSaveTimerTick(object? sender, EventArgs e)
+    {
+        FlushPendingOffsetSave();
+    }
+
+    private void FlushPendingOffsetSave()
+    {
+        if (!offsetSaveTimer.Enabled)
+        {
+            return;
+        }
+
+        offsetSaveTimer.Stop();
+        TrySaveCurrentState("Overlay changes could not be saved.");
     }
 
     private void CheckBoxChanged(object? sender, EventArgs e)

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -95,6 +95,16 @@ public sealed class OverlayCollection
     public OxyPlot.WindowsForms.PlotView PlotView { get; }
     public Form1 Form { get; }
 
+    // Lands any debounced offset saves immediately; the shell calls this on
+    // close so an offset changed within the debounce window still persists.
+    public void FlushPendingSaves()
+    {
+        foreach (Overlay overlay in overlays)
+        {
+            overlay.FlushPendingOffsetSave();
+        }
+    }
+
     public void Prepare(Mode mode)
     {
         Mode overlayMode = OverlayModeFor(mode);
@@ -1998,7 +2008,7 @@ public sealed class Overlay
         FlushPendingOffsetSave();
     }
 
-    private void FlushPendingOffsetSave()
+    internal void FlushPendingOffsetSave()
     {
         if (!offsetSaveTimer.Enabled)
         {

--- a/source/Overlays/OverlayTextFile.cs
+++ b/source/Overlays/OverlayTextFile.cs
@@ -21,7 +21,11 @@ public static class OverlayTextFile
         IEnumerable<string> lines = points.Select(point => string.Create(
             CultureInfo.InvariantCulture,
             $"{point.X:R} {point.Y:R}"));
-        File.WriteAllLines(path, lines);
+        // Temp file + move so an interrupted export cannot truncate an existing
+        // file the user picked (mirrors OverlayFile.Save).
+        string tempPath = path + ".tmp";
+        File.WriteAllLines(tempPath, lines);
+        File.Move(tempPath, path, overwrite: true);
     }
 
     public static OverlayPoint[] Import(string path)

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -718,8 +718,22 @@ internal sealed class PlotModelFactory
             noiseMeasurement.SampleRate,
             noiseMeasurement.SequenceLength,
             liveSpectrumOptions.SmoothingInverseOctaves);
-        int count = Math.Min(magnitudePoints.Count, coherencePoints.Count);
+        int count = magnitudePoints.Count;
         double threshold = thresholdPercent / 100.0;
+
+        // The two resamplers use different grids (fixed 20-20 kHz vs bin-width
+        // and Nyquist bounded, with empty bands skipped), so coherence must be
+        // matched to each magnitude point by frequency, not by index. Missing
+        // coverage counts as trusted, so a degenerate coherence set cannot
+        // blank the whole live trace.
+        var trustedFlags = new bool[count];
+        int cursor = 0;
+        for (int i = 0; i < count; i++)
+        {
+            trustedFlags[i] =
+                NearestCoherence(coherencePoints, magnitudePoints[i].X, ref cursor) >=
+                threshold;
+        }
 
         var trusted = new LineSeries
         {
@@ -736,7 +750,7 @@ internal sealed class PlotModelFactory
             TrackerFormatString = "{0}\n{2:0.0} Hz\n{4:0.00} dB"
         };
 
-        bool IsTrusted(int index) => coherencePoints[index].Y >= threshold;
+        bool IsTrusted(int index) => trustedFlags[index];
 
         for (int i = 0; i < count; i++)
         {
@@ -756,6 +770,34 @@ internal sealed class PlotModelFactory
         }
 
         return (trusted, untrusted);
+    }
+
+    // Nearest coherence sample for a frequency; both point lists are sorted by
+    // X, so a forward-moving cursor keeps the whole pairing pass linear.
+    private static double NearestCoherence(
+        List<SignalPoint> coherencePoints,
+        double frequency,
+        ref int cursor)
+    {
+        if (coherencePoints.Count == 0)
+        {
+            return 1.0;
+        }
+
+        while (cursor + 1 < coherencePoints.Count &&
+            coherencePoints[cursor + 1].X <= frequency)
+        {
+            cursor++;
+        }
+
+        double value = coherencePoints[cursor].Y;
+        if (cursor + 1 < coherencePoints.Count &&
+            coherencePoints[cursor + 1].X - frequency < frequency - coherencePoints[cursor].X)
+        {
+            value = coherencePoints[cursor + 1].Y;
+        }
+
+        return value;
     }
 
     private List<SignalPoint> ResampleCoherence(

--- a/source/Plotting/WaterfallSeries.cs
+++ b/source/Plotting/WaterfallSeries.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using OxyPlot;
 using OxyPlot.Axes;
 using OxyPlot.Series;
@@ -88,7 +89,8 @@ namespace Resonalyze
     {
         public WaterfallSeries()
         {
-            TrackerFormatString = "X: {0:0.000}\r\nY: {1:0.000}\r\nIterations: {2}";
+            // {0} is the series title by convention; the coordinates are {1}/{2}.
+            TrackerFormatString = "X: {1:0.000}\r\nY: {2:0.000}";
             RawSlices = new List<Slice>();
             ResampleSlices = new List<Slice>();
             GenerateOptions = new WaterfallGenerateOptions();
@@ -96,6 +98,12 @@ namespace Resonalyze
 
         public List<Slice> RawSlices { get; }
         public List<Slice> ResampleSlices { get; }
+
+        private int rawSlicesRevision;
+        private int resampledRevision = -1;
+        private double resampledMinFrequency = double.NaN;
+        private double resampledMaxFrequency = double.NaN;
+        private int resampledWidth = -1;
 
         /// <summary>
         /// Gets or sets the color axis.
@@ -135,8 +143,7 @@ namespace Resonalyze
                     this.TrackerFormatString,
                     string.Empty,
                     p.X,
-                    p.Y,
-                    999)
+                    p.Y)
             };
         }
 
@@ -269,7 +276,10 @@ namespace Resonalyze
                     if (labelAcc > labelStep)
                     {
                         labelAcc = 0;
-                        rc.DrawText(new ScreenPoint(corner.X + width, corner.Y), Math.Round(pointSeries[i].TimeOffset * 1000, 2).ToString() + "ms", OxyColors.Aqua);
+                        rc.DrawText(
+                            new ScreenPoint(corner.X + width, corner.Y),
+                            (pointSeries[i].TimeOffset * 1000).ToString("0.##", CultureInfo.InvariantCulture) + "ms",
+                            OxyColors.Aqua);
                     }
                 }
             }
@@ -292,6 +302,13 @@ namespace Resonalyze
 
                     ScreenPoint cornerUp = Lerp(p4, p5, frequencyPosition);
                     ScreenPoint cornerDown = Lerp(p0, p6, frequencyPosition);
+
+                    // A slice with no usable data resamples to an empty list;
+                    // indexing it by pixel column would throw inside Render.
+                    if (ResampleSlices[slice].Data.Count < width)
+                    {
+                        continue;
+                    }
 
                     for (int pInd = 0; pInd < width; pInd++)
                     {
@@ -338,7 +355,10 @@ namespace Resonalyze
                 {
                     ScreenPoint pos = Lerp(p5, p6, label / GenerateOptions.Periods);
 
-                    rc.DrawText(pos, Math.Round(label).ToString() + " periods", OxyColors.Aqua);
+                    rc.DrawText(
+                        pos,
+                        Math.Round(label).ToString(CultureInfo.InvariantCulture) + " periods",
+                        OxyColors.Aqua);
                 }
             }
 
@@ -376,6 +396,7 @@ namespace Resonalyze
         public void FillFourierWaterfallData(IImpulseMeasurement measurement)
         {
             RawSlices.Clear();
+            rawSlicesRevision++;
 
             int window = GenerateOptions.Window;
             int step = GenerateOptions.Step;
@@ -451,6 +472,22 @@ namespace Resonalyze
 
         public void Resample(double minFrequency, double maxFrequency, int width)
         {
+            // Render calls this on every plot invalidation (pan, resize, label
+            // refresh); re-smoothing all slices is only needed when the view
+            // window or the underlying data actually changed.
+            if (resampledRevision == rawSlicesRevision &&
+                resampledMinFrequency == minFrequency &&
+                resampledMaxFrequency == maxFrequency &&
+                resampledWidth == width)
+            {
+                return;
+            }
+
+            resampledRevision = rawSlicesRevision;
+            resampledMinFrequency = minFrequency;
+            resampledMaxFrequency = maxFrequency;
+            resampledWidth = width;
+
             ResampleSlices.Clear();
             if (GenerateOptions.WaterfallMode == WaterfallMode.Fourier)
             {

--- a/source/Settings/ApplicationUpdateService.cs
+++ b/source/Settings/ApplicationUpdateService.cs
@@ -65,7 +65,7 @@ internal static class ApplicationUpdateService
             return;
         }
 
-        if (!IsInstalledBuild())
+        if (!IsInstalledBuild() || !HasSignaturePublicKey())
         {
             OpenReleasePage(latestReleaseUrl);
             return;
@@ -104,16 +104,20 @@ internal static class ApplicationUpdateService
         Initialize(owner);
     }
 
+    private static bool HasSignaturePublicKey() =>
+        !string.IsNullOrWhiteSpace(ApplicationVersionInfo.GetSparklePublicKey());
+
     private static SparkleUpdater CreateUpdater(Form? owner)
     {
+        // Always Strict: falling back to UseIfPossible when the embedded key is
+        // missing would make a build without a key silently accept unsigned
+        // updates. StartAutomaticUpdate routes keyless builds to the release
+        // page instead of the updater.
         string publicKey = ApplicationVersionInfo.GetSparklePublicKey() ?? string.Empty;
-        SecurityMode securityMode = string.IsNullOrWhiteSpace(publicKey)
-            ? SecurityMode.UseIfPossible
-            : SecurityMode.Strict;
 
         var sparkleUpdater = new SparkleUpdater(
             AppCastUrl,
-            new Ed25519Checker(securityMode, publicKey, string.Empty))
+            new Ed25519Checker(SecurityMode.Strict, publicKey, string.Empty))
         {
             UIFactory = new UIFactory(owner?.Icon),
             RelaunchAfterUpdate = false,

--- a/source/Settings/GitHubReleaseChecker.cs
+++ b/source/Settings/GitHubReleaseChecker.cs
@@ -39,15 +39,22 @@ internal static class GitHubReleaseChecker
             return null;
         }
 
-        string releaseUrl = string.IsNullOrWhiteSpace(latest.HtmlUrl)
-            ? ReleasesPageUrl
-            : latest.HtmlUrl;
+        // The URL ends up in Process.Start with ShellExecute; never pass through
+        // anything but an https github.com link, even from a trusted API.
+        string releaseUrl = IsTrustedReleaseUrl(latest.HtmlUrl)
+            ? latest.HtmlUrl!
+            : ReleasesPageUrl;
         bool updateAvailable = ApplicationVersionInfo.IsOlderThan(latest.TagName);
         return new ReleaseCheckResult(
             latest.TagName,
             releaseUrl,
             updateAvailable);
     }
+
+    internal static bool IsTrustedReleaseUrl(string? url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out Uri? parsed) &&
+        parsed.Scheme == Uri.UriSchemeHttps &&
+        string.Equals(parsed.Host, "github.com", StringComparison.OrdinalIgnoreCase);
 
     private static HttpClient CreateHttpClient()
     {

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -61,8 +61,15 @@ internal sealed class MeasurementSettingsFile
     public void Save()
     {
         SchemaVersion = CurrentSchemaVersion;
-        using FileStream stream = File.Create(PathOnDisk);
-        JsonSerializer.Serialize(stream, this, SerializerOptions);
+        // Temp file + move keeps the settings intact if the write is interrupted;
+        // a corrupted file silently loads as defaults.
+        string tempPath = PathOnDisk + ".tmp";
+        using (FileStream stream = File.Create(tempPath))
+        {
+            JsonSerializer.Serialize(stream, this, SerializerOptions);
+        }
+
+        File.Move(tempPath, PathOnDisk, overwrite: true);
     }
 
     public void ApplyTo(

--- a/source/Shell/Form1.History.cs
+++ b/source/Shell/Form1.History.cs
@@ -34,12 +34,7 @@ public partial class Form1
 
     private void HandleHistoryChanged()
     {
-        if (IsDisposed || !IsHandleCreated)
-        {
-            return;
-        }
-
-        BeginInvoke((MethodInvoker)delegate
+        TryBeginInvokeOnUiThread(() =>
         {
             dockedHistoryHost.InvokeIfOpen<MeasurementHistoryWindow>(dialog =>
             {
@@ -54,6 +49,13 @@ public partial class Form1
 
     private async void HandleHistoryEntryActivated(Guid entryId)
     {
+        // Restoring a snapshot while a sweep is running would call Init on an
+        // active measurement and fail; ignore the activation instead.
+        if (expSweepMeasurement.InProgress)
+        {
+            return;
+        }
+
         try
         {
             MeasurementHistorySnapshot? snapshot =

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -268,12 +268,7 @@ public partial class Form1
 
     private void HandleMeasurementCompleted(bool success)
     {
-        if (IsDisposed || !IsHandleCreated)
-        {
-            return;
-        }
-
-        BeginInvoke((MethodInvoker)delegate
+        TryBeginInvokeOnUiThread(() =>
         {
             if (success)
             {
@@ -301,12 +296,7 @@ public partial class Form1
 
     private void HandleAverageProgressChanged(SweepAverageProgress progress)
     {
-        if (IsDisposed || !IsHandleCreated)
-        {
-            return;
-        }
-
-        BeginInvoke((MethodInvoker)delegate
+        TryBeginInvokeOnUiThread(() =>
         {
             buttonRecord.Text = progress.State == SweepAverageProgressState.WaitingForConfirmation
                 ? $"Next run ({progress.CurrentRun + 1}/{progress.TotalRuns})"

--- a/source/Shell/Form1.Lifecycle.cs
+++ b/source/Shell/Form1.Lifecycle.cs
@@ -38,6 +38,14 @@ public partial class Form1
         }
 
         e.Cancel = true;
+        if (closingInProgress)
+        {
+            // A second close request while the aborts are still awaited would
+            // re-run the whole teardown; the first pass finishes the close.
+            return;
+        }
+
+        closingInProgress = true;
         Enabled = false;
         FlushMeasurementSettings();
         PersistCurrentSessionState();

--- a/source/Shell/Form1.Lifecycle.cs
+++ b/source/Shell/Form1.Lifecycle.cs
@@ -48,6 +48,7 @@ public partial class Form1
         closingInProgress = true;
         Enabled = false;
         FlushMeasurementSettings();
+        overlayCollection.FlushPendingSaves();
         PersistCurrentSessionState();
         startupAudioWarmupCancellation?.Cancel();
         await Task.WhenAll(

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -122,6 +122,13 @@ public partial class Form1
             }
 
             await WaitForStartupAudioWarmupAsync();
+            if (expSweepMeasurement.InProgress)
+            {
+                // A second click can arrive while the warm-up is awaited;
+                // starting again would call Init on a running measurement.
+                return;
+            }
+
             PrepareSweepMeasurementForRun();
             EnterMeasurementRunningState();
             _ = expSweepMeasurement.RunAsync();

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -82,6 +82,7 @@ namespace Resonalyze
         private Guid? currentHistoryEntryId;
         private bool hasCurrentImpulseResponse;
         private bool closingPrepared;
+        private bool closingInProgress;
         private bool resourcesDisposed;
         private bool updateCheckStarted;
         private bool measurementSettingsSavePending;
@@ -137,6 +138,27 @@ namespace Resonalyze
             WireControllerEvents();
             InitializeStartupState();
             WireFormEvents();
+        }
+
+        // BeginInvoke can still throw if the handle is destroyed between the guard
+        // and the call — measurement events arrive from audio worker threads while
+        // the form closes on the UI thread.
+        private bool TryBeginInvokeOnUiThread(Action action)
+        {
+            if (IsDisposed || !IsHandleCreated)
+            {
+                return false;
+            }
+
+            try
+            {
+                BeginInvoke(action);
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
         }
 
         private SignalGeneratorPlaybackSettings CreateSignalGeneratorPlaybackSettings() =>

--- a/source/Tools/EqWizardPanel.cs
+++ b/source/Tools/EqWizardPanel.cs
@@ -613,8 +613,9 @@ public partial class EqWizardPanel : UserControl
     }
 
     // Fits the PEQ bands and preamp automatically so Source + EQ approaches Target,
-    // then writes the result into the controls.
-    private void AutoTune()
+    // then writes the result into the controls. The fit runs on a worker thread —
+    // tuning up to 32 bands takes long enough to visibly freeze the UI.
+    private async void AutoTune()
     {
         TargetOverlayOption? selected = SelectedTargetOverlay;
         // Pass a neutral EQ so the render gives the raw source and a target aligned
@@ -637,8 +638,32 @@ public partial class EqWizardPanel : UserControl
         var target = render.Target.Points
             .Select(point => new SignalPoint(point.X, point.Y))
             .ToList();
+        EqAutoTuner.Options options = CreateAutoTuneOptions();
 
-        EqualizationCurve tuned = EqAutoTuner.Tune(source, target, CreateAutoTuneOptions());
+        EqualizationCurve tuned;
+        buttonAutoTune.Enabled = false;
+        try
+        {
+            tuned = await Task.Run(() => EqAutoTuner.Tune(source, target, options));
+        }
+        catch (Exception exception)
+        {
+            ShowFileError("Auto Tune failed.", exception);
+            return;
+        }
+        finally
+        {
+            if (!IsDisposed)
+            {
+                buttonAutoTune.Enabled = true;
+            }
+        }
+
+        if (IsDisposed)
+        {
+            return;
+        }
+
         // A freshly tuned EQ should be audible/visible, so leave bypass off.
         checkBoxBypass.Checked = false;
         ApplyEqualizationCurve(tuned);
@@ -691,18 +716,18 @@ public partial class EqWizardPanel : UserControl
                 if (i < curve.Bands.Count)
                 {
                     PeqBand band = curve.Bands[i];
-                    slot.FrequencyInput.Value = Clamp(slot.FrequencyInput, band.FrequencyHz);
-                    slot.QInput.Value = Clamp(slot.QInput, band.Q);
-                    slot.GainInput.Value = Clamp(slot.GainInput, band.GainDb);
+                    slot.FrequencyInput.Value = slot.FrequencyInput.ClampValue(band.FrequencyHz);
+                    slot.QInput.Value = slot.QInput.ClampValue(band.Q);
+                    slot.GainInput.Value = slot.GainInput.ClampValue(band.GainDb);
                 }
                 else
                 {
                     // No band for this slot: leave it transparent.
-                    slot.GainInput.Value = Clamp(slot.GainInput, 0);
+                    slot.GainInput.Value = slot.GainInput.ClampValue(0);
                 }
             }
 
-            NumericGain.Value = Clamp(NumericGain, curve.PreampDb);
+            NumericGain.Value = NumericGain.ClampValue(curve.PreampDb);
         }
         finally
         {
@@ -726,13 +751,6 @@ public partial class EqWizardPanel : UserControl
         }
 
         return (minHz, maxHz);
-    }
-
-    // Rounds to the control's precision and clamps to its range.
-    private static decimal Clamp(DarkNumericUpDown control, double value)
-    {
-        decimal rounded = (decimal)Math.Round(value, control.DecimalPlaces);
-        return Math.Clamp(rounded, control.Minimum, control.Maximum);
     }
 
     private const string TuningSheetFilter = "Tuning sheet (PDF) (*.pdf)|*.pdf";

--- a/source/Tools/SignalGeneratorPanel.cs
+++ b/source/Tools/SignalGeneratorPanel.cs
@@ -17,7 +17,7 @@ public partial class SignalGeneratorPanel : UserControl
 {
     private IWavePlayer? player;
     private WaveStream? playbackStream;
-    private MemoryStream? playbackMemoryStream;
+    private PcmStreamSet? pcmStreams;
 
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -80,6 +80,9 @@ public partial class SignalGeneratorPanel : UserControl
                 SelectedSignalType,
                 (double)numericFrequency.Value,
                 (double)numericLevel.Value / 100.0);
+            // 10 ms ramps: an abrupt start/end is an audible click, unfriendly
+            // to tweeters at the levels this tool is used at.
+            SignalFade.ApplyFadeInOut(monoSamples, settings.SampleRate / 100);
 
             if (settings.Backend == AudioBackend.Asio)
             {
@@ -95,11 +98,11 @@ public partial class SignalGeneratorPanel : UserControl
                 {
                     DeviceNumber = settings.WaveOutputDeviceNumber
                 };
-                playbackStream = CreatePcmStream(
+                pcmStreams = new PcmStreamSet(
                     monoSamples,
                     settings.SampleRate,
-                    settings.BitsPerSample,
-                    settings.PlaybackChannel);
+                    settings.BitsPerSample);
+                playbackStream = pcmStreams.GetStream(settings.PlaybackChannel);
             }
 
             player.Init(playbackStream);
@@ -191,31 +194,6 @@ public partial class SignalGeneratorPanel : UserControl
         return result;
     }
 
-    private RawSourceWaveStream CreatePcmStream(
-        IReadOnlyList<float> monoSamples,
-        int sampleRate,
-        int bitsPerSample,
-        PlaybackChannel channel)
-    {
-        int outputChannelCount = channel == PlaybackChannel.Mono ? 1 : 2;
-        int bytesPerSample = bitsPerSample / 8;
-        int maxValue = int.MaxValue >> (32 - bitsPerSample);
-        var data = new byte[monoSamples.Count * bytesPerSample * outputChannelCount];
-
-        for (int sampleIndex = 0; sampleIndex < monoSamples.Count; sampleIndex++)
-        {
-            int sample = (int)(Math.Clamp(monoSamples[sampleIndex], -1.0f, 1.0f) * maxValue);
-            sample *= (int)Math.Pow(256, 4 - bytesPerSample);
-            byte[] bytes = BitConverter.GetBytes(sample);
-            WriteSample(data, sampleIndex, bytes, bytesPerSample, outputChannelCount, channel);
-        }
-
-        playbackMemoryStream = new MemoryStream(data, writable: false);
-        return new RawSourceWaveStream(
-            playbackMemoryStream,
-            new WaveFormat(sampleRate, bitsPerSample, outputChannelCount));
-    }
-
     private void PlayerPlaybackStopped(object? sender, StoppedEventArgs e)
     {
         void UpdateUi()
@@ -236,7 +214,15 @@ public partial class SignalGeneratorPanel : UserControl
 
         if (InvokeRequired)
         {
-            BeginInvoke((Action)UpdateUi);
+            try
+            {
+                BeginInvoke((Action)UpdateUi);
+            }
+            catch (InvalidOperationException)
+            {
+                // The handle was destroyed between the guard and the call.
+                DisposePlayback();
+            }
             return;
         }
 
@@ -271,8 +257,8 @@ public partial class SignalGeneratorPanel : UserControl
 
         playbackStream?.Dispose();
         playbackStream = null;
-        playbackMemoryStream?.Dispose();
-        playbackMemoryStream = null;
+        pcmStreams?.Dispose();
+        pcmStreams = null;
     }
 
     internal void RefreshAudioSettings()
@@ -323,38 +309,6 @@ public partial class SignalGeneratorPanel : UserControl
             SignalGeneratorType.WhiteNoise => NoiseColor.White,
             _ => NoiseColor.PinkPeriodic
         };
-
-    private static void WriteSample(
-        byte[] destination,
-        int sampleIndex,
-        byte[] source,
-        int bytesPerSample,
-        int channelCount,
-        PlaybackChannel channel)
-    {
-        int frameOffset = sampleIndex * bytesPerSample * channelCount;
-        int sourceOffset = 4 - bytesPerSample;
-
-        if (channel == PlaybackChannel.Mono)
-        {
-            Array.Copy(source, sourceOffset, destination, frameOffset, bytesPerSample);
-            return;
-        }
-
-        if (channel is PlaybackChannel.Left or PlaybackChannel.Stereo)
-        {
-            Array.Copy(source, sourceOffset, destination, frameOffset, bytesPerSample);
-        }
-        if (channel is PlaybackChannel.Right or PlaybackChannel.Stereo)
-        {
-            Array.Copy(
-                source,
-                sourceOffset,
-                destination,
-                frameOffset + bytesPerSample,
-                bytesPerSample);
-        }
-    }
 
     private enum SignalGeneratorType
     {

--- a/source/Ui/CoalescingDispatcher.cs
+++ b/source/Ui/CoalescingDispatcher.cs
@@ -1,0 +1,63 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Marshals values from a high-rate producer to a consumer with latest-wins
+/// coalescing: at most one dispatch is in flight at a time, and it always
+/// delivers the most recent value. Audio callbacks can fire a thousand times
+/// per second at small buffer sizes; posting every snapshot to the UI message
+/// queue would flood the pump with stale updates.
+/// </summary>
+internal sealed class CoalescingDispatcher<T>
+{
+    private readonly object sync = new();
+    private readonly Func<Action, bool> tryPost;
+    private readonly Action<T> apply;
+    private T pendingValue = default!;
+    private bool dispatchQueued;
+
+    /// <param name="tryPost">
+    /// Schedules the drain callback on the consumer thread; returns false when
+    /// dispatch is impossible (e.g. the target handle is gone) so the queued
+    /// flag is released and a later offer can try again.
+    /// </param>
+    /// <param name="apply">Receives the newest value on the consumer thread.</param>
+    public CoalescingDispatcher(Func<Action, bool> tryPost, Action<T> apply)
+    {
+        this.tryPost = tryPost;
+        this.apply = apply;
+    }
+
+    public void Offer(T value)
+    {
+        lock (sync)
+        {
+            pendingValue = value;
+            if (dispatchQueued)
+            {
+                return;
+            }
+
+            dispatchQueued = true;
+        }
+
+        if (!tryPost(Drain))
+        {
+            lock (sync)
+            {
+                dispatchQueued = false;
+            }
+        }
+    }
+
+    private void Drain()
+    {
+        T value;
+        lock (sync)
+        {
+            value = pendingValue;
+            dispatchQueued = false;
+        }
+
+        apply(value);
+    }
+}

--- a/source/Ui/Controls/DarkNumericUpDown.cs
+++ b/source/Ui/Controls/DarkNumericUpDown.cs
@@ -545,6 +545,14 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
             return true;
         }
 
+        if (keyData == Keys.Enter)
+        {
+            // A dialog's AcceptButton consumes Enter before the editor's KeyDown
+            // ever fires; commit here so the accept handler reads the typed text
+            // rather than the last committed value.
+            CommitEditorText();
+        }
+
         return base.ProcessCmdKey(ref msg, keyData);
     }
 
@@ -599,24 +607,8 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
         }
     }
 
-    private bool TryParseEditorText(out decimal parsed)
-    {
-        string text = editor.Text.Trim();
-        if (decimal.TryParse(
-            text,
-            NumberStyles.Number,
-            CultureInfo.CurrentCulture,
-            out parsed))
-        {
-            return true;
-        }
-
-        return decimal.TryParse(
-            text,
-            NumberStyles.Number,
-            CultureInfo.InvariantCulture,
-            out parsed);
-    }
+    private bool TryParseEditorText(out decimal parsed) =>
+        NumericTextParser.TryParse(editor.Text, CultureInfo.CurrentCulture, out parsed);
 
     private void UpdateEditorText()
     {
@@ -642,13 +634,17 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
         return currentValue.ToString(format, CultureInfo.CurrentCulture);
     }
 
+    // Commit first: stepping must apply to what the user typed, not overwrite
+    // uncommitted editor text with lastCommitted ± increment.
     private void StepUp()
     {
+        CommitEditorText();
         Value += increment;
     }
 
     private void StepDown()
     {
+        CommitEditorText();
         Value -= increment;
     }
 

--- a/source/Ui/Controls/InputLevelMeterController.cs
+++ b/source/Ui/Controls/InputLevelMeterController.cs
@@ -6,6 +6,10 @@ internal sealed class InputLevelMeterController : IDisposable
     private readonly InputLevelMeterPanel panel;
     private readonly ExpSweepMeasurement sweepMeasurement;
     private readonly NoiseMeasurement noiseMeasurement;
+    // Levels arrive on audio worker threads on every buffer, which outpaces the
+    // message pump at small ASIO buffer sizes; coalesce to a single queued UI
+    // update carrying the newest snapshot.
+    private readonly CoalescingDispatcher<InputLevelMeterSnapshot> dispatcher;
     private bool disposed;
 
     public InputLevelMeterController(
@@ -18,9 +22,12 @@ internal sealed class InputLevelMeterController : IDisposable
         this.panel = panel;
         this.sweepMeasurement = sweepMeasurement;
         this.noiseMeasurement = noiseMeasurement;
+        dispatcher = new CoalescingDispatcher<InputLevelMeterSnapshot>(
+            TryPostToOwner,
+            ApplyOnUiThread);
 
-        sweepMeasurement.LevelsAvailable += ApplyLevels;
-        noiseMeasurement.LevelsAvailable += ApplyLevels;
+        sweepMeasurement.LevelsAvailable += HandleLevels;
+        noiseMeasurement.LevelsAvailable += HandleLevels;
     }
 
     public void Clear()
@@ -30,7 +37,14 @@ internal sealed class InputLevelMeterController : IDisposable
             return;
         }
 
-        owner.BeginInvoke((MethodInvoker)panel.ClearLevels);
+        try
+        {
+            owner.BeginInvoke((MethodInvoker)panel.ClearLevels);
+        }
+        catch (InvalidOperationException)
+        {
+            // The handle was destroyed between the guard and the call.
+        }
     }
 
     public void Dispose()
@@ -41,17 +55,43 @@ internal sealed class InputLevelMeterController : IDisposable
         }
 
         disposed = true;
-        sweepMeasurement.LevelsAvailable -= ApplyLevels;
-        noiseMeasurement.LevelsAvailable -= ApplyLevels;
+        sweepMeasurement.LevelsAvailable -= HandleLevels;
+        noiseMeasurement.LevelsAvailable -= HandleLevels;
     }
 
-    private void ApplyLevels(InputLevelMeterSnapshot snapshot)
+    private void HandleLevels(InputLevelMeterSnapshot snapshot)
     {
-        if (disposed || owner.IsDisposed || !owner.IsHandleCreated)
+        if (disposed)
         {
             return;
         }
 
-        owner.BeginInvoke((MethodInvoker)(() => panel.SetLevels(snapshot)));
+        dispatcher.Offer(snapshot);
+    }
+
+    private bool TryPostToOwner(Action drain)
+    {
+        if (disposed || owner.IsDisposed || !owner.IsHandleCreated)
+        {
+            return false;
+        }
+
+        try
+        {
+            owner.BeginInvoke(drain);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private void ApplyOnUiThread(InputLevelMeterSnapshot snapshot)
+    {
+        if (!disposed && !panel.IsDisposed)
+        {
+            panel.SetLevels(snapshot);
+        }
     }
 }

--- a/source/Ui/Controls/NumericTextParser.cs
+++ b/source/Ui/Controls/NumericTextParser.cs
@@ -1,0 +1,84 @@
+using System.Globalization;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Culture-tolerant numeric text parsing for the dark numeric fields. A lone
+/// '.' or ',' is treated as the decimal separator regardless of culture:
+/// decimal.TryParse's group-separator leniency would otherwise parse "1.5"
+/// typed in a comma-decimal locale as 15. The only exception is the culture's
+/// own group separator in a plausible thousands position — "12,000" in en-US
+/// must keep round-tripping from the thousands display format.
+/// </summary>
+internal static class NumericTextParser
+{
+    public static bool TryParse(string? text, CultureInfo culture, out decimal value)
+    {
+        value = 0;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        text = text.Trim();
+        int separatorIndex = -1;
+        int separatorCount = 0;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] is '.' or ',')
+            {
+                separatorIndex = i;
+                separatorCount++;
+            }
+        }
+
+        if (separatorCount == 1 && !IsPlausibleThousands(text, separatorIndex, culture))
+        {
+            text = string.Concat(
+                text.AsSpan(0, separatorIndex),
+                culture.NumberFormat.NumberDecimalSeparator,
+                text.AsSpan(separatorIndex + 1));
+        }
+
+        if (decimal.TryParse(text, NumberStyles.Number, culture, out value))
+        {
+            return true;
+        }
+
+        return decimal.TryParse(
+            text,
+            NumberStyles.Number,
+            CultureInfo.InvariantCulture,
+            out value);
+    }
+
+    private static bool IsPlausibleThousands(
+        string text,
+        int separatorIndex,
+        CultureInfo culture)
+    {
+        string groupSeparator = culture.NumberFormat.NumberGroupSeparator;
+        if (groupSeparator.Length != 1 ||
+            text[separatorIndex] != groupSeparator[0] ||
+            separatorIndex == 0 ||
+            !char.IsAsciiDigit(text[separatorIndex - 1]))
+        {
+            return false;
+        }
+
+        if (text.Length - separatorIndex - 1 != 3)
+        {
+            return false;
+        }
+
+        for (int i = separatorIndex + 1; i < text.Length; i++)
+        {
+            if (!char.IsAsciiDigit(text[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Resonalyze.App.Tests/CoalescingDispatcherTests.cs
+++ b/tests/Resonalyze.App.Tests/CoalescingDispatcherTests.cs
@@ -1,0 +1,139 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class CoalescingDispatcherTests
+{
+    [Fact]
+    public void Offer_PostsOnceUntilDrainedAndDeliversLatestValue()
+    {
+        var posted = new List<Action>();
+        var applied = new List<int>();
+        var dispatcher = new CoalescingDispatcher<int>(
+            drain =>
+            {
+                posted.Add(drain);
+                return true;
+            },
+            applied.Add);
+
+        dispatcher.Offer(1);
+        dispatcher.Offer(2);
+        dispatcher.Offer(3);
+
+        Assert.Single(posted);
+
+        posted[0]();
+
+        Assert.Equal(new[] { 3 }, applied);
+    }
+
+    [Fact]
+    public void Offer_PostsAgainAfterDrain()
+    {
+        var posted = new List<Action>();
+        var applied = new List<int>();
+        var dispatcher = new CoalescingDispatcher<int>(
+            drain =>
+            {
+                posted.Add(drain);
+                return true;
+            },
+            applied.Add);
+
+        dispatcher.Offer(1);
+        posted[0]();
+        dispatcher.Offer(2);
+        posted[1]();
+
+        Assert.Equal(2, posted.Count);
+        Assert.Equal(new[] { 1, 2 }, applied);
+    }
+
+    [Fact]
+    public void Offer_RetriesPostAfterFailedDispatch()
+    {
+        int postAttempts = 0;
+        bool allowPost = false;
+        var applied = new List<int>();
+        Action? lastDrain = null;
+        var dispatcher = new CoalescingDispatcher<int>(
+            drain =>
+            {
+                postAttempts++;
+                if (!allowPost)
+                {
+                    return false;
+                }
+
+                lastDrain = drain;
+                return true;
+            },
+            applied.Add);
+
+        // A failed post (handle not created yet / already destroyed) must not
+        // leave the dispatcher stuck with a "queued" flag no drain will reset.
+        dispatcher.Offer(1);
+        Assert.Equal(1, postAttempts);
+
+        allowPost = true;
+        dispatcher.Offer(2);
+        Assert.Equal(2, postAttempts);
+
+        lastDrain!();
+        Assert.Equal(new[] { 2 }, applied);
+    }
+
+    [Fact]
+    public void Offer_DuringDrainQueuesAFreshDispatch()
+    {
+        var posted = new List<Action>();
+        var applied = new List<int>();
+        CoalescingDispatcher<int> dispatcher = null!;
+        dispatcher = new CoalescingDispatcher<int>(
+            drain =>
+            {
+                posted.Add(drain);
+                return true;
+            },
+            value =>
+            {
+                applied.Add(value);
+                if (value == 1)
+                {
+                    // A producer racing with the drain: the new value needs its
+                    // own dispatch because this drain already took a snapshot.
+                    dispatcher.Offer(2);
+                }
+            });
+
+        dispatcher.Offer(1);
+        posted[0]();
+
+        Assert.Equal(2, posted.Count);
+        posted[1]();
+        Assert.Equal(new[] { 1, 2 }, applied);
+    }
+
+    [Fact]
+    public void Offer_IsSafeUnderConcurrentProducers()
+    {
+        var applied = new List<int>();
+        var pending = new System.Collections.Concurrent.ConcurrentQueue<Action>();
+        var dispatcher = new CoalescingDispatcher<int>(
+            drain =>
+            {
+                pending.Enqueue(drain);
+                return true;
+            },
+            applied.Add);
+
+        Parallel.For(0, 10_000, i => dispatcher.Offer(i));
+        while (pending.TryDequeue(out Action? drain))
+        {
+            drain();
+        }
+
+        // Far fewer dispatches than offers, and every drain applied something.
+        Assert.True(applied.Count <= 10_000);
+        Assert.True(applied.Count >= 1);
+    }
+}

--- a/tests/Resonalyze.App.Tests/GitHubReleaseCheckerTests.cs
+++ b/tests/Resonalyze.App.Tests/GitHubReleaseCheckerTests.cs
@@ -1,0 +1,30 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class GitHubReleaseCheckerTests
+{
+    [Theory]
+    [InlineData("https://github.com/DIMOSUS/Resonalyze/releases/tag/v0.2.0")]
+    [InlineData("https://github.com/DIMOSUS/Resonalyze/releases")]
+    [InlineData("HTTPS://GITHUB.COM/DIMOSUS/Resonalyze/releases")]
+    public void IsTrustedReleaseUrl_AcceptsHttpsGitHubUrls(string url)
+    {
+        Assert.True(GitHubReleaseChecker.IsTrustedReleaseUrl(url));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("http://github.com/DIMOSUS/Resonalyze/releases")]
+    [InlineData("https://github.com.evil.example/DIMOSUS/Resonalyze")]
+    [InlineData("https://evil.example/github.com")]
+    [InlineData("file:///C:/Windows/System32/calc.exe")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("releases/tag/v0.2.0")]
+    public void IsTrustedReleaseUrl_RejectsEverythingElse(string? url)
+    {
+        // The value is opened with ShellExecute; only an https github.com link
+        // from the release API may pass through.
+        Assert.False(GitHubReleaseChecker.IsTrustedReleaseUrl(url));
+    }
+}

--- a/tests/Resonalyze.App.Tests/ImpulseResponseFileAtomicSaveTests.cs
+++ b/tests/Resonalyze.App.Tests/ImpulseResponseFileAtomicSaveTests.cs
@@ -1,0 +1,74 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class ImpulseResponseFileAtomicSaveTests : IDisposable
+{
+    private readonly string directory;
+
+    public ImpulseResponseFileAtomicSaveTests()
+    {
+        directory = Path.Combine(
+            Path.GetTempPath(),
+            $"resonalyze-ir-atomic-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsync_OverwritesExistingFileAndLeavesNoTempFile()
+    {
+        string path = Path.Combine(directory, "ir.json");
+        await CreateFile(sampleValue: 1.0).SaveAsync(path);
+        await CreateFile(sampleValue: 0.5).SaveAsync(path);
+
+        ImpulseResponseFile loaded = await ImpulseResponseFile.LoadAsync(path);
+        Assert.Equal(0.5, loaded.SweepDeconvolutionRealSamples[0]);
+        Assert.Equal(new[] { "ir.json" }, ListFileNames());
+    }
+
+    [Fact]
+    public async Task SaveAsync_KeepsExistingFileIntactWhenWritingFails()
+    {
+        string path = Path.Combine(directory, "ir.json");
+        await CreateFile(sampleValue: 1.0).SaveAsync(path);
+
+        // A cancelled write must not have truncated the previously saved file.
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            CreateFile(sampleValue: 0.5).SaveAsync(path, cancellation.Token));
+
+        ImpulseResponseFile survivor = await ImpulseResponseFile.LoadAsync(path);
+        Assert.Equal(1.0, survivor.SweepDeconvolutionRealSamples[0]);
+        Assert.Equal(new[] { "ir.json" }, ListFileNames());
+    }
+
+    private string[] ListFileNames() =>
+        Directory.GetFiles(directory)
+            .Select(Path.GetFileName)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .Cast<string>()
+            .ToArray();
+
+    internal static ImpulseResponseFile CreateFile(double sampleValue) =>
+        new()
+        {
+            SavedAtUtc = new DateTimeOffset(2026, 7, 7, 12, 0, 0, TimeSpan.Zero),
+            SampleRate = 48_000,
+            Bits = 24,
+            Octaves = 10,
+            SweepDurationSeconds = 1.0,
+            PlayChannel = PlaybackChannel.Left,
+            SweepDeconvolutionPeakIndex = 0,
+            SweepDeconvolutionRealSamples = [sampleValue, 0.25]
+        };
+}

--- a/tests/Resonalyze.App.Tests/MeasurementHistoryPersistenceTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementHistoryPersistenceTests.cs
@@ -1,0 +1,97 @@
+using Resonalyze.History;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class MeasurementHistoryPersistenceTests : IDisposable
+{
+    private readonly string directory;
+    private readonly string storePath;
+
+    public MeasurementHistoryPersistenceTests()
+    {
+        directory = Path.Combine(
+            Path.GetTempPath(),
+            $"resonalyze-history-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        storePath = Path.Combine(directory, "measurement-history.json");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public void SaveAndLoad_RoundTripsFileBackedEntries()
+    {
+        string sourcePath = Path.Combine(directory, "measurement.json");
+        File.WriteAllText(sourcePath, "{}");
+        var persistence = new MeasurementHistoryPersistence(storePath);
+        MeasurementHistoryEntry entry = CreateEntry(sourcePath);
+
+        persistence.Save(new[] { entry });
+        IReadOnlyList<MeasurementHistoryEntry> loaded = persistence.Load();
+
+        Assert.Single(loaded);
+        Assert.Equal(entry.Id, loaded[0].Id);
+        Assert.Equal(sourcePath, loaded[0].SourceFilePath);
+        Assert.Null(loaded[0].Snapshot);
+        // The atomic write must not leave its temp file behind.
+        Assert.DoesNotContain(
+            Directory.GetFiles(directory),
+            file => file.EndsWith(".tmp", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Save_SkipsInMemoryEntries()
+    {
+        var persistence = new MeasurementHistoryPersistence(storePath);
+
+        persistence.Save(new[] { CreateEntry(sourceFilePath: null) });
+
+        Assert.Empty(persistence.Load());
+    }
+
+    [Fact]
+    public void Load_DropsEntriesWhoseSourceFileIsMissing()
+    {
+        string sourcePath = Path.Combine(directory, "deleted.json");
+        File.WriteAllText(sourcePath, "{}");
+        var persistence = new MeasurementHistoryPersistence(storePath);
+        persistence.Save(new[] { CreateEntry(sourcePath) });
+        File.Delete(sourcePath);
+
+        Assert.Empty(persistence.Load());
+    }
+
+    [Fact]
+    public void Load_ReturnsEmptyOnCorruptedStore()
+    {
+        File.WriteAllText(storePath, "not json at all {{{");
+
+        var persistence = new MeasurementHistoryPersistence(storePath);
+
+        Assert.Empty(persistence.Load());
+    }
+
+    internal static MeasurementHistoryEntry CreateEntry(string? sourceFilePath) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = "entry",
+            Timestamp = new DateTimeOffset(2026, 7, 7, 12, 0, 0, TimeSpan.Zero),
+            SourceFilePath = sourceFilePath,
+            Metadata = new MeasurementHistorySnapshotMetadata
+            {
+                Bits = 24,
+                MeterSnapshot = InputLevelMeterSnapshot.Empty
+            },
+            Preview = new MeasurementHistoryPreview()
+        };
+}

--- a/tests/Resonalyze.App.Tests/MeasurementHistoryServiceTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementHistoryServiceTests.cs
@@ -1,0 +1,89 @@
+using Resonalyze.History;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class MeasurementHistoryServiceTests : IDisposable
+{
+    private readonly string directory;
+
+    public MeasurementHistoryServiceTests()
+    {
+        directory = Path.Combine(
+            Path.GetTempPath(),
+            $"resonalyze-history-service-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task FileBackedEntries_KeepAtMostOneFullSnapshotInMemory()
+    {
+        MeasurementHistoryService service = CreateService();
+        string pathA = await CreateImpulseResponseFileAsync("a.json");
+        string pathB = await CreateImpulseResponseFileAsync("b.json");
+
+        Guid idA = service.AddOrUpdateLoadedFile(
+            pathA,
+            await ImpulseResponseFile.LoadAsync(pathA),
+            new MeasurementSessionSnapshot());
+        Guid idB = service.AddOrUpdateLoadedFile(
+            pathB,
+            await ImpulseResponseFile.LoadAsync(pathB),
+            new MeasurementSessionSnapshot());
+
+        // Each snapshot holds the complete IR; only the most recent file-backed
+        // entry may keep one — the file itself remains the source of truth.
+        Assert.Null(service.FindById(idA)!.Snapshot);
+        Assert.NotNull(service.FindById(idB)!.Snapshot);
+
+        MeasurementHistorySnapshot? reloaded = await service.GetSnapshotAsync(idA);
+
+        Assert.NotNull(reloaded);
+        Assert.NotNull(service.FindById(idA)!.Snapshot);
+        Assert.Null(service.FindById(idB)!.Snapshot);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_ReloadsEvictedSnapshotFromDisk()
+    {
+        MeasurementHistoryService service = CreateService();
+        string pathA = await CreateImpulseResponseFileAsync("a.json");
+        string pathB = await CreateImpulseResponseFileAsync("b.json");
+        Guid idA = service.AddOrUpdateLoadedFile(
+            pathA,
+            await ImpulseResponseFile.LoadAsync(pathA),
+            new MeasurementSessionSnapshot());
+        service.AddOrUpdateLoadedFile(
+            pathB,
+            await ImpulseResponseFile.LoadAsync(pathB),
+            new MeasurementSessionSnapshot());
+
+        MeasurementHistorySnapshot? snapshot = await service.GetSnapshotAsync(idA);
+
+        Assert.NotNull(snapshot);
+        Assert.Equal(48_000, snapshot!.SampleRate);
+        Assert.NotEmpty(snapshot.SweepDeconvolutionImpulseResponse);
+    }
+
+    private MeasurementHistoryService CreateService() =>
+        new(new MeasurementHistoryPersistence(
+            Path.Combine(directory, "measurement-history.json")));
+
+    private async Task<string> CreateImpulseResponseFileAsync(string fileName)
+    {
+        string path = Path.Combine(directory, fileName);
+        await ImpulseResponseFileAtomicSaveTests.CreateFile(sampleValue: 1.0)
+            .SaveAsync(path);
+        return path;
+    }
+}

--- a/tests/Resonalyze.App.Tests/ModeControllerTests.cs
+++ b/tests/Resonalyze.App.Tests/ModeControllerTests.cs
@@ -1,0 +1,129 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class ModeControllerTests
+{
+    [Fact]
+    public async Task SelectAsync_RunsCallbacksInOrder()
+    {
+        var calls = new List<string>();
+        ModeController controller = CreateController(
+            calls,
+            changeMode: _ => Task.CompletedTask);
+
+        await controller.SelectAsync(ModeTab.Impulse);
+
+        Assert.Equal(
+            new[] { "change:ImpulseResponse", "tab:Impulse", "draw:True", "restore" },
+            calls);
+        Assert.Equal(ModeTab.Impulse, controller.ActiveTab);
+    }
+
+    [Fact]
+    public async Task SelectAsync_SerializesOverlappingSwitches()
+    {
+        var calls = new List<string>();
+        var firstSwitchBlocked = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        int changeModeCalls = 0;
+        ModeController controller = CreateController(
+            calls,
+            changeMode: _ =>
+            {
+                changeModeCalls++;
+                return changeModeCalls == 1
+                    ? firstSwitchBlocked.Task
+                    : Task.CompletedTask;
+            });
+
+        Task first = controller.SelectAsync(ModeTab.Impulse);
+        Task second = controller.SelectAsync(ModeTab.Phase);
+
+        // The second switch must queue behind the first, not interleave with it.
+        Assert.Equal(1, changeModeCalls);
+        Assert.DoesNotContain("tab:Impulse", calls);
+
+        firstSwitchBlocked.SetResult();
+        await first;
+        await second;
+
+        Assert.Equal(2, changeModeCalls);
+        Assert.Equal(ModeTab.Phase, controller.ActiveTab);
+        Assert.Equal(
+            new[]
+            {
+                "change:ImpulseResponse", "tab:Impulse", "draw:True", "restore",
+                "change:PhaseResponse", "tab:Phase", "draw:True", "restore"
+            },
+            calls);
+    }
+
+    [Fact]
+    public async Task SelectAsync_ContinuesAfterFailedSwitch()
+    {
+        var calls = new List<string>();
+        bool fail = true;
+        ModeController controller = CreateController(
+            calls,
+            changeMode: _ =>
+            {
+                if (fail)
+                {
+                    fail = false;
+                    throw new InvalidOperationException("boom");
+                }
+
+                return Task.CompletedTask;
+            });
+
+        Task failed = controller.SelectAsync(ModeTab.Impulse);
+        Task recovered = controller.SelectAsync(ModeTab.Phase);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => failed);
+        await recovered;
+
+        Assert.Equal(ModeTab.Phase, controller.ActiveTab);
+        Assert.Contains("tab:Phase", calls);
+        Assert.DoesNotContain("tab:Impulse", calls);
+    }
+
+    [Fact]
+    public async Task SelectAsync_DrawSkipsCurvesWhenModeDoesNotSupportThem()
+    {
+        var calls = new List<string>();
+        ModeController controller = CreateController(
+            calls,
+            changeMode: _ => Task.CompletedTask,
+            supportsCurveDrawing: _ => false);
+
+        await controller.SelectAsync(ModeTab.LiveSpectrum);
+
+        Assert.Contains("draw:False", calls);
+    }
+
+    private static ModeController CreateController(
+        List<string> calls,
+        Func<Mode, Task> changeMode,
+        Func<ModeTab, bool>? supportsCurveDrawing = null)
+    {
+        return new ModeController(
+            mode =>
+            {
+                calls.Add($"change:{mode}");
+                return changeMode(mode);
+            },
+            tab => calls.Add($"tab:{tab}"),
+            includeCurves => calls.Add($"draw:{includeCurves}"),
+            () => calls.Add("restore"),
+            () => true,
+            tab => GetMode(tab),
+            supportsCurveDrawing ?? (_ => true));
+    }
+
+    private static Mode GetMode(ModeTab tab) => tab switch
+    {
+        ModeTab.Impulse => Mode.ImpulseResponse,
+        ModeTab.Phase => Mode.PhaseResponse,
+        ModeTab.LiveSpectrum => Mode.LiveSpectrum,
+        _ => Mode.FrequencyResponse
+    };
+}

--- a/tests/Resonalyze.App.Tests/NumericTextParserTests.cs
+++ b/tests/Resonalyze.App.Tests/NumericTextParserTests.cs
@@ -1,0 +1,64 @@
+using System.Globalization;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class NumericTextParserTests
+{
+    private static readonly CultureInfo EnUs = CultureInfo.GetCultureInfo("en-US");
+    private static readonly CultureInfo DeDe = CultureInfo.GetCultureInfo("de-DE");
+    private static readonly CultureInfo RuRu = CultureInfo.GetCultureInfo("ru-RU");
+
+    [Theory]
+    [InlineData("1.5", 1.5)]
+    [InlineData("1,5", 1.5)]
+    [InlineData("-3.25", -3.25)]
+    [InlineData("-3,25", -3.25)]
+    [InlineData("42", 42)]
+    public void TryParse_LoneSeparatorIsDecimalInAnyCulture(string text, double expected)
+    {
+        foreach (CultureInfo culture in new[] { EnUs, DeDe, RuRu })
+        {
+            // decimal.TryParse alone would read "1.5" in de-DE as fifteen: the
+            // dot is the German group separator and group sizes are not checked.
+            Assert.True(NumericTextParser.TryParse(text, culture, out decimal value));
+            Assert.Equal((decimal)expected, value);
+        }
+    }
+
+    [Fact]
+    public void TryParse_KeepsPlausibleThousandsOfTheCulture()
+    {
+        Assert.True(NumericTextParser.TryParse("12,000", EnUs, out decimal enUs));
+        Assert.Equal(12_000m, enUs);
+
+        Assert.True(NumericTextParser.TryParse("12.000", DeDe, out decimal deDe));
+        Assert.Equal(12_000m, deDe);
+    }
+
+    [Fact]
+    public void TryParse_FullThousandsFormatRoundTrips()
+    {
+        Assert.True(NumericTextParser.TryParse("1,234.5", EnUs, out decimal value));
+        Assert.Equal(1_234.5m, value);
+    }
+
+    [Fact]
+    public void TryParse_ThousandsPositionOfForeignSeparatorIsStillDecimal()
+    {
+        // '.' is not the en-US group separator, so "1.234" is one point two
+        // three four — not twelve hundred.
+        Assert.True(NumericTextParser.TryParse("1.234", EnUs, out decimal value));
+        Assert.Equal(1.234m, value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData("1..5")]
+    public void TryParse_RejectsUnparsableText(string? text)
+    {
+        Assert.False(NumericTextParser.TryParse(text, EnUs, out _));
+    }
+}

--- a/tests/Resonalyze.App.Tests/PcmStreamSetTests.cs
+++ b/tests/Resonalyze.App.Tests/PcmStreamSetTests.cs
@@ -1,0 +1,73 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class PcmStreamSetTests
+{
+    [Fact]
+    public void Pack_Encodes16BitMonoLittleEndian()
+    {
+        float[] samples = [0.0f, 1.0f, -1.0f];
+
+        byte[] data = PcmStreamSet.Pack(samples, 16, PlaybackChannel.Mono);
+
+        Assert.Equal(6, data.Length);
+        Assert.Equal((short)0, BitConverter.ToInt16(data, 0));
+        Assert.Equal((short)32767, BitConverter.ToInt16(data, 2));
+        Assert.Equal((short)-32767, BitConverter.ToInt16(data, 4));
+    }
+
+    [Fact]
+    public void Pack_LeftRoutingLeavesRightChannelSilent()
+    {
+        float[] samples = [0.5f];
+
+        byte[] data = PcmStreamSet.Pack(samples, 16, PlaybackChannel.Left);
+
+        Assert.Equal(4, data.Length);
+        Assert.Equal((short)16383, BitConverter.ToInt16(data, 0));
+        Assert.Equal((short)0, BitConverter.ToInt16(data, 2));
+    }
+
+    [Fact]
+    public void Pack_StereoDuplicatesTheSignal()
+    {
+        float[] samples = [0.5f];
+
+        byte[] data = PcmStreamSet.Pack(samples, 16, PlaybackChannel.Stereo);
+
+        Assert.Equal(BitConverter.ToInt16(data, 0), BitConverter.ToInt16(data, 2));
+    }
+
+    [Fact]
+    public void Pack_Encodes24BitSamples()
+    {
+        float[] samples = [1.0f, -1.0f];
+
+        byte[] data = PcmStreamSet.Pack(samples, 24, PlaybackChannel.Mono);
+
+        Assert.Equal(6, data.Length);
+        // 0x7FFFFF little-endian, then its negation in two's complement.
+        Assert.Equal(new byte[] { 0xFF, 0xFF, 0x7F }, data[..3]);
+        int negative = data[3] | (data[4] << 8) | (data[5] << 16);
+        if ((negative & 0x800000) != 0)
+        {
+            negative |= unchecked((int)0xFF000000);
+        }
+
+        Assert.Equal(-8388607, negative);
+    }
+
+    [Fact]
+    public void GetStream_IsLazyAndReturnsTheSameInstance()
+    {
+        using var set = new PcmStreamSet([0.25f, -0.25f], 48_000, 16);
+
+        var first = set.GetStream(PlaybackChannel.Stereo);
+        var second = set.GetStream(PlaybackChannel.Stereo);
+
+        Assert.Same(first, second);
+        Assert.Equal(2, first.WaveFormat.Channels);
+        Assert.Equal(48_000, first.WaveFormat.SampleRate);
+        Assert.Equal(16, first.WaveFormat.BitsPerSample);
+        Assert.Equal(8, first.Length);
+    }
+}

--- a/tests/Resonalyze.App.Tests/SignalFadeTests.cs
+++ b/tests/Resonalyze.App.Tests/SignalFadeTests.cs
@@ -1,0 +1,44 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class SignalFadeTests
+{
+    [Fact]
+    public void ApplyFadeInOut_SilencesEdgesAndKeepsTheMiddle()
+    {
+        var samples = new float[100];
+        Array.Fill(samples, 1.0f);
+
+        SignalFade.ApplyFadeInOut(samples, fadeSamples: 10);
+
+        Assert.Equal(0.0f, samples[0]);
+        Assert.Equal(0.0f, samples[^1]);
+        Assert.True(samples[5] > 0.0f && samples[5] < 1.0f);
+        Assert.Equal(1.0f, samples[50]);
+        // Symmetric ramp: the fade-out mirrors the fade-in.
+        Assert.Equal(samples[3], samples[^4], precision: 6);
+    }
+
+    [Fact]
+    public void ApplyFadeInOut_ClampsFadeToHalfTheBuffer()
+    {
+        var samples = new float[4];
+        Array.Fill(samples, 1.0f);
+
+        SignalFade.ApplyFadeInOut(samples, fadeSamples: 1000);
+
+        Assert.Equal(0.0f, samples[0]);
+        Assert.Equal(0.0f, samples[^1]);
+    }
+
+    [Fact]
+    public void ApplyFadeInOut_IgnoresDegenerateInput()
+    {
+        var single = new float[] { 1.0f };
+        SignalFade.ApplyFadeInOut(single, fadeSamples: 8);
+        Assert.Equal(1.0f, single[0]);
+
+        var samples = new float[] { 1.0f, 1.0f };
+        SignalFade.ApplyFadeInOut(samples, fadeSamples: 0);
+        Assert.Equal(new[] { 1.0f, 1.0f }, samples);
+    }
+}


### PR DESCRIPTION
All six stages of the remaining-areas code review, one commit per stage.

## Stage 1 — Shell / mode switching / UI marshaling
- **Mode switches serialized** (`ModeController.SelectAsync` re-entrancy could leave `ActiveTab`/`CurrentMode` describing different modes); a failed switch doesn't break the chain.
- **Double-click on Record no longer crashes** (`Init` on a running measurement in an `async void` handler).
- **Level metering no longer floods the UI queue** — `CoalescingDispatcher<T>` replaces per-audio-callback `BeginInvoke`.
- Guard→BeginInvoke race closed (`TryBeginInvokeOnUiThread`); history activation during a sweep ignored; `FormClosing` re-entry guarded.

## Stage 2 — History / impulse-response files
- **Atomic saves** for `ImpulseResponseFile` and the history store (truncate-then-write destroyed data on a crash mid-write).
- **Bounded snapshot memory** — at most one file-backed entry keeps its full IR snapshot cached; injectable store path for tests.

## Stage 3 — Auto-update path / settings
- **No unsigned-update fallback** (always `SecurityMode.Strict`; keyless builds go to the release page; CI fails on an empty `SPARKLE_PUBLIC_KEY`).
- **Release URL validated** before ShellExecute (https + github.com only); `MeasurementSettingsFile.Save` atomic.

## Stage 4 — Signal sources / Signal Generator
- **`PcmStreamSet`**: three identical PCM-packing copies deduplicated; per-routing streams built lazily (~60 MB saved on long noise buffers); no per-sample allocation.
- **10 ms raised-cosine ramps** on generator output (click-free, tweeter-friendly edges); `PlaybackStopped` marshal guarded.

## Stage 5 — EQ Wizard
- **Auto Tune runs on a worker thread** (32-band fits froze the UI); failures show an error instead of crashing the handler.
- NaN-safe control writes via `ClampValue` (imported-profile NaN previously threw `OverflowException`).

## Stage 6 — Custom controls / Plotting / Overlays
- **`NumericTextParser`**: a lone `.`/`,` is the decimal separator in any culture — `decimal.TryParse` group-separator leniency parsed `1.5` in a comma-decimal locale as **15** (silently 10× wrong, then clamped). Culture thousands (`12,000` en-US) still round-trip.
- **Up/Down/wheel commit typed text before stepping** (previously overwrote it with lastValue ± step); **Enter commits before a dialog's AcceptButton** reads the value (it read the stale one).
- **Waterfall**: tracker args were shifted one position (X blank, Y = frequency, "Iterations" = dB); empty burst-decay slices no longer throw inside `Render`; slices aren't re-resampled on every pan/resize (view-window + revision cache); labels invariant-culture.
- **Live-spectrum coherence gating matched by frequency, not index** — the magnitude and coherence resample grids differ (bounds + skipped empty bands), so trusted/dimmed segments landed on the wrong frequencies; degenerate coherence can no longer blank the trace.
- **Overlays**: offset spinner no longer serializes the slot + fsyncs per tick (500 ms debounce, flushed before mode-switch reload); only captured-slot changes rebuild calculated overlays (a target offset re-ran ComplexSum analysis per tick); text export writes temp + move.

## Tests
Stage 1: ModeController (4), CoalescingDispatcher (5). Stage 2: atomic IR save (2), history persistence (4), snapshot cache (2). Stage 3: trusted-URL predicate (12 cases). Stage 4: PCM packing (5), fades (3). Stage 6: NumericTextParser (en-US/de-DE/ru-RU semantics).
Solution + App.Tests compile 0/0 (`EnableWindowsTargeting`); 263 DSP tests pass locally; app tests run on Windows CI here.

## Reviewed, reported, intentionally not changed
- Shell: `UpdatePeakInfo` unsynchronized pair read; Options dialogs' `FormClosed` unsubscribe misses handle-less closes; `WireLiveApply` wires only dialog-open controls; `CloseReason.WindowsShutDown` ignored.
- Update path: version comparison ignores prerelease identifiers (`-rc.1` → `-rc.2` doesn't prompt); uninstaller leaves settings behind.
- Controls: per-paint Pen/Brush churn in dark controls; `DarkComboBox` swallows Enter (no AcceptButton path from a combo) and doesn't take focus on click; `BeginInit` is a no-op (property-order-sensitive clamping); tools menu rebuilt per open.
- Plotting: live-path allocation churn (fresh series + several list copies per 30 fps tick); `fftLength` reconstruction from coherence length off by 2 (systematic tiny frequency skew); `LogarithmicClipAxis` label trim; dead `FourierCSD` enum value.
- Overlays: 30 fps target render rebuilds constant target/tolerance curves each tick (caching + extracting pure render math from `Overlay.cs` is the highest-value future refactor, with `OverlaySlotState` to kill the triple field-mapping); 12 JSON files re-read on every mode switch; amplitude-space A−B clamps negative results to −160 dB instead of a gap; corrupt slot files silently present as empty and can be overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv