### PR TITLE
Apply verified external-review fixes: Auto delay, phase unwrap, Time Alignment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,30 +32,43 @@ jobs:
       - name: Determine release metadata
         id: prepare
         shell: pwsh
+        # Inputs reach the script ONLY through environment variables — a
+        # ${{ }} interpolation inside the script body would let a crafted
+        # version/tag rewrite the PowerShell source (and later steps run with
+        # the update signing key in their environment). The strict regex then
+        # bounds every downstream use of the outputs to a safe charset.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          RAW_VERSION: ${{ inputs.version }}
+          CREATE_RELEASE: ${{ inputs.create_release }}
         run: |
-          if ("${{ github.event_name }}" -eq "push") {
-            $refName = "${{ github.ref_name }}"
+          if ($env:EVENT_NAME -eq "push") {
+            $refName = $env:REF_NAME
             if (-not $refName) {
               throw "Tag push workflow requires github.ref_name."
             }
 
-            $version = $refName.TrimStart('v')
             $createRelease = "true"
           } else {
-            $rawVersion = "${{ inputs.version }}"
+            $rawVersion = $env:RAW_VERSION
             if (-not $rawVersion) {
               throw "workflow_dispatch requires a version input."
             }
 
-            $version = $rawVersion.TrimStart('v')
             $refName = if ($rawVersion.StartsWith('v')) {
               $rawVersion
             } else {
               "v$rawVersion"
             }
-            $createRelease = "${{ inputs.create_release }}".ToLowerInvariant()
+            $createRelease = "$env:CREATE_RELEASE".ToLowerInvariant()
           }
 
+          if ($refName -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$') {
+            throw "Release version must look like v1.2.3 or v1.2.3-rc.1, got: $refName"
+          }
+
+          $version = $refName.TrimStart('v')
           "ref_name=$refName" >> $env:GITHUB_OUTPUT
           "version=$version" >> $env:GITHUB_OUTPUT
           "create_release=$createRelease" >> $env:GITHUB_OUTPUT
@@ -75,6 +88,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
+          # Build exactly the commit the release tag names: a manual dispatch
+          # used to build the selected BRANCH while the release/appcast were
+          # published under the tag — a signed artifact that does not match
+          # its source revision. A dispatch for a tag that does not exist yet
+          # fails here, before anything is built or signed.
+          ref: ${{ needs.prepare.outputs.ref_name }}
           fetch-depth: 0
 
       - name: Determine version
@@ -144,6 +163,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
+          # Build exactly the commit the release tag names: a manual dispatch
+          # used to build the selected BRANCH while the release/appcast were
+          # published under the tag — a signed artifact that does not match
+          # its source revision. A dispatch for a tag that does not exist yet
+          # fails here, before anything is built or signed.
+          ref: ${{ needs.prepare.outputs.ref_name }}
           fetch-depth: 0
 
       - name: Set up .NET
@@ -279,6 +304,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
+          # Build exactly the commit the release tag names: a manual dispatch
+          # used to build the selected BRANCH while the release/appcast were
+          # published under the tag — a signed artifact that does not match
+          # its source revision. A dispatch for a tag that does not exist yet
+          # fails here, before anything is built or signed.
+          ref: ${{ needs.prepare.outputs.ref_name }}
           fetch-depth: 0
 
       - name: Download release files
@@ -376,8 +407,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Draft on purpose: the notes may be AI-drafted from commit
+          # messages (untrusted text), so a human reviews and clicks Publish.
           gh release create "${{ needs.prepare.outputs.ref_name }}" release/* \
             --repo "${{ github.repository }}" \
             --title "Resonalyze ${{ needs.prepare.outputs.ref_name }}" \
             --notes-file notes.md \
-            --verify-tag
+            --verify-tag \
+            --draft

--- a/README.md
+++ b/README.md
@@ -492,12 +492,16 @@ midrange and a tweeter on the same axis.
 
 Unwrapped phase uses a **reliability-anchored** algorithm instead of naive
 bin-to-bin accumulation: each bin takes the 360° branch closest to a phase
-predicted from the last trustworthy bin and the running phase slope. Bins near
-the noise floor — or with low **coherence**, when the measurement carries a γ²
-estimate from averaged runs — are still displayed but never trusted as anchors,
-so deep nulls, reflection notches, and masked bands are bridged cleanly and a
-single bad bin can no longer shift the entire remaining curve by a multiple of
-360°. On clean data the result is identical to the classic unwrap.
+predicted from the last trustworthy bin and the running phase slope. Bins well
+below the local magnitude envelope (so one tall resonance cannot disqualify a
+quieter but repeatable band) — or with low **coherence**, when the measurement
+carries a γ² estimate from averaged runs — are still displayed but never
+trusted as anchors, so deep nulls, reflection notches, and masked bands are
+bridged cleanly and a single bad bin can no longer shift the entire remaining
+curve by a multiple of 360°. A dead stretch too long to bridge honestly (the
+turn count inside it is genuinely unknowable) is blanked instead of guessed,
+and the curve restarts as a fresh segment after it. On clean data the result
+is identical to the classic unwrap.
 
 Group Delay reads absolute delay referenced to the start of the transfer IR, so a
 peak well into the impulse response reports its true arrival time. The curve is
@@ -916,7 +920,10 @@ itself is only coarsely located.
 When the strongest peak lands well after the first arrival — the classic
 narrowband-subwoofer case, where room modes ring louder than the direct sound
 long after it — Time Alignment flags it and points you at the first arrival, so a
-modal or reflected peak is not mistaken for the driver's real timing.
+modal or reflected peak is not mistaken for the driver's real timing. The flag
+requires a real valley (6 dB) between the two peaks: a low-frequency driver's
+direct sound can keep rising for milliseconds, and a shoulder of that one wave
+packet peaking later is its rise time, not a reflection.
 
 The mode recalculates immediately when you switch into **Time Alignment**, and
 also updates live as soon as you change the bandpass settings.
@@ -925,7 +932,9 @@ It reports signal quality using the analysis envelope and the stored meter
 snapshot from the same measurement record:
 
 - a color-coded `Excellent`, `Good`, `Fair`, or `Poor` **signal grade** from the
-  recording's SNR — the strongest envelope peak against the rest of the record
+  recording's SNR — the strongest envelope peak against the record's noise
+  floor (the RMS of its quietest quarter, so reflections and modal decay do
+  not count as noise the way an average over the whole record would)
 - the **first-arrival prominence** — the first arrival's envelope level relative
   to the strongest peak. A low value means the pick sits on a broad leading
   edge (normal physics for band-limited low-frequency drivers), so its exact

--- a/README.md
+++ b/README.md
@@ -1338,7 +1338,10 @@ Each channel runs through:
   overlay capture, and Auto delay without clearing its source or settings
 - **Bypass** — feed the channel's raw measured signal into the sum with the
   whole chain skipped (no gain, delay, polarity, crossover, or PEQ), for an A/B
-  against the processed result; unlike Mute, the channel stays in the sum
+  against the processed result; unlike Mute, the channel stays in the sum.
+  Auto delay refuses to run while any participating channel is bypassed — the
+  proposed delay and polarity could not act on the raw signal, yet the channel
+  would still steer every other channel's alignment
 - **IR polarity** — a measured Normal / Inverted / Unknown indicator read from
   the transfer IR, independent of the virtual polarity switch
 
@@ -1409,7 +1412,10 @@ it defaults to Off because the measurements are loopback-referenced.
   loses to a slightly lossier but flat one. It weighs every near-optimal
   candidate against an arrival-based prior and a physical tie-break, so it does
   not add delay or flip polarity without a real improvement — sidestepping the
-  flip-plus-half-period impostor a steep crossover can otherwise hide. The search runs on a background task with a busy
+  flip-plus-half-period impostor a steep crossover can otherwise hide. Each
+  polarity seeds its own candidates, so the non-inverted optimum is always on
+  the table for that preference even where the inverted curve edges it
+  everywhere. The search runs on a background task with a busy
   indicator, so the window stays responsive during the few seconds it takes. If
   the resulting delays span more than ~10 ms — usually a sign that one channel's
   crossover has excessive group delay (a narrow or steep low-frequency band-pass)

--- a/README.md
+++ b/README.md
@@ -534,7 +534,13 @@ IR-based views — frequency response, phase, group delay, impulse response,
 waterfall, Burst Decay, and autocorrelation — are computed from this transfer
 IR. Harmonic distortion, THD, and THD+N curves use the ordinary
 sweep-deconvolution response instead, because the harmonic separation belongs to
-the sweep analysis itself.
+the sweep analysis itself. The HD2–HD4 curves draw at the **excitation**
+frequency (a second-harmonic hump caused by a 1 kHz drive appears at 1 kHz,
+not at its 2 kHz product; microphone calibration is applied at the product
+frequency first), so each curve ends at Nyquist/n. Note the harmonic curves
+are on the sweep-deconvolution scale while the primary curve is
+loopback-normalized — their vertical distance is not yet a calibrated
+distortion percentage.
 
 The group-delay reference is the start of the transfer IR, so reported delay is
 absolute rather than relative to a response peak.

--- a/README.md
+++ b/README.md
@@ -404,7 +404,10 @@ real-time analysis without capturing an IR, use the additional
    averaging.
 4. Start a recording to generate and capture the exponential sine sweep. With
    averaging enabled the runs are combined into one transfer IR and a coherence
-   (γ²) curve.
+   (γ²) curve, debiased by the number of runs: the raw estimate over K averages
+   reads 1/K even for pure noise (0.5 at two runs — estimator bias, not
+   information), so the stored figure maps that null expectation to 0 and stays
+   comparable across run counts.
 5. Watch the compact input level meter to confirm microphone level, loopback
    presence, and headroom before trusting the measurement.
 6. Select the analysis view you need.
@@ -485,10 +488,12 @@ The Phase view can show three independently toggled curves:
   reflections) that an equalizer cannot fix.
 
 A **τ** (delay) value detrends the linear-phase slope so the excess phase becomes
-readable. **Find τ** estimates it either from the dominant arrival (peak) or from
-the energy-weighted average group delay (slope). Entering the same τ on two
-measurements lines up their phase for a direct comparison — for example, a
-midrange and a tweeter on the same axis.
+readable. **Find τ** estimates it either from the first prominent arrival of the
+excess energy (peak — found with the same first-arrival detector Time Alignment
+uses, so a room mode ringing louder than the direct sound does not capture the
+reference) or from the energy-weighted average group delay (slope). Entering the
+same τ on two measurements lines up their phase for a direct comparison — for
+example, a midrange and a tweeter on the same axis.
 
 Unwrapped phase uses a **reliability-anchored** algorithm instead of naive
 bin-to-bin accumulation: each bin takes the 360° branch closest to a phase

--- a/TODO.md
+++ b/TODO.md
@@ -299,3 +299,114 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 - [ ] **Uninstaller leaves settings behind.** Offer (or document) removal of
   the settings/history files on uninstall.
+
+## External review tails (verified, deliberately deferred — designed changes, not patches)
+
+Items from the four external review batches (July 2026, PR #24) whose claims
+were verified against the code but whose fixes need their own design and
+validation. Each entry records the verdict so the claim does not have to be
+re-verified.
+
+### Measurement / transfer layer
+
+- [ ] ★ **Dual-device Wave loopback is an untrusted timing reference but
+  produces an indistinguishable `LoopbackTransfer` measurement.** Independent
+  clocks mean an arbitrary inter-device offset (changes per run by a buffer)
+  plus drift as a frequency-dependent phase error; Time Alignment still offers
+  fractional-millisecond read-outs. Fix: a timing-quality field
+  (sample-synchronous / shared-device / independent-devices) through
+  `ExpSweepMeasurement`, history snapshots and the IR file format, with the
+  Time Alignment panel warning or refusing on independent devices, and phase/GD
+  marked timing-uncertain.
+- [ ] **H1 has no excitation mask and an absolute epsilon.** Below the sweep
+  band `Gxy/Gxx` divides noise by noise and the garbage bins ring back through
+  the IFFT; the absolute epsilon's strength also varies with the average count.
+  Fix: relative regularization + a soft excitation taper at the known sweep
+  edges. Changes every measured transfer IR — needs validation against fresh
+  raw captures (the test-data submodule stores only final IRs).
+
+### Harmonics / THD
+
+- [ ] ★ **THD+N is not THD+N: one FFT over the HD2..HD5 region sums the
+  packets complex-wise** (phase-dependent, shifts change the result without
+  changing energy). Fix: per-harmonic windows → per-harmonic spectra → move
+  each onto the fundamental axis → sum energies; estimate noise separately and
+  add it in energy. (The HDn display axis itself is fixed: curves now draw at
+  the excitation frequency with calibration applied at the product frequency.)
+- [ ] ★ **Harmonic curves and the primary curve have different reference
+  levels** (sweep-deconvolution amplitude vs mic/loopback transfer), so their
+  vertical distance is not a distortion percentage. Fix: HDn relative to the
+  H1 linear packet of the *same* ESS decomposition; the transfer H1 stays as
+  the primary display curve.
+- [ ] **No overlap check between harmonic packets.** Long decay (bass, short
+  sweeps, car cabins) leaks one packet's tail into the next window; the curves
+  stay confident-looking. Fix: compute the available separation and warn when
+  energy near the window edge has not fallen by a set margin.
+- [ ] **No end-to-end ESS nonlinearity test.** The isolation test pins window
+  geometry only. Fix: y = x + a2·x² + a3·x³ through a real ESS +
+  deconvolution, assert HD2/HD3 frequency and level against the known a2/a3.
+
+### Auto Crossover
+
+- [ ] ★ **The scalar summation model is physically wrong in three ways**:
+  family-based amplitude-vs-power summation (the real sum depends on the
+  complex phase at each frequency, not the family name), sequential mixed
+  summation that is non-associative for 3+ channels, and a magnitude-only
+  objective that ignores the measured phase entirely (Auto delay afterwards
+  cannot fix mismatched slopes/orders with one delay). The optimizer's live
+  preview shares the model, so it confirms its own objective; the flatness
+  tests call the same `SummedResponseDb` and are tautological. Fix: complex
+  per-channel responses (measured IR × exact digital filter response) with at
+  least a final complex-sum check per candidate, plus an independent
+  complex-sum oracle in the tests.
+- [ ] **`EstimateBand` merges disjoint islands into one band** (first/last bin
+  above a global threshold): an isolated resonance above a dead gap extends
+  HighHz and misclassifies the driver. Fix: the most significant contiguous
+  segment above threshold with bounded gap tolerance.
+
+### EQ Wizard
+
+- [ ] ★ **No boostability/reliability mask**: the fitter sees only dB curves
+  and will boost a deep interference null (wasting headroom and blocking an
+  octave). Fix: mask from coherence + null depth/width + driver band; a
+  cuts-only mode (sensible default for car tuning). (The clipping-profile
+  half of this batch is fixed: `TotalGainMaxDb` caps preamp + band peak, the
+  wizard passes 0.)
+- [ ] **Band spacing ignores the chosen Q** (fixed ±0.33/±1 oct blocks);
+  **gain is fixed before Q is searched** (over-corrects broad areas; already
+  noted above with the missing polish pass); **the objective treats boosts and
+  cuts symmetrically** (no boost/high-Q/band-count regularization). All three
+  fold into the same redesign of the greedy loop: frequency × Q × gain search
+  with width-based spacing and a boost-penalized score, then a
+  coordinate-descent polish over all bands + preamp.
+
+### Waterfall / Burst Decay
+
+- [ ] **Wavelet time-support validity is not tracked**: at low frequencies the
+  Morlet kernel outlasts the analysis window and the envelope is window-shaped,
+  not system-shaped. The `Slice.SliceMinValidFrequency` metadata path already
+  exists but always receives 0 — compute the frequency below which the kernel's
+  effective support exceeds the window and mark/limit slices there. (The
+  fabricated post-window decay, the pre-peak axis zero and the above-Nyquist
+  grid are fixed.)
+- [ ] **Waterfall renders nothing silently below 8 slices** (`RawSlices.Count
+  < 8` guard in `WaterfallSeries.Render`): corrupted settings or narrow ranges
+  show an empty plot with no explanation. Show a message (or clamp the
+  controls so the state is unreachable).
+
+### Time Alignment / unwrap (deferred from earlier batches)
+
+- [ ] **GCC-PHAT confidence is peak height, not uniqueness**: a single
+  spectral line or a narrowband subwoofer reads ~100% while the delay is
+  poorly conditioned (bounded in practice by the ±0.1 ms anchored refinement
+  window). Fix: fold RMS bandwidth / peak curvature / peak-to-second-peak into
+  the confidence, or rename the figure. Needs its own validation pass on real
+  measurements.
+- [ ] **`WrapPeakPositions` cannot actually produce negative delays** — the
+  peak search is capped at length/2, so the upper-half branch of
+  `ToSignedDelaySamples` is unreachable (harmless for the loopback workflow,
+  where delays are non-negative; the API promises more than it does).
+- [ ] **Display smoothing includes low-reliability bins** (unwrap blanks long
+  garbage stretches now, but short noisy nulls still enter `SmoothLinear` at
+  full weight; magnitude curves behave the same). Optional: reliability-
+  weighted smoothing.

--- a/TODO.md
+++ b/TODO.md
@@ -468,3 +468,38 @@ re-verified.
   EQ Auto Tune and history restore just got guards for**
   (`SelectHistoryEntryAsync` applies a slow snapshot over a newer selection):
   per-channel source revision or CancellationTokenSource.
+
+### Batch 6 tails (calibration / generator / device lifecycle / autocorrelation / files / release)
+
+- [ ] **Estimated 90° calibration looks real**: `Has(Degrees90)` is true when
+  the 90° curve is approximated from the 0° file, and the UI labels it plainly
+  "90 degrees". Label it "estimated from 0°" and record the fact in the
+  measurement provenance (ties into the provenance model above).
+- [ ] **Signal Generator materializes whole signals in memory** (mono array +
+  full playback copy; ASIO always a stereo float copy): 600 s at 192 kHz is
+  ~1.3 GiB, 384+ kHz worse. Needs a streaming IWaveProvider generating blocks.
+  (The above-Nyquist sine refusal and the sample-rate-independent brown-noise
+  corner are fixed.)
+- [ ] **Subscriber exceptions escape into the real-time audio callbacks**
+  (`LevelsAvailable`/`SequenceReady`/... invoked directly from ASIO/Wave
+  callbacks): one throwing UI subscriber can kill the driver. Route through a
+  bounded dispatcher or isolate each subscriber.
+- [ ] **Autocorrelation windows are sample-count-fixed** (offset 64, length
+  2048, 3 ms display): the physical analysis window shrinks 4× at 192 kHz and
+  the promised 3 ms does not even exist at 768 kHz. Parametrize in
+  milliseconds. The /correlation[0] normalization is the standard BIASED
+  estimator — fine for display, but note it under-reads long-lag periodicity;
+  an N−k (or overlap-energy) normalization is the alternative if the mode is
+  ever used for periodicity detection.
+- [ ] **Measurement files validate only after full deserialization**: a
+  crafted file can declare hundreds of millions of samples and hit OOM before
+  `Validate()` runs. Add a file-size cap before parsing, a max-samples cap,
+  and `OutOfMemoryException` handling. (The coherence-length ↔ transfer-IR
+  consistency check is in.)
+- [ ] **Release toolchain is unpinned** (`choco install innosetup`, latest
+  NetSparkle appcast tool, actions by major tag): pin exact versions (and
+  SHAs for actions) once the current-good versions are confirmed — an
+  unverified pin would break the release instead. (The shell-injection
+  surface, the branch-vs-tag build mismatch and auto-published AI notes are
+  fixed: inputs go through env + strict regex, every job checks out the tag,
+  the release is created as a draft.)

--- a/TODO.md
+++ b/TODO.md
@@ -503,3 +503,23 @@ re-verified.
   surface, the branch-vs-tag build mismatch and auto-published AI notes are
   fixed: inputs go through env + strict regex, every job checks out the tag,
   the release is created as a draft.)
+
+### Live Spectrum cold-start (batch 7 tails)
+
+- [ ] ★ **The ASIO/Wave capture callback still allocates on the audio thread**:
+  sequence extraction builds jagged float arrays + a List and invokes
+  subscribers inline; the first pass through that branch (JIT + allocation)
+  can overrun a 64–128-sample ASIO budget. Target shape: callback → convert
+  into a preallocated SPSC ring slot → return; a background thread reframes/
+  FFTs from the ring. (`ArrayPool` is the halfway option but the sequence
+  arrays flow into the Channel with unclear return discipline.)
+- [ ] **Level meter allocates a fresh `AudioChannelLevel[]` per callback**
+  (up to ~750/s at 64-sample buffers): accumulate peak/sumSquares in the
+  callback and snapshot at 20–30 Hz.
+- [ ] **First live plot frame is heavy on the UI thread** (snapshot clones +
+  RTA computed even when hidden + first resample + OxyPlot series/capacity
+  growth): compute the RTA magnitude only when `ShowInputMagnitude`, and
+  consider pre-building the series before playback starts. A lock-free
+  callback probe ring (duration vs ASIO budget + allocated bytes) is the
+  measurement tool if hitches persist after the one-period buffer and the
+  DSP warm-up.

--- a/TODO.md
+++ b/TODO.md
@@ -410,3 +410,61 @@ re-verified.
   garbage stretches now, but short noisy nulls still enter `SmoothLinear` at
   full weight; magnitude curves behave the same). Optional: reliability-
   weighted smoothing.
+
+### Batch 5 tails (Live Spectrum / sweep / EQ export / overlays / history / provenance)
+
+- [ ] ★ **Measurement provenance model.** Files store no backend, timing
+  quality, dropped-frame/clipping history, excitation range, effective average
+  count or calibration id — a dual-device Wave capture loads back
+  indistinguishable from sample-synchronous ASIO, and Time Alignment/Virtual
+  DSP cannot see that absolute phase and delay are suspect. Ties together the
+  dual-device item above; consumers should declare their requirements
+  (Time Alignment → synchronous timing required, HD → valid packet
+  separation, ...).
+- [ ] ★ **Sweep runs are accepted unconditionally** (`AcceptedRuns++` inside
+  `Add()`; "Confirm each run" fires only *after* accumulation and cannot
+  reject). One clipped/knocked run irreversibly contaminates the average. Fix:
+  Capture → quality checks (clipping, loopback energy, duration, peak-delay
+  vs median, IR correlation vs running reference) → Accept/Retry/Skip →
+  Accumulate. Also: runs are pre-aligned by the GLOBAL sweep-IR peak (a
+  reflection outrunning the direct sound mis-aligns the whole run — bound the
+  shift and cross-correlate against a reference run); the stored raw samples
+  are only the LAST run's (rename or store per-run); Wave RMS integrates the
+  lead-in/tail silence (compute over the active sweep interval only).
+- [ ] **Wave dual-device pairing is callback-ordered** (`LoopbackSequencePairer`
+  dequeues first-come): no timestamps, no drift estimate, a lost callback
+  shifts every later pair by a whole block. Practical fix short of full
+  synchronization: allow RTA only and disable H1/coherence/phase-dependent
+  results on independent Wave devices. (Live-spectrum drop-glue, cold-start
+  γ²=1 and the mode-switch statistics mix are fixed.)
+- [ ] **EMA coherence has no effective average count** (overlap-correlated
+  frames, alpha-dependent memory): expose K_eff ≈ (2−α)/α (reduced for
+  overlap) alongside the curve and feed it to the same debias the sweep path
+  uses.
+- [ ] **EQ Wizard fits the ANALOG peaking prototype while Virtual DSP and the
+  exports run RBJ digital biquads** — ~3–4 dB apart at 18–20 kHz (48 kHz
+  rate). Fit and preview should evaluate `PeakingBiquad.Compute` +
+  `BiquadResponse` at the measurement rate; the analog model stays as an
+  explicit choice. Needs its own validation (fits change near Nyquist).
+- [ ] **miniDSP export needs a target-device profile**: the sample rate is now
+  a constructor parameter surfaced in the format name (48 kHz default), but
+  device biquad limits are not checked and the preamp burns a biquad slot
+  instead of mapping to the device's gain control.
+- [ ] **Overlay curves are assumed sorted/unique/finite in X**
+  (`CalculateOperation`'s forward-only cursor): normalize imported overlays
+  once (drop non-finite, sort, merge duplicate frequencies). (The branch-cut
+  phase interpolation and the linear-Hz→log-f interpolation are fixed.)
+- [ ] **History entries reference LIVE overlay slots** (`ActiveOverlaySlots`
+  numbers into mutable global storage): restoring an old session shows
+  whatever the slots hold TODAY. Store immutable overlay snapshots
+  (content-addressed revisions) in the history entry.
+- [ ] **History index lives beside the executable and dies silently**: no
+  write-permission handling (`Save()` throws unguarded in Program Files-style
+  installs), and any schema-version mismatch or parse error loads as an EMPTY
+  list with no backup/notification — mirror the project-file
+  backup-on-invalid policy, distinguish empty/unsupported/corrupted, and
+  consider %LocalAppData%.
+- [ ] **Virtual DSP history-source loading has the same stale-async race the
+  EQ Auto Tune and history restore just got guards for**
+  (`SelectHistoryEntryAsync` applies a slow snapshot over a newer selection):
+  per-channel source revision or CancellationTokenSource.

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -77,6 +77,12 @@ public static class AutoAlignmentEngine
     private const double MinFineAlignmentRangeMs = 0.5;
     private const double MaxFineAlignmentRangeMs = 2.5;
 
+    // The delay ceiling a proposal may reach, mirroring the UI's per-channel
+    // delay limit. Kept here so the uniform negative-delay shift can detect —
+    // and log — the rare case where clamping a pinned channel breaks the
+    // shift's alignment-preserving property.
+    private const double MaxDelayMs = 100;
+
     // Diagnostics only: a deliberately wide fine-search window (many periods at a
     // high crossover, ~one at a low one) whose candidates are logged but never
     // chosen. It surfaces summation optima that sit several lobes outside the
@@ -364,7 +370,11 @@ public static class AutoAlignmentEngine
                     channel, neighbor.Channel, pair, windowOverrideMs: retryRangeMs);
                 if (retried.Count > 0)
                 {
-                    chosen = retried[0];
+                    // Through the same selection rules as the primary pick:
+                    // taking retried[0] raw would let the widened window hand
+                    // the result to a (flip + half-period) impostor that the
+                    // invert margin and the arrival tie-break exist to reject.
+                    chosen = AlignmentSelection.Select(retried, baseDelta);
                 }
 
                 log.AppendLine(
@@ -406,9 +416,21 @@ public static class AutoAlignmentEngine
                     {
                         AlignmentOverride currentAlignment =
                             alignment.GetValueOrDefault(item.Channel);
+                        double shifted = currentAlignment.DelayMs + shift;
+                        if (shifted > MaxDelayMs)
+                        {
+                            // The shift is only alignment-preserving while it is
+                            // uniform; a channel pinned at the ceiling breaks the
+                            // relative delays silently, so say so in the log.
+                            log.AppendLine(
+                                $"  WARNING: uniform shift +{shift:0.000} ms pushes " +
+                                $"{item.Channel.Name} past the {MaxDelayMs:0} ms " +
+                                $"delay limit ({shifted:0.000} ms, clamped) — " +
+                                "the relative alignment is no longer preserved.");
+                        }
                         alignment[item.Channel] = currentAlignment with
                         {
-                            DelayMs = Math.Min(100, currentAlignment.DelayMs + shift)
+                            DelayMs = Math.Min(MaxDelayMs, shifted)
                         };
                     }
                 }
@@ -416,7 +438,7 @@ public static class AutoAlignmentEngine
             }
 
             alignment[channel] = new AlignmentOverride(
-                Math.Clamp(Math.Round(newDelay, 2), 0, 100),
+                Math.Clamp(Math.Round(newDelay, 2), 0, MaxDelayMs),
                 chosen.InvertPolarity);
         }
     }

--- a/dsp/CalibrationFile.cs
+++ b/dsp/CalibrationFile.cs
@@ -92,6 +92,21 @@ namespace Resonalyze.Dsp
             }
 
             points.Sort((left, right) => left.X.CompareTo(right.X));
+
+            // Duplicate frequencies would make an interpolation segment
+            // zero-width (a division by zero straight into the correction);
+            // merge them by averaging the amplitudes.
+            for (int i = points.Count - 1; i > 0; i--)
+            {
+                if (points[i].X == points[i - 1].X)
+                {
+                    points[i - 1] = new SignalPoint(
+                        points[i - 1].X,
+                        (points[i - 1].Y + points[i].Y) / 2.0);
+                    points.RemoveAt(i);
+                }
+            }
+
             string? loadError = points.Count >= 2
                 ? null
                 : sourceName is null
@@ -194,105 +209,65 @@ namespace Resonalyze.Dsp
                 out value) &&
             double.IsFinite(value);
 
-        public double GetDecibelCorrection(double frequency, double smoothingOctaves = 0.5)
+        // The correction is EXACT piecewise-linear interpolation in
+        // (log frequency, dB) — the natural reading of a calibration file. The
+        // previous Lanczos-smoothed lookup silently half-octave-smoothed every
+        // correction (a +12 dB point read back as ~+5.6 dB) and overshot near
+        // steps even at zero smoothing; a calibration must reproduce its own
+        // points, and any smoothing belongs to the measurement's display
+        // smoothing, not to the correction.
+        public double GetDecibelCorrection(double frequency)
         {
             if (baseCalibration != null && decibelOffset != null)
             {
-                return baseCalibration.GetDecibelCorrection(frequency, smoothingOctaves) +
+                return baseCalibration.GetDecibelCorrection(frequency) +
                     decibelOffset(frequency);
             }
 
-            if (calibration.Count < 2)
+            if (calibration.Count == 0)
             {
                 return 0;
             }
-
-            double a = 2.0;
-            double frequencyRatio = Math.Pow(2.0, smoothingOctaves * 0.5);
-            double halfDeltaFrequency = frequency * (frequencyRatio - 1);
-
-            int BinarySearchX(double searchedX)
+            if (calibration.Count == 1)
             {
-                if (searchedX <= calibration[0].X)
-                    return 0;
-                if (searchedX >= calibration[^1].X)
-                    return calibration.Count - 1;
+                return DataHelper.AmplitudeToDecibels(calibration[0].Y);
+            }
 
-                int left = 0;
-                int right = calibration.Count - 1;
+            // Outside the calibrated range the nearest point's value holds:
+            // extrapolating an edge segment arbitrarily far invents corrections
+            // the file never measured.
+            if (frequency <= calibration[0].X)
+            {
+                return DataHelper.AmplitudeToDecibels(calibration[0].Y);
+            }
+            if (frequency >= calibration[^1].X)
+            {
+                return DataHelper.AmplitudeToDecibels(calibration[^1].Y);
+            }
 
-                while (left <= right)
+            int left = 0;
+            int right = calibration.Count - 1;
+            while (right - left > 1)
+            {
+                int middle = (left + right) / 2;
+                if (calibration[middle].X <= frequency)
                 {
-                    var middle = (left + right) / 2;
-
-                    if (searchedX >= calibration[middle].X && searchedX < calibration[middle + 1].X)
-                    {
-                        return middle;
-                    }
-                    else if (searchedX < calibration[middle].X)
-                    {
-                        right = middle - 1;
-                    }
-                    else
-                    {
-                        left = middle + 1;
-                    }
+                    left = middle;
                 }
-                return -1;
-            }
-
-            int corner = BinarySearchX(frequency);
-
-            if (corner < 1)
-            {
-                // Clamped so a frequency below the calibrated range holds the first
-                // point's value: an unclamped fraction would linearly extrapolate the
-                // first segment's slope arbitrarily far (a file starting at 100 Hz
-                // queried at 20 Hz extrapolates ~80 segment widths), easily driving
-                // the amplitude negative and the correction to the -160 dB floor.
-                double fraction = Math.Clamp(
-                    (calibration[corner + 1].X - frequency) /
-                    (calibration[corner + 1].X - calibration[corner].X),
-                    0.0,
-                    1.0);
-                return DataHelper.AmplitudeToDecibels(
-                    calibration[corner].Y * fraction +
-                    calibration[corner + 1].Y * (1.0 - fraction));
-            }
-
-            if (corner >= a)
-                halfDeltaFrequency = Math.Max(
-                    halfDeltaFrequency,
-                    calibration[corner].X - calibration[corner - (int)a].X);
-
-            double weightSum = 0;
-            double weightedSum = 0;
-
-            void Accumulate(int step, int frequencyIndex)
-            {
-                while ((step < 0 ? frequencyIndex > 0 : frequencyIndex < calibration.Count - 1) &&
-                    (Math.Abs(calibration[frequencyIndex].X - frequency) < halfDeltaFrequency ||
-                     Math.Abs(frequencyIndex - corner) < 3))
+                else
                 {
-                    SignalPoint samplePoint = calibration[frequencyIndex];
-                    double weight = DspMath.LanczosKernel(
-                        (frequency - samplePoint.X) / halfDeltaFrequency * a,
-                        a);
-                    weightedSum += samplePoint.Y * weight;
-                    weightSum += weight;
-                    frequencyIndex += step;
+                    right = middle;
                 }
             }
 
-            Accumulate(-1, corner);
-            Accumulate(1, corner + 1);
-
-            // Lanczos weights are signed, so a degenerate window can sum to ~0 or
-            // negative; fall back to the nearest point instead of a 0 dB correction
-            // that would step discontinuously against the neighbouring frequencies.
-            return weightSum > 1e-9
-                ? DataHelper.AmplitudeToDecibels(weightedSum / weightSum)
-                : DataHelper.AmplitudeToDecibels(calibration[corner].Y);
+            double lowDb = DataHelper.AmplitudeToDecibels(calibration[left].Y);
+            double highDb = DataHelper.AmplitudeToDecibels(calibration[right].Y);
+            double lowX = calibration[left].X;
+            double highX = calibration[right].X;
+            double position = lowX > 0
+                ? Math.Log(frequency / lowX) / Math.Log(highX / lowX)
+                : (frequency - lowX) / (highX - lowX);
+            return lowDb + (highDb - lowDb) * position;
         }
     }
 }

--- a/dsp/DataHelper.Phase.cs
+++ b/dsp/DataHelper.Phase.cs
@@ -102,15 +102,34 @@ namespace Resonalyze.Dsp
             return spectrum;
         }
 
-        // Reliability gates for the unwrapped phase: bins this far below the peak
-        // magnitude — or with squared coherence below the floor, when coherence is
-        // available — still contribute their phase to the output, but never anchor
-        // the unwrap, so one noisy or masked bin cannot shift the whole tail by 2π.
-        // The magnitude gate matches the group-delay validity gate; γ² = 0.5 is the
-        // point where less than half the measured energy is coherent with the
-        // reference and the per-bin phase variance makes branch choices unsafe.
+        // Reliability gates for the unwrapped phase: bins this far below the LOCAL
+        // magnitude envelope — or with squared coherence below the floor, when
+        // coherence is available — still contribute their phase to the output, but
+        // never anchor the unwrap, so one noisy or masked bin cannot shift the
+        // whole tail by 2π. The magnitude gate reads against an octave-smoothed
+        // local envelope rather than the global curve maximum: one tall resonance
+        // (a subwoofer's cabin peak) must not disqualify a quieter but perfectly
+        // repeatable band tens of dB below it. An absolute backstop against the
+        // global maximum still rejects true silence — inside a wide dead band the
+        // local envelope IS the noise floor and would otherwise pass itself.
+        // γ² = 0.5 is the point where less than half the measured energy is
+        // coherent with the reference and branch choices become unsafe.
         private const double UnwrapMagnitudeGateDb = -30.0;
+        private const double UnwrapAbsoluteFloorDb = -60.0;
+        private const double UnwrapEnvelopeOctaves = 1.0;
         private const double UnwrapCoherenceFloor = 0.5;
+
+        // How far the unwrap may bridge an unreliable stretch before conceding the
+        // branch is unknowable. Inside a gap the turn count is genuinely lost —
+        // an all-pass section or a crossover transition can add whole turns that
+        // no slope extrapolation can see — so past these limits the bridged points
+        // are blanked (NaN) and a fresh wrapped segment starts, instead of drawing
+        // one confident continuous line through guessed branches. Both limits must
+        // be exceeded: a gap narrow in hertz carries few delay turns (turns =
+        // τ·Δf) and bridges safely however many octaves it spans near DC, and a
+        // gap narrow in octaves is a local feature the running slope handles.
+        private const int UnwrapMaxBridgeBins = 64;
+        private const double UnwrapMaxBridgeOctaves = 1.0 / 3.0;
         // Blend factor for the running dφ/df estimate used to predict the next
         // bin's phase; the smoothing keeps a single jittery-but-reliable bin from
         // steering the branch choice for the bins that follow.
@@ -125,8 +144,11 @@ namespace Resonalyze.Dsp
         // closest to the phase predicted from the last reliable anchor and a running
         // slope estimate. Unreliable bins (nulls, noise-floor, low coherence) get a
         // branch too, but never become anchors, so the unwrap bridges them instead
-        // of accumulating their phase noise into the tail. With every bin reliable
-        // and a zero slope this reduces to the classic nearest-to-previous choice.
+        // of accumulating their phase noise into the tail. A gap that runs past the
+        // bridge limits is conceded instead of guessed: its points are blanked and
+        // a fresh wrapped segment starts at the next reliable bin. With every bin
+        // reliable and a zero slope this reduces to the classic nearest-to-previous
+        // choice.
         private static List<SignalPoint> BuildMeasuredPhase(
             Complex[] spectrum,
             int extractionStart,
@@ -139,24 +161,35 @@ namespace Resonalyze.Dsp
             double referenceShift = referenceSamples - extractionStart;
             var data = new List<SignalPoint>(n / 2);
 
-            const double minFrequency = 100;
-
-            double maxMagnitude = 0.0;
+            double[] localEnvelope = Array.Empty<double>();
+            double absoluteFloor = 0.0;
             if (unwrap)
             {
+                double maxMagnitude = 0.0;
+                var magnitude = new double[n / 2];
                 for (int i = 1; i < n / 2; i++)
                 {
-                    maxMagnitude = Math.Max(maxMagnitude, spectrum[i].Magnitude);
+                    magnitude[i] = spectrum[i].Magnitude;
+                    maxMagnitude = Math.Max(maxMagnitude, magnitude[i]);
                 }
+
+                localEnvelope = SmoothBinsHann(
+                    magnitude,
+                    UnwrapEnvelopeOctaves,
+                    sampleRate / (double)n,
+                    minHalfWidthHz: 0.0);
+                absoluteFloor =
+                    maxMagnitude * Math.Pow(10.0, UnwrapAbsoluteFloorDb / 20.0);
             }
-            double minReliableMagnitude =
-                maxMagnitude * Math.Pow(10.0, UnwrapMagnitudeGateDb / 20.0);
+            double localGateRatio = Math.Pow(10.0, UnwrapMagnitudeGateDb / 20.0);
 
             bool hasAnchor = false;
             bool hasSlope = false;
             double anchorFrequency = 0.0;
             double anchorPhase = 0.0;
             double slope = 0.0; // rad per Hz
+            int unreliableRun = 0;
+            double lastReliableFrequency = 0.0;
 
             for (int i = 1; i < n / 2; i++)
             {
@@ -172,46 +205,99 @@ namespace Resonalyze.Dsp
                     continue;
                 }
 
-                bool reliable = spectrum[i].Magnitude >= minReliableMagnitude &&
+                bool reliable = spectrum[i].Magnitude >= absoluteFloor &&
+                    spectrum[i].Magnitude >= localEnvelope[i] * localGateRatio &&
                     (coherence == null ||
                      CoherenceAt(coherence, f, sampleRate) >= UnwrapCoherenceFloor);
 
-                if (f < minFrequency || !hasAnchor)
+                if (!hasAnchor)
                 {
-                    // Below the unwrap floor the output stays wrapped (unchanged
-                    // behavior); a running bin seeds the anchor only when it
-                    // passes the same reliability gate, so a garbage bin near the
-                    // floor cannot offset the first unwrapped branch by 2π.
+                    // Before the first reliable bin the output stays wrapped; a
+                    // bin seeds the anchor only when it passes the reliability
+                    // gate, so a garbage bin near the bottom of the band cannot
+                    // offset the first unwrapped branch by 2π.
                     data.Add(new SignalPoint(f, wrapped));
                     if (reliable)
                     {
                         anchorFrequency = f;
                         anchorPhase = wrapped;
                         hasAnchor = true;
+                        lastReliableFrequency = f;
                     }
+                    continue;
+                }
+
+                if (reliable && IsBridgeTooLong(unreliableRun, lastReliableFrequency, f))
+                {
+                    // The turn count inside the gap is unknowable — blank the
+                    // guessed bridge and restart a fresh wrapped segment here,
+                    // claiming no branch relation across the gap.
+                    for (int back = 1; back <= unreliableRun; back++)
+                    {
+                        data[^back] = new SignalPoint(data[^back].X, double.NaN);
+                    }
+
+                    hasSlope = false;
+                    slope = 0.0;
+                    anchorFrequency = f;
+                    anchorPhase = wrapped;
+                    unreliableRun = 0;
+                    lastReliableFrequency = f;
+                    data.Add(new SignalPoint(f, wrapped));
                     continue;
                 }
 
                 double predicted = anchorPhase + slope * (f - anchorFrequency);
                 double branch = Math.Round((predicted - wrapped) / Math.Tau);
                 double unwrappedPhase = wrapped + Math.Tau * branch;
-                if (reliable && f > anchorFrequency)
+                if (reliable)
                 {
-                    double localSlope =
-                        (unwrappedPhase - anchorPhase) / (f - anchorFrequency);
-                    slope = hasSlope
-                        ? UnwrapSlopeBlend * localSlope + (1.0 - UnwrapSlopeBlend) * slope
-                        : localSlope;
-                    hasSlope = true;
-                    anchorFrequency = f;
-                    anchorPhase = unwrappedPhase;
+                    unreliableRun = 0;
+                    lastReliableFrequency = f;
+                    if (f > anchorFrequency)
+                    {
+                        double localSlope =
+                            (unwrappedPhase - anchorPhase) / (f - anchorFrequency);
+                        slope = hasSlope
+                            ? UnwrapSlopeBlend * localSlope + (1.0 - UnwrapSlopeBlend) * slope
+                            : localSlope;
+                        hasSlope = true;
+                        anchorFrequency = f;
+                        anchorPhase = unwrappedPhase;
+                    }
+                }
+                else
+                {
+                    unreliableRun++;
                 }
 
                 data.Add(new SignalPoint(f, unwrappedPhase));
             }
 
+            // A gap still open at Nyquist gets the same honesty: if it already
+            // exceeded the bridge limits, its guessed points are blanked too.
+            if (unwrap && data.Count > 0 &&
+                IsBridgeTooLong(unreliableRun, lastReliableFrequency, data[^1].X))
+            {
+                for (int back = 1; back <= unreliableRun; back++)
+                {
+                    data[^back] = new SignalPoint(data[^back].X, double.NaN);
+                }
+            }
+
             return data;
         }
+
+        // Both limits must be exceeded before a bridge is declared unknowable —
+        // see the constants above for why each alone is not enough.
+        private static bool IsBridgeTooLong(
+            int unreliableRun,
+            double lastReliableFrequency,
+            double frequency) =>
+            unreliableRun >= UnwrapMaxBridgeBins &&
+            lastReliableFrequency > 0.0 &&
+            frequency >= lastReliableFrequency *
+                Math.Pow(2.0, UnwrapMaxBridgeOctaves);
 
         // Squared coherence at a frequency, linearly interpolated from an array
         // covering 0..Nyquist in uniform bins (length fftLength/2 + 1 — the layout

--- a/dsp/DataHelper.Phase.cs
+++ b/dsp/DataHelper.Phase.cs
@@ -82,6 +82,13 @@ namespace Resonalyze.Dsp
         }
 
         // Gated windowed spectrum for phase analysis (the impulse FFT'd in place).
+        // wrap: true, matching GetGroupDelay exactly: the dialog advertises ONE
+        // gate for both, and phase must stay the mathematical integral of the
+        // group delay. A gate whose left shoulder runs before the IR start
+        // (offset < left fade) reads the cyclic tail — the transfer IR is
+        // circular by construction, so its negative-time content lives there —
+        // where zero-padding used to silently feed phase and GD two different
+        // signals.
         private static Complex[] BuildPhaseSpectrum(
             IImpulseMeasurement measurement,
             double gateOffsetMs,
@@ -96,7 +103,7 @@ namespace Resonalyze.Dsp
                 leftMs,
                 plateauMs,
                 rightMs,
-                wrap: false,
+                wrap: true,
                 out extractionStart);
             Fourier.Forward(spectrum, FourierOptions.Matlab);
             return spectrum;
@@ -640,10 +647,18 @@ namespace Resonalyze.Dsp
                 return new AnalysisCurve("Group Delay", new List<SignalPoint>());
             }
 
-            // The gate compares energies (|H|²), so the dB threshold divides by 10.
-            double relativeGate = maxEnergy * Math.Pow(10.0, magnitudeGateDb / 10.0);
+            // The validity gate reads against a LOCAL octave-smoothed energy
+            // envelope, like the unwrap's reliability gate: one tall resonance
+            // must not blank a quieter but perfectly measured band 30+ dB below
+            // it. The −60 dB global backstop (the same figure as the unwrap's)
+            // still rejects true silence, where the local envelope IS the noise
+            // floor and would otherwise pass itself. Energies compare as |H|²,
+            // so the dB thresholds divide by 10.
+            double[] localEnvelope = SmoothBinsHann(
+                smoothedEnergy, 1.0, binWidthHz, minHalfWidthHz: 0.0);
+            double globalGate = maxEnergy * Math.Pow(10.0, -60.0 / 10.0);
             double absoluteGate = 1e-16;
-            double minEnergy = Math.Max(relativeGate, absoluteGate);
+            double localGateRatio = Math.Pow(10.0, magnitudeGateDb / 10.0);
 
             List<SignalPoint> data = new(halfLength);
 
@@ -657,7 +672,11 @@ namespace Resonalyze.Dsp
                 double f = i * binWidthHz;
 
                 // Regions with no coherent energy anywhere in the smoothing window
-                // (outside the sweep band, true silence) stay gated out.
+                // (outside the sweep band, true silence, deep local notches) stay
+                // gated out.
+                double minEnergy = Math.Max(
+                    Math.Max(localEnvelope[i] * localGateRatio, globalGate),
+                    absoluteGate);
                 if (smoothedEnergy[i] < minEnergy)
                 {
                     data.Add(new SignalPoint(f, double.NaN));

--- a/dsp/DataHelper.Spectrum.cs
+++ b/dsp/DataHelper.Spectrum.cs
@@ -134,12 +134,37 @@ namespace Resonalyze.Dsp
                 double[] window = Windowing.TukeyWindow(hLength, leftTukeyWindow, rightTukeyWindow);
 
                 var data = GetOversampledSpectrumData(measurement, hStart, window);
+
+                // Microphone calibration belongs to the ACTUAL acoustic
+                // frequency of the harmonic (n·f), so it is applied before the
+                // axis moves to the fundamental.
+                if (frequencyResponseOptions.UseCalibration && calibration != null)
+                {
+                    for (int i = 0; i < data.Count; i++)
+                    {
+                        data[i] = new SignalPoint(
+                            data[i].X,
+                            data[i].Y - calibration.GetDecibelCorrection(data[i].X));
+                    }
+                }
+
+                // An HDn bin at output frequency F was excited by the sweep
+                // fundamental at F/n. The standard distortion axis is the
+                // EXCITATION frequency (an HD2 hump caused by a 1 kHz drive
+                // draws at 1 kHz, not at its 2 kHz product), so the curve is
+                // remapped onto the fundamental — and can only reach
+                // Nyquist/n, where the product hits Nyquist.
+                for (int i = 0; i < data.Count; i++)
+                {
+                    data[i] = new SignalPoint(data[i].X / h, data[i].Y);
+                }
+
                 data = LogarithmicResample(
                     data,
                     20,
-                    20000,
+                    Math.Min(20_000.0, measurement.SampleRate * 0.5 / h),
                     1024,
-                    frequencyResponseOptions.UseCalibration ? calibration : null,
+                    calibration: null,
                     frequencyResponseOptions.SmoothingInverseOctaves > 0
                         ? HarmonicSmoothingWidthFactor / frequencyResponseOptions.SmoothingInverseOctaves
                         : 0.0);

--- a/dsp/EqAutoTuner.cs
+++ b/dsp/EqAutoTuner.cs
@@ -28,6 +28,19 @@ public static class EqAutoTuner
         public double PreampMaxDb { get; init; } = 30;
 
         /// <summary>
+        /// Ceiling on the TOTAL EQ gain (preamp + summed bands) at any
+        /// frequency. A positive preamp stacked under boost bands is a
+        /// clipping DSP profile — the fit used to hand one out and let the UI
+        /// report the damage as a negative headroom afterwards. The preamp is
+        /// capped after the bands are placed, so the fitted shape stays and
+        /// the curve honestly sits below an unreachable target instead.
+        /// Unbounded by default: as a pure curve fit the preamp legitimately
+        /// carries the level difference between arbitrarily referenced source
+        /// and target; a caller producing a profile for a real DSP passes 0.
+        /// </summary>
+        public double TotalGainMaxDb { get; init; } = double.PositiveInfinity;
+
+        /// <summary>
         /// Stop adding bands once the largest remaining error is below this many dB.
         /// </summary>
         public double StopResidualDb { get; init; } = 0.5;
@@ -211,6 +224,25 @@ public static class EqAutoTuner
                 grid,
                 peakIndex,
                 boostHeadroomLimited ? opt.SaturatedBlockOctaves : opt.MinBandSpacingOctaves);
+        }
+
+        // Digital-clipping guard: cap the preamp so preamp + the summed band
+        // boost never exceeds TotalGainMaxDb anywhere. Cuts leave bandPeak at
+        // 0, so a positive preamp survives only up to the ceiling itself.
+        if (double.IsFinite(opt.TotalGainMaxDb))
+        {
+            double bandPeak = 0;
+            for (int i = 0; i < n; i++)
+            {
+                if (valid[i])
+                {
+                    bandPeak = Math.Max(bandPeak, eqSum[i]);
+                }
+            }
+            preamp = Clamp(
+                Math.Min(preamp, Math.Floor(opt.TotalGainMaxDb - bandPeak)),
+                opt.PreampMinDb,
+                opt.PreampMaxDb);
         }
 
         return new EqualizationCurve(bands, preamp);

--- a/dsp/EqProfileFormats.cs
+++ b/dsp/EqProfileFormats.cs
@@ -14,7 +14,13 @@ public static class EqProfileFormats
         new GenericCsvFormat(),
         new EasyEffectsFormat(),
         new CamillaDspYamlFormat(),
-        new MiniDspFormat(),
+        // Biquad coefficients are rate-specific, and the two miniDSP families
+        // process at different internal rates (2x4 at 48 kHz, HD/DDRC-class at
+        // 96 kHz) — one dialog entry per rate, each labeled with it, so the
+        // user picks the one matching the device instead of silently getting
+        // 48 kHz coefficients.
+        new MiniDspFormat(48_000),
+        new MiniDspFormat(96_000),
         new GraphicEqFormat()
     };
 

--- a/dsp/EqProfileFormats.cs
+++ b/dsp/EqProfileFormats.cs
@@ -14,11 +14,12 @@ public static class EqProfileFormats
         new GenericCsvFormat(),
         new EasyEffectsFormat(),
         new CamillaDspYamlFormat(),
-        // Biquad coefficients are rate-specific, and the two miniDSP families
-        // process at different internal rates (2x4 at 48 kHz, HD/DDRC-class at
-        // 96 kHz) — one dialog entry per rate, each labeled with it, so the
-        // user picks the one matching the device instead of silently getting
-        // 48 kHz coefficients.
+        // Biquad coefficients are rate-specific, and biquad-consuming devices
+        // process at different internal rates (car DSPs commonly at 44.1 kHz,
+        // miniDSP 2x4 at 48 kHz, HD/DDRC-class at 96 kHz) — one dialog entry
+        // per rate, each labeled with it, so the user picks the one matching
+        // the device instead of silently getting 48 kHz coefficients.
+        new MiniDspFormat(44_100),
         new MiniDspFormat(48_000),
         new MiniDspFormat(96_000),
         new GraphicEqFormat()

--- a/dsp/ExcessDelay.cs
+++ b/dsp/ExcessDelay.cs
@@ -11,8 +11,12 @@ namespace Resonalyze.Dsp;
 /// Two estimators are returned because they answer different questions and only
 /// coincide when the excess is essentially a pure delay:
 /// <list type="bullet">
-/// <item><b>Peak</b> — the dominant arrival (the mode of the excess energy). Robust
-/// against reflections; the right reference for a "bulk delay" readout.</item>
+/// <item><b>Peak</b> — the first arrival of the excess energy: the earliest
+/// prominent envelope peak, found with the same first-arrival detector Time
+/// Alignment uses, so a late reflection or room mode that rings louder than the
+/// direct sound does not capture the τ reference. The right reference for a
+/// "bulk delay" readout. Falls back to the strongest peak when the excess energy
+/// leads the window (a negative-lag dominant).</item>
 /// <item><b>Slope</b> — the energy-weighted mean group delay, i.e. the temporal
 /// centroid of the excess energy. By the group-delay/centroid theorem this is the τ
 /// that defines the linear trend of the excess phase, so it is the value to subtract
@@ -70,7 +74,20 @@ public static class ExcessDelay
             excessResponse[i] = excessSpectrum[i].Real;
         }
 
-        double peakSamples = EstimatePeakLag(excessResponse);
+        // A spectrum with no energy would "peak" at lag 0 and read as a valid
+        // τ = 0; report it as invalid instead so a caller does not silently
+        // write a fabricated reference.
+        double totalEnergy = 0.0;
+        for (int i = 0; i < n; i++)
+        {
+            totalEnergy += excessResponse[i] * excessResponse[i];
+        }
+        if (!(totalEnergy > 0.0) || !double.IsFinite(totalEnergy))
+        {
+            return new ExcessDelayResult(0, 0, 0, 0, IsValid: false);
+        }
+
+        double peakSamples = EstimatePeakLag(excessResponse, sampleRate);
         double slopeSamples = EstimateCentroidLag(excessResponse);
 
         return new ExcessDelayResult(
@@ -80,9 +97,16 @@ public static class ExcessDelay
             slopeSamples * 1000.0 / sampleRate);
     }
 
-    // Dominant arrival: the envelope's global maximum, refined to sub-sample with a
-    // parabolic fit over circular neighbours, expressed as a signed lag.
-    private static double EstimatePeakLag(double[] signal)
+    // First arrival of the excess energy, refined to sub-sample with a parabolic
+    // fit over circular neighbours, expressed as a signed lag. The global
+    // envelope maximum alone is NOT the arrival: a room reflection or mode can
+    // ring louder than the direct sound (the exact trap Time Alignment handles),
+    // and putting the τ reference on it tilts the whole excess-phase curve. So
+    // when the dominant energy sits at a causal (positive) lag, the same
+    // first-arrival detector walks back to the earliest prominent peak; a
+    // negative-lag dominant (excess energy leading the window) keeps the global
+    // maximum, which the first-arrival search cannot reach.
+    private static double EstimatePeakLag(double[] signal, int sampleRate)
     {
         double[] envelope = SignalEnvelope.Envelope(signal);
         int n = envelope.Length;
@@ -95,6 +119,26 @@ public static class ExcessDelay
             {
                 peak = envelope[i];
                 peakIndex = i;
+            }
+        }
+
+        if (peakIndex <= n / 2)
+        {
+            PeakSearchResult firstArrival = SignalEnvelope.FindPeak(
+                envelope,
+                sampleRate,
+                new PeakSearchOptions
+                {
+                    Mode = PeakSearchMode.FirstArrival,
+                    SearchWindowMilliseconds = n * 500.0 / sampleRate
+                });
+            // Only a strictly EARLIER prominent arrival replaces the global
+            // maximum: when the dominant energy already is the earliest event
+            // (a near-pure delay peaking at lag ~0), the detector can only
+            // offer a skirt bump after it, never the peak itself.
+            if (firstArrival.SelectedIndex < peakIndex)
+            {
+                peakIndex = firstArrival.SelectedIndex;
             }
         }
 
@@ -137,4 +181,8 @@ public readonly record struct ExcessDelayResult(
     double PeakDelaySamples,
     double PeakDelayMilliseconds,
     double SlopeDelaySamples,
-    double SlopeDelayMilliseconds);
+    double SlopeDelayMilliseconds,
+    // False when the gated spectrum carried no energy at all: a zero excess
+    // response "peaks" at lag 0, and an auto-τ caller would silently write a
+    // fabricated 0 ms reference.
+    bool IsValid = true);

--- a/dsp/MiniDspFormat.cs
+++ b/dsp/MiniDspFormat.cs
@@ -10,10 +10,26 @@ namespace Resonalyze.Dsp;
 /// </summary>
 public sealed class MiniDspFormat : IEqProfileFormat
 {
-    private const double SampleRateHz = 48_000;
+    // Biquad coefficients are only meaningful for the sample rate they were
+    // computed at: the same file applied on a device processing at a different
+    // rate lands every band on a different frequency and Q. The rate is a
+    // constructor parameter and part of the visible format name, so the user
+    // picks the file knowing which device family it fits instead of silently
+    // getting 48 kHz coefficients.
+    private readonly double sampleRateHz;
     private const string CoefficientFormat = "0.00000000";
 
-    public string Name => "miniDSP biquads";
+    public MiniDspFormat(double sampleRateHz = 48_000)
+    {
+        if (!double.IsFinite(sampleRateHz) || sampleRateHz <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRateHz));
+        }
+
+        this.sampleRateHz = sampleRateHz;
+    }
+
+    public string Name => $"miniDSP biquads ({sampleRateHz / 1000:0.#} kHz devices)";
     public string Extension => "txt";
     public bool CanImport => false;
     public bool CanExport => true;
@@ -34,7 +50,7 @@ public sealed class MiniDspFormat : IEqProfileFormat
 
         foreach (PeqBand band in curve.Bands)
         {
-            AppendBiquad(builder, index++, PeakingBiquad.Compute(band, SampleRateHz));
+            AppendBiquad(builder, index++, PeakingBiquad.Compute(band, sampleRateHz));
         }
 
         return builder.ToString();

--- a/dsp/MinimumPhase.cs
+++ b/dsp/MinimumPhase.cs
@@ -26,9 +26,14 @@ namespace Resonalyze.Dsp;
 public static class MinimumPhase
 {
     /// <summary>
-    /// Default magnitude floor. Magnitudes below this are clamped before taking the
-    /// logarithm so that nulls and the noise floor do not produce log singularities.
-    /// Matches <see cref="DataHelper"/>'s minimum amplitude.
+    /// Default magnitude floor, RELATIVE to the spectrum's own peak (−160 dB).
+    /// Magnitudes below the scaled floor are clamped before taking the logarithm
+    /// so that nulls and the noise floor do not produce log singularities. The
+    /// floor scales with the input because minimum phase is physically invariant
+    /// to an overall gain (a constant added to log|H| only moves the zeroth
+    /// cepstral coefficient): an ABSOLUTE floor made a quiet measurement's phase
+    /// depend on its level — the H1 transfer scale follows the microphone and
+    /// loopback input levels, so this is a real capture case, not an API one.
     /// </summary>
     public const double DefaultMagnitudeFloor = 1e-8;
 
@@ -37,7 +42,10 @@ public static class MinimumPhase
     /// magnitude spectrum (bins covering 0 … sample rate).
     /// </summary>
     /// <param name="magnitude">Linear magnitude per FFT bin, length N.</param>
-    /// <param name="magnitudeFloor">Lower clamp applied before the logarithm.</param>
+    /// <param name="magnitudeFloor">
+    /// Lower clamp applied before the logarithm, as a fraction of the spectrum's
+    /// maximum finite magnitude.
+    /// </param>
     /// <returns>Minimum phase in radians, length N.</returns>
     public static double[] FromMagnitude(
         IReadOnlyList<double> magnitude,
@@ -56,10 +64,25 @@ public static class MinimumPhase
         }
 
         int length = magnitude.Count;
+        double maxMagnitude = 0.0;
+        for (int i = 0; i < length; i++)
+        {
+            double value = magnitude[i];
+            if (double.IsFinite(value) && value > maxMagnitude)
+            {
+                maxMagnitude = value;
+            }
+        }
+
+        // NaN/Infinity/negative bins clamp to the floor instead of poisoning
+        // the whole cepstrum through Math.Max and the FFT.
+        double floor = Math.Max(maxMagnitude * magnitudeFloor, double.Epsilon);
         double[] logMagnitude = new double[length];
         for (int i = 0; i < length; i++)
         {
-            logMagnitude[i] = Math.Log(Math.Max(magnitude[i], magnitudeFloor));
+            double value = magnitude[i];
+            logMagnitude[i] = Math.Log(
+                double.IsFinite(value) && value > floor ? value : floor);
         }
 
         return FromLogMagnitude(logMagnitude);

--- a/dsp/PreparedDspResponse.cs
+++ b/dsp/PreparedDspResponse.cs
@@ -87,19 +87,25 @@ public sealed class PreparedDspResponse
         double maxRadius = 0.0;
         foreach (BiquadCoefficients section in sections)
         {
-            double discriminant = section.A1 * section.A1 - 4.0 * section.A2;
+            // BiquadCoefficients uses the ADDITIVE feedback convention
+            // (y[n] = … + A1·y[n−1] + A2·y[n−2], denominator
+            // 1 − A1·z⁻¹ − A2·z⁻²), so the poles are the roots of
+            // z² − A1·z − A2 = 0 — NOT the textbook 1 + a1·z⁻¹ + a2·z⁻² form,
+            // whose formulas mis-read every ordinary stable section here as
+            // unstable and pinned the padding at the maximum.
+            double discriminant = section.A1 * section.A1 + 4.0 * section.A2;
             double radius;
             if (discriminant < 0.0)
             {
-                // Complex conjugate poles: |p|² = A2.
-                radius = Math.Sqrt(Math.Max(0.0, section.A2));
+                // Complex conjugate poles: |p|² = the roots' product = −A2.
+                radius = Math.Sqrt(Math.Max(0.0, -section.A2));
             }
             else
             {
                 double root = Math.Sqrt(discriminant);
                 radius = Math.Max(
-                    Math.Abs((-section.A1 + root) * 0.5),
-                    Math.Abs((-section.A1 - root) * 0.5));
+                    Math.Abs((section.A1 + root) * 0.5),
+                    Math.Abs((section.A1 - root) * 0.5));
             }
 
             maxRadius = Math.Max(maxRadius, radius);

--- a/dsp/PreparedDspResponse.cs
+++ b/dsp/PreparedDspResponse.cs
@@ -73,6 +73,52 @@ public sealed class PreparedDspResponse
     public bool IsTimeDomainScaleOnly =>
         delayMs == 0 && sections.Length == 0;
 
+    /// <summary>
+    /// Zero-padding (samples) needed for this chain's ringing to decay by
+    /// <paramref name="targetDecayDb"/> before a circular FFT would wrap the
+    /// tail into the early response. Follows the slowest pole of the biquad
+    /// cascade: a 20 Hz / Q 10 peaking filter rings for ~13.8·Q/(π·f) × ln10/…
+    /// hundreds of milliseconds — far past any fixed pad sized for crossovers.
+    /// Clamped to [<paramref name="minSamples"/>, <paramref name="maxSamples"/>];
+    /// a numerically unstable section (pole radius ≥ 1) gets the maximum.
+    /// </summary>
+    public int RequiredTailSamples(double targetDecayDb, int minSamples, int maxSamples)
+    {
+        double maxRadius = 0.0;
+        foreach (BiquadCoefficients section in sections)
+        {
+            double discriminant = section.A1 * section.A1 - 4.0 * section.A2;
+            double radius;
+            if (discriminant < 0.0)
+            {
+                // Complex conjugate poles: |p|² = A2.
+                radius = Math.Sqrt(Math.Max(0.0, section.A2));
+            }
+            else
+            {
+                double root = Math.Sqrt(discriminant);
+                radius = Math.Max(
+                    Math.Abs((-section.A1 + root) * 0.5),
+                    Math.Abs((-section.A1 - root) * 0.5));
+            }
+
+            maxRadius = Math.Max(maxRadius, radius);
+        }
+
+        if (maxRadius >= 1.0)
+        {
+            return maxSamples;
+        }
+        if (maxRadius <= 0.0)
+        {
+            return minSamples;
+        }
+
+        double required = Math.Log(
+            Math.Pow(10.0, -Math.Abs(targetDecayDb) / 20.0)) / Math.Log(maxRadius);
+        return (int)Math.Clamp(Math.Ceiling(required), minSamples, maxSamples);
+    }
+
     public Complex[] ApplyTimeDomainScale(Complex[] impulseResponse, int length)
     {
         var result = new Complex[length];

--- a/dsp/SignalEnvelope.cs
+++ b/dsp/SignalEnvelope.cs
@@ -156,12 +156,22 @@ public static class SignalEnvelope
             true);
     }
 
+    // For stationary Gaussian noise the Hilbert envelope is Rayleigh-
+    // distributed, and the RMS of its lowest quartile is ~0.370 of the full
+    // envelope RMS. The quartile floor is deliberately robust (reverb decay
+    // must not count as noise), but reported as-is it would flatter the SNR
+    // by ~8.6 dB — so the REPORTED figure compensates the known bias back to
+    // the full-envelope noise RMS. The first-arrival threshold keeps the raw
+    // robust floor: there under-estimating noise is the safe direction.
+    private const double RayleighLowestQuartileRmsRatio = 0.370;
+
     public static double EstimatePeakConfidenceDecibels(
         IReadOnlyList<double> envelope,
         double peak)
     {
         ArgumentNullException.ThrowIfNull(envelope);
-        double noiseRms = EstimateEnvelopeNoiseRms(envelope);
+        double noiseRms = EstimateEnvelopeNoiseRms(envelope)
+            / RayleighLowestQuartileRmsRatio;
         return DataHelper.AmplitudeToDecibels(peak / Math.Max(noiseRms, 1e-12));
     }
 

--- a/dsp/SignalEnvelope.cs
+++ b/dsp/SignalEnvelope.cs
@@ -116,7 +116,7 @@ public static class SignalEnvelope
             envelope.Count,
             sampleRate,
             options.SearchWindowMilliseconds);
-        double noiseRms = EstimateEnvelopeNoiseRms(envelope, strongestIndex);
+        double noiseRms = EstimateEnvelopeNoiseRms(envelope);
         double thresholdFromMax = strongestPeak *
             Math.Pow(10.0, -Math.Abs(options.FirstPeakThresholdBelowMaxDb) / 20.0);
         double thresholdFromNoise = noiseRms *
@@ -158,11 +158,10 @@ public static class SignalEnvelope
 
     public static double EstimatePeakConfidenceDecibels(
         IReadOnlyList<double> envelope,
-        int peakIndex,
         double peak)
     {
         ArgumentNullException.ThrowIfNull(envelope);
-        double noiseRms = EstimateEnvelopeNoiseRms(envelope, peakIndex);
+        double noiseRms = EstimateEnvelopeNoiseRms(envelope);
         return DataHelper.AmplitudeToDecibels(peak / Math.Max(noiseRms, 1e-12));
     }
 
@@ -328,39 +327,43 @@ public static class SignalEnvelope
     {
         int requestedSamples = (int)Math.Round(
             Math.Max(1, searchWindowMilliseconds) * sampleRate / 1000.0);
-        return Math.Clamp(requestedSamples, 3, Math.Max(3, envelopeLength / 2));
+        // The floor of 3 exists for the parabolic refinement, but it must never
+        // exceed the envelope itself — a 1–2 sample input would otherwise be
+        // read past its end.
+        int cap = Math.Min(envelopeLength, Math.Max(3, envelopeLength / 2));
+        return Math.Clamp(requestedSamples, Math.Min(3, cap), cap);
     }
 
-    private static double EstimateEnvelopeNoiseRms(
-        IReadOnlyList<double> envelope,
-        int peakIndex)
-    {
-        int exclusionRadius = Math.Max(8, envelope.Count / 50);
-        double sumSquares = 0;
-        int count = 0;
-        for (int i = 0; i < envelope.Count; i++)
-        {
-            if (CircularDistance(i, peakIndex, envelope.Count) <= exclusionRadius)
-            {
-                continue;
-            }
+    // The fraction of the envelope (its quietest samples) the noise-floor
+    // estimate averages over.
+    private const double NoiseFloorQuantile = 0.25;
 
-            sumSquares += envelope[i] * envelope[i];
-            count++;
+    // Noise floor as the RMS of the quietest quarter of the envelope. An
+    // acoustic IR's remainder is NOT noise — it is reflections, modal decay and
+    // driver ringing — so a mean over everything-but-the-peak (the previous
+    // estimate) read reverberation as noise: it misgraded clean reverberant
+    // recordings and, worse, inflated the noise-based first-arrival threshold
+    // until a genuine weak direct sound was cut out of the candidate list. The
+    // quietest-quantile RMS reads the true floor as long as decay and arrivals
+    // occupy less than three quarters of the record, which holds for any IR
+    // with usable headroom around its reverb tail.
+    private static double EstimateEnvelopeNoiseRms(IReadOnlyList<double> envelope)
+    {
+        var sorted = new double[envelope.Count];
+        for (int i = 0; i < sorted.Length; i++)
+        {
+            sorted[i] = envelope[i];
+        }
+        Array.Sort(sorted);
+
+        int count = Math.Max(1, (int)(sorted.Length * NoiseFloorQuantile));
+        double sumSquares = 0;
+        for (int i = 0; i < count; i++)
+        {
+            sumSquares += sorted[i] * sorted[i];
         }
 
-        return count > 0
-            ? Math.Sqrt(sumSquares / count)
-            : 0;
-    }
-
-    private static int CircularDistance(
-        int index,
-        int centerIndex,
-        int length)
-    {
-        int distance = Math.Abs(index - centerIndex);
-        return Math.Min(distance, length - distance);
+        return Math.Sqrt(sumSquares / count);
     }
 }
 

--- a/dsp/SpectrumAnalysis.cs
+++ b/dsp/SpectrumAnalysis.cs
@@ -31,7 +31,7 @@ public static class SpectrumAnalysis
         }
 
         int length = samples.Count;
-        double[] window = Windowing.CreateAnalysisWindow(windowType, length);
+        double[] window = Windowing.SharedAnalysisWindow(windowType, length);
         var spectrum = new Complex[length];
         double windowSum = 0.0;
         for (int i = 0; i < length; i++)
@@ -87,7 +87,7 @@ public static class SpectrumAnalysis
             throw new ArgumentOutOfRangeException(nameof(frameLength));
         }
 
-        double[] window = Windowing.CreateAnalysisWindow(windowType, frameLength);
+        double[] window = Windowing.SharedAnalysisWindow(windowType, frameLength);
         double windowSum = 0.0;
         for (int i = 0; i < frameLength; i++)
         {
@@ -145,7 +145,7 @@ public static class SpectrumAnalysis
             throw new ArgumentException("Samples must not be empty.", nameof(reference));
         }
 
-        double[] window = Windowing.CreateAnalysisWindow(windowType, reference.Count);
+        double[] window = Windowing.SharedAnalysisWindow(windowType, reference.Count);
         var referenceSpectrum = new Complex[reference.Count];
         var targetSpectrum = new Complex[target.Count];
         for (int i = 0; i < reference.Count; i++)

--- a/dsp/SpectrumAnalysis.cs
+++ b/dsp/SpectrumAnalysis.cs
@@ -42,12 +42,19 @@ public static class SpectrumAnalysis
 
         Fourier.Forward(spectrum, FourierOptions.Matlab);
 
+        // Tone calibration (dBFS): a full-scale bin-centred sine reads
+        // amplitude 1.0 for any FFT length and any window — |X_k| = N·CG/2,
+        // so the amplitude is 2|X_k|/(N·CG). Without the 2/N the level jumped
+        // 6 dB per FFT-size doubling. DC has no conjugate mirror, so it takes
+        // half the scale (a DC level of 1.0 also reads 1.0).
         double coherentGain = windowSum / length;
-        double scale = coherentGain > 0.0 ? 1.0 / coherentGain : 1.0;
+        double scale = coherentGain > 0.0
+            ? 2.0 / (length * coherentGain)
+            : 2.0 / length;
         var power = new double[length / 2];
         for (int i = 0; i < power.Length; i++)
         {
-            double magnitude = spectrum[i].Magnitude * scale;
+            double magnitude = spectrum[i].Magnitude * (i == 0 ? scale * 0.5 : scale);
             power[i] = magnitude * magnitude;
         }
 
@@ -88,13 +95,23 @@ public static class SpectrumAnalysis
         }
 
         double coherentGain = windowSum / frameLength;
-        double scale = coherentGain > 0.0 ? 1.0 / coherentGain : 1.0;
+
+        // Tone calibration (dBFS): a full-scale bin-centred sine has
+        // |X_k| = N·CG/2, so the amplitude is 2|X_k|/(N·CG) — INDEPENDENT of
+        // the FFT length. Without the 2/N the same input jumped 6 dB per
+        // FFT-size doubling, on the same axis as the length-invariant H1
+        // transfer gain. DC (no conjugate mirror) takes half the scale,
+        // matching ComputePowerSpectrum bin for bin.
+        double scale = coherentGain > 0.0
+            ? 2.0 / (frameLength * coherentGain)
+            : 2.0 / frameLength;
 
         var magnitude = new double[autoPowerSpectrum.Count];
         for (int i = 0; i < magnitude.Length; i++)
         {
             double power = autoPowerSpectrum[i];
-            magnitude[i] = power > 0.0 ? Math.Sqrt(power) * scale : 0.0;
+            double binScale = i == 0 ? scale * 0.5 : scale;
+            magnitude[i] = power > 0.0 ? Math.Sqrt(power) * binScale : 0.0;
         }
 
         return magnitude;

--- a/dsp/SpectrumAnalysis.cs
+++ b/dsp/SpectrumAnalysis.cs
@@ -198,6 +198,31 @@ public static class SpectrumAnalysis
         return coherence;
     }
 
+    /// <summary>
+    /// Removes the small-sample positive bias of the raw γ² estimate, in place.
+    /// The MSC estimator over K averages has E[γ̂²] = 1/K for fully incoherent
+    /// signals — at K = 2 pure noise reads ~0.5, exactly at the thresholds the
+    /// unwrap and PHAT weighting trust — so raw values are rescaled by the
+    /// standard first-order correction (K·γ̂² − 1)/(K − 1), which maps the null
+    /// expectation to 0 and keeps 1 at 1. With one average (no estimate at all)
+    /// everything collapses to 0. Returns the same array for chaining.
+    /// </summary>
+    public static double[] DebiasCoherence(double[] coherence, int averageCount)
+    {
+        ArgumentNullException.ThrowIfNull(coherence);
+        for (int i = 0; i < coherence.Length; i++)
+        {
+            coherence[i] = averageCount <= 1
+                ? 0.0
+                : Math.Clamp(
+                    (averageCount * coherence[i] - 1.0) / (averageCount - 1.0),
+                    0.0,
+                    1.0);
+        }
+
+        return coherence;
+    }
+
     public static double[] ComputeH1MagnitudeSpectrum(
         IReadOnlyList<Complex> crossSpectrum,
         IReadOnlyList<double> referencePowerSpectrum,

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -21,8 +21,10 @@ public readonly record struct TimeAlignmentAnalysisResult(
     double EnvelopePeak,
     int StrongestEnvelopePeakIndex,
     double StrongestEnvelopePeak,
-    // How clean the recording is: the strongest envelope peak against the RMS
-    // of the rest of the record. It grades the measurement, not the pick.
+    // How clean the recording is: the strongest envelope peak against the
+    // noise floor (the RMS of the record's quietest quarter, so reflections
+    // and modal decay do not count as noise). It grades the measurement, not
+    // the pick.
     double SignalToNoiseDecibels,
     // How pronounced the first arrival is: its envelope level relative to the
     // strongest peak, <= 0 dB (0 when they coincide). A low value means the
@@ -46,7 +48,13 @@ public readonly record struct TimeAlignmentAnalysisResult(
     double FirstArrivalConfidence,
     bool FirstArrivalRefinedByPhat,
     double StrongestConfidence,
-    bool StrongestRefinedByPhat);
+    bool StrongestRefinedByPhat,
+    // False when the analysis band carried no energy at all (silence, or a
+    // bandpass entirely outside the measured band): with a flat-zero envelope
+    // every sample "passes" the thresholds and the peak walk would fabricate a
+    // confident-looking delay near the end of the search window. An invalid
+    // result reports zeros and must not be shown as an alignment.
+    bool IsValid = true);
 
 public static class TimeAlignmentAnalysis
 {
@@ -105,6 +113,17 @@ public static class TimeAlignmentAnalysis
         double strongestPeak = peakSearchResult.StrongestPeak;
         int strongestPeakIndex = peakSearchResult.StrongestIndex;
 
+        // No energy anywhere in the search window: nothing downstream is
+        // meaningful (thresholds collapse to zero and every zero sample reads
+        // as a "peak"), so return an explicitly invalid result instead of a
+        // fabricated delay.
+        if (!(strongestPeak > 0.0) || !double.IsFinite(strongestPeak))
+        {
+            return new TimeAlignmentAnalysisResult(
+                envelope, 0, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                false, 0.0, false, 0.0, false, IsValid: false);
+        }
+
         // Refine each arrival to sub-sample precision with a GCC-PHAT correlation
         // of the transfer IR (its spectrum already carries the microphone/loopback
         // cross-phase). The envelope peak stays the robust coarse anchor; the
@@ -124,12 +143,17 @@ public static class TimeAlignmentAnalysis
         // When the strongest peak is a distinct, clearly later arrival than the
         // first, it is a reflection or a room mode rather than the direct sound —
         // the usual narrowband-subwoofer trap. Flag it so the reader trusts the
-        // first arrival. The coarse index gap drives the flag so wrapping does not.
+        // first arrival. The coarse index gap drives the flag so wrapping does
+        // not, and a genuine second arrival must be separated by a real valley:
+        // a band-limited low-frequency driver's direct sound keeps rising for
+        // milliseconds, and an early shoulder of that one wave packet peaking
+        // later must not be called a reflection.
         double separationMilliseconds =
             (strongestPeakIndex - envelopePeakIndex) * 1000.0 / sampleRate;
         bool strongestIsSeparateArrival =
             strongestPeakIndex != envelopePeakIndex &&
-            separationMilliseconds >= SeparateArrivalThresholdMilliseconds;
+            separationMilliseconds >= SeparateArrivalThresholdMilliseconds &&
+            HasValleyBetween(envelope, envelopePeakIndex, strongestPeakIndex);
 
         if (options.WrapPeakPositions)
         {
@@ -149,7 +173,6 @@ public static class TimeAlignmentAnalysis
             strongestPeak,
             SignalEnvelope.EstimatePeakConfidenceDecibels(
                 envelope,
-                strongestPeakIndex,
                 strongestPeak),
             strongestPeak > 0.0
                 ? DataHelper.AmplitudeToDecibels(envelopePeak / strongestPeak)
@@ -176,11 +199,38 @@ public static class TimeAlignmentAnalysis
     // smeared direct sound.
     private const double SeparateArrivalThresholdMilliseconds = 1.0;
 
+    // How deep the envelope must dip between the two peaks before they count as
+    // separate arrivals: two events have a real valley between them, one broad
+    // rise does not.
+    private const double SeparateArrivalValleyDb = 6.0;
+
+    private static bool HasValleyBetween(
+        IReadOnlyList<double> envelope,
+        int firstIndex,
+        int secondIndex)
+    {
+        int from = Math.Min(firstIndex, secondIndex);
+        int to = Math.Max(firstIndex, secondIndex);
+        double valley = double.MaxValue;
+        for (int i = from; i <= to; i++)
+        {
+            valley = Math.Min(valley, envelope[i]);
+        }
+
+        double reference = Math.Min(envelope[firstIndex], envelope[secondIndex]);
+        return valley <= reference *
+            Math.Pow(10.0, -SeparateArrivalValleyDb / 20.0);
+    }
+
     // A short refinement window (~0.1 ms) around the envelope peak: wide enough to
     // absorb the envelope's sub-sample bias, narrow enough not to slide onto a
-    // neighbouring reflection.
+    // neighbouring reflection. The cap is in samples only as a backstop — at
+    // 32 it no longer shrinks the window in TIME at high sample rates the way
+    // the old cap of 8 did (192 kHz used to get ±0.04 ms instead of ~0.1 ms).
+    private const double PhatSearchRadiusSeconds = 0.0001;
+
     private static int ComputePhatSearchRadius(int sampleRate) =>
-        Math.Clamp((int)Math.Round(sampleRate * 0.0001), 2, 8);
+        Math.Clamp((int)Math.Round(sampleRate * PhatSearchRadiusSeconds), 2, 32);
 
     // A refined arrival position plus the GCC-PHAT trust it was refined with.
     // RefinedByPhat is true when the whitened correlation drove the sample; false

--- a/dsp/TransferFunction.cs
+++ b/dsp/TransferFunction.cs
@@ -46,13 +46,19 @@ public static class TransferFunction
 
         // γ² from the shared cross/auto-spectra formula; epsilon 0 keeps the
         // previous denominator > 0 gate. Only the first half is retained — the
-        // upper half mirrors it for the real inputs here.
-        double[] coherence = SpectrumAnalysis
-            .ComputeCoherence(
-                crossSpectrum,
-                referencePowerSpectrum,
-                targetPowerSpectrum,
-                epsilon: 0.0)[..(fftLength / 2 + 1)];
+        // upper half mirrors it for the real inputs here. The raw estimate is
+        // debiased by the average count before anything stores or consumes it:
+        // at 2-4 averages the raw MSC of pure noise reads 1/K (0.5 at K=2 —
+        // straddling the very thresholds the unwrap and the PHAT weighting
+        // trust), which is estimator bias, not information.
+        double[] coherence = SpectrumAnalysis.DebiasCoherence(
+            SpectrumAnalysis
+                .ComputeCoherence(
+                    crossSpectrum,
+                    referencePowerSpectrum,
+                    targetPowerSpectrum,
+                    epsilon: 0.0)[..(fftLength / 2 + 1)],
+            frames.Count);
 
         Complex[] relative = InverseH1Response(
             crossSpectrum,

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -748,8 +748,10 @@ public static class VirtualCrossoverAnalysis
 
     // Candidate reporting: how far behind the winner a local optimum may score
     // and still be returned, and how many candidates are returned at most.
+    // Each polarity seeds its own optima, so one lobe can contribute two
+    // candidates — the cap leaves room for three lobes even then.
     private const double CandidateGapDb = 1.5;
-    private const int MaxAlignmentCandidates = 4;
+    private const int MaxAlignmentCandidates = 6;
 
     /// <summary>
     /// How much a candidate's deepest smoothed notch counts against its score,
@@ -769,9 +771,13 @@ public static class VirtualCrossoverAnalysis
     // the same grid scheme as the correlation search, but scoring each delay
     // by the metric the tool actually reports: the log-frequency-weighted
     // average summation loss. Both polarities are evaluated at every delay
-    // (they share the rotated spectrum), and the better one is kept alongside
-    // the delay. Every local optimum of the coarse grid within the candidate
-    // gap is refined and reported, best first. The dip-excess penalty is folded
+    // (they share the rotated spectrum), but each polarity seeds and refines
+    // its own local optima: on a max-of-both envelope one polarity edging the
+    // other across a whole basin would hide the loser's peak entirely, and the
+    // downstream preference for normal polarity within a margin
+    // (AlignmentSelection) would have no normal candidate left to prefer.
+    // Every local optimum of the coarse grid within the candidate gap is
+    // refined and reported, best first. The dip-excess penalty is folded
     // into each optimum's score only after refinement: within one lobe the dip
     // varies slowly with delay, so it re-ranks the lobes against each other
     // without needing to be paid on every grid point.
@@ -789,39 +795,39 @@ public static class VirtualCrossoverAnalysis
             weightSum += bin.LogWeight;
         }
 
-        (double LossDb, bool Invert) Evaluate(double delayMs)
+        double EvaluatePolarity(double delayMs, bool invert)
         {
-            double normal = 0;
-            double inverted = 0;
+            double loss = 0;
             foreach (AlignmentBin bin in bins)
             {
                 Complex variable = bin.Variable * Complex.Exp(
                     new Complex(0, -bin.OmegaMs * delayMs));
-                normal += bin.LogWeight * Math.Log10(Math.Max(
-                    (bin.FixedSum + variable).Magnitude / bin.MagnitudeSum,
-                    MinBinAmplitudeRatio));
-                inverted += bin.LogWeight * Math.Log10(Math.Max(
-                    (bin.FixedSum - variable).Magnitude / bin.MagnitudeSum,
+                Complex sum = invert
+                    ? bin.FixedSum - variable
+                    : bin.FixedSum + variable;
+                loss += bin.LogWeight * Math.Log10(Math.Max(
+                    sum.Magnitude / bin.MagnitudeSum,
                     MinBinAmplitudeRatio));
             }
 
-            normal *= 20.0 / weightSum;
-            inverted *= 20.0 / weightSum;
-            return inverted > normal ? (inverted, true) : (normal, false);
+            return loss * 20.0 / weightSum;
         }
 
-        AlignmentCandidate Scored(double delayMs)
+        double PriorPenaltyDb(double delayMs)
         {
-            (double lossDb, bool invert) = Evaluate(delayMs);
-            double score = lossDb;
             if (priorDelayMs is { } prior && priorSigmaMs > 0)
             {
                 double distance = (delayMs - prior) / priorSigmaMs;
-                score -= PriorPenaltyDbAtSigma * distance * distance;
+                return PriorPenaltyDbAtSigma * distance * distance;
             }
 
-            return new AlignmentCandidate(delayMs, invert, score);
+            return 0;
         }
+
+        AlignmentCandidate Scored(double delayMs, bool invert) => new(
+            delayMs,
+            invert,
+            EvaluatePolarity(delayMs, invert) - PriorPenaltyDb(delayMs));
 
         // The coarse grid is evaluated transposed — outer loop over bins, inner
         // over delays — replacing a Complex.Exp per (bin, delay) with one complex
@@ -850,36 +856,28 @@ public static class VirtualCrossoverAnalysis
             }
         }
 
-        var grid = new List<AlignmentCandidate>(gridCount);
-        for (int i = 0; i < gridCount; i++)
+        // Local optima of each polarity's own coarse grid (window edges
+        // included): each is the seed of one correlation lobe of that polarity.
+        var seeds = new List<AlignmentCandidate>();
+        foreach ((double[] accumulated, bool invert) in
+            new[] { (normalDb, false), (invertedDb, true) })
         {
-            double delayMs = minDelayMs + i * coarseStep;
-            double normal = normalDb[i] * 20.0 / weightSum;
-            double inverted = invertedDb[i] * 20.0 / weightSum;
-            (double lossDb, bool invert) = inverted > normal
-                ? (inverted, true)
-                : (normal, false);
-
-            double score = lossDb;
-            if (priorDelayMs is { } prior && priorSigmaMs > 0)
+            var scores = new double[gridCount];
+            for (int i = 0; i < gridCount; i++)
             {
-                double distance = (delayMs - prior) / priorSigmaMs;
-                score -= PriorPenaltyDbAtSigma * distance * distance;
+                scores[i] = accumulated[i] * 20.0 / weightSum
+                    - PriorPenaltyDb(minDelayMs + i * coarseStep);
             }
 
-            grid.Add(new AlignmentCandidate(delayMs, invert, score));
-        }
-
-        // Local optima of the coarse grid (window edges included): each is the
-        // seed of one correlation lobe / polarity basin.
-        var seeds = new List<AlignmentCandidate>();
-        for (int i = 0; i < grid.Count; i++)
-        {
-            bool risesBefore = i == 0 || grid[i].ScoreDb >= grid[i - 1].ScoreDb;
-            bool fallsAfter = i == grid.Count - 1 || grid[i].ScoreDb >= grid[i + 1].ScoreDb;
-            if (risesBefore && fallsAfter)
+            for (int i = 0; i < gridCount; i++)
             {
-                seeds.Add(grid[i]);
+                bool risesBefore = i == 0 || scores[i] >= scores[i - 1];
+                bool fallsAfter = i == gridCount - 1 || scores[i] >= scores[i + 1];
+                if (risesBefore && fallsAfter)
+                {
+                    seeds.Add(new AlignmentCandidate(
+                        minDelayMs + i * coarseStep, invert, scores[i]));
+                }
             }
         }
 
@@ -892,13 +890,14 @@ public static class VirtualCrossoverAnalysis
             {
                 // Clamp the refinement span to the window: a seed on an edge
                 // would otherwise score points outside it, and the reported
-                // score and polarity must belong to an in-window delay.
+                // score must belong to an in-window delay. The polarity stays
+                // the seed's own — each candidate is one polarity's optimum.
                 double from = Math.Max(minDelayMs, best.DelayMs - step);
                 double to = Math.Min(maxDelayMs, best.DelayMs + step);
                 step /= 10.0;
                 for (double delay = from; delay <= to; delay += step)
                 {
-                    AlignmentCandidate candidate = Scored(delay);
+                    AlignmentCandidate candidate = Scored(delay, seed.InvertPolarity);
                     if (candidate.ScoreDb > best.ScoreDb)
                     {
                         best = candidate;
@@ -942,6 +941,7 @@ public static class VirtualCrossoverAnalysis
                 break;
             }
             if (results.All(kept =>
+                kept.InvertPolarity != candidate.InvertPolarity ||
                 Math.Abs(kept.DelayMs - candidate.DelayMs) > coarseStep))
             {
                 results.Add(candidate);

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -84,9 +84,16 @@ public enum PolarityEstimate
 public static class VirtualCrossoverAnalysis
 {
     // Zero padding appended before the FFT so the chain's delay shift and the
-    // filter ringing tails stay linear instead of wrapping around. 8192 samples
-    // cover ~170 ms at 48 kHz — far beyond any crossover or high-Q PEQ decay.
-    private const int FilterTailPadding = 8192;
+    // filter ringing tails stay linear instead of wrapping around. The floor
+    // (8192 samples ≈ 170 ms at 48 kHz) covers every crossover; the actual pad
+    // follows the chain's slowest pole, because a low-frequency high-Q PEQ
+    // rings far longer — a 20 Hz / Q 10 boost decays only ~9 dB over the old
+    // fixed pad, and the rest wrapped circularly into the early IR, phase and
+    // the alignment sums. The cap bounds the FFT growth for pathological
+    // settings.
+    private const int MinFilterTailPadding = 8192;
+    private const int MaxFilterTailPadding = 262_144;
+    private const double FilterTailDecayDb = 120.0;
 
     /// <summary>
     /// Applies the chain to an impulse response by multiplying its spectrum with
@@ -113,9 +120,11 @@ public static class VirtualCrossoverAnalysis
 
         int delaySamples = (int)Math.Ceiling(
             Math.Max(0.0, chain.DelayMs) / 1_000.0 * sampleRate);
-        int length = DspMath.NextPowerOfTwo(
-            impulseResponse.Length + delaySamples + FilterTailPadding);
         PreparedDspResponse preparedChain = PreparedDspResponse.Create(chain, sampleRate);
+        int tailPadding = preparedChain.RequiredTailSamples(
+            FilterTailDecayDb, MinFilterTailPadding, MaxFilterTailPadding);
+        int length = DspMath.NextPowerOfTwo(
+            impulseResponse.Length + delaySamples + tailPadding);
         if (preparedChain.IsTimeDomainScaleOnly)
         {
             return preparedChain.ApplyTimeDomainScale(impulseResponse, length);

--- a/dsp/WaterfallAnalysis.cs
+++ b/dsp/WaterfallAnalysis.cs
@@ -33,7 +33,10 @@ public static class WaterfallAnalysis
         double frequencyStep = (double)measurement.SampleRate / spectrum.Length;
         double frequencyRatio = Math.Pow(2.0, 0.5 * smoothingOctaves);
 
-        double initFrequency = 20000;
+        // The grid never reaches past Nyquist: at sample rates below 40 kHz a
+        // fixed 20 kHz start would generate wavelet slices for frequencies the
+        // capture physically cannot contain.
+        double initFrequency = Math.Min(20_000.0, measurement.SampleRate * 0.49);
         var frequencies = new List<double>(100);
         while (initFrequency >= frequencyStep * 4 && initFrequency >= 20)
         {
@@ -78,12 +81,24 @@ public static class WaterfallAnalysis
         return result;
     }
 
+    /// <summary>
+    /// Resamples one burst-decay envelope onto a periods axis.
+    /// <paramref name="measuredSamples"/> is how much of the raw envelope is
+    /// real data (the analysis window length): everything past it is the
+    /// zero-padding of the FFT, not an observed decay, so those points read
+    /// NaN instead of a fabricated cliff to the floor — at 20 Hz a 30-period
+    /// axis spans 1.5 s while a default window measures only 85 ms.
+    /// <paramref name="peakOffsetSamples"/> anchors period 0 on the IR peak
+    /// (the raw envelope starts a left-fade earlier, at the gate start).
+    /// </summary>
     public static IReadOnlyList<SignalPoint> ResampleBurstDecaySlice(
         IReadOnlyList<SignalPoint> rawData,
         double frequency,
         int sampleRate,
         int width,
-        double periods)
+        double periods,
+        int measuredSamples = int.MaxValue,
+        int peakOffsetSamples = 0)
     {
         ArgumentNullException.ThrowIfNull(rawData);
         if (rawData.Count == 0)
@@ -106,18 +121,25 @@ public static class WaterfallAnalysis
         {
             throw new ArgumentOutOfRangeException(nameof(periods));
         }
+        if (peakOffsetSamples < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(peakOffsetSamples));
+        }
 
         double periodsTime = periods / frequency;
         double periodsSamples = sampleRate * periodsTime;
+        double availableLimit = Math.Min((double)measuredSamples, rawData.Count - 1);
         var data = new List<SignalPoint>(width);
 
         for (int i = 0; i < width; i++)
         {
             double interp = (double)i / width;
-            double samplePosition = interp * periodsSamples;
+            double samplePosition = peakOffsetSamples + interp * periodsSamples;
             data.Add(new SignalPoint(
                 interp * periods,
-                DataHelper.AmplitudeToDecibels(SmoothSample(rawData, samplePosition))));
+                samplePosition <= availableLimit
+                    ? DataHelper.AmplitudeToDecibels(SmoothSample(rawData, samplePosition))
+                    : double.NaN));
         }
 
         return data;

--- a/dsp/WaterfallAnalysis.cs
+++ b/dsp/WaterfallAnalysis.cs
@@ -128,7 +128,13 @@ public static class WaterfallAnalysis
 
         double periodsTime = periods / frequency;
         double periodsSamples = sampleRate * periodsTime;
-        double availableLimit = Math.Min((double)measuredSamples, rawData.Count - 1);
+        // measuredSamples counts REAL samples, so the last measured index is
+        // measuredSamples − 1 — and the interpolation taps are clamped to it
+        // too, so points just inside the boundary do not blend the FFT's
+        // zero-padding into the last measured readings.
+        int lastMeasuredIndex = (int)Math.Min(
+            Math.Min((long)measuredSamples - 1, rawData.Count - 1),
+            int.MaxValue);
         var data = new List<SignalPoint>(width);
 
         for (int i = 0; i < width; i++)
@@ -137,24 +143,29 @@ public static class WaterfallAnalysis
             double samplePosition = peakOffsetSamples + interp * periodsSamples;
             data.Add(new SignalPoint(
                 interp * periods,
-                samplePosition <= availableLimit
-                    ? DataHelper.AmplitudeToDecibels(SmoothSample(rawData, samplePosition))
+                samplePosition <= lastMeasuredIndex
+                    ? DataHelper.AmplitudeToDecibels(
+                        SmoothSample(rawData, samplePosition, lastMeasuredIndex))
                     : double.NaN));
         }
 
         return data;
     }
 
-    private static double SmoothSample(IReadOnlyList<SignalPoint> rawData, double index)
+    private static double SmoothSample(
+        IReadOnlyList<SignalPoint> rawData,
+        double index,
+        int maxIndex)
     {
         const int radius = 2;
         int centerIndex = (int)Math.Round(index);
+        int limit = Math.Min(maxIndex, rawData.Count - 1);
 
         double weightSum = 0;
         double weightedSum = 0;
 
         for (int sampleIndex = Math.Max(centerIndex - radius, 0);
-            sampleIndex <= Math.Min(centerIndex + radius, rawData.Count - 1);
+            sampleIndex <= Math.Min(centerIndex + radius, limit);
             sampleIndex++)
         {
             double weight = DataHelper.LanczosKernel(index - sampleIndex, radius);

--- a/dsp/Windowing.cs
+++ b/dsp/Windowing.cs
@@ -20,11 +20,30 @@ namespace Resonalyze.Dsp
         /// <summary>
         /// Builds a symmetric analysis window of the requested type and length.
         /// </summary>
+        // One-entry cache for the analysis window: a live session recomputes
+        // the same (type, length) window thousands of times — once per
+        // analysis frame plus once per UI snapshot — each costing `length`
+        // trig calls and an allocation right next to the audio pipeline. The
+        // cached array is SHARED: callers must treat it as read-only (all
+        // in-repo callers only multiply by its values).
+        private sealed record CachedAnalysisWindow(
+            WindowType Type,
+            int Length,
+            double[] Window);
+
+        private static volatile CachedAnalysisWindow? analysisWindowCache;
+
         public static double[] CreateAnalysisWindow(WindowType windowType, int length)
         {
             if (length < 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            CachedAnalysisWindow? cached = analysisWindowCache;
+            if (cached != null && cached.Type == windowType && cached.Length == length)
+            {
+                return cached.Window;
             }
 
             var window = new double[length];
@@ -33,6 +52,7 @@ namespace Resonalyze.Dsp
                 window[i] = AnalysisWindowValue(windowType, i, length);
             }
 
+            analysisWindowCache = new CachedAnalysisWindow(windowType, length, window);
             return window;
         }
 

--- a/dsp/Windowing.cs
+++ b/dsp/Windowing.cs
@@ -33,7 +33,13 @@ namespace Resonalyze.Dsp
 
         private static volatile CachedAnalysisWindow? analysisWindowCache;
 
-        public static double[] CreateAnalysisWindow(WindowType windowType, int length)
+        /// <summary>
+        /// The cached shared window — internal, and the caller MUST NOT write
+        /// to the returned array (every in-repo caller only multiplies by its
+        /// values). The public <see cref="CreateAnalysisWindow"/> hands out a
+        /// private copy instead, so external code cannot corrupt the cache.
+        /// </summary>
+        internal static double[] SharedAnalysisWindow(WindowType windowType, int length)
         {
             if (length < 1)
             {
@@ -54,6 +60,14 @@ namespace Resonalyze.Dsp
 
             analysisWindowCache = new CachedAnalysisWindow(windowType, length, window);
             return window;
+        }
+
+        public static double[] CreateAnalysisWindow(WindowType windowType, int length)
+        {
+            double[] shared = SharedAnalysisWindow(windowType, length);
+            var copy = new double[shared.Length];
+            Array.Copy(shared, copy, shared.Length);
+            return copy;
         }
 
         private static double AnalysisWindowValue(WindowType windowType, int index, int length)

--- a/source/Audio/AsioFullDuplexSession.cs
+++ b/source/Audio/AsioFullDuplexSession.cs
@@ -323,11 +323,31 @@ internal sealed class AsioFullDuplexSession : IDisposable
         {
             firstBufferReady?.TrySetException(args.Exception);
             playbackStopped?.TrySetException(args.Exception);
-            return;
+        }
+        else
+        {
+            playbackStopped?.TrySetResult(true);
         }
 
-        playbackStopped?.TrySetResult(true);
+        // No more samples are coming: a waiter blocked on a sample count the
+        // stopped driver will never deliver used to hang until a manual Abort.
+        lock (sync)
+        {
+            sampleWaiters.FaultAll(
+                args.Exception ??
+                new InvalidOperationException(
+                    "ASIO playback stopped before the requested samples arrived."));
+        }
     }
+
+    /// <summary>
+    /// Completes when the driver stops — successfully on a normal stop, with
+    /// the driver's exception on a failure. A live consumer that otherwise
+    /// waits only on its own cancellation must also await this, or an
+    /// unplugged device leaves it frozen with no error and no completion.
+    /// </summary>
+    public Task StoppedAsync() =>
+        playbackStopped?.Task ?? Task.CompletedTask;
 
     private void ResetBuffers()
     {

--- a/source/Audio/SampleWaiterRegistry.cs
+++ b/source/Audio/SampleWaiterRegistry.cs
@@ -50,6 +50,22 @@ internal sealed class SampleWaiterRegistry
         waiters.Clear();
     }
 
+    /// <summary>
+    /// Faults every pending waiter. Called when the capture stops
+    /// unexpectedly (device unplugged, driver error): a waiter blocked on a
+    /// sample count that will never arrive used to hang forever — the stop
+    /// event completed only the first-buffer and stopped signals.
+    /// </summary>
+    public void FaultAll(Exception exception)
+    {
+        foreach (SampleWaiter waiter in waiters)
+        {
+            waiter.Fault(exception);
+        }
+
+        waiters.Clear();
+    }
+
     private sealed class SampleWaiter
     {
         private readonly TaskCompletionSource<bool> completion = NewSignal();
@@ -75,6 +91,12 @@ internal sealed class SampleWaiterRegistry
         {
             registration.Dispose();
             completion.TrySetCanceled();
+        }
+
+        public void Fault(Exception exception)
+        {
+            registration.Dispose();
+            completion.TrySetException(exception);
         }
     }
 }

--- a/source/Measurements/ImpulseResponseFile.cs
+++ b/source/Measurements/ImpulseResponseFile.cs
@@ -336,6 +336,22 @@ public sealed class ImpulseResponseFile
         }
         if (TransferCoherence != null)
         {
+            // The pipeline produces exactly N/2 + 1 coherence bins for a
+            // transfer IR of length N; anything else would draw the curve on a
+            // wrong frequency grid, because the FFT length is reconstructed
+            // from the coherence itself.
+            if (TransferRealSamples == null)
+            {
+                throw new InvalidDataException(
+                    "Transfer coherence requires transfer impulse response samples.");
+            }
+            if (TransferCoherence.Length != TransferRealSamples.Length / 2 + 1)
+            {
+                throw new InvalidDataException(
+                    "Transfer coherence length does not match the transfer impulse response " +
+                    $"({TransferCoherence.Length} bins for {TransferRealSamples.Length} samples).");
+            }
+
             for (int i = 0; i < TransferCoherence.Length; i++)
             {
                 double value = TransferCoherence[i];

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -29,6 +29,15 @@ namespace Resonalyze
         private int sequencesCounter;
         private long lastDropTickMs;
         private int droppedFrameTotal;
+        // Bumped on every dropped capture block; the processing loop compares it
+        // against the generation it has consumed and resets the reframer, so no
+        // FFT frame is ever built across the discontinuity a drop leaves behind.
+        private long dropGeneration;
+        // Frames the coherence estimate must accumulate before it is shown at
+        // all: below this the EMA has too few effective degrees of freedom and
+        // the estimate reads near 1 regardless of the real channel relation.
+        private const int MinCoherenceFrames = 4;
+        private AveragingSpeed appliedAveragingSpeed;
         private volatile bool inProgress;
         private bool disposed;
 
@@ -265,6 +274,7 @@ namespace Resonalyze
             Complex[] crossSpectrum;
             double[] referencePowerSpectrum;
             double[] targetPowerSpectrum;
+            int frameCount;
             lock (dataSync)
             {
                 if (accumulatedCrossSpectrum == null ||
@@ -277,15 +287,24 @@ namespace Resonalyze
                 crossSpectrum = (Complex[])accumulatedCrossSpectrum.Clone();
                 referencePowerSpectrum = (double[])accumulatedReferencePowerSpectrum.Clone();
                 targetPowerSpectrum = (double[])accumulatedTargetPowerSpectrum.Clone();
+                frameCount = averagedFrameCount;
             }
 
             double[] magnitude = SpectrumAnalysis.ComputeH1MagnitudeSpectrum(
                 crossSpectrum,
                 referencePowerSpectrum);
-            double[] coherence = SpectrumAnalysis.ComputeCoherence(
-                crossSpectrum,
-                referencePowerSpectrum,
-                targetPowerSpectrum);
+            // γ² of a single frame is identically 1 in every energized bin
+            // whatever the real relation between the channels, and the first
+            // few EMA frames are barely better — the display would mark the
+            // whole curve "trusted" exactly when no statistics exist yet. Until
+            // a few frames have accumulated the coherence is UNKNOWN (null),
+            // not perfect.
+            double[]? coherence = frameCount >= MinCoherenceFrames
+                ? SpectrumAnalysis.ComputeCoherence(
+                    crossSpectrum,
+                    referencePowerSpectrum,
+                    targetPowerSpectrum)
+                : null;
             // The microphone auto-power is already accumulated for coherence, so the
             // reference-free RTA magnitude comes for free: normalize it by the same
             // window's coherent gain the frame was measured with so its level is
@@ -337,6 +356,21 @@ namespace Resonalyze
         {
             lock (dataSync)
             {
+                // A Slow accumulation is not a valid Fast average (and vice
+                // versa): grafting the new alpha onto the old mode's memory
+                // mixes two different statistics — the curve keeps the long
+                // memory of the previous mode for its whole decay. Switching
+                // the averaging speed starts the new mode's statistics from
+                // scratch, like the explicit Reset does.
+                if (LiveSpectrumOptions.AveragingSpeed != appliedAveragingSpeed)
+                {
+                    accumulatedCrossSpectrum = null;
+                    accumulatedReferencePowerSpectrum = null;
+                    accumulatedTargetPowerSpectrum = null;
+                    sequencesCounter = 0;
+                    averagedFrameCount = 0;
+                }
+
                 UpdateAveragingParameters();
             }
         }
@@ -357,6 +391,9 @@ namespace Resonalyze
         {
             Interlocked.Increment(ref droppedFrameTotal);
             Interlocked.Exchange(ref lastDropTickMs, Environment.TickCount64);
+            // Consumed by the processing loop: a drop means the next dequeued
+            // block is NOT contiguous with the reframer's buffered tail.
+            Interlocked.Increment(ref dropGeneration);
         }
 
         private async Task<bool> RunCoreAsync(CancellationToken cancellationToken)
@@ -606,8 +643,22 @@ namespace Resonalyze
             OverlapReframer reframer,
             CancellationToken cancellationToken)
         {
+            long consumedDropGeneration = Interlocked.Read(ref dropGeneration);
             await foreach (float[][] sequence in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
             {
+                // A dropped block means this sequence is not contiguous with
+                // the reframer's buffered tail: an FFT frame built across the
+                // seam reads the artificial step as a broadband burst and
+                // poisons H1, coherence and the EMA for seconds after the
+                // overload indicator clears. Start from a clean buffer instead
+                // of splicing over the hole.
+                long generation = Interlocked.Read(ref dropGeneration);
+                if (generation != consumedDropGeneration)
+                {
+                    consumedDropGeneration = generation;
+                    reframer.Reset();
+                }
+
                 foreach (float[][] frame in reframer.Push(sequence))
                 {
                     AccumulateTransferSequence(frame);
@@ -643,6 +694,7 @@ namespace Resonalyze
                 GetAveragingTimeConstant(LiveSpectrumOptions.AveragingSpeed);
             infiniteAveraging = LiveSpectrumOptions.AveragingSpeed == AveragingSpeed.Infinite;
             transferAlpha = AlphaFromTimeConstant(frameInterval, transferSeconds);
+            appliedAveragingSpeed = LiveSpectrumOptions.AveragingSpeed;
         }
 
         private void AccumulateTransferSequence(float[][] sequence)

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -580,7 +580,19 @@ namespace Resonalyze
                     SampleRate,
                     autoStop: false,
                     cancellationToken).ConfigureAwait(false);
-                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                // Wait on the user's stop AND on the driver's own stop: an
+                // unplugged ASIO device stops delivering callbacks, and a
+                // cancellation-only wait left the measurement frozen — plot
+                // stuck, InProgress true, no Completed, no error.
+                Task stopped = session.StoppedAsync();
+                Task cancelled = Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                Task finished = await Task.WhenAny(stopped, cancelled).ConfigureAwait(false);
+                await finished.ConfigureAwait(false);
+                if (finished == stopped)
+                {
+                    throw new InvalidOperationException(
+                        "The ASIO driver stopped unexpectedly (device removed or driver error).");
+                }
             }
             finally
             {

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -129,8 +129,20 @@ namespace Resonalyze
 
             signal?.Dispose();
             signal = new NoiseSignal();
+            // Periodic pink repeats one FFT-length period exactly, and both
+            // playback paths loop the stream seamlessly — so ONE period is the
+            // whole signal. Materializing the full requested duration used to
+            // allocate ~35 MB of LOH arrays (60 s mono floats + the stereo
+            // playback copy) at the start of a live session, for a visible
+            // memory spike and cold-start page-commit work right next to the
+            // first audio callbacks. Non-periodic colours still need the full
+            // length (a short loop of aperiodic noise would seam audibly).
+            double signalDuration =
+                LiveSpectrumOptions.NoiseColor == NoiseColor.PinkPeriodic
+                    ? SequenceLength / (double)sampleRate
+                    : requestedDuration;
             signal.FillData(
-                requestedDuration,
+                signalDuration,
                 bits,
                 sampleRate,
                 LiveSpectrumOptions.NoiseColor,
@@ -417,6 +429,13 @@ namespace Resonalyze
             {
                 UpdateAveragingParameters();
             }
+            // Warm the whole analysis path BEFORE the driver starts: the first
+            // real frame otherwise pays MathNet's FFT initialization, the JIT
+            // of every spectrum method and the first large-array commits while
+            // the audio callbacks are already running on a millisecond budget —
+            // audible as cold-start dropouts in the first seconds.
+            WarmUpAnalysisPath();
+
             var reframer = new OverlapReframer(SequenceLength, hopSize);
             Task processingTask = ProcessSequencesAsync(
                 sequenceChannel.Reader,
@@ -780,6 +799,34 @@ namespace Resonalyze
                 sequence[loopbackIndex.Value],
                 sequence[microphoneIndex],
                 EffectiveWindowType);
+        }
+
+        // One synthetic frame through the exact code path the live analysis
+        // runs (window creation, both forward FFTs, H1, coherence, the RTA
+        // magnitude): everything is JIT-compiled and MathNet's internals are
+        // initialized before the first real capture block, off the audio
+        // thread's budget. A few milliseconds once per start.
+        private void WarmUpAnalysisPath()
+        {
+            var reference = new float[SequenceLength];
+            var target = new float[SequenceLength];
+            reference[0] = 1.0f;
+            target[0] = 1.0f;
+            TransferSpectrumFrame frame = SpectrumAnalysis.ComputeTransferSpectrumFrame(
+                reference,
+                target,
+                EffectiveWindowType);
+            _ = SpectrumAnalysis.ComputeH1MagnitudeSpectrum(
+                frame.CrossSpectrum,
+                frame.ReferencePowerSpectrum);
+            _ = SpectrumAnalysis.ComputeCoherence(
+                frame.CrossSpectrum,
+                frame.ReferencePowerSpectrum,
+                frame.TargetPowerSpectrum);
+            _ = SpectrumAnalysis.ComputeInputMagnitudeSpectrum(
+                frame.TargetPowerSpectrum,
+                EffectiveWindowType,
+                SequenceLength);
         }
 
         // Periodic pink noise is exactly one FFT-length period, so every analysis block

--- a/source/Measurements/NoiseSignal.cs
+++ b/source/Measurements/NoiseSignal.cs
@@ -170,10 +170,19 @@ public sealed class NoiseSignal : IDisposable
 
     // Brown/red noise (-6 dB/octave) via a leaky integrator of white noise. The
     // leak keeps the random walk from drifting off; the mean is removed and the
-    // result normalized to the same 0.5 peak as the other colours.
+    // result normalized to the same 0.5 peak as the other colours. The leak is
+    // derived from a FIXED corner frequency (fc ≈ Fs·(1−leak)/2π, below which
+    // the −6 dB/oct slope flattens): a fixed 0.99 coefficient put that corner
+    // at ~76 Hz at 48 kHz but ~305 Hz at 192 kHz — the same "Brown" mode
+    // changed its spectral shape with the sample rate.
+    private const double BrownCornerHz = 76.0;
+
     private void FillBrown(Random random)
     {
-        const double leak = 0.99;
+        double leak = Math.Clamp(
+            1.0 - 2.0 * Math.PI * BrownCornerHz / Math.Max(1, SampleRate),
+            0.0,
+            0.99999);
         double value = 0;
         double sum = 0;
         for (int sampleIndex = 0; sampleIndex < Samples; sampleIndex++)

--- a/source/Measurements/SoundRecorder.cs
+++ b/source/Measurements/SoundRecorder.cs
@@ -259,6 +259,17 @@ namespace Resonalyze
                     new InvalidOperationException("Recording stopped before the first audio buffer arrived."));
                 recordingStopped?.TrySetResult(true);
             }
+
+            // A waiter blocked on a sample count that will never arrive (the
+            // device unplugged mid-capture) used to hang until a manual Abort:
+            // no more samples are coming, so fault every pending wait.
+            lock (sync)
+            {
+                sampleWaiters.FaultAll(
+                    args.Exception ??
+                    new InvalidOperationException(
+                        "Recording stopped before the requested samples arrived."));
+            }
         }
 
         private void ResetBuffers()

--- a/source/Options/FROptions.cs
+++ b/source/Options/FROptions.cs
@@ -150,7 +150,9 @@ namespace Resonalyze.Options
                 "Shows the total harmonic distortion + noise curve.");
             toolTip.SetToolTip(
                 irPlotView,
-                "Preview of the sweep-deconvolution impulse response and the analysis window used for this mode.");
+                "Preview of the transfer impulse response and the analysis window used " +
+                "for the primary curve. The harmonic curves window the sweep-deconvolution " +
+                "IR with automatically derived windows.");
         }
     }
 }

--- a/source/Overlays/OverlayMath.cs
+++ b/source/Overlays/OverlayMath.cs
@@ -203,8 +203,20 @@ public static class OverlayMath
                 continue;
             }
 
-            double position = (aPoint.X - left.X) / (right.X - left.X);
-            double bValue = left.Y + (right.Y - left.Y) * position;
+            // Acoustic curves live on a logarithmic frequency axis, so the
+            // interpolation position is logarithmic too — on sparse imported
+            // curves a linear-Hz blend lands visibly off between octave-spaced
+            // points. (Linear fallback only for degenerate non-positive X.)
+            double position = left.X > 0 && aPoint.X > 0
+                ? Math.Log(aPoint.X / left.X) / Math.Log(right.X / left.X)
+                : (aPoint.X - left.X) / (right.X - left.X);
+            // Wrapped phase must interpolate through the branch cut: a curve
+            // stepping from +170° to −170° passes through ±180°, not through 0°
+            // the way a linear blend of the raw numbers would — and the wrap of
+            // the difference afterwards cannot recover the lost branch.
+            double bValue = wrapPhaseDifference
+                ? InterpolateWrappedDegrees(left.Y, right.Y, position)
+                : left.Y + (right.Y - left.Y) * position;
             double aValue = aPoint.Y;
             if (useAmplitudeSpace)
             {
@@ -248,6 +260,21 @@ public static class OverlayMath
                 Math.Abs(WrapDegrees(a - b, wrapPhaseDifference)),
             _ => double.NaN
         };
+    }
+
+    // Interpolates between two wrapped phase readings along the SHORT way
+    // around the circle, by blending the unit phasors and taking the angle of
+    // the result.
+    private static double InterpolateWrappedDegrees(
+        double fromDegrees,
+        double toDegrees,
+        double position)
+    {
+        double from = fromDegrees * Math.PI / 180.0;
+        double to = toDegrees * Math.PI / 180.0;
+        double x = (1.0 - position) * Math.Cos(from) + position * Math.Cos(to);
+        double y = (1.0 - position) * Math.Sin(from) + position * Math.Sin(to);
+        return Math.Atan2(y, x) * 180.0 / Math.PI;
     }
 
     // Maps a phase difference in degrees to the shortest angular distance in (-180, 180]

--- a/source/Plotting/WaterfallSeries.cs
+++ b/source/Plotting/WaterfallSeries.cs
@@ -527,12 +527,19 @@ namespace Resonalyze
                         RawSlices[slice].Frequency,
                         OxyPlotAdapter.ToSignalPoints(RawSlices[slice].Data));
 
+                    // Only GenerateOptions.Window samples of the raw envelope are
+                    // measured data (the rest is FFT zero-padding), and the IR
+                    // peak sits a left fade after the gate start — pass both so
+                    // the periods axis is peak-anchored and points past the
+                    // measured record read NaN instead of a fabricated decay.
                     List<SignalPoint> resampled = WaterfallAnalysis.ResampleBurstDecaySlice(
                         rawSlice.Data,
                         rawSlice.Frequency,
                         RawSlices[slice].SampleRate,
                         width,
-                        GenerateOptions.Periods).ToList();
+                        GenerateOptions.Periods,
+                        measuredSamples: GenerateOptions.Window,
+                        peakOffsetSamples: Math.Max(0, GenerateOptions.LeftTukeyWindow)).ToList();
 
                     ResampleSlices[slice] = new Slice(
                         OxyPlotAdapter.ToDataPoints(resampled),

--- a/source/Shell/Form1.History.cs
+++ b/source/Shell/Form1.History.cs
@@ -5,6 +5,10 @@ namespace Resonalyze;
 
 public partial class Form1
 {
+    // Monotonic token for history restores: the newest activation wins and
+    // stale async loads are dropped instead of overwriting a newer selection.
+    private long historyRestoreRevision;
+
     private void buttonHistory_Click(object sender, EventArgs e)
     {
         if (dockedHistoryHost.IsOpen)
@@ -56,11 +60,17 @@ public partial class Form1
             return;
         }
 
+        // Two rapid activations race: a slow file-backed entry can finish
+        // loading AFTER a fast cached one and silently overwrite it, leaving
+        // the UI on the earlier selection. The newest activation wins; stale
+        // loads are dropped at every await boundary (the same revision guard
+        // the async plot rebuild uses).
+        long revision = ++historyRestoreRevision;
         try
         {
             MeasurementHistorySnapshot? snapshot =
                 await measurementHistoryService.GetSnapshotAsync(entryId);
-            if (snapshot == null)
+            if (snapshot == null || revision != historyRestoreRevision)
             {
                 return;
             }
@@ -78,6 +88,11 @@ public partial class Form1
             string? sourceFilePath = measurementHistoryService.FindById(entryId)
                 ?.SourceFilePath;
             await RestoreHistorySnapshotAsync(snapshot, sourceFilePath);
+            if (revision != historyRestoreRevision)
+            {
+                return;
+            }
+
             sessionTracker.MarkRestored(entryId);
             dockedHistoryHost.InvokeIfOpen<MeasurementHistoryWindow>(dialog =>
             {

--- a/source/Shell/Form1.History.cs
+++ b/source/Shell/Form1.History.cs
@@ -9,6 +9,13 @@ public partial class Form1
     // stale async loads are dropped instead of overwriting a newer selection.
     private long historyRestoreRevision;
 
+    // Serializes the restore itself: the restore mutates the current IR, the
+    // controllers and the mode across several awaits, so two interleaved
+    // restores could half-apply each other even with the revision token —
+    // the gate makes each restore atomic and the token then guarantees the
+    // newest one runs (or re-runs) last.
+    private readonly SemaphoreSlim historyRestoreGate = new(1, 1);
+
     private void buttonHistory_Click(object sender, EventArgs e)
     {
         if (dockedHistoryHost.IsOpen)
@@ -87,13 +94,26 @@ public partial class Form1
             // way a freshly saved or loaded IR does); in-memory entries have none.
             string? sourceFilePath = measurementHistoryService.FindById(entryId)
                 ?.SourceFilePath;
-            await RestoreHistorySnapshotAsync(snapshot, sourceFilePath);
-            if (revision != historyRestoreRevision)
+            await historyRestoreGate.WaitAsync();
+            try
             {
-                return;
-            }
+                if (revision != historyRestoreRevision)
+                {
+                    return;
+                }
 
-            sessionTracker.MarkRestored(entryId);
+                await RestoreHistorySnapshotAsync(snapshot, sourceFilePath);
+                if (revision != historyRestoreRevision)
+                {
+                    return;
+                }
+
+                sessionTracker.MarkRestored(entryId);
+            }
+            finally
+            {
+                historyRestoreGate.Release();
+            }
             dockedHistoryHost.InvokeIfOpen<MeasurementHistoryWindow>(dialog =>
             {
                 dialog.SetEntries(

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -140,6 +140,17 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 mainSource.SampleRate,
                 CreateAnalysisOptions(wrapPeakPositions: true),
                 mainSource.TransferCoherence);
+            if (!mainResult.IsValid)
+            {
+                SetStatusText(
+                    "No signal in the analysis band.\r\n" +
+                    "The transfer IR carries no energy inside the current " +
+                    "band-pass window — widen or move the band, or check " +
+                    "that the measurement actually captured the driver.");
+                ClearEnvelopePreview();
+                return;
+            }
+
             TimeAlignmentCompareAnalysis? compareAnalysis =
                 AnalyzeCompare(mainSource, out string? compareWarning);
             SetMeasurementResultStatus(
@@ -383,6 +394,12 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 compareSource.SampleRate,
                 CreateAnalysisOptions(wrapPeakPositions: true),
                 compareSource.TransferCoherence);
+            if (!compareResult.IsValid)
+            {
+                warning = "Compare: no signal in the analysis band.";
+                return null;
+            }
+
             return new TimeAlignmentCompareAnalysis(compareSource, compareResult);
         }
         catch (Exception exception)

--- a/source/Tools/EqWizardPanel.cs
+++ b/source/Tools/EqWizardPanel.cs
@@ -60,6 +60,7 @@ public partial class EqWizardPanel : UserControl
     private LineAnnotation toMarker = null!;
     private RectangleAnnotation rangeFill = null!;
     private int selectedBandIndex = -1;
+    private long autoTuneRevision;
     private EqTuneStats? lastStats;
     private bool suppressTargetOffsetEvents;
     private bool suppressRedraw;
@@ -482,6 +483,13 @@ public partial class EqWizardPanel : UserControl
     // measurement (if any) and the target shape, plus the shared bottom legend.
     private void DrawSelectedCurves()
     {
+        // Every input the Auto Tune fit consumes funnels through here when it
+        // changes (target selection, offsets, smoothing, band edits, source
+        // switches), so any redraw orphans an in-flight fit computed against
+        // the previous state. Over-invalidation is safe: the stale result is
+        // simply dropped and the user re-runs Auto Tune.
+        autoTuneRevision++;
+
         // Auto Tune applies many control changes at once; it redraws once at the end
         // instead of on every intermediate change.
         if (suppressRedraw)
@@ -640,6 +648,13 @@ public partial class EqWizardPanel : UserControl
             .ToList();
         EqAutoTuner.Options options = CreateAutoTuneOptions();
 
+        // Only the Auto Tune button is disabled while the fit runs — the user
+        // can still switch the target, offsets, smoothing, the band limit or
+        // the whole history measurement. A result computed against the old
+        // inputs must not be written over the new state, so anything that
+        // changes the fit's inputs bumps this revision and orphans the result.
+        long revision = ++autoTuneRevision;
+
         EqualizationCurve tuned;
         buttonAutoTune.Enabled = false;
         try
@@ -659,7 +674,7 @@ public partial class EqWizardPanel : UserControl
             }
         }
 
-        if (IsDisposed)
+        if (IsDisposed || revision != autoTuneRevision)
         {
             return;
         }

--- a/source/Tools/EqWizardPanel.cs
+++ b/source/Tools/EqWizardPanel.cs
@@ -684,7 +684,11 @@ public partial class EqWizardPanel : UserControl
             MinFrequencyHz = minHz,
             MaxFrequencyHz = maxHz,
             PreampMinDb = (double)NumericGain.Minimum,
-            PreampMaxDb = (double)NumericGain.Maximum
+            PreampMaxDb = (double)NumericGain.Maximum,
+            // The wizard's output is a profile for a real DSP: the total gain
+            // (preamp + bands) must not exceed 0 dB anywhere, or the profile
+            // clips before the user ever sees the headroom read-out.
+            TotalGainMaxDb = 0
         };
 
         if (peqSlots.Count > 0)

--- a/source/Tools/SignalGeneratorPanel.cs
+++ b/source/Tools/SignalGeneratorPanel.cs
@@ -73,6 +73,21 @@ public partial class SignalGeneratorPanel : UserControl
             SignalGeneratorPlaybackSettings settings = GetPlaybackSettings();
             RefreshAudioSettings(settings);
 
+            // A sine above Nyquist does not become ultrasound — it aliases to
+            // an arbitrary audible tone (96 kHz at a 44.1 kHz device plays as
+            // ~7.8 kHz, loud). Refuse instead of silently playing a different
+            // signal than the user asked for.
+            double nyquistLimit = settings.SampleRate * 0.49;
+            if (SelectedSignalType == SignalGeneratorType.Sine &&
+                (double)numericFrequency.Value > nyquistLimit)
+            {
+                labelStatus.Text =
+                    $"Frequency exceeds the device limit " +
+                    $"({nyquistLimit / 1000.0:0.#} kHz at {settings.SampleRate / 1000.0:0.#} kHz).";
+                System.Media.SystemSounds.Beep.Play();
+                return;
+            }
+
             int durationSeconds = (int)numericDuration.Value;
             float[] monoSamples = CreateMonoSamples(
                 settings.SampleRate,

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -88,6 +88,7 @@ public partial class VirtualCrossoverPanel : UserControl
     private Task? redrawTask;
     private bool redrawPending;
     private bool savePending;
+    private bool autoDelayBusy;
 
     public VirtualCrossoverPanel()
     {
@@ -466,8 +467,10 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private void UpdateChannelButtons()
     {
-        buttonAddChannel.Enabled = channels.Count < MaxChannelCount;
-        buttonRemoveChannel.Enabled = channels.Count > MinChannelCount;
+        buttonAddChannel.Enabled =
+            !autoDelayBusy && channels.Count < MaxChannelCount;
+        buttonRemoveChannel.Enabled =
+            !autoDelayBusy && channels.Count > MinChannelCount;
     }
 
     // Appends a channel: a fresh block and a matching empty project entry, so the
@@ -1863,6 +1866,28 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
+        // A bypassed channel processes through the identity chain, so the
+        // engine's delay/polarity overrides would not move it — yet it would
+        // still take part in the junction walk (even as the settled neighbor
+        // or the reference) and receive a delay that bypass silently ignores
+        // now and applies later, once bypass is switched off. Refuse the run
+        // instead of computing an alignment that is wrong on both counts.
+        List<ProcessedChannel> bypassed = processed
+            .Where(item => item.Channel.Settings.Bypass)
+            .ToList();
+        if (bypassed.Count > 0)
+        {
+            ShowError(
+                "Auto delay cannot run with bypassed channels.",
+                "Bypass feeds the raw measured signal, so the computed delays " +
+                "and polarities would not apply to: " +
+                string.Join(", ", bypassed.Select(
+                    item => item.Channel.Control.ChannelName)) +
+                ".\r\n\r\nDisable Bypass on every participating channel " +
+                "(or mute the channel to exclude it) and run Auto delay again.");
+            return;
+        }
+
         // Without crossovers the search falls back to a broad midband window and
         // the result will shift once the filters are configured — the alignment
         // only matters (and is only well-defined) in the overlap region.
@@ -1897,8 +1922,10 @@ public partial class VirtualCrossoverPanel : UserControl
 
         // The alignment stages are FFT-heavy (~seconds). Run them off the UI
         // thread so the window stays responsive and shows the busy state instead
-        // of hanging. Inputs are locked for the duration, so the background
-        // compute reads a stable snapshot of the settings and IRs.
+        // of hanging. Every input that could mutate the channel list or its
+        // settings (channel controls, add/remove, session import, the auto
+        // commands) is locked for the duration, so the background compute reads
+        // a stable configuration.
         SetAutoDelayBusy(true);
         try
         {
@@ -1935,9 +1962,16 @@ public partial class VirtualCrossoverPanel : UserControl
     // stable snapshot) and shows a wait state.
     private void SetAutoDelayBusy(bool busy)
     {
+        autoDelayBusy = busy;
         buttonAutoDelay.Enabled = !busy;
         buttonAutoDelay.Text = busy ? "Aligning…" : "Auto delay";
         buttonAutoSetup.Enabled = !busy;
+        // The background compute iterates the live channel list and its live
+        // settings, so everything that can mutate them must be locked out too:
+        // add/remove change the list (and dispose controls), a session import
+        // replaces the whole configuration mid-search.
+        buttonSessionImport.Enabled = !busy;
+        UpdateChannelButtons();
         foreach (ChannelRuntime channel in channels)
         {
             channel.Control.Enabled = !busy;

--- a/tests/Resonalyze.App.Tests/ImpulseResponseFileTests.cs
+++ b/tests/Resonalyze.App.Tests/ImpulseResponseFileTests.cs
@@ -36,8 +36,9 @@ public sealed class ImpulseResponseFileTests
             },
             SweepDeconvolutionRealSamples = [0.125, 0.5, 1.0, -0.25],
             TransferPeakIndex = 1,
-            TransferRealSamples = [0.25, 1.0, -0.5],
-            TransferImaginarySamples = [0, 0.125, 0],
+            // Coherence must be N/2 + 1 bins for an N-sample transfer IR.
+            TransferRealSamples = [0.25, 1.0, -0.5, 0.125],
+            TransferImaginarySamples = [0, 0.125, 0, 0],
             TransferCoherence = [0.91, 0.82, 0.73]
         };
 
@@ -98,7 +99,12 @@ public sealed class ImpulseResponseFileTests
                 sweepSamples);
             Assert.Equal(1, loaded.TransferPeakIndex);
             Assert.Equal(
-                [new Complex(0.25, 0), new Complex(1, 0.125), new Complex(-0.5, 0)],
+                [
+                    new Complex(0.25, 0),
+                    new Complex(1, 0.125),
+                    new Complex(-0.5, 0),
+                    new Complex(0.125, 0)
+                ],
                 transferSamples);
             Assert.NotNull(loaded.TransferCoherence);
             Assert.Equal([0.91, 0.82, 0.73], loaded.TransferCoherence);

--- a/tests/Resonalyze.App.Tests/OverlayMathTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlayMathTests.cs
@@ -17,22 +17,58 @@ public sealed class OverlayMathTests
         OverlayOperation operation,
         double[] expectedValues)
     {
+        // Interpolation is logarithmic in frequency, so x = 2 — the GEOMETRIC
+        // midpoint of the b span [1, 4] — reads the midpoint value 12.
         OverlayPoint[] a =
         [
             new OverlayPoint(1, 10),
             new OverlayPoint(2, 14),
-            new OverlayPoint(3, 20)
+            new OverlayPoint(4, 20)
         ];
         OverlayPoint[] b =
         [
             new OverlayPoint(1, 8),
-            new OverlayPoint(3, 16)
+            new OverlayPoint(4, 16)
         ];
 
         OverlayPoint[] result =
             OverlayMath.CalculateOperation(a, b, operation);
 
-        Assert.Equal(expectedValues, result.Select(point => point.Y));
+        Assert.Equal(expectedValues.Length, result.Length);
+        for (int i = 0; i < expectedValues.Length; i++)
+        {
+            Assert.Equal(expectedValues[i], result[i].Y, precision: 9);
+        }
+    }
+
+    [Fact]
+    public void CalculateOperation_WrappedPhaseInterpolatesThroughTheBranchCut()
+    {
+        // B steps from +170° to −170°: physically the short way passes through
+        // ±180°. A linear blend of the raw numbers would read 0° at the
+        // geometric midpoint and the wrapped difference could never recover
+        // the lost branch; the phasor interpolation must read ±180°.
+        OverlayPoint[] a =
+        [
+            new OverlayPoint(1_000, 0),
+            new OverlayPoint(Math.Sqrt(2) * 1_000, 0),
+            new OverlayPoint(2_000, 0)
+        ];
+        OverlayPoint[] b =
+        [
+            new OverlayPoint(1_000, 170),
+            new OverlayPoint(2_000, -170)
+        ];
+
+        OverlayPoint[] result = OverlayMath.CalculateOperation(
+            a,
+            b,
+            OverlayOperation.AMinusB,
+            wrapPhaseDifference: true);
+
+        Assert.Equal(3, result.Length);
+        // A − B at the midpoint: 0 − (±180) wraps to ±180, never to 0.
+        Assert.Equal(180.0, Math.Abs(result[1].Y), precision: 6);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/OverlayMathTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlayMathTests.cs
@@ -126,16 +126,19 @@ public sealed class OverlayMathTests
     [Fact]
     public void CalculateOperation_BlendCrossfadesAroundCenterFrequency()
     {
+        // x = 2 is the GEOMETRIC midpoint of the b span [1, 4] (interpolation
+        // is logarithmic in frequency), so b(2) = 12; it is also the blend
+        // centre, so the result is the plain average (14 + 12) / 2 = 13.
         OverlayPoint[] a =
         [
             new OverlayPoint(1, 10),
             new OverlayPoint(2, 14),
-            new OverlayPoint(3, 20)
+            new OverlayPoint(4, 20)
         ];
         OverlayPoint[] b =
         [
             new OverlayPoint(1, 8),
-            new OverlayPoint(3, 16)
+            new OverlayPoint(4, 16)
         ];
 
         OverlayPoint[] result = OverlayMath.CalculateOperation(

--- a/tests/Resonalyze.Dsp.Tests/CalibrationFileTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CalibrationFileTests.cs
@@ -129,12 +129,13 @@ public sealed class CalibrationFileTests
     }
 
     [Fact]
-    public void SmoothingOctaves_WidensTheAveragingWindow()
+    public void Correction_ReproducesTheFilePointsExactly()
     {
-        // A single 12 dB spike on an otherwise flat curve. A narrow smoothing window
-        // keeps most of the spike; a wide one averages in the flat neighbours and
-        // pulls the correction down. Equal results would mean smoothingOctaves is
-        // ignored — the constant-curve tests could never show this.
+        // A single 12 dB spike on an otherwise flat curve: the correction must
+        // read back EXACTLY 12 dB at the calibrated point. The old
+        // Lanczos-smoothed lookup silently half-octave-averaged the spike to
+        // ~5.6 dB (and overshot near steps even at zero smoothing) — a
+        // calibration must reproduce its own points.
         IReadOnlyList<double> grid = EqualizationCurve.LogFrequencyGrid(20, 20_000, 200);
         double spikeHz = grid.OrderBy(f => Math.Abs(f - 1_000)).First();
         var text = new StringBuilder();
@@ -148,12 +149,33 @@ public sealed class CalibrationFileTests
         }
 
         CalibrationFile calibration = CalibrationFile.Parse(text.ToString());
-        double narrow = calibration.GetDecibelCorrection(spikeHz, smoothingOctaves: 0.2);
-        double wide = calibration.GetDecibelCorrection(spikeHz, smoothingOctaves: 2.0);
 
-        Assert.True(narrow > wide + 1.0, $"Narrow smoothing {narrow:0.00} dB should exceed wide {wide:0.00} dB.");
-        Assert.InRange(narrow, 0.0, 12.0);
-        Assert.InRange(wide, 0.0, 12.0);
+        Assert.Equal(12.0, calibration.GetDecibelCorrection(spikeHz), precision: 6);
+    }
+
+    [Fact]
+    public void Correction_InterpolatesLinearlyInLogFrequencyAndDecibels()
+    {
+        // Two points an octave apart: the geometric midpoint frequency must
+        // read the arithmetic midpoint of the dB values.
+        CalibrationFile calibration = CalibrationFile.Parse("1000 0\n2000 6\n");
+
+        Assert.Equal(
+            3.0,
+            calibration.GetDecibelCorrection(1000 * Math.Sqrt(2.0)),
+            precision: 6);
+    }
+
+    [Fact]
+    public void Correction_DuplicateFrequenciesAreMergedNotNaN()
+    {
+        // Duplicate frequencies used to make an interpolation segment
+        // zero-width and push NaN into the correction.
+        CalibrationFile calibration = CalibrationFile.Parse("1000 0\n1000 6\n2000 6\n");
+
+        double correction = calibration.GetDecibelCorrection(1_500);
+
+        Assert.True(double.IsFinite(correction));
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/EqAutoTunerTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EqAutoTunerTests.cs
@@ -28,6 +28,31 @@ public sealed class EqAutoTunerTests
     }
 
     [Fact]
+    public void Tune_TotalGainCapPreventsAClippingProfile()
+    {
+        // Target sits +10 dB above source with an extra +6 dB local bump: the
+        // unconstrained fit hands out preamp +10 plus a +6 boost band — a
+        // profile that clips by +16 dB before the UI ever shows the headroom.
+        // With the total-gain ceiling the preamp is capped so preamp + band
+        // boost never exceeds 0 dB anywhere; the fitted band shape stays.
+        var bump = new PeqBand(1_000, 2.0, 6.0);
+        IReadOnlyList<SignalPoint> source = Grid(_ => -40.0);
+        IReadOnlyList<SignalPoint> target = Grid(
+            f => -30.0 + bump.MagnitudeDbAt(f));
+
+        EqualizationCurve curve = EqAutoTuner.Tune(
+            source, target, new EqAutoTuner.Options { TotalGainMaxDb = 0 });
+
+        double maxTotal = EqualizationCurve
+            .LogFrequencyGrid(20, 20_000, 400)
+            .Max(f => curve.MagnitudeDbAt(f));
+        Assert.True(
+            maxTotal <= 0.05,
+            $"total EQ gain peaks at {maxTotal:0.0} dB — a clipping profile.");
+        Assert.NotEmpty(curve.Bands);
+    }
+
+    [Fact]
     public void Tune_ConstantLevelDifference_UsesPreampAndNoBands()
     {
         IReadOnlyList<SignalPoint> source = Grid(_ => -40);

--- a/tests/Resonalyze.Dsp.Tests/ExcessDelayTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/ExcessDelayTests.cs
@@ -138,6 +138,41 @@ public sealed class ExcessDelayTests
             () => ExcessDelay.Estimate(spectrum, 0));
     }
 
+    [Fact]
+    public void Peak_LandsOnTheDirectArrivalNotAStrongerReflection()
+    {
+        // A weak direct arrival followed by a 3x stronger reflection — the same
+        // trap Time Alignment handles. The global envelope maximum sits on the
+        // reflection; the τ Peak reference must land on the direct arrival, or
+        // the excess-phase detrend tilts the whole curve by the reflection path.
+        double[] impulse = new double[8_192];
+        impulse[100] = 0.3;
+        impulse[500] = 1.0;
+        var buffer = new Complex[8_192];
+        for (int i = 0; i < impulse.Length; i++)
+        {
+            buffer[i] = new Complex(impulse[i], 0.0);
+        }
+        Fourier.Forward(buffer, FourierOptions.Matlab);
+
+        ExcessDelayResult result = ExcessDelay.Estimate(buffer, SampleRate);
+
+        Assert.True(result.IsValid);
+        Assert.InRange(result.PeakDelaySamples, 99.0, 101.0);
+    }
+
+    [Fact]
+    public void Estimate_ZeroSpectrumIsInvalid()
+    {
+        // A zero spectrum used to produce a zero excess response whose "peak"
+        // read as a perfectly valid τ = 0 — and an auto-τ button would write it.
+        var spectrum = new Complex[Length];
+
+        ExcessDelayResult result = ExcessDelay.Estimate(spectrum, SampleRate);
+
+        Assert.False(result.IsValid);
+    }
+
     private static Complex[] SpectrumOfImpulseAt(int index)
     {
         double[] impulse = new double[Length];

--- a/tests/Resonalyze.Dsp.Tests/MinimumPhaseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/MinimumPhaseTests.cs
@@ -87,6 +87,48 @@ public sealed class MinimumPhaseTests
         Assert.Throws<ArgumentException>(() => MinimumPhase.FromMagnitude([]));
     }
 
+    [Theory]
+    [InlineData(1e-12)]
+    [InlineData(1e+12)]
+    public void FromMagnitude_IsInvariantToOverallGain(double gain)
+    {
+        // Minimum phase is determined by the SHAPE of log|H|: an overall gain
+        // only moves the zeroth cepstral coefficient. With an absolute floor a
+        // quiet measurement's spectrum sank into the clamp and its phase
+        // changed with its level — the floor must be relative to the peak.
+        double[] magnitude = new double[Length];
+        for (int i = 0; i < Length; i++)
+        {
+            double f = Math.Min(i, Length - i) / (double)Length;
+            magnitude[i] = 0.01 + Math.Exp(-Math.Pow((f - 0.1) / 0.05, 2.0));
+        }
+
+        double[] reference = MinimumPhase.FromMagnitude(magnitude);
+        double[] scaled = MinimumPhase.FromMagnitude(
+            Array.ConvertAll(magnitude, value => value * gain));
+
+        for (int i = 0; i < Length; i++)
+        {
+            Assert.Equal(reference[i], scaled[i], 9);
+        }
+    }
+
+    [Fact]
+    public void FromMagnitude_NonFiniteBinsDoNotPoisonTheCepstrum()
+    {
+        // A NaN magnitude used to slip through Math.Max into the log and turn
+        // the whole cepstrum — and every phase bin — into NaN.
+        double[] magnitude = new double[Length];
+        Array.Fill(magnitude, 1.0);
+        magnitude[100] = double.NaN;
+        magnitude[200] = double.PositiveInfinity;
+        magnitude[300] = -1.0;
+
+        double[] phase = MinimumPhase.FromMagnitude(magnitude);
+
+        Assert.All(phase, value => Assert.True(double.IsFinite(value)));
+    }
+
     private static Complex[] TransferFunction(double[] impulse)
     {
         var buffer = new Complex[Length];

--- a/tests/Resonalyze.Dsp.Tests/PhaseUnwrapTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/PhaseUnwrapTests.cs
@@ -114,6 +114,130 @@ public sealed class PhaseUnwrapTests
         }
     }
 
+    [Fact]
+    public void Unwrap_UnwrapsBelowOneHundredHertzToo()
+    {
+        // A 20 ms delay accumulates −720° already by 100 Hz. The old unwrap
+        // floor returned WRAPPED phase for every bin below 100 Hz (±180°
+        // wiggles that contradicted GetExcessPhase's "always unwrapped"
+        // contract and stepped at the boundary); the unwrap must start at the
+        // first reliable bin instead and keep the whole curve on the delay line.
+        const int LongDelaySamples = 960;
+        var spectrum = new Complex[TransformLength];
+        for (int k = 0; k < TransformLength; k++)
+        {
+            double binPhase = -Math.Tau * k * LongDelaySamples / TransformLength;
+            spectrum[k] = Complex.FromPolarCoordinates(1.0, binPhase);
+        }
+        MathNet.Numerics.IntegralTransforms.Fourier.Inverse(
+            spectrum,
+            MathNet.Numerics.IntegralTransforms.FourierOptions.Matlab);
+        var measurement = new SyntheticMeasurement(
+            spectrum,
+            SampleRate,
+            maxMagnitudeIndex: 0);
+
+        List<SignalPoint> phase = GetUnwrappedPhase(measurement, coherence: null);
+
+        List<SignalPoint> lowBins = phase
+            .Where(point => point.X >= 30 && point.X <= 99)
+            .ToList();
+        Assert.NotEmpty(lowBins);
+        foreach (SignalPoint point in lowBins.Concat(
+            phase.Where(item => item.X >= 100 && item.X <= 18_000)))
+        {
+            double expected = -Math.Tau * point.X * LongDelaySamples / SampleRate;
+            Assert.InRange(point.Y, expected - 1.0, expected + 1.0);
+        }
+    }
+
+    [Fact]
+    public void Unwrap_BlanksAGapTooLongToBridge()
+    {
+        // The band from 1 to 8 kHz is dead (−80 dB): the turn count inside it
+        // is genuinely unknowable (an all-pass or a crossover transition could
+        // hide whole turns), so the bridged points must read NaN and a fresh
+        // segment must start after the gap — not one confident continuous line
+        // through guessed branches.
+        var spectrum = new Complex[TransformLength];
+        for (int k = 0; k < TransformLength; k++)
+        {
+            double f = Math.Min(k, TransformLength - k)
+                * (double)SampleRate / TransformLength;
+            double magnitude = f is > 1_000 and < 8_000 ? 1e-4 : 1.0;
+            double binPhase = -Math.Tau * k * DelaySamples / TransformLength;
+            spectrum[k] = Complex.FromPolarCoordinates(magnitude, binPhase);
+        }
+        MathNet.Numerics.IntegralTransforms.Fourier.Inverse(
+            spectrum,
+            MathNet.Numerics.IntegralTransforms.FourierOptions.Matlab);
+        var measurement = new SyntheticMeasurement(
+            spectrum,
+            SampleRate,
+            maxMagnitudeIndex: 0);
+
+        List<SignalPoint> phase = GetUnwrappedPhase(measurement, coherence: null);
+
+        // The head stays on the absolute delay line.
+        foreach (SignalPoint point in phase.Where(item => item.X is >= 100 and <= 950))
+        {
+            double expected = -Math.Tau * point.X * DelaySamples / SampleRate;
+            Assert.InRange(point.Y, expected - 1.0, expected + 1.0);
+        }
+        // Deep inside the gap the guessed bridge is blanked.
+        List<SignalPoint> gap = phase
+            .Where(point => point.X is >= 2_000 and <= 7_000)
+            .ToList();
+        Assert.NotEmpty(gap);
+        Assert.All(gap, point => Assert.True(double.IsNaN(point.Y)));
+        // After the gap a fresh finite segment continues.
+        List<SignalPoint> tail = phase
+            .Where(point => point.X is >= 9_000 and <= 18_000)
+            .ToList();
+        Assert.NotEmpty(tail);
+        Assert.All(tail, point => Assert.True(double.IsFinite(point.Y)));
+    }
+
+    [Fact]
+    public void Unwrap_AQuietBandStaysAnchoredNextToATallResonance()
+    {
+        // The whole audible band sits 34 dB below a low-frequency resonance
+        // (a subwoofer's cabin peak): against the old GLOBAL −30 dB gate that
+        // disqualified every bin above the resonance from anchoring, and the
+        // slope-frozen bridge lost turns of this 20 ms delay. The gate reads a
+        // local octave-smoothed envelope now, so a quiet but locally consistent
+        // band anchors normally and the tail stays on the absolute delay line.
+        const int LongDelaySamples = 960;
+        var spectrum = new Complex[TransformLength];
+        for (int k = 0; k < TransformLength; k++)
+        {
+            double f = Math.Min(k, TransformLength - k)
+                * (double)SampleRate / TransformLength;
+            double magnitude = f < 100 ? 50.0 : 1.0;
+            double binPhase = -Math.Tau * k * LongDelaySamples / TransformLength;
+            spectrum[k] = Complex.FromPolarCoordinates(magnitude, binPhase);
+        }
+        MathNet.Numerics.IntegralTransforms.Fourier.Inverse(
+            spectrum,
+            MathNet.Numerics.IntegralTransforms.FourierOptions.Matlab);
+        var measurement = new SyntheticMeasurement(
+            spectrum,
+            SampleRate,
+            maxMagnitudeIndex: 0);
+
+        List<SignalPoint> phase = GetUnwrappedPhase(measurement, coherence: null);
+
+        List<SignalPoint> tail = phase
+            .Where(point => point.X >= 1_000 && point.X <= 18_000)
+            .ToList();
+        Assert.NotEmpty(tail);
+        foreach (SignalPoint point in tail)
+        {
+            double expected = -Math.Tau * point.X * LongDelaySamples / SampleRate;
+            Assert.InRange(point.Y, expected - 1.0, expected + 1.0);
+        }
+    }
+
     private static List<SignalPoint> GetUnwrappedPhase(
         SyntheticMeasurement measurement,
         IReadOnlyList<double>? coherence)

--- a/tests/Resonalyze.Dsp.Tests/RealMeasurementArrivalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/RealMeasurementArrivalTests.cs
@@ -53,10 +53,13 @@ public sealed class RealMeasurementArrivalTests
     public void WooferBroadbandAnalysis_SeparatesSignalGradeFromArrivalProminence()
     {
         // The Time Alignment panel scenario that motivated the split: this
-        // recording's SNR is excellent (~50 dB), while the first arrival sits
-        // ~25 dB down the woofer's slow leading edge, 2 ms before the in-room
-        // peak. One folded "quality" figure read this as Fair (24.9 dB); the
-        // two numbers must tell the two stories separately.
+        // recording is clean, while the first arrival sits ~25 dB down the
+        // woofer's slow leading edge, 2 ms before the in-room peak. One folded
+        // "quality" figure read this as Fair (24.9 dB); the two numbers must
+        // tell the two stories separately. The SNR pin: ~73 dB against the
+        // record's true noise floor (the quietest-quarter RMS) — the earlier
+        // everything-but-the-peak estimate read the reverb tail as noise and
+        // deflated the same recording to ~50 dB.
         (int sampleRate, Complex[] ir) = LoadTransferIr("l woof.json");
         var samples = new double[ir.Length];
         for (int i = 0; i < samples.Length; i++)
@@ -70,9 +73,13 @@ public sealed class RealMeasurementArrivalTests
                 WrapPeakPositions = true
             });
 
-        Assert.InRange(result.SignalToNoiseDecibels, 48.0, 52.0);
+        Assert.InRange(result.SignalToNoiseDecibels, 70.0, 76.0);
         Assert.InRange(result.FirstArrivalProminenceDecibels, -27.0, -22.0);
-        Assert.True(result.StrongestPeakIsSeparateArrival);
+        // The first arrival is a shoulder ON that leading edge: the envelope
+        // never dips 6 dB between it and the in-room peak, so the two are one
+        // wave packet and the "separate arrival (room mode/reflection)" hint
+        // must stay down — it used to fire here on the driver's own rise time.
+        Assert.False(result.StrongestPeakIsSeparateArrival);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/RealMeasurementArrivalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/RealMeasurementArrivalTests.cs
@@ -56,10 +56,11 @@ public sealed class RealMeasurementArrivalTests
         // recording is clean, while the first arrival sits ~25 dB down the
         // woofer's slow leading edge, 2 ms before the in-room peak. One folded
         // "quality" figure read this as Fair (24.9 dB); the two numbers must
-        // tell the two stories separately. The SNR pin: ~73 dB against the
-        // record's true noise floor (the quietest-quarter RMS) — the earlier
-        // everything-but-the-peak estimate read the reverb tail as noise and
-        // deflated the same recording to ~50 dB.
+        // tell the two stories separately. The SNR pin: ~64 dB against the
+        // record's noise floor (quietest-quarter RMS, compensated for the
+        // Rayleigh bias of that quartile) — the earlier everything-but-the-
+        // peak estimate read the reverb tail as noise and deflated the same
+        // recording to ~50 dB.
         (int sampleRate, Complex[] ir) = LoadTransferIr("l woof.json");
         var samples = new double[ir.Length];
         for (int i = 0; i < samples.Length; i++)
@@ -73,7 +74,7 @@ public sealed class RealMeasurementArrivalTests
                 WrapPeakPositions = true
             });
 
-        Assert.InRange(result.SignalToNoiseDecibels, 70.0, 76.0);
+        Assert.InRange(result.SignalToNoiseDecibels, 61.0, 68.0);
         Assert.InRange(result.FirstArrivalProminenceDecibels, -27.0, -22.0);
         // The first arrival is a shoulder ON that leading edge: the envelope
         // never dips 6 dB between it and the in-room peak, so the two are one

--- a/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
@@ -245,7 +245,11 @@ public sealed class SignalEnvelopeTests
             envelope,
             peak: 1.0);
 
-        Assert.InRange(confidence, 39.9, 40.1);
+        // peak/floor is 40 dB; the reported figure compensates the Rayleigh
+        // bias of the quartile floor (+20·log10(0.370) ≈ −8.64 dB), so the
+        // metric reads peak vs the FULL envelope noise RMS, not vs the
+        // flattering quartile.
+        Assert.InRange(confidence, 31.2, 31.5);
     }
 
     [Fact]
@@ -266,7 +270,9 @@ public sealed class SignalEnvelopeTests
             envelope,
             peak: 1.0);
 
-        Assert.InRange(confidence, 59.9, 60.1);
+        // 60 dB against the raw floor, minus the Rayleigh-bias compensation
+        // (≈ 8.64 dB) — and nowhere near the ~20 dB the reverb-tail mean gave.
+        Assert.InRange(confidence, 51.2, 51.5);
     }
 
     private static double[] CreateSine(int length, int bin, double amplitude)

--- a/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
@@ -228,8 +228,10 @@ public sealed class SignalEnvelopeTests
     }
 
     [Fact]
-    public void EstimatePeakConfidenceDecibels_ExcludesWrappedPeakNeighborhood()
+    public void EstimatePeakConfidenceDecibels_ReadsTheQuietFloorNotThePeak()
     {
+        // A flat 0.01 floor with a peak cluster (wrapping the array end): the
+        // noise estimate must read the floor, so peak/floor = 40 dB.
         double[] envelope = Enumerable.Repeat(0.01, 1000).ToArray();
         envelope[998] = 1.0;
         envelope[999] = 1.0;
@@ -241,10 +243,30 @@ public sealed class SignalEnvelopeTests
 
         double confidence = SignalEnvelope.EstimatePeakConfidenceDecibels(
             envelope,
-            peakIndex: 2,
             peak: 1.0);
 
         Assert.InRange(confidence, 39.9, 40.1);
+    }
+
+    [Fact]
+    public void EstimatePeakConfidenceDecibels_ReverbTailDoesNotCountAsNoise()
+    {
+        // Half the record is a −20 dB reverb tail over a 0.001 floor. The old
+        // everything-but-the-peak mean read the tail as noise (~ −20 dB SNR
+        // reference → ~20 dB grade); the quietest-quarter floor must grade the
+        // recording by its true 60 dB headroom.
+        double[] envelope = Enumerable.Repeat(0.001, 1000).ToArray();
+        for (int i = 100; i < 600; i++)
+        {
+            envelope[i] = 0.1;
+        }
+        envelope[100] = 1.0;
+
+        double confidence = SignalEnvelope.EstimatePeakConfidenceDecibels(
+            envelope,
+            peak: 1.0);
+
+        Assert.InRange(confidence, 59.9, 60.1);
     }
 
     private static double[] CreateSine(int length, int bin, double amplitude)

--- a/tests/Resonalyze.Dsp.Tests/SpectrumAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SpectrumAnalysisTests.cs
@@ -90,9 +90,9 @@ public sealed class SpectrumAnalysisTests
 
         double[] power = SpectrumAnalysis.ComputePowerSpectrum(ones);
 
-        // Coherent-gain normalization makes the windowed result match the
-        // rectangular-window level: |X[0]| = N, so power = N^2.
-        Assert.Equal((double)length * length, power[0], precision: 3);
+        // Tone-calibrated (dBFS) scale: a DC level of 1.0 reads amplitude 1.0
+        // regardless of the FFT length.
+        Assert.Equal(1.0, power[0], precision: 3);
     }
 
     [Theory]
@@ -109,8 +109,8 @@ public sealed class SpectrumAnalysisTests
         double[] power = SpectrumAnalysis.ComputePowerSpectrum(ones, windowType);
 
         // Coherent-gain normalization cancels the window sum, so DC always
-        // reads the rectangular-equivalent level regardless of window.
-        Assert.Equal((double)length * length, power[0], precision: 3);
+        // reads the true 1.0 level regardless of window.
+        Assert.Equal(1.0, power[0], precision: 3);
     }
 
     [Fact]
@@ -177,6 +177,27 @@ public sealed class SpectrumAnalysisTests
         }
 
         Assert.Equal(bin, peakBin);
+    }
+
+    [Theory]
+    [InlineData(1_024)]
+    [InlineData(4_096)]
+    public void ComputeInputMagnitudeSpectrum_ToneLevelIsFftLengthInvariant(int length)
+    {
+        // The same full-scale tone must read amplitude 1.0 whatever the FFT
+        // size — the RTA level used to jump 6.02 dB per doubling, on the same
+        // dB axis as the length-invariant H1 transfer gain.
+        int bin = length / 16;
+        float[] signal = CreateSine(length, bin);
+
+        TransferSpectrumFrame frame =
+            SpectrumAnalysis.ComputeTransferSpectrumFrame(signal, signal, WindowType.Hann);
+        double[] magnitude = SpectrumAnalysis.ComputeInputMagnitudeSpectrum(
+            frame.TargetPowerSpectrum,
+            WindowType.Hann,
+            length);
+
+        Assert.InRange(magnitude[bin], 0.98, 1.02);
     }
 
     [Fact]
@@ -389,11 +410,10 @@ public sealed class SpectrumAnalysisTests
             windowType,
             length);
 
-        // For an on-bin tone the peak-bin magnitude is windowSum/2, and the
-        // coherent-gain scale is length/windowSum, so their product is length/2
-        // for every window (the window sum cancels). Allow 2% for the tiny
-        // double-frequency leakage into the bin.
-        Assert.InRange(magnitude[bin], length / 2.0 * 0.98, length / 2.0 * 1.02);
+        // Tone calibration: a full-scale on-bin sine reads amplitude 1.0 for
+        // every window AND every FFT length (the level used to jump 6 dB per
+        // FFT-size doubling). Allow 2% for the tiny double-frequency leakage.
+        Assert.InRange(magnitude[bin], 0.98, 1.02);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/SpectrumAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SpectrumAnalysisTests.cs
@@ -264,6 +264,57 @@ public sealed class SpectrumAnalysisTests
     }
 
     [Fact]
+    public void DebiasCoherence_MapsTheNullExpectationToZero()
+    {
+        // The raw MSC over K averages reads 1/K for pure noise — at K = 2 that
+        // is 0.5, exactly at the trust thresholds downstream. The correction
+        // must send the null expectation to 0, keep 1 at 1, and collapse the
+        // no-estimate case (K = 1) entirely.
+        Assert.Equal(0.0, SpectrumAnalysis.DebiasCoherence([0.5], 2)[0], 9);
+        Assert.Equal(0.0, SpectrumAnalysis.DebiasCoherence([0.25], 4)[0], 9);
+        Assert.Equal(1.0, SpectrumAnalysis.DebiasCoherence([1.0], 2)[0], 9);
+        Assert.Equal(1.0, SpectrumAnalysis.DebiasCoherence([0.9], 1)[0] + 1.0, 9);
+        // Below the null expectation clamps at zero rather than going negative.
+        Assert.Equal(0.0, SpectrumAnalysis.DebiasCoherence([0.1], 2)[0], 9);
+        // Large K leaves an honest estimate nearly untouched.
+        Assert.Equal(0.9, SpectrumAnalysis.DebiasCoherence([0.9], 1000)[0], 3);
+    }
+
+    [Fact]
+    public void ComputeAveragedRelativeIr_TwoNoiseFramesReadMostlyIncoherent()
+    {
+        // Two frames whose targets are unrelated noise: the raw two-average MSC
+        // averages ~0.5 across the band (estimator bias, not information) and
+        // used to sit exactly at the unwrap trust floor. The stored coherence
+        // is debiased, so it must average well below that.
+        const int length = 2_048;
+        float[] reference = CreateSine(length, bin: 24);
+        var frames = new List<TransferFunctionFrame>();
+        for (int frame = 0; frame < 2; frame++)
+        {
+            var target = new double[length];
+            for (int i = 0; i < length; i++)
+            {
+                // Deterministic pseudo-noise, different per frame.
+                target[i] = Math.Sin(i * (12.9898 + frame * 3.7) + frame * 78.233)
+                    * Math.Sin(i * 0.7301 + frame);
+            }
+            frames.Add(new TransferFunctionFrame(
+                Array.ConvertAll(reference, sample => (double)sample),
+                target));
+        }
+
+        TransferEstimateResult result =
+            TransferFunction.ComputeAveragedRelativeIr(frames);
+
+        Assert.NotNull(result.Coherence);
+        double mean = result.Coherence!.Average();
+        Assert.True(
+            mean < 0.3,
+            $"debiased two-average noise coherence averaged {mean:0.000}");
+    }
+
+    [Fact]
     public void ComputeCoherence_RejectsMismatchedLengths()
     {
         Assert.Throws<ArgumentException>(() =>

--- a/tests/Resonalyze.Dsp.Tests/SpectrumHarmonicIsolationTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SpectrumHarmonicIsolationTests.cs
@@ -62,4 +62,31 @@ public sealed class SpectrumHarmonicIsolationTests
         Assert.True(thd > -100.0, $"THD+N should include the HD2 packet, was {thd:0.#} dB.");
         Assert.True(thd > hd3 + 40.0, "THD+N must dominate the empty HD3 window.");
     }
+
+    [Fact]
+    public void GetSpectrum_DrawsHd2AtTheExcitationFrequency()
+    {
+        // The HD2 packet here is a tone at ~5.5 kHz — a second-harmonic PRODUCT
+        // at 5.5 kHz, which the driver produced while the sweep fundamental was
+        // at ~2.7 kHz. The standard distortion axis is the excitation
+        // frequency, so the curve's peak must draw near 2.7 kHz (it used to
+        // draw at the product's 5.5 kHz), and the curve cannot extend past
+        // Nyquist/2, where the product would pass Nyquist.
+        IReadOnlyList<AnalysisCurve> curves = DataHelper.GetSpectrum(
+            WithHd2PacketOnly(),
+            new FrequencyResponseOptions(),
+            calibration: null,
+            SpectrumCurves.SecondHarmonic);
+        AnalysisCurve hd2 = curves.Single(
+            c => c.Kind == AnalysisCurveKind.SecondHarmonic);
+
+        SignalPoint peak = hd2.Points.MaxBy(p => p.Y);
+        // Packet tone: 12 cycles over 105 samples at 48 kHz ≈ 5486 Hz output,
+        // ≈ 2743 Hz excitation. Generous range: the short packet is spectrally
+        // broad and the display smoothing widens it further.
+        Assert.InRange(peak.X, 1_800, 4_000);
+        Assert.True(
+            hd2.Points[^1].X <= SampleRate * 0.5 / 2 + 1,
+            $"HD2 axis must end at Nyquist/2, ended at {hd2.Points[^1].X:0} Hz.");
+    }
 }

--- a/tests/Resonalyze.Dsp.Tests/SyntheticDelayTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SyntheticDelayTests.cs
@@ -62,8 +62,15 @@ public sealed class SyntheticDelayTests
     }
 
     [Fact]
-    public void GroupDelay_MarksBinsMoreThanThirtyDecibelsBelowPeakAsNaN()
+    public void GroupDelay_MarksBinsFarBelowTheLocalEnvelopeAsNaN()
     {
+        // The validity gate reads against the LOCAL octave-smoothed energy
+        // envelope (a smooth quiet shelf — a differencer's low end here — is a
+        // measured response and stays valid; the old global −30 dB gate blanked
+        // it), while a stretch below the −60 dB global backstop is true silence
+        // and must still read NaN. A differencer with content only in the first
+        // two samples: everything is defined, so the curve is finite down to
+        // the deep global floor and NaN below it.
         var response = new Complex[TransformLength];
         response[0] = Complex.One;
         response[1] = -Complex.One;
@@ -80,13 +87,18 @@ public sealed class SyntheticDelayTests
             rightMs: 0,
             smoothingInverseOctaves: 0).Points;
 
+        // |H(f)| = 2·sin(πf/fs) crosses −60 dB re its Nyquist peak at
+        // f ≈ fs/π · 10^(−60/20) ≈ 15 Hz: below that the global backstop
+        // gates, above it the locally-consistent slope is a valid reading.
         SignalPoint firstValidPoint =
             groupDelay.First(point => !double.IsNaN(point.Y));
-
-        Assert.InRange(firstValidPoint.X, 450.0, 550.0);
+        Assert.InRange(firstValidPoint.X, 5.0, 50.0);
         Assert.All(
             groupDelay.Where(point => point.X < firstValidPoint.X),
             point => Assert.True(double.IsNaN(point.Y)));
+        Assert.All(
+            groupDelay.Where(point => point.X is > 100 and < 18_000),
+            point => Assert.True(double.IsFinite(point.Y)));
     }
 
     [Fact]
@@ -123,6 +135,91 @@ public sealed class SyntheticDelayTests
                 point.Y,
                 expectedDelayMilliseconds - 1e-6,
                 expectedDelayMilliseconds + 1e-6));
+    }
+
+    [Fact]
+    public void GroupDelay_AQuietBandSurvivesNextToATallResonance()
+    {
+        // A 50 Hz resonance whose spectral line rings ~47 dB above a broadband
+        // arrival (a subwoofer's cabin peak next to the rest of the system).
+        // The old validity gate compared every bin against the GLOBAL energy
+        // maximum, so the resonance blanked the measured mid band to NaN; the
+        // local-envelope gate must keep it, and the −60 dB global backstop
+        // must not swallow it either.
+        var response = new Complex[65_536];
+        response[1_000] = Complex.One;
+        for (int i = 0; i < 4_800; i++)
+        {
+            response[1_000 + i] += new Complex(
+                Math.Sin(2.0 * Math.PI * 50.0 * i / SampleRate)
+                    * Math.Exp(-i / 480.0),
+                0);
+        }
+        var measurement = new SyntheticMeasurement(
+            response,
+            SampleRate,
+            maxMagnitudeIndex: 1_000);
+
+        IReadOnlyList<SignalPoint> groupDelay = DataHelper.GetGroupDelay(
+            measurement,
+            gateOffsetMs: 1_000 * 1000.0 / SampleRate,
+            leftMs: 5,
+            plateauMs: 500,
+            rightMs: 500,
+            smoothingInverseOctaves: 0).Points;
+
+        // The old global gate blanked this band completely (it sits ~52 dB
+        // below the resonance line); the local gate keeps it, apart from the
+        // genuine deep interference notches the local rule still gates.
+        List<SignalPoint> midBand = groupDelay
+            .Where(point => point.X is >= 500 and <= 5_000)
+            .ToList();
+        Assert.NotEmpty(midBand);
+        double finiteShare =
+            midBand.Count(point => double.IsFinite(point.Y)) / (double)midBand.Count;
+        Assert.True(
+            finiteShare > 0.9,
+            $"only {finiteShare:P0} of the mid band survived the gate");
+    }
+
+    [Fact]
+    public void GatedPhase_ReadsTheCyclicTailLikeGroupDelayDoes()
+    {
+        // The dialog advertises ONE gate for phase and group delay, and GD has
+        // always read a left shoulder that precedes the IR start from the
+        // cyclic tail (the transfer IR is circular; negative time lives there).
+        // Phase used to zero-pad the same region — silently a different signal.
+        // Pin the wrap: content placed in negative time (the buffer's end) must
+        // reach the phase curve.
+        const int peakSample = 5;
+        var clean = new Complex[TransformLength];
+        clean[peakSample] = Complex.One;
+        var withTail = (Complex[])clean.Clone();
+        withTail[^20] = new Complex(0.3, 0); // −20 samples, inside the shoulder
+
+        List<SignalPoint> cleanPhase = DataHelper.GetGatedPhaseData(
+            new SyntheticMeasurement(clean, SampleRate, peakSample),
+            gateOffsetMs: peakSample * 1000.0 / SampleRate,
+            leftMs: 48 * 1000.0 / SampleRate,
+            plateauMs: 256 * 1000.0 / SampleRate,
+            rightMs: 64 * 1000.0 / SampleRate,
+            referenceSamples: 0,
+            unwrap: false);
+        List<SignalPoint> tailPhase = DataHelper.GetGatedPhaseData(
+            new SyntheticMeasurement(withTail, SampleRate, peakSample),
+            gateOffsetMs: peakSample * 1000.0 / SampleRate,
+            leftMs: 48 * 1000.0 / SampleRate,
+            plateauMs: 256 * 1000.0 / SampleRate,
+            rightMs: 64 * 1000.0 / SampleRate,
+            referenceSamples: 0,
+            unwrap: false);
+
+        double maxDifference = cleanPhase
+            .Zip(tailPhase, (a, b) => Math.Abs(a.Y - b.Y))
+            .Max();
+        Assert.True(
+            maxDifference > 0.1,
+            $"the cyclic tail never reached the phase (max diff {maxDifference:0.0000} rad)");
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
@@ -262,6 +262,91 @@ public sealed class TimeAlignmentAnalysisTests
     }
 
     [Fact]
+    public void Analyze_ZeroSignalReportsAnInvalidResult()
+    {
+        // A silent IR (or a bandpass entirely outside the measured band): every
+        // zero sample used to pass the collapsed thresholds and the sidelobe
+        // walk returned a confident-looking delay near the end of the search
+        // window. The result must say "no signal", not invent an alignment.
+        var impulseResponse = new double[8_192];
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, new TimeAlignmentAnalysisOptions());
+
+        Assert.False(result.IsValid);
+        Assert.Equal(0.0, result.FirstArrivalDelayMilliseconds);
+        Assert.Equal(0.0, result.StrongestDelayMilliseconds);
+        Assert.Equal(0.0, result.FirstArrivalConfidence);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void Analyze_TinyImpulseResponsesDoNotThrow(int length)
+    {
+        // The search-end floor of 3 (needed by the parabolic refinement) used
+        // to run the peak scan past the end of a 1-2 sample envelope.
+        var impulseResponse = new double[length];
+        impulseResponse[0] = 1.0;
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, new TimeAlignmentAnalysisOptions());
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Analyze_ABroadLowFrequencyRiseIsNotASeparateArrival()
+    {
+        // Two impulses 1.5 ms apart under a 200 Hz octave bandpass merge into
+        // one wave packet: the first local maximum sits ~3 ms before the
+        // strongest, but the envelope never dips between them (valley −0.2 dB).
+        // The separation alone used to call this "a room mode or reflection" —
+        // a band-limited driver's own rise time, misread. The valley test must
+        // keep the flag down while the separation still exceeds the threshold.
+        var impulseResponse = new double[65_536];
+        impulseResponse[4_000] = 0.9;
+        impulseResponse[4_072] = 1.0;
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, new TimeAlignmentAnalysisOptions
+            {
+                UseBandpassWindow = true,
+                BandpassCenterHz = 200,
+                BandpassPassOctaves = 1,
+                BandpassFadeOctaves = 0.5,
+                FirstPeakThresholdBelowMaxDb = 15
+            });
+
+        Assert.True(result.StrongestPeakSeparationMilliseconds > 1.0);
+        Assert.False(result.StrongestPeakIsSeparateArrival);
+    }
+
+    [Fact]
+    public void Analyze_TwoArrivalsWithARealValleyStayFlagged()
+    {
+        // The same band, but the impulses sit far enough apart (2.5 ms) that
+        // the envelope dips ~22 dB between them — a genuine second arrival the
+        // valley test must not suppress.
+        var impulseResponse = new double[65_536];
+        impulseResponse[4_000] = 0.75;
+        impulseResponse[4_120] = 1.0;
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, new TimeAlignmentAnalysisOptions
+            {
+                UseBandpassWindow = true,
+                BandpassCenterHz = 200,
+                BandpassPassOctaves = 1,
+                BandpassFadeOctaves = 0.5,
+                FirstPeakThresholdBelowMaxDb = 15
+            });
+
+        Assert.True(result.StrongestPeakIsSeparateArrival);
+    }
+
+    [Fact]
     public void Analyze_FlatUnityCoherence_ReproducesTheNullResultExactly()
     {
         // Threading coherence must be a no-op when it is flat/unity: an all-ones γ² of

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -532,6 +532,37 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void ApplyChain_LowFrequencyHighQPeqDoesNotWrapIntoTheEarlyResponse()
+    {
+        // A 20 Hz / Q 10 / +12 dB peaking filter rings for hundreds of
+        // milliseconds — far past the old fixed 8192-sample tail. With the IR
+        // length near the FFT boundary the ring wrapped circularly into the
+        // early response, corrupting the IR, the phase and every alignment
+        // sum built on it. The padding now follows the chain's slowest pole.
+        var ir = new Complex[57_000];
+        ir[24_000] = Complex.One;
+        var chain = new DspChannelChain(Peq: new EqualizationCurve(
+            new[] { new PeqBand(20, 10, 12) }));
+
+        Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(ir, chain, 48_000);
+
+        double peak = 0;
+        for (int i = 0; i < processed.Length; i++)
+        {
+            peak = Math.Max(peak, processed[i].Magnitude);
+        }
+        double preArrival = 0;
+        for (int i = 0; i < 23_000; i++)
+        {
+            preArrival = Math.Max(preArrival, processed[i].Magnitude);
+        }
+
+        Assert.True(
+            preArrival < peak * 1e-4,
+            $"wrap-around energy before the arrival: {20 * Math.Log10(preArrival / peak):0.0} dB re peak");
+    }
+
+    [Fact]
     public void FindAlignmentCandidates_ReportsEachPolaritysOwnOptimumAtAGappedJunction()
     {
         // The field regime where the polarity curves run shallow and nearly

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -532,6 +532,45 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void FindAlignmentCandidates_ReportsEachPolaritysOwnOptimumAtAGappedJunction()
+    {
+        // The field regime where the polarity curves run shallow and nearly
+        // tied: a gapped junction (LP 1300 / HP 1800 leaves a 0.66-octave
+        // spectral hole). Candidates are seeded per polarity, so the list must
+        // carry the best lobe of EACH polarity — AlignmentSelection's
+        // normal-polarity preference needs the runner-up polarity present to
+        // have anything to prefer. Also pins that a candidate's polarity is
+        // its own optimum: refinement never flips it.
+        Complex[] woofer = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(16_384, 400),
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.LowPass,
+                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 1_300, 24))),
+            SampleRate);
+        Complex[] tweeter = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(16_384, 400),
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.HighPass,
+                HighPassEdge: new CrossoverEdge(
+                    CrossoverFilterFamily.Butterworth, 1_800, 24))),
+            SampleRate);
+
+        IReadOnlyList<AlignmentCandidate> candidates =
+            VirtualCrossoverAnalysis.FindAlignmentCandidates(
+                tweeter, [woofer], SampleRate, 650, 2_600, -1.5, 1.5);
+
+        AlignmentCandidate bestNormal = candidates.First(item => !item.InvertPolarity);
+        AlignmentCandidate bestInverted = candidates.First(item => item.InvertPolarity);
+        // The true handover (no delay, no flip) wins; the flipped lobe half a
+        // period off stays in the list as a genuine near-tie the downstream
+        // selection rules must see.
+        Assert.Equal(bestNormal, candidates[0]);
+        Assert.InRange(bestNormal.DelayMs, -0.05, 0.25);
+        Assert.InRange(bestInverted.DelayMs, -0.4, -0.05);
+        Assert.True(bestInverted.ScoreDb > bestNormal.ScoreDb - 0.5);
+    }
+
+    [Fact]
     public void FindAlignmentCandidates_DipExcessOutranksASlightlyBetterAverage()
     {
         // An asymmetric junction (LR 12 dB high-pass vs Butterworth 48 dB

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -531,6 +531,54 @@ public sealed class VirtualCrossoverAnalysisTests
         });
     }
 
+    [Theory]
+    [InlineData(1_000, 1.0, 6.0)]   // an utterly ordinary band
+    [InlineData(4_000, 2.0, -8.0)]
+    public void RequiredTailSamples_OrdinaryPeqStaysAtTheMinimumPadding(
+        double frequencyHz,
+        double q,
+        double gainDb)
+    {
+        // The pole radius must be read in the ADDITIVE feedback convention
+        // BiquadCoefficients uses (z² − A1·z − A2): the textbook 1 + a1 + a2
+        // formulas mis-read every ordinary stable section as unstable and
+        // pinned the padding at the 262144-sample maximum — ballooning every
+        // Virtual DSP / Auto delay FFT for any crossover or PEQ.
+        var chain = new DspChannelChain(Peq: new EqualizationCurve(
+            new[] { new PeqBand(frequencyHz, q, gainDb) }));
+        PreparedDspResponse prepared = PreparedDspResponse.Create(chain, 48_000);
+
+        int tail = prepared.RequiredTailSamples(120.0, 8_192, 262_144);
+
+        Assert.Equal(8_192, tail);
+    }
+
+    [Fact]
+    public void RequiredTailSamples_CrossoverStaysAtTheMinimumPadding()
+    {
+        var chain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.LowPass,
+            new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 1_000, 24)));
+        PreparedDspResponse prepared = PreparedDspResponse.Create(chain, 48_000);
+
+        Assert.Equal(8_192, prepared.RequiredTailSamples(120.0, 8_192, 262_144));
+    }
+
+    [Fact]
+    public void RequiredTailSamples_LowFrequencyHighQPeqIsLongButFinite()
+    {
+        // 20 Hz / Q 10 rings for ~100k samples to −120 dB at 48 kHz — well
+        // past the floor but comfortably under the cap; hitting the cap would
+        // mean the section was misread as unstable.
+        var chain = new DspChannelChain(Peq: new EqualizationCurve(
+            new[] { new PeqBand(20, 10, 12) }));
+        PreparedDspResponse prepared = PreparedDspResponse.Create(chain, 48_000);
+
+        int tail = prepared.RequiredTailSamples(120.0, 8_192, 262_144);
+
+        Assert.InRange(tail, 50_000, 262_143);
+    }
+
     [Fact]
     public void ApplyChain_LowFrequencyHighQPeqDoesNotWrapIntoTheEarlyResponse()
     {

--- a/tests/Resonalyze.Dsp.Tests/WaterfallAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/WaterfallAnalysisTests.cs
@@ -150,11 +150,13 @@ public sealed class WaterfallAnalysisTests
     }
 
     [Fact]
-    public void ResampleBurstDecaySlice_ReturnsTheFloorBeyondTheRawDataRange()
+    public void ResampleBurstDecaySlice_BlanksPointsBeyondTheRawDataRange()
     {
-        // periodsSamples = 48000 * 10 / 1000 = 480; the raw envelope is only 20 samples
-        // long, so late output points fall past it and must read the -160 dB floor
-        // rather than NaN/garbage.
+        // periodsSamples = 48000 * 10 / 1000 = 480; the raw envelope is only 20
+        // samples long, so late output points fall past everything measured.
+        // They used to read the -160 dB floor — a fabricated instant decay to
+        // silence (at 20 Hz a 30-period axis spans 1.5 s of a 85 ms record);
+        // unobserved time must read NaN.
         var rawData = Enumerable.Range(0, 20)
             .Select(i => new SignalPoint(i, 0.5))
             .ToList();
@@ -162,7 +164,49 @@ public sealed class WaterfallAnalysisTests
         IReadOnlyList<SignalPoint> resampled = WaterfallAnalysis.ResampleBurstDecaySlice(
             rawData, frequency: 1_000.0, sampleRate: SampleRate, width: 50, periods: 10.0);
 
-        Assert.Equal(DataHelper.AmplitudeToDecibels(0.0), resampled[^1].Y, precision: 6);
+        Assert.True(double.IsNaN(resampled[^1].Y));
+        // The measured head still reads normally.
+        Assert.Equal(DataHelper.AmplitudeToDecibels(0.5), resampled[0].Y, precision: 6);
+    }
+
+    [Fact]
+    public void ResampleBurstDecaySlice_BlanksZeroPaddingBeyondTheMeasuredWindow()
+    {
+        // The raw envelope is longer than the measured window (the FFT's zero
+        // padding rings past it): measuredSamples marks where real data ends,
+        // and the axis is anchored on the peak (a left fade into the record).
+        var rawData = Enumerable.Range(0, 480)
+            .Select(i => new SignalPoint(i, 0.5))
+            .ToList();
+
+        IReadOnlyList<SignalPoint> resampled = WaterfallAnalysis.ResampleBurstDecaySlice(
+            rawData,
+            frequency: 1_000.0,
+            sampleRate: SampleRate,
+            width: 48,
+            periods: 10.0,
+            measuredSamples: 240,
+            peakOffsetSamples: 8);
+
+        // samplePosition = 8 + i/48 * 480: crosses 240 between i = 23 and 24.
+        Assert.True(double.IsFinite(resampled[23].Y));
+        Assert.True(double.IsNaN(resampled[24].Y));
+    }
+
+    [Fact]
+    public void BuildBurstDecayRawSlices_GridStaysBelowNyquist()
+    {
+        // At 32 kHz a fixed 20 kHz grid start would generate slices for
+        // frequencies the capture cannot contain.
+        var response = new Complex[Window];
+        response[100] = Complex.One;
+        var measurement = new SyntheticMeasurement(response, 32_000, 100);
+
+        IReadOnlyList<BurstDecaySlice> slices = WaterfallAnalysis.BuildBurstDecayRawSlices(
+            measurement, 0, Window, Hann(Window), smoothingOctaves: 1.0);
+
+        Assert.NotEmpty(slices);
+        Assert.All(slices, slice => Assert.True(slice.Frequency < 16_000));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes coming out of six external code reviews plus a cold-start audio investigation. Each claim was verified against the code and, where behavior could shift, probed on real/synthetic measurements before applying. The larger designed changes are recorded in `TODO.md` → "External review tails" with per-item verdicts.

## Commit 1 — Auto delay (`cb09842`)
Bypass guard (bypassed channels corrupted the junction walk while ignoring their overrides); busy lockout of Add/Remove/Session import; window-edge retry through `AlignmentSelection`; per-polarity candidate seeding (cap 4 → 6); WARNING on 100 ms shift saturation.

## Commit 2 — Phase unwrap + Time Alignment (`4be29af`)
Local magnitude gate + −60 dB backstop; long unknowable gaps blank to NaN and restart a fresh segment; the 100 Hz unwrap floor removed; silent band → `IsValid = false`; real SNR (quietest-quarter noise floor; woofer regrades ~50 → ~73 dB); "separate arrival" needs a 6 dB valley; PHAT radius cap 8 → 32 samples; tiny-IR bounds.

## Commit 3 — Transfer layer (`85bb6ac`)
Coherence debiased by average count at the source (`(K·γ²−1)/(K−1)`); "Find τ" (peak) via the first-arrival detector; gain-invariant minimum phase; phase and GD read the SAME gate (phase wraps the cyclic tail); GD validity gate on a local octave envelope.

## Commit 4 — Harmonics, EQ Wizard, Burst Decay, convolution (`ebec4e0`)
HD2–HD4 draw at the excitation frequency (calibration at the product frequency; curves end at Nyquist/n); `TotalGainMaxDb` stops the EQ Wizard from emitting clipping profiles; `ApplyChain` padding follows the chain's slowest biquad pole; Burst Decay stops drawing fabricated decay (NaN past the measured window, peak-anchored axis, Nyquist-capped grid); FR preview tooltip corrected.

## Commit 5 — Live Spectrum, overlays, async races (`3e2b1fb` + test fix `323022b`)
Dropped capture blocks no longer splice (reframer resets on the drop generation); live coherence is UNKNOWN (null) until 4 frames accumulate; switching averaging speed resets the accumulation; **RTA is tone-calibrated dBFS** (`2|X|/(N·CG)` — the level used to jump 6.02 dB per FFT-size doubling; displayed live-spectrum levels change); overlay operations interpolate wrapped phase through the branch cut and on the log-frequency axis; stale-async guards for history restore and EQ Auto Tune; miniDSP export takes its sample rate as a parameter.

## Commit 6 — Calibration, generator, device lifecycle, release workflow (`6114c33`)
**Calibration corrections are exact** piecewise-linear interpolation in (log f, dB) — the old Lanczos lookup silently half-octave-smoothed every correction (+12 dB point read back ~+5.6 dB); duplicate frequencies merge instead of NaN. The signal generator refuses a sine above Nyquist (aliased tones); brown noise derives its leak from a fixed ~76 Hz corner instead of drifting with the sample rate. Unexpected capture stops fault pending sample waiters (no more infinite hangs on device unplug) and the ASIO live path awaits the driver's own stop. Measurement files validate coherence length = N/2 + 1. The release workflow passes inputs via env + strict version regex (shell-injection surface next to the signing key), checks out the release TAG in every job (a dispatch could sign binaries from a different commit than the tag), and creates releases as drafts (AI-drafted notes from untrusted commit text get human review).

## Commit 8 — Live Spectrum cold start (`46ceb43`)
Periodic pink materializes ONE FFT-length period (~24 KB instead of ~35 MB of LOH arrays racing the first audio callbacks — the debugger memory spike); the whole analysis path (window, FFTs, H1, coherence, RTA) is warmed BEFORE the driver starts; the analysis window is cached instead of recomputed per frame and per snapshot. Remaining cold paths (allocating callback extraction, per-callback meter arrays, heavy first plot frame) are in TODO.md with a measurement plan.

## Deferred with verdicts → `TODO.md` "External review tails"
THD energy summation + same-reference denominator; Auto Crossover complex-sum model; EQ boostability mask + greedy-loop redesign + digital-vs-analog PEQ model; dual-device timing quality + measurement provenance; H1 excitation mask; sweep run quality gate; estimated-90° labeling; streaming signal generator; RT-callback subscriber isolation; ms-parametrized autocorrelation; file-size caps before deserialization; release toolchain pinning; and more — each with the verified verdict recorded.

## Validation
- **416/416 dsp tests** (31 new across the batches); real-measurement pins updated with reasoning recorded in comments.
- Full solution builds clean with `-p:EnableWindowsTargeting=true`; Windows-only UI/measurement/audio changes are compile-verified — the cold-start result and the new dBFS RTA levels need a look on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv