### PR TITLE
Reliability-anchored phase unwrap with coherence weighting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,9 +16,6 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 - [ ] **`CrossoverAutoSetup.Optimizer.Score()` recomputes every channel** on
   each junction/gain trial (~300–1500 calls per junction). Filter magnitudes
   are cached, but the amplitudes of untouched channels are not.
-- [ ] **Naive neighbor-to-neighbor phase unwrap** (`DataHelper`): one noisy
-  bin shifts the whole tail by ±2π; the 100 Hz threshold softens but doesn't
-  cure it. Consider magnitude/coherence-weighted unwrapping.
 - [ ] **Duplication:** the coherence formula lives twice
   (`SpectrumAnalysis.ComputeCoherence` vs inline in
   `TransferFunction.ComputeAveragedRelativeIr`); `DspChannelChain.Response`

--- a/dsp/DataHelper.cs
+++ b/dsp/DataHelper.cs
@@ -326,7 +326,8 @@ namespace Resonalyze.Dsp
             int offset,
             int length,
             double[] window,
-            bool unwrap)
+            bool unwrap,
+            IReadOnlyList<double>? coherence = null)
         {
             Complex[] spectrum = ExtractWindow(
                 measurement,
@@ -343,7 +344,8 @@ namespace Resonalyze.Dsp
                 extractionStart: offset,
                 referenceSamples: 0,
                 measurement.SampleRate,
-                unwrap);
+                unwrap,
+                coherence);
         }
 
         // Fixed analysis length for the gated phase / group-delay FFTs. The gate
@@ -413,24 +415,61 @@ namespace Resonalyze.Dsp
             return spectrum;
         }
 
+        // Reliability gates for the unwrapped phase: bins this far below the peak
+        // magnitude — or with squared coherence below the floor, when coherence is
+        // available — still contribute their phase to the output, but never anchor
+        // the unwrap, so one noisy or masked bin cannot shift the whole tail by 2π.
+        // The magnitude gate matches the group-delay validity gate; γ² = 0.5 is the
+        // point where less than half the measured energy is coherent with the
+        // reference and the per-bin phase variance makes branch choices unsafe.
+        private const double UnwrapMagnitudeGateDb = -30.0;
+        private const double UnwrapCoherenceFloor = 0.5;
+        // Blend factor for the running dφ/df estimate used to predict the next
+        // bin's phase; the smoothing keeps a single jittery-but-reliable bin from
+        // steering the branch choice for the bins that follow.
+        private const double UnwrapSlopeBlend = 0.25;
+
         // Measured phase (radians) referenced to an absolute sample, for bins
         // 1..n/2-1. The reference is shared across measurements (common origin), so
         // setting it equal across two captures preserves their relative phase; setting
         // it to a measurement's own arrival flattens that curve.
