### PR TITLE
Form1 decomposition, third slice: session identity and overlay-slot memory

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -164,10 +164,14 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   calibration cache + warn-once bookkeeping (`MicrophoneCalibrationService`),
   the startup warm-up task/cancellation pair (`StartupAudioWarmup`), the
   settings-save debounce (`DebouncedSaver`), the Compare selection read by
-  plot-build workers (`CompareSelection`) and the record-button long-press
-  state machine (`ButtonLongPressBehavior`) own their state now. Still on
-  Form1: history/current-IR state, overlay slot tracking and the lifecycle
-  flags — keep carving one concern at a time.
+  plot-build workers (`CompareSelection`), the record-button long-press
+  state machine (`ButtonLongPressBehavior`), the current-measurement/history
+  identity (`MeasurementSessionTracker`) and the per-mode overlay-slot memory
+  (`ActiveOverlaySlotTracker`) own their state now. What remains on Form1 is
+  the lifecycle/close flags (`closingPrepared`, `closingInProgress`,
+  `resourcesDisposed`, `shutdownFastClose`, `updateCheckStarted`) and the
+  transient UI bits (compare menu strip) — inherently form-bound; further
+  slicing is optional polish rather than a concurrency risk.
 - [ ] **`WireLiveApply` covers only dialog-open controls.** Controls created
   after wiring never get live-apply behavior.
 

--- a/source/History/MeasurementSessionTracker.cs
+++ b/source/History/MeasurementSessionTracker.cs
@@ -1,0 +1,115 @@
+namespace Resonalyze.History;
+
+/// <summary>
+/// Owns the "current measurement" identity that used to live as two raw
+/// fields on <c>Form1</c>: which history entry the loaded impulse response
+/// belongs to, and whether an impulse response is loaded at all. Every
+/// transition that pairs those flags with a history-service call (finished
+/// sweep, loaded/saved file, restored or deleted entry, fresh session) goes
+/// through here, so the invariants live in one place. UI-thread only.
+/// </summary>
+internal sealed class MeasurementSessionTracker
+{
+    private readonly MeasurementHistoryService history;
+    private readonly Func<MeasurementSessionSnapshot> captureSession;
+
+    public MeasurementSessionTracker(
+        MeasurementHistoryService history,
+        Func<MeasurementSessionSnapshot> captureSession)
+    {
+        this.history = history;
+        this.captureSession = captureSession;
+    }
+
+    public Guid? CurrentEntryId { get; private set; }
+
+    public bool HasImpulseResponse { get; private set; }
+
+    /// <summary>A sweep starts or a fresh session begins: nothing current.</summary>
+    public void Reset()
+    {
+        CurrentEntryId = null;
+        HasImpulseResponse = false;
+    }
+
+    public void SetImpulseResponseAvailable(bool available)
+    {
+        HasImpulseResponse = available;
+    }
+
+    /// <summary>
+    /// A finished sweep becomes a new in-memory history entry and the
+    /// current one.
+    /// </summary>
+    public void MarkMeasurementCompleted(ExpSweepMeasurement measurement)
+    {
+        HasImpulseResponse = true;
+        CurrentEntryId = history.AddMeasurement(measurement, captureSession());
+    }
+
+    /// <summary>A file was loaded: its file-backed entry becomes current.</summary>
+    public void MarkLoadedFile(string filePath, ImpulseResponseFile file)
+    {
+        HasImpulseResponse = true;
+        CurrentEntryId = history.AddOrUpdateLoadedFile(filePath, file, captureSession());
+    }
+
+    /// <summary>
+    /// The current measurement was saved to a file: the current entry is
+    /// marked saved, or a file-backed entry is created and becomes current
+    /// when nothing was current (an unsaved measurement loaded before the
+    /// history service existed, or a deleted entry).
+    /// </summary>
+    public void MarkSavedFile(string filePath, ImpulseResponseFile file)
+    {
+        if (CurrentEntryId.HasValue)
+        {
+            history.MarkSaved(
+                CurrentEntryId.Value,
+                filePath,
+                file,
+                captureSession());
+        }
+        else
+        {
+            CurrentEntryId = history.AddOrUpdateLoadedFile(
+                filePath,
+                file,
+                captureSession());
+        }
+    }
+
+    /// <summary>A history entry was restored into the app and becomes current.</summary>
+    public void MarkRestored(Guid entryId)
+    {
+        HasImpulseResponse = true;
+        CurrentEntryId = entryId;
+    }
+
+    /// <summary>
+    /// An entry was deleted: the current pointer is dropped but the loaded
+    /// impulse response stays usable.
+    /// </summary>
+    public void ForgetEntry(Guid entryId)
+    {
+        if (CurrentEntryId == entryId)
+        {
+            CurrentEntryId = null;
+        }
+    }
+
+    /// <summary>
+    /// Writes the live working state (mode + per-mode settings + active
+    /// overlays) back into the current entry. Safe to call when nothing is
+    /// selected or no measurement is loaded.
+    /// </summary>
+    public void PersistCurrentSessionState()
+    {
+        if (!CurrentEntryId.HasValue || !HasImpulseResponse)
+        {
+            return;
+        }
+
+        history.UpdateSession(CurrentEntryId.Value, captureSession());
+    }
+}

