### PR TITLE
Close TODO.md blocks 1–2: silent settings/results corruption and live-path performance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -74,14 +74,11 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   threads and read from the UI without synchronization; a torn read can show a
   momentarily inconsistent meter (display-only; same family as the
   `UpdatePeakInfo` item below).
-- [ ] **`RestoreImpulseResponse` regenerates the whole sweep.** Restoring a
-  measurement from a file or history calls `Init` → `Sweep.FillData`, which
-  synthesizes the full sweep and inverse filter just to satisfy
-  `HarmonicIROffset`; playback data isn't needed until the next run. Make the
-  generation lazy.
-- [ ] **New `AsioFullDuplexSession` per averaging run.** Every run of an
-  averaged sweep re-initializes the ASIO driver; slow drivers add seconds per
-  run. Reuse one session across the run loop.
+- [ ] **Verify the reused ASIO session on hardware.** Averaged sweeps now keep
+  one open ASIO session across runs (the driver plays silence between runs and
+  only the capture accumulator restarts). Verified by construction only — run
+  an averaged ASIO measurement on real hardware (ideally with a slow driver)
+  before relying on it.
 - [ ] **Third copy of the level-metering math.** `ChannelLevelAccumulator`
   (peak/RMS/dB + 0.999 full-scale threshold) duplicates
   `AudioLevelMetering` and the recorder metering loops.
@@ -169,22 +166,13 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 ## Overlays
 
-- [ ] ★ **Cache the target-overlay render path.** `Overlay.cs` rebuilds the
-  constant target/tolerance curves on every live tick (~30 fps) even though
-  they only change when the user edits the target. Cache the built curves and
-  invalidate on edit. The clean way in: extract the pure curve math out of
-  `Overlay.cs` into a testable class, and introduce an `OverlaySlotState`
-  record to replace the triple field-mapping between overlay, slot file and
-  UI state.
-- [ ] **Slot files re-read per mode switch.** All 12 overlay slot JSON files
-  are re-read from disk on every mode switch; cache them and reload only on
-  external change.
+- [ ] **Introduce an `OverlaySlotState` record** to replace the triple
+  field-mapping between overlay, slot file and UI state (the render-path
+  caching and the pure-math extraction from `Overlay.cs` are done; this
+  structural half remains).
 
 ## Plotting
 
-- [ ] **Live-path allocation churn.** The live spectrum rebuilds fresh series
-  objects plus several list copies on every 30 fps tick; reuse series and
-  update points in place.
 - [ ] **`LogarithmicClipAxis` label trim.** Edge tick labels can be trimmed at
   the plot boundary.
 - [ ] **Dead `FourierCSD` enum value.** Unused member of the transform enum;

--- a/TODO.md
+++ b/TODO.md
@@ -5,12 +5,10 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 ## DSP library (`dsp/`)
 
-- [ ] **`CalibrationFile` swallows a missing/unreadable file.** `HasData` makes
-  it detectable, but nothing surfaces an error to the user — measurements just
-  run uncalibrated. Add a `TryLoad`-style factory that reports the failure.
-  Related: this is the only dsp class doing filesystem I/O; aligning it with
-  the "parser accepts text" pattern of the EQ formats would simplify both
-  error handling and tests.
+- [ ] **`CalibrationFile` does filesystem I/O in the dsp layer.** The silent
+  failures are fixed (`LoadError` is surfaced in the options panel and once per
+  session at plot time), but aligning the class with the "parser accepts text"
+  pattern of the EQ formats would still simplify error handling and tests.
 - [ ] **`EqAutoTuner` greedy fit has no polish pass.** Band gain is fixed from
   the residual at the peak before Q is chosen (no joint gain/Q optimization),
   there is no final coordinate-descent pass (`CrossoverAutoSetup` already has
@@ -84,39 +82,17 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 - [ ] **New `AsioFullDuplexSession` per averaging run.** Every run of an
   averaged sweep re-initializes the ASIO driver; slow drivers add seconds per
   run. Reuse one session across the run loop.
-- [ ] **A stop failure demotes a finished measurement.** In
-  `RunCoreAsync`'s finally, a recorder stop timeout sets `success = false`
-  after `ApplyAverageResult` already published results and raised
-  `ImpulseResponseChanged` — the UI shows "Error" and skips the history entry
-  for a measurement whose data is fine. Decide the intended semantics.
 - [ ] **Third copy of the level-metering math.** `ChannelLevelAccumulator`
   (peak/RMS/dB + 0.999 full-scale threshold) duplicates
   `AudioLevelMetering` and the recorder metering loops.
 
-## Audio device catalogs
-
-- [ ] **Missing device silently becomes the first one.**
-  `AsioDeviceCatalog.FindDriverIndex`/`FindChannelIndex` and
-  `AudioDeviceCatalog.FindDeviceIndex` return index 0 when the saved
-  driver/channel/device no longer exists, so the options UI silently shows a
-  different device than the one configured. Worst case: a vanished separate
-  Wave loopback device maps to "Default recording device" instead of the
-  "Same as microphone device" sentinel — the configuration silently changes
-  meaning. Surface "(missing)" / fall back to the sentinel instead.
-
 ## Options panels
 
-- [ ] **Mono recording device irreversibly resets the loopback channel.**
-  `MeasurementOptions` forces the loopback combo to "None" when the selected
-  device reports one channel; selecting a stereo device again does not restore
-  the previous choice, and the next apply persists `null` — measurements stop
-  working. Keep the last user choice in a shadow field (the pattern
-  `LiveSpectrumOpt` already uses) and restore it.
-- [ ] **Missing 90° calibration silently downgrades the persisted mode.**
-  `MicrophoneCalibrationComboHelper` drops the `Degrees90` entry when the file
-  is absent, so `FindIndex` lands on "Off" and the next apply persists it —
-  the user's preference is permanently lost. Keep the entry (marked "(file
-  missing)") or preserve the stored mode.
+- [ ] **Loopback channel can still persist as `null` across a restart.** The
+  in-session loss is fixed (a shadow field restores the choice when a stereo
+  device is selected again), but applying while a mono/missing device is
+  selected persists "None"; after a restart there is nothing to restore. Would
+  need the preferred offset persisted separately from the effective one.
 - [ ] **ASIO driver opened twice when the measurement panel opens.**
   `Init` runs `RefreshSampleRateOptions` and `RefreshAsioDriverInfo`, each of
   which instantiates `AsioOut` (a synchronous COM driver open that can take
@@ -131,12 +107,15 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 - [ ] **`SetOptions` reads bits from the measurement, not the control.**
   Three sources of truth for the sample size in `MeasurementOptions`; harmless
   while the control is read-only, a silent no-op the day it is enabled.
-- [ ] **`TukeyWindowControlHelper` silently clamps window values** when the
-  window length shrinks (fires `ValueChanged` → live apply persists the
-  clamped value with no feedback) and overrides the designer maxima.
+- [ ] **`TukeyWindowControlHelper` clamps are irreversible.** Shrinking the
+  window length clamps the fade values (semantically required, and visible in
+  the controls), but growing it back does not restore them; a shadow-value
+  restore like the loopback-channel one would make the clamp reversible.
 - [ ] **`LiveSpectrumOpt` shadow fields update only on
-  `SelectionChangeCommitted`** — a programmatic combo change is displayed but
-  never persisted; also three identical floor-index loops worth one helper.
+  `SelectionChangeCommitted`.** Re-verified: the R reset button raises
+  `SelectionChangeCommitted` too, so no current path loses a change — this is
+  fragility for future programmatic writes, not an active bug. Also three
+  identical floor-index loops worth one helper.
 
 ## UI chrome
 
@@ -200,22 +179,12 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 - [ ] **Slot files re-read per mode switch.** All 12 overlay slot JSON files
   are re-read from disk on every mode switch; cache them and reload only on
   external change.
-- [ ] **Calculated A−B clamps instead of gapping.** Amplitude-space
-  subtraction clamps negative results to −160 dB; a NaN gap in the curve would
-  be honest instead of drawing a floor.
-- [ ] **Corrupt slot files fail silently.** A corrupt slot JSON presents as an
-  empty slot and can be silently overwritten; surface a warning and keep the
-  damaged file (e.g. rename to `.corrupt`).
 
 ## Plotting
 
 - [ ] **Live-path allocation churn.** The live spectrum rebuilds fresh series
   objects plus several list copies on every 30 fps tick; reuse series and
   update points in place.
-- [ ] **`fftLength` off by 2.** Reconstructing the FFT length from the
-  coherence array length is off by 2, giving a systematic (tiny) frequency
-  skew in the live transfer function; pass the real FFT length through instead
-  of deriving it.
 - [ ] **`LogarithmicClipAxis` label trim.** Edge tick labels can be trimmed at
   the plot boundary.
 - [ ] **Dead `FourierCSD` enum value.** Unused member of the transform enum;

--- a/dsp/CalibrationFile.cs
+++ b/dsp/CalibrationFile.cs
@@ -18,10 +18,20 @@ namespace Resonalyze.Dsp
         {
             if (!System.IO.File.Exists(file))
             {
+                LoadError = $"Calibration file not found: {file}";
                 return;
             }
 
-            string[] lines = System.IO.File.ReadAllLines(file);
+            string[] lines;
+            try
+            {
+                lines = System.IO.File.ReadAllLines(file);
+            }
+            catch (Exception exception)
+            {
+                LoadError = $"Calibration file could not be read: {exception.Message}";
+                return;
+            }
 
             foreach (string line in lines)
             {
@@ -32,6 +42,11 @@ namespace Resonalyze.Dsp
             }
 
             calibration.Sort((left, right) => left.X.CompareTo(right.X));
+            if (calibration.Count < 2)
+            {
+                LoadError =
+                    $"Calibration file contains no frequency/level pairs: {file}";
+            }
         }
 
         private CalibrationFile(
@@ -40,6 +55,7 @@ namespace Resonalyze.Dsp
         {
             this.baseCalibration = baseCalibration;
             this.decibelOffset = decibelOffset;
+            LoadError = baseCalibration.LoadError;
         }
 
         /// <summary>
@@ -48,6 +64,14 @@ namespace Resonalyze.Dsp
         /// the 0 dB fallback of a missing or unparsable file.
         /// </summary>
         public bool HasData => baseCalibration?.HasData ?? calibration.Count >= 2;
+
+        /// <summary>
+        /// Human-readable reason why no usable correction was loaded (missing
+        /// file, unreadable file, or no parsable frequency/level pairs), or null
+        /// when the calibration loaded. Callers surface this instead of letting
+        /// a measurement silently run uncalibrated.
+        /// </summary>
+        public string? LoadError { get; }
 
         public static CalibrationFile CreateNinetyDegreeApproximation(
             CalibrationFile zeroDegreeCalibration) =>

--- a/source/Audio/AsioDeviceCatalog.cs
+++ b/source/Audio/AsioDeviceCatalog.cs
@@ -32,28 +32,33 @@ public static class AsioDeviceCatalog
         }
     }
 
+    /// <summary>
+    /// Index of the named driver; 0 (the first driver) when no name is saved
+    /// yet; -1 when the saved driver is not in the list. A missing driver must
+    /// stay visible as its own entry instead of remapping to another driver,
+    /// or the next apply silently re-targets the persisted configuration.
+    /// </summary>
     public static int FindDriverIndex(
         IReadOnlyList<AsioDeviceInfo> drivers,
         string? driverName)
     {
-        if (drivers.Count == 0)
-        {
-            return -1;
-        }
         if (string.IsNullOrWhiteSpace(driverName))
         {
-            return 0;
+            return drivers.Count == 0 ? -1 : 0;
         }
 
-        int index = drivers
-            .Select((driver, position) => new { driver, position })
-            .FirstOrDefault(item =>
-                string.Equals(
-                    item.driver.DriverName,
-                    driverName,
-                    StringComparison.OrdinalIgnoreCase))
-            ?.position ?? -1;
-        return index >= 0 ? index : 0;
+        for (int i = 0; i < drivers.Count; i++)
+        {
+            if (string.Equals(
+                drivers[i].DriverName,
+                driverName,
+                StringComparison.OrdinalIgnoreCase))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public static AsioDriverInfo GetDriverInfo(
@@ -131,20 +136,24 @@ public static class AsioDeviceCatalog
         }
     }
 
+    /// <summary>
+    /// Index of the channel with the given offset, or -1 when the driver does
+    /// not report it (fewer channels, or the driver failed to open). Callers
+    /// keep the offset visible as a "(missing)" entry so it survives an apply.
+    /// </summary>
     public static int FindChannelIndex(
         IReadOnlyList<AsioChannelInfo> channels,
         int offset)
     {
-        if (channels.Count == 0)
+        for (int i = 0; i < channels.Count; i++)
         {
-            return -1;
+            if (channels[i].Offset == offset)
+            {
+                return i;
+            }
         }
 
-        int index = channels
-            .Select((channel, position) => new { channel, position })
-            .FirstOrDefault(item => item.channel.Offset == offset)
-            ?.position ?? -1;
-        return index >= 0 ? index : 0;
+        return -1;
     }
 
     public static bool IsLoopbackChannel(AsioChannelInfo channel)

--- a/source/Audio/AsioDeviceInfo.cs
+++ b/source/Audio/AsioDeviceInfo.cs
@@ -1,8 +1,9 @@
 namespace Resonalyze;
 
-public sealed record AsioDeviceInfo(string DriverName)
+public sealed record AsioDeviceInfo(string DriverName, bool Missing = false)
 {
-    public override string ToString() => DriverName;
+    public override string ToString() =>
+        Missing ? $"(missing) {DriverName}" : DriverName;
 }
 
 public sealed record AsioChannelInfo(int Offset, string Name)

--- a/source/Audio/AsioFullDuplexSession.cs
+++ b/source/Audio/AsioFullDuplexSession.cs
@@ -81,35 +81,47 @@ internal sealed class AsioFullDuplexSession : IDisposable
             InputChannelOffset = 0,
             ChannelOffset = outputChannelOffset
         };
