### PR TITLE
Extract correctness kernels from VirtualCrossoverPanel (not a cosmetic split)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -70,8 +70,23 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   `BackupNoticePath`, and the Virtual DSP panel shows a one-time notice telling
   the user their unreadable session was moved aside and a `.backup` exists to
   recover from.
-- [ ] **Split `VirtualCrossoverPanel` (~2.6k lines)** into partial
-  classes/controllers.
+- [~] **`VirtualCrossoverPanel` (~2.6k lines) — correctness kernels extracted;
+  a cosmetic partial-split was deliberately rejected.** A move-only partial
+  split would not reduce coupling — it just spreads the God-object across files.
+  Instead the genuinely non-UI, correctness-critical logic was pulled out into
+  tested units: `VirtualCrossoverSourceRules` (the source-compatibility decision,
+  previously hand-rolled as two inverse predicates that could drift),
+  `VirtualCrossoverAnalysis.SumLossCurve` (the one per-point sum-loss definition
+  now shared by the drawn curve, `AverageSumLossDb` and `MinimumSumLossDb` — the
+  drawn "Sum loss" curve had reimplemented the tested formula on an untested
+  path), `PreparedDspResponse.GroupDelayMs` (a pure τ_g routine that lived in the
+  panel), and the band arithmetic (`GetCrossoverWindow`/`BandCenterHz`/
+  `OverlapBand`) into `VirtualCrossoverJunctions`. All are unit-tested (dsp on
+  Linux, junction/source rules on Windows CI). The panel remains a large
+  view-controller by nature (~60-70% is irreducible WinForms/OxyPlot wiring);
+  deeper extractions (decouple `ChannelRuntime` from its control, then the
+  process/alignment cores) are deferred to a Windows session where the
+  interactive paths can be exercised.
 - [ ] **`DelayTableText` parses rendered fixed-width columns** (18/37 chars)
   for copy-values instead of holding a value model (format+parse are at least
   co-located and tested now). *Deferred:* the current form is clean and tested;

--- a/dsp/PreparedDspResponse.cs
+++ b/dsp/PreparedDspResponse.cs
@@ -100,6 +100,30 @@ public sealed class PreparedDspResponse
         return Response(z1, delay);
     }
 
+    /// <summary>
+    /// Filter group delay τ_g = -dφ/dω at <paramref name="frequencyHz"/>, in
+    /// milliseconds, read from the complex response by a central difference
+    /// (-Im(H'/H) / 2π). Working from the complex response avoids phase
+    /// unwrapping, which a coarse log grid could alias at a steep crossover.
+    /// </summary>
+    public double GroupDelayMs(double frequencyHz)
+    {
+        double delta = Math.Max(frequencyHz * 1e-3, 1e-6);
+        double lowFrequency = Math.Max(frequencyHz - delta, 1e-3);
+        double highFrequency = frequencyHz + delta;
+        Complex low = Response(lowFrequency);
+        Complex high = Response(highFrequency);
+        Complex center = Response(frequencyHz);
+        if (center.Magnitude < 1e-20)
+        {
+            return 0;
+        }
+
+        Complex derivative = (high - low) / (highFrequency - lowFrequency);
+        double phaseSlope = (derivative / center).Imaginary; // dφ/df
+        return -phaseSlope / (2.0 * Math.PI) * 1000.0;
+    }
+
     public void ApplyToSpectrum(Complex[] spectrum)
     {
         if (sections.Length == 0)

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -948,6 +948,44 @@ public static class VirtualCrossoverAnalysis
     }
 
     /// <summary>
