### PR TITLE
Review of remaining areas: measurement orchestrators, device catalogs, Options, UI chrome, PDF

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -69,6 +69,38 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   for copy-values instead of holding a value model (format+parse are at least
   co-located and tested now).
 
+## Measurement orchestrators
+
+- [ ] **`CurrentLevels` torn reads.** `ExpSweepMeasurement.CurrentLevels` (an
+  ~50-byte `InputLevelMeterSnapshot` struct) is written from audio worker
+  threads and read from the UI without synchronization; a torn read can show a
+  momentarily inconsistent meter (display-only; same family as the
+  `UpdatePeakInfo` item below).
+- [ ] **`RestoreImpulseResponse` regenerates the whole sweep.** Restoring a
+  measurement from a file or history calls `Init` → `Sweep.FillData`, which
+  synthesizes the full sweep and inverse filter just to satisfy
+  `HarmonicIROffset`; playback data isn't needed until the next run. Make the
+  generation lazy.
+- [ ] **New `AsioFullDuplexSession` per averaging run.** Every run of an
+  averaged sweep re-initializes the ASIO driver; slow drivers add seconds per
+  run. Reuse one session across the run loop.
+- [ ] **A stop failure demotes a finished measurement.** In
+  `RunCoreAsync`'s finally, a recorder stop timeout sets `success = false`
+  after `ApplyAverageResult` already published results and raised
+  `ImpulseResponseChanged` — the UI shows "Error" and skips the history entry
+  for a measurement whose data is fine. Decide the intended semantics.
+- [ ] **Third copy of the level-metering math.** `ChannelLevelAccumulator`
+  (peak/RMS/dB + 0.999 full-scale threshold) duplicates
+  `AudioLevelMetering` and the recorder metering loops.
+
+## Audio device catalogs
+
+- [ ] **Missing device silently becomes the first one.**
+  `AsioDeviceCatalog.FindDriverIndex`/`FindChannelIndex` and
+  `AudioDeviceCatalog.FindDeviceIndex` return index 0 when the saved
+  driver/channel/device no longer exists, so the options UI silently shows a
+  different device than the one configured. Surface "(missing)" instead.
+
 ## Audio capture layer
 
 - [ ] **Merge the `SoundRecorder` / `AsioFullDuplexSession` twins.** The

--- a/TODO.md
+++ b/TODO.md
@@ -99,7 +99,71 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   `AsioDeviceCatalog.FindDriverIndex`/`FindChannelIndex` and
   `AudioDeviceCatalog.FindDeviceIndex` return index 0 when the saved
   driver/channel/device no longer exists, so the options UI silently shows a
-  different device than the one configured. Surface "(missing)" instead.
+  different device than the one configured. Worst case: a vanished separate
+  Wave loopback device maps to "Default recording device" instead of the
+  "Same as microphone device" sentinel — the configuration silently changes
+  meaning. Surface "(missing)" / fall back to the sentinel instead.
+
+## Options panels
+
+- [ ] **Mono recording device irreversibly resets the loopback channel.**
+  `MeasurementOptions` forces the loopback combo to "None" when the selected
+  device reports one channel; selecting a stereo device again does not restore
+  the previous choice, and the next apply persists `null` — measurements stop
+  working. Keep the last user choice in a shadow field (the pattern
+  `LiveSpectrumOpt` already uses) and restore it.
+- [ ] **Missing 90° calibration silently downgrades the persisted mode.**
+  `MicrophoneCalibrationComboHelper` drops the `Degrees90` entry when the file
+  is absent, so `FindIndex` lands on "Off" and the next apply persists it —
+  the user's preference is permanently lost. Keep the entry (marked "(file
+  missing)") or preserve the stored mode.
+- [ ] **ASIO driver opened twice when the measurement panel opens.**
+  `Init` runs `RefreshSampleRateOptions` and `RefreshAsioDriverInfo`, each of
+  which instantiates `AsioOut` (a synchronous COM driver open that can take
+  seconds). Fetch the driver info and supported rates in one open, ideally off
+  the UI thread.
+- [ ] **Five IR-preview panels are one copy-pasted class.** `FROptions`,
+  `GDOpt`, `PROpt`, `BDOpt`, `WaterfallOptions` duplicate the
+  `ImpulseResponseChanged` subscribe/unsubscribe dance, the `BeginInvoke`
+  marshal and the clamping helper — and have already drifted (only `GDOpt`
+  suppresses the 3–6 redundant preview renders during `Init`). Extract a
+  shared base.
+- [ ] **`SetOptions` reads bits from the measurement, not the control.**
+  Three sources of truth for the sample size in `MeasurementOptions`; harmless
+  while the control is read-only, a silent no-op the day it is enabled.
+- [ ] **`TukeyWindowControlHelper` silently clamps window values** when the
+  window length shrinks (fires `ValueChanged` → live apply persists the
+  clamped value with no feedback) and overrides the designer maxima.
+- [ ] **`LiveSpectrumOpt` shadow fields update only on
+  `SelectionChangeCommitted`** — a programmatic combo change is displayed but
+  never persisted; also three identical floor-index loops worth one helper.
+
+## UI chrome
+
+- [ ] **`ChromeTitleBar` caches the DPI scale once at `Initialize`.** No
+  `DpiChanged` handling: moving the window to a monitor with different DPI
+  (PerMonitorV2) leaves the bar height, button widths and tab layout at the
+  old scale. Refresh the cached metrics and re-run layout on DPI change.
+- [ ] **Top-edge resize grip still dead over child controls.** The
+  HTTRANSPARENT fix covers the title-bar panel itself; points over the tab
+  buttons and window buttons (which reach y=0) still hit-test as client.
+  Standard chrome resolves this per child; low value, document or fix later.
+- [ ] **`ColorPickerDialog` preview panel is not double-buffered** and the
+  hue slider repaints its full rainbow per mouse-move; caching the rainbow in
+  a bitmap (invalidated on resize) would finish what the pen-reuse fix
+  started.
+
+## PDF export
+
+- [ ] **~90 duplicated lines between the two PDF exporters.**
+  `LoadBanner`/`AddImage`/`AddFilterCards` are byte-identical in
+  `TuningSheetPdf` and `VirtualCrossoverSheetPdf`; extract a shared helper.
+  MigraDoc 6 supports `AddImage("base64:...")`, which would also remove the
+  temp-file dance entirely.
+- [ ] **No deconvolution flatness test.** The sweep + inverse-filter math was
+  verified numerically during review (in-band ripple < 0.01 dB), but nothing
+  in the test suite pins it; a `SyntheticMeasurement`-style flatness test
+  would lock the `2/N` scaling and envelope compensation down.
 
 ## Audio capture layer
 

--- a/source/Audio/AsioInputProbe.cs
+++ b/source/Audio/AsioInputProbe.cs
@@ -72,7 +72,11 @@ internal static class AsioInputProbe
                     channel.Name,
                     ToDecibels(GetPeak(data)),
                     ToDecibels(GetRms(data)),
-                    index == 0 ? 1.0 : GetCorrelation(samples[0], data));
+                    index == 0
+                        ? 1.0
+                        : samples.Length > 0
+                            ? GetCorrelation(samples[0], data)
+                            : 0.0);
             })
             .ToArray();
     }

--- a/source/Audio/FloatArrayWaveStream.cs
+++ b/source/Audio/FloatArrayWaveStream.cs
@@ -63,7 +63,8 @@ internal sealed class FloatArrayWaveStream : WaveStream
 
     private static void WriteFloat(byte[] destination, int offset, float value)
     {
-        byte[] bytes = BitConverter.GetBytes(value);
-        Array.Copy(bytes, 0, destination, offset, sizeof(float));
+        // No per-sample byte[] allocation: this runs once per sample over
+        // buffers up to minutes long when the signal is prepared.
+        BitConverter.TryWriteBytes(destination.AsSpan(offset), value);
     }
 }

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -19,6 +19,9 @@ internal sealed class LiveSpectrumController : IDisposable
     private readonly Action updateRecordButton;
     private readonly Action updatePlotLabels;
     private readonly LiveSpectrumOptions liveSpectrumOptions;