+        //
+        // Unwrapping is anchored to reliable bins: each bin takes the 2π branch
+        // closest to the phase predicted from the last reliable anchor and a running
+        // slope estimate. Unreliable bins (nulls, noise-floor, low coherence) get a
+        // branch too, but never become anchors, so the unwrap bridges them instead
+        // of accumulating their phase noise into the tail. With every bin reliable
+        // and a zero slope this reduces to the classic nearest-to-previous choice.
         private static List<SignalPoint> BuildMeasuredPhase(
             Complex[] spectrum,
             int extractionStart,
             double referenceSamples,
             int sampleRate,
-            bool unwrap)
+            bool unwrap,
+            IReadOnlyList<double>? coherence = null)
         {
             int n = spectrum.Length;
             double referenceShift = referenceSamples - extractionStart;
             var data = new List<SignalPoint>(n / 2);
 
             const double minFrequency = 100;
-            double phaseAccumulator = 0.0;
-            double prevWrapped = 0.0;
+
+            double maxMagnitude = 0.0;
+            if (unwrap)
+            {
+                for (int i = 1; i < n / 2; i++)
+                {
+                    maxMagnitude = Math.Max(maxMagnitude, spectrum[i].Magnitude);
+                }
+            }
+            double minReliableMagnitude =
+                maxMagnitude * Math.Pow(10.0, UnwrapMagnitudeGateDb / 20.0);
+
+            bool hasAnchor = false;
+            bool hasSlope = false;
+            double anchorFrequency = 0.0;
+            double anchorPhase = 0.0;
+            double slope = 0.0; // rad per Hz
 
             for (int i = 1; i < n / 2; i++)
             {
@@ -446,20 +485,72 @@ namespace Resonalyze.Dsp
                     continue;
                 }
 
-                if (i > 1 && f >= minFrequency)
+                if (f < minFrequency || !hasAnchor)
                 {
-                    double delta = wrapped - prevWrapped;
-                    if (delta > Math.PI)
-                        phaseAccumulator -= Math.Tau;
-                    else if (delta < -Math.PI)
-                        phaseAccumulator += Math.Tau;
+                    // Below the unwrap floor the output stays wrapped (unchanged
+                    // behavior); the running bin still seeds the anchor so the
+                    // unwrap continues seamlessly from the last one.
+                    data.Add(new SignalPoint(f, wrapped));
+                    anchorFrequency = f;
+                    anchorPhase = wrapped;
+                    hasAnchor = true;
+                    continue;
                 }
 
-                prevWrapped = wrapped;
-                data.Add(new SignalPoint(f, wrapped + phaseAccumulator));
+                double predicted = anchorPhase + slope * (f - anchorFrequency);
+                double branch = Math.Round((predicted - wrapped) / Math.Tau);
+                double unwrappedPhase = wrapped + Math.Tau * branch;
+
+                bool reliable = spectrum[i].Magnitude >= minReliableMagnitude &&
+                    (coherence == null ||
+                     CoherenceAt(coherence, f, sampleRate) >= UnwrapCoherenceFloor);
+                if (reliable && f > anchorFrequency)
+                {
+                    double localSlope =
+                        (unwrappedPhase - anchorPhase) / (f - anchorFrequency);
+                    slope = hasSlope
+                        ? UnwrapSlopeBlend * localSlope + (1.0 - UnwrapSlopeBlend) * slope
+                        : localSlope;
+                    hasSlope = true;
+                    anchorFrequency = f;
+                    anchorPhase = unwrappedPhase;
+                }
+
+                data.Add(new SignalPoint(f, unwrappedPhase));
             }
 
             return data;
+        }
+
+        // Squared coherence at a frequency, linearly interpolated from an array
+        // covering 0..Nyquist in uniform bins (length fftLength/2 + 1 — the layout
+        // produced by TransferFunction.ComputeAveragedRelativeIr), so the coherence
+        // grid does not need to match the phase FFT grid. Degenerate inputs count
+        // as trusted, mirroring how the plots treat missing coherence coverage.
+        private static double CoherenceAt(
+            IReadOnlyList<double> coherence,
+            double frequency,
+            int sampleRate)
+        {
+            if (coherence.Count < 2 || sampleRate <= 0)
+            {
+                return 1.0;
+            }
+
+            double position = frequency * (coherence.Count - 1) * 2.0 / sampleRate;
+            if (position <= 0.0)
+            {
+                return coherence[0];
+            }
+            if (position >= coherence.Count - 1)
+            {
+                return coherence[coherence.Count - 1];
+            }
+
+            int index = (int)Math.Floor(position);
+            double fraction = position - index;
+            return coherence[index] +
+                (coherence[index + 1] - coherence[index]) * fraction;
         }
 
         /// <summary>
@@ -477,7 +568,8 @@ namespace Resonalyze.Dsp
             double plateauMs,
             double rightMs,
             double referenceSamples,
-            bool unwrap)
+            bool unwrap,
+            IReadOnlyList<double>? coherence = null)
         {
             Complex[] spectrum = BuildPhaseSpectrum(
                 measurement,
@@ -491,7 +583,8 @@ namespace Resonalyze.Dsp
                 extractionStart,
                 referenceSamples,
                 measurement.SampleRate,
-                unwrap);
+                unwrap,
+                coherence);
         }
 
         public static AnalysisCurve GetPhase(
@@ -502,7 +595,8 @@ namespace Resonalyze.Dsp
             double rightMs,
             double detrendMilliseconds,
             double smoothingInverseOctaves,
-            bool unwrap)
+            bool unwrap,
+            IReadOnlyList<double>? coherence = null)
         {
             List<SignalPoint> phase = GetGatedPhaseData(
                 measurement,
@@ -511,7 +605,8 @@ namespace Resonalyze.Dsp
                 plateauMs,
                 rightMs,
                 detrendMilliseconds * measurement.SampleRate / 1000.0,
-                unwrap);
+                unwrap,
+                coherence);
 
             List<SignalPoint> data = new(phase.Count);
             foreach (SignalPoint point in phase)