+    /// The per-point summation-loss curve (dB, &lt;= 0): the complex sum minus the
+    /// phase-blind magnitude sum of the channel curves, over their shared index
+    /// grid (truncated to the shortest). This is the single definition the panel's
+    /// drawn "Sum loss" curve, <see cref="AverageSumLossDb"/> and
+    /// <see cref="MinimumSumLossDb"/> all read, so the drawn and measured loss
+    /// cannot drift apart.
+    /// </summary>
+    public static List<SignalPoint> SumLossCurve(
+        IReadOnlyList<SignalPoint> sumCurve,
+        IReadOnlyList<IReadOnlyList<SignalPoint>> channelCurves)
+    {
+        ArgumentNullException.ThrowIfNull(sumCurve);
+        ArgumentNullException.ThrowIfNull(channelCurves);
+
+        int count = sumCurve.Count;
+        foreach (IReadOnlyList<SignalPoint> curve in channelCurves)
+        {
+            count = Math.Min(count, curve.Count);
+        }
+
+        var points = new List<SignalPoint>(Math.Max(0, count));
+        for (int i = 0; i < count; i++)
+        {
+            double magnitudeSum = 0;
+            foreach (IReadOnlyList<SignalPoint> curve in channelCurves)
+            {
+                magnitudeSum += DataHelper.DecibelsToAmplitude(curve[i].Y);
+            }
+
+            points.Add(new SignalPoint(
+                sumCurve[i].X,
+                sumCurve[i].Y - DataHelper.AmplitudeToDecibels(magnitudeSum)));
+        }
+
+        return points;
+    }
+
+    /// <summary>
     /// The average summation loss (dB, &lt;= 0) inside the frequency window: how
     /// far the complex sum falls short of the phase-blind magnitude sum. The
     /// curves must share one frequency grid (index-aligned).
@@ -965,32 +1003,18 @@ public static class VirtualCrossoverAnalysis
             return null;
         }
 
-        int count = sumCurve.Count;
-        foreach (IReadOnlyList<SignalPoint> curve in channelCurves)
-        {
-            count = Math.Min(count, curve.Count);
-        }
-
         double total = 0;
         int samples = 0;
-        for (int i = 0; i < count; i++)
+        foreach (SignalPoint point in SumLossCurve(sumCurve, channelCurves))
         {
-            double frequency = sumCurve[i].X;
-            if (frequency < minFrequencyHz || frequency > maxFrequencyHz)
+            if (point.X < minFrequencyHz || point.X > maxFrequencyHz)
             {
                 continue;
             }
 
-            double magnitudeSum = 0;
-            foreach (IReadOnlyList<SignalPoint> curve in channelCurves)
+            if (double.IsFinite(point.Y))
             {
-                magnitudeSum += DataHelper.DecibelsToAmplitude(curve[i].Y);
-            }
-
-            double loss = sumCurve[i].Y - DataHelper.AmplitudeToDecibels(magnitudeSum);
-            if (double.IsFinite(loss))
-            {
-                total += loss;
+                total += point.Y;
                 samples++;
             }
         }
@@ -1018,31 +1042,17 @@ public static class VirtualCrossoverAnalysis
             return null;
         }
 
-        int count = sumCurve.Count;
-        foreach (IReadOnlyList<SignalPoint> curve in channelCurves)
-        {
-            count = Math.Min(count, curve.Count);
-        }
-
         double? minimum = null;
-        for (int i = 0; i < count; i++)
+        foreach (SignalPoint point in SumLossCurve(sumCurve, channelCurves))
         {
-            double frequency = sumCurve[i].X;
-            if (frequency < minFrequencyHz || frequency > maxFrequencyHz)
+            if (point.X < minFrequencyHz || point.X > maxFrequencyHz)
             {
                 continue;
             }
 
-            double magnitudeSum = 0;
-            foreach (IReadOnlyList<SignalPoint> curve in channelCurves)
+            if (double.IsFinite(point.Y) && (minimum == null || point.Y < minimum))
             {
-                magnitudeSum += DataHelper.DecibelsToAmplitude(curve[i].Y);
-            }
-
-            double loss = sumCurve[i].Y - DataHelper.AmplitudeToDecibels(magnitudeSum);
-            if (double.IsFinite(loss) && (minimum == null || loss < minimum))
-            {
-                minimum = loss;
+                minimum = point.Y;
             }
         }
 

--- a/source/Tools/VirtualCrossoverJunctions.cs
+++ b/source/Tools/VirtualCrossoverJunctions.cs
@@ -50,4 +50,50 @@ internal static class VirtualCrossoverJunctions
         return Math.Sqrt(
             Math.Sqrt(lowerLow * lowerHigh) * Math.Sqrt(upperLow * upperHigh));
     }
