### PR TITLE
Add reference-free RTA overlay to Live Spectrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,7 +683,17 @@ cumulative average indefinitely. **Reset Average** clears the running average an
 peak-hold envelope without restarting the measurement.
 
 **Main curve** (on by default) shows the primary live trace itself; turning it
-off leaves only the optional peak-hold and coherence curves.
+off leaves only the optional RTA, peak-hold, and coherence curves.
+
+**RTA (input)** (off by default) overlays a reference-free real-time analyzer
+curve: the plain magnitude spectrum of the microphone input **alone**, with no
+division by the loopback reference. It is what a classic RTA shows — the actual
+spectral content the microphone hears — and is drawn on the same dB axis as the
+transfer function. Because it is a single-channel level rather than a ratio, its
+vertical position is uncalibrated (it floats with input gain), and coherence does
+not apply to it, so it is never dimmed by the **Coherence Limit**. Its level is
+normalized by the analysis window's coherent gain, so switching windows does not
+shift it.
 
 **Peak Hold** overlays a second curve that retains the maximum level seen on the
 trace until it is reset. **Coherence** (on by default) toggles the γ² curve

--- a/dsp/SpectrumAnalysis.cs
+++ b/dsp/SpectrumAnalysis.cs
@@ -54,6 +54,52 @@ public static class SpectrumAnalysis
         return power;
     }
 
+    /// <summary>
+    /// Converts an accumulated single-input auto-power spectrum — the windowed,
+    /// not-yet-gain-corrected |FFT|² produced as the target power by
+    /// <see cref="ComputeTransferSpectrumFrame"/> — into a tone-calibrated
+    /// magnitude spectrum. The result is normalized by the analysis window's
+    /// coherent gain, so a tone reads the same level regardless of window, the
+    /// same convention as <see cref="ComputePowerSpectrum"/>. This is the
+    /// reference-free RTA magnitude: it reflects the input level alone with no
+    /// division by any reference channel, so unlike the H1 transfer function it
+    /// carries neither coherence nor phase. <paramref name="frameLength"/> is the
+    /// pre-FFT block length the auto-power was measured with (twice the bin count
+    /// for a real signal); it is needed to recover the window's coherent gain.
+    /// By the identity sqrt(|FFT|²)·scale, the result equals the square root of
+    /// <see cref="ComputePowerSpectrum"/> of the same block bin-for-bin.
+    /// </summary>
+    public static double[] ComputeInputMagnitudeSpectrum(
+        IReadOnlyList<double> autoPowerSpectrum,
+        WindowType windowType,
+        int frameLength)
+    {
+        ArgumentNullException.ThrowIfNull(autoPowerSpectrum);
+        if (frameLength < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(frameLength));
+        }
+
+        double[] window = Windowing.CreateAnalysisWindow(windowType, frameLength);
+        double windowSum = 0.0;
+        for (int i = 0; i < frameLength; i++)
+        {
+            windowSum += window[i];
+        }
+
+        double coherentGain = windowSum / frameLength;
+        double scale = coherentGain > 0.0 ? 1.0 / coherentGain : 1.0;
+
+        var magnitude = new double[autoPowerSpectrum.Count];
+        for (int i = 0; i < magnitude.Length; i++)
+        {
+            double power = autoPowerSpectrum[i];
+            magnitude[i] = power > 0.0 ? Math.Sqrt(power) * scale : 0.0;
+        }
+
+        return magnitude;
+    }
+
     public static double[] ComputeTransferMagnitudeSpectrum(
         IReadOnlyList<float> reference,
         IReadOnlyList<float> target,

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -30,6 +30,7 @@ internal sealed class LiveSpectrumController : IDisposable
     private const string LiveSpectrumLowCoherenceTag = "live-spectrum:low-coherence";
     private const string LiveSpectrumCoherenceTag = "live-spectrum:coherence";
     private const string LiveSpectrumPeakHoldTag = "live-spectrum:peak-hold";
+    private const string LiveSpectrumInputMagnitudeTag = "live-spectrum:input-magnitude";
     private const string OverloadAnnotationTag = "live-spectrum:overload";
     private const long PeakHoldSuppressionMs = 1000;
     private bool disposed;
@@ -46,6 +47,7 @@ internal sealed class LiveSpectrumController : IDisposable
     private LineSeries? trustedSeries;
     private LineSeries? untrustedSeries;
     private LineSeries? coherenceSeries;
+    private LineSeries? inputMagnitudeSeries;
     private PlotModel? attachedModel;
 
     public LiveSpectrumController(
@@ -395,6 +397,25 @@ internal sealed class LiveSpectrumController : IDisposable
             }
         }
 