--- a/source/Overlays/ActiveOverlaySlotTracker.cs
+++ b/source/Overlays/ActiveOverlaySlotTracker.cs
@@ -1,0 +1,44 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Remembers which overlay slots are checked per overlay mode across tab
+/// switches, replacing the raw dictionary on <c>Form1</c>: the shell captures
+/// the active set when leaving a mode, restores it when entering one, and the
+/// Virtual DSP overlay capture arms its freshly saved slot so it arrives
+/// already checked. UI-thread only.
+/// </summary>
+internal sealed class ActiveOverlaySlotTracker
+{
+    private readonly Dictionary<Mode, List<int>> slotsByMode = new();
+
+    public void Store(Mode overlayMode, List<int> activeSlots)
+    {
+        slotsByMode[overlayMode] = activeSlots;
+    }
+
+    public bool TryGet(Mode overlayMode, out List<int> activeSlots)
+    {
+        if (slotsByMode.TryGetValue(overlayMode, out List<int>? stored))
+        {
+            activeSlots = stored;
+            return true;
+        }
+
+        activeSlots = new List<int>();
+        return false;
+    }
+
+    public void MarkActive(Mode overlayMode, int slot)
+    {
+        if (!slotsByMode.TryGetValue(overlayMode, out List<int>? active))
+        {
+            active = new List<int>();
+            slotsByMode[overlayMode] = active;
+        }
+
+        if (!active.Contains(slot))
+        {
+            active.Add(slot);
+        }
+    }
+}

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -60,21 +60,7 @@ public partial class Form1
                 ImpulseResponseFile file =
                     ImpulseResponseFile.Capture(expSweepMeasurement);
                 await file.SaveAsync(dialog.FileName);
-                if (currentHistoryEntryId.HasValue)
-                {
-                    measurementHistoryService.MarkSaved(
-                        currentHistoryEntryId.Value,
-                        dialog.FileName,
-                        file,
-                        CaptureCurrentSessionSnapshot());
-                }
-                else
-                {
-                    currentHistoryEntryId = measurementHistoryService.AddOrUpdateLoadedFile(
-                        dialog.FileName,
-                        file,
-                        CaptureCurrentSessionSnapshot());
-                }
+                sessionTracker.MarkSavedFile(dialog.FileName, file);
                 SetImpulseResponseSourceFile(dialog.FileName);
                 UpdateLastImpulseResponseDirectory(dialog.FileName);
                 RefreshCurrentModePlot();
@@ -141,10 +127,7 @@ public partial class Form1
                     file.AcceptedAverageRunCount);
                 expSweepMeasurement.RestoreLevelSnapshot(file.GetMeterSnapshot());
                 ApplyLoadedImpulseResponseState(dialog.FileName);
-                currentHistoryEntryId = measurementHistoryService.AddOrUpdateLoadedFile(
-                    dialog.FileName,
-                    file,
-                    CaptureCurrentSessionSnapshot());
+                sessionTracker.MarkLoadedFile(dialog.FileName, file);
             }
             catch (Exception exception)
             {

--- a/source/Shell/Form1.History.cs
+++ b/source/Shell/Form1.History.cs
@@ -26,8 +26,8 @@ public partial class Form1
                 dialog.NewSessionRequested += HandleNewSessionRequested;
                 dialog.SetEntries(
                     measurementHistoryService.Entries,
-                    currentHistoryEntryId,
-                    currentHistoryEntryId);
+                    sessionTracker.CurrentEntryId,
+                    sessionTracker.CurrentEntryId);
             },
             async _ => await Task.CompletedTask);
     }