-        if (!driver.IsSampleRateSupported(sampleRate))
+        try
         {
-            throw new InvalidOperationException(
-                $"ASIO driver '{driverName}' does not support {sampleRate} Hz.");
-        }
-        if (inputChannelOffset < 0 ||
-            driverRecordChannelCount > driver.DriverInputChannelCount)
-        {
-            throw new InvalidOperationException(
-                $"ASIO input channel {inputChannelOffset + 1} is not available for driver '{driverName}'.");
-        }
-        if (outputChannelOffset < 0 ||
-            outputChannelOffset + playbackProvider.WaveFormat.Channels > driver.DriverOutputChannelCount)
-        {
-            throw new InvalidOperationException(
-                $"ASIO output channel pair starting at {outputChannelOffset + 1} is not available for driver '{driverName}'.");
-        }
+            if (!driver.IsSampleRateSupported(sampleRate))
+            {
+                throw new InvalidOperationException(
+                    $"ASIO driver '{driverName}' does not support {sampleRate} Hz.");
+            }
+            if (inputChannelOffset < 0 ||
+                driverRecordChannelCount > driver.DriverInputChannelCount)
+            {
+                throw new InvalidOperationException(
+                    $"ASIO input channel {inputChannelOffset + 1} is not available for driver '{driverName}'.");
+            }
+            if (outputChannelOffset < 0 ||
+                outputChannelOffset + playbackProvider.WaveFormat.Channels > driver.DriverOutputChannelCount)
+            {
+                throw new InvalidOperationException(
+                    $"ASIO output channel pair starting at {outputChannelOffset + 1} is not available for driver '{driverName}'.");
+            }
 
-        driver.AudioAvailable += ReceiveAudio;
-        driver.PlaybackStopped += PlaybackStopped;
-        driver.InitRecordAndPlayback(
-            playbackProvider,
-            driverRecordChannelCount,
-            sampleRate);
-        driver.Play();
+            driver.AudioAvailable += ReceiveAudio;
+            driver.PlaybackStopped += PlaybackStopped;
+            driver.InitRecordAndPlayback(
+                playbackProvider,
+                driverRecordChannelCount,
+                sampleRate);
+            driver.Play();
 
-        using CancellationTokenRegistration registration =
-            cancellationToken.Register(() => firstBufferReady.TrySetCanceled(cancellationToken));
-        await firstBufferReady.Task.ConfigureAwait(false);
+            using CancellationTokenRegistration registration =
+                cancellationToken.Register(() => firstBufferReady.TrySetCanceled(cancellationToken));
+            await firstBufferReady.Task.ConfigureAwait(false);
+        }
+        catch
+        {
+            // A driver that fails validation or playback startup (or never
+            // produces the first callback before cancellation) must be detached
+            // here; otherwise it keeps running with live callbacks until the
+            // owner's teardown gets around to disposing the session.
+            StopAndDisposeDriver();
+            throw;
+        }
     }
 
     /// <summary>

--- a/source/Audio/AsioFullDuplexSession.cs
+++ b/source/Audio/AsioFullDuplexSession.cs
@@ -112,6 +112,40 @@ internal sealed class AsioFullDuplexSession : IDisposable
         await firstBufferReady.Task.ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Starts a fresh capture on the running driver. An averaged sweep reuses
+    /// the open ASIO session across runs — the driver keeps playing whatever
+    /// the provider produces (silence after the sweep ends) and only the
+    /// accumulator restarts, instead of paying a full driver re-initialization
+    /// (seconds on slow drivers) for every run.
+    /// </summary>
+    public void ResetCapture(int expectedTotalSamples)
+    {
+        ThrowIfDisposed();
+        this.expectedTotalSamples = expectedTotalSamples;
+        ResetBuffers();
+    }
+
+    /// <summary>
+    /// Stops accumulating samples while the driver keeps running (and keeps
+    /// raising level meters) — used between averaging runs, where minutes of a
+    /// confirmation pause would otherwise grow the capture buffer with
+    /// silence. <see cref="ResetCapture"/> starts the next run's capture.
+    /// </summary>
+    public void PauseCapture()
+    {
+        ThrowIfDisposed();
+        lock (sync)
+        {
+            accumulator = null;
+            foreach (SoundRecorderSampleWaiter waiter in sampleWaiters)
+            {
+                waiter.Cancel();
+            }
+            sampleWaiters.Clear();
+        }
+    }
+
     public Task WaitForSamplesAsync(int sampleCount, CancellationToken cancellationToken)
     {
         if (sampleCount <= 0)
@@ -244,23 +278,23 @@ internal sealed class AsioFullDuplexSession : IDisposable
             sumSquares[channel] = sum;
         }
 
-        List<float[][]>? readySequences;
+        // A paused capture (accumulator == null) skips accumulation but keeps
+        // metering, so the input meter stays live between averaging runs.
+        List<float[][]>? readySequences = null;
         lock (sync)
         {
-            if (accumulator == null)
+            if (accumulator != null)
             {
-                return;
-            }
+                accumulator.Append(convertScratch, frames);
+                readySequences = accumulator.ExtractReadySequences();
 
-            accumulator.Append(convertScratch, frames);
-            readySequences = accumulator.ExtractReadySequences();
-
-            for (int i = sampleWaiters.Count - 1; i >= 0; i--)
-            {
-                if (accumulator.ReadSamples >= sampleWaiters[i].SampleCount)
+                for (int i = sampleWaiters.Count - 1; i >= 0; i--)
                 {
-                    sampleWaiters[i].Complete();
-                    sampleWaiters.RemoveAt(i);
+                    if (accumulator.ReadSamples >= sampleWaiters[i].SampleCount)
+                    {
+                        sampleWaiters[i].Complete();
+                        sampleWaiters.RemoveAt(i);
+                    }
                 }
             }
         }

--- a/source/Audio/AudioDeviceInfo.cs
+++ b/source/Audio/AudioDeviceInfo.cs
@@ -40,17 +40,34 @@ public static class AudioDeviceCatalog
         return devices;
     }
 
