### PR TITLE
UI polish: build Tools menu once, cache hue rainbow, surface project backup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,14 +65,18 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   (`VirtualCrossoverAutoSetupDialog`): extra channel rows use hardcoded pixel
   offsets (`RowTop = 42`, `RowStep = 28`), so rows 4–8 can overlap scaled
   designer controls. Verify on Windows and switch to layout-panel positioning.
-- [ ] **The project-file `.backup` rename is silent.** An unusable autosave
-  is preserved next to the project file now, but nothing tells the user it
-  happened or that a `.backup` is there to recover from.
+- [x] **The project-file `.backup` rename is silent** — done.
+  `LoadOrDefault` now surfaces the created backup path through
+  `BackupNoticePath`, and the Virtual DSP panel shows a one-time notice telling
+  the user their unreadable session was moved aside and a `.backup` exists to
+  recover from.
 - [ ] **Split `VirtualCrossoverPanel` (~2.6k lines)** into partial
   classes/controllers.
 - [ ] **`DelayTableText` parses rendered fixed-width columns** (18/37 chars)
   for copy-values instead of holding a value model (format+parse are at least
-  co-located and tested now).
+  co-located and tested now). *Deferred:* the current form is clean and tested;
+  a value model would push the change into the panel's click-position→cell
+  mapping, which is UI interaction best verified on Windows, for low payoff.
 
 ## Measurement orchestrators
 
@@ -123,10 +127,10 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   HTTRANSPARENT fix covers the title-bar panel itself; points over the tab
   buttons and window buttons (which reach y=0) still hit-test as client.
   Standard chrome resolves this per child; low value, document or fix later.
-- [ ] **`ColorPickerDialog` preview panel is not double-buffered** and the
-  hue slider repaints its full rainbow per mouse-move; caching the rainbow in
-  a bitmap (invalidated on resize) would finish what the pen-reuse fix
-  started.
+- [x] **`ColorPickerDialog` hue slider repaints its full rainbow per
+  mouse-move** — done. The rainbow (which depends only on size) is cached in a
+  bitmap, rebuilt only on resize and disposed with the slider; the preview panel
+  already sets `DoubleBuffered`.
 
 ## PDF export
 
@@ -177,10 +181,14 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 ## Custom controls (dark theme)
 
-- [ ] **Per-paint Pen/Brush churn.** Dark controls allocate pens/brushes in
-  every `OnPaint`; cache per-color instances.
-- [ ] **Tools menu rebuilt on every open.** Rebuilding the drop-down each time
-  is wasted work and loses per-item state; build once and update.
+- [ ] **Per-paint Pen/Brush churn** — verified low value, left as is. Most of
+  the dark-control paint brushes are genuinely state-dependent (Enabled / hover
+  / pressed / focus), so only ~2 constant-palette pens per control could be
+  cached; trading two allocations per (non-hot) repaint for app-lifetime static
+  GDI handles isn't worth it. Revisit only if the palette becomes dynamic.
+- [x] **Tools menu rebuilt on every open** — done. `ChromeTitleBar` builds the
+  Tools drop-down once (the tab actions are fixed at wire-up) and re-shows it;
+  the single menu is disposed with the control.
 
 ## Shell
 
@@ -200,7 +208,10 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   transient UI bits (compare menu strip) — inherently form-bound; further
   slicing is optional polish rather than a concurrency risk.
 - [ ] **`WireLiveApply` covers only dialog-open controls.** Controls created
-  after wiring never get live-apply behavior.
+  after wiring never get live-apply behavior. *Deferred to a Windows session:*
+  the fix hooks `ControlAdded` recursively and re-enters the same apply
+  debounce, so it needs a live check that dynamically-added rows (e.g. the
+  crossover auto-setup channels) apply exactly once.
 
 ## Update path / installer
 

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -196,13 +196,34 @@ public partial class VirtualCrossoverPanel : UserControl
     {
         try
         {
-            await ApplyProjectAsync(VirtualCrossoverProjectFile.LoadOrDefault());
+            VirtualCrossoverProjectFile loaded = VirtualCrossoverProjectFile.LoadOrDefault();
+            await ApplyProjectAsync(loaded);
+            NotifyIfProjectBackedUp(loaded.BackupNoticePath);
         }
         catch (Exception exception)
         {
             System.Diagnostics.Debug.WriteLine(
                 $"Virtual DSP project load failed: {exception}");
         }
+    }
+
+    // Tell the user, once, when their unreadable session file was moved aside so
+    // they know a .backup exists to recover from (previously a silent rename).
+    private void NotifyIfProjectBackedUp(string? backupPath)
+    {
+        if (backupPath == null || IsDisposed)
+        {
+            return;
+        }
+
+        MessageBox.Show(
+            this,
+            "The saved Virtual DSP session could not be opened, so it was moved " +
+            $"aside to:\r\n\r\n{backupPath}\r\n\r\nA fresh session was started; your " +
+            "previous file is preserved there for recovery.",
+            "Virtual DSP",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Information);
     }
 
     // Binds a project (the internal autosave or an imported session) to the UI:

