### PR TITLE
Raise dsp test-coverage quality: close the audit's meaningful gaps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -55,6 +55,38 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   `2×` smoothing width harmonic/THD curves use over the primary). No behavior
   change.
 
+- [x] **DSP test-coverage quality pass** — done. An audit of the dsp suite (real
+  cobertura line/branch numbers plus a per-module adversarial review of test
+  *meaningfulness*, not just presence) found one entirely-untested module and a
+  systemic "constant-input" smell (resampler, calibration, HD/THD isolation
+  exercised only on flat data, so the interesting math ran but was never pinned).
+  Closed with ~60 new tests, all cross-platform and CI-verifiable:
+  `WaterfallAnalysis` (was 0%: Morlet localisation/decay, frequency-grid geometry,
+  resample dB/floor); the degrees-domain phase API (`GetPhase`/`GetMinimumPhase`/
+  `GetExcessPhase`/`EstimatePhaseDetrend`); `LogarithmicResample`/`CalibrationFile`
+  known-answer tests on *non-constant* data; `DspMath.LanczosKernel`; window
+  coefficients; the `SignalEnvelope` SNR gate; `TransferFunction` coherence<1 and
+  the PHAT degenerate guard; the `AutoAlignmentEngine` downward walk;
+  `PeakingBiquad` digital-vs-analog off-centre; `CrossoverAutoSetup` Midbass;
+  `VirtualCrossover` degenerate window + loss diagnostics; `EqAutoTuner` NaN mask /
+  clamp / Q fallback; and MiniDSP/GraphicEQ/EasyEffects/Calibration numeric
+  payloads. Overall dsp line coverage 89% → 95%, branch 83% → 89%.
+  **Deliberate residuals (not shipped as tests, would have asserted unreachable or
+  tautological behaviour):**
+  - `TimeAlignmentAnalysis.ToSignedDelaySamples` subtraction branch: the peak
+    search is capped at `length/2`, so a detected arrival never lands above the
+    wrap pivot through the public `Analyze`. Only the pivot and comparison
+    direction are pinned (a no-op test); the negative-arrival arithmetic is not
+    reachable at the API boundary.
+  - `FindBandLimitedCorrelationDelay` collapse fallback (`highHz <= lowHz`): only
+    reachable when `centerFrequencyHz > Nyquist`, which the app never passes, and
+    the fallback does not actually reorder the band when `lowHz > 0.95·Nyquist`.
+    Latent robustness gap, not a live bug; the reachable Nyquist clamp is tested.
+  - `SearchAlignmentCandidatesByLoss` exact 1/f-weighted `LossDb`/`DipDb` values:
+    a byte-exact known-answer would have to re-derive the 1/6-octave-smoothed
+    log-weighted kernel (brittle). Covered instead by a relative test (aligned ~0
+    vs offset cancellation) that pins the diagnostics as non-vacuous.
+
 ## Virtual DSP / Time Alignment
 
 - [ ] **Time Alignment analysis is not cached** — `RefreshAnalysis`

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -115,6 +115,26 @@ public sealed class AutoAlignmentEngineTests
     }
 
     [Fact]
+    public void Compute_ReferenceIsNotTheBottomChannel_WalksDownward()
+    {
+        // Mirror image of the two-way test: here the TWEETER arrives latest, so it
+        // becomes the reference at band index 1 and the woofer (index 0) is aligned
+        // through the downward-walk branch (byBand[i+1] / pairs[i]) — the opposite
+        // index arithmetic to the upward walk every other test exercises.
+        var woofer = new TestChannel("W", DelayedImpulse(0.0));
+        var tweeter = new TestChannel("T", DelayedImpulse(1.0));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([woofer, tweeter], [1_000], log);
+
+        Assert.False(alignment.ContainsKey(tweeter)); // reference stays put
+        Assert.InRange(alignment[woofer].DelayMs, 0.95, 1.05);
+        Assert.False(alignment[woofer].InvertPolarity);
+        Assert.Contains("Reference: T", log.ToString());
+    }
+
+    [Fact]
     public void Compute_DetectsAnInvertedChannel()
     {
         var woofer = new TestChannel("W", DelayedImpulse(1.0));

--- a/tests/Resonalyze.Dsp.Tests/CalibrationFileTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CalibrationFileTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text;
 using Resonalyze.Dsp;
 
 namespace Resonalyze.Dsp.Tests;
@@ -97,7 +99,72 @@ public sealed class CalibrationFileTests
 
         double correction = calibration.GetDecibelCorrection(20_000);
 
-        Assert.InRange(correction, 1.0, 3.5);
+        // The final 1000->5000 Hz segment has a real +2 dB slope; above the range the
+        // correction must HOLD the last point (3.0 dB), not extrapolate the slope
+        // upward. The previous 1.0-3.5 window passed even for a wrong hold value.
+        Assert.Equal(3.0, correction, precision: 6);
+    }
+
+    [Fact]
+    public void ManyPointCurve_BinarySearchLandsOnTheCorrectSegment()
+    {
+        // A 200-point curve forces the interior binary-search descent (right = mid-1,
+        // left = mid+1) that the 3-point files never reach — those resolve on the
+        // first probe. A step at 1500 Hz makes each flat plateau an exact known value,
+        // so a wrong search comparison would read the other plateau.
+        var text = new StringBuilder();
+        foreach (double frequency in EqualizationCurve.LogFrequencyGrid(20, 20_000, 200))
+        {
+            double db = frequency < 1_500 ? 0.0 : 6.0;
+            text.Append(frequency.ToString("R", CultureInfo.InvariantCulture))
+                .Append(' ')
+                .Append(db.ToString(CultureInfo.InvariantCulture))
+                .Append('\n');
+        }
+
+        CalibrationFile calibration = CalibrationFile.Parse(text.ToString());
+
+        Assert.Equal(0.0, calibration.GetDecibelCorrection(200), precision: 5);   // low plateau
+        Assert.Equal(6.0, calibration.GetDecibelCorrection(8_000), precision: 5); // high plateau
+    }
+
+    [Fact]
+    public void SmoothingOctaves_WidensTheAveragingWindow()
+    {
+        // A single 12 dB spike on an otherwise flat curve. A narrow smoothing window
+        // keeps most of the spike; a wide one averages in the flat neighbours and
+        // pulls the correction down. Equal results would mean smoothingOctaves is
+        // ignored — the constant-curve tests could never show this.
+        IReadOnlyList<double> grid = EqualizationCurve.LogFrequencyGrid(20, 20_000, 200);
+        double spikeHz = grid.OrderBy(f => Math.Abs(f - 1_000)).First();
+        var text = new StringBuilder();
+        foreach (double frequency in grid)
+        {
+            double db = frequency == spikeHz ? 12.0 : 0.0;
+            text.Append(frequency.ToString("R", CultureInfo.InvariantCulture))
+                .Append(' ')
+                .Append(db.ToString(CultureInfo.InvariantCulture))
+                .Append('\n');
+        }
+
+        CalibrationFile calibration = CalibrationFile.Parse(text.ToString());
+        double narrow = calibration.GetDecibelCorrection(spikeHz, smoothingOctaves: 0.2);
+        double wide = calibration.GetDecibelCorrection(spikeHz, smoothingOctaves: 2.0);
+
+        Assert.True(narrow > wide + 1.0, $"Narrow smoothing {narrow:0.00} dB should exceed wide {wide:0.00} dB.");
+        Assert.InRange(narrow, 0.0, 12.0);
+        Assert.InRange(wide, 0.0, 12.0);
+    }
+
+    [Fact]
+    public void MissingFile_YieldsNoCorrection()
+    {
+        string missing = Path.Combine(
+            Path.GetTempPath(), $"resonalyze-missing-{Guid.NewGuid():N}.txt");
+
+        var calibration = new CalibrationFile(missing);
+
+        Assert.Equal(0.0, calibration.GetDecibelCorrection(1_000));
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/CrossoverAutoSetupTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverAutoSetupTests.cs
@@ -102,6 +102,28 @@ public sealed class CrossoverAutoSetupTests
     }
 
     [Fact]
