### PR TITLE
Keep Auto delay on the direct-arrival lobe; add a polarity-flip null read-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -1354,9 +1354,16 @@ the channels track each other through the crossover region. The Phase view has a
 manual **Gate...** dialog with an IR preview, Tukey left / plateau / right
 window controls, gate offset, and a shared τ detrend so reflections can be cut
 out without breaking relative phase. A second plot shows each DSP chain's own
-magnitude and phase (without the driver). A **Sum loss avg** read-out over the
-crossover window turns tuning into a number you can minimize — or use the
-classic null test: invert one channel and tune the delay for the deepest notch.
+magnitude and phase (without the driver). A **Sum loss** read-out (avg / dip /
+null per junction plus a total) turns tuning into numbers you can minimize. The
+**null** figure is the classic tuner's polarity-flip check computed for you:
+the deepest notch the sum develops in the pair band with the junction's upper
+channel inverted — the deeper it drops, the better the pair's phase match at
+the handover. One caveat the read-out inherits from the physics: a
+whole-period delay error keeps the phase at the crossover frequency aligned
+and nulls just as deeply, so read it as confirmation of a candidate alignment,
+not as a lobe selector — the avg/dip figures and the arrival-anchored Auto
+delay are what guard against cycle skips.
 
 Editing a chain recomputes the prediction on a background task, so dragging a
 gain, delay, or crossover value stays responsive even with several channels

--- a/README.md
+++ b/README.md
@@ -1346,7 +1346,10 @@ The filters are evaluated as the **digital biquad cascades a real DSP runs**
 miniDSP-class hardware up to Nyquist, not just an analog textbook curve.
 
 The acoustic plot shows raw and processed curves per channel, the complex
-**Sum**, and the **Sum loss** curve, with a **Phase view** toggle to check that
+**Sum**, and the **Sum loss** curve (blanked where every channel is filtered
+more than 40 dB below the loudest point — out there the "loss" would be the
+phase arithmetic of noise floors, not audible summation), with a **Phase view**
+toggle to check that
 the channels track each other through the crossover region. The Phase view has a
 manual **Gate...** dialog with an IR preview, Tukey left / plateau / right
 window controls, gate offset, and a shared τ detrend so reflections can be cut
@@ -1379,9 +1382,14 @@ it defaults to Off because the measurements are loopback-referenced.
   narrowing the window past an outer driver adds a subsonic / brickwall
   band-limit on that channel.
 - **Auto delay** aligns in two stages: band-limited first arrivals — refined by a
-  GCC-PHAT cross-correlation where it carries a reliable peak — set the coarse
-  offsets, then a fractional-delay search minimizes the sum-loss metric at each
-  junction. Each candidate is scored by its in-band average loss *and* how far
+  GCC-PHAT cross-correlation where it carries a reliable, unambiguous peak (a
+  junction whose corners leave a spectral gap degenerates the correlation into
+  near-equal lobes, and a near-tie between its peak and trough sends the seed
+  back to the arrival estimate) — set the coarse offsets, then a
+  fractional-delay search minimizes the sum-loss metric at each junction,
+  reading the same direct-sound gate as the displayed metric so late room
+  reflections the alignment cannot change do not steer it. Each candidate is
+  scored by its in-band average loss *and* how far
   its deepest smoothed notch falls below that average, so a solution that only
   looks good on average while hiding a sharp cancellation at the crossover
   loses to a slightly lossier but flat one. It weighs every near-optimal

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -92,6 +92,17 @@ public static class AutoAlignmentEngine
     // from a seed that still lands a little off.
     private const double PhatSeedMinCoefficient = 0.15;
 
+    // The minimum dominance (Confidence: |best extremum| minus |its rival|) the
+    // PHAT correlation must show before its peak position is trusted as the seed.
+    // A junction whose corners leave a spectral gap (e.g. LP 1300 / HP 1800)
+    // narrows the effective overlap, and the whitened correlation degenerates
+    // into a comb of near-equal lobes: the peak coefficient still looks healthy,
+    // but which lobe it sits on is decided by noise — trusting it can move the
+    // seed whole periods off the arrival estimate (a cycle skip the prior then
+    // cements). Peak-vs-trough closeness is exactly that lobe ambiguity, so a
+    // near-tie sends the seed back to the polarity-blind arrival envelope.
+    private const double PhatSeedMinDominance = 0.1;
+
     // How much better (in score dB) a wide-window optimum must be before it
     // unseats the arrival-anchored fine pick. The narrow window is centered on
     // the coarse arrival, which at a high crossover can be a whole lobe off (its
