### PR TITLE
Deduplicate PDF exporters, IR-preview panels, recorder machinery and level metering

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -61,9 +61,6 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   only the capture accumulator restarts). Verified by construction only — run
   an averaged ASIO measurement on real hardware (ideally with a slow driver)
   before relying on it.
-- [ ] **Third copy of the level-metering math.** `ChannelLevelAccumulator`
-  (peak/RMS/dB + 0.999 full-scale threshold) duplicates
-  `AudioLevelMetering` and the recorder metering loops.
 
 ## Options panels
 
@@ -77,12 +74,6 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   which instantiates `AsioOut` (a synchronous COM driver open that can take
   seconds). Fetch the driver info and supported rates in one open, ideally off
   the UI thread.
-- [ ] **Five IR-preview panels are one copy-pasted class.** `FROptions`,
-  `GDOpt`, `PROpt`, `BDOpt`, `WaterfallOptions` duplicate the
-  `ImpulseResponseChanged` subscribe/unsubscribe dance, the `BeginInvoke`
-  marshal and the clamping helper — and have already drifted (only `GDOpt`
-  suppresses the 3–6 redundant preview renders during `Init`). Extract a
-  shared base.
 - [ ] **`SetOptions` reads bits from the measurement, not the control.**
   Three sources of truth for the sample size in `MeasurementOptions`; harmless
   while the control is read-only, a silent no-op the day it is enabled.
@@ -113,13 +104,10 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 ## PDF export
 
-- [ ] **~90 duplicated lines between the two PDF exporters.**
-  `LoadBanner`/`AddImage`/`AddFilterCards` are byte-identical in
-  `TuningSheetPdf` and `VirtualCrossoverSheetPdf` (as are the small
-  `Signed`/`Number` formatters, whose only remaining copy is in
-  `TuningSheetPdf`); extract a shared helper. MigraDoc 6 supports
-  `AddImage("base64:...")`, which would also remove the temp-file dance
-  entirely.
+- [ ] **The PDF images still go through temp files.** The shared `PdfSheet`
+  helper centralised the temp-file dance, but MigraDoc 6 supports
+  `AddImage("base64:...")`, which would remove it entirely (needs a Windows
+  render check that the sheets stay pixel-identical).
 - [ ] **No deconvolution flatness test.** The sweep + inverse-filter math was
   verified numerically during review (in-band ripple < 0.01 dB), but nothing
   in the test suite pins it; a `SyntheticMeasurement`-style flatness test
@@ -127,9 +115,12 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 ## Audio capture layer
 
-- [ ] **Merge the `SoundRecorder` / `AsioFullDuplexSession` twins.** The
-  accumulator core is shared, but the paired waiter classes, stop-timeout
-  machinery and events (~150 lines) are still duplicated.
+- [ ] **`SoundRecorder` / `AsioFullDuplexSession` remain separate classes.**
+  The waiter registry, stop-timeout machinery, accumulator core and metering
+  math are shared now; what is left duplicated is the thin device glue (the
+  start/first-buffer/stopped signal choreography and the event triple). A full
+  merge would need a common device abstraction — low value until the WASAPI
+  migration below forces one.
 - [ ] **ASIO converts channels `0..offset+count` instead of a window from
   `InputChannelOffset`** (`AsioFullDuplexSession`): a mic on input 7 converts
   all 8 channels per callback. Possibly a NAudio `SetChannelOffset` workaround
@@ -140,10 +131,6 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 - [ ] **Synchronous `LevelsAvailable` subscribers can still stall the ASIO
   callback** if a subscriber does a blocking `Invoke` to the UI thread; verify
   live (the meter itself now coalesces, but the contract isn't enforced).
-- [ ] **Dual-device level-binding duplication** —
-  `HandleMicrophoneOnlyLevels`/`HandleLoopbackOnlyLevels`/
-  `RaiseCombinedDualDeviceLevels`/`CreateEntry` nearly verbatim in both
-  `ExpSweepMeasurement` and `NoiseMeasurement`.
 - [ ] **`GetSamplesSnapshot` copies the whole buffer under the callback
   lock**; safe only because it's called after `StopAsync`, which the contract
   doesn't enforce.

--- a/source/Audio/AsioFullDuplexSession.cs
+++ b/source/Audio/AsioFullDuplexSession.cs
@@ -4,9 +4,8 @@ namespace Resonalyze;
 
 internal sealed class AsioFullDuplexSession : IDisposable
 {
-    private static readonly TimeSpan StopTimeout = TimeSpan.FromSeconds(3);
     private readonly object sync = new();
-    private readonly List<SoundRecorderSampleWaiter> sampleWaiters = new();
+    private readonly SampleWaiterRegistry sampleWaiters = new();
     private readonly string driverName;
     private readonly int inputChannelOffset;
     private readonly int outputChannelOffset;
@@ -150,11 +149,7 @@ internal sealed class AsioFullDuplexSession : IDisposable
         lock (sync)
         {
             accumulator = null;
-            foreach (SoundRecorderSampleWaiter waiter in sampleWaiters)
-            {
-                waiter.Cancel();
-            }
-            sampleWaiters.Clear();
+            sampleWaiters.CancelAll();
         }
     }
 
@@ -172,20 +167,18 @@ internal sealed class AsioFullDuplexSession : IDisposable
                 return Task.CompletedTask;
             }
 
-            var waiter = new SoundRecorderSampleWaiter(sampleCount, cancellationToken);
-            sampleWaiters.Add(waiter);
-            return waiter.Task;
+            return sampleWaiters.Add(sampleCount, cancellationToken);
         }
     }
 
     public async Task StopAsync()
     {
         AsioOut? activeDriver;
-        Task stoppedTask;
+        TaskCompletionSource<bool>? stoppedSignal;
         lock (sync)
         {
             activeDriver = driver;
-            stoppedTask = playbackStopped?.Task ?? Task.CompletedTask;
+            stoppedSignal = playbackStopped;
         }
 
         if (activeDriver == null)
@@ -195,22 +188,11 @@ internal sealed class AsioFullDuplexSession : IDisposable
 
         try
         {
-            activeDriver.Stop();
-        }
-        catch (InvalidOperationException)
-        {
-            playbackStopped?.TrySetResult(true);
-        }
-
-        try
-        {
-            await stoppedTask.WaitAsync(StopTimeout).ConfigureAwait(false);
-        }
-        catch (TimeoutException exception)
-        {
-            throw new TimeoutException(
-                $"The ASIO driver did not stop within {StopTimeout.TotalSeconds:0} seconds.",
-                exception);
+            await AudioCaptureStop.StopAndWaitAsync(
+                activeDriver.Stop,
+                stoppedSignal,
+                stoppedSignal?.Task ?? Task.CompletedTask,
+                "The ASIO driver").ConfigureAwait(false);
         }
         finally
         {
@@ -240,11 +222,7 @@ internal sealed class AsioFullDuplexSession : IDisposable
         StopAndDisposeDriver();
         lock (sync)
         {
-            foreach (SoundRecorderSampleWaiter waiter in sampleWaiters)
-            {
-                waiter.Cancel();
-            }
-            sampleWaiters.Clear();
+            sampleWaiters.CancelAll();
         }
 
         GC.SuppressFinalize(this);
@@ -299,15 +277,7 @@ internal sealed class AsioFullDuplexSession : IDisposable
             {
                 accumulator.Append(convertScratch, frames);
                 readySequences = accumulator.ExtractReadySequences();
-
-                for (int i = sampleWaiters.Count - 1; i >= 0; i--)
-                {
-                    if (accumulator.ReadSamples >= sampleWaiters[i].SampleCount)
-                    {
-                        sampleWaiters[i].Complete();
-                        sampleWaiters.RemoveAt(i);
-                    }
-                }
+                sampleWaiters.CompleteUpTo(accumulator.ReadSamples);
             }
         }
 
@@ -371,11 +341,7 @@ internal sealed class AsioFullDuplexSession : IDisposable
                 Sequence,
                 Math.Max(expectedTotalSamples, 8192));
 
-            foreach (SoundRecorderSampleWaiter waiter in sampleWaiters)
-            {
-                waiter.Cancel();
-            }
-            sampleWaiters.Clear();
+            sampleWaiters.CancelAll();
         }
     }
 
@@ -411,38 +377,10 @@ internal sealed class AsioFullDuplexSession : IDisposable
     }
 
     private static TaskCompletionSource<bool> NewSignal() =>
-        new(TaskCreationOptions.RunContinuationsAsynchronously);
+        SampleWaiterRegistry.NewSignal();
 
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(disposed, this);
-    }
-
-    private sealed class SoundRecorderSampleWaiter
-    {
-        private readonly TaskCompletionSource<bool> completion = NewSignal();
-        private readonly CancellationTokenRegistration registration;
-
-        public SoundRecorderSampleWaiter(int sampleCount, CancellationToken cancellationToken)
-        {
-            SampleCount = sampleCount;
-            registration = cancellationToken.Register(() =>
-                completion.TrySetCanceled(cancellationToken));
-        }
-
-        public int SampleCount { get; }
-        public Task Task => completion.Task;
-
-        public void Complete()
-        {
-            registration.Dispose();
-            completion.TrySetResult(true);
-        }
-
-        public void Cancel()
-        {
-            registration.Dispose();
-            completion.TrySetCanceled();
-        }
     }
 }

--- a/source/Audio/AudioCaptureStop.cs
+++ b/source/Audio/AudioCaptureStop.cs
@@ -1,0 +1,39 @@
+namespace Resonalyze;
+
+/// <summary>
+/// The stop-and-wait machinery shared by the capture classes: request a device
+/// stop (a stop on an already-stopped device throws InvalidOperationException,
+/// which counts as stopped) and await the stopped signal with the shared
+/// timeout. Detaching and disposing the device stays with the caller.
+/// </summary>
+internal static class AudioCaptureStop
+{
+    public static readonly TimeSpan StopTimeout = TimeSpan.FromSeconds(3);
+
+    public static async Task StopAndWaitAsync(
+        Action requestStop,
+        TaskCompletionSource<bool>? stoppedSignal,
+        Task stoppedTask,
+        string deviceDescription)
+    {
+        try
+        {
+            requestStop();
+        }
+        catch (InvalidOperationException)
+        {
+            stoppedSignal?.TrySetResult(true);
+        }
+
+        try
+        {
+            await stoppedTask.WaitAsync(StopTimeout).ConfigureAwait(false);
+        }
+        catch (TimeoutException exception)
+        {
+            throw new TimeoutException(
+                $"{deviceDescription} did not stop within {StopTimeout.TotalSeconds:0} seconds.",
+                exception);
+        }
+    }
+}

--- a/source/Audio/AudioLevelMetering.cs
+++ b/source/Audio/AudioLevelMetering.cs
@@ -4,6 +4,22 @@ namespace Resonalyze;
 
 internal static class AudioLevelMetering
 {
+    /// <summary>Peak amplitude at or above which a channel counts as full scale.</summary>
+    public const double FullScaleThreshold = 0.999;
+
+    /// <summary>
+    /// The one Peak/RMS/dB summary all metering paths share: from an
+    /// accumulated peak, sum of squares and sample count.
+    /// </summary>
+    public static AudioChannelLevel Measure(double peak, double sumSquares, long sampleCount)
+    {
+        double rms = Math.Sqrt(Math.Max(sumSquares, 0) / Math.Max(sampleCount, 1));
+        return new AudioChannelLevel(
+            DataHelper.AmplitudeToDecibels(peak),
+            DataHelper.AmplitudeToDecibels(rms),
+            peak >= FullScaleThreshold);
+    }
+
     /// <summary>Peak/RMS level of one recorded channel.</summary>
     public static AudioChannelLevel MeasureSamples(IReadOnlyList<float> samples)
     {
@@ -18,13 +34,7 @@ internal static class AudioLevelMetering
             sumSquares += (double)samples[i] * samples[i];
         }
 
-        double rms = samples.Count > 0
-            ? Math.Sqrt(sumSquares / samples.Count)
-            : 0;
-        return new AudioChannelLevel(
-            DataHelper.AmplitudeToDecibels(peak),
-            DataHelper.AmplitudeToDecibels(rms),
-            peak >= 0.999);
+        return Measure(peak, sumSquares, samples.Count);
     }
 
     public static AudioChannelLevel[] MeasureChannels(
@@ -40,15 +50,9 @@ internal static class AudioLevelMetering
         }
 
         var levels = new AudioChannelLevel[peaks.Length];