@@ -41,8 +41,8 @@ public partial class Form1
                 Guid? selectedEntryId = dialog.SelectedEntryId;
                 dialog.SetEntries(
                     measurementHistoryService.Entries,
-                    selectedEntryId ?? currentHistoryEntryId,
-                    currentHistoryEntryId);
+                    selectedEntryId ?? sessionTracker.CurrentEntryId,
+                    sessionTracker.CurrentEntryId);
             });
         });
     }
@@ -68,9 +68,9 @@ public partial class Form1
             // Before leaving the current entry, write the live working state back
             // into it so that returning later restores the latest mode/settings/
             // overlays rather than the state captured at save time.
-            if (currentHistoryEntryId != entryId)
+            if (sessionTracker.CurrentEntryId != entryId)
             {
-                PersistCurrentSessionState();
+                sessionTracker.PersistCurrentSessionState();
             }
 
             // File-backed entries keep their file name in the plot titles (the same
@@ -78,7 +78,7 @@ public partial class Form1
             string? sourceFilePath = measurementHistoryService.FindById(entryId)
                 ?.SourceFilePath;
             await RestoreHistorySnapshotAsync(snapshot, sourceFilePath);
-            currentHistoryEntryId = entryId;
+            sessionTracker.MarkRestored(entryId);
             dockedHistoryHost.InvokeIfOpen<MeasurementHistoryWindow>(dialog =>
             {
                 dialog.SetEntries(
@@ -137,7 +137,7 @@ public partial class Form1
                 dialog.FileName,
                 file,
                 snapshot.Session);
-            if (currentHistoryEntryId == entryId)
+            if (sessionTracker.CurrentEntryId == entryId)
             {
                 SetImpulseResponseSourceFile(dialog.FileName);
                 UpdateLastImpulseResponseDirectory(dialog.FileName);
@@ -162,10 +162,7 @@ public partial class Form1
             return;
         }
 
-        if (currentHistoryEntryId == entryId)
-        {
-            currentHistoryEntryId = null;
-        }
+        sessionTracker.ForgetEntry(entryId);
 
         dockedHistoryHost.InvokeIfOpen<MeasurementHistoryWindow>(dialog =>
         {
@@ -173,7 +170,7 @@ public partial class Form1
             dialog.SetEntries(
                 measurementHistoryService.Entries,
                 dialog.SelectedEntryId,
-                currentHistoryEntryId);
+                sessionTracker.CurrentEntryId);
         });
     }
 
@@ -204,7 +201,7 @@ public partial class Form1
 
         ApplyMeasurementConfigurationToControllers();
         SetImpulseResponseSourceFile(sourceFilePath);
-        hasCurrentImpulseResponse = true;
+        sessionTracker.SetImpulseResponseAvailable(true);
         UpdatePeakInfo();
 
         if (snapshot.Session != null)
@@ -247,7 +244,7 @@ public partial class Form1
     // overlays' own on-disk files are left intact.
     private async Task StartNewSessionAsync()
     {
-        PersistCurrentSessionState();
+        sessionTracker.PersistCurrentSessionState();
 
         if (liveSpectrumController.InProgress)
         {
@@ -255,7 +252,7 @@ public partial class Form1
         }
         liveSpectrumController.ForgetLastCurve();
 
-        currentHistoryEntryId = null;
+        sessionTracker.Reset();
         SetImpulseResponseAvailability(false);
         SetImpulseResponseSourceFile(null);
 
@@ -271,21 +268,6 @@ public partial class Form1
 
         dockedHistoryHost.InvokeIfOpen<MeasurementHistoryWindow>(dialog =>
             dialog.SetEntries(measurementHistoryService.Entries, null, null));
-    }
-
-    // Writes the live working state (mode + per-mode settings + active overlays)
-    // back into the currently-selected history entry. Safe to call when nothing is
-    // selected or no measurement is loaded.
-    private void PersistCurrentSessionState()
-    {
-        if (!currentHistoryEntryId.HasValue || !hasCurrentImpulseResponse)
-        {
-            return;
-        }
-
-        measurementHistoryService.UpdateSession(
-            currentHistoryEntryId.Value,
-            CaptureCurrentSessionSnapshot());
     }
 
     private MeasurementSessionSnapshot CaptureCurrentSessionSnapshot()

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -194,9 +194,7 @@ public partial class Form1
                 buttonRecord.Text = "Ready";
                 plotModelFactory.SetImpulseResponseFileName(null);
                 SetImpulseResponseAvailability(true);