@@ -613,7 +708,8 @@ namespace Resonalyze.Dsp
             double plateauMs,
             double rightMs,
             double detrendMilliseconds,
-            double smoothingInverseOctaves)
+            double smoothingInverseOctaves,
+            IReadOnlyList<double>? coherence = null)
         {
             Complex[] spectrum = BuildPhaseSpectrum(
                 measurement,
@@ -634,7 +730,8 @@ namespace Resonalyze.Dsp
                 extractionStart,
                 referenceSamples,
                 measurement.SampleRate,
-                unwrap: true);
+                unwrap: true,
+                coherence);
 
             int n = spectrum.Length;
             double[] magnitude = new double[n];

--- a/dsp/DataHelper.cs
+++ b/dsp/DataHelper.cs
@@ -485,25 +485,29 @@ namespace Resonalyze.Dsp
                     continue;
                 }
 
+                bool reliable = spectrum[i].Magnitude >= minReliableMagnitude &&
+                    (coherence == null ||
+                     CoherenceAt(coherence, f, sampleRate) >= UnwrapCoherenceFloor);
+
                 if (f < minFrequency || !hasAnchor)
                 {
                     // Below the unwrap floor the output stays wrapped (unchanged
-                    // behavior); the running bin still seeds the anchor so the
-                    // unwrap continues seamlessly from the last one.
+                    // behavior); a running bin seeds the anchor only when it
+                    // passes the same reliability gate, so a garbage bin near the
+                    // floor cannot offset the first unwrapped branch by 2π.
                     data.Add(new SignalPoint(f, wrapped));
-                    anchorFrequency = f;
-                    anchorPhase = wrapped;
-                    hasAnchor = true;
+                    if (reliable)
+                    {
+                        anchorFrequency = f;
+                        anchorPhase = wrapped;
+                        hasAnchor = true;
+                    }
                     continue;
                 }
 
                 double predicted = anchorPhase + slope * (f - anchorFrequency);
                 double branch = Math.Round((predicted - wrapped) / Math.Tau);
                 double unwrappedPhase = wrapped + Math.Tau * branch;
-
-                bool reliable = spectrum[i].Magnitude >= minReliableMagnitude &&
-                    (coherence == null ||
-                     CoherenceAt(coherence, f, sampleRate) >= UnwrapCoherenceFloor);
                 if (reliable && f > anchorFrequency)
                 {
                     double localSlope =

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -160,7 +160,8 @@ internal sealed class PlotModelFactory
                     phaseResponseOptions.PhaseRightMs,
                     phaseResponseOptions.PhaseDetrendMs,
                     phaseResponseOptions.SmoothingInverseOctaves,
-                    phaseResponseOptions.Unwrap);
+                    phaseResponseOptions.Unwrap,
+                    expSweepMeasurement.TransferCoherence);
 
                 // Measured phase can be either representation; tag it so overlay
                 // math knows whether a difference must use the wrapped formula.
@@ -202,7 +203,8 @@ internal sealed class PlotModelFactory
                     phaseResponseOptions.PhasePlateauMs,
                     phaseResponseOptions.PhaseRightMs,
                     phaseResponseOptions.PhaseDetrendMs,
-                    phaseResponseOptions.SmoothingInverseOctaves);
+                    phaseResponseOptions.SmoothingInverseOctaves,
+                    expSweepMeasurement.TransferCoherence);
 
                 // Excess phase stays continuous (unwrapped) regardless of the detrend
                 // choice; a residual slope is still an unwrapped representation.