+        // Reference-free RTA magnitude of the microphone input, overlaid on the
+        // same dB axis. It is independent of coherence and the reference channel,
+        // so it is never split or dimmed by the coherence threshold.
+        if (snapshot.InputMagnitude != null && liveSpectrumOptions.ShowInputMagnitude)
+        {
+            if (inputMagnitudeSeries == null)
+            {
+                inputMagnitudeSeries =
+                    plotModelFactory.BuildInputMagnitudeSeries(snapshot.InputMagnitude);
+                inputMagnitudeSeries.Tag = LiveSpectrumInputMagnitudeTag;
+            }
+            else
+            {
+                plotModelFactory.UpdateInputMagnitudeSeries(
+                    inputMagnitudeSeries, snapshot.InputMagnitude);
+            }
+            model.Series.Add(inputMagnitudeSeries);
+        }
+
         if (snapshot.Coherence != null && liveSpectrumOptions.ShowCoherence)
         {
             if (coherenceSeries == null)
@@ -477,7 +498,8 @@ internal sealed class LiveSpectrumController : IDisposable
                 Equals(series.Tag, LiveSpectrumTag) ||
                 Equals(series.Tag, LiveSpectrumLowCoherenceTag) ||
                 Equals(series.Tag, LiveSpectrumCoherenceTag) ||
-                Equals(series.Tag, LiveSpectrumPeakHoldTag))
+                Equals(series.Tag, LiveSpectrumPeakHoldTag) ||
+                Equals(series.Tag, LiveSpectrumInputMagnitudeTag))
             .ToList();
         foreach (OxyPlot.Series.Series series in liveSpectrumSeries)
         {

--- a/source/Measurements/LiveSpectrumSnapshot.cs
+++ b/source/Measurements/LiveSpectrumSnapshot.cs
@@ -4,9 +4,13 @@ namespace Resonalyze
     /// A consistent display snapshot of the live analyzer state. Magnitude is a
     /// linear amplitude curve (one value per FFT bin). Coherence is the
     /// magnitude-squared coherence γ² in [0, 1] and is only present in
-    /// transfer-function mode.
+    /// transfer-function mode. InputMagnitude is the reference-free RTA magnitude
+    /// of the measured (microphone) input alone — a plain single-channel spectrum
+    /// with no division by the loopback reference, so it carries no coherence and
+    /// no phase.
     /// </summary>
     public sealed record LiveSpectrumSnapshot(
         double[] Magnitude,
-        double[]? Coherence);
+        double[]? Coherence,
+        double[]? InputMagnitude = null);
 }

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -286,7 +286,15 @@ namespace Resonalyze
                 crossSpectrum,
                 referencePowerSpectrum,
                 targetPowerSpectrum);
-            return new LiveSpectrumSnapshot(magnitude, coherence);
+            // The microphone auto-power is already accumulated for coherence, so the
+            // reference-free RTA magnitude comes for free: normalize it by the same
+            // window's coherent gain the frame was measured with so its level is
+            // window-independent, matching ComputePowerSpectrum's convention.
+            double[] inputMagnitude = SpectrumAnalysis.ComputeInputMagnitudeSpectrum(
+                targetPowerSpectrum,
+                EffectiveWindowType,
+                SequenceLength);
+            return new LiveSpectrumSnapshot(magnitude, coherence, inputMagnitude);
         }
 
         private static double AlphaFromTimeConstant(double frameInterval, double timeConstant)

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -662,25 +662,22 @@ namespace Resonalyze
                         return;
                     }
 