+    /// <summary>
+    /// Index of the device with the given number, or -1 when it is absent.
+    /// Callers must keep an absent device visible (see
+    /// <see cref="CreateMissingDevice"/>) instead of remapping the selection —
+    /// falling back to another entry would silently re-target the persisted
+    /// configuration on the next apply.
+    /// </summary>
     public static int FindDeviceIndex(
         IReadOnlyList<AudioDeviceInfo> devices,
         int deviceNumber)
     {
-        int index = devices
-            .Select((device, i) => new { device, i })
-            .FirstOrDefault(candidate =>
-                candidate.device.DeviceNumber == deviceNumber)
-            ?.i ?? 0;
-        return index;
+        for (int i = 0; i < devices.Count; i++)
+        {
+            if (devices[i].DeviceNumber == deviceNumber)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
+
+    /// <summary>
+    /// Placeholder entry for a persisted device that is not currently present,
+    /// keeping its number so an apply re-persists the same configuration.
+    /// </summary>
+    public static AudioDeviceInfo CreateMissingDevice(int deviceNumber) =>
+        new(deviceNumber, $"(missing) Device #{deviceNumber}");
 
     public static IReadOnlyList<int> GetSupportedWaveSampleRates(
         int playbackDeviceNumber,

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -37,6 +37,16 @@ internal sealed class LiveSpectrumController : IDisposable
     private double[]? peakHoldMagnitude;
     private long peakHoldResumeTick;
     private LiveSpectrumSnapshot? lastSnapshot;
+    // The ~30 fps redraw reuses these series and refills their points in place;
+    // recreating the plot objects (and their point lists) every tick was pure
+    // allocation churn. They are removed from and re-added to the model each
+    // tick, which keeps today's z-order against overlays.
+    private LineSeries? peakHoldSeries;
+    private LineSeries? mainSeries;
+    private LineSeries? trustedSeries;
+    private LineSeries? untrustedSeries;
+    private LineSeries? coherenceSeries;
+    private PlotModel? attachedModel;
 
     public LiveSpectrumController(
         Form owner,
@@ -314,14 +324,28 @@ internal sealed class LiveSpectrumController : IDisposable
 
     private void AddLiveSpectrumSeries(PlotModel model, LiveSpectrumSnapshot snapshot)
     {
+        // A reused series must never sit in two models at once: detach the set
+        // from the previous model when the plot model has been rebuilt.
+        if (attachedModel != null && !ReferenceEquals(attachedModel, model))
+        {
+            RemoveLiveSpectrumSeries(attachedModel);
+        }
+        attachedModel = model;
+
         if (liveSpectrumOptions.PeakHold)
         {
             UpdatePeakHold(snapshot.Magnitude);
             if (peakHoldMagnitude != null)
             {
-                LineSeries peakHoldSeries =
-                    plotModelFactory.BuildPeakHoldSeries(peakHoldMagnitude);
-                peakHoldSeries.Tag = LiveSpectrumPeakHoldTag;
+                if (peakHoldSeries == null)
+                {
+                    peakHoldSeries = plotModelFactory.BuildPeakHoldSeries(peakHoldMagnitude);
+                    peakHoldSeries.Tag = LiveSpectrumPeakHoldTag;
+                }
+                else
+                {
+                    plotModelFactory.UpdatePeakHoldSeries(peakHoldSeries, peakHoldMagnitude);
+                }
                 model.Series.Add(peakHoldSeries);
             }
         }
@@ -331,32 +355,57 @@ internal sealed class LiveSpectrumController : IDisposable
             if (snapshot.Coherence != null &&
                 liveSpectrumOptions.CoherenceThresholdPercent > 0)
             {
-                (LineSeries trusted, LineSeries untrusted) =
-                    plotModelFactory.BuildNoiseSeriesSegmented(
+                if (trustedSeries == null || untrustedSeries == null)
+                {
+                    (trustedSeries, untrustedSeries) =
+                        plotModelFactory.BuildNoiseSeriesSegmented(
+                            snapshot.Magnitude,
+                            snapshot.Coherence,
+                            liveSpectrumOptions.CoherenceThresholdPercent);
+                    // Keep the trusted (above-threshold) curve as the canonical primary
+                    // trace so the current-measurement target source uses it, not the
+                    // low-coherence segment.
+                    untrustedSeries.Tag = LiveSpectrumLowCoherenceTag;
+                    trustedSeries.Tag = LiveSpectrumTag;
+                }
+                else
+                {
+                    plotModelFactory.UpdateNoiseSeriesSegmented(
+                        trustedSeries,
+                        untrustedSeries,
                         snapshot.Magnitude,
                         snapshot.Coherence,
                         liveSpectrumOptions.CoherenceThresholdPercent);
-                // Keep the trusted (above-threshold) curve as the canonical primary
-                // trace so the current-measurement target source uses it, not the
-                // low-coherence segment.
-                untrusted.Tag = LiveSpectrumLowCoherenceTag;
-                trusted.Tag = LiveSpectrumTag;
-                model.Series.Add(untrusted);
-                model.Series.Add(trusted);
+                }
+                model.Series.Add(untrustedSeries);
+                model.Series.Add(trustedSeries);
             }
             else
             {
-                LineSeries series = plotModelFactory.BuildNoiseSeries(snapshot.Magnitude);
-                series.Tag = LiveSpectrumTag;
-                model.Series.Add(series);
+                if (mainSeries == null)
+                {
+                    mainSeries = plotModelFactory.BuildNoiseSeries(snapshot.Magnitude);
+                    mainSeries.Tag = LiveSpectrumTag;
+                }
+                else
+                {
+                    plotModelFactory.UpdateNoiseSeries(mainSeries, snapshot.Magnitude);
+                }
+                model.Series.Add(mainSeries);
             }
         }
 
         if (snapshot.Coherence != null && liveSpectrumOptions.ShowCoherence)
         {
-            LineSeries coherenceSeries =
-                plotModelFactory.BuildCoherenceSeries(snapshot.Coherence);
-            coherenceSeries.Tag = LiveSpectrumCoherenceTag;
+            if (coherenceSeries == null)
+            {
+                coherenceSeries = plotModelFactory.BuildCoherenceSeries(snapshot.Coherence);
+                coherenceSeries.Tag = LiveSpectrumCoherenceTag;
+            }
+            else
+            {
+                plotModelFactory.UpdateCoherenceSeries(coherenceSeries, snapshot.Coherence);
+            }
             model.Series.Add(coherenceSeries);
         }
     }

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -409,6 +409,7 @@ namespace Resonalyze
             ExponentialSineSweep sweep = Sweep!;
             SoundRecorder recorder = soundRecorder!;
             bool success = false;
+            AsioSweepCapture? asioCapture = null;
 
             try
             {
@@ -421,9 +422,18 @@ namespace Resonalyze
                         requestedRuns,
                         accumulator.AcceptedRuns,
                         SweepAverageProgressState.Running));
-                    CapturedSweepSamples captured = AudioBackend == AudioBackend.Asio
-                        ? await CaptureAsioAsync(sweep, cancellationToken).ConfigureAwait(false)
-                        : await CaptureWaveAsync(sweep, recorder, cancellationToken).ConfigureAwait(false);
+                    CapturedSweepSamples captured;
+                    if (AudioBackend == AudioBackend.Asio)
+                    {
+                        asioCapture ??= new AsioSweepCapture(this, sweep);
+                        captured = await asioCapture.CaptureRunAsync(cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        captured = await CaptureWaveAsync(sweep, recorder, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
                     SweepRunAnalysis analysis = AnalyzeCapturedRun(captured, sweep);
                     accumulator.Add(analysis);
 
@@ -451,6 +461,10 @@ namespace Resonalyze
             {
                 try
                 {
+                    if (asioCapture != null)
+                    {
+                        await asioCapture.DisposeAsync().ConfigureAwait(false);
+                    }
                     await recorder.StopRecordingAsync().ConfigureAwait(false);
                     SoundRecorder? loopback = loopbackRecorder;
                     if (loopback != null)
@@ -460,7 +474,7 @@ namespace Resonalyze
                 }
                 catch (Exception exception)
                 {
-                    // A recorder stop failure must not demote results that were
+                    // A device stop failure must not demote results that were
                     // already published: ApplyAverageResult has run and raised
                     // ImpulseResponseChanged, so the captured data is complete
                     // regardless of how the device teardown went.
@@ -606,51 +620,102 @@ namespace Resonalyze
                 ValidateSharedDeviceStereo: false);
         }
 
-        private async Task<CapturedSweepSamples> CaptureAsioAsync(
-            ExponentialSineSweep sweep,
-            CancellationToken cancellationToken)
+        // Owns the ASIO session for a whole measurement. The driver is opened
+        // once and kept running across the averaging runs (re-initializing it
+        // per run costs seconds on slow drivers); each run restarts only the
+        // capture accumulator and rewinds the sweep stream.
+        private sealed class AsioSweepCapture : IAsyncDisposable
         {
-            int firstInputOffset = GetAsioCaptureFirstInputOffset();
-            int inputChannelCount = GetRequiredAsioInputChannelCount(firstInputOffset);
+            private readonly ExpSweepMeasurement owner;
+            private readonly ExponentialSineSweep sweep;
+            private readonly AsioFullDuplexSession session;
+            private readonly FloatArrayWaveStream stream;
+            private readonly int firstInputOffset;
+            private bool started;
 
-            using var session = new AsioFullDuplexSession(
-                AsioDriverName ?? string.Empty,
-                firstInputOffset,
-                AsioOutputChannelOffset,
-                inputChannelCount);
-            session.LevelsAvailable += channels => RaiseLevels(
-                MapLevelsByIndex(
-                    channels,
-                    AsioInputChannelOffset - firstInputOffset,
-                    AsioLoopbackInputChannelOffset.HasValue
-                        ? AsioLoopbackInputChannelOffset.Value - firstInputOffset
-                        : null));
-            using FloatArrayWaveStream stream = FloatArrayWaveStream.FromMonoSamples(
-                sweep.SweepData,
-                SampleRate,
-                PlaybackChannel);
+            public AsioSweepCapture(ExpSweepMeasurement owner, ExponentialSineSweep sweep)
+            {
+                this.owner = owner;
+                this.sweep = sweep;
+                firstInputOffset = owner.GetAsioCaptureFirstInputOffset();
+                session = new AsioFullDuplexSession(
+                    owner.AsioDriverName ?? string.Empty,
+                    firstInputOffset,
+                    owner.AsioOutputChannelOffset,
+                    owner.GetRequiredAsioInputChannelCount(firstInputOffset));
+                session.LevelsAvailable += channels => owner.RaiseLevels(
+                    MapLevelsByIndex(
+                        channels,
+                        owner.AsioInputChannelOffset - firstInputOffset,
+                        owner.AsioLoopbackInputChannelOffset.HasValue
+                            ? owner.AsioLoopbackInputChannelOffset.Value - firstInputOffset
+                            : null));
+                stream = FloatArrayWaveStream.FromMonoSamples(
+                    sweep.SweepData,
+                    owner.SampleRate,
+                    owner.PlaybackChannel);
+            }
 
-            await session.StartAsync(
-                stream,
-                SampleRate,
-                autoStop: false,
-                cancellationToken,
-                expectedTotalSamples: sweep.SweepSamples + SampleRate * 2)
-                .ConfigureAwait(false);
-            int requiredSamples = session.ReadSamples + sweep.SweepSamples + SampleRate;
-            await session.WaitForSamplesAsync(requiredSamples, cancellationToken)
-                .ConfigureAwait(false);
-            await session.StopAsync().ConfigureAwait(false);
+            public async Task<CapturedSweepSamples> CaptureRunAsync(
+                CancellationToken cancellationToken)
+            {
+                int expectedTotalSamples = sweep.SweepSamples + owner.SampleRate * 2;
+                if (!started)
+                {
+                    stream.Position = 0;
+                    await session.StartAsync(
+                        stream,
+                        owner.SampleRate,
+                        autoStop: false,
+                        cancellationToken,
+                        expectedTotalSamples)
+                        .ConfigureAwait(false);
+                    started = true;
+                }
+                else
+                {
+                    // The stream has run out (the driver is playing silence);
+                    // a fresh accumulator starts this run's capture and the
+                    // rewind replays the sweep. Reset first so the capture is
+                    // guaranteed to contain the sweep from its first sample.
+                    session.ResetCapture(expectedTotalSamples);
+                    stream.Position = 0;
+                }
 
-            int microphoneIndex = AsioInputChannelOffset - firstInputOffset;
-            int? loopbackIndex = AsioLoopbackInputChannelOffset.HasValue
-                ? AsioLoopbackInputChannelOffset.Value - firstInputOffset
-                : null;
-            return new CapturedSweepSamples(
-                session.GetSamplesSnapshot(),
-                microphoneIndex,
-                loopbackIndex,
-                ValidateSharedDeviceStereo: false);
+                int requiredSamples =
+                    session.ReadSamples + sweep.SweepSamples + owner.SampleRate;
+                await session.WaitForSamplesAsync(requiredSamples, cancellationToken)
+                    .ConfigureAwait(false);
+
+                float[][] samples = session.GetSamplesSnapshot();
+                // Between runs the driver keeps playing silence; pausing the
+                // capture keeps a minutes-long confirmation wait from growing
+                // the buffer while the level meter stays live.
+                session.PauseCapture();
+
+                int microphoneIndex = owner.AsioInputChannelOffset - firstInputOffset;
+                int? loopbackIndex = owner.AsioLoopbackInputChannelOffset.HasValue
+                    ? owner.AsioLoopbackInputChannelOffset.Value - firstInputOffset
+                    : null;
+                return new CapturedSweepSamples(
+                    samples,
+                    microphoneIndex,
+                    loopbackIndex,
+                    ValidateSharedDeviceStereo: false);
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                try
+                {
+                    await session.StopAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    session.Dispose();
+                    stream.Dispose();
+                }
+            }
         }
 
         private static async Task PlayToEndAsync(WaveOutEvent player, CancellationToken cancellationToken)

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -460,8 +460,11 @@ namespace Resonalyze
                 }
                 catch (Exception exception)
                 {
+                    // A recorder stop failure must not demote results that were
+                    // already published: ApplyAverageResult has run and raised
+                    // ImpulseResponseChanged, so the captured data is complete
+                    // regardless of how the device teardown went.
                     LastError ??= exception;
-                    success = false;
                 }
 
                 lock (stateSync)

--- a/source/Measurements/ExponentialSineSweep.cs
+++ b/source/Measurements/ExponentialSineSweep.cs
@@ -17,10 +17,28 @@ public sealed class ExponentialSineSweep : IDisposable
 {
     private PcmStreamSet? streamSet;
     private bool disposed;
+    private bool generated;
+    private float[] sweepData = Array.Empty<float>();
+    private float[] inverseFilter = Array.Empty<float>();
 
-    public float[] SweepData { get; private set; } = Array.Empty<float>();
-    public float[] InverseFilter { get; private set; } = Array.Empty<float>();
-    public float[] Frequencies { get; private set; } = Array.Empty<float>();
+    public float[] SweepData
+    {
+        get
+        {
+            EnsureGenerated();
+            return sweepData;
+        }
+    }
+
+    public float[] InverseFilter
+    {
+        get
+        {
+            EnsureGenerated();
+            return inverseFilter;
+        }
+    }
+
     public int SampleRate { get; private set; }
     public int SweepSamples { get; private set; }
     public int BitsPerSample { get; private set; }
@@ -73,6 +91,12 @@ public sealed class ExponentialSineSweep : IDisposable
         return cycleCount * 2.0 * Math.PI / phaseFactor;
     }
 
+    /// <summary>
+    /// Sets the sweep parameters and the resulting sample count. The signal
+    /// itself is synthesized lazily on first use: restoring a measurement from
+    /// a file or History only needs the parameters (for HarmonicIROffset and
+    /// the panels), not megabytes of sweep and inverse-filter data.
+    /// </summary>
     public void FillData(
         int octaves,
         double requestedDuration,
@@ -87,54 +111,70 @@ public sealed class ExponentialSineSweep : IDisposable
         SampleRate = sampleRate;
         RequestedDuration = requestedDuration;
 
-        double frequencyRatio = Math.Pow(2.0, octaves);
-        double logarithmicRatio = Math.Log(frequencyRatio);
-        double phaseFactor = (Math.PI / frequencyRatio) / logarithmicRatio;
         double exactLength = ComputeQuantizedSweepLength(
             octaves,
             requestedDuration,
             sampleRate);
-        int sampleCount = Math.Max(1, (int)Math.Round(exactLength));
+        SweepSamples = Math.Max(1, (int)Math.Round(exactLength));
 
-        SweepSamples = sampleCount;
-        SweepData = new float[sampleCount];
-        InverseFilter = new float[sampleCount];
-        Frequencies = new float[sampleCount];
+        generated = false;
+        sweepData = Array.Empty<float>();
+        inverseFilter = Array.Empty<float>();
+        streamSet?.Dispose();
+        streamSet = null;
+    }
 
-        double octaveLength = sampleCount / (double)octaves;
+    private void EnsureGenerated()
+    {
+        ThrowIfDisposed();
+        if (generated)
+        {
+            return;
+        }
+        if (SweepSamples <= 0)
+        {
+            throw new InvalidOperationException("The sweep is not configured.");
+        }
+
+        double frequencyRatio = Math.Pow(2.0, Octaves);
+        double logarithmicRatio = Math.Log(frequencyRatio);
+        double phaseFactor = (Math.PI / frequencyRatio) / logarithmicRatio;
+        double exactLength = ComputeQuantizedSweepLength(
+            Octaves,
+            RequestedDuration,
+            SampleRate);
+        int sampleCount = SweepSamples;
+
+        sweepData = new float[sampleCount];
+        inverseFilter = new float[sampleCount];
+
+        double octaveLength = sampleCount / (double)Octaves;
         for (int i = 0; i < sampleCount; i++)
         {
             double exponentialPosition = Math.Exp(i / (double)sampleCount * logarithmicRatio);
-            Frequencies[i] =
-                (float)(sampleRate / 2.0 / frequencyRatio * (exactLength / sampleCount) * exponentialPosition);
-            SweepData[i] =
+            sweepData[i] =
                 (float)Math.Sin(phaseFactor * exactLength * exponentialPosition) *
                 (float)Math.Min(i / octaveLength, 1.0);
         }
 
         // Time reversal performs the deconvolution. The exponential envelope compensates
         // for the sweep spending progressively less time per hertz at high frequencies.
-        double inverseScale = octaves * Math.Log(2.0) / (1.0 - Math.Pow(2.0, -octaves));
-        double perSampleDecay = Math.Pow(2.0, octaves / (double)sampleCount);
+        double inverseScale = Octaves * Math.Log(2.0) / (1.0 - Math.Pow(2.0, -Octaves));
+        double perSampleDecay = Math.Pow(2.0, Octaves / (double)sampleCount);
         for (int i = 0; i < sampleCount; i++)
         {
-            InverseFilter[i] =
-                (float)(SweepData[sampleCount - i - 1] * Math.Pow(perSampleDecay, -i) * inverseScale);
+            inverseFilter[i] =
+                (float)(sweepData[sampleCount - i - 1] * Math.Pow(perSampleDecay, -i) * inverseScale);
         }
 
-        streamSet?.Dispose();
-        streamSet = new PcmStreamSet(SweepData, sampleRate, bitsPerSample);
+        streamSet = new PcmStreamSet(sweepData, SampleRate, BitsPerSample);
+        generated = true;
     }
 
     public RawSourceWaveStream GetStream(PlaybackChannel channel)
     {
-        ThrowIfDisposed();
-        if (streamSet == null)
-        {
-            throw new InvalidOperationException("The sweep is not generated.");
-        }
-
-        return streamSet.GetStream(channel);
+        EnsureGenerated();
+        return streamSet!.GetStream(channel);
     }
 
     private static void ValidateGenerationParameters(

--- a/source/Measurements/SoundRecorder.cs
+++ b/source/Measurements/SoundRecorder.cs
@@ -81,11 +81,22 @@ namespace Resonalyze
             };
             waveSource.DataAvailable += ReceiveData;
             waveSource.RecordingStopped += RecordingStopped;
-            waveSource.StartRecording();
+            try
+            {
+                waveSource.StartRecording();
 
-            using CancellationTokenRegistration registration =
-                cancellationToken.Register(() => firstBufferReady.TrySetCanceled(cancellationToken));
-            await firstBufferReady.Task.ConfigureAwait(false);
+                using CancellationTokenRegistration registration =
+                    cancellationToken.Register(() => firstBufferReady.TrySetCanceled(cancellationToken));
+                await firstBufferReady.Task.ConfigureAwait(false);
+            }
+            catch
+            {
+                // If the device fails to start, stops before the first buffer,
+                // or the caller cancels while waiting for that first buffer, do
+                // not leave an active WaveInEvent (and its callbacks) behind.
+                StopAndDisposeSource();
+                throw;
+            }
         }
 
         public Task WaitForSamplesAsync(int sampleCount, CancellationToken cancellationToken)

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Resonalyze.Dsp;
 
 namespace Resonalyze.Options
 {
@@ -27,6 +28,11 @@ namespace Resonalyze.Options
         private bool initializing;
         private string? microphoneCalibration0DegreesPath;
         private string? microphoneCalibration90DegreesPath;
+        // Remembers the loopback channel choice while a mono or missing
+        // recording device forces the combo to "None", so selecting a stereo
+        // device again restores it instead of losing it on the next apply.
+        private int? preferredWaveLoopbackChannelOffset;
+        private bool updatingWaveLoopbackSelection;
 
         private DarkComboBox comboBoxPlaybackDevice => waveAudioBackendPanel.ComboBoxPlaybackDevice;
 
@@ -137,7 +143,8 @@ namespace Resonalyze.Options
             playbackDevices = AudioDeviceCatalog.GetPlaybackDevices();
             comboBoxPlaybackDevice.Items.Clear();
             comboBoxPlaybackDevice.Items.AddRange(playbackDevices.Cast<object>().ToArray());
-            comboBoxPlaybackDevice.SelectedIndex = AudioDeviceCatalog.FindDeviceIndex(
+            SelectDeviceOrShowMissing(
+                comboBoxPlaybackDevice,
                 playbackDevices,
                 settings.OutputDeviceNumber);
             ConfigureDropDownWidth(comboBoxPlaybackDevice);
@@ -146,7 +153,8 @@ namespace Resonalyze.Options
             recordingDevices = AudioDeviceCatalog.GetRecordingDevices();
             comboBoxRecordingDevice.Items.Clear();
             comboBoxRecordingDevice.Items.AddRange(recordingDevices.Cast<object>().ToArray());
-            comboBoxRecordingDevice.SelectedIndex = AudioDeviceCatalog.FindDeviceIndex(
+            SelectDeviceOrShowMissing(
+                comboBoxRecordingDevice,
                 recordingDevices,
                 settings.InputDeviceNumber);
             ConfigureDropDownWidth(comboBoxRecordingDevice);
@@ -157,11 +165,18 @@ namespace Resonalyze.Options
                 SharedLoopbackDeviceSentinel,
                 "Same as microphone device"));
             comboBoxWaveLoopbackDevice.Items.AddRange(recordingDevices.Cast<object>().ToArray());
-            comboBoxWaveLoopbackDevice.SelectedIndex = settings.WaveLoopbackDeviceNumber.HasValue
-                ? 1 + AudioDeviceCatalog.FindDeviceIndex(
+            if (settings.WaveLoopbackDeviceNumber is int loopbackDeviceNumber)
+            {
+                SelectDeviceOrShowMissing(
+                    comboBoxWaveLoopbackDevice,
                     recordingDevices,
-                    settings.WaveLoopbackDeviceNumber.Value)
-                : 0;
+                    loopbackDeviceNumber,
+                    itemOffset: 1);
+            }
+            else
+            {
+                comboBoxWaveLoopbackDevice.SelectedIndex = 0;
+            }
             ConfigureDropDownWidth(comboBoxWaveLoopbackDevice);
             UpdateComboBoxToolTip(comboBoxWaveLoopbackDevice);
 
@@ -171,12 +186,25 @@ namespace Resonalyze.Options
 
             asioDrivers = AsioDeviceCatalog.GetDrivers();
             comboBoxAsioDriver.Items.Clear();
-            if (asioDrivers.Count > 0)
+            comboBoxAsioDriver.Items.AddRange(asioDrivers.Cast<object>().ToArray());
+            int asioDriverIndex = AsioDeviceCatalog.FindDriverIndex(
+                asioDrivers,
+                settings.AsioDriverName);
+            if (asioDriverIndex < 0 && !string.IsNullOrWhiteSpace(settings.AsioDriverName))
             {
-                comboBoxAsioDriver.Items.AddRange(asioDrivers.Cast<object>().ToArray());
-                comboBoxAsioDriver.SelectedIndex = AsioDeviceCatalog.FindDriverIndex(
-                    asioDrivers,
-                    settings.AsioDriverName);
+                // The saved driver is currently absent (uninstalled, or the ASIO
+                // subsystem is unavailable). Keep it selectable so an apply
+                // re-persists the same name instead of another driver or null.
+                comboBoxAsioDriver.Items.Add(
+                    new AsioDeviceInfo(settings.AsioDriverName, Missing: true));
+                asioDriverIndex = comboBoxAsioDriver.Items.Count - 1;
+            }
+            if (asioDriverIndex >= 0)
+            {
+                comboBoxAsioDriver.SelectedIndex = asioDriverIndex;
+            }
+            if (comboBoxAsioDriver.Items.Count > 0)
+            {
                 ConfigureDropDownWidth(comboBoxAsioDriver);
                 UpdateComboBoxToolTip(comboBoxAsioDriver);
             }
@@ -350,9 +378,27 @@ namespace Resonalyze.Options
                 }
             }
 
-            return dialog.ShowDialog(this) == DialogResult.OK
-                ? dialog.FileName
-                : currentPath;
+            if (dialog.ShowDialog(this) != DialogResult.OK)
+            {
+                return currentPath;
+            }
+
+            // Probe the pick immediately: a file that cannot be parsed would
+            // otherwise fail silently at plot time and leave every measurement
+            // uncalibrated. The selection is kept so the user can fix the file.
+            var probe = new CalibrationFile(dialog.FileName);
+            if (!probe.HasData)
+            {
+                MessageBox.Show(
+                    this,
+                    "The selected calibration file could not be loaded; measurements " +
+                    $"will be shown uncalibrated until it is fixed.\r\n\r\n{probe.LoadError}",
+                    "Microphone calibration",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
+
+            return dialog.FileName;
         }
 
         private void UpdateCalibrationButtons()
@@ -373,19 +419,21 @@ namespace Resonalyze.Options
             string? path)
         {
             string? normalized = NormalizeCalibrationPath(path);
-            bool missing = normalized != null && !File.Exists(normalized);
+            // Covers a deleted file and an existing-but-unparsable one; both
+            // silently disable the correction at plot time otherwise.
+            string? problem = normalized == null
+                ? null
+                : new CalibrationFile(normalized).LoadError;
             selectButton.Text = normalized == null
                 ? "Select file..."
                 : Path.GetFileName(normalized);
-            selectButton.ForeColor = missing ? Color.LightSalmon : Color.White;
+            selectButton.ForeColor = problem != null ? Color.LightSalmon : Color.White;
             clearButton.Enabled = normalized != null;
             deviceToolTip.SetToolTip(
                 selectButton,
                 normalized == null
                     ? "No calibration file selected."
-                    : missing
-                        ? $"Calibration file not found: {normalized}"
-                        : normalized);
+                    : problem ?? normalized);
             deviceToolTip.SetToolTip(
                 clearButton,
                 normalized == null
@@ -453,6 +501,10 @@ namespace Resonalyze.Options
                 return;
             }
 
+            if (!updatingWaveLoopbackSelection)
+            {
+                preferredWaveLoopbackChannelOffset = GetSelectedWaveLoopbackChannelOffset();
+            }
             UpdateWaveLoopbackControls();
             RefreshSampleRateOptions(GetSelectedSampleRate());
         }
@@ -646,15 +698,34 @@ namespace Resonalyze.Options
                     .ToArray());
             comboBoxAsioOutputChannel.Items.AddRange(
                 asioDriverInfo.OutputChannels.Cast<object>().ToArray());
-            comboBoxAsioInputChannel.SelectedIndex = AsioDeviceCatalog.FindChannelIndex(
+            // With no driver selected at all there is nothing to preserve; with a
+            // named driver that cannot be opened (busy/uninstalled) the saved
+            // channel routing must not collapse to channel 1 / "None" and get
+            // re-persisted by the next apply.
+            bool preserveOffsets = !string.IsNullOrWhiteSpace(asioDriverInfo.DriverName);
+            comboBoxAsioInputChannel.SelectedIndex = SelectAsioChannelIndex(
+                comboBoxAsioInputChannel,
                 asioDriverInfo.InputChannels,
-                preferredInputOffset);
-            comboBoxAsioLoopbackChannel.SelectedIndex = FindInputChannelOptionIndex(
+                preferredInputOffset,
+                preserveOffsets);
+            int loopbackIndex = FindInputChannelOptionIndex(
                 comboBoxAsioLoopbackChannel,
                 preferredLoopbackOffset);
-            comboBoxAsioOutputChannel.SelectedIndex = AsioDeviceCatalog.FindChannelIndex(
+            if (loopbackIndex < 0 &&
+                preserveOffsets &&
+                preferredLoopbackOffset is int missingLoopbackOffset)
+            {
+                comboBoxAsioLoopbackChannel.Items.Add(new InputChannelOption(
+                    missingLoopbackOffset,
+                    $"{missingLoopbackOffset + 1}: (missing)"));
+                loopbackIndex = comboBoxAsioLoopbackChannel.Items.Count - 1;
+            }
+            comboBoxAsioLoopbackChannel.SelectedIndex = Math.Max(0, loopbackIndex);
+            comboBoxAsioOutputChannel.SelectedIndex = SelectAsioChannelIndex(
+                comboBoxAsioOutputChannel,
                 asioDriverInfo.OutputChannels,
-                preferredOutputOffset);
+                preferredOutputOffset,
+                preserveOffsets);
 
             UpdateAsioStatusLabels();
         }
@@ -710,6 +781,7 @@ namespace Resonalyze.Options
                 preferredLoopbackOffset.HasValue
                     ? preferredLoopbackOffset.Value == 1 ? 2 : 1
                     : 0;
+            preferredWaveLoopbackChannelOffset = preferredLoopbackOffset;
             UpdateWaveLoopbackControls();
         }
 
