### PR TITLE
Virtual DSP: extract the Auto delay engine into dsp, close block-3 tech debt

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -192,6 +192,14 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 ## Shell
 
+- [ ] ★ **`Form1` is still the concurrency hub.** ~40 mutable fields on one
+  object are touched by the UI thread, `Task.Run` plot builds and
+  audio-callback events, guarded case by case with ad-hoc locks and flags
+  (`closingInProgress`, `calibrationCache`, `reportedCalibrationProblems`).
+  The torn-read items in this file are symptoms; the structural fix is moving
+  per-mode state into services/controllers so new code does not need manual
+  guarding. Incremental — carve out one concern at a time, calibration state
+  is a natural first candidate.
 - [ ] **`UpdatePeakInfo` unsynchronized pair read.** Peak value and peak index
   are read as two separate volatile-ish reads and can disagree; publish them
   as one immutable pair.

--- a/TODO.md
+++ b/TODO.md
@@ -37,10 +37,6 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 ## Virtual DSP / Time Alignment
 
-- [ ] ★ **Extract `ComputeAutoAlignment` into a testable service.** The
-  two-stage Auto-delay orchestrator (~250 lines in `VirtualCrossoverPanel`:
-  retries, wide-window promotion, candidate tie-breaks) is untested panel
-  code. Highest-value extraction left from the PR #1 review.
 - [ ] **Time Alignment analysis is not cached** — `RefreshAnalysis`
   (`TimeAlignmentPanelController`) recomputes Hilbert + GCC-PHAT on every tab
   show even when inputs are unchanged. Needs a live-app check to avoid stale
@@ -49,20 +45,11 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   (`VirtualCrossoverAutoSetupDialog`): extra channel rows use hardcoded pixel
   offsets (`RowTop = 42`, `RowStep = 28`), so rows 4–8 can overlap scaled
   designer controls. Verify on Windows and switch to layout-panel positioning.
-- [ ] **Project-file version has no migration path**
-  (`VirtualCrossoverProjectFile.Validate`): any version mismatch throws, so
-  after a future format change the autosave is silently replaced. Decide on a
-  migrate-or-backup policy.
-- [ ] **Split `VirtualCrossoverPanel` (~2.9k lines)** into partial
-  classes/controllers (after the `ComputeAutoAlignment` extraction).
-- [ ] **`BuildPhasePoints` duplicates the Tukey gate construction** of
-  `DataHelper.ExtractGatedWindowedImpulse` and will drift from Phase mode.
-- [ ] **Small duplication:** `ChannelName` exists twice (panel vs
-  `VirtualCrossoverSheet`), `Signed`/`Number` formatters twice (Sheet vs
-  SheetPdf).
-- [ ] **File-format selection by `FilterIndex`** (`LoadPeq`,
-  `ExportTuningSheet`) is implicitly coupled to `EqProfileFormats.All` order;
-  reordering the list silently breaks the dialogs.
+- [ ] **The project-file `.backup` rename is silent.** An unusable autosave
+  is preserved next to the project file now, but nothing tells the user it
+  happened or that a `.backup` is there to recover from.
+- [ ] **Split `VirtualCrossoverPanel` (~2.6k lines)** into partial
+  classes/controllers.
 - [ ] **`DelayTableText` parses rendered fixed-width columns** (18/37 chars)
   for copy-values instead of holding a value model (format+parse are at least
   co-located and tested now).
@@ -133,9 +120,11 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 - [ ] **~90 duplicated lines between the two PDF exporters.**
   `LoadBanner`/`AddImage`/`AddFilterCards` are byte-identical in