@@ -180,7 +191,9 @@ public static class AutoAlignmentEngine
                     DiagnosticCorrelationRangeMs,
                     centerLagMs: lowerArrival - upperArrival,
                     phaseTransform: true);
-            bool trustPhat = phat.PositivePeak.Coefficient >= PhatSeedMinCoefficient;
+            bool trustPhat =
+                phat.PositivePeak.Coefficient >= PhatSeedMinCoefficient &&
+                phat.Confidence >= PhatSeedMinDominance;
             double increment =
                 trustPhat ? -phat.PositivePeak.DelayMs : upperArrival - lowerArrival;
             timeline[pair.Upper.Channel] = timeline[pair.Lower.Channel] + increment;
@@ -203,7 +216,8 @@ public static class AutoAlignmentEngine
                 $"(peaks {lowerPeakMs:0.000} / {upperPeakMs:0.000} ms), " +
                 $"diff {upperArrival - lowerArrival:+0.000;-0.000} ms, " +
                 $"phat peak {phat.PositivePeak.DelayMs:+0.000;-0.000} ms " +
-                $"(r {phat.PositivePeak.Coefficient:+0.000;-0.000}) -> seed " +
+                $"(r {phat.PositivePeak.Coefficient:+0.000;-0.000}, " +
+                $"dom {phat.Confidence:0.000}) -> seed " +
                 $"{(trustPhat ? "phat" : "arrival")}");
         }
 

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -525,6 +525,19 @@ public static class VirtualCrossoverAnalysis
         double LogWeight,
         double MagnitudeSum);
 
+    // The direct-sound gate applied to every response before the alignment
+    // spectra are taken: the same shape as the panel's default frequency-
+    // response window (4096 samples, 256-sample cosine fades, anchored one
+    // fade-length before the earliest channel peak). Reading the full IR
+    // instead would fold the entire room decay into every bin — hundreds of
+    // milliseconds of reverberation whose comb structure the alignment cannot
+    // change — so the search would optimize (and be misled by) reflections
+    // while the panel displays the gated direct sound. One gate shared by all
+    // channels, like the metric's shared anchor, so the loss keeps its 0 dB
+    // ceiling.
+    private const int AlignmentGateLengthSamples = 4096;
+    private const int AlignmentGateFadeSamples = 256;
+
     // The per-bin spectra inside the frequency window, decimated to a bounded
     // bin count so the search stays fast for long IRs. The fixed channels act
     // as one combined source (superposition).
@@ -553,15 +566,31 @@ public static class VirtualCrossoverAnalysis
             throw new ArgumentException("The search window is invalid.");
         }
 
-        int length = DspMath.NextPowerOfTwo(Math.Max(
-            variableImpulseResponse.Length,
-            fixedImpulseResponses.Max(ir => ir.Length)));
+        int anchor = FindPeakIndex(variableImpulseResponse);
+        foreach (Complex[] ir in fixedImpulseResponses)
+        {
+            anchor = Math.Min(anchor, FindPeakIndex(ir));
+        }
 