@@ -725,8 +797,23 @@ namespace Resonalyze.Options
             bool supportsLoopback = SelectedRecordingDeviceSupportsWaveLoopback();
             if (!supportsLoopback && comboBoxWaveLoopbackChannel.Items.Count > 0)
             {
-                comboBoxWaveLoopbackChannel.SelectedIndex = 0;
+                // Forced, not a user choice: the preferred offset is kept so a
+                // stereo device restores it below.
+                SetWaveLoopbackSelection(0);
                 loopbackSelected = false;
+            }
+            else if (supportsLoopback &&
+                !loopbackSelected &&
+                preferredWaveLoopbackChannelOffset is int rememberedOffset)
+            {
+                int rememberedIndex = FindInputChannelOptionIndex(
+                    comboBoxWaveLoopbackChannel,
+                    rememberedOffset);
+                if (rememberedIndex >= 0)
+                {
+                    SetWaveLoopbackSelection(rememberedIndex);
+                    loopbackSelected = true;
+                }
             }
             comboBoxWaveLoopbackChannel.Enabled =
                 comboBoxAudioBackend.SelectedIndex != (int)AudioBackend.Asio &&
@@ -765,6 +852,25 @@ namespace Resonalyze.Options
             labelWaveLoopbackStatus.ForeColor = supportsLoopback
                 ? Color.LightGray
                 : Color.LightSalmon;
+        }
+
+        private void SetWaveLoopbackSelection(int index)
+        {
+            if (comboBoxWaveLoopbackChannel.SelectedIndex == index)
+            {
+                return;
+            }
+
+            bool wasUpdating = updatingWaveLoopbackSelection;
+            updatingWaveLoopbackSelection = true;
+            try
+            {
+                comboBoxWaveLoopbackChannel.SelectedIndex = index;
+            }
+            finally
+            {
+                updatingWaveLoopbackSelection = wasUpdating;
+            }
         }
 
         private Font NormalStatusFont =>
@@ -819,7 +925,46 @@ namespace Resonalyze.Options
                 }
             }
 
-            return 0;
+            return -1;
+        }
+
+        // A persisted device that is not currently present stays visible as a
+        // "(missing)" entry with its original number, so an apply cannot
+        // silently re-target the configuration to another device.
+        private static void SelectDeviceOrShowMissing(
+            DarkComboBox comboBox,
+            IReadOnlyList<AudioDeviceInfo> devices,
+            int deviceNumber,
+            int itemOffset = 0)
+        {
+            int index = AudioDeviceCatalog.FindDeviceIndex(devices, deviceNumber);
+            if (index >= 0)
+            {
+                comboBox.SelectedIndex = itemOffset + index;
+                return;
+            }
+
+            comboBox.Items.Add(AudioDeviceCatalog.CreateMissingDevice(deviceNumber));
+            comboBox.SelectedIndex = comboBox.Items.Count - 1;
+        }
+
+        // Same idea for ASIO channels: an offset the driver does not currently
+        // report (fewer channels, or the driver failed to open — e.g. it is in
+        // use by another application) must survive the panel round-trip.
+        private static int SelectAsioChannelIndex(
+            DarkComboBox comboBox,
+            IReadOnlyList<AsioChannelInfo> channels,
+            int preferredOffset,
+            bool preserveMissingOffset)
+        {
+            int index = AsioDeviceCatalog.FindChannelIndex(channels, preferredOffset);
+            if (index >= 0 || !preserveMissingOffset)
+            {
+                return index;
+            }
+
+            comboBox.Items.Add(new AsioChannelInfo(preferredOffset, "(missing)"));
+            return comboBox.Items.Count - 1;
         }
 
         private void ValidateSelectedAsioDriver(int sampleRate)