--- a/source/Tools/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossoverProjectFile.cs
@@ -281,6 +281,15 @@ public sealed class VirtualCrossoverProjectFile
     /// save overwrites the project path, and a downgrade or a bug must not
     /// cost the user their tuning session.
     /// </summary>
+    /// <summary>
+    /// When <see cref="LoadOrDefault"/> could not use an existing file and moved
+    /// it aside, this holds the path of the <c>.backup</c> it created so the tool
+    /// can tell the user their previous session was preserved. Null on a clean
+    /// load (or when the aside-move itself failed). Not serialized.
+    /// </summary>
+    [JsonIgnore]
+    public string? BackupNoticePath { get; private set; }
+
     public static VirtualCrossoverProjectFile LoadOrDefault(string? rootDirectory = null)
     {
         string path = GetPath(rootDirectory);
@@ -306,24 +315,30 @@ public sealed class VirtualCrossoverProjectFile
         }
         catch
         {
-            BackupUnusableFile(path);
-            return new VirtualCrossoverProjectFile();
+            return new VirtualCrossoverProjectFile
+            {
+                BackupNoticePath = BackupUnusableFile(path)
+            };
         }
     }
 
-    private static void BackupUnusableFile(string path)
+    private static string? BackupUnusableFile(string path)
     {
         try
         {
             if (File.Exists(path))
             {
-                File.Move(path, path + ".backup", overwrite: true);
+                string backupPath = path + ".backup";
+                File.Move(path, backupPath, overwrite: true);
+                return backupPath;
             }
         }
         catch
         {
             // Best effort (the file may be locked); startup must not block.
         }
+
+        return null;
     }
 
     public void Validate()

--- a/source/Ui/Controls/ChromeTitleBar.cs
+++ b/source/Ui/Controls/ChromeTitleBar.cs
@@ -362,17 +362,34 @@ internal sealed class ChromeTitleBar : Panel
             return;
         }
 
