### PR TITLE
Options panels: single-source bit depth + shared floor-index helper

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -88,18 +88,24 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   which instantiates `AsioOut` (a synchronous COM driver open that can take
   seconds). Fetch the driver info and supported rates in one open, ideally off
   the UI thread.
-- [ ] **`SetOptions` reads bits from the measurement, not the control.**
-  Three sources of truth for the sample size in `MeasurementOptions`; harmless
-  while the control is read-only, a silent no-op the day it is enabled.
+- [x] **`SetOptions` reads bits from the measurement, not the control** — done.
+  `MeasurementOptions` now reads the bit depth from `numericUpDownBits` (the
+  single UI source of truth, matching `GetSupportedSampleRates`). Behavior is
+  unchanged while the control is read-only; it stops silently ignoring the
+  control the day it becomes editable.
 - [ ] **`TukeyWindowControlHelper` clamps are irreversible.** Shrinking the
   window length clamps the fade values (semantically required, and visible in
   the controls), but growing it back does not restore them; a shadow-value
   restore like the loopback-channel one would make the clamp reversible.
+  *Deferred to a Windows session:* it is a deliberate behavior change with
+  control-value re-entrancy across three panels (FR/Waterfall/BurstDecay) that
+  needs a live render check, not a Linux compile.
 - [ ] **`LiveSpectrumOpt` shadow fields update only on
   `SelectionChangeCommitted`.** Re-verified: the R reset button raises
   `SelectionChangeCommitted` too, so no current path loses a change — this is
-  fragility for future programmatic writes, not an active bug. Also three
-  identical floor-index loops worth one helper.
+  fragility for future programmatic writes, not an active bug. (The three
+  identical floor-index loops are now one shared `FloorIndex` helper; the
+  shadow-on-committed behavior is left as-is by design.)
 
 ## UI chrome
 

--- a/source/Options/LiveSpectrumOpt.cs
+++ b/source/Options/LiveSpectrumOpt.cs
@@ -139,18 +139,24 @@ namespace Resonalyze.Options
                     : CoherenceLimits[0];
         }
 
-        private static int FindCoherenceLimitIndex(int thresholdPercent)
+        private static int FindCoherenceLimitIndex(int thresholdPercent) =>
+            FloorIndex(CoherenceLimits, thresholdPercent);
+
+        // Index of the largest entry that does not exceed target, or 0 when target
+        // sits below the whole array. Shared by the coherence-limit, overlap and
+        // sequence-length combos, whose option arrays are all ascending.
+        private static int FloorIndex(IReadOnlyList<int> ascending, int target)
         {
-            int normalizedIndex = 0;
-            for (int index = 0; index < CoherenceLimits.Length; index++)
+            int index = 0;
+            for (int i = 0; i < ascending.Count; i++)
             {
-                if (thresholdPercent >= CoherenceLimits[index])
+                if (target >= ascending[i])
                 {
-                    normalizedIndex = index;
+                    index = i;
                 }
             }
 
-            return normalizedIndex;
+            return index;
         }
 
         private sealed class CoherenceLimitOption
@@ -264,19 +270,8 @@ namespace Resonalyze.Options
             public override string ToString() => DisplayName;
         }
 
-        private static int FindOverlapIndex(int overlapPercent)
-        {
-            int normalizedIndex = 0;
-            for (int index = 0; index < OverlapPercents.Length; index++)
-            {
-                if (overlapPercent >= OverlapPercents[index])
-                {
-                    normalizedIndex = index;
-                }
-            }
-
-            return normalizedIndex;
-        }
+        private static int FindOverlapIndex(int overlapPercent) =>
+            FloorIndex(OverlapPercents, overlapPercent);
 
         private sealed class OverlapOption
         {
@@ -293,19 +288,8 @@ namespace Resonalyze.Options
             }
         }
 
-        private static int NormalizeSequenceLength(int sequenceLength)
-        {
-            int normalized = SequenceLengths[0];
-            foreach (int candidate in SequenceLengths)
-            {
-                if (sequenceLength >= candidate)
-                {
-                    normalized = candidate;
-                }
-            }
-
-            return normalized;
-        }
+        private static int NormalizeSequenceLength(int sequenceLength) =>
+            SequenceLengths[FloorIndex(SequenceLengths, sequenceLength)];
 
         private int FindNoiseColorIndex(NoiseColor noiseColor)
         {

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -244,7 +244,11 @@ namespace Resonalyze.Options
                 NormalizeCalibrationPath(microphoneCalibration90DegreesPath);
 
             int sampleRate = GetSelectedSampleRate();
-            int bits = expSweepMeasurement.Bits;
+            // Read the bit depth from the control, the single UI source of truth,
+            // matching GetSupportedSampleRates. Equal to expSweepMeasurement.Bits
+            // while the control is read-only, so this is a no-op today; it stops
+            // silently ignoring the control the day it becomes editable.
+            int bits = (int)numericUpDownBits.Value;
             PlaybackChannel playbackChannel = (PlaybackChannel)comboBoxChannel.SelectedIndex;
             double requestedDuration = (double)numericUpDownRequestedDuration.Value * 0.001;
             int octaves = (int)numericUpDownOctaves.Value;


### PR DESCRIPTION
Two pure-refactor items from the Options-panel cluster in the tech-debt register (`TODO.md` / `HANDOFF.md`). Both are behavior-preserving and compiler-checked; the two behavior-changing items in the same cluster are deliberately deferred (see below).

## 1. `SetOptions` reads bit depth from the control, not the measurement
`MeasurementOptions.SetOptions` now reads the bit depth from `numericUpDownBits` — the single UI source of truth, matching `GetSupportedSampleRates` — instead of `expSweepMeasurement.Bits`. While the control is read-only the two are always equal at every apply, so this is a **no-op today**; it removes the latent third source of truth that would silently ignore the control the day it becomes editable.

## 2. One shared `FloorIndex` helper in `LiveSpectrumOpt`
The three identical ascending "largest entry ≤ target, else index 0" loops (`FindCoherenceLimitIndex`, `FindOverlapIndex`, `NormalizeSequenceLength`) collapse to one `FloorIndex(IReadOnlyList<int>, int)`. The value-returning `NormalizeSequenceLength` becomes `SequenceLengths[FloorIndex(...)]`. No behavior change.

## Deferred (same cluster, needs a live Windows check)
Not in this PR — both are deliberate behavior changes that can't be verified from a Linux compile:
- **`TukeyWindowControlHelper` clamp reversibility** — restoring clamped fade values when the window grows back involves control-value re-entrancy across three panels (FR/Waterfall/BurstDecay); needs a live render check.
- **Loopback channel persisting `null` across restart** — the mono→restart→stereo restore path needs a live app to verify.

Both are noted in `TODO.md`.

## Verification
- `dotnet build source/Resonalyze.sln -c Release -p:EnableWindowsTargeting=true` — clean, 0 warnings.
- `dotnet test tests/Resonalyze.Dsp.Tests` — 288 passed (unaffected; these are `source/` changes).
- App tests (`net10.0-windows`) run on CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_