+
+    /// <summary>
+    /// Geometric-mean centre of a channel's playing band, used to order the
+    /// channels along the spectrum.
+    /// </summary>
+    public static double BandCenterHz(VirtualCrossoverChannelSettings settings)
+    {
+        (double lowHz, double highHz) = GetChannelBand(settings);
+        return Math.Sqrt(lowHz * highHz);
+    }
+
+    /// <summary>
+    /// An octave to each side of a handover frequency, clamped to the audio band:
+    /// the overlap region where two adjacent drivers genuinely sum.
+    /// </summary>
+    public static (double LowHz, double HighHz) OverlapBand(double centerHz) =>
+        (Math.Max(20, centerHz / 2), Math.Min(20_000, centerHz * 2));
+
+    /// <summary>
+    /// The frequency window worth plotting for a set of channels: an octave below
+    /// the lowest crossover corner to an octave above the highest, clamped to the
+    /// audio band, or a sensible default when no channel is filtered.
+    /// </summary>
+    public static (double MinHz, double MaxHz) GetCrossoverWindow(
+        IEnumerable<VirtualCrossoverChannelSettings> channels)
+    {
+        var corners = new List<double>();
+        foreach (VirtualCrossoverChannelSettings settings in channels)
+        {
+            if (settings.CrossoverKind is CrossoverKind.LowPass or CrossoverKind.BandPass)
+            {
+                corners.Add(settings.LowPassEdge.FrequencyHz);
+            }
+            if (settings.CrossoverKind is CrossoverKind.HighPass or CrossoverKind.BandPass)
+            {
+                corners.Add(settings.HighPassEdge.FrequencyHz);
+            }
+        }
+
+        if (corners.Count == 0)
+        {
+            return (100, 10_000);
+        }
+
+        return (Math.Max(20, corners.Min() / 2), Math.Min(20_000, corners.Max() * 2));
+    }
 }

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -738,14 +738,21 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         // A mismatched sample rate is not a dead end: the user picks whether the
-        // new measurement wins (clearing the incompatible channels) or loses.
-        List<ChannelRuntime> mismatched = channels
-            .Where(other => other != channel &&
-                other.TransferImpulseResponse != null &&
-                other.SampleRate != snapshot.SampleRate)
-            .ToList();
-        if (mismatched.Count > 0)
+        // new measurement wins (clearing the incompatible channels) or loses. The
+        // compatibility decision is shared with the silent reload path.
+        VirtualCrossoverSourceRules.Decision decision = VirtualCrossoverSourceRules.Evaluate(
+            hasTransferIr: true,
+            candidateSampleRate: snapshot.SampleRate,
+            otherResolvedSampleRates: channels
+                .Where(other => other != channel && other.TransferImpulseResponse != null)
+                .Select(other => other.SampleRate));
+        if (decision == VirtualCrossoverSourceRules.Decision.NeedsConfirmClear)
         {
+            List<ChannelRuntime> mismatched = channels
+                .Where(other => other != channel &&
+                    other.TransferImpulseResponse != null &&
+                    other.SampleRate != snapshot.SampleRate)
+                .ToList();
             string mismatchedList = string.Join(
                 ", ",
                 mismatched.Select(other =>
@@ -832,15 +839,17 @@ public partial class VirtualCrossoverPanel : UserControl
                 snapshot = MeasurementHistoryService.CreateSnapshot(file);
             }
 
-            // The same compatibility rules as TryAcceptSource: the file behind a
-            // stored path may have been replaced since the project was saved. An
-            // incompatible source stays unresolved (the button shows the warning
-            // glyph) instead of silently producing a physically wrong sum.
-            bool compatible = channels.All(other =>
-                other == channel ||
-                other.TransferImpulseResponse == null ||
-                other.SampleRate == snapshot?.SampleRate);
-            if (compatible &&
+            // The same compatibility decision as TryAcceptSource (the file behind a
+            // stored path may have been replaced since the project was saved), but
+            // here an incompatible source stays unresolved — the button shows the
+            // warning glyph — instead of prompting: a silent reload cannot ask.
+            VirtualCrossoverSourceRules.Decision decision = VirtualCrossoverSourceRules.Evaluate(
+                hasTransferIr: snapshot?.TransferImpulseResponse is { Length: > 0 },
+                candidateSampleRate: snapshot?.SampleRate ?? 0,
+                otherResolvedSampleRates: channels
+                    .Where(other => other != channel && other.TransferImpulseResponse != null)
+                    .Select(other => other.SampleRate));
+            if (decision == VirtualCrossoverSourceRules.Decision.Accept &&
                 snapshot?.TransferImpulseResponse is { Length: > 0 } transferIr)
             {
                 channel.TransferImpulseResponse = transferIr;
@@ -1624,19 +1633,11 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             // The signed dB gap between the complex sum and the phase-blind
             // magnitude sum of the processed channels (<= 0 by the triangle
-            // inequality); all curves share the same fixed log grid.
-            int count = magnitudes.Min(curve => curve.Points.Count);
-            count = Math.Min(count, sumCurve.Points.Count);
-            var points = new List<SignalPoint>(count);
-            for (int i = 0; i < count; i++)
-            {
-                double magnitudeSum = magnitudes.Sum(
-                    curve => DataHelper.DecibelsToAmplitude(curve.Points[i].Y));
-                points.Add(new SignalPoint(
-                    sumCurve.Points[i].X,
-                    sumCurve.Points[i].Y - DataHelper.AmplitudeToDecibels(magnitudeSum)));
-            }
-
+            // inequality); shares the one SumLossCurve definition with the metric,
+            // so the drawn curve and the measured loss cannot drift apart.
+            List<SignalPoint> points = VirtualCrossoverAnalysis.SumLossCurve(
+                sumCurve.Points,
+                magnitudes.Select(curve => curve.Points).ToList());
             AddCurve(model, "Sum loss", points, LossColor, 1.8, LineStyle.Dash);
         }
     }
@@ -1646,32 +1647,10 @@ public partial class VirtualCrossoverPanel : UserControl
     // The frequency window the metric and Auto delay operate in: around the
     // corner frequencies the channels actually use (one octave to each side),
     // or a broad midband default when no crossover is configured yet.
-    private (double MinHz, double MaxHz) GetCrossoverWindow(
-        List<ProcessedChannel> processed)
-    {
-        var corners = new List<double>();
-        foreach (ProcessedChannel item in processed)
-        {
-            VirtualCrossoverChannelSettings settings = item.Channel.Settings;
-            if (settings.CrossoverKind is CrossoverKind.LowPass or CrossoverKind.BandPass)
-            {
-                corners.Add(settings.LowPassEdge.FrequencyHz);
-            }
-            if (settings.CrossoverKind is CrossoverKind.HighPass or CrossoverKind.BandPass)
-            {
-                corners.Add(settings.HighPassEdge.FrequencyHz);
-            }
-        }
-
-        if (corners.Count == 0)
-        {
-            return (100, 10_000);
-        }
-
-        return (
-            Math.Max(20, corners.Min() / 2),
-            Math.Min(20_000, corners.Max() * 2));
-    }
+    private static (double MinHz, double MaxHz) GetCrossoverWindow(
+        List<ProcessedChannel> processed) =>
+        VirtualCrossoverJunctions.GetCrossoverWindow(
+            processed.Select(item => item.Channel.Settings));
 
     private void UpdateMetric(
         List<ProcessedChannel> processed,
@@ -2057,11 +2036,7 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private static List<ProcessedChannel> OrderByBand(List<ProcessedChannel> processed) =>
         processed
-            .OrderBy(item =>
-            {
-                (double lowHz, double highHz) = GetChannelBand(item.Channel.Settings);
-                return Math.Sqrt(lowHz * highHz);
-            })
+            .OrderBy(item => VirtualCrossoverJunctions.BandCenterHz(item.Channel.Settings))
             .ToList();
 
     private static List<AdjacentPair> GetAdjacentPairs(List<ProcessedChannel> byBand)
@@ -2071,20 +2046,17 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             double pairHz = GetPairCrossoverHz(
                 byBand[i].Channel.Settings, byBand[i + 1].Channel.Settings);
+            (double bandLowHz, double bandHighHz) = VirtualCrossoverJunctions.OverlapBand(pairHz);
             pairs.Add(new AdjacentPair(
                 byBand[i],
                 byBand[i + 1],
                 pairHz,
-                Math.Max(20, pairHz / 2),
-                Math.Min(20_000, pairHz * 2)));
+                bandLowHz,
+                bandHighHz));
         }
 
         return pairs;
     }