-  `TuningSheetPdf` and `VirtualCrossoverSheetPdf`; extract a shared helper.
-  MigraDoc 6 supports `AddImage("base64:...")`, which would also remove the
-  temp-file dance entirely.
+  `TuningSheetPdf` and `VirtualCrossoverSheetPdf` (as are the small
+  `Signed`/`Number` formatters, whose only remaining copy is in
+  `TuningSheetPdf`); extract a shared helper. MigraDoc 6 supports
+  `AddImage("base64:...")`, which would also remove the temp-file dance
+  entirely.
 - [ ] **No deconvolution flatness test.** The sweep + inverse-filter math was
   verified numerically during review (in-band ripple < 0.01 dB), but nothing
   in the test suite pins it; a `SyntheticMeasurement`-style flatness test

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1,0 +1,494 @@
+using System.Numerics;
+using System.Text;
+
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// The delay/polarity proposal Auto delay computes for one channel: the
+/// absolute delay to apply and whether the channel's polarity should flip.
+/// </summary>
+public readonly record struct AlignmentOverride(
+    double DelayMs,
+    bool InvertPolarity);
+
+/// <summary>
+/// A channel as the alignment engine sees it: an identity (reference
+/// equality keys the override maps), a display name for the diagnostic log
+/// and a sample rate. The caller's channel model implements this.
+/// </summary>
+public interface IAlignmentChannel
+{
+    string Name { get; }
+    int SampleRate { get; }
+}
+
+/// <summary>
+/// One channel's processed impulse response for an alignment round: the full
+/// DSP chain applied, ready for arrival detection and correlation.
+/// </summary>
+public sealed record AlignmentSnapshot(
+    IAlignmentChannel Channel,
+    Complex[] ImpulseResponse,
+    int PeakIndex);
+
+/// <summary>
+/// Adjacent channels along the spectrum with their shared junction: the pair
+/// crossover frequency and the band (an octave to each side) where the two
+/// drivers genuinely overlap. This band is where coarse arrivals are
+/// compared and where the fine delay search correlates.
+/// </summary>
+public sealed record AlignmentJunction(
+    AlignmentSnapshot Lower,
+    AlignmentSnapshot Upper,
+    double CrossoverHz,
+    double BandLowHz,
+    double BandHighHz);
+
+/// <summary>
+/// Re-runs the caller's channel processing with the given delay/polarity
+/// overrides applied (a channel absent from the map processes with zero
+/// delay and normal polarity) and returns fresh snapshots. Called from the
+/// engine's search loops, typically on a background thread — implementations
+/// must not touch shared mutable state.
+/// </summary>
+public delegate IReadOnlyList<AlignmentSnapshot> AlignmentReprocessor(
+    IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides);
+
+/// <summary>
+/// Two-stage automatic time alignment of a multi-way system. Stage 1:
+/// Time-Alignment-style band-limited first arrivals give a coarse delay per
+/// channel (robust, no phase ambiguity). Stage 2: walking pair by pair
+/// outward from the reference, a phase correlation fine-tunes each channel
+/// against its settled neighbor inside their shared pair band, also deciding
+/// whether its polarity should flip. The latest-arriving channel is the
+/// fixed reference, so the proposed delays stay non-negative by
+/// construction.
+/// </summary>
+public static class AutoAlignmentEngine
+{
+    // Bounds of the stage-2 fine-search span. The span scales with the
+    // crossover frequency (half its period) because the coarse arrival error
+    // grows with the period — but it never drops below half a millisecond:
+    // arrival estimates carry a floor of error (filter group-delay asymmetry,
+    // driver rise time) that does not shrink with the junction period, so at a
+    // high split half a period would regularly miss the true optimum. The
+    // extra lobes a wide window admits are handled by the candidate list, the
+    // arrival prior, and the physical tie-break in AlignmentSelection.
+    private const double MinFineAlignmentRangeMs = 0.5;
+    private const double MaxFineAlignmentRangeMs = 2.5;
+
+    // Diagnostics only: a deliberately wide fine-search window (many periods at a
+    // high crossover, ~one at a low one) whose candidates are logged but never
+    // chosen. It surfaces summation optima that sit several lobes outside the
+    // working window, so a log can show whether a better lobe exists there.
+    private const double DiagnosticFineRangeMs = 3.0;
+    private const double DiagnosticCorrelationRangeMs = 3.0;
+
+    // The minimum non-inverted PHAT peak correlation for its position to seed the
+    // stage-2 window instead of the arrival envelope. Below it the peak is noise
+    // (a low-frequency junction with too few in-band periods), and the arrival
+    // estimate stands. Deliberately low: even a modest genuine peak beats the
+    // arrival envelope, and the loss search plus the wide-window promotion recover
+    // from a seed that still lands a little off.
+    private const double PhatSeedMinCoefficient = 0.15;
+
+    // How much better (in score dB) a wide-window optimum must be before it
+    // unseats the arrival-anchored fine pick. The narrow window is centered on
+    // the coarse arrival, which at a high crossover can be a whole lobe off (its
+    // period is a fraction of the arrival uncertainty); the promotion recovers
+    // that lobe, while the margin keeps the physically-minimal arrival pick
+    // unless a distinctly better summation exists elsewhere.
+    private const double WideWindowPromotionMarginDb = 0.2;
+
+    /// <summary>
+    /// Runs the two-stage alignment. <paramref name="channelsByBand"/> holds
+    /// the initial snapshots ordered along the spectrum;
+    /// <paramref name="pairs"/>[i] joins channels i and i+1 of that order.
+    /// Results land in <paramref name="alignment"/>; the run's diagnostic
+    /// trace is appended to <paramref name="log"/>. Previous delay/polarity
+    /// settings play no part: the caller produces the initial snapshots with
+    /// zero overrides and the engine computes an absolute proposal.
+    /// </summary>
+    public static void Compute(
+        IReadOnlyList<AlignmentSnapshot> channelsByBand,
+        IReadOnlyList<AlignmentJunction> pairs,
+        AlignmentReprocessor reprocess,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        StringBuilder log)
+    {
+        ArgumentNullException.ThrowIfNull(channelsByBand);
+        ArgumentNullException.ThrowIfNull(pairs);
+        ArgumentNullException.ThrowIfNull(reprocess);
+        ArgumentNullException.ThrowIfNull(alignment);
+        ArgumentNullException.ThrowIfNull(log);
+        if (channelsByBand.Count < 2)
+        {
+            throw new ArgumentException(
+                "At least two channels are required.",
+                nameof(channelsByBand));
+        }
+        if (pairs.Count != channelsByBand.Count - 1)
+        {
+            throw new ArgumentException(
+                "One junction is required between each adjacent channel pair.",
+                nameof(pairs));
+        }
+
+        List<AlignmentSnapshot> byBand = channelsByBand.ToList();
+        AppendCorrelationAlignmentDiagnostics(log, pairs);
+
+        // Stage 1: coarse offsets from band-limited first arrivals, refined by the
+        // GCC-PHAT peak where it is trustworthy. Arrivals of different drivers are
+        // only comparable inside a SHARED band — a woofer's envelope in its own low
+        // band rises milliseconds later than a tweeter's in its high band. So each
+        // adjacent pair is measured around its own crossover frequency, and the
+        // pairwise differences chain into one relative timeline that seeds stage 2.
+        var timeline = new Dictionary<IAlignmentChannel, double>
+        {
+            [byBand[0].Channel] = 0
+        };
+        foreach (AlignmentJunction pair in pairs)
+        {
+            double lowerArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+                pair.Lower.ImpulseResponse,
+                pair.Lower.Channel.SampleRate,
+                pair.BandLowHz,
+                pair.BandHighHz);
+            double upperArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+                pair.Upper.ImpulseResponse,
+                pair.Upper.Channel.SampleRate,
+                pair.BandLowHz,
+                pair.BandHighHz);
+
+            // Refine the coarse offset with the non-inverted GCC-PHAT peak: at a
+            // mid/high junction it lands the stage-2 window on the correct lobe
+            // directly, sparing the wide-window recovery. Only the peak POSITION
+            // is used (polarity and the final lobe stay with the loss search), and
+            // only when the peak carries a real correlation — otherwise the arrival
+            // envelope stands. The PHAT window is centered on the arrival estimate,
+            // so a trusted peak is by construction within reach of it. The timeline
+            // stores arrivals as (upper - lower); the PHAT peak is the delay to add
+            // to the upper channel, i.e. the same quantity negated.
+            double passOctaves = Math.Log2(pair.BandHighHz / pair.BandLowHz);
+            CorrelationAlignmentResult phat =
+                VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
+                    pair.Lower.ImpulseResponse,
+                    pair.Upper.ImpulseResponse,
+                    pair.Lower.Channel.SampleRate,
+                    pair.CrossoverHz,
+                    passOctaves,
+                    DiagnosticCorrelationRangeMs,
+                    centerLagMs: lowerArrival - upperArrival,
+                    phaseTransform: true);
+            bool trustPhat = phat.PositivePeak.Coefficient >= PhatSeedMinCoefficient;
+            double increment =
+                trustPhat ? -phat.PositivePeak.DelayMs : upperArrival - lowerArrival;
+            timeline[pair.Upper.Channel] = timeline[pair.Lower.Channel] + increment;
+
+            // Full-band processed-IR peak times, a detector-independent arrival
+            // proxy: a band-limited arrival that sits many ms LATER than its own
+            // channel's energy peak is a detector artifact (a late in-band lobe),
+            // not a real arrival.
+            double lowerPeakMs =
+                pair.Lower.PeakIndex * 1000.0 / pair.Lower.Channel.SampleRate;
+            double upperPeakMs =
+                pair.Upper.PeakIndex * 1000.0 / pair.Upper.Channel.SampleRate;
+
+            log.AppendLine(
+                $"Pair {pair.Lower.Channel.Name}/" +
+                $"{pair.Upper.Channel.Name}: " +
+                $"fc {pair.CrossoverHz:0} Hz, " +
+                $"band {pair.BandLowHz:0}-{pair.BandHighHz:0} Hz, " +
+                $"arrivals {lowerArrival:0.000} / {upperArrival:0.000} ms " +
+                $"(peaks {lowerPeakMs:0.000} / {upperPeakMs:0.000} ms), " +
+                $"diff {upperArrival - lowerArrival:+0.000;-0.000} ms, " +
+                $"phat peak {phat.PositivePeak.DelayMs:+0.000;-0.000} ms " +
+                $"(r {phat.PositivePeak.Coefficient:+0.000;-0.000}) -> seed " +
+                $"{(trustPhat ? "phat" : "arrival")}");
+        }
+
+        // The relatively latest channel is the fixed reference; everyone else is
+        // delayed toward it, so the coarse deltas are non-negative.
+        double latest = timeline.Values.Max();
+        IAlignmentChannel reference =
+            timeline.First(pair => pair.Value == latest).Key;
+        log.AppendLine($"Reference: {reference.Name}");
+
+        // Stage 2: sequential pairwise fine alignment, walking outward from the
+        // reference along the band order. Each channel is phase-correlated
+        // against its already-settled neighbor only, inside their shared pair
+        // band, so the search window is sized by THAT junction — a mid channel
+        // must not have its low-junction window squeezed to the period of its
+        // high junction. An arrival error at a low junction then propagates
+        // through the chain and moves the whole upper group together, which a
+        // per-channel search against all fixed channels at once cannot do.
+        int referenceIndex = byBand.FindIndex(item => item.Channel == reference);
+        var searchOrder =
+            new List<(AlignmentSnapshot Target, AlignmentSnapshot Neighbor, AlignmentJunction Pair)>();
+        for (int i = referenceIndex - 1; i >= 0; i--)
+        {
+            searchOrder.Add((byBand[i], byBand[i + 1], pairs[i]));
+        }
+        for (int i = referenceIndex + 1; i < byBand.Count; i++)
+        {
+            searchOrder.Add((byBand[i], byBand[i - 1], pairs[i - 1]));
+        }
+
+        // One junction search: candidates of the prior-penalized loss score in
+        // a window around the coarse delta (the PHAT-seeded timeline, arrival
+        // envelope where PHAT was untrusted). The window is half the period of
+        // THIS junction's crossover — wide enough to absorb the coarse error
+        // (which grows with the period), narrow enough not to span two
+        // same-polarity lobes. The base doubles as a soft prior: a quadratic dB
+        // penalty that deters far lobes.
+        (IReadOnlyList<AlignmentCandidate> Candidates, double BaseDelta, double HalfPeriodMs)
+            SearchJunction(
+                IAlignmentChannel channel,
+                IAlignmentChannel neighborChannel,
+                AlignmentJunction junction,
+                double? windowOverrideMs = null)
+        {
+            // Reprocess so the settled neighbors participate with their new
+            // delays and polarities. The searched channel is dropped from the
+            // override map so its response is the raw, undelayed IR — the search
+            // provides the delay, and chosen.DelayMs is then the absolute delay
+            // to assign. Without this reset, a uniform shift applied earlier to
+            // a not-yet-searched channel (the negative-delay branch below) would
+            // bake a stray offset into variableIr that the reported delay does
+            // not account for, mis-aligning that channel by the shift.
+            var searchAlignment =
+                new Dictionary<IAlignmentChannel, AlignmentOverride>(alignment);
+            searchAlignment.Remove(channel);
+            IReadOnlyList<AlignmentSnapshot> current = reprocess(searchAlignment);
+            Complex[] variableIr = current
+                .First(item => item.Channel == channel).ImpulseResponse;
+            var neighborIrs = new List<Complex[]>
+            {
+                current.First(item => item.Channel == neighborChannel).ImpulseResponse
+            };
+
+            double halfPeriodMs = 500.0 / junction.CrossoverHz;
+            double rangeMs = windowOverrideMs ?? Math.Clamp(
+                halfPeriodMs, MinFineAlignmentRangeMs, MaxFineAlignmentRangeMs);
+            double baseDelta = alignment.GetValueOrDefault(neighborChannel).DelayMs
+                + timeline[neighborChannel] - timeline[channel];
+            IReadOnlyList<AlignmentCandidate> candidates =
+                VirtualCrossoverAnalysis.FindAlignmentCandidates(
+                    variableIr,
+                    neighborIrs,
+                    channel.SampleRate,
+                    junction.BandLowHz,
+                    junction.BandHighHz,
+                    baseDelta - rangeMs,
+                    baseDelta + rangeMs,
+                    priorDelayMs: baseDelta,
+                    priorSigmaMs: rangeMs / 2);
+            return (candidates, baseDelta, halfPeriodMs);
+        }
+
+        foreach ((AlignmentSnapshot target, AlignmentSnapshot neighbor, AlignmentJunction pair)
+            in searchOrder)
+        {
+            IAlignmentChannel channel = target.Channel;
+            (IReadOnlyList<AlignmentCandidate> candidates, double baseDelta,
+                double halfPeriodMs) = SearchJunction(channel, neighbor.Channel, pair);
+            log.AppendLine(
+                $"Channel {channel.Name}: " +
+                $"vs {neighbor.Channel.Name} " +
+                $"in {pair.BandLowHz:0}-{pair.BandHighHz:0} Hz, " +
+                $"base {baseDelta:0.000} ms, candidates " +
+                string.Join("; ", candidates.Select(item =>
+                    $"{item.DelayMs:0.000} ms" +
+                    $"{(item.InvertPolarity ? " inv" : "")} " +
+                    $"(score {item.ScoreDb:0.00}, avg {item.LossDb:0.00}, " +
+                    $"dip {item.DipDb:0.0} dB)")));
+
+            AlignmentCandidate chosen = candidates.Count > 0
+                ? AlignmentSelection.Select(candidates, baseDelta)
+                : new AlignmentCandidate(baseDelta, false, 0);
+            if (candidates.Count > 0 && chosen != candidates[0])
+            {
+                log.AppendLine(
+                    $"  preferred {chosen.DelayMs:0.000} ms" +
+                    $"{(chosen.InvertPolarity ? " inv" : "")} over " +
+                    $"{candidates[0].DelayMs:0.000} ms" +
+                    $"{(candidates[0].InvertPolarity ? " inv" : "")} " +
+                    $"(margin {candidates[0].ScoreDb - chosen.ScoreDb:0.00} dB)");
+            }
+
+            // Diagnostic wide sweep: the same junction searched across a much
+            // wider window so lobes beyond the working range appear in the log.
+            // Purely informational — the chosen result above is untouched.
+            (IReadOnlyList<AlignmentCandidate> wide, double wideBase, _) =
+                SearchJunction(
+                    channel, neighbor.Channel, pair,
+                    windowOverrideMs: DiagnosticFineRangeMs);
+            log.AppendLine(
+                $"  [diag] wide +-{DiagnosticFineRangeMs:0.0} ms " +
+                $"(base {wideBase:0.000} ms): " +
+                (wide.Count > 0
+                    ? string.Join("; ", wide.Select(item =>
+                        $"{item.DelayMs:0.000} ms" +
+                        $"{(item.InvertPolarity ? " inv" : "")} " +
+                        $"(score {item.ScoreDb:0.00}, avg {item.LossDb:0.00}, " +
+                        $"dip {item.DipDb:0.0} dB)"))
+                    : "none"));
+
+            double fineRangeMs = Math.Clamp(
+                halfPeriodMs, MinFineAlignmentRangeMs, MaxFineAlignmentRangeMs);
+
+            // A result pinned to the window edge means the optimum lies beyond
+            // the coarse estimate's reach — retry once, widened but still short
+            // of a full period so the search cannot land on the next lobe. The
+            // edge hit means the base itself is suspect, so the retry relaxes
+            // the prior along with the window.
+            double retryRangeMs = Math.Min(1.8 * halfPeriodMs, 3.0);
+            if (retryRangeMs > fineRangeMs &&
+                Math.Abs(chosen.DelayMs - baseDelta) >= fineRangeMs - 0.02)
+            {
+                (IReadOnlyList<AlignmentCandidate> retried, _, _) = SearchJunction(
+                    channel, neighbor.Channel, pair, windowOverrideMs: retryRangeMs);
+                if (retried.Count > 0)
+                {
+                    chosen = retried[0];
+                }
+
+                log.AppendLine(
+                    $"  WARNING: fine result at the search edge; widened to " +
+                    $"±{retryRangeMs:0.000} ms -> {chosen.DelayMs:0.000} ms, " +
+                    $"invert {(chosen.InvertPolarity ? "yes" : "no")}");
+            }
+
+            // Promote the wide-window optimum when it clearly beats the
+            // arrival-anchored pick: the coarse arrival can sit a whole lobe off
+            // at a high crossover, and the narrow window cannot reach the true
+            // summation optimum a few periods away. AlignmentSelection applies
+            // the same flip/tie rules to the wide set, and the margin ensures a
+            // mere lobe/flip impostor cannot pull the result off the arrival.
+            if (wide.Count > 0)
+            {
+                AlignmentCandidate wideChosen = AlignmentSelection.Select(wide, wideBase);
+                if (wideChosen.ScoreDb > chosen.ScoreDb + WideWindowPromotionMarginDb)
+                {
+                    log.AppendLine(
+                        $"  promoted {wideChosen.DelayMs:0.000} ms" +
+                        $"{(wideChosen.InvertPolarity ? " inv" : "")} " +
+                        $"over {chosen.DelayMs:0.000} ms" +
+                        $"{(chosen.InvertPolarity ? " inv" : "")} " +
+                        $"(gain {wideChosen.ScoreDb - chosen.ScoreDb:0.00} dB)");
+                    chosen = wideChosen;
+                }
+            }
+
+            double newDelay = chosen.DelayMs;
+            if (newDelay < 0)
+            {
+                // A physically impossible negative delay: push every channel by
+                // the deficit instead — a uniform shift preserves the alignment.
+                double shift = -newDelay;
+                foreach (AlignmentSnapshot item in byBand)
+                {
+                    if (item.Channel != channel)
+                    {
+                        AlignmentOverride currentAlignment =
+                            alignment.GetValueOrDefault(item.Channel);
+                        alignment[item.Channel] = currentAlignment with
+                        {
+                            DelayMs = Math.Min(100, currentAlignment.DelayMs + shift)
+                        };
+                    }
+                }
+                newDelay = 0;
+            }
+
+            alignment[channel] = new AlignmentOverride(
+                Math.Clamp(Math.Round(newDelay, 2), 0, 100),
+                chosen.InvertPolarity);
+        }
+    }
+
+    private static void AppendCorrelationAlignmentDiagnostics(
+        StringBuilder log,
+        IReadOnlyList<AlignmentJunction> pairs)
+    {
+        if (pairs.Count == 0)
+        {
+            return;
+        }
+
+        log.AppendLine();
+        log.AppendLine(
+            "[corr] band-limited cross-correlation diagnostics " +
+            "(full pair band, " +
+            $"window ±{DiagnosticCorrelationRangeMs:0.###} ms; " +
+            "[corr] raw amplitude, [phat] phase-transform / whitened)");
+
+        foreach (AlignmentJunction pair in pairs)
+        {
+            // The full pair band, so the correlation reads the same overlap the
+            // stage-2 loss search does. The pair band spans fc/2..fc*2 around the
+            // crossover, so its width in octaves is log2(high/low).
+            double passOctaves = Math.Log2(pair.BandHighHz / pair.BandLowHz);
+
+            // Center the lag window on the arrival-based "delay to add to upper"
+            // (lower arrival minus upper arrival), the same coarse estimate stage 1
+            // computes, so a several-millisecond low-frequency offset stays in the
+            // window instead of falling off its zero-centered edge.
+            double lowerArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+                pair.Lower.ImpulseResponse,
+                pair.Lower.Channel.SampleRate,
+                pair.BandLowHz,
+                pair.BandHighHz);
+            double upperArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+                pair.Upper.ImpulseResponse,
+                pair.Upper.Channel.SampleRate,
+                pair.BandLowHz,
+                pair.BandHighHz);
+            double centerLagMs = lowerArrival - upperArrival;
+
+            AppendCorrelationMode(
+                log, pair, "corr", passOctaves, centerLagMs, phaseTransform: false);
+            AppendCorrelationMode(
+                log, pair, "phat", passOctaves, centerLagMs, phaseTransform: true);
+        }
+
+        log.AppendLine();
+    }
+
+    private static void AppendCorrelationMode(
+        StringBuilder log,
+        AlignmentJunction pair,
+        string tag,
+        double passOctaves,
+        double centerLagMs,
+        bool phaseTransform)
+    {
+        CorrelationAlignmentResult result =
+            VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
+                pair.Lower.ImpulseResponse,
+                pair.Upper.ImpulseResponse,
+                pair.Lower.Channel.SampleRate,
+                pair.CrossoverHz,
+                passOctaves,
+                DiagnosticCorrelationRangeMs,
+                centerLagMs,
+                phaseTransform);
+        CorrelationDelayCandidate best = result.BestByMagnitude;
+
+        log.AppendLine(
+            $"[{tag}] {pair.Lower.Channel.Name}/" +
+            $"{pair.Upper.Channel.Name}: " +
+            $"fc {result.CenterFrequencyHz:0} Hz, " +
+            $"band {result.BandLowHz:0}-{result.BandHighHz:0} Hz, " +
+            $"delay to add to {pair.Upper.Channel.Name}: " +
+            $"{best.DelayMs:+0.000;-0.000} ms, " +
+            $"invert {(best.InvertPolarity ? "yes" : "no")}, " +
+            $"r {best.Coefficient:+0.000;-0.000}, " +
+            $"confidence {result.Confidence:0.000}");
+        log.AppendLine(
+            $"  [{tag}] peak {result.PositivePeak.DelayMs:+0.000;-0.000} ms " +
+            $"(r {result.PositivePeak.Coefficient:+0.000;-0.000}); " +
+            $"trough {result.NegativeTrough.DelayMs:+0.000;-0.000} ms " +
+            $"(r {result.NegativeTrough.Coefficient:+0.000;-0.000}, inv)");
+    }
+}