-                    if (infiniteAveraging)
-                    {
-                        // Honest cumulative mean: seed with the first real frame.
-                        accumulatedCrossSpectrum = frame.CrossSpectrum.ToArray();
-                        accumulatedReferencePowerSpectrum =
-                            frame.ReferencePowerSpectrum.ToArray();
-                        accumulatedTargetPowerSpectrum =
-                            frame.TargetPowerSpectrum.ToArray();
-                        averagedFrameCount = 1;
-                        sequencesCounter++;
-                        return;
-                    }
-
-                    accumulatedCrossSpectrum = new Complex[frame.CrossSpectrum.Length];
+                    // Seed the accumulators with the first real frame for every
+                    // averaging mode. Cross- and reference-power carry the same
+                    // running scale as target-power, so H1 magnitude and coherence
+                    // divide it out regardless of the seed; but the RTA overlay
+                    // reads sqrt(target-power) directly, so a zero seed would make
+                    // it start sqrt(alpha) low and ramp up over the averaging time
+                    // constant even for a steady input. Seeding gives an unbiased
+                    // running estimate from the first frame instead.
+                    accumulatedCrossSpectrum = frame.CrossSpectrum.ToArray();
                     accumulatedReferencePowerSpectrum =
-                        new double[frame.ReferencePowerSpectrum.Length];
+                        frame.ReferencePowerSpectrum.ToArray();
                     accumulatedTargetPowerSpectrum =
-                        new double[frame.TargetPowerSpectrum.Length];
+                        frame.TargetPowerSpectrum.ToArray();
                     averagedFrameCount = 1;
+                    sequencesCounter++;
+                    return;
                 }
 
                 double alpha = infiniteAveraging

--- a/source/Options/LiveSpectrumOpt.Designer.cs
+++ b/source/Options/LiveSpectrumOpt.Designer.cs
@@ -52,6 +52,8 @@ namespace Resonalyze.Options
             labelCurves = new Label();
             labelMainCurve = new Label();
             checkMainCurve = new CheckBox();
+            labelInputMagnitude = new Label();
+            checkInputMagnitude = new CheckBox();
             SuspendLayout();
             //
             // comboCalibration
@@ -205,7 +207,7 @@ namespace Resonalyze.Options
             //
             label8.AutoSize = true;
             label8.ForeColor = SystemColors.ControlLight;
-            label8.Location = new Point(12, 309);
+            label8.Location = new Point(12, 332);
             label8.Name = "label8";
             label8.Size = new Size(60, 15);
             label8.TabIndex = 59;
@@ -215,7 +217,7 @@ namespace Resonalyze.Options
             //
             checkPeakHold.AutoSize = true;
             checkPeakHold.ForeColor = SystemColors.ControlLight;
-            checkPeakHold.Location = new Point(238, 309);
+            checkPeakHold.Location = new Point(238, 332);
             checkPeakHold.Name = "checkPeakHold";
             checkPeakHold.Size = new Size(15, 14);
             checkPeakHold.TabIndex = 60;
@@ -225,7 +227,7 @@ namespace Resonalyze.Options
             //
             label9.AutoSize = true;
             label9.ForeColor = SystemColors.ControlLight;
-            label9.Location = new Point(12, 286);
+            label9.Location = new Point(12, 309);
             label9.Name = "label9";
             label9.Size = new Size(64, 15);
             label9.TabIndex = 62;
@@ -235,7 +237,7 @@ namespace Resonalyze.Options
             //
             checkCoherence.AutoSize = true;
             checkCoherence.ForeColor = SystemColors.ControlLight;
-            checkCoherence.Location = new Point(238, 286);
+            checkCoherence.Location = new Point(238, 309);
             checkCoherence.Name = "checkCoherence";
             checkCoherence.Size = new Size(15, 14);
             checkCoherence.TabIndex = 63;
@@ -267,7 +269,7 @@ namespace Resonalyze.Options
             buttonResetAverage.BackColor = Color.FromArgb(50, 55, 80);
             buttonResetAverage.FlatStyle = FlatStyle.Popup;
             buttonResetAverage.ForeColor = Color.White;
-            buttonResetAverage.Location = new Point(12, 335);
+            buttonResetAverage.Location = new Point(12, 358);
             buttonResetAverage.Name = "buttonResetAverage";
             buttonResetAverage.Size = new Size(241, 23);
             buttonResetAverage.TabIndex = 61;