+    // Same guard the sweep path has (Form1.ShowMeasurementError): no modal
+    // error dialog while the owner is tearing down.
+    private readonly Func<bool> suppressErrorDialogs;
     // The live transfer-function curve carries a CurveTag (like every analysis curve)
     // so overlays can bind to it by key; the remaining live-spectrum helper series stay
     // string-tagged for internal bookkeeping only.
@@ -46,7 +49,8 @@ internal sealed class LiveSpectrumController : IDisposable
         Action updateOverlayAvailability,
         Action updateRecordButton,
         Action updatePlotLabels,
-        LiveSpectrumOptions liveSpectrumOptions)
+        LiveSpectrumOptions liveSpectrumOptions,
+        Func<bool> suppressErrorDialogs)
     {
         this.owner = owner;
         this.measurement = measurement;
@@ -59,6 +63,7 @@ internal sealed class LiveSpectrumController : IDisposable
         this.updateRecordButton = updateRecordButton;
         this.updatePlotLabels = updatePlotLabels;
         this.liveSpectrumOptions = liveSpectrumOptions;
+        this.suppressErrorDialogs = suppressErrorDialogs;
         measurement.Completed += MeasurementCompleted;
         timer.Tick += TimerTick;
     }
@@ -451,7 +456,8 @@ internal sealed class LiveSpectrumController : IDisposable
                 // which used to reset the UI silently.
                 if (!success &&
                     measurement.LastError is Exception error &&
-                    !owner.IsDisposed)
+                    !owner.IsDisposed &&
+                    !suppressErrorDialogs())
                 {
                     MessageBox.Show(
                         owner,

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -446,6 +446,20 @@ internal sealed class LiveSpectrumController : IDisposable
                 updateOverlayAvailability();
                 updateRecordButton();
                 updatePlotLabels();
+                // A user stop cancels the capture and reports success; reaching
+                // here with an error means the device or driver failed mid-run,
+                // which used to reset the UI silently.
+                if (!success &&
+                    measurement.LastError is Exception error &&
+                    !owner.IsDisposed)
+                {
+                    MessageBox.Show(
+                        owner,
+                        $"The live measurement failed.\r\n\r\n{error.Message}",
+                        "Live Spectrum",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Warning);
+                }
             });
         }
         catch (InvalidOperationException)

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -893,23 +893,6 @@ namespace Resonalyze
                 AsioInputChannelOffset,
                 AsioLoopbackInputChannelOffset);
 
-        private static int FindPeakIndex(IReadOnlyList<double> samples)
-        {
-            double maxMagnitude = 0;
-            int peakIndex = 0;
-            for (int i = 0; i < samples.Count; i++)
-            {
-                double magnitude = Math.Abs(samples[i]);
-                if (magnitude > maxMagnitude)
-                {
-                    maxMagnitude = magnitude;
-                    peakIndex = i;
-                }
-            }
-
-            return peakIndex;
-        }
-
         private static int FindPeakIndex(IReadOnlyList<Complex> samples)
         {
             double maxMagnitude = 0;

--- a/source/Measurements/ExponentialSineSweep.cs
+++ b/source/Measurements/ExponentialSineSweep.cs
@@ -29,23 +29,48 @@ public sealed class ExponentialSineSweep : IDisposable
     public double ComputedDuration =>
         SampleRate > 0 ? SweepSamples / (double)SampleRate : 0.0;
 
-    public double CalculateDuration(double requestedDuration)
+    /// <summary>
+    /// The duration the sweep will actually have for the given parameters,
+    /// after cycle quantization. Static so the option panels can preview a
+    /// configuration without depending on the last generated sweep's state.
+    /// Degenerate inputs return 0 instead of throwing — this feeds display
+    /// fields on settings-load paths.
+    /// </summary>
+    public static double CalculateDuration(
+        int octaves,
+        double requestedDuration,
+        int sampleRate)
     {
-        ValidateGenerationParameters(Octaves, requestedDuration, BitsPerSample, SampleRate);
+        if (octaves <= 0 ||
+            sampleRate <= 0 ||
+            !double.IsFinite(requestedDuration) ||
+            requestedDuration <= 0)
+        {
+            return 0.0;
+        }
 
-        double frequencyRatio = Math.Pow(2.0, Octaves);
+        double exactLength = ComputeQuantizedSweepLength(
+            octaves,
+            requestedDuration,
+            sampleRate);
+        return Math.Max(1, (int)Math.Round(exactLength)) / (double)sampleRate;
+    }
+
+    // Quantizing the phase count makes the sweep end at a full cycle. This reduces
+    // the discontinuity at the boundary without changing the requested duration materially.
+    private static double ComputeQuantizedSweepLength(
+        int octaves,
+        double requestedDuration,
+        int sampleRate)
+    {
+        double frequencyRatio = Math.Pow(2.0, octaves);
         double logarithmicRatio = Math.Log(frequencyRatio);
-        double targetLength = SampleRate * requestedDuration;
         double phaseFactor = (Math.PI / frequencyRatio) / logarithmicRatio;
-
-        // Quantizing the phase count makes the sweep end at a full cycle. This reduces
-        // the discontinuity at the boundary without changing the requested duration materially.
+        double targetLength = sampleRate * requestedDuration;
         double cycleCount = Math.Max(
             1,
             Math.Round(phaseFactor * targetLength / (2.0 * Math.PI)));
-        double exactLength = cycleCount * 2.0 * Math.PI / phaseFactor;
-
-        return Math.Max(1, (int)Math.Round(exactLength)) / (double)SampleRate;
+        return cycleCount * 2.0 * Math.PI / phaseFactor;
     }
 
     public void FillData(
@@ -65,11 +90,10 @@ public sealed class ExponentialSineSweep : IDisposable
         double frequencyRatio = Math.Pow(2.0, octaves);
         double logarithmicRatio = Math.Log(frequencyRatio);
         double phaseFactor = (Math.PI / frequencyRatio) / logarithmicRatio;
-        double targetLength = sampleRate * requestedDuration;
-        double cycleCount = Math.Max(
-            1,
-            Math.Round(phaseFactor * targetLength / (2.0 * Math.PI)));
-        double exactLength = cycleCount * 2.0 * Math.PI / phaseFactor;
+        double exactLength = ComputeQuantizedSweepLength(
+            octaves,
+            requestedDuration,
+            sampleRate);
         int sampleCount = Math.Max(1, (int)Math.Round(exactLength));
 
         SweepSamples = sampleCount;

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -657,7 +657,7 @@ namespace Resonalyze
             {
                 foreach (float[][] frame in reframer.Push(sequence))
                 {
-                    AccumulateSequence(frame);
+                    AccumulateTransferSequence(frame);
                 }
             }
         }
@@ -690,11 +690,6 @@ namespace Resonalyze
                 GetAveragingTimeConstant(LiveSpectrumOptions.AveragingSpeed);
             infiniteAveraging = LiveSpectrumOptions.AveragingSpeed == AveragingSpeed.Infinite;
             transferAlpha = AlphaFromTimeConstant(frameInterval, transferSeconds);
-        }
-
-        private void AccumulateSequence(float[][] sequence)
-        {
-            AccumulateTransferSequence(sequence);
         }
 
         private void AccumulateTransferSequence(float[][] sequence)

--- a/source/Measurements/NoiseSignal.cs
+++ b/source/Measurements/NoiseSignal.cs
@@ -44,6 +44,16 @@ public sealed class NoiseSignal : IDisposable
         SampleRate = sampleRate;
         RequestedDuration = requestedDuration;
         Samples = checked((int)(sampleRate * requestedDuration));
+        if (noiseColor == NoiseColor.PinkPeriodic)
+        {
+            // The buffer is looped by playback; a length that is not a whole
+            // number of periods puts a phase jump at every loop seam, and the
+            // analyzer's rectangular window assumes exact periodicity.
+            int period = Math.Max(2, periodLength);
+            Samples = period * Math.Max(
+                1,
+                (int)Math.Round(sampleRate * requestedDuration / (double)period));
+        }
 
         FloatData = new float[Samples];
 