--- a/dsp/DataHelper.cs
+++ b/dsp/DataHelper.cs
@@ -462,6 +462,38 @@ namespace Resonalyze.Dsp
             return data;
         }
 
+        /// <summary>
+        /// Wrapped or unwrapped gated phase (radians) using the same gate
+        /// construction as <see cref="GetPhase"/>, referenced to an absolute
+        /// sample position (fractional samples allowed, so a τ reference is
+        /// not limited to whole samples). For callers that render their own
+        /// phase view (the Virtual DSP tool) without drifting from the Phase
+        /// mode's gating.
+        /// </summary>
+        public static List<SignalPoint> GetGatedPhaseData(
+            IImpulseMeasurement measurement,
+            double gateOffsetMs,
+            double leftMs,
+            double plateauMs,
+            double rightMs,
+            double referenceSamples,
+            bool unwrap)
+        {
+            Complex[] spectrum = BuildPhaseSpectrum(
+                measurement,
+                gateOffsetMs,
+                leftMs,
+                plateauMs,
+                rightMs,
+                out int extractionStart);
+            return BuildMeasuredPhase(
+                spectrum,
+                extractionStart,
+                referenceSamples,
+                measurement.SampleRate,
+                unwrap);
+        }
+
         public static AnalysisCurve GetPhase(
             IImpulseMeasurement measurement,
             double gateOffsetMs,
@@ -472,21 +504,13 @@ namespace Resonalyze.Dsp
             double smoothingInverseOctaves,
             bool unwrap)
         {
-            Complex[] spectrum = BuildPhaseSpectrum(
+            List<SignalPoint> phase = GetGatedPhaseData(
                 measurement,
                 gateOffsetMs,
                 leftMs,
                 plateauMs,
                 rightMs,
-                out int extractionStart);
-
-            double referenceSamples =
-                detrendMilliseconds * measurement.SampleRate / 1000.0;
-            List<SignalPoint> phase = BuildMeasuredPhase(
-                spectrum,
-                extractionStart,
-                referenceSamples,
-                measurement.SampleRate,
+                detrendMilliseconds * measurement.SampleRate / 1000.0,
                 unwrap);
 
             List<SignalPoint> data = new(phase.Count);

--- a/source/Tools/EqFormatFileDialogs.cs
+++ b/source/Tools/EqFormatFileDialogs.cs
@@ -1,0 +1,44 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Builds the file-dialog Filter string for a list of EQ profile formats and
+/// resolves the dialog's 1-based <c>FilterIndex</c> back to the format, so
+/// the string and the lookup can never disagree about ordering or the
+/// off-by-one.
+/// </summary>
+internal static class EqFormatFileDialogs
+{
+    internal static string BuildFilter(
+        IReadOnlyList<IEqProfileFormat> formats,
+        string? trailingFilter = null)
+    {
+        string filter = string.Join(
+            "|",
+            formats.Select(format =>
+                $"{format.Name} (*.{format.Extension})|*.{format.Extension}"));
+        return trailingFilter == null ? filter : $"{filter}|{trailingFilter}";
+    }
+
+    /// <summary>
+    /// The format the dialog's <paramref name="filterIndex"/> selects, or
+    /// null when the index points past the format list — i.e. at a trailing
+    /// non-format entry appended via
+    /// <see cref="BuildFilter(IReadOnlyList{IEqProfileFormat}, string?)"/>.
+    /// An index below the list (defensive; dialogs start at 1) resolves to
+    /// the first format.
+    /// </summary>
+    internal static IEqProfileFormat? ResolveFormat(
+        IReadOnlyList<IEqProfileFormat> formats,
+        int filterIndex)
+    {
+        int index = filterIndex - 1;
+        if (index >= formats.Count)
+        {
+            return null;
+        }
+
+        return formats[Math.Max(0, index)];
+    }
+}

--- a/source/Tools/EqWizardPanel.cs
+++ b/source/Tools/EqWizardPanel.cs
@@ -765,7 +765,7 @@ public partial class EqWizardPanel : UserControl
             AddExtension = true,
             DefaultExt = formats[0].Extension,
             FileName = "eq",
-            Filter = BuildFormatFilter(formats) + "|" + TuningSheetFilter,
+            Filter = EqFormatFileDialogs.BuildFilter(formats, TuningSheetFilter),
             Title = "Export PEQ"
         };
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK)
@@ -773,20 +773,21 @@ public partial class EqWizardPanel : UserControl
             return;
         }
 
-        int selected = dialog.FilterIndex - 1;
+        IEqProfileFormat? format = EqFormatFileDialogs.ResolveFormat(
+            formats, dialog.FilterIndex);
         EqualizationCurve curve = BuildEqualizationCurve();
         try
         {
-            if (selected >= formats.Count)
+            if (format == null)
             {
-                // The tuning sheet is the last filter entry; its title is the file name.
+                // The tuning sheet is the trailing filter entry; its title is
+                // the file name.
                 string title = System.IO.Path.GetFileNameWithoutExtension(dialog.FileName);
                 (double minHz, double maxHz) = GetFrequencyWindow();
                 TuningSheetPdf.Export(dialog.FileName, title, curve, minHz, maxHz, lastStats);
             }
             else
             {
-                IEqProfileFormat format = formats[Math.Clamp(selected, 0, formats.Count - 1)];
                 System.IO.File.WriteAllText(dialog.FileName, format.Export(curve));
             }
         }
@@ -804,7 +805,7 @@ public partial class EqWizardPanel : UserControl
         using var dialog = new OpenFileDialog
         {
             CheckFileExists = true,
-            Filter = BuildFormatFilter(formats),
+            Filter = EqFormatFileDialogs.BuildFilter(formats),
             Title = "Import PEQ"
         };
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK)
@@ -812,7 +813,9 @@ public partial class EqWizardPanel : UserControl
             return;
         }
 