-        double safeSampleCount = Math.Max(sampleCount, 1);
         for (int i = 0; i < peaks.Length; i++)
         {
-            double peak = Math.Clamp(peaks[i], 0, 1);
-            double rms = Math.Sqrt(Math.Max(sumSquares[i], 0) / safeSampleCount);
-            levels[i] = new AudioChannelLevel(
-                DataHelper.AmplitudeToDecibels(peak),
-                DataHelper.AmplitudeToDecibels(rms),
-                peak >= 0.999);
+            levels[i] = Measure(Math.Clamp(peaks[i], 0, 1), sumSquares[i], sampleCount);
         }
 
         return levels;

--- a/source/Audio/SampleWaiterRegistry.cs
+++ b/source/Audio/SampleWaiterRegistry.cs
@@ -1,0 +1,80 @@
+namespace Resonalyze;
+
+/// <summary>
+/// The sample-count waiter list shared by the capture classes (SoundRecorder,
+/// AsioFullDuplexSession): callers await "N samples recorded" and the audio
+/// callback completes the due waiters as the accumulator advances.
+///
+/// The registry does no locking of its own — every member must be called under
+/// the owner's capture lock, the same lock that guards the accumulator, so a
+/// waiter can never be added after its threshold silently passed. Completing
+/// under the lock is safe because the signals run their continuations
+/// asynchronously.
+/// </summary>
+internal sealed class SampleWaiterRegistry
+{
+    private readonly List<SampleWaiter> waiters = new();
+
+    /// <summary>
+    /// A capture signal whose awaiters never run inline on the audio thread.
+    /// </summary>
+    public static TaskCompletionSource<bool> NewSignal() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task Add(int sampleCount, CancellationToken cancellationToken)
+    {
+        var waiter = new SampleWaiter(sampleCount, cancellationToken);
+        waiters.Add(waiter);
+        return waiter.Task;
+    }
+
+    public void CompleteUpTo(int readSamples)
+    {
+        for (int i = waiters.Count - 1; i >= 0; i--)
+        {
+            if (readSamples >= waiters[i].SampleCount)
+            {
+                waiters[i].Complete();
+                waiters.RemoveAt(i);
+            }
+        }
+    }
+
+    public void CancelAll()
+    {
+        foreach (SampleWaiter waiter in waiters)
+        {
+            waiter.Cancel();
+        }
+
+        waiters.Clear();
+    }
+
+    private sealed class SampleWaiter
+    {
+        private readonly TaskCompletionSource<bool> completion = NewSignal();
+        private readonly CancellationTokenRegistration registration;
+
+        public SampleWaiter(int sampleCount, CancellationToken cancellationToken)
+        {
+            SampleCount = sampleCount;
+            registration = cancellationToken.Register(() =>
+                completion.TrySetCanceled(cancellationToken));
+        }
+
+        public int SampleCount { get; }
+        public Task Task => completion.Task;
+
+        public void Complete()
+        {
+            registration.Dispose();
+            completion.TrySetResult(true);
+        }
+
+        public void Cancel()
+        {
+            registration.Dispose();
+            completion.TrySetCanceled();
+        }
+    }
+}

--- a/source/Measurements/DualDeviceLevelCombiner.cs
+++ b/source/Measurements/DualDeviceLevelCombiner.cs
@@ -1,0 +1,60 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Combines the level callbacks of two independent recorders (the microphone
+/// and a separate loopback device) into one meter snapshot: keeps the latest
+/// levels of each so both meters update live whichever device reported last.
+/// Shared by the sweep and noise measurements.
+/// </summary>
+internal sealed class DualDeviceLevelCombiner
+{
+    private readonly object sync = new();
+    private AudioChannelLevel[] latestMicrophone = Array.Empty<AudioChannelLevel>();
+    private AudioChannelLevel[] latestLoopback = Array.Empty<AudioChannelLevel>();
+
+    public void Reset()
+    {
+        lock (sync)
+        {
+            latestMicrophone = Array.Empty<AudioChannelLevel>();
+            latestLoopback = Array.Empty<AudioChannelLevel>();
+        }
+    }
+
+    public void SetMicrophone(AudioChannelLevel[] channels)
+    {
+        lock (sync)
+        {
+            latestMicrophone = channels;
+        }
+    }
+
+    public void SetLoopback(AudioChannelLevel[] channels)
+    {
+        lock (sync)
+        {
+            latestLoopback = channels;
+        }
+    }
+
+    public InputLevelMeterSnapshot Combine(int microphoneIndex, int? loopbackIndex)
+    {
+        AudioChannelLevel[] microphoneChannels;
+        AudioChannelLevel[] loopbackChannels;
+        lock (sync)
+        {
+            microphoneChannels = latestMicrophone;
+            loopbackChannels = latestLoopback;
+        }
+
+        InputLevelMeterEntry microphone = InputLevelMapping.CreateEntry(
+            InputLevelMapping.TryGetLevel(microphoneChannels, microphoneIndex),
+            fullScaleReference: false);
+        InputLevelMeterEntry loopback = InputLevelMapping.CreateEntry(
+            loopbackIndex.HasValue
+                ? InputLevelMapping.TryGetLevel(loopbackChannels, loopbackIndex.Value)
+                : null,
+            fullScaleReference: true);
+        return new InputLevelMeterSnapshot(microphone, loopback);
+    }
+}

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -12,11 +12,9 @@ namespace Resonalyze
     public sealed class ExpSweepMeasurement : IDisposable
     {
         private readonly object stateSync = new();
-        private readonly object levelSync = new();
+        private readonly DualDeviceLevelCombiner dualDeviceLevels = new();
         private SoundRecorder? soundRecorder;
         private SoundRecorder? loopbackRecorder;
-        private AudioChannelLevel[] latestMicrophoneLevels = Array.Empty<AudioChannelLevel>();
-        private AudioChannelLevel[] latestLoopbackLevels = Array.Empty<AudioChannelLevel>();
         private CancellationTokenSource? cancellationTokenSource;
         private Task<bool>? measurementTask;
         private TaskCompletionSource<bool>? averageConfirmation;
@@ -140,11 +138,7 @@ namespace Resonalyze
             Sweep.FillData(octaves, requestedDuration, bits, sampleRate);
 
             DisposeRecorders();
-            lock (levelSync)
-            {
-                latestMicrophoneLevels = Array.Empty<AudioChannelLevel>();
-                latestLoopbackLevels = Array.Empty<AudioChannelLevel>();
-            }
+            dualDeviceLevels.Reset();
 
             bool separateLoopbackDevice = UsesSeparateWaveLoopbackDevice;
             soundRecorder = new SoundRecorder();
@@ -374,45 +368,24 @@ namespace Resonalyze
         }
 
         // With a separate loopback device, the microphone and loopback levels arrive from two
-        // independent recorders. Keep the latest of each and raise a combined snapshot so both
-        // meters update live.
+        // independent recorders; the combiner keeps the latest of each so both meters update live.
         private void HandleMicrophoneOnlyLevels(AudioChannelLevel[] channels)
         {
-            lock (levelSync)
-            {
-                latestMicrophoneLevels = channels;
-            }
+            dualDeviceLevels.SetMicrophone(channels);
             RaiseCombinedDualDeviceLevels();
         }
 
         private void HandleLoopbackOnlyLevels(AudioChannelLevel[] channels)
         {
-            lock (levelSync)
-            {
-                latestLoopbackLevels = channels;
-            }
+            dualDeviceLevels.SetLoopback(channels);
             RaiseCombinedDualDeviceLevels();
         }
 
         private void RaiseCombinedDualDeviceLevels()
         {
-            AudioChannelLevel[] microphoneChannels;
-            AudioChannelLevel[] loopbackChannels;
-            lock (levelSync)
-            {
-                microphoneChannels = latestMicrophoneLevels;
-                loopbackChannels = latestLoopbackLevels;
-            }
-
-            InputLevelMeterEntry microphone = CreateEntry(
-                TryGetLevel(microphoneChannels, WaveInputChannelOffset),
-                fullScaleReference: false);
-            InputLevelMeterEntry loopback = CreateEntry(
-                WaveLoopbackInputChannelOffset is int loopbackChannel
-                    ? TryGetLevel(loopbackChannels, loopbackChannel)
-                    : null,
-                fullScaleReference: true);
-            RaiseLevels(new InputLevelMeterSnapshot(microphone, loopback));
+            RaiseLevels(dualDeviceLevels.Combine(
+                WaveInputChannelOffset,
+                WaveLoopbackInputChannelOffset));
         }
 
         private async Task<bool> RunCoreAsync(CancellationToken cancellationToken)
@@ -655,7 +628,7 @@ namespace Resonalyze
                     owner.AsioOutputChannelOffset,
                     owner.GetRequiredAsioInputChannelCount(firstInputOffset));
                 session.LevelsAvailable += channels => owner.RaiseLevels(
-                    MapLevelsByIndex(
+                    InputLevelMapping.Map(
                         channels,
                         owner.AsioInputChannelOffset - firstInputOffset,
                         owner.AsioLoopbackInputChannelOffset.HasValue
@@ -886,65 +859,20 @@ namespace Resonalyze
             int? loopbackIndex)
         {
             AudioChannelLevel[] measuredLevels = MeasureRecordedChannels(sampleChannels);
-            return MapLevelsByIndex(measuredLevels, microphoneIndex, loopbackIndex);
+            return InputLevelMapping.Map(measuredLevels, microphoneIndex, loopbackIndex);
         }
 
         private InputLevelMeterSnapshot MapWaveLevels(AudioChannelLevel[] channels)
         {
-            return MapLevelsByIndex(
+            return InputLevelMapping.Map(
                 channels,
                 WaveInputChannelOffset,
                 WaveLoopbackInputChannelOffset);
         }
 
-        private static InputLevelMeterSnapshot MapLevelsByIndex(
-            AudioChannelLevel[] channels,
-            int microphoneIndex,
-            int? loopbackIndex)
-        {
-            InputLevelMeterEntry microphone = CreateEntry(
-                TryGetLevel(channels, microphoneIndex),
-                fullScaleReference: false);
-            InputLevelMeterEntry loopback = CreateEntry(
-                loopbackIndex.HasValue
-                    ? TryGetLevel(channels, loopbackIndex.Value)
-                    : null,
-                fullScaleReference: true);
-            return new InputLevelMeterSnapshot(
-                microphone,
-                loopback);
-        }
-
         private void RaiseLevels(InputLevelMeterSnapshot snapshot)
         {
             LevelsAvailable?.Invoke(snapshot);
-        }
-
-        private static AudioChannelLevel? TryGetLevel(
-            AudioChannelLevel[] channels,
-            int channelIndex)
-        {
-            return (uint)channelIndex < (uint)channels.Length
-                ? channels[channelIndex]
-                : null;
-        }
-
-        private static InputLevelMeterEntry CreateEntry(
-            AudioChannelLevel? level,
-            bool fullScaleReference)
-        {
-            if (level == null)
-            {
-                return InputLevelMeterEntry.Unavailable;
-            }
-
-            AudioChannelLevel value = level.Value;
-            return new InputLevelMeterEntry(
-                true,
-                value.PeakDbFs,
-                value.RmsDbFs,
-                !fullScaleReference && value.FullScale,
-                fullScaleReference && value.FullScale);
         }
 
         private static AudioChannelLevel[] MeasureRecordedChannels(float[][] sampleChannels)
@@ -1145,13 +1073,13 @@ namespace Resonalyze
                     return InputLevelMeterEntry.Unavailable;
                 }
 
-                double rms = Math.Sqrt(sumSquares / sampleCount);
+                AudioChannelLevel level = AudioLevelMetering.Measure(peak, sumSquares, sampleCount);
                 return new InputLevelMeterEntry(
                     true,
-                    DataHelper.AmplitudeToDecibels(peak),
-                    DataHelper.AmplitudeToDecibels(rms),
-                    !fullScaleReference && peak >= 0.999,
-                    fullScaleReference && peak >= 0.999);
+                    level.PeakDbFs,
+                    level.RmsDbFs,
+                    !fullScaleReference && level.FullScale,
+                    fullScaleReference && level.FullScale);
             }
         }
 