-                currentHistoryEntryId = measurementHistoryService.AddMeasurement(
-                    expSweepMeasurement,
-                    CaptureCurrentSessionSnapshot());
+                sessionTracker.MarkMeasurementCompleted(expSweepMeasurement);
             }
             else
             {

--- a/source/Shell/Form1.Lifecycle.cs
+++ b/source/Shell/Form1.Lifecycle.cs
@@ -51,7 +51,7 @@ public partial class Form1
             startupAudioWarmup.Cancel();
             FlushMeasurementSettings();
             overlayCollection.FlushPendingSaves();
-            PersistCurrentSessionState();
+            sessionTracker.PersistCurrentSessionState();
             return;
         }
 
@@ -67,7 +67,7 @@ public partial class Form1
         Enabled = false;
         FlushMeasurementSettings();
         overlayCollection.FlushPendingSaves();
-        PersistCurrentSessionState();
+        sessionTracker.PersistCurrentSessionState();
         startupAudioWarmup.Cancel();
         await Task.WhenAll(
             expSweepMeasurement.AbortAsync(),

--- a/source/Shell/Form1.Plotting.cs
+++ b/source/Shell/Form1.Plotting.cs
@@ -80,8 +80,9 @@ public partial class Form1
             return;
         }
 
-        activeOverlaySlotsByMode[OverlayCollection.OverlayModeFor(CurrentMode)] =
-            overlayCollection.CaptureActiveSlots(CurrentMode);
+        activeOverlaySlots.Store(
+            OverlayCollection.OverlayModeFor(CurrentMode),
+            overlayCollection.CaptureActiveSlots(CurrentMode));
     }
 
     private void RestoreActiveOverlaySlotsForCurrentMode()
@@ -95,9 +96,7 @@ public partial class Form1
         }
 
         Mode overlayMode = OverlayCollection.OverlayModeFor(CurrentMode);
-        if (activeOverlaySlotsByMode.TryGetValue(
-                overlayMode,
-                out List<int>? activeSlots))
+        if (activeOverlaySlots.TryGet(overlayMode, out List<int> activeSlots))
         {
             overlayCollection.RestoreActiveSlots(CurrentMode, activeSlots);
         }
@@ -138,19 +137,7 @@ public partial class Form1
                 Points = points
             };
             file.Save();
-
-            if (!activeOverlaySlotsByMode.TryGetValue(
-                    Mode.FrequencyResponse,
-                    out List<int>? active))
-            {
-                active = new List<int>();
-                activeOverlaySlotsByMode[Mode.FrequencyResponse] = active;
-            }
-            if (!active.Contains(slot))
-            {
-                active.Add(slot);
-            }
-
+            activeOverlaySlots.MarkActive(Mode.FrequencyResponse, slot);
             return slot;
         }
 
@@ -327,5 +314,5 @@ public partial class Form1
     }
 
     private bool CanDrawCurrentMeasurement() =>
-        hasCurrentImpulseResponse && !expSweepMeasurement.InProgress;
+        sessionTracker.HasImpulseResponse && !expSweepMeasurement.InProgress;
 }

--- a/source/Shell/Form1.State.cs
+++ b/source/Shell/Form1.State.cs
@@ -21,7 +21,7 @@ public partial class Form1
 
     private void SetImpulseResponseAvailability(bool available)
     {
-        hasCurrentImpulseResponse = available;
+        sessionTracker.SetImpulseResponseAvailable(available);
         commandController.SetSaveAvailable(available);
         commandController.SetLoadAvailable(true);
     }
@@ -29,8 +29,7 @@ public partial class Form1
     private void EnterMeasurementRunningState()
     {
         buttonRecord.Text = "Running...";
-        currentHistoryEntryId = null;
-        hasCurrentImpulseResponse = false;
+        sessionTracker.Reset();
         SetImpulseResponseSourceFile(null);
         UpdatePeakInfo();
         commandController.SetSaveAvailable(false);
@@ -45,7 +44,7 @@ public partial class Form1
         {
             UpdateLastImpulseResponseDirectory(filePath);
         }
-        hasCurrentImpulseResponse = true;
+        sessionTracker.SetImpulseResponseAvailable(true);
         UpdatePeakInfo();
         RefreshCurrentModePlot();
     }

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -72,14 +72,13 @@ namespace Resonalyze
         private readonly MeasurementSettingsFile measurementSettings;
         private readonly MeasurementHistoryService measurementHistoryService = new();
         private readonly IReadOnlyDictionary<ModeTab, ModeDescriptor> modeDescriptors;
