### PR TITLE
Fix the small correctness tail: torn reads, shutdown close, SemVer prerelease, dark controls

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,11 +56,6 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 ## Measurement orchestrators
 
-- [ ] **`CurrentLevels` torn reads.** `ExpSweepMeasurement.CurrentLevels` (an
-  ~50-byte `InputLevelMeterSnapshot` struct) is written from audio worker
-  threads and read from the UI without synchronization; a torn read can show a
-  momentarily inconsistent meter (display-only; same family as the
-  `UpdatePeakInfo` item below).
 - [ ] **Verify the reused ASIO session on hardware.** Averaged sweeps now keep
   one open ASIO session across runs (the driver plays silence between runs and
   only the capture accumulator restarts). Verified by construction only — run
@@ -163,19 +158,13 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 ## Plotting
 
 - [ ] **`LogarithmicClipAxis` label trim.** Edge tick labels can be trimmed at
-  the plot boundary.
-- [ ] **Dead `FourierCSD` enum value.** Unused member of the transform enum;
-  remove or implement.
+  the plot boundary. Purely visual; needs a Windows render to reproduce before
+  a fix can be verified — deferred with the other live-app checks.
 
 ## Custom controls (dark theme)
 
 - [ ] **Per-paint Pen/Brush churn.** Dark controls allocate pens/brushes in
   every `OnPaint`; cache per-color instances.
-- [ ] **`DarkComboBox` keyboard/focus gaps.** Swallows Enter (so a dialog's
-  AcceptButton never fires from a combo) and doesn't take focus on click.
-- [ ] **`DarkNumericUpDown.BeginInit` is a no-op.** Designer property order
-  can clamp `Value` against a not-yet-set `Minimum`/`Maximum`; implement real
-  init batching.
 - [ ] **Tools menu rebuilt on every open.** Rebuilding the drop-down each time
   is wasted work and loses per-item state; build once and update.
 
@@ -185,26 +174,14 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   object are touched by the UI thread, `Task.Run` plot builds and
   audio-callback events, guarded case by case with ad-hoc locks and flags
   (`closingInProgress`, `calibrationCache`, `reportedCalibrationProblems`).
-  The torn-read items in this file are symptoms; the structural fix is moving
+  The now-fixed torn-read items were symptoms; the structural fix is moving
   per-mode state into services/controllers so new code does not need manual
   guarding. Incremental — carve out one concern at a time, calibration state
   is a natural first candidate.
-- [ ] **`UpdatePeakInfo` unsynchronized pair read.** Peak value and peak index
-  are read as two separate volatile-ish reads and can disagree; publish them
-  as one immutable pair.
-- [ ] **Options dialogs leak handlers on handle-less close.** `FormClosed`
-  unsubscribe never runs when a dialog is disposed without having shown;
-  unsubscribe in `Dispose` as well.
 - [ ] **`WireLiveApply` covers only dialog-open controls.** Controls created
   after wiring never get live-apply behavior.
-- [ ] **`CloseReason.WindowsShutDown` ignored.** `Form1_FormClosing` cancels
-  the close to run async teardown even during OS shutdown; detect shutdown and
-  do a fast synchronous flush instead.
 
 ## Update path / installer
 
-- [ ] **Prerelease identifiers ignored in version comparison.**
-  `1.2.0-rc.1` → `1.2.0-rc.2` does not prompt for an update; compare full
-  SemVer including prerelease ids.
 - [ ] **Uninstaller leaves settings behind.** Offer (or document) removal of
   the settings/history files on uninstall.