-        Complex[] variableSpectrum = ForwardSpectrum(variableImpulseResponse, length);
+        // The earliest arrival must land on the window's plateau, never inside
+        // the fade-in: a fade would attenuate the channels' arrivals unequally
+        // (they sit at different fade depths) and bias the loss. When the peak
+        // sits closer to the start than a full fade, the fade shrinks to fit.
+        int leftFadeSamples = Math.Min(AlignmentGateFadeSamples, anchor);
+        int gateStart = anchor - leftFadeSamples;
+        double[] gate = Windowing.TukeyWindow(
+            AlignmentGateLengthSamples,
+            2.0 * leftFadeSamples / AlignmentGateLengthSamples,
+            2.0 * AlignmentGateFadeSamples / AlignmentGateLengthSamples);
+
+        int length = AlignmentGateLengthSamples;
+        Complex[] variableSpectrum = ForwardSpectrum(
+            GateDirectSound(variableImpulseResponse, gateStart, gate), length);
         var fixedSpectrum = new Complex[length];
         foreach (Complex[] ir in fixedImpulseResponses)
         {
-            Complex[] spectrum = ForwardSpectrum(ir, length);
+            Complex[] spectrum = ForwardSpectrum(
+                GateDirectSound(ir, gateStart, gate), length);
             for (int i = 0; i < length; i++)
             {
                 fixedSpectrum[i] += spectrum[i];
@@ -968,6 +997,21 @@ public static class VirtualCrossoverAnalysis
         return results;
     }
 
+    private static Complex[] GateDirectSound(
+        Complex[] impulseResponse,
+        int gateStart,
+        double[] gate)
+    {
+        var gated = new Complex[gate.Length];
+        int count = Math.Min(gate.Length, impulseResponse.Length - gateStart);
+        for (int i = 0; i < count; i++)
+        {
+            gated[i] = impulseResponse[gateStart + i] * gate[i];
+        }
+
+        return gated;
+    }
+
     private static Complex[] ForwardSpectrum(Complex[] impulseResponse, int length)
     {
         var spectrum = new Complex[length];
@@ -977,10 +1021,22 @@ public static class VirtualCrossoverAnalysis
     }
 
     /// <summary>
+    /// How far below the loudest in-curve level the channels' combined magnitude
+    /// may fall before the summation loss stops being measured at that point.
+    /// Where every channel is filtered that far down, the "loss" is the phase
+    /// arithmetic of two noise floors — it swings to deep fake dips well outside
+    /// any driver's band — so those points become NaN: the drawn curve breaks
+    /// and the average/dip read-outs skip them.
+    /// </summary>
+    public const double SumLossLevelGateDb = 40;
+
+    /// <summary>
     /// The per-point summation-loss curve (dB, &lt;= 0): the complex sum minus the
     /// phase-blind magnitude sum of the channel curves, over their shared index
-    /// grid (truncated to the shortest). This is the single definition the panel's
-    /// drawn "Sum loss" curve, <see cref="AverageSumLossDb"/> and
+    /// grid (truncated to the shortest). Points where the combined magnitude sits
+    /// more than <see cref="SumLossLevelGateDb"/> below its in-curve peak read
+    /// NaN (see there). This is the single definition the panel's drawn
+    /// "Sum loss" curve, <see cref="AverageSumLossDb"/> and
     /// <see cref="MinimumSumLossDb"/> all read, so the drawn and measured loss
     /// cannot drift apart.
     /// </summary>
@@ -997,7 +1053,8 @@ public static class VirtualCrossoverAnalysis
             count = Math.Min(count, curve.Count);
         }
 
-        var points = new List<SignalPoint>(Math.Max(0, count));
+        var magnitudeSums = new double[Math.Max(0, count)];
+        double peakMagnitude = 0;
         for (int i = 0; i < count; i++)
         {
             double magnitudeSum = 0;
@@ -1006,9 +1063,23 @@ public static class VirtualCrossoverAnalysis
                 magnitudeSum += DataHelper.DecibelsToAmplitude(curve[i].Y);
             }
 
+            magnitudeSums[i] = magnitudeSum;
+            if (double.IsFinite(magnitudeSum))
+            {
+                peakMagnitude = Math.Max(peakMagnitude, magnitudeSum);
+            }
+        }
+
+        double gateFloor =
+            peakMagnitude * DataHelper.DecibelsToAmplitude(-SumLossLevelGateDb);
+        var points = new List<SignalPoint>(Math.Max(0, count));
+        for (int i = 0; i < count; i++)
+        {
             points.Add(new SignalPoint(
                 sumCurve[i].X,
-                sumCurve[i].Y - DataHelper.AmplitudeToDecibels(magnitudeSum)));
+                magnitudeSums[i] >= gateFloor
+                    ? sumCurve[i].Y - DataHelper.AmplitudeToDecibels(magnitudeSums[i])
+                    : double.NaN));
         }
 
         return points;