--- a/source/Measurements/InputLevelMapping.cs
+++ b/source/Measurements/InputLevelMapping.cs
@@ -1,0 +1,53 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Maps recorded per-channel levels onto the input meter snapshot (microphone +
+/// loopback entries) — the one place that decides how a full-scale channel is
+/// flagged: the microphone counts as clipped, the loopback as the full-scale
+/// reference. Shared by the sweep and noise measurements.
+/// </summary>
+internal static class InputLevelMapping
+{
+    public static InputLevelMeterSnapshot Map(
+        AudioChannelLevel[] channels,
+        int microphoneIndex,
+        int? loopbackIndex)
+    {
+        InputLevelMeterEntry microphone = CreateEntry(
+            TryGetLevel(channels, microphoneIndex),
+            fullScaleReference: false);
+        InputLevelMeterEntry loopback = CreateEntry(
+            loopbackIndex.HasValue
+                ? TryGetLevel(channels, loopbackIndex.Value)
+                : null,
+            fullScaleReference: true);
+        return new InputLevelMeterSnapshot(microphone, loopback);
+    }
+
+    public static InputLevelMeterEntry CreateEntry(
+        AudioChannelLevel? level,
+        bool fullScaleReference)
+    {
+        if (level == null)
+        {
+            return InputLevelMeterEntry.Unavailable;
+        }
+
+        AudioChannelLevel value = level.Value;
+        return new InputLevelMeterEntry(
+            true,
+            value.PeakDbFs,
+            value.RmsDbFs,
+            !fullScaleReference && value.FullScale,
+            fullScaleReference && value.FullScale);
+    }
+
+    public static AudioChannelLevel? TryGetLevel(
+        AudioChannelLevel[] channels,
+        int channelIndex)
+    {
+        return (uint)channelIndex < (uint)channels.Length
+            ? channels[channelIndex]
+            : null;
+    }
+}

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -13,12 +13,10 @@ namespace Resonalyze
     {
         private readonly object stateSync = new();
         private readonly object dataSync = new();
-        private readonly object levelSync = new();
+        private readonly DualDeviceLevelCombiner dualDeviceLevels = new();
         private SoundRecorder? soundRecorder;
         private SoundRecorder? loopbackRecorder;
         private LoopbackSequencePairer? loopbackPairer;
-        private AudioChannelLevel[] latestMicrophoneLevels = Array.Empty<AudioChannelLevel>();
-        private AudioChannelLevel[] latestLoopbackLevels = Array.Empty<AudioChannelLevel>();
         private CancellationTokenSource? cancellationTokenSource;
         private Task<bool>? measurementTask;
         private ChannelWriter<float[][]>? sequenceWriter;
@@ -130,11 +128,7 @@ namespace Resonalyze
                 SequenceLength);
 
             DisposeRecorders();
-            lock (levelSync)
-            {
-                latestMicrophoneLevels = Array.Empty<AudioChannelLevel>();
-                latestLoopbackLevels = Array.Empty<AudioChannelLevel>();
-            }
+            dualDeviceLevels.Reset();
 
             bool separateLoopbackDevice = PairsSeparateLoopbackDevice;
             soundRecorder = new SoundRecorder();
@@ -567,85 +561,36 @@ namespace Resonalyze
             RaiseLevels(channels);
         }
 
-        // Separate loopback device: microphone and loopback levels come from two recorders.
-        // Keep the latest of each and raise a combined snapshot so both meters update live.
+        // Separate loopback device: microphone and loopback levels come from two recorders;
+        // the combiner keeps the latest of each so both meters update live.
         private void HandleMicrophoneOnlyLevels(AudioChannelLevel[] channels)
         {
-            lock (levelSync)
-            {
-                latestMicrophoneLevels = channels;
-            }
+            dualDeviceLevels.SetMicrophone(channels);
             RaiseCombinedDualDeviceLevels();
         }
 
         private void HandleLoopbackOnlyLevels(AudioChannelLevel[] channels)
         {
-            lock (levelSync)
-            {
-                latestLoopbackLevels = channels;
-            }
+            dualDeviceLevels.SetLoopback(channels);
             RaiseCombinedDualDeviceLevels();
         }
 
         private void RaiseCombinedDualDeviceLevels()
         {
-            AudioChannelLevel[] microphoneChannels;
-            AudioChannelLevel[] loopbackChannels;
-            lock (levelSync)
-            {
-                microphoneChannels = latestMicrophoneLevels;
-                loopbackChannels = latestLoopbackLevels;
-            }
-
-            InputLevelMeterEntry microphone = CreateLevelEntry(
-                microphoneChannels,
+            LevelsAvailable?.Invoke(dualDeviceLevels.Combine(
                 WaveInputChannelOffset,
-                loopbackReference: false);
-            InputLevelMeterEntry loopback = WaveLoopbackInputChannelOffset is int loopbackChannel
-                ? CreateLevelEntry(loopbackChannels, loopbackChannel, loopbackReference: true)
-                : InputLevelMeterEntry.Unavailable;
-            LevelsAvailable?.Invoke(new InputLevelMeterSnapshot(microphone, loopback));
+                WaveLoopbackInputChannelOffset));
         }
-
-        private static InputLevelMeterEntry CreateLevelEntry(
-            AudioChannelLevel[] channels,
-            int index,
-            bool loopbackReference) =>
-            (uint)index < (uint)channels.Length
-                ? new InputLevelMeterEntry(
-                    true,
-                    channels[index].PeakDbFs,
-                    channels[index].RmsDbFs,
-                    !loopbackReference && channels[index].FullScale,
-                    loopbackReference && channels[index].FullScale)
-                : InputLevelMeterEntry.Unavailable;
 
         private void RaiseLevels(AudioChannelLevel[] channels)
         {
-            int microphoneIndex = GetMicrophoneSequenceIndex();
-            int? loopbackIndex = GetLoopbackSequenceIndex();
-
-            InputLevelMeterEntry microphone =
-                (uint)microphoneIndex < (uint)channels.Length
-                ? new InputLevelMeterEntry(
-                    true,
-                    channels[microphoneIndex].PeakDbFs,
-                    channels[microphoneIndex].RmsDbFs,
-                    channels[microphoneIndex].FullScale,
-                    false)
-                : InputLevelMeterEntry.Unavailable;
-            InputLevelMeterEntry loopback =
-                loopbackIndex.HasValue && (uint)loopbackIndex.Value < (uint)channels.Length
-                    ? new InputLevelMeterEntry(
-                        true,
-                        channels[loopbackIndex.Value].PeakDbFs,
-                        channels[loopbackIndex.Value].RmsDbFs,
-                        channels[loopbackIndex.Value].FullScale,
-                        true)
-                    : InputLevelMeterEntry.Unavailable;
-            LevelsAvailable?.Invoke(new InputLevelMeterSnapshot(
-                microphone,
-                loopback));
+            // The shared mapping flags a full-scale loopback as the reference (not
+            // clipped), matching the dual-device path above; this path used to set
+            // both flags at once.
+            LevelsAvailable?.Invoke(InputLevelMapping.Map(
+                channels,
+                GetMicrophoneSequenceIndex(),
+                GetLoopbackSequenceIndex()));
         }
 
         private async Task ProcessSequencesAsync(

--- a/source/Measurements/SoundRecorder.cs
+++ b/source/Measurements/SoundRecorder.cs
@@ -7,9 +7,8 @@ namespace Resonalyze
     /// </summary>
     public sealed class SoundRecorder : IDisposable
     {
-        private static readonly TimeSpan StopTimeout = TimeSpan.FromSeconds(3);
         private readonly object sync = new();
-        private readonly List<SampleWaiter> sampleWaiters = new();
+        private readonly SampleWaiterRegistry sampleWaiters = new();
         private WaveInEvent? waveSource;
         private CaptureAccumulator? accumulator;
         private float[][] decodeScratch = Array.Empty<float[]>();
@@ -113,20 +112,18 @@ namespace Resonalyze
                     return Task.CompletedTask;
                 }
 
-                var waiter = new SampleWaiter(sampleCount, cancellationToken);
-                sampleWaiters.Add(waiter);
-                return waiter.Task;
+                return sampleWaiters.Add(sampleCount, cancellationToken);
             }
         }
 
         public async Task StopRecordingAsync()
         {
             WaveInEvent? source;
-            Task stoppedTask;
+            TaskCompletionSource<bool>? stoppedSignal;
             lock (sync)
             {
                 source = waveSource;
-                stoppedTask = recordingStopped?.Task ?? Task.CompletedTask;
+                stoppedSignal = recordingStopped;
             }
 
             if (source == null)
@@ -136,22 +133,11 @@ namespace Resonalyze
 
             try
             {
-                source.StopRecording();
-            }
-            catch (InvalidOperationException)
-            {
-                recordingStopped?.TrySetResult(true);
-            }
-
-            try
-            {
-                await stoppedTask.WaitAsync(StopTimeout).ConfigureAwait(false);
-            }
-            catch (TimeoutException exception)
-            {
-                throw new TimeoutException(
-                    $"The audio input did not stop within {StopTimeout.TotalSeconds:0} seconds.",
-                    exception);
+                await AudioCaptureStop.StopAndWaitAsync(
+                    source.StopRecording,
+                    stoppedSignal,
+                    stoppedSignal?.Task ?? Task.CompletedTask,
+                    "The audio input").ConfigureAwait(false);
             }
             finally
             {
@@ -206,15 +192,7 @@ namespace Resonalyze
 
                 accumulator.Append(decodeScratch, frameCount);
                 readySequences = accumulator.ExtractReadySequences();
-
-                for (int i = sampleWaiters.Count - 1; i >= 0; i--)
-                {
-                    if (accumulator.ReadSamples >= sampleWaiters[i].SampleCount)
-                    {
-                        sampleWaiters[i].Complete();
-                        sampleWaiters.RemoveAt(i);
-                    }
-                }
+                sampleWaiters.CompleteUpTo(accumulator.ReadSamples);
             }
 
             firstBufferReady?.TrySetResult(true);
@@ -294,11 +272,7 @@ namespace Resonalyze
                     Sequence,
                     Math.Max(expectedTotalSamples, SampleRate));
 
-                foreach (SampleWaiter waiter in sampleWaiters)
-                {
-                    waiter.Cancel();
-                }
-                sampleWaiters.Clear();
+                sampleWaiters.CancelAll();
             }
         }
 
@@ -333,7 +307,7 @@ namespace Resonalyze
         }
 
         private static TaskCompletionSource<bool> NewSignal() =>
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
+            SampleWaiterRegistry.NewSignal();
 
         private void ThrowIfDisposed()
         {
@@ -354,41 +328,9 @@ namespace Resonalyze
             StopAndDisposeSource();
             lock (sync)
             {
-                foreach (SampleWaiter waiter in sampleWaiters)
-                {
-                    waiter.Cancel();
-                }
-                sampleWaiters.Clear();
+                sampleWaiters.CancelAll();
             }
             GC.SuppressFinalize(this);
-        }
-
-        private sealed class SampleWaiter
-        {
-            private readonly TaskCompletionSource<bool> completion = NewSignal();
-            private readonly CancellationTokenRegistration registration;
-
-            public SampleWaiter(int sampleCount, CancellationToken cancellationToken)
-            {
-                SampleCount = sampleCount;
-                registration = cancellationToken.Register(() =>
-                    completion.TrySetCanceled(cancellationToken));
-            }
-
-            public int SampleCount { get; }
-            public Task Task => completion.Task;
-
-            public void Complete()
-            {
-                registration.Dispose();
-                completion.TrySetResult(true);
-            }
-
-            public void Cancel()
-            {
-                registration.Dispose();
-                completion.TrySetCanceled();
-            }
         }
     }
 }