--- a/source/History/MeasurementHistoryService.cs
+++ b/source/History/MeasurementHistoryService.cs
@@ -207,16 +207,18 @@ internal sealed class MeasurementHistoryService
         ExpSweepMeasurement measurement,
         MeasurementSessionSnapshot? session)
     {
-        Complex[] sweep = measurement.SweepDeconvolutionImpulseResponse
+        MeasurementImpulseResponse sweepDeconvolution = measurement.SweepDeconvolution
             ?? throw new InvalidOperationException("Measurement has no sweep-deconvolution IR.");
-        Complex[]? transfer = measurement.TransferImpulseResponse?.ToArray();
+        MeasurementImpulseResponse? transferResult = measurement.Transfer;
+        Complex[] sweep = sweepDeconvolution.ImpulseResponse;
+        Complex[]? transfer = transferResult?.ImpulseResponse.ToArray();
         MeasurementHistoryPreview preview = MeasurementHistoryPreviewBuilder.Build(
             sweep,
-            measurement.SweepDeconvolutionPeakIndex,
+            sweepDeconvolution.PeakIndex,
             measurement.SampleRate,
             measurement.MeasurementMode,
             transfer,
-            transfer != null ? measurement.TransferPeakIndex : null);
+            transferResult?.PeakIndex);
 
         return new MeasurementHistorySnapshot
         {
@@ -226,8 +228,8 @@ internal sealed class MeasurementHistoryService
             SweepDurationSeconds = measurement.Sweep?.ComputedDuration ?? 0.0,
             PlayChannel = measurement.PlaybackChannel,
             MeasurementMode = measurement.MeasurementMode,
-            SweepDeconvolutionPeakIndex = measurement.SweepDeconvolutionPeakIndex,
-            TransferPeakIndex = transfer != null ? measurement.TransferPeakIndex : null,
+            SweepDeconvolutionPeakIndex = sweepDeconvolution.PeakIndex,
+            TransferPeakIndex = transferResult?.PeakIndex,
             AverageRunCount = measurement.AverageRunCount,
             AcceptedAverageRunCount = measurement.AcceptedAverageRunCount,
             SweepDeconvolutionImpulseResponse = sweep.ToArray(),

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -23,6 +23,14 @@ namespace Resonalyze
         private volatile bool inProgress;
         private volatile bool waitingForAverageConfirmation;
         private bool disposed;
+        // Results are published from the measurement worker and read by the UI
+        // without locks. Each impulse response travels with its peak index as one
+        // immutable reference so a reader can never pair a new response with a
+        // stale index. The level snapshot is a multi-field struct and is kept
+        // boxed for the same reason: a reference swap is atomic, a struct copy is not.
+        private volatile MeasurementImpulseResponse? sweepDeconvolutionResult;
+        private volatile MeasurementImpulseResponse? transferResult;
+        private volatile object currentLevels = InputLevelMeterSnapshot.Empty;
 
         public event Action<bool>? Completed;
         public event Action? ImpulseResponseChanged;
@@ -30,10 +38,12 @@ namespace Resonalyze
         internal event Action<InputLevelMeterSnapshot>? LevelsAvailable;
 
         public ExponentialSineSweep? Sweep { get; private set; }
-        public Complex[]? SweepDeconvolutionImpulseResponse { get; private set; }
-        public int SweepDeconvolutionPeakIndex { get; private set; }
-        public Complex[]? TransferImpulseResponse { get; private set; }
-        public int TransferPeakIndex { get; private set; }
+        public MeasurementImpulseResponse? SweepDeconvolution => sweepDeconvolutionResult;
+        public MeasurementImpulseResponse? Transfer => transferResult;
+        public Complex[]? SweepDeconvolutionImpulseResponse => sweepDeconvolutionResult?.ImpulseResponse;
+        public int SweepDeconvolutionPeakIndex => sweepDeconvolutionResult?.PeakIndex ?? 0;
+        public Complex[]? TransferImpulseResponse => transferResult?.ImpulseResponse;
+        public int TransferPeakIndex => transferResult?.PeakIndex ?? 0;
         public double[]? TransferCoherence { get; private set; }
         public float[]? MicrophoneRecordedSamples { get; private set; }
         public float[]? LoopbackRecordedSamples { get; private set; }
@@ -65,8 +75,11 @@ namespace Resonalyze
         public Exception? LastError { get; private set; }
         public int RecordedSamples => soundRecorder?.ReadSamples ?? 0;
         public bool WaitingForAverageConfirmation => waitingForAverageConfirmation;
-        internal InputLevelMeterSnapshot CurrentLevels { get; private set; } =
-            InputLevelMeterSnapshot.Empty;
+        internal InputLevelMeterSnapshot CurrentLevels
+        {
+            get => (InputLevelMeterSnapshot)currentLevels;
+            private set => currentLevels = value;
+        }
 
         public void Init(
             int octaves,
@@ -110,10 +123,8 @@ namespace Resonalyze
             AsioInputChannelOffset = asioInputChannelOffset;
             AsioLoopbackInputChannelOffset = asioLoopbackInputChannelOffset;
             AsioOutputChannelOffset = asioOutputChannelOffset;
-            SweepDeconvolutionImpulseResponse = null;
-            SweepDeconvolutionPeakIndex = 0;
-            TransferImpulseResponse = null;
-            TransferPeakIndex = 0;
+            sweepDeconvolutionResult = null;
+            transferResult = null;
             TransferCoherence = null;
             MicrophoneRecordedSamples = null;
             LoopbackRecordedSamples = null;
@@ -206,10 +217,8 @@ namespace Resonalyze
                 cancellationTokenSource?.Dispose();
                 cancellationTokenSource = new CancellationTokenSource();
                 inProgress = true;
-                SweepDeconvolutionImpulseResponse = null;
-                SweepDeconvolutionPeakIndex = 0;
-                TransferImpulseResponse = null;
-                TransferPeakIndex = 0;
+                sweepDeconvolutionResult = null;
+                transferResult = null;
                 TransferCoherence = null;
                 MicrophoneRecordedSamples = null;
                 LoopbackRecordedSamples = null;
@@ -331,16 +340,18 @@ namespace Resonalyze
                 WaveLoopbackDeviceNumber,
                 AverageRunCount,
                 ConfirmEachAverageRun);
-            SweepDeconvolutionImpulseResponse = sweepDeconvolutionImpulseResponse.ToArray();
-            SweepDeconvolutionPeakIndex = sweepDeconvolutionPeakIndex;
-            TransferImpulseResponse = transferImpulseResponse?.ToArray();
+            sweepDeconvolutionResult = new MeasurementImpulseResponse(
+                sweepDeconvolutionImpulseResponse.ToArray(),
+                sweepDeconvolutionPeakIndex);
+            transferResult = transferImpulseResponse != null
+                ? new MeasurementImpulseResponse(
+                    transferImpulseResponse.ToArray(),
+                    transferPeakIndex!.Value)
+                : null;
             TransferCoherence = transferCoherence?.ToArray();
             MicrophoneRecordedSamples = null;
             LoopbackRecordedSamples = null;
             MeasurementMode = measurementMode;
-            TransferPeakIndex = transferImpulseResponse != null
-                ? transferPeakIndex!.Value
-                : 0;
             AverageRunCount = Math.Clamp(averageRunCount, 1, 64);
             AcceptedAverageRunCount = Math.Clamp(
                 acceptedAverageRunCount,
@@ -819,10 +830,14 @@ namespace Resonalyze
 
         private void ApplyAverageResult(SweepAverageResult result)
         {
-            SweepDeconvolutionImpulseResponse = result.SweepImpulseResponse;
-            SweepDeconvolutionPeakIndex = result.SweepPeakIndex;
-            TransferImpulseResponse = result.TransferImpulseResponse;
-            TransferPeakIndex = result.TransferPeakIndex;
+            sweepDeconvolutionResult = new MeasurementImpulseResponse(
+                result.SweepImpulseResponse,
+                result.SweepPeakIndex);
+            transferResult = result.TransferImpulseResponse != null
+                ? new MeasurementImpulseResponse(
+                    result.TransferImpulseResponse,
+                    result.TransferPeakIndex)
+                : null;
             TransferCoherence = result.TransferCoherence;
             MicrophoneRecordedSamples = result.MicrophoneRecordedSamples;
             LoopbackRecordedSamples = result.LoopbackRecordedSamples;
@@ -1177,6 +1192,14 @@ namespace Resonalyze
             GC.SuppressFinalize(this);
         }
     }
+
+    /// <summary>
+    /// An impulse response published together with the index of its peak as one
+    /// immutable reference, so cross-thread readers always see a matching pair.
+    /// </summary>
+    public sealed record MeasurementImpulseResponse(
+        Complex[] ImpulseResponse,
+        int PeakIndex);
 }
 
 public readonly record struct SweepAverageProgress(

--- a/source/Measurements/ImpulseResponseFile.cs
+++ b/source/Measurements/ImpulseResponseFile.cs
@@ -65,8 +65,10 @@ public sealed class ImpulseResponseFile
     public static ImpulseResponseFile Capture(ExpSweepMeasurement measurement)
     {
         ArgumentNullException.ThrowIfNull(measurement);
-        Complex[] sweepImpulseResponse = measurement.SweepDeconvolutionImpulseResponse
+        MeasurementImpulseResponse sweepDeconvolution = measurement.SweepDeconvolution
             ?? throw new InvalidOperationException("There is no impulse response to save.");
+        MeasurementImpulseResponse? transfer = measurement.Transfer;
+        Complex[] sweepImpulseResponse = sweepDeconvolution.ImpulseResponse;
         ExponentialSineSweep sweep = measurement.Sweep
             ?? throw new InvalidOperationException("The sweep measurement is not initialized.");
 
@@ -75,16 +77,17 @@ public sealed class ImpulseResponseFile
         double[]? transferRealSamples = null;
         double[]? transferImaginarySamples = null;
         int? transferPeakIndex = null;
-        if (measurement.TransferImpulseResponse is { Length: > 0 } transferImpulseResponse)
+        if (transfer is { ImpulseResponse.Length: > 0 })
         {
             (transferRealSamples, transferImaginarySamples) =
-                ConvertSamples(transferImpulseResponse, "Transfer impulse response");
-            transferPeakIndex = measurement.TransferPeakIndex;
+                ConvertSamples(transfer.ImpulseResponse, "Transfer impulse response");
+            transferPeakIndex = transfer.PeakIndex;
         }
+        InputLevelMeterSnapshot levels = measurement.CurrentLevels;
         LevelSnapshotFileEntry? microphoneLevels =
-            CreateLevelSnapshotFileEntry(measurement.CurrentLevels.Microphone);
+            CreateLevelSnapshotFileEntry(levels.Microphone);
         LevelSnapshotFileEntry? loopbackLevels =
-            CreateLevelSnapshotFileEntry(measurement.CurrentLevels.Loopback);
+            CreateLevelSnapshotFileEntry(levels.Loopback);
 
         return new ImpulseResponseFile
         {
@@ -95,7 +98,7 @@ public sealed class ImpulseResponseFile
             SweepDurationSeconds = sweep.ComputedDuration,
             PlayChannel = measurement.PlaybackChannel,
             MeasurementMode = measurement.MeasurementMode,
-            SweepDeconvolutionPeakIndex = measurement.SweepDeconvolutionPeakIndex,
+            SweepDeconvolutionPeakIndex = sweepDeconvolution.PeakIndex,
             AverageRunCount = measurement.AverageRunCount,
             AcceptedAverageRunCount = measurement.AcceptedAverageRunCount,
             TransferPeakIndex = transferPeakIndex,
@@ -104,13 +107,11 @@ public sealed class ImpulseResponseFile
             PreviewFrequencyResponse = CreatePreviewFileEntry(
                 MeasurementHistoryPreviewBuilder.Build(
                     sweepImpulseResponse,
-                    measurement.SweepDeconvolutionPeakIndex,
+                    sweepDeconvolution.PeakIndex,
                     measurement.SampleRate,
                     measurement.MeasurementMode,
-                    measurement.TransferImpulseResponse,
-                    measurement.TransferImpulseResponse is { Length: > 0 }
-                        ? measurement.TransferPeakIndex
-                        : null)),
+                    transfer?.ImpulseResponse,
+                    transferPeakIndex)),
             SweepDeconvolutionRealSamples = sweepRealSamples,
             SweepDeconvolutionImaginarySamples = sweepImaginarySamples,
             TransferRealSamples = transferRealSamples,

--- a/source/Options/ACOpt.cs
+++ b/source/Options/ACOpt.cs
@@ -11,7 +11,7 @@ namespace Resonalyze.Options
         {
             InitializeComponent();
             InitializeToolTips();
-            FormClosed += (_, _) => toolTip.Dispose();
+            Disposed += (_, _) => toolTip.Dispose();
         }
 
         public void Init(ExpSweepMeasurement expSweepMeasurement, ImpulseResponseOptions opt)

--- a/source/Options/BDOpt.cs
+++ b/source/Options/BDOpt.cs
@@ -22,7 +22,10 @@ namespace Resonalyze.Options
             numericRightWindow.ValueChanged += TukeyWindow_ValueChanged;
             SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
             InitializeToolTips();
-            FormClosed += BDOpt_FormClosed;
+            // Disposed, not FormClosed: a dialog disposed without ever having been
+            // shown (e.g. the docked host closing it while the owner is minimized)
+            // never raises FormClosed, which leaked the measurement subscription.
+            Disposed += BDOpt_Disposed;
         }
 
         public void Init(ExpSweepMeasurement expSweepMeasurement, WaterfallGenerateOptions burstDecayGenOptions)