-        toolsMenu?.Dispose();
-        toolsMenu = new ContextMenuStrip
+        // The tab actions are fixed at wire-up time, so the menu is identical on
+        // every open — build it once and just re-show it.
+        toolsMenu ??= BuildToolsMenu(tabActions);
+        toolsMenu.Show(toolsDropDownButton, new Point(0, toolsDropDownButton.Height));
+    }
+
+    private ContextMenuStrip BuildToolsMenu(IReadOnlyDictionary<ModeTab, Action> tabActions)
+    {
+        var menu = new ContextMenuStrip
         {
             BackColor = UiPalette.ButtonBackground,
             ForeColor = UiPalette.TitleBarTextBright,
             ShowImageMargin = false
         };
-        AddToolsMenuItem(toolsMenu, "Virtual DSP", ModeTab.ToolsVirtualCrossover, tabActions);
-        AddToolsMenuItem(toolsMenu, "EQ Wizard", ModeTab.ToolsEqWizard, tabActions);
-        AddToolsMenuItem(toolsMenu, "Signal Generator", ModeTab.ToolsSignalGenerator, tabActions);
-        toolsMenu.Show(toolsDropDownButton, new Point(0, toolsDropDownButton.Height));
+        AddToolsMenuItem(menu, "Virtual DSP", ModeTab.ToolsVirtualCrossover, tabActions);
+        AddToolsMenuItem(menu, "EQ Wizard", ModeTab.ToolsEqWizard, tabActions);
+        AddToolsMenuItem(menu, "Signal Generator", ModeTab.ToolsSignalGenerator, tabActions);
+        return menu;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            toolsMenu?.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 
     private void AddToolsMenuItem(

--- a/source/Ui/Dialogs/ColorPickerDialog.cs
+++ b/source/Ui/Dialogs/ColorPickerDialog.cs
@@ -386,6 +386,7 @@ internal sealed class HueSlider : Control
 {
     private double hue;
     private bool dragging;
+    private Bitmap? rainbowCache;
 
     public HueSlider()
     {
@@ -410,26 +411,55 @@ internal sealed class HueSlider : Control
     protected override void OnPaint(PaintEventArgs args)
     {
         base.OnPaint(args);
-        int height = Math.Max(1, ClientSize.Height - 1);
-        // One reusable pen; this paints per mouse-move while dragging the hue.
-        using (var pen = new Pen(Color.Black))
+        int width = Math.Max(1, ClientSize.Width);
+        int height = Math.Max(1, ClientSize.Height);
+
+        // The rainbow depends only on size, but was redrawn line-by-line on every
+        // paint — including every mouse-move while dragging. Cache it and rebuild
+        // only when the control resizes.
+        if (rainbowCache == null || rainbowCache.Width != width || rainbowCache.Height != height)
         {
-            for (int y = 0; y < ClientSize.Height; y++)
-            {
-                double rowHue = y / (double)height * 360.0;
-                pen.Color = HsvColor.ToColor(rowHue, 1, 1);
-                args.Graphics.DrawLine(pen, 0, y, ClientSize.Width, y);
-            }
+            rainbowCache?.Dispose();
+            rainbowCache = BuildRainbow(width, height);
         }
 
-        float markerY = (float)(hue / 360.0 * height);
+        args.Graphics.DrawImageUnscaled(rainbowCache, 0, 0);
+
+        int span = Math.Max(1, height - 1);
+        float markerY = (float)(hue / 360.0 * span);
         using var markerPen = new Pen(Color.White, 2);
         args.Graphics.DrawRectangle(
             markerPen,
             1,
-            Math.Clamp(markerY - 2, 0, ClientSize.Height - 4),
-            ClientSize.Width - 3,
+            Math.Clamp(markerY - 2, 0, height - 4),
+            width - 3,
             4);
+    }
+
+    private static Bitmap BuildRainbow(int width, int height)
+    {
+        var bitmap = new Bitmap(width, height);
+        int span = Math.Max(1, height - 1);
+        using var graphics = Graphics.FromImage(bitmap);
+        using var pen = new Pen(Color.Black);
+        for (int y = 0; y < height; y++)
+        {
+            double rowHue = y / (double)span * 360.0;
+            pen.Color = HsvColor.ToColor(rowHue, 1, 1);
+            graphics.DrawLine(pen, 0, y, width, y);
+        }
+
+        return bitmap;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            rainbowCache?.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 
     protected override void OnMouseDown(MouseEventArgs args)

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -132,6 +132,9 @@ public sealed class VirtualCrossoverProjectFileTests
             // fresh default instead of overwriting it on the next save.
             Assert.False(File.Exists(path));
             Assert.Equal(futureText, File.ReadAllText(path + ".backup"));
+
+            // The path is surfaced so the tool can tell the user a backup exists.
+            Assert.Equal(path + ".backup", loaded.BackupNoticePath);
         }
         finally
         {
@@ -177,6 +180,7 @@ public sealed class VirtualCrossoverProjectFileTests
             Assert.Equal(-4, loaded.Channels[0].GainDb);
             Assert.True(File.Exists(path));
             Assert.False(File.Exists(path + ".backup"));
+            Assert.Null(loaded.BackupNoticePath);
         }
         finally
         {


### PR DESCRIPTION
The first installment of the UI-polish batch (`TODO.md` item 9) — three small, self-contained items. Each claim was verified against the code first.

## Changes
- **Tools menu built once.** `ChromeTitleBar.ShowToolsMenu` disposed and rebuilt the drop-down on every open. The tab actions are fixed at wire-up, so the menu is now built once and re-shown; the single instance is disposed with the control.
- **Hue-slider rainbow cached.** The `ColorPickerDialog` hue slider redrew its rainbow line-by-line on every paint — including each mouse-move while dragging — though it depends only on size. It is now rendered once into a bitmap, rebuilt only on resize and disposed with the slider. (The preview panel already sets `DoubleBuffered`.)
- **Project `.backup` rename surfaced.** `VirtualCrossoverProjectFile.LoadOrDefault` moved an unusable session aside to `.backup` silently. It now exposes the created path via a new `[JsonIgnore] BackupNoticePath`, and the Virtual DSP panel shows a one-time notice so the user knows their previous session was preserved and where.

## Deferred (verified, not done here)
Three item-9 sub-items are deliberately left, with reasons recorded in `TODO.md`:
- **Dark-control pen/brush caching** — low value: almost all paint brushes are state-dependent (Enabled/hover/pressed/focus); only ~2 constant pens per control could be cached, not worth app-lifetime static GDI handles.
- **`DelayTableText` value model** — the current form is clean and tested; a model pushes the change into the panel's click-position→cell mapping (UI interaction, Windows-only) for low payoff.
- **`WireLiveApply` for late-created controls** — a behavior change with `ControlAdded` re-entrancy that needs a live Windows check.

The larger **`VirtualCrossoverPanel` split** (item 9) will follow as its own PR — it is a big move-only refactor best reviewed in isolation.

## Verification
- `dotnet build source/Resonalyze.sln -c Release -p:EnableWindowsTargeting=true` — clean, 0 warnings.
- New App.Tests cover the load-side backup behavior (`BackupNoticePath` set on an unusable file, null on a clean load). App tests run on Windows CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_