@@ -229,7 +231,8 @@ internal sealed class PlotModelFactory
                         phaseResponseOptions.PhaseRightMs,
                         phaseResponseOptions.PhaseDetrendMs,
                         phaseResponseOptions.SmoothingInverseOctaves,
-                        phaseResponseOptions.Unwrap);
+                        phaseResponseOptions.Unwrap,
+                        compare.Coherence);
                     AddCompareLineSeries(
                         model,
                         compareCurve,
@@ -266,7 +269,8 @@ internal sealed class PlotModelFactory
                         phaseResponseOptions.PhasePlateauMs,
                         phaseResponseOptions.PhaseRightMs,
                         phaseResponseOptions.PhaseDetrendMs,
-                        phaseResponseOptions.SmoothingInverseOctaves);
+                        phaseResponseOptions.SmoothingInverseOctaves,
+                        compare.Coherence);
                     AddCompareLineSeries(
                         model,
                         compareCurve,
@@ -1040,7 +1044,8 @@ internal sealed class PlotModelFactory
     // Builds a view over the Compare transfer IR so the gated phase / group-delay
     // math runs on it identically. Requires a matching sample rate, otherwise the
     // gate (in ms) and the frequency axis would not align with the main measurement.
-    private (IImpulseMeasurement Measurement, string DisplayName)? TryCreateCompareMeasurement()
+    private (IImpulseMeasurement Measurement, string DisplayName, double[]? Coherence)?
+        TryCreateCompareMeasurement()
     {
         if (getCompareSource?.Invoke() is not { } compare)
         {
@@ -1056,7 +1061,8 @@ internal sealed class PlotModelFactory
         int peakIndex = Math.Clamp(compare.TransferPeakIndex, 0, transferIr.Length - 1);
         return (
             new ImpulseMeasurementView(transferIr, peakIndex, compare.SampleRate),
-            compare.DisplayName);
+            compare.DisplayName,
+            compare.TransferCoherence);
     }
 
     // The Compare sweep-deconvolution measurement, used for the Frequency Response

--- a/source/Shell/CompareSelection.cs
+++ b/source/Shell/CompareSelection.cs
@@ -52,7 +52,8 @@ internal sealed class CompareSelection
             selection.Snapshot.TransferImpulseResponse ?? Array.Empty<Complex>(),
             selection.Snapshot.TransferPeakIndex ?? 0,
             sweepIr,
-            selection.Snapshot.SweepDeconvolutionPeakIndex);
+            selection.Snapshot.SweepDeconvolutionPeakIndex,
+            selection.Snapshot.TransferCoherence);
     }
 
     public TimeAlignmentCompareMeasurement? GetTimeAlignmentMeasurement() =>
@@ -77,4 +78,5 @@ public readonly record struct CompareAnalysisSource(
     Complex[] TransferImpulseResponse,
     int TransferPeakIndex,
     Complex[] SweepDeconvolutionImpulseResponse,
-    int SweepDeconvolutionPeakIndex);
+    int SweepDeconvolutionPeakIndex,
+    double[]? TransferCoherence = null);

--- a/tests/Resonalyze.App.Tests/CompareSelectionTests.cs
+++ b/tests/Resonalyze.App.Tests/CompareSelectionTests.cs
@@ -46,10 +46,12 @@ public sealed class CompareSelectionTests
         var selection = new CompareSelection();
         Complex[] sweepIr = [new(1, 0), new(0.5, 0)];
         Complex[] transferIr = [new(0.25, 0)];
+        double[] coherence = [1.0, 0.5, 0.9];
         selection.Set("a.json", null, CreateSnapshot(
             sweepIr,
             transferIr,
-            transferPeakIndex: 7));
+            transferPeakIndex: 7,
+            coherence));
 
         CompareAnalysisSource? source = selection.GetAnalysisSource();
 
@@ -60,6 +62,7 @@ public sealed class CompareSelectionTests
         Assert.Equal(3, source.Value.SweepDeconvolutionPeakIndex);
         Assert.Same(transferIr, source.Value.TransferImpulseResponse);
         Assert.Equal(7, source.Value.TransferPeakIndex);
+        Assert.Same(coherence, source.Value.TransferCoherence);
     }
 
     [Fact]
