### PR TITLE
DSP layer cleanup: flatness test, coherence dedup, documented constants

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,21 +16,30 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 - [ ] **`CrossoverAutoSetup.Optimizer.Score()` recomputes every channel** on
   each junction/gain trial (~300–1500 calls per junction). Filter magnitudes
   are cached, but the amplitudes of untouched channels are not.
-- [ ] **Duplication:** the coherence formula lives twice
-  (`SpectrumAnalysis.ComputeCoherence` vs inline in
-  `TransferFunction.ComputeAveragedRelativeIr`); `DspChannelChain.Response`
-  re-implements `PreparedDspResponse.Create`;
-  `SweepAnalysis.DeconvolveWithInverseFilter` has three overloads with manual
-  float→double conversion; the single-frame `TransferFunction.ComputeRelativeIr`
-  is dead outside tests.
+- [ ] **Duplication (partly resolved, partly deliberate):** the coherence
+  formula no longer lives twice — `TransferFunction.ComputeAveragedRelativeIr`
+  now calls `SpectrumAnalysis.ComputeCoherence`. The unused
+  `SweepAnalysis.DeconvolveWithInverseFilter(float, double)` overload was
+  removed; the remaining two share the single `ToDoubles` converter.
+  **Kept by design:** `DspChannelChain.Response` looks like a re-implementation
+  of `PreparedDspResponse` but is the independent per-frequency reference the
+  DSP tests use as an oracle (`PreparedDspResponse_MatchesDspChannelChainResponse`,
+  `ApplyChain_MatchesReference`) — merging it would make those checks tautological.
+  The single-frame `TransferFunction.ComputeRelativeIr` is unused in production
+  but shares all its internals with the averaged path (no code is duplicated) and
+  is the directly-tested single-frame H1 primitive with a `filter` parameter, so
+  it stays as a tested entry point.
 - [ ] **`FrequencyResponseOptions` is a grab-bag** mixing FR windows,
   phase/group-delay gates and a dozen UI visibility flags (`ShowHd2`,
   `ShowGroupDelay`, …) — presentation flags leaked into the DSP library.
 - [ ] **`DataHelper` is a ~1160-line god-object**; split into
   Spectrum/Phase/Impulse/Resampling modules.
-- [ ] **Undocumented magic numbers in harmonic analysis** (`DataHelper`):
-  window bounds `h+0.03`/`h−0.5`, THD window `5.5…1.5`, silent doubling of
-  harmonic smoothing. Document or name them.
+- [x] **Undocumented magic numbers in harmonic analysis** (`DataHelper`) —
+  done. Named and documented: `HarmonicWindowUpperGuard`/`HarmonicWindowLowerReach`
+  (the `h+0.03`/`h−0.5` isolation window), `ThdWindowUpperHarmonic`/
+  `ThdWindowLowerHarmonic` (`5.5…1.5`) and `HarmonicSmoothingWidthFactor` (the
+  `2×` smoothing width harmonic/THD curves use over the primary). No behavior
+  change.
 
 ## Virtual DSP / Time Alignment
 
@@ -105,10 +114,11 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   helper centralised the temp-file dance, but MigraDoc 6 supports
   `AddImage("base64:...")`, which would remove it entirely (needs a Windows
   render check that the sheets stay pixel-identical).
-- [ ] **No deconvolution flatness test.** The sweep + inverse-filter math was
-  verified numerically during review (in-band ripple < 0.01 dB), but nothing
-  in the test suite pins it; a `SyntheticMeasurement`-style flatness test
-  would lock the `2/N` scaling and envelope compensation down.
+- [x] **No deconvolution flatness test** — done.
+  `SweepDeconvolutionFlatnessTests` regenerates an exponential sine sweep and
+  its inverse filter, deconvolves the unity round-trip, and asserts the in-band
+  magnitude is flat (measured ripple 0.04 dB around a 0.01 dB mean), pinning the
+  `2/N` scaling and the inverse-filter envelope compensation.
 
 ## Audio capture layer
 