@@ -304,14 +306,36 @@ namespace Resonalyze.Options
             checkMainCurve.TabIndex = 68;
             checkMainCurve.UseVisualStyleBackColor = true;
             //
+            // labelInputMagnitude
+            //
+            labelInputMagnitude.AutoSize = true;
+            labelInputMagnitude.ForeColor = SystemColors.ControlLight;
+            labelInputMagnitude.Location = new Point(12, 286);
+            labelInputMagnitude.Name = "labelInputMagnitude";
+            labelInputMagnitude.Size = new Size(67, 15);
+            labelInputMagnitude.TabIndex = 69;
+            labelInputMagnitude.Text = "RTA (input)";
+            //
+            // checkInputMagnitude
+            //
+            checkInputMagnitude.AutoSize = true;
+            checkInputMagnitude.ForeColor = SystemColors.ControlLight;
+            checkInputMagnitude.Location = new Point(238, 286);
+            checkInputMagnitude.Name = "checkInputMagnitude";
+            checkInputMagnitude.Size = new Size(15, 14);
+            checkInputMagnitude.TabIndex = 70;
+            checkInputMagnitude.UseVisualStyleBackColor = true;
+            //
             // LiveSpectrumOpt
             //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(45, 50, 60);
-            ClientSize = new Size(265, 370);
+            ClientSize = new Size(265, 393);
             Controls.Add(signalTypeComboBox);
             Controls.Add(labelSignalType);
+            Controls.Add(checkInputMagnitude);
+            Controls.Add(labelInputMagnitude);
             Controls.Add(checkMainCurve);
             Controls.Add(labelMainCurve);
             Controls.Add(labelCurves);
@@ -370,5 +394,7 @@ namespace Resonalyze.Options
         private Label labelCurves;
         private Label labelMainCurve;
         private CheckBox checkMainCurve;
+        private Label labelInputMagnitude;
+        private CheckBox checkInputMagnitude;
     }
 }

--- a/source/Options/LiveSpectrumOpt.cs
+++ b/source/Options/LiveSpectrumOpt.cs
@@ -96,6 +96,7 @@ namespace Resonalyze.Options
                 FindCoherenceLimitIndex(options.CoherenceThresholdPercent);
 
             checkMainCurve.Checked = options.ShowMainCurve;
