### PR TITLE
Stereo Virtual DSP: L/R channel pairs and a scene-offset Auto delay cascade

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,13 @@ file is provided with every release.
   measurements (`Main ⊕ Compare`) with Compare delay/polarity controls, plus a
   **sum-loss** curve — accounts for delay, polarity, and phase the way dB-curve
   math cannot
-- **Virtual DSP** tool: run up to eight measured drivers through virtual
-  DSP chains — gain, delay, polarity, Butterworth / Linkwitz-Riley / Bessel
-  crossovers, and imported PEQ — and see their complex sum, sum loss, phase
-  tracking, auto crossover proposals, auto delay, gated phase view, overlay
-  capture, sessions, and tuning-sheet export
+- **Virtual DSP** tool: run up to eight measured L/R driver pairs (with mono
+  channels for a shared subwoofer) through virtual DSP chains — gain, delay,
+  polarity, Butterworth / Linkwitz-Riley / Bessel crossovers, and imported
+  PEQ — and see their complex sum, sum loss, the opposite side's sum, phase
+  tracking, per-pair Δ L−R timing, auto crossover proposals, a stereo-aware
+  auto delay with a scene offset, gated phase view, overlay capture, sessions,
+  and tuning-sheet export
 - Live Spectrum: real-time loopback transfer function with selectable excitation
   (leakage-free periodic pink, pink, brown/red, white noise) and coherence
 - Frequency response, phase, group delay, waterfall, Burst Decay, and
@@ -193,7 +195,8 @@ Resonalyze is built around a focused engineering workflow:
   the crossover frequencies, filter families, slopes, and cut-only gains that
   flatten the summed magnitude (favoring tight, minimally overlapping splits),
   and **Auto delay** aligns each junction's delay and polarity against the
-  phase-aware sum.
+  phase-aware sum — across both stereo sides in one run, holding a
+  configurable L/R scene offset between the sides.
 - **Practical loudspeaker alignment**
   Time Alignment reports first arrival and strongest peak, each refined to
   sub-sample precision by a GCC-PHAT cross-correlation, plus distance at 20 °C,
@@ -1294,8 +1297,8 @@ between tools and DSPs:
 
 - **Import + export:** Equalizer APO, REW filter settings, Generic CSV,
   EasyEffects (JSON), CamillaDSP (YAML)
-- **Export only:** miniDSP biquads (RBJ coefficients), GraphicEQ (Wavelet /
-  JamesDSP)
+- **Export only:** miniDSP biquads (RBJ coefficients, at 44.1 / 48 / 96 kHz to
+  match the DSP's internal rate), GraphicEQ (Wavelet / JamesDSP)
 
 Import is deliberately lenient: comments, blank lines, disabled (`OFF`) filters,
 non-peaking filter types, and malformed entries are skipped rather than rejected.
@@ -1335,11 +1338,15 @@ where the signal is going before pressing **Play**.
 
 The **Virtual DSP** (under the **Tools** tab) is the summation-prediction
 workflow taken to its conclusion: measure each driver once, then design the
-whole DSP setup virtually. Channels (A, B, C, …) each pick a measurement — from a
-file or from History — and run it through a virtual DSP chain. **Add channel** /
-**Remove channel** grow the setup from two up to eight channels; the blocks live
-in a scrolling list, so a many-way system stays in one window without crowding
-the plots.
+whole DSP setup virtually. Channels (A, B, C, …) are stereo **L/R pairs**: each
+side picks its own measurement — from a file or from History — and runs its own
+virtual DSP chain. Tight **L / R** selector radios switch which side the block's
+controls edit (the plots follow), **L→R** / **R→L** buttons copy chain settings
+across sides for the channels you tick in a small dialog, and a **Mono**
+checkbox turns a pair into a single shared driver — the typical one-subwoofer
+car layout — that feeds both sides' sums. **Add channel** / **Remove channel**
+grow the setup from two up to eight pairs; the blocks live in a scrolling list,
+so a many-way system stays in one window without crowding the plots.
 
 Each channel runs through:
 
@@ -1347,7 +1354,7 @@ Each channel runs through:
   one playback chain; compensate any difference here
 - **Delay** (ms) with a live **mm** read-out — the ruler check against the
   physical driver offset (343 m/s)
-- **Invert polarity** — the DSP polarity switch
+- **Invert** — the DSP polarity switch
 - **Crossover** — Off, low-pass, high-pass, or band-pass; each edge picks
   **Butterworth** (6–48 dB/oct), **Linkwitz-Riley** (12/24/48 dB/oct), or
   **Bessel** (6–48 dB/oct, near-constant group delay) with its own corner
@@ -1375,8 +1382,10 @@ The filters are evaluated as the **digital biquad cascades a real DSP runs**
 (bilinear transform at the measurement sample rate), so the prediction matches
 miniDSP-class hardware up to Nyquist, not just an analog textbook curve.
 
-The acoustic plot shows raw and processed curves per channel, the complex
-**Sum**, and the **Sum loss** curve (blanked where every channel is filtered
+The acoustic plot shows raw and processed curves per channel for the active
+side, the complex **Sum**, the **opposite side's Sum** as a dashed translucent
+curve (so the two sides' tunes compare at a glance without flipping back and
+forth), and the **Sum loss** curve (blanked where every channel is filtered
 more than 40 dB below the loudest point — out there the "loss" would be the
 phase arithmetic of noise floors, not audible summation), with a **Phase view**
 toggle to check that
@@ -1384,16 +1393,15 @@ the channels track each other through the crossover region. The Phase view has a
 manual **Gate...** dialog with an IR preview, Tukey left / plateau / right
 window controls, gate offset, and a shared τ detrend so reflections can be cut
 out without breaking relative phase. A second plot shows each DSP chain's own
-magnitude and phase (without the driver). A **Sum loss** read-out (avg / dip /
-null per junction plus a total) turns tuning into numbers you can minimize. The
-**null** figure is the classic tuner's polarity-flip check computed for you:
-the deepest notch the sum develops in the pair band with the junction's upper
-channel inverted — the deeper it drops, the better the pair's phase match at
-the handover. One caveat the read-out inherits from the physics: a
-whole-period delay error keeps the phase at the crossover frequency aligned
-and nulls just as deeply, so read it as confirmation of a candidate alignment,
-not as a lobe selector — the avg/dip figures and the arrival-anchored Auto
-delay are what guard against cycle skips.
+magnitude and phase (without the driver). A **Sum loss** read-out (avg / dip
+per junction plus a total) turns tuning into numbers you can minimize, and a
+**Δ L−R** block below it reports each stereo pair's final inter-side timing:
+the difference of the two sides' band-limited envelope arrivals in the pair's
+shared band, fully processed chains included. Positive means the right side
+leads — the same sign convention as the scene offset, so after a stereo Auto
+delay every row should read the offset. A pair whose arrival cannot be
+measured reliably (a silent band, or a near-noise record) shows an honest
+dash instead of a precise-looking number.
 
 Editing a chain recomputes the prediction on a background task, so dragging a
 gain, delay, or crossover value stays responsive even with several channels
@@ -1441,12 +1449,29 @@ it defaults to Off because the measurements are loopback-referenced.
   crossover has excessive group delay (a narrow or steep low-frequency band-pass)
   — a banner flags the lagging driver so you can soften its filter instead of
   dialing in an absurd bulk delay.
+  With stereo pairs, Auto delay tunes **both sides in one run**: the left side
+  aligns first, the top pair is bridged by band-limited envelope arrivals
+  honoring the **L/R offset** field — positive makes the right side lead,
+  pulling the image toward the dash center for a left-seated listener (the
+  field's tooltip carries the sign cheat-sheet) — with the right top's polarity
+  matched to the left's, and the right side then descends junction by junction
+  from the bridged top. Pairs whose shared band reaches the localization region
+  are pinned to the scene: their right channel lands exactly the offset behind
+  its left counterpart (±0.05 ms of junction fine-tuning), because the stereo
+  image outranks the handover there, while pure low-frequency pairs keep the
+  free junction search with the cross-side timing as a gentle prior only. A
+  final scene-preserving pass may then shift BOTH sides of a pair by one shared
+  delta — which cannot touch the image — to recover junction summation the pin
+  cost. A **Mono** channel (the shared subwoofer) is timed by the left pass
+  alone; its junction against the right side is measured and reported, with a
+  warning when only a manual compromise delay would serve both sides.
 - **Capture to overlay** saves the predicted sum as a Captured overlay in
   Frequency Response — compare it against real measurements and target curves,
   or feed it onward to the EQ Wizard.
 - **Export…** writes the whole setup as a tuning sheet (printable PDF or plain
-  text): per channel the gain, delay in ms and mm, polarity, crossover filters,
-  and PEQ bands — exactly the list you type into the DSP.
+  text): for every side of every pair (a mono pair prints once) the gain, delay
+  in ms and mm, polarity, crossover filters, and PEQ bands — exactly the list
+  you type into the DSP, both sides in one sheet.
 - **Save session... / Load session...** exports or imports the complete session
   JSON (sources, chains, gate, and view state) for sharing or archiving.
 

--- a/README.md
+++ b/README.md
@@ -1395,13 +1395,18 @@ window controls, gate offset, and a shared τ detrend so reflections can be cut
 out without breaking relative phase. A second plot shows each DSP chain's own
 magnitude and phase (without the driver). A **Sum loss** read-out (avg / dip
 per junction plus a total) turns tuning into numbers you can minimize, and a
-**Δ L−R** block below it reports each stereo pair's final inter-side timing:
-the difference of the two sides' band-limited envelope arrivals in the pair's
-shared band, fully processed chains included. Positive means the right side
-leads — the same sign convention as the scene offset, so after a stereo Auto
-delay every row should read the offset. A pair whose arrival cannot be
-measured reliably (a silent band, or a near-noise record) shows an honest
-dash instead of a precise-looking number.
+**Δ L−R** block below it reports each stereo pair's final inter-side state:
+the two sides' band-limited envelope arrivals in the pair's shared band
+(fully processed chains included) with their difference — positive means the
+right side leads, the same sign convention as the scene offset, so after a
+stereo Auto delay every row should read the offset — and, below the timing, a
+**Level Δ L−R** row per pair: the gated band-level asymmetry of the two sides
+(positive: left louder). Timing (ITD) and level (ILD) steer the image
+together, so this is the read-out for the by-ear gain trim that finishes the
+centering; note a single microphone underestimates the binaural difference
+(no head shadow), so expect to trim a little more than it shows. A side whose
+arrival cannot be measured reliably (a silent band, or a near-noise record)
+shows an honest dash instead of a precise-looking number.
 
 Editing a chain recomputes the prediction on a background task, so dragging a
 gain, delay, or crossover value stays responsive even with several channels

--- a/TODO.md
+++ b/TODO.md
@@ -149,6 +149,15 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   woof/mid left 3.878 vs manual 3.84 — via the normal-polarity margin, which
   won by only 0.02 dB there, see next item; right mid/twr −0.635 vs manual
   ~0.68 on the mid side).
+- [ ] **Stereo scene diagnostics (Δ per band)**: the stereo Auto delay cascade
+  (left walk → arrival bridge with the scene offset → right descent) is in;
+  the complementary *verification* layer is not — per-band L−R arrival
+  differences of the FINAL tune, compared across bands (probe showed 0.06 ms
+  repeatability on real measurements), with a warning when a band's Δ walks
+  off the top pair's by a sizable fraction of its junction period (a period
+  slip that survived the per-side sum optimization), and optionally a
+  candidate-list re-pick to fix it for free. Also: L/R polarity consistency
+  per band.
 - [ ] **`AlignmentSelection` normal-polarity margin near-miss on real data**:
   at the user's left woof/mid junction the inverted impostor out-scores the
   true normal candidate by 0.23 dB — the 0.25 dB

--- a/TODO.md
+++ b/TODO.md
@@ -169,6 +169,19 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   slip that survived the per-side sum optimization), and optionally a
   candidate-list re-pick to fix it for free. Also: L/R polarity consistency
   per band.
+- [ ] **`SceneLockToleranceMs = 0.05` is aggressive for pairs whose
+  localizable band is narrow and low** (e.g. reaching only ~300–400 Hz):
+  the band passes the minimum-width admission, but the temporal certainty of
+  such a narrow-band envelope arrival is typically worse than 0.05 ms, so the
+  lock can pin the channel inside the measurement noise. Acceptable today
+  thanks to the guards around it — the minimum lock-band width, the SNR gate,
+  the lock refusing an invalid arrival, and the scene-preserving co-move that
+  recovers junction quality afterwards — but non-blocking risk, recorded
+  2026-07-10. Follow-up: make the tolerance a function of the lock band's
+  width/center (roughly: a fraction of the band-center period, floored at
+  0.05 ms), or of an explicit arrival-uncertainty estimate (envelope rise
+  time / FirstArrivalProminence), so a wide tweeter band keeps the tight pin
+  while a barely-localizable pair gets an honest slack.
 - [x] **Stereo level (ILD) read-out next to Δ** — done: the metric block
   gained a "Level Δ L−R (dB)" row per pair (`MeasureBandLevelDb`: gated,
   log-frequency-weighted band level of each processed side; gated by the

--- a/TODO.md
+++ b/TODO.md
@@ -169,7 +169,12 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   slip that survived the per-side sum optimization), and optionally a
   candidate-list re-pick to fix it for free. Also: L/R polarity consistency
   per band.
-- [ ] **Stereo level (ILD) read-out next to Δ** — field-confirmed follow-up
+- [x] **Stereo level (ILD) read-out next to Δ** — done: the metric block
+  gained a "Level Δ L−R (dB)" row per pair (`MeasureBandLevelDb`: gated,
+  log-frequency-weighted band level of each processed side; gated by the
+  same per-side arrival reliability; tooltip explains the sign and the
+  single-mic-vs-binaural gap). Deliberately a diagnostic, no auto gain trim.
+  Original note — field-confirmed follow-up
   (2026-07-10): with the cascade's delays in the car the user reported the
   scene "dead center" and same-channel drivers indistinguishable by ear, but
   full centering ALSO needed a manual −3…−4 dB trim of the LEFT mid+tweeter:

--- a/TODO.md
+++ b/TODO.md
@@ -149,6 +149,17 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   woof/mid left 3.878 vs manual 3.84 — via the normal-polarity margin, which
   won by only 0.02 dB there, see next item; right mid/twr −0.635 vs manual
   ~0.68 on the mid side).
+  **Follow-up (same day, after the scene-preserving co-move shifted the D
+  pair −0.52 ms):** re-probed at the final cascade state, asking whether the
+  flat-slope point now agrees with the validated tune. It does not — the
+  verdict got stronger: the C/D flat-slope residual reads −1.36 T on the left
+  and +1.71 T on the right (B/C: −1.06 / −0.87 T), i.e. the two sides want
+  OPPOSITE corrections (left +0.53 ms, right −1.84 ms), so no scene-preserving
+  pair move can satisfy the slope criterion on both sides even in principle.
+  On the left the loss-optimal co-move went in exactly the opposite direction
+  from the flat-slope point's wish while landing on the user's hand tune. The
+  per-side filter+driver group-delay asymmetry is real and side-asymmetric;
+  the refutation stands.
 - [ ] **Stereo scene diagnostics (Δ per band)**: the stereo Auto delay cascade
   (left walk → arrival bridge with the scene offset → right descent) is in;
   the complementary *verification* layer is not — per-band L−R arrival

--- a/TODO.md
+++ b/TODO.md
@@ -169,6 +169,20 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
   slip that survived the per-side sum optimization), and optionally a
   candidate-list re-pick to fix it for free. Also: L/R polarity consistency
   per band.
+- [ ] **Stereo level (ILD) read-out next to Δ** — field-confirmed follow-up
+  (2026-07-10): with the cascade's delays in the car the user reported the
+  scene "dead center" and same-channel drivers indistinguishable by ear, but
+  full centering ALSO needed a manual −3…−4 dB trim of the LEFT mid+tweeter:
+  level steers the image alongside timing. The same asymmetry shows in the
+  measurements — gated band level L−R of the final processed sides on
+  `assets/test_data`: mid +1.6 dB (175–1300; +1.2 in 300–1300), twr +0.6 dB,
+  woof +4.3 dB — same sign, smaller magnitude than perceived, as expected:
+  one omni mic at the head position sees no head shadow, so the effective
+  binaural ILD is larger than the measured single-point figure. Feature: a
+  per-pair L−R level column in the metric block (measured in the pair's
+  shared band, same gate as the sum loss) as a *diagnostic* — do NOT auto-trim
+  gains from it (it under-corrects vs binaural perception and taste); at most
+  a gentle hint when the localization-band level asymmetry exceeds ~2 dB.
 - [ ] **`AlignmentSelection` normal-polarity margin near-miss on real data**:
   at the user's left woof/mid junction the inverted impostor out-scores the
   true normal candidate by 0.23 dB — the 0.25 dB

--- a/TODO.md
+++ b/TODO.md
@@ -124,6 +124,39 @@ reported instead of fixed. Grouped by area, highest-value items marked ★.
 
 ## Virtual DSP / Time Alignment
 
+- [✗] **Phase-slope (residual group delay) as an Auto delay score prior —
+  REFUTED on the user's real measurements** (probed 2026-07-10, five junctions
+  of the left 4-way + right mid/twr from `assets/test_data`). The idea:
+  penalize candidates whose inter-channel phase slope across the pair band is
+  non-flat, since a lobe impostor differs by exactly one period of residual
+  delay. The probe measured the flat-slope delay per junction (wrap-safe
+  adjacent-bin phase increments of the gated cross-spectrum, two weightings —
+  both agree) and compared it with the summation winner and the user's manual
+  tune. Result: at the true alignment the inter-channel phase slope is NOT
+  flat — it carries the honest group-delay difference of drivers plus
+  non-matched crossover filters, and that reaches a FULL period at real
+  junctions: left woof/mid true lobe sits 1.02 T from the flat-slope point;
+  right mid/twr (the gapped BW24 LP 1300 / HP 1800 junction) true lobe sits
+  1.82 T away while the flat-slope point lands on the old field-failure
+  answer (~mid +2.0 ms) — flat phase slope is mathematically the GCC-PHAT
+  peak, so this prior would re-trust exactly the PHAT lobe position the
+  `PhatSeedMinDominance` gate was added to distrust. Any weight strong enough
+  to separate lobes (≥0.5 dB/T) flips the right mid/twr winner to a wrong
+  inverted candidate. Do not implement as a score term; at most surface the
+  per-candidate residual GD as a log diagnostic. Side finding, positive: on
+  every junction with a known manual reference the current score+selection
+  already reproduces the user's tune (mid/twr left −0.154 vs manual −0.16 ms;
+  woof/mid left 3.878 vs manual 3.84 — via the normal-polarity margin, which
+  won by only 0.02 dB there, see next item; right mid/twr −0.635 vs manual
+  ~0.68 on the mid side).
+- [ ] **`AlignmentSelection` normal-polarity margin near-miss on real data**:
+  at the user's left woof/mid junction the inverted impostor out-scores the
+  true normal candidate by 0.23 dB — the 0.25 dB
+  `DefaultInvertPreferenceMarginDb` saves the pick by just 0.02 dB. One noisier
+  measurement could flip it. Worth revisiting with more field measurements
+  (margin as a function of junction frequency / band coherence, or an
+  independent polarity witness such as `EstimatePolarity` on the band-passed
+  arrivals) before touching the constant.
 - [ ] **Time Alignment analysis is not cached** — `RefreshAnalysis`
   (`TimeAlignmentPanelController`) recomputes Hilbert + GCC-PHAT on every tab
   show even when inputs are unchanged. Needs a live-app check to avoid stale

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -334,7 +334,8 @@ public static class AutoAlignmentEngine
         StringBuilder log,
         IAlignmentChannel? secondaryNeighbor = null,
         AlignmentJunction? secondaryPair = null,
-        double? priorOverrideMs = null)
+        double? priorOverrideMs = null,
+        double? sceneLockToleranceMs = null)
     {
         double primaryBase = alignment.GetValueOrDefault(neighborChannel).DelayMs
             + timeline[neighborChannel] - timeline[channel];
@@ -391,6 +392,14 @@ public static class AutoAlignmentEngine
                 halfPeriodMs, MinFineAlignmentRangeMs, MaxFineAlignmentRangeMs);
             double windowLowMs = Math.Min(primaryBase, secondaryBase) - rangeMs;
             double windowHighMs = Math.Max(primaryBase, secondaryBase) + rangeMs;
+            if (sceneLockToleranceMs is { } lockTolerance && windowOverrideMs == null)
+            {
+                // The scene mandate: the window IS the tolerance around the
+                // cross-side target — the search only fine-tunes the junction
+                // sum (and decides polarity) inside it.
+                windowLowMs = anchorMs - lockTolerance;
+                windowHighMs = anchorMs + lockTolerance;
+            }
             IReadOnlyList<AlignmentCandidate> candidates =
                 VirtualCrossoverAnalysis.FindAlignmentCandidates(
                     variableIr,
@@ -417,6 +426,9 @@ public static class AutoAlignmentEngine
                 (secondaryNeighbor != null ? $" / {secondaryBase:0.000}" : "") +
                 $" ms, prior {anchorMs:0.000} ms" +
                 (priorOverrideMs != null ? " (cross-side)" : "") +
+                (sceneLockToleranceMs is { } tol
+                    ? $", SCENE-LOCKED \u00b1{tol:0.00} ms"
+                    : "") +
                 ", candidates " +
                 string.Join("; ", candidates.Select(item =>
                     $"{item.DelayMs:0.000} ms" +
@@ -460,7 +472,8 @@ public static class AutoAlignmentEngine
             double retryRangeMs = Math.Min(1.8 * halfPeriodMs, 3.0);
             bool atEdge = chosen.DelayMs <= windowLow + 0.02 ||
                 chosen.DelayMs >= windowHigh - 0.02;
-            if (retryRangeMs > (windowHigh - windowLow) / 2.0 && atEdge)
+            if (sceneLockToleranceMs == null &&
+                retryRangeMs > (windowHigh - windowLow) / 2.0 && atEdge)
             {
                 (IReadOnlyList<AlignmentCandidate> retried, _, _) =
                     SearchJunction(windowOverrideMs: retryRangeMs);
@@ -487,7 +500,7 @@ public static class AutoAlignmentEngine
             // mere lobe/flip impostor cannot pull the result off the arrival —
             // and with a cross-side prior in the scores, a promotion that walks
             // away from the other side's timing pays for that distance too.
-            if (wide.Count > 0)
+            if (wide.Count > 0 && sceneLockToleranceMs == null)
             {
                 AlignmentCandidate wideChosen = AlignmentSelection.Select(wide, anchorMs);
                 if (wideChosen.ScoreDb > chosen.ScoreDb + WideWindowPromotionMarginDb)
@@ -787,10 +800,23 @@ public static class AutoAlignmentEngine
                 secondaryPair = plan.RightPairs[Math.Min(index, otherIndex)];
             }
 
+            // The scene mandate: pairs reaching the localization region are
+            // pinned to the cross-side target; pure low-frequency pairs keep
+            // the free joint-junction search (no localization there, soft
+            // envelopes, summation is what remains audible).
+            double? crossTarget = CrossSideTargetMs(channel);
+            StereoPairLink? channelLink = plan.PairLinks?.FirstOrDefault(
+                item => item.Right == channel);
+            double? sceneLock = crossTarget != null &&
+                channelLink is { } lockLink &&
+                lockLink.BandHighHz >= SceneLockMinimumBandHighHz
+                    ? SceneLockToleranceMs
+                    : null;
+
             AlignChannelAtJunction(
                 channel, neighbor, pair,
                 rightTimeline, allChannels, reprocess, alignment, log,
-                secondary, secondaryPair, CrossSideTargetMs(channel));
+                secondary, secondaryPair, crossTarget, sceneLock);
         }
         for (int i = bridgeIndex - 1; i >= 0; i--)
         {
@@ -800,6 +826,12 @@ public static class AutoAlignmentEngine
         {
             AlignRight(i, i - 1, plan.RightPairs[i - 1]);
         }
+
+        // Scene-preserving re-balance: with right channels pinned to the
+        // scene, their junction sums pay the price — moving BOTH sides of a
+        // pair by one shared delta keeps the pair's L-R timing (the scene)
+        // untouched while trading junction loss between the sides.
+        RebalancePairsKeepingScene(plan, reprocess, alignment, log);
 
         // Final normalization: the smallest total latency that preserves every
         // relation — the minimum proposed delay lands exactly at zero.
@@ -828,6 +860,24 @@ public static class AutoAlignmentEngine
     // below this is a mis-picked band or a broken capture, and the bridge is
     // the one number that times a whole side.
     private const double BridgeMinimumSnrDb = 12;
+
+    // The scene mandate for the right descent: a channel whose pair band
+    // reaches into the localization region is PINNED to the cross-side target
+    // (the left counterpart's settled arrival minus the scene offset) and may
+    // fine-tune its junction sum only within this tolerance — the stereo
+    // image outranks the junction handover. Pairs living entirely below the
+    // localization region (the woofers) keep the free joint-junction search:
+    // the ear does not localize there, low-band envelope arrivals are soft,
+    // and the summation is what remains audible.
+    private const double SceneLockToleranceMs = 0.05;
+    private const double SceneLockMinimumBandHighHz = 300;
+
+    // The scene-preserving re-balance pass: both sides of a pair may move by
+    // the SAME delta (which leaves the pair's L-R timing untouched) to trade
+    // junction loss between the sides. Bounded search, and a move must buy at
+    // least the minimum gain in the mean adjacent-junction loss to apply.
+    private const double PairComoveSearchRangeMs = 1.2;
+    private const double PairComoveMinimumGainDb = 0.05;
 
     // Decides the right bridge channel's polarity once its delay is already in
     // the alignment map. Primary evidence: the measured acoustic signs of the
@@ -890,6 +940,147 @@ public static class AutoAlignmentEngine
 
         log.AppendLine(
             $"  bridge polarity: {(invert ? "inverted" : "normal")} ({reason})");
+    }
+
+    // Moves both sides of one linked pair by the same delta — the pair's L-R
+    // timing (the scene) is invariant under a co-move — searching for the
+    // delta that minimizes the MEAN loss of every junction adjacent to the
+    // pair on both sides. The left side may get slightly worse: by the scene
+    // mandate the pinned right channel could not chase its own junction
+    // optimum, and this is the only lever that can recover junction quality
+    // without touching the image. Top pair first, so lower pairs re-balance
+    // against the already-settled uppers.
+    private static void RebalancePairsKeepingScene(
+        StereoAlignmentPlan plan,
+        AlignmentReprocessor reprocess,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        StringBuilder log)
+    {
+        if (plan.PairLinks == null)
+        {
+            return;
+        }
+
+        foreach (StereoPairLink link in plan.PairLinks
+            .Where(item => item.BandHighHz >= SceneLockMinimumBandHighHz)
+            .OrderByDescending(item => item.BandHighHz))
+        {
+            AlignmentOverride leftOverride = alignment.GetValueOrDefault(link.Left);
+            AlignmentOverride rightOverride = alignment.GetValueOrDefault(link.Right);
+
+            // Every junction the pair's channels take part in, on either side.
+            List<AlignmentJunction> adjacent = plan.LeftPairs
+                .Where(pair => pair.Lower.Channel == link.Left ||
+                    pair.Upper.Channel == link.Left)
+                .Concat(plan.RightPairs.Where(pair =>
+                    pair.Lower.Channel == link.Right ||
+                    pair.Upper.Channel == link.Right))
+                .ToList();
+            if (adjacent.Count == 0)
+            {
+                continue;
+            }
+
+            double Score(double deltaMs)
+            {
+                var trial = new Dictionary<IAlignmentChannel, AlignmentOverride>(alignment)
+                {
+                    [link.Left] = leftOverride with
+                    {
+                        DelayMs = leftOverride.DelayMs + deltaMs
+                    },
+                    [link.Right] = rightOverride with
+                    {
+                        DelayMs = rightOverride.DelayMs + deltaMs
+                    }
+                };
+                IReadOnlyList<AlignmentSnapshot> current = reprocess(trial);
+                Complex[] IrOf(IAlignmentChannel channel) =>
+                    current.First(item => item.Channel == channel).ImpulseResponse;
+
+                double total = 0;
+                int count = 0;
+                foreach (AlignmentJunction junction in adjacent)
+                {
+                    (double LossDb, double DipDb)? loss =
+                        VirtualCrossoverAnalysis.MeasureSumLoss(
+                            IrOf(junction.Upper.Channel),
+                            new List<Complex[]> { IrOf(junction.Lower.Channel) },
+                            junction.Upper.Channel.SampleRate,
+                            junction.BandLowHz,
+                            junction.BandHighHz);
+                    if (loss is { } measured)
+                    {
+                        // The same dip-excess penalty the candidate scores
+                        // carry: a mean of averages alone would happily buy a
+                        // hundredth of a dB with a deep narrow cancellation
+                        // notch on the other side's junction.
+                        total += measured.LossDb +
+                            VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
+                            (measured.DipDb - measured.LossDb);
+                        count++;
+                    }
+                }
+
+                return count > 0 ? total / count : double.NegativeInfinity;
+            }
+
+            // Negative deltas may not push either channel below zero.
+            double minDelta = -Math.Min(
+                Math.Min(leftOverride.DelayMs, rightOverride.DelayMs),
+                PairComoveSearchRangeMs);
+            double baseline = Score(0);
+            double bestDelta = 0;
+            double bestScore = baseline;
+            for (double delta = minDelta; delta <= PairComoveSearchRangeMs + 1e-9;
+                delta += 0.1)
+            {
+                double score = Score(delta);
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    bestDelta = delta;
+                }
+            }
+            for (double delta = Math.Max(minDelta, bestDelta - 0.1);
+                delta <= Math.Min(PairComoveSearchRangeMs, bestDelta + 0.1) + 1e-9;
+                delta += 0.02)
+            {
+                double score = Score(delta);
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    bestDelta = delta;
+                }
+            }
+
+            if (bestDelta != 0 && bestScore > baseline + PairComoveMinimumGainDb)
+            {
+                bestDelta = Math.Round(bestDelta, 2);
+                alignment[link.Left] = leftOverride with
+                {
+                    DelayMs = Math.Clamp(
+                        Math.Round(leftOverride.DelayMs + bestDelta, 2), 0, MaxDelayMs)
+                };
+                alignment[link.Right] = rightOverride with
+                {
+                    DelayMs = Math.Clamp(
+                        Math.Round(rightOverride.DelayMs + bestDelta, 2), 0, MaxDelayMs)
+                };
+                log.AppendLine(
+                    $"Co-move {link.Left.Name}+{link.Right.Name}: " +
+                    $"{bestDelta:+0.00;-0.00} ms to both sides " +
+                    $"(mean dip-penalized junction loss {baseline:0.00} -> " +
+                    $"{bestScore:0.00} dB; scene untouched)");
+            }
+            else
+            {
+                log.AppendLine(
+                    $"Co-move {link.Left.Name}+{link.Right.Name}: kept " +
+                    $"(best gain {bestScore - baseline:0.00} dB below the " +
+                    $"{PairComoveMinimumGainDb:0.00} dB threshold)");
+            }
+        }
     }
 
     // A junction whose both sides are already final — the mono subwoofer

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -582,21 +582,52 @@ public static class AutoAlignmentEngine
         // toward the right — the dash-center convention for a left-seated
         // driver; a right-seated driver enters a negative offset.
         IReadOnlyList<AlignmentSnapshot> settled = reprocess(alignment);
-        double leftArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-            settled.First(item => item.Channel == plan.BridgeLeft).ImpulseResponse,
-            plan.BridgeLeft.SampleRate,
-            plan.BridgeBandLowHz,
-            plan.BridgeBandHighHz);
-        double rightArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-            settled.First(item => item.Channel == plan.BridgeRight).ImpulseResponse,
-            plan.BridgeRight.SampleRate,
-            plan.BridgeBandLowHz,
-            plan.BridgeBandHighHz);
+        TimeAlignmentAnalysisResult leftBridge =
+            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                settled.First(item => item.Channel == plan.BridgeLeft).ImpulseResponse,
+                plan.BridgeLeft.SampleRate,
+                plan.BridgeBandLowHz,
+                plan.BridgeBandHighHz);
+        TimeAlignmentAnalysisResult rightBridge =
+            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                settled.First(item => item.Channel == plan.BridgeRight).ImpulseResponse,
+                plan.BridgeRight.SampleRate,
+                plan.BridgeBandLowHz,
+                plan.BridgeBandHighHz);
+
+        // The bridge is the SINGLE link between the sides, so its arrivals are
+        // gated instead of trusted: a silent band reports zeros (IsValid off),
+        // and a near-noise arrival would time one whole side by garbage —
+        // either way the honest outcome is a refusal with the reason, not a
+        // plausible-looking wrong alignment.
+        if (!leftBridge.IsValid || !rightBridge.IsValid ||
+            leftBridge.SignalToNoiseDecibels < BridgeMinimumSnrDb ||
+            rightBridge.SignalToNoiseDecibels < BridgeMinimumSnrDb)
+        {
+            throw new InvalidOperationException(
+                "The stereo bridge could not be measured in " +
+                $"{plan.BridgeBandLowHz:0}-{plan.BridgeBandHighHz:0} Hz: " +
+                $"{plan.BridgeLeft.Name} " +
+                (leftBridge.IsValid
+                    ? $"SNR {leftBridge.SignalToNoiseDecibels:0.0} dB"
+                    : "has no energy in the band") +
+                $", {plan.BridgeRight.Name} " +
+                (rightBridge.IsValid
+                    ? $"SNR {rightBridge.SignalToNoiseDecibels:0.0} dB"
+                    : "has no energy in the band") +
+                $" (minimum {BridgeMinimumSnrDb:0} dB). " +
+                "Check the top pair's sources and crossover band.");
+        }
+
+        double leftArrival = leftBridge.FirstArrivalDelayMilliseconds;
+        double rightArrival = rightBridge.FirstArrivalDelayMilliseconds;
         double bridgeDelay = leftArrival - rightArrival - plan.SceneOffsetMs;
         log.AppendLine(
             $"Bridge {plan.BridgeLeft.Name} -> {plan.BridgeRight.Name}: " +
             $"band {plan.BridgeBandLowHz:0}-{plan.BridgeBandHighHz:0} Hz, " +
-            $"arrivals L {leftArrival:0.000} / R {rightArrival:0.000} ms, " +
+            $"arrivals L {leftArrival:0.000} / R {rightArrival:0.000} ms " +
+            $"(SNR {leftBridge.SignalToNoiseDecibels:0.0} / " +
+            $"{rightBridge.SignalToNoiseDecibels:0.0} dB), " +
             $"scene offset {plan.SceneOffsetMs:+0.000;-0.000} ms " +
             $"(positive: right leads) -> right delay {bridgeDelay:0.000} ms");
         if (bridgeDelay < 0)
@@ -611,11 +642,19 @@ public static class AutoAlignmentEngine
                 $"  advanced via a uniform +{shift:0.000} ms shift " +
                 "of every settled channel");
         }
-        // The bridge sets only the timing; the polarity of the right top stays
-        // with the channel's own switch (arrivals are polarity-blind, and a
-        // symmetric install wires both tweeters alike).
         alignment[plan.BridgeRight] = new AlignmentOverride(
             Math.Clamp(Math.Round(bridgeDelay, 2), 0, MaxDelayMs), false);
+
+        // The arrival is polarity-blind, so the right top's polarity is chosen
+        // HERE, after the delay is fixed: the left walk may well have inverted
+        // the left top (its own junction decides that), and every other right
+        // driver aligns to the right top afterwards — a mismatched top sign
+        // would flip the whole right side against the left and cancel
+        // center-panned content. With the delay pinned there is no lobe
+        // ambiguity left: the effective acoustic signs of the two settled tops
+        // are simply compared (sum-loss comparison of the two signs as the
+        // fallback when a sign is unreadable).
+        ChooseBridgePolarity(plan, reprocess, alignment, log);
 
         // Stage R: descent from the bridged top toward the low end (and up
         // from it, if the caller had to bridge a non-top pair) — the same walk
@@ -667,6 +706,75 @@ public static class AutoAlignmentEngine
                 $"Normalized: -{minimum:0.000} ms off every channel " +
                 "(minimum delay back to zero)");
         }
+    }
+
+    // The minimum record signal-to-noise (dB) either bridge arrival must carry
+    // before the bridge is trusted. Clean measurements run 40-70 dB; a figure
+    // below this is a mis-picked band or a broken capture, and the bridge is
+    // the one number that times a whole side.
+    private const double BridgeMinimumSnrDb = 12;
+
+    // Decides the right bridge channel's polarity once its delay is already in
+    // the alignment map. Primary evidence: the measured acoustic signs of the
+    // two settled top responses (EstimatePolarity on the processed IRs — the
+    // left one includes whatever inversion its own junction chose). Fallback
+    // when a sign is unreadable: the bridge-band sum loss of the two possible
+    // signs — with the delay fixed only two hypotheses exist, so the lobe
+    // ambiguity that bans loss-driven polarity searches does not apply.
+    private static void ChooseBridgePolarity(
+        StereoAlignmentPlan plan,
+        AlignmentReprocessor reprocess,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        StringBuilder log)
+    {
+        IReadOnlyList<AlignmentSnapshot> bridged = reprocess(alignment);
+        Complex[] leftTop = bridged
+            .First(item => item.Channel == plan.BridgeLeft).ImpulseResponse;
+        Complex[] rightTop = bridged
+            .First(item => item.Channel == plan.BridgeRight).ImpulseResponse;
+
+        PolarityEstimate leftSign = VirtualCrossoverAnalysis.EstimatePolarity(leftTop);
+        PolarityEstimate rightSign = VirtualCrossoverAnalysis.EstimatePolarity(rightTop);
+        bool invert;
+        string reason;
+        if (leftSign != PolarityEstimate.Unknown &&
+            rightSign != PolarityEstimate.Unknown)
+        {
+            invert = leftSign != rightSign;
+            reason = $"measured signs L {leftSign} / R {rightSign}";
+        }
+        else
+        {
+            var invertedRightTop = new Complex[rightTop.Length];
+            for (int i = 0; i < rightTop.Length; i++)
+            {
+                invertedRightTop[i] = -rightTop[i];
+            }
+
+            var leftOnly = new List<Complex[]> { leftTop };
+            (double LossDb, double DipDb)? normalLoss =
+                VirtualCrossoverAnalysis.MeasureSumLoss(
+                    rightTop, leftOnly, plan.BridgeRight.SampleRate,
+                    plan.BridgeBandLowHz, plan.BridgeBandHighHz);
+            (double LossDb, double DipDb)? invertedLoss =
+                VirtualCrossoverAnalysis.MeasureSumLoss(
+                    invertedRightTop, leftOnly, plan.BridgeRight.SampleRate,
+                    plan.BridgeBandLowHz, plan.BridgeBandHighHz);
+            invert = invertedLoss.HasValue && normalLoss.HasValue &&
+                invertedLoss.Value.LossDb > normalLoss.Value.LossDb;
+            reason = "sign unreadable, bridge-band loss " +
+                $"normal {normalLoss?.LossDb:0.00} / " +
+                $"inverted {invertedLoss?.LossDb:0.00} dB";
+        }
+
+        if (invert)
+        {
+            alignment[plan.BridgeRight] =
+                alignment[plan.BridgeRight] with { InvertPolarity = true };
+        }
+
+        log.AppendLine(
+            $"  bridge polarity: {(invert ? "inverted" : "normal")} ({reason})");
     }
 
     // A junction whose both sides are already final — the mono subwoofer

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -45,6 +45,29 @@ public sealed record AlignmentJunction(
     double BandHighHz);
 
 /// <summary>
+/// The inputs of a stereo alignment run (see
+/// <see cref="AutoAlignmentEngine.ComputeStereo"/>). Mono channels appear in
+/// BOTH by-band lists as the same <see cref="IAlignmentChannel"/> instance and
+/// are tuned once, by the left pass. The bridge is the highest-frequency pair
+/// with sources on both sides; its band is the top channels' own playing band.
+/// <see cref="SceneOffsetMs"/> is positive when the right side should LEAD
+/// (arrive earlier at the microphone) by that much — the "image toward the
+/// dash center" convention for a left-seated listener; negative for a
+/// right-seated one.
+/// </summary>
+public sealed record StereoAlignmentPlan(
+    IReadOnlyList<AlignmentSnapshot> LeftChannelsByBand,
+    IReadOnlyList<AlignmentJunction> LeftPairs,
+    IReadOnlyList<AlignmentSnapshot> RightChannelsByBand,
+    IReadOnlyList<AlignmentJunction> RightPairs,
+    IReadOnlyCollection<IAlignmentChannel> MonoChannels,
+    IAlignmentChannel BridgeLeft,
+    IAlignmentChannel BridgeRight,
+    double BridgeBandLowHz,
+    double BridgeBandHighHz,
+    double SceneOffsetMs);
+
+/// <summary>
 /// Re-runs the caller's channel processing with the given delay/polarity
 /// overrides applied (a channel absent from the map processes with zero
 /// delay and normal polarity) and returns fresh snapshots. Called from the
@@ -154,12 +177,52 @@ public static class AutoAlignmentEngine
         List<AlignmentSnapshot> byBand = channelsByBand.ToList();
         AppendCorrelationAlignmentDiagnostics(log, pairs);
 
-        // Stage 1: coarse offsets from band-limited first arrivals, refined by the
-        // GCC-PHAT peak where it is trustworthy. Arrivals of different drivers are
-        // only comparable inside a SHARED band — a woofer's envelope in its own low
-        // band rises milliseconds later than a tweeter's in its high band. So each
-        // adjacent pair is measured around its own crossover frequency, and the
-        // pairwise differences chain into one relative timeline that seeds stage 2.
+        Dictionary<IAlignmentChannel, double> timeline =
+            BuildArrivalTimeline(byBand, pairs, log);
+
+        // The relatively latest channel is the fixed reference; everyone else is
+        // delayed toward it, so the coarse deltas are non-negative.
+        double latest = timeline.Values.Max();
+        IAlignmentChannel reference =
+            timeline.First(pair => pair.Value == latest).Key;
+        log.AppendLine($"Reference: {reference.Name}");
+
+        // Stage 2: sequential pairwise fine alignment, walking outward from the
+        // reference along the band order. Each channel is phase-correlated
+        // against its already-settled neighbor only, inside their shared pair
+        // band, so the search window is sized by THAT junction — a mid channel
+        // must not have its low-junction window squeezed to the period of its
+        // high junction. An arrival error at a low junction then propagates
+        // through the chain and moves the whole upper group together, which a
+        // per-channel search against all fixed channels at once cannot do.
+        int referenceIndex = byBand.FindIndex(item => item.Channel == reference);
+        for (int i = referenceIndex - 1; i >= 0; i--)
+        {
+            AlignChannelAtJunction(
+                byBand[i].Channel, byBand[i + 1].Channel, pairs[i],
+                timeline, byBand, reprocess, alignment, log);
+        }
+        for (int i = referenceIndex + 1; i < byBand.Count; i++)
+        {
+            AlignChannelAtJunction(
+                byBand[i].Channel, byBand[i - 1].Channel, pairs[i - 1],
+                timeline, byBand, reprocess, alignment, log);
+        }
+    }
+
+    // Stage 1: coarse offsets from band-limited first arrivals, refined by the
+    // GCC-PHAT peak where it is trustworthy. Arrivals of different drivers are
+    // only comparable inside a SHARED band — a woofer's envelope in its own low
+    // band rises milliseconds later than a tweeter's in its high band. So each
+    // adjacent pair is measured around its own crossover frequency, and the
+    // pairwise differences chain into one relative timeline. Only the
+    // differences matter downstream, so the anchor value of the first channel
+    // is arbitrary (zero).
+    private static Dictionary<IAlignmentChannel, double> BuildArrivalTimeline(
+        IReadOnlyList<AlignmentSnapshot> byBand,
+        IReadOnlyList<AlignmentJunction> pairs,
+        StringBuilder log)
+    {
         var timeline = new Dictionary<IAlignmentChannel, double>
         {
             [byBand[0].Channel] = 0
@@ -227,33 +290,26 @@ public static class AutoAlignmentEngine
                 $"{(trustPhat ? "phat" : "arrival")}");
         }
 
-        // The relatively latest channel is the fixed reference; everyone else is
-        // delayed toward it, so the coarse deltas are non-negative.
-        double latest = timeline.Values.Max();
-        IAlignmentChannel reference =
-            timeline.First(pair => pair.Value == latest).Key;
-        log.AppendLine($"Reference: {reference.Name}");
+        return timeline;
+    }
 
-        // Stage 2: sequential pairwise fine alignment, walking outward from the
-        // reference along the band order. Each channel is phase-correlated
-        // against its already-settled neighbor only, inside their shared pair
-        // band, so the search window is sized by THAT junction — a mid channel
-        // must not have its low-junction window squeezed to the period of its
-        // high junction. An arrival error at a low junction then propagates
-        // through the chain and moves the whole upper group together, which a
-        // per-channel search against all fixed channels at once cannot do.
-        int referenceIndex = byBand.FindIndex(item => item.Channel == reference);
-        var searchOrder =
-            new List<(AlignmentSnapshot Target, AlignmentSnapshot Neighbor, AlignmentJunction Pair)>();
-        for (int i = referenceIndex - 1; i >= 0; i--)
-        {
-            searchOrder.Add((byBand[i], byBand[i + 1], pairs[i]));
-        }
-        for (int i = referenceIndex + 1; i < byBand.Count; i++)
-        {
-            searchOrder.Add((byBand[i], byBand[i - 1], pairs[i - 1]));
-        }
-
+    // Fine-aligns one channel against its settled neighbor at their shared
+    // junction and writes the result into the alignment map: the stage-2 body
+    // shared by the mono walk and the stereo right-side descent. A physically
+    // impossible negative delay is converted into a uniform shift of every
+    // OTHER channel in <paramref name="shiftScope"/> (a uniform shift preserves
+    // the alignment) — in a stereo run the scope must span BOTH sides, or the
+    // shift would silently break the inter-side scene offset.
+    private static void AlignChannelAtJunction(
+        IAlignmentChannel channel,
+        IAlignmentChannel neighborChannel,
+        AlignmentJunction pair,
+        IReadOnlyDictionary<IAlignmentChannel, double> timeline,
+        IReadOnlyList<AlignmentSnapshot> shiftScope,
+        AlignmentReprocessor reprocess,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        StringBuilder log)
+    {
         // One junction search: candidates of the prior-penalized loss score in
         // a window around the coarse delta (the PHAT-seeded timeline, arrival
         // envelope where PHAT was untrusted). The window is half the period of
@@ -262,11 +318,7 @@ public static class AutoAlignmentEngine
         // same-polarity lobes. The base doubles as a soft prior: a quadratic dB
         // penalty that deters far lobes.
         (IReadOnlyList<AlignmentCandidate> Candidates, double BaseDelta, double HalfPeriodMs)
-            SearchJunction(
-                IAlignmentChannel channel,
-                IAlignmentChannel neighborChannel,
-                AlignmentJunction junction,
-                double? windowOverrideMs = null)
+            SearchJunction(double? windowOverrideMs = null)
         {
             // Reprocess so the settled neighbors participate with their new
             // delays and polarities. The searched channel is dropped from the
@@ -287,7 +339,7 @@ public static class AutoAlignmentEngine
                 current.First(item => item.Channel == neighborChannel).ImpulseResponse
             };
 
-            double halfPeriodMs = 500.0 / junction.CrossoverHz;
+            double halfPeriodMs = 500.0 / pair.CrossoverHz;
             double rangeMs = windowOverrideMs ?? Math.Clamp(
                 halfPeriodMs, MinFineAlignmentRangeMs, MaxFineAlignmentRangeMs);
             double baseDelta = alignment.GetValueOrDefault(neighborChannel).DelayMs
@@ -297,8 +349,8 @@ public static class AutoAlignmentEngine
                     variableIr,
                     neighborIrs,
                     channel.SampleRate,
-                    junction.BandLowHz,
-                    junction.BandHighHz,
+                    pair.BandLowHz,
+                    pair.BandHighHz,
                     baseDelta - rangeMs,
                     baseDelta + rangeMs,
                     priorDelayMs: baseDelta,
@@ -306,15 +358,12 @@ public static class AutoAlignmentEngine
             return (candidates, baseDelta, halfPeriodMs);
         }
 
-        foreach ((AlignmentSnapshot target, AlignmentSnapshot neighbor, AlignmentJunction pair)
-            in searchOrder)
         {
-            IAlignmentChannel channel = target.Channel;
             (IReadOnlyList<AlignmentCandidate> candidates, double baseDelta,
-                double halfPeriodMs) = SearchJunction(channel, neighbor.Channel, pair);
+                double halfPeriodMs) = SearchJunction();
             log.AppendLine(
                 $"Channel {channel.Name}: " +
-                $"vs {neighbor.Channel.Name} " +
+                $"vs {neighborChannel.Name} " +
                 $"in {pair.BandLowHz:0}-{pair.BandHighHz:0} Hz, " +
                 $"base {baseDelta:0.000} ms, candidates " +
                 string.Join("; ", candidates.Select(item =>
@@ -340,9 +389,7 @@ public static class AutoAlignmentEngine
             // wider window so lobes beyond the working range appear in the log.
             // Purely informational — the chosen result above is untouched.
             (IReadOnlyList<AlignmentCandidate> wide, double wideBase, _) =
-                SearchJunction(
-                    channel, neighbor.Channel, pair,
-                    windowOverrideMs: DiagnosticFineRangeMs);
+                SearchJunction(windowOverrideMs: DiagnosticFineRangeMs);
             log.AppendLine(
                 $"  [diag] wide +-{DiagnosticFineRangeMs:0.0} ms " +
                 $"(base {wideBase:0.000} ms): " +
@@ -366,8 +413,8 @@ public static class AutoAlignmentEngine
             if (retryRangeMs > fineRangeMs &&
                 Math.Abs(chosen.DelayMs - baseDelta) >= fineRangeMs - 0.02)
             {
-                (IReadOnlyList<AlignmentCandidate> retried, _, _) = SearchJunction(
-                    channel, neighbor.Channel, pair, windowOverrideMs: retryRangeMs);
+                (IReadOnlyList<AlignmentCandidate> retried, _, _) =
+                    SearchJunction(windowOverrideMs: retryRangeMs);
                 if (retried.Count > 0)
                 {
                     // Through the same selection rules as the primary pick:
@@ -409,31 +456,7 @@ public static class AutoAlignmentEngine
             {
                 // A physically impossible negative delay: push every channel by
                 // the deficit instead — a uniform shift preserves the alignment.
-                double shift = -newDelay;
-                foreach (AlignmentSnapshot item in byBand)
-                {
-                    if (item.Channel != channel)
-                    {
-                        AlignmentOverride currentAlignment =
-                            alignment.GetValueOrDefault(item.Channel);
-                        double shifted = currentAlignment.DelayMs + shift;
-                        if (shifted > MaxDelayMs)
-                        {
-                            // The shift is only alignment-preserving while it is
-                            // uniform; a channel pinned at the ceiling breaks the
-                            // relative delays silently, so say so in the log.
-                            log.AppendLine(
-                                $"  WARNING: uniform shift +{shift:0.000} ms pushes " +
-                                $"{item.Channel.Name} past the {MaxDelayMs:0} ms " +
-                                $"delay limit ({shifted:0.000} ms, clamped) — " +
-                                "the relative alignment is no longer preserved.");
-                        }
-                        alignment[item.Channel] = currentAlignment with
-                        {
-                            DelayMs = Math.Min(MaxDelayMs, shifted)
-                        };
-                    }
-                }
+                ShiftAllExcept(shiftScope, channel, -newDelay, alignment, log);
                 newDelay = 0;
             }
 
@@ -441,6 +464,250 @@ public static class AutoAlignmentEngine
                 Math.Clamp(Math.Round(newDelay, 2), 0, MaxDelayMs),
                 chosen.InvertPolarity);
         }
+    }
+
+    // A uniform delay shift of every channel in the scope but one: the standard
+    // way to "advance" a channel that would otherwise need a negative delay.
+    // Uniformity is what preserves the alignment, so the scope must cover every
+    // channel whose relative timing has already been settled.
+    private static void ShiftAllExcept(
+        IReadOnlyList<AlignmentSnapshot> scope,
+        IAlignmentChannel except,
+        double shiftMs,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        StringBuilder log)
+    {
+        foreach (AlignmentSnapshot item in scope)
+        {
+            if (item.Channel != except)
+            {
+                AlignmentOverride currentAlignment =
+                    alignment.GetValueOrDefault(item.Channel);
+                double shifted = currentAlignment.DelayMs + shiftMs;
+                if (shifted > MaxDelayMs)
+                {
+                    // The shift is only alignment-preserving while it is
+                    // uniform; a channel pinned at the ceiling breaks the
+                    // relative delays silently, so say so in the log.
+                    log.AppendLine(
+                        $"  WARNING: uniform shift +{shiftMs:0.000} ms pushes " +
+                        $"{item.Channel.Name} past the {MaxDelayMs:0} ms " +
+                        $"delay limit ({shifted:0.000} ms, clamped) — " +
+                        "the relative alignment is no longer preserved.");
+                }
+                alignment[item.Channel] = currentAlignment with
+                {
+                    DelayMs = Math.Min(MaxDelayMs, shifted)
+                };
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stereo alignment cascade over two sides that never meet at a crossover:
+    /// (1) the left side aligns exactly like <see cref="Compute"/> (any mono
+    /// channels — typically the shared subwoofer — are part of that walk and
+    /// are FINAL afterwards); (2) the bridge fits the right top channel to the
+    /// settled left top by band-limited envelope arrivals in the top band,
+    /// honoring <see cref="StereoAlignmentPlan.SceneOffsetMs"/>; (3) the right
+    /// side descends junction by junction from the bridged top, skipping mono
+    /// channels (their right-side junction is measured and logged, not tuned);
+    /// (4) the union of both sides is shifted so the minimum delay is exactly
+    /// zero. Every uniform shift spans BOTH sides, preserving the scene offset
+    /// the bridge established.
+    /// </summary>
+    public static void ComputeStereo(
+        StereoAlignmentPlan plan,
+        AlignmentReprocessor reprocess,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        StringBuilder log)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(reprocess);
+        ArgumentNullException.ThrowIfNull(alignment);
+        ArgumentNullException.ThrowIfNull(log);
+        List<AlignmentSnapshot> rightByBand = plan.RightChannelsByBand.ToList();
+        if (rightByBand.Count == 0 ||
+            plan.RightPairs.Count != rightByBand.Count - 1)
+        {
+            throw new ArgumentException(
+                "One junction is required between each adjacent right channel pair.",
+                nameof(plan));
+        }
+        int bridgeIndex = rightByBand.FindIndex(
+            item => item.Channel == plan.BridgeRight);
+        if (bridgeIndex < 0 ||
+            plan.LeftChannelsByBand.All(item => item.Channel != plan.BridgeLeft))
+        {
+            throw new ArgumentException(
+                "The bridge channels must be members of their side's channel list.",
+                nameof(plan));
+        }
+        if (plan.MonoChannels.Contains(plan.BridgeRight))
+        {
+            throw new ArgumentException(
+                "A mono channel cannot be the stereo bridge.",
+                nameof(plan));
+        }
+        if (plan.MonoChannels.Any(mono =>
+            plan.LeftChannelsByBand.All(item => item.Channel != mono)))
+        {
+            throw new ArgumentException(
+                "Every mono channel must be part of the left walk that tunes it.",
+                nameof(plan));
+        }
+
+        // Stage L: the left side, exactly like a mono run.
+        Compute(plan.LeftChannelsByBand, plan.LeftPairs, reprocess, alignment, log);
+
+        // The union of both sides: the scope of every uniform shift from here
+        // on. Shifting one side alone would silently break the inter-side
+        // offset the bridge establishes.
+        var allChannels = new List<AlignmentSnapshot>(plan.LeftChannelsByBand);
+        foreach (AlignmentSnapshot item in rightByBand)
+        {
+            if (allChannels.All(existing => existing.Channel != item.Channel))
+            {
+                allChannels.Add(item);
+            }
+        }
+
+        // Stage bridge: envelope arrivals in the top band, NOT a cross-
+        // correlation — same-band L/R drivers sit in different spots with
+        // different room paths, and their cross-correlation at high
+        // frequencies is lobe-ambiguous noise (probed on real car
+        // measurements: r ~0.3, dominance ~0.01), while the envelope arrival
+        // is the quantity the stereo image follows up there. A positive scene
+        // offset makes the right side LEAD (arrive earlier), pulling the image
+        // toward the right — the dash-center convention for a left-seated
+        // driver; a right-seated driver enters a negative offset.
+        IReadOnlyList<AlignmentSnapshot> settled = reprocess(alignment);
+        double leftArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            settled.First(item => item.Channel == plan.BridgeLeft).ImpulseResponse,
+            plan.BridgeLeft.SampleRate,
+            plan.BridgeBandLowHz,
+            plan.BridgeBandHighHz);
+        double rightArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            settled.First(item => item.Channel == plan.BridgeRight).ImpulseResponse,
+            plan.BridgeRight.SampleRate,
+            plan.BridgeBandLowHz,
+            plan.BridgeBandHighHz);
+        double bridgeDelay = leftArrival - rightArrival - plan.SceneOffsetMs;
+        log.AppendLine(
+            $"Bridge {plan.BridgeLeft.Name} -> {plan.BridgeRight.Name}: " +
+            $"band {plan.BridgeBandLowHz:0}-{plan.BridgeBandHighHz:0} Hz, " +
+            $"arrivals L {leftArrival:0.000} / R {rightArrival:0.000} ms, " +
+            $"scene offset {plan.SceneOffsetMs:+0.000;-0.000} ms " +
+            $"(positive: right leads) -> right delay {bridgeDelay:0.000} ms");
+        if (bridgeDelay < 0)
+        {
+            // The right top must be ADVANCED — typical when the right side is
+            // the far one. Impossible directly, so everything settled so far
+            // is delayed by the deficit and the right top starts at zero.
+            double shift = -bridgeDelay;
+            ShiftAllExcept(allChannels, plan.BridgeRight, shift, alignment, log);
+            bridgeDelay = 0;
+            log.AppendLine(
+                $"  advanced via a uniform +{shift:0.000} ms shift " +
+                "of every settled channel");
+        }
+        // The bridge sets only the timing; the polarity of the right top stays
+        // with the channel's own switch (arrivals are polarity-blind, and a
+        // symmetric install wires both tweeters alike).
+        alignment[plan.BridgeRight] = new AlignmentOverride(
+            Math.Clamp(Math.Round(bridgeDelay, 2), 0, MaxDelayMs), false);
+
+        // Stage R: descent from the bridged top toward the low end (and up
+        // from it, if the caller had to bridge a non-top pair) — the same walk
+        // as stage 2, referenced to the bridge. Mono channels are final from
+        // the left pass: never searched again, their right-side junction is
+        // only measured.
+        Dictionary<IAlignmentChannel, double> rightTimeline =
+            BuildArrivalTimeline(rightByBand, plan.RightPairs, log);
+        void AlignRight(int index, int neighborIndex, AlignmentJunction pair)
+        {
+            IAlignmentChannel channel = rightByBand[index].Channel;
+            IAlignmentChannel neighbor = rightByBand[neighborIndex].Channel;
+            if (plan.MonoChannels.Contains(channel))
+            {
+                MeasureFixedJunction(pair, channel, neighbor, reprocess, alignment, log);
+                return;
+            }
+
+            AlignChannelAtJunction(
+                channel, neighbor, pair,
+                rightTimeline, allChannels, reprocess, alignment, log);
+        }
+        for (int i = bridgeIndex - 1; i >= 0; i--)
+        {
+            AlignRight(i, i + 1, plan.RightPairs[i]);
+        }
+        for (int i = bridgeIndex + 1; i < rightByBand.Count; i++)
+        {
+            AlignRight(i, i - 1, plan.RightPairs[i - 1]);
+        }
+
+        // Final normalization: the smallest total latency that preserves every
+        // relation — the minimum proposed delay lands exactly at zero.
+        // (Channels without an entry sit at zero, so this only acts when a
+        // uniform shift raised the whole field.)
+        double minimum = allChannels.Min(
+            item => alignment.GetValueOrDefault(item.Channel).DelayMs);
+        if (minimum > 0.005)
+        {
+            foreach (AlignmentSnapshot item in allChannels)
+            {
+                AlignmentOverride current = alignment.GetValueOrDefault(item.Channel);
+                alignment[item.Channel] = current with
+                {
+                    DelayMs = Math.Round(current.DelayMs - minimum, 2)
+                };
+            }
+            log.AppendLine(
+                $"Normalized: -{minimum:0.000} ms off every channel " +
+                "(minimum delay back to zero)");
+        }
+    }
+
+    // A junction whose both sides are already final — the mono subwoofer
+    // pinned by the left pass against a settled right channel. Nothing is
+    // searched; the resulting loss belongs in the log because it is the price
+    // of sharing one mono channel between two differently-timed sides.
+    private static void MeasureFixedJunction(
+        AlignmentJunction pair,
+        IAlignmentChannel monoChannel,
+        IAlignmentChannel otherChannel,
+        AlignmentReprocessor reprocess,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        StringBuilder log)
+    {
+        IReadOnlyList<AlignmentSnapshot> current = reprocess(alignment);
+        Complex[] mono = current
+            .First(item => item.Channel == monoChannel).ImpulseResponse;
+        Complex[] other = current
+            .First(item => item.Channel == otherChannel).ImpulseResponse;
+        (double LossDb, double DipDb)? loss = VirtualCrossoverAnalysis.MeasureSumLoss(
+            mono,
+            new List<Complex[]> { other },
+            monoChannel.SampleRate,
+            pair.BandLowHz,
+            pair.BandHighHz);
+        if (loss is not { } measured)
+        {
+            log.AppendLine(
+                $"Junction {monoChannel.Name}/{otherChannel.Name} (mono, fixed): " +
+                "no bins in the pair band");
+            return;
+        }
+
+        log.AppendLine(
+            $"Junction {monoChannel.Name}/{otherChannel.Name} " +
+            $"(mono, timed by the left side): avg {measured.LossDb:0.00} dB, " +
+            $"dip {measured.DipDb:0.0} dB " +
+            $"in {pair.BandLowHz:0}-{pair.BandHighHz:0} Hz" +
+            (measured.LossDb < -1.0 || measured.DipDb < -6.0
+                ? " — WARNING: consider a compromise mono delay by hand"
+                : string.Empty));
     }
 
     private static void AppendCorrelationAlignmentDiagnostics(

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -665,8 +665,8 @@ public static class AutoAlignmentEngine
         // either way the honest outcome is a refusal with the reason, not a
         // plausible-looking wrong alignment.
         if (!leftBridge.IsValid || !rightBridge.IsValid ||
-            leftBridge.SignalToNoiseDecibels < BridgeMinimumSnrDb ||
-            rightBridge.SignalToNoiseDecibels < BridgeMinimumSnrDb)
+            leftBridge.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
+            rightBridge.SignalToNoiseDecibels < MinimumArrivalSnrDb)
         {
             throw new InvalidOperationException(
                 "The stereo bridge could not be measured in " +
@@ -679,7 +679,7 @@ public static class AutoAlignmentEngine
                 (rightBridge.IsValid
                     ? $"SNR {rightBridge.SignalToNoiseDecibels:0.0} dB"
                     : "has no energy in the band") +
-                $" (minimum {BridgeMinimumSnrDb:0} dB). " +
+                $" (minimum {MinimumArrivalSnrDb:0} dB). " +
                 "Check the top pair's sources and crossover band.");
         }
 
@@ -730,20 +730,20 @@ public static class AutoAlignmentEngine
 
         // The delay that would land this right channel's arrival exactly the
         // scene offset ahead of its settled left counterpart's, measured by
-        // envelope arrivals in the pair's shared band. Used as the search
-        // prior: a gentle, polarity-blind pull toward the other side's timing
-        // that breaks near-ties between lobes the junction sum cannot
-        // distinguish. Unmeasurable (silent band, low SNR) falls back to null
-        // and the search keeps its own-side anchor.
-        double? CrossSideTargetMs(IAlignmentChannel rightChannel)
+        // envelope arrivals in the given band. Used as the search prior: a
+        // gentle, polarity-blind pull toward the other side's timing that
+        // breaks near-ties between lobes the junction sum cannot distinguish
+        // — and as the pin of a scene lock, which measures the LOCALIZATION
+        // sub-band of the pair's shared band (the part the scene actually
+        // follows) rather than the full intersection. Unmeasurable (silent
+        // band, low SNR) falls back to null and the search keeps its own-side
+        // anchor.
+        double? CrossSideTargetMs(
+            IAlignmentChannel rightChannel,
+            StereoPairLink link,
+            double bandLowHz,
+            double bandHighHz)
         {
-            StereoPairLink? link = plan.PairLinks?.FirstOrDefault(
-                item => item.Right == rightChannel);
-            if (link == null)
-            {
-                return null;
-            }
-
             var searchAlignment =
                 new Dictionary<IAlignmentChannel, AlignmentOverride>(alignment);
             searchAlignment.Remove(rightChannel);
@@ -751,14 +751,14 @@ public static class AutoAlignmentEngine
             TimeAlignmentAnalysisResult leftArrival =
                 VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
                     current.First(item => item.Channel == link.Left).ImpulseResponse,
-                    link.Left.SampleRate, link.BandLowHz, link.BandHighHz);
+                    link.Left.SampleRate, bandLowHz, bandHighHz);
             TimeAlignmentAnalysisResult rightRaw =
                 VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
                     current.First(item => item.Channel == rightChannel).ImpulseResponse,
-                    rightChannel.SampleRate, link.BandLowHz, link.BandHighHz);
+                    rightChannel.SampleRate, bandLowHz, bandHighHz);
             if (!leftArrival.IsValid || !rightRaw.IsValid ||
-                leftArrival.SignalToNoiseDecibels < BridgeMinimumSnrDb ||
-                rightRaw.SignalToNoiseDecibels < BridgeMinimumSnrDb)
+                leftArrival.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
+                rightRaw.SignalToNoiseDecibels < MinimumArrivalSnrDb)
             {
                 return null;
             }
@@ -770,7 +770,7 @@ public static class AutoAlignmentEngine
                 $"  cross-side prior {rightChannel.Name}: target {target:0.000} ms " +
                 $"(L arrival {leftArrival.FirstArrivalDelayMilliseconds:0.000}, " +
                 $"raw R {rightRaw.FirstArrivalDelayMilliseconds:0.000} ms " +
-                $"in {link.BandLowHz:0}-{link.BandHighHz:0} Hz)");
+                $"in {bandLowHz:0}-{bandHighHz:0} Hz)");
             return target;
         }
 
@@ -801,17 +801,26 @@ public static class AutoAlignmentEngine
             }
 
             // The scene mandate: pairs reaching the localization region are
-            // pinned to the cross-side target; pure low-frequency pairs keep
-            // the free joint-junction search (no localization there, soft
-            // envelopes, summation is what remains audible).
-            double? crossTarget = CrossSideTargetMs(channel);
+            // pinned to the cross-side target, which is then measured in the
+            // localization sub-band alone — the low end of a wide shared band
+            // (soft envelopes, no localization) must not smear the pin. Pure
+            // low-frequency pairs keep the free joint-junction search with
+            // the full-band target as a gentle prior only.
             StereoPairLink? channelLink = plan.PairLinks?.FirstOrDefault(
                 item => item.Right == channel);
-            double? sceneLock = crossTarget != null &&
-                channelLink is { } lockLink &&
-                lockLink.BandHighHz >= SceneLockMinimumBandHighHz
-                    ? SceneLockToleranceMs
-                    : null;
+            bool lockable = channelLink != null && IsSceneLockable(channelLink);
+            double? crossTarget = channelLink == null
+                ? null
+                : CrossSideTargetMs(
+                    channel,
+                    channelLink,
+                    lockable
+                        ? Math.Max(channelLink.BandLowHz, SceneLockLocalizationLowHz)
+                        : channelLink.BandLowHz,
+                    channelLink.BandHighHz);
+            double? sceneLock = lockable && crossTarget != null
+                ? SceneLockToleranceMs
+                : null;
 
             AlignChannelAtJunction(
                 channel, neighbor, pair,
@@ -855,11 +864,15 @@ public static class AutoAlignmentEngine
         }
     }
 
-    // The minimum record signal-to-noise (dB) either bridge arrival must carry
-    // before the bridge is trusted. Clean measurements run 40-70 dB; a figure
-    // below this is a mis-picked band or a broken capture, and the bridge is
-    // the one number that times a whole side.
-    private const double BridgeMinimumSnrDb = 12;
+    /// <summary>
+    /// The minimum record signal-to-noise (dB) a band-limited arrival must
+    /// carry before an inter-side decision trusts it: the bridge arrivals,
+    /// the cross-side descent targets, and the panel's final Δ L−R read-out
+    /// all gate on this. Clean measurements run 40-70 dB; a figure below this
+    /// is a mis-picked band or a broken capture, and the bridge is the one
+    /// number that times a whole side.
+    /// </summary>
+    public const double MinimumArrivalSnrDb = 12;
 
     // The scene mandate for the right descent: a channel whose pair band
     // reaches into the localization region is PINNED to the cross-side target
@@ -870,7 +883,22 @@ public static class AutoAlignmentEngine
     // the ear does not localize there, low-band envelope arrivals are soft,
     // and the summation is what remains audible.
     private const double SceneLockToleranceMs = 0.05;
-    private const double SceneLockMinimumBandHighHz = 300;
+
+    // The lower edge of the localization region. Only the part of a pair's
+    // shared band ABOVE this edge carries scene information, so the lock's
+    // cross-side target is measured in that sub-band — and a pair whose band
+    // merely pokes past the edge (e.g. 80-310 Hz) has too little localizable
+    // content to pin: the lock requires at least a third of an octave above
+    // the edge, the same admission rule the arrival analysis itself applies.
+    private const double SceneLockLocalizationLowHz = 300;
+
+    // Whether a linked pair reaches far enough into the localization region
+    // for the scene to outrank its junction sums: locked in the descent,
+    // co-moved by the re-balance pass.
+    private static bool IsSceneLockable(StereoPairLink link) =>
+        link.BandHighHz >=
+        Math.Max(link.BandLowHz, SceneLockLocalizationLowHz) *
+        VirtualCrossoverAnalysis.MinimumArrivalBandRatio;
 
     // The scene-preserving re-balance pass: both sides of a pair may move by
     // the SAME delta (which leaves the pair's L-R timing untouched) to trade
@@ -945,11 +973,14 @@ public static class AutoAlignmentEngine
     // Moves both sides of one linked pair by the same delta — the pair's L-R
     // timing (the scene) is invariant under a co-move — searching for the
     // delta that minimizes the MEAN loss of every junction adjacent to the
-    // pair on both sides. The left side may get slightly worse: by the scene
+    // pair on either side. The left side may get slightly worse: by the scene
     // mandate the pinned right channel could not chase its own junction
     // optimum, and this is the only lever that can recover junction quality
     // without touching the image. Top pair first, so lower pairs re-balance
-    // against the already-settled uppers.
+    // against the already-settled uppers. The scan is analytic: ONE reprocess
+    // fixes the pair's current responses, each junction gets its gated
+    // spectra built once, and every probed delta is an e^{-jωΔ} rotation of
+    // the moving channel — the probe loop runs no DSP chains at all.
     private static void RebalancePairsKeepingScene(
         StereoAlignmentPlan plan,
         AlignmentReprocessor reprocess,
@@ -962,7 +993,7 @@ public static class AutoAlignmentEngine
         }
 
         foreach (StereoPairLink link in plan.PairLinks
-            .Where(item => item.BandHighHz >= SceneLockMinimumBandHighHz)
+            .Where(IsSceneLockable)
             .OrderByDescending(item => item.BandHighHz))
         {
             AlignmentOverride leftOverride = alignment.GetValueOrDefault(link.Left);
@@ -981,59 +1012,77 @@ public static class AutoAlignmentEngine
                 continue;
             }
 
-            double Score(double deltaMs)
+            IReadOnlyList<AlignmentSnapshot> current = reprocess(alignment);
+            Complex[] IrOf(IAlignmentChannel channel) =>
+                current.First(item => item.Channel == channel).ImpulseResponse;
+
+            // One evaluator per junction: the pair member is the rotated
+            // (moving) channel, its junction neighbor stays fixed. A junction
+            // between the pair and its neighbor never has both ends moving —
+            // the pair's two channels sit on different sides.
+            var evaluators = new List<VirtualCrossoverAnalysis.SumLossEvaluator>();
+            foreach (AlignmentJunction junction in adjacent)
             {
-                var trial = new Dictionary<IAlignmentChannel, AlignmentOverride>(alignment)
+                bool lowerMoves = junction.Lower.Channel == link.Left ||
+                    junction.Lower.Channel == link.Right;
+                IAlignmentChannel mover = lowerMoves
+                    ? junction.Lower.Channel
+                    : junction.Upper.Channel;
+                IAlignmentChannel neighbor = lowerMoves
+                    ? junction.Upper.Channel
+                    : junction.Lower.Channel;
+                VirtualCrossoverAnalysis.SumLossEvaluator? evaluator =
+                    VirtualCrossoverAnalysis.SumLossEvaluator.Create(
+                        IrOf(mover),
+                        new List<Complex[]> { IrOf(neighbor) },
+                        mover.SampleRate,
+                        junction.BandLowHz,
+                        junction.BandHighHz);
+                if (evaluator != null)
                 {
-                    [link.Left] = leftOverride with
-                    {
-                        DelayMs = leftOverride.DelayMs + deltaMs
-                    },
-                    [link.Right] = rightOverride with
-                    {
-                        DelayMs = rightOverride.DelayMs + deltaMs
-                    }
-                };
-                IReadOnlyList<AlignmentSnapshot> current = reprocess(trial);
-                Complex[] IrOf(IAlignmentChannel channel) =>
-                    current.First(item => item.Channel == channel).ImpulseResponse;
-
-                double total = 0;
-                int count = 0;
-                foreach (AlignmentJunction junction in adjacent)
-                {
-                    (double LossDb, double DipDb)? loss =
-                        VirtualCrossoverAnalysis.MeasureSumLoss(
-                            IrOf(junction.Upper.Channel),
-                            new List<Complex[]> { IrOf(junction.Lower.Channel) },
-                            junction.Upper.Channel.SampleRate,
-                            junction.BandLowHz,
-                            junction.BandHighHz);
-                    if (loss is { } measured)
-                    {
-                        // The same dip-excess penalty the candidate scores
-                        // carry: a mean of averages alone would happily buy a
-                        // hundredth of a dB with a deep narrow cancellation
-                        // notch on the other side's junction.
-                        total += measured.LossDb +
-                            VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
-                            (measured.DipDb - measured.LossDb);
-                        count++;
-                    }
+                    evaluators.Add(evaluator);
                 }
-
-                return count > 0 ? total / count : double.NegativeInfinity;
+            }
+            if (evaluators.Count == 0)
+            {
+                continue;
             }
 
-            // Negative deltas may not push either channel below zero.
+            double Score(double deltaMs)
+            {
+                double total = 0;
+                foreach (VirtualCrossoverAnalysis.SumLossEvaluator evaluator
+                    in evaluators)
+                {
+                    (double lossDb, double dipDb) = evaluator.Evaluate(deltaMs);
+                    // The same dip-excess penalty the candidate scores carry:
+                    // a mean of averages alone would happily buy a hundredth
+                    // of a dB with a deep narrow cancellation notch on the
+                    // other side's junction.
+                    total += lossDb +
+                        VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
+                        (dipDb - lossDb);
+                }
+
+                return total / evaluators.Count;
+            }
+
+            // Both bounds are fixed BEFORE the search so the winning delta
+            // applies verbatim to both sides: negative deltas may not push
+            // either channel below zero, positive ones may not push either
+            // past the delay ceiling. Clamping after the fact would move the
+            // two sides unequally and silently bend the very scene this pass
+            // exists to preserve.
             double minDelta = -Math.Min(
                 Math.Min(leftOverride.DelayMs, rightOverride.DelayMs),
                 PairComoveSearchRangeMs);
+            double maxDelta = Math.Min(
+                PairComoveSearchRangeMs,
+                MaxDelayMs - Math.Max(leftOverride.DelayMs, rightOverride.DelayMs));
             double baseline = Score(0);
             double bestDelta = 0;
             double bestScore = baseline;
-            for (double delta = minDelta; delta <= PairComoveSearchRangeMs + 1e-9;
-                delta += 0.1)
+            for (double delta = minDelta; delta <= maxDelta + 1e-9; delta += 0.1)
             {
                 double score = Score(delta);
                 if (score > bestScore)
@@ -1043,7 +1092,7 @@ public static class AutoAlignmentEngine
                 }
             }
             for (double delta = Math.Max(minDelta, bestDelta - 0.1);
-                delta <= Math.Min(PairComoveSearchRangeMs, bestDelta + 0.1) + 1e-9;
+                delta <= Math.Min(maxDelta, bestDelta + 0.1) + 1e-9;
                 delta += 0.02)
             {
                 double score = Score(delta);
@@ -1056,16 +1105,18 @@ public static class AutoAlignmentEngine
 
             if (bestDelta != 0 && bestScore > baseline + PairComoveMinimumGainDb)
             {
-                bestDelta = Math.Round(bestDelta, 2);
+                // Rounded toward the window so the rounding itself cannot
+                // step past a bound the search respected.
+                bestDelta = Math.Clamp(Math.Round(bestDelta, 2),
+                    Math.Ceiling(minDelta * 100) / 100,
+                    Math.Floor(maxDelta * 100) / 100);
                 alignment[link.Left] = leftOverride with
                 {
-                    DelayMs = Math.Clamp(
-                        Math.Round(leftOverride.DelayMs + bestDelta, 2), 0, MaxDelayMs)
+                    DelayMs = Math.Round(leftOverride.DelayMs + bestDelta, 2)
                 };
                 alignment[link.Right] = rightOverride with
                 {
-                    DelayMs = Math.Clamp(
-                        Math.Round(rightOverride.DelayMs + bestDelta, 2), 0, MaxDelayMs)
+                    DelayMs = Math.Round(rightOverride.DelayMs + bestDelta, 2)
                 };
                 log.AppendLine(
                     $"Co-move {link.Left.Name}+{link.Right.Name}: " +

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -65,7 +65,23 @@ public sealed record StereoAlignmentPlan(
     IAlignmentChannel BridgeRight,
     double BridgeBandLowHz,
     double BridgeBandHighHz,
-    double SceneOffsetMs);
+    double SceneOffsetMs,
+    IReadOnlyList<StereoPairLink>? PairLinks = null);
+
+/// <summary>
+/// One L/R driver pair below the bridge, with the band both sides actually
+/// share (the intersection of their playing bands). The right descent uses it
+/// to aim its gentle prior at the delay that would land the right driver's
+/// arrival exactly the scene offset ahead of the left one's — the "Δ" the
+/// metric panel verifies afterwards — so a lobe that is a whole period off
+/// the other side pays the prior penalty even when its own-side junction sum
+/// looks perfect.
+/// </summary>
+public sealed record StereoPairLink(
+    IAlignmentChannel Left,
+    IAlignmentChannel Right,
+    double BandLowHz,
+    double BandHighHz);
 
 /// <summary>
 /// Re-runs the caller's channel processing with the given delay/polarity
@@ -293,13 +309,20 @@ public static class AutoAlignmentEngine
         return timeline;
     }
 
-    // Fine-aligns one channel against its settled neighbor at their shared
-    // junction and writes the result into the alignment map: the stage-2 body
-    // shared by the mono walk and the stereo right-side descent. A physically
-    // impossible negative delay is converted into a uniform shift of every
-    // OTHER channel in <paramref name="shiftScope"/> (a uniform shift preserves
-    // the alignment) — in a stereo run the scope must span BOTH sides, or the
-    // shift would silently break the inter-side scene offset.
+    // Fine-aligns one channel against its settled neighbor(s) and writes the
+    // result into the alignment map: the stage-2 body shared by the mono walk
+    // and the stereo right-side descent. With a SECONDARY settled neighbor
+    // (the shared mono subwoofer below a descent channel) the search optimizes
+    // BOTH junctions at once: both neighbors join the fixed set, the band
+    // spans both junctions, and the window covers both junctions' coarse
+    // bases — otherwise the channel buys a perfect upper junction while
+    // parking a whole period off its lower one. An external prior (the
+    // cross-side Δ-consistent delay) replaces the base as the gentle
+    // tie-break when supplied. A physically impossible negative delay is
+    // converted into a uniform shift of every OTHER channel in
+    // <paramref name="shiftScope"/> (a uniform shift preserves the alignment)
+    // — in a stereo run the scope must span BOTH sides, or the shift would
+    // silently break the inter-side scene offset.
     private static void AlignChannelAtJunction(
         IAlignmentChannel channel,
         IAlignmentChannel neighborChannel,
@@ -308,16 +331,36 @@ public static class AutoAlignmentEngine
         IReadOnlyList<AlignmentSnapshot> shiftScope,
         AlignmentReprocessor reprocess,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
-        StringBuilder log)
+        StringBuilder log,
+        IAlignmentChannel? secondaryNeighbor = null,
+        AlignmentJunction? secondaryPair = null,
+        double? priorOverrideMs = null)
     {
+        double primaryBase = alignment.GetValueOrDefault(neighborChannel).DelayMs
+            + timeline[neighborChannel] - timeline[channel];
+        double secondaryBase = secondaryNeighbor != null
+            ? alignment.GetValueOrDefault(secondaryNeighbor).DelayMs
+                + timeline[secondaryNeighbor] - timeline[channel]
+            : primaryBase;
+        double bandLowHz = Math.Min(
+            pair.BandLowHz, secondaryPair?.BandLowHz ?? pair.BandLowHz);
+        double bandHighHz = Math.Max(
+            pair.BandHighHz, secondaryPair?.BandHighHz ?? pair.BandHighHz);
+        double halfPeriodMs = Math.Max(
+            500.0 / pair.CrossoverHz,
+            secondaryPair != null ? 500.0 / secondaryPair.CrossoverHz : 0);
+        // The anchor of the near-tie selection and (absent an external prior)
+        // of the quadratic lobe deterrent: between the two coarse bases when
+        // both junctions constrain the channel.
+        double anchorMs = priorOverrideMs ?? (primaryBase + secondaryBase) / 2.0;
+
         // One junction search: candidates of the prior-penalized loss score in
-        // a window around the coarse delta (the PHAT-seeded timeline, arrival
-        // envelope where PHAT was untrusted). The window is half the period of
-        // THIS junction's crossover — wide enough to absorb the coarse error
+        // a window spanning the coarse base(s) (the PHAT-seeded timeline,
+        // arrival envelope where PHAT was untrusted) plus half a period of the
+        // slowest involved crossover — wide enough to absorb the coarse error
         // (which grows with the period), narrow enough not to span two
-        // same-polarity lobes. The base doubles as a soft prior: a quadratic dB
-        // penalty that deters far lobes.
-        (IReadOnlyList<AlignmentCandidate> Candidates, double BaseDelta, double HalfPeriodMs)
+        // same-polarity lobes of one base.
+        (IReadOnlyList<AlignmentCandidate> Candidates, double WindowLowMs, double WindowHighMs)
             SearchJunction(double? windowOverrideMs = null)
         {
             // Reprocess so the settled neighbors participate with their new
@@ -338,34 +381,43 @@ public static class AutoAlignmentEngine
             {
                 current.First(item => item.Channel == neighborChannel).ImpulseResponse
             };
+            if (secondaryNeighbor != null)
+            {
+                neighborIrs.Add(current
+                    .First(item => item.Channel == secondaryNeighbor).ImpulseResponse);
+            }
 
-            double halfPeriodMs = 500.0 / pair.CrossoverHz;
             double rangeMs = windowOverrideMs ?? Math.Clamp(
                 halfPeriodMs, MinFineAlignmentRangeMs, MaxFineAlignmentRangeMs);
-            double baseDelta = alignment.GetValueOrDefault(neighborChannel).DelayMs
-                + timeline[neighborChannel] - timeline[channel];
+            double windowLowMs = Math.Min(primaryBase, secondaryBase) - rangeMs;
+            double windowHighMs = Math.Max(primaryBase, secondaryBase) + rangeMs;
             IReadOnlyList<AlignmentCandidate> candidates =
                 VirtualCrossoverAnalysis.FindAlignmentCandidates(
                     variableIr,
                     neighborIrs,
                     channel.SampleRate,
-                    pair.BandLowHz,
-                    pair.BandHighHz,
-                    baseDelta - rangeMs,
-                    baseDelta + rangeMs,
-                    priorDelayMs: baseDelta,
-                    priorSigmaMs: rangeMs / 2);
-            return (candidates, baseDelta, halfPeriodMs);
+                    bandLowHz,
+                    bandHighHz,
+                    windowLowMs,
+                    windowHighMs,
+                    priorDelayMs: anchorMs,
+                    priorSigmaMs: (windowHighMs - windowLowMs) / 4.0);
+            return (candidates, windowLowMs, windowHighMs);
         }
 
         {
-            (IReadOnlyList<AlignmentCandidate> candidates, double baseDelta,
-                double halfPeriodMs) = SearchJunction();
+            (IReadOnlyList<AlignmentCandidate> candidates,
+                double windowLow, double windowHigh) = SearchJunction();
             log.AppendLine(
                 $"Channel {channel.Name}: " +
-                $"vs {neighborChannel.Name} " +
-                $"in {pair.BandLowHz:0}-{pair.BandHighHz:0} Hz, " +
-                $"base {baseDelta:0.000} ms, candidates " +
+                $"vs {neighborChannel.Name}" +
+                (secondaryNeighbor != null ? $" + {secondaryNeighbor.Name}" : "") +
+                $" in {bandLowHz:0}-{bandHighHz:0} Hz, " +
+                $"base {primaryBase:0.000}" +
+                (secondaryNeighbor != null ? $" / {secondaryBase:0.000}" : "") +
+                $" ms, prior {anchorMs:0.000} ms" +
+                (priorOverrideMs != null ? " (cross-side)" : "") +
+                ", candidates " +
                 string.Join("; ", candidates.Select(item =>
                     $"{item.DelayMs:0.000} ms" +
                     $"{(item.InvertPolarity ? " inv" : "")} " +
@@ -373,8 +425,8 @@ public static class AutoAlignmentEngine
                     $"dip {item.DipDb:0.0} dB)")));
 
             AlignmentCandidate chosen = candidates.Count > 0
-                ? AlignmentSelection.Select(candidates, baseDelta)
-                : new AlignmentCandidate(baseDelta, false, 0);
+                ? AlignmentSelection.Select(candidates, anchorMs)
+                : new AlignmentCandidate(anchorMs, false, 0);
             if (candidates.Count > 0 && chosen != candidates[0])
             {
                 log.AppendLine(
@@ -388,11 +440,10 @@ public static class AutoAlignmentEngine
             // Diagnostic wide sweep: the same junction searched across a much
             // wider window so lobes beyond the working range appear in the log.
             // Purely informational — the chosen result above is untouched.
-            (IReadOnlyList<AlignmentCandidate> wide, double wideBase, _) =
+            (IReadOnlyList<AlignmentCandidate> wide, double wideLow, double wideHigh) =
                 SearchJunction(windowOverrideMs: DiagnosticFineRangeMs);
             log.AppendLine(
-                $"  [diag] wide +-{DiagnosticFineRangeMs:0.0} ms " +
-                $"(base {wideBase:0.000} ms): " +
+                $"  [diag] wide {wideLow:0.000}..{wideHigh:0.000} ms: " +
                 (wide.Count > 0
                     ? string.Join("; ", wide.Select(item =>
                         $"{item.DelayMs:0.000} ms" +
@@ -401,17 +452,15 @@ public static class AutoAlignmentEngine
                         $"dip {item.DipDb:0.0} dB)"))
                     : "none"));
 
-            double fineRangeMs = Math.Clamp(
-                halfPeriodMs, MinFineAlignmentRangeMs, MaxFineAlignmentRangeMs);
-
             // A result pinned to the window edge means the optimum lies beyond
             // the coarse estimate's reach — retry once, widened but still short
             // of a full period so the search cannot land on the next lobe. The
             // edge hit means the base itself is suspect, so the retry relaxes
             // the prior along with the window.
             double retryRangeMs = Math.Min(1.8 * halfPeriodMs, 3.0);
-            if (retryRangeMs > fineRangeMs &&
-                Math.Abs(chosen.DelayMs - baseDelta) >= fineRangeMs - 0.02)
+            bool atEdge = chosen.DelayMs <= windowLow + 0.02 ||
+                chosen.DelayMs >= windowHigh - 0.02;
+            if (retryRangeMs > (windowHigh - windowLow) / 2.0 && atEdge)
             {
                 (IReadOnlyList<AlignmentCandidate> retried, _, _) =
                     SearchJunction(windowOverrideMs: retryRangeMs);
@@ -421,7 +470,7 @@ public static class AutoAlignmentEngine
                     // taking retried[0] raw would let the widened window hand
                     // the result to a (flip + half-period) impostor that the
                     // invert margin and the arrival tie-break exist to reject.
-                    chosen = AlignmentSelection.Select(retried, baseDelta);
+                    chosen = AlignmentSelection.Select(retried, anchorMs);
                 }
 
                 log.AppendLine(
@@ -435,10 +484,12 @@ public static class AutoAlignmentEngine
             // at a high crossover, and the narrow window cannot reach the true
             // summation optimum a few periods away. AlignmentSelection applies
             // the same flip/tie rules to the wide set, and the margin ensures a
-            // mere lobe/flip impostor cannot pull the result off the arrival.
+            // mere lobe/flip impostor cannot pull the result off the arrival —
+            // and with a cross-side prior in the scores, a promotion that walks
+            // away from the other side's timing pays for that distance too.
             if (wide.Count > 0)
             {
-                AlignmentCandidate wideChosen = AlignmentSelection.Select(wide, wideBase);
+                AlignmentCandidate wideChosen = AlignmentSelection.Select(wide, anchorMs);
                 if (wideChosen.ScoreDb > chosen.ScoreDb + WideWindowPromotionMarginDb)
                 {
                     log.AppendLine(
@@ -663,6 +714,53 @@ public static class AutoAlignmentEngine
         // only measured.
         Dictionary<IAlignmentChannel, double> rightTimeline =
             BuildArrivalTimeline(rightByBand, plan.RightPairs, log);
+
+        // The delay that would land this right channel's arrival exactly the
+        // scene offset ahead of its settled left counterpart's, measured by
+        // envelope arrivals in the pair's shared band. Used as the search
+        // prior: a gentle, polarity-blind pull toward the other side's timing
+        // that breaks near-ties between lobes the junction sum cannot
+        // distinguish. Unmeasurable (silent band, low SNR) falls back to null
+        // and the search keeps its own-side anchor.
+        double? CrossSideTargetMs(IAlignmentChannel rightChannel)
+        {
+            StereoPairLink? link = plan.PairLinks?.FirstOrDefault(
+                item => item.Right == rightChannel);
+            if (link == null)
+            {
+                return null;
+            }
+
+            var searchAlignment =
+                new Dictionary<IAlignmentChannel, AlignmentOverride>(alignment);
+            searchAlignment.Remove(rightChannel);
+            IReadOnlyList<AlignmentSnapshot> current = reprocess(searchAlignment);
+            TimeAlignmentAnalysisResult leftArrival =
+                VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                    current.First(item => item.Channel == link.Left).ImpulseResponse,
+                    link.Left.SampleRate, link.BandLowHz, link.BandHighHz);
+            TimeAlignmentAnalysisResult rightRaw =
+                VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                    current.First(item => item.Channel == rightChannel).ImpulseResponse,
+                    rightChannel.SampleRate, link.BandLowHz, link.BandHighHz);
+            if (!leftArrival.IsValid || !rightRaw.IsValid ||
+                leftArrival.SignalToNoiseDecibels < BridgeMinimumSnrDb ||
+                rightRaw.SignalToNoiseDecibels < BridgeMinimumSnrDb)
+            {
+                return null;
+            }
+
+            double target = leftArrival.FirstArrivalDelayMilliseconds
+                - plan.SceneOffsetMs
+                - rightRaw.FirstArrivalDelayMilliseconds;
+            log.AppendLine(
+                $"  cross-side prior {rightChannel.Name}: target {target:0.000} ms " +
+                $"(L arrival {leftArrival.FirstArrivalDelayMilliseconds:0.000}, " +
+                $"raw R {rightRaw.FirstArrivalDelayMilliseconds:0.000} ms " +
+                $"in {link.BandLowHz:0}-{link.BandHighHz:0} Hz)");
+            return target;
+        }
+
         void AlignRight(int index, int neighborIndex, AlignmentJunction pair)
         {
             IAlignmentChannel channel = rightByBand[index].Channel;
@@ -673,9 +771,26 @@ public static class AutoAlignmentEngine
                 return;
             }
 
+            // The neighbor on the FAR side of the walk joins the search as a
+            // second fixed reference when it is already final — during the
+            // descent that is the shared mono channel below. Without it the
+            // channel optimizes its junction toward the bridge and can park a
+            // whole period off the junction it shares with the settled mono —
+            // a perfect upper sum bought with a ruined subwoofer handover.
+            IAlignmentChannel? secondary = null;
+            AlignmentJunction? secondaryPair = null;
+            int otherIndex = index + (index - neighborIndex);
+            if (otherIndex >= 0 && otherIndex < rightByBand.Count &&
+                plan.MonoChannels.Contains(rightByBand[otherIndex].Channel))
+            {
+                secondary = rightByBand[otherIndex].Channel;
+                secondaryPair = plan.RightPairs[Math.Min(index, otherIndex)];
+            }
+
             AlignChannelAtJunction(
                 channel, neighbor, pair,
-                rightTimeline, allChannels, reprocess, alignment, log);
+                rightTimeline, allChannels, reprocess, alignment, log,
+                secondary, secondaryPair, CrossSideTargetMs(channel));
         }
         for (int i = bridgeIndex - 1; i >= 0; i--)
         {

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -296,6 +296,23 @@ public static class VirtualCrossoverAnalysis
         Complex[] impulseResponse,
         int sampleRate,
         double lowFrequencyHz,
+        double highFrequencyHz) =>
+        AnalyzeBandLimitedArrival(
+            impulseResponse, sampleRate, lowFrequencyHz, highFrequencyHz)
+            .FirstArrivalDelayMilliseconds;
+
+    /// <summary>
+    /// The full band-limited arrival analysis behind
+    /// <see cref="FindBandLimitedArrivalMs"/>, including the quality figures
+    /// the bare delay hides: <c>IsValid</c> (a silent band reports zeros, not
+    /// a real arrival) and the record's signal-to-noise. Callers whose result
+    /// hinges on ONE arrival pair — the stereo bridge — must gate on these
+    /// instead of trusting the number.
+    /// </summary>
+    public static TimeAlignmentAnalysisResult AnalyzeBandLimitedArrival(
+        Complex[] impulseResponse,
+        int sampleRate,
+        double lowFrequencyHz,
         double highFrequencyHz)
     {
         ArgumentNullException.ThrowIfNull(impulseResponse);
@@ -322,7 +339,7 @@ public static class VirtualCrossoverAnalysis
         // Gentle spectral fades and a moderate threshold: the zero-phase bandpass
         // rings symmetrically around the arrival, and steep edges plus a deep
         // threshold would let the detector fire on a pre-ringing lobe.
-        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+        return TimeAlignmentAnalysis.Analyze(
             samples,
             sampleRate,
             new TimeAlignmentAnalysisOptions
@@ -332,8 +349,7 @@ public static class VirtualCrossoverAnalysis
                 BandpassPassOctaves = Math.Log2(high / low),
                 BandpassFadeOctaves = 1.0,
                 FirstPeakThresholdBelowMaxDb = 15
-        });
-        return result.FirstArrivalDelayMilliseconds;
+            });
     }
 
     /// <summary>

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1087,6 +1087,67 @@ public static class VirtualCrossoverAnalysis
     }
 
     /// <summary>
+    /// The gated band level (dB) of one processed response: the same
+    /// direct-sound Tukey gate as the alignment spectra, anchored at the
+    /// response's own peak, then the log-frequency-weighted mean of the bin
+    /// magnitudes in dB inside the band. The absolute figure carries an
+    /// arbitrary reference (the raw transfer-spectrum scale), so it is meant
+    /// for DIFFERENCES between responses measured over the same band — e.g.
+    /// the L−R level asymmetry of a stereo pair, the companion of the
+    /// arrival Δ: timing (ITD) and level (ILD) steer the image together.
+    /// Null when the band holds no bins.
+    /// </summary>
+    public static double? MeasureBandLevelDb(
+        Complex[] impulseResponse,
+        int sampleRate,
+        double minFrequencyHz,
+        double maxFrequencyHz)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        if (impulseResponse.Length == 0)
+        {
+            throw new ArgumentException(
+                "The impulse response is empty.",
+                nameof(impulseResponse));
+        }
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+        if (!(minFrequencyHz > 0) || !(maxFrequencyHz > minFrequencyHz))
+        {
+            throw new ArgumentException("The band is invalid.");
+        }
+
+        int anchor = FindPeakIndex(impulseResponse);
+        int leftFade = Math.Min(AlignmentGateFadeSamples, anchor);
+        double[] gate = Windowing.TukeyWindow(
+            AlignmentGateLengthSamples,
+            2.0 * leftFade / AlignmentGateLengthSamples,
+            2.0 * AlignmentGateFadeSamples / AlignmentGateLengthSamples);
+        int length = AlignmentGateLengthSamples;
+        Complex[] spectrum = ForwardSpectrum(
+            GateDirectSound(impulseResponse, anchor - leftFade, gate), length);
+
+        int firstBin = Math.Max(
+            1, (int)Math.Ceiling(minFrequencyHz * length / sampleRate));
+        int lastBin = Math.Min(
+            length / 2 - 1, (int)Math.Floor(maxFrequencyHz * length / sampleRate));
+        double total = 0;
+        double weightSum = 0;
+        for (int bin = firstBin; bin <= lastBin; bin++)
+        {
+            double frequencyHz = bin * (double)sampleRate / length;
+            double weight = 1.0 / frequencyHz;
+            total += weight * 20.0 * Math.Log10(
+                Math.Max(spectrum[bin].Magnitude, 1e-12));
+            weightSum += weight;
+        }
+
+        return weightSum > 0 ? total / weightSum : null;
+    }
+
+    /// <summary>
     /// A reusable junction-loss probe for searches that slide ONE channel
     /// against fixed neighbors: the gated alignment spectra are built once
     /// from the responses as given, and every probe rotates the variable

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -302,12 +302,26 @@ public static class VirtualCrossoverAnalysis
             .FirstArrivalDelayMilliseconds;
 
     /// <summary>
+    /// The minimum band width (as a high/low frequency ratio: a third of an
+    /// octave) a band-limited arrival analysis accepts. Narrower bands leave
+    /// the envelope detector too few in-band periods to place an arrival, so
+    /// <see cref="AnalyzeBandLimitedArrival"/> refuses them as invalid instead
+    /// of silently widening the band — an arrival measured outside the band
+    /// the caller asked for answers a different question. Callers admitting
+    /// shared bands (the stereo bridge, the L/R pair links) test against the
+    /// same figure.
+    /// </summary>
+    public static readonly double MinimumArrivalBandRatio = Math.Pow(2.0, 1.0 / 3.0);
+
+    /// <summary>
     /// The full band-limited arrival analysis behind
     /// <see cref="FindBandLimitedArrivalMs"/>, including the quality figures
     /// the bare delay hides: <c>IsValid</c> (a silent band reports zeros, not
     /// a real arrival) and the record's signal-to-noise. Callers whose result
     /// hinges on ONE arrival pair — the stereo bridge — must gate on these
-    /// instead of trusting the number.
+    /// instead of trusting the number. The band is analyzed exactly as given
+    /// (clamped to the audible range); a band narrower than
+    /// <see cref="MinimumArrivalBandRatio"/> is refused as invalid.
     /// </summary>
     public static TimeAlignmentAnalysisResult AnalyzeBandLimitedArrival(
         Complex[] impulseResponse,
@@ -328,7 +342,13 @@ public static class VirtualCrossoverAnalysis
         }
 
         double low = Math.Clamp(lowFrequencyHz, 20, 20_000);
-        double high = Math.Clamp(highFrequencyHz, low * Math.Sqrt(2.0), 20_000);
+        double high = Math.Min(highFrequencyHz, 20_000);
+        if (high < low * MinimumArrivalBandRatio)
+        {
+            return new TimeAlignmentAnalysisResult(
+                Array.Empty<double>(), 0, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, false, 0.0, false, 0.0, false, IsValid: false);
+        }
 
         var samples = new double[impulseResponse.Length];
         for (int i = 0; i < samples.Length; i++)
@@ -1064,6 +1084,70 @@ public static class VirtualCrossoverAnalysis
         }
 
         return DetailedLoss(bins, weightSum, delayMs: 0, invert: false);
+    }
+
+    /// <summary>
+    /// A reusable junction-loss probe for searches that slide ONE channel
+    /// against fixed neighbors: the gated alignment spectra are built once
+    /// from the responses as given, and every probe rotates the variable
+    /// spectrum by e^{-jωΔ} — exactly an extra Δ ms of delay — instead of
+    /// re-running the channels' full DSP chains per candidate delta.
+    /// <c>Evaluate(0)</c> reproduces <see cref="MeasureSumLoss"/> on the same
+    /// responses. The direct-sound gate stays anchored where the responses
+    /// currently sit, which is exact for the probes' small deltas (a fraction
+    /// of the gate length).
+    /// </summary>
+    public sealed class SumLossEvaluator
+    {
+        private readonly List<AlignmentBin> bins;
+        private readonly double weightSum;
+
+        private SumLossEvaluator(List<AlignmentBin> bins, double weightSum)
+        {
+            this.bins = bins;
+            this.weightSum = weightSum;
+        }
+
+        /// <summary>
+        /// Builds an evaluator over the given band — the same gate, bins and
+        /// weights as <see cref="MeasureSumLoss"/>. Null when the band holds
+        /// no usable bins.
+        /// </summary>
+        public static SumLossEvaluator? Create(
+            Complex[] variableImpulseResponse,
+            IReadOnlyList<Complex[]> fixedImpulseResponses,
+            int sampleRate,
+            double minFrequencyHz,
+            double maxFrequencyHz)
+        {
+            List<AlignmentBin> bins = BuildAlignmentBins(
+                variableImpulseResponse,
+                fixedImpulseResponses,
+                sampleRate,
+                minFrequencyHz,
+                maxFrequencyHz,
+                minDelayMs: -1,
+                maxDelayMs: 1);
+            if (bins.Count == 0)
+            {
+                return null;
+            }
+
+            double weightSum = 0;
+            foreach (AlignmentBin bin in bins)
+            {
+                weightSum += bin.LogWeight;
+            }
+
+            return new SumLossEvaluator(bins, weightSum);
+        }
+
+        /// <summary>
+        /// The in-band average loss and 1/6-octave dip with the variable
+        /// channel delayed by <paramref name="extraDelayMs"/> more.
+        /// </summary>
+        public (double LossDb, double DipDb) Evaluate(double extraDelayMs) =>
+            DetailedLoss(bins, weightSum, extraDelayMs, invert: false);
     }
 
     private static Complex[] GateDirectSound(

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -925,7 +925,7 @@ public static class VirtualCrossoverAnalysis
         for (int i = 0; i < refined.Count; i++)
         {
             (double lossDb, double dipDb) = DetailedLoss(
-                refined[i].DelayMs, refined[i].InvertPolarity);
+                bins, weightSum, refined[i].DelayMs, refined[i].InvertPolarity);
             refined[i] = refined[i] with
             {
                 ScoreDb = refined[i].ScoreDb
@@ -957,53 +957,97 @@ public static class VirtualCrossoverAnalysis
             }
         }
 
-        (double LossDb, double DipDb) DetailedLoss(double delayMs, bool invert)
+        return results;
+    }
+
+    // The raw in-band average loss (no prior/penalties) and the deepest
+    // 1/6-octave-smoothed loss notch of one delay/polarity choice.
+    private static (double LossDb, double DipDb) DetailedLoss(
+        List<AlignmentBin> bins,
+        double weightSum,
+        double delayMs,
+        bool invert)
+    {
+        var losses = new double[bins.Count];
+        double total = 0;
+        for (int i = 0; i < bins.Count; i++)
         {
-            var losses = new double[bins.Count];
-            double total = 0;
-            for (int i = 0; i < bins.Count; i++)
-            {
-                AlignmentBin bin = bins[i];
-                Complex variable = bin.Variable * Complex.Exp(
-                    new Complex(0, -bin.OmegaMs * delayMs));
-                Complex sum = invert
-                    ? bin.FixedSum - variable
-                    : bin.FixedSum + variable;
-                double lossDb = 20 * Math.Log10(Math.Max(
-                    sum.Magnitude / bin.MagnitudeSum, MinBinAmplitudeRatio));
-                losses[i] = lossDb;
-                total += bin.LogWeight * lossDb;
-            }
-
-            // The dip reads the minimum of a 1/6-octave moving average, so a
-            // single-bin modal notch cannot pose as the junction's dip while a
-            // genuine cancellation trough still reads at full depth.
-            double halfWindowRatio = Math.Pow(2, 1.0 / 12);
-            double dip = 0;
-            double windowSum = 0;
-            int lo = 0;
-            int hi = 0;
-            for (int i = 0; i < bins.Count; i++)
-            {
-                double center = bins[i].OmegaMs;
-                while (hi < bins.Count && bins[hi].OmegaMs <= center * halfWindowRatio)
-                {
-                    windowSum += losses[hi];
-                    hi++;
-                }
-                while (bins[lo].OmegaMs < center / halfWindowRatio)
-                {
-                    windowSum -= losses[lo];
-                    lo++;
-                }
-
-                dip = Math.Min(dip, windowSum / (hi - lo));
-            }
-
-            return (total / weightSum, dip);
+            AlignmentBin bin = bins[i];
+            Complex variable = bin.Variable * Complex.Exp(
+                new Complex(0, -bin.OmegaMs * delayMs));
+            Complex sum = invert
+                ? bin.FixedSum - variable
+                : bin.FixedSum + variable;
+            double lossDb = 20 * Math.Log10(Math.Max(
+                sum.Magnitude / bin.MagnitudeSum, MinBinAmplitudeRatio));
+            losses[i] = lossDb;
+            total += bin.LogWeight * lossDb;
         }
 
-        return results;
+        // The dip reads the minimum of a 1/6-octave moving average, so a
+        // single-bin modal notch cannot pose as the junction's dip while a
+        // genuine cancellation trough still reads at full depth.
+        double halfWindowRatio = Math.Pow(2, 1.0 / 12);
+        double dip = 0;
+        double windowSum = 0;
+        int lo = 0;
+        int hi = 0;
+        for (int i = 0; i < bins.Count; i++)
+        {
+            double center = bins[i].OmegaMs;
+            while (hi < bins.Count && bins[hi].OmegaMs <= center * halfWindowRatio)
+            {
+                windowSum += losses[hi];
+                hi++;
+            }
+            while (bins[lo].OmegaMs < center / halfWindowRatio)
+            {
+                windowSum -= losses[lo];
+                lo++;
+            }
+
+            dip = Math.Min(dip, windowSum / (hi - lo));
+        }
+
+        return (total / weightSum, dip);
+    }
+
+    /// <summary>
+    /// Measures the summation loss of already-settled responses without any
+    /// search: the same gated, log-frequency-weighted average and 1/6-octave
+    /// dip the alignment score reads, at the responses' current timing. Used
+    /// for junctions no search may touch (a mono channel pinned by the other
+    /// side's pass). Null when the band holds no usable bins.
+    /// </summary>
+    public static (double LossDb, double DipDb)? MeasureSumLoss(
+        Complex[] variableImpulseResponse,
+        IReadOnlyList<Complex[]> fixedImpulseResponses,
+        int sampleRate,
+        double minFrequencyHz,
+        double maxFrequencyHz)
+    {
+        // The delay window only gates parameter validation here — the
+        // measurement itself evaluates the responses exactly as given.
+        List<AlignmentBin> bins = BuildAlignmentBins(
+            variableImpulseResponse,
+            fixedImpulseResponses,
+            sampleRate,
+            minFrequencyHz,
+            maxFrequencyHz,
+            minDelayMs: -1,
+            maxDelayMs: 1);
+        if (bins.Count == 0)
+        {
+            return null;
+        }
+
+        double weightSum = 0;
+        foreach (AlignmentBin bin in bins)
+        {
+            weightSum += bin.LogWeight;
+        }
+
+        return DetailedLoss(bins, weightSum, delayMs: 0, invert: false);
     }
 
     private static Complex[] GateDirectSound(

--- a/source/Tools/VirtualCrossoverChannelControl.Designer.cs
+++ b/source/Tools/VirtualCrossoverChannelControl.Designer.cs
@@ -37,6 +37,7 @@ namespace Resonalyze
             numericDelay = new DarkNumericUpDown();
             labelDelayMm = new Label();
             checkBoxInvert = new CheckBox();
+            checkBoxMono = new CheckBox();
             labelCrossover = new Label();
             comboBoxCrossoverKind = new DarkComboBox();
             labelMeasuredPolarity = new Label();
@@ -160,11 +161,23 @@ namespace Resonalyze
             checkBoxInvert.ForeColor = Color.FromArgb(210, 214, 222);
             checkBoxInvert.Location = new Point(78, 62);
             checkBoxInvert.Name = "checkBoxInvert";
-            checkBoxInvert.Size = new Size(100, 19);
+            checkBoxInvert.Size = new Size(60, 19);
             checkBoxInvert.TabIndex = 7;
-            checkBoxInvert.Text = "Invert polarity";
+            checkBoxInvert.Text = "Invert";
             checkBoxInvert.UseVisualStyleBackColor = true;
-            // 
+            //
+            // checkBoxMono
+            //
+            checkBoxMono.AutoSize = true;
+            checkBoxMono.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            checkBoxMono.ForeColor = Color.FromArgb(210, 214, 222);
+            checkBoxMono.Location = new Point(150, 62);
+            checkBoxMono.Name = "checkBoxMono";
+            checkBoxMono.Size = new Size(60, 19);
+            checkBoxMono.TabIndex = 27;
+            checkBoxMono.Text = "Mono";
+            checkBoxMono.UseVisualStyleBackColor = true;
+            //
             // labelCrossover
             // 
             labelCrossover.AutoSize = true;
@@ -414,6 +427,7 @@ namespace Resonalyze
             Controls.Add(numericDelay);
             Controls.Add(labelDelayMm);
             Controls.Add(checkBoxInvert);
+            Controls.Add(checkBoxMono);
             Controls.Add(labelCrossover);
             Controls.Add(comboBoxCrossoverKind);
             Controls.Add(labelMeasuredPolarity);
@@ -457,6 +471,7 @@ namespace Resonalyze
         private DarkNumericUpDown numericDelay;
         private Label labelDelayMm;
         private CheckBox checkBoxInvert;
+        private CheckBox checkBoxMono;
         private Label labelCrossover;
         private DarkComboBox comboBoxCrossoverKind;
         private Label labelMeasuredPolarity;

--- a/source/Tools/VirtualCrossoverChannelControl.cs
+++ b/source/Tools/VirtualCrossoverChannelControl.cs
@@ -54,6 +54,7 @@ public partial class VirtualCrossoverChannelControl : UserControl
     internal DarkNumericUpDown GainInput => numericGain;
     internal DarkNumericUpDown DelayInput => numericDelay;
     internal CheckBox InvertCheckBox => checkBoxInvert;
+    internal CheckBox MonoCheckBox => checkBoxMono;
     internal DarkComboBox CrossoverKindComboBox => comboBoxCrossoverKind;
     internal DarkNumericUpDown HighPassFrequencyInput => numericHighPassHz;
     internal DarkComboBox HighPassFamilyComboBox => comboBoxHighPassFamily;
@@ -256,6 +257,7 @@ public partial class VirtualCrossoverChannelControl : UserControl
             RaiseSettingsChanged();
         };
         checkBoxInvert.CheckedChanged += (_, _) => RaiseSettingsChanged();
+        checkBoxMono.CheckedChanged += (_, _) => RaiseSettingsChanged();
         comboBoxCrossoverKind.SelectedIndexChanged += (_, _) =>
         {
             UpdateCrossoverAvailability();

--- a/source/Tools/VirtualCrossoverCopySideDialog.cs
+++ b/source/Tools/VirtualCrossoverCopySideDialog.cs
@@ -1,0 +1,90 @@
+namespace Resonalyze;
+
+/// <summary>
+/// The channel picker behind the Virtual DSP "L→R" / "R→L" commands: which
+/// pairs have their DSP settings (gain, crossover, PEQ) copied from one side
+/// onto the other. Mono pairs never appear here — they have a single settings
+/// set by definition. Sources and delays are deliberately not copied: each
+/// side has its own measurement and its own arrival timing.
+/// </summary>
+internal sealed class VirtualCrossoverCopySideDialog : Form
+{
+    private readonly List<CheckBox> channelBoxes = new();
+
+    public VirtualCrossoverCopySideDialog(
+        bool fromRightToLeft,
+        IReadOnlyList<string> channelLabels)
+    {
+        ArgumentNullException.ThrowIfNull(channelLabels);
+
+        SuspendLayout();
+        Text = fromRightToLeft ? "Copy R → L" : "Copy L → R";
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MaximizeBox = false;
+        MinimizeBox = false;
+        ShowInTaskbar = false;
+        StartPosition = FormStartPosition.CenterParent;
+        BackColor = Color.FromArgb(40, 44, 54);
+        ForeColor = Color.White;
+        Font = new Font("Segoe UI", 9F);
+        AutoScaleMode = AutoScaleMode.Font;
+
+        var caption = new Label
+        {
+            AutoSize = true,
+            ForeColor = Color.FromArgb(210, 214, 222),
+            Location = new Point(12, 12),
+            Text = "Copy gain, crossover and PEQ for the selected channels.\n" +
+                "Sources and delays stay with their side."
+        };
+        Controls.Add(caption);
+
+        int y = 52;
+        foreach (string label in channelLabels)
+        {
+            var box = new CheckBox
+            {
+                AutoSize = true,
+                Checked = true,
+                Location = new Point(16, y),
+                Text = label
+            };
+            channelBoxes.Add(box);
+            Controls.Add(box);
+            y += 25;
+        }
+
+        var okButton = new Button
+        {
+            BackColor = Color.FromArgb(46, 51, 67),
+            DialogResult = DialogResult.OK,
+            FlatStyle = FlatStyle.Popup,
+            Location = new Point(160, y + 10),
+            Size = new Size(80, 26),
+            Text = "Copy"
+        };
+        var cancelButton = new Button
+        {
+            BackColor = Color.FromArgb(46, 51, 67),
+            DialogResult = DialogResult.Cancel,
+            FlatStyle = FlatStyle.Popup,
+            Location = new Point(248, y + 10),
+            Size = new Size(80, 26),
+            Text = "Cancel"
+        };
+        Controls.Add(okButton);
+        Controls.Add(cancelButton);
+        AcceptButton = okButton;
+        CancelButton = cancelButton;
+        ClientSize = new Size(340, y + 46);
+        ResumeLayout(false);
+        PerformLayout();
+    }
+
+    /// <summary>Indices (into the constructor's label list) the user left checked.</summary>
+    public IReadOnlyList<int> SelectedIndices => channelBoxes
+        .Select((box, index) => (box.Checked, index))
+        .Where(item => item.Checked)
+        .Select(item => item.index)
+        .ToList();
+}

--- a/source/Tools/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossoverMetric.cs
@@ -119,7 +119,9 @@ internal static class VirtualCrossoverMetric
                     ? $"{delta.Channel}: {delta.DeltaMs.Value:+0.000;-0.000} ms " +
                       $"({FrequencyText.Format(delta.LowHz)} \u2013 " +
                       $"{FrequencyText.Format(delta.HighHz)})"
-                    : $"{delta.Channel}: \u2014 (no measurable arrival)"));
+                    : $"{delta.Channel}: \u2014 (no measurable arrival)")) +
+            "\r\nLow-band envelopes rise slowly, so the lowest rows carry " +
+            "extra tolerance (a fraction of a millisecond is noise there).";
     }
 
     /// <summary>

--- a/source/Tools/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossoverMetric.cs
@@ -10,16 +10,14 @@ internal static class VirtualCrossoverMetric
 {
     /// <summary>
     /// One sum-loss read-out: a junction pair (or the total across the crossover
-    /// window), its average and dip in dB, the polarity-flip null depth (the
-    /// deepest notch of the sum with the pair's upper channel inverted — the
-    /// classic tuner's check: a phase-aligned pair cancels into a deep null;
-    /// junction entries only), and the band it was measured over.
+    /// window), its average and dip in dB, and the band it was measured over.
+    /// (The polarity-flip null depth used to be a third column; it proved
+    /// uninformative in practice and was dropped along with its computation.)
     /// </summary>
     internal readonly record struct Entry(
         string Junction,
         double AverageDb,
         double? DipDb,
-        double? NullDb,
         double LowHz,
         double HighHz,
         bool IsTotal);
@@ -38,8 +36,7 @@ internal static class VirtualCrossoverMetric
         IEnumerable<string> parts = entries.Select(entry =>
         {
             string body = $"{entry.AverageDb:0.0} dB" +
-                (entry.DipDb.HasValue ? $", dip {entry.DipDb.Value:0.0} dB" : "") +
-                (entry.NullDb.HasValue ? $", null {entry.NullDb.Value:0.0} dB" : "");
+                (entry.DipDb.HasValue ? $", dip {entry.DipDb.Value:0.0} dB" : "");
             return entry.IsTotal ? "total " + body : $"{entry.Junction} {body}";
         });
         return "Sum loss avg: " + string.Join("   ", parts);
@@ -47,29 +44,82 @@ internal static class VirtualCrossoverMetric
 
     /// <summary>
     /// Compact per-junction column for the narrow host read-out panel: a
-    /// monospace "name  avg / dip / null" line each, no frequency ranges (those
-    /// are on hover).
+    /// monospace "name  avg / dip" line each, no frequency ranges (those are
+    /// on hover).
     /// </summary>
     public static string FormatCompact(IReadOnlyList<Entry> entries)
     {
         if (entries.Count == 0)
         {
-            return "Sum loss (dB)\r\n  avg / dip / null\r\n\r\n—";
+            return "Sum loss (dB)\r\n  avg / dip\r\n\r\n—";
         }
 
         var builder = new System.Text.StringBuilder(
-            "Sum loss (dB)\r\n  avg / dip / null\r\n\r\n");
+            "Sum loss (dB)\r\n  avg / dip\r\n\r\n");
         foreach (Entry entry in entries)
         {
             string name = (entry.IsTotal ? "Total" : entry.Junction).PadRight(6);
             string dip = entry.DipDb.HasValue ? $"{entry.DipDb.Value,5:0.0}" : "    —";
-            string flipNull = entry.NullDb.HasValue
-                ? $"{entry.NullDb.Value,5:0.0}"
-                : "    —";
-            builder.AppendLine($"{name}{entry.AverageDb,5:0.0} /{dip} /{flipNull}");
+            builder.AppendLine($"{name}{entry.AverageDb,5:0.0} /{dip}");
         }
 
         return builder.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// One channel pair's final inter-side timing read-out: the difference of
+    /// the two sides' band-limited envelope arrivals (their fully processed
+    /// responses, delays included) in the pair's shared band. Positive means
+    /// the RIGHT side leads — the same sign convention as the Auto delay scene
+    /// offset, so after a stereo run every row should read the offset. Null
+    /// when an arrival is unmeasurable (a silent band).
+    /// </summary>
+    internal readonly record struct StereoDelta(
+        string Channel,
+        double? DeltaMs,
+        double LowHz,
+        double HighHz);
+
+    /// <summary>
+    /// Compact per-channel Δ block for the host read-out panel, appended below
+    /// the sum-loss column.
+    /// </summary>
+    public static string FormatStereoDeltasCompact(IReadOnlyList<StereoDelta> deltas)
+    {
+        if (deltas.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new System.Text.StringBuilder("\u0394 L\u2212R (ms)\r\n");
+        foreach (StereoDelta delta in deltas)
+        {
+            string value = delta.DeltaMs.HasValue
+                ? $"{delta.DeltaMs.Value,6:+0.00;-0.00}"
+                : "     \u2014";
+            builder.AppendLine($"{delta.Channel.PadRight(6)}{value}");
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    /// <summary>Full \u0394 breakdown for the tooltip, with the measured bands.</summary>
+    public static string FormatStereoDeltasDetail(IReadOnlyList<StereoDelta> deltas)
+    {
+        if (deltas.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        return "\u0394 L\u2212R: envelope arrival of the processed left side minus the " +
+            "right one\r\n(positive: right leads; after a stereo Auto delay " +
+            "every channel should read the scene offset)\r\n" +
+            string.Join("\r\n", deltas.Select(delta =>
+                delta.DeltaMs.HasValue
+                    ? $"{delta.Channel}: {delta.DeltaMs.Value:+0.000;-0.000} ms " +
+                      $"({FrequencyText.Format(delta.LowHz)} \u2013 " +
+                      $"{FrequencyText.Format(delta.HighHz)})"
+                    : $"{delta.Channel}: \u2014 (no measurable arrival)"));
     }
 
     /// <summary>
@@ -87,10 +137,7 @@ internal static class VirtualCrossoverMetric
         {
             string name = entry.IsTotal ? "Total" : entry.Junction;
             string dip = entry.DipDb.HasValue ? $", dip {entry.DipDb.Value:0.0} dB" : "";
-            string flipNull = entry.NullDb.HasValue
-                ? $", flip null {entry.NullDb.Value:0.0} dB"
-                : "";
-            return $"{name}: {entry.AverageDb:0.0} dB avg{dip}{flipNull} " +
+            return $"{name}: {entry.AverageDb:0.0} dB avg{dip} " +
                 $"({FrequencyText.Format(entry.LowHz)} – {FrequencyText.Format(entry.HighHz)})";
         }));
     }

--- a/source/Tools/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossoverMetric.cs
@@ -67,22 +67,30 @@ internal static class VirtualCrossoverMetric
     }
 
     /// <summary>
-    /// One channel pair's final inter-side timing read-out: the difference of
-    /// the two sides' band-limited envelope arrivals (their fully processed
-    /// responses, delays included) in the pair's shared band. Positive means
-    /// the RIGHT side leads — the same sign convention as the Auto delay scene
-    /// offset, so after a stereo run every row should read the offset. Null
-    /// when an arrival is unmeasurable (a silent band).
+    /// One channel pair's final inter-side timing read-out: the two sides'
+    /// band-limited envelope arrivals (their fully processed responses,
+    /// delays included) in the pair's shared band, in ms from the transfer
+    /// IR start. A side is null when its arrival is unmeasurable or
+    /// unreliable (a silent band, a near-noise record). Delta is left minus
+    /// right, so positive means the RIGHT side leads — the same sign
+    /// convention as the Auto delay scene offset, so after a stereo run
+    /// every row should read the offset.
     /// </summary>
     internal readonly record struct StereoDelta(
         string Channel,
-        double? DeltaMs,
+        double? LeftMs,
+        double? RightMs,
         double LowHz,
-        double HighHz);
+        double HighHz)
+    {
+        public double? DeltaMs => LeftMs.HasValue && RightMs.HasValue
+            ? LeftMs.Value - RightMs.Value
+            : null;
+    }
 
     /// <summary>
-    /// Compact per-channel Δ block for the host read-out panel, appended below
-    /// the sum-loss column.
+    /// Compact per-channel arrival block for the host read-out panel,
+    /// appended below the sum-loss column: one L / R / delta row per pair.
     /// </summary>
     public static string FormatStereoDeltasCompact(IReadOnlyList<StereoDelta> deltas)
     {
@@ -91,19 +99,27 @@ internal static class VirtualCrossoverMetric
             return string.Empty;
         }
 
-        var builder = new System.Text.StringBuilder("\u0394 L\u2212R (ms)\r\n");
+        static string Side(double? value) =>
+            value.HasValue ? $"{value.Value,7:0.00}" : "      \u2014";
+
+        var builder = new System.Text.StringBuilder(
+            "Arrival (ms)\r\n         L      R  \u0394 L\u2212R\r\n");
         foreach (StereoDelta delta in deltas)
         {
-            string value = delta.DeltaMs.HasValue
-                ? $"{delta.DeltaMs.Value,6:+0.00;-0.00}"
-                : "     \u2014";
-            builder.AppendLine($"{delta.Channel.PadRight(6)}{value}");
+            string deltaText = delta.DeltaMs.HasValue
+                ? $"{delta.DeltaMs.Value,7:+0.00;-0.00}"
+                : "      \u2014";
+            builder.AppendLine(
+                $"{delta.Channel.PadRight(3)}" +
+                $"{Side(delta.LeftMs)}{Side(delta.RightMs)}{deltaText}");
         }
 
         return builder.ToString().TrimEnd();
     }
 
-    /// <summary>Full \u0394 breakdown for the tooltip, with the measured bands.</summary>
+    /// <summary>
+    /// Full L / R / delta breakdown for the tooltip, with the measured bands.
+    /// </summary>
     public static string FormatStereoDeltasDetail(IReadOnlyList<StereoDelta> deltas)
     {
         if (deltas.Count == 0)
@@ -111,15 +127,28 @@ internal static class VirtualCrossoverMetric
             return string.Empty;
         }
 
-        return "\u0394 L\u2212R: envelope arrival of the processed left side minus the " +
-            "right one\r\n(positive: right leads; after a stereo Auto delay " +
-            "every channel should read the scene offset)\r\n" +
+        static string Side(double? value) =>
+            value.HasValue ? $"{value.Value:0.000}" : "\u2014";
+
+        return "Final envelope arrivals of the processed sides (ms from the " +
+            "IR start, delays\r\nincluded) and \u0394 L\u2212R (positive: right leads; " +
+            "after a stereo Auto delay every\r\nchannel should read the scene " +
+            "offset)\r\n" +
             string.Join("\r\n", deltas.Select(delta =>
-                delta.DeltaMs.HasValue
-                    ? $"{delta.Channel}: {delta.DeltaMs.Value:+0.000;-0.000} ms " +
-                      $"({FrequencyText.Format(delta.LowHz)} \u2013 " +
-                      $"{FrequencyText.Format(delta.HighHz)})"
-                    : $"{delta.Channel}: \u2014 (no measurable arrival)")) +
+            {
+                if (!delta.LeftMs.HasValue && !delta.RightMs.HasValue)
+                {
+                    return $"{delta.Channel}: \u2014 (no measurable arrival)";
+                }
+
+                string deltaText = delta.DeltaMs.HasValue
+                    ? $"{delta.DeltaMs.Value:+0.000;-0.000} ms"
+                    : "\u2014";
+                return $"{delta.Channel}: L {Side(delta.LeftMs)} / " +
+                    $"R {Side(delta.RightMs)} ms, \u0394 {deltaText} " +
+                    $"({FrequencyText.Format(delta.LowHz)} \u2013 " +
+                    $"{FrequencyText.Format(delta.HighHz)})";
+            })) +
             "\r\nLow-band envelopes rise slowly, so the lowest rows carry " +
             "extra tolerance (a fraction of a millisecond is noise there).";
     }

--- a/source/Tools/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossoverMetric.cs
@@ -67,21 +67,25 @@ internal static class VirtualCrossoverMetric
     }
 
     /// <summary>
-    /// One channel pair's final inter-side timing read-out: the two sides'
+    /// One channel pair's final inter-side read-out: the two sides'
     /// band-limited envelope arrivals (their fully processed responses,
     /// delays included) in the pair's shared band, in ms from the transfer
-    /// IR start. A side is null when its arrival is unmeasurable or
-    /// unreliable (a silent band, a near-noise record). Delta is left minus
-    /// right, so positive means the RIGHT side leads — the same sign
-    /// convention as the Auto delay scene offset, so after a stereo run
-    /// every row should read the offset.
+    /// IR start, plus the sides' gated band-level difference in dB. A side's
+    /// arrival is null when it is unmeasurable or unreliable (a silent band,
+    /// a near-noise record); the level delta is null under the same gate.
+    /// The timing delta is left minus right, so positive means the RIGHT
+    /// side leads — the same sign convention as the Auto delay scene offset,
+    /// so after a stereo run every row should read the offset. The level
+    /// delta is also left minus right: positive = the LEFT side is louder
+    /// at the microphone.
     /// </summary>
     internal readonly record struct StereoDelta(
         string Channel,
         double? LeftMs,
         double? RightMs,
         double LowHz,
-        double HighHz)
+        double HighHz,
+        double? LevelDeltaDb = null)
     {
         public double? DeltaMs => LeftMs.HasValue && RightMs.HasValue
             ? LeftMs.Value - RightMs.Value
@@ -90,7 +94,9 @@ internal static class VirtualCrossoverMetric
 
     /// <summary>
     /// Compact per-channel arrival block for the host read-out panel,
-    /// appended below the sum-loss column: one L / R / delta row per pair.
+    /// appended below the sum-loss column: one L / R / delta row per pair,
+    /// then the pairs' level asymmetry (the ILD companion of the timing
+    /// delta).
     /// </summary>
     public static string FormatStereoDeltasCompact(IReadOnlyList<StereoDelta> deltas)
     {
@@ -112,6 +118,16 @@ internal static class VirtualCrossoverMetric
             builder.AppendLine(
                 $"{delta.Channel.PadRight(3)}" +
                 $"{Side(delta.LeftMs)}{Side(delta.RightMs)}{deltaText}");
+        }
+
+        builder.AppendLine();
+        builder.AppendLine("Level \u0394 L\u2212R (dB)");
+        foreach (StereoDelta delta in deltas)
+        {
+            string levelText = delta.LevelDeltaDb.HasValue
+                ? $"{delta.LevelDeltaDb.Value,7:+0.0;-0.0}"
+                : "      \u2014";
+            builder.AppendLine($"{delta.Channel.PadRight(3)}{levelText}");
         }
 
         return builder.ToString().TrimEnd();
@@ -144,13 +160,21 @@ internal static class VirtualCrossoverMetric
                 string deltaText = delta.DeltaMs.HasValue
                     ? $"{delta.DeltaMs.Value:+0.000;-0.000} ms"
                     : "\u2014";
+                string levelText = delta.LevelDeltaDb.HasValue
+                    ? $", level {delta.LevelDeltaDb.Value:+0.0;-0.0} dB"
+                    : string.Empty;
                 return $"{delta.Channel}: L {Side(delta.LeftMs)} / " +
-                    $"R {Side(delta.RightMs)} ms, \u0394 {deltaText} " +
+                    $"R {Side(delta.RightMs)} ms, \u0394 {deltaText}{levelText} " +
                     $"({FrequencyText.Format(delta.LowHz)} \u2013 " +
                     $"{FrequencyText.Format(delta.HighHz)})";
             })) +
             "\r\nLow-band envelopes rise slowly, so the lowest rows carry " +
-            "extra tolerance (a fraction of a millisecond is noise there).";
+            "extra tolerance (a fraction of a millisecond is noise there)." +
+            "\r\nLevel \u0394 is the gated band level of the processed sides " +
+            "(positive: LEFT louder).\r\nTrim the louder side's gain by ear " +
+            "to center the image alongside the timing \u2014\r\na single " +
+            "microphone underestimates the binaural difference (no head " +
+            "shadow).";
     }
 
     /// <summary>

--- a/source/Tools/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossoverPanel.Designer.cs
@@ -34,6 +34,11 @@ namespace Resonalyze
             channelListPanel = new FlowLayoutPanel();
             buttonAddChannel = new Button();
             buttonRemoveChannel = new Button();
+            sideSelectorPanel = new Panel();
+            radioSideLeft = new RadioButton();
+            radioSideRight = new RadioButton();
+            labelSceneOffset = new Label();
+            numericSceneOffset = new DarkNumericUpDown();
             labelView = new Label();
             checkBoxShowSum = new CheckBox();
             checkBoxShowLoss = new CheckBox();
@@ -56,6 +61,8 @@ namespace Resonalyze
             radioDspPhase = new RadioButton();
             radioDspGroupDelay = new RadioButton();
             dspModePanel.SuspendLayout();
+            sideSelectorPanel.SuspendLayout();
+            (numericSceneOffset).BeginInit();
             SuspendLayout();
             // 
             // mainPlotView
@@ -92,7 +99,7 @@ namespace Resonalyze
             channelListPanel.FlowDirection = FlowDirection.TopDown;
             channelListPanel.Location = new Point(6, 6);
             channelListPanel.Name = "channelListPanel";
-            channelListPanel.Size = new Size(347, 716);
+            channelListPanel.Size = new Size(347, 684);
             channelListPanel.TabIndex = 3;
             channelListPanel.WrapContents = false;
             // 
@@ -102,7 +109,7 @@ namespace Resonalyze
             buttonAddChannel.BackColor = Color.FromArgb(46, 51, 67);
             buttonAddChannel.FlatStyle = FlatStyle.Popup;
             buttonAddChannel.ForeColor = Color.White;
-            buttonAddChannel.Location = new Point(6, 732);
+            buttonAddChannel.Location = new Point(6, 700);
             buttonAddChannel.Name = "buttonAddChannel";
             buttonAddChannel.Size = new Size(158, 24);
             buttonAddChannel.TabIndex = 4;
@@ -115,13 +122,81 @@ namespace Resonalyze
             buttonRemoveChannel.BackColor = Color.FromArgb(46, 51, 67);
             buttonRemoveChannel.FlatStyle = FlatStyle.Popup;
             buttonRemoveChannel.ForeColor = Color.White;
-            buttonRemoveChannel.Location = new Point(171, 732);
+            buttonRemoveChannel.Location = new Point(171, 700);
             buttonRemoveChannel.Name = "buttonRemoveChannel";
             buttonRemoveChannel.Size = new Size(158, 24);
             buttonRemoveChannel.TabIndex = 5;
             buttonRemoveChannel.Text = "Remove channel";
             buttonRemoveChannel.UseVisualStyleBackColor = false;
-            // 
+            //
+            // sideSelectorPanel
+            //
+            // The side radios live in their own container so they form a radio
+            // group of their own — as direct panel children they would join the
+            // Magnitude/Phase view group.
+            sideSelectorPanel.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            sideSelectorPanel.BackColor = Color.FromArgb(40, 44, 54);
+            sideSelectorPanel.Controls.Add(radioSideLeft);
+            sideSelectorPanel.Controls.Add(radioSideRight);
+            sideSelectorPanel.Location = new Point(6, 730);
+            sideSelectorPanel.Name = "sideSelectorPanel";
+            sideSelectorPanel.Size = new Size(347, 24);
+            sideSelectorPanel.TabIndex = 21;
+            //
+            // radioSideLeft
+            //
+            radioSideLeft.AutoSize = true;
+            radioSideLeft.Checked = true;
+            radioSideLeft.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            radioSideLeft.ForeColor = Color.FromArgb(210, 214, 222);
+            radioSideLeft.Location = new Point(0, 2);
+            radioSideLeft.Name = "radioSideLeft";
+            radioSideLeft.Size = new Size(120, 19);
+            radioSideLeft.TabIndex = 0;
+            radioSideLeft.TabStop = true;
+            radioSideLeft.Text = "L";
+            radioSideLeft.UseVisualStyleBackColor = true;
+            //
+            // radioSideRight
+            //
+            radioSideRight.AutoSize = true;
+            radioSideRight.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            radioSideRight.ForeColor = Color.FromArgb(210, 214, 222);
+            radioSideRight.Location = new Point(171, 2);
+            radioSideRight.Name = "radioSideRight";
+            radioSideRight.Size = new Size(120, 19);
+            radioSideRight.TabIndex = 1;
+            radioSideRight.Text = "R";
+            radioSideRight.UseVisualStyleBackColor = true;
+            //
+            // labelSceneOffset
+            //
+            labelSceneOffset.AutoSize = true;
+            labelSceneOffset.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            labelSceneOffset.ForeColor = Color.FromArgb(210, 214, 222);
+            labelSceneOffset.Location = new Point(358, 532);
+            labelSceneOffset.Name = "labelSceneOffset";
+            labelSceneOffset.Size = new Size(90, 15);
+            labelSceneOffset.TabIndex = 22;
+            labelSceneOffset.Text = "L/R offset, ms";
+            //
+            // numericSceneOffset
+            //
+            numericSceneOffset.BackColor = Color.FromArgb(55, 60, 72);
+            numericSceneOffset.DecimalPlaces = 2;
+            numericSceneOffset.ForeColor = Color.White;
+            numericSceneOffset.Increment = new decimal(new int[] { 5, 0, 0, 131072 });
+            numericSceneOffset.Location = new Point(358, 550);
+            numericSceneOffset.Maximum = new decimal(new int[] { 5, 0, 0, 0 });
+            numericSceneOffset.Minimum = new decimal(new int[] { 5, 0, 0, int.MinValue });
+            numericSceneOffset.MinimumSize = new Size(36, 19);
+            numericSceneOffset.Name = "numericSceneOffset";
+            numericSceneOffset.Size = new Size(125, 19);
+            numericSceneOffset.TabIndex = 23;
+            numericSceneOffset.TextAlign = HorizontalAlignment.Right;
+            numericSceneOffset.ThousandsSeparator = false;
+            numericSceneOffset.Value = new decimal(new int[] { 25, 0, 0, 131072 });
+            //
             // labelView
             // 
             labelView.AutoSize = true;
@@ -211,7 +286,7 @@ namespace Resonalyze
             buttonAutoDelay.BackColor = Color.FromArgb(46, 51, 67);
             buttonAutoDelay.FlatStyle = FlatStyle.Popup;
             buttonAutoDelay.ForeColor = Color.White;
-            buttonAutoDelay.Location = new Point(358, 529);
+            buttonAutoDelay.Location = new Point(358, 577);
             buttonAutoDelay.Name = "buttonAutoDelay";
             buttonAutoDelay.Size = new Size(125, 24);
             buttonAutoDelay.TabIndex = 12;
@@ -393,6 +468,9 @@ namespace Resonalyze
             Controls.Add(channelListPanel);
             Controls.Add(buttonAddChannel);
             Controls.Add(buttonRemoveChannel);
+            Controls.Add(sideSelectorPanel);
+            Controls.Add(labelSceneOffset);
+            Controls.Add(numericSceneOffset);
             Controls.Add(dspPlotView);
             Controls.Add(mainPlotView);
             Font = new Font("Segoe UI", 9F);
@@ -402,6 +480,9 @@ namespace Resonalyze
             Size = new Size(1246, 770);
             dspModePanel.ResumeLayout(false);
             dspModePanel.PerformLayout();
+            sideSelectorPanel.ResumeLayout(false);
+            sideSelectorPanel.PerformLayout();
+            (numericSceneOffset).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -412,6 +493,11 @@ namespace Resonalyze
         private FlowLayoutPanel channelListPanel;
         private Button buttonAddChannel;
         private Button buttonRemoveChannel;
+        private Panel sideSelectorPanel;
+        private RadioButton radioSideLeft;
+        private RadioButton radioSideRight;
+        private Label labelSceneOffset;
+        private DarkNumericUpDown numericSceneOffset;
         private Label labelView;
         private CheckBox checkBoxShowSum;
         private CheckBox checkBoxShowLoss;

--- a/source/Tools/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossoverPanel.Designer.cs
@@ -37,6 +37,8 @@ namespace Resonalyze
             sideSelectorPanel = new Panel();
             radioSideLeft = new RadioButton();
             radioSideRight = new RadioButton();
+            buttonCopyLeftToRight = new Button();
+            buttonCopyRightToLeft = new Button();
             labelSceneOffset = new Label();
             numericSceneOffset = new DarkNumericUpDown();
             labelView = new Label();
@@ -138,6 +140,8 @@ namespace Resonalyze
             sideSelectorPanel.BackColor = Color.FromArgb(40, 44, 54);
             sideSelectorPanel.Controls.Add(radioSideLeft);
             sideSelectorPanel.Controls.Add(radioSideRight);
+            sideSelectorPanel.Controls.Add(buttonCopyLeftToRight);
+            sideSelectorPanel.Controls.Add(buttonCopyRightToLeft);
             sideSelectorPanel.Location = new Point(6, 730);
             sideSelectorPanel.Name = "sideSelectorPanel";
             sideSelectorPanel.Size = new Size(347, 24);
@@ -151,7 +155,7 @@ namespace Resonalyze
             radioSideLeft.ForeColor = Color.FromArgb(210, 214, 222);
             radioSideLeft.Location = new Point(0, 2);
             radioSideLeft.Name = "radioSideLeft";
-            radioSideLeft.Size = new Size(120, 19);
+            radioSideLeft.Size = new Size(50, 19);
             radioSideLeft.TabIndex = 0;
             radioSideLeft.TabStop = true;
             radioSideLeft.Text = "L";
@@ -162,12 +166,36 @@ namespace Resonalyze
             radioSideRight.AutoSize = true;
             radioSideRight.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             radioSideRight.ForeColor = Color.FromArgb(210, 214, 222);
-            radioSideRight.Location = new Point(171, 2);
+            radioSideRight.Location = new Point(52, 2);
             radioSideRight.Name = "radioSideRight";
-            radioSideRight.Size = new Size(120, 19);
+            radioSideRight.Size = new Size(50, 19);
             radioSideRight.TabIndex = 1;
             radioSideRight.Text = "R";
             radioSideRight.UseVisualStyleBackColor = true;
+            //
+            // buttonCopyLeftToRight
+            //
+            buttonCopyLeftToRight.BackColor = Color.FromArgb(46, 51, 67);
+            buttonCopyLeftToRight.FlatStyle = FlatStyle.Popup;
+            buttonCopyLeftToRight.ForeColor = Color.White;
+            buttonCopyLeftToRight.Location = new Point(115, 0);
+            buttonCopyLeftToRight.Name = "buttonCopyLeftToRight";
+            buttonCopyLeftToRight.Size = new Size(56, 23);
+            buttonCopyLeftToRight.TabIndex = 2;
+            buttonCopyLeftToRight.Text = "L→R";
+            buttonCopyLeftToRight.UseVisualStyleBackColor = false;
+            //
+            // buttonCopyRightToLeft
+            //
+            buttonCopyRightToLeft.BackColor = Color.FromArgb(46, 51, 67);
+            buttonCopyRightToLeft.FlatStyle = FlatStyle.Popup;
+            buttonCopyRightToLeft.ForeColor = Color.White;
+            buttonCopyRightToLeft.Location = new Point(177, 0);
+            buttonCopyRightToLeft.Name = "buttonCopyRightToLeft";
+            buttonCopyRightToLeft.Size = new Size(56, 23);
+            buttonCopyRightToLeft.TabIndex = 3;
+            buttonCopyRightToLeft.Text = "R→L";
+            buttonCopyRightToLeft.UseVisualStyleBackColor = false;
             //
             // labelSceneOffset
             //
@@ -496,6 +524,8 @@ namespace Resonalyze
         private Panel sideSelectorPanel;
         private RadioButton radioSideLeft;
         private RadioButton radioSideRight;
+        private Button buttonCopyLeftToRight;
+        private Button buttonCopyRightToLeft;
         private Label labelSceneOffset;
         private DarkNumericUpDown numericSceneOffset;
         private Label labelView;

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -888,12 +888,16 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private async Task ChooseSourceFileAsync(ChannelRuntime channel)
     {
-        // The side AND the pair are captured NOW: the user can flip the L/R
-        // selector — or import a whole different session — while the file
-        // loads below, and the measurement must land on the side whose Source
-        // button was clicked, or nowhere at all.
+        // The CONCRETE slot and settings are captured NOW: the user can flip
+        // the L/R selector, toggle Mono (which reroutes SideState) — or
+        // import a whole different session — while the file loads below, and
+        // the measurement must land in the slot whose Source button was
+        // clicked, or nowhere at all. The revision (taken when the load
+        // starts) guards the landing: any Clear() of the slot or a newer
+        // pick into it refuses this one.
         bool rightSide = channel.ActiveRight;
-        VirtualCrossoverChannelPairSettings pair = channel.Pair;
+        ChannelSideState targetState = channel.SideState(rightSide);
+        VirtualCrossoverChannelSettings targetSettings = channel.SideSettings(rightSide);
         using var dialog = new OpenFileDialog
         {
             CheckFileExists = true,
@@ -907,13 +911,12 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
+        int revision = targetState.BeginSourceLoad();
         try
         {
             ImpulseResponseFile file = await ImpulseResponseFile.LoadAsync(dialog.FileName);
-            if (IsDisposed || channel.Pair != pair)
+            if (IsDisposed)
             {
-                // A session import replaced the configuration mid-load: the
-                // completed read belongs to a pair that is no longer bound.
                 return;
             }
 
@@ -921,6 +924,9 @@ public partial class VirtualCrossoverPanel : UserControl
             if (!TryAcceptSource(
                 channel,
                 rightSide,
+                targetState,
+                targetSettings,
+                revision,
                 snapshot,
                 Path.GetFileName(dialog.FileName),
                 dialog.FileName,
@@ -937,19 +943,20 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private async Task SelectHistoryEntryAsync(ChannelRuntime channel, Guid entryId)
     {
-        // Same side/pair capture as ChooseSourceFileAsync: the snapshot load
-        // is asynchronous and both the L/R selector and session import stay
-        // live meanwhile.
+        // Same slot/settings/revision capture as ChooseSourceFileAsync: the
+        // snapshot load is asynchronous and the L/R selector, the Mono
+        // checkbox and session import all stay live meanwhile.
         bool rightSide = channel.ActiveRight;
-        VirtualCrossoverChannelPairSettings pair = channel.Pair;
+        ChannelSideState targetState = channel.SideState(rightSide);
+        VirtualCrossoverChannelSettings targetSettings = channel.SideSettings(rightSide);
+        int revision = targetState.BeginSourceLoad();
         try
         {
             MeasurementHistoryEntry? entry = HistoryService?.FindById(entryId);
             MeasurementHistorySnapshot? snapshot = HistoryService == null
                 ? null
                 : await HistoryService.GetSnapshotAsync(entryId);
-            if (entry == null || snapshot == null ||
-                IsDisposed || channel.Pair != pair)
+            if (entry == null || snapshot == null || IsDisposed)
             {
                 return;
             }
@@ -957,6 +964,9 @@ public partial class VirtualCrossoverPanel : UserControl
             TryAcceptSource(
                 channel,
                 rightSide,
+                targetState,
+                targetSettings,
+                revision,
                 snapshot,
                 entry.FileNameOrDisplayName,
                 entry.SourceFilePath,
@@ -971,14 +981,26 @@ public partial class VirtualCrossoverPanel : UserControl
     // Validates and installs a resolved measurement as the channel's source. The
     // virtual sum only has physical meaning for loopback-referenced transfer IRs
     // sharing one sample rate, so both are enforced here with an explanation.
+    // The target slot and settings are the caller's PRE-AWAIT captures — never
+    // re-derived here, where a mid-load Mono toggle would reroute them — and
+    // the revision refuses a landing the slot has moved past (cleared by a
+    // project import or mono toggle, or superseded by a newer pick).
     private bool TryAcceptSource(
         ChannelRuntime channel,
         bool rightSide,
+        ChannelSideState targetState,
+        VirtualCrossoverChannelSettings targetSettings,
+        int sourceRevision,
         MeasurementHistorySnapshot snapshot,
         string displayName,
         string? sourceFilePath,
         Guid? historyEntryId)
     {
+        if (targetState.SourceRevision != sourceRevision)
+        {
+            return false;
+        }
+
         if (snapshot.TransferImpulseResponse is not { Length: > 0 } transferIr)
         {
             ShowError(
@@ -993,7 +1015,6 @@ public partial class VirtualCrossoverPanel : UserControl
         // compatibility decision is shared with the silent reload path, and it
         // scans EVERY resolved side of every pair — the virtual sums of both
         // sides read one shared rate.
-        ChannelSideState targetState = channel.SideState(rightSide);
         VirtualCrossoverSourceRules.Decision decision = VirtualCrossoverSourceRules.Evaluate(
             hasTransferIr: true,
             candidateSampleRate: snapshot.SampleRate,
@@ -1024,6 +1045,13 @@ public partial class VirtualCrossoverPanel : UserControl
                 return false;
             }
 
+            // The modal dialog pumped messages: a project-import continuation
+            // may have wiped the slot underneath it while the user decided.
+            if (targetState.SourceRevision != sourceRevision)
+            {
+                return false;
+            }
+
             foreach ((ChannelRuntime other, bool otherRight, _) in mismatched)
             {
                 ClearSourceCore(other, otherRight);
@@ -1035,8 +1063,6 @@ public partial class VirtualCrossoverPanel : UserControl
         targetState.TransferPeakIndex = Math.Clamp(
             snapshot.TransferPeakIndex ?? 0, 0, transferIr.Length - 1);
         targetState.SampleRate = snapshot.SampleRate;
-        VirtualCrossoverChannelSettings targetSettings =
-            channel.SideSettings(rightSide);
         targetSettings.DisplayName = displayName;
         targetSettings.SourceFilePath = sourceFilePath;
         targetSettings.HistoryEntryId = historyEntryId;
@@ -1108,6 +1134,12 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
+        // The same in-flight guard as the interactive pickers: rapid mono
+        // off→on→off leaves several of these resolves airborne at once, and
+        // only the latest one — or none, if the slot was cleared after it
+        // started — may land. Snapshot loading below is the await that lets
+        // the UI act meanwhile.
+        int revision = state.BeginSourceLoad();
         try
         {
             MeasurementHistorySnapshot? snapshot = null;
@@ -1134,7 +1166,8 @@ public partial class VirtualCrossoverPanel : UserControl
                 otherResolvedSampleRates: ResolvedSidesExcept(state)
                     .Select(item => item.State.SampleRate));
             if (decision == VirtualCrossoverSourceRules.Decision.Accept &&
-                snapshot?.TransferImpulseResponse is { Length: > 0 } transferIr)
+                snapshot?.TransferImpulseResponse is { Length: > 0 } transferIr &&
+                state.SourceRevision == revision)
             {
                 state.TransferImpulseResponse = transferIr;
                 state.ProcessedCache = null;
@@ -2098,8 +2131,11 @@ public partial class VirtualCrossoverPanel : UserControl
                 VirtualCrossoverJunctions.GetChannelBand(rightSettings);
             double lowHz = Math.Max(leftLow, rightLow);
             double highHz = Math.Min(leftHigh, rightHigh);
-            if (highHz <= lowHz)
+            if (highHz < lowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
             {
+                // The arrival analysis refuses a band this narrow (it is not
+                // widened behind the caller's back), so the row would only
+                // ever read "—" — leave it out entirely.
                 continue;
             }
 
@@ -2193,10 +2229,18 @@ public partial class VirtualCrossoverPanel : UserControl
             }
         }
 
+        // The same reliability gate the engine's inter-side decisions apply:
+        // a formally valid arrival with a near-noise record would print a
+        // precise-looking Δ the user might chase with manual delays — an
+        // honest "—" is the right read-out there.
+        static bool Reliable(TimeAlignmentAnalysisResult arrival) =>
+            arrival.IsValid &&
+            arrival.SignalToNoiseDecibels >= AutoAlignmentEngine.MinimumArrivalSnrDb;
+
         return jobs
             .Select(job => new VirtualCrossoverMetric.StereoDelta(
                 job.Channel,
-                job.Left.Arrival!.Value.IsValid && job.Right.Arrival!.Value.IsValid
+                Reliable(job.Left.Arrival!.Value) && Reliable(job.Right.Arrival!.Value)
                     ? job.Left.Arrival!.Value.FirstArrivalDelayMilliseconds -
                         job.Right.Arrival!.Value.FirstArrivalDelayMilliseconds
                     : null,
@@ -2778,7 +2822,8 @@ public partial class VirtualCrossoverPanel : UserControl
             VirtualCrossoverJunctions.GetChannelBand(bridgeRight.Settings);
         double bridgeBandLowHz = Math.Max(leftBandLowHz, rightBandLowHz);
         double bridgeBandHighHz = Math.Min(leftBandHighHz, rightBandHighHz);
-        if (bridgeBandHighHz < bridgeBandLowHz * Math.Pow(2.0, 1.0 / 3.0))
+        if (bridgeBandHighHz <
+            bridgeBandLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
         {
             ShowError(
                 "The stereo bridge has no usable shared band.",
@@ -2917,7 +2962,10 @@ public partial class VirtualCrossoverPanel : UserControl
                 VirtualCrossoverJunctions.GetChannelBand(right.Settings);
             double lowHz = Math.Max(leftLow, rightLow);
             double highHz = Math.Min(leftHigh, rightHigh);
-            if (highHz > lowHz)
+            // The link's band must satisfy the arrival analysis' own
+            // admission rule — the band is no longer silently widened for a
+            // too-narrow intersection, so such a link could never measure.
+            if (highHz >= lowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
             {
                 pairLinks.Add(new StereoPairLink(left, right, lowHz, highHz));
             }
@@ -3593,6 +3641,17 @@ public partial class VirtualCrossoverPanel : UserControl
         public (Complex[] ProcessedIr, double LowHz, double HighHz,
             TimeAlignmentAnalysisResult Result)? ArrivalCache { get; set; }
 
+        // Invalidation counter for in-flight asynchronous source loads: a
+        // load captures the revision when it starts (BeginSourceLoad, which
+        // also invalidates any OLDER in-flight load into this slot, so the
+        // user's latest pick wins regardless of completion order) and may
+        // write back only while the revision still matches. Clear() bumps it
+        // too: a project import or mono toggle mid-load kills the landing
+        // instead of hiding a stale measurement in a slot that was wiped.
+        public int SourceRevision { get; private set; }
+
+        public int BeginSourceLoad() => ++SourceRevision;
+
         public void Clear()
         {
             TransferImpulseResponse = null;
@@ -3600,6 +3659,7 @@ public partial class VirtualCrossoverPanel : UserControl
             SampleRate = 0;
             ProcessedCache = null;
             ArrivalCache = null;
+            SourceRevision++;
         }
     }
 

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -2083,6 +2083,7 @@ public partial class VirtualCrossoverPanel : UserControl
         public int ProcessedPeak { get; set; }
         public bool ProcessedFromCache { get; set; }
         public TimeAlignmentAnalysisResult? Arrival { get; set; }
+        public double? LevelDb { get; set; }
         public bool ArrivalFromCache { get; set; }
     }
 
@@ -2166,6 +2167,7 @@ public partial class VirtualCrossoverPanel : UserControl
                     arrival.LowHz == lowHz && arrival.HighHz == highHz)
                 {
                     side.Arrival = arrival.Result;
+                    side.LevelDb = arrival.LevelDb;
                     side.ArrivalFromCache = true;
                 }
 
@@ -2203,6 +2205,9 @@ public partial class VirtualCrossoverPanel : UserControl
                                 VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
                                     side.ProcessedIr, side.SampleRate,
                                     job.LowHz, job.HighHz);
+                            side.LevelDb = VirtualCrossoverAnalysis.MeasureBandLevelDb(
+                                side.ProcessedIr, side.SampleRate,
+                                job.LowHz, job.HighHz);
                         }
                     }
                 }
@@ -2223,7 +2228,7 @@ public partial class VirtualCrossoverPanel : UserControl
                     {
                         side.State.ArrivalCache =
                             (side.ProcessedIr!, job.LowHz, job.HighHz,
-                                side.Arrival!.Value);
+                                side.Arrival!.Value, side.LevelDb);
                     }
                 }
             }
@@ -2233,20 +2238,32 @@ public partial class VirtualCrossoverPanel : UserControl
         // per side: a formally valid arrival with a near-noise record would
         // print a precise-looking figure the user might chase with manual
         // delays — an honest "—" is the right read-out there. The Δ column
-        // follows automatically (it needs both sides).
-        static double? ReliableArrivalMs(TimeAlignmentAnalysisResult arrival) =>
+        // follows automatically (it needs both sides), and the level Δ is
+        // gated the same way: a band that cannot place an arrival is reading
+        // its noise floor, not a driver level.
+        static bool Reliable(TimeAlignmentAnalysisResult arrival) =>
             arrival.IsValid &&
-            arrival.SignalToNoiseDecibels >= AutoAlignmentEngine.MinimumArrivalSnrDb
-                ? arrival.FirstArrivalDelayMilliseconds
-                : null;
+            arrival.SignalToNoiseDecibels >= AutoAlignmentEngine.MinimumArrivalSnrDb;
 
         return jobs
-            .Select(job => new VirtualCrossoverMetric.StereoDelta(
-                job.Channel,
-                ReliableArrivalMs(job.Left.Arrival!.Value),
-                ReliableArrivalMs(job.Right.Arrival!.Value),
-                job.LowHz,
-                job.HighHz))
+            .Select(job =>
+            {
+                TimeAlignmentAnalysisResult left = job.Left.Arrival!.Value;
+                TimeAlignmentAnalysisResult right = job.Right.Arrival!.Value;
+                bool leftReliable = Reliable(left);
+                bool rightReliable = Reliable(right);
+                return new VirtualCrossoverMetric.StereoDelta(
+                    job.Channel,
+                    leftReliable ? left.FirstArrivalDelayMilliseconds : null,
+                    rightReliable ? right.FirstArrivalDelayMilliseconds : null,
+                    job.LowHz,
+                    job.HighHz,
+                    leftReliable && rightReliable &&
+                    job.Left.LevelDb is { } leftLevel &&
+                    job.Right.LevelDb is { } rightLevel
+                        ? leftLevel - rightLevel
+                        : null);
+            })
             .ToList();
     }
 
@@ -3635,12 +3652,15 @@ public partial class VirtualCrossoverPanel : UserControl
         public int SampleRate { get; set; }
         public ProcessedChannelCache? ProcessedCache { get; set; }
 
-        // The band-limited envelope arrival of this side's PROCESSED response,
-        // keyed by the processed array's identity and the measured band — the
-        // Δ L−R read-out re-runs on every redraw, and the Hilbert analysis of
-        // a full-length IR is far too heavy to repeat when nothing changed.
+        // The band-limited envelope arrival and gated band level of this
+        // side's PROCESSED response, keyed by the processed array's identity
+        // and the measured band — the L/R/Δ read-out re-runs on every redraw,
+        // and the Hilbert analysis of a full-length IR is far too heavy to
+        // repeat when nothing changed. The level rides in the same cache
+        // entry: it is measured over the same band from the same response.
         public (Complex[] ProcessedIr, double LowHz, double HighHz,
-            TimeAlignmentAnalysisResult Result)? ArrivalCache { get; set; }
+            TimeAlignmentAnalysisResult Result, double? LevelDb)?
+            ArrivalCache { get; set; }
 
         // Invalidation counter for in-flight asynchronous source loads: a
         // load captures the revision when it starts (BeginSourceLoad, which

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -235,7 +235,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // Match the block list to the project's channel count (validated into the
         // supported range on load), so an imported 2- or 6-channel session shows
         // exactly its channels.
-        SetChannelCount(project.Channels.Count);
+        SetChannelCount(project.Pairs.Count);
 
         suppressProjectEvents = true;
         try
@@ -244,6 +244,10 @@ public partial class VirtualCrossoverPanel : UserControl
             checkBoxShowLoss.Checked = project.ShowLossCurve;
             radioViewPhase.Checked = project.ShowPhaseView;
             radioViewMagnitude.Checked = !project.ShowPhaseView;
+            radioSideRight.Checked = project.ActiveSideRight;
+            radioSideLeft.Checked = !project.ActiveSideRight;
+            numericSceneOffset.Value = Clamp(
+                numericSceneOffset, project.StereoSceneOffsetMs);
             ConfigureMainValueAxis();
             UpdateGateButtonAvailability();
             comboBoxSmoothing.SelectedItem =
@@ -256,7 +260,8 @@ public partial class VirtualCrossoverPanel : UserControl
 
             for (int i = 0; i < channels.Count; i++)
             {
-                channels[i].Settings = project.Channels[i];
+                channels[i].Pair = project.Pairs[i];
+                channels[i].ActiveRight = project.ActiveSideRight;
                 ApplySettingsToControl(channels[i]);
             }
         }
@@ -269,14 +274,27 @@ public partial class VirtualCrossoverPanel : UserControl
 
         foreach (ChannelRuntime channel in channels)
         {
-            // Discard the previous project's resolved measurement first, so an
-            // imported channel without a source does not keep stale audio.
-            channel.TransferImpulseResponse = null;
-            channel.ProcessedCache = null;
-            channel.SampleRate = 0;
-            await ResolveSourceAsync(channel, showErrors: false);
+            // Both sides resolve up front (the stereo Auto delay needs them
+            // simultaneously), each after discarding the previous project's
+            // resolved measurement so an imported side without a source does
+            // not keep stale audio.
+            foreach (bool rightSide in new[] { false, true })
+            {
+                // A mono pair has one state slot; its second iteration would
+                // just wipe and re-resolve what the first one loaded.
+                if (channel.Pair.Mono && rightSide)
+                {
+                    continue;
+                }
+
+                channel.SideState(rightSide).Clear();
+                await ResolveSourceAsync(channel, rightSide, showErrors: false);
+            }
+
+            UpdateSourceButton(channel);
         }
 
+        UpdateSideRadioTexts();
         RedrawAll();
     }
 
@@ -402,6 +420,66 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             if (radioDspGroupDelay.Checked) OnDspPlotModeChanged();
         };
+        // Two-radio group: listening to one of them reacts exactly once per
+        // side switch.
+        radioSideRight.CheckedChanged += (_, _) => OnActiveSideChanged();
+        numericSceneOffset.ValueChanged += (_, _) => OnSceneOffsetChanged();
+    }
+
+    // Flips the whole tool to the other side of every pair: the channel
+    // controls rebind to that side's settings, and the plots, metric and delay
+    // read-outs recompute from its measurements. Each side keeps its own
+    // processed-IR cache, so switching back and forth is cheap.
+    private void OnActiveSideChanged()
+    {
+        if (suppressProjectEvents)
+        {
+            return;
+        }
+
+        bool rightSide = radioSideRight.Checked;
+        project.ActiveSideRight = rightSide;
+        suppressProjectEvents = true;
+        try
+        {
+            foreach (ChannelRuntime channel in channels)
+            {
+                channel.ActiveRight = rightSide;
+                ApplySettingsToControl(channel);
+            }
+        }
+        finally
+        {
+            suppressProjectEvents = false;
+        }
+
+        UpdateSideRadioTexts();
+        ScheduleSave();
+        RedrawAll();
+    }
+
+    private void OnSceneOffsetChanged()
+    {
+        if (suppressProjectEvents)
+        {
+            return;
+        }
+
+        project.StereoSceneOffsetMs = (double)numericSceneOffset.Value;
+        ScheduleSave();
+    }
+
+    // The side radios double as source indicators (● has at least one source,
+    // ○ none), so switching to an empty side is never a surprise blank plot.
+    private void UpdateSideRadioTexts()
+    {
+        bool leftAny = channels.Any(channel =>
+            channel.SideState(false).TransferImpulseResponse != null);
+        bool rightAny = channels.Any(channel =>
+            !channel.Pair.Mono &&
+            channel.SideState(true).TransferImpulseResponse != null);
+        radioSideLeft.Text = leftAny ? "L ●" : "L ○";
+        radioSideRight.Text = rightAny ? "R ●" : "R ○";
     }
 
     // ----------------------------------------------------------- channel list
@@ -473,8 +551,8 @@ public partial class VirtualCrossoverPanel : UserControl
             !autoDelayBusy && channels.Count > MinChannelCount;
     }
 
-    // Appends a channel: a fresh block and a matching empty project entry, so the
-    // new channel simply has no source until the user picks one.
+    // Appends a channel pair: a fresh block and a matching empty project entry,
+    // so the new channel simply has no sources until the user picks them.
     private void AddChannel()
     {
         if (channels.Count >= MaxChannelCount)
@@ -482,20 +560,21 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
-        var settings = new VirtualCrossoverChannelSettings();
-        project.Channels.Add(settings);
+        var pair = new VirtualCrossoverChannelPairSettings();
+        project.Pairs.Add(pair);
         SetChannelCount(channels.Count + 1);
-        // Bind the new block to its settings the same way ApplyProjectAsync does.
+        // Bind the new block to its pair the same way ApplyProjectAsync does.
         ChannelRuntime added = channels[^1];
-        added.Settings = settings;
+        added.Pair = pair;
+        added.ActiveRight = project.ActiveSideRight;
         ApplySettingsToControl(added);
 
         ScheduleSave();
         RedrawAll();
     }
 
-    // Drops the last channel and its project entry. Its resolved measurement goes
-    // with the disposed block; the remaining channels are untouched.
+    // Drops the last channel pair and its project entry. Its resolved
+    // measurements go with the disposed block; the remaining pairs are untouched.
     private void RemoveChannel()
     {
         if (channels.Count <= MinChannelCount)
@@ -504,10 +583,10 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         SetChannelCount(channels.Count - 1);
-        if (project.Channels.Count > channels.Count)
+        if (project.Pairs.Count > channels.Count)
         {
-            project.Channels.RemoveRange(
-                channels.Count, project.Channels.Count - channels.Count);
+            project.Pairs.RemoveRange(
+                channels.Count, project.Pairs.Count - channels.Count);
         }
 
         ScheduleSave();
@@ -521,7 +600,36 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
-        ReadControlIntoSettings(channel);
+        // Flipping Mono while the RIGHT side is shown swaps which settings
+        // object the control edits (a mono pair always answers with the left
+        // side), so the values just read from the control belong to the OLD
+        // binding and must not be written through the new one — rebind the
+        // control instead.
+        bool wasMono = channel.Pair.Mono;
+        bool monoNow = channel.Control.MonoCheckBox.Checked;
+        if (wasMono != monoNow && channel.ActiveRight)
+        {
+            channel.Pair.Mono = monoNow;
+            suppressProjectEvents = true;
+            try
+            {
+                ApplySettingsToControl(channel);
+            }
+            finally
+            {
+                suppressProjectEvents = false;
+            }
+        }
+        else
+        {
+            ReadControlIntoSettings(channel);
+        }
+
+        if (wasMono != monoNow)
+        {
+            UpdateSideRadioTexts();
+        }
+
         ScheduleSave();
         RedrawAll();
     }
@@ -580,6 +688,7 @@ public partial class VirtualCrossoverPanel : UserControl
             control.ShowRawCheckBox.Checked = settings.ShowRawCurve;
             control.ShowProcessedCheckBox.Checked = settings.ShowProcessedCurve;
             control.BypassCheckBox.Checked = settings.Bypass;
+            control.MonoCheckBox.Checked = channel.Pair.Mono;
             control.Muted = !settings.Enabled;
         });
 
@@ -601,6 +710,7 @@ public partial class VirtualCrossoverPanel : UserControl
         settings.ShowProcessedCurve = control.ShowProcessedCheckBox.Checked;
         settings.Enabled = !control.Muted;
         settings.Bypass = control.BypassCheckBox.Checked;
+        channel.Pair.Mono = control.MonoCheckBox.Checked;
     }
 
     private static decimal Clamp(DarkNumericUpDown control, double value)
@@ -741,25 +851,26 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         // A mismatched sample rate is not a dead end: the user picks whether the
-        // new measurement wins (clearing the incompatible channels) or loses. The
-        // compatibility decision is shared with the silent reload path.
+        // new measurement wins (clearing the incompatible sides) or loses. The
+        // compatibility decision is shared with the silent reload path, and it
+        // scans EVERY resolved side of every pair — the virtual sums of both
+        // sides read one shared rate.
+        ChannelSideState targetState = channel.SideState(channel.ActiveRight);
         VirtualCrossoverSourceRules.Decision decision = VirtualCrossoverSourceRules.Evaluate(
             hasTransferIr: true,
             candidateSampleRate: snapshot.SampleRate,
-            otherResolvedSampleRates: channels
-                .Where(other => other != channel && other.TransferImpulseResponse != null)
-                .Select(other => other.SampleRate));
+            otherResolvedSampleRates: ResolvedSidesExcept(targetState)
+                .Select(item => item.State.SampleRate));
         if (decision == VirtualCrossoverSourceRules.Decision.NeedsConfirmClear)
         {
-            List<ChannelRuntime> mismatched = channels
-                .Where(other => other != channel &&
-                    other.TransferImpulseResponse != null &&
-                    other.SampleRate != snapshot.SampleRate)
+            var mismatched = ResolvedSidesExcept(targetState)
+                .Where(item => item.State.SampleRate != snapshot.SampleRate)
                 .ToList();
             string mismatchedList = string.Join(
                 ", ",
-                mismatched.Select(other =>
-                    $"{other.Control.ChannelName} ({other.SampleRate} Hz)"));
+                mismatched.Select(item =>
+                    $"{SideLabel(item.Channel, item.RightSide)} " +
+                    $"({item.State.SampleRate} Hz)"));
             DialogResult answer = MessageBox.Show(
                 FindForm(),
                 $"This measurement is {snapshot.SampleRate} Hz, but channel " +
@@ -775,9 +886,9 @@ public partial class VirtualCrossoverPanel : UserControl
                 return false;
             }
 
-            foreach (ChannelRuntime other in mismatched)
+            foreach ((ChannelRuntime other, bool otherRight, _) in mismatched)
             {
-                ClearSourceCore(other);
+                ClearSourceCore(other, otherRight);
             }
         }
 
@@ -791,38 +902,69 @@ public partial class VirtualCrossoverPanel : UserControl
         channel.Settings.HistoryEntryId = historyEntryId;
 
         UpdateSourceButton(channel);
+        UpdateSideRadioTexts();
         ScheduleSave();
         RedrawAll();
         return true;
     }
 
+    // Every resolved (channel, side) except the given side state; mono pairs
+    // expose only their single left-side slot.
+    private IEnumerable<(ChannelRuntime Channel, bool RightSide, ChannelSideState State)>
+        ResolvedSidesExcept(ChannelSideState? except)
+    {
+        foreach (ChannelRuntime channel in channels)
+        {
+            foreach (bool rightSide in new[] { false, true })
+            {
+                if (channel.Pair.Mono && rightSide)
+                {
+                    continue;
+                }
+
+                ChannelSideState state = channel.SideState(rightSide);
+                if (state != except && state.TransferImpulseResponse != null)
+                {
+                    yield return (channel, rightSide, state);
+                }
+            }
+        }
+    }
+
+    private static string SideLabel(ChannelRuntime channel, bool rightSide) =>
+        channel.Pair.Mono
+            ? $"{channel.Control.ChannelName} (mono)"
+            : $"{channel.Control.ChannelName} {(rightSide ? "R" : "L")}";
+
     private void ClearSource(ChannelRuntime channel)
     {
-        ClearSourceCore(channel);
+        ClearSourceCore(channel, channel.ActiveRight);
         ScheduleSave();
         RedrawAll();
     }
 
-    private void ClearSourceCore(ChannelRuntime channel)
+    private void ClearSourceCore(ChannelRuntime channel, bool rightSide)
     {
-        channel.TransferImpulseResponse = null;
-        channel.ProcessedCache = null;
-        channel.SampleRate = 0;
-        channel.Settings.DisplayName = string.Empty;
-        channel.Settings.SourceFilePath = null;
-        channel.Settings.HistoryEntryId = null;
+        channel.SideState(rightSide).Clear();
+        VirtualCrossoverChannelSettings settings = channel.SideSettings(rightSide);
+        settings.DisplayName = string.Empty;
+        settings.SourceFilePath = null;
+        settings.HistoryEntryId = null;
         UpdateSourceButton(channel);
+        UpdateSideRadioTexts();
     }
 
-    // Re-resolves a persisted source reference: the history entry first (it
-    // survives file moves), then the file path. A source that no longer exists
-    // degrades to an unresolved channel instead of failing the project load.
-    private async Task ResolveSourceAsync(ChannelRuntime channel, bool showErrors)
+    // Re-resolves one side's persisted source reference: the history entry
+    // first (it survives file moves), then the file path. A source that no
+    // longer exists degrades to an unresolved side instead of failing the
+    // project load.
+    private async Task ResolveSourceAsync(
+        ChannelRuntime channel, bool rightSide, bool showErrors)
     {
-        VirtualCrossoverChannelSettings settings = channel.Settings;
+        VirtualCrossoverChannelSettings settings = channel.SideSettings(rightSide);
+        ChannelSideState state = channel.SideState(rightSide);
         if (!settings.HasSource)
         {
-            UpdateSourceButton(channel);
             return;
         }
 
@@ -849,25 +991,22 @@ public partial class VirtualCrossoverPanel : UserControl
             VirtualCrossoverSourceRules.Decision decision = VirtualCrossoverSourceRules.Evaluate(
                 hasTransferIr: snapshot?.TransferImpulseResponse is { Length: > 0 },
                 candidateSampleRate: snapshot?.SampleRate ?? 0,
-                otherResolvedSampleRates: channels
-                    .Where(other => other != channel && other.TransferImpulseResponse != null)
-                    .Select(other => other.SampleRate));
+                otherResolvedSampleRates: ResolvedSidesExcept(state)
+                    .Select(item => item.State.SampleRate));
             if (decision == VirtualCrossoverSourceRules.Decision.Accept &&
                 snapshot?.TransferImpulseResponse is { Length: > 0 } transferIr)
             {
-                channel.TransferImpulseResponse = transferIr;
-                channel.ProcessedCache = null;
-                channel.TransferPeakIndex = Math.Clamp(
+                state.TransferImpulseResponse = transferIr;
+                state.ProcessedCache = null;
+                state.TransferPeakIndex = Math.Clamp(
                     snapshot.TransferPeakIndex ?? 0, 0, transferIr.Length - 1);
-                channel.SampleRate = snapshot.SampleRate;
+                state.SampleRate = snapshot.SampleRate;
             }
         }
         catch (Exception exception) when (!showErrors)
         {
             _ = exception;
         }
-
-        UpdateSourceButton(channel);
     }
 
     private void UpdateSourceButton(ChannelRuntime channel)
@@ -1174,8 +1313,28 @@ public partial class VirtualCrossoverPanel : UserControl
             "arrivals set the coarse delays, then a phase search\r\n" +
             "(±half a crossover period) fine-tunes them and flips\r\n" +
             "polarity when the channels sum better inverted.\r\n" +
+            "With both sides loaded the run is STEREO: the left side\r\n" +
+            "aligns first, the right top driver is timed to the left\r\n" +
+            "one (honoring the L/R offset), and the right side\r\n" +
+            "descends from it — so the stereo image stays put.\r\n" +
             "Set the crossover filters first — the search targets\r\n" +
             "the overlap region around their corner frequencies.");
+        toolTip.SetToolTip(
+            numericSceneOffset,
+            "Stereo scene offset for Auto delay (ms).\r\n" +
+            "Positive: the RIGHT side arrives earlier by this much,\r\n" +
+            "pulling the image from the driver's axis toward the\r\n" +
+            "dash center on a left-hand-drive car. Typical: 0.2–0.3 ms.\r\n" +
+            "Right-hand drive: enter a negative value.\r\n" +
+            "0 = image centered on the measurement position.");
+        toolTip.SetToolTip(
+            radioSideLeft,
+            "Show and edit the LEFT side of every channel pair.\r\n" +
+            "● — at least one source is loaded on this side.");
+        toolTip.SetToolTip(
+            radioSideRight,
+            "Show and edit the RIGHT side of every channel pair.\r\n" +
+            "● — at least one source is loaded on this side.");
         toolTip.SetToolTip(
             buttonAutoSetup,
             "Crossover wizard: detect each channel's driver type from\r\n" +
@@ -1224,6 +1383,13 @@ public partial class VirtualCrossoverPanel : UserControl
                 "Bypass the DSP chain: feed the raw measured signal with\r\n" +
                 "no gain, delay, polarity, crossover or PEQ — the driver's\r\n" +
                 "natural band-pass, for an A/B against the processed result.");
+            toolTip.SetToolTip(
+                channel.Control.MonoCheckBox,
+                "One physical driver serving both sides (typically the\r\n" +
+                "subwoofer): a single set of settings participates in the\r\n" +
+                "L and R views and calculations alike. The stereo Auto\r\n" +
+                "delay tunes it with the left side and reports the right\r\n" +
+                "junction it pins.");
             toolTip.SetToolTip(
                 channel.Control.MeasuredPolarityLabel,
                 "Acoustic polarity read from the measured IR\r\n" +
@@ -1858,6 +2024,24 @@ public partial class VirtualCrossoverPanel : UserControl
     // every time.
     private async void AutoAlignDelay()
     {
+        // Stereo whenever the data allows it: some non-mono pair has BOTH
+        // sides resolved (the highest such pair becomes the L/R bridge) and
+        // the left side can hold its own walk. Otherwise the classic
+        // single-side run on whatever side is displayed.
+        (List<SideAlignmentChannel> leftSide, List<SideAlignmentChannel> rightSide) =
+            CollectStereoSides();
+        SideAlignmentChannel? bridgeRight = rightSide
+            .Where(item => item.RightSide &&
+                leftSide.Any(left =>
+                    left.Runtime == item.Runtime && !left.RightSide))
+            .OrderBy(item => VirtualCrossoverJunctions.BandCenterHz(item.Settings))
+            .LastOrDefault();
+        if (bridgeRight != null && leftSide.Count >= 2)
+        {
+            await AutoAlignStereoAsync(leftSide, rightSide, bridgeRight);
+            return;
+        }
+
         var alignment = new Dictionary<ChannelRuntime, AlignmentOverride>();
         List<ProcessedChannel> processed = ProcessChannels(alignment);
         if (processed.Count < 2)
@@ -2070,6 +2254,262 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             alignment[(ChannelRuntime)channel] = result;
         }
+    }
+
+    // The per-side participants of a stereo Auto delay run: every enabled
+    // channel side with a resolved measurement. A mono pair contributes ONE
+    // instance (its left side), shared by both lists — the engine tunes it in
+    // the left pass and treats it as fixed on the right.
+    private (List<SideAlignmentChannel> Left, List<SideAlignmentChannel> Right)
+        CollectStereoSides()
+    {
+        var left = new List<SideAlignmentChannel>();
+        var right = new List<SideAlignmentChannel>();
+        foreach (ChannelRuntime channel in channels)
+        {
+            if (channel.SideSettings(false).Enabled &&
+                channel.SideState(false).TransferImpulseResponse != null)
+            {
+                var side = new SideAlignmentChannel(channel, false);
+                left.Add(side);
+                if (channel.Pair.Mono)
+                {
+                    right.Add(side);
+                }
+            }
+
+            if (!channel.Pair.Mono &&
+                channel.SideSettings(true).Enabled &&
+                channel.SideState(true).TransferImpulseResponse != null)
+            {
+                right.Add(new SideAlignmentChannel(channel, true));
+            }
+        }
+
+        return (left, right);
+    }
+
+    // The stereo Auto delay: left side first, then the L/R bridge at the top
+    // pair honoring the scene offset, then the right-side descent — the
+    // cascade itself lives in AutoAlignmentEngine.ComputeStereo (dsp,
+    // unit-tested on synthetic systems and real car measurements).
+    private async Task AutoAlignStereoAsync(
+        List<SideAlignmentChannel> leftSide,
+        List<SideAlignmentChannel> rightSide,
+        SideAlignmentChannel bridgeRight)
+    {
+        List<SideAlignmentChannel> union = leftSide.Concat(rightSide)
+            .Distinct()
+            .ToList();
+
+        // Same reasoning as the single-side run: a bypassed side processes
+        // through the identity chain, so the computed delay would silently not
+        // apply — refuse instead of proposing a wrong alignment.
+        List<SideAlignmentChannel> bypassed = union
+            .Where(item => item.Settings.Bypass)
+            .ToList();
+        if (bypassed.Count > 0)
+        {
+            ShowError(
+                "Auto delay cannot run with bypassed channels.",
+                "Bypass feeds the raw measured signal, so the computed delays " +
+                "and polarities would not apply to: " +
+                string.Join(", ", bypassed.Select(item => item.Name)) +
+                ".\r\n\r\nDisable Bypass on every participating channel " +
+                "(or mute the channel to exclude it) and run Auto delay again.");
+            return;
+        }
+
+        bool anyCrossover = union.Any(
+            item => item.Settings.CrossoverKind != CrossoverKind.Off);
+        if (!anyCrossover)
+        {
+            DialogResult answer = MessageBox.Show(
+                FindForm(),
+                "No channel has a crossover configured, so the delay search " +
+                "will use a broad 100 Hz – 10 kHz window instead of the " +
+                "crossover region." +
+                Environment.NewLine + Environment.NewLine +
+                "For an accurate alignment set the crossover filters first, " +
+                "then run Auto delay again." +
+                Environment.NewLine + Environment.NewLine +
+                "Run the broad-window search anyway?",
+                "Virtual DSP",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning);
+            if (answer != DialogResult.Yes)
+            {
+                return;
+            }
+        }
+
+        SideAlignmentChannel bridgeLeft = leftSide.First(
+            item => item.Runtime == bridgeRight.Runtime && !item.RightSide);
+        (double bridgeBandLowHz, double bridgeBandHighHz) =
+            VirtualCrossoverJunctions.GetChannelBand(bridgeLeft.Settings);
+        double sceneOffsetMs = project.StereoSceneOffsetMs;
+
+        var log = new System.Text.StringBuilder();
+        log.AppendLine($"Auto delay (stereo) {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+        log.AppendLine(
+            $"Scene offset {sceneOffsetMs:+0.00;-0.00} ms (positive: right side leads); " +
+            $"bridge {bridgeLeft.Name} -> {bridgeRight.Name} " +
+            $"in {bridgeBandLowHz:0}-{bridgeBandHighHz:0} Hz");
+        log.AppendLine("Previous delay / polarity settings ignored for this run.");
+
+        var engineAlignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        SetAutoDelayBusy(true);
+        try
+        {
+            await Task.Run(() => ComputeStereoAlignment(
+                leftSide, rightSide, union, bridgeLeft, bridgeRight,
+                bridgeBandLowHz, bridgeBandHighHz, sceneOffsetMs,
+                engineAlignment, log));
+            if (IsDisposed || !IsHandleCreated)
+            {
+                return;
+            }
+
+            ApplyStereoAlignmentResult(union, engineAlignment, log);
+        }
+        catch (Exception exception)
+        {
+            System.Diagnostics.Debug.WriteLine($"Auto delay failed: {exception}");
+            if (!IsDisposed && IsHandleCreated)
+            {
+                ShowError("Auto delay failed.", exception.Message);
+            }
+        }
+        finally
+        {
+            if (!IsDisposed)
+            {
+                SetAutoDelayBusy(false);
+            }
+        }
+    }
+
+    // Bridges the pair/side model to the stereo engine on a background thread,
+    // with the same thread-confined FFT cache idea as the single-side run.
+    private void ComputeStereoAlignment(
+        List<SideAlignmentChannel> leftSide,
+        List<SideAlignmentChannel> rightSide,
+        List<SideAlignmentChannel> union,
+        SideAlignmentChannel bridgeLeft,
+        SideAlignmentChannel bridgeRight,
+        double bridgeBandLowHz,
+        double bridgeBandHighHz,
+        double sceneOffsetMs,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        System.Text.StringBuilder log)
+    {
+        var searchCache = new Dictionary<SideAlignmentChannel, ProcessedChannelCache>();
+        AlignmentSnapshot Process(SideAlignmentChannel side, AlignmentOverride over)
+        {
+            Complex[] ir = side.State.TransferImpulseResponse!;
+            DspChannelChain chain = side.Settings.ToChain() with
+            {
+                DelayMs = over.DelayMs,
+                InvertPolarity = over.InvertPolarity
+            };
+            var key = new ProcessedChannelCacheKey(ir, side.State.SampleRate, chain);
+            ProcessedChannelCache? cached = searchCache.GetValueOrDefault(side);
+            if (cached?.Key.Equals(key) != true)
+            {
+                Complex[] result = VirtualCrossoverAnalysis.ApplyChain(
+                    ir, chain, side.State.SampleRate);
+                cached = new ProcessedChannelCache(
+                    key, result, VirtualCrossoverAnalysis.FindPeakIndex(result));
+                searchCache[side] = cached;
+            }
+
+            return new AlignmentSnapshot(side, cached.ImpulseResponse, cached.PeakIndex);
+        }
+
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            union
+                .Select(side => Process(side, overrides.GetValueOrDefault(side)))
+                .ToList();
+
+        Dictionary<SideAlignmentChannel, AlignmentSnapshot> initial = union
+            .ToDictionary(side => side, side => Process(side, default));
+        List<AlignmentSnapshot> ByBand(List<SideAlignmentChannel> sides) => sides
+            .OrderBy(side => VirtualCrossoverJunctions.BandCenterHz(side.Settings))
+            .Select(side => initial[side])
+            .ToList();
+        List<AlignmentJunction> Pairs(List<AlignmentSnapshot> byBand)
+        {
+            var pairs = new List<AlignmentJunction>();
+            for (int i = 0; i < byBand.Count - 1; i++)
+            {
+                double pairHz = VirtualCrossoverJunctions.GetPairCrossoverHz(
+                    ((SideAlignmentChannel)byBand[i].Channel).Settings,
+                    ((SideAlignmentChannel)byBand[i + 1].Channel).Settings);
+                (double bandLowHz, double bandHighHz) =
+                    VirtualCrossoverJunctions.OverlapBand(pairHz);
+                pairs.Add(new AlignmentJunction(
+                    byBand[i], byBand[i + 1], pairHz, bandLowHz, bandHighHz));
+            }
+
+            return pairs;
+        }
+
+        List<AlignmentSnapshot> leftByBand = ByBand(leftSide);
+        List<AlignmentSnapshot> rightByBand = ByBand(rightSide);
+        AutoAlignmentEngine.ComputeStereo(
+            new StereoAlignmentPlan(
+                leftByBand,
+                Pairs(leftByBand),
+                rightByBand,
+                Pairs(rightByBand),
+                union.Where(side => side.Runtime.Pair.Mono)
+                    .Cast<IAlignmentChannel>()
+                    .ToList(),
+                bridgeLeft,
+                bridgeRight,
+                bridgeBandLowHz,
+                bridgeBandHighHz,
+                sceneOffsetMs),
+            Reprocess,
+            alignment,
+            log);
+    }
+
+    // Applies the stereo proposal to BOTH sides' settings, rebinds the visible
+    // controls and closes the log with the active side's metric.
+    private void ApplyStereoAlignmentResult(
+        List<SideAlignmentChannel> union,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        System.Text.StringBuilder log)
+    {
+        foreach (SideAlignmentChannel side in union)
+        {
+            AlignmentOverride result = alignment.GetValueOrDefault(side);
+            side.Settings.DelayMs = Math.Round(result.DelayMs, 2);
+            side.Settings.InvertPolarity = result.InvertPolarity;
+            log.AppendLine(
+                $"Result {side.Name}: delay {side.Settings.DelayMs:0.00} ms, " +
+                $"invert {(side.Settings.InvertPolarity ? "yes" : "no")}");
+        }
+
+        foreach (ChannelRuntime channel in union
+            .Select(side => side.Runtime)
+            .Distinct())
+        {
+            ApplySettingsToControl(channel);
+        }
+
+        ScheduleSave();
+        RedrawAll();
+        // The read-out follows the active side; the log records which one.
+        List<ProcessedChannel> outcome = ProcessChannels();
+        (List<AnalysisCurve>? outcomeMagnitudes, AnalysisCurve? outcomeSum) =
+            BuildMetricCurves(outcome);
+        log.AppendLine($"Metric ({(project.ActiveSideRight ? "R" : "L")} side):");
+        log.AppendLine(FormatMetricDetail(
+            BuildMetricEntries(outcome, outcomeMagnitudes, outcomeSum)));
+        WriteAlignmentLog(log.ToString());
     }
 
     // A diagnostic trace of the last Auto delay run (pair bands, arrivals,
@@ -2665,10 +3105,35 @@ public partial class VirtualCrossoverPanel : UserControl
             MessageBoxIcon.Error);
     }
 
-    // Runtime state of one channel block: the bound project settings plus the
-    // resolved source measurement (null while unresolved).
+    // The resolved source measurement of one SIDE of a channel pair (null while
+    // unresolved), plus that side's interactive processed-IR cache.
+    private sealed class ChannelSideState
+    {
+        public Complex[]? TransferImpulseResponse { get; set; }
+        public int TransferPeakIndex { get; set; }
+        public int SampleRate { get; set; }
+        public ProcessedChannelCache? ProcessedCache { get; set; }
+
+        public void Clear()
+        {
+            TransferImpulseResponse = null;
+            TransferPeakIndex = 0;
+            SampleRate = 0;
+            ProcessedCache = null;
+        }
+    }
+
+    // Runtime state of one channel block — since the stereo rework, one L/R
+    // PAIR. The block's controls and every interactive computation read the
+    // ACTIVE side through the delegating members below, so the rest of the
+    // panel works unchanged; the side toggle just flips ActiveRight and
+    // rebinds. A mono pair (shared subwoofer) routes both sides to the left
+    // settings and state.
     private sealed class ChannelRuntime : IAlignmentChannel
     {
+        private readonly ChannelSideState leftState = new();
+        private readonly ChannelSideState rightState = new();
+
         public ChannelRuntime(VirtualCrossoverChannelControl control)
         {
             Control = control;
@@ -2678,11 +3143,61 @@ public partial class VirtualCrossoverPanel : UserControl
         // The alignment engine's log identity; ChannelName is a plain string
         // property, safe to read off the UI thread.
         public string Name => Control.ChannelName;
-        public VirtualCrossoverChannelSettings Settings { get; set; } = new();
-        public Complex[]? TransferImpulseResponse { get; set; }
-        public int TransferPeakIndex { get; set; }
-        public int SampleRate { get; set; }
-        public ProcessedChannelCache? ProcessedCache { get; set; }
+
+        public VirtualCrossoverChannelPairSettings Pair { get; set; } = new();
+        public bool ActiveRight { get; set; }
+
+        public ChannelSideState SideState(bool rightSide) =>
+            Pair.Mono || !rightSide ? leftState : rightState;
+        public VirtualCrossoverChannelSettings SideSettings(bool rightSide) =>
+            Pair.SideFor(rightSide);
+        private ChannelSideState Active => SideState(ActiveRight);
+
+        public VirtualCrossoverChannelSettings Settings => Pair.SideFor(ActiveRight);
+        public Complex[]? TransferImpulseResponse
+        {
+            get => Active.TransferImpulseResponse;
+            set => Active.TransferImpulseResponse = value;
+        }
+        public int TransferPeakIndex
+        {
+            get => Active.TransferPeakIndex;
+            set => Active.TransferPeakIndex = value;
+        }
+        public int SampleRate
+        {
+            get => Active.SampleRate;
+            set => Active.SampleRate = value;
+        }
+        public ProcessedChannelCache? ProcessedCache
+        {
+            get => Active.ProcessedCache;
+            set => Active.ProcessedCache = value;
+        }
+    }
+
+    // One side of a channel pair as the STEREO alignment engine sees it: the
+    // engine needs distinct identities for the left and right drivers of one
+    // block, while the interactive paths keep using ChannelRuntime itself. A
+    // mono pair contributes a single instance (rightSide: false) to both
+    // sides' channel lists.
+    private sealed class SideAlignmentChannel : IAlignmentChannel
+    {
+        public SideAlignmentChannel(ChannelRuntime runtime, bool rightSide)
+        {
+            Runtime = runtime;
+            RightSide = rightSide;
+        }
+
+        public ChannelRuntime Runtime { get; }
+        public bool RightSide { get; }
+        public VirtualCrossoverChannelSettings Settings =>
+            Runtime.SideSettings(RightSide);
+        public ChannelSideState State => Runtime.SideState(RightSide);
+        public string Name => Runtime.Pair.Mono
+            ? $"{Runtime.Name} (mono)"
+            : $"{Runtime.Name} {(RightSide ? "R" : "L")}";
+        public int SampleRate => State.SampleRate;
     }
 
     private sealed record ProcessedChannelCache(

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -772,13 +772,17 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private async Task ChooseSourceFileAsync(ChannelRuntime channel)
     {
+        // The side is captured NOW: the user can flip the L/R selector while
+        // the file loads below, and the measurement must still land on the
+        // side whose Source button was clicked.
+        bool rightSide = channel.ActiveRight;
         using var dialog = new OpenFileDialog
         {
             CheckFileExists = true,
             Filter = "Resonalyze impulse response (*.json)|*.json|All files (*.*)|*.*",
             Multiselect = false,
             RestoreDirectory = true,
-            Title = $"Choose channel {channel.Control.ChannelName} impulse response"
+            Title = $"Choose channel {SideLabel(channel, rightSide)} impulse response"
         };
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK)
         {
@@ -791,6 +795,7 @@ public partial class VirtualCrossoverPanel : UserControl
             MeasurementHistorySnapshot snapshot = MeasurementHistoryService.CreateSnapshot(file);
             if (!TryAcceptSource(
                 channel,
+                rightSide,
                 snapshot,
                 Path.GetFileName(dialog.FileName),
                 dialog.FileName,
@@ -807,6 +812,9 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private async Task SelectHistoryEntryAsync(ChannelRuntime channel, Guid entryId)
     {
+        // Same side capture as ChooseSourceFileAsync: the snapshot load is
+        // asynchronous and the L/R selector stays live meanwhile.
+        bool rightSide = channel.ActiveRight;
         try
         {
             MeasurementHistoryEntry? entry = HistoryService?.FindById(entryId);
@@ -820,6 +828,7 @@ public partial class VirtualCrossoverPanel : UserControl
 
             TryAcceptSource(
                 channel,
+                rightSide,
                 snapshot,
                 entry.FileNameOrDisplayName,
                 entry.SourceFilePath,
@@ -836,6 +845,7 @@ public partial class VirtualCrossoverPanel : UserControl
     // sharing one sample rate, so both are enforced here with an explanation.
     private bool TryAcceptSource(
         ChannelRuntime channel,
+        bool rightSide,
         MeasurementHistorySnapshot snapshot,
         string displayName,
         string? sourceFilePath,
@@ -855,7 +865,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // compatibility decision is shared with the silent reload path, and it
         // scans EVERY resolved side of every pair — the virtual sums of both
         // sides read one shared rate.
-        ChannelSideState targetState = channel.SideState(channel.ActiveRight);
+        ChannelSideState targetState = channel.SideState(rightSide);
         VirtualCrossoverSourceRules.Decision decision = VirtualCrossoverSourceRules.Evaluate(
             hasTransferIr: true,
             candidateSampleRate: snapshot.SampleRate,
@@ -892,14 +902,16 @@ public partial class VirtualCrossoverPanel : UserControl
             }
         }
 
-        channel.TransferImpulseResponse = transferIr;
-        channel.ProcessedCache = null;
-        channel.TransferPeakIndex = Math.Clamp(
+        targetState.TransferImpulseResponse = transferIr;
+        targetState.ProcessedCache = null;
+        targetState.TransferPeakIndex = Math.Clamp(
             snapshot.TransferPeakIndex ?? 0, 0, transferIr.Length - 1);
-        channel.SampleRate = snapshot.SampleRate;
-        channel.Settings.DisplayName = displayName;
-        channel.Settings.SourceFilePath = sourceFilePath;
-        channel.Settings.HistoryEntryId = historyEntryId;
+        targetState.SampleRate = snapshot.SampleRate;
+        VirtualCrossoverChannelSettings targetSettings =
+            channel.SideSettings(rightSide);
+        targetSettings.DisplayName = displayName;
+        targetSettings.SourceFilePath = sourceFilePath;
+        targetSettings.HistoryEntryId = historyEntryId;
 
         UpdateSourceButton(channel);
         UpdateSideRadioTexts();
@@ -2153,8 +2165,14 @@ public partial class VirtualCrossoverPanel : UserControl
         // The background compute iterates the live channel list and its live
         // settings, so everything that can mutate them must be locked out too:
         // add/remove change the list (and dispose controls), a session import
-        // replaces the whole configuration mid-search.
+        // replaces the whole configuration mid-search. The side radios flip
+        // the mutable ActiveRight the single-side run reads through — flipping
+        // mid-run would hand the worker the other side's measurements and land
+        // the results on the wrong side's settings.
         buttonSessionImport.Enabled = !busy;
+        radioSideLeft.Enabled = !busy;
+        radioSideRight.Enabled = !busy;
+        numericSceneOffset.Enabled = !busy;
         UpdateChannelButtons();
         foreach (ChannelRuntime channel in channels)
         {

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -90,6 +90,13 @@ public partial class VirtualCrossoverPanel : UserControl
     private bool savePending;
     private bool autoDelayBusy;
 
+    // Bumped whenever the displayed side (or the whole project) changes: a
+    // redraw pass that started before the bump computed the OLD side's IRs,
+    // and drawing them against the new side's live settings would paint one
+    // mixed frame before the pending repaint corrects it. Stale passes check
+    // this after their await and skip the paint instead.
+    private long displayRevision;
+
     public VirtualCrossoverPanel()
     {
         InitializeComponent();
@@ -232,6 +239,7 @@ public partial class VirtualCrossoverPanel : UserControl
     private async Task ApplyProjectAsync(VirtualCrossoverProjectFile newProject)
     {
         project = newProject;
+        displayRevision++;
         // Match the block list to the project's channel count (validated into the
         // supported range on load), so an imported 2- or 6-channel session shows
         // exactly its channels.
@@ -274,20 +282,21 @@ public partial class VirtualCrossoverPanel : UserControl
 
         foreach (ChannelRuntime channel in channels)
         {
-            // Both sides resolve up front (the stereo Auto delay needs them
-            // simultaneously), each after discarding the previous project's
-            // resolved measurement so an imported side without a source does
-            // not keep stale audio.
+            // BOTH physical slots are wiped first — through the effective
+            // accessor a mono pair's real right slot is unreachable, and a
+            // stale measurement from the previous project would otherwise
+            // resurface the moment the pair stops being mono. Then both sides
+            // resolve up front (the stereo Auto delay needs them together); a
+            // mono pair resolves its single slot once.
+            channel.PhysicalSideState(false).Clear();
+            channel.PhysicalSideState(true).Clear();
             foreach (bool rightSide in new[] { false, true })
             {
-                // A mono pair has one state slot; its second iteration would
-                // just wipe and re-resolve what the first one loaded.
                 if (channel.Pair.Mono && rightSide)
                 {
                     continue;
                 }
 
-                channel.SideState(rightSide).Clear();
                 await ResolveSourceAsync(channel, rightSide, showErrors: false);
             }
 
@@ -439,6 +448,7 @@ public partial class VirtualCrossoverPanel : UserControl
 
         bool rightSide = radioSideRight.Checked;
         project.ActiveSideRight = rightSide;
+        displayRevision++;
         suppressProjectEvents = true;
         try
         {
@@ -627,11 +637,51 @@ public partial class VirtualCrossoverPanel : UserControl
 
         if (wasMono != monoNow)
         {
+            if (monoNow)
+            {
+                // The right slot becomes unreachable behind the mono routing;
+                // dropping its runtime now means nothing stale can hide there.
+                // The right SETTINGS survive, so unchecking restores the side
+                // through a normal re-resolve below.
+                channel.PhysicalSideState(true).Clear();
+            }
+            else
+            {
+                // Back to stereo: the right side re-resolves from its persisted
+                // source reference through the usual compatibility validation
+                // instead of resurfacing whatever cache the slot last held.
+                ReresolveRightSide(channel);
+            }
+
             UpdateSideRadioTexts();
         }
 
         ScheduleSave();
         RedrawAll();
+    }
+
+    // Fire-and-forget with a guard, like LoadProjectSafely: called from a
+    // synchronous settings-changed handler.
+    private async void ReresolveRightSide(ChannelRuntime channel)
+    {
+        try
+        {
+            channel.PhysicalSideState(true).Clear();
+            await ResolveSourceAsync(channel, rightSide: true, showErrors: false);
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            UpdateSourceButton(channel);
+            UpdateSideRadioTexts();
+            RedrawAll();
+        }
+        catch (Exception exception)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"Virtual DSP right-side re-resolve failed: {exception}");
+        }
     }
 
     private void OnViewModeChanged()
@@ -772,10 +822,12 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private async Task ChooseSourceFileAsync(ChannelRuntime channel)
     {
-        // The side is captured NOW: the user can flip the L/R selector while
-        // the file loads below, and the measurement must still land on the
-        // side whose Source button was clicked.
+        // The side AND the pair are captured NOW: the user can flip the L/R
+        // selector — or import a whole different session — while the file
+        // loads below, and the measurement must land on the side whose Source
+        // button was clicked, or nowhere at all.
         bool rightSide = channel.ActiveRight;
+        VirtualCrossoverChannelPairSettings pair = channel.Pair;
         using var dialog = new OpenFileDialog
         {
             CheckFileExists = true,
@@ -792,6 +844,13 @@ public partial class VirtualCrossoverPanel : UserControl
         try
         {
             ImpulseResponseFile file = await ImpulseResponseFile.LoadAsync(dialog.FileName);
+            if (IsDisposed || channel.Pair != pair)
+            {
+                // A session import replaced the configuration mid-load: the
+                // completed read belongs to a pair that is no longer bound.
+                return;
+            }
+
             MeasurementHistorySnapshot snapshot = MeasurementHistoryService.CreateSnapshot(file);
             if (!TryAcceptSource(
                 channel,
@@ -812,16 +871,19 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private async Task SelectHistoryEntryAsync(ChannelRuntime channel, Guid entryId)
     {
-        // Same side capture as ChooseSourceFileAsync: the snapshot load is
-        // asynchronous and the L/R selector stays live meanwhile.
+        // Same side/pair capture as ChooseSourceFileAsync: the snapshot load
+        // is asynchronous and both the L/R selector and session import stay
+        // live meanwhile.
         bool rightSide = channel.ActiveRight;
+        VirtualCrossoverChannelPairSettings pair = channel.Pair;
         try
         {
             MeasurementHistoryEntry? entry = HistoryService?.FindById(entryId);
             MeasurementHistorySnapshot? snapshot = HistoryService == null
                 ? null
                 : await HistoryService.GetSnapshotAsync(entryId);
-            if (entry == null || snapshot == null)
+            if (entry == null || snapshot == null ||
+                IsDisposed || channel.Pair != pair)
             {
                 return;
             }
@@ -1645,10 +1707,14 @@ public partial class VirtualCrossoverPanel : UserControl
 
     // One channel whose processed IR the cache does not already hold, snapshotted
     // so the background task reads nothing but the immutable transfer IR and the
-    // value-typed chain.
+    // value-typed chain. The concrete side STATE is captured too: the cache
+    // write happens after an await, and by then the active side may have
+    // flipped — writing through the runtime's delegating property would then
+    // stamp one side's FFT into the other side's cache slot.
     private sealed record PendingChannel(
         int Index,
         ChannelRuntime Channel,
+        ChannelSideState State,
         Complex[] TransferIr,
         int SampleRate,
         DspChannelChain Chain,
@@ -1668,8 +1734,9 @@ public partial class VirtualCrossoverPanel : UserControl
         for (int i = 0; i < channels.Count; i++)
         {
             ChannelRuntime channel = channels[i];
+            ChannelSideState state = channel.SideState(channel.ActiveRight);
             if (!channel.Settings.Enabled ||
-                channel.TransferImpulseResponse is not { } ir)
+                state.TransferImpulseResponse is not { } ir)
             {
                 continue;
             }
@@ -1677,19 +1744,20 @@ public partial class VirtualCrossoverPanel : UserControl
             DspChannelChain chain = channel.Settings.Bypass
                 ? DspChannelChain.Identity
                 : channel.Settings.ToChain();
-            var key = new ProcessedChannelCacheKey(ir, channel.SampleRate, chain);
-            if (channel.ProcessedCache?.Key.Equals(key) == true)
+            var key = new ProcessedChannelCacheKey(ir, state.SampleRate, chain);
+            if (state.ProcessedCache?.Key.Equals(key) == true)
             {
                 results[i] = new ProcessedChannel(
                     channel,
-                    channel.ProcessedCache.ImpulseResponse,
-                    channel.ProcessedCache.PeakIndex,
+                    state.ProcessedCache.ImpulseResponse,
+                    state.ProcessedCache.PeakIndex,
                     ChannelColors[i]);
                 continue;
             }
 
             jobs.Add(new PendingChannel(
-                i, channel, ir, channel.SampleRate, chain, key, ChannelColors[i]));
+                i, channel, state, ir, state.SampleRate, chain, key,
+                ChannelColors[i]));
         }
 
         if (jobs.Count > 0)
@@ -1707,7 +1775,7 @@ public partial class VirtualCrossoverPanel : UserControl
 
             foreach ((PendingChannel job, Complex[] result, int peak) in computed)
             {
-                job.Channel.ProcessedCache = new ProcessedChannelCache(job.Key, result, peak);
+                job.State.ProcessedCache = new ProcessedChannelCache(job.Key, result, peak);
                 results[job.Index] = new ProcessedChannel(job.Channel, result, peak, job.Color);
             }
         }
@@ -1727,9 +1795,16 @@ public partial class VirtualCrossoverPanel : UserControl
         // The heavy ApplyChain FFTs run off the UI thread; the existing curves stay
         // on screen until the new data is ready, so there is no clear-then-fill
         // flicker during the compute.
+        long revision = displayRevision;
         List<ProcessedChannel> processed = await ProcessChannelsAsync();
         if (mainPlotView.IsDisposed)
         {
+            return;
+        }
+        if (revision != displayRevision)
+        {
+            // The displayed side flipped mid-compute: these IRs belong to the
+            // previous side, and the side switch has already queued a repaint.
             return;
         }
 
@@ -2363,8 +2438,29 @@ public partial class VirtualCrossoverPanel : UserControl
 
         SideAlignmentChannel bridgeLeft = leftSide.First(
             item => item.Runtime == bridgeRight.Runtime && !item.RightSide);
-        (double bridgeBandLowHz, double bridgeBandHighHz) =
+        // The two sides carry independent crossover settings, so the bridge
+        // band is the INTERSECTION of their playing bands: measured in one
+        // side's exclusive range, the arrival would time signal the other
+        // side does not even reproduce. No usable overlap → refuse with the
+        // reason instead of bridging on noise.
+        (double leftBandLowHz, double leftBandHighHz) =
             VirtualCrossoverJunctions.GetChannelBand(bridgeLeft.Settings);
+        (double rightBandLowHz, double rightBandHighHz) =
+            VirtualCrossoverJunctions.GetChannelBand(bridgeRight.Settings);
+        double bridgeBandLowHz = Math.Max(leftBandLowHz, rightBandLowHz);
+        double bridgeBandHighHz = Math.Min(leftBandHighHz, rightBandHighHz);
+        if (bridgeBandHighHz < bridgeBandLowHz * Math.Pow(2.0, 1.0 / 3.0))
+        {
+            ShowError(
+                "The stereo bridge has no usable shared band.",
+                $"The top pair's crossover bands barely overlap: " +
+                $"{bridgeLeft.Name} plays {leftBandLowHz:0}-{leftBandHighHz:0} Hz, " +
+                $"{bridgeRight.Name} plays {rightBandLowHz:0}-{rightBandHighHz:0} Hz. " +
+                "Align the pair's crossover settings so the sides share at " +
+                "least a third of an octave and run Auto delay again.");
+            return;
+        }
+
         double sceneOffsetMs = project.StereoSceneOffsetMs;
 
         var log = new System.Text.StringBuilder();
@@ -2889,9 +2985,12 @@ public partial class VirtualCrossoverPanel : UserControl
             BuildMetricCurves(metricChannels);
         string metricLine = FormatMetricLabel(
             BuildMetricEntries(metricChannels, metricMagnitudes, metricSum));
-        int sampleRate = channels
-            .Where(channel => channel.TransferImpulseResponse != null)
-            .Select(channel => channel.SampleRate)
+        // The sheet prints BOTH sides, so the rate comes from any physically
+        // resolved side — reading only the active side through the delegating
+        // properties would fall back to 48 kHz when, say, the shown left side
+        // is empty and every 44.1 kHz source sits on the right.
+        int sampleRate = ResolvedSidesExcept(null)
+            .Select(item => item.State.SampleRate)
             .FirstOrDefault(48_000);
         try
         {
@@ -3165,8 +3264,18 @@ public partial class VirtualCrossoverPanel : UserControl
         public VirtualCrossoverChannelPairSettings Pair { get; set; } = new();
         public bool ActiveRight { get; set; }
 
+        // The EFFECTIVE side slot: what the views and calculations read — a
+        // mono pair routes both sides to its single left slot.
         public ChannelSideState SideState(bool rightSide) =>
             Pair.Mono || !rightSide ? leftState : rightState;
+
+        // The PHYSICAL side slot, mono routing ignored. Lifetime management
+        // (project load, mono toggling) must use this one: through the
+        // effective accessor a mono pair's real right slot is unreachable, so
+        // a stale measurement could hide there and resurface the moment the
+        // pair stops being mono.
+        public ChannelSideState PhysicalSideState(bool rightSide) =>
+            rightSide ? rightState : leftState;
         public VirtualCrossoverChannelSettings SideSettings(bool rightSide) =>
             Pair.SideFor(rightSide);
         private ChannelSideState Active => SideState(ActiveRight);

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -1884,6 +1884,20 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
+        // The stereo Δ block and the opposite-side sum read BOTH sides'
+        // processed responses; their caches make an unchanged configuration
+        // free. Same staleness rule as above.
+        List<VirtualCrossoverMetric.StereoDelta> stereoDeltas =
+            await ComputeStereoDeltasAsync();
+        AnalysisCurve? oppositeSum =
+            checkBoxShowSum.Checked && !radioViewPhase.Checked
+                ? await ComputeOppositeSumCurveAsync()
+                : null;
+        if (mainPlotView.IsDisposed || revision != displayRevision)
+        {
+            return;
+        }
+
         RemoveCurveSeries(model);
         hintAnnotation.Text = processed.Count == 0 ? NoSourcesHint : string.Empty;
 
@@ -1892,7 +1906,7 @@ public partial class VirtualCrossoverPanel : UserControl
         (List<AnalysisCurve>? magnitudes, AnalysisCurve? sumCurve) =
             BuildMetricCurves(processed);
 
-        UpdateMetric(processed, magnitudes, sumCurve);
+        UpdateMetric(processed, magnitudes, sumCurve, stereoDeltas);
         UpdateCrossoverWarning(processed);
 
         if (processed.Count > 0)
@@ -1903,7 +1917,7 @@ public partial class VirtualCrossoverPanel : UserControl
             }
             else
             {
-                DrawMagnitudeCurves(model, processed, magnitudes, sumCurve);
+                DrawMagnitudeCurves(model, processed, magnitudes, sumCurve, oppositeSum);
             }
         }
 
@@ -1915,7 +1929,8 @@ public partial class VirtualCrossoverPanel : UserControl
         PlotModel model,
         List<ProcessedChannel> processed,
         List<AnalysisCurve>? magnitudes,
-        AnalysisCurve? sumCurve)
+        AnalysisCurve? sumCurve,
+        AnalysisCurve? oppositeSumCurve = null)
     {
         for (int i = 0; i < processed.Count; i++)
         {
@@ -1959,6 +1974,18 @@ public partial class VirtualCrossoverPanel : UserControl
         if (checkBoxShowSum.Checked)
         {
             AddCurve(model, "Sum", sumCurve.Points, SumColor, 2.4, LineStyle.Solid);
+            if (oppositeSumCurve != null)
+            {
+                // The other side's sum, dashed and translucent: the two tunes
+                // compare at a glance without flipping the L/R selector.
+                AddCurve(
+                    model,
+                    $"Sum {(project.ActiveSideRight ? "L" : "R")}",
+                    oppositeSumCurve.Points,
+                    OxyColor.FromAColor(110, SumColor),
+                    1.8,
+                    LineStyle.Dash);
+            }
         }
 
         if (checkBoxShowLoss.Checked)
@@ -1987,15 +2014,278 @@ public partial class VirtualCrossoverPanel : UserControl
     private void UpdateMetric(
         List<ProcessedChannel> processed,
         List<AnalysisCurve>? magnitudes,
-        AnalysisCurve? sumCurve)
+        AnalysisCurve? sumCurve,
+        IReadOnlyList<VirtualCrossoverMetric.StereoDelta>? stereoDeltas = null)
     {
         // The read-out lives in the host's right-side panel (where overlays sit in
         // analysis modes), as a compact per-junction column with the full banded
-        // breakdown on hover.
+        // breakdown on hover. The stereo Δ block (final L−R envelope arrival
+        // difference per pair) appends below the sum-loss column.
         List<VirtualCrossoverMetric.Entry> entries = BuildMetricEntries(processed, magnitudes, sumCurve);
-        MetricChanged?.Invoke(
-            FormatMetricCompact(entries),
-            entries.Count > 0 ? FormatMetricDetail(entries) : string.Empty);
+        string compact = FormatMetricCompact(entries);
+        string detail = entries.Count > 0 ? FormatMetricDetail(entries) : string.Empty;
+        if (stereoDeltas is { Count: > 0 })
+        {
+            compact += "\r\n\r\n" +
+                VirtualCrossoverMetric.FormatStereoDeltasCompact(stereoDeltas);
+            detail += (detail.Length > 0 ? "\r\n\r\n" : string.Empty) +
+                VirtualCrossoverMetric.FormatStereoDeltasDetail(stereoDeltas);
+        }
+
+        MetricChanged?.Invoke(compact, detail);
+    }
+
+    // One channel side snapshotted on the UI thread for background processing
+    // (the stereo Δ read-out and the opposite-side sum): the background pass
+    // reads nothing mutable. Processed/Arrival start from the side's caches
+    // and are filled on a miss.
+    private sealed class SideProcessJob
+    {
+        public required ChannelSideState State { get; init; }
+        public required Complex[] TransferIr { get; init; }
+        public required int SampleRate { get; init; }
+        public required DspChannelChain Chain { get; init; }
+        public required ProcessedChannelCacheKey Key { get; init; }
+        public Complex[]? ProcessedIr { get; set; }
+        public int ProcessedPeak { get; set; }
+        public bool ProcessedFromCache { get; set; }
+        public TimeAlignmentAnalysisResult? Arrival { get; set; }
+        public bool ArrivalFromCache { get; set; }
+    }
+
+    private sealed record StereoDeltaJob(
+        string Channel,
+        double LowHz,
+        double HighHz,
+        SideProcessJob Left,
+        SideProcessJob Right);
+
+    /// <summary>
+    /// The final per-pair L−R timing: both sides' fully processed responses
+    /// (current delays included) get their band-limited envelope arrival read
+    /// in the pair's shared band, and the difference (positive: right leads —
+    /// the scene-offset convention) feeds the metric read-out. Only complete
+    /// stereo pairs measure: mono pairs have one response, bypassed or muted
+    /// sides are not a final tune. Heavy work runs off the UI thread and both
+    /// the processed IRs and the arrivals are cached per side, so an unchanged
+    /// configuration costs nothing on redraw.
+    /// </summary>
+    private async Task<List<VirtualCrossoverMetric.StereoDelta>> ComputeStereoDeltasAsync()
+    {
+        var jobs = new List<StereoDeltaJob>();
+        foreach (ChannelRuntime channel in channels)
+        {
+            if (channel.Pair.Mono)
+            {
+                continue;
+            }
+
+            VirtualCrossoverChannelSettings leftSettings = channel.SideSettings(false);
+            VirtualCrossoverChannelSettings rightSettings = channel.SideSettings(true);
+            ChannelSideState leftState = channel.PhysicalSideState(false);
+            ChannelSideState rightState = channel.PhysicalSideState(true);
+            if (!leftSettings.Enabled || !rightSettings.Enabled ||
+                leftSettings.Bypass || rightSettings.Bypass ||
+                leftState.TransferImpulseResponse is not { } leftIr ||
+                rightState.TransferImpulseResponse is not { } rightIr)
+            {
+                continue;
+            }
+
+            (double leftLow, double leftHigh) =
+                VirtualCrossoverJunctions.GetChannelBand(leftSettings);
+            (double rightLow, double rightHigh) =
+                VirtualCrossoverJunctions.GetChannelBand(rightSettings);
+            double lowHz = Math.Max(leftLow, rightLow);
+            double highHz = Math.Min(leftHigh, rightHigh);
+            if (highHz <= lowHz)
+            {
+                continue;
+            }
+
+            SideProcessJob Snapshot(
+                ChannelSideState state,
+                VirtualCrossoverChannelSettings settings,
+                Complex[] ir)
+            {
+                DspChannelChain chain = settings.ToChain();
+                var key = new ProcessedChannelCacheKey(ir, state.SampleRate, chain);
+                var side = new SideProcessJob
+                {
+                    State = state,
+                    TransferIr = ir,
+                    SampleRate = state.SampleRate,
+                    Chain = chain,
+                    Key = key
+                };
+                if (state.ProcessedCache?.Key.Equals(key) == true)
+                {
+                    side.ProcessedIr = state.ProcessedCache.ImpulseResponse;
+                    side.ProcessedPeak = state.ProcessedCache.PeakIndex;
+                    side.ProcessedFromCache = true;
+                }
+                if (side.ProcessedIr != null &&
+                    state.ArrivalCache is { } arrival &&
+                    ReferenceEquals(arrival.ProcessedIr, side.ProcessedIr) &&
+                    arrival.LowHz == lowHz && arrival.HighHz == highHz)
+                {
+                    side.Arrival = arrival.Result;
+                    side.ArrivalFromCache = true;
+                }
+
+                return side;
+            }
+
+            jobs.Add(new StereoDeltaJob(
+                channel.Control.ChannelName,
+                lowHz,
+                highHz,
+                Snapshot(leftState, leftSettings, leftIr),
+                Snapshot(rightState, rightSettings, rightIr)));
+        }
+
+        bool anyWork = jobs.Any(job =>
+            job.Left.Arrival == null || job.Right.Arrival == null);
+        if (anyWork)
+        {
+            await Task.Run(() =>
+            {
+                foreach (StereoDeltaJob job in jobs)
+                {
+                    foreach (SideProcessJob side in new[] { job.Left, job.Right })
+                    {
+                        if (side.ProcessedIr == null)
+                        {
+                            side.ProcessedIr = VirtualCrossoverAnalysis.ApplyChain(
+                                side.TransferIr, side.Chain, side.SampleRate);
+                            side.ProcessedPeak =
+                                VirtualCrossoverAnalysis.FindPeakIndex(side.ProcessedIr);
+                        }
+                        if (side.Arrival == null)
+                        {
+                            side.Arrival =
+                                VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                                    side.ProcessedIr, side.SampleRate,
+                                    job.LowHz, job.HighHz);
+                        }
+                    }
+                }
+            });
+
+            // Cache write-back stays on the UI thread, like every other cache
+            // in this panel.
+            foreach (StereoDeltaJob job in jobs)
+            {
+                foreach (SideProcessJob side in new[] { job.Left, job.Right })
+                {
+                    if (!side.ProcessedFromCache)
+                    {
+                        side.State.ProcessedCache = new ProcessedChannelCache(
+                            side.Key, side.ProcessedIr!, side.ProcessedPeak);
+                    }
+                    if (!side.ArrivalFromCache)
+                    {
+                        side.State.ArrivalCache =
+                            (side.ProcessedIr!, job.LowHz, job.HighHz,
+                                side.Arrival!.Value);
+                    }
+                }
+            }
+        }
+
+        return jobs
+            .Select(job => new VirtualCrossoverMetric.StereoDelta(
+                job.Channel,
+                job.Left.Arrival!.Value.IsValid && job.Right.Arrival!.Value.IsValid
+                    ? job.Left.Arrival!.Value.FirstArrivalDelayMilliseconds -
+                        job.Right.Arrival!.Value.FirstArrivalDelayMilliseconds
+                    : null,
+                job.LowHz,
+                job.HighHz))
+            .ToList();
+    }
+
+    /// <summary>
+    /// The complex-sum magnitude of the OPPOSITE side (dashed and translucent
+    /// on the plot), so the two sides' tunes compare at a glance without
+    /// flipping back and forth. Mono channels contribute their single response
+    /// to both sides' sums, exactly as they do physically. Null when the
+    /// opposite side has fewer than two participating channels — a "sum" of
+    /// one driver is just that driver. Shares the per-side processed caches
+    /// with everything else, so an unchanged opposite side costs nothing.
+    /// </summary>
+    private async Task<AnalysisCurve?> ComputeOppositeSumCurveAsync()
+    {
+        bool oppositeRight = !project.ActiveSideRight;
+        var jobs = new List<SideProcessJob>();
+        foreach (ChannelRuntime channel in channels)
+        {
+            VirtualCrossoverChannelSettings settings =
+                channel.SideSettings(oppositeRight);
+            ChannelSideState state = channel.SideState(oppositeRight);
+            if (!settings.Enabled ||
+                state.TransferImpulseResponse is not { } ir)
+            {
+                continue;
+            }
+
+            DspChannelChain chain = settings.Bypass
+                ? DspChannelChain.Identity
+                : settings.ToChain();
+            var key = new ProcessedChannelCacheKey(ir, state.SampleRate, chain);
+            var side = new SideProcessJob
+            {
+                State = state,
+                TransferIr = ir,
+                SampleRate = state.SampleRate,
+                Chain = chain,
+                Key = key
+            };
+            if (state.ProcessedCache?.Key.Equals(key) == true)
+            {
+                side.ProcessedIr = state.ProcessedCache.ImpulseResponse;
+                side.ProcessedPeak = state.ProcessedCache.PeakIndex;
+                side.ProcessedFromCache = true;
+            }
+
+            jobs.Add(side);
+        }
+
+        if (jobs.Count < 2)
+        {
+            return null;
+        }
+
+        if (jobs.Any(side => side.ProcessedIr == null))
+        {
+            await Task.Run(() =>
+            {
+                foreach (SideProcessJob side in jobs)
+                {
+                    if (side.ProcessedIr == null)
+                    {
+                        side.ProcessedIr = VirtualCrossoverAnalysis.ApplyChain(
+                            side.TransferIr, side.Chain, side.SampleRate);
+                        side.ProcessedPeak =
+                            VirtualCrossoverAnalysis.FindPeakIndex(side.ProcessedIr);
+                    }
+                }
+            });
+
+            foreach (SideProcessJob side in jobs)
+            {
+                if (!side.ProcessedFromCache)
+                {
+                    side.State.ProcessedCache = new ProcessedChannelCache(
+                        side.Key, side.ProcessedIr!, side.ProcessedPeak);
+                }
+            }
+        }
+
+        Complex[] sum = VirtualCrossoverAnalysis.SumImpulseResponses(
+            jobs.Select(side => side.ProcessedIr!).ToList());
+        int anchor = jobs.Min(side => side.ProcessedPeak);
+        return BuildMagnitudeCurve(sum, anchor, jobs[0].SampleRate);
     }
 
     // The magnitude curves and complex sum the metric reads, built the same way
@@ -2061,7 +2351,6 @@ public partial class VirtualCrossoverPanel : UserControl
                     $"{pair.Upper.Channel.Control.ChannelName}",
                     pairLoss.Value,
                     pairDip,
-                    ComputePairNullDepthDb(processed, channelPoints, pair),
                     pair.BandLowHz,
                     pair.BandHighHz,
                     IsTotal: false));
@@ -2076,48 +2365,10 @@ public partial class VirtualCrossoverPanel : UserControl
         if (loss.HasValue)
         {
             entries.Add(new VirtualCrossoverMetric.Entry(
-                "total", loss.Value, dip, NullDb: null, minHz, maxHz, IsTotal: true));
+                "total", loss.Value, dip, minHz, maxHz, IsTotal: true));
         }
 
         return entries;
-    }
-
-    // The classic tuner's polarity-flip check, computed instead of performed:
-    // the full processed sum with the pair's upper channel inverted, read as
-    // the deepest sum-loss notch inside the pair band. A phase-aligned pair
-    // cancels coherently there, so the deeper this null, the better the pair's
-    // phase match — without touching the actual polarity switch. Display-only
-    // by design: a whole-period delay error keeps the phase at the crossover
-    // frequency aligned and can null just as deeply (verified on real
-    // measurements, where a two-period cycle skip out-nulled the true
-    // alignment), so this figure must never drive a search or selection.
-    private double? ComputePairNullDepthDb(
-        List<ProcessedChannel> processed,
-        List<IReadOnlyList<SignalPoint>> channelPoints,
-        AdjacentPair pair)
-    {
-        List<Complex[]> responses = processed
-            .Select(item => item == pair.Upper
-                ? InvertPolarity(item.ImpulseResponse)
-                : item.ImpulseResponse)
-            .ToList();
-        Complex[] flippedSum = VirtualCrossoverAnalysis.SumImpulseResponses(responses);
-        int anchor = processed.Min(item => item.PeakIndex);
-        AnalysisCurve flippedCurve = BuildMagnitudeCurve(
-            flippedSum, anchor, processed[0].Channel.SampleRate);
-        return VirtualCrossoverAnalysis.MinimumSumLossDb(
-            flippedCurve.Points, channelPoints, pair.BandLowHz, pair.BandHighHz);
-    }
-
-    private static Complex[] InvertPolarity(Complex[] impulseResponse)
-    {
-        var inverted = new Complex[impulseResponse.Length];
-        for (int i = 0; i < inverted.Length; i++)
-        {
-            inverted[i] = -impulseResponse[i];
-        }
-
-        return inverted;
     }
 
     // The metric text renderings live in VirtualCrossoverMetric, where they are
@@ -3309,12 +3560,20 @@ public partial class VirtualCrossoverPanel : UserControl
         public int SampleRate { get; set; }
         public ProcessedChannelCache? ProcessedCache { get; set; }
 
+        // The band-limited envelope arrival of this side's PROCESSED response,
+        // keyed by the processed array's identity and the measured band — the
+        // Δ L−R read-out re-runs on every redraw, and the Hilbert analysis of
+        // a full-length IR is far too heavy to repeat when nothing changed.
+        public (Complex[] ProcessedIr, double LowHz, double HighHz,
+            TimeAlignmentAnalysisResult Result)? ArrivalCache { get; set; }
+
         public void Clear()
         {
             TransferImpulseResponse = null;
             TransferPeakIndex = 0;
             SampleRate = 0;
             ProcessedCache = null;
+            ArrivalCache = null;
         }
     }
 

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -2229,21 +2229,22 @@ public partial class VirtualCrossoverPanel : UserControl
             }
         }
 
-        // The same reliability gate the engine's inter-side decisions apply:
-        // a formally valid arrival with a near-noise record would print a
-        // precise-looking Δ the user might chase with manual delays — an
-        // honest "—" is the right read-out there.
-        static bool Reliable(TimeAlignmentAnalysisResult arrival) =>
+        // The same reliability gate the engine's inter-side decisions apply,
+        // per side: a formally valid arrival with a near-noise record would
+        // print a precise-looking figure the user might chase with manual
+        // delays — an honest "—" is the right read-out there. The Δ column
+        // follows automatically (it needs both sides).
+        static double? ReliableArrivalMs(TimeAlignmentAnalysisResult arrival) =>
             arrival.IsValid &&
-            arrival.SignalToNoiseDecibels >= AutoAlignmentEngine.MinimumArrivalSnrDb;
+            arrival.SignalToNoiseDecibels >= AutoAlignmentEngine.MinimumArrivalSnrDb
+                ? arrival.FirstArrivalDelayMilliseconds
+                : null;
 
         return jobs
             .Select(job => new VirtualCrossoverMetric.StereoDelta(
                 job.Channel,
-                Reliable(job.Left.Arrival!.Value) && Reliable(job.Right.Arrival!.Value)
-                    ? job.Left.Arrival!.Value.FirstArrivalDelayMilliseconds -
-                        job.Right.Arrival!.Value.FirstArrivalDelayMilliseconds
-                    : null,
+                ReliableArrivalMs(job.Left.Arrival!.Value),
+                ReliableArrivalMs(job.Right.Arrival!.Value),
                 job.LowHz,
                 job.HighHz))
             .ToList();

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -131,6 +131,8 @@ public partial class VirtualCrossoverPanel : UserControl
         buttonSessionExport.Click += (_, _) => ExportSession();
         buttonAddChannel.Click += (_, _) => AddChannel();
         buttonRemoveChannel.Click += (_, _) => RemoveChannel();
+        buttonCopyLeftToRight.Click += (_, _) => CopySideSettings(fromRight: false);
+        buttonCopyRightToLeft.Click += (_, _) => CopySideSettings(fromRight: true);
 
         saveTimer.Tick += (_, _) => FlushProject();
         // The designer file owns Dispose; the unsaved project state and the
@@ -477,6 +479,70 @@ public partial class VirtualCrossoverPanel : UserControl
 
         project.StereoSceneOffsetMs = (double)numericSceneOffset.Value;
         ScheduleSave();
+    }
+
+    // The "L→R" / "R→L" commands: copy the DSP-chain part of one side's
+    // settings (gain, crossover, PEQ) onto the other for the channels the user
+    // picks. Sources and delays stay side-specific — each side has its own
+    // measurement and its own arrival — and polarity stays with the alignment.
+    // Mono pairs have one settings set and are not offered.
+    private void CopySideSettings(bool fromRight)
+    {
+        List<ChannelRuntime> candidates = channels
+            .Where(channel => !channel.Pair.Mono)
+            .ToList();
+        if (candidates.Count == 0)
+        {
+            System.Media.SystemSounds.Beep.Play();
+            return;
+        }
+
+        List<string> labels = candidates
+            .Select(channel =>
+            {
+                string source = channel.SideSettings(fromRight).DisplayName;
+                return string.IsNullOrWhiteSpace(source)
+                    ? channel.Control.ChannelName
+                    : $"{channel.Control.ChannelName} — {source}";
+            })
+            .ToList();
+        using var dialog = new VirtualCrossoverCopySideDialog(fromRight, labels);
+        if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
+            dialog.SelectedIndices.Count == 0)
+        {
+            return;
+        }
+
+        bool targetSideShown = project.ActiveSideRight == !fromRight;
+        foreach (int index in dialog.SelectedIndices)
+        {
+            ChannelRuntime channel = candidates[index];
+            CopyChainSettings(
+                channel.SideSettings(fromRight),
+                channel.SideSettings(!fromRight));
+            if (targetSideShown)
+            {
+                ApplySettingsToControl(channel);
+            }
+        }
+
+        ScheduleSave();
+        RedrawAll();
+    }
+
+    // The "what the DSP does" part of one side, copied onto the other. PeqBand
+    // is an immutable record, so a fresh list is a deep enough copy.
+    private static void CopyChainSettings(
+        VirtualCrossoverChannelSettings from,
+        VirtualCrossoverChannelSettings to)
+    {
+        to.GainDb = from.GainDb;
+        to.CrossoverKind = from.CrossoverKind;
+        to.HighPassEdge = from.HighPassEdge;
+        to.LowPassEdge = from.LowPassEdge;
+        to.PeqPreampDb = from.PeqPreampDb;
+        to.PeqBands = from.PeqBands.ToList();
+        to.PeqSourceName = from.PeqSourceName;
     }
 
     // The side radios double as source indicators (● has at least one source,
@@ -1410,6 +1476,16 @@ public partial class VirtualCrossoverPanel : UserControl
             "Show and edit the RIGHT side of every channel pair.\r\n" +
             "● — at least one source is loaded on this side.");
         toolTip.SetToolTip(
+            buttonCopyLeftToRight,
+            "Copy the LEFT side's gain, crossover and PEQ onto the\r\n" +
+            "RIGHT side for the channels you pick. Sources and delays\r\n" +
+            "stay with their side; mono channels are not offered.");
+        toolTip.SetToolTip(
+            buttonCopyRightToLeft,
+            "Copy the RIGHT side's gain, crossover and PEQ onto the\r\n" +
+            "LEFT side for the channels you pick. Sources and delays\r\n" +
+            "stay with their side; mono channels are not offered.");
+        toolTip.SetToolTip(
             buttonAutoSetup,
             "Crossover wizard: detect each channel's driver type from\r\n" +
             "its response, confirm the types, and get a starting point —\r\n" +
@@ -2248,6 +2324,8 @@ public partial class VirtualCrossoverPanel : UserControl
         radioSideLeft.Enabled = !busy;
         radioSideRight.Enabled = !busy;
         numericSceneOffset.Enabled = !busy;
+        buttonCopyLeftToRight.Enabled = !busy;
+        buttonCopyRightToLeft.Enabled = !busy;
         UpdateChannelButtons();
         foreach (ChannelRuntime channel in channels)
         {

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -2898,6 +2898,31 @@ public partial class VirtualCrossoverPanel : UserControl
             return pairs;
         }
 
+        // The L/R pair links (the shared playing band of each stereo pair)
+        // aim the descent's gentle prior at the cross-side-consistent delay —
+        // the same Δ the metric panel verifies afterwards.
+        var pairLinks = new List<StereoPairLink>();
+        foreach (SideAlignmentChannel right in rightSide.Where(side => side.RightSide))
+        {
+            SideAlignmentChannel? left = leftSide.FirstOrDefault(
+                side => side.Runtime == right.Runtime && !side.RightSide);
+            if (left == null)
+            {
+                continue;
+            }
+
+            (double leftLow, double leftHigh) =
+                VirtualCrossoverJunctions.GetChannelBand(left.Settings);
+            (double rightLow, double rightHigh) =
+                VirtualCrossoverJunctions.GetChannelBand(right.Settings);
+            double lowHz = Math.Max(leftLow, rightLow);
+            double highHz = Math.Min(leftHigh, rightHigh);
+            if (highHz > lowHz)
+            {
+                pairLinks.Add(new StereoPairLink(left, right, lowHz, highHz));
+            }
+        }
+
         List<AlignmentSnapshot> leftByBand = ByBand(leftSide);
         List<AlignmentSnapshot> rightByBand = ByBand(rightSide);
         AutoAlignmentEngine.ComputeStereo(
@@ -2913,7 +2938,8 @@ public partial class VirtualCrossoverPanel : UserControl
                 bridgeRight,
                 bridgeBandLowHz,
                 bridgeBandHighHz,
-                sceneOffsetMs),
+                sceneOffsetMs,
+                pairLinks),
             Reprocess,
             alignment,
             log);

--- a/source/Tools/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossoverProjectFile.cs
@@ -126,9 +126,36 @@ public sealed class VirtualCrossoverChannelSettings
 }
 
 /// <summary>
-/// Persists the Virtual DSP tool state (channels, their DSP chains and the
-/// plot view flags) so a tuning session survives an application restart. The
-/// channel count is user-resizable in the tool, from two up to
+/// One speaker of the car as the Virtual DSP tool models it since schema v2: a
+/// left/right PAIR of measurement + DSP chain sets under one channel letter.
+/// A mono pair (the shared subwoofer) has one physical driver serving both
+/// sides: only <see cref="Left"/> is meaningful and it participates in both
+/// side views and both sides' calculations.
+/// </summary>
+public sealed class VirtualCrossoverChannelPairSettings
+{
+    public bool Mono { get; set; }
+    public VirtualCrossoverChannelSettings Left { get; set; } = new();
+    public VirtualCrossoverChannelSettings Right { get; set; } = new();
+
+    /// <summary>
+    /// The settings the given side view edits and computes with: a mono pair
+    /// always answers with its single (left) set.
+    /// </summary>
+    public VirtualCrossoverChannelSettings SideFor(bool rightSide) =>
+        Mono || !rightSide ? Left : Right;
+
+    public void Validate()
+    {
+        Left.Validate();
+        Right.Validate();
+    }
+}
+
+/// <summary>
+/// Persists the Virtual DSP tool state (channel pairs, their DSP chains and
+/// the plot view flags) so a tuning session survives an application restart.
+/// The pair count is user-resizable in the tool, from two up to
 /// <see cref="MaximumChannelCount"/>.
 /// </summary>
 public sealed class VirtualCrossoverProjectFile
@@ -136,12 +163,19 @@ public sealed class VirtualCrossoverProjectFile
     public const string CurrentFormat = "resonalyze-virtual-crossover";
 
     // Bump on an incompatible schema change and add a per-version migration
-    // step in LoadOrDefault before Validate. Files from a NEWER version
-    // (a downgraded app) are never migrated: LoadOrDefault backs them up and
-    // starts fresh, LoadFrom rejects them with an explicit error.
-    public const int CurrentVersion = 1;
+    // step in Migrate below. Files from a NEWER version (a downgraded app)
+    // are never migrated: LoadOrDefault backs them up and starts fresh,
+    // LoadFrom rejects them with an explicit error.
+    public const int CurrentVersion = 2;
     public const int MaximumChannelCount = 8;
     private const string FileName = "virtual-crossover.json";
+
+    /// <summary>
+    /// The widest scene offset (ms) the stereo Auto delay accepts: beyond a
+    /// couple of milliseconds an inter-side lead is no longer an image shift
+    /// but an audible echo, so a larger magnitude is a typo.
+    /// </summary>
+    public const double MaximumSceneOffsetMs = 5;
 
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
@@ -157,14 +191,27 @@ public sealed class VirtualCrossoverProjectFile
     public int Version { get; set; } = CurrentVersion;
     public DateTimeOffset SavedAtUtc { get; set; }
 
-    // One entry per channel block in the tool (A, B, C); a channel without a
-    // source simply does not participate in the sum.
-    public List<VirtualCrossoverChannelSettings> Channels { get; set; } =
+    // Schema v1 payload, kept only so old files deserialize for migration:
+    // Migrate moves these into Pairs (as the left side) and empties the list.
+    // v2 files serialize it as an empty array.
+    public List<VirtualCrossoverChannelSettings> Channels { get; set; } = new();
+
+    // One entry per channel block in the tool (A, B, C), each an L/R pair; a
+    // side without a source simply does not participate in that side's sum.
+    public List<VirtualCrossoverChannelPairSettings> Pairs { get; set; } =
     [
-        new VirtualCrossoverChannelSettings(),
-        new VirtualCrossoverChannelSettings(),
-        new VirtualCrossoverChannelSettings()
+        new VirtualCrossoverChannelPairSettings(),
+        new VirtualCrossoverChannelPairSettings(),
+        new VirtualCrossoverChannelPairSettings()
     ];
+
+    // The stereo Auto delay scene offset (ms): positive makes the right side
+    // LEAD (arrive earlier), pulling the image toward the dash center for a
+    // left-seated driver; right-seated drivers use a negative value.
+    public double StereoSceneOffsetMs { get; set; } = 0.25;
+
+    // Which side the tool currently displays and edits (view state).
+    public bool ActiveSideRight { get; set; }
 
     // Acoustic-plot view state shared by all channels.
     public bool ShowSumCurve { get; set; } = true;
@@ -269,8 +316,31 @@ public sealed class VirtualCrossoverProjectFile
                 stream,
                 SerializerOptions)
             ?? throw new InvalidDataException("The session file is empty.");
+        Migrate(file);
         file.Validate();
         return file;
+    }
+
+    // Per-version upgrade steps, applied before validation. Newer-than-current
+    // versions are deliberately NOT touched: validation rejects them and the
+    // callers handle that (backup + fresh, or an explicit import error).
+    private static void Migrate(VirtualCrossoverProjectFile file)
+    {
+        if (file.Version == 1)
+        {
+            // v1 stored single-sided channels; they become the LEFT side of a
+            // pair (the historical measurements were the user's only side) and
+            // the right side starts empty.
+            file.Pairs = file.Channels
+                .Select(channel => new VirtualCrossoverChannelPairSettings
+                {
+                    Left = channel,
+                    Right = new VirtualCrossoverChannelSettings()
+                })
+                .ToList();
+            file.Channels = new List<VirtualCrossoverChannelSettings>();
+            file.Version = 2;
+        }
     }
 
     /// <summary>
@@ -310,6 +380,7 @@ public sealed class VirtualCrossoverProjectFile
                     stream,
                     SerializerOptions)
                 ?? throw new InvalidDataException("The project file is empty.");
+            Migrate(file);
             file.Validate();
             return file;
         }
@@ -353,10 +424,15 @@ public sealed class VirtualCrossoverProjectFile
             throw new InvalidDataException(
                 $"Unsupported virtual crossover version {Version}.");
         }
-        if (Channels.Count is < 2 or > MaximumChannelCount)
+        if (Pairs.Count is < 2 or > MaximumChannelCount)
         {
             throw new InvalidDataException(
                 "The virtual crossover channel count is invalid.");
+        }
+        if (!double.IsFinite(StereoSceneOffsetMs) ||
+            Math.Abs(StereoSceneOffsetMs) > MaximumSceneOffsetMs)
+        {
+            throw new InvalidDataException("The stereo scene offset is invalid.");
         }
         if (!OverlaySmoothing.IsValid(SmoothingInverseOctaves))
         {
@@ -391,9 +467,9 @@ public sealed class VirtualCrossoverProjectFile
             throw new InvalidDataException("The phase gate window is invalid.");
         }
 
-        foreach (VirtualCrossoverChannelSettings channel in Channels)
+        foreach (VirtualCrossoverChannelPairSettings pair in Pairs)
         {
-            channel.Validate();
+            pair.Validate();
         }
     }
 

--- a/source/Tools/VirtualCrossoverSheet.cs
+++ b/source/Tools/VirtualCrossoverSheet.cs
@@ -27,34 +27,38 @@ internal static class VirtualCrossoverSheet
             builder.AppendLine(metricLine);
         }
 
-        for (int i = 0; i < project.Channels.Count; i++)
+        for (int i = 0; i < project.Pairs.Count; i++)
         {
-            VirtualCrossoverChannelSettings channel = project.Channels[i];
-            if (!channel.HasSource)
+            foreach ((VirtualCrossoverChannelSettings channel, string sideSuffix)
+                in SideSections(project.Pairs[i]))
             {
-                continue;
-            }
-
-            builder.AppendLine();
-            builder.AppendLine($"Channel {ChannelName(i)} — {channel.DisplayName}");
-            builder.AppendLine($"  Gain       {Signed(channel.GainDb)} dB");
-            builder.AppendLine(
-                $"  Delay      {Number(channel.DelayMs, "0.00")} ms" +
-                $"  (= {Number(channel.DelayMs * Acoustics.SpeedOfSoundAt20CMetersPerSecond, "0.#")} mm)");
-            builder.AppendLine(
-                $"  Polarity   {(channel.InvertPolarity ? "Inverted" : "Normal")}");
-            builder.AppendLine($"  Crossover  {DescribeCrossover(channel)}");
-            if (channel.PeqBands.Count > 0 || channel.PeqPreampDb != 0)
-            {
-                builder.AppendLine(
-                    $"  PEQ        {channel.PeqSourceName ?? "custom"}, " +
-                    $"preamp {Signed(channel.PeqPreampDb)} dB");
-                for (int band = 0; band < channel.PeqBands.Count; band++)
+                if (!channel.HasSource)
                 {
-                    PeqBand peq = channel.PeqBands[band];
+                    continue;
+                }
+
+                builder.AppendLine();
+                builder.AppendLine(
+                    $"Channel {ChannelName(i)}{sideSuffix} — {channel.DisplayName}");
+                builder.AppendLine($"  Gain       {Signed(channel.GainDb)} dB");
+                builder.AppendLine(
+                    $"  Delay      {Number(channel.DelayMs, "0.00")} ms" +
+                    $"  (= {Number(channel.DelayMs * Acoustics.SpeedOfSoundAt20CMetersPerSecond, "0.#")} mm)");
+                builder.AppendLine(
+                    $"  Polarity   {(channel.InvertPolarity ? "Inverted" : "Normal")}");
+                builder.AppendLine($"  Crossover  {DescribeCrossover(channel)}");
+                if (channel.PeqBands.Count > 0 || channel.PeqPreampDb != 0)
+                {
                     builder.AppendLine(
-                        $"    Filter {band + 1}: ON PK Fc {Number(peq.FrequencyHz, "0.###")} Hz " +
-                        $"Gain {Signed(peq.GainDb)} dB Q {Number(peq.Q, "0.0#")}");
+                        $"  PEQ        {channel.PeqSourceName ?? "custom"}, " +
+                        $"preamp {Signed(channel.PeqPreampDb)} dB");
+                    for (int band = 0; band < channel.PeqBands.Count; band++)
+                    {
+                        PeqBand peq = channel.PeqBands[band];
+                        builder.AppendLine(
+                            $"    Filter {band + 1}: ON PK Fc {Number(peq.FrequencyHz, "0.###")} Hz " +
+                            $"Gain {Signed(peq.GainDb)} dB Q {Number(peq.Q, "0.0#")}");
+                    }
                 }
             }
         }
@@ -63,6 +67,25 @@ internal static class VirtualCrossoverSheet
     }
 
     public static string ChannelName(int index) => ((char)('A' + index)).ToString();
+
+    /// <summary>
+    /// The printable sides of one channel pair: a mono pair is a single
+    /// "(mono)" section, a stereo pair prints its left and right sides
+    /// separately.
+    /// </summary>
+    internal static IEnumerable<(VirtualCrossoverChannelSettings Settings, string SideSuffix)>
+        SideSections(VirtualCrossoverChannelPairSettings pair)
+    {
+        ArgumentNullException.ThrowIfNull(pair);
+        if (pair.Mono)
+        {
+            yield return (pair.Left, " (mono)");
+            yield break;
+        }
+
+        yield return (pair.Left, " L");
+        yield return (pair.Right, " R");
+    }
 
     public static string DescribeCrossover(VirtualCrossoverChannelSettings channel)
     {

--- a/source/Tools/VirtualCrossoverSheetPdf.cs
+++ b/source/Tools/VirtualCrossoverSheetPdf.cs
@@ -47,12 +47,21 @@ internal static class VirtualCrossoverSheetPdf
 
         using var sheet = new PdfSheet("Virtual DSP", subtitleText);
 
-        var participating = new List<(int Index, VirtualCrossoverChannelSettings Channel)>();
-        for (int i = 0; i < project.Channels.Count; i++)
+        // Both sides of every pair print in one sheet; a mono pair prints
+        // once. On the graph the right side reuses the pair's hue dashed.
+        var participating =
+            new List<(int Index, string SideSuffix, bool Dashed,
+                VirtualCrossoverChannelSettings Channel)>();
+        for (int i = 0; i < project.Pairs.Count; i++)
         {
-            if (project.Channels[i].HasSource)
+            foreach ((VirtualCrossoverChannelSettings channel, string sideSuffix)
+                in VirtualCrossoverSheet.SideSections(project.Pairs[i]))
             {
-                participating.Add((i, project.Channels[i]));
+                if (channel.HasSource)
+                {
+                    participating.Add(
+                        (i, sideSuffix, sideSuffix == " R", channel));
+                }
             }
         }
 
@@ -63,9 +72,10 @@ internal static class VirtualCrossoverSheetPdf
                 Unit.FromCentimeter(17));
         }
 
-        foreach ((int index, VirtualCrossoverChannelSettings channel) in participating)
+        foreach ((int index, string sideSuffix, _, VirtualCrossoverChannelSettings channel)
+            in participating)
         {
-            AddChannelSection(sheet, index, channel);
+            AddChannelSection(sheet, index, sideSuffix, channel);
         }
 
         sheet.Save(filePath);
@@ -74,11 +84,13 @@ internal static class VirtualCrossoverSheetPdf
     private static void AddChannelSection(
         PdfSheet sheet,
         int index,
+        string sideSuffix,
         VirtualCrossoverChannelSettings channel)
     {
         Section section = sheet.Section;
         Paragraph heading = section.AddParagraph(
-            $"Channel {VirtualCrossoverSheet.ChannelName(index)} — {channel.DisplayName}");
+            $"Channel {VirtualCrossoverSheet.ChannelName(index)}{sideSuffix} — " +
+            channel.DisplayName);
         heading.Format.Font.Bold = true;
         heading.Format.Font.Size = 15;
         heading.Format.SpaceBefore = Unit.FromMillimeter(5);
@@ -121,10 +133,12 @@ internal static class VirtualCrossoverSheetPdf
         valueParagraph.Format.Font.Bold = true;
     }
 
-    // A compact white graph of every participating channel's DSP chain magnitude
-    // (gain + crossover + PEQ; the delay has no magnitude effect).
+    // A compact white graph of every participating channel side's DSP chain
+    // magnitude (gain + crossover + PEQ; the delay has no magnitude effect).
+    // Left and right sides of one pair share a hue; the right side is dashed.
     private static byte[] RenderChainsGraph(
-        IReadOnlyList<(int Index, VirtualCrossoverChannelSettings Channel)> channels,
+        IReadOnlyList<(int Index, string SideSuffix, bool Dashed,
+            VirtualCrossoverChannelSettings Channel)> channels,
         int sampleRate)
     {
         IReadOnlyList<double> grid = EqualizationCurve.LogFrequencyGrid(20, 20_000, 200);
@@ -148,14 +162,16 @@ internal static class VirtualCrossoverSheetPdf
 
         double minDb = -6;
         double maxDb = 6;
-        foreach ((int index, VirtualCrossoverChannelSettings channel) in channels)
+        foreach ((int index, string sideSuffix, bool dashed,
+            VirtualCrossoverChannelSettings channel) in channels)
         {
             DspChannelChain chain = channel.ToChain() with { DelayMs = 0 };
             var series = new LineSeries
             {
                 Color = ChainColors[index % ChainColors.Length],
                 StrokeThickness = 2,
-                Title = $"Channel {VirtualCrossoverSheet.ChannelName(index)}"
+                LineStyle = dashed ? LineStyle.Dash : LineStyle.Solid,
+                Title = $"Channel {VirtualCrossoverSheet.ChannelName(index)}{sideSuffix}"
             };
             foreach (double frequency in grid)
             {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -5,10 +5,10 @@ namespace Resonalyze.App.Tests;
 public sealed class VirtualCrossoverMetricTests
 {
     private static readonly VirtualCrossoverMetric.Entry Junction =
-        new("A/B", -1.23, -6.5, -17.4, 900, 3_600, IsTotal: false);
+        new("A/B", -1.23, -6.5, 900, 3_600, IsTotal: false);
 
     private static readonly VirtualCrossoverMetric.Entry Total =
-        new("total", -0.8, null, null, 100, 10_000, IsTotal: true);
+        new("total", -0.8, null, 100, 10_000, IsTotal: true);
 
     [Fact]
     public void FormatLabel_EmptyShowsPlaceholder()
@@ -26,8 +26,7 @@ public sealed class VirtualCrossoverMetricTests
             string text = VirtualCrossoverMetric.FormatLabel([Junction, Total]);
 
             Assert.Equal(
-                "Sum loss avg: A/B -1.2 dB, dip -6.5 dB, null -17.4 dB   " +
-                "total -0.8 dB",
+                "Sum loss avg: A/B -1.2 dB, dip -6.5 dB   total -0.8 dB",
                 text);
         });
     }
@@ -39,9 +38,9 @@ public sealed class VirtualCrossoverMetricTests
         {
             string text = VirtualCrossoverMetric.FormatCompact([Junction, Total]);
 
-            Assert.StartsWith("Sum loss (dB)\r\n  avg / dip / null\r\n\r\n", text);
-            Assert.Contains("A/B    -1.2 / -6.5 /-17.4", text);
-            Assert.Contains("Total  -0.8 /    — /    —", text);
+            Assert.StartsWith("Sum loss (dB)\r\n  avg / dip\r\n\r\n", text);
+            Assert.Contains("A/B    -1.2 / -6.5", text);
+            Assert.Contains("Total  -0.8 /    —", text);
         });
     }
 
@@ -53,9 +52,55 @@ public sealed class VirtualCrossoverMetricTests
             string text = VirtualCrossoverMetric.FormatDetail([Junction]);
 
             Assert.Equal(
-                "Sum loss avg\r\nA/B: -1.2 dB avg, dip -6.5 dB, " +
-                "flip null -17.4 dB (900 Hz – 3.6 kHz)",
+                "Sum loss avg\r\nA/B: -1.2 dB avg, dip -6.5 dB " +
+                "(900 Hz – 3.6 kHz)",
                 text);
+        });
+    }
+
+    [Fact]
+    public void FormatStereoDeltasCompact_ListsPerChannelDeltasAndDashesInvalidOnes()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            string text = VirtualCrossoverMetric.FormatStereoDeltasCompact(
+            [
+                new VirtualCrossoverMetric.StereoDelta("B", 0.25, 175, 1_300),
+                new VirtualCrossoverMetric.StereoDelta("C", -0.07, 1_800, 20_000),
+                new VirtualCrossoverMetric.StereoDelta("D", null, 1_800, 20_000)
+            ]);
+
+            Assert.Equal(
+                "\u0394 L\u2212R (ms)\r\n" +
+                "B      +0.25\r\n" +
+                "C      -0.07\r\n" +
+                "D          \u2014",
+                text);
+        });
+    }
+
+    [Fact]
+    public void FormatStereoDeltasCompact_EmptyListRendersNothing()
+    {
+        Assert.Equal(
+            string.Empty,
+            VirtualCrossoverMetric.FormatStereoDeltasCompact([]));
+    }
+
+    [Fact]
+    public void FormatStereoDeltasDetail_ExplainsTheSignAndIncludesBands()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            string text = VirtualCrossoverMetric.FormatStereoDeltasDetail(
+            [
+                new VirtualCrossoverMetric.StereoDelta("B", 0.253, 175, 1_300),
+                new VirtualCrossoverMetric.StereoDelta("D", null, 1_800, 20_000)
+            ]);
+
+            Assert.Contains("positive: right leads", text);
+            Assert.Contains("B: +0.253 ms (175 Hz \u2013 1.3 kHz)", text);
+            Assert.Contains("D: \u2014 (no measurable arrival)", text);
         });
     }
 

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -65,9 +65,12 @@ public sealed class VirtualCrossoverMetricTests
         {
             string text = VirtualCrossoverMetric.FormatStereoDeltasCompact(
             [
-                new VirtualCrossoverMetric.StereoDelta("B", 25.98, 25.73, 175, 1_300),
-                new VirtualCrossoverMetric.StereoDelta("C", 15.34, 15.41, 1_800, 20_000),
-                new VirtualCrossoverMetric.StereoDelta("D", null, 13.62, 1_800, 20_000)
+                new VirtualCrossoverMetric.StereoDelta(
+                    "B", 25.98, 25.73, 175, 1_300, LevelDeltaDb: 1.63),
+                new VirtualCrossoverMetric.StereoDelta(
+                    "C", 15.34, 15.41, 1_800, 20_000, LevelDeltaDb: -0.62),
+                new VirtualCrossoverMetric.StereoDelta(
+                    "D", null, 13.62, 1_800, 20_000)
             ]);
 
             Assert.Equal(
@@ -75,7 +78,12 @@ public sealed class VirtualCrossoverMetricTests
                 "         L      R  \u0394 L\u2212R\r\n" +
                 "B    25.98  25.73  +0.25\r\n" +
                 "C    15.34  15.41  -0.07\r\n" +
-                "D        \u2014  13.62      \u2014",
+                "D        \u2014  13.62      \u2014\r\n" +
+                "\r\n" +
+                "Level \u0394 L\u2212R (dB)\r\n" +
+                "B     +1.6\r\n" +
+                "C     -0.6\r\n" +
+                "D        \u2014",
                 text);
         });
     }
@@ -95,19 +103,24 @@ public sealed class VirtualCrossoverMetricTests
         {
             string text = VirtualCrossoverMetric.FormatStereoDeltasDetail(
             [
-                new VirtualCrossoverMetric.StereoDelta("B", 25.977, 25.724, 175, 1_300),
-                new VirtualCrossoverMetric.StereoDelta("C", null, 13.618, 1_800, 20_000),
-                new VirtualCrossoverMetric.StereoDelta("D", null, null, 1_800, 20_000)
+                new VirtualCrossoverMetric.StereoDelta(
+                    "B", 25.977, 25.724, 175, 1_300, LevelDeltaDb: 1.63),
+                new VirtualCrossoverMetric.StereoDelta(
+                    "C", null, 13.618, 1_800, 20_000),
+                new VirtualCrossoverMetric.StereoDelta(
+                    "D", null, null, 1_800, 20_000)
             ]);
 
             Assert.Contains("positive: right leads", text);
             Assert.Contains(
-                "B: L 25.977 / R 25.724 ms, \u0394 +0.253 ms (175 Hz \u2013 1.3 kHz)",
+                "B: L 25.977 / R 25.724 ms, \u0394 +0.253 ms, level +1.6 dB " +
+                "(175 Hz \u2013 1.3 kHz)",
                 text);
             Assert.Contains(
                 "C: L \u2014 / R 13.618 ms, \u0394 \u2014 (1.8 kHz \u2013 20 kHz)",
                 text);
             Assert.Contains("D: \u2014 (no measurable arrival)", text);
+            Assert.Contains("positive: LEFT louder", text);
         });
     }
 

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -59,22 +59,23 @@ public sealed class VirtualCrossoverMetricTests
     }
 
     [Fact]
-    public void FormatStereoDeltasCompact_ListsPerChannelDeltasAndDashesInvalidOnes()
+    public void FormatStereoDeltasCompact_ListsPerChannelArrivalsAndDashesUnreliableSides()
     {
         RunWithInvariantCulture(() =>
         {
             string text = VirtualCrossoverMetric.FormatStereoDeltasCompact(
             [
-                new VirtualCrossoverMetric.StereoDelta("B", 0.25, 175, 1_300),
-                new VirtualCrossoverMetric.StereoDelta("C", -0.07, 1_800, 20_000),
-                new VirtualCrossoverMetric.StereoDelta("D", null, 1_800, 20_000)
+                new VirtualCrossoverMetric.StereoDelta("B", 25.98, 25.73, 175, 1_300),
+                new VirtualCrossoverMetric.StereoDelta("C", 15.34, 15.41, 1_800, 20_000),
+                new VirtualCrossoverMetric.StereoDelta("D", null, 13.62, 1_800, 20_000)
             ]);
 
             Assert.Equal(
-                "\u0394 L\u2212R (ms)\r\n" +
-                "B      +0.25\r\n" +
-                "C      -0.07\r\n" +
-                "D          \u2014",
+                "Arrival (ms)\r\n" +
+                "         L      R  \u0394 L\u2212R\r\n" +
+                "B    25.98  25.73  +0.25\r\n" +
+                "C    15.34  15.41  -0.07\r\n" +
+                "D        \u2014  13.62      \u2014",
                 text);
         });
     }
@@ -88,18 +89,24 @@ public sealed class VirtualCrossoverMetricTests
     }
 
     [Fact]
-    public void FormatStereoDeltasDetail_ExplainsTheSignAndIncludesBands()
+    public void FormatStereoDeltasDetail_ListsSidesExplainsTheSignAndIncludesBands()
     {
         RunWithInvariantCulture(() =>
         {
             string text = VirtualCrossoverMetric.FormatStereoDeltasDetail(
             [
-                new VirtualCrossoverMetric.StereoDelta("B", 0.253, 175, 1_300),
-                new VirtualCrossoverMetric.StereoDelta("D", null, 1_800, 20_000)
+                new VirtualCrossoverMetric.StereoDelta("B", 25.977, 25.724, 175, 1_300),
+                new VirtualCrossoverMetric.StereoDelta("C", null, 13.618, 1_800, 20_000),
+                new VirtualCrossoverMetric.StereoDelta("D", null, null, 1_800, 20_000)
             ]);
 
             Assert.Contains("positive: right leads", text);
-            Assert.Contains("B: +0.253 ms (175 Hz \u2013 1.3 kHz)", text);
+            Assert.Contains(
+                "B: L 25.977 / R 25.724 ms, \u0394 +0.253 ms (175 Hz \u2013 1.3 kHz)",
+                text);
+            Assert.Contains(
+                "C: L \u2014 / R 13.618 ms, \u0394 \u2014 (1.8 kHz \u2013 20 kHz)",
+                text);
             Assert.Contains("D: \u2014 (no measurable arrival)", text);
         });
     }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -21,7 +21,10 @@ public sealed class VirtualCrossoverProjectFileTests
                 PhaseGateRightMs = 2.0,
                 PhaseDetrendMs = 13.07
             };
-            original.Channels[0] = new VirtualCrossoverChannelSettings
+            original.StereoSceneOffsetMs = -0.4;
+            original.ActiveSideRight = true;
+            original.Pairs[0].Mono = true;
+            original.Pairs[0].Left = new VirtualCrossoverChannelSettings
             {
                 Enabled = false,
                 Bypass = true,
@@ -53,10 +56,13 @@ public sealed class VirtualCrossoverProjectFileTests
             Assert.Equal(original.PhaseGatePlateauMs, loaded.PhaseGatePlateauMs);
             Assert.Equal(original.PhaseGateRightMs, loaded.PhaseGateRightMs);
             Assert.Equal(original.PhaseDetrendMs, loaded.PhaseDetrendMs);
-            Assert.Equal(original.Channels.Count, loaded.Channels.Count);
+            Assert.Equal(original.StereoSceneOffsetMs, loaded.StereoSceneOffsetMs);
+            Assert.Equal(original.ActiveSideRight, loaded.ActiveSideRight);
+            Assert.Equal(original.Pairs.Count, loaded.Pairs.Count);
+            Assert.True(loaded.Pairs[0].Mono);
 
-            VirtualCrossoverChannelSettings expected = original.Channels[0];
-            VirtualCrossoverChannelSettings actual = loaded.Channels[0];
+            VirtualCrossoverChannelSettings expected = original.Pairs[0].Left;
+            VirtualCrossoverChannelSettings actual = loaded.Pairs[0].Left;
             Assert.Equal(expected.Enabled, actual.Enabled);
             Assert.Equal(expected.Bypass, actual.Bypass);
             Assert.Equal(expected.DisplayName, actual.DisplayName);
@@ -88,14 +94,14 @@ public sealed class VirtualCrossoverProjectFileTests
         {
             VirtualCrossoverProjectFile missing =
                 VirtualCrossoverProjectFile.LoadOrDefault(root);
-            Assert.Equal(3, missing.Channels.Count);
+            Assert.Equal(3, missing.Pairs.Count);
             Assert.True(missing.ShowSumCurve);
 
             string path = VirtualCrossoverProjectFile.GetPath(root);
             File.WriteAllText(path, "{ not json ");
             VirtualCrossoverProjectFile corrupt =
                 VirtualCrossoverProjectFile.LoadOrDefault(root);
-            Assert.Equal(3, corrupt.Channels.Count);
+            Assert.Equal(3, corrupt.Pairs.Count);
 
             // The unusable file is parked as .backup so the next scheduled
             // save cannot silently destroy it.
@@ -115,7 +121,7 @@ public sealed class VirtualCrossoverProjectFileTests
         try
         {
             var future = new VirtualCrossoverProjectFile();
-            future.Channels[0].GainDb = -10;
+            future.Pairs[0].Left.GainDb = -10;
             future.Save(root);
 
             string path = VirtualCrossoverProjectFile.GetPath(root);
@@ -126,7 +132,7 @@ public sealed class VirtualCrossoverProjectFileTests
 
             VirtualCrossoverProjectFile loaded =
                 VirtualCrossoverProjectFile.LoadOrDefault(root);
-            Assert.Equal(0, loaded.Channels[0].GainDb);
+            Assert.Equal(0, loaded.Pairs[0].Left.GainDb);
 
             // A downgraded app keeps the newer session parked next to the
             // fresh default instead of overwriting it on the next save.
@@ -170,14 +176,14 @@ public sealed class VirtualCrossoverProjectFileTests
         try
         {
             var original = new VirtualCrossoverProjectFile();
-            original.Channels[0].GainDb = -4;
+            original.Pairs[0].Left.GainDb = -4;
             original.Save(root);
 
             VirtualCrossoverProjectFile loaded =
                 VirtualCrossoverProjectFile.LoadOrDefault(root);
 
             string path = VirtualCrossoverProjectFile.GetPath(root);
-            Assert.Equal(-4, loaded.Channels[0].GainDb);
+            Assert.Equal(-4, loaded.Pairs[0].Left.GainDb);
             Assert.True(File.Exists(path));
             Assert.False(File.Exists(path + ".backup"));
             Assert.Null(loaded.BackupNoticePath);
@@ -199,10 +205,10 @@ public sealed class VirtualCrossoverProjectFileTests
                 CalibrationMode = MicrophoneCalibrationMode.Degrees90,
                 DspPlotMode = DspPlotMode.GroupDelay
             };
-            while (original.Channels.Count <
+            while (original.Pairs.Count <
                 VirtualCrossoverProjectFile.MaximumChannelCount)
             {
-                original.Channels.Add(new VirtualCrossoverChannelSettings());
+                original.Pairs.Add(new VirtualCrossoverChannelPairSettings());
             }
 
             original.Save(root);
@@ -211,7 +217,7 @@ public sealed class VirtualCrossoverProjectFileTests
 
             Assert.Equal(
                 VirtualCrossoverProjectFile.MaximumChannelCount,
-                loaded.Channels.Count);
+                loaded.Pairs.Count);
             Assert.Equal(MicrophoneCalibrationMode.Degrees90, loaded.CalibrationMode);
             Assert.Equal(DspPlotMode.GroupDelay, loaded.DspPlotMode);
         }
@@ -225,29 +231,36 @@ public sealed class VirtualCrossoverProjectFileTests
     public void Save_RejectsInvalidChannelValues()
     {
         var negativeDelay = new VirtualCrossoverProjectFile();
-        negativeDelay.Channels[0].DelayMs = -1;
+        negativeDelay.Pairs[0].Left.DelayMs = -1;
         Assert.Throws<InvalidDataException>(() => negativeDelay.Validate());
 
         var badSlope = new VirtualCrossoverProjectFile();
-        badSlope.Channels[0].LowPassEdge = new CrossoverEdge(
+        badSlope.Pairs[0].Left.LowPassEdge = new CrossoverEdge(
             CrossoverFilterFamily.LinkwitzRiley, 1_000, 18);
         Assert.Throws<InvalidDataException>(() => badSlope.Validate());
 
         var badBand = new VirtualCrossoverProjectFile();
-        badBand.Channels[0].PeqBands = [new PeqBand(0, 1.0, 3.0)];
+        badBand.Pairs[0].Right.PeqBands = [new PeqBand(0, 1.0, 3.0)];
         Assert.Throws<InvalidDataException>(() => badBand.Validate());
 
         var tooFewChannels = new VirtualCrossoverProjectFile();
-        tooFewChannels.Channels.RemoveRange(1, 2);
+        tooFewChannels.Pairs.RemoveRange(1, 2);
         Assert.Throws<InvalidDataException>(() => tooFewChannels.Validate());
 
         var tooManyChannels = new VirtualCrossoverProjectFile();
-        while (tooManyChannels.Channels.Count <=
+        while (tooManyChannels.Pairs.Count <=
             VirtualCrossoverProjectFile.MaximumChannelCount)
         {
-            tooManyChannels.Channels.Add(new VirtualCrossoverChannelSettings());
+            tooManyChannels.Pairs.Add(new VirtualCrossoverChannelPairSettings());
         }
         Assert.Throws<InvalidDataException>(() => tooManyChannels.Validate());
+
+        var badSceneOffset = new VirtualCrossoverProjectFile
+        {
+            StereoSceneOffsetMs =
+                VirtualCrossoverProjectFile.MaximumSceneOffsetMs + 1
+        };
+        Assert.Throws<InvalidDataException>(() => badSceneOffset.Validate());
 
         var badCalibrationMode = new VirtualCrossoverProjectFile
         {
@@ -296,16 +309,16 @@ public sealed class VirtualCrossoverProjectFileTests
         try
         {
             var original = new VirtualCrossoverProjectFile { ShowLossCurve = true };
-            original.Channels[0].DisplayName = "woofer";
-            original.Channels[0].SourceFilePath = @"C:\m\woofer.json";
-            original.Channels[0].DelayMs = 1.25;
+            original.Pairs[0].Left.DisplayName = "woofer";
+            original.Pairs[0].Left.SourceFilePath = @"C:\m\woofer.json";
+            original.Pairs[0].Right.DelayMs = 1.25;
 
             original.SaveTo(path);
             VirtualCrossoverProjectFile loaded = VirtualCrossoverProjectFile.LoadFrom(path);
 
             Assert.True(loaded.ShowLossCurve);
-            Assert.Equal("woofer", loaded.Channels[0].DisplayName);
-            Assert.Equal(1.25, loaded.Channels[0].DelayMs);
+            Assert.Equal("woofer", loaded.Pairs[0].Left.DisplayName);
+            Assert.Equal(1.25, loaded.Pairs[0].Right.DelayMs);
         }
         finally
         {
@@ -337,6 +350,80 @@ public sealed class VirtualCrossoverProjectFileTests
         {
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    [Fact]
+    public void LoadOrDefault_MigratesAVersion1SingleSidedProjectToPairs()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            // A real v1 payload shape: a "channels" list, no "pairs".
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, """
+                {
+                  "format": "resonalyze-virtual-crossover",
+                  "version": 1,
+                  "channels": [
+                    {
+                      "displayName": "woofer.json",
+                      "sourceFilePath": "C:\\m\\woofer.json",
+                      "gainDb": -2.5,
+                      "delayMs": 4.78,
+                      "invertPolarity": true,
+                      "crossoverKind": "LowPass",
+                      "lowPassEdge": { "family": "Butterworth", "frequencyHz": 175, "slopeDbPerOctave": 24 }
+                    },
+                    { "displayName": "", "gainDb": 0, "delayMs": 0 }
+                  ],
+                  "showSumCurve": true
+                }
+                """);
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            // The historical single-sided channels become the LEFT sides of
+            // fresh pairs; the right sides start empty and nothing is lost.
+            Assert.Equal(VirtualCrossoverProjectFile.CurrentVersion, loaded.Version);
+            Assert.Null(loaded.BackupNoticePath);
+            Assert.Equal(2, loaded.Pairs.Count);
+            Assert.Empty(loaded.Channels);
+            VirtualCrossoverChannelSettings woofer = loaded.Pairs[0].Left;
+            Assert.Equal("woofer.json", woofer.DisplayName);
+            Assert.Equal(-2.5, woofer.GainDb);
+            Assert.Equal(4.78, woofer.DelayMs);
+            Assert.True(woofer.InvertPolarity);
+            Assert.Equal(CrossoverKind.LowPass, woofer.CrossoverKind);
+            Assert.False(loaded.Pairs[0].Mono);
+            Assert.False(loaded.Pairs[0].Right.HasSource);
+
+            // The migrated project persists as v2 and round-trips.
+            loaded.Save(root);
+            VirtualCrossoverProjectFile reloaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+            Assert.Equal(2, reloaded.Pairs.Count);
+            Assert.Equal("woofer.json", reloaded.Pairs[0].Left.DisplayName);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SideFor_MonoPairAnswersWithTheLeftSideForBothViews()
+    {
+        var pair = new VirtualCrossoverChannelPairSettings { Mono = true };
+        pair.Left.GainDb = -3;
+        pair.Right.GainDb = 12;
+
+        Assert.Same(pair.Left, pair.SideFor(rightSide: false));
+        Assert.Same(pair.Left, pair.SideFor(rightSide: true));
+
+        pair.Mono = false;
+        Assert.Same(pair.Right, pair.SideFor(rightSide: true));
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
@@ -9,15 +9,19 @@ public sealed class VirtualCrossoverSheetPdfTests
     public void Export_WritesAValidPdfFile()
     {
         var project = new VirtualCrossoverProjectFile();
-        project.Channels[0].SourceFilePath = "sub.json";
-        project.Channels[0].DisplayName = "Sub";
-        project.Channels[0].GainDb = -3.0;
-        project.Channels[0].DelayMs = 1.5;
-        project.Channels[0].CrossoverKind = CrossoverKind.LowPass;
-        project.Channels[1].SourceFilePath = "top.json";
-        project.Channels[1].DisplayName = "Top";
-        project.Channels[1].CrossoverKind = CrossoverKind.HighPass;
-        project.Channels[1].PeqBands.Add(new PeqBand(1000, 2.0, -3.0));
+        project.Pairs[0].Mono = true;
+        project.Pairs[0].Left.SourceFilePath = "sub.json";
+        project.Pairs[0].Left.DisplayName = "Sub";
+        project.Pairs[0].Left.GainDb = -3.0;
+        project.Pairs[0].Left.DelayMs = 1.5;
+        project.Pairs[0].Left.CrossoverKind = CrossoverKind.LowPass;
+        project.Pairs[1].Left.SourceFilePath = "top.json";
+        project.Pairs[1].Left.DisplayName = "Top";
+        project.Pairs[1].Left.CrossoverKind = CrossoverKind.HighPass;
+        project.Pairs[1].Left.PeqBands.Add(new PeqBand(1000, 2.0, -3.0));
+        project.Pairs[1].Right.SourceFilePath = "top r.json";
+        project.Pairs[1].Right.DisplayName = "Top R";
+        project.Pairs[1].Right.CrossoverKind = CrossoverKind.HighPass;
 
         string path = Path.Combine(Path.GetTempPath(), $"vdsp_{Guid.NewGuid():N}.pdf");
         try

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetTests.cs
@@ -7,7 +7,8 @@ public sealed class VirtualCrossoverSheetTests
     private static VirtualCrossoverProjectFile CreateProject()
     {
         var project = new VirtualCrossoverProjectFile();
-        project.Channels[0] = new VirtualCrossoverChannelSettings
+        project.Pairs[0].Mono = true;
+        project.Pairs[0].Left = new VirtualCrossoverChannelSettings
         {
             DisplayName = "woofer.json",
             SourceFilePath = @"C:\m\woofer.json",
@@ -20,14 +21,22 @@ public sealed class VirtualCrossoverSheetTests
             PeqBands = [new PeqBand(120, 2.0, -4.0)],
             PeqSourceName = "woofer-peq.txt"
         };
-        project.Channels[1] = new VirtualCrossoverChannelSettings
+        project.Pairs[1].Left = new VirtualCrossoverChannelSettings
         {
             DisplayName = "tweeter.json",
             SourceFilePath = @"C:\m\tweeter.json",
             CrossoverKind = CrossoverKind.HighPass,
             HighPassEdge = new CrossoverEdge(CrossoverFilterFamily.Butterworth, 2_000, 18)
         };
-        // The third channel has no source and must not appear on the sheet.
+        project.Pairs[1].Right = new VirtualCrossoverChannelSettings
+        {
+            DisplayName = "tweeter R.json",
+            SourceFilePath = @"C:\m\tweeter R.json",
+            CrossoverKind = CrossoverKind.HighPass,
+            HighPassEdge = new CrossoverEdge(CrossoverFilterFamily.Butterworth, 2_000, 18),
+            DelayMs = 0.68
+        };
+        // The third pair has no source and must not appear on the sheet.
         return project;
     }
 
@@ -37,7 +46,8 @@ public sealed class VirtualCrossoverSheetTests
         string text = VirtualCrossoverSheet.FormatText(CreateProject(), "Sum loss avg: -1.8 dB");
 
         Assert.Contains("Sum loss avg: -1.8 dB", text);
-        Assert.Contains("Channel A — woofer.json", text);
+        // The mono pair prints ONE section; the stereo pair prints both sides.
+        Assert.Contains("Channel A (mono) — woofer.json", text);
         Assert.Contains("-2.5 dB", text);
         Assert.Contains("0.42 ms", text);
         Assert.Contains("144.1 mm", text);
@@ -46,7 +56,9 @@ public sealed class VirtualCrossoverSheetTests
         Assert.Contains("woofer-peq.txt, preamp -1.5 dB", text);
         Assert.Contains("Filter 1: ON PK Fc 120 Hz Gain -4.0 dB Q 2.0", text);
 
-        Assert.Contains("Channel B — tweeter.json", text);
+        Assert.Contains("Channel B L — tweeter.json", text);
+        Assert.Contains("Channel B R — tweeter R.json", text);
+        Assert.Contains("0.68 ms", text);
         Assert.Contains("High-pass Butterworth 18 dB/oct @ 2000 Hz", text);
         Assert.Contains("Normal", text);
 

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentRealDataTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentRealDataTests.cs
@@ -102,6 +102,12 @@ public sealed class StereoAlignmentRealDataTests
         const double SceneOffsetMs = 0.25;
         const double BridgeBandLowHz = 1_800;
         const double BridgeBandHighHz = 12_000;
+        List<StereoPairLink> pairLinks =
+        [
+            new(leftWoof, rightWoof, 80, 175),
+            new(leftMid, rightMid, 175, 1_300),
+            new(leftTwr, rightTwr, 1_800, 12_000)
+        ];
         var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
         var log = new StringBuilder();
         AutoAlignmentEngine.ComputeStereo(
@@ -115,7 +121,8 @@ public sealed class StereoAlignmentRealDataTests
                 rightTwr,
                 BridgeBandLowHz,
                 BridgeBandHighHz,
-                SceneOffsetMs),
+                SceneOffsetMs,
+                pairLinks),
             Reprocess,
             alignment,
             log);
@@ -156,6 +163,27 @@ public sealed class StereoAlignmentRealDataTests
 
         // The pinned right sub junction is reported, not tuned.
         Assert.Contains("mono, timed by the left side", log.ToString());
+
+        // The field regression this cabin exposed: the right woofer used to
+        // optimize ONLY its junction toward the bridge and parked a whole
+        // 175 Hz period off the shared sub (junction avg −4.9 dB, and 5.4 ms
+        // away from the left woofer). With the joint two-neighbor search it
+        // must sit within a cabin-width of the left woofer and keep the sub
+        // handover healthy on BOTH sides.
+        double leftWoofDelay = alignment.GetValueOrDefault(leftWoof).DelayMs;
+        double rightWoofDelay = alignment.GetValueOrDefault(rightWoof).DelayMs;
+        Assert.InRange(Math.Abs(leftWoofDelay - rightWoofDelay), 0, 1.5);
+
+        (double LossDb, double DipDb)? rightSubJunction =
+            VirtualCrossoverAnalysis.MeasureSumLoss(
+                final.First(item => item.Channel == rightWoof).ImpulseResponse,
+                new List<Complex[]>
+                {
+                    final.First(item => item.Channel == sub).ImpulseResponse
+                },
+                rightWoof.SampleRate, 40, 160);
+        Assert.NotNull(rightSubJunction);
+        Assert.InRange(rightSubJunction.Value.LossDb, -1.5, 0);
     }
 
     private static (int SampleRate, Complex[] Ir) LoadTransferIr(string fileName)

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentRealDataTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentRealDataTests.cs
@@ -184,6 +184,29 @@ public sealed class StereoAlignmentRealDataTests
                 rightWoof.SampleRate, 40, 160);
         Assert.NotNull(rightSubJunction);
         Assert.InRange(rightSubJunction.Value.LossDb, -1.5, 0);
+
+        // The scene mandate: the mids live squarely in the localization
+        // region, so their pair is PINNED to the scene offset (±0.05 ms plus
+        // the arrival detector's ~0.06 ms repeatability) — the field failure
+        // had them drifting 0.43 ms left of the target because nothing
+        // constrained the descent below the bridge.
+        double leftMidArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            final.First(item => item.Channel == leftMid).ImpulseResponse,
+            leftMid.SampleRate, 175, 1_300);
+        double rightMidArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            final.First(item => item.Channel == rightMid).ImpulseResponse,
+            rightMid.SampleRate, 175, 1_300);
+        Assert.InRange(leftMidArrival - rightMidArrival, 0.10, 0.40);
+
+        // The scene-preserving co-move may shift a pair, but never its L−R
+        // timing: the tweeter pair still reads the scene offset at the end.
+        double leftTwrArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            final.First(item => item.Channel == leftTwr).ImpulseResponse,
+            leftTwr.SampleRate, BridgeBandLowHz, BridgeBandHighHz);
+        double rightTwrArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            final.First(item => item.Channel == rightTwr).ImpulseResponse,
+            rightTwr.SampleRate, BridgeBandLowHz, BridgeBandHighHz);
+        Assert.InRange(leftTwrArrival - rightTwrArrival, 0.15, 0.35);
     }
 
     private static (int SampleRate, Complex[] Ir) LoadTransferIr(string fileName)

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentRealDataTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentRealDataTests.cs
@@ -1,0 +1,204 @@
+using System.Numerics;
+using System.Text;
+using System.Text.Json;
+
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The stereo cascade on the real measurements in <c>assets/test_data</c>:
+/// the user's left 4-way (shared mono sub) bridged to the right 3-way at the
+/// tweeter pair with the 0.25 ms dash-center scene offset. Pins the contract
+/// the synthetic tests cannot: on real cabin acoustics the bridge lands the
+/// right tweeter's band-limited arrival exactly the offset behind the left
+/// one, the mono sub keeps its left-pass timing, and no delay is negative.
+/// </summary>
+public sealed class StereoAlignmentRealDataTests
+{
+    private sealed record Channel(
+        string Name,
+        int SampleRate,
+        Complex[] RawIr,
+        DspChannelChain BaseChain) : IAlignmentChannel;
+
+    private static CrossoverEdge Bw(double frequencyHz) =>
+        new(CrossoverFilterFamily.Butterworth, frequencyHz, 24);
+
+    [Fact]
+    public void ComputeStereo_RealCabin_BridgesTheTweetersAndKeepsTheMonoSub()
+    {
+        Channel Load(string file, string name, DspChannelChain chain)
+        {
+            (int rate, Complex[] ir) = LoadTransferIr(file);
+            return new Channel(name, rate, ir, chain);
+        }
+
+        Channel sub = Load("sub woof closed window.json", "sub", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.LowPass, Bw(80))));
+        Channel leftWoof = Load("l woof.json", "L woof", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(175), Bw(80))));
+        Channel leftMid = Load("l mid.json", "L mid", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(1_300), Bw(175))));
+        Channel leftTwr = Load("l twr.json", "L twr", new DspChannelChain(
+            GainDb: -5,
+            Crossover: new CrossoverSpec(CrossoverKind.HighPass, HighPassEdge: Bw(1_800))));
+        Channel rightWoof = Load("r woof.json", "R woof", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(175), Bw(80))));
+        Channel rightMid = Load("r mid.json", "R mid", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(1_300), Bw(175))));
+        Channel rightTwr = Load("r twr.json", "R twr", new DspChannelChain(
+            GainDb: -5,
+            Crossover: new CrossoverSpec(CrossoverKind.HighPass, HighPassEdge: Bw(1_800))));
+
+        Channel[] all = [sub, leftWoof, leftMid, leftTwr, rightWoof, rightMid, rightTwr];
+        Channel[] leftByBand = [sub, leftWoof, leftMid, leftTwr];
+        Channel[] rightByBand = [sub, rightWoof, rightMid, rightTwr];
+
+        // The engine re-evaluates the same override maps many times across the
+        // junction walks; caching processed IRs keeps the real-data run fast.
+        var cache = new Dictionary<(Channel, double, bool), AlignmentSnapshot>();
+        AlignmentSnapshot Snapshot(Channel channel, AlignmentOverride over)
+        {
+            (Channel, double, bool) key = (channel, over.DelayMs, over.InvertPolarity);
+            if (!cache.TryGetValue(key, out AlignmentSnapshot? hit))
+            {
+                Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(
+                    channel.RawIr,
+                    channel.BaseChain with
+                    {
+                        DelayMs = over.DelayMs,
+                        InvertPolarity = over.InvertPolarity
+                    },
+                    channel.SampleRate);
+                hit = new AlignmentSnapshot(
+                    channel, processed, VirtualCrossoverAnalysis.FindPeakIndex(processed));
+                cache[key] = hit;
+            }
+
+            return hit;
+        }
+
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            all.Select(channel =>
+                Snapshot(channel, overrides.GetValueOrDefault(channel))).ToList();
+
+        List<AlignmentSnapshot> leftSnapshots = leftByBand
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        List<AlignmentSnapshot> rightSnapshots = rightByBand
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        AlignmentJunction Junction(
+            AlignmentSnapshot lower, AlignmentSnapshot upper, double fc) =>
+            new(lower, upper, fc, Math.Max(20, fc / 2), Math.Min(20_000, fc * 2));
+        double[] crossovers = [80, 175, 1_300];
+        List<AlignmentJunction> leftPairs = crossovers
+            .Select((fc, i) => Junction(leftSnapshots[i], leftSnapshots[i + 1], fc))
+            .ToList();
+        List<AlignmentJunction> rightPairs = crossovers
+            .Select((fc, i) => Junction(rightSnapshots[i], rightSnapshots[i + 1], fc))
+            .ToList();
+
+        const double SceneOffsetMs = 0.25;
+        const double BridgeBandLowHz = 1_800;
+        const double BridgeBandHighHz = 12_000;
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        var log = new StringBuilder();
+        AutoAlignmentEngine.ComputeStereo(
+            new StereoAlignmentPlan(
+                leftSnapshots,
+                leftPairs,
+                rightSnapshots,
+                rightPairs,
+                new HashSet<IAlignmentChannel> { sub },
+                leftTwr,
+                rightTwr,
+                BridgeBandLowHz,
+                BridgeBandHighHz,
+                SceneOffsetMs),
+            Reprocess,
+            alignment,
+            log);
+
+        // Every proposal is a physically realizable non-negative delay and the
+        // field is normalized: something sits at zero.
+        Assert.All(all, channel =>
+            Assert.True(alignment.GetValueOrDefault(channel).DelayMs >= 0));
+        Assert.InRange(
+            all.Min(channel => alignment.GetValueOrDefault(channel).DelayMs),
+            0, 0.011);
+
+        // The bridge contract on real acoustics: with the final delays applied,
+        // the right tweeter's band-limited arrival trails the left one by the
+        // scene offset (right LEADS by 0.25 ms). Tolerance covers the 0.01 ms
+        // delay rounding and the arrival detector's repeatability (~0.06 ms on
+        // these measurements).
+        IReadOnlyList<AlignmentSnapshot> final = Reprocess(alignment);
+        double leftArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            final.First(item => item.Channel == leftTwr).ImpulseResponse,
+            leftTwr.SampleRate, BridgeBandLowHz, BridgeBandHighHz);
+        double rightArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            final.First(item => item.Channel == rightTwr).ImpulseResponse,
+            rightTwr.SampleRate, BridgeBandLowHz, BridgeBandHighHz);
+        Assert.InRange(leftArrival - rightArrival, 0.15, 0.35);
+
+        // The mono sub is timed by the left side alone: its delay relative to
+        // the left woofer must match a left-only engine run bit for bit (both
+        // runs may differ by uniform shifts only).
+        var leftOnly = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        AutoAlignmentEngine.Compute(
+            leftSnapshots, leftPairs, Reprocess, leftOnly, new StringBuilder());
+        double stereoRelative = alignment.GetValueOrDefault(sub).DelayMs
+            - alignment.GetValueOrDefault(leftWoof).DelayMs;
+        double leftOnlyRelative = leftOnly.GetValueOrDefault(sub).DelayMs
+            - leftOnly.GetValueOrDefault(leftWoof).DelayMs;
+        Assert.InRange(Math.Abs(stereoRelative - leftOnlyRelative), 0, 0.011);
+
+        // The pinned right sub junction is reported, not tuned.
+        Assert.Contains("mono, timed by the left side", log.ToString());
+    }
+
+    private static (int SampleRate, Complex[] Ir) LoadTransferIr(string fileName)
+    {
+        string path = Path.Combine(FindTestDataDirectory(), fileName);
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException(
+                $"{fileName} is missing - initialize the measurement-data " +
+                "submodule with 'git submodule update --init assets/test_data'.",
+                path);
+        }
+
+        using FileStream stream = File.OpenRead(path);
+        using JsonDocument document = JsonDocument.Parse(stream);
+        JsonElement root = document.RootElement;
+        int sampleRate = root.GetProperty("sampleRate").GetInt32();
+        JsonElement samples = root.GetProperty("transferRealSamples");
+        var impulseResponse = new Complex[samples.GetArrayLength()];
+        int index = 0;
+        foreach (JsonElement sample in samples.EnumerateArray())
+        {
+            impulseResponse[index++] = new Complex(sample.GetDouble(), 0.0);
+        }
+
+        return (sampleRate, impulseResponse);
+    }
+
+    private static string FindTestDataDirectory()
+    {
+        DirectoryInfo? current = new(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            string candidate = Path.Combine(current.FullName, "assets", "test_data");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "assets/test_data was not found above the test binary.");
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -1,0 +1,257 @@
+using System.Numerics;
+using System.Text;
+
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The stereo alignment cascade: left side first, then the top-pair arrival
+/// bridge with the scene offset (positive = the right side leads), then the
+/// right-side descent that must not touch mono channels. The synthetic
+/// systems place impulses at known positions, so every stage's contribution
+/// is verifiable arithmetic.
+/// </summary>
+public sealed class StereoAlignmentTests
+{
+    private const int SampleRate = 48_000;
+    private const int IrLength = 16_384;
+    private const int BasePosition = 480; // 10 ms at 48 kHz.
+
+    private sealed class TestChannel(string name, Complex[] ir) : IAlignmentChannel
+    {
+        public string Name { get; } = name;
+        public int SampleRate => StereoAlignmentTests.SampleRate;
+        public Complex[] Ir { get; } = ir;
+    }
+
+    private static Complex[] ImpulseAtMs(double offsetMs)
+    {
+        var ir = new Complex[IrLength];
+        int position = BasePosition + (int)Math.Round(offsetMs / 1000.0 * SampleRate);
+        ir[position] = Complex.One;
+        return ir;
+    }
+
+    private static AlignmentSnapshot Snapshot(
+        TestChannel channel, AlignmentOverride over)
+    {
+        Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(
+            channel.Ir,
+            new DspChannelChain(
+                DelayMs: over.DelayMs, InvertPolarity: over.InvertPolarity),
+            SampleRate);
+        return new AlignmentSnapshot(
+            channel, processed, VirtualCrossoverAnalysis.FindPeakIndex(processed));
+    }
+
+    private static AlignmentJunction Junction(
+        AlignmentSnapshot lower, AlignmentSnapshot upper, double fc) =>
+        new(lower, upper, fc, Math.Max(20, fc / 2), Math.Min(20_000, fc * 2));
+
+    /// <summary>
+    /// The user's shape of system: a shared mono sub, then woof/mid/twr per
+    /// side. The left side sits at its base positions; the right side arrives
+    /// 1.5 ms later across the board (the far side of the cabin).
+    /// </summary>
+    private static (TestChannel Sub,
+        TestChannel[] Left, TestChannel[] Right,
+        Dictionary<IAlignmentChannel, AlignmentOverride> Alignment,
+        StringBuilder Log)
+        RunStereo(double sceneOffsetMs, double rightLateMs = 1.5)
+    {
+        var sub = new TestChannel("sub", ImpulseAtMs(2.0));
+        var leftWoof = new TestChannel("L woof", ImpulseAtMs(1.0));
+        var leftMid = new TestChannel("L mid", ImpulseAtMs(0.4));
+        var leftTwr = new TestChannel("L twr", ImpulseAtMs(0.0));
+        var rightWoof = new TestChannel("R woof", ImpulseAtMs(1.0 + rightLateMs));
+        var rightMid = new TestChannel("R mid", ImpulseAtMs(0.4 + rightLateMs));
+        var rightTwr = new TestChannel("R twr", ImpulseAtMs(0.0 + rightLateMs));
+
+        TestChannel[] leftByBand = [sub, leftWoof, leftMid, leftTwr];
+        TestChannel[] rightByBand = [sub, rightWoof, rightMid, rightTwr];
+        TestChannel[] all = [sub, leftWoof, leftMid, leftTwr, rightWoof, rightMid, rightTwr];
+
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            all.Select(channel =>
+                Snapshot(channel, overrides.GetValueOrDefault(channel))).ToList();
+
+        List<AlignmentSnapshot> initial = all
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        AlignmentSnapshot Of(TestChannel channel) =>
+            initial.First(item => item.Channel == channel);
+
+        List<AlignmentSnapshot> leftSnapshots =
+            leftByBand.Select(Of).ToList();
+        List<AlignmentSnapshot> rightSnapshots =
+            rightByBand.Select(Of).ToList();
+        double[] crossovers = [80, 400, 2_500];
+        List<AlignmentJunction> leftPairs = crossovers
+            .Select((fc, i) => Junction(leftSnapshots[i], leftSnapshots[i + 1], fc))
+            .ToList();
+        List<AlignmentJunction> rightPairs = crossovers
+            .Select((fc, i) => Junction(rightSnapshots[i], rightSnapshots[i + 1], fc))
+            .ToList();
+
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        var log = new StringBuilder();
+        AutoAlignmentEngine.ComputeStereo(
+            new StereoAlignmentPlan(
+                leftSnapshots,
+                leftPairs,
+                rightSnapshots,
+                rightPairs,
+                new HashSet<IAlignmentChannel> { sub },
+                leftTwr,
+                rightTwr,
+                BridgeBandLowHz: 2_500,
+                BridgeBandHighHz: 12_000,
+                SceneOffsetMs: sceneOffsetMs),
+            Reprocess,
+            alignment,
+            log);
+
+        return (sub,
+            [leftWoof, leftMid, leftTwr],
+            [rightWoof, rightMid, rightTwr],
+            alignment, log);
+    }
+
+    // The final arrival of a channel = its impulse position + proposed delay.
+    private static double FinalArrivalMs(
+        TestChannel channel,
+        double naturalMs,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment) =>
+        naturalMs + alignment.GetValueOrDefault(channel).DelayMs;
+
+    [Fact]
+    public void ComputeStereo_BridgeHonorsTheSceneOffsetSign()
+    {
+        // Positive offset: the right side must LEAD by 0.25 ms — its top
+        // channel's final arrival is 0.25 ms EARLIER than the left top's.
+        (TestChannel _, TestChannel[] left, TestChannel[] right,
+            Dictionary<IAlignmentChannel, AlignmentOverride> alignment, _) =
+            RunStereo(sceneOffsetMs: 0.25);
+
+        double leftTop = FinalArrivalMs(left[2], 0.0, alignment);
+        double rightTop = FinalArrivalMs(right[2], 1.5, alignment);
+        Assert.InRange(leftTop - rightTop, 0.20, 0.30);
+    }
+
+    [Fact]
+    public void ComputeStereo_NegativeOffsetLeadsTheLeftSide()
+    {
+        (TestChannel _, TestChannel[] left, TestChannel[] right,
+            Dictionary<IAlignmentChannel, AlignmentOverride> alignment, _) =
+            RunStereo(sceneOffsetMs: -0.25);
+
+        double leftTop = FinalArrivalMs(left[2], 0.0, alignment);
+        double rightTop = FinalArrivalMs(right[2], 1.5, alignment);
+        Assert.InRange(leftTop - rightTop, -0.30, -0.20);
+    }
+
+    [Fact]
+    public void ComputeStereo_AlignsBothSidesInternallyAndKeepsDelaysNonNegative()
+    {
+        // Within each side every junction is a pure delay offset, so the
+        // cascade must equalize the in-band arrivals side by side. The right
+        // side is the far one: making it lead requires advancing it, which is
+        // only expressible by shifting the left field up — the engine's
+        // uniform-shift branch — and the minimum delay must land on zero.
+        (TestChannel sub, TestChannel[] left, TestChannel[] right,
+            Dictionary<IAlignmentChannel, AlignmentOverride> alignment, _) =
+            RunStereo(sceneOffsetMs: 0.25);
+
+        double[] naturals = [1.0, 0.4, 0.0];
+        for (int i = 0; i < 2; i++)
+        {
+            Assert.InRange(
+                Math.Abs(
+                    FinalArrivalMs(left[i], naturals[i], alignment) -
+                    FinalArrivalMs(left[i + 1], naturals[i + 1], alignment)),
+                0, 0.1);
+            Assert.InRange(
+                Math.Abs(
+                    FinalArrivalMs(right[i], naturals[i] + 1.5, alignment) -
+                    FinalArrivalMs(right[i + 1], naturals[i + 1] + 1.5, alignment)),
+                0, 0.1);
+        }
+
+        double minimum = new[] { sub, left[0], left[1], left[2], right[0], right[1], right[2] }
+            .Min(channel => alignment.GetValueOrDefault(channel).DelayMs);
+        Assert.InRange(minimum, 0, 0.011);
+        Assert.All(
+            alignment.Values,
+            over => Assert.True(over.DelayMs >= 0));
+    }
+
+    [Fact]
+    public void ComputeStereo_MonoSubIsTimedByTheLeftPassOnly()
+    {
+        // The sub's delay must equal what a LEFT-ONLY run gives it, up to the
+        // uniform shifts the stereo stages add on top of everyone: relative to
+        // its left woofer neighbor the sub's timing must be identical in both
+        // runs. The right pass may only measure its junction, never move it.
+        (TestChannel sub, TestChannel[] left, _,
+            Dictionary<IAlignmentChannel, AlignmentOverride> stereo,
+            StringBuilder log) = RunStereo(sceneOffsetMs: 0.25);
+
+        // Left-only reference run on identical geometry.
+        var subOnly = new TestChannel("sub", ImpulseAtMs(2.0));
+        var woof = new TestChannel("L woof", ImpulseAtMs(1.0));
+        var mid = new TestChannel("L mid", ImpulseAtMs(0.4));
+        var twr = new TestChannel("L twr", ImpulseAtMs(0.0));
+        TestChannel[] channels = [subOnly, woof, mid, twr];
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            channels.Select(channel =>
+                Snapshot(channel, overrides.GetValueOrDefault(channel))).ToList();
+        List<AlignmentSnapshot> snapshots = channels
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        double[] crossovers = [80, 400, 2_500];
+        var monoAlignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        AutoAlignmentEngine.Compute(
+            snapshots,
+            crossovers.Select((fc, i) =>
+                Junction(snapshots[i], snapshots[i + 1], fc)).ToList(),
+            Reprocess,
+            monoAlignment,
+            new StringBuilder());
+
+        double stereoRelative = stereo.GetValueOrDefault(sub).DelayMs
+            - stereo.GetValueOrDefault(left[0]).DelayMs;
+        double monoRelative = monoAlignment.GetValueOrDefault(subOnly).DelayMs
+            - monoAlignment.GetValueOrDefault(woof).DelayMs;
+        Assert.InRange(Math.Abs(stereoRelative - monoRelative), 0, 0.011);
+
+        // The right pass reports the pinned junction instead of tuning it.
+        Assert.Contains("mono, timed by the left side", log.ToString());
+    }
+
+    [Fact]
+    public void ComputeStereo_RejectsAMonoBridge()
+    {
+        var mono = new TestChannel("mono", ImpulseAtMs(0));
+        var left = new TestChannel("L", ImpulseAtMs(0));
+        AlignmentSnapshot monoSnapshot = Snapshot(mono, default);
+        AlignmentSnapshot leftSnapshot = Snapshot(left, default);
+        var plan = new StereoAlignmentPlan(
+            [leftSnapshot, monoSnapshot],
+            [Junction(leftSnapshot, monoSnapshot, 1_000)],
+            [monoSnapshot],
+            [],
+            new HashSet<IAlignmentChannel> { mono },
+            left,
+            mono,
+            1_000,
+            4_000,
+            0);
+
+        Assert.Throws<ArgumentException>(() => AutoAlignmentEngine.ComputeStereo(
+            plan,
+            overrides => [monoSnapshot, leftSnapshot],
+            new Dictionary<IAlignmentChannel, AlignmentOverride>(),
+            new StringBuilder()));
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -167,6 +167,11 @@ public sealed class StereoAlignmentTests
             Dictionary<IAlignmentChannel, AlignmentOverride> alignment, _) =
             RunStereo(sceneOffsetMs: 0.25);
 
+        // The right woofer sits between TWO settled references (the mono sub
+        // below, its mid above) and optimizes both junctions jointly, so it
+        // may split a small residual between them instead of hugging the
+        // upper neighbor exactly — hence the slightly wider right-side
+        // tolerance.
         double[] naturals = [1.0, 0.4, 0.0];
         for (int i = 0; i < 2; i++)
         {
@@ -179,7 +184,7 @@ public sealed class StereoAlignmentTests
                 Math.Abs(
                     FinalArrivalMs(right[i], naturals[i] + 1.5, alignment) -
                     FinalArrivalMs(right[i + 1], naturals[i + 1] + 1.5, alignment)),
-                0, 0.1);
+                0, 0.2);
         }
 
         double minimum = new[] { sub, left[0], left[1], left[2], right[0], right[1], right[2] }

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -23,11 +23,11 @@ public sealed class StereoAlignmentTests
         public Complex[] Ir { get; } = ir;
     }
 
-    private static Complex[] ImpulseAtMs(double offsetMs)
+    private static Complex[] ImpulseAtMs(double offsetMs, double amplitude = 1.0)
     {
         var ir = new Complex[IrLength];
         int position = BasePosition + (int)Math.Round(offsetMs / 1000.0 * SampleRate);
-        ir[position] = Complex.One;
+        ir[position] = amplitude;
         return ir;
     }
 
@@ -56,15 +56,20 @@ public sealed class StereoAlignmentTests
         TestChannel[] Left, TestChannel[] Right,
         Dictionary<IAlignmentChannel, AlignmentOverride> Alignment,
         StringBuilder Log)
-        RunStereo(double sceneOffsetMs, double rightLateMs = 1.5)
+        RunStereo(
+            double sceneOffsetMs,
+            double rightLateMs = 1.5,
+            double leftTopAmplitude = 1.0,
+            double rightTopAmplitude = 1.0)
     {
         var sub = new TestChannel("sub", ImpulseAtMs(2.0));
         var leftWoof = new TestChannel("L woof", ImpulseAtMs(1.0));
         var leftMid = new TestChannel("L mid", ImpulseAtMs(0.4));
-        var leftTwr = new TestChannel("L twr", ImpulseAtMs(0.0));
+        var leftTwr = new TestChannel("L twr", ImpulseAtMs(0.0, leftTopAmplitude));
         var rightWoof = new TestChannel("R woof", ImpulseAtMs(1.0 + rightLateMs));
         var rightMid = new TestChannel("R mid", ImpulseAtMs(0.4 + rightLateMs));
-        var rightTwr = new TestChannel("R twr", ImpulseAtMs(0.0 + rightLateMs));
+        var rightTwr = new TestChannel(
+            "R twr", ImpulseAtMs(0.0 + rightLateMs, rightTopAmplitude));
 
         TestChannel[] leftByBand = [sub, leftWoof, leftMid, leftTwr];
         TestChannel[] rightByBand = [sub, rightWoof, rightMid, rightTwr];
@@ -227,6 +232,107 @@ public sealed class StereoAlignmentTests
 
         // The right pass reports the pinned junction instead of tuning it.
         Assert.Contains("mono, timed by the left side", log.ToString());
+    }
+
+    [Fact]
+    public void ComputeStereo_BridgeMatchesTheRightTopPolarityToTheLeft()
+    {
+        // The right tweeter is wired backwards (negative impulse). The
+        // arrival-based bridge is polarity-blind, so without the explicit sign
+        // match the whole right side would align to a flipped reference and
+        // end up in opposite global polarity — the bridge must invert it.
+        (TestChannel _, TestChannel[] left, TestChannel[] right,
+            Dictionary<IAlignmentChannel, AlignmentOverride> alignment, _) =
+            RunStereo(sceneOffsetMs: 0.25, rightTopAmplitude: -1.0);
+
+        Assert.False(alignment.GetValueOrDefault(left[2]).InvertPolarity);
+        Assert.True(alignment.GetValueOrDefault(right[2]).InvertPolarity);
+        // The descent then aligns the (positive) right mid against the
+        // corrected top: no compensating flip below.
+        Assert.False(alignment.GetValueOrDefault(right[1]).InvertPolarity);
+    }
+
+    [Fact]
+    public void ComputeStereo_BridgeFollowsAnInvertedLeftTop()
+    {
+        // BOTH tops are wired backwards. The left walk inverts the left top at
+        // its own junction (it sums better flipped against the positive mid);
+        // the bridge must then flip the right top too, so the EFFECTIVE
+        // acoustic signs of the two tops agree: raw sign XOR invert must be
+        // equal on both sides.
+        (TestChannel _, TestChannel[] left, TestChannel[] right,
+            Dictionary<IAlignmentChannel, AlignmentOverride> alignment, _) =
+            RunStereo(
+                sceneOffsetMs: 0.25,
+                leftTopAmplitude: -1.0,
+                rightTopAmplitude: -1.0);
+
+        bool leftInvert = alignment.GetValueOrDefault(left[2]).InvertPolarity;
+        bool rightInvert = alignment.GetValueOrDefault(right[2]).InvertPolarity;
+        // Both raw signs are negative, so equal effective signs mean equal
+        // invert flags — and the left walk is expected to have flipped its top.
+        Assert.True(leftInvert);
+        Assert.Equal(leftInvert, rightInvert);
+    }
+
+    [Fact]
+    public void ComputeStereo_RefusesAnUnmeasurableBridgeWithoutTouchingTheRightSide()
+    {
+        // The right top is silent: its band-limited arrival is invalid, and a
+        // best-effort bridge would time the whole right side by garbage
+        // (0 − 0 − offset). The cascade must refuse with an explanation, and
+        // the right side must carry no proposals the caller could apply.
+        var sub = new TestChannel("sub", ImpulseAtMs(2.0));
+        var leftWoof = new TestChannel("L woof", ImpulseAtMs(1.0));
+        var leftTwr = new TestChannel("L twr", ImpulseAtMs(0.0));
+        var rightWoof = new TestChannel("R woof", ImpulseAtMs(2.5));
+        var rightTwr = new TestChannel("R twr", new Complex[IrLength]);
+        TestChannel[] all = [sub, leftWoof, leftTwr, rightWoof, rightTwr];
+
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            all.Select(channel =>
+                Snapshot(channel, overrides.GetValueOrDefault(channel))).ToList();
+
+        List<AlignmentSnapshot> initial = all
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        AlignmentSnapshot Of(TestChannel channel) =>
+            initial.First(item => item.Channel == channel);
+        List<AlignmentSnapshot> leftByBand = [Of(sub), Of(leftWoof), Of(leftTwr)];
+        List<AlignmentSnapshot> rightByBand = [Of(sub), Of(rightWoof), Of(rightTwr)];
+        List<AlignmentJunction> leftPairs =
+        [
+            Junction(leftByBand[0], leftByBand[1], 80),
+            Junction(leftByBand[1], leftByBand[2], 2_500)
+        ];
+        List<AlignmentJunction> rightPairs =
+        [
+            Junction(rightByBand[0], rightByBand[1], 80),
+            Junction(rightByBand[1], rightByBand[2], 2_500)
+        ];
+
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        InvalidOperationException refusal = Assert.Throws<InvalidOperationException>(
+            () => AutoAlignmentEngine.ComputeStereo(
+                new StereoAlignmentPlan(
+                    leftByBand,
+                    leftPairs,
+                    rightByBand,
+                    rightPairs,
+                    new HashSet<IAlignmentChannel> { sub },
+                    leftTwr,
+                    rightTwr,
+                    BridgeBandLowHz: 2_500,
+                    BridgeBandHighHz: 12_000,
+                    SceneOffsetMs: 0.25),
+                Reprocess,
+                alignment,
+                new StringBuilder()));
+
+        Assert.Contains("bridge", refusal.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(alignment.ContainsKey(rightTwr));
+        Assert.False(alignment.ContainsKey(rightWoof));
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -51,6 +51,13 @@ public sealed class StereoAlignmentTests
     /// The user's shape of system: a shared mono sub, then woof/mid/twr per
     /// side. The left side sits at its base positions; the right side arrives
     /// 1.5 ms later across the board (the far side of the cabin).
+    /// <paramref name="linkBands"/> (woof/mid/twr order, null entries skipped)
+    /// turns on the L/R pair links; <paramref name="rightMidEchoMs"/> gives
+    /// the right mid a second, stronger lobe that far behind its arrival (the
+    /// scene-lock antagonist: correlation-driven searches chase the strong
+    /// lobe, the scene follows the first one); <paramref name="leftLateMs"/>
+    /// pushes the whole left side late (near-delay-ceiling scenarios);
+    /// <paramref name="reprocessCount"/>[0] counts reprocess invocations.
     /// </summary>
     private static (TestChannel Sub,
         TestChannel[] Left, TestChannel[] Right,
@@ -60,14 +67,27 @@ public sealed class StereoAlignmentTests
             double sceneOffsetMs,
             double rightLateMs = 1.5,
             double leftTopAmplitude = 1.0,
-            double rightTopAmplitude = 1.0)
+            double rightTopAmplitude = 1.0,
+            (double LowHz, double HighHz)?[]? linkBands = null,
+            double rightMidEchoMs = 0,
+            double leftLateMs = 0,
+            int[]? reprocessCount = null)
     {
-        var sub = new TestChannel("sub", ImpulseAtMs(2.0));
-        var leftWoof = new TestChannel("L woof", ImpulseAtMs(1.0));
-        var leftMid = new TestChannel("L mid", ImpulseAtMs(0.4));
-        var leftTwr = new TestChannel("L twr", ImpulseAtMs(0.0, leftTopAmplitude));
+        var sub = new TestChannel("sub", ImpulseAtMs(2.0 + leftLateMs));
+        var leftWoof = new TestChannel("L woof", ImpulseAtMs(1.0 + leftLateMs));
+        var leftMid = new TestChannel("L mid", ImpulseAtMs(0.4 + leftLateMs));
+        var leftTwr = new TestChannel(
+            "L twr", ImpulseAtMs(0.0 + leftLateMs, leftTopAmplitude));
         var rightWoof = new TestChannel("R woof", ImpulseAtMs(1.0 + rightLateMs));
-        var rightMid = new TestChannel("R mid", ImpulseAtMs(0.4 + rightLateMs));
+        Complex[] rightMidIr = ImpulseAtMs(
+            0.4 + rightLateMs, rightMidEchoMs > 0 ? 0.6 : 1.0);
+        if (rightMidEchoMs > 0)
+        {
+            int echoPosition = BasePosition + (int)Math.Round(
+                (0.4 + rightLateMs + rightMidEchoMs) / 1000.0 * SampleRate);
+            rightMidIr[echoPosition] += Complex.One;
+        }
+        var rightMid = new TestChannel("R mid", rightMidIr);
         var rightTwr = new TestChannel(
             "R twr", ImpulseAtMs(0.0 + rightLateMs, rightTopAmplitude));
 
@@ -75,10 +95,34 @@ public sealed class StereoAlignmentTests
         TestChannel[] rightByBand = [sub, rightWoof, rightMid, rightTwr];
         TestChannel[] all = [sub, leftWoof, leftMid, leftTwr, rightWoof, rightMid, rightTwr];
 
+        List<StereoPairLink>? pairLinks = null;
+        if (linkBands != null)
+        {
+            (TestChannel Left, TestChannel Right)[] linkChannels =
+                [(leftWoof, rightWoof), (leftMid, rightMid), (leftTwr, rightTwr)];
+            pairLinks = new List<StereoPairLink>();
+            for (int i = 0; i < linkBands.Length; i++)
+            {
+                if (linkBands[i] is { } band)
+                {
+                    pairLinks.Add(new StereoPairLink(
+                        linkChannels[i].Left, linkChannels[i].Right,
+                        band.LowHz, band.HighHz));
+                }
+            }
+        }
+
         IReadOnlyList<AlignmentSnapshot> Reprocess(
-            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
-            all.Select(channel =>
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides)
+        {
+            if (reprocessCount != null)
+            {
+                reprocessCount[0]++;
+            }
+
+            return all.Select(channel =>
                 Snapshot(channel, overrides.GetValueOrDefault(channel))).ToList();
+        }
 
         List<AlignmentSnapshot> initial = all
             .Select(channel => Snapshot(channel, default))
@@ -111,7 +155,8 @@ public sealed class StereoAlignmentTests
                 rightTwr,
                 BridgeBandLowHz: 2_500,
                 BridgeBandHighHz: 12_000,
-                SceneOffsetMs: sceneOffsetMs),
+                SceneOffsetMs: sceneOffsetMs,
+                pairLinks),
             Reprocess,
             alignment,
             log);
@@ -364,5 +409,144 @@ public sealed class StereoAlignmentTests
             overrides => [monoSnapshot, leftSnapshot],
             new Dictionary<IAlignmentChannel, AlignmentOverride>(),
             new StringBuilder()));
+    }
+
+    private static readonly (double LowHz, double HighHz)?[] UserLinkBands =
+        [(80, 175), (400, 2_500), (2_500, 12_000)];
+
+    // The channel's final band-limited envelope arrival with its proposed
+    // delay applied — the quantity the Δ L−R read-out (and the scene) follows.
+    private static double FinalBandArrivalMs(
+        TestChannel channel,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        double lowHz,
+        double highHz)
+    {
+        AlignmentSnapshot snapshot = Snapshot(
+            channel, alignment.GetValueOrDefault(channel));
+        return VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            snapshot.ImpulseResponse, SampleRate, lowHz, highHz);
+    }
+
+    [Fact]
+    public void ComputeStereo_SceneLockPinsTheMidPairToTheOffset()
+    {
+        // The right mid's response opens with its true arrival and carries a
+        // STRONGER lobe 0.7 ms behind it. Correlation-driven machinery (the
+        // PHAT timeline seed, the junction-sum optimum) chases the strong
+        // lobe, which would park the pair's first arrivals — what the stereo
+        // image follows — 0.7 ms off the scene. The lock must pin the mid to
+        // the cross-side target: first arrivals 0.25 ms apart, right leading.
+        (TestChannel _, TestChannel[] left, TestChannel[] right,
+            Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+            StringBuilder log) = RunStereo(
+                sceneOffsetMs: 0.25,
+                linkBands: UserLinkBands,
+                rightMidEchoMs: 0.7);
+
+        Assert.Contains("SCENE-LOCKED", log.ToString());
+        double delta =
+            FinalBandArrivalMs(left[1], alignment, 400, 2_500) -
+            FinalBandArrivalMs(right[1], alignment, 400, 2_500);
+        Assert.InRange(delta, 0.15, 0.35);
+    }
+
+    [Fact]
+    public void ComputeStereo_PureLowBandPairKeepsTheFreeSearch()
+    {
+        // The woofer link's shared band (80-175 Hz) never reaches the
+        // localization region, so the scene mandate does not apply: the pair
+        // keeps the free joint-junction search and the cross-side target
+        // stays a gentle prior only. The mid link (400-2500 Hz) is locked.
+        (TestChannel _, TestChannel[] _, TestChannel[] _,
+            Dictionary<IAlignmentChannel, AlignmentOverride> _,
+            StringBuilder log) = RunStereo(
+                sceneOffsetMs: 0.25,
+                linkBands: UserLinkBands);
+
+        string[] lines = log.ToString().Split('\n');
+        string woofLine = Array.Find(lines,
+            line => line.StartsWith("Channel R woof:"))!;
+        Assert.NotNull(woofLine);
+        Assert.DoesNotContain("SCENE-LOCKED", woofLine);
+        Assert.Contains("(cross-side)", woofLine);
+        string midLine = Array.Find(lines,
+            line => line.StartsWith("Channel R mid:"))!;
+        Assert.NotNull(midLine);
+        Assert.Contains("SCENE-LOCKED", midLine);
+    }
+
+    [Fact]
+    public void ComputeStereo_NarrowSharedBandGetsNoLockAndNoPrior()
+    {
+        // A link whose shared band is narrower than the arrival analysis
+        // admits (1000-1100 Hz is a seventh of an octave) must not produce a
+        // cross-side target at all — the band is no longer silently widened
+        // into a measurable one — and without a target there is no lock: the
+        // channel falls back to its own-side anchor and the run completes.
+        (TestChannel sub, TestChannel[] left, TestChannel[] right,
+            Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+            StringBuilder log) = RunStereo(
+                sceneOffsetMs: 0.25,
+                linkBands: [null, (1_000, 1_100), null]);
+
+        Assert.DoesNotContain("cross-side prior R mid", log.ToString());
+        Assert.DoesNotContain("SCENE-LOCKED", log.ToString());
+        Assert.All(
+            new[] { sub, left[0], left[1], left[2], right[0], right[1], right[2] },
+            channel => Assert.True(
+                alignment.GetValueOrDefault(channel).DelayMs is >= 0 and <= 100));
+    }
+
+    [Fact]
+    public void ComputeStereo_NearTheDelayCeilingTheSceneSurvives()
+    {
+        // The left side is 99.2 ms late, parking the whole right side just
+        // under the 100 ms delay ceiling. Every pass that adds delay from
+        // here — the co-move above all — must bound its window by the ceiling
+        // UP FRONT: clamping one side after the fact would move the two sides
+        // unequally and silently bend the scene. Both linked pairs must still
+        // read the scene offset at the end and nothing may exceed the limit.
+        (TestChannel sub, TestChannel[] left, TestChannel[] right,
+            Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+            StringBuilder log) = RunStereo(
+                sceneOffsetMs: 0.25,
+                rightLateMs: 0,
+                linkBands: UserLinkBands,
+                leftLateMs: 99.2);
+
+        Assert.Contains("Co-move", log.ToString());
+        Assert.All(
+            new[] { sub, left[0], left[1], left[2], right[0], right[1], right[2] },
+            channel => Assert.True(
+                alignment.GetValueOrDefault(channel).DelayMs is >= 0 and <= 100));
+
+        double twrDelta =
+            FinalBandArrivalMs(left[2], alignment, 2_500, 12_000) -
+            FinalBandArrivalMs(right[2], alignment, 2_500, 12_000);
+        Assert.InRange(twrDelta, 0.15, 0.35);
+        double midDelta =
+            FinalBandArrivalMs(left[1], alignment, 400, 2_500) -
+            FinalBandArrivalMs(right[1], alignment, 400, 2_500);
+        Assert.InRange(midDelta, 0.15, 0.35);
+    }
+
+    [Fact]
+    public void ComputeStereo_ReprocessCallCountStaysBounded()
+    {
+        // The engine's cost unit is one reprocess: every channel's full DSP
+        // chain re-run. The junction walks legitimately spend a couple per
+        // channel; the co-move pass must spend ONE per linked pair (its delta
+        // scan is an analytic spectrum rotation, not a re-render). The old
+        // implementation burned ~40 reprocesses per pair inside the co-move
+        // alone, so this ceiling breaks loudly if per-delta re-rendering ever
+        // creeps back in.
+        int[] count = [0];
+        RunStereo(
+            sceneOffsetMs: 0.25,
+            linkBands: UserLinkBands,
+            reprocessCount: count);
+
+        Assert.InRange(count[0], 1, 40);
     }
 }

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -742,6 +742,38 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void AnalyzeBandLimitedArrival_RefusesABandNarrowerThanAThirdOctave()
+    {
+        // The band used to be widened to at least half an octave behind the
+        // caller's back, so a deliberately exact band (an L/R shared band, a
+        // localization sub-band) was silently replaced by a different
+        // question. Now the band passes through as given and a band too
+        // narrow to place an arrival in is refused as invalid — not answered
+        // with a plausible-looking number from a wider band.
+        Complex[] ir = UnitImpulse(8_192, 480);
+
+        TimeAlignmentAnalysisResult narrow =
+            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                ir, SampleRate, 1_000, 1_100);
+
+        Assert.False(narrow.IsValid);
+    }
+
+    [Fact]
+    public void AnalyzeBandLimitedArrival_AcceptsExactlyAThirdOctave()
+    {
+        Complex[] ir = UnitImpulse(8_192, 480);
+
+        TimeAlignmentAnalysisResult result =
+            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                ir, SampleRate, 1_000,
+                1_000 * VirtualCrossoverAnalysis.MinimumArrivalBandRatio);
+
+        Assert.True(result.IsValid);
+        Assert.InRange(result.FirstArrivalDelayMilliseconds, 9.5, 10.5);
+    }
+
+    [Fact]
     public void FindBandLimitedCorrelationDelay_ReturnsDelayToAddToSecondSignal()
     {
         Complex[] first = UnitImpulse(8_192, 2_000);

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -742,6 +742,39 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void MeasureBandLevelDb_ReadsTheGainDifferenceBetweenResponses()
+    {
+        // The absolute figure carries an arbitrary reference; the contract is
+        // the DIFFERENCE between two responses over the same band — here an
+        // exact virtual -6 dB gain stage.
+        Complex[] reference = UnitImpulse(8_192, 480);
+        Complex[] quieter = VirtualCrossoverAnalysis.ApplyChain(
+            reference,
+            new DspChannelChain(GainDb: -6),
+            SampleRate);
+
+        double? referenceLevel = VirtualCrossoverAnalysis.MeasureBandLevelDb(
+            reference, SampleRate, 300, 3_000);
+        double? quieterLevel = VirtualCrossoverAnalysis.MeasureBandLevelDb(
+            quieter, SampleRate, 300, 3_000);
+
+        Assert.NotNull(referenceLevel);
+        Assert.NotNull(quieterLevel);
+        Assert.Equal(6.0, referenceLevel.Value - quieterLevel.Value, 2);
+    }
+
+    [Fact]
+    public void MeasureBandLevelDb_BandWithoutBinsReturnsNull()
+    {
+        // 23 990 - 23 999 Hz at 48 kHz falls between the last usable FFT bin
+        // and Nyquist: no bins, no level.
+        Complex[] ir = UnitImpulse(8_192, 480);
+
+        Assert.Null(VirtualCrossoverAnalysis.MeasureBandLevelDb(
+            ir, SampleRate, 23_990, 23_999));
+    }
+
+    [Fact]
     public void AnalyzeBandLimitedArrival_RefusesABandNarrowerThanAThirdOctave()
     {
         // The band used to be widened to at least half an octave behind the


### PR DESCRIPTION
Turns every Virtual DSP channel into a left/right pair so both sides of the car participate in the calculations, and teaches Auto delay to align the whole system at once without wrecking the stereo image.

## Why

Per-side sum-loss alignment is blind to inter-side timing: each side can be locally perfect while, say, the tweeters end up a period apart and the image collapses to one side at high frequencies. The loopback time reference makes L and R measurements directly comparable, so the fix is a cascade that carries the alignment across the sides through ONE well-measured link.

## dsp — `AutoAlignmentEngine.ComputeStereo`

1. **Left pass** — the left side aligns exactly like a mono run; mono channels (the shared subwoofer) are part of it and are final afterwards.
2. **Bridge** — the right top driver is timed to the settled left one by band-limited **envelope arrivals** in the top band, honoring the scene offset (positive = the right side leads — the dash-center convention for a left-seated driver). Cross-correlation is deliberately not used: between different drivers in different cabin spots it is lobe-ambiguous noise at high frequencies (probed on real measurements: r ≈ 0.3, dominance ≈ 0.01), while the envelope arrival repeats to ~0.06 ms.
3. **Right descent** — junction by junction from the bridged top with the existing sum-loss search; the junction a mono channel pins is measured and logged, never re-tuned.
4. **Normalization** — uniform shifts always span BOTH sides (preserving the scene offset), and the final minimum delay lands exactly at zero.

Stage 1/2 of the mono `Compute` are extracted into shared helpers (`BuildArrivalTimeline`, `AlignChannelAtJunction`, `ShiftAllExcept`) with unchanged behavior; `VirtualCrossoverAnalysis.MeasureSumLoss` reads the gated average/dip loss of already-settled responses.

## App

- **Project schema v2**: `Pairs` (Left/Right settings + `Mono` flag) replace the single-sided `Channels`; v1 files migrate in both loaders (old channels become the left sides, nothing lost); `StereoSceneOffsetMs` (default 0.25) and the active side persist.
- **Panel**: L/R side radios under Add/Remove with source indicators (● / ○); side switching rebinds every channel block and recomputes the plots, metric and delay read-outs (per-side processed caches keep it cheap); the channel block gains a **Mono** checkbox next to the shortened "Invert"; an **L/R offset** numeric with a sign cheat-sheet tooltip sits before Auto delay.
- **Auto delay** runs the stereo cascade whenever some pair has both sides loaded, falling back to the classic single-side run otherwise; results apply to both sides' settings.
- **Tuning sheet** (text + PDF) prints both sides in one export; a mono pair prints once; on the PDF graph the right side shares its pair's hue, dashed.

Also in this branch: the refutation record for the phase-slope score prior (probed on the real measurements — the flat-phase-slope point is the GCC-PHAT lobe, up to 1.8 periods off the true alignment at gapped junctions) and the 44.1 kHz biquad-export entry for car DSP devices.

## Validation

- **426/426 dsp tests**, including new synthetic stereo-cascade tests (offset sign both ways, per-side equalization, the mono sub pinned by the left pass, min-delay normalization, mono-bridge rejection) and a real-cabin pin on the `assets/test_data` L/R measurements: the bridge lands the tweeter pair 0.25 ms apart and the sub keeps its left-only timing.
- Full solution builds clean with `-p:EnableWindowsTargeting=true`; App.Tests (v1→v2 migration, sheet sections, mono `SideFor` contract) run on Windows CI.
- Needs a look on real hardware/Windows: the new panel layout (side radios, offset numeric, Mono checkbox) and a live stereo Auto delay run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_