--- a/dsp/DataHelper.cs
+++ b/dsp/DataHelper.cs
@@ -115,6 +115,26 @@ namespace Resonalyze.Dsp
     {
         private const double MinimumAmplitude = 1e-8;
 
+        // Harmonic isolation geometry, expressed in harmonic-number space because
+        // HarmonicIROffset(h) maps a (fractional) harmonic number to the IR index
+        // where that distortion packet sits — the offset grows with h, so a larger
+        // number is an earlier sample. An HDn packet is windowed from a hair above
+        // its own harmonic (n + guard, the earliest edge) down to halfway toward
+        // the next-lower harmonic (n - half), which brackets the packet while
+        // excluding its neighbours.
+        private const double HarmonicWindowUpperGuard = 0.03;
+        private const double HarmonicWindowLowerReach = 0.5;
+
+        // THD+N integrates everything from just below the fundamental (1.5, halfway
+        // between the linear response and HD2) up past the fifth harmonic (5.5),
+        // capturing HD2..HD5 plus the noise between them in one window.
+        private const double ThdWindowLowerHarmonic = 1.5;
+        private const double ThdWindowUpperHarmonic = 5.5;
+
+        // Harmonic and THD curves are far noisier than the primary response, so
+        // they are smoothed over twice the primary's fractional-octave width.
+        private const double HarmonicSmoothingWidthFactor = 2.0;
+
         public static double AmplitudeToDecibels(double amplitude)
         {
             return 20.0 * Math.Log10(Math.Max(amplitude, MinimumAmplitude));
@@ -261,8 +281,8 @@ namespace Resonalyze.Dsp
 
                 int peak = peakIndex - (int)measurement.HarmonicIROffset(h);
 
-                int hStart = peakIndex - (int)measurement.HarmonicIROffset(h + 0.03);
-                int hEnd = peakIndex - (int)measurement.HarmonicIROffset(h - 0.5);
+                int hStart = peakIndex - (int)measurement.HarmonicIROffset(h + HarmonicWindowUpperGuard);
+                int hEnd = peakIndex - (int)measurement.HarmonicIROffset(h - HarmonicWindowLowerReach);
                 int hLength = hEnd - hStart;
 
                 int leftOffset = peak - hStart;
@@ -279,7 +299,7 @@ namespace Resonalyze.Dsp
                     1024,
                     frequencyResponseOptions.UseCalibration ? calibration : null,
                     frequencyResponseOptions.SmoothingInverseOctaves > 0
-                        ? 2.0 / frequencyResponseOptions.SmoothingInverseOctaves
+                        ? HarmonicSmoothingWidthFactor / frequencyResponseOptions.SmoothingInverseOctaves
                         : 0.0);
                 curves.Add(new AnalysisCurve(
                     $"HD{h}",
@@ -294,8 +314,8 @@ namespace Resonalyze.Dsp
 
             if (wantThd)
             {
-                int hStart = peakIndex - (int)measurement.HarmonicIROffset(5.5);
-                int hEnd = peakIndex - (int)measurement.HarmonicIROffset(1.5);
+                int hStart = peakIndex - (int)measurement.HarmonicIROffset(ThdWindowUpperHarmonic);
+                int hEnd = peakIndex - (int)measurement.HarmonicIROffset(ThdWindowLowerHarmonic);
                 int hLength = hEnd - hStart;
 
                 double leftTukeyWindow = 0.05;
@@ -310,7 +330,7 @@ namespace Resonalyze.Dsp
                     1024,
                     frequencyResponseOptions.UseCalibration ? calibration : null,
                     frequencyResponseOptions.SmoothingInverseOctaves > 0
-                        ? 2.0 / frequencyResponseOptions.SmoothingInverseOctaves
+                        ? HarmonicSmoothingWidthFactor / frequencyResponseOptions.SmoothingInverseOctaves
                         : 0.0);
                 curves.Add(new AnalysisCurve(
                     "THD+N",

--- a/dsp/SweepAnalysis.cs
+++ b/dsp/SweepAnalysis.cs
@@ -13,24 +13,12 @@ public static class SweepAnalysis
         IReadOnlyList<float> inverseFilter,
         double normalization = 2.0)
     {
+        ArgumentNullException.ThrowIfNull(recorded);
         ArgumentNullException.ThrowIfNull(inverseFilter);
 
         return DeconvolveWithInverseFilter(
-            recorded,
-            ToDoubles(inverseFilter),
-            normalization);
-    }
-
-    public static SweepDeconvolutionResult DeconvolveWithInverseFilter(
-        IReadOnlyList<float> recorded,
-        IReadOnlyList<double> inverseFilter,
-        double normalization = 2.0)
-    {
-        ArgumentNullException.ThrowIfNull(recorded);
-
-        return DeconvolveWithInverseFilter(
             ToDoubles(recorded),
-            inverseFilter,
+            ToDoubles(inverseFilter),
             normalization);
     }
 

--- a/dsp/TransferFunction.cs
+++ b/dsp/TransferFunction.cs
@@ -44,14 +44,15 @@ public static class TransferFunction
                 targetPowerSpectrum);
         }
 
-        var coherence = new double[fftLength / 2 + 1];
-        for (int bin = 0; bin < coherence.Length; bin++)
-        {
-            double denominator = referencePowerSpectrum[bin] * targetPowerSpectrum[bin];
-            coherence[bin] = denominator > 0
-                ? Math.Clamp(MagnitudeSquared(crossSpectrum[bin]) / denominator, 0.0, 1.0)
-                : 0.0;
-        }
+        // γ² from the shared cross/auto-spectra formula; epsilon 0 keeps the
+        // previous denominator > 0 gate. Only the first half is retained — the
+        // upper half mirrors it for the real inputs here.
+        double[] coherence = SpectrumAnalysis
+            .ComputeCoherence(
+                crossSpectrum,
+                referencePowerSpectrum,
+                targetPowerSpectrum,
+                epsilon: 0.0)[..(fftLength / 2 + 1)];
 
         Complex[] relative = InverseH1Response(
             crossSpectrum,

--- a/tests/Resonalyze.Dsp.Tests/SweepDeconvolutionFlatnessTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SweepDeconvolutionFlatnessTests.cs
@@ -1,0 +1,142 @@
+using System.Numerics;
+using MathNet.Numerics.IntegralTransforms;
+
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// Round-trip flatness of <see cref="SweepAnalysis.DeconvolveWithInverseFilter"/>.
+/// An exponential sine sweep played through a unity ("wire") system and
+/// deconvolved with its own amplitude-compensated inverse filter must collapse
+/// to a clean impulse whose in-band magnitude response is flat. This pins two
+/// numbers that are easy to break silently: the <c>2/N</c> normalization the
+/// measurement layer applies (<c>ExpSweepMeasurement</c> passes
+/// <c>2.0 / InverseFilter.Length</c>) and the exponential envelope compensation
+/// baked into the inverse filter — a drift in either would tilt or ripple the
+/// response instead of leaving it flat.
+///
+/// The sweep and inverse filter are regenerated here rather than reused from
+/// <c>ExponentialSineSweep</c>, which lives in the Windows-only app project;
+/// the math mirrors it exactly so the test still guards the real signal chain.
+/// </summary>
+public sealed class SweepDeconvolutionFlatnessTests
+{
+    private const int SampleRate = 48_000;
+    private const int Octaves = 10;
+    private const double RequestedDuration = 1.0;
+
+    [Fact]
+    public void UnityRoundTrip_IsFlatInBand()
+    {
+        GeneratedSweep sweep = GenerateSweep(Octaves, RequestedDuration, SampleRate);
+
+        // Recording the sweep through a unity system is just the sweep itself.
+        SweepDeconvolutionResult result = SweepAnalysis.DeconvolveWithInverseFilter(
+            sweep.Sweep,
+            sweep.InverseFilter,
+            2.0 / sweep.InverseFilter.Length);
+
+        double[] magnitudeDb = MagnitudeSpectrumDb(result.ImpulseResponse, out int spectrumLength);
+
+        // Restrict to the reliable interior of the swept band: skip the first
+        // octave (the sweep fades in there) and stay below the top of the range.
+        double lowHz = sweep.StartFrequency * 4.0;
+        double highHz = sweep.EndFrequency * 0.5;
+        double binToHz = SampleRate / (double)spectrumLength;
+
+        var inBand = new List<double>();
+        for (int bin = 1; bin < magnitudeDb.Length; bin++)
+        {
+            double f = bin * binToHz;
+            if (f >= lowHz && f <= highHz)
+            {
+                inBand.Add(magnitudeDb[bin]);
+            }
+        }
+
+        Assert.NotEmpty(inBand);
+        double mean = inBand.Average();
+        double maxDeviation = inBand.Max(db => Math.Abs(db - mean));
+
+        // In-band ripple is a fraction of a dB; a broken normalization or a
+        // dropped envelope term would blow this well past 1 dB.
+        Assert.True(
+            maxDeviation < 0.25,
+            $"In-band ripple {maxDeviation:F4} dB around mean {mean:F4} dB exceeded 0.25 dB.");
+
+        // The 2/N scaling puts the flat band near unity gain (0 dB); pin it so a
+        // scaling regression that stays flat but shifts level is still caught.
+        Assert.InRange(mean, -1.0, 1.0);
+    }
+
+    private static double[] MagnitudeSpectrumDb(double[] impulseResponse, out int spectrumLength)
+    {
+        int fftLength = DspMath.NextPowerOfTwo(impulseResponse.Length);
+        spectrumLength = fftLength;
+        var spectrum = new Complex[fftLength];
+        for (int i = 0; i < impulseResponse.Length; i++)
+        {
+            spectrum[i] = new Complex(impulseResponse[i], 0.0);
+        }
+
+        Fourier.Forward(spectrum, FourierOptions.Matlab);
+
+        int half = fftLength / 2 + 1;
+        var magnitudeDb = new double[half];
+        for (int bin = 0; bin < half; bin++)
+        {
+            double magnitude = spectrum[bin].Magnitude;
+            magnitudeDb[bin] = 20.0 * Math.Log10(Math.Max(magnitude, 1e-12));
+        }
+
+        return magnitudeDb;
+    }
+
+    private readonly record struct GeneratedSweep(
+        float[] Sweep,
+        float[] InverseFilter,
+        double StartFrequency,
+        double EndFrequency);
+
+    // Mirrors ExponentialSineSweep: quantized cycle length, amplitude-ramped
+    // sweep and envelope-compensated, time-reversed inverse filter.
+    private static GeneratedSweep GenerateSweep(int octaves, double requestedDuration, int sampleRate)
+    {
+        double frequencyRatio = Math.Pow(2.0, octaves);
+        double logarithmicRatio = Math.Log(frequencyRatio);
+        double phaseFactor = (Math.PI / frequencyRatio) / logarithmicRatio;
+
+        double targetLength = sampleRate * requestedDuration;
+        double cycleCount = Math.Max(
+            1,
+            Math.Round(phaseFactor * targetLength / (2.0 * Math.PI)));
+        double exactLength = cycleCount * 2.0 * Math.PI / phaseFactor;
+        int sampleCount = Math.Max(1, (int)Math.Round(exactLength));
+
+        var sweep = new float[sampleCount];
+        var inverseFilter = new float[sampleCount];
+        double octaveLength = sampleCount / (double)octaves;
+        for (int i = 0; i < sampleCount; i++)
+        {
+            double exponentialPosition = Math.Exp(i / (double)sampleCount * logarithmicRatio);
+            sweep[i] =
+                (float)Math.Sin(phaseFactor * exactLength * exponentialPosition) *
+                (float)Math.Min(i / octaveLength, 1.0);
+        }
+
+        double inverseScale = octaves * Math.Log(2.0) / (1.0 - Math.Pow(2.0, -octaves));
+        double perSampleDecay = Math.Pow(2.0, octaves / (double)sampleCount);
+        for (int i = 0; i < sampleCount; i++)
+        {
+            inverseFilter[i] =
+                (float)(sweep[sampleCount - i - 1] * Math.Pow(perSampleDecay, -i) * inverseScale);
+        }
+
+        // Instantaneous angular frequency (rad/sample) of the sweep phase
+        // phaseFactor·exactLength·exp(i/N·L) is its derivative in i.
+        double startOmega = phaseFactor * exactLength * logarithmicRatio / sampleCount;
+        double startFrequency = startOmega / (2.0 * Math.PI) * sampleRate;
+        double endFrequency = startFrequency * frequencyRatio;
+
+        return new GeneratedSweep(sweep, inverseFilter, startFrequency, endFrequency);
+    }
+}


### PR DESCRIPTION
Three mechanical, locally-verifiable DSP-layer items from the tech-debt register (`TODO.md` / `HANDOFF.md`). Each TODO claim was verified against the code first; two of the four duplication sub-claims turned out to be deliberate and are documented rather than "fixed".

## 1. Sweep deconvolution flatness test
New `SweepDeconvolutionFlatnessTests` regenerates an exponential sine sweep and its amplitude-compensated inverse filter (the math mirrors `ExponentialSineSweep`, which lives in the Windows-only app project), deconvolves the unity ("wire") round-trip through `SweepAnalysis.DeconvolveWithInverseFilter`, and asserts the in-band magnitude response is flat. This pins two numbers that could drift silently: the `2/N` normalization the measurement layer applies (`ExpSweepMeasurement` passes `2.0 / InverseFilter.Length`) and the exponential envelope compensation baked into the inverse filter.

Measured on the round-trip: in-band ripple **0.043 dB** around a **0.010 dB** mean, peak **0.995**. The test bounds ripple at 0.25 dB (~6× headroom, not flaky across platforms) and the mean at ±1 dB (dropping the `/N` would shift the level ~+90 dB).

## 2. Duplication — partly deduped, partly deliberate
- **Coherence formula** genuinely lived twice → `TransferFunction.ComputeAveragedRelativeIr` now computes γ² through the shared `SpectrumAnalysis.ComputeCoherence` and slices to the first half. `epsilon: 0.0` preserves the previous `denominator > 0` gate, so behavior is unchanged (the multi-run coherence and phase-unwrap tests that consume it stay green).
- **Dead overload removed**: `DeconvolveWithInverseFilter(IReadOnlyList<float>, IReadOnlyList<double>, …)` had zero callers. The two remaining overloads share the single `ToDoubles` converter.
- **Kept by design** (documented in `TODO.md`): `DspChannelChain.Response` reads like a re-implementation of `PreparedDspResponse`, but it is the independent per-frequency reference that `PreparedDspResponse_MatchesDspChannelChainResponse` and `ApplyChain_MatchesReference` validate the optimized bulk path against — merging it would make those checks tautological. The single-frame `TransferFunction.ComputeRelativeIr` is unused in production but shares all its internals with the averaged path (no code is duplicated) and is the directly-tested single-frame H1 primitive with a `filter` parameter, so it stays.

## 3. Named the magic numbers in harmonic analysis (`DataHelper`)
Pure renaming, no behavior change. The bare literals in the HDn/THD window extraction are now documented constants:
- `HarmonicWindowUpperGuard` (0.03) / `HarmonicWindowLowerReach` (0.5) — the harmonic isolation window in harmonic-number space (`HarmonicIROffset` maps a fractional harmonic number to an IR index).
- `ThdWindowUpperHarmonic` (5.5) / `ThdWindowLowerHarmonic` (1.5) — the THD+N integration window (HD2..HD5 plus noise).
- `HarmonicSmoothingWidthFactor` (2.0) — harmonic/THD curves are smoothed over twice the primary response's fractional-octave width.

## Verification
- `dotnet build source/Resonalyze.sln -c Release -p:EnableWindowsTargeting=true` — clean, 0 warnings (the app project compiles after the overload removal).
- `dotnet test tests/Resonalyze.Dsp.Tests` — **281 passed** (280 prior + the new flatness test).
- App tests (`net10.0-windows`) run on CI here.

No behavior changes outside the coherence-formula move (numerically equivalent) and the removed dead overload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_