-        private readonly Dictionary<Mode, List<int>> activeOverlaySlotsByMode = new();
+        private readonly ActiveOverlaySlotTracker activeOverlaySlots = new();
         private readonly PlotLabelsPanelController plotLabelsPanelController;
         private readonly InputLevelMeterController inputLevelMeterController;
         private readonly DockedModeSettingsHost dockedModeSettingsHost;
         private readonly DockedModeSettingsHost dockedMeasurementSettingsHost;
         private readonly DockedModeSettingsHost dockedHistoryHost;
-        private Guid? currentHistoryEntryId;
-        private bool hasCurrentImpulseResponse;
+        private readonly MeasurementSessionTracker sessionTracker;
         private bool closingPrepared;
         private bool closingInProgress;
         private bool resourcesDisposed;
@@ -116,6 +115,9 @@ namespace Resonalyze
             microphoneCalibration = new MicrophoneCalibrationService(
                 GetConfiguredMicrophoneCalibrationPath,
                 ShowCalibrationProblem);
+            sessionTracker = new MeasurementSessionTracker(
+                measurementHistoryService,
+                CaptureCurrentSessionSnapshot);
             Form1ControllerDependencies dependencies = CreateControllerDependencies();
             overlayCollection = dependencies.OverlayCollection;
             plotLabelsPanelController = dependencies.PlotLabelsPanelController;

--- a/tests/Resonalyze.App.Tests/ActiveOverlaySlotTrackerTests.cs
+++ b/tests/Resonalyze.App.Tests/ActiveOverlaySlotTrackerTests.cs
@@ -1,0 +1,55 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The per-mode active-overlay-slot memory moved off Form1 into
+/// <see cref="ActiveOverlaySlotTracker"/>; these pin the capture/restore
+/// roundtrip and the Virtual DSP arm-new-slot path.
+/// </summary>
+public sealed class ActiveOverlaySlotTrackerTests
+{
+    [Fact]
+    public void TryGet_ReturnsFalseForAnUnknownMode()
+    {
+        var tracker = new ActiveOverlaySlotTracker();
+
+        Assert.False(tracker.TryGet(Mode.FrequencyResponse, out List<int> slots));
+        Assert.Empty(slots);
+    }
+
+    [Fact]
+    public void Store_RoundTripsPerMode()
+    {
+        var tracker = new ActiveOverlaySlotTracker();
+        tracker.Store(Mode.FrequencyResponse, [1, 3]);
+        tracker.Store(Mode.PhaseResponse, [2]);
+
+        Assert.True(tracker.TryGet(Mode.FrequencyResponse, out List<int> frequency));
+        Assert.Equal([1, 3], frequency);
+        Assert.True(tracker.TryGet(Mode.PhaseResponse, out List<int> phase));
+        Assert.Equal([2], phase);
+    }
+
+    [Fact]
+    public void MarkActive_CreatesTheModeListAndDeduplicates()
+    {
+        var tracker = new ActiveOverlaySlotTracker();
+
+        tracker.MarkActive(Mode.FrequencyResponse, 5);
+        tracker.MarkActive(Mode.FrequencyResponse, 5);
+
+        Assert.True(tracker.TryGet(Mode.FrequencyResponse, out List<int> slots));
+        Assert.Equal([5], slots);
+    }
+
+    [Fact]
+    public void MarkActive_AppendsToAStoredSelection()
+    {
+        var tracker = new ActiveOverlaySlotTracker();
+        tracker.Store(Mode.FrequencyResponse, [1]);
+
+        tracker.MarkActive(Mode.FrequencyResponse, 4);
+
+        Assert.True(tracker.TryGet(Mode.FrequencyResponse, out List<int> slots));
+        Assert.Equal([1, 4], slots);
+    }
+}