+            checkInputMagnitude.Checked = options.ShowInputMagnitude;
             checkPeakHold.Checked = options.PeakHold;
             checkCoherence.Checked = options.ShowCoherence;
             MicrophoneCalibrationComboHelper.Configure(
@@ -131,6 +132,7 @@ namespace Resonalyze.Options
                     ? averagingOption.Speed
                     : AveragingSpeed.Medium;
             options.ShowMainCurve = checkMainCurve.Checked;
+            options.ShowInputMagnitude = checkInputMagnitude.Checked;
             options.PeakHold = checkPeakHold.Checked;
             options.ShowCoherence = checkCoherence.Checked;
             options.CoherenceThresholdPercent =
@@ -347,6 +349,9 @@ namespace Resonalyze.Options
             toolTip.SetToolTip(
                 checkMainCurve,
                 "Shows the main live trace (the spectrum / transfer-function curve).");
+            toolTip.SetToolTip(
+                checkInputMagnitude,
+                "Overlays a reference-free RTA curve: the plain magnitude spectrum of the microphone input alone, with no division by the loopback reference. Independent of coherence.");
             toolTip.SetToolTip(
                 checkPeakHold,
                 "Overlays a peak-hold envelope that retains the maximum level seen on the curve until reset.");

--- a/source/Options/LiveSpectrumOptions.cs
+++ b/source/Options/LiveSpectrumOptions.cs
@@ -62,6 +62,13 @@ namespace Resonalyze.Options
         /// <summary>Shows the main live trace (the spectrum / transfer-function curve).</summary>
         public bool ShowMainCurve { get; set; } = true;
 
+        /// <summary>
+        /// Overlays a reference-free RTA curve: the plain magnitude spectrum of the
+        /// measured (microphone) input, with no division by the loopback reference.
+        /// Off by default.
+        /// </summary>
+        public bool ShowInputMagnitude { get; set; }
+
         /// <summary>Shows a peak-hold envelope curve of the displayed trace.</summary>
         public bool PeakHold { get; set; }
 

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -645,6 +645,21 @@ internal sealed class PlotModelFactory
     public void UpdateNoiseSeries(LineSeries series, double[] magnitude) =>
         FillPoints(series, ResampleLiveSpectrumMagnitude(magnitude));
 
+    public LineSeries BuildInputMagnitudeSeries(double[] inputMagnitude)
+    {
+        var series = new LineSeries
+        {
+            Color = OxyColor.FromRgb(80, 170, 255),
+            Title = "Input Spectrum (RTA)",
+            TrackerFormatString = "{0}\n{2:0.0} Hz\n{4:0.00} dB"
+        };
+        UpdateInputMagnitudeSeries(series, inputMagnitude);
+        return series;
+    }
+
+    public void UpdateInputMagnitudeSeries(LineSeries series, double[] inputMagnitude) =>
+        FillPoints(series, ResampleLiveSpectrumMagnitude(inputMagnitude));
+
     public LineSeries BuildPeakHoldSeries(double[] peakHoldData)
     {
         var series = new LineSeries

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -407,6 +407,7 @@ internal sealed class MeasurementSettingsFile
         public WindowType WindowType { get; set; } = WindowType.Hann;
         public AveragingSpeed AveragingSpeed { get; set; } = AveragingSpeed.Medium;
         public bool ShowMainCurve { get; set; } = true;
+        public bool ShowInputMagnitude { get; set; }
         public bool PeakHold { get; set; }
         public bool ShowCoherence { get; set; } = true;
         public int CoherenceThresholdPercent { get; set; } = 25;
@@ -431,6 +432,7 @@ internal sealed class MeasurementSettingsFile
                     ? options.AveragingSpeed
                     : AveragingSpeed.Medium,
                 ShowMainCurve = options.ShowMainCurve,
+                ShowInputMagnitude = options.ShowInputMagnitude,
                 PeakHold = options.PeakHold,
                 ShowCoherence = options.ShowCoherence,
                 CoherenceThresholdPercent =
@@ -454,6 +456,7 @@ internal sealed class MeasurementSettingsFile
                 ? AveragingSpeed
                 : AveragingSpeed.Medium;
             options.ShowMainCurve = ShowMainCurve;
+            options.ShowInputMagnitude = ShowInputMagnitude;
             options.PeakHold = PeakHold;
             options.ShowCoherence = ShowCoherence;
             options.CoherenceThresholdPercent =

--- a/tests/Resonalyze.Dsp.Tests/SpectrumAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SpectrumAnalysisTests.cs
@@ -289,6 +289,69 @@ public sealed class SpectrumAnalysisTests
                 [1.0, 2.0]));
     }
 