--- a/source/Tools/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossoverMetric.cs
@@ -10,12 +10,16 @@ internal static class VirtualCrossoverMetric
 {
     /// <summary>
     /// One sum-loss read-out: a junction pair (or the total across the crossover
-    /// window), its average and dip in dB, and the band it was measured over.
+    /// window), its average and dip in dB, the polarity-flip null depth (the
+    /// deepest notch of the sum with the pair's upper channel inverted — the
+    /// classic tuner's check: a phase-aligned pair cancels into a deep null;
+    /// junction entries only), and the band it was measured over.
     /// </summary>
     internal readonly record struct Entry(
         string Junction,
         double AverageDb,
         double? DipDb,
+        double? NullDb,
         double LowHz,
         double HighHz,
         bool IsTotal);
@@ -34,7 +38,8 @@ internal static class VirtualCrossoverMetric
         IEnumerable<string> parts = entries.Select(entry =>
         {
             string body = $"{entry.AverageDb:0.0} dB" +
-                (entry.DipDb.HasValue ? $", dip {entry.DipDb.Value:0.0} dB" : "");
+                (entry.DipDb.HasValue ? $", dip {entry.DipDb.Value:0.0} dB" : "") +
+                (entry.NullDb.HasValue ? $", null {entry.NullDb.Value:0.0} dB" : "");
             return entry.IsTotal ? "total " + body : $"{entry.Junction} {body}";
         });
         return "Sum loss avg: " + string.Join("   ", parts);
@@ -42,22 +47,26 @@ internal static class VirtualCrossoverMetric
 
     /// <summary>
     /// Compact per-junction column for the narrow host read-out panel: a
-    /// monospace "name  avg / dip" line each, no frequency ranges (those are on
-    /// hover).
+    /// monospace "name  avg / dip / null" line each, no frequency ranges (those
+    /// are on hover).
     /// </summary>
     public static string FormatCompact(IReadOnlyList<Entry> entries)
     {
         if (entries.Count == 0)
         {
-            return "Sum loss (dB)\r\n  avg / dip\r\n\r\n—";
+            return "Sum loss (dB)\r\n  avg / dip / null\r\n\r\n—";
         }
 
-        var builder = new System.Text.StringBuilder("Sum loss (dB)\r\n  avg / dip\r\n\r\n");
+        var builder = new System.Text.StringBuilder(
+            "Sum loss (dB)\r\n  avg / dip / null\r\n\r\n");
         foreach (Entry entry in entries)
         {
             string name = (entry.IsTotal ? "Total" : entry.Junction).PadRight(6);
             string dip = entry.DipDb.HasValue ? $"{entry.DipDb.Value,5:0.0}" : "    —";
-            builder.AppendLine($"{name}{entry.AverageDb,5:0.0} /{dip}");
+            string flipNull = entry.NullDb.HasValue
+                ? $"{entry.NullDb.Value,5:0.0}"
+                : "    —";
+            builder.AppendLine($"{name}{entry.AverageDb,5:0.0} /{dip} /{flipNull}");
         }
 
         return builder.ToString().TrimEnd();
@@ -78,7 +87,10 @@ internal static class VirtualCrossoverMetric
         {
             string name = entry.IsTotal ? "Total" : entry.Junction;
             string dip = entry.DipDb.HasValue ? $", dip {entry.DipDb.Value:0.0} dB" : "";
-            return $"{name}: {entry.AverageDb:0.0} dB avg{dip} " +
+            string flipNull = entry.NullDb.HasValue
+                ? $", flip null {entry.NullDb.Value:0.0} dB"
+                : "";
+            return $"{name}: {entry.AverageDb:0.0} dB avg{dip}{flipNull} " +
                 $"({FrequencyText.Format(entry.LowHz)} – {FrequencyText.Format(entry.HighHz)})";
         }));
     }

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -1729,6 +1729,7 @@ public partial class VirtualCrossoverPanel : UserControl
                     $"{pair.Upper.Channel.Control.ChannelName}",
                     pairLoss.Value,
                     pairDip,
+                    ComputePairNullDepthDb(processed, channelPoints, pair),
                     pair.BandLowHz,
                     pair.BandHighHz,
                     IsTotal: false));
@@ -1743,10 +1744,48 @@ public partial class VirtualCrossoverPanel : UserControl
         if (loss.HasValue)
         {
             entries.Add(new VirtualCrossoverMetric.Entry(
-                "total", loss.Value, dip, minHz, maxHz, IsTotal: true));
+                "total", loss.Value, dip, NullDb: null, minHz, maxHz, IsTotal: true));
         }
 
         return entries;