--- a/source/Options/IROpt.cs
+++ b/source/Options/IROpt.cs
@@ -24,7 +24,9 @@ namespace Resonalyze.Options
 
         public void Init(ExpSweepMeasurement expSweepMeasurement, ImpulseResponseOptions opt)
         {
-            numericLength.Value = opt.Length;
+            // The settings file clamps to a wider range than the control; an
+            // out-of-range persisted value must not throw when the panel opens.
+            numericLength.Value = numericLength.ClampValue(opt.Length);
             checkLogarithmic.Checked = opt.Logarithmic;
             checkBoxShowImpulse.Checked = opt.ShowImpulse;
         }

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -90,6 +90,7 @@ namespace Resonalyze.Options
             comboBoxRecordingDevice.SelectedIndexChanged += comboBoxRecordingDevice_SelectedIndexChanged;
             comboBoxWaveLoopbackDevice.SelectedIndexChanged += comboBoxWaveLoopbackDevice_SelectedIndexChanged;
             comboBoxWaveLoopbackChannel.SelectedIndexChanged += comboBoxWaveLoopbackChannel_SelectedIndexChanged;
+            comboBoxWaveInputChannel.SelectedIndexChanged += comboBoxWaveInputChannel_SelectedIndexChanged;
             comboBoxAsioDriver.SelectedIndexChanged += comboBoxAsioDriver_SelectedIndexChanged;
             buttonAsioInputProbe.Click += buttonAsioInputProbe_Click;
             buttonAsioControlPanel.Click += buttonAsioControlPanel_Click;
@@ -110,8 +111,10 @@ namespace Resonalyze.Options
         {
             initializing = true;
             this.expSweepMeasurement = expSweepMeasurement;
-            ExponentialSineSweep sweep = expSweepMeasurement.Sweep
-                ?? throw new InvalidOperationException("Sweep measurement is not initialized.");
+            if (expSweepMeasurement.Sweep == null)
+            {
+                throw new InvalidOperationException("Sweep measurement is not initialized.");
+            }
             numericUpDownBits.Value = settings.Bits is 16 or 24 ? settings.Bits : 24;
 
             comboBoxChannel.Items.Clear();
@@ -178,10 +181,17 @@ namespace Resonalyze.Options
                 UpdateComboBoxToolTip(comboBoxAsioDriver);
             }
 
-            numericUpDownRequestedDuration.Value = (int)(settings.RequestedDurationSeconds * 1000.0);
-            numericUpDownComputeDuration.Value =
-                (int)(sweep.CalculateDuration(settings.RequestedDurationSeconds) * 1000.0);
-            numericUpDownOctaves.Value = settings.Octaves;
+            // Clamped: the settings file is not normalized against the control
+            // ranges, and (int) truncation used to shave a millisecond off
+            // durations that are not exactly representable in binary.
+            numericUpDownRequestedDuration.Value = numericUpDownRequestedDuration.ClampValue(
+                Math.Round(settings.RequestedDurationSeconds * 1000.0));
+            numericUpDownOctaves.Value = numericUpDownOctaves.ClampValue(settings.Octaves);
+            numericUpDownComputeDuration.Value = numericUpDownComputeDuration.ClampValue(
+                Math.Round(ExponentialSineSweep.CalculateDuration(
+                    settings.Octaves,
+                    settings.RequestedDurationSeconds,
+                    settings.SampleRate) * 1000.0));
             numericUpDownAverageRunCount.Value = Math.Clamp(settings.AverageRunCount, 1, 64);
             checkBoxConfirmEachAverageRun.Checked = settings.ConfirmEachAverageRun;
             microphoneCalibration0DegreesPath = settings.MicrophoneCalibration0DegreesPath;
@@ -388,18 +398,30 @@ namespace Resonalyze.Options
 
         private void numericUpDownRequestedDuration_ValueChanged(object sender, EventArgs e)
         {
-            ExponentialSineSweep? sweep = expSweepMeasurement?.Sweep;
-            if (sweep == null)
-            {
-                return;
-            }
-
-            numericUpDownComputeDuration.Value =
-                (int)(sweep.CalculateDuration((int)numericUpDownRequestedDuration.Value * 0.001) * 1000.0);
+            // Computed from the values shown in the panel, not from the last
+            // generated sweep's state (which is stale until the next run).
+            numericUpDownComputeDuration.Value = numericUpDownComputeDuration.ClampValue(
+                Math.Round(ExponentialSineSweep.CalculateDuration(
+                    (int)numericUpDownOctaves.Value,
+                    (double)numericUpDownRequestedDuration.Value * 0.001,
+                    GetSelectedSampleRate()) * 1000.0));
         }
 
         private void comboBoxAudioBackend_SelectedIndexChanged(object sender, EventArgs e) =>
             HandleAudioConfigurationChanged();
+
+        private void comboBoxWaveInputChannel_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            if (initializing)
+            {
+                return;
+            }
+
+            // With a separate loopback device the microphone channel choice
+            // changes how many channels the device must open, and therefore
+            // which sample rates it supports.
+            RefreshSampleRateOptions(GetSelectedSampleRate());
+        }
 
         private void comboBoxPlaybackDevice_SelectedIndexChanged(object? sender, EventArgs e)
         {
@@ -845,6 +867,13 @@ namespace Resonalyze.Options
                         outputChannelOffset,
                         milliseconds: 1000,
                         CancellationToken.None);
+                // The docked panel can be closed while the ~1 s capture runs;
+                // touching the disposed form would throw out of an async void
+                // handler and kill the process.
+                if (IsDisposed)
+                {
+                    return;
+                }
                 MessageBox.Show(
                     this,
                     FormatAsioInputProbeResults(results),
@@ -854,6 +883,10 @@ namespace Resonalyze.Options
             }
             catch (Exception exception)
             {
+                if (IsDisposed)
+                {
+                    return;
+                }
                 MessageBox.Show(
                     this,
                     exception.Message,
@@ -863,8 +896,11 @@ namespace Resonalyze.Options
             }
             finally
             {
-                buttonAsioInputProbe.Text = "Test ASIO Inputs";
-                UpdateAudioBackendControls();
+                if (!IsDisposed)
+                {
+                    buttonAsioInputProbe.Text = "Test ASIO Inputs";
+                    UpdateAudioBackendControls();
+                }
             }
         }
 
@@ -893,10 +929,15 @@ namespace Resonalyze.Options
             }
 
             RefreshSampleRateOptions(GetSelectedSampleRate());
-            RefreshAsioDriverInfo(
-                GetSelectedAsioInputChannelOffset(),
-                GetSelectedAsioOutputChannelOffset(),
-                GetSelectedAsioLoopbackInputChannelOffset());
+            if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.Asio)
+            {
+                // Opening the ASIO driver is a synchronous COM instantiation
+                // that can take seconds; don't pay it for Wave-side changes.
+                RefreshAsioDriverInfo(
+                    GetSelectedAsioInputChannelOffset(),
+                    GetSelectedAsioOutputChannelOffset(),
+                    GetSelectedAsioLoopbackInputChannelOffset());
+            }
             UpdateAudioBackendControls();
         }
 
@@ -1008,9 +1049,13 @@ namespace Resonalyze.Options
 
         private int GetSelectedWaveRecordingChannelCount()
         {
-            return comboBoxWaveLoopbackChannel.SelectedItem is InputChannelOption { Offset: not null }
-                ? 2
-                : 1;
+            // The microphone on channel 2 (offset 1) needs a 2-channel format
+            // even without a loopback selection.
+            int loopbackChannels =
+                comboBoxWaveLoopbackChannel.SelectedItem is InputChannelOption { Offset: not null }
+                    ? 2
+                    : 1;
+            return Math.Max(GetSelectedWaveInputChannelOffset() + 1, loopbackChannels);
         }
 
         private int GetSelectedAsioInputChannelOffset()

--- a/source/Options/WaterfallOptions.cs
+++ b/source/Options/WaterfallOptions.cs
@@ -39,23 +39,25 @@ namespace Resonalyze.Options
 
             this.expSweepMeasurement = expSweepMeasurement;
 
-            numericSampleRate.Value = expSweepMeasurement.SampleRate;
+            numericSampleRate.Value = numericSampleRate.ClampValue(expSweepMeasurement.SampleRate);
 
-            numericWindow.Value = waterfallGenerateOptions.Window;
-            numericSlices.Value = waterfallGenerateOptions.SliceCount;
+            // The settings file clamps to wider ranges than the controls; an
+            // out-of-range persisted value must not throw when the panel opens.
+            numericWindow.Value = numericWindow.ClampValue(waterfallGenerateOptions.Window);
+            numericSlices.Value = numericSlices.ClampValue(waterfallGenerateOptions.SliceCount);
             lastNonZeroStep = waterfallGenerateOptions.Step == 0 ? 1 : waterfallGenerateOptions.Step;
-            numericStep.Value = lastNonZeroStep;
-            numericCaptureTime.Value = (decimal)CalcCapturedTime;
+            numericStep.Value = numericStep.ClampValue((double)lastNonZeroStep);
+            numericCaptureTime.Value = numericCaptureTime.ClampValue((double)CalcCapturedTime);
 
-            numericLeftWindow.Value = waterfallGenerateOptions.LeftTukeyWindow;
-            numericRightWindow.Value = waterfallGenerateOptions.RightTukeyWindow;
+            numericLeftWindow.Value = numericLeftWindow.ClampValue(waterfallGenerateOptions.LeftTukeyWindow);
+            numericRightWindow.Value = numericRightWindow.ClampValue(waterfallGenerateOptions.RightTukeyWindow);
 
-            numericDbRange.Value = waterfallGenerateOptions.DbRange;
+            numericDbRange.Value = numericDbRange.ClampValue(waterfallGenerateOptions.DbRange);
 
             comboSmoothingInverseOctaves.SelectedItem =
                 SmoothingPresetOptions.Normalize(waterfallGenerateOptions.SmoothingInverseOctaves);
 
-            numericOffset.Value = waterfallGenerateOptions.Offset;
+            numericOffset.Value = numericOffset.ClampValue(waterfallGenerateOptions.Offset);
             UpdateTukeyWindowLimits();
             UpdateIrPreview();
         }

--- a/source/Program.cs
+++ b/source/Program.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Resonalyze;
 
 internal static class Program
@@ -5,8 +7,45 @@ internal static class Program
     [STAThread]
     private static void Main()
     {
+        // Audio callbacks and measurement tasks run on worker threads; without
+        // these hooks any exception escaping them killed the process with no
+        // trace at all. Best-effort: log, then let the failure proceed.
+        AppDomain.CurrentDomain.UnhandledException += (_, args) =>
+            TryWriteCrashLog(args.ExceptionObject as Exception);
+        Application.ThreadException += (_, args) =>
+        {
+            TryWriteCrashLog(args.Exception);
+            MessageBox.Show(
+                $"An unexpected error occurred.\r\n\r\n{args.Exception.Message}\r\n\r\n" +
+                $"Details were written to crash.log next to the application.",
+                "Resonalyze",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+        };
+
         ApplicationConfiguration.Initialize();
         AppProfiler.SetThreadName("UI");
         Application.Run(new Form1());
+    }
+
+    private static void TryWriteCrashLog(Exception? exception)
+    {
+        if (exception == null)
+        {
+            return;
+        }
+
+        try
+        {
+            string path = Path.Combine(AppContext.BaseDirectory, "crash.log");
+            string entry = string.Create(
+                CultureInfo.InvariantCulture,
+                $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {exception}\r\n\r\n");
+            File.AppendAllText(path, entry);
+        }
+        catch
+        {
+            // Logging must never make a crash worse.
+        }
     }
 }

--- a/source/Shell/DockedModeSettingsHost.cs
+++ b/source/Shell/DockedModeSettingsHost.cs
@@ -21,7 +21,6 @@ internal sealed class DockedModeSettingsHost : IDisposable
         this.anchorControl = anchorControl;
 
         owner.LocationChanged += OwnerLayoutChanged;
-        owner.Resize += OwnerLayoutChanged;
         owner.SizeChanged += OwnerLayoutChanged;
         anchorControl.SizeChanged += OwnerLayoutChanged;
     }
@@ -102,7 +101,6 @@ internal sealed class DockedModeSettingsHost : IDisposable
 
         disposed = true;
         owner.LocationChanged -= OwnerLayoutChanged;
-        owner.Resize -= OwnerLayoutChanged;
         owner.SizeChanged -= OwnerLayoutChanged;
         anchorControl.SizeChanged -= OwnerLayoutChanged;
         Close();
@@ -151,7 +149,7 @@ internal sealed class DockedModeSettingsHost : IDisposable
                         button.Enabled = false;
                         try
                         {
-                            await apply();
+                            await ApplySafelyAsync(dialog, apply);
                         }
                         finally
                         {
@@ -167,6 +165,29 @@ internal sealed class DockedModeSettingsHost : IDisposable
         if (applyOnChange)
         {
             WireLiveApply(dialog, apply);
+        }
+    }
+
+    // Both apply paths run in async void contexts (a Click handler and a
+    // BeginInvoke continuation); an exception escaping them would kill the
+    // process instead of surfacing as a dialog.
+    private static async Task ApplySafelyAsync(Form dialog, Func<Task> apply)
+    {
+        try
+        {
+            await apply();
+        }
+        catch (Exception exception)
+        {
+            if (!dialog.IsDisposed)
+            {
+                MessageBox.Show(
+                    dialog,
+                    $"Applying the settings failed.\r\n\r\n{exception.Message}",
+                    "Settings",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
         }
     }
 
@@ -205,7 +226,7 @@ internal sealed class DockedModeSettingsHost : IDisposable
             pending = false;
             try
             {
-                await apply();
+                await ApplySafelyAsync(dialog, apply);
             }
             finally
             {
@@ -347,7 +368,10 @@ internal sealed class DockedModeSettingsHost : IDisposable
 
     private void DialogFormClosing(object? sender, FormClosingEventArgs e)
     {
-        if (allowProgrammaticClose)
+        // Only swallow direct user closes (the docked panel has no close UI of
+        // its own); cancelling owner/shutdown closes would block app exit and
+        // Windows logoff.
+        if (allowProgrammaticClose || e.CloseReason != CloseReason.UserClosing)
         {
             return;
         }

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -283,6 +283,7 @@ public partial class Form1
             {
                 buttonRecord.Text = expSweepMeasurement.LastError == null ? "Aborted" : "Error";
                 SetImpulseResponseAvailability(false);
+                ShowMeasurementError("The measurement failed.", expSweepMeasurement.LastError);
             }
 
             UpdatePeakInfo();

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -54,7 +54,8 @@ public partial class Form1
             UpdateOverlayAvailability,
             UpdateRecordButtonForCurrentMode,
             UpdatePlotLabelsPanel,
-            liveSpectrumOptions);
+            liveSpectrumOptions,
+            () => closingInProgress);
         ModeController createdModeController = new(
             ChangeModeAsync,
             SetActiveModeTab,

--- a/source/Shell/Form1.Lifecycle.cs
+++ b/source/Shell/Form1.Lifecycle.cs
@@ -13,7 +13,8 @@ public partial class Form1
     protected override void WndProc(ref Message m)
     {
         if (m.Msg == ChromeTitleBar.WmNcHitTest &&
-            !chromeTitleBar.IsCustomMaximized)
+            !chromeTitleBar.IsCustomMaximized &&
+            WindowState == FormWindowState.Normal)
         {
             base.WndProc(ref m);
             if ((int)m.Result == ChromeTitleBar.HtClient)
@@ -22,7 +23,8 @@ public partial class Form1
                     ChromeTitleBar.GetPointFromLParam(m.LParam));
                 m.Result = ChromeTitleBar.GetResizeHitTest(
                     point,
-                    ClientSize);
+                    ClientSize,
+                    chromeTitleBar.ScaledResizeGripSize);
             }
             return;
         }

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -161,6 +161,23 @@ namespace Resonalyze
             }
         }
 