+    [Theory]
+    [InlineData(WindowType.Hann)]
+    [InlineData(WindowType.FlatTop)]
+    [InlineData(WindowType.BlackmanHarris)]
+    [InlineData(WindowType.Rectangular)]
+    public void ComputeInputMagnitudeSpectrum_EqualsSqrtOfPowerSpectrum(WindowType windowType)
+    {
+        const int length = 512;
+        const int bin = 40;
+        float[] signal = CreateSine(length, bin);
+
+        TransferSpectrumFrame frame =
+            SpectrumAnalysis.ComputeTransferSpectrumFrame(signal, signal, windowType);
+        double[] magnitude = SpectrumAnalysis.ComputeInputMagnitudeSpectrum(
+            frame.TargetPowerSpectrum,
+            windowType,
+            length);
+        double[] power = SpectrumAnalysis.ComputePowerSpectrum(signal, windowType);
+
+        // The RTA magnitude is coherent-gain-normalized just like the trusted
+        // single-block power spectrum, so it must equal its square root exactly
+        // (same window, same |FFT|², same scale).
+        Assert.Equal(power.Length, magnitude.Length);
+        for (int i = 0; i < magnitude.Length; i++)
+        {
+            Assert.Equal(Math.Sqrt(power[i]), magnitude[i], precision: 9);
+        }
+    }
+
+    [Theory]
+    [InlineData(WindowType.Hann)]
+    [InlineData(WindowType.FlatTop)]
+    [InlineData(WindowType.BlackmanHarris)]
+    [InlineData(WindowType.Rectangular)]
+    public void ComputeInputMagnitudeSpectrum_ToneLevelIsWindowInvariant(WindowType windowType)
+    {
+        const int length = 512;
+        const int bin = 40;
+        // A full-scale tone sitting exactly on a bin: coherent-gain
+        // normalization must recover the same peak amplitude for every window.
+        float[] signal = CreateSine(length, bin);
+
+        TransferSpectrumFrame frame =
+            SpectrumAnalysis.ComputeTransferSpectrumFrame(signal, signal, windowType);
+        double[] magnitude = SpectrumAnalysis.ComputeInputMagnitudeSpectrum(
+            frame.TargetPowerSpectrum,
+            windowType,
+            length);
+
+        // For an on-bin tone the peak-bin magnitude is windowSum/2, and the
+        // coherent-gain scale is length/windowSum, so their product is length/2
+        // for every window (the window sum cancels). Allow 2% for the tiny
+        // double-frequency leakage into the bin.
+        Assert.InRange(magnitude[bin], length / 2.0 * 0.98, length / 2.0 * 1.02);
+    }
+
+    [Fact]
+    public void ComputeInputMagnitudeSpectrum_RejectsTooShortFrame()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            SpectrumAnalysis.ComputeInputMagnitudeSpectrum([1.0], WindowType.Hann, 1));
+    }
+
     private static float[] CreateImpulse(int length)
     {
         var impulse = new float[length];


### PR DESCRIPTION
## Summary

Live Spectrum is a dual-FFT **transfer-function** analyzer (H1, referenced to loopback), so it had no plain **magnitude-only RTA** — a common request when you want to see the spectral content the microphone actually hears (music, room noise, a PA) rather than a reference-normalized ratio.

This adds an optional **"RTA (input)"** overlay: the plain magnitude spectrum of the microphone input **alone**, with no division by the loopback reference. Off by default; drawn on the same dB axis as the transfer function.

## How it works

The microphone auto-power spectrum is **already accumulated** for the coherence estimate, so the RTA curve needs **no extra FFT work** — only a conversion to a displayable magnitude.

- New `SpectrumAnalysis.ComputeInputMagnitudeSpectrum(autoPower, window, frameLength)` converts the accumulated (windowed, un-normalized) `|FFT|²` into a tone-calibrated magnitude, normalizing by the analysis window's **coherent gain** so the level is window-independent — the same convention as the existing `ComputePowerSpectrum`. By construction the result equals `sqrt(ComputePowerSpectrum(block))` bin-for-bin.

## Design notes

- **Reference-free / coherence-independent.** Because the RTA curve is a single-channel level rather than a ratio, coherence does not apply to it, so it is **never** dimmed or split by the **Coherence Limit** (which still governs the transfer-function curve as before). Its vertical position is uncalibrated (it floats with input gain).
- **Display-only toggle.** Does not restart capture — it flows through the cheap live-refresh path, not the measurement-restart path.
- The existing loopback requirement for the mode is unchanged; the RTA curve rides alongside the transfer function rather than replacing it.

## Tests

- 9 new dsp tests in `SpectrumAnalysisTests`: the exact `RTA == sqrt(ComputePowerSpectrum)` invariant across all four windows, tone-level window-invariance, and an argument guard.
- Full dsp suite: **374 passed**.
- Note: `source/` (WinForms app) only builds on Windows; the dialog/plot wiring is verified by CI (windows-latest), not locally. The DSP core is fully covered by the tests above.

## Files

- `dsp/SpectrumAnalysis.cs`, `tests/Resonalyze.Dsp.Tests/SpectrumAnalysisTests.cs`
- `source/Measurements/{LiveSpectrumSnapshot,NoiseMeasurement}.cs`
- `source/Plotting/PlotModelFactory.cs`, `source/LiveSpectrum/LiveSpectrumController.cs`
- `source/Options/{LiveSpectrumOptions,LiveSpectrumOpt,LiveSpectrumOpt.Designer}.cs`
- `source/Settings/MeasurementSettingsFile.cs`
- `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_