--- a/source/Options/MicrophoneCalibrationComboHelper.cs
+++ b/source/Options/MicrophoneCalibrationComboHelper.cs
@@ -13,26 +13,17 @@ internal static class MicrophoneCalibrationComboHelper
     {
         comboBox.Items.Clear();
         comboBox.DropDownStyle = ComboBoxStyle.DropDownList;
-        comboBox.Items.Add(new MicrophoneCalibrationOption(
-            MicrophoneCalibrationMode.Off,
-            "Off"));
-
-        if (hasZeroDegreeCalibration)
+        IReadOnlyList<MicrophoneCalibrationOption> options = BuildOptions(
+            selectedMode,
+            hasZeroDegreeCalibration,
+            hasNinetyDegreeCalibration);
+        foreach (MicrophoneCalibrationOption option in options)
         {
-            comboBox.Items.Add(new MicrophoneCalibrationOption(
-                MicrophoneCalibrationMode.Degrees0,
-                "0 degrees"));
+            comboBox.Items.Add(option);
         }
 
-        if (hasNinetyDegreeCalibration)
-        {
-            comboBox.Items.Add(new MicrophoneCalibrationOption(
-                MicrophoneCalibrationMode.Degrees90,
-                "90 degrees"));
-        }
-
-        comboBox.SelectedIndex = FindIndex(comboBox, selectedMode);
-        comboBox.Enabled = comboBox.Items.Count > 1;
+        comboBox.SelectedIndex = FindIndex(options, selectedMode);
+        comboBox.Enabled = options.Count > 1;
     }
 
     public static MicrophoneCalibrationMode GetSelectedMode(DarkComboBox comboBox) =>
@@ -40,14 +31,45 @@ internal static class MicrophoneCalibrationComboHelper
             ? option.Mode
             : MicrophoneCalibrationMode.Off;
 
-    private static int FindIndex(
-        DarkComboBox comboBox,
+    // The persisted mode stays selectable even when its file is currently
+    // missing. Dropping the entry would land the selection on "Off" and the
+    // next apply would silently overwrite the stored preference.
+    internal static IReadOnlyList<MicrophoneCalibrationOption> BuildOptions(
+        MicrophoneCalibrationMode selectedMode,
+        bool hasZeroDegreeCalibration,
+        bool hasNinetyDegreeCalibration)
+    {
+        var options = new List<MicrophoneCalibrationOption>
+        {
+            new(MicrophoneCalibrationMode.Off, "Off")
+        };
+
+        if (hasZeroDegreeCalibration ||
+            selectedMode == MicrophoneCalibrationMode.Degrees0)
+        {
+            options.Add(new MicrophoneCalibrationOption(
+                MicrophoneCalibrationMode.Degrees0,
+                hasZeroDegreeCalibration ? "0 degrees" : "0 degrees (file missing)"));
+        }
+
+        if (hasNinetyDegreeCalibration ||
+            selectedMode == MicrophoneCalibrationMode.Degrees90)
+        {
+            options.Add(new MicrophoneCalibrationOption(
+                MicrophoneCalibrationMode.Degrees90,
+                hasNinetyDegreeCalibration ? "90 degrees" : "90 degrees (file missing)"));
+        }
+
+        return options;
+    }
+
+    internal static int FindIndex(
+        IReadOnlyList<MicrophoneCalibrationOption> options,
         MicrophoneCalibrationMode selectedMode)
     {
-        for (int index = 0; index < comboBox.Items.Count; index++)
+        for (int index = 0; index < options.Count; index++)
         {
-            if (comboBox.Items[index] is MicrophoneCalibrationOption option &&
-                option.Mode == selectedMode)
+            if (options[index].Mode == selectedMode)
             {
                 return index;
             }
@@ -56,7 +78,7 @@ internal static class MicrophoneCalibrationComboHelper
         return 0;
     }
 
-    private sealed class MicrophoneCalibrationOption
+    internal sealed class MicrophoneCalibrationOption
     {
         public MicrophoneCalibrationOption(
             MicrophoneCalibrationMode mode,
@@ -68,7 +90,7 @@ internal static class MicrophoneCalibrationComboHelper
 
         public MicrophoneCalibrationMode Mode { get; }
 
-        private string DisplayName { get; }
+        public string DisplayName { get; }
 
         public override string ToString() => DisplayName;
     }

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -590,6 +590,7 @@ public sealed class Overlay
 
     // Target kind.
     private bool targetConfigured;
+    private readonly TargetOverlayCurveBuilder targetCurveBuilder = new();
     private int targetSourceSlot;
     private TargetPreset targetPreset = TargetPreset.HarmanRoom;
     private double targetTiltDbPerOctave;
@@ -819,7 +820,7 @@ public sealed class Overlay
     // Builds this Target overlay's shape on the default grid for the EQ Wizard
     // plot, returning a self-contained curve description (no plot mutation).
     internal EqWizardCurve? BuildTargetWizardCurve() =>
-        BuildTargetWizardCurveOn(DefaultTargetGrid);
+        BuildTargetWizardCurveOn(TargetOverlayCurveBuilder.DefaultTargetGrid);
 
     // Same target shape, evaluated at the supplied frequencies so it lines up
     // point-for-point with the source curve (needed for an exact area fill).
@@ -994,17 +995,13 @@ public sealed class Overlay
     {
         double offset = (double)offsetControl.Value;
 
-        // The target shape and its tolerance band are parametric over frequency, so
-        // always build them on the full grid — they must never be clipped to the
-        // measurement, even when its coverage is partial or absent.
-        TargetCurveResult result = OverlayMath.BuildTarget(
-            DefaultTargetGrid,
+        // The shape and tolerance band are constant between edits; the builder
+        // caches them so the ~30 fps live redraw does not rebuild the grid math.
+        TargetOverlayShape shape = targetCurveBuilder.BuildShape(
             spec,
             offset,
-            toleranceDb,
-            0,
-            TargetDeviationMode.None);
-        if (result.Target.Length < 2)
+            toleranceDb);
+        if (shape.Target.Length < 2)
         {
             return false;
         }
@@ -1012,26 +1009,24 @@ public sealed class Overlay
         // Deviation / EQ correction compares against the incoming curve, so it is
         // built from the source and clipped to wherever that curve has data (gaps
         // appear where, for example, coherence is below the threshold).
-        OverlayPoint[] deviation = Array.Empty<OverlayPoint>();
-        if (deviationMode != TargetDeviationMode.None &&
-            ResolveTargetSource(sourceSlot) is { Length: >= 2 } source)
-        {
-            deviation = OverlayMath.BuildTarget(
-                source,
-                spec,
-                offset,
-                0,
-                smoothing,
-                deviationMode).Deviation;
-        }
+        DataPoint[] deviation =
+            deviationMode != TargetDeviationMode.None &&
+            ResolveTargetSource(sourceSlot) is { Length: >= 2 } source
+                ? TargetOverlayCurveBuilder.BuildDeviation(
+                    source,
+                    spec,
+                    offset,
+                    smoothing,
+                    deviationMode)
+                : Array.Empty<DataPoint>();
 
         byte alpha = (byte)Math.Round(opacity / 100.0 * 255);
         OxyColor lineColor = OxyColor.FromArgb(alpha, color.R, color.G, color.B);
         string? trackerFormat = OverlayCollection.GetTrackerFormatString(SeriesMode);
 
         // Tolerance band first so the curves draw on top of it.
-        if (result.ToleranceUpper.Length >= 2 &&
-            result.ToleranceLower.Length == result.ToleranceUpper.Length)
+        if (shape.ToleranceUpper.Length >= 2 &&
+            shape.ToleranceLower.Length == shape.ToleranceUpper.Length)
         {
             var band = new OxyPlot.Series.AreaSeries
             {
@@ -1040,8 +1035,8 @@ public sealed class Overlay
                 StrokeThickness = 0,
                 Tag = GetTag("tolerance")
             };
-            band.Points.AddRange(result.ToleranceUpper.Select(p => new DataPoint(p.X, p.Y)));
-            band.Points2.AddRange(result.ToleranceLower.Select(p => new DataPoint(p.X, p.Y)));
+            band.Points.AddRange(shape.ToleranceUpper);
+            band.Points2.AddRange(shape.ToleranceLower);
             model.Series.Add(band);
         }
 
@@ -1057,7 +1052,7 @@ public sealed class Overlay
         {
             targetSeries.TrackerFormatString = trackerFormat;
         }
-        targetSeries.Points.AddRange(result.Target.Select(p => new DataPoint(p.X, p.Y)));
+        targetSeries.Points.AddRange(shape.Target);
         model.Series.Add(targetSeries);
 
         if (deviation.Length >= 2)
@@ -1077,8 +1072,7 @@ public sealed class Overlay
             {
                 deviationSeries.TrackerFormatString = trackerFormat;
             }
-            deviationSeries.Points.AddRange(
-                deviation.Select(p => new DataPoint(p.X, p.Y)));
+            deviationSeries.Points.AddRange(deviation);
             model.Series.Add(deviationSeries);
         }
 
@@ -1109,26 +1103,6 @@ public sealed class Overlay
             settings.LineStyle,
             settings.Name.Length > 0 ? settings.Name : Title);
         RefreshPlot(model);
-    }
-
-    // Log-spaced 20 Hz … 20 kHz grid used to draw a target shape and its tolerance
-    // band when no measurement curve is on the plot to supply frequencies.
-    private static readonly OverlayPoint[] DefaultTargetGrid = BuildDefaultTargetGrid();
-
-    private static OverlayPoint[] BuildDefaultTargetGrid()
-    {
-        const double minHz = 20.0;
-        const double maxHz = 20_000.0;
-        const int count = 512;
-        var grid = new OverlayPoint[count];
-        double logMin = Math.Log10(minHz);
-        double logStep = (Math.Log10(maxHz) - logMin) / (count - 1);
-        for (int i = 0; i < count; i++)
-        {
-            grid[i] = new OverlayPoint(Math.Pow(10.0, logMin + i * logStep), 0.0);
-        }
-
-        return grid;
     }
 
     private TargetCurveSpec CurrentTargetSpec() => new(

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -696,6 +696,30 @@ public sealed class Overlay
         {
             Debug.WriteLine(
                 $"Failed to load overlay slot {Index} for {mode}: {exception}");
+            QuarantineCorruptSlot(mode, exception);
+        }
+    }
+
+    // A slot file that fails to load used to present as an empty slot and the
+    // next capture silently overwrote it. Setting it aside keeps the damaged
+    // data recoverable and makes each broken file warn exactly once.
+    private void QuarantineCorruptSlot(Mode mode, Exception error)
+    {
+        try
+        {
+            string? quarantinePath = OverlayFile.QuarantineCorruptFile(mode, Index);
+            if (quarantinePath != null)
+            {
+                ShowStorageError(
+                    $"Overlay slot {Index} for {mode} could not be loaded; " +
+                    $"the file was kept as {Path.GetFileName(quarantinePath)}.",
+                    error);
+            }
+        }
+        catch
+        {
+            // A transiently locked file stays in place and is retried on the
+            // next mode switch; quarantining must never break the switch itself.
         }
     }
 

--- a/source/Overlays/OverlayFile.cs
+++ b/source/Overlays/OverlayFile.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -11,6 +12,15 @@ public sealed class OverlayFile
     public const string CurrentFormat = "resonalyze-overlay";
     public const int CurrentVersion = 5;
     public const int MaximumSlotCount = 12;
+
+    // Every mode switch re-reads all 12 slot files; the cache turns the
+    // unchanged case into a stat call. In-app Save/Delete/Quarantine invalidate
+    // their entry, external edits are caught by the write-stamp check. Loaded
+    // instances are never mutated by callers (ApplyFile copies the values out).
+    private static readonly ConcurrentDictionary<
+        string,
+        (DateTime WriteTimeUtc, long Length, OverlayFile File)> LoadCache =
+        new(StringComparer.OrdinalIgnoreCase);
 
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
@@ -123,6 +133,9 @@ public sealed class OverlayFile
             }
 
             File.Move(temporaryPath, path, overwrite: true);
+            // Invalidate rather than store `this`: the cache must only hold
+            // instances that no caller can mutate, i.e. those Load creates.
+            LoadCache.TryRemove(path, out _);
         }
         finally
         {
@@ -139,9 +152,18 @@ public sealed class OverlayFile
         string? rootDirectory = null)
     {
         string path = GetPath(mode, slot, rootDirectory);
-        if (!File.Exists(path))
+        var info = new FileInfo(path);
+        if (!info.Exists)
         {
+            LoadCache.TryRemove(path, out _);
             return null;
+        }
+
+        if (LoadCache.TryGetValue(path, out var cached) &&
+            cached.WriteTimeUtc == info.LastWriteTimeUtc &&
+            cached.Length == info.Length)
+        {
+            return cached.File;
         }
 
         using FileStream stream = new(
@@ -161,6 +183,7 @@ public sealed class OverlayFile
                 "The overlay file does not match its mode and slot.");
         }
 
+        LoadCache[path] = (info.LastWriteTimeUtc, info.Length, file);
         return file;
     }
 
@@ -182,6 +205,7 @@ public sealed class OverlayFile
 
         string quarantinePath = path + ".corrupt";
         File.Move(path, quarantinePath, overwrite: true);
+        LoadCache.TryRemove(path, out _);
         return quarantinePath;
     }
 