-
-    private static (double LowHz, double HighHz) GetChannelBand(
-        VirtualCrossoverChannelSettings settings) =>
-        VirtualCrossoverJunctions.GetChannelBand(settings);
 
     private AnalysisCurve BuildMagnitudeCurve(
         Complex[] impulseResponse,
@@ -2311,33 +2283,9 @@ public partial class VirtualCrossoverPanel : UserControl
         DspPlotMode mode) => mode switch
     {
         DspPlotMode.Phase => response.Response(frequency).Phase / Math.PI * 180.0,
-        DspPlotMode.GroupDelay => GroupDelayMilliseconds(response, frequency),
+        DspPlotMode.GroupDelay => response.GroupDelayMs(frequency),
         _ => DataHelper.AmplitudeToDecibels(response.Response(frequency).Magnitude)
     };
-
-    // Filter group delay τ_g = -dφ/dω, read from the complex response by a central
-    // difference: -Im(H'(f)/H(f)) / (2π), in milliseconds. Working from the
-    // complex response avoids phase unwrapping, which a coarse log grid could alias
-    // at a steep crossover.
-    private static double GroupDelayMilliseconds(
-        PreparedDspResponse response,
-        double frequency)
-    {
-        double delta = Math.Max(frequency * 1e-3, 1e-6);
-        double lowFrequency = Math.Max(frequency - delta, 1e-3);
-        double highFrequency = frequency + delta;
-        Complex low = response.Response(lowFrequency);
-        Complex high = response.Response(highFrequency);
-        Complex center = response.Response(frequency);
-        if (center.Magnitude < 1e-20)
-        {
-            return 0;
-        }
-
-        Complex derivative = (high - low) / (highFrequency - lowFrequency);
-        double phaseSlope = (derivative / center).Imaginary; // dφ/df
-        return -phaseSlope / (2.0 * Math.PI) * 1000.0;
-    }
 
     // ------------------------------------------------------- capture / export
 