+        // Measurement failures used to surface only as an "Error" record button;
+        // the stored exception text was never shown to the user.
+        private void ShowMeasurementError(string summary, Exception? error)
+        {
+            if (error == null || closingInProgress)
+            {
+                return;
+            }
+
+            MessageBox.Show(
+                this,
+                $"{summary}\r\n\r\n{error.Message}",
+                "Measurement",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning);
+        }
+
         private SignalGeneratorPlaybackSettings CreateSignalGeneratorPlaybackSettings() =>
             new(
                 expSweepMeasurement.AudioBackend,

--- a/source/Tools/TuningSheetPdf.cs
+++ b/source/Tools/TuningSheetPdf.cs
@@ -101,9 +101,10 @@ internal static class TuningSheetPdf
                 {
                     File.Delete(temp);
                 }
-                catch (IOException)
+                catch (Exception)
                 {
-                    // Best effort cleanup.
+                    // Best-effort cleanup; a leftover temp image must not fail
+                    // (or mask the failure of) an export.
                 }
             }
         }

--- a/source/Tools/VirtualCrossoverSheetPdf.cs
+++ b/source/Tools/VirtualCrossoverSheetPdf.cs
@@ -121,9 +121,10 @@ internal static class VirtualCrossoverSheetPdf
                 {
                     File.Delete(temp);
                 }
-                catch (IOException)
+                catch (Exception)
                 {
-                    // Best effort cleanup.
+                    // Best-effort cleanup; a leftover temp image must not fail
+                    // (or mask the failure of) an export.
                 }
             }
         }
@@ -271,6 +272,15 @@ internal static class VirtualCrossoverSheetPdf
             TextColor = OxyColors.Black,
             IsLegendVisible = true
         };
+        // OxyPlot 2.x renders no legend unless one is explicitly added; the
+        // per-series channel titles were invisible in the exported sheet.
+        model.Legends.Add(new OxyPlot.Legends.Legend
+        {
+            LegendPosition = OxyPlot.Legends.LegendPosition.TopRight,
+            LegendTextColor = OxyColors.Black,
+            LegendBorder = OxyColors.Gray,
+            LegendBackground = OxyColors.White
+        });
 
         double minDb = -6;
         double maxDb = 6;

--- a/source/Ui/Controls/ChromeTitleBar.cs
+++ b/source/Ui/Controls/ChromeTitleBar.cs
@@ -14,6 +14,7 @@ internal sealed class ChromeTitleBar : Panel
     public const int HtClient = 1;
 
     private const int WmNcLeftButtonDown = 0xA1;
+    private const int HtTransparent = -1;
     private const int HtCaption = 2;
     private const int HtLeft = 10;
     private const int HtRight = 11;
@@ -49,6 +50,34 @@ internal sealed class ChromeTitleBar : Panel
     }
 
     public bool IsCustomMaximized => isCustomMaximized;
+
+    public int ScaledResizeGripSize => Scale(ResizeGripSize);
+
+    // The title bar panel covers the whole top strip of the borderless form, so
+    // WM_NCHITTEST for the top resize grip never reaches the form — without
+    // this the window cannot be resized from its top edge at all. Returning
+    // HTTRANSPARENT hands the hit test to the form, whose WndProc maps the
+    // strip to HTTOP/HTTOPLEFT/HTTOPRIGHT.
+    protected override void WndProc(ref Message m)
+    {
+        if (m.Msg == WmNcHitTest &&
+            initialized &&
+            !isCustomMaximized &&
+            form.WindowState == FormWindowState.Normal)
+        {
+            Point clientPoint = PointToClient(GetPointFromLParam(m.LParam));
+            int grip = ScaledResizeGripSize;
+            if (clientPoint.Y <= grip ||
+                clientPoint.X <= grip ||
+                clientPoint.X >= Width - grip)
+            {
+                m.Result = (IntPtr)HtTransparent;
+                return;
+            }
+        }
+
+        base.WndProc(ref m);
+    }
 
     // Wires the title bar to its owning form. Called once after the designer has
     // added the control to the form.
@@ -135,12 +164,15 @@ internal sealed class ChromeTitleBar : Panel
         return new Point(x, y);
     }
 
