### PR TITLE
Form1 decomposition, first slices: calibration, warm-up, save debounce, Compare, long-press

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -157,14 +157,16 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 ## Shell
 
-- [ ] ★ **`Form1` is still the concurrency hub.** ~40 mutable fields on one
-  object are touched by the UI thread, `Task.Run` plot builds and
-  audio-callback events, guarded case by case with ad-hoc locks and flags
-  (`closingInProgress`, `calibrationCache`, `reportedCalibrationProblems`).
-  The now-fixed torn-read items were symptoms; the structural fix is moving
-  per-mode state into services/controllers so new code does not need manual
-  guarding. Incremental — carve out one concern at a time, calibration state
-  is a natural first candidate.
+- [ ] ★ **`Form1` is still the concurrency hub.** Mutable state on one object
+  is touched by the UI thread, `Task.Run` plot builds and audio-callback
+  events, guarded case by case with ad-hoc flags (`closingInProgress`,
+  `closingPrepared`, `shutdownFastClose`). The first carve-outs are done: the
+  calibration cache + warn-once bookkeeping (`MicrophoneCalibrationService`),
+  the startup warm-up task/cancellation pair (`StartupAudioWarmup`) and the
+  settings-save debounce (`DebouncedSaver`) own their state now. Still on
+  Form1: compare selection, record-button long-press, history/current-IR
+  state, overlay slot tracking and the lifecycle flags — keep carving one
+  concern at a time.
 - [ ] **`WireLiveApply` covers only dialog-open controls.** Controls created
   after wiring never get live-apply behavior.
 

--- a/TODO.md
+++ b/TODO.md
@@ -162,11 +162,12 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   events, guarded case by case with ad-hoc flags (`closingInProgress`,
   `closingPrepared`, `shutdownFastClose`). The first carve-outs are done: the
   calibration cache + warn-once bookkeeping (`MicrophoneCalibrationService`),
-  the startup warm-up task/cancellation pair (`StartupAudioWarmup`) and the
-  settings-save debounce (`DebouncedSaver`) own their state now. Still on
-  Form1: compare selection, record-button long-press, history/current-IR
-  state, overlay slot tracking and the lifecycle flags — keep carving one
-  concern at a time.
+  the startup warm-up task/cancellation pair (`StartupAudioWarmup`), the
+  settings-save debounce (`DebouncedSaver`), the Compare selection read by
+  plot-build workers (`CompareSelection`) and the record-button long-press
+  state machine (`ButtonLongPressBehavior`) own their state now. Still on
+  Form1: history/current-IR state, overlay slot tracking and the lifecycle
+  flags — keep carving one concern at a time.
 - [ ] **`WireLiveApply` covers only dialog-open controls.** Controls created
   after wiring never get live-apply behavior.
 

--- a/source/Measurements/MicrophoneCalibrationService.cs
+++ b/source/Measurements/MicrophoneCalibrationService.cs
@@ -1,0 +1,178 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Owns the microphone-calibration state that used to live on <c>Form1</c>:
+/// resolves the configured 0°/90° paths (including the legacy
+/// <c>calibration.txt</c> fallback and the 90°-from-0° approximation), caches
+/// loaded files, and reports each unusable path at most once per session
+/// through the callback. <see cref="Get"/> runs on <c>Task.Run</c> plot-build
+/// workers as well as the UI thread, so all mutable state is guarded here and
+/// the problem callback must marshal to the UI itself.
+/// </summary>
+internal sealed class MicrophoneCalibrationService
+{
+    private readonly object sync = new();
+    private readonly Dictionary<string, CalibrationFile> cache = new(
+        StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> reportedProblems = new(
+        StringComparer.OrdinalIgnoreCase);
+    private readonly Func<MicrophoneCalibrationMode, string?> getConfiguredPath;
+    private readonly Action<string, string?> reportProblem;
+    private readonly string legacyZeroDegreePath;
+
+    public MicrophoneCalibrationService(
+        Func<MicrophoneCalibrationMode, string?> getConfiguredPath,
+        Action<string, string?> reportProblem,
+        string? legacyZeroDegreeDirectory = null)
+    {
+        this.getConfiguredPath = getConfiguredPath;
+        this.reportProblem = reportProblem;
+        legacyZeroDegreePath = Path.Combine(
+            legacyZeroDegreeDirectory ?? AppContext.BaseDirectory,
+            "calibration.txt");
+    }
+
+    /// <summary>
+    /// Whether <see cref="Get"/> would return a calibration for the mode. 90°
+    /// counts as available when only a 0° file is configured, because the 90°
+    /// approximation can be derived from it.
+    /// </summary>
+    public bool Has(MicrophoneCalibrationMode mode) =>
+        mode == MicrophoneCalibrationMode.Degrees90
+            ? ResolvePath(MicrophoneCalibrationMode.Degrees90) != null ||
+              ResolvePath(MicrophoneCalibrationMode.Degrees0) != null
+            : ResolvePath(mode) != null;
+
+    public CalibrationFile? Get(MicrophoneCalibrationMode mode)
+    {
+        WarnIfConfiguredMissing(mode);
+        string? path = ResolvePath(mode);
+        if (path == null)
+        {
+            return mode == MicrophoneCalibrationMode.Degrees90
+                ? GetApproximateNinetyDegree()
+                : null;
+        }
+
+        return GetLoaded(path);
+    }
+
+    /// <summary>
+    /// Drops the cached files so the next <see cref="Get"/> reloads from disk
+    /// (called when the configured paths may have changed). The problem
+    /// reports deliberately survive: each unusable path warns once per
+    /// session, not once per settings change.
+    /// </summary>
+    public void InvalidateCache()
+    {
+        lock (sync)
+        {
+            cache.Clear();
+        }
+    }
+
+    private CalibrationFile GetLoaded(string path)
+    {
+        CalibrationFile? calibrationFile;
+        string? problemReason = null;
+        bool reportNow = false;
+        lock (sync)
+        {
+            if (!cache.TryGetValue(path, out calibrationFile))
+            {
+                calibrationFile = new CalibrationFile(path);
+                cache[path] = calibrationFile;
+                if (!calibrationFile.HasData)
+                {
+                    reportNow = reportedProblems.Add(path);
+                    problemReason = calibrationFile.LoadError;
+                }
+            }
+        }
+
+        if (reportNow)
+        {
+            reportProblem(path, problemReason);
+        }
+
+        return calibrationFile;
+    }
+
+    // ResolvePath maps a configured-but-deleted file to null, which used to
+    // silently disable the correction for every plot.
+    private void WarnIfConfiguredMissing(MicrophoneCalibrationMode mode)
+    {
+        string? configured = getConfiguredPath(mode);
+        if (string.IsNullOrWhiteSpace(configured) || File.Exists(configured))
+        {
+            return;
+        }
+
+        bool reportNow;
+        lock (sync)
+        {
+            reportNow = reportedProblems.Add(configured);
+        }
+
+        if (reportNow)
+        {
+            reportProblem(configured, $"Calibration file not found: {configured}");
+        }
+    }
+
+    private CalibrationFile? GetApproximateNinetyDegree()
+    {
+        string? zeroDegreePath = ResolvePath(MicrophoneCalibrationMode.Degrees0);
+        if (zeroDegreePath == null)
+        {
+            return null;
+        }
+
+        string cacheKey = $"approx90:{zeroDegreePath}";
+        lock (sync)
+        {
+            if (cache.TryGetValue(cacheKey, out CalibrationFile? cached))
+            {
+                return cached;
+            }
+        }
+
+        CalibrationFile zeroDegreeCalibration =
+            Get(MicrophoneCalibrationMode.Degrees0)
+            ?? throw new InvalidOperationException(
+                "0 degree microphone calibration is not available.");
+        CalibrationFile approximation = CalibrationFile.CreateNinetyDegreeApproximation(
+            zeroDegreeCalibration);
+        // Two concurrent plot builds can both reach this point; the first
+        // insert wins so every caller sees the same instance.
+        lock (sync)
+        {
+            if (cache.TryGetValue(cacheKey, out CalibrationFile? raced))
+            {
+                return raced;
+            }
+
+            cache[cacheKey] = approximation;
+            return approximation;
+        }
+    }
+
+    private string? ResolvePath(MicrophoneCalibrationMode mode)
+    {
+        string? path = getConfiguredPath(mode);
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            return File.Exists(path) ? path : null;
+        }
+
+        if (mode == MicrophoneCalibrationMode.Degrees0 &&
+            File.Exists(legacyZeroDegreePath))
+        {
+            return legacyZeroDegreePath;
+        }
+
+        return null;
+    }
+}