+    public void Propose_MidbassHandoversStayInItsSensibleRange()
+    {
+        // A three-way with an explicit Midbass driver exercises the Midbass row of
+        // SensibleRange (80-500 Hz), which the other systems never hit. Its lower
+        // handover to the sub lands inside that range; the upper handover to the
+        // tweeter is pulled higher by the tweeter's own range but must stay ordered.
+        var sub = new AutoSetupSource(BandCurve(20, 120, 0), DriverType.Subwoofer);
+        var midbass = new AutoSetupSource(BandCurve(100, 800, 0), DriverType.Midbass);
+        var tweeter = new AutoSetupSource(BandCurve(2_000, 20_000, 0), DriverType.Tweeter);
+
+        IReadOnlyList<CrossoverProposal> proposals = CrossoverAutoSetup.Propose(
+            [sub, midbass, tweeter], Options());
+
+        Assert.Equal(3, proposals.Count);
+        double subToMidbass = proposals[0].LowPassEdge!.Value.FrequencyHz;
+        double midbassToTweeter = proposals[1].LowPassEdge!.Value.FrequencyHz;
+        Assert.InRange(subToMidbass, 80, 500); // midbass sensible-range low side
+        Assert.True(subToMidbass < midbassToTweeter, "Handovers must stay ordered.");
+        Assert.InRange(midbassToTweeter, 500, 2_000);
+    }
+
+    [Fact]
     public void EstimateBand_ReadsEdgesLevelAndType()
     {
         Assert.Equal(

--- a/tests/Resonalyze.Dsp.Tests/DataHelperImpulseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/DataHelperImpulseTests.cs
@@ -1,0 +1,93 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class DataHelperImpulseTests
+{
+    private const int SampleRate = 48_000;
+
+    private static SyntheticMeasurement WithPeakAt(int peakIndex, int length)
+    {
+        var ir = new Complex[length];
+        // A clear dominant peak plus a smaller lobe so "the peak" is unambiguous.
+        ir[peakIndex] = new Complex(1.0, 0.0);
+        if (peakIndex + 40 < length)
+        {
+            ir[peakIndex + 40] = new Complex(0.25, 0.0);
+        }
+
+        return new SyntheticMeasurement(ir, SampleRate, peakIndex);
+    }
+
+    [Fact]
+    public void GetImpulse_PlacesThePeakAtZeroWithTheExpectedLength()
+    {
+        SyntheticMeasurement measurement = WithPeakAt(peakIndex: 1_000, length: 8_192);
+        var opt = new ImpulseResponseOptions { Length = 4_096, Logarithmic = false };
+
+        AnalysisCurve curve = DataHelper.GetImpulse(measurement, opt);
+
+        Assert.Equal(512 + opt.Length, curve.Points.Count);
+        SignalPoint peak = curve.Points.MaxBy(p => Math.Abs(p.Y));
+        Assert.Equal(0.0, peak.X, precision: 12);
+        Assert.Equal(1.0, peak.Y, precision: 12);
+    }
+
+    [Fact]
+    public void GetImpulse_LogarithmicNormalizesThePeakToZeroDecibels()
+    {
+        SyntheticMeasurement measurement = WithPeakAt(peakIndex: 1_000, length: 8_192);
+        var opt = new ImpulseResponseOptions { Length = 4_096, Logarithmic = true };
+
+        AnalysisCurve curve = DataHelper.GetImpulse(measurement, opt);
+
+        SignalPoint loudest = curve.Points.MaxBy(p => p.Y);
+        Assert.Equal(0.0, loudest.Y, precision: 9); // peak is the 0 dB reference
+        Assert.Equal(0.0, loudest.X, precision: 12);
+    }
+
+    [Fact]
+    public void GetImpulseFromStart_UsesAbsoluteSamplesAndClampsToTheAvailableLength()
+    {
+        // peakIndex + Length (1000 + 4096 = 5096) exceeds the 2000-sample response, so
+        // the curve must clamp to the available length and keep the X axis absolute.
+        SyntheticMeasurement measurement = WithPeakAt(peakIndex: 1_000, length: 2_000);
+        var opt = new ImpulseResponseOptions { Length = 4_096, Logarithmic = false };
+
+        AnalysisCurve curve = DataHelper.GetImpulseFromStart(measurement, opt);
+
+        Assert.Equal(2_000, curve.Points.Count);
+        Assert.Equal(0.0, curve.Points[0].X, precision: 12); // absolute samples start at 0
+        SignalPoint peak = curve.Points.MaxBy(p => Math.Abs(p.Y));
+        Assert.Equal(1_000.0, peak.X, precision: 12); // peak stays at its absolute index
+    }
+
+    [Fact]
+    public void GetImpulseFromStart_EmptyResponseYieldsASingleSample()
+    {
+        var measurement = new SyntheticMeasurement(Array.Empty<Complex>(), SampleRate, 0);
+        var opt = new ImpulseResponseOptions { Length = 4_096 };
+
+        AnalysisCurve curve = DataHelper.GetImpulseFromStart(measurement, opt);
+
+        Assert.Single(curve.Points);
+    }
+
+    [Theory]
+    [InlineData(0.5, 4.0, 1.5, 1000.0 / 6.0)] // gate 6 ms -> ~166.67 Hz
+    [InlineData(1.0, 1.0, 0.0, 500.0)]         // gate 2 ms -> 500 Hz
+    public void GateMinReliableFrequencyHz_IsOneOverTheGateDuration(
+        double leftMs, double plateauMs, double rightMs, double expected)
+    {
+        Assert.Equal(
+            expected,
+            FrequencyResponseOptions.GateMinReliableFrequencyHz(leftMs, plateauMs, rightMs),
+            precision: 9);
+    }
+
+    [Fact]
+    public void GateMinReliableFrequencyHz_ZeroDurationGateReturnsZero()
+    {
+        Assert.Equal(0.0, FrequencyResponseOptions.GateMinReliableFrequencyHz(0.0, 0.0, 0.0));
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/DataHelperResampleTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/DataHelperResampleTests.cs
@@ -35,6 +35,29 @@ public sealed class DataHelperResampleTests
     }
 
     [Fact]
+    public void LogarithmicResample_PlacesAnIsolatedFeatureAtTheCorrectOutputFrequency()
+    {
+        // A single distinct bin at 1 kHz against a flat 0 dB floor. With a very small
+        // smoothing width the Lanczos window collapses to +/-2 input bins (10 Hz
+        // apart), and the kernel is exactly zero at those integer offsets, so the
+        // 1 kHz output point reads ONLY the 1 kHz bin. This pins LogPositionToFrequency,
+        // the BinarySearchX centre, and the kernel weighting together: a frequency-axis
+        // inversion or an off-by-one centre would read a 0 dB neighbour instead of -6.
+        List<SignalPoint> input = BuildLinearGrid(startHz: 10, stepHz: 10, count: 2000, decibels: 0.0);
+        input[99] = new SignalPoint(1_000.0, -6.0); // bin index 99 -> 1000 Hz
+
+        // steps = 3 over [100, 10000] puts output[1] at the geometric mean = 1000 Hz.
+        List<SignalPoint> output = DataHelper.LogarithmicResample(
+            input, start: 100, stop: 10_000, steps: 3, smoothingOctaves: 0.01);
+
+        Assert.Equal(1_000.0, output[1].X, precision: 6);
+        Assert.Equal(-6.0, output[1].Y, precision: 6);
+        // The flat-floor endpoints stay at 0 dB, confirming the feature did not leak.
+        Assert.Equal(0.0, output[0].Y, precision: 6);
+        Assert.Equal(0.0, output[2].Y, precision: 6);
+    }
+
+    [Fact]
     public void SmoothLinear_PreservesConstantLevel()
     {
         List<SignalPoint> input = BuildLinearGrid(

--- a/tests/Resonalyze.Dsp.Tests/DspMathTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/DspMathTests.cs
@@ -33,4 +33,36 @@ public sealed class DspMathTests
     {
         Assert.Equal(expected, DspMath.WrapIndex(index, length));
     }
+
+    [Fact]
+    public void LanczosKernel_IsUnityAtTheCentre()
+    {
+        Assert.Equal(1.0, DspMath.LanczosKernel(0.0, 2.0), precision: 12);
+    }
+
+    [Theory]
+    [InlineData(1.0, 2.0)] // integer offset -> sinc zero
+    [InlineData(2.0, 2.0)] // support edge |x| >= a -> zero
+    [InlineData(3.0, 2.0)] // outside support -> zero
+    public void LanczosKernel_IsZeroAtIntegerOffsetsAndBeyondSupport(double x, double a)
+    {
+        Assert.Equal(0.0, DspMath.LanczosKernel(x, a), precision: 12);
+    }
+
+    [Fact]
+    public void LanczosKernel_MatchesTheWindowedSincFormulaAtAnInteriorPoint()
+    {
+        // a * sinc(pi x) * sinc(pi x / a) at x = 0.5, a = 2:
+        // 2 * sin(pi/2) * sin(pi/4) / (pi/2)^2 = 0.5731591682...
+        Assert.Equal(0.5731591682, DspMath.LanczosKernel(0.5, 2.0), precision: 9);
+    }
+
+    [Fact]
+    public void LanczosKernel_IsSymmetric()
+    {
+        Assert.Equal(
+            DspMath.LanczosKernel(0.7, 2.0),
+            DspMath.LanczosKernel(-0.7, 2.0),
+            precision: 12);
+    }
 }

--- a/tests/Resonalyze.Dsp.Tests/EqAutoTunerTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EqAutoTunerTests.cs
@@ -140,6 +140,68 @@ public sealed class EqAutoTunerTests
     }
 
     [Fact]
+    public void Tune_ClampsCutBandsToTheConfiguredFloor()
+    {
+        // A +20 dB peak needs a -20 dB cut, but the band floor is -15 dB: every band
+        // must respect Math.Max(desired, BandGainMinDb). The existing test only pins
+        // the boost ceiling; this pins the cut floor.
+        IReadOnlyList<SignalPoint> source = Grid(f => new PeqBand(1_000, 3.0, 20.0).MagnitudeDbAt(f));
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+
+        EqualizationCurve curve = EqAutoTuner.Tune(
+            source,
+            target,
+            new EqAutoTuner.Options { BandGainMinDb = -15, PreampMinDb = 0 });
+
+        Assert.NotEmpty(curve.Bands);
+        Assert.All(curve.Bands, band => Assert.True(band.GainDb >= -15 - 1e-9));
+    }
+
+    [Fact]
+    public void Tune_PartialOverlap_FitsTheOverlapWithoutNaN()
+    {
+        // The source only covers 50-5000 Hz, so grid bins outside it resample to NaN
+        // and the valid[]/validCount mask must exclude them (validCount > 0). This is
+        // the realistic case; every other fitting test spans the full grid.
+        IReadOnlyList<double> full = EqualizationCurve.LogFrequencyGrid(20, 20_000, 400);
+        var bump = new PeqBand(1_000, 2.0, 8.0);
+        IReadOnlyList<SignalPoint> source = full
+            .Where(f => f is >= 50 and <= 5_000)
+            .Select(f => new SignalPoint(f, bump.MagnitudeDbAt(f)))
+            .ToList();
+        IReadOnlyList<SignalPoint> target = full.Select(f => new SignalPoint(f, 0.0)).ToList();
+
+        EqualizationCurve curve = EqAutoTuner.Tune(source, target);
+
+        Assert.NotEmpty(curve.Bands);
+        Assert.All(curve.Bands, b => Assert.InRange(b.FrequencyHz, 50, 5_000));
+        // No band produces a NaN anywhere on the audible grid.
+        Assert.All(full, f => Assert.True(double.IsFinite(curve.MagnitudeDbAt(f))));
+        // The fit substantially reduces the error inside the overlap.
+        double initial = FitRmsDb(new EqualizationCurve([]), source, source.Select(p => new SignalPoint(p.X, 0.0)).ToList());
+        double final = FitRmsDb(curve, source, source.Select(p => new SignalPoint(p.X, 0.0)).ToList());
+        Assert.True(final < initial * 0.5, $"Overlap error not reduced: {initial:0.00} -> {final:0.00} dB.");
+    }
+
+    [Fact]
+    public void Tune_QRangeExcludingAllCandidates_FallsBackWithoutThrowing()
+    {
+        // [QMin, QMax] = [3, 3.5] excludes every entry of the fixed candidate-Q list
+        // (2.8 and 4.0 straddle it), so the fitter must fall back to a single clamped
+        // Q rather than crash on an empty candidate array.
+        IReadOnlyList<SignalPoint> source = Grid(_ => 0.0);
+        IReadOnlyList<SignalPoint> target = Grid(f => new PeqBand(1_000, 3.0, 6.0).MagnitudeDbAt(f));
+
+        EqualizationCurve curve = EqAutoTuner.Tune(
+            source,
+            target,
+            new EqAutoTuner.Options { QMin = 3.0, QMax = 3.5 });
+
+        Assert.NotEmpty(curve.Bands);
+        Assert.All(curve.Bands, band => Assert.InRange(band.Q, 3.0, 3.5));
+    }
+
+    [Fact]
     public void Tune_NoOverlappingFrequencyData_ReturnsEmptyCurve()
     {
         // Source and target cover disjoint frequency ranges -> nothing to fit.

--- a/tests/Resonalyze.Dsp.Tests/EqProfileFormatsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EqProfileFormatsTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Resonalyze.Dsp.Tests;
 
 public sealed class EqProfileFormatsTests
@@ -82,6 +84,47 @@ public sealed class EqProfileFormatsTests
     }
 
     [Fact]
+    public void EasyEffects_ReadsAnEqualizerAtTheRootWithoutTheOutputWrapper()
+    {
+        // Older presets have the equalizer at the JSON root (no "output" wrapper) and
+        // some place bands directly under the equalizer (no "left" host).
+        string json =
+            "{ \"num-bands\": 1, \"output-gain\": -2," +
+            " \"band0\": { \"type\": \"Bell\", \"frequency\": 1000, \"gain\": 6, \"q\": 1 } }";
+
+        EqualizationCurve curve = new EasyEffectsFormat().Import(json);
+
+        Assert.Equal(-2, curve.PreampDb, 4);
+        Assert.Single(curve.Bands);
+        Assert.Equal(1000, curve.Bands[0].FrequencyHz, 4);
+    }
+
+    [Fact]
+    public void EasyEffects_ValidJsonThatIsNotAPreset_ReturnsEmptyCurve()
+    {
+        EqualizationCurve curve = new EasyEffectsFormat().Import("{ \"something\": 1, \"else\": true }");
+
+        Assert.Empty(curve.Bands);
+    }
+
+    [Fact]
+    public void EasyEffects_DropsDegenerateBellBands()
+    {
+        // A Bell band with q = 0 and one with a negative frequency are degenerate and
+        // must be rejected by the TryReadBand guard, leaving only the valid band.
+        string json =
+            "{ \"output\": { \"equalizer\": { \"output-gain\": 0, \"left\": {" +
+            " \"band0\": { \"type\": \"Bell\", \"frequency\": 1000, \"gain\": 6, \"q\": 0 }," +
+            " \"band1\": { \"type\": \"Bell\", \"frequency\": -100, \"gain\": 3, \"q\": 1 }," +
+            " \"band2\": { \"type\": \"Bell\", \"frequency\": 4000, \"gain\": -3, \"q\": 2 } } } } }";
+
+        EqualizationCurve curve = new EasyEffectsFormat().Import(json);
+
+        Assert.Single(curve.Bands);
+        Assert.Equal(4000, curve.Bands[0].FrequencyHz, 4);
+    }
+
+    [Fact]
     public void CamillaDsp_ExportHasPeakingFiltersAndPipeline()
     {
         string yaml = new CamillaDspYamlFormat().Export(SampleCurve());
@@ -133,12 +176,72 @@ public sealed class EqProfileFormatsTests
     }
 
     [Fact]
+    public void MiniDsp_ExportsThePreampGainAndBandCoefficients()
+    {
+        // These export-only formats have no round-trip safety net, so their numeric
+        // payload is otherwise unverified. Pin the actual coefficients: a leading
+        // gain biquad for the -6 dB preamp plus one biquad per band, matching
+        // PeakingBiquad.Compute at 48 kHz.
+        EqualizationCurve curve = SampleCurve();
+        string text = new MiniDspFormat().Export(curve);
+
+        double[] b0 = Coefficients(text, "b0=");
+        double[] a2 = Coefficients(text, "a2=");
+
+        Assert.Equal(1 + curve.Bands.Count, b0.Length); // preamp + bands
+        Assert.Equal(Math.Pow(10.0, curve.PreampDb / 20.0), b0[0], 6); // 10^(-6/20)
+
+        BiquadCoefficients firstBand = PeakingBiquad.Compute(curve.Bands[0], 48_000);
+        Assert.Equal(firstBand.B0, b0[1], 6);
+        Assert.Equal(firstBand.A2, a2[1], 6);
+    }
+
+    private static double[] Coefficients(string text, string prefix) => text
+        .Split('\n')
+        .Where(line => line.StartsWith(prefix, StringComparison.Ordinal))
+        .Select(line => double.Parse(
+            line[prefix.Length..].TrimEnd(',', '\r'), CultureInfo.InvariantCulture))
+        .ToArray();
+
+    [Fact]
     public void GraphicEq_ExportsFrequencyGainPairs()
     {
         string text = new GraphicEqFormat().Export(SampleCurve());
 
         Assert.StartsWith("GraphicEQ:", text);
         Assert.Contains(";", text);
+    }
+
+    [Fact]
+    public void GraphicEq_ExportsAscendingFrequenciesWithMatchingGains()
+    {
+        EqualizationCurve curve = SampleCurve();
+        string text = new GraphicEqFormat().Export(curve);
+
+        string[] pairs = text["GraphicEQ: ".Length..]
+            .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        double[] freqs = pairs
+            .Select(p => double.Parse(p.Split(' ')[0], CultureInfo.InvariantCulture))
+            .ToArray();
+        double[] gains = pairs
+            .Select(p => double.Parse(p.Split(' ')[1], CultureInfo.InvariantCulture))
+            .ToArray();
+
+        Assert.Equal(64, pairs.Length);
+        Assert.Equal(20.0, freqs[0]);
+        Assert.Equal(20_000.0, freqs[^1]);
+        // The frequency column is strictly ascending; the gain column is not — if the
+        // two columns were swapped this would fail, pinning the column order.
+        for (int i = 1; i < freqs.Length; i++)
+        {
+            Assert.True(freqs[i] > freqs[i - 1], "Frequencies must ascend.");
+        }
+        // The gain at each grid point is the curve's magnitude there (to one decimal).
+        IReadOnlyList<double> grid = EqualizationCurve.LogFrequencyGrid(20, 20_000, 64);
+        for (int i = 0; i < grid.Count; i++)
+        {
+            Assert.Equal(Math.Round(curve.MagnitudeDbAt(grid[i]), 1), gains[i], 3);
+        }
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/PeakingBiquadTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/PeakingBiquadTests.cs
@@ -33,4 +33,34 @@ public sealed class PeakingBiquadTests
         Assert.Throws<ArgumentOutOfRangeException>(
             () => PeakingBiquad.Compute(new PeqBand(600, 4.0, 6.0), 0));
     }
+
+    [Theory]
+    [InlineData(8.0)]   // boost
+    [InlineData(-8.0)]  // cut
+    public void DigitalResponse_MatchesTheAnalogPrototypeOffCentre(double gainDb)
+    {
+        // The bandwidth is set by alpha = sin(w0)/(2Q); a wrong alpha (e.g. dropping
+        // the factor of 2) would still hit the centre gain and stay finite, so the
+        // passthrough/finite tests miss it. Well below Nyquist the digital filter
+        // must track the independent analog peaking prototype off-centre to a few
+        // hundredths of a dB — pinning the bandwidth, cross-checked against a
+        // formula the biquad code never touches.
+        const double fs = 48_000;
+        const double f0 = 1_000;
+        const double q = 2.0;
+        var band = new PeqBand(f0, q, gainDb);
+        BiquadCoefficients coefficients = PeakingBiquad.Compute(band, fs);
+
+        foreach (double frequency in new[] { f0 / 2.0, f0, 2.0 * f0 })
+        {
+            double digitalDb = 20.0 * Math.Log10(
+                BiquadResponse.Evaluate(coefficients, frequency, fs).Magnitude);
+            Assert.Equal(band.MagnitudeDbAt(frequency), digitalDb, tolerance: 0.3);
+        }
+
+        // The centre must sit exactly on the band gain in both formulations.
+        double centreDigital = 20.0 * Math.Log10(
+            BiquadResponse.Evaluate(coefficients, f0, fs).Magnitude);
+        Assert.Equal(gainDb, centreDigital, tolerance: 0.01);
+    }
 }

--- a/tests/Resonalyze.Dsp.Tests/PhaseCurvesTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/PhaseCurvesTests.cs
@@ -1,0 +1,132 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+// Exercises the public degrees-domain phase API (GetPhase / GetMinimumPhase /
+// GetExcessPhase / EstimatePhaseDetrend). The radian core these wrap is covered by
+// GatedPhaseDataTests, MinimumPhaseTests and ExcessDelayTests; here we pin the
+// wrappers themselves — the degrees conversion, the measured-minus-minimum excess
+// composition (incl. its bin alignment) and the absolute-sample detrend offset.
+public sealed class PhaseCurvesTests
+{
+    private const int SampleRate = 48_000;
+
+    private static SyntheticMeasurement Delay(int sampleIndex)
+    {
+        var ir = new Complex[8_192];
+        ir[sampleIndex] = Complex.One;
+        return new SyntheticMeasurement(ir, SampleRate, sampleIndex);
+    }
+
+    private static SyntheticMeasurement MinimumPhaseFilterAt(int sampleIndex)
+    {
+        // H(z) = 1 - 0.7 z^-1 + 0.2 z^-2 has both zeros inside the unit circle
+        // (|z| = sqrt(0.2) ~= 0.447), so it is minimum phase: its excess phase is ~0.
+        var ir = new Complex[8_192];
+        ir[sampleIndex] = new Complex(1.0, 0.0);
+        ir[sampleIndex + 1] = new Complex(-0.7, 0.0);
+        ir[sampleIndex + 2] = new Complex(0.2, 0.0);
+        return new SyntheticMeasurement(ir, SampleRate, sampleIndex);
+    }
+
+    [Fact]
+    public void GetPhase_IsTheGatedRadianPhaseConvertedToDegrees()
+    {
+        SyntheticMeasurement measurement = Delay(960);
+
+        AnalysisCurve degrees = DataHelper.GetPhase(
+            measurement, gateOffsetMs: 20.0, leftMs: 1.0, plateauMs: 5.0, rightMs: 10.0,
+            detrendMilliseconds: 0.0, smoothingInverseOctaves: 0.0, unwrap: true);
+
+        List<SignalPoint> radians = DataHelper.GetGatedPhaseData(
+            measurement, 20.0, 1.0, 5.0, 10.0, referenceSamples: 0.0, unwrap: true);
+
+        Assert.Equal(radians.Count, degrees.Points.Count);
+        for (int i = 0; i < radians.Count; i++)
+        {
+            Assert.Equal(radians[i].X, degrees.Points[i].X, precision: 9);
+            Assert.Equal(radians[i].Y / Math.PI * 180.0, degrees.Points[i].Y, precision: 9);
+        }
+    }
+
+    [Fact]
+    public void GetMinimumPhase_OfAFlatMagnitudeResponseIsNearZeroDegrees()
+    {
+        // A pure delay has flat magnitude, so its minimum-phase component is ~0.
+        AnalysisCurve curve = DataHelper.GetMinimumPhase(
+            Delay(960), gateOffsetMs: 20.0, leftMs: 1.0, plateauMs: 5.0, rightMs: 10.0,
+            smoothingInverseOctaves: 0.0);
+
+        Assert.Equal(AnalysisCurveKind.MinimumPhase, curve.Kind);
+        Assert.NotEmpty(curve.Points);
+        double previousX = double.NegativeInfinity;
+        foreach (SignalPoint point in curve.Points)
+        {
+            Assert.True(point.X > previousX, "Frequency axis must be strictly ascending.");
+            previousX = point.X;
+        }
+        foreach (SignalPoint point in curve.Points.Where(p => p.X is >= 200 and <= 5_000))
+        {
+            Assert.True(Math.Abs(point.Y) < 2.0, $"Minimum phase {point.Y:0.###} deg at {point.X:0.#} Hz.");
+        }
+    }
+
+    [Fact]
+    public void GetExcessPhase_OfAMinimumPhaseSystemIsNearZero()
+    {
+        // Referenced to its own arrival (detrend = 20 ms = 960 samples), the measured
+        // phase of a minimum-phase filter equals its minimum phase, so the excess
+        // (measured - minimum) collapses to ~0. A sign flip or a minimumPhase[j+1]
+        // vs [j] off-by-one would leave a large residual.
+        AnalysisCurve excess = DataHelper.GetExcessPhase(
+            MinimumPhaseFilterAt(960), gateOffsetMs: 20.0, leftMs: 1.0, plateauMs: 5.0, rightMs: 10.0,
+            detrendMilliseconds: 20.0, smoothingInverseOctaves: 0.0);
+
+        Assert.Equal(AnalysisCurveKind.ExcessPhase, excess.Kind);
+        foreach (SignalPoint point in excess.Points.Where(p => p.X is >= 200 and <= 5_000))
+        {
+            Assert.True(Math.Abs(point.Y) < 5.0, $"Excess phase {point.Y:0.###} deg at {point.X:0.#} Hz.");
+        }
+    }
+
+    [Fact]
+    public void GetExcessPhase_OfAPureDelayTracksTheMeasuredPhase()
+    {
+        // With no detrend the minimum-phase part is ~0, so the excess must follow the
+        // (large, unflattened) measured delay phase. This pins the subtraction sign:
+        // a flip would return the negated ramp.
+        var measurement = Delay(960);
+        AnalysisCurve excess = DataHelper.GetExcessPhase(
+            measurement, 20.0, 1.0, 5.0, 10.0,
+            detrendMilliseconds: 0.0, smoothingInverseOctaves: 0.0);
+
+        List<SignalPoint> measured = DataHelper.GetGatedPhaseData(
+            measurement, 20.0, 1.0, 5.0, 10.0, referenceSamples: 0.0, unwrap: true);
+
+        Assert.Equal(measured.Count, excess.Points.Count);
+        foreach ((SignalPoint m, SignalPoint e) in measured.Zip(excess.Points))
+        {
+            if (m.X is < 200 or > 5_000)
+            {
+                continue;
+            }
+            Assert.Equal(m.Y / Math.PI * 180.0, e.Y, tolerance: 5.0);
+        }
+    }
+
+    [Theory]
+    [InlineData(1_440, 30.0)] // 30 ms
+    [InlineData(960, 20.0)]   // 20 ms
+    public void EstimatePhaseDetrend_ReturnsTheAbsoluteArrivalTime(int sampleIndex, double expectedMs)
+    {
+        // The estimate is absolute (referenced to IR sample 0). Dropping the
+        // extractionStart offset would report the arrival relative to the gate start
+        // (a few hundred microseconds) instead of its true tens-of-ms position.
+        (double slopeMs, double peakMs) = DataHelper.EstimatePhaseDetrend(
+            Delay(sampleIndex),
+            gateOffsetMs: expectedMs, leftMs: 1.0, plateauMs: 8.0, rightMs: 3.0);
+
+        Assert.Equal(expectedMs, slopeMs, tolerance: 0.05);
+        Assert.Equal(expectedMs, peakMs, tolerance: 0.05);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
@@ -118,6 +118,56 @@ public sealed class SignalEnvelopeTests
     }
 
     [Fact]
+    public void FindFractionalPeakOffset_FlatTripleReturnsZero()
+    {
+        // previous - 2*center + next == 0: the parabola is degenerate, so the offset
+        // must be exactly the flat-guard value rather than a division by ~zero.
+        Assert.Equal(0.0, SignalEnvelope.FindFractionalPeakOffset(1.0, 1.0, 1.0));
+    }
+
+    [Fact]
+    public void FindFractionalPeakOffset_ReturnsTheParabolicVertex()
+    {
+        // 0.5 * (previous - next) / (previous - 2*center + next)
+        // = 0.5 * (1 - 2) / (1 - 8 + 2) = 0.5 * (-1) / (-5) = 0.1.
+        Assert.Equal(0.1, SignalEnvelope.FindFractionalPeakOffset(1.0, 4.0, 2.0), precision: 12);
+    }
+
+    [Fact]
+    public void FindPeak_SnrGateRejectsASubNoiseEarlyBumpUnlessSnrIsRelaxed()
+    {
+        // A 0.01 noise bed with an early bump (0.08) and a much later strong peak
+        // (1.0). The bump clears the -25 dB-below-max threshold (0.056), so only the
+        // SNR gate can decide it. Raising FirstPeakMinimumSnrDb lifts the noise-based
+        // threshold above the bump; relaxing it lets the bump through. This is the
+        // only lever that changes, so the flip pins the SNR branch.
+        var envelope = new double[2_000];
+        Array.Fill(envelope, 0.01);
+        envelope[100] = 0.08; // early candidate arrival
+        envelope[500] = 1.0;  // dominant peak
+
+        PeakSearchResult strict = SignalEnvelope.FindPeak(
+            envelope, 48_000,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                FirstPeakThresholdBelowMaxDb = 25,
+                FirstPeakMinimumSnrDb = 30,
+            });
+        PeakSearchResult relaxed = SignalEnvelope.FindPeak(
+            envelope, 48_000,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                FirstPeakThresholdBelowMaxDb = 25,
+                FirstPeakMinimumSnrDb = 0,
+            });
+
+        Assert.Equal(500, strict.SelectedIndex);  // sub-SNR bump rejected -> strongest peak
+        Assert.Equal(100, relaxed.SelectedIndex);  // bump accepted as the first arrival
+    }
+
+    [Fact]
     public void EstimatePeakConfidenceDecibels_ExcludesWrappedPeakNeighborhood()
     {
         double[] envelope = Enumerable.Repeat(0.01, 1000).ToArray();

--- a/tests/Resonalyze.Dsp.Tests/SpectrumHarmonicIsolationTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SpectrumHarmonicIsolationTests.cs
@@ -1,0 +1,65 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+// SpectrumCurveSelectionTests only pins WHICH curves GetSpectrum returns. This pins
+// that each harmonic curve isolates the RIGHT region of the impulse response: the
+// HDn window is centred on HarmonicIROffset(n), so a distortion packet sitting only
+// at the HD2 offset must light up HD2 (and the HD2..HD5 THD window) while HD3/HD4 —
+// whose windows bracket empty IR regions — stay on the floor. A shifted window,
+// a wrong harmonic-offset mapping, or a degenerate window would break this.
+public sealed class SpectrumHarmonicIsolationTests
+{
+    private const int SampleRate = 48_000;
+    private const int PeakIndex = 8_000;
+
+    // A linear offset in harmonic-number space: HarmonicIROffset(n) = 200*(n-1), so
+    // HD2 sits 200 samples before the peak, HD3 at 400, HD4 at 600. GetSpectrum uses
+    // the same mapping to place its windows, so placement and isolation stay consistent.
+    private static SyntheticMeasurement WithHd2PacketOnly()
+    {
+        var ir = new Complex[16_384];
+        ir[PeakIndex] = Complex.One; // linear arrival
+
+        // Fill the HD2 window region [peak-206, peak-100] with a tone. The HD3 window
+        // ([peak-406, peak-300]) and HD4 window ([peak-606, peak-500]) stay empty.
+        for (int i = PeakIndex - 205; i <= PeakIndex - 101; i++)
+        {
+            ir[i] = new Complex(Math.Sin(2.0 * Math.PI * 12.0 * (i - (PeakIndex - 205)) / 105.0), 0.0);
+        }
+
+        return new SyntheticMeasurement(
+            ir, SampleRate, PeakIndex, harmonicOffset: h => 200.0 * (h - 1));
+    }
+
+    private static double MaxDb(AnalysisCurve curve) => curve.Points.Max(p => p.Y);
+
+    [Fact]
+    public void GetSpectrum_IsolatesTheHarmonicWindowToTheCorrectIrRegion()
+    {
+        IReadOnlyList<AnalysisCurve> curves = DataHelper.GetSpectrum(
+            WithHd2PacketOnly(),
+            new FrequencyResponseOptions(),
+            calibration: null,
+            SpectrumCurves.SecondHarmonic
+                | SpectrumCurves.ThirdHarmonic
+                | SpectrumCurves.FourthHarmonic
+                | SpectrumCurves.ThdPlusNoise);
+
+        double hd2 = MaxDb(curves.Single(c => c.Kind == AnalysisCurveKind.SecondHarmonic));
+        double hd3 = MaxDb(curves.Single(c => c.Kind == AnalysisCurveKind.ThirdHarmonic));
+        double hd4 = MaxDb(curves.Single(c => c.Kind == AnalysisCurveKind.FourthHarmonic));
+        double thd = MaxDb(curves.Single(c => c.Kind == AnalysisCurveKind.ThdPlusNoise));
+
+        // The packet lives only in the HD2 window, so HD2 carries real energy while
+        // the empty HD3/HD4 windows collapse to the -160 dB floor.
+        Assert.True(hd2 > -100.0, $"HD2 should carry the packet's energy, was {hd2:0.#} dB.");
+        Assert.True(hd3 < -140.0, $"HD3 window is empty, should be near the floor, was {hd3:0.#} dB.");
+        Assert.True(hd4 < -140.0, $"HD4 window is empty, should be near the floor, was {hd4:0.#} dB.");
+        Assert.True(hd2 > hd3 + 40.0 && hd2 > hd4 + 40.0, "HD2 must dominate the empty windows.");
+
+        // The THD+N window spans HD2..HD5, so it also captures the packet.
+        Assert.True(thd > -100.0, $"THD+N should include the HD2 packet, was {thd:0.#} dB.");
+        Assert.True(thd > hd3 + 40.0, "THD+N must dominate the empty HD3 window.");
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/SweepAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SweepAnalysisTests.cs
@@ -1,0 +1,40 @@
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class SweepAnalysisTests
+{
+    [Fact]
+    public void DeconvolveWithInverseFilter_ReportsThePeakIndexOfTheConvolution()
+    {
+        // recorded = delta at 30, inverse filter = delta at 20. Their convolution is a
+        // single delta at 30 + 20 = 50, so the reported peak index must be 50. The
+        // flatness test only checks a shift-invariant magnitude spectrum, so a wrong
+        // peak search (off-by-one, min-vs-max flip) is invisible there but caught here.
+        var recorded = new double[128];
+        recorded[30] = 1.0;
+        var inverseFilter = new double[64];
+        inverseFilter[20] = 1.0;
+
+        SweepDeconvolutionResult result = SweepAnalysis.DeconvolveWithInverseFilter(
+            recorded, inverseFilter);
+
+        Assert.Equal(50, result.PeakIndex);
+        Assert.True(
+            Math.Abs(result.ImpulseResponse[50]) >= result.ImpulseResponse.Max(Math.Abs) - 1e-12,
+            "The reported peak index must hold the largest-magnitude sample.");
+    }
+
+    [Fact]
+    public void DeconvolveWithInverseFilter_PeakTracksTheDelay()
+    {
+        // Shift the recorded delta and the peak index must move with it.
+        var recorded = new double[128];
+        recorded[70] = 1.0;
+        var inverseFilter = new double[64];
+        inverseFilter[5] = 1.0;
+
+        SweepDeconvolutionResult result = SweepAnalysis.DeconvolveWithInverseFilter(
+            recorded, inverseFilter);
+
+        Assert.Equal(75, result.PeakIndex);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
@@ -35,6 +35,70 @@ public sealed class TimeAlignmentAnalysisTests
     }
 
     [Fact]
+    public void Analyze_ReportsTheStrongestArrivalSampleAndDelayForACleanImpulse()
+    {
+        var impulseResponse = new double[8_192];
+        impulseResponse[300] = 1.0;
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, new TimeAlignmentAnalysisOptions());
+
+        // The strongest peak (the analytic-envelope main lobe) lands on the arrival:
+        // 300 samples at 48 kHz = 6.25 ms. The refined sample and its ms twin agree.
+        Assert.Equal(300, result.StrongestEnvelopePeakIndex);
+        Assert.InRange(result.StrongestPeakSample, 299.5, 300.5);
+        Assert.InRange(result.StrongestDelayMilliseconds, 6.24, 6.26);
+        Assert.Equal(
+            result.StrongestPeakSample * 1000.0 / SampleRate,
+            result.StrongestDelayMilliseconds,
+            precision: 9);
+        // The first arrival is at or before the strongest, never after it.
+        Assert.True(result.FirstArrivalPeakSample <= result.StrongestPeakSample + 0.5);
+    }
+
+    [Fact]
+    public void Analyze_LocatesTheStrongArrivalAndAnEarlierFirstArrivalInTheTwoPeakTrap()
+    {
+        var impulseResponse = new double[8_192];
+        impulseResponse[100] = 0.3; // weak direct arrival
+        impulseResponse[500] = 1.0; // strong late arrival (room mode)
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, new TimeAlignmentAnalysisOptions());
+
+        // The strongest peak main lobe sits on the 1.0 arrival (500 samples, 10.417 ms).
+        Assert.Equal(500, result.StrongestEnvelopePeakIndex);
+        Assert.InRange(result.StrongestPeakSample, 499.0, 501.0);
+        Assert.InRange(result.StrongestDelayMilliseconds, 10.38, 10.44);
+        // The first arrival is detected near the weak 100-sample pulse — hundreds of
+        // samples earlier than the strongest, i.e. the module did not collapse both
+        // onto the dominant peak.
+        Assert.InRange(result.FirstArrivalPeakSample, 90.0, 110.0);
+        Assert.True(result.StrongestPeakSample - result.FirstArrivalPeakSample > 300.0);
+    }
+
+    [Fact]
+    public void Analyze_WrapPeakPositionsLeavesASubHalfArrivalUnchanged()
+    {
+        // The peak search is capped at length/2, so a real arrival always lands in
+        // the lower half of the buffer and ToSignedDelaySamples' pivot (length*0.5)
+        // must leave it untouched. A flipped comparison would wrap this normal
+        // arrival to a large negative delay; running with and without the flag and
+        // requiring identical output pins the pivot and its direction.
+        var impulseResponse = new double[8_192];
+        impulseResponse[300] = 1.0;
+
+        TimeAlignmentAnalysisResult unwrapped = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, new TimeAlignmentAnalysisOptions());
+        TimeAlignmentAnalysisResult wrapped = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, new TimeAlignmentAnalysisOptions { WrapPeakPositions = true });
+
+        Assert.Equal(unwrapped.FirstArrivalPeakSample, wrapped.FirstArrivalPeakSample, precision: 12);
+        Assert.Equal(unwrapped.StrongestPeakSample, wrapped.StrongestPeakSample, precision: 12);
+        Assert.True(wrapped.FirstArrivalPeakSample > 0);
+    }
+
+    [Fact]
     public void Analyze_DoesNotFlagACloseSecondPeakBelowTheThreshold()
     {
         // Two peaks only ~0.4 ms apart: too close to matter for alignment, so no

--- a/tests/Resonalyze.Dsp.Tests/TransferFunctionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferFunctionTests.cs
@@ -197,7 +197,64 @@ public sealed class TransferFunctionTests
         Assert.NotNull(result.Coherence);
         Assert.Equal(delay, result.PeakIndex);
         Assert.Equal(1.0, result.ImpulseResponse[delay], precision: 9);
-        Assert.All(result.Coherence!, value => Assert.InRange(value, 0.0, 1.0));
+        // Identical frames are perfectly coherent: every interior bin must read ~1,
+        // not merely "somewhere in [0, 1]".
+        for (int bin = 1; bin < result.Coherence!.Length - 1; bin++)
+        {
+            Assert.InRange(result.Coherence[bin], 0.999, 1.0 + 1e-9);
+        }
+    }
+
+    [Fact]
+    public void ComputeAveragedRelativeIr_IncoherentFramesDropCoherenceBelowOne()
+    {
+        // Reference is an impulse (flat spectrum); each target is the same delayed
+        // impulse plus an uncorrelated spike whose sign alternates across frames. The
+        // spikes sum to zero, so the averaged H1 still recovers the clean delay, but
+        // their power inflates the target auto-spectrum and pushes coherence well
+        // below one at every bin. A vacuous "in [0,1]" check would miss this.
+        const int delay = 9;
+        double[] reference = CreateImpulse(128);
+        double[] target = Delay(reference, delay);
+
+        var frames = new List<TransferFunctionFrame>();
+        double[] signs = [1.0, -1.0, 1.0, -1.0];
+        foreach (double sign in signs)
+        {
+            double[] noisy = (double[])target.Clone();
+            noisy[40] += sign * 0.5; // uncorrelated with the reference impulse
+            frames.Add(new TransferFunctionFrame(reference, noisy));
+        }
+
+        TransferEstimateResult result = TransferFunction.ComputeAveragedRelativeIr(frames);
+
+        Assert.NotNull(result.Coherence);
+        double maxCoherence = 0;
+        for (int bin = 1; bin < result.Coherence!.Length - 1; bin++)
+        {
+            maxCoherence = Math.Max(maxCoherence, result.Coherence[bin]);
+        }
+        Assert.True(maxCoherence < 0.95, $"Expected coherence below 1 everywhere, peak was {maxCoherence:0.###}.");
+
+        // The zero-mean spikes cancel in the average, so the delay is still clean.
+        Assert.Equal(delay, result.PeakIndex);
+        Assert.Equal(1.0, result.ImpulseResponse[delay], precision: 9);
+    }
+
+    [Fact]
+    public void RefineAround_DegenerateCorrelationReportsNoRefinementWithoutNaN()
+    {
+        // An all-zero IR whitens to an empty band (weightSum 0, normalizer 0), so the
+        // refinement must bail out cleanly rather than divide by zero.
+        PhaseTransformCorrelation correlation =
+            TransferFunction.ComputePhaseTransformFromResponse(new double[128]);
+
+        PhaseTransformDelay delay = correlation.RefineAround(coarseLagSamples: 10, searchRadiusSamples: 4);
+
+        Assert.Equal(0.0, delay.PeakCorrelation);
+        Assert.False(delay.Refined);
+        Assert.Equal(10, delay.LagSamples);
+        Assert.False(double.IsNaN(delay.PeakCorrelation) || double.IsInfinity(delay.PeakCorrelation));
     }
 
     private static double[] CreateImpulse(int length)

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -538,8 +538,11 @@ public sealed class VirtualCrossoverAnalysisTests
         double arrivalMs = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
             ir, SampleRate, 20, 1_000);
 