--- a/tests/Resonalyze.App.Tests/MeasurementSessionTrackerTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementSessionTrackerTests.cs
@@ -1,0 +1,185 @@
+using Resonalyze.History;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The current-measurement identity (history entry id + loaded-IR flag) moved
+/// off Form1 into <see cref="MeasurementSessionTracker"/>; these pin the
+/// transitions the shell relies on: load/save wiring into the history
+/// service, the persist guard, and the delete-keeps-the-loaded-IR rule.
+/// </summary>
+public sealed class MeasurementSessionTrackerTests : IDisposable
+{
+    private readonly string directory;
+    private int sessionCaptures;
+
+    public MeasurementSessionTrackerTests()
+    {
+        directory = Path.Combine(
+            Path.GetTempPath(),
+            $"resonalyze-session-tracker-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public void Initially_NothingIsCurrentAndPersistIsANoOp()
+    {
+        (MeasurementSessionTracker tracker, _) = CreateTracker();
+
+        tracker.PersistCurrentSessionState();
+
+        Assert.Null(tracker.CurrentEntryId);
+        Assert.False(tracker.HasImpulseResponse);
+        Assert.Equal(0, sessionCaptures);
+    }
+
+    [Fact]
+    public async Task MarkLoadedFile_CreatesTheFileBackedEntryAndMakesItCurrent()
+    {
+        (MeasurementSessionTracker tracker, MeasurementHistoryService history) =
+            CreateTracker();
+        (string path, ImpulseResponseFile file) = await CreateImpulseResponseFileAsync(
+            "a.json");
+
+        tracker.MarkLoadedFile(path, file);
+
+        Assert.True(tracker.HasImpulseResponse);
+        Assert.NotNull(tracker.CurrentEntryId);
+        MeasurementHistoryEntry entry = Assert.Single(history.Entries);
+        Assert.Equal(entry.Id, tracker.CurrentEntryId);
+        Assert.Equal(path, entry.SourceFilePath);
+    }
+
+    [Fact]
+    public async Task MarkSavedFile_WithoutACurrentEntry_CreatesOneAndMakesItCurrent()
+    {
+        (MeasurementSessionTracker tracker, MeasurementHistoryService history) =
+            CreateTracker();
+        (string path, ImpulseResponseFile file) = await CreateImpulseResponseFileAsync(
+            "saved.json");
+
+        tracker.MarkSavedFile(path, file);
+
+        MeasurementHistoryEntry entry = Assert.Single(history.Entries);
+        Assert.Equal(entry.Id, tracker.CurrentEntryId);
+        Assert.Equal(path, entry.SourceFilePath);
+    }
+
+    [Fact]
+    public async Task MarkSavedFile_WithACurrentEntry_MarksItSavedAndKeepsItCurrent()
+    {
+        (MeasurementSessionTracker tracker, MeasurementHistoryService history) =
+            CreateTracker();
+        (string loadedPath, ImpulseResponseFile loadedFile) =
+            await CreateImpulseResponseFileAsync("a.json");
+        tracker.MarkLoadedFile(loadedPath, loadedFile);
+        Guid? currentBeforeSave = tracker.CurrentEntryId;
+        (string savedPath, ImpulseResponseFile savedFile) =
+            await CreateImpulseResponseFileAsync("b.json");
+
+        tracker.MarkSavedFile(savedPath, savedFile);
+
+        Assert.Equal(currentBeforeSave, tracker.CurrentEntryId);
+        MeasurementHistoryEntry entry = Assert.Single(history.Entries);
+        Assert.Equal(savedPath, entry.SourceFilePath);
+    }
+
+    [Fact]
+    public async Task ForgetEntry_DropsTheCurrentPointerButKeepsTheLoadedIr()
+    {
+        (MeasurementSessionTracker tracker, _) = CreateTracker();
+        (string path, ImpulseResponseFile file) = await CreateImpulseResponseFileAsync(
+            "a.json");
+        tracker.MarkLoadedFile(path, file);
+        Guid current = tracker.CurrentEntryId!.Value;
+
+        tracker.ForgetEntry(Guid.NewGuid());
+        Assert.Equal(current, tracker.CurrentEntryId);
+
+        tracker.ForgetEntry(current);
+        Assert.Null(tracker.CurrentEntryId);
+        Assert.True(tracker.HasImpulseResponse);
+    }
+
+    [Fact]
+    public async Task PersistCurrentSessionState_WritesTheCapturedSessionIntoTheEntry()
+    {
+        (MeasurementSessionTracker tracker, MeasurementHistoryService history) =
+            CreateTracker();
+        (string path, ImpulseResponseFile file) = await CreateImpulseResponseFileAsync(
+            "a.json");
+        tracker.MarkLoadedFile(path, file);
+        int capturesAfterLoad = sessionCaptures;
+
+        tracker.PersistCurrentSessionState();
+
+        Assert.Equal(capturesAfterLoad + 1, sessionCaptures);
+        Assert.NotNull(history.FindById(tracker.CurrentEntryId!.Value)!.Session);
+    }
+
+    [Fact]
+    public async Task PersistCurrentSessionState_SkipsWhenNoImpulseResponseIsLoaded()
+    {
+        (MeasurementSessionTracker tracker, _) = CreateTracker();
+        (string path, ImpulseResponseFile file) = await CreateImpulseResponseFileAsync(
+            "a.json");
+        tracker.MarkLoadedFile(path, file);
+        tracker.SetImpulseResponseAvailable(false);
+        int capturesAfterLoad = sessionCaptures;
+
+        tracker.PersistCurrentSessionState();
+
+        Assert.Equal(capturesAfterLoad, sessionCaptures);
+    }
+
+    [Fact]
+    public void MarkRestoredAndReset_ToggleTheWholeIdentity()
+    {
+        (MeasurementSessionTracker tracker, _) = CreateTracker();
+        Guid entryId = Guid.NewGuid();
+
+        tracker.MarkRestored(entryId);
+        Assert.Equal(entryId, tracker.CurrentEntryId);
+        Assert.True(tracker.HasImpulseResponse);
+
+        tracker.Reset();
+        Assert.Null(tracker.CurrentEntryId);
+        Assert.False(tracker.HasImpulseResponse);
+    }
+
+    private (MeasurementSessionTracker Tracker, MeasurementHistoryService History)
+        CreateTracker()
+    {
+        var history = new MeasurementHistoryService(new MeasurementHistoryPersistence(
+            Path.Combine(directory, "measurement-history.json")));
+        var tracker = new MeasurementSessionTracker(
+            history,
+            () =>
+            {
+                sessionCaptures++;
+                return new MeasurementSessionSnapshot();
+            });
+        return (tracker, history);
+    }
+
+    private async Task<(string Path, ImpulseResponseFile File)>
+        CreateImpulseResponseFileAsync(string fileName)
+    {
+        string path = Path.Combine(directory, fileName);
+        ImpulseResponseFile file = ImpulseResponseFileAtomicSaveTests.CreateFile(
+            sampleValue: 1.0);
+        await file.SaveAsync(path);
+        return (path, file);
+    }
+}


### PR DESCRIPTION
Third slice of the ★ "Form1 is the concurrency hub" TODO item, following up on #8. Form1 loses its last collection field and three more mutable fields; what remains on the form is the lifecycle/close flags and transient UI state — inherently form-bound, so this slice effectively closes the concurrency-risk part of the ★ item.

## Extracted classes

- **`MeasurementSessionTracker`** — owns the current-measurement identity that lived as two raw fields (`currentHistoryEntryId` + `hasCurrentImpulseResponse`) touched from six partials. Every transition that pairs those flags with a `MeasurementHistoryService` call goes through one place now: finished sweep (`MarkMeasurementCompleted`), loaded/saved file (`MarkLoadedFile`/`MarkSavedFile`, including the create-entry-when-nothing-is-current save path), restored entry (`MarkRestored`), deleted entry (`ForgetEntry` — drops the pointer but keeps the loaded IR usable), fresh session (`Reset`), and the persist-working-state guard (`PersistCurrentSessionState`). The session capture stays on Form1 and is injected as a delegate.
- **`ActiveOverlaySlotTracker`** — owns the per-mode active-overlay-slot dictionary; mode switches capture/restore through it, and the Virtual DSP overlay capture arms its freshly saved slot with one `MarkActive` call instead of inline dictionary fiddling.

## Behavior notes

No intended behavior changes. Call ordering is preserved where it matters: the loaded-IR flag is still set before `SelectModeAsync` during a history restore (the mode switch draws the current measurement only when the flag is up), and the session snapshot is still captured at the same points as before (after the file save / after the loaded state is applied).

## Tests

11 new App.Tests (Windows CI): tracker transitions against a real `MeasurementHistoryService` with temp persistence — load creates the file-backed entry and makes it current, save with/without a current entry, delete keeps the loaded IR, persist writes the captured session into the entry and skips when nothing is loaded, restore/reset toggle the whole identity; slot tracker store/roundtrip, dedup, append-to-stored.

Local: full solution build clean (0 warnings), dsp tests 276/276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_