--- a/source/Measurements/StartupAudioWarmup.cs
+++ b/source/Measurements/StartupAudioWarmup.cs
@@ -1,0 +1,70 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Owns the one-shot, best-effort audio warm-up started when the shell is
+/// first shown. The cancellation source and task used to live as raw fields
+/// on <c>Form1</c>, cancelled from three different close paths; the pair is
+/// managed in one place now. The warm-up body itself is injected so this
+/// class stays free of device and UI concerns.
+/// </summary>
+internal sealed class StartupAudioWarmup : IDisposable
+{
+    private readonly Func<CancellationToken, Task> warmUp;
+    private CancellationTokenSource? cancellation;
+    private Task? task;
+
+    public StartupAudioWarmup(Func<CancellationToken, Task> warmUp)
+    {
+        this.warmUp = warmUp;
+    }
+
+    /// <summary>Starts the warm-up once; later calls are no-ops.</summary>
+    public void Start()
+    {
+        if (task != null)
+        {
+            return;
+        }
+
+        cancellation = new CancellationTokenSource();
+        task = warmUp(cancellation.Token);
+    }
+
+    /// <summary>
+    /// Completes when the warm-up has finished (immediately when it never
+    /// started). Warm-up failures are intentionally non-fatal, so faults are
+    /// swallowed here.
+    /// </summary>
+    public async Task WaitAsync()
+    {
+        Task? started = task;
+        if (started == null || started.IsCompleted)
+        {
+            return;
+        }
+
+        try
+        {
+            await started;
+        }
+        catch
+        {
+            // Warm-up failures are intentionally non-fatal.
+        }
+    }
+
+    /// <summary>
+    /// Requests cancellation without disposing — the fast OS-shutdown close
+    /// path cancels and lets the process exit.
+    /// </summary>
+    public void Cancel()
+    {
+        cancellation?.Cancel();
+    }
+
+    public void Dispose()
+    {
+        cancellation?.Cancel();
+        cancellation?.Dispose();
+    }
+}

--- a/source/Shell/ButtonLongPressBehavior.cs
+++ b/source/Shell/ButtonLongPressBehavior.cs
@@ -1,0 +1,84 @@
+using System.Windows.Forms;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Long-press detection for a button: holding the left mouse button down for
+/// the configured delay fires <c>onLongPress</c> and swallows the click that
+/// the release would otherwise deliver. Replaces the timer + two flags that
+/// lived as raw fields on <c>Form1</c> (the record button uses it to cancel
+/// a whole averaged-measurement series). UI-thread only.
+/// </summary>
+internal sealed class ButtonLongPressBehavior : IDisposable
+{
+    private readonly System.Windows.Forms.Timer timer;
+    private readonly Func<bool> canTrigger;
+    private readonly Func<Task> onLongPress;
+    private bool triggered;
+    private bool suppressNextClick;
+
+    public ButtonLongPressBehavior(
+        Control button,
+        int longPressMilliseconds,
+        Func<bool> canTrigger,
+        Func<Task> onLongPress)
+    {
+        this.canTrigger = canTrigger;
+        this.onLongPress = onLongPress;
+        timer = new System.Windows.Forms.Timer { Interval = longPressMilliseconds };
+        timer.Tick += async (_, _) => await HandleLongPressElapsedAsync();
+        button.MouseDown += (_, e) => HandleMouseDown(e.Button);
+        button.MouseUp += (_, _) => timer.Stop();
+        button.MouseLeave += (_, _) => timer.Stop();
+    }
+
+    /// <summary>
+    /// Called at the start of the button's Click handler: stops a pending
+    /// long-press countdown and returns true exactly once after a long press
+    /// fired, so the click that ends the press is swallowed.
+    /// </summary>
+    public bool ConsumeClickSuppression()
+    {
+        timer.Stop();
+        if (!suppressNextClick)
+        {
+            return false;
+        }
+
+        suppressNextClick = false;
+        return true;
+    }
+
+    public void Dispose()
+    {
+        timer.Stop();
+        timer.Dispose();
+    }
+
+    // The two handlers below are internal so tests can drive the state
+    // machine directly — the WinForms timer needs a message pump to tick.
+    internal void HandleMouseDown(MouseButtons buttons)
+    {
+        if (buttons != MouseButtons.Left || !canTrigger())
+        {
+            return;
+        }
+
+        triggered = false;
+        suppressNextClick = false;
+        timer.Start();
+    }
+
+    internal async Task HandleLongPressElapsedAsync()
+    {
+        timer.Stop();
+        if (!canTrigger() || triggered)
+        {
+            return;
+        }
+
+        triggered = true;
+        suppressNextClick = true;
+        await onLongPress();
+    }
+}

--- a/source/Shell/CompareSelection.cs
+++ b/source/Shell/CompareSelection.cs
@@ -1,0 +1,80 @@
+using System.Numerics;
+using Resonalyze.History;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Owns the Compare measurement selection that used to live as a raw field on
+/// <c>Form1</c>. Written on the UI thread (choose file / history entry /
+/// clear); read by <c>Task.Run</c> plot builds through
+/// <see cref="GetAnalysisSource"/>, so the reference is volatile and every
+/// reader snapshots it once — the selection itself is immutable.
+/// </summary>
+internal sealed class CompareSelection
+{
+    private volatile CompareMeasurementSelection? current;
+
+    /// <summary>Raised after Set/Clear, on the caller's (UI) thread.</summary>
+    public event Action? Changed;
+
+    public CompareMeasurementSelection? Current => current;
+
+    public void Set(
+        string displayName,
+        string? sourceFilePath,
+        MeasurementHistorySnapshot snapshot)
+    {
+        current = new CompareMeasurementSelection(displayName, sourceFilePath, snapshot);
+        Changed?.Invoke();
+    }
+
+    public void Clear()
+    {
+        current = null;
+        Changed?.Invoke();
+    }
+
+    // Exposes the Compare measurement's impulse responses for the mode plots: the
+    // transfer IR (Phase / Group Delay / Impulse) and the sweep-deconvolution IR
+    // (Frequency Response). Each consumer checks the response it needs, so a Compare
+    // without a transfer IR still contributes a Frequency Response curve.
+    public CompareAnalysisSource? GetAnalysisSource()
+    {
+        if (current is not { } selection ||
+            selection.Snapshot.SweepDeconvolutionImpulseResponse is not { Length: > 0 } sweepIr)
+        {
+            return null;
+        }
+
+        return new CompareAnalysisSource(
+            selection.DisplayName,
+            selection.Snapshot.SampleRate,
+            selection.Snapshot.TransferImpulseResponse ?? Array.Empty<Complex>(),
+            selection.Snapshot.TransferPeakIndex ?? 0,
+            sweepIr,
+            selection.Snapshot.SweepDeconvolutionPeakIndex);
+    }
+
+    public TimeAlignmentCompareMeasurement? GetTimeAlignmentMeasurement() =>
+        current is not { } selection
+            ? null
+            : new TimeAlignmentCompareMeasurement(
+                selection.DisplayName,
+                selection.Snapshot);
+}
+
+internal sealed record CompareMeasurementSelection(
+    string DisplayName,
+    string? SourceFilePath,
+    MeasurementHistorySnapshot Snapshot);
+
+// The Compare measurement's impulse responses used by the mode plots: the transfer IR
+// (Phase / Group Delay / Impulse and the gated IR preview) and the sweep-deconvolution
+// IR (Frequency Response magnitude). Matching sample rate is validated by the consumers.
+public readonly record struct CompareAnalysisSource(
+    string DisplayName,
+    int SampleRate,
+    Complex[] TransferImpulseResponse,
+    int TransferPeakIndex,
+    Complex[] SweepDeconvolutionImpulseResponse,
+    int SweepDeconvolutionPeakIndex);