@@ -191,6 +215,7 @@ public sealed class OverlayFile
         string? rootDirectory = null)
     {
         string path = GetPath(mode, slot, rootDirectory);
+        LoadCache.TryRemove(path, out _);
         if (File.Exists(path))
         {
             File.Delete(path);

--- a/source/Overlays/OverlayFile.cs
+++ b/source/Overlays/OverlayFile.cs
@@ -164,6 +164,27 @@ public sealed class OverlayFile
         return file;
     }
 
+    /// <summary>
+    /// Moves a slot file that failed to load aside as "&lt;name&gt;.corrupt" so
+    /// the next save cannot silently overwrite the damaged data. Returns the
+    /// quarantine path, or null when there is no slot file to move.
+    /// </summary>
+    public static string? QuarantineCorruptFile(
+        Mode mode,
+        int slot,
+        string? rootDirectory = null)
+    {
+        string path = GetPath(mode, slot, rootDirectory);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        string quarantinePath = path + ".corrupt";
+        File.Move(path, quarantinePath, overwrite: true);
+        return quarantinePath;
+    }
+
     public static void Delete(
         Mode mode,
         int slot,

--- a/source/Overlays/OverlayMath.cs
+++ b/source/Overlays/OverlayMath.cs
@@ -216,7 +216,12 @@ public static class OverlayMath
                 : ApplyOperation(aValue, bValue, operation, wrapPhaseDifference);
             if (useAmplitudeSpace)
             {
-                value = DataHelper.AmplitudeToDecibels(value);
+                // A non-positive amplitude difference has no dB representation;
+                // emit NaN so the plot draws an honest gap instead of the
+                // -160 dB floor the conversion would clamp to.
+                value = value > 0
+                    ? DataHelper.AmplitudeToDecibels(value)
+                    : double.NaN;
             }
             if (!double.IsInfinity(value))
             {

--- a/source/Overlays/TargetOverlayCurveBuilder.cs
+++ b/source/Overlays/TargetOverlayCurveBuilder.cs
@@ -1,0 +1,107 @@
+using OxyPlot;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Builds the plot-ready curves of a Target overlay. The parametric target
+/// shape and its tolerance band depend only on the spec, offset and tolerance,
+/// so they are cached and reused across the ~30 fps live redraws; only the
+/// deviation curve, which follows the measurement, is rebuilt per call.
+/// </summary>
+internal sealed class TargetOverlayCurveBuilder
+{
+    /// <summary>
+    /// Log-spaced 20 Hz … 20 kHz grid used to draw a target shape and its
+    /// tolerance band. The shape is parametric over frequency and must never
+    /// be clipped to the measurement, even when its coverage is partial.
+    /// </summary>
+    internal static readonly OverlayPoint[] DefaultTargetGrid = BuildDefaultTargetGrid();
+
+    private TargetShapeKey? cachedKey;
+    private TargetOverlayShape? cachedShape;
+
+    public TargetOverlayShape BuildShape(
+        TargetCurveSpec spec,
+        double offsetDb,
+        double toleranceDb)
+    {
+        var key = new TargetShapeKey(spec, offsetDb, toleranceDb);
+        if (cachedShape != null && key == cachedKey)
+        {
+            return cachedShape;
+        }
+
+        TargetCurveResult result = OverlayMath.BuildTarget(
+            DefaultTargetGrid,
+            spec,
+            offsetDb,
+            toleranceDb,
+            0,
+            TargetDeviationMode.None);
+        cachedShape = new TargetOverlayShape(
+            ToDataPoints(result.Target),
+            ToDataPoints(result.ToleranceUpper),
+            ToDataPoints(result.ToleranceLower));
+        cachedKey = key;
+        return cachedShape;
+    }
+
+    public static DataPoint[] BuildDeviation(
+        IReadOnlyList<OverlayPoint> source,
+        TargetCurveSpec spec,
+        double offsetDb,
+        int smoothingInverseOctaves,
+        TargetDeviationMode deviationMode)
+    {
+        if (deviationMode == TargetDeviationMode.None || source.Count < 2)
+        {
+            return Array.Empty<DataPoint>();
+        }
+
+        return ToDataPoints(OverlayMath.BuildTarget(
+            source,
+            spec,
+            offsetDb,
+            0,
+            smoothingInverseOctaves,
+            deviationMode).Deviation);
+    }
+
+    private static DataPoint[] ToDataPoints(OverlayPoint[] points)
+    {
+        var result = new DataPoint[points.Length];
+        for (int i = 0; i < points.Length; i++)
+        {
+            result[i] = new DataPoint(points[i].X, points[i].Y);
+        }
+
+        return result;
+    }
+
+    private static OverlayPoint[] BuildDefaultTargetGrid()
+    {
+        const double minHz = 20.0;
+        const double maxHz = 20_000.0;
+        const int count = 512;
+        var grid = new OverlayPoint[count];
+        double logMin = Math.Log10(minHz);
+        double logStep = (Math.Log10(maxHz) - logMin) / (count - 1);
+        for (int i = 0; i < count; i++)
+        {
+            grid[i] = new OverlayPoint(Math.Pow(10.0, logMin + i * logStep), 0.0);
+        }
+
+        return grid;
+    }
+
+    private sealed record TargetShapeKey(
+        TargetCurveSpec Spec,
+        double OffsetDb,
+        double ToleranceDb);
+}
+
+/// <summary>Plot-ready curves of a target shape; arrays are cached, do not mutate.</summary>
+internal sealed record TargetOverlayShape(
+    DataPoint[] Target,
+    DataPoint[] ToleranceUpper,
+    DataPoint[] ToleranceLower);

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -619,10 +619,15 @@ internal sealed class PlotModelFactory
             Title = "Live Transfer Function",
             TrackerFormatString = "{0}\n{2:0.0} Hz\n{4:0.00} dB"
         };
-        series.Points.AddRange(
-            OxyPlotAdapter.ToDataPoints(ResampleLiveSpectrumMagnitude(accumulatedData)));
+        UpdateNoiseSeries(series, accumulatedData);
         return series;
     }
+
+    // The ~30 fps live redraw refills the existing series in place; reusing the
+    // series object (and its point list's capacity) avoids re-allocating plot
+    // objects on every tick.
+    public void UpdateNoiseSeries(LineSeries series, double[] magnitude) =>
+        FillPoints(series, ResampleLiveSpectrumMagnitude(magnitude));
 
     public LineSeries BuildPeakHoldSeries(double[] peakHoldData)
     {
@@ -634,9 +639,20 @@ internal sealed class PlotModelFactory
             Title = "Peak Hold",
             TrackerFormatString = "{0}\n{2:0.0} Hz\n{4:0.00} dB"
         };
-        series.Points.AddRange(
-            OxyPlotAdapter.ToDataPoints(ResampleLiveSpectrumMagnitude(peakHoldData)));
+        UpdatePeakHoldSeries(series, peakHoldData);
         return series;
+    }
+
+    public void UpdatePeakHoldSeries(LineSeries series, double[] peakHoldData) =>
+        FillPoints(series, ResampleLiveSpectrumMagnitude(peakHoldData));
+
+    private static void FillPoints(LineSeries series, List<SignalPoint> points)
+    {
+        series.Points.Clear();
+        foreach (SignalPoint point in points)
+        {
+            series.Points.Add(new DataPoint(point.X, point.Y));
+        }
     }
 
     private List<SignalPoint> ResampleLiveSpectrumMagnitude(double[] magnitude)
@@ -673,6 +689,13 @@ internal sealed class PlotModelFactory
             liveSpectrumOptions.SmoothingInverseOctaves);
     }
 
+    public void UpdateCoherenceSeries(LineSeries series, double[] coherence) =>
+        FillPoints(series, ResampleCoherence(
+            coherence,
+            noiseMeasurement.SampleRate,
+            noiseMeasurement.SequenceLength,
+            liveSpectrumOptions.SmoothingInverseOctaves));
+
     private LineSeries BuildCoherenceSeries(
         double[] coherence,
         int sampleRate,
@@ -689,15 +712,11 @@ internal sealed class PlotModelFactory
             LineStyle = LineStyle.Dash,
             TrackerFormatString = "{0}\n{2:0.0} Hz\n{4:0.00} \u03B3\u00B2" // γ²
         };
-        foreach (SignalPoint point in ResampleCoherence(
+        FillPoints(series, ResampleCoherence(
             coherence,
             sampleRate,
             fftLength,
-            smoothingInverseOctaves))
-        {
-            series.Points.Add(new DataPoint(point.X, point.Y));
-        }
-
+            smoothingInverseOctaves));
         return series;
     }
 
@@ -708,6 +727,31 @@ internal sealed class PlotModelFactory
     /// points so the two lines join seamlessly.
     /// </summary>
     public (LineSeries Trusted, LineSeries Untrusted) BuildNoiseSeriesSegmented(
+        double[] magnitude,
+        double[] coherence,
+        int thresholdPercent)
+    {
+        var trusted = new LineSeries
+        {
+            Color = OxyColor.FromRgb(255, 0, 127),
+            Title = "Live Transfer Function",
+            TrackerFormatString = "{0}\n{2:0.0} Hz\n{4:0.00} dB"
+        };
+        var untrusted = new LineSeries
+        {
+            Color = OxyColor.FromAColor(140, OxyColor.FromRgb(170, 170, 170)),
+            LineStyle = LineStyle.Dash,
+            StrokeThickness = 1.0,
+            Title = "Low coherence",
+            TrackerFormatString = "{0}\n{2:0.0} Hz\n{4:0.00} dB"
+        };
+        UpdateNoiseSeriesSegmented(trusted, untrusted, magnitude, coherence, thresholdPercent);
+        return (trusted, untrusted);
+    }
+
+    public void UpdateNoiseSeriesSegmented(
+        LineSeries trusted,
+        LineSeries untrusted,
         double[] magnitude,
         double[] coherence,
         int thresholdPercent)
@@ -735,23 +779,10 @@ internal sealed class PlotModelFactory
                 threshold;
         }
 
-        var trusted = new LineSeries
-        {
-            Color = OxyColor.FromRgb(255, 0, 127),
-            Title = "Live Transfer Function",
-            TrackerFormatString = "{0}\n{2:0.0} Hz\n{4:0.00} dB"
-        };
-        var untrusted = new LineSeries
-        {
-            Color = OxyColor.FromAColor(140, OxyColor.FromRgb(170, 170, 170)),
-            LineStyle = LineStyle.Dash,
-            StrokeThickness = 1.0,
-            Title = "Low coherence",
-            TrackerFormatString = "{0}\n{2:0.0} Hz\n{4:0.00} dB"
-        };
-
         bool IsTrusted(int index) => trustedFlags[index];
 
+        trusted.Points.Clear();
+        untrusted.Points.Clear();
         for (int i = 0; i < count; i++)
         {
             bool trustedHere = IsTrusted(i);
@@ -768,8 +799,6 @@ internal sealed class PlotModelFactory
                 frequency,
                 !trustedHere || boundary ? decibels : double.NaN));
         }
-
-        return (trusted, untrusted);
     }
 
     // Nearest coherence sample for a frequency; both point lists are sorted by

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -162,6 +162,7 @@ public partial class Form1
 
     private CalibrationFile? GetMicrophoneCalibration(MicrophoneCalibrationMode mode)
     {
+        WarnIfConfiguredCalibrationMissing(mode);
         if (mode == MicrophoneCalibrationMode.Degrees90 &&
             GetMicrophoneCalibrationPath(MicrophoneCalibrationMode.Degrees90) == null)
         {
@@ -178,9 +179,33 @@ public partial class Form1
         {
             calibrationFile = new CalibrationFile(path);
             calibrationCache[path] = calibrationFile;
+            if (!calibrationFile.HasData)
+            {
+                WarnCalibrationProblemOnce(path, calibrationFile.LoadError);
+            }
         }
 
         return calibrationFile;
+    }
+
+    // GetMicrophoneCalibrationPath maps a configured-but-deleted file to null,
+    // which used to silently disable the correction for every plot.
+    private void WarnIfConfiguredCalibrationMissing(MicrophoneCalibrationMode mode)
+    {
+        string? configured = mode switch
+        {
+            MicrophoneCalibrationMode.Degrees0 =>
+                measurementSettings.Measurement.MicrophoneCalibration0DegreesPath,
+            MicrophoneCalibrationMode.Degrees90 =>
+                measurementSettings.Measurement.MicrophoneCalibration90DegreesPath,
+            _ => null
+        };
+        if (!string.IsNullOrWhiteSpace(configured) && !File.Exists(configured))
+        {
+            WarnCalibrationProblemOnce(
+                configured,
+                $"Calibration file not found: {configured}");
+        }
     }
 
     private CalibrationFile? GetApproximateNinetyDegreeCalibration()

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -175,17 +175,23 @@ public partial class Form1
             return null;
         }
 
-        if (!calibrationCache.TryGetValue(path, out CalibrationFile? calibrationFile))
+        // Plot models are built on Task.Run workers, and two rapid refreshes
+        // can run concurrently — the cache dictionary must not be mutated
+        // unsynchronized (the lock is reentrant for the approximation path).
+        lock (calibrationCache)
         {
-            calibrationFile = new CalibrationFile(path);
-            calibrationCache[path] = calibrationFile;
-            if (!calibrationFile.HasData)
+            if (!calibrationCache.TryGetValue(path, out CalibrationFile? calibrationFile))
             {
-                WarnCalibrationProblemOnce(path, calibrationFile.LoadError);
+                calibrationFile = new CalibrationFile(path);
+                calibrationCache[path] = calibrationFile;
+                if (!calibrationFile.HasData)
+                {
+                    WarnCalibrationProblemOnce(path, calibrationFile.LoadError);
+                }
             }
-        }
 
-        return calibrationFile;
+            return calibrationFile;
+        }
     }
 
     // GetMicrophoneCalibrationPath maps a configured-but-deleted file to null,
@@ -218,18 +224,21 @@ public partial class Form1
         }
 
         string cacheKey = $"approx90:{zeroDegreePath}";
-        if (!calibrationCache.TryGetValue(cacheKey, out CalibrationFile? calibrationFile))
+        lock (calibrationCache)
         {
-            CalibrationFile zeroDegreeCalibration =
-                GetMicrophoneCalibration(MicrophoneCalibrationMode.Degrees0)
-                ?? throw new InvalidOperationException(
-                    "0 degree microphone calibration is not available.");
-            calibrationFile = CalibrationFile.CreateNinetyDegreeApproximation(
-                zeroDegreeCalibration);
-            calibrationCache[cacheKey] = calibrationFile;
-        }
+            if (!calibrationCache.TryGetValue(cacheKey, out CalibrationFile? calibrationFile))
+            {
+                CalibrationFile zeroDegreeCalibration =
+                    GetMicrophoneCalibration(MicrophoneCalibrationMode.Degrees0)
+                    ?? throw new InvalidOperationException(
+                        "0 degree microphone calibration is not available.");
+                calibrationFile = CalibrationFile.CreateNinetyDegreeApproximation(
+                    zeroDegreeCalibration);
+                calibrationCache[cacheKey] = calibrationFile;
+            }
 