--- a/source/Tools/VirtualCrossoverSourceRules.cs
+++ b/source/Tools/VirtualCrossoverSourceRules.cs
@@ -1,0 +1,46 @@
+namespace Resonalyze;
+
+/// <summary>
+/// The pure source-compatibility policy of the Virtual DSP tool: whether a
+/// candidate measurement can drive a channel. The rule was previously hand-rolled
+/// in two places (interactive assignment and silent project reload) as mutually
+/// inverse predicates that could drift; this is the single decision both share.
+/// Kept UI-free so it is unit-testable.
+/// </summary>
+internal static class VirtualCrossoverSourceRules
+{
+    public enum Decision
+    {
+        /// <summary>No loopback transfer IR — the source can never drive a channel.</summary>
+        Reject,
+
+        /// <summary>
+        /// Usable, but one or more already-assigned channels run at a different
+        /// sample rate and must be cleared first (all channels must share one).
+        /// </summary>
+        NeedsConfirmClear,
+
+        /// <summary>Usable as-is.</summary>
+        Accept
+    }
+
+    /// <summary>
+    /// Decides whether a candidate source is compatible with the channels that
+    /// already have a resolved transfer IR. <paramref name="otherResolvedSampleRates"/>
+    /// is the sample rate of every OTHER channel that currently has a source.
+    /// </summary>
+    public static Decision Evaluate(
+        bool hasTransferIr,
+        int candidateSampleRate,
+        IEnumerable<int> otherResolvedSampleRates)
+    {
+        ArgumentNullException.ThrowIfNull(otherResolvedSampleRates);
+        if (!hasTransferIr)
+        {
+            return Decision.Reject;
+        }
+
+        bool anyMismatch = otherResolvedSampleRates.Any(rate => rate != candidateSampleRate);
+        return anyMismatch ? Decision.NeedsConfirmClear : Decision.Accept;
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverJunctionsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverJunctionsTests.cs
@@ -80,4 +80,58 @@ public sealed class VirtualCrossoverJunctionsTests
             VirtualCrossoverJunctions.GetPairCrossoverHz(lower, upper),
             precision: 6);
     }