--- a/source/Options/BDOpt.cs
+++ b/source/Options/BDOpt.cs
@@ -10,11 +10,8 @@ using System.Windows.Forms;
 
 namespace Resonalyze.Options
 {
-    public partial class BDOpt : Form
+    public partial class BDOpt : ImpulsePreviewOptionsForm
     {
-        private readonly ToolTip toolTip = new();
-        private ExpSweepMeasurement? expSweepMeasurement;
-
         public BDOpt()
         {
             InitializeComponent();
@@ -22,43 +19,31 @@ namespace Resonalyze.Options
             numericRightWindow.ValueChanged += TukeyWindow_ValueChanged;
             SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
             InitializeToolTips();
-            // Disposed, not FormClosed: a dialog disposed without ever having been
-            // shown (e.g. the docked host closing it while the owner is minimized)
-            // never raises FormClosed, which leaked the measurement subscription.
-            Disposed += BDOpt_Disposed;
         }
 
         public void Init(ExpSweepMeasurement expSweepMeasurement, WaterfallGenerateOptions burstDecayGenOptions)
         {
-            if (!ReferenceEquals(this.expSweepMeasurement, expSweepMeasurement))
+            AttachMeasurement(expSweepMeasurement);
+            InitializeControls(() =>
             {
-                if (this.expSweepMeasurement != null)
-                {
-                    this.expSweepMeasurement.ImpulseResponseChanged -= ExpSweepMeasurement_ImpulseResponseChanged;
-                }
+                numericSampleRate.Value = expSweepMeasurement.SampleRate;
 
-                expSweepMeasurement.ImpulseResponseChanged += ExpSweepMeasurement_ImpulseResponseChanged;
-            }
+                numericWindow.Value = burstDecayGenOptions.Window;
+                numericCaptureTime.Value = (decimal)CalcCapturedTime;
 
-            this.expSweepMeasurement = expSweepMeasurement;
+                numericLeftWindow.Value = burstDecayGenOptions.LeftTukeyWindow;
+                numericRightWindow.Value = burstDecayGenOptions.RightTukeyWindow;
 
-            numericSampleRate.Value = expSweepMeasurement.SampleRate;
+                numericDbRange.Value = burstDecayGenOptions.DbRange;
 
-            numericWindow.Value = burstDecayGenOptions.Window;
-            numericCaptureTime.Value = (decimal)CalcCapturedTime;
+                comboSmoothingInverseOctaves.SelectedItem =
+                    SmoothingPresetOptions.Normalize(burstDecayGenOptions.SmoothingInverseOctaves);
 
-            numericLeftWindow.Value = burstDecayGenOptions.LeftTukeyWindow;
-            numericRightWindow.Value = burstDecayGenOptions.RightTukeyWindow;
+                numericOffset.Value = burstDecayGenOptions.Offset;
 
-            numericDbRange.Value = burstDecayGenOptions.DbRange;
-
-            comboSmoothingInverseOctaves.SelectedItem =
-                SmoothingPresetOptions.Normalize(burstDecayGenOptions.SmoothingInverseOctaves);
-
-            numericOffset.Value = burstDecayGenOptions.Offset;
-
-            numericPeriods.Value = (int)burstDecayGenOptions.Periods;
-            UpdateTukeyWindowLimits();
+                numericPeriods.Value = (int)burstDecayGenOptions.Periods;
+                UpdateTukeyWindowLimits();
+            });
             UpdateIrPreview();
         }
 
@@ -86,7 +71,7 @@ namespace Resonalyze.Options
         {
             get
             {
-                int sampleRate = expSweepMeasurement?.SampleRate ?? 0;
+                int sampleRate = Measurement?.SampleRate ?? 0;
                 return sampleRate > 0
                     ? (double)numericWindow.Value / sampleRate * 1000.0
                     : 0;
@@ -114,47 +99,21 @@ namespace Resonalyze.Options
                 numericRightWindow);
         }
 
-        private void UpdateIrPreview()
+        protected override void RenderIrPreview()
         {
-            if (expSweepMeasurement == null)
+            if (Measurement == null)
             {
                 return;
             }
 
             ImpulseWindowPreview.Update(
                 irPlotView,
-                expSweepMeasurement,
+                Measurement,
                 (int)numericWindow.Value,
                 (int)numericLeftWindow.Value,
                 (int)numericRightWindow.Value,
                 (int)numericOffset.Value,
                 IrPreviewSource.Primary);
-        }
-
-        private void ExpSweepMeasurement_ImpulseResponseChanged()
-        {
-            if (IsDisposed)
-            {
-                return;
-            }
-
-            if (IsHandleCreated && InvokeRequired)
-            {
-                BeginInvoke((MethodInvoker)UpdateIrPreview);
-                return;
-            }
-
-            UpdateIrPreview();
-        }
-
-        private void BDOpt_Disposed(object? sender, EventArgs e)
-        {
-            if (expSweepMeasurement != null)
-            {
-                expSweepMeasurement.ImpulseResponseChanged -= ExpSweepMeasurement_ImpulseResponseChanged;
-            }
-
-            toolTip.Dispose();
         }
 
         private void InitializeToolTips()

--- a/source/Options/FROptions.cs
+++ b/source/Options/FROptions.cs
@@ -11,11 +11,8 @@ using Resonalyze.Dsp;
 
 namespace Resonalyze.Options
 {
-    public partial class FROptions : Form
+    public partial class FROptions : ImpulsePreviewOptionsForm
     {
-        private readonly ToolTip toolTip = new();
-        private ExpSweepMeasurement? expSweepMeasurement;
-
         public FROptions()
         {
             InitializeComponent();
@@ -23,10 +20,6 @@ namespace Resonalyze.Options
             numericRightWindow.ValueChanged += TukeyWindow_ValueChanged;
             SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
             InitializeToolTips();
-            // Disposed, not FormClosed: a dialog disposed without ever having been
-            // shown (e.g. the docked host closing it while the owner is minimized)
-            // never raises FormClosed, which leaked the measurement subscription.
-            Disposed += FROptions_Disposed;
         }
 
         public void Init(
@@ -35,34 +28,27 @@ namespace Resonalyze.Options
             bool hasZeroDegreeCalibration,
             bool hasNinetyDegreeCalibration)
         {
-            if (!ReferenceEquals(this.expSweepMeasurement, expSweepMeasurement))
+            AttachMeasurement(expSweepMeasurement);
+            InitializeControls(() =>
             {
-                if (this.expSweepMeasurement != null)
-                {
-                    this.expSweepMeasurement.ImpulseResponseChanged -= ExpSweepMeasurement_ImpulseResponseChanged;
-                }
-
-                expSweepMeasurement.ImpulseResponseChanged += ExpSweepMeasurement_ImpulseResponseChanged;
-            }
-
-            this.expSweepMeasurement = expSweepMeasurement;
-            numericWindow.Value = frequencyResponseOptions.Window;
-            numericLeftWindow.Value = frequencyResponseOptions.LeftTukeyWindow;
-            numericRightWindow.Value = frequencyResponseOptions.RightTukeyWindow;
-            comboSmoothingInverseOctaves.SelectedItem =
-                SmoothingPresetOptions.Normalize(frequencyResponseOptions.SmoothingInverseOctaves);
-            MicrophoneCalibrationComboHelper.Configure(
-                comboCalibration,
-                frequencyResponseOptions.CalibrationMode,
-                hasZeroDegreeCalibration,
-                hasNinetyDegreeCalibration);
-            checkBoxShowPrimary.Checked = frequencyResponseOptions.ShowPrimary;
-            checkBoxShowCoherence.Checked = frequencyResponseOptions.ShowCoherence;
-            checkBoxShowHd2.Checked = frequencyResponseOptions.ShowHd2;
-            checkBoxShowHd3.Checked = frequencyResponseOptions.ShowHd3;
-            checkBoxShowHd4.Checked = frequencyResponseOptions.ShowHd4;
-            checkBoxShowThdPlusNoise.Checked = frequencyResponseOptions.ShowThdPlusNoise;
-            UpdateTukeyWindowLimits();
+                numericWindow.Value = frequencyResponseOptions.Window;
+                numericLeftWindow.Value = frequencyResponseOptions.LeftTukeyWindow;
+                numericRightWindow.Value = frequencyResponseOptions.RightTukeyWindow;
+                comboSmoothingInverseOctaves.SelectedItem =
+                    SmoothingPresetOptions.Normalize(frequencyResponseOptions.SmoothingInverseOctaves);
+                MicrophoneCalibrationComboHelper.Configure(
+                    comboCalibration,
+                    frequencyResponseOptions.CalibrationMode,
+                    hasZeroDegreeCalibration,
+                    hasNinetyDegreeCalibration);
+                checkBoxShowPrimary.Checked = frequencyResponseOptions.ShowPrimary;
+                checkBoxShowCoherence.Checked = frequencyResponseOptions.ShowCoherence;
+                checkBoxShowHd2.Checked = frequencyResponseOptions.ShowHd2;
+                checkBoxShowHd3.Checked = frequencyResponseOptions.ShowHd3;
+                checkBoxShowHd4.Checked = frequencyResponseOptions.ShowHd4;
+                checkBoxShowThdPlusNoise.Checked = frequencyResponseOptions.ShowThdPlusNoise;
+                UpdateTukeyWindowLimits();
+            });
             UpdateIrPreview();
         }
 
@@ -106,48 +92,22 @@ namespace Resonalyze.Options
                 numericRightWindow);
         }
 
-        private void UpdateIrPreview()
+        protected override void RenderIrPreview()
         {
-            if (expSweepMeasurement == null)
+            if (Measurement == null)
             {
                 return;
             }
 
             ImpulseWindowPreview.Update(
                 irPlotView,
-                expSweepMeasurement,
+                Measurement,
                 (int)numericWindow.Value,
                 (int)numericLeftWindow.Value,
                 (int)numericRightWindow.Value,
                 offset: 0,
                 // FR magnitude is now windowed on the transfer IR, so preview that window.
                 IrPreviewSource.Primary);
-        }
-
-        private void ExpSweepMeasurement_ImpulseResponseChanged()
-        {
-            if (IsDisposed)
-            {
-                return;
-            }
-
-            if (IsHandleCreated && InvokeRequired)
-            {
-                BeginInvoke((MethodInvoker)UpdateIrPreview);
-                return;
-            }
-
-            UpdateIrPreview();
-        }
-
-        private void FROptions_Disposed(object? sender, EventArgs e)
-        {
-            if (expSweepMeasurement != null)
-            {
-                expSweepMeasurement.ImpulseResponseChanged -= ExpSweepMeasurement_ImpulseResponseChanged;
-            }
-
-            toolTip.Dispose();
         }
 
         private void InitializeToolTips()

--- a/source/Options/GDOpt.cs
+++ b/source/Options/GDOpt.cs
@@ -4,12 +4,9 @@ using Resonalyze.Dsp;
 
 namespace Resonalyze.Options;
 