@@ -144,7 +147,7 @@ namespace Resonalyze.Options
             UpdateIrPreview();
         }
 
-        private void BDOpt_FormClosed(object? sender, FormClosedEventArgs e)
+        private void BDOpt_Disposed(object? sender, EventArgs e)
         {
             if (expSweepMeasurement != null)
             {

--- a/source/Options/FROptions.cs
+++ b/source/Options/FROptions.cs
@@ -23,7 +23,10 @@ namespace Resonalyze.Options
             numericRightWindow.ValueChanged += TukeyWindow_ValueChanged;
             SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
             InitializeToolTips();
-            FormClosed += FROptions_FormClosed;
+            // Disposed, not FormClosed: a dialog disposed without ever having been
+            // shown (e.g. the docked host closing it while the owner is minimized)
+            // never raises FormClosed, which leaked the measurement subscription.
+            Disposed += FROptions_Disposed;
         }
 
         public void Init(
@@ -137,7 +140,7 @@ namespace Resonalyze.Options
             UpdateIrPreview();
         }
 
-        private void FROptions_FormClosed(object? sender, FormClosedEventArgs e)
+        private void FROptions_Disposed(object? sender, EventArgs e)
         {
             if (expSweepMeasurement != null)
             {

--- a/source/Options/GDOpt.cs
+++ b/source/Options/GDOpt.cs
@@ -22,7 +22,10 @@ public partial class GDOpt : Form
         ConfigureResetDefaults();
         SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
         InitializeToolTips();
-        FormClosed += GDOpt_FormClosed;
+        // Disposed, not FormClosed: a dialog disposed without ever having been
+        // shown (e.g. the docked host closing it while the owner is minimized)
+        // never raises FormClosed, which leaked the measurement subscription.
+        Disposed += GDOpt_Disposed;
     }
 
     public void Init(
@@ -94,14 +97,14 @@ public partial class GDOpt : Form
     private void buttonFit_Click(object? sender, EventArgs e)
     {
         if (expSweepMeasurement is not { } measurement ||
-            measurement.TransferImpulseResponse is not { Length: > 0 } ||
+            measurement.Transfer is not { ImpulseResponse.Length: > 0 } transfer ||
             measurement.SampleRate <= 0)
         {
             System.Media.SystemSounds.Beep.Play();
             return;
         }
 
-        double onsetMs = measurement.TransferPeakIndex * 1000.0 / measurement.SampleRate;
+        double onsetMs = transfer.PeakIndex * 1000.0 / measurement.SampleRate;
         numericGateOffset.Value = ClampToControl(numericGateOffset, onsetMs);
     }
 
@@ -144,7 +147,7 @@ public partial class GDOpt : Form
         UpdateIrPreview();
     }
 
-    private void GDOpt_FormClosed(object? sender, FormClosedEventArgs e)
+    private void GDOpt_Disposed(object? sender, EventArgs e)
     {
         if (expSweepMeasurement != null)
         {

--- a/source/Options/IROpt.cs
+++ b/source/Options/IROpt.cs
@@ -19,7 +19,7 @@ namespace Resonalyze.Options
         {
             InitializeComponent();
             InitializeToolTips();
-            FormClosed += (_, _) => toolTip.Dispose();
+            Disposed += (_, _) => toolTip.Dispose();
         }
 
         public void Init(ExpSweepMeasurement expSweepMeasurement, ImpulseResponseOptions opt)

--- a/source/Options/ImpulseWindowPreview.cs
+++ b/source/Options/ImpulseWindowPreview.cs
@@ -420,17 +420,17 @@ internal static class ImpulseWindowPreview
         return source switch
         {
             IrPreviewSource.SweepDeconvolution =>
-                measurement.SweepDeconvolutionImpulseResponse is { Length: > 0 } sweepIr
+                measurement.SweepDeconvolution is { ImpulseResponse.Length: > 0 } sweepResult
                     ? new IrSource(
-                        sweepIr,
-                        measurement.SweepDeconvolutionPeakIndex,
+                        sweepResult.ImpulseResponse,
+                        sweepResult.PeakIndex,
                         false,
                         "Sweep IR Window")
                     : null,
             IrPreviewSource.TransferFromStart =>
-                measurement.TransferImpulseResponse is { Length: > 0 } transferIr
+                measurement.Transfer is { ImpulseResponse.Length: > 0 } transferResult
                     ? new IrSource(
-                        transferIr,
+                        transferResult.ImpulseResponse,
                         0,
                         true,
                         "Transfer IR Window")
@@ -438,10 +438,10 @@ internal static class ImpulseWindowPreview
                         measurement,
                         IrPreviewSource.SweepDeconvolution),
             _ =>
-                measurement.TransferImpulseResponse is { Length: > 0 } primaryTransferIr
+                measurement.Transfer is { ImpulseResponse.Length: > 0 } primaryTransferResult
                     ? new IrSource(
-                        primaryTransferIr,
-                        measurement.TransferPeakIndex,
+                        primaryTransferResult.ImpulseResponse,
+                        primaryTransferResult.PeakIndex,
                         false,
                         "Transfer IR Window")
                     : SelectImpulseResponse(

--- a/source/Options/LiveSpectrumOpt.cs
+++ b/source/Options/LiveSpectrumOpt.cs
@@ -31,7 +31,7 @@ namespace Resonalyze.Options
             windowComboBox.SelectionChangeCommitted += (_, _) => CaptureUserWindow();
             overlapComboBox.SelectionChangeCommitted += (_, _) => CaptureUserOverlap();
             InitializeToolTips();
-            FormClosed += (_, _) => toolTip.Dispose();
+            Disposed += (_, _) => toolTip.Dispose();
         }
 
         public void Init(

--- a/source/Options/PROpt.cs
+++ b/source/Options/PROpt.cs
@@ -22,7 +22,10 @@ namespace Resonalyze.Options
             ConfigureResetDefaults();
             SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
             InitializeToolTips();
-            FormClosed += PROpt_FormClosed;
+            // Disposed, not FormClosed: a dialog disposed without ever having been
+            // shown (e.g. the docked host closing it while the owner is minimized)
+            // never raises FormClosed, which leaked the measurement subscription.
+            Disposed += PROpt_Disposed;
         }
 
         public void Init(
@@ -128,14 +131,14 @@ namespace Resonalyze.Options
         private void buttonFit_Click(object? sender, EventArgs e)
         {
             if (expSweepMeasurement is not { } measurement ||
-                measurement.TransferImpulseResponse is not { Length: > 0 } ||
+                measurement.Transfer is not { ImpulseResponse.Length: > 0 } transfer ||
                 measurement.SampleRate <= 0)
             {
                 System.Media.SystemSounds.Beep.Play();
                 return;
             }
 
-            double onsetMs = measurement.TransferPeakIndex * 1000.0 / measurement.SampleRate;
+            double onsetMs = transfer.PeakIndex * 1000.0 / measurement.SampleRate;
             numericGateOffset.Value = ClampToControl(numericGateOffset, onsetMs);
         }
 
@@ -205,7 +208,7 @@ namespace Resonalyze.Options
             UpdateIrPreview();
         }
 
-        private void PROpt_FormClosed(object? sender, FormClosedEventArgs e)
+        private void PROpt_Disposed(object? sender, EventArgs e)
         {
             if (expSweepMeasurement != null)
             {

--- a/source/Options/WaterfallOptions.cs
+++ b/source/Options/WaterfallOptions.cs
@@ -22,7 +22,10 @@ namespace Resonalyze.Options
             numericRightWindow.ValueChanged += TukeyWindow_ValueChanged;
             SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
             InitializeToolTips();
-            FormClosed += WaterfallOptions_FormClosed;
+            // Disposed, not FormClosed: a dialog disposed without ever having been
+            // shown (e.g. the docked host closing it while the owner is minimized)
+            // never raises FormClosed, which leaked the measurement subscription.
+            Disposed += WaterfallOptions_Disposed;
         }
 
         public void Init(ExpSweepMeasurement expSweepMeasurement, WaterfallGenerateOptions waterfallGenerateOptions)
@@ -163,7 +166,7 @@ namespace Resonalyze.Options
             UpdateIrPreview();
         }
 
-        private void WaterfallOptions_FormClosed(object? sender, FormClosedEventArgs e)
+        private void WaterfallOptions_Disposed(object? sender, EventArgs e)
         {
             if (expSweepMeasurement != null)
             {

--- a/source/Plotting/MeasurementPlotContext.cs
+++ b/source/Plotting/MeasurementPlotContext.cs
@@ -41,23 +41,23 @@ internal sealed class MeasurementPlotContext
     // on HasTransferImpulseResponse; the sweep deconvolution is reserved for harmonics/noise.
     public IImpulseMeasurement CreatePrimaryMeasurement()
     {
-        Complex[] transferIr = expSweepMeasurement.TransferImpulseResponse
+        MeasurementImpulseResponse transfer = expSweepMeasurement.Transfer
             ?? throw new InvalidOperationException(
                 "Transfer impulse response is not available.");
         return new ImpulseMeasurementView(
-            transferIr,
-            expSweepMeasurement.TransferPeakIndex,
+            transfer.ImpulseResponse,
+            transfer.PeakIndex,
             expSweepMeasurement.SampleRate);
     }
 
     public IImpulseMeasurement CreateSweepDeconvolutionMeasurement()
     {
-        Complex[] sweepIr = expSweepMeasurement.SweepDeconvolutionImpulseResponse
+        MeasurementImpulseResponse sweepDeconvolution = expSweepMeasurement.SweepDeconvolution
             ?? throw new InvalidOperationException(
                 "Sweep deconvolution impulse response is not available.");
         return new ImpulseMeasurementView(
-            sweepIr,
-            expSweepMeasurement.SweepDeconvolutionPeakIndex,
+            sweepDeconvolution.ImpulseResponse,
+            sweepDeconvolution.PeakIndex,
             expSweepMeasurement.SampleRate,
             expSweepMeasurement.HarmonicIROffset);
     }

--- a/source/Plotting/WaterfallSeries.cs
+++ b/source/Plotting/WaterfallSeries.cs
@@ -67,7 +67,6 @@ namespace Resonalyze
     public enum WaterfallMode
     {
         Fourier,
-        FourierCSD,
         BurstDecay
     }
 

--- a/source/Settings/ApplicationVersionInfo.cs
+++ b/source/Settings/ApplicationVersionInfo.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reflection;
 
 namespace Resonalyze;
@@ -26,29 +27,69 @@ internal static class ApplicationVersionInfo
                 string.Equals(attribute.Key, "SparklePublicKey", StringComparison.Ordinal))?
             .Value;
 
-    public static bool IsOlderThan(string otherVersion)
+    public static bool IsOlderThan(string otherVersion) =>
+        IsOlderThan(GetInformationalVersion(), otherVersion);
+
+    // Exposed for tests: pure comparison of two raw version strings.
+    internal static bool IsOlderThan(string currentRawVersion, string otherVersion)
     {
-        string currentRawVersion = GetInformationalVersion();
-        if (!TryParseComparableVersion(currentRawVersion, out Version? current, out bool currentPrerelease) ||
-            !TryParseComparableVersion(otherVersion, out Version? other, out bool otherPrerelease))
+        if (!TryParseComparableVersion(currentRawVersion, out Version? current, out string? currentPrerelease) ||
+            !TryParseComparableVersion(otherVersion, out Version? other, out string? otherPrerelease))
         {
             return false;
         }
 
-        Version currentVersion = current!;
-        Version otherVersionComparable = other!;
-        int versionCompare = currentVersion.CompareTo(otherVersionComparable);
+        int versionCompare = current!.CompareTo(other!);
         if (versionCompare != 0)
         {
             return versionCompare < 0;
         }
 
-        if (currentPrerelease && IsDevelopmentBuild(currentRawVersion))
+        if (currentPrerelease != null && IsDevelopmentBuild(currentRawVersion))
         {
             return false;
         }
 
-        return currentPrerelease && !otherPrerelease;
+        return ComparePrereleaseIdentifiers(currentPrerelease, otherPrerelease) < 0;
+    }
+
+    // SemVer 2.0 §11: a prerelease sorts before its release; identifiers are compared
+    // dot by dot — numerics numerically, alphanumerics ordinally, numeric before
+    // alphanumeric — and a shorter identifier list sorts before a longer equal prefix.
+    private static int ComparePrereleaseIdentifiers(string? current, string? other)
+    {
+        if (current == null)
+        {
+            return other == null ? 0 : 1;
+        }
+        if (other == null)
+        {
+            return -1;
+        }
+
+        string[] currentIdentifiers = current.Split('.');
+        string[] otherIdentifiers = other.Split('.');
+        int sharedCount = Math.Min(currentIdentifiers.Length, otherIdentifiers.Length);
+        for (int i = 0; i < sharedCount; i++)
+        {
+            bool currentIsNumeric = int.TryParse(
+                currentIdentifiers[i], NumberStyles.None, CultureInfo.InvariantCulture, out int currentNumber);
+            bool otherIsNumeric = int.TryParse(
+                otherIdentifiers[i], NumberStyles.None, CultureInfo.InvariantCulture, out int otherNumber);
+            int compare = (currentIsNumeric, otherIsNumeric) switch
+            {
+                (true, true) => currentNumber.CompareTo(otherNumber),
+                (true, false) => -1,
+                (false, true) => 1,
+                _ => string.CompareOrdinal(currentIdentifiers[i], otherIdentifiers[i])
+            };
+            if (compare != 0)
+            {
+                return compare;
+            }
+        }
+
+        return currentIdentifiers.Length.CompareTo(otherIdentifiers.Length);
     }
 
     private static string GetInformationalVersion()
@@ -65,9 +106,9 @@ internal static class ApplicationVersionInfo
     private static bool TryParseComparableVersion(
         string rawVersion,
         out Version? version,
-        out bool prerelease)
+        out string? prerelease)
     {
-        prerelease = false;
+        prerelease = null;
         version = null;
         if (string.IsNullOrWhiteSpace(rawVersion))
         {
@@ -89,7 +130,7 @@ internal static class ApplicationVersionInfo
         int prereleaseSeparator = normalized.IndexOf('-');
         if (prereleaseSeparator >= 0)
         {
-            prerelease = true;
+            prerelease = normalized[(prereleaseSeparator + 1)..];
             normalized = normalized[..prereleaseSeparator];
         }
 

--- a/source/Shell/Form1.Lifecycle.cs
+++ b/source/Shell/Form1.Lifecycle.cs
@@ -44,8 +44,10 @@ public partial class Form1
             // Cancelling the close during OS shutdown makes Windows report the app
             // as blocking shutdown, and the process may be killed before the async
             // teardown finishes. Persist user data synchronously and let the close
-            // proceed; device teardown is left to the OS.
+            // proceed; device teardown is left to the OS (the flag also keeps the
+            // Dispose that follows the close from blocking on it).
             closingPrepared = true;
+            shutdownFastClose = true;
             startupAudioWarmupCancellation?.Cancel();
             FlushMeasurementSettings();
             overlayCollection.FlushPendingSaves();
@@ -86,6 +88,16 @@ public partial class Form1
         }
 
         resourcesDisposed = true;
+        if (shutdownFastClose)
+        {
+            // OS shutdown: ExpSweepMeasurement.Dispose (and the controllers) wait
+            // synchronously on in-flight work, which would stall shutdown on the
+            // very teardown the fast-close path avoids. Cancelling is enough —
+            // the process is about to exit and the OS reclaims devices and timers.
+            startupAudioWarmupCancellation?.Cancel();
+            return;
+        }
+
         startupAudioWarmupCancellation?.Cancel();
         startupAudioWarmupCancellation?.Dispose();
         compareMenuStrip?.Dispose();

--- a/source/Shell/Form1.Lifecycle.cs
+++ b/source/Shell/Form1.Lifecycle.cs
@@ -39,6 +39,20 @@ public partial class Form1
             return;
         }
 
+        if (e.CloseReason == CloseReason.WindowsShutDown)
+        {
+            // Cancelling the close during OS shutdown makes Windows report the app
+            // as blocking shutdown, and the process may be killed before the async
+            // teardown finishes. Persist user data synchronously and let the close
+            // proceed; device teardown is left to the OS.
+            closingPrepared = true;
+            startupAudioWarmupCancellation?.Cancel();
+            FlushMeasurementSettings();
+            overlayCollection.FlushPendingSaves();
+            PersistCurrentSessionState();
+            return;
+        }
+
         e.Cancel = true;
         if (closingInProgress)
         {

--- a/source/Shell/Form1.Plotting.cs
+++ b/source/Shell/Form1.Plotting.cs
@@ -297,13 +297,13 @@ public partial class Form1
         }
 
         string transferPeak;
-        if (expSweepMeasurement.TransferImpulseResponse == null)
+        if (expSweepMeasurement.Transfer is not { } transfer)
         {
             transferPeak = "--";
         }
         else
         {
-            int peakSamples = expSweepMeasurement.TransferPeakIndex;
+            int peakSamples = transfer.PeakIndex;
             double peakMs = expSweepMeasurement.SampleRate > 0
                 ? peakSamples * 1000.0 / expSweepMeasurement.SampleRate
                 : 0;

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -86,6 +86,9 @@ namespace Resonalyze
         private bool closingPrepared;
         private bool closingInProgress;
         private bool resourcesDisposed;
+        // Set on CloseReason.WindowsShutDown: DisposeAppResources must skip its
+        // blocking device teardown while the OS is waiting for the process to exit.
+        private bool shutdownFastClose;
         private bool updateCheckStarted;
         private bool measurementSettingsSavePending;
         private readonly System.Windows.Forms.Timer measurementSettingsSaveTimer = new()

--- a/source/Ui/Controls/DarkComboBox.cs
+++ b/source/Ui/Controls/DarkComboBox.cs
@@ -85,6 +85,11 @@ public sealed class DarkComboBox : UserControl
                 return;
             }
 
+            if (!ContainsFocus)
+            {
+                Focus();
+            }
+
             buttonPressed = true;
             buttonPanel.Invalidate();
         };
@@ -132,6 +137,11 @@ public sealed class DarkComboBox : UserControl
             if (e.Button != MouseButtons.Left || !Enabled)
             {
                 return;
+            }
+
+            if (!ContainsFocus)
+            {
+                Focus();
             }
 
             resetPressed = true;
@@ -453,7 +463,7 @@ public sealed class DarkComboBox : UserControl
 
     protected override bool IsInputKey(Keys keyData)
     {
-        return keyData is Keys.Up or Keys.Down or Keys.Space or Keys.Enter
+        return keyData is Keys.Up or Keys.Down or Keys.Space
             ? true
             : base.IsInputKey(keyData);
     }
@@ -465,11 +475,12 @@ public sealed class DarkComboBox : UserControl
             return base.ProcessCmdKey(ref msg, keyData);
         }
 
+        // Enter is deliberately not handled: like a native ComboBox, it must
+        // reach the dialog so an AcceptButton can fire while the combo has focus.
         switch (keyData)
         {
             case Keys.F4:
             case Keys.Space:
-            case Keys.Enter:
             case Keys.Alt | Keys.Down:
                 ToggleDropDown();
                 return true;
@@ -490,8 +501,19 @@ public sealed class DarkComboBox : UserControl
     protected override void OnMouseDown(MouseEventArgs e)
     {
         base.OnMouseDown(e);
-        if (e.Button == MouseButtons.Left &&
-            !buttonPanel.Bounds.Contains(e.Location) &&
+        if (e.Button != MouseButtons.Left)
+        {
+            return;
+        }
+
+        // A UserControl does not take focus on click by itself; without this the
+        // combo never shows keyboard focus and arrow keys keep going elsewhere.
+        if (Enabled && !ContainsFocus)
+        {
+            Focus();
+        }
+
+        if (!buttonPanel.Bounds.Contains(e.Location) &&
             !(resetPanel.Visible && resetPanel.Bounds.Contains(e.Location)) &&
             !ShouldSuppressToggle())
         {

--- a/source/Ui/Controls/DarkNumericUpDown.cs
+++ b/source/Ui/Controls/DarkNumericUpDown.cs
@@ -31,6 +31,7 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
     private decimal? defaultValue;
     private BorderStyle borderStyle = BorderStyle.None;
     private bool readOnly;
+    private bool initializing;
 
     public DarkNumericUpDown()
     {
@@ -86,6 +87,14 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
             }
 
             minimum = value;
+            if (initializing)
+            {
+                // Between BeginInit and EndInit the designer sets properties in
+                // arbitrary order; defer the range/value reconciliation to EndInit
+                // so Value is never clamped against a not-yet-assigned bound.
+                return;
+            }
+
             if (maximum < minimum)
             {
                 maximum = minimum;
@@ -109,6 +118,11 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
             }
 
             maximum = value;
+            if (initializing)
+            {
+                return;
+            }
+
             if (minimum > maximum)
             {
                 minimum = maximum;
@@ -242,6 +256,12 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
         get => value;
         set
         {
+            if (initializing)
+            {
+                this.value = value;
+                return;
+            }
+
             decimal newValue = Clamp(RoundToDecimalPlaces(value));
             if (this.value == newValue)
             {
@@ -795,10 +815,21 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
 
     public void BeginInit()
     {
+        initializing = true;
     }
 
     public void EndInit()
     {
+        initializing = false;
+        // Reconcile the batched assignments now that every property has landed:
+        // designer property order can no longer clamp Value against a default bound.
+        if (maximum < minimum)
+        {
+            maximum = minimum;
+        }
+
+        value = Clamp(RoundToDecimalPlaces(value));
+        UpdateEditorText();
         LayoutEditor();
         Invalidate();
     }

--- a/source/Ui/Dialogs/MeasurementHistoryWindow.cs
+++ b/source/Ui/Dialogs/MeasurementHistoryWindow.cs
@@ -26,7 +26,7 @@ internal partial class MeasurementHistoryWindow : Form
         StartPosition = FormStartPosition.CenterParent;
         ConfigureNewSessionButton();
         ConfigureGrid();
-        FormClosed += (_, _) =>
+        Disposed += (_, _) =>
         {
             historyToolTip.Dispose();
             activeEntryFont.Dispose();

--- a/tests/Resonalyze.App.Tests/ApplicationVersionInfoTests.cs
+++ b/tests/Resonalyze.App.Tests/ApplicationVersionInfoTests.cs
@@ -1,0 +1,55 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class ApplicationVersionInfoTests
+{
+    [Theory]
+    [InlineData("1.2.0", "1.2.1")]
+    [InlineData("1.2.0-rc.1", "1.2.0-rc.2")]
+    [InlineData("1.2.0-rc.1", "1.2.0")]
+    [InlineData("1.2.0-alpha", "1.2.0-beta")]
+    // Numeric identifiers compare numerically, not as text.
+    [InlineData("1.2.0-alpha.9", "1.2.0-alpha.10")]
+    // A shorter identifier list sorts before a longer one with the same prefix.
+    [InlineData("1.2.0-rc", "1.2.0-rc.1")]
+    // Numeric identifiers sort before alphanumeric ones.
+    [InlineData("1.2.0-1", "1.2.0-alpha")]
+    [InlineData("v1.2.0-rc.1", "v1.2.0-rc.2")]
+    // Build metadata is ignored.
+    [InlineData("1.2.0-rc.2+build.5", "1.2.0-rc.3")]
+    public void IsOlderThan_DetectsAnAvailableUpdate(string current, string other)
+    {
+        Assert.True(ApplicationVersionInfo.IsOlderThan(current, other));
+    }
+
+    [Theory]
+    [InlineData("1.2.0", "1.2.0")]
+    [InlineData("1.2.1", "1.2.0")]
+    [InlineData("1.2.0-rc.1", "1.2.0-rc.1")]
+    [InlineData("1.2.0-rc.2", "1.2.0-rc.1")]
+    // A release is never older than any prerelease of the same core.
+    [InlineData("1.2.0", "1.2.0-rc.9")]
+    [InlineData("1.2.1-rc.1", "1.2.0")]
+    public void IsOlderThan_DoesNotPromptForSameOrOlder(string current, string other)
+    {
+        Assert.False(ApplicationVersionInfo.IsOlderThan(current, other));
+    }
+
+    [Fact]
+    public void IsOlderThan_KeepsDevelopmentBuildsQuietOnTheSameCore()
+    {
+        Assert.False(ApplicationVersionInfo.IsOlderThan("1.2.0-dev.5", "1.2.0"));
+        Assert.False(ApplicationVersionInfo.IsOlderThan("1.2.0-dev.5", "1.2.0-rc.1"));
+        // A genuinely newer core still prompts.
+        Assert.True(ApplicationVersionInfo.IsOlderThan("1.2.0-dev.5", "1.2.1"));
+    }
+
+    [Theory]
+    [InlineData("garbage", "1.2.0")]
+    [InlineData("1.2.0", "garbage")]
+    [InlineData("", "1.2.0")]
+    [InlineData("1.2.0", "")]
+    public void IsOlderThan_TreatsUnparsableVersionsAsUpToDate(string current, string other)
+    {
+        Assert.False(ApplicationVersionInfo.IsOlderThan(current, other));
+    }
+}


### PR DESCRIPTION
Block 4 of the tech-debt register (`TODO.md`): the small correctness items that survived verification. Every claim was re-checked against the code before fixing; one item was deliberately deferred (see below).

## Torn / paired reads (`ExpSweepMeasurement`)

`ApplyAverageResult` runs on the measurement worker (after `ConfigureAwait(false)`), while the UI reads results without locks. Two races existed:

- **`CurrentLevels`** — a multi-field `InputLevelMeterSnapshot` struct assigned from the worker; an unsynchronized struct copy can tear.
- **IR + peak index** — `TransferImpulseResponse` and `TransferPeakIndex` (and the sweep-deconvolution pair) were written as separate assignments and read as separate property reads, so a reader could pair a new response with a stale index.

Fix: each impulse response is now published together with its peak index as one immutable `MeasurementImpulseResponse` record behind a `volatile` field, and the level snapshot is stored boxed — a reference swap is atomic, a struct copy is not. The old flat properties remain as derived reads, and every same-scope pair reader (`UpdatePeakInfo`, `MeasurementPlotContext`, `ImpulseWindowPreview`, `ImpulseResponseFile.Capture`, history capture, the Fit buttons in PROpt/GDOpt) now grabs one snapshot instead of two reads.

## SemVer prerelease comparison

`ApplicationVersionInfo.IsOlderThan` dropped everything after `-`, so `1.2.0-rc.1 → 1.2.0-rc.2` never prompted for an update. It now compares prerelease identifiers per SemVer 2.0 §11: dot-separated, numerics numerically, alphanumerics ordinally, numeric before alphanumeric, shorter list before a longer equal prefix. The existing rules are preserved: prerelease < release on the same core, and `-dev.` builds stay quiet on an equal core. A pure two-string overload is exposed for tests — 22 new cases in `ApplicationVersionInfoTests`.

## `CloseReason.WindowsShutDown`

`Form1_FormClosing` always cancelled the close to run async teardown, which during OS shutdown makes Windows report the app as blocking (and the process can be killed mid-teardown, losing the async flush entirely). On shutdown it now persists settings, overlay saves, and session state synchronously and lets the close proceed; device teardown is left to the OS.

## Options-dialog handler leak

Confirmed scenario: `DockedModeSettingsHost.Show` with a minimized owner creates and `Init`s the dialog (subscribing it to `ImpulseResponseChanged`) but never shows it; `Close()` on a form whose handle was never created does not raise `FormClosed`, so the unsubscribe never ran and the measurement kept the disposed panel alive. All options panels (and the history window's tooltip/font cleanup) now clean up in `Disposed`, which fires on every path.

## Dark controls

- **`DarkComboBox`**: no longer handles Enter in `ProcessCmdKey`/`IsInputKey`, so a dialog's AcceptButton fires while the combo has focus (matching native ComboBox behavior); takes focus on click of the body, arrow, and reset button.
- **`DarkNumericUpDown`**: `BeginInit`/`EndInit` now really batch — between them, `Minimum`/`Maximum`/`Value` assignments are stored raw and reconciled once in `EndInit`, so designer property order can no longer clamp `Value` against a default bound.

## Plotting

- Removed the dead `WaterfallMode.FourierCSD` enum member. Safe: the persisted mode is always overwritten by `ApplyTo(..., requiredMode)` on load, values are serialized as strings, and the settings loader falls back to defaults on any parse error.
- **Deferred**: the `LogarithmicClipAxis` edge-label trim stays in `TODO.md` — it is a purely visual defect that cannot be reproduced or verified without a Windows render.

## Tests

- Local (Linux): full solution builds with 0 warnings; all 276 dsp tests pass.
- CI (Windows): runs the App.Tests suite including the new `ApplicationVersionInfoTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_