--- a/source/Shell/DebouncedSaver.cs
+++ b/source/Shell/DebouncedSaver.cs
@@ -1,0 +1,47 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Debounces a save action: <see cref="Schedule"/> (re)arms the delay so the
+/// write happens once the UI has been quiet, <see cref="Flush"/> writes a
+/// pending save immediately (close paths, panel-closed hooks). Replaces the
+/// timer + pending-flag pair that lived as raw fields on <c>Form1</c>.
+/// UI-thread only — built on the WinForms timer.
+/// </summary>
+internal sealed class DebouncedSaver : IDisposable
+{
+    private readonly System.Windows.Forms.Timer timer;
+    private readonly Action save;
+    private bool savePending;
+
+    public DebouncedSaver(int delayMilliseconds, Action save)
+    {
+        this.save = save;
+        timer = new System.Windows.Forms.Timer { Interval = delayMilliseconds };
+        timer.Tick += (_, _) => Flush();
+    }
+
+    public void Schedule()
+    {
+        savePending = true;
+        timer.Stop();
+        timer.Start();
+    }
+
+    public void Flush()
+    {
+        timer.Stop();
+        if (!savePending)
+        {
+            return;
+        }
+
+        savePending = false;
+        save();
+    }
+
+    public void Dispose()
+    {
+        timer.Stop();
+        timer.Dispose();
+    }
+}

--- a/source/Shell/Form1.Compare.cs
+++ b/source/Shell/Form1.Compare.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using Resonalyze.History;
 using Resonalyze.Options;
 
@@ -27,8 +26,8 @@ public partial class Form1
         compareMenuStrip.Items.Add(new ToolStripSeparator());
 
         ToolStripMenuItem clearItem = new("Clear");
-        clearItem.Enabled = compareMeasurement != null;
-        clearItem.Click += (_, _) => ClearCompareMeasurement();
+        clearItem.Enabled = compareSelection.Current != null;
+        clearItem.Click += (_, _) => compareSelection.Clear();
         compareMenuStrip.Items.Add(clearItem);
 
         compareMenuStrip.Show(buttonCompare, new Point(0, buttonCompare.Height));
@@ -82,7 +81,7 @@ public partial class Form1
             ImpulseResponseFile file = await ImpulseResponseFile.LoadAsync(dialog.FileName);
             MeasurementHistorySnapshot snapshot =
                 MeasurementHistoryService.CreateSnapshot(file);
-            SetCompareMeasurement(
+            compareSelection.Set(
                 Path.GetFileName(dialog.FileName),
                 dialog.FileName,
                 snapshot);
@@ -111,7 +110,7 @@ public partial class Form1
                 return;
             }
 
-            SetCompareMeasurement(
+            compareSelection.Set(
                 entry.FileNameOrDisplayName,
                 entry.SourceFilePath,
                 snapshot);
@@ -127,24 +126,6 @@ public partial class Form1
         }
     }
 
-    private void SetCompareMeasurement(
-        string displayName,
-        string? sourceFilePath,
-        MeasurementHistorySnapshot snapshot)
-    {
-        compareMeasurement = new CompareMeasurementSelection(
-            displayName,
-            sourceFilePath,
-            snapshot);
-        OnCompareMeasurementChanged();
-    }
-
-    private void ClearCompareMeasurement()
-    {
-        compareMeasurement = null;
-        OnCompareMeasurementChanged();
-    }
-
     // Compare drives Time Alignment, the Phase / Group Delay plots, and the gated IR
     // preview inside their docked settings, so refresh whichever of those is live.
     private void OnCompareMeasurementChanged()
@@ -154,27 +135,6 @@ public partial class Form1
         RefreshCurrentModePlot();
         dockedModeSettingsHost.InvokeIfOpen<PROpt>(dialog => dialog.RefreshComparePreview());
         dockedModeSettingsHost.InvokeIfOpen<GDOpt>(dialog => dialog.RefreshComparePreview());
-    }
-
-    // Exposes the Compare measurement's impulse responses for the mode plots: the
-    // transfer IR (Phase / Group Delay / Impulse) and the sweep-deconvolution IR
-    // (Frequency Response). Each consumer checks the response it needs, so a Compare
-    // without a transfer IR still contributes a Frequency Response curve.
-    internal CompareAnalysisSource? GetCompareAnalysisSource()
-    {
-        if (compareMeasurement is not { } selection ||
-            selection.Snapshot.SweepDeconvolutionImpulseResponse is not { Length: > 0 } sweepIr)
-        {
-            return null;
-        }
-
-        return new CompareAnalysisSource(
-            selection.DisplayName,
-            selection.Snapshot.SampleRate,
-            selection.Snapshot.TransferImpulseResponse ?? Array.Empty<Complex>(),
-            selection.Snapshot.TransferPeakIndex ?? 0,
-            sweepIr,
-            selection.Snapshot.SweepDeconvolutionPeakIndex);
     }
 
     // The complex (vector) sum of the Main and Compare transfer responses for the
@@ -198,21 +158,15 @@ public partial class Form1
             .ToArray();
     }
 
-    private TimeAlignmentCompareMeasurement? GetTimeAlignmentCompareMeasurement() =>
-        compareMeasurement == null
-            ? null
-            : new TimeAlignmentCompareMeasurement(
-                compareMeasurement.DisplayName,
-                compareMeasurement.Snapshot);
-
     private void UpdateCompareButton()
     {
-        buttonCompare.Text = compareMeasurement?.DisplayName ?? "Compare";
+        CompareMeasurementSelection? selection = compareSelection.Current;
+        buttonCompare.Text = selection?.DisplayName ?? "Compare";
         toolTip1.SetToolTip(
             buttonCompare,
-            compareMeasurement == null
+            selection == null
                 ? "Choose a second impulse response for comparison"
-                : BuildCompareButtonToolTip(compareMeasurement));
+                : BuildCompareButtonToolTip(selection));
     }
 
     private static string BuildCompareHistoryItemText(MeasurementHistoryEntry entry)
@@ -235,20 +189,4 @@ public partial class Form1
 
         return selection.DisplayName;
     }
-
-    private sealed record CompareMeasurementSelection(
-        string DisplayName,
-        string? SourceFilePath,
-        MeasurementHistorySnapshot Snapshot);
 }
-
-// The Compare measurement's impulse responses used by the mode plots: the transfer IR
-// (Phase / Group Delay / Impulse and the gated IR preview) and the sweep-deconvolution
-// IR (Frequency Response magnitude). Matching sample rate is validated by the consumers.
-public readonly record struct CompareAnalysisSource(
-    string DisplayName,
-    int SampleRate,
-    Complex[] TransferImpulseResponse,
-    int TransferPeakIndex,
-    Complex[] SweepDeconvolutionImpulseResponse,
-    int SweepDeconvolutionPeakIndex);

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -34,7 +34,7 @@ public partial class Form1
         PlotModelFactory createdPlotModelFactory = new(
             expSweepMeasurement,
             noiseMeasurement,
-            GetMicrophoneCalibration,
+            microphoneCalibration.Get,
             frequencyResponseOptions,
             phaseResponseOptions,
             groupDelayOptions,
@@ -155,50 +155,8 @@ public partial class Form1
         _ = SelectModeAsync(ModeTab.Frequency);
     }
 