-        IEqProfileFormat format = formats[Math.Clamp(dialog.FilterIndex - 1, 0, formats.Count - 1)];
+        // No trailing entry, so the index always resolves to a format.
+        IEqProfileFormat format =
+            EqFormatFileDialogs.ResolveFormat(formats, dialog.FilterIndex)!;
         EqualizationCurve curve;
         try
         {
@@ -828,11 +831,6 @@ public partial class EqWizardPanel : UserControl
         checkBoxBypass.Checked = false;
         ApplyEqualizationCurve(curve);
     }
-
-    private static string BuildFormatFilter(IReadOnlyList<IEqProfileFormat> formats) =>
-        string.Join(
-            "|",
-            formats.Select(format => $"{format.Name} (*.{format.Extension})|*.{format.Extension}"));
 
     private void ShowFileError(string message, Exception exception)
     {

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -1268,10 +1268,6 @@ public partial class VirtualCrossoverPanel : UserControl
         int PeakIndex,
         OxyColor Color);
 
-    private readonly record struct AlignmentOverride(
-        double DelayMs,
-        bool InvertPolarity);
-
     private sealed class ProcessedChannelCacheKey : IEquatable<ProcessedChannelCacheKey>
     {
         private readonly Complex[] source;
@@ -1812,56 +1808,12 @@ public partial class VirtualCrossoverPanel : UserControl
         labelCrossoverWarning.Visible = true;
     }
 
-    // Bounds of the stage-2 fine-search span. The span scales with the
-    // crossover frequency (half its period) because the coarse arrival error
-    // grows with the period — but it never drops below half a millisecond:
-    // arrival estimates carry a floor of error (filter group-delay asymmetry,
-    // driver rise time) that does not shrink with the junction period, so at a
-    // high split half a period would regularly miss the true optimum. The
-    // extra lobes a wide window admits are handled by the candidate list, the
-    // arrival prior, and the physical tie-break in SelectCandidate.
-    private const double MinFineAlignmentRangeMs = 0.5;
-    private const double MaxFineAlignmentRangeMs = 2.5;
-
-    // Diagnostics only: a deliberately wide fine-search window (many periods at a
-    // high crossover, ~one at a low one) whose candidates are logged but never
-    // chosen. It surfaces summation optima that sit several lobes outside the
-    // working window, so a log can show whether a better lobe exists there.
-    private const double DiagnosticFineRangeMs = 3.0;
-    private const double DiagnosticCorrelationRangeMs = 3.0;
-
-    // The minimum non-inverted PHAT peak correlation for its position to seed the
-    // stage-2 window instead of the arrival envelope. Below it the peak is noise
-    // (a low-frequency junction with too few in-band periods), and the arrival
-    // estimate stands. Deliberately low: even a modest genuine peak beats the
-    // arrival envelope, and the loss search plus the wide-window promotion recover
-    // from a seed that still lands a little off.
-    private const double PhatSeedMinCoefficient = 0.15;
-
-    // How much better (in score dB) a wide-window optimum must be before it
-    // unseats the arrival-anchored fine pick. The narrow window is centered on
-    // the coarse arrival, which at a high crossover can be a whole lobe off (its
-    // period is a fraction of the arrival uncertainty); the promotion recovers
-    // that lobe, while the margin keeps the physically-minimal arrival pick
-    // unless a distinctly better summation exists elsewhere.
-    private const double WideWindowPromotionMarginDb = 0.2;
-
-    // The invert-preference and delay-tie margins live with the selection
-    // logic in AlignmentSelection (Resonalyze.Dsp), where they are unit-tested.
-    private static AlignmentCandidate SelectCandidate(
-        IReadOnlyList<AlignmentCandidate> candidates,
-        double baseDeltaMs) =>
-        AlignmentSelection.Select(candidates, baseDeltaMs);
-
-    // Two-stage alignment. Stage 1: Time-Alignment-style band-limited first
-    // arrivals give a coarse delay per channel (robust, no phase ambiguity).
-    // Stage 2: walking pair by pair outward from the reference, a phase
-    // correlation fine-tunes each channel against its settled neighbor inside
-    // their shared pair band, also deciding whether its polarity should flip.
-    // The latest-arriving channel is the fixed reference, so the proposed
-    // delays stay non-negative by construction. Previous Auto/manual delay and
-    // polarity settings are ignored: the command recomputes an absolute proposal
-    // from the current sources, crossover filters, gains and PEQ every time.
+    // The two alignment stages, their tuning constants and the selection
+    // tie-breaks live in AutoAlignmentEngine / AlignmentSelection
+    // (Resonalyze.Dsp), where they are unit-tested. Previous Auto/manual delay
+    // and polarity settings are ignored: the command recomputes an absolute
+    // proposal from the current sources, crossover filters, gains and PEQ
+    // every time.
     private async void AutoAlignDelay()
     {
         var alignment = new Dictionary<ChannelRuntime, AlignmentOverride>();
@@ -1992,373 +1944,59 @@ public partial class VirtualCrossoverPanel : UserControl
         WriteAlignmentLog(log.ToString());
     }
 