-        return calibrationFile;
+            return calibrationFile;
+        }
     }
 
     private string? GetMicrophoneCalibrationPath(MicrophoneCalibrationMode mode)
@@ -265,7 +274,10 @@ public partial class Form1
 
     private void RefreshCalibrationConsumers()
     {
-        calibrationCache.Clear();
+        lock (calibrationCache)
+        {
+            calibrationCache.Clear();
+        }
         if (virtualCrossoverPanel != null)
         {
             virtualCrossoverPanel.ConfigureCalibration(

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -183,11 +183,19 @@ namespace Resonalyze
         // A configured calibration that fails to load must not silently produce
         // uncalibrated curves. Warned once per path per session; queued through
         // BeginInvoke so a plot build is never interrupted by a modal dialog.
+        // Called from Task.Run plot builds, so the set is guarded by a lock.
         private void WarnCalibrationProblemOnce(string path, string? reason)
         {
-            if (closingInProgress || !reportedCalibrationProblems.Add(path))
+            if (closingInProgress)
             {
                 return;
+            }
+            lock (reportedCalibrationProblems)
+            {
+                if (!reportedCalibrationProblems.Add(path))
+                {
+                    return;
+                }
             }
 
             TryBeginInvokeOnUiThread(() =>

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -35,6 +35,8 @@ namespace Resonalyze
         private readonly NoiseMeasurement noiseMeasurement = new();
         private readonly Dictionary<string, CalibrationFile> calibrationCache = new(
             StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> reportedCalibrationProblems = new(
+            StringComparer.OrdinalIgnoreCase);
         private readonly WaterfallGenerateOptions waterfallGenOptions = new()
         {
             WaterfallMode = WaterfallMode.Fourier,
@@ -176,6 +178,33 @@ namespace Resonalyze
                 "Measurement",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Warning);
+        }
+
+        // A configured calibration that fails to load must not silently produce
+        // uncalibrated curves. Warned once per path per session; queued through
+        // BeginInvoke so a plot build is never interrupted by a modal dialog.
+        private void WarnCalibrationProblemOnce(string path, string? reason)
+        {
+            if (closingInProgress || !reportedCalibrationProblems.Add(path))
+            {
+                return;
+            }
+
+            TryBeginInvokeOnUiThread(() =>
+            {
+                if (closingInProgress)
+                {
+                    return;
+                }
+
+                MessageBox.Show(
+                    this,
+                    "The selected microphone calibration could not be loaded; " +
+                    $"curves are shown uncalibrated.\r\n\r\n{reason ?? path}",
+                    "Microphone calibration",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            });
         }
 
         private SignalGeneratorPlaybackSettings CreateSignalGeneratorPlaybackSettings() =>

--- a/tests/Resonalyze.App.Tests/DeviceCatalogLookupTests.cs
+++ b/tests/Resonalyze.App.Tests/DeviceCatalogLookupTests.cs
@@ -1,0 +1,113 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// A saved device/driver/channel that is no longer present must be reported as
+/// absent (-1), never silently remapped to the first list entry — the options
+/// panel would re-persist the wrong device on the next apply.
+/// </summary>
+public sealed class DeviceCatalogLookupTests
+{
+    [Fact]
+    public void FindDeviceIndex_FindsDeviceByNumber()
+    {
+        AudioDeviceInfo[] devices =
+        [
+            new AudioDeviceInfo(-1, "Default recording device"),
+            new AudioDeviceInfo(0, "Line In"),
+            new AudioDeviceInfo(1, "USB Interface", Channels: 2)
+        ];
+
+        Assert.Equal(0, AudioDeviceCatalog.FindDeviceIndex(devices, -1));
+        Assert.Equal(2, AudioDeviceCatalog.FindDeviceIndex(devices, 1));
+    }
+
+    [Fact]
+    public void FindDeviceIndex_ReportsMissingDeviceInsteadOfFirstEntry()
+    {
+        AudioDeviceInfo[] devices =
+        [
+            new AudioDeviceInfo(-1, "Default recording device"),
+            new AudioDeviceInfo(0, "Line In")
+        ];
+
+        Assert.Equal(-1, AudioDeviceCatalog.FindDeviceIndex(devices, 7));
+    }
+
+    [Fact]
+    public void CreateMissingDevice_KeepsTheDeviceNumberAndMarksTheName()
+    {
+        AudioDeviceInfo missing = AudioDeviceCatalog.CreateMissingDevice(7);
+
+        Assert.Equal(7, missing.DeviceNumber);
+        Assert.Contains("(missing)", missing.Name);
+    }
+
+    [Fact]
+    public void FindDriverIndex_FindsDriverCaseInsensitively()
+    {
+        AsioDeviceInfo[] drivers =
+        [
+            new AsioDeviceInfo("Focusrite USB ASIO"),
+            new AsioDeviceInfo("RME Fireface")
+        ];
+
+        Assert.Equal(1, AsioDeviceCatalog.FindDriverIndex(drivers, "rme fireface"));
+    }
+
+    [Fact]
+    public void FindDriverIndex_DefaultsToFirstDriverOnlyWhenNoNameIsSaved()
+    {
+        AsioDeviceInfo[] drivers = [new AsioDeviceInfo("Focusrite USB ASIO")];
+
+        Assert.Equal(0, AsioDeviceCatalog.FindDriverIndex(drivers, null));
+        Assert.Equal(0, AsioDeviceCatalog.FindDriverIndex(drivers, " "));
+        Assert.Equal(-1, AsioDeviceCatalog.FindDriverIndex(
+            Array.Empty<AsioDeviceInfo>(),
+            null));
+    }
+
+    [Fact]
+    public void FindDriverIndex_ReportsMissingDriverInsteadOfFirstEntry()
+    {
+        AsioDeviceInfo[] drivers = [new AsioDeviceInfo("Focusrite USB ASIO")];
+
+        Assert.Equal(-1, AsioDeviceCatalog.FindDriverIndex(drivers, "RME Fireface"));
+    }
+
+    [Fact]
+    public void MissingAsioDriver_KeepsItsNameAndMarksTheDisplayText()
+    {
+        var missing = new AsioDeviceInfo("RME Fireface", Missing: true);
+
+        Assert.Equal("RME Fireface", missing.DriverName);
+        Assert.Equal("(missing) RME Fireface", missing.ToString());
+    }
+
+    [Fact]
+    public void FindChannelIndex_FindsChannelByOffset()
+    {
+        AsioChannelInfo[] channels =
+        [
+            new AsioChannelInfo(0, "Input 1"),
+            new AsioChannelInfo(1, "Input 2"),
+            new AsioChannelInfo(2, "Input 3")
+        ];
+
+        Assert.Equal(2, AsioDeviceCatalog.FindChannelIndex(channels, 2));
+    }
+
+    [Fact]
+    public void FindChannelIndex_ReportsMissingOffsetInsteadOfFirstChannel()
+    {
+        AsioChannelInfo[] channels =
+        [
+            new AsioChannelInfo(0, "Input 1"),
+            new AsioChannelInfo(1, "Input 2")
+        ];
+
+        Assert.Equal(-1, AsioDeviceCatalog.FindChannelIndex(channels, 7));
+        Assert.Equal(-1, AsioDeviceCatalog.FindChannelIndex(
+            Array.Empty<AsioChannelInfo>(),
+            0));
+    }
+}

--- a/tests/Resonalyze.App.Tests/MicrophoneCalibrationComboHelperTests.cs
+++ b/tests/Resonalyze.App.Tests/MicrophoneCalibrationComboHelperTests.cs
@@ -1,0 +1,92 @@
+using Resonalyze.Dsp;
+using Resonalyze.Options;
+using CalibrationOptions =
+    System.Collections.Generic.IReadOnlyList<
+        Resonalyze.Options.MicrophoneCalibrationComboHelper.MicrophoneCalibrationOption>;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The persisted calibration mode must stay selectable when its file is
+/// missing; dropping the entry used to land the selection on "Off" and the
+/// next apply permanently overwrote the stored preference.
+/// </summary>
+public sealed class MicrophoneCalibrationComboHelperTests
+{
+    [Fact]
+    public void BuildOptions_ListsAvailableProfiles()
+    {
+        CalibrationOptions options = MicrophoneCalibrationComboHelper.BuildOptions(
+            MicrophoneCalibrationMode.Off,
+            hasZeroDegreeCalibration: true,
+            hasNinetyDegreeCalibration: true);
+
+        Assert.Equal(
+            [
+                MicrophoneCalibrationMode.Off,
+                MicrophoneCalibrationMode.Degrees0,
+                MicrophoneCalibrationMode.Degrees90
+            ],
+            options.Select(option => option.Mode));
+        Assert.Equal(0, MicrophoneCalibrationComboHelper.FindIndex(
+            options,
+            MicrophoneCalibrationMode.Off));
+    }
+
+    [Fact]
+    public void BuildOptions_OmitsUnselectedProfilesWithoutFiles()
+    {
+        CalibrationOptions options = MicrophoneCalibrationComboHelper.BuildOptions(
+            MicrophoneCalibrationMode.Off,
+            hasZeroDegreeCalibration: false,
+            hasNinetyDegreeCalibration: false);
+
+        Assert.Equal(
+            [MicrophoneCalibrationMode.Off],
+            options.Select(option => option.Mode));
+    }
+
+    [Theory]
+    [InlineData(MicrophoneCalibrationMode.Degrees0, "0 degrees (file missing)")]
+    [InlineData(MicrophoneCalibrationMode.Degrees90, "90 degrees (file missing)")]
+    public void BuildOptions_KeepsSelectedModeWhenItsFileIsMissing(
+        MicrophoneCalibrationMode selectedMode,
+        string expectedDisplayName)
+    {
+        CalibrationOptions options = MicrophoneCalibrationComboHelper.BuildOptions(
+            selectedMode,
+            hasZeroDegreeCalibration: false,
+            hasNinetyDegreeCalibration: false);
+
+        int index = MicrophoneCalibrationComboHelper.FindIndex(options, selectedMode);
+        Assert.True(index > 0);
+        Assert.Equal(selectedMode, options[index].Mode);
+        Assert.Equal(expectedDisplayName, options[index].DisplayName);
+    }
+
+    [Fact]
+    public void BuildOptions_DoesNotMarkAvailableProfiles()
+    {
+        CalibrationOptions options = MicrophoneCalibrationComboHelper.BuildOptions(
+            MicrophoneCalibrationMode.Degrees90,
+            hasZeroDegreeCalibration: true,
+            hasNinetyDegreeCalibration: true);
+
+        Assert.All(
+            options,
+            option => Assert.DoesNotContain("missing", option.DisplayName));
+    }
+
+    [Fact]
+    public void FindIndex_FallsBackToOffForAnAbsentMode()
+    {
+        CalibrationOptions options = MicrophoneCalibrationComboHelper.BuildOptions(
+            MicrophoneCalibrationMode.Off,
+            hasZeroDegreeCalibration: false,
+            hasNinetyDegreeCalibration: false);
+
+        Assert.Equal(0, MicrophoneCalibrationComboHelper.FindIndex(
+            options,
+            MicrophoneCalibrationMode.Degrees90));
+    }
+}

--- a/tests/Resonalyze.App.Tests/OverlayFileTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlayFileTests.cs
@@ -610,6 +610,70 @@ public sealed class OverlayFileTests
     }
 
     [Fact]
+    public void Load_ReturnsTheCachedInstanceWhileTheFileIsUnchanged()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            CreateMinimalOverlay(Mode.FrequencyResponse, 6).Save(root);
+
+            OverlayFile? first = OverlayFile.Load(Mode.FrequencyResponse, 6, root);
+            OverlayFile? second = OverlayFile.Load(Mode.FrequencyResponse, 6, root);
+
+            Assert.NotNull(first);
+            Assert.Same(first, second);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Load_ReloadsAfterSaveInvalidatesTheCache()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            CreateMinimalOverlay(Mode.FrequencyResponse, 6).Save(root);
+            OverlayFile? original = OverlayFile.Load(Mode.FrequencyResponse, 6, root);
+
+            OverlayFile updated = CreateMinimalOverlay(Mode.FrequencyResponse, 6);
+            updated.Title = "Renamed after the first load";
+            updated.Save(root);
+            OverlayFile? reloaded = OverlayFile.Load(Mode.FrequencyResponse, 6, root);
+
+            Assert.NotNull(original);
+            Assert.NotNull(reloaded);
+            Assert.NotSame(original, reloaded);
+            Assert.Equal("Renamed after the first load", reloaded.Title);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Load_ReturnsNullAfterDeleteEvenWhenCached()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            CreateMinimalOverlay(Mode.FrequencyResponse, 6).Save(root);
+            Assert.NotNull(OverlayFile.Load(Mode.FrequencyResponse, 6, root));
+
+            OverlayFile.Delete(Mode.FrequencyResponse, 6, root);
+
+            Assert.Null(OverlayFile.Load(Mode.FrequencyResponse, 6, root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void QuarantineCorruptFile_ReturnsNullWhenSlotFileIsAbsent()
     {
         string root = CreateTemporaryDirectory();

--- a/tests/Resonalyze.App.Tests/OverlayFileTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlayFileTests.cs
@@ -563,6 +563,69 @@ public sealed class OverlayFileTests
         CreateMinimalOverlay(mode, slot).Save(root);
     }
 
+    [Fact]
+    public void Load_ThrowsOnCorruptJson()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            string path = OverlayFile.GetPath(Mode.FrequencyResponse, 3, root);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, "{ not valid json");
+
+            Assert.ThrowsAny<Exception>(() =>
+                OverlayFile.Load(Mode.FrequencyResponse, 3, root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void QuarantineCorruptFile_MovesSlotFileAsideAndPreservesContent()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            string path = OverlayFile.GetPath(Mode.FrequencyResponse, 3, root);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, "{ not valid json");
+
+            string? quarantinePath = OverlayFile.QuarantineCorruptFile(
+                Mode.FrequencyResponse,
+                3,
+                root);
+
+            Assert.Equal(path + ".corrupt", quarantinePath);
+            Assert.False(File.Exists(path));
+            Assert.Equal("{ not valid json", File.ReadAllText(quarantinePath!));
+            // The slot now loads as empty instead of failing again.
+            Assert.Null(OverlayFile.Load(Mode.FrequencyResponse, 3, root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void QuarantineCorruptFile_ReturnsNullWhenSlotFileIsAbsent()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            Assert.Null(OverlayFile.QuarantineCorruptFile(
+                Mode.FrequencyResponse,
+                3,
+                root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static OverlayFile CreateMinimalOverlay(Mode mode, int slot)
     {
         return new OverlayFile

--- a/tests/Resonalyze.App.Tests/OverlayMathTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlayMathTests.cs
@@ -36,6 +36,58 @@ public sealed class OverlayMathTests
     }
 
     [Fact]
+    public void CalculateOperation_AmplitudeSpaceDifferenceKeepsPositiveResults()
+    {
+        // A is 6 dB above B everywhere, so the amplitude difference is positive
+        // and has a real dB value.
+        OverlayPoint[] a =
+        [
+            new OverlayPoint(100, 6),
+            new OverlayPoint(1_000, 6)
+        ];
+        OverlayPoint[] b =
+        [
+            new OverlayPoint(100, 0),
+            new OverlayPoint(1_000, 0)
+        ];
+
+        OverlayPoint[] result = OverlayMath.CalculateOperation(
+            a,
+            b,
+            OverlayOperation.AMinusB,
+            useAmplitudeSpace: true);
+
+        Assert.All(result, point => Assert.True(double.IsFinite(point.Y)));
+    }
+
+    [Fact]
+    public void CalculateOperation_AmplitudeSpaceDifferenceGapsNegativeResults()
+    {
+        // B is louder than A, so the amplitude difference is negative: there is
+        // no dB value for it. The curve must show a gap (NaN), not a -160 dB
+        // floor pretending to be data.
+        OverlayPoint[] a =
+        [
+            new OverlayPoint(100, 0),
+            new OverlayPoint(1_000, 0)
+        ];
+        OverlayPoint[] b =
+        [
+            new OverlayPoint(100, 6),
+            new OverlayPoint(1_000, 6)
+        ];
+
+        OverlayPoint[] result = OverlayMath.CalculateOperation(
+            a,
+            b,
+            OverlayOperation.AMinusB,
+            useAmplitudeSpace: true);
+
+        Assert.NotEmpty(result);
+        Assert.All(result, point => Assert.True(double.IsNaN(point.Y)));
+    }
+
+    [Fact]
     public void CalculateOperation_BlendCrossfadesAroundCenterFrequency()
     {
         OverlayPoint[] a =

--- a/tests/Resonalyze.App.Tests/TargetOverlayCurveBuilderTests.cs
+++ b/tests/Resonalyze.App.Tests/TargetOverlayCurveBuilderTests.cs
@@ -1,0 +1,124 @@
+using OxyPlot;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class TargetOverlayCurveBuilderTests
+{
+    private static readonly TargetCurveSpec FlatSpec =
+        TargetCurveSpec.FromPreset(TargetPreset.Flat);
+
+    [Fact]
+    public void BuildShape_ReturnsTargetOnTheFullGrid()
+    {
+        var builder = new TargetOverlayCurveBuilder();
+
+        TargetOverlayShape shape = builder.BuildShape(FlatSpec, offsetDb: 0, toleranceDb: 0);
+
+        Assert.Equal(TargetOverlayCurveBuilder.DefaultTargetGrid.Length, shape.Target.Length);
+        Assert.Equal(20.0, shape.Target[0].X, precision: 6);
+        Assert.Equal(20_000.0, shape.Target[^1].X, precision: 6);
+        Assert.Empty(shape.ToleranceUpper);
+        Assert.Empty(shape.ToleranceLower);
+    }
+
+    [Fact]
+    public void BuildShape_AppliesOffsetAndToleranceBand()
+    {
+        var builder = new TargetOverlayCurveBuilder();
+
+        TargetOverlayShape shape = builder.BuildShape(FlatSpec, offsetDb: -3, toleranceDb: 2);
+
+        Assert.All(shape.Target, point => Assert.Equal(-3, point.Y, precision: 9));
+        Assert.Equal(shape.Target.Length, shape.ToleranceUpper.Length);
+        Assert.Equal(shape.Target.Length, shape.ToleranceLower.Length);
+        Assert.All(shape.ToleranceUpper, point => Assert.Equal(-1, point.Y, precision: 9));
+        Assert.All(shape.ToleranceLower, point => Assert.Equal(-5, point.Y, precision: 9));
+    }
+
+    [Fact]
+    public void BuildShape_ReusesTheCachedShapeForUnchangedInputs()
+    {
+        var builder = new TargetOverlayCurveBuilder();
+
+        TargetOverlayShape first = builder.BuildShape(FlatSpec, offsetDb: 1, toleranceDb: 2);
+        TargetOverlayShape second = builder.BuildShape(FlatSpec, offsetDb: 1, toleranceDb: 2);
+        // Records compare by value; the equal spec instance must also hit.
+        TargetOverlayShape third = builder.BuildShape(
+            TargetCurveSpec.FromPreset(TargetPreset.Flat),
+            offsetDb: 1,
+            toleranceDb: 2);
+
+        Assert.Same(first, second);
+        Assert.Same(first, third);
+    }
+
+    [Theory]
+    [InlineData(1.5, 2.0, 2.0)]
+    [InlineData(1.0, 2.5, 2.0)]
+    [InlineData(1.0, 2.0, 3.0)]
+    public void BuildShape_RebuildsWhenAnyInputChanges(
+        double offsetDb,
+        double toleranceDb,
+        double tiltDbPerOctave)
+    {
+        var builder = new TargetOverlayCurveBuilder();
+        TargetOverlayShape baseline = builder.BuildShape(
+            FlatSpec with { TiltDbPerOctave = 2.0 },
+            offsetDb: 1.0,
+            toleranceDb: 2.0);
+
+        TargetOverlayShape changed = builder.BuildShape(
+            FlatSpec with { TiltDbPerOctave = tiltDbPerOctave },
+            offsetDb,
+            toleranceDb);
+
+        Assert.NotSame(baseline, changed);
+    }
+
+    [Fact]
+    public void BuildDeviation_FollowsTheSelectedMode()
+    {
+        // Source sits 4 dB above a flat 0 dB target everywhere.
+        OverlayPoint[] source =
+        [
+            new OverlayPoint(100, 4),
+            new OverlayPoint(1_000, 4),
+            new OverlayPoint(10_000, 4)
+        ];
+
+        DataPoint[] deviation = TargetOverlayCurveBuilder.BuildDeviation(
+            source,
+            FlatSpec,
+            offsetDb: 0,
+            smoothingInverseOctaves: 0,
+            TargetDeviationMode.Deviation);
+        DataPoint[] correction = TargetOverlayCurveBuilder.BuildDeviation(
+            source,
+            FlatSpec,
+            offsetDb: 0,
+            smoothingInverseOctaves: 0,
+            TargetDeviationMode.Correction);
+
+        Assert.All(deviation, point => Assert.Equal(4, point.Y, precision: 9));
+        Assert.All(correction, point => Assert.Equal(-4, point.Y, precision: 9));
+    }
+
+    [Fact]
+    public void BuildDeviation_IsEmptyForNoneModeOrDegenerateSource()
+    {
+        OverlayPoint[] source = [new OverlayPoint(100, 4), new OverlayPoint(1_000, 4)];
+
+        Assert.Empty(TargetOverlayCurveBuilder.BuildDeviation(
+            source,
+            FlatSpec,
+            0,
+            0,
+            TargetDeviationMode.None));
+        Assert.Empty(TargetOverlayCurveBuilder.BuildDeviation(
+            [new OverlayPoint(100, 4)],
+            FlatSpec,
+            0,
+            0,
+            TargetDeviationMode.Deviation));
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/CalibrationFileTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CalibrationFileTests.cs
@@ -117,6 +117,59 @@ public sealed class CalibrationFileTests
             .HasData);
     }
 
+    [Fact]
+    public void LoadError_ReportsMissingFile()
+    {
+        string missing = Path.Combine(
+            Path.GetTempPath(),
+            $"resonalyze-calibration-missing-{Guid.NewGuid():N}.txt");
+
+        var calibration = new CalibrationFile(missing);
+
+        Assert.False(calibration.HasData);
+        Assert.Contains("not found", calibration.LoadError);
+    }
+
+    [Fact]
+    public void LoadError_ReportsFileWithoutParsablePairs()
+    {
+        string path = WriteCalibrationFile(
+            "# header only\n" +
+            "no numbers here\n");
+
+        var calibration = new CalibrationFile(path);
+
+        Assert.False(calibration.HasData);
+        Assert.Contains("no frequency/level pairs", calibration.LoadError);
+    }
+
+    [Fact]
+    public void LoadError_IsNullForValidFile()
+    {
+        string path = WriteCalibrationFile(
+            "20 2.5\n" +
+            "20000 2.5\n");
+
+        var calibration = new CalibrationFile(path);
+
+        Assert.True(calibration.HasData);
+        Assert.Null(calibration.LoadError);
+    }
+
+    [Fact]
+    public void LoadError_PropagatesThroughNinetyDegreeApproximation()
+    {
+        string missing = Path.Combine(
+            Path.GetTempPath(),
+            $"resonalyze-calibration-missing-{Guid.NewGuid():N}.txt");
+
+        CalibrationFile approximation =
+            CalibrationFile.CreateNinetyDegreeApproximation(new CalibrationFile(missing));
+
+        Assert.False(approximation.HasData);
+        Assert.Contains("not found", approximation.LoadError);
+    }
+
     private static string WriteCalibrationFile(string text)
     {
         string path = Path.Combine(


### PR DESCRIPTION
Two batches from `TODO.md`, prioritized by user impact.

## Block 1 — nothing silently corrupts settings or results anymore

**Persisted audio settings:**
- A missing Wave device, ASIO driver, or ASIO channel used to remap to the first list entry (worst case: a vanished separate loopback device became "Default recording device", and a **busy ASIO driver reset every channel route to channel 1/None**) — and the next apply persisted the remap. They now stay selected as `(missing)` placeholders that keep the stored identity, so an apply round-trips the same configuration.
- A mono/missing recording device no longer irreversibly clears the Wave loopback channel: the choice is kept in a shadow field and restored when a stereo device is selected again.
- A calibration mode whose file is absent stays selectable as `90 degrees (file missing)` instead of silently downgrading the persisted mode to Off.

**Measurement results:**
- `CalibrationFile` gained `LoadError`; a missing/unreadable/unparsable file is now reported when picking it, highlighted in Record Settings, and warned about once per session at plot time — instead of silently producing uncalibrated curves.
- A recorder stop timeout no longer demotes an already-published measurement to "Error" (data is complete by then; the entry stays in History).
- Amplitude-space overlay `A−B` draws an honest NaN gap instead of a −160 dB floor.
- A corrupt overlay slot file is quarantined as `.corrupt` with a warning instead of being silently overwritten by the next capture.

Re-verified and dropped from TODO as **not** bugs: the coherence `fftLength` reconstruction (exact for the N/2+1 sweep array) and the `LiveSpectrumOpt` shadow-field gap (the R reset raises `SelectionChangeCommitted`).

## Block 2 — live and averaging paths stop doing per-tick/per-run busywork

- ★ Target-overlay shape/tolerance curves are built by a new pure `TargetOverlayCurveBuilder` and **cached between edits**; the ~30 fps live redraw no longer re-evaluates the 512-point parametric grid (only the deviation follows the trace).
- The live spectrum **reuses its five plot series** and refills points in place instead of recreating plot objects every tick.
- Overlay slot files are **cached by write stamp** — a mode switch costs 12 stat calls, not 12 JSON reads+parses (in-app save/delete invalidate; external edits caught by the stamp).
- `ExponentialSineSweep` computes its sample count eagerly but synthesizes the signal/inverse filter/PCM streams **lazily** — loading a file or History entry no longer pays for megabytes of sweep synthesis (dead `Frequencies` array removed).
- Averaged ASIO sweeps keep **one driver session open across runs**: each run restarts only the capture accumulator and rewinds the sweep stream; between runs capture pauses while the level meter stays live, so a long "Confirm each run" wait costs neither driver re-init (seconds on slow drivers) nor buffer growth.

## Tests
- New: device-catalog lookups, calibration combo options, `TargetOverlayCurveBuilder` (caching/invalidation/deviation), overlay-file cache and quarantine, amplitude-space NaN gaps, `CalibrationFile.LoadError` (dsp).
- 267 dsp tests green locally; full solution builds with 0 warnings. App tests run on Windows CI in this PR.

## ⚠️ Needs manual hardware verification
The reused ASIO session (block 2, last item) is verified by construction only — please run an **averaged ASIO measurement** (ideally with a slow driver, with and without "Confirm each run") before relying on it. Tracked in `TODO.md`.

Also includes the README contributing-section update (crash.log, TODO.md) that went to main directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_