-    private bool HasMicrophoneCalibration(MicrophoneCalibrationMode mode) =>
-        mode == MicrophoneCalibrationMode.Degrees90
-            ? HasApproximateNinetyDegreeCalibration()
-            : GetMicrophoneCalibrationPath(mode) != null;
-
-    private CalibrationFile? GetMicrophoneCalibration(MicrophoneCalibrationMode mode)
-    {
-        WarnIfConfiguredCalibrationMissing(mode);
-        if (mode == MicrophoneCalibrationMode.Degrees90 &&
-            GetMicrophoneCalibrationPath(MicrophoneCalibrationMode.Degrees90) == null)
-        {
-            return GetApproximateNinetyDegreeCalibration();
-        }
-
-        string? path = GetMicrophoneCalibrationPath(mode);
-        if (path == null)
-        {
-            return null;
-        }
-
-        // Plot models are built on Task.Run workers, and two rapid refreshes
-        // can run concurrently — the cache dictionary must not be mutated
-        // unsynchronized (the lock is reentrant for the approximation path).
-        lock (calibrationCache)
-        {
-            if (!calibrationCache.TryGetValue(path, out CalibrationFile? calibrationFile))
-            {
-                calibrationFile = new CalibrationFile(path);
-                calibrationCache[path] = calibrationFile;
-                if (!calibrationFile.HasData)
-                {
-                    WarnCalibrationProblemOnce(path, calibrationFile.LoadError);
-                }
-            }
-
-            return calibrationFile;
-        }
-    }
-
-    // GetMicrophoneCalibrationPath maps a configured-but-deleted file to null,
-    // which used to silently disable the correction for every plot.
-    private void WarnIfConfiguredCalibrationMissing(MicrophoneCalibrationMode mode)
-    {
-        string? configured = mode switch
+    private string? GetConfiguredMicrophoneCalibrationPath(MicrophoneCalibrationMode mode) =>
+        mode switch
         {
             MicrophoneCalibrationMode.Degrees0 =>
                 measurementSettings.Measurement.MicrophoneCalibration0DegreesPath,
@@ -206,90 +164,21 @@ public partial class Form1
                 measurementSettings.Measurement.MicrophoneCalibration90DegreesPath,
             _ => null
         };
-        if (!string.IsNullOrWhiteSpace(configured) && !File.Exists(configured))
-        {
-            WarnCalibrationProblemOnce(
-                configured,
-                $"Calibration file not found: {configured}");
-        }
-    }
-
-    private CalibrationFile? GetApproximateNinetyDegreeCalibration()
-    {
-        string? zeroDegreePath = GetMicrophoneCalibrationPath(
-            MicrophoneCalibrationMode.Degrees0);
-        if (zeroDegreePath == null)
-        {
-            return null;
-        }
-
-        string cacheKey = $"approx90:{zeroDegreePath}";
-        lock (calibrationCache)
-        {
-            if (!calibrationCache.TryGetValue(cacheKey, out CalibrationFile? calibrationFile))
-            {
-                CalibrationFile zeroDegreeCalibration =
-                    GetMicrophoneCalibration(MicrophoneCalibrationMode.Degrees0)
-                    ?? throw new InvalidOperationException(
-                        "0 degree microphone calibration is not available.");
-                calibrationFile = CalibrationFile.CreateNinetyDegreeApproximation(
-                    zeroDegreeCalibration);
-                calibrationCache[cacheKey] = calibrationFile;
-            }
-
-            return calibrationFile;
-        }
-    }
-
-    private string? GetMicrophoneCalibrationPath(MicrophoneCalibrationMode mode)
-    {
-        string? path = mode switch
-        {
-            MicrophoneCalibrationMode.Degrees0 =>
-                measurementSettings.Measurement.MicrophoneCalibration0DegreesPath,
-            MicrophoneCalibrationMode.Degrees90 =>
-                measurementSettings.Measurement.MicrophoneCalibration90DegreesPath,
-            _ => null
-        };
-        if (!string.IsNullOrWhiteSpace(path))
-        {
-            return File.Exists(path) ? path : null;
-        }
-
-        if (mode == MicrophoneCalibrationMode.Degrees0)
-        {
-            string legacyPath = Path.Combine(AppContext.BaseDirectory, "calibration.txt");
-            if (File.Exists(legacyPath))
-            {
-                return legacyPath;
-            }
-        }
-
-        return null;
-    }
-
-    private bool HasApproximateNinetyDegreeCalibration() =>
-        GetMicrophoneCalibrationPath(MicrophoneCalibrationMode.Degrees90) != null ||
-        GetMicrophoneCalibrationPath(MicrophoneCalibrationMode.Degrees0) != null;
 
     private void RefreshCalibrationConsumers()
     {
-        lock (calibrationCache)
-        {
-            calibrationCache.Clear();
-        }
+        microphoneCalibration.InvalidateCache();
         if (virtualCrossoverPanel != null)
         {
             virtualCrossoverPanel.ConfigureCalibration(
-                GetMicrophoneCalibration,
-                HasMicrophoneCalibration(MicrophoneCalibrationMode.Degrees0),
-                HasMicrophoneCalibration(MicrophoneCalibrationMode.Degrees90));
+                microphoneCalibration.Get,
+                microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees0),
+                microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees90));
         }
     }
 
     private void WireFormEvents()
     {
-        measurementSettingsSaveTimer.Tick += MeasurementSettingsSaveTimer_Tick;
         recordButtonLongPressTimer.Tick += RecordButtonLongPressTimer_Tick;
         buttonRecord.MouseDown += buttonRecord_MouseDown;
         buttonRecord.MouseLeave += buttonRecord_MouseLeave;
@@ -297,11 +186,6 @@ public partial class Form1
         buttonCompare.Click += buttonCompare_Click;
         FormClosing += Form1_FormClosing;
         Shown += Form1_Shown;
-    }
-
-    private void MeasurementSettingsSaveTimer_Tick(object? sender, EventArgs e)
-    {
-        FlushMeasurementSettings();
     }
 
     private void HandleMeasurementCompleted(bool success)

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -42,7 +42,7 @@ public partial class Form1
             liveSpectrumOptions,
             waterfallGenOptions,
             burstDecayGenOptions);
-        createdPlotModelFactory.SetCompareSourceProvider(GetCompareAnalysisSource);
+        createdPlotModelFactory.SetCompareSourceProvider(compareSelection.GetAnalysisSource);
         LiveSpectrumController createdLiveSpectrumController = new(
             this,
             noiseMeasurement,
@@ -79,7 +79,7 @@ public partial class Form1
             expSweepMeasurement,
             () => SaveMeasurementSettings(),
             () => plotModelFactory.ImpulseResponseFileName,
-            GetTimeAlignmentCompareMeasurement);
+            compareSelection.GetTimeAlignmentMeasurement);
         InputLevelMeterController createdInputLevelMeterController = new(
             this,
             inputLevelMeterPanel,
@@ -130,6 +130,7 @@ public partial class Form1
             FlushMeasurementSettingsIfClosed(dockedMeasurementSettingsHost);
         };
         dockedHistoryHost.StateChanged += (_, _) => UpdateHistoryButton();
+        compareSelection.Changed += OnCompareMeasurementChanged;
         expSweepMeasurement.Completed += HandleMeasurementCompleted;
         expSweepMeasurement.AverageProgressChanged += HandleAverageProgressChanged;
         measurementHistoryService.Changed += HandleHistoryChanged;
@@ -179,10 +180,6 @@ public partial class Form1
 
     private void WireFormEvents()
     {
-        recordButtonLongPressTimer.Tick += RecordButtonLongPressTimer_Tick;
-        buttonRecord.MouseDown += buttonRecord_MouseDown;
-        buttonRecord.MouseLeave += buttonRecord_MouseLeave;
-        buttonRecord.MouseUp += buttonRecord_MouseUp;
         buttonCompare.Click += buttonCompare_Click;
         FormClosing += Form1_FormClosing;
         Shown += Form1_Shown;

--- a/source/Shell/Form1.Lifecycle.cs
+++ b/source/Shell/Form1.Lifecycle.cs
@@ -48,7 +48,7 @@ public partial class Form1
             // Dispose that follows the close from blocking on it).
             closingPrepared = true;
             shutdownFastClose = true;
-            startupAudioWarmupCancellation?.Cancel();
+            startupAudioWarmup.Cancel();
             FlushMeasurementSettings();
             overlayCollection.FlushPendingSaves();
             PersistCurrentSessionState();
@@ -68,12 +68,12 @@ public partial class Form1
         FlushMeasurementSettings();
         overlayCollection.FlushPendingSaves();
         PersistCurrentSessionState();
-        startupAudioWarmupCancellation?.Cancel();
+        startupAudioWarmup.Cancel();
         await Task.WhenAll(
             expSweepMeasurement.AbortAsync(),
             timeAlignmentController.AbortAsync(),
             liveSpectrumController.AbortAsync(),
-            startupAudioWarmupTask ?? Task.CompletedTask);
+            startupAudioWarmup.WaitAsync());
 
         DisposeAppResources();
         closingPrepared = true;
@@ -94,18 +94,16 @@ public partial class Form1
             // synchronously on in-flight work, which would stall shutdown on the
             // very teardown the fast-close path avoids. Cancelling is enough —
             // the process is about to exit and the OS reclaims devices and timers.
-            startupAudioWarmupCancellation?.Cancel();
+            startupAudioWarmup.Cancel();
             return;
         }
 