@@ -88,7 +91,8 @@ public sealed class CompareSelectionTests
     private static MeasurementHistorySnapshot CreateSnapshot(
         Complex[]? sweepIr = null,
         Complex[]? transferIr = null,
-        int? transferPeakIndex = null) =>
+        int? transferPeakIndex = null,
+        double[]? coherence = null) =>
         new()
         {
             SampleRate = 48_000,
@@ -96,6 +100,7 @@ public sealed class CompareSelectionTests
             SweepDeconvolutionPeakIndex = 3,
             TransferImpulseResponse = transferIr,
             TransferPeakIndex = transferPeakIndex,
+            TransferCoherence = coherence,
             MeterSnapshot = InputLevelMeterSnapshot.Empty,
             Preview = new MeasurementHistoryPreview()
         };

--- a/tests/Resonalyze.Dsp.Tests/PhaseUnwrapTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/PhaseUnwrapTests.cs
@@ -1,0 +1,161 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The unwrap in BuildMeasuredPhase is anchored to reliable bins (relative
+/// magnitude, optionally squared coherence): a noisy null or a low-coherence
+/// band contributes its phase to the output but can no longer shift the whole
+/// tail by 2π. The corrupted spectra here are crafted so the classic
+/// nearest-to-previous-bin unwrap provably mis-accumulates (+2π into the
+/// tail): the first garbage bin sits just past −π from its neighbor and the
+/// second one steps back in-range, so nothing ever compensates.
+/// </summary>
+public sealed class PhaseUnwrapTests
+{
+    private const int SampleRate = 48_000;
+    private const int TransformLength = 4096;
+    private const int DelaySamples = 24;
+    // Bin 512 of 4096 at 48 kHz = 6 kHz, where the true wrapped phase of the
+    // 24-sample delay is exactly 0 (512·24/4096 = 3 full turns) — the garbage
+    // phases below are chosen relative to that.
+    private const int CorruptedBin = 512;
+    private const double GarbagePhase1 = -3.12;
+    private const double GarbagePhase2 = -1.5;
+
+    [Fact]
+    public void Unwrap_BridgesANoisyNull_WithoutShiftingTheTail()
+    {
+        // A deep null (−80 dB) with garbage phase: the magnitude gate alone
+        // must keep the tail on the true delay line.
+        SyntheticMeasurement measurement = CreateDelayedImpulseWithCorruptedBins(
+            corruptedMagnitude: 1e-4);
+
+        List<SignalPoint> phase = GetUnwrappedPhase(measurement, coherence: null);
+
+        AssertTailOnDelayLine(phase);
+    }
+
+    [Fact]
+    public void Unwrap_UsesCoherence_WhenTheGarbageBinsHaveFullMagnitude()
+    {
+        // Full-magnitude garbage (e.g. a masked band in a noisy room): the
+        // magnitude gate cannot see it, so only the coherence floor keeps the
+        // bins from anchoring the unwrap. The coherence array deliberately
+        // uses a coarser grid than the phase FFT (1025 bins = fftLength 2048)
+        // to exercise the frequency-based interpolation.
+        SyntheticMeasurement measurement = CreateDelayedImpulseWithCorruptedBins(
+            corruptedMagnitude: 1.0);
+        double[] coherence = new double[1025];
+        Array.Fill(coherence, 0.95);
+        int coherenceFftLength = (coherence.Length - 1) * 2;
+        for (int bin = 0; bin < coherence.Length; bin++)
+        {
+            double f = bin * (double)SampleRate / coherenceFftLength;
+            if (f is >= 5_800 and <= 6_200)
+            {
+                coherence[bin] = 0.1;
+            }
+        }
+
+        List<SignalPoint> phase = GetUnwrappedPhase(measurement, coherence);
+
+        AssertTailOnDelayLine(phase);
+    }
+
+    [Fact]
+    public void Unwrap_WithUniformlyHighCoherence_MatchesTheUnweightedResult()
+    {
+        var response = new Complex[TransformLength];
+        response[DelaySamples] = Complex.One;
+        var measurement = new SyntheticMeasurement(
+            response,
+            SampleRate,
+            maxMagnitudeIndex: 0);
+        double[] coherence = new double[1025];
+        Array.Fill(coherence, 1.0);
+
+        List<SignalPoint> unweighted = GetUnwrappedPhase(measurement, coherence: null);
+        List<SignalPoint> weighted = GetUnwrappedPhase(measurement, coherence);
+
+        Assert.Equal(unweighted.Count, weighted.Count);
+        for (int i = 0; i < unweighted.Count; i++)
+        {
+            Assert.Equal(unweighted[i].X, weighted[i].X);
+            Assert.Equal(unweighted[i].Y, weighted[i].Y);
+        }
+    }
+
+    private static List<SignalPoint> GetUnwrappedPhase(
+        SyntheticMeasurement measurement,
+        IReadOnlyList<double>? coherence)
+    {
+        double[] rectangularWindow =
+            Enumerable.Repeat(1.0, TransformLength).ToArray();
+        return DataHelper.GetPhaseData(
+            measurement,
+            offset: 0,
+            length: TransformLength,
+            window: rectangularWindow,
+            unwrap: true,
+            coherence);
+    }
+
+    // The delayed impulse in the frequency domain (H_k = e^{-i·2πk·d/n}) with
+    // two corrupted bins: garbage phases at the given magnitude, mirrored so
+    // the time-domain signal stays real.
+    private static SyntheticMeasurement CreateDelayedImpulseWithCorruptedBins(
+        double corruptedMagnitude)
+    {
+        var spectrum = new Complex[TransformLength];
+        for (int k = 0; k < TransformLength; k++)
+        {
+            double phase = -Math.Tau * k * DelaySamples / TransformLength;
+            spectrum[k] = Complex.FromPolarCoordinates(1.0, phase);
+        }
+
+        SetBinWithMirror(spectrum, CorruptedBin, corruptedMagnitude, GarbagePhase1);
+        SetBinWithMirror(spectrum, CorruptedBin + 1, corruptedMagnitude, GarbagePhase2);
+
+        MathNet.Numerics.IntegralTransforms.Fourier.Inverse(
+            spectrum,
+            MathNet.Numerics.IntegralTransforms.FourierOptions.Matlab);
+        return new SyntheticMeasurement(spectrum, SampleRate, maxMagnitudeIndex: 0);
+    }
+
+    private static void SetBinWithMirror(
+        Complex[] spectrum,
+        int bin,
+        double magnitude,
+        double phase)
+    {
+        spectrum[bin] = Complex.FromPolarCoordinates(magnitude, phase);
+        spectrum[spectrum.Length - bin] = Complex.Conjugate(spectrum[bin]);
+    }
+
+    // Beyond the corrupted band the unwrapped phase must sit on the analytic
+    // delay line −2πf·d/sr; a 2π tail shift would miss by ~6.28 rad.
+    private static void AssertTailOnDelayLine(List<SignalPoint> phase)
+    {
+        List<SignalPoint> tail = phase
+            .Where(point => point.X >= 7_000 && point.X <= 18_000)
+            .ToList();
+        Assert.NotEmpty(tail);
+        foreach (SignalPoint point in tail)
+        {
+            double expected = -Math.Tau * point.X * DelaySamples / SampleRate;
+            Assert.InRange(point.Y, expected - 1.0, expected + 1.0);
+        }
+
+        // And the clean stretch before the corruption stays correct too.
+        List<SignalPoint> head = phase
+            .Where(point => point.X >= 1_000 && point.X <= 5_500)
+            .ToList();
+        Assert.NotEmpty(head);
+        foreach (SignalPoint point in head)
+        {
+            double expected = -Math.Tau * point.X * DelaySamples / SampleRate;
+            Assert.InRange(point.Y, expected - 1.0, expected + 1.0);
+        }
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/PhaseUnwrapTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/PhaseUnwrapTests.cs
@@ -64,6 +64,34 @@ public sealed class PhaseUnwrapTests
     }
 
     [Fact]
+    public void Unwrap_DoesNotAnchorOnAGarbageBinBelowTheFloor()
+    {
+        // A garbage null just below the 100 Hz unwrap floor (bin 8 = 93.75 Hz)
+        // must stay display-only: if it seeded the anchor, the first reliable
+        // bin above the floor would branch against its phase (3.33 rad away
+        // from the true value here) and carry a spurious +2π into everything
+        // that follows.
+        var spectrum = new Complex[TransformLength];
+        for (int k = 0; k < TransformLength; k++)
+        {
+            double phase = -Math.Tau * k * DelaySamples / TransformLength;
+            spectrum[k] = Complex.FromPolarCoordinates(1.0, phase);
+        }
+        SetBinWithMirror(spectrum, bin: 8, magnitude: 1e-4, phase: 3.0);
+        MathNet.Numerics.IntegralTransforms.Fourier.Inverse(
+            spectrum,
+            MathNet.Numerics.IntegralTransforms.FourierOptions.Matlab);
+        var measurement = new SyntheticMeasurement(
+            spectrum,
+            SampleRate,
+            maxMagnitudeIndex: 0);
+
+        List<SignalPoint> phaseData = GetUnwrappedPhase(measurement, coherence: null);
+
+        AssertTailOnDelayLine(phaseData);
+    }
+
+    [Fact]
     public void Unwrap_WithUniformlyHighCoherence_MatchesTheUnweightedResult()
     {
         var response = new Complex[TransformLength];


### PR DESCRIPTION
Closes the "naive neighbor-to-neighbor phase unwrap" TODO item: one noisy bin could shift the whole unwrapped tail by ±2π, and the 100 Hz floor only softened that.

## Algorithm

`BuildMeasuredPhase` now anchors the unwrap to reliable bins. Each bin takes the 2π branch closest to a phase **predicted** from the last reliable anchor plus a running dφ/df estimate (exponentially blended so a single jittery-but-reliable bin cannot steer the branch choices that follow). A bin is unreliable when it sits more than 30 dB below the peak magnitude (the same validity gate group delay uses) — or, when the measurement has coherence (averaged runs), when its γ² is below 0.5. Unreliable bins still contribute their phase to the output, but never become anchors, so a noisy null or a masked band is **bridged** instead of accumulating into the tail.

Degenerate cases reduce exactly to the previous behavior: with every bin reliable and a zero slope the branch choice is the classic nearest-to-previous-bin one, so clean measurements produce bit-identical curves — the pre-existing phase-slope test with its 1e-10 tolerance pins this, and it passes unchanged. Output below the 100 Hz floor stays wrapped, as before.

## Coherence plumbing

This is where coherence earns its keep: a magnitude gate cannot see full-level bins whose *phase* is garbage (noisy room, masked band) — the coherence floor can. The optional `coherence` parameter on `GetPhase` / `GetGatedPhaseData` / `GetPhaseData` / `GetExcessPhase` accepts the transfer-FFT-grid array (`fftLength/2 + 1` bins to Nyquist, the `ComputeAveragedRelativeIr` layout) and interpolates it by frequency, so the coherence grid does not need to match the phase FFT grid.

- `PlotModelFactory` threads `TransferCoherence` into the main and Compare measured-phase and excess-phase curves.
- `CompareAnalysisSource` now carries the Compare snapshot's `TransferCoherence`.
- Group delay is untouched (derivative formula, no unwrap); the Virtual DSP phase view uses wrapped output and is unaffected.

## Tests

Three new dsp tests build spectra where the old accumulator provably mis-unwraps (the two garbage bins are placed so the first delta crosses −π and nothing ever compensates — analytic +2π tail shift, far outside the 1 rad assertion band):

- a −80 dB garbage null bridged by the magnitude gate alone;
- full-magnitude garbage bridged **only** by the coherence floor, with the coherence array on a deliberately coarser grid (1025 bins vs the 4096-point phase FFT) to exercise the frequency-based interpolation;
- exact bin-by-bin parity between weighted and unweighted output when coherence is uniformly high.

`CompareSelectionTests` extended for the coherence mapping. Local: 279 dsp tests pass, full solution builds with 0 warnings.

Nice-to-have live check on Windows: the phase tail of a noisy averaged measurement should no longer jump by multiples of 360° past deep nulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_