+
+    [Fact]
+    public void BandCenterHz_IsTheGeometricMeanOfTheBand()
+    {
+        var settings = new VirtualCrossoverChannelSettings
+        {
+            CrossoverKind = CrossoverKind.BandPass,
+            HighPassEdge = new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 100, 24),
+            LowPassEdge = new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 1_000, 24)
+        };
+
+        Assert.Equal(
+            Math.Sqrt(100.0 * 1_000),
+            VirtualCrossoverJunctions.BandCenterHz(settings),
+            precision: 6);
+    }
+
+    [Fact]
+    public void OverlapBand_IsAnOctaveEachSideClampedToTheAudioBand()
+    {
+        Assert.Equal((500, 2_000), VirtualCrossoverJunctions.OverlapBand(1_000));
+        // Low side clamps to the 20 Hz floor: 30/2 = 15 -> 20; high side 30*2 = 60.
+        Assert.Equal((20, 60), VirtualCrossoverJunctions.OverlapBand(30));
+        // High side clamps to the 20 kHz ceiling: 15_000*2 = 30_000 -> 20_000;
+        // low side 15_000/2 = 7_500.
+        Assert.Equal((7_500, 20_000), VirtualCrossoverJunctions.OverlapBand(15_000));
+    }
+
+    [Fact]
+    public void GetCrossoverWindow_DefaultsWhenNoChannelIsFiltered()
+    {
+        Assert.Equal(
+            (100, 10_000),
+            VirtualCrossoverJunctions.GetCrossoverWindow(
+                [new VirtualCrossoverChannelSettings(), new VirtualCrossoverChannelSettings()]));
+    }
+
+    [Fact]
+    public void GetCrossoverWindow_SpansAnOctaveAroundTheExtremeCorners()
+    {
+        var low = new VirtualCrossoverChannelSettings
+        {
+            CrossoverKind = CrossoverKind.LowPass,
+            LowPassEdge = new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 200, 24)
+        };
+        var high = new VirtualCrossoverChannelSettings
+        {
+            CrossoverKind = CrossoverKind.HighPass,
+            HighPassEdge = new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 4_000, 24)
+        };
+
+        // Lowest corner 200 -> /2 = 100; highest corner 4000 -> *2 = 8000.
+        Assert.Equal((100, 8_000), VirtualCrossoverJunctions.GetCrossoverWindow([low, high]));
+    }
 }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSourceRulesTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSourceRulesTests.cs