-        startupAudioWarmupCancellation?.Cancel();
-        startupAudioWarmupCancellation?.Dispose();
+        startupAudioWarmup.Dispose();
         compareMenuStrip?.Dispose();
         dockedModeSettingsHost.Dispose();
         dockedMeasurementSettingsHost.Dispose();
         dockedHistoryHost.Dispose();
-        measurementSettingsSaveTimer.Stop();
-        measurementSettingsSaveTimer.Dispose();
+        measurementSettingsSaver.Dispose();
         recordButtonLongPressTimer.Stop();
         recordButtonLongPressTimer.Dispose();
         inputLevelMeterController.Dispose();

--- a/source/Shell/Form1.Lifecycle.cs
+++ b/source/Shell/Form1.Lifecycle.cs
@@ -104,8 +104,7 @@ public partial class Form1
         dockedMeasurementSettingsHost.Dispose();
         dockedHistoryHost.Dispose();
         measurementSettingsSaver.Dispose();
-        recordButtonLongPressTimer.Stop();
-        recordButtonLongPressTimer.Dispose();
+        recordButtonLongPress.Dispose();
         inputLevelMeterController.Dispose();
         expSweepMeasurement.Dispose();
         timeAlignmentController.Dispose();

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -81,7 +81,7 @@ public partial class Form1
         {
             if (!liveSpectrumController.InProgress)
             {
-                await WaitForStartupAudioWarmupAsync();
+                await startupAudioWarmup.WaitAsync();
             }
 
             await liveSpectrumController.ToggleAsync();
@@ -121,7 +121,7 @@ public partial class Form1
                 return;
             }
 
-            await WaitForStartupAudioWarmupAsync();
+            await startupAudioWarmup.WaitAsync();
             if (expSweepMeasurement.InProgress)
             {
                 // A second click can arrive while the warm-up is awaited;
@@ -227,15 +227,10 @@ public partial class Form1
 
     private void StartStartupAudioWarmup()
     {
-        if (startupAudioWarmupTask != null ||
-            measurementSettings.Measurement.AudioBackend != AudioBackend.Asio)
+        if (measurementSettings.Measurement.AudioBackend == AudioBackend.Asio)
         {
-            return;
+            startupAudioWarmup.Start();
         }
-
-        startupAudioWarmupCancellation = new CancellationTokenSource();
-        startupAudioWarmupTask =
-            WarmUpStartupAudioAsync(startupAudioWarmupCancellation.Token);
     }
 
     private async Task WarmUpStartupAudioAsync(CancellationToken cancellationToken)
@@ -264,21 +259,4 @@ public partial class Form1
         }
     }
 
-    private async Task WaitForStartupAudioWarmupAsync()
-    {
-        Task? task = startupAudioWarmupTask;
-        if (task == null || task.IsCompleted)
-        {
-            return;
-        }
-
-        try
-        {
-            await task;
-        }
-        catch
-        {
-            // Warm-up failures are intentionally non-fatal.
-        }
-    }
 }

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -65,10 +65,8 @@ public partial class Form1
 
     private async void buttonRecord_Click(object sender, EventArgs e)
     {
-        recordButtonLongPressTimer.Stop();
-        if (suppressNextRecordButtonClick)
+        if (recordButtonLongPress.ConsumeClickSuppression())
         {
-            suppressNextRecordButtonClick = false;
             return;
         }
 
@@ -133,42 +131,6 @@ public partial class Form1
             EnterMeasurementRunningState();
             _ = expSweepMeasurement.RunAsync();
         }
-    }
-
-    private void buttonRecord_MouseDown(object? sender, MouseEventArgs e)
-    {
-        if (e.Button != MouseButtons.Left || !CanLongPressCancelMeasurementSeries())
-        {
-            return;
-        }
-
-        recordButtonLongPressTriggered = false;
-        suppressNextRecordButtonClick = false;
-        recordButtonLongPressTimer.Start();
-    }
-
-    private void buttonRecord_MouseUp(object? sender, MouseEventArgs e)
-    {
-        recordButtonLongPressTimer.Stop();
-    }
-
-    private void buttonRecord_MouseLeave(object? sender, EventArgs e)
-    {
-        recordButtonLongPressTimer.Stop();
-    }
-
-    private async void RecordButtonLongPressTimer_Tick(object? sender, EventArgs e)
-    {
-        recordButtonLongPressTimer.Stop();
-        if (!CanLongPressCancelMeasurementSeries() || recordButtonLongPressTriggered)
-        {
-            return;
-        }
-
-        recordButtonLongPressTriggered = true;
-        suppressNextRecordButtonClick = true;
-        buttonRecord.Text = "Aborting...";
-        await expSweepMeasurement.AbortAsync();
     }
 
     private bool CanLongPressCancelMeasurementSeries() =>

--- a/source/Shell/Form1.ModeCatalog.cs
+++ b/source/Shell/Form1.ModeCatalog.cs
@@ -44,8 +44,8 @@ public partial class Form1
                     opt => opt.Init(
                         expSweepMeasurement,
                         frequencyResponseOptions,
-                        HasMicrophoneCalibration(MicrophoneCalibrationMode.Degrees0),
-                        HasMicrophoneCalibration(MicrophoneCalibrationMode.Degrees90)),
+                        microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees0),
+                        microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees90)),
                     opt => opt.SetOptions(frequencyResponseOptions))),
             [ModeTab.Phase] = new(
                 ModeTab.Phase,

--- a/source/Shell/Form1.ModeCatalog.cs
+++ b/source/Shell/Form1.ModeCatalog.cs
@@ -59,7 +59,7 @@ public partial class Form1
                 OpenSettings: () => ToggleModeOptions(
                     ModeTab.Phase,
                     () => new PROpt(),
-                    opt => opt.Init(expSweepMeasurement, phaseResponseOptions, GetCompareAnalysisSource),
+                    opt => opt.Init(expSweepMeasurement, phaseResponseOptions, compareSelection.GetAnalysisSource),
                     opt => opt.SetOptions(phaseResponseOptions))),
             [ModeTab.GroupDelay] = new(
                 ModeTab.GroupDelay,
@@ -73,7 +73,7 @@ public partial class Form1
                 OpenSettings: () => ToggleModeOptions(
                     ModeTab.GroupDelay,
                     () => new GDOpt(),
-                    opt => opt.Init(expSweepMeasurement, groupDelayOptions, GetCompareAnalysisSource),
+                    opt => opt.Init(expSweepMeasurement, groupDelayOptions, compareSelection.GetAnalysisSource),
                     opt => opt.SetOptions(groupDelayOptions))),
             [ModeTab.Waterfall] = new(
                 ModeTab.Waterfall,

--- a/source/Shell/Form1.ModeSettings.cs
+++ b/source/Shell/Form1.ModeSettings.cs
@@ -86,21 +86,12 @@ public partial class Form1
             return;
         }
 
-        measurementSettingsSavePending = true;
-        measurementSettingsSaveTimer.Stop();
-        measurementSettingsSaveTimer.Start();
+        measurementSettingsSaver.Schedule();
     }
 
     private void FlushMeasurementSettings()
     {
-        measurementSettingsSaveTimer.Stop();
-        if (!measurementSettingsSavePending)
-        {
-            return;
-        }
-
-        measurementSettingsSavePending = false;
-        measurementSettings.Save();
+        measurementSettingsSaver.Flush();
     }
 
     private DialogResult ShowSettingsDialog(Form dialog)
@@ -144,8 +135,8 @@ public partial class Form1
             {
                 opt.Init(
                     liveSpectrumOptions,
-                    HasMicrophoneCalibration(MicrophoneCalibrationMode.Degrees0),
-                    HasMicrophoneCalibration(MicrophoneCalibrationMode.Degrees90));
+                    microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees0),
+                    microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees90));
                 opt.ResetAverageRequested += liveSpectrumController.ResetAverage;
             },
             ApplyLiveSpectrumOptionsAsync,

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -33,10 +33,7 @@ namespace Resonalyze
         private readonly OverlayCollection overlayCollection;
         private readonly ExpSweepMeasurement expSweepMeasurement = new();
         private readonly NoiseMeasurement noiseMeasurement = new();