-    // The FFT-heavy alignment stages, isolated so they can run on a background
-    // thread: they read `processed` (immutable IRs) and the locked channel
-    // settings, fill `alignment` and `log`, and touch no UI (ChannelName is a
-    // plain field). Only the non-cached ProcessChannels path is used, so nothing
-    // shared is mutated.
+    // Bridges the panel's channel model to the dsp AutoAlignmentEngine (where
+    // the FFT-heavy alignment stages live, unit-tested): snapshots + junctions
+    // in, an override map out. Runs on a background thread; the reprocess
+    // delegate owns the thread-confined FFT cache — between consecutive
+    // junction searches only one or two channels change their overrides, so
+    // the other channels' processed IRs are reused instead of re-FFT'd, and
+    // the shared UI-thread cache is never touched.
     private void ComputeAutoAlignment(
         List<ProcessedChannel> processed,
         Dictionary<ChannelRuntime, AlignmentOverride> alignment,
         System.Text.StringBuilder log)
     {
-        // Thread-confined FFT cache for the junction searches below: between
-        // consecutive searches only the overrides of one or two channels change,
-        // so the other channels' processed IRs are reused instead of re-FFT'd.
         var searchCache = new Dictionary<ChannelRuntime, ProcessedChannelCache>();
-
-        // Stage 1: coarse offsets from band-limited first arrivals, refined by the
-        // GCC-PHAT peak where it is trustworthy. Arrivals of different drivers are
-        // only comparable inside a SHARED band — a woofer's envelope in its own low
-        // band rises milliseconds later than a tweeter's in its high band. So each
-        // adjacent pair is measured around its own crossover frequency, and the
-        // pairwise differences chain into one relative timeline that seeds stage 2.
         List<ProcessedChannel> byBand = OrderByBand(processed);
         List<AdjacentPair> pairs = GetAdjacentPairs(byBand);
-        AppendCorrelationAlignmentDiagnostics(log, pairs);
 
-        var timeline = new Dictionary<ChannelRuntime, double> { [byBand[0].Channel] = 0 };
-        foreach (AdjacentPair pair in pairs)
-        {
-            double lowerArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                pair.Lower.ImpulseResponse,
-                pair.Lower.Channel.SampleRate,
-                pair.BandLowHz,
-                pair.BandHighHz);
-            double upperArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                pair.Upper.ImpulseResponse,
-                pair.Upper.Channel.SampleRate,
-                pair.BandLowHz,
-                pair.BandHighHz);
-
-            // Refine the coarse offset with the non-inverted GCC-PHAT peak: at a
-            // mid/high junction it lands the stage-2 window on the correct lobe
-            // directly, sparing the wide-window recovery. Only the peak POSITION
-            // is used (polarity and the final lobe stay with the loss search), and
-            // only when the peak carries a real correlation — otherwise the arrival
-            // envelope stands. The PHAT window is centered on the arrival estimate,
-            // so a trusted peak is by construction within reach of it. The timeline
-            // stores arrivals as (upper - lower); the PHAT peak is the delay to add
-            // to the upper channel, i.e. the same quantity negated.
-            double passOctaves = Math.Log2(pair.BandHighHz / pair.BandLowHz);
-            CorrelationAlignmentResult phat =
-                VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
-                    pair.Lower.ImpulseResponse,
-                    pair.Upper.ImpulseResponse,
-                    pair.Lower.Channel.SampleRate,
-                    pair.CrossoverHz,
-                    passOctaves,
-                    DiagnosticCorrelationRangeMs,
-                    centerLagMs: lowerArrival - upperArrival,
-                    phaseTransform: true);
-            bool trustPhat = phat.PositivePeak.Coefficient >= PhatSeedMinCoefficient;
-            double increment =
-                trustPhat ? -phat.PositivePeak.DelayMs : upperArrival - lowerArrival;
-            timeline[pair.Upper.Channel] = timeline[pair.Lower.Channel] + increment;
-
-            // Full-band processed-IR peak times, a detector-independent arrival
-            // proxy: a band-limited arrival that sits many ms LATER than its own
-            // channel's energy peak is a detector artifact (a late in-band lobe),
-            // not a real arrival.
-            double lowerPeakMs =
-                pair.Lower.PeakIndex * 1000.0 / pair.Lower.Channel.SampleRate;
-            double upperPeakMs =
-                pair.Upper.PeakIndex * 1000.0 / pair.Upper.Channel.SampleRate;
-
-            log.AppendLine(
-                $"Pair {pair.Lower.Channel.Control.ChannelName}/" +
-                $"{pair.Upper.Channel.Control.ChannelName}: " +
-                $"fc {pair.CrossoverHz:0} Hz, " +
-                $"band {pair.BandLowHz:0}-{pair.BandHighHz:0} Hz, " +
-                $"arrivals {lowerArrival:0.000} / {upperArrival:0.000} ms " +
-                $"(peaks {lowerPeakMs:0.000} / {upperPeakMs:0.000} ms), " +
-                $"diff {upperArrival - lowerArrival:+0.000;-0.000} ms, " +
-                $"phat peak {phat.PositivePeak.DelayMs:+0.000;-0.000} ms " +
-                $"(r {phat.PositivePeak.Coefficient:+0.000;-0.000}) -> seed " +
-                $"{(trustPhat ? "phat" : "arrival")}");
-        }
-
-        // The relatively latest channel is the fixed reference; everyone else is
-        // delayed toward it, so the coarse deltas are non-negative.
-        double latest = timeline.Values.Max();
-        ChannelRuntime reference = timeline.First(pair => pair.Value == latest).Key;
-        log.AppendLine($"Reference: {reference.Control.ChannelName}");
-
-        // Stage 2: sequential pairwise fine alignment, walking outward from the
-        // reference along the band order. Each channel is phase-correlated
-        // against its already-settled neighbor only, inside their shared pair
-        // band, so the search window is sized by THAT junction — a mid channel
-        // must not have its low-junction window squeezed to the period of its
-        // high junction. An arrival error at a low junction then propagates
-        // through the chain and moves the whole upper group together, which a
-        // per-channel search against all fixed channels at once cannot do.
-        int referenceIndex = byBand.FindIndex(item => item.Channel == reference);
-        var searchOrder =
-            new List<(ProcessedChannel Target, ProcessedChannel Neighbor, AdjacentPair Pair)>();
-        for (int i = referenceIndex - 1; i >= 0; i--)
-        {
-            searchOrder.Add((byBand[i], byBand[i + 1], pairs[i]));
-        }
-        for (int i = referenceIndex + 1; i < byBand.Count; i++)
-        {
-            searchOrder.Add((byBand[i], byBand[i - 1], pairs[i - 1]));
-        }
-
-        // One junction search: candidates of the prior-penalized loss score in
-        // a window around the coarse delta (the PHAT-seeded timeline, arrival
-        // envelope where PHAT was untrusted). The window is half the period of
-        // THIS junction's crossover — wide enough to absorb the coarse error
-        // (which grows with the period), narrow enough not to span two
-        // same-polarity lobes. The base doubles as a soft prior: a quadratic dB
-        // penalty that deters far lobes.
-        (IReadOnlyList<AlignmentCandidate> Candidates, double BaseDelta, double HalfPeriodMs)
-            SearchJunction(
-                ChannelRuntime channel,
-                ChannelRuntime neighborChannel,
-                AdjacentPair junction,
-                double? windowOverrideMs = null)
-        {
-            // Reprocess so the settled neighbors participate with their new
-            // delays and polarities. The searched channel is dropped from the
-            // override map so its response is the raw, undelayed IR — the search
-            // provides the delay, and chosen.DelayMs is then the absolute delay
-            // to assign. Without this reset, a uniform shift applied earlier to
-            // a not-yet-searched channel (the negative-delay branch below) would
-            // bake a stray offset into variableIr that the reported delay does
-            // not account for, mis-aligning that channel by the shift.
-            var searchAlignment = new Dictionary<ChannelRuntime, AlignmentOverride>(alignment);
-            searchAlignment.Remove(channel);
-            List<ProcessedChannel> current = ProcessChannels(searchAlignment, searchCache);
-            Complex[] variableIr = current
-                .First(item => item.Channel == channel).ImpulseResponse;
-            var neighborIrs = new List<Complex[]>
-            {
-                current.First(item => item.Channel == neighborChannel).ImpulseResponse
-            };
-
-            double halfPeriodMs = 500.0 / junction.CrossoverHz;
-            double rangeMs = windowOverrideMs ?? Math.Clamp(
-                halfPeriodMs, MinFineAlignmentRangeMs, MaxFineAlignmentRangeMs);
-            double baseDelta = alignment.GetValueOrDefault(neighborChannel).DelayMs
-                + timeline[neighborChannel] - timeline[channel];
-            IReadOnlyList<AlignmentCandidate> candidates =
-                VirtualCrossoverAnalysis.FindAlignmentCandidates(
-                    variableIr,
-                    neighborIrs,
-                    channel.SampleRate,
-                    junction.BandLowHz,
-                    junction.BandHighHz,
-                    baseDelta - rangeMs,
-                    baseDelta + rangeMs,
-                    priorDelayMs: baseDelta,
-                    priorSigmaMs: rangeMs / 2);
-            return (candidates, baseDelta, halfPeriodMs);
-        }
-
-        foreach ((ProcessedChannel target, ProcessedChannel neighbor, AdjacentPair pair)
-            in searchOrder)
-        {
-            ChannelRuntime channel = target.Channel;
-            (IReadOnlyList<AlignmentCandidate> candidates, double baseDelta,
-                double halfPeriodMs) = SearchJunction(channel, neighbor.Channel, pair);
-            log.AppendLine(
-                $"Channel {channel.Control.ChannelName}: " +
-                $"vs {neighbor.Channel.Control.ChannelName} " +
-                $"in {pair.BandLowHz:0}-{pair.BandHighHz:0} Hz, " +
-                $"base {baseDelta:0.000} ms, candidates " +
-                string.Join("; ", candidates.Select(item =>
-                    $"{item.DelayMs:0.000} ms" +
-                    $"{(item.InvertPolarity ? " inv" : "")} " +
-                    $"(score {item.ScoreDb:0.00}, avg {item.LossDb:0.00}, " +
-                    $"dip {item.DipDb:0.0} dB)")));
-
-            AlignmentCandidate chosen = candidates.Count > 0
-                ? SelectCandidate(candidates, baseDelta)
-                : new AlignmentCandidate(baseDelta, false, 0);
-            if (candidates.Count > 0 && chosen != candidates[0])
-            {
-                log.AppendLine(
-                    $"  preferred {chosen.DelayMs:0.000} ms" +
-                    $"{(chosen.InvertPolarity ? " inv" : "")} over " +
-                    $"{candidates[0].DelayMs:0.000} ms" +
-                    $"{(candidates[0].InvertPolarity ? " inv" : "")} " +
-                    $"(margin {candidates[0].ScoreDb - chosen.ScoreDb:0.00} dB)");
-            }
-
-            // Diagnostic wide sweep: the same junction searched across a much
-            // wider window so lobes beyond the working range appear in the log.
-            // Purely informational — the chosen result above is untouched.
-            (IReadOnlyList<AlignmentCandidate> wide, double wideBase, _) =
-                SearchJunction(
-                    channel, neighbor.Channel, pair,
-                    windowOverrideMs: DiagnosticFineRangeMs);
-            log.AppendLine(
-                $"  [diag] wide +-{DiagnosticFineRangeMs:0.0} ms " +
-                $"(base {wideBase:0.000} ms): " +
-                (wide.Count > 0
-                    ? string.Join("; ", wide.Select(item =>
-                        $"{item.DelayMs:0.000} ms" +
-                        $"{(item.InvertPolarity ? " inv" : "")} " +
-                        $"(score {item.ScoreDb:0.00}, avg {item.LossDb:0.00}, " +
-                        $"dip {item.DipDb:0.0} dB)"))
-                    : "none"));
-
-            double fineRangeMs = Math.Clamp(
-                halfPeriodMs, MinFineAlignmentRangeMs, MaxFineAlignmentRangeMs);
-
-            // A result pinned to the window edge means the optimum lies beyond
-            // the coarse estimate's reach — retry once, widened but still short
-            // of a full period so the search cannot land on the next lobe. The
-            // edge hit means the base itself is suspect, so the retry relaxes
-            // the prior along with the window.
-            double retryRangeMs = Math.Min(1.8 * halfPeriodMs, 3.0);
-            if (retryRangeMs > fineRangeMs &&
-                Math.Abs(chosen.DelayMs - baseDelta) >= fineRangeMs - 0.02)
-            {
-                (IReadOnlyList<AlignmentCandidate> retried, _, _) = SearchJunction(
-                    channel, neighbor.Channel, pair, windowOverrideMs: retryRangeMs);
-                if (retried.Count > 0)
-                {
-                    chosen = retried[0];
-                }
-
-                log.AppendLine(
-                    $"  WARNING: fine result at the search edge; widened to " +
-                    $"±{retryRangeMs:0.000} ms -> {chosen.DelayMs:0.000} ms, " +
-                    $"invert {(chosen.InvertPolarity ? "yes" : "no")}");
-            }
-
-            // Promote the wide-window optimum when it clearly beats the
-            // arrival-anchored pick: the coarse arrival can sit a whole lobe off
-            // at a high crossover, and the narrow window cannot reach the true
-            // summation optimum a few periods away. SelectCandidate applies the
-            // same flip/tie rules to the wide set, and the margin ensures a mere
-            // lobe/flip impostor cannot pull the result off the arrival.
-            if (wide.Count > 0)
-            {
-                AlignmentCandidate wideChosen = SelectCandidate(wide, wideBase);
-                if (wideChosen.ScoreDb > chosen.ScoreDb + WideWindowPromotionMarginDb)
-                {
-                    log.AppendLine(
-                        $"  promoted {wideChosen.DelayMs:0.000} ms" +
-                        $"{(wideChosen.InvertPolarity ? " inv" : "")} " +
-                        $"over {chosen.DelayMs:0.000} ms" +
-                        $"{(chosen.InvertPolarity ? " inv" : "")} " +
-                        $"(gain {wideChosen.ScoreDb - chosen.ScoreDb:0.00} dB)");
-                    chosen = wideChosen;
-                }
-            }
-
-            double newDelay = chosen.DelayMs;
-            if (newDelay < 0)
-            {
-                // A physically impossible negative delay: push every channel by
-                // the deficit instead — a uniform shift preserves the alignment.
-                double shift = -newDelay;
-                foreach (ProcessedChannel item in processed)
-                {
-                    if (item.Channel != channel)
-                    {
-                        AlignmentOverride currentAlignment =
-                            alignment.GetValueOrDefault(item.Channel);
-                        alignment[item.Channel] = currentAlignment with
-                        {
-                            DelayMs = Math.Min(100, currentAlignment.DelayMs + shift)
-                        };
-                    }
-                }
-                newDelay = 0;
-            }
-
-            alignment[channel] = new AlignmentOverride(
-                Math.Clamp(Math.Round(newDelay, 2), 0, 100),
-                chosen.InvertPolarity);
-        }
-    }
-
-    private static void AppendCorrelationAlignmentDiagnostics(
-        System.Text.StringBuilder log,
-        IReadOnlyList<AdjacentPair> pairs)
-    {
-        if (pairs.Count == 0)
-        {
-            return;
-        }
-
-        log.AppendLine();
-        log.AppendLine(
-            "[corr] band-limited cross-correlation diagnostics " +
-            "(full pair band, " +
-            $"window ±{DiagnosticCorrelationRangeMs:0.###} ms; " +
-            "[corr] raw amplitude, [phat] phase-transform / whitened)");
-
-        foreach (AdjacentPair pair in pairs)
-        {
-            // The full pair band, so the correlation reads the same overlap the
-            // stage-2 loss search does. The pair band spans fc/2..fc*2 around the
-            // crossover, so its width in octaves is log2(high/low).
-            double passOctaves = Math.Log2(pair.BandHighHz / pair.BandLowHz);
-
-            // Center the lag window on the arrival-based "delay to add to upper"
-            // (lower arrival minus upper arrival), the same coarse estimate stage 1
-            // computes, so a several-millisecond low-frequency offset stays in the
-            // window instead of falling off its zero-centered edge.
-            double lowerArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                pair.Lower.ImpulseResponse,
-                pair.Lower.Channel.SampleRate,
-                pair.BandLowHz,
-                pair.BandHighHz);
-            double upperArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                pair.Upper.ImpulseResponse,
-                pair.Upper.Channel.SampleRate,
-                pair.BandLowHz,
-                pair.BandHighHz);
-            double centerLagMs = lowerArrival - upperArrival;
-
-            AppendCorrelationMode(
-                log, pair, "corr", passOctaves, centerLagMs, phaseTransform: false);
-            AppendCorrelationMode(
-                log, pair, "phat", passOctaves, centerLagMs, phaseTransform: true);
-        }
-
-        log.AppendLine();
-    }
-
-    private static void AppendCorrelationMode(
-        System.Text.StringBuilder log,
-        AdjacentPair pair,
-        string tag,
-        double passOctaves,
-        double centerLagMs,
-        bool phaseTransform)
-    {
-        CorrelationAlignmentResult result =
-            VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
-                pair.Lower.ImpulseResponse,
-                pair.Upper.ImpulseResponse,
-                pair.Lower.Channel.SampleRate,
+        var snapshots = byBand.ToDictionary(
+            item => item.Channel,
+            item => new AlignmentSnapshot(
+                item.Channel, item.ImpulseResponse, item.PeakIndex));
+        List<AlignmentJunction> junctions = pairs
+            .Select(pair => new AlignmentJunction(
+                snapshots[pair.Lower.Channel],
+                snapshots[pair.Upper.Channel],
                 pair.CrossoverHz,
-                passOctaves,
-                DiagnosticCorrelationRangeMs,
-                centerLagMs,
-                phaseTransform);
-        CorrelationDelayCandidate best = result.BestByMagnitude;
+                pair.BandLowHz,
+                pair.BandHighHz))
+            .ToList();
 