+    }
+
+    // The classic tuner's polarity-flip check, computed instead of performed:
+    // the full processed sum with the pair's upper channel inverted, read as
+    // the deepest sum-loss notch inside the pair band. A phase-aligned pair
+    // cancels coherently there, so the deeper this null, the better the pair's
+    // phase match — without touching the actual polarity switch. Display-only
+    // by design: a whole-period delay error keeps the phase at the crossover
+    // frequency aligned and can null just as deeply (verified on real
+    // measurements, where a two-period cycle skip out-nulled the true
+    // alignment), so this figure must never drive a search or selection.
+    private double? ComputePairNullDepthDb(
+        List<ProcessedChannel> processed,
+        List<IReadOnlyList<SignalPoint>> channelPoints,
+        AdjacentPair pair)
+    {
+        List<Complex[]> responses = processed
+            .Select(item => item == pair.Upper
+                ? InvertPolarity(item.ImpulseResponse)
+                : item.ImpulseResponse)
+            .ToList();
+        Complex[] flippedSum = VirtualCrossoverAnalysis.SumImpulseResponses(responses);
+        int anchor = processed.Min(item => item.PeakIndex);
+        AnalysisCurve flippedCurve = BuildMagnitudeCurve(
+            flippedSum, anchor, processed[0].Channel.SampleRate);
+        return VirtualCrossoverAnalysis.MinimumSumLossDb(
+            flippedCurve.Points, channelPoints, pair.BandLowHz, pair.BandHighHz);
+    }
+
+    private static Complex[] InvertPolarity(Complex[] impulseResponse)
+    {
+        var inverted = new Complex[impulseResponse.Length];
+        for (int i = 0; i < inverted.Length; i++)
+        {
+            inverted[i] = -impulseResponse[i];
+        }
+
+        return inverted;
     }
 
     // The metric text renderings live in VirtualCrossoverMetric, where they are

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -5,10 +5,10 @@ namespace Resonalyze.App.Tests;
 public sealed class VirtualCrossoverMetricTests
 {
     private static readonly VirtualCrossoverMetric.Entry Junction =
-        new("A/B", -1.23, -6.5, 900, 3_600, IsTotal: false);
+        new("A/B", -1.23, -6.5, -17.4, 900, 3_600, IsTotal: false);
 
     private static readonly VirtualCrossoverMetric.Entry Total =
-        new("total", -0.8, null, 100, 10_000, IsTotal: true);
+        new("total", -0.8, null, null, 100, 10_000, IsTotal: true);
 
     [Fact]
     public void FormatLabel_EmptyShowsPlaceholder()
@@ -26,7 +26,8 @@ public sealed class VirtualCrossoverMetricTests
             string text = VirtualCrossoverMetric.FormatLabel([Junction, Total]);
 
             Assert.Equal(
-                "Sum loss avg: A/B -1.2 dB, dip -6.5 dB   total -0.8 dB",
+                "Sum loss avg: A/B -1.2 dB, dip -6.5 dB, null -17.4 dB   " +
+                "total -0.8 dB",
                 text);
         });
     }
@@ -38,9 +39,9 @@ public sealed class VirtualCrossoverMetricTests
         {
             string text = VirtualCrossoverMetric.FormatCompact([Junction, Total]);
 
-            Assert.StartsWith("Sum loss (dB)\r\n  avg / dip\r\n\r\n", text);
-            Assert.Contains("A/B    -1.2 / -6.5", text);
-            Assert.Contains("Total  -0.8 /    —", text);
+            Assert.StartsWith("Sum loss (dB)\r\n  avg / dip / null\r\n\r\n", text);
+            Assert.Contains("A/B    -1.2 / -6.5 /-17.4", text);
+            Assert.Contains("Total  -0.8 /    — /    —", text);
         });
     }
 
@@ -52,7 +53,8 @@ public sealed class VirtualCrossoverMetricTests
             string text = VirtualCrossoverMetric.FormatDetail([Junction]);
 
             Assert.Equal(
-                "Sum loss avg\r\nA/B: -1.2 dB avg, dip -6.5 dB (900 Hz – 3.6 kHz)",
+                "Sum loss avg\r\nA/B: -1.2 dB avg, dip -6.5 dB, " +
+                "flip null -17.4 dB (900 Hz – 3.6 kHz)",
                 text);
         });
     }