-        private readonly Dictionary<string, CalibrationFile> calibrationCache = new(
-            StringComparer.OrdinalIgnoreCase);
-        private readonly HashSet<string> reportedCalibrationProblems = new(
-            StringComparer.OrdinalIgnoreCase);
+        private readonly MicrophoneCalibrationService microphoneCalibration;
         private readonly WaterfallGenerateOptions waterfallGenOptions = new()
         {
             WaterfallMode = WaterfallMode.Fourier,
@@ -90,19 +87,14 @@ namespace Resonalyze
         // blocking device teardown while the OS is waiting for the process to exit.
         private bool shutdownFastClose;
         private bool updateCheckStarted;
-        private bool measurementSettingsSavePending;
-        private readonly System.Windows.Forms.Timer measurementSettingsSaveTimer = new()
-        {
-            Interval = MeasurementSettingsSaveDelayMilliseconds
-        };
+        private readonly DebouncedSaver measurementSettingsSaver;
+        private readonly StartupAudioWarmup startupAudioWarmup;
         private readonly System.Windows.Forms.Timer recordButtonLongPressTimer = new()
         {
             Interval = RecordButtonLongPressMilliseconds
         };
         private CompareMeasurementSelection? compareMeasurement;
         private ContextMenuStrip? compareMenuStrip;
-        private CancellationTokenSource? startupAudioWarmupCancellation;
-        private Task? startupAudioWarmupTask;
         private bool recordButtonLongPressTriggered;
         private bool suppressNextRecordButtonClick;
 
@@ -113,6 +105,13 @@ namespace Resonalyze
             PlotInteraction.EnableDoubleClickAxisReset(plotView1);
             plotView1.Paint += (_, _) => AppProfiler.FrameMark("main-plot");
             measurementSettings = MeasurementSettingsFile.LoadOrDefault();
+            measurementSettingsSaver = new DebouncedSaver(
+                MeasurementSettingsSaveDelayMilliseconds,
+                measurementSettings.Save);
+            startupAudioWarmup = new StartupAudioWarmup(WarmUpStartupAudioAsync);
+            microphoneCalibration = new MicrophoneCalibrationService(
+                GetConfiguredMicrophoneCalibrationPath,
+                ShowCalibrationProblem);
             Form1ControllerDependencies dependencies = CreateControllerDependencies();
             overlayCollection = dependencies.OverlayCollection;
             plotLabelsPanelController = dependencies.PlotLabelsPanelController;
@@ -184,21 +183,15 @@ namespace Resonalyze
         }
 
         // A configured calibration that fails to load must not silently produce