-        log.AppendLine(
-            $"[{tag}] {pair.Lower.Channel.Control.ChannelName}/" +
-            $"{pair.Upper.Channel.Control.ChannelName}: " +
-            $"fc {result.CenterFrequencyHz:0} Hz, " +
-            $"band {result.BandLowHz:0}-{result.BandHighHz:0} Hz, " +
-            $"delay to add to {pair.Upper.Channel.Control.ChannelName}: " +
-            $"{best.DelayMs:+0.000;-0.000} ms, " +
-            $"invert {(best.InvertPolarity ? "yes" : "no")}, " +
-            $"r {best.Coefficient:+0.000;-0.000}, " +
-            $"confidence {result.Confidence:0.000}");
-        log.AppendLine(
-            $"  [{tag}] peak {result.PositivePeak.DelayMs:+0.000;-0.000} ms " +
-            $"(r {result.PositivePeak.Coefficient:+0.000;-0.000}); " +
-            $"trough {result.NegativeTrough.DelayMs:+0.000;-0.000} ms " +
-            $"(r {result.NegativeTrough.Coefficient:+0.000;-0.000}, inv)");
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides)
+        {
+            var mapped = overrides.ToDictionary(
+                entry => (ChannelRuntime)entry.Key,
+                entry => entry.Value);
+            return ProcessChannels(mapped, searchCache)
+                .Select(item => new AlignmentSnapshot(
+                    item.Channel, item.ImpulseResponse, item.PeakIndex))
+                .ToList();
+        }
+
+        var engineAlignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        AutoAlignmentEngine.Compute(
+            byBand.Select(item => snapshots[item.Channel]).ToList(),
+            junctions,
+            Reprocess,
+            engineAlignment,
+            log);
+
+        foreach ((IAlignmentChannel channel, AlignmentOverride result) in engineAlignment)
+        {
+            alignment[(ChannelRuntime)channel] = result;
+        }
     }
 
     // A diagnostic trace of the last Auto delay run (pair bands, arrivals,
@@ -3015,7 +2653,7 @@ public partial class VirtualCrossoverPanel : UserControl
 
     // Runtime state of one channel block: the bound project settings plus the
     // resolved source measurement (null while unresolved).
-    private sealed class ChannelRuntime
+    private sealed class ChannelRuntime : IAlignmentChannel
     {
         public ChannelRuntime(VirtualCrossoverChannelControl control)
         {
@@ -3023,6 +2661,9 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         public VirtualCrossoverChannelControl Control { get; }
+        // The alignment engine's log identity; ChannelName is a plain string
+        // property, safe to read off the UI thread.
+        public string Name => Control.ChannelName;
         public VirtualCrossoverChannelSettings Settings { get; set; } = new();
         public Complex[]? TransferImpulseResponse { get; set; }
         public int TransferPeakIndex { get; set; }

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -867,9 +867,7 @@ public partial class VirtualCrossoverPanel : UserControl
         using var dialog = new OpenFileDialog
         {
             CheckFileExists = true,
-            Filter = string.Join(
-                "|",
-                formats.Select(format => $"{format.Name} (*.{format.Extension})|*.{format.Extension}")),
+            Filter = EqFormatFileDialogs.BuildFilter(formats),
             Title = $"Load channel {channel.Control.ChannelName} PEQ"
         };
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK)
@@ -877,7 +875,9 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
-        IEqProfileFormat chosen = formats[Math.Clamp(dialog.FilterIndex - 1, 0, formats.Count - 1)];
+        // No trailing entry, so the index always resolves to a format.
+        IEqProfileFormat chosen =
+            EqFormatFileDialogs.ResolveFormat(formats, dialog.FilterIndex)!;
         EqualizationCurve curve;
         try
         {

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -2136,44 +2136,21 @@ public partial class VirtualCrossoverPanel : UserControl
         double gateOffsetMs,
         double detrendMs)
     {
-        // The same gate construction as the Phase mode: a Tukey window of
-        // left + plateau + right whose left shoulder ends at the gate offset,
-        // zero-padded to the fixed FFT length so the frequency grid is constant.
-        int length = DataHelper.GatedFftLength;
-        int gateOffset = (int)Math.Round(gateOffsetMs / 1_000.0 * sampleRate);
-        int left = MillisecondsToSamples(
-            gatePreview?.LeftMs ?? project.PhaseGateLeftMs, sampleRate);
-        int plateau = MillisecondsToSamples(
-            gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs, sampleRate);
-        int right = MillisecondsToSamples(
-            gatePreview?.RightMs ?? project.PhaseGateRightMs, sampleRate);
-
-        int gate = Math.Clamp(left + plateau + right, 1, length);
-        left = Math.Min(left, gate);
-        right = Math.Min(right, gate - left);
-
-        double[] tukey = Windowing.TukeyWindow(
-            gate,
-            (double)left / gate * 2.0,
-            (double)right / gate * 2.0);
-        double[] window = new double[length];
-        Array.Copy(tukey, window, gate);
-
-        int gateStart = gateOffset - left;
-        // The τ detrend is the phase reference. GetPhaseData re-references to a
-        // whole sample (the view's PeakIndex); the fractional remainder is
-        // applied per point below, so τ resolution is not limited to samples.
-        double detrendSamples = detrendMs / 1_000.0 * sampleRate;
-        int referenceSample = Math.Clamp(
-            (int)Math.Round(detrendSamples), 0, impulseResponse.Length - 1);
-        double residualSeconds = (detrendSamples - referenceSample) / sampleRate;
-
-        var view = new ImpulseMeasurementView(impulseResponse, referenceSample, sampleRate);
-        // GetPhaseData extracts at PeakIndex + offset and re-references the phase
-        // to PeakIndex, so every curve built with the same τ is directly
-        // comparable regardless of where the gate sits.
-        List<SignalPoint> phase = DataHelper.GetPhaseData(
-            view, gateStart - referenceSample, length, window, unwrap: false);
+        // The gate construction is shared with the Phase mode (DataHelper's
+        // gated extraction): a Tukey window of left + plateau + right whose
+        // left shoulder ends at the gate offset, zero-padded to the fixed FFT
+        // length so the frequency grid is constant. The τ detrend is the
+        // fractional-sample phase reference; every curve built with the same τ
+        // is directly comparable regardless of where its gate sits.
+        var view = new ImpulseMeasurementView(impulseResponse, 0, sampleRate);
+        List<SignalPoint> phase = DataHelper.GetGatedPhaseData(
+            view,
+            gateOffsetMs,
+            gatePreview?.LeftMs ?? project.PhaseGateLeftMs,
+            gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs,
+            gatePreview?.RightMs ?? project.PhaseGateRightMs,
+            referenceSamples: detrendMs / 1_000.0 * sampleRate,
+            unwrap: false);
 
         var points = new List<SignalPoint>(phase.Count);
         foreach (SignalPoint point in phase)
@@ -2183,16 +2160,11 @@ public partial class VirtualCrossoverPanel : UserControl
                 continue;
             }
 
-            double corrected = point.Y + Math.Tau * point.X * residualSeconds;
-            corrected = Math.Atan2(Math.Sin(corrected), Math.Cos(corrected));
-            points.Add(new SignalPoint(point.X, corrected / Math.PI * 180.0));
+            points.Add(new SignalPoint(point.X, point.Y / Math.PI * 180.0));
         }
 
         return points;
     }
-
-    private static int MillisecondsToSamples(double milliseconds, int sampleRate) =>
-        (int)Math.Round(Math.Max(0.0, milliseconds) * sampleRate / 1_000.0);
 
     // Opens the manual phase-gate dialog: the gate offset and Tukey shoulders
     // with a live preview of every processed channel IR, so reflections can be

--- a/source/Tools/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossoverProjectFile.cs
@@ -134,6 +134,11 @@ public sealed class VirtualCrossoverChannelSettings
 public sealed class VirtualCrossoverProjectFile
 {
     public const string CurrentFormat = "resonalyze-virtual-crossover";
+
+    // Bump on an incompatible schema change and add a per-version migration
+    // step in LoadOrDefault before Validate. Files from a NEWER version
+    // (a downgraded app) are never migrated: LoadOrDefault backs them up and
+    // starts fresh, LoadFrom rejects them with an explicit error.
     public const int CurrentVersion = 1;
     public const int MaximumChannelCount = 8;
     private const string FileName = "virtual-crossover.json";
@@ -269,15 +274,18 @@ public sealed class VirtualCrossoverProjectFile
     }
 
     /// <summary>
-    /// Loads the saved project, falling back to a fresh two-channel default when
-    /// the file is missing, unreadable or from an unknown version — the tool state
-    /// is a convenience, so it must never block startup.
+    /// Loads the saved project, falling back to a fresh default when the file
+    /// is missing, unreadable or from an unknown version — the tool state is a
+    /// convenience, so it must never block startup. A file that exists but
+    /// cannot be used is renamed to <c>.backup</c> first: the next scheduled
+    /// save overwrites the project path, and a downgrade or a bug must not
+    /// cost the user their tuning session.
     /// </summary>
     public static VirtualCrossoverProjectFile LoadOrDefault(string? rootDirectory = null)
     {
+        string path = GetPath(rootDirectory);
         try
         {
-            string path = GetPath(rootDirectory);
             if (!File.Exists(path))
             {
                 return new VirtualCrossoverProjectFile();
@@ -288,21 +296,33 @@ public sealed class VirtualCrossoverProjectFile
                 FileMode.Open,
                 FileAccess.Read,
                 FileShare.Read);
-            VirtualCrossoverProjectFile? file =
+            VirtualCrossoverProjectFile file =
                 JsonSerializer.Deserialize<VirtualCrossoverProjectFile>(
                     stream,
-                    SerializerOptions);
-            if (file == null)
-            {
-                return new VirtualCrossoverProjectFile();
-            }
-
+                    SerializerOptions)
+                ?? throw new InvalidDataException("The project file is empty.");
             file.Validate();
             return file;
         }
         catch
         {
+            BackupUnusableFile(path);
             return new VirtualCrossoverProjectFile();
+        }
+    }
+
+    private static void BackupUnusableFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Move(path, path + ".backup", overwrite: true);
+            }
+        }
+        catch
+        {
+            // Best effort (the file may be locked); startup must not block.
         }
     }
 