--- a/tests/Resonalyze.Dsp.Tests/RealMeasurementArrivalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/RealMeasurementArrivalTests.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using System.Text;
 using System.Text.Json;
 
 namespace Resonalyze.Dsp.Tests;
@@ -73,6 +74,82 @@ public sealed class RealMeasurementArrivalTests
         Assert.InRange(result.FirstArrivalProminenceDecibels, -27.0, -22.0);
         Assert.True(result.StrongestPeakIsSeparateArrival);
     }
+
+    [Fact]
+    public void RightMidTweeterPair_AutoDelayStaysOnTheDirectArrivalLobe()
+    {
+        // The right channel's C/D junction (mid BP 175-1300 vs tweeter HP 1800,
+        // -5 dB) leaves a spectral gap between the corners, so the whitened
+        // pair correlation degenerates into near-equal lobes. The field failure:
+        // its peak (r 0.47, but peak-vs-trough dominance only 0.02) was trusted
+        // as the stage-2 seed and sat two 1300 Hz periods off the arrival — Auto
+        // delay proposed 2.22 ms for the mid where the summation optimum (the
+        // user's manual pick) sits near 0.68 ms. The seed dominance gate plus
+        // the direct-sound-gated loss must keep the result on the arrival lobe.
+        (int midRate, Complex[] midIr) = LoadTransferIr("r mid.json");
+        (int twrRate, Complex[] twrIr) = LoadTransferIr("r twr.json");
+        var midChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.BandPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 1300, 24),
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 175, 24)));
+        var twrChain = new DspChannelChain(
+            GainDb: -5,
+            Crossover: new CrossoverSpec(
+                CrossoverKind.HighPass,
+                HighPassEdge: new CrossoverEdge(
+                    CrossoverFilterFamily.Butterworth, 1800, 24)));
+
+        var mid = new AlignmentTestChannel("C:mid", midRate, midIr, midChain);
+        var twr = new AlignmentTestChannel("D:twr", twrRate, twrIr, twrChain);
+        AlignmentTestChannel[] channels = [mid, twr];
+
+        AlignmentSnapshot Snapshot(AlignmentTestChannel channel, AlignmentOverride over)
+        {
+            Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(
+                channel.RawIr,
+                channel.BaseChain with
+                {
+                    DelayMs = over.DelayMs,
+                    InvertPolarity = over.InvertPolarity
+                },
+                channel.SampleRate);
+            return new AlignmentSnapshot(
+                channel, processed, VirtualCrossoverAnalysis.FindPeakIndex(processed));
+        }
+
+        List<AlignmentSnapshot> baseSnapshots = channels
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        var junctions = new List<AlignmentJunction>
+        {
+            new(baseSnapshots[0], baseSnapshots[1], 1300, 650, 2600)
+        };
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+
+        AutoAlignmentEngine.Compute(
+            baseSnapshots,
+            junctions,
+            overrides => channels
+                .Select(channel => Snapshot(
+                    channel, overrides.GetValueOrDefault(channel)))
+                .ToList(),
+            alignment,
+            new StringBuilder());
+
+        // A uniform shift of both channels is the same alignment, so the pin is
+        // the net mid-vs-tweeter delay: the arrival lobe, not 2 periods later.
+        double netDelayMs = alignment.GetValueOrDefault(mid).DelayMs
+            - alignment.GetValueOrDefault(twr).DelayMs;
+        Assert.InRange(netDelayMs, 0.3, 1.0);
+        Assert.False(alignment.GetValueOrDefault(mid).InvertPolarity);
+        Assert.False(alignment.GetValueOrDefault(twr).InvertPolarity);
+    }
+
+    private sealed record AlignmentTestChannel(
+        string Name,
+        int SampleRate,
+        Complex[] RawIr,
+        DspChannelChain BaseChain) : IAlignmentChannel;
 
     private static (int SampleRate, Complex[] Ir) LoadTransferIr(string fileName)
     {

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -390,6 +390,34 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void SumLossCurve_GatesPointsWhereEveryChannelIsFilteredAway()
+    {
+        // Outside every channel's band the "loss" is the phase arithmetic of
+        // noise floors — it swings to deep fake dips no listener can hear. A
+        // point whose combined channel magnitude sits more than the level gate
+        // below the in-curve peak reads NaN, so the drawn curve breaks there
+        // and the avg/dip read-outs skip it instead of reporting the fake dip.
+        var channel = new List<SignalPoint>
+        {
+            new(30, -70.0), new(1_000, 0.0), new(2_000, 0.0)
+        };
+        var sum = new List<SignalPoint>
+        {
+            new(30, -76.0), new(1_000, 0.0), new(2_000, 0.0)
+        };
+
+        List<SignalPoint> loss = VirtualCrossoverAnalysis.SumLossCurve(sum, [channel]);
+
+        Assert.True(double.IsNaN(loss[0].Y));
+        Assert.Equal(0.0, loss[1].Y, 3);
+        Assert.Equal(0.0, loss[2].Y, 3);
+        double? dip = VirtualCrossoverAnalysis.MinimumSumLossDb(
+            sum, [channel], 20, 3_000);
+        Assert.NotNull(dip);
+        Assert.Equal(0.0, dip.Value, 3);
+    }
+
+    [Fact]
     public void GroupDelayMs_OfAPureDelay_EqualsTheDelay()
     {
         // A pure delay has a constant group delay equal to the delay itself.


### PR DESCRIPTION
## Field failure

On the right channel's C/D pair (mid BP 175–1300 vs tweeter HP 1800 −5 dB, A/B muted), Auto delay proposed **2.22 ms** for the mid where the summation optimum sits near **0.68 ms** — a two-period cycle skip at the 1300 Hz junction (2.22 − 0.68 = 1.54 ms = exactly 2 × 1/1300 s). Reproduced end-to-end on the `assets/test_data` measurements.

## Root causes and fixes

1. **PHAT seed trusted a lobe-ambiguous correlation.** A junction whose corners leave a spectral gap (LP 1300 / HP 1800) degenerates the whitened pair correlation into near-equal lobes: the peak still reads r 0.474, but its dominance over the trough is only 0.024 — which lobe wins is noise. The stage-2 seed now also requires peak-vs-trough dominance (`Confidence ≥ 0.1`); a near-tie falls back to the arrival estimate. The diagnostic log prints the dominance (`dom`) next to the peak.

2. **The loss search read the full ungated IR**, folding hundreds of milliseconds of room reverberation into every bin, so it optimized a different function than the displayed sum-loss metric (dip −2.8 vs −3.7 dB at the same delay). The alignment spectra are now taken through the same direct-sound gate as the panel metric (4096 samples, 256-sample Tukey fades, shared earliest-peak anchor, arrival kept on the plateau). Also ~100× less FFT work per search.

3. **The sum-loss curve reported deep fake dips where every channel is filtered away** (both drivers at −90…−119 dB below 40 Hz — the phase arithmetic of noise floors). Points whose combined magnitude sits more than 40 dB below the in-curve peak now read NaN: the drawn curve breaks and the avg/dip read-outs skip them.

## Polarity-flip null read-out

Each junction row of the Sum loss read-out gains a **null** column — the classic tuner's check computed instead of performed: the deepest sum-loss notch in the pair band with the junction's upper channel inverted. Deeper null = better phase match at the handover.

Display-only by design: probing the real measurements showed the two-period cycle skip **out-nulling** the true alignment (−8.2 vs −6.2 dB) — a whole-period delay error keeps the phase at the crossover frequency aligned, so the flip test is blind modulo the period. The code comment and README pin that caveat; the figure never drives a search or selection.

## Validation

- Failing right pair: engine now lands at **0.63 ms** net (the user's manual lobe), no inversion.
- Reference left 4-way: metric-identical to the known-good Auto delay log (avg within 0.01 dB, dips within 0.13 dB — same optimum basin).
- New pins: a real-measurement regression test (`RightMidTweeterPair_AutoDelayStaysOnTheDirectArrivalLobe`) and a sum-loss gate test.
- 386/386 dsp tests pass; full solution builds with `-p:EnableWindowsTargeting=true`. The widened read-out panel (`avg / dip / null`) is compile-verified only — worth a visual check on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_