@@ -1,0 +1,60 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class VirtualCrossoverSourceRulesTests
+{
+    [Fact]
+    public void NoTransferIr_IsRejected()
+    {
+        Assert.Equal(
+            VirtualCrossoverSourceRules.Decision.Reject,
+            VirtualCrossoverSourceRules.Evaluate(
+                hasTransferIr: false,
+                candidateSampleRate: 48_000,
+                otherResolvedSampleRates: [48_000]));
+    }
+
+    [Fact]
+    public void FirstSource_WithNoOtherChannels_IsAccepted()
+    {
+        Assert.Equal(
+            VirtualCrossoverSourceRules.Decision.Accept,
+            VirtualCrossoverSourceRules.Evaluate(
+                hasTransferIr: true,
+                candidateSampleRate: 48_000,
+                otherResolvedSampleRates: []));
+    }
+
+    [Fact]
+    public void MatchingSampleRates_AreAccepted()
+    {
+        Assert.Equal(
+            VirtualCrossoverSourceRules.Decision.Accept,
+            VirtualCrossoverSourceRules.Evaluate(
+                hasTransferIr: true,
+                candidateSampleRate: 48_000,
+                otherResolvedSampleRates: [48_000, 48_000]));
+    }
+
+    [Fact]
+    public void AMismatchedSampleRate_NeedsConfirmClear()
+    {
+        Assert.Equal(
+            VirtualCrossoverSourceRules.Decision.NeedsConfirmClear,
+            VirtualCrossoverSourceRules.Evaluate(
+                hasTransferIr: true,
+                candidateSampleRate: 48_000,
+                otherResolvedSampleRates: [48_000, 44_100]));
+    }
+
+    [Fact]
+    public void NoTransferIr_TakesPriorityOverAMismatch()
+    {
+        // The missing-IR reject wins even when a rate mismatch also exists.
+        Assert.Equal(
+            VirtualCrossoverSourceRules.Decision.Reject,
+            VirtualCrossoverSourceRules.Evaluate(
+                hasTransferIr: false,
+                candidateSampleRate: 48_000,
+                otherResolvedSampleRates: [44_100]));
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -358,6 +358,51 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void SumLossCurve_IsThePerPointComplexVsMagnitudeSumGap()
+    {
+        // Two identical +0 dB channels: their phase-blind magnitude sum is +6.02 dB,
+        // so the loss at each point is the sum curve minus 6.02.
+        var channel = new List<SignalPoint>
+        {
+            new(500, 0.0), new(1_000, 0.0), new(2_000, 0.0)
+        };
+        var sum = new List<SignalPoint>
+        {
+            new(500, 6.0206), new(1_000, 0.0), new(2_000, 6.0206)
+        };
+
+        List<SignalPoint> loss = VirtualCrossoverAnalysis.SumLossCurve(sum, [channel, channel]);
+
+        Assert.Equal(3, loss.Count);
+        Assert.Equal(500, loss[0].X);
+        Assert.Equal(0.0, loss[0].Y, 3);
+        Assert.Equal(-6.0206, loss[1].Y, 3);
+        Assert.Equal(0.0, loss[2].Y, 3);
+    }
+
+    [Fact]
+    public void SumLossCurve_TruncatesToTheShortestGrid()
+    {
+        var shortChannel = new List<SignalPoint> { new(500, 0.0) };
+        var sum = new List<SignalPoint> { new(500, 0.0), new(1_000, 0.0) };
+
+        Assert.Single(VirtualCrossoverAnalysis.SumLossCurve(sum, [shortChannel]));
+    }
+
+    [Fact]
+    public void GroupDelayMs_OfAPureDelay_EqualsTheDelay()
+    {
+        // A pure delay has a constant group delay equal to the delay itself.
+        PreparedDspResponse prepared =
+            PreparedDspResponse.Create(new DspChannelChain(DelayMs: 1.5), SampleRate);
+
+        foreach (double frequency in new[] { 100.0, 1_000.0, 5_000.0 })
+        {
+            Assert.Equal(1.5, prepared.GroupDelayMs(frequency), 2);
+        }
+    }
+
+    [Fact]
     public void FindBestAlignment_DetectsAnInvertedChannel()
     {
         // The variable channel is a delayed AND inverted copy: the search must


### PR DESCRIPTION
The `TODO.md` item asked to "split VirtualCrossoverPanel (~2.6k lines)". A scout pass confirmed a move-only partial split would only spread the God-object across files without reducing any coupling — masking, not fixing. Instead this pulls the genuinely non-UI, correctness-critical logic out into tested units and leaves the control-touching code in the panel. Verified against a three-lens adversarial review (all four extractions confirmed behavior-preserving).

## What was extracted
- **`VirtualCrossoverSourceRules`** — the source-compatibility decision, previously hand-rolled in two places (interactive assign vs silent reload) as mutually-inverse predicates that could drift. Both paths now share one decision. Behavior is unchanged: the interactive path still prompts-and-clears mismatched channels, the reload still leaves an incompatible source unresolved (it can't prompt).
- **`VirtualCrossoverAnalysis.SumLossCurve`** — the single per-point sum-loss definition, now shared by the drawn "Sum loss" curve, `AverageSumLossDb` and `MinimumSumLossDb`. The drawn curve had **reimplemented the tested formula on an untested path** — a silent-drift hole, now closed. (`MinimumSumLossDb` was a third copy.)
- **`PreparedDspResponse.GroupDelayMs`** — the pure central-difference group-delay routine, moved from the panel into the dsp layer beside the response it operates on.
- **`VirtualCrossoverJunctions.GetCrossoverWindow` / `BandCenterHz` / `OverlapBand`** — the pure band arithmetic, with the octave-window idiom deduplicated.

## Honest scope
Even after this the panel remains a large view-controller (~60-70% is irreducible WinForms/OxyPlot wiring, marshalling, dialogs). The win is not "the God-object is gone" — it is that the correctness-critical numeric code (loss, group delay, source policy, band math) is now **deduplicated and under test on Linux/CI** instead of reachable only through a live Windows panel. Deeper extractions (decouple `ChannelRuntime` from its embedded control, then the process/alignment cores) are deferred to a Windows session where the interactive paths can be exercised; this is recorded in `TODO.md`.

## Verification
- `dotnet build source/Resonalyze.sln -c Release -p:EnableWindowsTargeting=true` — clean, 0 warnings.
- `dotnet test tests/Resonalyze.Dsp.Tests` — **297 passed**, incl. new `SumLossCurve` and `GroupDelayMs` tests; the existing `AverageSumLossDb`/`MinimumSumLossDb` tests guard the sum-loss refactor.
- New App.Tests (`VirtualCrossoverJunctions` band helpers, `VirtualCrossoverSourceRules`) run on Windows CI.
- Adversarial review confirmed all four extractions behavior-preserving and caught one self-contradictory `OverlapBand` unit test (wrong expected tuple), now fixed.

No behavior change intended — each extraction leaves the control-touching code behind in the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_