-        // uncalibrated curves. Warned once per path per session; queued through
-        // BeginInvoke so a plot build is never interrupted by a modal dialog.
-        // Called from Task.Run plot builds, so the set is guarded by a lock.
-        private void WarnCalibrationProblemOnce(string path, string? reason)
+        // uncalibrated curves. MicrophoneCalibrationService already deduplicates
+        // (once per path per session) and calls this from Task.Run plot builds,
+        // so the warning is queued through BeginInvoke — a plot build is never
+        // interrupted by a modal dialog.
+        private void ShowCalibrationProblem(string path, string? reason)
         {
             if (closingInProgress)
             {
                 return;
-            }
-            lock (reportedCalibrationProblems)
-            {
-                if (!reportedCalibrationProblems.Add(path))
-                {
-                    return;
-                }
             }
 
             TryBeginInvokeOnUiThread(() =>

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -89,14 +89,9 @@ namespace Resonalyze
         private bool updateCheckStarted;
         private readonly DebouncedSaver measurementSettingsSaver;
         private readonly StartupAudioWarmup startupAudioWarmup;
-        private readonly System.Windows.Forms.Timer recordButtonLongPressTimer = new()
-        {
-            Interval = RecordButtonLongPressMilliseconds
-        };
-        private CompareMeasurementSelection? compareMeasurement;
+        private readonly ButtonLongPressBehavior recordButtonLongPress;
+        private readonly CompareSelection compareSelection = new();
         private ContextMenuStrip? compareMenuStrip;
-        private bool recordButtonLongPressTriggered;
-        private bool suppressNextRecordButtonClick;
 
         public Form1()
         {
@@ -109,6 +104,15 @@ namespace Resonalyze
                 MeasurementSettingsSaveDelayMilliseconds,
                 measurementSettings.Save);
             startupAudioWarmup = new StartupAudioWarmup(WarmUpStartupAudioAsync);
+            recordButtonLongPress = new ButtonLongPressBehavior(
+                buttonRecord,
+                RecordButtonLongPressMilliseconds,
+                CanLongPressCancelMeasurementSeries,
+                async () =>
+                {
+                    buttonRecord.Text = "Aborting...";
+                    await expSweepMeasurement.AbortAsync();
+                });
             microphoneCalibration = new MicrophoneCalibrationService(
                 GetConfiguredMicrophoneCalibrationPath,
                 ShowCalibrationProblem);

--- a/tests/Resonalyze.App.Tests/ButtonLongPressBehaviorTests.cs
+++ b/tests/Resonalyze.App.Tests/ButtonLongPressBehaviorTests.cs
@@ -1,0 +1,101 @@
+using System.Windows.Forms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The record-button long-press state machine moved off Form1 into
+/// <see cref="ButtonLongPressBehavior"/>; these drive the internal handlers
+/// directly (the WinForms timer needs a message pump) and pin the fire-once
+/// and click-suppression semantics.
+/// </summary>
+public sealed class ButtonLongPressBehaviorTests
+{
+    [Fact]
+    public async Task LongPress_FiresOnceAndSuppressesExactlyOneClick()
+    {
+        using var button = new Button();
+        int longPresses = 0;
+        using var behavior = new ButtonLongPressBehavior(
+            button,
+            650,
+            canTrigger: () => true,
+            onLongPress: () =>
+            {
+                longPresses++;
+                return Task.CompletedTask;
+            });
+
+        behavior.HandleMouseDown(MouseButtons.Left);
+        await behavior.HandleLongPressElapsedAsync();
+        await behavior.HandleLongPressElapsedAsync();
+
+        Assert.Equal(1, longPresses);
+        Assert.True(behavior.ConsumeClickSuppression());
+        Assert.False(behavior.ConsumeClickSuppression());
+    }
+
+    [Fact]
+    public void Click_WithoutLongPress_IsNotSuppressed()
+    {
+        using var button = new Button();
+        using var behavior = new ButtonLongPressBehavior(
+            button,
+            650,
+            canTrigger: () => true,
+            onLongPress: () => Task.CompletedTask);
+
+        behavior.HandleMouseDown(MouseButtons.Left);
+
+        Assert.False(behavior.ConsumeClickSuppression());
+    }
+
+    [Fact]
+    public async Task Elapsed_DoesNotFireWhenTheConditionTurnedFalse()
+    {
+        using var button = new Button();
+        bool canTrigger = true;
+        int longPresses = 0;
+        using var behavior = new ButtonLongPressBehavior(
+            button,
+            650,
+            canTrigger: () => canTrigger,
+            onLongPress: () =>
+            {
+                longPresses++;
+                return Task.CompletedTask;
+            });
+
+        behavior.HandleMouseDown(MouseButtons.Left);
+        canTrigger = false;
+        await behavior.HandleLongPressElapsedAsync();
+
+        Assert.Equal(0, longPresses);
+        Assert.False(behavior.ConsumeClickSuppression());
+    }
+
+    [Fact]
+    public async Task NewPress_AfterALongPress_ArmsAFreshCycle()
+    {
+        using var button = new Button();
+        int longPresses = 0;
+        using var behavior = new ButtonLongPressBehavior(
+            button,
+            650,
+            canTrigger: () => true,
+            onLongPress: () =>
+            {
+                longPresses++;
+                return Task.CompletedTask;
+            });
+
+        behavior.HandleMouseDown(MouseButtons.Left);
+        await behavior.HandleLongPressElapsedAsync();
+        Assert.True(behavior.ConsumeClickSuppression());
+
+        behavior.HandleMouseDown(MouseButtons.Left);
+        await behavior.HandleLongPressElapsedAsync();
+
+        Assert.Equal(2, longPresses);
+        Assert.True(behavior.ConsumeClickSuppression());
+    }
+}

--- a/tests/Resonalyze.App.Tests/CompareSelectionTests.cs
+++ b/tests/Resonalyze.App.Tests/CompareSelectionTests.cs
@@ -1,0 +1,102 @@
+using System.Numerics;
+using Resonalyze.History;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The Compare selection moved off Form1 into <see cref="CompareSelection"/>;
+/// these pin the analysis-source mapping the mode plots rely on (a Compare
+/// without a transfer IR still contributes a Frequency Response curve) and
+/// the Changed notification driving the UI refresh.
+/// </summary>
+public sealed class CompareSelectionTests
+{
+    [Fact]
+    public void GetAnalysisSource_ReturnsNullWithoutASelection()
+    {
+        var selection = new CompareSelection();
+
+        Assert.Null(selection.Current);
+        Assert.Null(selection.GetAnalysisSource());
+        Assert.Null(selection.GetTimeAlignmentMeasurement());
+    }
+
+    [Fact]
+    public void Set_RaisesChangedAndExposesTheSelection()
+    {
+        var selection = new CompareSelection();
+        int changes = 0;
+        selection.Changed += () => changes++;
+
+        selection.Set("a.json", @"C:\ir\a.json", CreateSnapshot());
+
+        Assert.Equal(1, changes);
+        Assert.Equal("a.json", selection.Current!.DisplayName);
+        Assert.Equal(@"C:\ir\a.json", selection.Current.SourceFilePath);
+
+        selection.Clear();
+
+        Assert.Equal(2, changes);
+        Assert.Null(selection.Current);
+    }
+
+    [Fact]
+    public void GetAnalysisSource_MapsTheSnapshotResponses()
+    {
+        var selection = new CompareSelection();
+        Complex[] sweepIr = [new(1, 0), new(0.5, 0)];
+        Complex[] transferIr = [new(0.25, 0)];
+        selection.Set("a.json", null, CreateSnapshot(
+            sweepIr,
+            transferIr,
+            transferPeakIndex: 7));
+
+        CompareAnalysisSource? source = selection.GetAnalysisSource();
+
+        Assert.NotNull(source);
+        Assert.Equal("a.json", source!.Value.DisplayName);
+        Assert.Equal(48_000, source.Value.SampleRate);
+        Assert.Same(sweepIr, source.Value.SweepDeconvolutionImpulseResponse);
+        Assert.Equal(3, source.Value.SweepDeconvolutionPeakIndex);
+        Assert.Same(transferIr, source.Value.TransferImpulseResponse);
+        Assert.Equal(7, source.Value.TransferPeakIndex);
+    }
+
+    [Fact]
+    public void GetAnalysisSource_WithoutTransferIr_StillContributesTheSweepIr()
+    {
+        var selection = new CompareSelection();
+        selection.Set("a.json", null, CreateSnapshot());
+
+        CompareAnalysisSource? source = selection.GetAnalysisSource();
+
+        Assert.NotNull(source);
+        Assert.Empty(source!.Value.TransferImpulseResponse);
+        Assert.Equal(0, source.Value.TransferPeakIndex);
+    }
+
+    [Fact]
+    public void GetAnalysisSource_ReturnsNullForAnEmptySweepIr()
+    {
+        var selection = new CompareSelection();
+        selection.Set("a.json", null, CreateSnapshot(sweepIr: Array.Empty<Complex>()));
+
+        Assert.Null(selection.GetAnalysisSource());
+        Assert.NotNull(selection.GetTimeAlignmentMeasurement());
+    }
+
+    private static MeasurementHistorySnapshot CreateSnapshot(
+        Complex[]? sweepIr = null,
+        Complex[]? transferIr = null,
+        int? transferPeakIndex = null) =>
+        new()
+        {
+            SampleRate = 48_000,
+            SweepDeconvolutionImpulseResponse = sweepIr ?? [new(1, 0)],
+            SweepDeconvolutionPeakIndex = 3,
+            TransferImpulseResponse = transferIr,
+            TransferPeakIndex = transferPeakIndex,
+            MeterSnapshot = InputLevelMeterSnapshot.Empty,
+            Preview = new MeasurementHistoryPreview()
+        };
+}

--- a/tests/Resonalyze.App.Tests/DebouncedSaverTests.cs
+++ b/tests/Resonalyze.App.Tests/DebouncedSaverTests.cs
@@ -1,0 +1,48 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The save-debounce timer/pending-flag pair moved off Form1 into
+/// <see cref="DebouncedSaver"/>; these pin the flush semantics the close
+/// paths rely on (the timer itself needs a message pump, so the tests drive
+/// Schedule/Flush directly).
+/// </summary>
+public sealed class DebouncedSaverTests
+{
+    [Fact]
+    public void Flush_WithoutSchedule_DoesNotSave()
+    {
+        int saves = 0;
+        using var saver = new DebouncedSaver(1000, () => saves++);
+
+        saver.Flush();
+
+        Assert.Equal(0, saves);
+    }
+
+    [Fact]
+    public void Flush_AfterSchedule_SavesExactlyOnce()
+    {
+        int saves = 0;
+        using var saver = new DebouncedSaver(1000, () => saves++);
+
+        saver.Schedule();
+        saver.Flush();
+        saver.Flush();
+
+        Assert.Equal(1, saves);
+    }
+
+    [Fact]
+    public void Schedule_AfterFlush_ArmsANewSave()
+    {
+        int saves = 0;
+        using var saver = new DebouncedSaver(1000, () => saves++);
+
+        saver.Schedule();
+        saver.Flush();
+        saver.Schedule();
+        saver.Flush();
+
+        Assert.Equal(2, saves);
+    }
+}

--- a/tests/Resonalyze.App.Tests/MicrophoneCalibrationServiceTests.cs
+++ b/tests/Resonalyze.App.Tests/MicrophoneCalibrationServiceTests.cs
@@ -1,0 +1,173 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The calibration cache, the once-per-session problem reporting and the path
+/// fallbacks moved off Form1 into <see cref="MicrophoneCalibrationService"/>;
+/// these pin the behavior the shell relied on: legacy calibration.txt lookup,
+/// the 90°-from-0° approximation, and warnings that never repeat within a
+/// session even across a cache invalidation.
+/// </summary>
+public sealed class MicrophoneCalibrationServiceTests : IDisposable
+{
+    private const string ValidCalibration = "20 2.5\n1000 2.5\n20000 2.5\n";
+
+    private readonly string tempDirectory;
+    private readonly List<(string Path, string? Reason)> reportedProblems = new();
+    private string? zeroDegreePath;
+    private string? ninetyDegreePath;
+
+    public MicrophoneCalibrationServiceTests()
+    {
+        tempDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "resonalyze-calibration-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public void Get_ReturnsNullAndStaysSilentWhenNothingIsConfigured()
+    {
+        MicrophoneCalibrationService service = CreateService();
+
+        Assert.Null(service.Get(MicrophoneCalibrationMode.Degrees0));
+        Assert.Null(service.Get(MicrophoneCalibrationMode.Degrees90));
+        Assert.False(service.Has(MicrophoneCalibrationMode.Degrees0));
+        Assert.False(service.Has(MicrophoneCalibrationMode.Degrees90));
+        Assert.Empty(reportedProblems);
+    }
+
+    [Fact]
+    public void Get_CachesTheLoadedFile()
+    {
+        zeroDegreePath = WriteFile("zero.txt", ValidCalibration);
+        MicrophoneCalibrationService service = CreateService();
+
+        CalibrationFile? first = service.Get(MicrophoneCalibrationMode.Degrees0);
+
+        Assert.NotNull(first);
+        Assert.True(first!.HasData);
+        Assert.Same(first, service.Get(MicrophoneCalibrationMode.Degrees0));
+        Assert.Empty(reportedProblems);
+    }
+
+    [Fact]
+    public void Get_ReportsAnUnparsableFileOncePerSession()
+    {
+        zeroDegreePath = WriteFile("broken.txt", "not a calibration\n");
+        MicrophoneCalibrationService service = CreateService();
+
+        CalibrationFile? calibration = service.Get(MicrophoneCalibrationMode.Degrees0);
+        service.Get(MicrophoneCalibrationMode.Degrees0);
+
+        Assert.NotNull(calibration);
+        Assert.False(calibration!.HasData);
+        (string path, string? reason) = Assert.Single(reportedProblems);
+        Assert.Equal(zeroDegreePath, path);
+        Assert.Equal(calibration.LoadError, reason);
+    }
+
+    [Fact]
+    public void Get_ReportsAConfiguredButMissingFileOncePerSession()
+    {
+        zeroDegreePath = Path.Combine(tempDirectory, "deleted.txt");
+        MicrophoneCalibrationService service = CreateService();
+
+        Assert.Null(service.Get(MicrophoneCalibrationMode.Degrees0));
+        Assert.Null(service.Get(MicrophoneCalibrationMode.Degrees0));
+
+        (string path, string? reason) = Assert.Single(reportedProblems);
+        Assert.Equal(zeroDegreePath, path);
+        Assert.Contains("not found", reason);
+    }
+
+    [Fact]
+    public void InvalidateCache_ReloadsFilesButKeepsSessionProblemReports()
+    {
+        zeroDegreePath = WriteFile("broken.txt", "not a calibration\n");
+        MicrophoneCalibrationService service = CreateService();
+        CalibrationFile? first = service.Get(MicrophoneCalibrationMode.Degrees0);
+
+        service.InvalidateCache();
+        CalibrationFile? second = service.Get(MicrophoneCalibrationMode.Degrees0);
+
+        Assert.NotSame(first, second);
+        Assert.Single(reportedProblems);
+    }
+
+    [Fact]
+    public void Get_FallsBackToTheLegacyZeroDegreeFile()
+    {
+        WriteFile("calibration.txt", ValidCalibration);
+        MicrophoneCalibrationService service = CreateService();
+
+        CalibrationFile? calibration = service.Get(MicrophoneCalibrationMode.Degrees0);
+
+        Assert.NotNull(calibration);
+        Assert.True(calibration!.HasData);
+        Assert.True(service.Has(MicrophoneCalibrationMode.Degrees0));
+        Assert.True(service.Has(MicrophoneCalibrationMode.Degrees90));
+    }
+
+    [Fact]
+    public void Get_NinetyDegrees_DerivesTheApproximationFromTheZeroDegreeFile()
+    {
+        zeroDegreePath = WriteFile("zero.txt", ValidCalibration);
+        MicrophoneCalibrationService service = CreateService();
+
+        CalibrationFile? ninety = service.Get(MicrophoneCalibrationMode.Degrees90);
+
+        Assert.NotNull(ninety);
+        Assert.True(ninety!.HasData);
+        Assert.True(service.Has(MicrophoneCalibrationMode.Degrees90));
+        Assert.NotSame(service.Get(MicrophoneCalibrationMode.Degrees0), ninety);
+        Assert.Same(ninety, service.Get(MicrophoneCalibrationMode.Degrees90));
+        Assert.Equal(
+            2.5 + CalibrationFile.Delta90Minus0(10_000),
+            ninety.GetDecibelCorrection(10_000),
+            precision: 6);
+    }
+
+    [Fact]
+    public void Get_NinetyDegrees_PrefersTheConfiguredNinetyDegreeFile()
+    {
+        zeroDegreePath = WriteFile("zero.txt", ValidCalibration);
+        ninetyDegreePath = WriteFile("ninety.txt", "20 1.0\n1000 1.0\n20000 1.0\n");
+        MicrophoneCalibrationService service = CreateService();
+
+        CalibrationFile? ninety = service.Get(MicrophoneCalibrationMode.Degrees90);
+
+        Assert.NotNull(ninety);
+        Assert.Equal(1.0, ninety!.GetDecibelCorrection(1000), precision: 6);
+    }
+
+    private MicrophoneCalibrationService CreateService() =>
+        new(
+            mode => mode switch
+            {
+                MicrophoneCalibrationMode.Degrees0 => zeroDegreePath,
+                MicrophoneCalibrationMode.Degrees90 => ninetyDegreePath,
+                _ => null
+            },
+            (path, reason) => reportedProblems.Add((path, reason)),
+            legacyZeroDegreeDirectory: tempDirectory);
+
+    private string WriteFile(string name, string content)
+    {
+        string path = Path.Combine(tempDirectory, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/tests/Resonalyze.App.Tests/StartupAudioWarmupTests.cs
+++ b/tests/Resonalyze.App.Tests/StartupAudioWarmupTests.cs
@@ -1,0 +1,72 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The startup warm-up task/cancellation pair moved off Form1 into
+/// <see cref="StartupAudioWarmup"/>; these pin the once-only start, the
+/// non-fatal wait and the cancel used by the close paths.
+/// </summary>
+public sealed class StartupAudioWarmupTests
+{
+    [Fact]
+    public async Task Start_RunsTheWarmUpOnlyOnce()
+    {
+        int starts = 0;
+        using var warmup = new StartupAudioWarmup(_ =>
+        {
+            starts++;
+            return Task.CompletedTask;
+        });
+
+        warmup.Start();
+        warmup.Start();
+        await warmup.WaitAsync();
+
+        Assert.Equal(1, starts);
+    }
+
+    [Fact]
+    public async Task WaitAsync_CompletesImmediatelyWhenNeverStarted()
+    {
+        using var warmup = new StartupAudioWarmup(_ => Task.CompletedTask);
+
+        await warmup.WaitAsync();
+    }
+
+    [Fact]
+    public async Task WaitAsync_SwallowsWarmUpFailures()
+    {
+        using var warmup = new StartupAudioWarmup(
+            async _ =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("driver failed");
+            });
+
+        warmup.Start();
+        await warmup.WaitAsync();
+    }
+
+    [Fact]
+    public async Task Cancel_SignalsTheWarmUpToken()
+    {
+        var cancelled = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var warmup = new StartupAudioWarmup(async token =>
+        {
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            }
+            catch (OperationCanceledException)
+            {
+                cancelled.TrySetResult(true);
+            }
+        });
+
+        warmup.Start();
+        warmup.Cancel();
+        await warmup.WaitAsync();
+
+        Assert.True(await cancelled.Task);
+    }
+}


### PR DESCRIPTION
First two slices of the ★ "Form1 is the concurrency hub" TODO item: five self-contained concerns move off Form1 into classes that own their state. Form1 loses ten mutable fields (including both ad-hoc lock objects and two raw timers) and ~280 lines.

## Extracted classes

- **`MicrophoneCalibrationService`** — owns the calibration cache, the once-per-session problem reporting and the path resolution (legacy `calibration.txt` fallback, 90°-from-0° approximation). `Get` runs on `Task.Run` plot-build workers as well as the UI thread, so all mutable state is guarded inside the service; the approximation path uses a double-checked insert instead of relying on reentrant locking. Form1 keeps only the `BeginInvoke` marshal for the warning dialog and the consumer wiring (`PlotModelFactory`, Virtual DSP panel, mode-settings dialogs).
- **`StartupAudioWarmup`** — the warm-up task/cancellation pair that three different close paths used to cancel through raw fields: `Start()` (once-only), `WaitAsync()` (non-fatal), `Cancel()` for the OS-shutdown fast close, `Dispose()` for the normal close. Semantics of every path are unchanged.
- **`DebouncedSaver`** — the settings-save timer + pending flag behind `Schedule()`/`Flush()`.
- **`CompareSelection`** — the Compare measurement selection and its analysis-source mapping. The selection is written on the UI thread but read by `Task.Run` plot builds (the `PlotModelFactory` compare-source provider), so the reference is now explicitly `volatile` and every reader snapshots it once. Form1 keeps the menu/dialog UI and reacts to the `Changed` event.
- **`ButtonLongPressBehavior`** — the long-press timer + triggered/suppress-next-click flags the record button uses to cancel an averaged-measurement series; the Click handler consumes the suppression through one call.

## Behavior notes

- No intended behavior changes; every guard (`IsDisposed`, `closingInProgress`, once-per-session warn dedup surviving cache invalidation, fast-close skipping the blocking teardown) is preserved.
- One deliberate structural change inside `MicrophoneCalibrationService`: two concurrent plot builds may now both compute the 90° approximation and the first insert wins (same instance for all callers), instead of one build blocking the other for the duration of the computation.

## Tests

19 new App.Tests (run on the Windows CI): calibration caching/identity, warn-once across `InvalidateCache`, legacy fallback, 90° approximation and preference for a configured 90° file; warm-up once-only start, non-fatal wait, cancellation; debounce flush semantics; Compare analysis-source mapping incl. the no-transfer-IR case and `Changed` notification; long-press fire-once, one-click suppression, condition re-check, re-arm.

Local: full solution build clean (0 warnings), dsp tests 276/276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_