-public partial class GDOpt : Form
+public partial class GDOpt : ImpulsePreviewOptionsForm
 {
-    private readonly ToolTip toolTip = new();
-    private ExpSweepMeasurement? expSweepMeasurement;
     private Func<CompareAnalysisSource?>? getCompare;
-    private bool initializing;
 
     public GDOpt()
     {
@@ -22,10 +19,6 @@ public partial class GDOpt : Form
         ConfigureResetDefaults();
         SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
         InitializeToolTips();
-        // Disposed, not FormClosed: a dialog disposed without ever having been
-        // shown (e.g. the docked host closing it while the owner is minimized)
-        // never raises FormClosed, which leaked the measurement subscription.
-        Disposed += GDOpt_Disposed;
     }
 
     public void Init(
@@ -33,20 +26,9 @@ public partial class GDOpt : Form
         FrequencyResponseOptions opt,
         Func<CompareAnalysisSource?>? getCompare = null)
     {
-        if (!ReferenceEquals(this.expSweepMeasurement, expSweepMeasurement))
-        {
-            if (this.expSweepMeasurement != null)
-            {
-                this.expSweepMeasurement.ImpulseResponseChanged -= ExpSweepMeasurement_ImpulseResponseChanged;
-            }
-
-            this.expSweepMeasurement = expSweepMeasurement;
-            this.expSweepMeasurement.ImpulseResponseChanged += ExpSweepMeasurement_ImpulseResponseChanged;
-        }
-
+        AttachMeasurement(expSweepMeasurement);
         this.getCompare = getCompare;
-        initializing = true;
-        try
+        InitializeControls(() =>
         {
             numericGateOffset.Value = ClampToControl(numericGateOffset, opt.GroupDelayGateOffsetMs);
             numericWindow.Value = ClampToControl(numericWindow, opt.GroupDelayPlateauMs);
@@ -56,11 +38,7 @@ public partial class GDOpt : Form
                 SmoothingPresetOptions.Normalize(opt.SmoothingInverseOctaves);
             checkBoxShowGroupDelay.Checked = opt.ShowGroupDelay;
             checkBoxShowCoherence.Checked = opt.ShowCoherence;
-        }
-        finally
-        {
-            initializing = false;
-        }
+        });
 
         UpdateMinFrequencyLabel();
         UpdateIrPreview();
@@ -96,7 +74,7 @@ public partial class GDOpt : Form
     // Snap the gate offset to the transfer IR peak (deterministic, gate-independent).
     private void buttonFit_Click(object? sender, EventArgs e)
     {
-        if (expSweepMeasurement is not { } measurement ||
+        if (Measurement is not { } measurement ||
             measurement.Transfer is not { ImpulseResponse.Length: > 0 } transfer ||
             measurement.SampleRate <= 0)
         {
@@ -131,57 +109,25 @@ public partial class GDOpt : Form
             : "Reliable from ≈ — Hz";
     }
 
-    private void ExpSweepMeasurement_ImpulseResponseChanged()
-    {
-        if (IsDisposed)
-        {
-            return;
-        }
-
-        if (IsHandleCreated && InvokeRequired)
-        {
-            BeginInvoke((MethodInvoker)UpdateIrPreview);
-            return;
-        }
-
-        UpdateIrPreview();
-    }
-
-    private void GDOpt_Disposed(object? sender, EventArgs e)
-    {
-        if (expSweepMeasurement != null)
-        {
-            expSweepMeasurement.ImpulseResponseChanged -= ExpSweepMeasurement_ImpulseResponseChanged;
-        }
-
-        toolTip.Dispose();
-    }
-
     // Re-draws the preview after the Compare selection changes while docked.
     public void RefreshComparePreview() => UpdateIrPreview();
 
-    private void UpdateIrPreview()
+    protected override void RenderIrPreview()
     {
-        if (initializing || expSweepMeasurement == null || expSweepMeasurement.SampleRate <= 0)
+        if (Measurement == null || Measurement.SampleRate <= 0)
         {
             return;
         }
 
         ImpulseWindowPreview.UpdateGated(
             irPlotView,
-            expSweepMeasurement,
+            Measurement,
             (double)numericGateOffset.Value,
             (double)numericLeftWindow.Value,
             (double)numericWindow.Value,
             (double)numericRightWindow.Value,
             IrPreviewSource.Primary,
             getCompare?.Invoke());
-    }
-
-    private static decimal ClampToControl(DarkNumericUpDown control, double value)
-    {
-        decimal candidate = double.IsFinite(value) ? (decimal)value : 0m;
-        return Math.Clamp(candidate, control.Minimum, control.Maximum);
     }
 
     private void InitializeToolTips()

--- a/source/Options/ImpulsePreviewOptionsForm.cs
+++ b/source/Options/ImpulsePreviewOptionsForm.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Windows.Forms;
+
+namespace Resonalyze.Options;
+
+/// <summary>
+/// Base class for the options panels with a live impulse-response preview
+/// (FROptions, GDOpt, PROpt, BDOpt, WaterfallOptions). Owns the plumbing that
+/// had drifted across five copies: the measurement subscription swap, the
+/// UI-thread marshal of ImpulseResponseChanged, the Disposed cleanup (a dialog
+/// disposed without ever having been shown never raises FormClosed), the
+/// suppression of redundant preview renders while Init writes control values,
+/// and the numeric clamp helper.
+/// </summary>
+public class ImpulsePreviewOptionsForm : Form
+{
+    protected readonly ToolTip toolTip = new();
+    private bool initializingControls;
+
+    public ImpulsePreviewOptionsForm()
+    {
+        Disposed += (_, _) =>
+        {
+            DetachMeasurement();
+            toolTip.Dispose();
+        };
+    }
+
+    protected ExpSweepMeasurement? Measurement { get; private set; }
+
+    /// <summary>
+    /// Points the panel at a measurement, re-targeting the
+    /// ImpulseResponseChanged subscription when the instance changes.
+    /// </summary>
+    protected void AttachMeasurement(ExpSweepMeasurement measurement)
+    {
+        ArgumentNullException.ThrowIfNull(measurement);
+        if (ReferenceEquals(Measurement, measurement))
+        {
+            return;
+        }
+
+        DetachMeasurement();
+        Measurement = measurement;
+        measurement.ImpulseResponseChanged += HandleImpulseResponseChanged;
+    }
+
+    /// <summary>
+    /// Runs Init's control writes with preview renders suppressed: every
+    /// ValueChanged would otherwise rebuild the preview several times before
+    /// Init's final explicit render.
+    /// </summary>
+    protected void InitializeControls(Action applyValues)
+    {
+        ArgumentNullException.ThrowIfNull(applyValues);
+        initializingControls = true;
+        try
+        {
+            applyValues();
+        }
+        finally
+        {
+            initializingControls = false;
+        }
+    }
+
+    protected void UpdateIrPreview()
+    {
+        if (initializingControls)
+        {
+            return;
+        }
+
+        RenderIrPreview();
+    }
+
+    /// <summary>
+    /// The panel's actual preview render; only called outside Init suppression.
+    /// </summary>
+    protected virtual void RenderIrPreview()
+    {
+    }
+
+    protected static decimal ClampToControl(DarkNumericUpDown control, double value)
+    {
+        decimal candidate = double.IsFinite(value) ? (decimal)value : 0m;
+        return Math.Clamp(candidate, control.Minimum, control.Maximum);
+    }
+
+    private void DetachMeasurement()
+    {
+        if (Measurement != null)
+        {
+            Measurement.ImpulseResponseChanged -= HandleImpulseResponseChanged;
+            Measurement = null;
+        }
+    }
+
+    private void HandleImpulseResponseChanged()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        if (IsHandleCreated && InvokeRequired)
+        {
+            BeginInvoke((MethodInvoker)UpdateIrPreview);
+            return;
+        }
+
+        UpdateIrPreview();
+    }
+}

--- a/source/Options/PROpt.cs
+++ b/source/Options/PROpt.cs
@@ -4,10 +4,8 @@ using Resonalyze.Dsp;
 
 namespace Resonalyze.Options
 {
-    public partial class PROpt : Form
+    public partial class PROpt : ImpulsePreviewOptionsForm
     {
-        private readonly ToolTip toolTip = new();
-        private ExpSweepMeasurement? expSweepMeasurement;
         private Func<CompareAnalysisSource?>? getCompare;
 
         public PROpt()
@@ -22,10 +20,6 @@ namespace Resonalyze.Options
             ConfigureResetDefaults();
             SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
             InitializeToolTips();
-            // Disposed, not FormClosed: a dialog disposed without ever having been
-            // shown (e.g. the docked host closing it while the owner is minimized)
-            // never raises FormClosed, which leaked the measurement subscription.
-            Disposed += PROpt_Disposed;
         }
 
         public void Init(
@@ -33,30 +27,23 @@ namespace Resonalyze.Options
             FrequencyResponseOptions opt,
             Func<CompareAnalysisSource?>? getCompare = null)
         {
-            if (!ReferenceEquals(this.expSweepMeasurement, expSweepMeasurement))
-            {
-                if (this.expSweepMeasurement != null)
-                {
-                    this.expSweepMeasurement.ImpulseResponseChanged -= ExpSweepMeasurement_ImpulseResponseChanged;
-                }
-
-                expSweepMeasurement.ImpulseResponseChanged += ExpSweepMeasurement_ImpulseResponseChanged;
-            }
-
-            this.expSweepMeasurement = expSweepMeasurement;
+            AttachMeasurement(expSweepMeasurement);
             this.getCompare = getCompare;
-            numericGateOffset.Value = ClampToControl(numericGateOffset, opt.PhaseGateOffsetMs);
-            numericWindow.Value = ClampToControl(numericWindow, opt.PhasePlateauMs);
-            numericLeftWindow.Value = ClampToControl(numericLeftWindow, opt.PhaseLeftMs);
-            numericRightWindow.Value = ClampToControl(numericRightWindow, opt.PhaseRightMs);
-            comboSmoothingInverseOctaves.SelectedItem =
-                SmoothingPresetOptions.Normalize(opt.SmoothingInverseOctaves);
-            numericOffset.Value = ClampToControl(numericOffset, opt.PhaseDetrendMs);
-            checkBoxUnwrap.Checked = opt.Unwrap;
-            checkBoxShowMeasured.Checked = opt.ShowMeasuredPhase;
-            checkBoxShowMinimum.Checked = opt.ShowMinimumPhase;
-            checkBoxShowExcess.Checked = opt.ShowExcessPhase;
-            checkBoxShowCoherence.Checked = opt.ShowCoherence;
+            InitializeControls(() =>
+            {
+                numericGateOffset.Value = ClampToControl(numericGateOffset, opt.PhaseGateOffsetMs);
+                numericWindow.Value = ClampToControl(numericWindow, opt.PhasePlateauMs);
+                numericLeftWindow.Value = ClampToControl(numericLeftWindow, opt.PhaseLeftMs);
+                numericRightWindow.Value = ClampToControl(numericRightWindow, opt.PhaseRightMs);
+                comboSmoothingInverseOctaves.SelectedItem =
+                    SmoothingPresetOptions.Normalize(opt.SmoothingInverseOctaves);
+                numericOffset.Value = ClampToControl(numericOffset, opt.PhaseDetrendMs);
+                checkBoxUnwrap.Checked = opt.Unwrap;
+                checkBoxShowMeasured.Checked = opt.ShowMeasuredPhase;
+                checkBoxShowMinimum.Checked = opt.ShowMinimumPhase;
+                checkBoxShowExcess.Checked = opt.ShowExcessPhase;
+                checkBoxShowCoherence.Checked = opt.ShowCoherence;
+            });
             UpdateMinFrequencyLabel();
             UpdateIrPreview();
         }
@@ -99,7 +86,7 @@ namespace Resonalyze.Options
         {
             // Phase analysis (and therefore τ) only works with a transfer IR, so
             // gate the auto-estimate on the same condition as Fit and the plot.
-            if (expSweepMeasurement is not { } measurement ||
+            if (Measurement is not { } measurement ||
                 measurement.TransferImpulseResponse is not { Length: > 0 } ||
                 measurement.InProgress)
             {
@@ -130,7 +117,7 @@ namespace Resonalyze.Options
         // Snap the gate offset to the transfer IR peak (deterministic, gate-independent).
         private void buttonFit_Click(object? sender, EventArgs e)
         {
-            if (expSweepMeasurement is not { } measurement ||
+            if (Measurement is not { } measurement ||
                 measurement.Transfer is not { ImpulseResponse.Length: > 0 } transfer ||
                 measurement.SampleRate <= 0)
             {
@@ -168,54 +155,22 @@ namespace Resonalyze.Options
         // Re-draws the preview after the Compare selection changes while docked.
         public void RefreshComparePreview() => UpdateIrPreview();
 
-        private void UpdateIrPreview()
+        protected override void RenderIrPreview()
         {
-            if (expSweepMeasurement == null || expSweepMeasurement.SampleRate <= 0)
+            if (Measurement == null || Measurement.SampleRate <= 0)
             {
                 return;
             }
 
             ImpulseWindowPreview.UpdateGated(
                 irPlotView,
-                expSweepMeasurement,
+                Measurement,
                 (double)numericGateOffset.Value,
                 (double)numericLeftWindow.Value,
                 (double)numericWindow.Value,
                 (double)numericRightWindow.Value,
                 IrPreviewSource.Primary,
                 getCompare?.Invoke());
-        }
-
-        private static decimal ClampToControl(DarkNumericUpDown control, double value)
-        {
-            decimal candidate = double.IsFinite(value) ? (decimal)value : 0m;
-            return Math.Clamp(candidate, control.Minimum, control.Maximum);
-        }
-
-        private void ExpSweepMeasurement_ImpulseResponseChanged()
-        {
-            if (IsDisposed)
-            {
-                return;
-            }
-
-            if (IsHandleCreated && InvokeRequired)
-            {
-                BeginInvoke((MethodInvoker)UpdateIrPreview);
-                return;
-            }
-
-            UpdateIrPreview();
-        }
-
-        private void PROpt_Disposed(object? sender, EventArgs e)
-        {
-            if (expSweepMeasurement != null)
-            {
-                expSweepMeasurement.ImpulseResponseChanged -= ExpSweepMeasurement_ImpulseResponseChanged;
-            }
-
-            toolTip.Dispose();
         }
 
         private void InitializeToolTips()

--- a/source/Options/WaterfallOptions.cs
+++ b/source/Options/WaterfallOptions.cs
@@ -9,10 +9,8 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 namespace Resonalyze.Options
 {
-    public partial class WaterfallOptions : Form
+    public partial class WaterfallOptions : ImpulsePreviewOptionsForm
     {
-        private readonly ToolTip toolTip = new();
-        private ExpSweepMeasurement? expSweepMeasurement;
         private decimal lastNonZeroStep = 4;
 
         public WaterfallOptions()
@@ -22,46 +20,34 @@ namespace Resonalyze.Options
             numericRightWindow.ValueChanged += TukeyWindow_ValueChanged;
             SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
             InitializeToolTips();
-            // Disposed, not FormClosed: a dialog disposed without ever having been
-            // shown (e.g. the docked host closing it while the owner is minimized)
-            // never raises FormClosed, which leaked the measurement subscription.
-            Disposed += WaterfallOptions_Disposed;
         }
 
         public void Init(ExpSweepMeasurement expSweepMeasurement, WaterfallGenerateOptions waterfallGenerateOptions)
         {
-            if (!ReferenceEquals(this.expSweepMeasurement, expSweepMeasurement))
+            AttachMeasurement(expSweepMeasurement);
+            InitializeControls(() =>
             {
-                if (this.expSweepMeasurement != null)
-                {
-                    this.expSweepMeasurement.ImpulseResponseChanged -= ExpSweepMeasurement_ImpulseResponseChanged;
-                }
+                numericSampleRate.Value = numericSampleRate.ClampValue(expSweepMeasurement.SampleRate);
 
-                expSweepMeasurement.ImpulseResponseChanged += ExpSweepMeasurement_ImpulseResponseChanged;
-            }
+                // The settings file clamps to wider ranges than the controls; an
+                // out-of-range persisted value must not throw when the panel opens.
+                numericWindow.Value = numericWindow.ClampValue(waterfallGenerateOptions.Window);
+                numericSlices.Value = numericSlices.ClampValue(waterfallGenerateOptions.SliceCount);
+                lastNonZeroStep = waterfallGenerateOptions.Step == 0 ? 1 : waterfallGenerateOptions.Step;
+                numericStep.Value = numericStep.ClampValue((double)lastNonZeroStep);
+                numericCaptureTime.Value = numericCaptureTime.ClampValue((double)CalcCapturedTime);
 
-            this.expSweepMeasurement = expSweepMeasurement;
+                numericLeftWindow.Value = numericLeftWindow.ClampValue(waterfallGenerateOptions.LeftTukeyWindow);
+                numericRightWindow.Value = numericRightWindow.ClampValue(waterfallGenerateOptions.RightTukeyWindow);
 
-            numericSampleRate.Value = numericSampleRate.ClampValue(expSweepMeasurement.SampleRate);
+                numericDbRange.Value = numericDbRange.ClampValue(waterfallGenerateOptions.DbRange);
 
-            // The settings file clamps to wider ranges than the controls; an
-            // out-of-range persisted value must not throw when the panel opens.
-            numericWindow.Value = numericWindow.ClampValue(waterfallGenerateOptions.Window);
-            numericSlices.Value = numericSlices.ClampValue(waterfallGenerateOptions.SliceCount);
-            lastNonZeroStep = waterfallGenerateOptions.Step == 0 ? 1 : waterfallGenerateOptions.Step;
-            numericStep.Value = numericStep.ClampValue((double)lastNonZeroStep);
-            numericCaptureTime.Value = numericCaptureTime.ClampValue((double)CalcCapturedTime);
+                comboSmoothingInverseOctaves.SelectedItem =
+                    SmoothingPresetOptions.Normalize(waterfallGenerateOptions.SmoothingInverseOctaves);
 
-            numericLeftWindow.Value = numericLeftWindow.ClampValue(waterfallGenerateOptions.LeftTukeyWindow);
-            numericRightWindow.Value = numericRightWindow.ClampValue(waterfallGenerateOptions.RightTukeyWindow);
-
-            numericDbRange.Value = numericDbRange.ClampValue(waterfallGenerateOptions.DbRange);
-
-            comboSmoothingInverseOctaves.SelectedItem =
-                SmoothingPresetOptions.Normalize(waterfallGenerateOptions.SmoothingInverseOctaves);
-
-            numericOffset.Value = numericOffset.ClampValue(waterfallGenerateOptions.Offset);
-            UpdateTukeyWindowLimits();
+                numericOffset.Value = numericOffset.ClampValue(waterfallGenerateOptions.Offset);
+                UpdateTukeyWindowLimits();
+            });
             UpdateIrPreview();
         }
 
@@ -89,7 +75,7 @@ namespace Resonalyze.Options
         {
             get
             {
-                int sampleRate = expSweepMeasurement?.SampleRate ?? 0;
+                int sampleRate = Measurement?.SampleRate ?? 0;
                 return sampleRate > 0
                     ? (double)numericSlices.Value * (double)numericStep.Value / sampleRate * 1000.0
                     : 0;
@@ -133,47 +119,21 @@ namespace Resonalyze.Options
                 numericRightWindow);
         }
 
-        private void UpdateIrPreview()
+        protected override void RenderIrPreview()
         {
-            if (expSweepMeasurement == null)
+            if (Measurement == null)
             {
                 return;
             }
 
             ImpulseWindowPreview.Update(
                 irPlotView,
-                expSweepMeasurement,
+                Measurement,
                 (int)numericWindow.Value,
                 (int)numericLeftWindow.Value,
                 (int)numericRightWindow.Value,
                 (int)numericOffset.Value,
                 IrPreviewSource.Primary);
-        }
-
-        private void ExpSweepMeasurement_ImpulseResponseChanged()
-        {
-            if (IsDisposed)
-            {
-                return;
-            }
-
-            if (IsHandleCreated && InvokeRequired)
-            {
-                BeginInvoke((MethodInvoker)UpdateIrPreview);
-                return;
-            }
-
-            UpdateIrPreview();
-        }
-
-        private void WaterfallOptions_Disposed(object? sender, EventArgs e)
-        {
-            if (expSweepMeasurement != null)
-            {
-                expSweepMeasurement.ImpulseResponseChanged -= ExpSweepMeasurement_ImpulseResponseChanged;
-            }
-
-            toolTip.Dispose();
         }
 
         private void InitializeToolTips()

--- a/source/Tools/PdfSheet.cs
+++ b/source/Tools/PdfSheet.cs
@@ -1,0 +1,161 @@
+using System.Reflection;
+using MigraDoc.DocumentObjectModel;
+using MigraDoc.DocumentObjectModel.Tables;
+using MigraDoc.Rendering;
+using Resonalyze.Dsp;
+using Color = MigraDoc.DocumentObjectModel.Color;
+
+namespace Resonalyze;
+
+/// <summary>
+/// The shared layout core of the tuning-sheet PDF exporters (TuningSheetPdf,
+/// VirtualCrossoverSheetPdf): the A4 scaffold with the product banner, title and
+/// subtitle, centred PNG images (via temp files — MigraDoc's AddImage takes a
+/// path), the PEQ filter cards, and the render-and-save step. Dispose deletes
+/// the temp images, so exporters wrap the sheet in a using block.
+/// </summary>
+internal sealed class PdfSheet : IDisposable
+{
+    public const int FilterCardColumns = 4;
+
+    public static readonly Color CaptionColor = Color.FromRgb(90, 90, 90);
+    public static readonly Color CardBorderColor = Color.FromRgb(210, 210, 210);
+
+    private readonly Document document;
+    private readonly List<string> tempImages = new();
+
+    public Section Section { get; }
+
+    public PdfSheet(string title, string subtitleText)
+    {
+        document = new Document();
+        Style normalStyle = document.Styles["Normal"]!;
+        normalStyle.Font.Name = "Segoe UI";
+        normalStyle.Font.Size = 11;
+
+        Section = document.AddSection();
+        PageSetup pageSetup = Section.PageSetup!;
+        pageSetup.PageFormat = PageFormat.A4;
+        pageSetup.TopMargin = Unit.FromCentimeter(1.2);
+        pageSetup.BottomMargin = Unit.FromCentimeter(1.2);
+        pageSetup.LeftMargin = Unit.FromCentimeter(1.5);
+        pageSetup.RightMargin = Unit.FromCentimeter(1.5);
+
+        byte[]? banner = LoadBanner();
+        if (banner != null)
+        {
+            AddImage(banner, Unit.FromCentimeter(11));
+        }
+
+        Paragraph titleParagraph = Section.AddParagraph(title);
+        titleParagraph.Format.Alignment = ParagraphAlignment.Center;
+        titleParagraph.Format.Font.Size = 24;
+        titleParagraph.Format.Font.Bold = true;
+        titleParagraph.Format.SpaceBefore = Unit.FromMillimeter(3);
+
+        Paragraph subtitle = Section.AddParagraph(subtitleText);
+        subtitle.Format.Alignment = ParagraphAlignment.Center;
+        subtitle.Format.Font.Size = 9;
+        subtitle.Format.Font.Color = Colors.Gray;
+        subtitle.Format.SpaceAfter = Unit.FromMillimeter(4);
+    }
+
+    public void AddImage(byte[] pngBytes, Unit width)
+    {
+        string tempPath = Path.Combine(Path.GetTempPath(), $"resonalyze_{Guid.NewGuid():N}.png");
+        File.WriteAllBytes(tempPath, pngBytes);
+        tempImages.Add(tempPath);
+
+        Paragraph paragraph = Section.AddParagraph();
+        paragraph.Format.Alignment = ParagraphAlignment.Center;
+        var image = paragraph.AddImage(tempPath);
+        image.Width = width;
+        image.LockAspectRatio = true;
+    }
+
+    public void AddFilterCards(IReadOnlyList<PeqBand> bands)
+    {
+        if (bands.Count == 0)
+        {
+            return;
+        }
+
+        var table = Section.AddTable();
+        for (int c = 0; c < FilterCardColumns; c++)
+        {
+            Column cardColumn = table.AddColumn(Unit.FromCentimeter(4.3));
+            cardColumn.LeftPadding = Unit.FromMillimeter(2.5);
+            cardColumn.RightPadding = Unit.FromMillimeter(2.5);
+        }
+
+        Row? row = null;
+        for (int i = 0; i < bands.Count; i++)
+        {
+            int column = i % FilterCardColumns;
+            if (column == 0)
+            {
+                row = table.AddRow();
+                row.TopPadding = Unit.FromMillimeter(2);
+                row.BottomPadding = Unit.FromMillimeter(2);
+            }
+
+            Cell cell = row!.Cells[column];
+            cell.Borders.Width = 0.5;
+            cell.Borders.Color = CardBorderColor;
+
+            PeqBand band = bands[i];
+            Paragraph name = cell.AddParagraph($"Filter {i + 1}");
+            name.Format.Font.Bold = true;
+            name.Format.Font.Size = 13;
+
+            Paragraph type = cell.AddParagraph("PK");
+            type.Format.Font.Color = CaptionColor;
+            type.Format.Font.Size = 9;
+
+            cell.AddParagraph($"{SheetFormat.Number(band.FrequencyHz, "0")} Hz").Format.Font.Size = 12;
+            Paragraph gain = cell.AddParagraph($"{SheetFormat.Signed(band.GainDb)} dB");
+            gain.Format.Font.Bold = true;
+            gain.Format.Font.Size = 12;
+            cell.AddParagraph($"Q {SheetFormat.Number(band.Q, "0.0")}").Format.Font.Size = 12;
+        }
+    }
+
+    public void Save(string filePath)
+    {
+        var renderer = new PdfDocumentRenderer { Document = document };
+        renderer.RenderDocument();
+        renderer.PdfDocument.Save(filePath);
+    }
+
+    public void Dispose()
+    {
+        foreach (string temp in tempImages)
+        {
+            try
+            {
+                File.Delete(temp);
+            }
+            catch (Exception)
+            {
+                // Best-effort cleanup; a leftover temp image must not fail
+                // (or mask the failure of) an export.
+            }
+        }
+
+        tempImages.Clear();
+    }
+
+    private static byte[]? LoadBanner()
+    {
+        using Stream? stream = Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream("Resonalyze.banner.jpg");
+        if (stream == null)
+        {
+            return null;
+        }
+
+        using var memory = new MemoryStream();
+        stream.CopyTo(memory);
+        return memory.ToArray();
+    }
+}

--- a/source/Tools/SheetFormat.cs
+++ b/source/Tools/SheetFormat.cs
@@ -1,0 +1,15 @@
+using System.Globalization;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Invariant-culture number formatting shared by the text and PDF tuning sheets.
+/// </summary>
+internal static class SheetFormat
+{
+    public static string Signed(double value) =>
+        value.ToString("+0.0;-0.0;0.0", CultureInfo.InvariantCulture);
+
+    public static string Number(double value, string format) =>
+        value.ToString(format, CultureInfo.InvariantCulture);
+}

--- a/source/Tools/TuningSheetPdf.cs
+++ b/source/Tools/TuningSheetPdf.cs
@@ -1,8 +1,6 @@
 using System.Globalization;
-using System.Reflection;
 using MigraDoc.DocumentObjectModel;
 using MigraDoc.DocumentObjectModel.Tables;
-using MigraDoc.Rendering;
 using OxyPlot;
 using OxyPlot.Annotations;
 using OxyPlot.Axes;
@@ -16,16 +14,13 @@ namespace Resonalyze;
 // Renders an EqualizationCurve as a phone-friendly "tuning sheet" PDF (MigraDoc /
 // PDFsharp): the product banner, a big title, the date and fit range, a small EQ
 // preview graph, the tuning statistics, the preamp and one card per PEQ band.
+// The shared layout (scaffold, images, filter cards) lives in PdfSheet.
 internal static class TuningSheetPdf
 {
-    private const int FilterCardColumns = 4;
-
-    private static readonly Color CaptionColor = Color.FromRgb(90, 90, 90);
     private static readonly Color GoodColor = Color.FromRgb(60, 150, 70);
     private static readonly Color WarnColor = Color.FromRgb(200, 150, 0);
     private static readonly Color BadColor = Color.FromRgb(200, 50, 40);
     private static readonly Color InfoColor = Color.FromRgb(20, 110, 180);
-    private static readonly Color CardBorderColor = Color.FromRgb(210, 210, 210);
 
     public static void Export(
         string filePath,
@@ -37,77 +32,28 @@ internal static class TuningSheetPdf
     {
         ArgumentNullException.ThrowIfNull(curve);
 
-        var tempImages = new List<string>();
-        try
+        using var sheet = new PdfSheet(
+            string.IsNullOrWhiteSpace(title) ? "Tuning sheet" : title,
+            $"Generated {DateTime.Now.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)}" +
+            $"   ·   Fit range {Number(fitMinHz, "0")}–{Number(fitMaxHz, "0")} Hz");
+        Section section = sheet.Section;
+
+        sheet.AddImage(RenderEqGraph(curve, fitMinHz, fitMaxHz), Unit.FromCentimeter(17));
+
+        if (stats != null)
         {
-            var document = new Document();
-            Style normalStyle = document.Styles["Normal"]!;
-            normalStyle.Font.Name = "Segoe UI";
-            normalStyle.Font.Size = 11;
-
-            Section section = document.AddSection();
-            PageSetup pageSetup = section.PageSetup!;
-            pageSetup.PageFormat = PageFormat.A4;
-            pageSetup.TopMargin = Unit.FromCentimeter(1.2);
-            pageSetup.BottomMargin = Unit.FromCentimeter(1.2);
-            pageSetup.LeftMargin = Unit.FromCentimeter(1.5);
-            pageSetup.RightMargin = Unit.FromCentimeter(1.5);
-
-            byte[]? banner = LoadBanner();
-            if (banner != null)
-            {
-                AddImage(section, banner, Unit.FromCentimeter(11), tempImages);
-            }
-
-            Paragraph titleParagraph = section.AddParagraph(
-                string.IsNullOrWhiteSpace(title) ? "Tuning sheet" : title);
-            titleParagraph.Format.Alignment = ParagraphAlignment.Center;
-            titleParagraph.Format.Font.Size = 24;
-            titleParagraph.Format.Font.Bold = true;
-            titleParagraph.Format.SpaceBefore = Unit.FromMillimeter(3);
-
-            Paragraph subtitle = section.AddParagraph(
-                $"Generated {DateTime.Now.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)}" +
-                $"   ·   Fit range {Number(fitMinHz, "0")}–{Number(fitMaxHz, "0")} Hz");
-            subtitle.Format.Alignment = ParagraphAlignment.Center;
-            subtitle.Format.Font.Size = 9;
-            subtitle.Format.Font.Color = Colors.Gray;
-            subtitle.Format.SpaceAfter = Unit.FromMillimeter(4);
-
-            AddImage(section, RenderEqGraph(curve, fitMinHz, fitMaxHz), Unit.FromCentimeter(17), tempImages);
-
-            if (stats != null)
-            {
-                AddStatsTable(section, stats);
-            }
-
-            Paragraph preamp = section.AddParagraph();
-            preamp.Format.SpaceBefore = Unit.FromMillimeter(5);
-            preamp.Format.Font.Size = 15;
-            preamp.AddFormattedText("Preamp   ", TextFormat.NotBold);
-            preamp.AddFormattedText($"{Signed(curve.PreampDb)} dB", TextFormat.Bold);
-
-            AddFilterCards(section, curve);
-
-            var renderer = new PdfDocumentRenderer { Document = document };
-            renderer.RenderDocument();
-            renderer.PdfDocument.Save(filePath);
+            AddStatsTable(section, stats);
         }
-        finally
-        {
-            foreach (string temp in tempImages)
-            {
-                try
-                {
-                    File.Delete(temp);
-                }
-                catch (Exception)
-                {
-                    // Best-effort cleanup; a leftover temp image must not fail
-                    // (or mask the failure of) an export.
-                }
-            }
-        }
+
+        Paragraph preamp = section.AddParagraph();
+        preamp.Format.SpaceBefore = Unit.FromMillimeter(5);
+        preamp.Format.Font.Size = 15;
+        preamp.AddFormattedText("Preamp   ", TextFormat.NotBold);
+        preamp.AddFormattedText($"{Signed(curve.PreampDb)} dB", TextFormat.Bold);
+
+        sheet.AddFilterCards(curve.Bands);
+
+        sheet.Save(filePath);
     }
 
     private static void AddStatsTable(Section section, EqTuneStats stats)
@@ -120,7 +66,7 @@ internal static class TuningSheetPdf
 
         var table = section.AddTable();
         table.Borders.Width = 0.5;
-        table.Borders.Color = CardBorderColor;
+        table.Borders.Color = PdfSheet.CardBorderColor;
         Column labelColumn = table.AddColumn(Unit.FromCentimeter(4.5));
         labelColumn.LeftPadding = Unit.FromMillimeter(2);
         Column valueColumn = table.AddColumn(Unit.FromCentimeter(3.5));
@@ -138,86 +84,12 @@ internal static class TuningSheetPdf
     {
         Row row = table.AddRow();
         Paragraph caption = row.Cells[0].AddParagraph(label);
-        caption.Format.Font.Color = CaptionColor;
+        caption.Format.Font.Color = PdfSheet.CaptionColor;
 
         Paragraph valueParagraph = row.Cells[1].AddParagraph(value);
         valueParagraph.Format.Alignment = ParagraphAlignment.Right;
         valueParagraph.Format.Font.Bold = true;
         valueParagraph.Format.Font.Color = valueColor;
-    }
-
-    private static void AddFilterCards(Section section, EqualizationCurve curve)
-    {
-        if (curve.Bands.Count == 0)
-        {
-            return;
-        }
-
-        var table = section.AddTable();
-        for (int c = 0; c < FilterCardColumns; c++)
-        {
-            Column cardColumn = table.AddColumn(Unit.FromCentimeter(4.3));
-            cardColumn.LeftPadding = Unit.FromMillimeter(2.5);
-            cardColumn.RightPadding = Unit.FromMillimeter(2.5);
-        }
-
-        Row? row = null;
-        for (int i = 0; i < curve.Bands.Count; i++)
-        {
-            int column = i % FilterCardColumns;
-            if (column == 0)
-            {
-                row = table.AddRow();
-                row.TopPadding = Unit.FromMillimeter(2);
-                row.BottomPadding = Unit.FromMillimeter(2);
-            }
-
-            Cell cell = row!.Cells[column];
-            cell.Borders.Width = 0.5;
-            cell.Borders.Color = CardBorderColor;
-
-            PeqBand band = curve.Bands[i];
-            Paragraph name = cell.AddParagraph($"Filter {i + 1}");
-            name.Format.Font.Bold = true;
-            name.Format.Font.Size = 13;
-
-            Paragraph type = cell.AddParagraph("PK");
-            type.Format.Font.Color = CaptionColor;
-            type.Format.Font.Size = 9;
-
-            cell.AddParagraph($"{Number(band.FrequencyHz, "0")} Hz").Format.Font.Size = 12;
-            Paragraph gain = cell.AddParagraph($"{Signed(band.GainDb)} dB");
-            gain.Format.Font.Bold = true;
-            gain.Format.Font.Size = 12;
-            cell.AddParagraph($"Q {Number(band.Q, "0.0")}").Format.Font.Size = 12;
-        }
-    }
-
-    private static void AddImage(Section section, byte[] pngBytes, Unit width, List<string> tempImages)
-    {
-        string tempPath = Path.Combine(Path.GetTempPath(), $"resonalyze_{Guid.NewGuid():N}.png");
-        File.WriteAllBytes(tempPath, pngBytes);
-        tempImages.Add(tempPath);
-
-        Paragraph paragraph = section.AddParagraph();
-        paragraph.Format.Alignment = ParagraphAlignment.Center;
-        var image = paragraph.AddImage(tempPath);
-        image.Width = width;
-        image.LockAspectRatio = true;
-    }
-
-    private static byte[]? LoadBanner()
-    {
-        using Stream? stream = Assembly.GetExecutingAssembly()
-            .GetManifestResourceStream("Resonalyze.banner.jpg");
-        if (stream == null)
-        {
-            return null;
-        }
-
-        using var memory = new MemoryStream();
-        stream.CopyTo(memory);
-        return memory.ToArray();
     }
 
     // A compact white EQ graph (combined bands + preamp) with the fit range shaded.
@@ -296,8 +168,8 @@ internal static class TuningSheetPdf
     }
 
     private static string Signed(double value) =>
-        value.ToString("+0.0;-0.0;0.0", CultureInfo.InvariantCulture);
+        SheetFormat.Signed(value);
 
     private static string Number(double value, string format) =>
-        value.ToString(format, CultureInfo.InvariantCulture);
+        SheetFormat.Number(value, format);
 }

--- a/source/Tools/VirtualCrossoverSheet.cs
+++ b/source/Tools/VirtualCrossoverSheet.cs
@@ -91,8 +91,8 @@ internal static class VirtualCrossoverSheet
     }
 
     internal static string Signed(double value) =>
-        value.ToString("+0.0;-0.0;0.0", CultureInfo.InvariantCulture);
+        SheetFormat.Signed(value);
 
     internal static string Number(double value, string format) =>
-        value.ToString(format, CultureInfo.InvariantCulture);
+        SheetFormat.Number(value, format);
 }

--- a/source/Tools/VirtualCrossoverSheetPdf.cs
+++ b/source/Tools/VirtualCrossoverSheetPdf.cs
@@ -1,14 +1,11 @@
 using System.Globalization;
-using System.Reflection;
 using MigraDoc.DocumentObjectModel;
 using MigraDoc.DocumentObjectModel.Tables;
-using MigraDoc.Rendering;
 using OxyPlot;
 using OxyPlot.Axes;
 using OxyPlot.Series;
 using OxyPlot.WindowsForms;
 using Resonalyze.Dsp;
-using Color = MigraDoc.DocumentObjectModel.Color;
 
 namespace Resonalyze;
 
@@ -16,13 +13,9 @@ namespace Resonalyze;
 // (MigraDoc / PDFsharp, same style as TuningSheetPdf): the product banner, the
 // title, a combined graph of every channel's DSP chain, and one section per
 // channel with the values to dial into the DSP plus its PEQ band cards.
+// The shared layout (scaffold, images, filter cards) lives in PdfSheet.
 internal static class VirtualCrossoverSheetPdf
 {
-    private const int FilterCardColumns = 4;
-
-    private static readonly Color CaptionColor = Color.FromRgb(90, 90, 90);
-    private static readonly Color CardBorderColor = Color.FromRgb(210, 210, 210);
-
     // Print-friendly (white background) variants of the on-screen channel
     // palette, hue for hue, one per possible channel so colours never repeat.
     private static readonly OxyColor[] ChainColors =
@@ -45,96 +38,45 @@ internal static class VirtualCrossoverSheetPdf
     {
         ArgumentNullException.ThrowIfNull(project);
 
-        var tempImages = new List<string>();
-        try
+        string subtitleText =
+            $"Generated {DateTime.Now.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)}";
+        if (!string.IsNullOrWhiteSpace(metricLine))
         {
-            var document = new Document();
-            Style normalStyle = document.Styles["Normal"]!;
-            normalStyle.Font.Name = "Segoe UI";
-            normalStyle.Font.Size = 11;
-
-            Section section = document.AddSection();
-            PageSetup pageSetup = section.PageSetup!;
-            pageSetup.PageFormat = PageFormat.A4;
-            pageSetup.TopMargin = Unit.FromCentimeter(1.2);
-            pageSetup.BottomMargin = Unit.FromCentimeter(1.2);
-            pageSetup.LeftMargin = Unit.FromCentimeter(1.5);
-            pageSetup.RightMargin = Unit.FromCentimeter(1.5);
-
-            byte[]? banner = LoadBanner();
-            if (banner != null)
-            {
-                AddImage(section, banner, Unit.FromCentimeter(11), tempImages);
-            }
-
-            Paragraph titleParagraph = section.AddParagraph("Virtual DSP");
-            titleParagraph.Format.Alignment = ParagraphAlignment.Center;
-            titleParagraph.Format.Font.Size = 24;
-            titleParagraph.Format.Font.Bold = true;
-            titleParagraph.Format.SpaceBefore = Unit.FromMillimeter(3);
-
-            string subtitleText =
-                $"Generated {DateTime.Now.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)}";
-            if (!string.IsNullOrWhiteSpace(metricLine))
-            {
-                subtitleText += $"   ·   {metricLine}";
-            }
-
-            Paragraph subtitle = section.AddParagraph(subtitleText);
-            subtitle.Format.Alignment = ParagraphAlignment.Center;
-            subtitle.Format.Font.Size = 9;
-            subtitle.Format.Font.Color = Colors.Gray;
-            subtitle.Format.SpaceAfter = Unit.FromMillimeter(4);
-
-            var participating = new List<(int Index, VirtualCrossoverChannelSettings Channel)>();
-            for (int i = 0; i < project.Channels.Count; i++)
-            {
-                if (project.Channels[i].HasSource)
-                {
-                    participating.Add((i, project.Channels[i]));
-                }
-            }
-
-            if (participating.Count > 0)
-            {
-                AddImage(
-                    section,
-                    RenderChainsGraph(participating, sampleRate),
-                    Unit.FromCentimeter(17),
-                    tempImages);
-            }
-
-            foreach ((int index, VirtualCrossoverChannelSettings channel) in participating)
-            {
-                AddChannelSection(section, index, channel);
-            }
-
-            var renderer = new PdfDocumentRenderer { Document = document };
-            renderer.RenderDocument();
-            renderer.PdfDocument.Save(filePath);
+            subtitleText += $"   ·   {metricLine}";
         }
-        finally
+
+        using var sheet = new PdfSheet("Virtual DSP", subtitleText);
+
+        var participating = new List<(int Index, VirtualCrossoverChannelSettings Channel)>();
+        for (int i = 0; i < project.Channels.Count; i++)
         {
-            foreach (string temp in tempImages)
+            if (project.Channels[i].HasSource)
             {
-                try
-                {
-                    File.Delete(temp);
-                }
-                catch (Exception)
-                {
-                    // Best-effort cleanup; a leftover temp image must not fail
-                    // (or mask the failure of) an export.
-                }
+                participating.Add((i, project.Channels[i]));
             }
         }
+
+        if (participating.Count > 0)
+        {
+            sheet.AddImage(
+                RenderChainsGraph(participating, sampleRate),
+                Unit.FromCentimeter(17));
+        }
+
+        foreach ((int index, VirtualCrossoverChannelSettings channel) in participating)
+        {
+            AddChannelSection(sheet, index, channel);
+        }
+
+        sheet.Save(filePath);
     }
 
     private static void AddChannelSection(
-        Section section,
+        PdfSheet sheet,
         int index,
         VirtualCrossoverChannelSettings channel)
     {
+        Section section = sheet.Section;
         Paragraph heading = section.AddParagraph(
             $"Channel {VirtualCrossoverSheet.ChannelName(index)} — {channel.DisplayName}");
         heading.Format.Font.Bold = true;
@@ -144,7 +86,7 @@ internal static class VirtualCrossoverSheetPdf
 
         var table = section.AddTable();
         table.Borders.Width = 0.5;
-        table.Borders.Color = CardBorderColor;
+        table.Borders.Color = PdfSheet.CardBorderColor;
         Column labelColumn = table.AddColumn(Unit.FromCentimeter(3.0));
         labelColumn.LeftPadding = Unit.FromMillimeter(2);
         Column valueColumn = table.AddColumn(Unit.FromCentimeter(11.0));
@@ -166,95 +108,17 @@ internal static class VirtualCrossoverSheetPdf
                 $"{channel.PeqSourceName ?? "custom"}, preamp {Signed(channel.PeqPreampDb)} dB");
         }
 
-        AddFilterCards(section, channel.PeqBands);
+        sheet.AddFilterCards(channel.PeqBands);
     }
 
     private static void AddRow(Table table, string label, string value)
     {
         Row row = table.AddRow();
         Paragraph caption = row.Cells[0].AddParagraph(label);
-        caption.Format.Font.Color = CaptionColor;
+        caption.Format.Font.Color = PdfSheet.CaptionColor;
 
         Paragraph valueParagraph = row.Cells[1].AddParagraph(value);
         valueParagraph.Format.Font.Bold = true;
-    }
-
-    private static void AddFilterCards(Section section, IReadOnlyList<PeqBand> bands)
-    {
-        if (bands.Count == 0)
-        {
-            return;
-        }
-
-        var table = section.AddTable();
-        for (int c = 0; c < FilterCardColumns; c++)
-        {
-            Column cardColumn = table.AddColumn(Unit.FromCentimeter(4.3));
-            cardColumn.LeftPadding = Unit.FromMillimeter(2.5);
-            cardColumn.RightPadding = Unit.FromMillimeter(2.5);
-        }
-
-        Row? row = null;
-        for (int i = 0; i < bands.Count; i++)
-        {
-            int column = i % FilterCardColumns;
-            if (column == 0)
-            {
-                row = table.AddRow();
-                row.TopPadding = Unit.FromMillimeter(2);
-                row.BottomPadding = Unit.FromMillimeter(2);
-            }
-
-            Cell cell = row!.Cells[column];
-            cell.Borders.Width = 0.5;
-            cell.Borders.Color = CardBorderColor;
-
-            PeqBand band = bands[i];
-            Paragraph name = cell.AddParagraph($"Filter {i + 1}");
-            name.Format.Font.Bold = true;
-            name.Format.Font.Size = 13;
-
-            Paragraph type = cell.AddParagraph("PK");
-            type.Format.Font.Color = CaptionColor;
-            type.Format.Font.Size = 9;
-
-            cell.AddParagraph($"{Number(band.FrequencyHz, "0")} Hz").Format.Font.Size = 12;
-            Paragraph gain = cell.AddParagraph($"{Signed(band.GainDb)} dB");
-            gain.Format.Font.Bold = true;
-            gain.Format.Font.Size = 12;
-            cell.AddParagraph($"Q {Number(band.Q, "0.0")}").Format.Font.Size = 12;
-        }
-    }
-
-    private static void AddImage(
-        Section section,
-        byte[] pngBytes,
-        Unit width,
-        List<string> tempImages)
-    {
-        string tempPath = Path.Combine(Path.GetTempPath(), $"resonalyze_{Guid.NewGuid():N}.png");
-        File.WriteAllBytes(tempPath, pngBytes);
-        tempImages.Add(tempPath);
-
-        Paragraph paragraph = section.AddParagraph();
-        paragraph.Format.Alignment = ParagraphAlignment.Center;
-        var image = paragraph.AddImage(tempPath);
-        image.Width = width;
-        image.LockAspectRatio = true;
-    }
-
-    private static byte[]? LoadBanner()
-    {
-        using Stream? stream = Assembly.GetExecutingAssembly()
-            .GetManifestResourceStream("Resonalyze.banner.jpg");
-        if (stream == null)
-        {
-            return null;
-        }
-
-        using var memory = new MemoryStream();
-        stream.CopyTo(memory);
-        return memory.ToArray();
     }
 
     // A compact white graph of every participating channel's DSP chain magnitude


### PR DESCRIPTION
Block 5 of the tech-debt register (`TODO.md`): the deduplication items, excluding the ★ Form1 decomposition. Net **−974/+234 lines** in the touched files, with the shared logic moved into seven small helpers. Every extraction is behavior-preserving except two deliberate drift alignments, called out below.

## PDF exporters → `PdfSheet` + `SheetFormat`

`TuningSheetPdf` and `VirtualCrossoverSheetPdf` shared ~170 copied lines each: the A4 scaffold (banner, centred title, subtitle), the temp-file PNG embedding, the PEQ filter cards, the render-and-save step and the temp cleanup. All of it now lives in `PdfSheet` (disposable; `Dispose` deletes the temp images), and the exporters keep only their own content. `SheetFormat` is the single `Signed`/`Number` implementation — the text sheet and both exporters delegate to it, closing the last formatter copy that lived in `TuningSheetPdf`. Public `Export` signatures are unchanged, so the existing PDF tests pin the behavior on CI.

## Five IR-preview panels → `ImpulsePreviewOptionsForm`

`FROptions`, `GDOpt`, `PROpt`, `BDOpt` and `WaterfallOptions` were one copy-pasted class around their settings: the `ImpulseResponseChanged` subscribe/unsubscribe swap in `Init`, the `IsDisposed`/`BeginInvoke` marshal, the `Disposed` cleanup and the numeric clamp helper. The base class owns all of it; each panel overrides `RenderIrPreview` and wraps its `Init` control writes in `InitializeControls`.

**Drift alignment #1:** the Init render-suppression only `GDOpt` had (each `ValueChanged` during `Init` rebuilt the preview, 3–6 redundant renders per panel open) now applies to all five panels — one explicit render at the end of `Init` instead.

## Recorder twins → `SampleWaiterRegistry` + `AudioCaptureStop`

`SoundRecorder` and `AsioFullDuplexSession` duplicated ~150 lines: byte-identical sample-count waiter classes and the stop-request/awaited-signal/3-second-timeout machinery. The registry is documented as lock-free — every member is called under the owner's capture lock, the same lock that guards the accumulator, so a waiter can never be added after its threshold silently passed. The `TODO.md` entry is rewritten honestly: what remains duplicated is thin device glue, and a full merge only makes sense together with the WASAPI migration.

## Level metering → one `AudioLevelMetering.Measure`

The peak/RMS/dB summary with the 0.999 full-scale threshold existed three times (`MeasureSamples`, `MeasureChannels`, the sweep-run `ChannelLevelAccumulator`). All three now derive from a single `Measure(peak, sumSquares, sampleCount)`; the codebase has exactly one occurrence of the `0.999` constant left, as `FullScaleThreshold`.

## Dual-device level binding → `InputLevelMapping` + `DualDeviceLevelCombiner`

`HandleMicrophoneOnlyLevels`/`HandleLoopbackOnlyLevels`/`RaiseCombinedDualDeviceLevels`/`CreateEntry` were nearly verbatim in `ExpSweepMeasurement` and `NoiseMeasurement`. The mapping (which entry counts as clipped vs. full-scale reference) and the two-recorder combiner (latest-of-each under one lock) are now shared.

**Drift alignment #2:** the noise single-device path used to flag a full-scale loopback as *clipped* (red error styling), while every other path — including the noise dual-device path in the same class — flags it as the *full-scale reference* (expected, not an error). It now uses the shared semantics; the ≥ −3 dBFS warning colour is threshold-based and unaffected.

## Tests

- Local (Linux): full solution builds with 0 warnings; all 276 dsp tests pass.
- CI (Windows): App.Tests including the PDF sheet tests, which exercise the new `PdfSheet` path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_