--- a/tests/Resonalyze.App.Tests/EqFormatFileDialogsTests.cs
+++ b/tests/Resonalyze.App.Tests/EqFormatFileDialogsTests.cs
@@ -1,0 +1,63 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class EqFormatFileDialogsTests
+{
+    [Fact]
+    public void BuildFilter_PairsEveryFormatNameWithItsPattern()
+    {
+        IReadOnlyList<IEqProfileFormat> formats = EqProfileFormats.Importable;
+
+        string filter = EqFormatFileDialogs.BuildFilter(formats);
+
+        // A dialog filter is name|pattern pairs joined by '|': 2N-1 separators.
+        Assert.Equal(formats.Count * 2 - 1, filter.Count(c => c == '|'));
+        string[] parts = filter.Split('|');
+        for (int i = 0; i < formats.Count; i++)
+        {
+            Assert.StartsWith(formats[i].Name, parts[2 * i]);
+            Assert.Equal($"*.{formats[i].Extension}", parts[2 * i + 1]);
+        }
+    }
+
+    [Fact]
+    public void BuildFilter_AppendsTheTrailingEntry()
+    {
+        IReadOnlyList<IEqProfileFormat> formats = EqProfileFormats.Exportable;
+
+        string filter = EqFormatFileDialogs.BuildFilter(
+            formats, "Tuning sheet (PDF) (*.pdf)|*.pdf");
+
+        Assert.EndsWith("|Tuning sheet (PDF) (*.pdf)|*.pdf", filter);
+        Assert.Equal((formats.Count + 1) * 2 - 1, filter.Count(c => c == '|'));
+    }
+
+    [Fact]
+    public void ResolveFormat_MapsTheOneBasedIndexOntoTheList()
+    {
+        IReadOnlyList<IEqProfileFormat> formats = EqProfileFormats.Importable;
+
+        Assert.Same(formats[0], EqFormatFileDialogs.ResolveFormat(formats, 1));
+        Assert.Same(
+            formats[^1],
+            EqFormatFileDialogs.ResolveFormat(formats, formats.Count));
+    }
+
+    [Fact]
+    public void ResolveFormat_ReturnsNullForATrailingEntry()
+    {
+        IReadOnlyList<IEqProfileFormat> formats = EqProfileFormats.Exportable;
+
+        Assert.Null(EqFormatFileDialogs.ResolveFormat(formats, formats.Count + 1));
+    }
+
+    [Fact]
+    public void ResolveFormat_ClampsAnIndexBelowTheList()
+    {
+        IReadOnlyList<IEqProfileFormat> formats = EqProfileFormats.Importable;
+
+        Assert.Same(formats[0], EqFormatFileDialogs.ResolveFormat(formats, 0));
+        Assert.Same(formats[0], EqFormatFileDialogs.ResolveFormat(formats, -3));
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -91,12 +91,16 @@ public sealed class VirtualCrossoverProjectFileTests
             Assert.Equal(3, missing.Channels.Count);
             Assert.True(missing.ShowSumCurve);
 
-            File.WriteAllText(
-                VirtualCrossoverProjectFile.GetPath(root),
-                "{ not json ");
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            File.WriteAllText(path, "{ not json ");
             VirtualCrossoverProjectFile corrupt =
                 VirtualCrossoverProjectFile.LoadOrDefault(root);
             Assert.Equal(3, corrupt.Channels.Count);
+
+            // The unusable file is parked as .backup so the next scheduled
+            // save cannot silently destroy it.
+            Assert.False(File.Exists(path));
+            Assert.Equal("{ not json ", File.ReadAllText(path + ".backup"));
         }
         finally
         {
@@ -105,7 +109,7 @@ public sealed class VirtualCrossoverProjectFileTests
     }
 
     [Fact]
-    public void LoadOrDefault_FallsBackOnAnUnknownVersion()
+    public void LoadOrDefault_FallsBackOnAnUnknownVersion_AndBacksTheFileUp()
     {
         string root = CreateTemporaryDirectory();
         try
@@ -115,15 +119,64 @@ public sealed class VirtualCrossoverProjectFileTests
             future.Save(root);
 
             string path = VirtualCrossoverProjectFile.GetPath(root);
-            File.WriteAllText(
-                path,
-                File.ReadAllText(path).Replace(
-                    $"\"version\": {VirtualCrossoverProjectFile.CurrentVersion}",
-                    $"\"version\": {VirtualCrossoverProjectFile.CurrentVersion + 1}"));
+            string futureText = File.ReadAllText(path).Replace(
+                $"\"version\": {VirtualCrossoverProjectFile.CurrentVersion}",
+                $"\"version\": {VirtualCrossoverProjectFile.CurrentVersion + 1}");
+            File.WriteAllText(path, futureText);
 
             VirtualCrossoverProjectFile loaded =
                 VirtualCrossoverProjectFile.LoadOrDefault(root);
             Assert.Equal(0, loaded.Channels[0].GainDb);
+
+            // A downgraded app keeps the newer session parked next to the
+            // fresh default instead of overwriting it on the next save.
+            Assert.False(File.Exists(path));
+            Assert.Equal(futureText, File.ReadAllText(path + ".backup"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadOrDefault_ReplacesAnOlderBackup()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path + ".backup", "older backup");
+            File.WriteAllText(path, "{ newer garbage ");
+
+            VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.Equal("{ newer garbage ", File.ReadAllText(path + ".backup"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadOrDefault_DoesNotDisturbAValidFileOrItsBackup()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var original = new VirtualCrossoverProjectFile();
+            original.Channels[0].GainDb = -4;
+            original.Save(root);
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            Assert.Equal(-4, loaded.Channels[0].GainDb);
+            Assert.True(File.Exists(path));
+            Assert.False(File.Exists(path + ".backup"));
         }
         finally
         {

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -1,0 +1,243 @@
+using System.Numerics;
+using System.Text;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class AutoAlignmentEngineTests
+{
+    private const int SampleRate = 48_000;
+    private const int IrLength = 8_192;
+    private const int BasePosition = 480; // 10 ms at 48 kHz.
+
+    /// <summary>
+    /// A synthetic channel: the initial IR feeds the stage-1 snapshots, the
+    /// reprocess IR feeds the stage-2 searches. They are usually the same;
+    /// tests that exercise the recovery paths (edge retry, wide-window
+    /// promotion, the negative-delay shift) give the searches an IR the
+    /// coarse stage did not see — the synthetic equivalent of a coarse
+    /// arrival estimate that is off.
+    /// </summary>
+    private sealed class TestChannel : IAlignmentChannel
+    {
+        public TestChannel(string name, Complex[] initialIr, Complex[]? reprocessIr = null)
+        {
+            Name = name;
+            InitialIr = initialIr;
+            ReprocessIr = reprocessIr ?? initialIr;
+        }
+
+        public string Name { get; }
+        public int SampleRate => AutoAlignmentEngineTests.SampleRate;
+        public Complex[] InitialIr { get; }
+        public Complex[] ReprocessIr { get; }
+    }
+
+    private static Complex[] UnitImpulse(int position)
+    {
+        var ir = new Complex[IrLength];
+        ir[position] = Complex.One;
+        return ir;
+    }
+
+    private static Complex[] DelayedImpulse(double delayMs, bool invert = false) =>
+        VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(BasePosition),
+            new DspChannelChain(DelayMs: delayMs, InvertPolarity: invert),
+            SampleRate);
+
+    private static Dictionary<IAlignmentChannel, AlignmentOverride> Run(
+        TestChannel[] byBand,
+        double[] crossoversHz,
+        StringBuilder log)
+    {
+        var snapshots = byBand.ToDictionary(
+            channel => channel,
+            channel => new AlignmentSnapshot(
+                channel,
+                channel.InitialIr,
+                VirtualCrossoverAnalysis.FindPeakIndex(channel.InitialIr)));
+        List<AlignmentJunction> junctions = crossoversHz
+            .Select((fc, i) => new AlignmentJunction(
+                snapshots[byBand[i]],
+                snapshots[byBand[i + 1]],
+                fc,
+                Math.Max(20, fc / 2),
+                Math.Min(20_000, fc * 2)))
+            .ToList();
+
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            byBand
+                .Select(channel =>
+                {
+                    AlignmentOverride o = overrides.GetValueOrDefault(channel);
+                    Complex[] ir = VirtualCrossoverAnalysis.ApplyChain(
+                        channel.ReprocessIr,
+                        new DspChannelChain(
+                            DelayMs: o.DelayMs,
+                            InvertPolarity: o.InvertPolarity),
+                        SampleRate);
+                    return new AlignmentSnapshot(
+                        channel, ir, VirtualCrossoverAnalysis.FindPeakIndex(ir));
+                })
+                .ToList();
+
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        AutoAlignmentEngine.Compute(
+            byBand.Select(channel => snapshots[channel]).ToList(),
+            junctions,
+            Reprocess,
+            alignment,
+            log);
+        return alignment;
+    }
+
+    [Fact]
+    public void Compute_RecoversAnInsertedDelay_TwoWay()
+    {
+        // The tweeter arrives 1 ms before the woofer; the woofer is the latest
+        // channel, so it anchors and the tweeter is delayed to meet it.
+        var woofer = new TestChannel("W", DelayedImpulse(1.0));
+        var tweeter = new TestChannel("T", DelayedImpulse(0.0));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([woofer, tweeter], [1_000], log);
+
+        Assert.False(alignment.ContainsKey(woofer));
+        AlignmentOverride result = alignment[tweeter];
+        Assert.InRange(result.DelayMs, 0.95, 1.05);
+        Assert.False(result.InvertPolarity);
+        // Applied delays are rounded to the panel's 0.01 ms display precision.
+        Assert.Equal(Math.Round(result.DelayMs, 2), result.DelayMs, 9);
+        Assert.Contains("Reference: W", log.ToString());
+        Assert.Contains("Pair W/T:", log.ToString());
+    }
+
+    [Fact]
+    public void Compute_DetectsAnInvertedChannel()
+    {
+        var woofer = new TestChannel("W", DelayedImpulse(1.0));
+        var tweeter = new TestChannel("T", DelayedImpulse(0.0, invert: true));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([woofer, tweeter], [1_000], log);
+
+        AlignmentOverride result = alignment[tweeter];
+        Assert.True(result.InvertPolarity);
+        Assert.InRange(result.DelayMs, 0.9, 1.1);
+    }
+
+    [Fact]
+    public void Compute_ChainsDelaysThroughASettledNeighbor_ThreeWay()
+    {
+        // Mid and tweeter both arrive 2 ms before the sub. The mid aligns to
+        // the sub directly; the tweeter never sees the sub — it aligns to the
+        // settled mid, so its delay must inherit the mid's 2 ms through the
+        // chain.
+        var sub = new TestChannel("S", DelayedImpulse(2.0));
+        var mid = new TestChannel("M", DelayedImpulse(0.0));
+        var tweeter = new TestChannel("T", DelayedImpulse(0.0));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([sub, mid, tweeter], [200, 2_000], log);
+
+        Assert.False(alignment.ContainsKey(sub));
+        Assert.InRange(alignment[mid].DelayMs, 1.9, 2.1);
+        Assert.InRange(alignment[tweeter].DelayMs, 1.9, 2.1);
+        Assert.False(alignment[mid].InvertPolarity);
+        Assert.False(alignment[tweeter].InvertPolarity);
+        Assert.Contains("Reference: S", log.ToString());
+    }
+
+    [Fact]
+    public void Compute_NegativeOptimum_ShiftsTheOtherChannelsInstead()
+    {
+        // Stage 1 sees the tweeter 0.1 ms early, but the search-time IR
+        // arrives 0.3 ms after the woofer: the optimum is a physically
+        // impossible -0.3 ms. The engine must zero the tweeter and push the
+        // woofer out by the deficit instead — a uniform shift that preserves
+        // the alignment.
+        var woofer = new TestChannel("W", DelayedImpulse(1.0));
+        var tweeter = new TestChannel(
+            "T", DelayedImpulse(0.9), reprocessIr: DelayedImpulse(1.3));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([woofer, tweeter], [1_000], log);
+
+        Assert.InRange(alignment[tweeter].DelayMs, -0.001, 0.001);
+        Assert.InRange(alignment[woofer].DelayMs, 0.25, 0.35);
+        Assert.False(alignment[woofer].InvertPolarity);
+    }
+
+    [Fact]
+    public void Compute_ResultAtTheWindowEdge_RetriesWidened()
+    {
+        // Stage 1 seeds the search at 1.0 ms, but the search-time optimum is
+        // +0.4 ms — just outside the [0.5, 1.5] fine window, so the first pass
+        // pins to the window edge (0.1 ms off the optimum, clearly the best
+        // in-window score) and the widened retry must find the true optimum.
+        // A farther-out optimum recovers through the wide-window promotion
+        // instead (next test), because the arrival prior pushes the selection
+        // off the edge and the retry never triggers.
+        var woofer = new TestChannel("W", DelayedImpulse(1.0));
+        var tweeter = new TestChannel(
+            "T", DelayedImpulse(0.0), reprocessIr: DelayedImpulse(0.6));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([woofer, tweeter], [1_000], log);
+
+        Assert.InRange(alignment[tweeter].DelayMs, 0.35, 0.45);
+        Assert.Contains("WARNING: fine result at the search edge", log.ToString());
+    }
+
+    [Fact]
+    public void Compute_OptimumBeyondTheRetryReach_PromotesTheWideWindowPick()
+    {
+        // A 2 kHz junction: the fine window is ±0.5 ms and the retry reach is
+        // ±0.45 ms (1.8 half-periods), while the search-time optimum sits at
+        // +2.5 ms — 1.5 ms past the stage-1 seed. Only the ±3 ms diagnostic
+        // sweep reaches it, and its clearly better summation must be promoted.
+        var woofer = new TestChannel("W", DelayedImpulse(1.0));
+        var tweeter = new TestChannel(
+            "T", DelayedImpulse(0.0), reprocessIr: DelayedImpulse(-1.5));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([woofer, tweeter], [2_000], log);
+
+        Assert.InRange(alignment[tweeter].DelayMs, 2.4, 2.6);
+        Assert.Contains("promoted", log.ToString());
+    }
+
+    [Fact]
+    public void Compute_RejectsInvalidInput()
+    {
+        var only = new TestChannel("A", DelayedImpulse(0.0));
+        var other = new TestChannel("B", DelayedImpulse(0.5));
+        var snapshot = new AlignmentSnapshot(
+            only, only.InitialIr, BasePosition);
+        var otherSnapshot = new AlignmentSnapshot(
+            other, other.InitialIr, BasePosition);
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            [snapshot, otherSnapshot];
+
+        Assert.Throws<ArgumentException>(() => AutoAlignmentEngine.Compute(
+            [snapshot],
+            [],
+            Reprocess,
+            new Dictionary<IAlignmentChannel, AlignmentOverride>(),
+            new StringBuilder()));
+        Assert.Throws<ArgumentException>(() => AutoAlignmentEngine.Compute(
+            [snapshot, otherSnapshot],
+            [],
+            Reprocess,
+            new Dictionary<IAlignmentChannel, AlignmentOverride>(),
+            new StringBuilder()));
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/GatedPhaseDataTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/GatedPhaseDataTests.cs
@@ -1,0 +1,106 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class GatedPhaseDataTests
+{
+    private const int SampleRate = 48_000;
+
+    private static Complex[] StructuredImpulse()
+    {
+        // An arrival plus a decaying inverted echo and a late reflection, so
+        // the phase carries real structure across the band.
+        var ir = new Complex[8_192];
+        ir[480] = Complex.One;
+        ir[600] = new Complex(-0.4, 0);
+        ir[900] = new Complex(0.2, 0);
+        return ir;
+    }
+
+    private static int MillisecondsToSamples(double milliseconds) =>
+        (int)Math.Round(Math.Max(0.0, milliseconds) * SampleRate / 1_000.0);
+
+    [Fact]
+    public void GetGatedPhaseData_MatchesTheManualWindowConstruction()
+    {
+        // The Virtual DSP tool used to build the gate by hand around
+        // GetPhaseData, with a whole-sample reference plus a per-point
+        // fractional-τ correction. GetGatedPhaseData replaced that path; this
+        // pins the equivalence so the shared construction cannot drift.
+        Complex[] ir = StructuredImpulse();
+        const double gateOffsetMs = 10.0;
+        const double leftMs = 2.0;
+        const double plateauMs = 8.0;
+        const double rightMs = 30.0;
+        const double detrendMs = 10.021; // deliberately off the sample grid
+
+        var view = new SyntheticMeasurement(ir, SampleRate, 0);
+        List<SignalPoint> actual = DataHelper.GetGatedPhaseData(
+            view, gateOffsetMs, leftMs, plateauMs, rightMs,
+            referenceSamples: detrendMs / 1_000.0 * SampleRate,
+            unwrap: false);
+
+        // The former manual construction, replicated verbatim.
+        int length = DataHelper.GatedFftLength;
+        int gateOffset = (int)Math.Round(gateOffsetMs / 1_000.0 * SampleRate);
+        int left = MillisecondsToSamples(leftMs);
+        int plateau = MillisecondsToSamples(plateauMs);
+        int right = MillisecondsToSamples(rightMs);
+        int gate = Math.Clamp(left + plateau + right, 1, length);
+        left = Math.Min(left, gate);
+        right = Math.Min(right, gate - left);
+        double[] tukey = Windowing.TukeyWindow(
+            gate, (double)left / gate * 2.0, (double)right / gate * 2.0);
+        double[] window = new double[length];
+        Array.Copy(tukey, window, gate);
+        int gateStart = gateOffset - left;
+        double detrendSamples = detrendMs / 1_000.0 * SampleRate;
+        int referenceSample = Math.Clamp(
+            (int)Math.Round(detrendSamples), 0, ir.Length - 1);
+        double residualSeconds = (detrendSamples - referenceSample) / SampleRate;
+        var referenceView = new SyntheticMeasurement(ir, SampleRate, referenceSample);
+        List<SignalPoint> expected = DataHelper.GetPhaseData(
+            referenceView, gateStart - referenceSample, length, window, unwrap: false);
+
+        Assert.Equal(expected.Count, actual.Count);
+        for (int i = 0; i < expected.Count; i++)
+        {
+            Assert.Equal(expected[i].X, actual[i].X, 9);
+            double corrected =
+                expected[i].Y + Math.Tau * expected[i].X * residualSeconds;
+            corrected = Math.Atan2(Math.Sin(corrected), Math.Cos(corrected));
+            // Compare as angles: both sides wrap to (-π, π], and values a hair
+            // from the boundary may land on opposite sides.
+            double delta = Math.IEEERemainder(corrected - actual[i].Y, Math.Tau);
+            Assert.True(
+                Math.Abs(delta) < 1e-9,
+                $"Phase mismatch at {actual[i].X:0.##} Hz: {delta:e}.");
+        }
+    }
+
+    [Fact]
+    public void GetGatedPhaseData_WholeSampleReferenceFlattensAPureDelay()
+    {
+        // A pure delay referenced to its own arrival must read (near) zero
+        // phase across the band.
+        var ir = new Complex[8_192];
+        ir[960] = Complex.One; // 20 ms
+        var view = new SyntheticMeasurement(ir, SampleRate, 0);
+
+        List<SignalPoint> phase = DataHelper.GetGatedPhaseData(
+            view,
+            gateOffsetMs: 20.0,
+            leftMs: 1.0,
+            plateauMs: 5.0,
+            rightMs: 10.0,
+            referenceSamples: 960,
+            unwrap: false);
+
+        foreach (SignalPoint point in phase.Where(p => p.X is >= 100 and <= 10_000))
+        {
+            Assert.True(
+                Math.Abs(point.Y) < 1e-6,
+                $"Residual phase {point.Y:e} at {point.X:0.##} Hz.");
+        }
+    }
+}


### PR DESCRIPTION
Block 3 of the TODO.md cleanup: the Virtual DSP tail. Four changes plus TODO bookkeeping.

## ★ `AutoAlignmentEngine` (dsp)

The two-stage Auto delay orchestrator (~280 lines: arrival timeline + PHAT seeding, pairwise fine search, edge retry, wide-window promotion, negative-delay uniform shift) moves out of `VirtualCrossoverPanel` into `dsp/AutoAlignmentEngine.cs`. The panel keeps a ~50-line adapter: `ChannelRuntime` implements `IAlignmentChannel`, reprocessing is a delegate that owns the thread-confined FFT cache, junctions/band ordering stay panel-side (already tested via `VirtualCrossoverJunctionsTests`). The diagnostic log (`virtual-dsp-align.log`) is unchanged line for line.

New `AutoAlignmentEngineTests` (7 tests, cross-platform): inserted-delay recovery, inverted-polarity detection, three-way chaining through a settled neighbor, negative optimum → uniform shift, window-edge retry, wide-window promotion, input guards. This logic previously had no tests at all.

## Shared gated-phase construction

`DataHelper.GetGatedPhaseData` is the gated phase by ms parameters with a **fractional-sample** reference; `GetPhase` becomes a thin wrapper. `VirtualCrossoverPanel.BuildPhasePoints` drops its hand-rolled copy of the Tukey gate construction *and* the whole-sample-reference + residual-τ correction dance. An equivalence test pins the old construction against the new entry point.

Behavior note: a negative gate offset now clamps to 0 like Phase mode (the gate dialog cannot produce one).

## `EqFormatFileDialogs`

One helper builds the file-dialog `Filter` string and resolves the 1-based `FilterIndex` back to the format from the same list. Replaces two filter-string builders and three hand-rolled off-by-one clamps (`EqWizardPanel` import/export, `VirtualCrossoverPanel.LoadPeq`); the trailing tuning-sheet PDF entry resolves to `null` instead of a positional `>= count` check. 5 App tests.

## Project-file backup policy

`VirtualCrossoverProjectFile.LoadOrDefault` used to swallow a broken or version-mismatched autosave and return a default, which the next scheduled save then wrote over the user's tuning session. The unusable file is now renamed to `.backup` first (best effort, replaces an older backup). Version policy documented at `CurrentVersion`: older versions get a migration step when one exists; newer versions (downgraded app) are backed up by `LoadOrDefault` and rejected by `LoadFrom`. 4 new App tests.

## TODO.md

Closed items removed; two stale claims corrected honestly (`ChannelName` and Sheet/SheetPdf `Signed`/`Number` were already deduplicated — the one remaining `Signed`/`Number` copy in `TuningSheetPdf` is folded into the PDF-exporters item). New residual: the `.backup` rename is silent.

## Verification

- Linux: solution builds with `-p:EnableWindowsTargeting=true`, 0 warnings; **276/276 dsp tests pass** (+9 new).
- App tests (incl. 9 new) compile on Linux and run on Windows CI in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_