-        // 480 samples at 48 kHz = 10 ms; the LR24 group delay adds a fraction.
-        Assert.InRange(arrivalMs, 9.5, 11.5);
+        // 480 samples at 48 kHz = 10 ms; the LR24 low-pass group delay adds a small
+        // fraction of a millisecond. The previous ±1.5 ms window was wide enough to
+        // pass even if the estimate ignored the offset entirely; this tighter window
+        // (commensurate with the actual group delay) requires it to track the arrival.
+        Assert.InRange(arrivalMs, 10.0, 10.6);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverEdgeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverEdgeTests.cs
@@ -1,0 +1,87 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+// Edge/guard coverage for VirtualCrossoverAnalysis: a degenerate (empty) frequency
+// window, the Nyquist band clamp, and the meaning of the reported loss diagnostics.
+public sealed class VirtualCrossoverEdgeTests
+{
+    private const int SampleRate = 48_000;
+
+    private static Complex[] UnitImpulse(int length, int position)
+    {
+        var ir = new Complex[length];
+        ir[position] = Complex.One;
+        return ir;
+    }
+
+    [Fact]
+    public void DegenerateWindowAboveNyquist_YieldsNoAlignment()
+    {
+        // 25-30 kHz sits entirely above the 24 kHz Nyquist, so no FFT bins fall in
+        // the window (lastBin < firstBin). The search must return the neutral result
+        // rather than indexing an empty bin list.
+        Complex[] variable = UnitImpulse(4_096, 100);
+        Complex[] fixedIr = UnitImpulse(4_096, 100);
+
+        Assert.Empty(VirtualCrossoverAnalysis.FindAlignmentCandidates(
+            variable, [fixedIr], SampleRate, 25_000, 30_000, -1, 1));
+        Assert.Equal(0.0, VirtualCrossoverAnalysis.FindBestDelayMs(
+            variable, [fixedIr], SampleRate, 25_000, 30_000, -1, 1));
+
+        AlignmentResult best = VirtualCrossoverAnalysis.FindBestAlignment(
+            variable, [fixedIr], SampleRate, 25_000, 30_000, -1, 1);
+        Assert.Equal(0.0, best.DelayMs);
+        Assert.False(best.InvertPolarity);
+    }
+
+    [Fact]
+    public void FindBandLimitedCorrelationDelay_ClampsAWidePassBandBelowNyquist()
+    {
+        // A very wide pass band would run past Nyquist; the search must clamp the
+        // upper edge (to 0.95*Nyquist) while keeping the band ordered and usable.
+        CorrelationAlignmentResult result =
+            VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
+                UnitImpulse(8_192, 2_000),
+                UnitImpulse(8_192, 1_952),
+                SampleRate,
+                centerFrequencyHz: 1_000,
+                passOctaves: 8.0,
+                searchRangeMs: 3.0);
+
+        Assert.True(result.BandLowHz < result.BandHighHz, "The clamped band must stay ordered.");
+        Assert.True(result.BandHighHz <= SampleRate / 2.0 * 0.95 + 1e-6, "Upper edge must sit below Nyquist.");
+        Assert.True(result.BandLowHz >= 20.0);
+    }
+
+    [Fact]
+    public void FindAlignmentCandidates_LossDiagnosticsReflectSummationQuality()
+    {
+        // Two identical, already-aligned channels sum constructively across the whole
+        // band, so the best candidate's average loss and worst dip are both ~0 dB.
+        Complex[] aligned = UnitImpulse(4_096, 100);
+        IReadOnlyList<AlignmentCandidate> alignedCandidates =
+            VirtualCrossoverAnalysis.FindAlignmentCandidates(
+                aligned, [UnitImpulse(4_096, 100)], SampleRate, 500, 2_000, -1, 1);
+
+        AlignmentCandidate best = alignedCandidates[0];
+        Assert.InRange(best.DelayMs, -0.05, 0.05);
+        Assert.False(best.InvertPolarity);
+        Assert.InRange(best.LossDb, -0.5, 0.5);
+        Assert.InRange(best.DipDb, -0.5, 0.5);
+
+        // A second channel offset by half a period at the band centre (1.25 kHz ->
+        // 0.4 ms) partially cancels: the same aligned pick now carries a real average
+        // loss and a still-deeper dip, so the diagnostics are not vacuous.
+        Complex[] offsetFixed = UnitImpulse(4_096, 100);
+        offsetFixed[100] = Complex.Zero;
+        offsetFixed[119] = Complex.One; // ~0.4 ms later
+        IReadOnlyList<AlignmentCandidate> cancelling =
+            VirtualCrossoverAnalysis.FindAlignmentCandidates(
+                aligned, [offsetFixed], SampleRate, 900, 1_600, -0.05, 0.05);
+
+        Assert.True(cancelling[0].LossDb < best.LossDb - 0.2,
+            $"Offset pair should show more loss ({cancelling[0].LossDb:0.00}) than the aligned pair ({best.LossDb:0.00}).");
+        Assert.True(cancelling[0].DipDb <= cancelling[0].LossDb + 1e-9, "The dip cannot sit above the average.");
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/WaterfallAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/WaterfallAnalysisTests.cs
@@ -1,0 +1,176 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class WaterfallAnalysisTests
+{
+    private const int SampleRate = 48_000;
+    private const int Window = 4096;
+
+    // A decaying sinusoid at a known frequency, laid straight into the impulse
+    // response so ExtractWindow (offset 0) reads exactly it.
+    private static SyntheticMeasurement DecayingTone(double frequencyHz, double tauSamples)
+    {
+        var ir = new Complex[Window];
+        for (int n = 0; n < Window; n++)
+        {
+            double envelope = Math.Exp(-n / tauSamples);
+            ir[n] = new Complex(envelope * Math.Sin(2.0 * Math.PI * frequencyHz * n / SampleRate), 0.0);
+        }
+
+        return new SyntheticMeasurement(ir, SampleRate, maxMagnitudeIndex: 0);
+    }
+
+    private static double[] Hann(int length)
+    {
+        double[] w = new double[length];
+        for (int n = 0; n < length; n++)
+        {
+            w[n] = 0.5 - 0.5 * Math.Cos(2.0 * Math.PI * n / (length - 1));
+        }
+
+        return w;
+    }
+
+    private static BurstDecaySlice ClosestSlice(IReadOnlyList<BurstDecaySlice> slices, double frequencyHz)
+    {
+        return slices.OrderBy(s => Math.Abs(Math.Log(s.Frequency / frequencyHz))).First();
+    }
+
+    private static double PeakMagnitude(BurstDecaySlice slice) => slice.Data.Max(p => p.Y);
+
+    [Fact]
+    public void BuildBurstDecayRawSlices_LocalizesEnergyToTheToneFrequency()
+    {
+        const double toneHz = 1_000.0;
+        IReadOnlyList<BurstDecaySlice> slices = WaterfallAnalysis.BuildBurstDecayRawSlices(
+            DecayingTone(toneHz, tauSamples: 1_500.0),
+            offset: 0,
+            window: Window,
+            windowFunction: Hann(Window),
+            smoothingOctaves: 1.0);
+
+        // The slice at the tone must be the global energy maximum and dominate slices
+        // two octaves away: a wrong Morlet centre (w0), a dropped negative-frequency
+        // wrap, or a broken normalization would smear or misplace this and fail.
+        double atTone = PeakMagnitude(ClosestSlice(slices, toneHz));
+        double twoOctavesUp = PeakMagnitude(ClosestSlice(slices, toneHz * 4.0));
+        double twoOctavesDown = PeakMagnitude(ClosestSlice(slices, toneHz / 4.0));
+
+        Assert.Equal(atTone, slices.Max(PeakMagnitude), precision: 12);
+        Assert.True(
+            atTone > 4.0 * twoOctavesUp,
+            $"Tone slice {atTone:e} not dominant over +2oct {twoOctavesUp:e}.");
+        Assert.True(
+            atTone > 4.0 * twoOctavesDown,
+            $"Tone slice {atTone:e} not dominant over -2oct {twoOctavesDown:e}.");
+    }
+
+    [Fact]
+    public void BuildBurstDecayRawSlices_EnvelopeDecaysForADecayingTone()
+    {
+        const double toneHz = 1_000.0;
+        IReadOnlyList<BurstDecaySlice> slices = WaterfallAnalysis.BuildBurstDecayRawSlices(
+            DecayingTone(toneHz, tauSamples: 800.0),
+            offset: 0,
+            window: Window,
+            windowFunction: Hann(Window),
+            smoothingOctaves: 1.0);
+
+        IReadOnlyList<SignalPoint> envelope = ClosestSlice(slices, toneHz).Data;
+        int quarter = envelope.Count / 4;
+        double firstQuarter = envelope.Take(quarter).Average(p => p.Y);
+        double lastQuarter = envelope.Skip(envelope.Count - quarter).Average(p => p.Y);
+
+        Assert.True(
+            firstQuarter > lastQuarter,
+            $"Envelope did not decay: first quarter {firstQuarter:e}, last {lastQuarter:e}.");
+    }
+
+    [Fact]
+    public void BuildBurstDecayRawSlices_FrequencyGridIsAscendingBoundedAndOctaveSpaced()
+    {
+        const double smoothingOctaves = 1.0;
+        IReadOnlyList<BurstDecaySlice> slices = WaterfallAnalysis.BuildBurstDecayRawSlices(
+            DecayingTone(1_000.0, tauSamples: 1_000.0),
+            offset: 0,
+            window: Window,
+            windowFunction: Hann(Window),
+            smoothingOctaves: smoothingOctaves);
+
+        double frequencyStep = (double)SampleRate / (Window * 4);
+        double expectedRatio = Math.Pow(2.0, 0.5 * smoothingOctaves);
+
+        double[] freqs = slices.Select(s => s.Frequency).ToArray();
+        Assert.NotEmpty(freqs);
+        for (int i = 0; i < freqs.Length; i++)
+        {
+            Assert.InRange(freqs[i], Math.Max(20.0, frequencyStep * 4), 20_000.0);
+            if (i > 0)
+            {
+                Assert.True(freqs[i] > freqs[i - 1], "Frequencies must be strictly ascending.");
+                Assert.Equal(expectedRatio, freqs[i] / freqs[i - 1], precision: 9);
+            }
+        }
+    }
+
+    [Fact]
+    public void BuildBurstDecayRawSlices_MoreSmoothingYieldsFewerSlices()
+    {
+        SyntheticMeasurement tone = DecayingTone(1_000.0, tauSamples: 1_000.0);
+
+        int narrow = WaterfallAnalysis.BuildBurstDecayRawSlices(
+            tone, 0, Window, Hann(Window), smoothingOctaves: 1.0).Count;
+        int wide = WaterfallAnalysis.BuildBurstDecayRawSlices(
+            tone, 0, Window, Hann(Window), smoothingOctaves: 2.0).Count;
+
+        Assert.True(wide < narrow, $"Expected fewer slices at 2 oct ({wide}) than 1 oct ({narrow}).");
+    }
+
+    [Fact]
+    public void ResampleBurstDecaySlice_MapsConstantAmplitudeToItsDecibelLevelOnAPeriodsAxis()
+    {
+        // A constant-amplitude raw envelope: every in-range sample smooths to the same
+        // amplitude, so the dB value is analytic and the X axis is the periods ramp.
+        const double amplitude = 0.5;
+        var rawData = Enumerable.Range(0, 200)
+            .Select(i => new SignalPoint(i, amplitude))
+            .ToList();
+        const int width = 50;
+        const double periods = 5.0;
+
+        IReadOnlyList<SignalPoint> resampled = WaterfallAnalysis.ResampleBurstDecaySlice(
+            rawData, frequency: 1_000.0, sampleRate: SampleRate, width: width, periods: periods);
+
+        Assert.Equal(width, resampled.Count);
+        Assert.Equal(0.0, resampled[0].X, precision: 12);
+        Assert.Equal((width - 1) / (double)width * periods, resampled[^1].X, precision: 12);
+        // periodsSamples = 48000 * 5 / 1000 = 240; index 5 -> samplePosition 24, well in range.
+        Assert.Equal(DataHelper.AmplitudeToDecibels(amplitude), resampled[5].Y, precision: 6);
+    }
+
+    [Fact]
+    public void ResampleBurstDecaySlice_ReturnsTheFloorBeyondTheRawDataRange()
+    {
+        // periodsSamples = 48000 * 10 / 1000 = 480; the raw envelope is only 20 samples
+        // long, so late output points fall past it and must read the -160 dB floor
+        // rather than NaN/garbage.
+        var rawData = Enumerable.Range(0, 20)
+            .Select(i => new SignalPoint(i, 0.5))
+            .ToList();
+
+        IReadOnlyList<SignalPoint> resampled = WaterfallAnalysis.ResampleBurstDecaySlice(
+            rawData, frequency: 1_000.0, sampleRate: SampleRate, width: 50, periods: 10.0);
+
+        Assert.Equal(DataHelper.AmplitudeToDecibels(0.0), resampled[^1].Y, precision: 6);
+    }
+
+    [Fact]
+    public void ResampleBurstDecaySlice_EmptyRawDataReturnsEmpty()
+    {
+        IReadOnlyList<SignalPoint> resampled = WaterfallAnalysis.ResampleBurstDecaySlice(
+            Array.Empty<SignalPoint>(), frequency: 1_000.0, sampleRate: SampleRate, width: 50, periods: 5.0);
+
+        Assert.Empty(resampled);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/WindowingTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/WindowingTests.cs
@@ -67,6 +67,40 @@ public sealed class WindowingTests
     }
 
     [Fact]
+    public void CreateAnalysisWindow_BlackmanHarrisHasItsKnownEndpointAndUnityCentre()
+    {
+        // Odd length -> the centre index has phase exactly pi, where the four terms
+        // sum to 1. The endpoints (phase 0) sum to the tiny 6e-5 pedestal. Both are
+        // fingerprints of the exact coefficients; a wrong term breaks them.
+        double[] window = Windowing.CreateAnalysisWindow(WindowType.BlackmanHarris, 65);
+
+        Assert.Equal(0.00006, window[0], precision: 8);
+        Assert.Equal(window[0], window[^1], precision: 12); // symmetric
+        Assert.Equal(1.0, window[32], precision: 9);         // centre
+    }
+
+    [Fact]
+    public void CreateAnalysisWindow_FlatTopHasItsKnownEndpointAndUnityCentre()
+    {
+        double[] window = Windowing.CreateAnalysisWindow(WindowType.FlatTop, 65);
+
+        // SRS five-term flat-top endpoint = 0.21557895 - 0.41663158 + 0.277263158
+        //   - 0.083578947 + 0.006947368 = -0.000421051 (slightly negative by design).
+        Assert.Equal(-0.000421051, window[0], precision: 9);
+        Assert.Equal(window[0], window[^1], precision: 12); // symmetric
+        // The published five-term coefficients sum to 1.000000003, so the unity
+        // plateau is exact only to ~7 places.
+        Assert.Equal(1.0, window[32], precision: 7);         // centre
+    }
+
+    [Fact]
+    public void CreateAnalysisWindow_RejectsNonPositiveLength()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Windowing.CreateAnalysisWindow(WindowType.Hann, 0));
+    }
+
+    [Fact]
     public void TukeyWindowHalfZeroPadded_KeepsSecondHalfZero()
     {
         double[] window = Windowing.TukeyWindowHalfZeroPadded(


### PR DESCRIPTION
## What & why

A coverage-**quality** audit of the `dsp/` suite — real cobertura line/branch numbers plus a per-module adversarial review of whether the existing tests actually *pin* behaviour, not just whether lines execute — surfaced one entirely-untested module and a systemic "constant-input" smell: the resampler, calibration lookup and HD/THD isolation were exercised only on flat/constant data, so their interesting math (interpolation kernel, frequency mapping, window geometry, binary-search corners) ran but was never constrained. This PR closes those gaps with ~60 new tests, all in the cross-platform DSP library and fully CI-verifiable on Linux.

**No production code changed** — tests only (plus a `TODO.md` note). The full dsp suite is green: **356 passed**.

Coverage moved **89.4% → 95.2% line, 83.1% → 88.6% branch**.

## Highlights

- **`WaterfallAnalysis` (was 0% — no test at all):** Morlet burst-decay frequency localisation + envelope decay, frequency-grid ordering/bounds/spacing/count, and `ResampleBurstDecaySlice` dB mapping / floor / empty handling.
- **Degrees-domain phase API** (`GetPhase` / `GetMinimumPhase` / `GetExcessPhase` / `EstimatePhaseDetrend`): the degrees conversion, the measured-minus-minimum excess composition and its bin alignment, and the absolute-sample τ detrend offset.
- **Killed the "constant-input" smell:** `LogarithmicResample` and `CalibrationFile` now have known-answer tests on *non-constant* data (a feature at a known frequency, a step curve forcing binary-search descent, a spike proving `smoothingOctaves` widens the window); plus `DspMath.LanczosKernel` exact values and FlatTop/BlackmanHarris window coefficients.
- **Untested branches / weak tests strengthened:** `SignalEnvelope` first-arrival SNR gate; `TransferFunction` coherence ≈1 vs <1 and the PHAT degenerate-correlation guard; `AutoAlignmentEngine` non-bottom-reference downward walk; `TimeAlignmentAnalysis` arrival values + wrap no-op; `PeakingBiquad` digital-vs-analog off-centre bandwidth; `CrossoverAutoSetup` Midbass sensible range; `VirtualCrossover` degenerate-window empties, Nyquist clamp and non-vacuous loss diagnostics; `EqAutoTuner` cut clamp / partial-overlap NaN mask / empty-Q fallback; and the MiniDSP / GraphicEQ / EasyEffects / Calibration numeric payloads.

## Honesty about scope

The audit produced 42 raw findings; an adversarial verification pass refuted 4 (already covered indirectly) and this PR implements the rest. Three were **deliberately not shipped as tests** because they would have asserted unreachable or tautological behaviour — each is recorded in `TODO.md` with the reasoning:

- `TimeAlignmentAnalysis.ToSignedDelaySamples` negative-arrival branch — the peak search is capped at `length/2`, so an arrival never lands above the wrap pivot through the public `Analyze`; only the pivot/comparison is pinned.
- `FindBandLimitedCorrelationDelay` collapse fallback — only reachable with `centerFrequencyHz > Nyquist` (never passed by the app), and the fallback doesn't actually reorder the band there; the reachable Nyquist clamp is tested.
- Exact 1/f-weighted `LossDb`/`DipDb` values — a byte-exact known answer would re-derive the smoothing kernel (brittle); covered by a relative aligned-vs-cancelling test instead.

## Test plan

`dotnet test tests/Resonalyze.Dsp.Tests -c Release` → 356 passed, 0 failed. The `net10.0-windows` App test project is unaffected (no source changes) and compiles as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_