-    public static IntPtr GetResizeHitTest(Point point, Size clientSize)
+    public static IntPtr GetResizeHitTest(Point point, Size clientSize) =>
+        GetResizeHitTest(point, clientSize, ResizeGripSize);
+
+    public static IntPtr GetResizeHitTest(Point point, Size clientSize, int gripSize)
     {
-        bool left = point.X <= ResizeGripSize;
-        bool right = point.X >= clientSize.Width - ResizeGripSize;
-        bool top = point.Y <= ResizeGripSize;
-        bool bottom = point.Y >= clientSize.Height - ResizeGripSize;
+        bool left = point.X <= gripSize;
+        bool right = point.X >= clientSize.Width - gripSize;
+        bool top = point.Y <= gripSize;
+        bool bottom = point.Y >= clientSize.Height - gripSize;
 
         if (left && top)
         {
@@ -464,7 +496,11 @@ internal sealed class ChromeTitleBar : Panel
 
     private void ToggleMaximized()
     {
-        if (isCustomMaximized)
+        // Dragging the caption lets Windows Aero-snap the borderless form into a
+        // REAL WindowState.Maximized without isCustomMaximized ever being set;
+        // treating that state as "not maximized" here would capture the
+        // maximized bounds into restoreBounds and lose the original size.
+        if (isCustomMaximized || form.WindowState == FormWindowState.Maximized)
         {
             RestoreWindowBounds();
             return;
@@ -475,7 +511,7 @@ internal sealed class ChromeTitleBar : Panel
 
     private void MaximizeToCurrentScreen()
     {
-        if (form.WindowState == FormWindowState.Minimized)
+        if (form.WindowState != FormWindowState.Normal)
         {
             return;
         }
@@ -489,6 +525,14 @@ internal sealed class ChromeTitleBar : Panel
 
     private void RestoreWindowBounds()
     {
+        if (form.WindowState == FormWindowState.Maximized)
+        {
+            // Snap-maximized: let Windows restore the pre-snap bounds it kept.
+            form.WindowState = FormWindowState.Normal;
+            isCustomMaximized = false;
+            return;
+        }
+
         if (!isCustomMaximized)
         {
             return;

--- a/source/Ui/Controls/InputLevelMeterPanel.cs
+++ b/source/Ui/Controls/InputLevelMeterPanel.cs
@@ -17,8 +17,8 @@ internal sealed class InputLevelMeterPanel : Control
     private static readonly Color PeakHoldColor = UiPalette.MeterPeakHold;
     private static readonly Color FullScaleColor = UiPalette.MeterFullScale;
     private static readonly Color DimFillColor = UiPalette.MeterDimFill;
-    private static readonly TimeSpan PeakHoldDuration = TimeSpan.FromMilliseconds(700);
-    private static readonly TimeSpan TextUpdateInterval = TimeSpan.FromMilliseconds(500);
+    private const long PeakHoldDurationMs = 700;
+    private const long TextUpdateIntervalMs = 500;
     private const double MinimumDecibels = -60;
     private const double MaximumDecibels = 0;
     private const double AttackFactor = 0.42;
@@ -29,7 +29,9 @@ internal sealed class InputLevelMeterPanel : Control
     private InputLevelMeterEntry loopbackTarget = InputLevelMeterEntry.Unavailable;
     private MeterVisualState microphoneState = MeterVisualState.CreateUnavailable();
     private MeterVisualState loopbackState = MeterVisualState.CreateUnavailable();
-    private DateTime lastAnimationTickUtc = DateTime.UtcNow;
+    // Monotonic clock: a wall-clock (NTP/DST) step must not distort the
+    // animation delta or the peak-hold timing.
+    private long lastAnimationTickMs = Environment.TickCount64;
 
     public InputLevelMeterPanel()
     {
@@ -142,7 +144,7 @@ internal sealed class InputLevelMeterPanel : Control
         if (state.Available)
         {
             DrawRmsFill(graphics, barRectangle, state);
-            DrawOverlayTicks(graphics, barRectangle);
+            DrawTicks(graphics, barRectangle, UiPalette.MeterGrid);
             DrawPeakMarker(graphics, barRectangle, state);
         }
 
@@ -162,33 +164,16 @@ internal sealed class InputLevelMeterPanel : Control
         graphics.FillRectangle(backgroundBrush, rectangle);
         using var borderPen = new Pen(active ? BorderColor : UiPalette.MeterBorderInactive);
         graphics.DrawRectangle(borderPen, rectangle);
-        DrawScaleTicks(graphics, rectangle, active);
+        DrawTicks(graphics, rectangle, UiPalette.MeterBand);
     }
 
-    private static void DrawScaleTicks(
+    private static void DrawTicks(
         Graphics graphics,
         Rectangle rectangle,
-        bool active)
+        Color tickColor)
     {
         Rectangle innerRectangle = Rectangle.Inflate(rectangle, -1, -1);
-        Color tickColor = active
-            ? UiPalette.MeterBand
-            : UiPalette.MeterBand;
         using var tickPen = new Pen(tickColor, 1);
-
-        for (int db = (int)MinimumDecibels + 5; db < MaximumDecibels; db += 5)
-        {
-            int x = innerRectangle.Left + (int)Math.Round((innerRectangle.Width - 1) * Normalize(db));
-            graphics.DrawLine(tickPen, x, innerRectangle.Top, x, innerRectangle.Bottom);
-        }
-    }
-
-    private static void DrawOverlayTicks(
-        Graphics graphics,
-        Rectangle rectangle)
-    {
-        Rectangle innerRectangle = Rectangle.Inflate(rectangle, -1, -1);
-        using var tickPen = new Pen(UiPalette.MeterGrid, 1);
 
         for (int db = (int)MinimumDecibels + 5; db < MaximumDecibels; db += 5)
         {
@@ -262,61 +247,67 @@ internal sealed class InputLevelMeterPanel : Control
         return (clamped - MinimumDecibels) / (MaximumDecibels - MinimumDecibels);
     }
 
-    private static Color Blend(Color a, Color b, float amount)
-    {
-        amount = Math.Clamp(amount, 0, 1);
-        int r = (int)Math.Round(a.R + (b.R - a.R) * amount);
-        int g = (int)Math.Round(a.G + (b.G - a.G) * amount);
-        int bl = (int)Math.Round(a.B + (b.B - a.B) * amount);
-        return Color.FromArgb(r, g, bl);
-    }
-
     protected override void OnHandleCreated(EventArgs e)
     {
         base.OnHandleCreated(e);
-        lastAnimationTickUtc = DateTime.UtcNow;
+        lastAnimationTickMs = Environment.TickCount64;
     }
 
     protected override Size DefaultSize => new(150, 88);
 
     private void Animate()
     {
-        DateTime now = DateTime.UtcNow;
-        double dt = Math.Max((now - lastAnimationTickUtc).TotalSeconds, 0.001);
-        lastAnimationTickUtc = now;
+        long now = Environment.TickCount64;
+        double dt = Math.Max((now - lastAnimationTickMs) / 1000.0, 0.001);
+        lastAnimationTickMs = now;
 
-        microphoneState = AdvanceState(microphoneState, microphoneTarget, now, dt);
-        loopbackState = AdvanceState(loopbackState, loopbackTarget, now, dt);
+        MeterVisualState newMicrophoneState =
+            AdvanceState(microphoneState, microphoneTarget, now, dt);
+        MeterVisualState newLoopbackState =
+            AdvanceState(loopbackState, loopbackTarget, now, dt);
+        if (newMicrophoneState == microphoneState &&
+            newLoopbackState == loopbackState)
+        {
+            // Idle meters (no measurement running) must not repaint at 30 Hz.
+            return;
+        }
+
+        microphoneState = newMicrophoneState;
+        loopbackState = newLoopbackState;
         Invalidate();
     }
 
     private static MeterVisualState AdvanceState(
         MeterVisualState state,
         InputLevelMeterEntry target,
-        DateTime now,
+        long nowMs,
         double dt)
     {
         if (!target.Available)
         {
-            return MeterVisualState.CreateUnavailable();
+            // Keep the existing unavailable state so idle ticks compare equal.
+            return state.Available ? MeterVisualState.CreateUnavailable() : state;
         }
 
         if (!state.Available)
         {
-            return MeterVisualState.CreateActive(target, now);
+            return MeterVisualState.CreateActive(target, nowMs);
         }
 
         double displayedPeak = Smooth(state.DisplayedPeakDbFs, target.PeakDbFs);
         double displayedRms = Smooth(state.DisplayedRmsDbFs, target.RmsDbFs);
 
         double holdPeak = state.HoldPeakDbFs;
-        DateTime holdTimestamp = state.HoldTimestampUtc;
-        if (displayedPeak >= holdPeak)
+        long holdTimestamp = state.HoldTimestampMs;
+        // Strictly greater: at equality (a fully converged meter) re-stamping
+        // the hold would make every tick "change" the state and defeat the
+        // idle repaint skip in Animate.
+        if (displayedPeak > holdPeak)
         {
             holdPeak = displayedPeak;
-            holdTimestamp = now;
+            holdTimestamp = nowMs;
         }
-        else if (now - holdTimestamp > PeakHoldDuration)
+        else if (nowMs - holdTimestamp > PeakHoldDurationMs)
         {
             holdPeak = Math.Max(
                 displayedPeak,
@@ -325,12 +316,12 @@ internal sealed class InputLevelMeterPanel : Control
 
         double textPeak = state.TextPeakDbFs;
         double textRms = state.TextRmsDbFs;
-        DateTime textTimestamp = state.LastTextUpdateUtc;
-        if (now - state.LastTextUpdateUtc >= TextUpdateInterval)
+        long textTimestamp = state.LastTextUpdateMs;
+        if (nowMs - state.LastTextUpdateMs >= TextUpdateIntervalMs)
         {
             textPeak = displayedPeak;
             textRms = displayedRms;
-            textTimestamp = now;
+            textTimestamp = nowMs;
         }
 
         return new MeterVisualState(
@@ -397,10 +388,10 @@ internal sealed class InputLevelMeterPanel : Control
         double DisplayedPeakDbFs,
         double DisplayedRmsDbFs,
         double HoldPeakDbFs,
-        DateTime HoldTimestampUtc,
+        long HoldTimestampMs,
         double TextPeakDbFs,
         double TextRmsDbFs,
-        DateTime LastTextUpdateUtc,
+        long LastTextUpdateMs,
         bool Clipped,
         bool FullScaleReference)
     {
@@ -409,24 +400,24 @@ internal sealed class InputLevelMeterPanel : Control
             MinimumDecibels,
             MinimumDecibels,
             MinimumDecibels,
-            DateTime.UtcNow,
+            0,
             MinimumDecibels,
             MinimumDecibels,
-            DateTime.UtcNow,
+            0,
             false,
             false);
 
         public static MeterVisualState CreateActive(
             InputLevelMeterEntry target,
-            DateTime now) => new(
+            long nowMs) => new(
             true,
             target.PeakDbFs,
             target.RmsDbFs,
             target.PeakDbFs,
-            now,
+            nowMs,
             target.PeakDbFs,
             target.RmsDbFs,
-            now,
+            nowMs,
             target.Clipped,
             target.FullScaleReference);
     }

--- a/source/Ui/Controls/PlotLabelsPanelController.cs
+++ b/source/Ui/Controls/PlotLabelsPanelController.cs
@@ -1,7 +1,6 @@
 using OxyPlot;
 using OxyPlot.Series;
 using OxyPlot.WindowsForms;
-using static System.Net.Mime.MediaTypeNames;
 using HorizontalAlignment = OxyPlot.HorizontalAlignment;
 
 namespace Resonalyze;
@@ -28,16 +27,16 @@ internal sealed class PlotLabelsPanelController
             return;
         }
 
-        List<LineSeries> series = plotView.Model?.Series
-            .OfType<LineSeries>()
-            .Where(item => !string.IsNullOrWhiteSpace(item.Title))
-            .Take(16)
-            .ToList() ?? new List<LineSeries>();
-
-        if (plotView == null || plotView.Model == null)
+        if (plotView.Model == null)
         {
             return;
         }
+
+        List<LineSeries> series = plotView.Model.Series
+            .OfType<LineSeries>()
+            .Where(item => !string.IsNullOrWhiteSpace(item.Title))
+            .Take(16)
+            .ToList();
 
         RemovePlotLabelAnnotations();
 
@@ -56,20 +55,22 @@ internal sealed class PlotLabelsPanelController
 
     private void AddEntry(int stringNumber, double offset, LineSeries series)
     {
-        if (plotView != null && plotView.Model != null)
+        if (plotView.Model == null)
         {
-            plotView.Model.Annotations.Add(new OverlayTextAnnotation()
-            {
-                IsPlotLabelOverlay = true,
-                TextFlowDirection = TextFlowDirection.BottomUp,
-                Text = "\u2501\u2501 " + series.Title ?? string.Empty,
-                TextPosition = new DataPoint(offset, stringNumber),
-                FontSize = 12,
-                FontWeight = 700,
-                TextColor = series.Color,
-                TextHorizontalAlignment = HorizontalAlignment.Left
-            });
+            return;
         }
+
+        plotView.Model.Annotations.Add(new OverlayTextAnnotation()
+        {
+            IsPlotLabelOverlay = true,
+            TextFlowDirection = TextFlowDirection.BottomUp,
+            Text = "\u2501\u2501 " + series.Title,
+            TextPosition = new DataPoint(offset, stringNumber),
+            FontSize = 12,
+            FontWeight = 700,
+            TextColor = series.Color,
+            TextHorizontalAlignment = HorizontalAlignment.Left
+        });
     }
 
     private void RemovePlotLabelAnnotations()

--- a/source/Ui/DarkScrollBars.cs
+++ b/source/Ui/DarkScrollBars.cs
@@ -46,13 +46,12 @@ internal static class DarkScrollBars
         }
 
         EnsureDarkAppMode();
+        // Always subscribe: WinForms can recreate the handle (RecreateHandle on
+        // certain property changes), which would silently revert the theme.
+        control.HandleCreated += (_, _) => ApplyTheme(control);
         if (control.IsHandleCreated)
         {
             ApplyTheme(control);
-        }
-        else
-        {
-            control.HandleCreated += (_, _) => ApplyTheme(control);
         }
     }
 

--- a/source/Ui/Dialogs/ApplicationUpdateDialog.cs
+++ b/source/Ui/Dialogs/ApplicationUpdateDialog.cs
@@ -108,6 +108,9 @@ internal sealed class ApplicationUpdateDialog : Form
         }
 
         CancelButton = cancelButton;
+        // Same runtime DPI scaling as the other hand-laid-out dialogs; without
+        // it the fixed pixel geometry clips the scaled text at 150 %+.
+        OverlayDialogControls.ApplyRuntimeDpiScale(this);
         ResumeLayout(false);
     }
 }

--- a/source/Ui/Dialogs/ColorPickerDialog.cs
+++ b/source/Ui/Dialogs/ColorPickerDialog.cs
@@ -328,9 +328,11 @@ internal sealed class ColorSpectrum : Control
         {
             args.Graphics.FillRectangle(saturationBrush, ClientRectangle);
         }
+        // Color.Transparent is transparent WHITE; GDI+ interpolates the raw
+        // channels, so mid-gradient it brightens instead of purely darkening.
         using (var valueBrush = new LinearGradientBrush(
             ClientRectangle,
-            Color.Transparent,
+            Color.FromArgb(0, Color.Black),
             Color.Black,
             LinearGradientMode.Vertical))
         {
@@ -409,11 +411,15 @@ internal sealed class HueSlider : Control
     {
         base.OnPaint(args);
         int height = Math.Max(1, ClientSize.Height - 1);
-        for (int y = 0; y < ClientSize.Height; y++)
+        // One reusable pen; this paints per mouse-move while dragging the hue.
+        using (var pen = new Pen(Color.Black))
         {
-            double rowHue = y / (double)height * 360.0;
-            using var pen = new Pen(HsvColor.ToColor(rowHue, 1, 1));
-            args.Graphics.DrawLine(pen, 0, y, ClientSize.Width, y);
+            for (int y = 0; y < ClientSize.Height; y++)
+            {
+                double rowHue = y / (double)height * 360.0;
+                pen.Color = HsvColor.ToColor(rowHue, 1, 1);
+                args.Graphics.DrawLine(pen, 0, y, ClientSize.Width, y);
+            }
         }
 
         float markerY = (float)(hue / 360.0 * height);

--- a/source/Ui/Dialogs/MeasurementHistoryWindow.cs
+++ b/source/Ui/Dialogs/MeasurementHistoryWindow.cs
@@ -12,6 +12,7 @@ internal partial class MeasurementHistoryWindow : Form
     private readonly Font activeEntryFont;
     private readonly ToolTip historyToolTip = new() { ShowAlways = true };
     private Guid? activeEntryId;
+    private bool suppressSelectionEvents;
 
     public event Action<Guid>? EntryActivated;
     public event Action<Guid>? SaveRequested;
@@ -25,7 +26,11 @@ internal partial class MeasurementHistoryWindow : Form
         StartPosition = FormStartPosition.CenterParent;
         ConfigureNewSessionButton();
         ConfigureGrid();
-        FormClosed += (_, _) => historyToolTip.Dispose();
+        FormClosed += (_, _) =>
+        {
+            historyToolTip.Dispose();
+            activeEntryFont.Dispose();
+        };
         historyDataGridView.SelectionChanged += HistoryDataGridView_SelectionChanged;
         historyDataGridView.CellContentClick += HistoryDataGridView_CellContentClick;
         historyDataGridView.CellDoubleClick += HistoryDataGridView_CellDoubleClick;
@@ -45,6 +50,9 @@ internal partial class MeasurementHistoryWindow : Form
     {
         this.activeEntryId = activeEntryId;
         historyDataGridView.SuspendLayout();
+        // Rows.Clear/Add/SelectRow each raise SelectionChanged, and every one
+        // rebuilt the whole preview plot; the explicit pass below is enough.
+        suppressSelectionEvents = true;
         try
         {
             historyDataGridView.Rows.Clear();
@@ -75,6 +83,7 @@ internal partial class MeasurementHistoryWindow : Form
         }
         finally
         {
+            suppressSelectionEvents = false;
             historyDataGridView.ResumeLayout();
         }
 
@@ -90,14 +99,22 @@ internal partial class MeasurementHistoryWindow : Form
         }
 
         int nextSelection = Math.Min(rowIndex, historyDataGridView.Rows.Count - 2);
-        historyDataGridView.Rows.RemoveAt(rowIndex);
-        rowEntryIds.RemoveAt(rowIndex);
-
-        if (nextSelection >= 0 && nextSelection < historyDataGridView.Rows.Count)
+        suppressSelectionEvents = true;
+        try
         {
-            historyDataGridView.ClearSelection();
-            historyDataGridView.Rows[nextSelection].Selected = true;
-            historyDataGridView.CurrentCell = historyDataGridView.Rows[nextSelection].Cells[0];
+            historyDataGridView.Rows.RemoveAt(rowIndex);
+            rowEntryIds.RemoveAt(rowIndex);
+
+            if (nextSelection >= 0 && nextSelection < historyDataGridView.Rows.Count)
+            {
+                historyDataGridView.ClearSelection();
+                historyDataGridView.Rows[nextSelection].Selected = true;
+                historyDataGridView.CurrentCell = historyDataGridView.Rows[nextSelection].Cells[0];
+            }
+        }
+        finally
+        {
+            suppressSelectionEvents = false;
         }
 
         ApplyRowStyles();
@@ -184,6 +201,11 @@ internal partial class MeasurementHistoryWindow : Form
 
     private void HistoryDataGridView_SelectionChanged(object? sender, EventArgs e)
     {
+        if (suppressSelectionEvents)
+        {
+            return;
+        }
+
         ApplyRowStyles();
         UpdatePreview();
     }
@@ -198,7 +220,12 @@ internal partial class MeasurementHistoryWindow : Form
         Guid entryId = rowEntryIds[e.RowIndex];
         if (e.ColumnIndex == 2)
         {
-            SaveRequested?.Invoke(entryId);
+            // File-backed rows render "-" here; the click must stay inert.
+            if (historyDataGridView.Rows[e.RowIndex].Tag is
+                MeasurementHistoryEntry { CanSave: true })
+            {
+                SaveRequested?.Invoke(entryId);
+            }
         }
         else if (e.ColumnIndex == 3)
         {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
@@ -1,0 +1,59 @@
+using Resonalyze;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class VirtualCrossoverSheetPdfTests
+{
+    [Fact]
+    public void Export_WritesAValidPdfFile()
+    {
+        var project = new VirtualCrossoverProjectFile();
+        project.Channels[0].SourceFilePath = "sub.json";
+        project.Channels[0].DisplayName = "Sub";
+        project.Channels[0].GainDb = -3.0;
+        project.Channels[0].DelayMs = 1.5;
+        project.Channels[0].CrossoverKind = CrossoverKind.LowPass;
+        project.Channels[1].SourceFilePath = "top.json";
+        project.Channels[1].DisplayName = "Top";
+        project.Channels[1].CrossoverKind = CrossoverKind.HighPass;
+        project.Channels[1].PeqBands.Add(new PeqBand(1000, 2.0, -3.0));
+
+        string path = Path.Combine(Path.GetTempPath(), $"vdsp_{Guid.NewGuid():N}.pdf");
+        try
+        {
+            VirtualCrossoverSheetPdf.Export(path, project, "metric: 0.42", 48_000);
+
+            byte[] bytes = File.ReadAllBytes(path);
+            Assert.True(bytes.Length > 0);
+            // Every PDF starts with the "%PDF" signature.
+            Assert.Equal("%PDF", System.Text.Encoding.ASCII.GetString(bytes, 0, 4));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Export_HandlesProjectWithoutSources()
+    {
+        var project = new VirtualCrossoverProjectFile();
+        string path = Path.Combine(Path.GetTempPath(), $"vdsp_{Guid.NewGuid():N}.pdf");
+        try
+        {
+            VirtualCrossoverSheetPdf.Export(path, project, metricLine: null, 44_100);
+            Assert.True(new FileInfo(path).Length > 0);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Final review round covering everything the previous two passes (#1, #2) did not: measurement orchestrators + live spectrum, audio device catalogs, `Options/` panels, UI chrome/dialogs and the PDF exporters. Every finding either fixed here or recorded in `TODO.md` (which this PR also extends).

## Stage A — measurement orchestrators / live spectrum

- **Measurement failures now show the error.** `ExpSweepMeasurement.LastError` / `NoiseMeasurement.LastError` were stored but never displayed — a failed sweep or live capture just flipped the Record button to "Error". Both paths now surface the exception text (skipped during app close; user aborts stay silent).
- Dead `FindPeakIndex(double)` overload and the `AccumulateSequence` pass-through removed.
- Verified clean (suspected, disproved): recorder buffers reset between averaging runs; live overlap changes restart the measurement (no α/hop desync); zero-seeded EMA cancels out of H1/coherence ratios.

## Stage B — device catalogs / capture-adjacent

- `AsioInputProbe` guards the correlation reference channel like the data channel instead of indexing `samples[0]` unconditionally.
- `FloatArrayWaveStream` packs floats without a `byte[]` allocation per sample (a 60 s noise buffer allocated ~5.7 M of them).

## Stage C — Options panels

- **Two app-crash paths closed:** the ASIO input probe continued onto a disposed docked panel after its ~1 s capture (exception out of `async void` kills the process), and `DockedModeSettingsHost`'s live-apply/Apply-button paths awaited `apply()` with no handler — a device error during apply crashed instead of showing a dialog.
- **Out-of-range persisted settings no longer crash panels on open** (`IROpt`, `WaterfallOptions`, `MeasurementOptions`): the settings file clamps to wider ranges than the controls; `Init` now clamps via `ClampValue`.
- Computed sweep duration uses a static `ExponentialSineSweep.CalculateDuration(octaves, duration, rate)` fed from the panel's own values — the old instance method read the *last generated* sweep's octaves/rate (stale on settings load, throwing before any `FillData`). Millisecond truncation → rounding.
- Wave input-channel changes refresh supported sample rates; the probed channel count accounts for a mic on channel 2; Wave-side changes no longer pay a synchronous (seconds-long on some drivers) ASIO driver open.

## Stage C — UI chrome / dialogs

- **Top-edge window resize works.** The title-bar panel swallowed `WM_NCHITTEST` for the whole top strip, so `HtTop`/`HtTopLeft`/`HtTopRight` were unreachable; it now returns `HTTRANSPARENT` in the grip strip. Grip size DPI-scaled (was 8 raw px).
- **Aero-snap maximize recognized:** drag-to-top sets real `WindowState.Maximized` without `isCustomMaximized`; double-click then captured the maximized bounds as the restore size, permanently losing the window size. Restore now goes through `WindowState`.
- Docked panels no longer cancel `WindowsShutDown`/owner closes (only direct user closes are swallowed).
- **Color picker rendered wrong colors:** the value gradient used `Color.Transparent` (= transparent *white*), brightening mid-gradient instead of purely darkening — the pixel under the marker didn't match `SelectedColor`. Hue slider reuses one pen (~190 Pen allocations per paint, per mouse-move).
- Level meter: monotonic clock (`TickCount64` — NTP steps distorted the animation), idle 30 Hz repaints skipped via state comparison, duplicated tick-drawing merged, dead `Blend` removed.
- History window: bold row font leaked one GDI handle per open/close; `SetEntries` triggered a full OxyPlot preview rebuild per row mutation (now one per refresh); clicking the "-" cell no longer raises `SaveRequested`.
- Dark scrollbars survive WinForms handle recreation; update dialog gets the runtime DPI scaling every sibling dialog already had.

## Stage C — PDF / startup / signals

- **Virtual DSP sheet legend actually renders** — OxyPlot 2.x draws no legend unless one is added to `Model.Legends`; up to 8 colored curves exported with nothing identifying the channels. Smoke tests for the exporter added (it had none).
- **Periodic pink noise is a whole number of periods.** The buffer was truncated to `rate × duration`, so every playback loop seam produced a mid-period phase jump — full-band leakage injected into the running transfer-function average, which analyzes rectangular-windowed exactly *because* it assumes periodicity.
- `Program.Main` hooks `UnhandledException`/`ThreadException` into `crash.log` — worker-thread exceptions previously killed the process with zero diagnostics.
- PDF temp-image cleanup is fully best-effort (`UnauthorizedAccessException` from the `finally` could mask a successful export); `PlotLabelsPanelController` cleanup (dead guards, stray `using`, `??` precedence).

## Tests

- New: `VirtualCrossoverSheetPdfTests` (2 smoke tests).
- Full solution + App.Tests: 0 errors / 0 warnings (`EnableWindowsTargeting`); 263 DSP tests pass locally. App tests get their Windows execution on this PR's CI.

## Reviewed, reported, not changed → `TODO.md`

This PR extends `TODO.md` with the round's deliberate non-fixes: `CurrentLevels` torn reads, sweep regeneration on restore, per-run ASIO session re-init, loopback-channel/calibration-mode intent loss in Options, the five copy-pasted IR-preview panels, `ChromeTitleBar` per-monitor DPI, PDF-exporter dedup, and a deconvolution flatness test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_