### PR TITLE
Crossover wizard: 50 ranked candidates with an achievability post-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1407,12 +1407,20 @@ it defaults to Off because the measurements are loopback-referenced.
   crossover-frequency window, and whether the two sides of a junction may take
   independent slopes (with that off the whole system uses one slope — every
   junction, both sides — searched over the slopes the allowed families offer).
-  It searches the crossover frequency, family, slope, and
-  cut-only gains to flatten the summed magnitude (a plain amplitude sum — the
-  assumption that Auto delay will bring each junction to its best alignment),
-  penalizing wide band overlap and keeping a practical minimum slope, so it
-  lands on a tight, engineer-sensible split rather than shallow filters that
-  only look flat by overlapping widely. Handovers stay within the sensible
+  It searches the crossover frequency, family, and slope to flatten the summed
+  magnitude (a plain amplitude sum — the assumption that Auto delay will bring
+  each junction to its best alignment), penalizing wide band overlap and
+  keeping a practical minimum slope, so it lands on a tight, engineer-sensible
+  split rather than shallow filters that only look flat by overlapping widely.
+  The gains, though, follow a car target curve rather than a flat sum: the
+  midrange and tweeter are levelled to each other (the louder attenuated), and
+  the subwoofer anchors the bass at a chosen elevation over that reference —
+  the **Sub level over mid/treble** field defaults to (and is capped at) the
+  measured elevation, so out of the box the sub keeps its own level and you
+  only trim the field down if you want less bass. The remaining drivers are fit
+  onto the resulting slope cut-only (a driver already below the target keeps
+  its level — no measured dip is boosted), and every gain is a cut, so the
+  result is headroom-safe. Handovers stay within the sensible
   range for the two driver types (so a woofer is not crossed up in its
   roll-off), land on human-friendly frequencies (5 Hz steps below 100 Hz,
   10 Hz below 1 kHz, 50 Hz above), and junctions below 300 Hz never get slopes

--- a/README.md
+++ b/README.md
@@ -1409,9 +1409,10 @@ it defaults to Off because the measurements are loopback-referenced.
   which filter
   families to allow (Butterworth / Linkwitz-Riley / Bessel), the
   crossover-frequency window, and whether the two sides of a junction may take
-  independent slopes (with that off each driver's own high-pass and low-pass
-  share one slope, so a channel never ends up 12 dB/oct on one shoulder and
-  18 on the other — but different drivers stay free to take different slopes).
+  independent slopes (on by default: a driver's high-pass and low-pass may
+  differ, so a woofer can low-pass steeply to the midrange while high-passing
+  gently from the sub; turn it off to tie each driver's two shoulders to one
+  slope). Different drivers always stay free to take different slopes.
   It searches the crossover frequency, family, and slope to flatten the summed
   magnitude (a plain amplitude sum — the assumption that Auto delay will bring
   each junction to its best alignment), penalizing wide band overlap and
@@ -1433,9 +1434,13 @@ it defaults to Off because the measurements are loopback-referenced.
   not the frequency, so the same steep slope is fine at a 250 Hz woofer/mid
   handover (~5 ms) but excluded at a 75 Hz sub/woofer one (~17 ms), and a
   low-group-delay family (Bessel) can go steeper down low than a Linkwitz-Riley
-  can. Group delay is identical for the low-pass and high-pass sides, so with
-  matched slopes a driver is held to the gentler of its two junctions; a steep
-  woofer low-pass paired with a gentle high-pass needs independent slopes on.
+  can. The budget caps how much steeper than the 24 dB/oct floor the search may
+  go; the floor itself is always kept, since a gentler crossover would break the
+  overlap rule, so at a very low junction the floor's larger group delay is
+  inherent to crossing there. Group delay is identical for the low-pass and
+  high-pass sides, so with matched slopes a driver is held to the gentler of its
+  two junctions; a steep woofer low-pass paired with a gentle high-pass needs
+  independent slopes on.
   A shallow filter that lets a driver bleed into a non-adjacent driver's band is
   still heavily penalized (a woofer should not be audible up at the tweeter). Placement heuristics steer the
   handovers further: a junction landing in the ear's most sensitive band

--- a/README.md
+++ b/README.md
@@ -1402,7 +1402,11 @@ the magnitude curves, drawing on the same profiles configured in Record Settings
 it defaults to Off because the measurements are loopback-referenced.
 
 - **Auto crossover...** estimates each channel's usable band and driver type
-  (subwoofer, woofer, midbass, midrange, or tweeter), then asks which filter
+  (subwoofer, woofer, midbass, midrange, or tweeter) — the band read is the most
+  prominent contiguous segment of the response, and when the measurement carries
+  coherence (γ²), a frequency the measurement did not trust cannot anchor a band
+  edge, so a noisy or non-linear resonance can't stretch the band. It then asks
+  which filter
   families to allow (Butterworth / Linkwitz-Riley / Bessel), the
   crossover-frequency window, and whether the two sides of a junction may take
   independent slopes (with that off each driver's own high-pass and low-pass

--- a/README.md
+++ b/README.md
@@ -1406,14 +1406,24 @@ it defaults to Off because the measurements are loopback-referenced.
   families to allow (Butterworth / Linkwitz-Riley / Bessel), the
   crossover-frequency window, and whether the two sides of a junction may take
   independent slopes. It searches the crossover frequency, family, slope, and
-  cut-only gains to flatten the summed magnitude — modelling each junction the
-  way its family sums (amplitude for LR/Bessel, power for Butterworth),
-  penalizing wide band overlap, and keeping a practical minimum slope, so it
-  lands on a tight, engineer-sensible split rather than shallow filters that only
-  look flat by overlapping widely. Handovers stay within the sensible range for
-  the two driver types (so a woofer is not crossed up in its roll-off), and
-  narrowing the window past an outer driver adds a subsonic / brickwall
-  band-limit on that channel.
+  cut-only gains to flatten the summed magnitude (a plain amplitude sum — the
+  assumption that Auto delay will bring each junction to its best alignment),
+  penalizing wide band overlap and keeping a practical minimum slope, so it
+  lands on a tight, engineer-sensible split rather than shallow filters that
+  only look flat by overlapping widely. Handovers stay within the sensible
+  range for the two driver types (so a woofer is not crossed up in its
+  roll-off), land on human-friendly frequencies (5 Hz steps below 100 Hz,
+  10 Hz below 1 kHz, 50 Hz above), and junctions below 300 Hz never get slopes
+  steeper than 24 dB/oct — the group delay of a steep low-frequency crossover
+  costs more than the protection it buys. Narrowing the window past an outer
+  driver adds a subsonic / brickwall band-limit on that channel.
+  Apply does more than take the flattest magnitude candidate: the wizard
+  expands ~50 near-optimal variants (always including the conventional
+  all-LR24 setup) and re-ranks them by the junction loss actually achievable
+  after the best per-junction delay, measured on your impulse responses with
+  the same alignment search Auto delay runs — so a candidate whose slopes
+  cannot phase-align at the handover loses to one that can, before you ever
+  run Auto delay. Ties go to the conventional 24 dB/oct proposal.
 - **Auto delay** aligns in two stages: band-limited first arrivals — refined by a
   GCC-PHAT cross-correlation where it carries a reliable, unambiguous peak (a
   junction whose corners leave a spectral gap degenerates the correlation into

--- a/README.md
+++ b/README.md
@@ -1405,10 +1405,9 @@ it defaults to Off because the measurements are loopback-referenced.
   (subwoofer, woofer, midbass, midrange, or tweeter), then asks which filter
   families to allow (Butterworth / Linkwitz-Riley / Bessel), the
   crossover-frequency window, and whether the two sides of a junction may take
-  independent slopes (with that off, both sides of each junction stay matched
-  — but different junctions may still settle on different slopes, so one
-  channel's high-pass and low-pass can differ). It searches the crossover
-  frequency, family, slope, and
+  independent slopes (with that off the whole system uses one slope — every
+  junction, both sides — searched over the slopes the allowed families offer).
+  It searches the crossover frequency, family, slope, and
   cut-only gains to flatten the summed magnitude (a plain amplitude sum — the
   assumption that Auto delay will bring each junction to its best alignment),
   penalizing wide band overlap and keeping a practical minimum slope, so it

--- a/README.md
+++ b/README.md
@@ -1405,7 +1405,10 @@ it defaults to Off because the measurements are loopback-referenced.
   (subwoofer, woofer, midbass, midrange, or tweeter), then asks which filter
   families to allow (Butterworth / Linkwitz-Riley / Bessel), the
   crossover-frequency window, and whether the two sides of a junction may take
-  independent slopes. It searches the crossover frequency, family, slope, and
+  independent slopes (with that off, both sides of each junction stay matched
+  — but different junctions may still settle on different slopes, so one
+  channel's high-pass and low-pass can differ). It searches the crossover
+  frequency, family, slope, and
   cut-only gains to flatten the summed magnitude (a plain amplitude sum — the
   assumption that Auto delay will bring each junction to its best alignment),
   penalizing wide band overlap and keeping a practical minimum slope, so it

--- a/README.md
+++ b/README.md
@@ -1426,8 +1426,16 @@ it defaults to Off because the measurements are loopback-referenced.
   roll-off), land on human-friendly frequencies (5 Hz steps below 100 Hz,
   10 Hz below 1 kHz, 50 Hz above), and junctions below 300 Hz never get slopes
   steeper than 24 dB/oct — the group delay of a steep low-frequency crossover
-  costs more than the protection it buys. Narrowing the window past an outer
-  driver adds a subsonic / brickwall band-limit on that channel.
+  costs more than the protection it buys. Two placement heuristics steer the
+  handovers further: a junction landing in the ear's most sensitive band
+  (2–4 kHz) is penalized, and two drivers that share a wide band are crossed
+  low — letting the upper (smaller) driver take over as early as it cleanly
+  can, for better dispersion and less excursion on the lower driver. So a
+  capable tweeter is crossed down toward its 1.5 kHz sensible floor (out of the
+  ear band) when its measured band supports it; a low tweeter handover is held
+  to at least 24 dB/oct so the tweeter is not driven too far down. Narrowing
+  the window past an outer driver adds a subsonic / brickwall band-limit on
+  that channel.
   Apply does more than take the flattest magnitude candidate: the wizard
   expands ~50 near-optimal variants (always including the conventional
   all-LR24 setup) and re-ranks them by the junction loss actually achievable

--- a/README.md
+++ b/README.md
@@ -1428,11 +1428,16 @@ it defaults to Off because the measurements are loopback-referenced.
   result is headroom-safe. Handovers stay within the sensible
   range for the two driver types (so a woofer is not crossed up in its
   roll-off), land on human-friendly frequencies (5 Hz steps below 100 Hz,
-  10 Hz below 1 kHz, 50 Hz above), and junctions below 300 Hz never get slopes
-  steeper than 24 dB/oct — the group delay of a steep low-frequency crossover
-  costs more than the protection it buys, while a shallow filter that lets a
-  driver bleed into a non-adjacent driver's band is heavily penalized (a woofer
-  should not still be audible up at the tweeter). Placement heuristics steer the
+  10 Hz below 1 kHz, 50 Hz above), and a slope is allowed only while the
+  filter's peak group delay stays within 10 ms — a bound on the delay itself,
+  not the frequency, so the same steep slope is fine at a 250 Hz woofer/mid
+  handover (~5 ms) but excluded at a 75 Hz sub/woofer one (~17 ms), and a
+  low-group-delay family (Bessel) can go steeper down low than a Linkwitz-Riley
+  can. Group delay is identical for the low-pass and high-pass sides, so with
+  matched slopes a driver is held to the gentler of its two junctions; a steep
+  woofer low-pass paired with a gentle high-pass needs independent slopes on.
+  A shallow filter that lets a driver bleed into a non-adjacent driver's band is
+  still heavily penalized (a woofer should not be audible up at the tweeter). Placement heuristics steer the
   handovers further: a junction landing in the ear's most sensitive band
   (2–4 kHz) is penalized, and two drivers that share a wide band are crossed
   low — letting the upper (smaller) driver take over as early as it cleanly

--- a/README.md
+++ b/README.md
@@ -1426,16 +1426,21 @@ it defaults to Off because the measurements are loopback-referenced.
   roll-off), land on human-friendly frequencies (5 Hz steps below 100 Hz,
   10 Hz below 1 kHz, 50 Hz above), and junctions below 300 Hz never get slopes
   steeper than 24 dB/oct — the group delay of a steep low-frequency crossover
-  costs more than the protection it buys. Two placement heuristics steer the
+  costs more than the protection it buys, while a shallow filter that lets a
+  driver bleed into a non-adjacent driver's band is heavily penalized (a woofer
+  should not still be audible up at the tweeter). Placement heuristics steer the
   handovers further: a junction landing in the ear's most sensitive band
   (2–4 kHz) is penalized, and two drivers that share a wide band are crossed
   low — letting the upper (smaller) driver take over as early as it cleanly
-  can, for better dispersion and less excursion on the lower driver. So a
-  capable tweeter is crossed down toward its 1.5 kHz sensible floor (out of the
-  ear band) when its measured band supports it; a low tweeter handover is held
-  to at least 24 dB/oct so the tweeter is not driven too far down. Narrowing
-  the window past an outer driver adds a subsonic / brickwall band-limit on
-  that channel.
+  can, for better dispersion and less excursion on the lower driver — except
+  the subwoofer, which is nudged UP toward the ~80 Hz localization limit rather
+  than pulled low. So a capable tweeter is crossed down toward its 1.7 kHz
+  sensible floor (out of the ear band) when its measured band supports it, and
+  a low tweeter handover is held to at least 24 dB/oct so the tweeter is not
+  driven too far down. In a stereo system both sides of a driver get the same
+  crossover — a crossover is one electrical filter, so only delay and level
+  differ per side. Narrowing the window past an outer driver adds a subsonic /
+  brickwall band-limit on that channel.
   Apply does more than take the flattest magnitude candidate: the wizard
   expands ~50 near-optimal variants (always including the conventional
   all-LR24 setup) and re-ranks them by the junction loss actually achievable

--- a/README.md
+++ b/README.md
@@ -1437,7 +1437,10 @@ it defaults to Off because the measurements are loopback-referenced.
   than pulled low. So a capable tweeter is crossed down toward its 1.7 kHz
   sensible floor (out of the ear band) when its measured band supports it, and
   a low tweeter handover is held to at least 24 dB/oct so the tweeter is not
-  driven too far down. In a stereo system both sides of a driver get the same
+  driven too far down. The same low-handover logic applies below: a midrange
+  with headroom down to its 200 Hz sensible floor lets the woofer/midbass hand
+  over early, before its cone-breakup region, so the wide woofer/mid overlap
+  does not linger up where it interferes badly. In a stereo system both sides of a driver get the same
   crossover — a crossover is one electrical filter, so only delay and level
   differ per side. Narrowing the window past an outer driver adds a subsonic /
   brickwall band-limit on that channel.

--- a/README.md
+++ b/README.md
@@ -1405,8 +1405,9 @@ it defaults to Off because the measurements are loopback-referenced.
   (subwoofer, woofer, midbass, midrange, or tweeter), then asks which filter
   families to allow (Butterworth / Linkwitz-Riley / Bessel), the
   crossover-frequency window, and whether the two sides of a junction may take
-  independent slopes (with that off the whole system uses one slope — every
-  junction, both sides — searched over the slopes the allowed families offer).
+  independent slopes (with that off each driver's own high-pass and low-pass
+  share one slope, so a channel never ends up 12 dB/oct on one shoulder and
+  18 on the other — but different drivers stay free to take different slopes).
   It searches the crossover frequency, family, and slope to flatten the summed
   magnitude (a plain amplitude sum — the assumption that Auto delay will bring
   each junction to its best alignment), penalizing wide band overlap and

--- a/TODO.md
+++ b/TODO.md
@@ -489,6 +489,17 @@ re-verified.
   that capped steep low slopes. The dialog also now catches ALL ranking
   exceptions (async void + WinForms context would otherwise kill the
   process), reporting them in a message box.
+  **Second review round (fixed):** (1) per-junction pool options are each
+  bounded against the descent optimum's neighbours, so combining them
+  independently could jointly break the half-octave minimum separation —
+  reproduced with a peaked middle driver (fc pair at ratio 1.375 < √2 in
+  the ranked list); combinations now pass a joint separation check before
+  the gain pass. (2) `IsConventional24` was derived from slopes alone, so
+  any all-24 pool candidate (16 flagged in one config, pure Butterworth in
+  another) could soak up the 0.25 dB tie preference; the flag now matches
+  the dedicated conventional run's signature — exactly one candidate, LR24
+  when LR is allowed. (3) The dialog freezes every ranking-input control
+  while the async ranking runs, so stale settings can't be applied.
 - [ ] **`EstimateBand` merges disjoint islands into one band** (first/last bin
   above a global threshold): an isolated resonance above a dead gap extends
   HighHz and misclassifies the driver. Fix: the most significant contiguous

--- a/TODO.md
+++ b/TODO.md
@@ -605,10 +605,21 @@ re-verified.
   early; still gated by the measured midrange band. Real 4-way then moved the
   woofer/mid junction 250 → 220 (all-families 75/220/1750, BW-only 65/220/1700),
   with 200 right behind in the pool — matching the user's manual find.
-- [ ] **`EstimateBand` merges disjoint islands into one band** (first/last bin
-  above a global threshold): an isolated resonance above a dead gap extends
-  HighHz and misclassifies the driver. Fix: the most significant contiguous
-  segment above threshold with bounded gap tolerance.
+- [x] **`EstimateBand` merges disjoint islands into one band (fixed 2026-07-12):**
+  it took the first and last bin above the −8 dB threshold, so an isolated
+  resonance past a deep dead gap stretched HighHz and could mislabel the driver
+  or skew the crossover bounds. Now the above-threshold points are grouped into
+  contiguous segments, bridging a below-threshold gap only while it stays within
+  `MaxBandGapOctaves = 0.5` (a narrow interference/room null a driver's own band
+  can have — a 1/3-octave-smoothed null lands there); the usable band is the most
+  PROMINENT segment (largest area above threshold integrated over log-frequency).
+  On the real left 4-way this trimmed two genuine over-extensions: midrange high
+  edge 4387 → 2768 Hz and tweeter 20000 → 11954 Hz (both were isolated HF
+  resonances past dead gaps). Two new synthetic tests pin it (isolated resonance
+  ignored; narrow in-band null bridged). Side effect on the auto winner: the
+  corrected band levels re-rank the flatness score slightly — woofer/mid 220 →
+  250, tweeter 1750 → 1700 — while the 200 Hz search floor and the 200–230
+  candidates stay in the top of the pool.
 
 ### EQ Wizard
 

--- a/TODO.md
+++ b/TODO.md
@@ -595,6 +595,16 @@ re-verified.
   (layout shift, lazy default fill, freeze-during-ranking). Not yet done: a
   treble down-tilt knob (the preview "predicted sum span" is now honestly large
   because the bass is intentionally lifted).
+  **Midrange sensible floor 250 → 200 (user feedback 2026-07-12):** on the real
+  left 4-way the woofer/midrange handover kept landing at 250 Hz with a wide
+  overlap; crossing nearer 200 Hz (which the user found by hand) weakens the
+  interference, but `SensibleRange(Midrange).LowHz = 250` clamped the search so
+  the achievability post-check never even evaluated ~200. Same conservative-floor
+  pattern as the tweeter. Lowered the midrange floor to 200 (a midrange has
+  headroom below its cone-breakup region), so the woofer/midbass can hand over
+  early; still gated by the measured midrange band. Real 4-way then moved the
+  woofer/mid junction 250 → 220 (all-families 75/220/1750, BW-only 65/220/1700),
+  with 200 right behind in the pool — matching the user's manual find.
 - [ ] **`EstimateBand` merges disjoint islands into one band** (first/last bin
   above a global threshold): an isolated resonance above a dead gap extends
   HighHz and misclassifies the driver. Fix: the most significant contiguous

--- a/TODO.md
+++ b/TODO.md
@@ -528,6 +528,22 @@ re-verified.
   Windows: the lock appears immediately, the plot note is legible (PlotView is
   custom-painted so it should not grey out), and controls re-enable exactly
   when the curves land.
+- [x] **Auto crossover placement heuristics (user request 2026-07-12):** two
+  frequency-placement penalties added to the flatness score, plus a tweeter
+  floor + protection rule. (1) **Ear band** — a junction in 2–4 kHz gets a soft
+  Gaussian penalty (`EarSensitivityWeightDb = 0.5`, centred ~2.83 kHz). (2)
+  **Wide overlap → low** — a junction is pulled toward the bottom of the two
+  drivers' shared band, scaled by its width in octaves
+  (`WideOverlapLowBiasWeightDb = 0.4`, "firm" per the user). (3) The tweeter's
+  `SensibleRange` floor dropped 2000 → **1500 Hz** so the search can cross a
+  capable tweeter low (the user's own tune crosses mid/tweeter at 1300/1800 for
+  the soundstage). (4) `TweeterProtectionHz = 2500`: a tweeter crossed below
+  that must stay ≥ 24 dB/oct (mirror of the <300 Hz bass cap), enforced in the
+  slope enumeration and `AllowedChannelSlopes`, so the low handover does not
+  overdrive the tweeter. On the real left 4-way the mid/tweeter moved 3900 →
+  1500 (LR24/LR24, tweeter steep) — matching the user's low-and-steep manual
+  choice. Weights are tunable; still gated by the measured tweeter band (a
+  tweeter rolled off by 2.5 kHz still crosses no lower).
 - [x] **Virtual DSP redraw multithreaded (2026-07-12):** the interactive redraw
   ran its heavy math on one core — `ProcessChannelsAsync` applied each channel's
   full-length ApplyChain cascade in a sequential `Select` inside one `Task.Run`,

--- a/TODO.md
+++ b/TODO.md
@@ -500,19 +500,21 @@ re-verified.
   the dedicated conventional run's signature — exactly one candidate, LR24
   when LR is allowed. (3) The dialog freezes every ranking-input control
   while the async ranking runs, so stale settings can't be applied.
-  **Matched slopes = one system slope (user decision 2026-07-12):** with
-  "Independent slopes per side" off the whole system uses ONE dB/oct —
-  every junction, both sides (families may still differ per junction). The
-  old semantics (sides matched per junction, junctions free) put a 12 dB
-  high-pass next to an 18 dB low-pass on one channel and read as broken.
-  Implemented as one pinned (forcedSlope) descent+pool per practical slope,
-  merged; the <300 Hz cap now also binds pinned runs, so a system-wide
-  36/48 is infeasible while a low junction exists. Real-data winner:
-  all-24 system (BW24@45 / LR24@250 / LR24@3850), pool 0.52 s, full ranked
-  3.6 s. Preview and applied result can no longer disagree on slopes;
-  the ranking may still move a crossover frequency by a lattice step
-  relative to the preview (two-phase Apply remains an option if that
-  still bothers in the field).
+  **Matched slopes = per-DRIVER, not per-system (corrected 2026-07-12):** with
+  "Independent slopes per side" off, each driver's two shoulders (its high-pass
+  and its low-pass) share one slope; DIFFERENT drivers stay free to differ.
+  First attempt (9889124) over-corrected to one slope for the WHOLE system —
+  wrong, reverted. The real bug: the pool (and even the descent) chose slopes
+  per JUNCTION independently, so a middle driver's HP (upper side of the
+  junction below) and LP (lower side of the junction above) drifted apart
+  (the 12/18 the user saw after Apply). Fix: when off, the slope is a property
+  of the channel — `EnumerateJunctionOptions` only varies frequency/family and
+  holds the two channels' slopes; a dedicated `OptimizeChannelSlope` pass tunes
+  each channel's slope (both shoulders together) over the slopes allowed at
+  BOTH its junctions; the pool inherits the descent's per-channel slopes.
+  Families still per junction. Real-data winner now
+  LR12@45 / (mb LR12, mid LR24)@250 / LR24@3950 — sub+midbass 12, mid+tweeter
+  24, each driver internally matched. Full ranked ~3.2 s.
   **Target-curve gains (user request 2026-07-12):** gains no longer flatten
   the sum — they follow a car target curve. (1) midrange & tweeter levelled to
   each other (louder attenuated); (2) the subwoofer anchors the bass at a

--- a/TODO.md
+++ b/TODO.md
@@ -638,6 +638,23 @@ re-verified.
   resolve, resampled onto the wizard's 1/3-octave grid by `CoherencePerPoint`,
   and threaded through the dialog into `AutoSetupSource`. App + App.Tests compile
   clean under EnableWindowsTargeting.
+- [x] **Slope cap is now a group-delay budget, not a frequency (2026-07-12):**
+  the flat "< 300 Hz → ≤ 24 dB/oct" cap is gone. A slope is allowed only while
+  the filter's peak group delay stays within `MaxCrossoverGroupDelaySeconds =
+  0.010` (10 ms), computed from the exact biquad cascade by the new
+  `CrossoverFilter.MaxGroupDelaySeconds` (τ = −dφ/dω, peak near the corner,
+  memoized per family/slope/fc). Group delay scales ≈ 1/f_c, so the same slope is
+  fine high up and excluded low down — and a low-GD family (Bessel) may go
+  steeper down low than an LR can. It is identical for LP and HP, so with matched
+  slopes a driver is still held to the gentler of its two junctions; a steep
+  woofer LP with a gentle HP needs independent slopes. Real left 4-way:
+  matched (default) winner sub steepened 75(BS24)→75(BS36) — Bessel 36 at 75 Hz
+  is only ~5.7 ms, which the old flat cap wrongly forbade; with independent
+  slopes on the woofer/mid junction jumps to LR48/LR48 (~5 ms) and the
+  achievability penalty drops 2.70 → 2.05 (the steep woofer LP cleans the
+  handover the user flagged). Two `CrossoverFilter` tests pin the GD values and
+  the LP=HP symmetry; the ranked-pool test now asserts the GD budget across every
+  candidate. Search timing unchanged (~2 s, GD memoized).
 
 ### EQ Wizard
 

--- a/TODO.md
+++ b/TODO.md
@@ -500,6 +500,19 @@ re-verified.
   the dedicated conventional run's signature — exactly one candidate, LR24
   when LR is allowed. (3) The dialog freezes every ranking-input control
   while the async ranking runs, so stale settings can't be applied.
+  **Matched slopes = one system slope (user decision 2026-07-12):** with
+  "Independent slopes per side" off the whole system uses ONE dB/oct —
+  every junction, both sides (families may still differ per junction). The
+  old semantics (sides matched per junction, junctions free) put a 12 dB
+  high-pass next to an 18 dB low-pass on one channel and read as broken.
+  Implemented as one pinned (forcedSlope) descent+pool per practical slope,
+  merged; the <300 Hz cap now also binds pinned runs, so a system-wide
+  36/48 is infeasible while a low junction exists. Real-data winner:
+  all-24 system (BW24@45 / LR24@250 / LR24@3850), pool 0.52 s, full ranked
+  3.6 s. Preview and applied result can no longer disagree on slopes;
+  the ranking may still move a crossover frequency by a lattice step
+  relative to the preview (two-phase Apply remains an option if that
+  still bothers in the field).
 - [ ] **`EstimateBand` merges disjoint islands into one band** (first/last bin
   above a global threshold): an isolated resonance above a dead gap extends
   HighHz and misclassifies the driver. Fix: the most significant contiguous

--- a/TODO.md
+++ b/TODO.md
@@ -620,6 +620,24 @@ re-verified.
   corrected band levels re-rank the flatness score slightly — woofer/mid 220 →
   250, tweeter 1750 → 1700 — while the 200 Hz search floor and the 200–230
   candidates stay in the top of the pool.
+- [x] **`EstimateBand` honours coherence when available (2026-07-12):** the band
+  read now takes optional per-point γ² (`AutoSetupSource.Coherence`, aligned 1:1
+  with the magnitude points). A frequency below `CoherenceFloor = 0.5` cannot
+  anchor a band edge, and each segment's prominence is γ²-weighted, so a noisy or
+  non-linear region (a breakup resonance, a channel picking up another driver)
+  cannot stretch the band the way a coherent passband does. Deliberately
+  conservative: the reference percentile still reads the whole curve (filtering
+  it to coherent points tracked the peak and shrank narrow-band drivers — a sub's
+  usable band collapsed 133 → 54 Hz, over-constraining its crossover), so on a
+  clean measurement coherence is a no-op. Validated on the real left 4-way: every
+  driver is γ² ≥ 0.5 across its passband, so all four bands are identical with and
+  without coherence — the gate only bites a genuinely untrusted measurement. Two
+  synthetic tests pin it (a loud incoherent region rejected; a coherent band not
+  chopped; mismatched-length coherence ignored). App plumbing (Windows-only,
+  needs a live check): `ChannelSideState.TransferCoherence` stored on source
+  resolve, resampled onto the wizard's 1/3-octave grid by `CoherencePerPoint`,
+  and threaded through the dialog into `AutoSetupSource`. App + App.Tests compile
+  clean under EnableWindowsTargeting.
 
 ### EQ Wizard
 

--- a/TODO.md
+++ b/TODO.md
@@ -513,6 +513,24 @@ re-verified.
   the ranking may still move a crossover frequency by a lattice step
   relative to the preview (two-phase Apply remains an option if that
   still bothers in the field).
+  **Target-curve gains (user request 2026-07-12):** gains no longer flatten
+  the sum — they follow a car target curve. (1) midrange & tweeter levelled to
+  each other (louder attenuated); (2) the subwoofer anchors the bass at a
+  chosen elevation over the reference — a new **Sub level over mid/treble**
+  dialog field, default & max = the measured elevation (sub at its raw level),
+  trimmable down to flatten; (3) the remaining drivers fit cut-only onto the
+  log-frequency slope between the sub anchor and the reference (a driver below
+  the target keeps its level — dips are never boosted). Reference level = the
+  quietest driver apart from the sub, so a hot sub can't drag it up and a
+  sub-less 2-way still levels its two drivers. `ApplyTargetCurveGains` /
+  `MeasuredSubElevationDb` replace the emitted gains after the crossover search
+  (which still uses the optimizer's flattening gains to CHOOSE crossovers).
+  Validated on the real left 4-way: default gives sub 0, midbass 0, mid 0,
+  tweeter −1.5 (= the user's in-car manual tune, whose −4 on mid/tweeter is the
+  separate L/R scene offset). Needs a live Windows check of the dialog field
+  (layout shift, lazy default fill, freeze-during-ranking). Not yet done: a
+  treble down-tilt knob (the preview "predicted sum span" is now honestly large
+  because the bass is intentionally lifted).
 - [ ] **`EstimateBand` merges disjoint islands into one band** (first/last bin
   above a global threshold): an isolated resonance above a dead gap extends
   HighHz and misclassifies the driver. Fix: the most significant contiguous

--- a/TODO.md
+++ b/TODO.md
@@ -528,6 +528,17 @@ re-verified.
   Windows: the lock appears immediately, the plot note is legible (PlotView is
   custom-painted so it should not grey out), and controls re-enable exactly
   when the curves land.
+- [x] **Virtual DSP redraw multithreaded (2026-07-12):** the interactive redraw
+  ran its heavy math on one core — `ProcessChannelsAsync` applied each channel's
+  full-length ApplyChain cascade in a sequential `Select` inside one `Task.Run`,
+  and `BuildMetricCurves` built each channel's magnitude spectrum sequentially.
+  Both are pure and independent, so both now fan out: ApplyChain via
+  `Parallel.For` (bit-identical output verified on the real 7-channel system,
+  2043 ms → 1074 ms on 4 cores, ~min(channels, cores)× ceiling) and the spectra
+  via `AsParallel().AsOrdered()`. Only full redraws (mode switch, session load,
+  bypass-all) recompute every channel and get the full win; a single-control
+  edit still recomputes one channel (nothing to parallelize). Cache write-back
+  stays on the UI thread after the await, so no races.
   **Target-curve gains (user request 2026-07-12):** gains no longer flatten
   the sum — they follow a car target curve. (1) midrange & tweeter levelled to
   each other (louder attenuated); (2) the subwoofer anchors the bass at a

--- a/TODO.md
+++ b/TODO.md
@@ -469,6 +469,26 @@ re-verified.
   delay). Deliberately NOT revisited: `AchievabilityWeight = 0.5` was chosen
   on one dataset (the left 4-way) — re-eyeball if field results disagree with
   the ranking. The dialog's async Apply path needs a live Windows check.
+  **PR #27 review follow-up (fixed):** the first post-check draft (1)
+  compared band-limited arrivals measured in DIFFERENT bands (each driver's
+  own band) — the exact mistake the stereo Δ metric and the engine already
+  warn about; the centers are now per-junction shared-band arrivals of the
+  raw channels, cached by (channel, band) so the Hilbert cost stays bounded;
+  (2) trusted the raw search winner — now the pick goes through
+  `AlignmentSelection.Select` with the arrival anchor, the engine's
+  arrival-anchored prior (sigma = window/4) and a widened edge retry, so an
+  inverted half-period impostor cannot fake achievability the real Auto
+  delay would refuse. Accepted simplifications vs the full engine (recorded,
+  not hidden): no PHAT-seeded timeline, no cascade reprocessing of settled
+  neighbors, no guarded wide-window promotion — junction deltas of a mono
+  N-way compose independently, and the post-check only RANKS. Notable
+  real-data effect of the honesty fix: on the left 4-way the conventional
+  LR24 candidate's sub/woof junction penalty rose ~1 dB (its previous low
+  loss came from an impostor lobe the selection now rejects) and LR12 at
+  40 Hz wins the junction — consistent with the very group-delay argument
+  that capped steep low slopes. The dialog also now catches ALL ranking
+  exceptions (async void + WinForms context would otherwise kill the
+  process), reporting them in a message box.
 - [ ] **`EstimateBand` merges disjoint islands into one band** (first/last bin
   above a global threshold): an isolated resonance above a dead gap extends
   HighHz and misclassifies the driver. Fix: the most significant contiguous

--- a/TODO.md
+++ b/TODO.md
@@ -655,6 +655,26 @@ re-verified.
   handover the user flagged). Two `CrossoverFilter` tests pin the GD values and
   the LP=HP symmetry; the ranked-pool test now asserts the GD budget across every
   candidate. Search timing unchanged (~2 s, GD memoized).
+- [x] **GD budget was bypassable via seed & conventional state — fixed
+  (review, 2026-07-12):** the budget was only applied while ENUMERATING options,
+  so two paths still produced budget-violating candidates: `Initialize` seeded a
+  fixed 24 dB/oct with no check, and the conventional run's `forcedSlope`
+  branch returned 24 unconditionally — at a junction low enough that even 24 dB/oct
+  exceeds 10 ms, `AllowedSlopes` returned EMPTY and those unchecked 24s survived.
+  Reframed the policy explicitly: the budget caps steepness ABOVE the practical
+  floor (24 dB/oct); the floor is ALWAYS admitted, since a gentler crossover
+  would break the overlap rule, so a very low junction's larger group delay is
+  inherent to crossing there, not a bypass. `AllowedSlopes` now floor-falls-back
+  (never empty) and gates the forced branch the same way; `Initialize` and the
+  band-limit brickwall seed via a new `GentlestAdmissibleSlope` (removed the
+  unchecked `PreferredSlope`). New regression test forces a sub-budget sub/woofer
+  junction and asserts every candidate — seed, descent, AND conventional — uses
+  exactly the floor there, never a steeper forbidden slope.
+- [x] **Independent slopes ON by default (user request 2026-07-12):** the wizard
+  checkbox and `CrossoverAutoSetupOptions.Default` now default to independent
+  slopes, so the auto-crossover can give the woofer a steep low-pass and a gentle
+  high-pass out of the box (the group-delay win above). Turning it off restores
+  the matched-shoulders behaviour.
 
 ### EQ Wizard
 

--- a/TODO.md
+++ b/TODO.md
@@ -438,17 +438,37 @@ re-verified.
 
 ### Auto Crossover
 
-- [ ] ★ **The scalar summation model is physically wrong in three ways**:
-  family-based amplitude-vs-power summation (the real sum depends on the
-  complex phase at each frequency, not the family name), sequential mixed
-  summation that is non-associative for 3+ channels, and a magnitude-only
-  objective that ignores the measured phase entirely (Auto delay afterwards
-  cannot fix mismatched slopes/orders with one delay). The optimizer's live
-  preview shares the model, so it confirms its own objective; the flatness
-  tests call the same `SummedResponseDb` and are tautological. Fix: complex
-  per-channel responses (measured IR × exact digital filter response) with at
-  least a final complex-sum check per candidate, plus an independent
-  complex-sum oracle in the tests.
+- [x] ★ **The scalar summation model is physically wrong in three ways** —
+  resolved (2026-07-11) after a design discussion with the user. Verdict: the
+  magnitude/delay DECOMPOSITION is intentional and stays (a joint delay ×
+  crossover search was rejected as intractable; the wizard assumes ideal
+  alignment and Auto delay realizes it) — but the three inconsistencies were
+  real and are fixed:
+  (1) family-based amplitude-vs-power summation and the non-associative mixed
+  sum are gone — channels now combine as a plain amplitude sum everywhere,
+  the consistent expression of the ideal-alignment assumption;
+  (2) the "magnitude-only objective cannot see which candidates Auto delay
+  can actually fix" gap is closed by `ProposeRanked`: ~50 near-optimal
+  candidates (per-junction top options crossed, plus a mandatory conventional
+  all-LR24 run) are re-ranked by the junction loss ACHIEVABLE after the best
+  per-junction delay, measured on the channels' IRs with the production
+  alignment search (`FindAlignmentCandidates`) on a shared 32k direct-sound
+  crop, in parallel; the conventional-24 candidate wins ties
+  (`Conventional24PreferenceDb = 0.25`). Real-data cost: 50 candidates ≈ 3.8 s
+  on a 4-core container (pool alone 0.4 s); the two cost cliffs found and
+  fixed on the way: per-candidate arrival analyses (now computed once from
+  the raw channels) and a frequency-independent search window (now
+  ±clamp(1200/fc, 2, 12) ms — the filter group delay it must absorb scales
+  as 1/fc);
+  (3) the tests now include an independent amplitude-sum oracle (exact filter
+  magnitudes, not `SummedResponseDb`'s internals).
+  Also shipped in the same rework, per the user's spec: crossover frequencies
+  search directly on a rounded lattice (5 Hz < 100 Hz, 10 Hz < 1 kHz, 50 Hz
+  above — which also made the magnitude-cache hit, pool of 50 in ~0.4 s), and
+  junctions below 300 Hz never get slopes steeper than 24 dB/oct (group
+  delay). Deliberately NOT revisited: `AchievabilityWeight = 0.5` was chosen
+  on one dataset (the left 4-way) — re-eyeball if field results disagree with
+  the ranking. The dialog's async Apply path needs a live Windows check.
 - [ ] **`EstimateBand` merges disjoint islands into one band** (first/last bin
   above a global threshold): an isolated resonance above a dead gap extends
   HighHz and misclassifies the driver. Fix: the most significant contiguous

--- a/TODO.md
+++ b/TODO.md
@@ -556,6 +556,16 @@ re-verified.
   tweeter; both push interior drivers to steeper (24) slopes. Real 4-way now:
   75 (BS24/BS24) / 250 (LR24/LR24) / 1750 (LR24/LR24) — all steep, sub ~80,
   mid/tweeter low, matching the user's manual tune.
+  **Min slope 18 → 24 (user feedback 2026-07-12):** 18 was still too shallow —
+  on the real woofer/midrange handover the per-channel compromise landed on
+  18 dB/oct, a wide overlap with strong interference Auto delay could not align
+  (the user saw ~−3.4/−9.9 dB). `MinPracticalSlopeDbPerOctave` is now 24, so
+  every crossover is >= 24 (the <300 Hz cap pins low junctions to exactly 24).
+  The flatness/achievability metric rates the shallow 18 slightly higher —
+  which is exactly why the auto kept picking it and the user heard interference
+  the metric misses — so the floor overrides it, matching the all-24 manual
+  tune. BW-only real 4-way then: 65 (BW24/BW24) / 250 (BW24/BW24) / 1700
+  (BW24/BW48); all-families unchanged (75/250/1750).
 - [x] **Virtual DSP redraw multithreaded (2026-07-12):** the interactive redraw
   ran its heavy math on one core — `ProcessChannelsAsync` applied each channel's
   full-length ApplyChain cascade in a sequential `Select` inside one `Task.Run`,

--- a/TODO.md
+++ b/TODO.md
@@ -544,6 +544,18 @@ re-verified.
   1500 (LR24/LR24, tweeter steep) — matching the user's low-and-steep manual
   choice. Weights are tunable; still gated by the measured tweeter band (a
   tweeter rolled off by 2.5 kHz still crosses no lower).
+  **Follow-up tuning (user feedback 2026-07-12):** (a) L/R now get the SAME
+  crossover — the wizard writes freq/family/slope/gain to BOTH sides of a
+  stereo pair (`OpenAutoSetupWizard`), only delay/scene-level differ per
+  side. (b) Tweeter floor 1500 → **1700** (1500 was too low by ear). (c) The
+  wide-overlap "cross low" rule is skipped for the subwoofer and replaced by
+  an UP nudge toward its ~80 Hz sensible top (`SubHandoverUpBiasWeightDb`) —
+  the sub was landing at 45 Hz. (d) `MinPracticalSlopeDbPerOctave` 12 → **18**
+  and `OverlapPenalty` extended to non-adjacent pairs
+  (`NonAdjacentOverlapWeight`): a 12 dB/oct woofer was bleeding up to the
+  tweeter; both push interior drivers to steeper (24) slopes. Real 4-way now:
+  75 (BS24/BS24) / 250 (LR24/LR24) / 1750 (LR24/LR24) — all steep, sub ~80,
+  mid/tweeter low, matching the user's manual tune.
 - [x] **Virtual DSP redraw multithreaded (2026-07-12):** the interactive redraw
   ran its heavy math on one core — `ProcessChannelsAsync` applied each channel's
   full-length ApplyChain cascade in a sequential `Select` inside one `Task.Run`,

--- a/TODO.md
+++ b/TODO.md
@@ -515,6 +515,19 @@ re-verified.
   Families still per junction. Real-data winner now
   LR12@45 / (mb LR12, mid LR24)@250 / LR24@3950 — sub+midbass 12, mid+tweeter
   24, each driver internally matched. Full ranked ~3.2 s.
+- [ ] **Virtual DSP load lock (2026-07-12, needs live Windows check):** opening
+  the panel spent 5-10 s re-resolving each channel's stored transfer IR while
+  the panel sat enabled showing the "no sources" hint, so the restored session
+  looked lost until it snapped in. `ApplyProjectAsync` now wraps the bind in
+  `SetProjectLoading(true/false)`: the whole control tree is disabled (a load
+  rebuilds the channel blocks, so the parent must carry the disable), the main
+  plot shows "Loading the previous session…", the metric shows "Loading
+  session…", and the cursor is a wait cursor; the final RedrawAll restores the
+  real plot/metric before the panel re-enables. Covers both the startup load
+  and a session import (both route through ApplyProjectAsync). Verify on
+  Windows: the lock appears immediately, the plot note is legible (PlotView is
+  custom-painted so it should not grey out), and controls re-enable exactly
+  when the curves land.
   **Target-curve gains (user request 2026-07-12):** gains no longer flatten
   the sum — they follow a car target curve. (1) midrange & tweeter levelled to
   each other (louder attenuated); (2) the subwoofer anchors the bass at a

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -375,7 +375,13 @@ public static class CrossoverAutoSetup
         DriverType.Subwoofer => (20, 80),
         DriverType.Woofer => (40, 250),
         DriverType.Midbass => (80, 500),
-        DriverType.Midrange => (250, 4_000),
+        // The 200 Hz floor (down from 250) lets the woofer/midbass hand over
+        // lower — before its cone-breakup region — when the midrange measures
+        // headroom down there; a wide overlap higher up interferes badly, and a
+        // midrange crossed low with a steep filter cleans the handover. Still
+        // gated by the measured midrange band (one rolled off by 300 Hz crosses
+        // no lower).
+        DriverType.Midrange => (200, 4_000),
         // A quality tweeter crossed low (with a steep filter) covers more of the
         // critical midrange for a better soundstage; the 1.7 kHz floor lets the
         // search go there, but only when the measured tweeter band supports it —

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -66,15 +66,20 @@ public sealed record RankedCrossoverProposal(
 /// fall inside, and whether the two sides of a junction may take different
 /// slopes. With <see cref="IndependentSlopes"/> off the whole system uses ONE
 /// slope — every junction, both sides — searched over the practical slopes the
-/// allowed families offer. The sample rate is needed because the optimizer
-/// evaluates the exact digital biquad cascades the DSP runs.
+/// allowed families offer. <see cref="SubElevationDb"/> is how far the lowest
+/// driver sits above the levelled midrange/tweeter reference in the target-curve
+/// gain fit (null uses the measured elevation, i.e. the lowest driver at its raw
+/// level); see <see cref="CrossoverAutoSetup.ApplyTargetCurveGains"/>. The sample
+/// rate is needed because the optimizer evaluates the exact digital biquad
+/// cascades the DSP runs.
 /// </summary>
 public sealed record CrossoverAutoSetupOptions(
     IReadOnlyList<CrossoverFilterFamily> Families,
     double MinCrossoverHz,
     double MaxCrossoverHz,
     bool IndependentSlopes,
-    double SampleRateHz)
+    double SampleRateHz,
+    double? SubElevationDb = null)
 {
     /// <summary>All families, the full 20 Hz – 20 kHz window, matched slopes.</summary>
     public static CrossoverAutoSetupOptions Default(double sampleRateHz) =>
@@ -369,12 +374,15 @@ public static class CrossoverAutoSetup
         }
 
         options = Normalize(options);
-        if (options.IndependentSlopes)
-        {
-            return new Optimizer(channels, options).Solve();
-        }
+        IReadOnlyList<CrossoverProposal> proposals = options.IndependentSlopes
+            ? new Optimizer(channels, options).Solve()
+            : BestUniformSlopeCandidate(channels, options).Proposals;
 
-        return BestUniformSlopeCandidate(channels, options).Proposals;
+        // The optimizer level-matched the drivers to flatten the sum, which is
+        // right for choosing the crossovers but not the gains the user wants.
+        // Replace them with the car target-curve fit.
+        return ApplyTargetCurveGains(
+            channels, proposals, options.SampleRateHz, options.SubElevationDb);
     }
 
     // With independent slopes off, "matched" means ONE slope for the whole
@@ -414,6 +422,195 @@ public static class CrossoverAutoSetup
         CrossoverFilter.SupportedSlopes(family)
             .Where(slope => slope >= MinPracticalSlopeDbPerOctave)
             .ToList();
+
+    // The per-driver context the target-curve gain fit needs: each channel's
+    // level over its assigned passband (between its crossovers), the reference
+    // (levelled midrange/tweeter) level, the bass-anchor channel, and the
+    // measured elevation of the bass over the reference.
+    private readonly record struct TargetCurveContext(
+        double[] PassbandLevelDb,
+        double[] PassbandCenterHz,
+        int BassIndex,
+        IReadOnlyList<int> ReferenceIndices,
+        int SlopeTopIndex,
+        double ReferenceLevelDb,
+        double MeasuredElevationDb);
+
+    private static TargetCurveContext BuildTargetCurveContext(
+        IReadOnlyList<AutoSetupSource> channels,
+        IReadOnlyList<CrossoverProposal> proposals,
+        double sampleRateHz)
+    {
+        int n = channels.Count;
+        var levels = new double[n];
+        var centers = new double[n];
+        double ceiling = Math.Min(20_000, sampleRateHz * 0.49);
+        for (int i = 0; i < n; i++)
+        {
+            DriverBandEstimate band = EstimateBand(channels[i].MagnitudeDb);
+            double low = proposals[i].HighPassEdge?.FrequencyHz ?? band.LowHz;
+            double high = proposals[i].LowPassEdge?.FrequencyHz ?? Math.Min(band.HighHz, ceiling);
+            if (high <= low)
+            {
+                (low, high) = (band.LowHz, band.HighHz);
+            }
+
+            levels[i] = AverageLevelDb(channels[i].MagnitudeDb, low, high);
+            centers[i] = Math.Sqrt(low * high);
+        }
+
+        int Find(DriverType type)
+        {
+            for (int i = 0; i < n; i++)
+            {
+                if (channels[i].Type == type)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        int mid = Find(DriverType.Midrange);
+        int tweeter = Find(DriverType.Tweeter);
+        var reference = new List<int>();
+        if (mid >= 0)
+        {
+            reference.Add(mid);
+        }
+        if (tweeter >= 0)
+        {
+            reference.Add(tweeter);
+        }
+
+        // Only a subwoofer is the elevated bass anchor. A woofer/midbass that
+        // happens to be the lowest driver (a 2-way without a sub) is a normal
+        // driver levelled into the system, not a hot sub to lift.
+        int bass = Find(DriverType.Subwoofer);
+
+        // The reference (flat-top) level is the quietest driver apart from the
+        // sub, so the whole system is cut to it and the sub is lifted on top.
+        // With the sub excluded, a hot woofer never drags the reference up.
+        double referenceLevel = double.PositiveInfinity;
+        for (int i = 0; i < n; i++)
+        {
+            if (i != bass && levels[i] < referenceLevel)
+            {
+                referenceLevel = levels[i];
+            }
+        }
+
+        // The slope runs up to where the flat top begins — the lowest reference
+        // member (the midrange when present, else the tweeter); with neither, the
+        // highest non-sub driver.
+        int slopeTop = reference.Count > 0
+            ? reference.MinBy(index => centers[index])
+            : Enumerable.Range(0, n)
+                .Where(i => i != bass)
+                .MaxBy(i => channels[i].Type);
+
+        double measuredElevation = bass < 0
+            ? 0
+            : Math.Max(0, levels[bass] - referenceLevel);
+        return new TargetCurveContext(
+            levels, centers, bass, reference, slopeTop, referenceLevel, measuredElevation);
+    }
+
+    /// <summary>
+    /// The elevation (dB) of the lowest driver over the levelled midrange/tweeter
+    /// reference, measured on the given proposal's passbands. This is the default
+    /// and the upper limit of the sub-elevation control: the user may only trim it
+    /// down (flattening the bottom), never boost past what was measured.
+    /// </summary>
+    public static double MeasuredSubElevationDb(
+        IReadOnlyList<AutoSetupSource> channels,
+        IReadOnlyList<CrossoverProposal> proposals,
+        double sampleRateHz)
+    {
+        ArgumentNullException.ThrowIfNull(channels);
+        ArgumentNullException.ThrowIfNull(proposals);
+        if (proposals.Count != channels.Count)
+        {
+            throw new ArgumentException(
+                "One proposal per channel is required.", nameof(proposals));
+        }
+
+        return BuildTargetCurveContext(channels, proposals, sampleRateHz).MeasuredElevationDb;
+    }
+
+    /// <summary>
+    /// Replaces the gains of an existing proposal with the car target-curve fit,
+    /// keeping the crossovers untouched. The midrange and tweeter are levelled to
+    /// each other (the louder attenuated); the lowest driver anchors the bass at
+    /// <paramref name="subElevationDb"/> above that reference (null = the measured
+    /// elevation, i.e. the lowest driver kept at its raw level); the remaining
+    /// drivers are fit onto the log-frequency line between those anchors, cut-only
+    /// — a driver already below the target keeps its level, so no measured dip is
+    /// filled with gain. Every gain is a cut (0 dB on the reference), so the result
+    /// is headroom-safe. Proposals are returned in the input order.
+    /// </summary>
+    public static IReadOnlyList<CrossoverProposal> ApplyTargetCurveGains(
+        IReadOnlyList<AutoSetupSource> channels,
+        IReadOnlyList<CrossoverProposal> proposals,
+        double sampleRateHz,
+        double? subElevationDb = null)
+    {
+        ArgumentNullException.ThrowIfNull(channels);
+        ArgumentNullException.ThrowIfNull(proposals);
+        if (proposals.Count != channels.Count)
+        {
+            throw new ArgumentException(
+                "One proposal per channel is required.", nameof(proposals));
+        }
+
+        TargetCurveContext context = BuildTargetCurveContext(channels, proposals, sampleRateHz);
+        double[] level = context.PassbandLevelDb;
+        double[] center = context.PassbandCenterHz;
+        double reference = context.ReferenceLevelDb;
+        double elevation = Math.Clamp(
+            subElevationDb ?? context.MeasuredElevationDb, 0, context.MeasuredElevationDb);
+
+        double subTarget = reference + elevation;
+        bool hasBass = context.BassIndex >= 0;
+        double subCenter = hasBass ? center[context.BassIndex] : 0;
+        double logSpan = hasBass ? Math.Log(center[context.SlopeTopIndex] / subCenter) : 0;
+
+        // With no sub the target is flat at the reference; otherwise it descends
+        // from the sub anchor to the reference across log-frequency.
+        double TargetAt(double frequencyHz) => hasBass && logSpan > 1e-9
+            ? subTarget - elevation * (Math.Log(frequencyHz / subCenter) / logSpan)
+            : reference;
+
+        var gains = new double[channels.Count];
+        for (int i = 0; i < channels.Count; i++)
+        {
+            if (context.ReferenceIndices.Contains(i))
+            {
+                // Level the midrange/tweeter to their quieter member.
+                gains[i] = reference - level[i];
+            }
+            else if (i == context.BassIndex)
+            {
+                // The bass anchor sits at reference + elevation; cut-only so a
+                // sub measured quieter than the reference is never boosted.
+                gains[i] = Math.Min(0, subTarget - level[i]);
+            }
+            else
+            {
+                // An intermediate driver: onto the target line, cut-only.
+                gains[i] = Math.Min(0, TargetAt(center[i]) - level[i]);
+            }
+        }
+
+        var results = new CrossoverProposal[channels.Count];
+        for (int i = 0; i < channels.Count; i++)
+        {
+            results[i] = proposals[i] with { GainDb = Math.Round(gains[i], 1) };
+        }
+
+        return results;
+    }
 
     /// <summary>
     /// The ranked wizard search: expands a pool of up to
@@ -554,7 +751,12 @@ public static class CrossoverAutoSetup
             {
                 double? penalty = penalties?[index];
                 return new RankedCrossoverProposal(
-                    candidate.Proposals,
+                    // The pool ranked with the optimizer's level-matched gains
+                    // (right for comparing crossovers); the emitted proposal
+                    // carries the car target-curve gains the user applies.
+                    ApplyTargetCurveGains(
+                        channels, candidate.Proposals, options.SampleRateHz,
+                        options.SubElevationDb),
                     candidate.MagnitudeScore,
                     penalty,
                     candidate.MagnitudeScore + AchievabilityWeight * (penalty ?? 0),

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -64,8 +64,10 @@ public sealed record RankedCrossoverProposal(
 /// The choices the crossover wizard asks for before optimizing: which filter
 /// families the optimizer may pick from, the frequency window crossovers must
 /// fall inside, and whether the two sides of a junction may take different
-/// slopes. The sample rate is needed because the optimizer evaluates the exact
-/// digital biquad cascades the DSP runs.
+/// slopes. With <see cref="IndependentSlopes"/> off the whole system uses ONE
+/// slope — every junction, both sides — searched over the practical slopes the
+/// allowed families offer. The sample rate is needed because the optimizer
+/// evaluates the exact digital biquad cascades the DSP runs.
 /// </summary>
 public sealed record CrossoverAutoSetupOptions(
     IReadOnlyList<CrossoverFilterFamily> Families,
@@ -367,8 +369,51 @@ public static class CrossoverAutoSetup
         }
 
         options = Normalize(options);
-        return new Optimizer(channels, options).Solve();
+        if (options.IndependentSlopes)
+        {
+            return new Optimizer(channels, options).Solve();
+        }
+
+        return BestUniformSlopeCandidate(channels, options).Proposals;
     }
+
+    // With independent slopes off, "matched" means ONE slope for the whole
+    // system: every junction (and both of its sides) uses the same dB/oct.
+    // A mixed 12/18 pair on one channel's two shoulders reads as broken to
+    // the user even though each junction is internally matched. Each
+    // feasible slope gets its own pinned descent; the best state wins.
+    private static PoolCandidate BestUniformSlopeCandidate(
+        IReadOnlyList<AutoSetupSource> channels,
+        CrossoverAutoSetupOptions options)
+    {
+        // Every family offers 24 dB/oct and slopes at or below the low-junction
+        // cap always pass the Capture guard, so at least one run produces a
+        // candidate.
+        return UniformSlopeCandidates(options.Families)
+            .Select(slope => new Optimizer(channels, options, forcedSlope: slope)
+                .SolvePool(1)
+                .FirstOrDefault())
+            .Where(candidate => candidate != null)
+            .MinBy(candidate => candidate!.MagnitudeScore)!;
+    }
+
+    // The system-wide slopes the matched-slopes mode may try: every practical
+    // slope some allowed family offers.
+    private static IReadOnlyList<int> UniformSlopeCandidates(
+        IReadOnlyList<CrossoverFilterFamily> families) =>
+        families
+            .SelectMany(PracticalSlopes)
+            .Distinct()
+            .OrderBy(slope => slope)
+            .ToList();
+
+    // The slopes a family offers above the practical floor: an engineer does
+    // not reach for a 6 dB/oct crossover — it protects nothing and leaves the
+    // drivers overlapping over a huge span.
+    private static IReadOnlyList<int> PracticalSlopes(CrossoverFilterFamily family) =>
+        CrossoverFilter.SupportedSlopes(family)
+            .Where(slope => slope >= MinPracticalSlopeDbPerOctave)
+            .ToList();
 
     /// <summary>
     /// The ranked wizard search: expands a pool of up to
@@ -415,8 +460,37 @@ public static class CrossoverAutoSetup
         }
 
         options = Normalize(options);
-        List<PoolCandidate> pool = new Optimizer(channels, options)
-            .SolvePool(candidateCount);
+        List<PoolCandidate> pool;
+        if (options.IndependentSlopes)
+        {
+            pool = new Optimizer(channels, options).SolvePool(candidateCount);
+        }
+        else
+        {
+            // Matched slopes = one slope for the whole system (see
+            // BestUniformSlopeCandidate): one pinned pool per feasible slope,
+            // merged, so every candidate is internally uniform while the
+            // ranking still weighs the slopes against each other.
+            pool = new List<PoolCandidate>();
+            var poolSeen = new HashSet<string>();
+            foreach (int slope in UniformSlopeCandidates(options.Families))
+            {
+                foreach (PoolCandidate candidate in
+                    new Optimizer(channels, options, forcedSlope: slope)
+                        .SolvePool(candidateCount))
+                {
+                    if (poolSeen.Add(candidate.Signature))
+                    {
+                        pool.Add(candidate);
+                    }
+                }
+            }
+
+            pool = pool
+                .OrderBy(candidate => candidate.MagnitudeScore)
+                .Take(candidateCount)
+                .ToList();
+        }
 
         // The conventional candidate: every slope locked to 24 dB/oct,
         // Linkwitz-Riley when the user allows it — what an engineer reaches
@@ -1037,6 +1111,20 @@ public static class CrossoverAutoSetup
             var seen = new HashSet<string>();
             void Capture()
             {
+                // A pinned steep slope can leave a low junction stranded at its
+                // seed frequency when no lattice point in its window allows the
+                // slope (AllowedSlopes empty) — such a state violates the
+                // low-junction cap and must not become a candidate.
+                for (int j = 0; j < channelCount - 1; j++)
+                {
+                    if (crossoverHz[j] < SteepSlopeMinimumJunctionHz &&
+                        (lowerSlope[j] > LowJunctionMaxSlopeDbPerOctave ||
+                            upperSlope[j] > LowJunctionMaxSlopeDbPerOctave))
+                    {
+                        return;
+                    }
+                }
+
                 NormalizeGainsCutOnly();
                 IReadOnlyList<CrossoverProposal> proposals = BuildProposals();
                 string signature = SignatureOf(proposals);
@@ -1164,6 +1252,15 @@ public static class CrossoverAutoSetup
         private void Initialize()
         {
             CrossoverFilterFamily family = PreferredFamily();
+            if (forcedSlope is int pinned && !PracticalSlopes(family).Contains(pinned))
+            {
+                // The preferred family may not offer the pinned slope (LR has
+                // no 18/36); seeding it anyway would ask CrossoverFilter for
+                // an unsupported cascade.
+                family = options.Families
+                    .FirstOrDefault(f => PracticalSlopes(f).Contains(pinned), family);
+            }
+
             int slope = forcedSlope ?? PreferredSlope(family);
             for (int j = 0; j < channelCount - 1; j++)
             {
@@ -1212,14 +1309,6 @@ public static class CrossoverAutoSetup
                 : slopes.MinBy(slope => Math.Abs(slope - CrossoverSlopeDbPerOctave));
         }
 
-        // The slopes a family offers above the practical floor: an engineer does
-        // not reach for a 6 dB/oct crossover — it protects nothing and leaves the
-        // drivers overlapping over a huge span.
-        private static IReadOnlyList<int> PracticalSlopes(CrossoverFilterFamily family) =>
-            CrossoverFilter.SupportedSlopes(family)
-                .Where(slope => slope >= MinPracticalSlopeDbPerOctave)
-                .ToList();
-
         // The slopes the search may actually try at this junction frequency:
         // the family's practical slopes, capped at 24 dB/oct below
         // SteepSlopeMinimumJunctionHz (group delay), or pinned to the forced
@@ -1227,14 +1316,22 @@ public static class CrossoverAutoSetup
         private IReadOnlyList<int> AllowedSlopes(CrossoverFilterFamily family, double fcHz)
         {
             IReadOnlyList<int> slopes = PracticalSlopes(family);
+            if (fcHz < SteepSlopeMinimumJunctionHz)
+            {
+                // The group-delay cap binds the pinned runs too: a system-wide
+                // 36/48 dB/oct candidate is simply infeasible while it owns a
+                // junction below 300 Hz.
+                slopes = slopes
+                    .Where(slope => slope <= LowJunctionMaxSlopeDbPerOctave)
+                    .ToList();
+            }
+
             if (forcedSlope is int locked)
             {
                 return slopes.Contains(locked) ? [locked] : [];
             }
 
-            return fcHz < SteepSlopeMinimumJunctionHz
-                ? slopes.Where(slope => slope <= LowJunctionMaxSlopeDbPerOctave).ToList()
-                : slopes;
+            return slopes;
         }
 
         // Cut-only seed: bring every band down to the quietest, measured over the

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -138,6 +138,15 @@ public static class CrossoverAutoSetup
     /// <summary>The steepest slope allowed for junctions below <see cref="SteepSlopeMinimumJunctionHz"/>.</summary>
     public const int LowJunctionMaxSlopeDbPerOctave = 24;
 
+    /// <summary>
+    /// The mirror of the low-bass cap, for tweeters: a tweeter crossed below this
+    /// frequency must use at least <see cref="CrossoverSlopeDbPerOctave"/> dB/oct,
+    /// or a shallow filter lets it play too far down and overexcurt. The placement
+    /// heuristics push a capable tweeter's handover low for a better soundstage,
+    /// so the steep-slope floor keeps that safe.
+    /// </summary>
+    public const double TweeterProtectionHz = 2_500;
+
     // The log-frequency grid the optimizer scores flatness on.
     private const int GridPointsPerOctave = 24;
 
@@ -251,6 +260,25 @@ public static class CrossoverAutoSetup
     private const double OverlapPenaltyDbPerOctave = 0.6;
     private const int MinPracticalSlopeDbPerOctave = 12;
 
+    // A handover in the ear's most sensitive band (2–4 kHz) puts the crossover's
+    // phase wobble, lobing and any residual dip right where they are most
+    // audible, so a junction landing there is penalized: a soft bump centred on
+    // the band's log-centre (~2.83 kHz), full inside and tapering ~an octave to
+    // each side. Gentle — a tie-breaker that steers a free handover out of the
+    // band, not an override of a genuinely flatter split.
+    private const double EarSensitivityLowHz = 2_000;
+    private const double EarSensitivityHighHz = 4_000;
+    private const double EarSensitivitySigmaOctaves = 0.5;
+    private const double EarSensitivityWeightDb = 0.5;
+
+    // When two adjacent drivers share a wide band, the handover can sit anywhere
+    // across it; an engineer crosses low, letting the upper (smaller) driver take
+    // over as early as it cleanly can (better dispersion up top, less excursion
+    // and breakup demand on the lower driver). So a junction is nudged toward the
+    // bottom of the drivers' shared band, the pull scaled by how wide that band
+    // is — negligible for a narrow overlap, firm for a broad one.
+    private const double WideOverlapLowBiasWeightDb = 0.4;
+
     /// <summary>
     /// Reads the usable band from a (smoothed) magnitude curve and suggests the
     /// driver class. The reference is an upper percentile of the curve, robust
@@ -334,7 +362,11 @@ public static class CrossoverAutoSetup
         DriverType.Woofer => (40, 250),
         DriverType.Midbass => (80, 500),
         DriverType.Midrange => (250, 4_000),
-        DriverType.Tweeter => (2_000, 20_000),
+        // A quality tweeter crossed low (with a steep filter) covers more of the
+        // critical midrange for a better soundstage; the 1.5 kHz floor lets the
+        // search go there, but only when the measured tweeter band supports it —
+        // a tweeter that has rolled off by 2.5 kHz still crosses no lower.
+        DriverType.Tweeter => (1_500, 20_000),
         _ => (20, 20_000)
     };
 
@@ -1455,6 +1487,15 @@ public static class CrossoverAutoSetup
                 : slopes;
         }
 
+        // The lowest slope a driver of this class may take at a handover of this
+        // frequency: a tweeter crossed below TweeterProtectionHz is held to at
+        // least 24 dB/oct so it does not play too far down; every other driver
+        // keeps the practical floor.
+        private static int SlopeFloor(DriverType sideType, double fcHz) =>
+            sideType == DriverType.Tweeter && fcHz < TweeterProtectionHz
+                ? CrossoverSlopeDbPerOctave
+                : MinPracticalSlopeDbPerOctave;
+
         // Cut-only seed: bring every band down to the quietest, measured over the
         // band it will actually cover with the seeded crossovers.
         private void InitializeGains()
@@ -1568,10 +1609,15 @@ public static class CrossoverAutoSetup
             List<int>? allowed = null;
             void Intersect(int junction)
             {
-                IReadOnlyList<int> slopes =
-                    AllowedSlopes(junctionFamily[junction], crossoverHz[junction]);
+                // Channel i sits on this junction; its own class sets the steep
+                // floor (a tweeter crossed low), while the junction frequency and
+                // family set the rest.
+                int floor = SlopeFloor(types[i], crossoverHz[junction]);
+                List<int> slopes = AllowedSlopes(junctionFamily[junction], crossoverHz[junction])
+                    .Where(slope => slope >= floor)
+                    .ToList();
                 allowed = allowed == null
-                    ? slopes.ToList()
+                    ? slopes
                     : allowed.Where(slopes.Contains).ToList();
             }
 
@@ -1636,6 +1682,11 @@ public static class CrossoverAutoSetup
             {
                 foreach (double fc in LatticePoints(low, high))
                 {
+                    // Steep-slope floors for this handover's two sides: a tweeter
+                    // crossed low must stay steep (its own class), the lower
+                    // driver keeps the practical floor.
+                    int lowerFloor = SlopeFloor(types[j], fc);
+                    int upperFloor = SlopeFloor(types[j + 1], fc);
                     foreach (CrossoverFilterFamily family in options.Families)
                     {
                         IReadOnlyList<int> slopes = AllowedSlopes(family, fc);
@@ -1643,15 +1694,26 @@ public static class CrossoverAutoSetup
                         {
                             foreach (int lower in slopes)
                             {
+                                if (lower < lowerFloor)
+                                {
+                                    continue;
+                                }
+
                                 foreach (int upper in slopes)
                                 {
+                                    if (upper < upperFloor)
+                                    {
+                                        continue;
+                                    }
+
                                     Set(j, family, fc, lower, upper);
                                     yield return new JunctionOption(
                                         family, fc, lower, upper, Score());
                                 }
                             }
                         }
-                        else if (slopes.Contains(savedLower) && slopes.Contains(savedUpper))
+                        else if (slopes.Contains(savedLower) && slopes.Contains(savedUpper) &&
+                            savedLower >= lowerFloor && savedUpper >= upperFloor)
                         {
                             Set(j, family, fc, savedLower, savedUpper);
                             yield return new JunctionOption(
@@ -1736,7 +1798,47 @@ public static class CrossoverAutoSetup
                 }
             }
 
-            return Flatness(scratchCombined) + OverlapPenalty(scratchUnits);
+            return Flatness(scratchCombined)
+                + OverlapPenalty(scratchUnits)
+                + FrequencyPlacementPenalty();
+        }
+
+        // Frequency-placement heuristics that depend only on where the junctions
+        // sit (not on the summed magnitude): keep handovers out of the ear's
+        // 2–4 kHz sensitivity band, and cross low when two drivers share a wide
+        // band. Both are gentle nudges added to the flatness score.
+        private double FrequencyPlacementPenalty()
+        {
+            double total = 0;
+            for (int j = 0; j < channelCount - 1; j++)
+            {
+                double fc = crossoverHz[j];
+                total += EarSensitivityWeightDb * EarSensitivityBump(fc);
+
+                // The band the two drivers share, and how far above its bottom
+                // this junction sits — both in octaves. A narrow overlap barely
+                // pulls; a wide one pulls firmly toward the low edge.
+                double overlapLow = bands[j + 1].LowHz;
+                double overlapHigh = bands[j].HighHz;
+                if (overlapHigh > overlapLow && fc > overlapLow)
+                {
+                    double overlapOctaves = Math.Log2(overlapHigh / overlapLow);
+                    double octavesAbove = Math.Log2(fc / overlapLow);
+                    total += WideOverlapLowBiasWeightDb * overlapOctaves * octavesAbove;
+                }
+            }
+
+            return total;
+        }
+
+        // A soft bump, full over 2–4 kHz and tapering ~an octave to each side,
+        // centred on the band's log-centre.
+        private static double EarSensitivityBump(double frequencyHz)
+        {
+            double center = Math.Sqrt(EarSensitivityLowHz * EarSensitivityHighHz);
+            double octavesFromCenter = Math.Log2(frequencyHz / center);
+            double z = octavesFromCenter / EarSensitivitySigmaOctaves;
+            return Math.Exp(-0.5 * z * z);
         }
 
         // RMS deviation of the summed magnitude from its own mean over the interior

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -258,7 +258,14 @@ public static class CrossoverAutoSetup
     // narrower overlap), and the search never goes below a practical slope: a
     // first-order (6 dB/oct) filter protects nothing.
     private const double OverlapPenaltyDbPerOctave = 0.6;
-    private const int MinPracticalSlopeDbPerOctave = 12;
+    private const int MinPracticalSlopeDbPerOctave = 18;
+
+    // A driver whose roll-off reaches past its neighbour into a non-adjacent
+    // driver's band overlaps where it never should; that overlap is weighted this
+    // much heavier per band of distance than an unavoidable adjacent handover, so
+    // a too-shallow filter (a 12 dB/oct woofer bleeding up to the tweeter) is
+    // pushed to a steeper slope.
+    private const double NonAdjacentOverlapWeight = 4.0;
 
     // A handover in the ear's most sensitive band (2–4 kHz) puts the crossover's
     // phase wobble, lobing and any residual dip right where they are most
@@ -270,6 +277,12 @@ public static class CrossoverAutoSetup
     private const double EarSensitivityHighHz = 4_000;
     private const double EarSensitivitySigmaOctaves = 0.5;
     private const double EarSensitivityWeightDb = 0.5;
+
+    // A subwoofer wants to hand over where it stops being localizable (~80 Hz),
+    // not as low as the flatness search would drag it — a sub crossed at 45 Hz
+    // leaves the woofer carrying real bass. So the sub handover is nudged up
+    // toward the top of its sensible range.
+    private const double SubHandoverUpBiasWeightDb = 0.6;
 
     // When two adjacent drivers share a wide band, the handover can sit anywhere
     // across it; an engineer crosses low, letting the upper (smaller) driver take
@@ -363,10 +376,10 @@ public static class CrossoverAutoSetup
         DriverType.Midbass => (80, 500),
         DriverType.Midrange => (250, 4_000),
         // A quality tweeter crossed low (with a steep filter) covers more of the
-        // critical midrange for a better soundstage; the 1.5 kHz floor lets the
+        // critical midrange for a better soundstage; the 1.7 kHz floor lets the
         // search go there, but only when the measured tweeter band supports it —
         // a tweeter that has rolled off by 2.5 kHz still crosses no lower.
-        DriverType.Tweeter => (1_500, 20_000),
+        DriverType.Tweeter => (1_700, 20_000),
         _ => (20, 20_000)
     };
 
@@ -1817,7 +1830,22 @@ public static class CrossoverAutoSetup
 
                 // The band the two drivers share, and how far above its bottom
                 // this junction sits — both in octaves. A narrow overlap barely
-                // pulls; a wide one pulls firmly toward the low edge.
+                // pulls; a wide one pulls firmly toward the low edge. Skipped for
+                // the subwoofer handover: a sub wants to hand over where it stops
+                // being localizable (~80 Hz), not as low as it can play.
+                if (types[j] == DriverType.Subwoofer)
+                {
+                    // The sub hands over UP toward the top of its sensible range,
+                    // never pulled low.
+                    double subTop = SensibleRange(DriverType.Subwoofer).HighHz;
+                    if (fc < subTop)
+                    {
+                        total += SubHandoverUpBiasWeightDb * Math.Log2(subTop / fc);
+                    }
+
+                    continue;
+                }
+
                 double overlapLow = bands[j + 1].LowHz;
                 double overlapHigh = bands[j].HighHz;
                 if (overlapHigh > overlapLow && fc > overlapLow)
@@ -1869,39 +1897,60 @@ public static class CrossoverAutoSetup
             return Math.Sqrt(sumSquares / count) + DipPenaltyWeight * worstDip;
         }
 
-        // How many octaves adjacent drivers meaningfully overlap, summed over the
-        // junctions. Each driver is normalized to its own passband peak (so gains
-        // and levels drop out) and the overlap is the log-frequency integral of the
-        // two normalized responses' product — near an octave for a clean LR24
-        // handover, several octaves for shallow filters. Steeper slopes shrink it.
+        // How many octaves drivers meaningfully overlap, summed over every pair.
+        // Each driver is normalized to its own passband peak (so gains and levels
+        // drop out) and the overlap is the log-frequency integral of the two
+        // normalized responses' product — near an octave for a clean LR24
+        // handover of adjacent drivers, several octaves for shallow filters.
+        // Adjacent overlap is unavoidable at a handover; a shallow roll-off that
+        // reaches PAST the neighbour into a non-adjacent driver's band (a 12 dB/oct
+        // woofer still audible up at the tweeter) is far worse, so that overlap is
+        // weighted much heavier — which pushes such a driver to a steeper slope.
         private double OverlapPenalty(double[][] amplitudes)
         {
             double octavesPerBin = 1.0 / GridPointsPerOctave;
-            double total = 0;
-            for (int j = 0; j < channelCount - 1; j++)
+            var peaks = new double[channelCount];
+            for (int i = 0; i < channelCount; i++)
             {
-                double[] lower = amplitudes[j];
-                double[] upper = amplitudes[j + 1];
-                double peakLower = 0;
-                double peakUpper = 0;
+                double peak = 0;
+                double[] amplitude = amplitudes[i];
                 for (int k = evalLow; k <= evalHigh; k++)
                 {
-                    peakLower = Math.Max(peakLower, lower[k]);
-                    peakUpper = Math.Max(peakUpper, upper[k]);
+                    peak = Math.Max(peak, amplitude[k]);
                 }
 
-                if (peakLower <= 0 || peakUpper <= 0)
+                peaks[i] = peak;
+            }
+
+            double total = 0;
+            for (int i = 0; i < channelCount; i++)
+            {
+                if (peaks[i] <= 0)
                 {
                     continue;
                 }
 
-                double overlap = 0;
-                for (int k = evalLow; k <= evalHigh; k++)
+                for (int m = i + 1; m < channelCount; m++)
                 {
-                    overlap += lower[k] / peakLower * (upper[k] / peakUpper);
-                }
+                    if (peaks[m] <= 0)
+                    {
+                        continue;
+                    }
 
-                total += overlap * octavesPerBin;
+                    double[] lower = amplitudes[i];
+                    double[] upper = amplitudes[m];
+                    double overlap = 0;
+                    for (int k = evalLow; k <= evalHigh; k++)
+                    {
+                        overlap += lower[k] / peaks[i] * (upper[k] / peaks[m]);
+                    }
+
+                    int distance = m - i;
+                    double weight = distance == 1
+                        ? 1.0
+                        : NonAdjacentOverlapWeight * (distance - 1);
+                    total += weight * overlap * octavesPerBin;
+                }
             }
 
             return OverlapPenaltyDbPerOctave * total;

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -27,10 +27,16 @@ public sealed record DriverBandEstimate(
     double LevelDb,
     DriverType SuggestedType);
 
-/// <summary>One wizard input: a channel's raw magnitude curve and its (confirmed) driver type.</summary>
+/// <summary>
+/// One wizard input: a channel's raw magnitude curve and its (confirmed) driver
+/// type. <see cref="Coherence"/> is the optional per-point γ² (0..1), aligned
+/// 1:1 with <see cref="MagnitudeDb"/>; when supplied it lets the band estimate
+/// discount frequencies the measurement does not trust. Null when unavailable.
+/// </summary>
 public sealed record AutoSetupSource(
     IReadOnlyList<SignalPoint> MagnitudeDb,
-    DriverType Type);
+    DriverType Type,
+    IReadOnlyList<double>? Coherence = null);
 
 /// <summary>
 /// The proposed DSP starting point for one channel: the crossover filters and a
@@ -119,6 +125,13 @@ public static class CrossoverAutoSetup
     // level. 8 dB sits between the -6 dB textbook edge and the -10 dB the
     // remaining room ripple of a 1/3-octave-smoothed in-room curve asks for.
     private const double BandEdgeDropDb = 8.0;
+
+    // When per-point coherence is supplied to EstimateBand, a frequency whose
+    // γ² is below this cannot anchor a band edge — it is treated as out of band
+    // even if its magnitude clears the threshold. 0.5 matches the phase-unwrap
+    // coherence floor: below it the transfer estimate is dominated by noise or
+    // non-linearity (a breakup resonance, or plain out-of-band SNR).
+    private const double CoherenceFloor = 0.5;
 
     // The widest below-threshold gap EstimateBand bridges inside one band. A
     // driver's own passband can have a narrow interference or room null that
@@ -304,12 +317,30 @@ public static class CrossoverAutoSetup
     /// <summary>
     /// Reads the usable band from a (smoothed) magnitude curve and suggests the
     /// driver class. The reference is an upper percentile of the curve, robust
-    /// against both narrow room dips and single peaks.
+    /// against both narrow room dips and single peaks. When per-point coherence
+    /// is supplied (γ², aligned 1:1 with the magnitude points, 0..1), it is used
+    /// to discount frequencies the measurement does not trust: an incoherent
+    /// point cannot anchor a band edge, and each segment's prominence is weighted
+    /// by γ² — so a noisy or non-linear resonance (low γ²) cannot stretch the
+    /// band the way a genuine, coherent passband does. A null or mismatched-length
+    /// coherence is ignored.
     /// </summary>
-    public static DriverBandEstimate EstimateBand(IReadOnlyList<SignalPoint> magnitudeDb)
+    public static DriverBandEstimate EstimateBand(
+        IReadOnlyList<SignalPoint> magnitudeDb,
+        IReadOnlyList<double>? coherence = null)
     {
         ArgumentNullException.ThrowIfNull(magnitudeDb);
 
+        // Coherence is honoured only when it lines up 1:1 with the magnitude
+        // points; a mismatched length is treated as absent rather than trusted.
+        bool useCoherence = coherence != null && coherence.Count == magnitudeDb.Count;
+        double Gamma(int i) => useCoherence ? coherence![i] : 1.0;
+
+        // The reference is read from the whole curve (not just coherent points):
+        // for a narrow-band driver like a sub, the passband is a small slice of
+        // the log grid, and filtering the percentile down to it would track the
+        // peak and shrink the usable band — over-constraining the crossover. The
+        // 85th percentile is already robust to the out-of-band floor.
         var levels = magnitudeDb
             .Where(point => double.IsFinite(point.Y))
             .Select(point => point.Y)
@@ -325,13 +356,14 @@ public static class CrossoverAutoSetup
         double reference = levels[(int)(levels.Count * 0.85)];
         double threshold = reference - BandEdgeDropDb;
 
-        // Group the above-threshold points into contiguous segments, bridging a
-        // below-threshold gap only while it stays within MaxBandGapOctaves (a
-        // narrow interference/room null the driver's own band can have). The
-        // usable band is then the most PROMINENT segment — the one with the
-        // largest area above threshold, integrated over log-frequency — so an
-        // isolated resonance sitting past a deep dead gap cannot extend the band
-        // and mislabel the driver or skew the crossover bounds.
+        // Group the trusted, above-threshold points into contiguous segments,
+        // bridging a below-threshold gap only while it stays within
+        // MaxBandGapOctaves (a narrow interference/room null the driver's own
+        // band can have). The usable band is then the most PROMINENT segment —
+        // the one with the largest γ²-weighted area above threshold, integrated
+        // over log-frequency — so an isolated resonance past a deep dead gap, or
+        // an incoherent noisy region, cannot extend the band and mislabel the
+        // driver or skew the crossover bounds.
         double bestLow = double.NaN;
         double bestHigh = double.NaN;
         double bestArea = double.NegativeInfinity;
@@ -350,9 +382,11 @@ public static class CrossoverAutoSetup
             }
         }
 
-        foreach (SignalPoint point in magnitudeDb)
+        for (int i = 0; i < magnitudeDb.Count; i++)
         {
-            if (!double.IsFinite(point.Y) || point.Y < threshold)
+            SignalPoint point = magnitudeDb[i];
+            double g2 = Gamma(i);
+            if (!double.IsFinite(point.Y) || point.Y < threshold || g2 < CoherenceFloor)
             {
                 continue;
             }
@@ -372,7 +406,7 @@ public static class CrossoverAutoSetup
                 segLow = point.X;
             }
             segHigh = point.X;
-            segArea += point.Y - threshold;
+            segArea += (point.Y - threshold) * g2;
             lastAboveHz = point.X;
         }
         CloseSegment();
@@ -518,7 +552,8 @@ public static class CrossoverAutoSetup
         double ceiling = Math.Min(20_000, sampleRateHz * 0.49);
         for (int i = 0; i < n; i++)
         {
-            DriverBandEstimate band = EstimateBand(channels[i].MagnitudeDb);
+            DriverBandEstimate band = EstimateBand(
+                channels[i].MagnitudeDb, channels[i].Coherence);
             double low = proposals[i].HighPassEdge?.FrequencyHz ?? band.LowHz;
             double high = proposals[i].LowPassEdge?.FrequencyHz ?? Math.Min(band.HighHz, ceiling);
             if (high <= low)
@@ -1227,7 +1262,9 @@ public static class CrossoverAutoSetup
                 .ToArray();
             inputIndex = ordered.Select(item => item.index).ToArray();
             curves = ordered.Select(item => item.channel.MagnitudeDb).ToArray();
-            bands = ordered.Select(item => EstimateBand(item.channel.MagnitudeDb)).ToArray();
+            bands = ordered
+                .Select(item => EstimateBand(item.channel.MagnitudeDb, item.channel.Coherence))
+                .ToArray();
             types = ordered.Select(item => item.channel.Type).ToArray();
 
             grid = BuildGrid(options.SampleRateHz);

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -64,9 +64,10 @@ public sealed record RankedCrossoverProposal(
 /// The choices the crossover wizard asks for before optimizing: which filter
 /// families the optimizer may pick from, the frequency window crossovers must
 /// fall inside, and whether the two sides of a junction may take different
-/// slopes. With <see cref="IndependentSlopes"/> off the whole system uses ONE
-/// slope — every junction, both sides — searched over the practical slopes the
-/// allowed families offer. <see cref="SubElevationDb"/> is how far the lowest
+/// slopes. With <see cref="IndependentSlopes"/> off, each DRIVER's two shoulders
+/// (its high-pass and low-pass) share one slope, so no channel ends up 12 dB/oct
+/// on one side and 18 on the other; different drivers stay free to take different
+/// slopes. <see cref="SubElevationDb"/> is how far the lowest
 /// driver sits above the levelled midrange/tweeter reference in the target-curve
 /// gain fit (null uses the measured elevation, i.e. the lowest driver at its raw
 /// level); see <see cref="CrossoverAutoSetup.ApplyTargetCurveGains"/>. The sample

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Numerics;
 
 namespace Resonalyze.Dsp;
@@ -455,16 +456,14 @@ public static class CrossoverAutoSetup
                 .ToArray();
             Complex[][] cropped = CropSharedDirectSoundWindow(
                 orderedIndex.Select(index => impulseResponses[index]).ToArray());
-            double[] junctionCenters = RawJunctionArrivalCentersMs(
-                cropped,
-                orderedIndex.Select(index => channels[index].MagnitudeDb).ToArray(),
-                sampleRate);
+            var arrivalCache =
+                new ConcurrentDictionary<(int Channel, long BandKey), (double Ms, bool Valid)>();
             penalties = pool
                 .AsParallel().AsOrdered()
                 .Select(candidate => AchievabilityPenaltyDb(
                     cropped,
                     orderedIndex.Select(index => candidate.Proposals[index]).ToArray(),
-                    junctionCenters,
+                    arrivalCache,
                     sampleRate))
                 .ToArray();
         }
@@ -519,48 +518,46 @@ public static class CrossoverAutoSetup
         return cropped;
     }
 
-    // The search-window center per junction: the raw channels' band-limited
-    // arrival difference in each driver's OWN band, computed once for all
-    // candidates (a per-candidate arrival analysis was the dominant cost of
-    // the post-check — the Hilbert envelope per candidate per junction cost
-    // more than every alignment search combined).
-    private static double[] RawJunctionArrivalCentersMs(
+    // The raw channel's band-limited arrival in the given SHARED junction
+    // band, cached across candidates. Arrivals from different measuring bands
+    // are NOT comparable (each band carries its own driver group delay and
+    // envelope rise — the same lesson the Auto delay engine and the stereo Δ
+    // metric already encode), so both sides of a junction must be measured in
+    // one band; the cache keeps the Hilbert-envelope cost bounded because the
+    // pool only ever probes a handful of lattice frequencies per junction.
+    private static (double Ms, bool Valid) CachedRawArrival(
+        ConcurrentDictionary<(int Channel, long BandKey), (double Ms, bool Valid)> cache,
         Complex[][] croppedOrdered,
-        IReadOnlyList<SignalPoint>[] orderedCurves,
+        int channel,
+        double bandLowHz,
+        double bandHighHz,
         int sampleRate)
     {
-        var arrivals = new double[croppedOrdered.Length];
-        var valid = new bool[croppedOrdered.Length];
-        for (int channel = 0; channel < croppedOrdered.Length; channel++)
+        long bandKey = ((long)Math.Round(bandLowHz) << 20) | (long)Math.Round(bandHighHz);
+        return cache.GetOrAdd((channel, bandKey), _ =>
         {
-            DriverBandEstimate band = EstimateBand(orderedCurves[channel]);
             TimeAlignmentAnalysisResult arrival =
                 VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
-                    croppedOrdered[channel], sampleRate, band.LowHz, band.HighHz);
-            arrivals[channel] = arrival.FirstArrivalDelayMilliseconds;
-            valid[channel] = arrival.IsValid;
-        }
-
-        var centers = new double[Math.Max(0, croppedOrdered.Length - 1)];
-        for (int j = 0; j < centers.Length; j++)
-        {
-            centers[j] = valid[j] && valid[j + 1]
-                ? arrivals[j] - arrivals[j + 1]
-                : 0;
-        }
-
-        return centers;
+                    croppedOrdered[channel], sampleRate, bandLowHz, bandHighHz);
+            return (arrival.FirstArrivalDelayMilliseconds, arrival.IsValid);
+        });
     }
 
     // The summed dip-penalized loss (positive dB, 0 = perfect handovers) that
-    // remains after the BEST per-junction delay for this candidate: each
-    // channel is processed with the candidate's filters and gain, then every
-    // adjacent junction runs the production alignment search in a window
-    // around the raw channels' arrival difference.
+    // remains after the delay the production selection policy would pick for
+    // this candidate: each channel is processed with the candidate's filters
+    // and gain, then every adjacent junction runs the production alignment
+    // search — arrival-anchored prior, AlignmentSelection tie-breaks (an
+    // inverted half-period impostor must not fake achievability the real
+    // Auto delay would refuse) and a widened retry when the pick lands on the
+    // window edge. Deliberate simplifications versus the full engine, judged
+    // acceptable for RANKING: no PHAT-seeded timeline and no cascade
+    // reprocessing of already-settled neighbors (junction deltas of a mono
+    // N-way compose independently).
     private static double AchievabilityPenaltyDb(
         Complex[][] croppedOrdered,
         CrossoverProposal[] orderedProposals,
-        double[] junctionCenters,
+        ConcurrentDictionary<(int Channel, long BandKey), (double Ms, bool Valid)> arrivalCache,
         int sampleRate)
     {
         var processed = new Complex[croppedOrdered.Length][];
@@ -590,26 +587,53 @@ public static class CrossoverAutoSetup
 
             double bandLow = Math.Max(20, Math.Min(lp, hp) / 2);
             double bandHigh = Math.Min(20_000, Math.Max(lp, hp) * 2);
-            double center = junctionCenters[j];
-            double halfWindow = PostCheckHalfWindowMs(Math.Min(lp, hp));
 
-            IReadOnlyList<AlignmentCandidate> found =
+            // Both sides measured in the SAME shared band; unreadable arrivals
+            // fall back to an unanchored search over the widest window.
+            (double lowerMs, bool lowerValid) = CachedRawArrival(
+                arrivalCache, croppedOrdered, j, bandLow, bandHigh, sampleRate);
+            (double upperMs, bool upperValid) = CachedRawArrival(
+                arrivalCache, croppedOrdered, j + 1, bandLow, bandHigh, sampleRate);
+            bool anchored = lowerValid && upperValid;
+            double center = anchored ? lowerMs - upperMs : 0;
+            double halfWindow = anchored
+                ? PostCheckHalfWindowMs(Math.Min(lp, hp))
+                : PostCheckMaxHalfWindowMs;
+
+            IReadOnlyList<AlignmentCandidate> Search(double half) =>
                 VirtualCrossoverAnalysis.FindAlignmentCandidates(
                     processed[j + 1],
                     [processed[j]],
                     sampleRate,
                     bandLow,
                     bandHigh,
-                    center - halfWindow,
-                    center + halfWindow);
+                    center - half,
+                    center + half,
+                    priorDelayMs: anchored ? center : null,
+                    priorSigmaMs: half / 2.0);
+
+            IReadOnlyList<AlignmentCandidate> found = Search(halfWindow);
             if (found.Count == 0)
             {
                 penalty += PostCheckMissingJunctionPenaltyDb;
                 continue;
             }
 
-            AlignmentCandidate best = found[0];
-            penalty += -(best.LossDb + DipPenaltyWeight * (best.DipDb - best.LossDb));
+            AlignmentCandidate chosen = AlignmentSelection.Select(found, center);
+            // A pick at the window edge means the true lobe may be cut off;
+            // one widened retry, re-selected through the same rules — taking
+            // the retried best raw would hand the widened window to exactly
+            // the impostor the selection exists to reject.
+            if (Math.Abs(chosen.DelayMs - center) >= halfWindow * 0.9)
+            {
+                IReadOnlyList<AlignmentCandidate> retried = Search(halfWindow * 2);
+                if (retried.Count > 0)
+                {
+                    chosen = AlignmentSelection.Select(retried, center);
+                }
+            }
+
+            penalty += -(chosen.LossDb + DipPenaltyWeight * (chosen.DipDb - chosen.LossDb));
         }
 
         return penalty;

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -259,7 +259,7 @@ public static class CrossoverAutoSetup
     // narrower overlap), and the search never goes below a practical slope: a
     // first-order (6 dB/oct) filter protects nothing.
     private const double OverlapPenaltyDbPerOctave = 0.6;
-    private const int MinPracticalSlopeDbPerOctave = 18;
+    private const int MinPracticalSlopeDbPerOctave = 24;
 
     // A driver whose roll-off reaches past its neighbour into a non-adjacent
     // driver's band overlaps where it never should; that overlap is weighted this
@@ -430,9 +430,13 @@ public static class CrossoverAutoSetup
             channels, proposals, options.SampleRateHz, options.SubElevationDb);
     }
 
-    // The slopes a family offers above the practical floor: an engineer does
-    // not reach for a 6 dB/oct crossover — it protects nothing and leaves the
-    // drivers overlapping over a huge span.
+    // The slopes a family offers above the practical floor. A shallow crossover
+    // (12/18 dB/oct) leaves adjacent drivers overlapping over a wide span where
+    // they interfere; on a real system the summed dip that leaves is worse than
+    // any group-delay a steeper filter costs, and Auto delay cannot align it
+    // away — so the floor is 24 dB/oct, matching how these systems are tuned by
+    // hand. (Below SteepSlopeMinimumJunctionHz the slope is also capped at 24 for
+    // group delay, pinning low junctions to exactly 24.)
     private static IReadOnlyList<int> PracticalSlopes(CrossoverFilterFamily family) =>
         CrossoverFilter.SupportedSlopes(family)
             .Where(slope => slope >= MinPracticalSlopeDbPerOctave)

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -88,7 +88,7 @@ public sealed record CrossoverAutoSetupOptions(
     double SampleRateHz,
     double? SubElevationDb = null)
 {
-    /// <summary>All families, the full 20 Hz – 20 kHz window, matched slopes.</summary>
+    /// <summary>All families, the full 20 Hz – 20 kHz window, independent slopes.</summary>
     public static CrossoverAutoSetupOptions Default(double sampleRateHz) =>
         new(
             [
@@ -98,7 +98,7 @@ public sealed record CrossoverAutoSetupOptions(
             ],
             20,
             20_000,
-            IndependentSlopes: false,
+            IndependentSlopes: true,
             sampleRateHz);
 }
 
@@ -158,6 +158,11 @@ public static class CrossoverAutoSetup
     /// low-pass and a high-pass, so this bounds both shoulders identically; with
     /// matched slopes a channel is still held to the gentler of its two junctions,
     /// so a steep woofer low-pass with a gentle high-pass needs independent slopes.
+    /// The bound caps how much STEEPER than the practical floor (24 dB/oct) the
+    /// search may go; the floor itself is always admitted, so at a junction low
+    /// enough that even 24 dB/oct exceeds this budget the floor still stands — a
+    /// gentler crossover would break the overlap policy, so that delay is inherent
+    /// to crossing so low, not a policy bypass.
     /// </summary>
     public const double MaxCrossoverGroupDelaySeconds = 0.010;
 
@@ -1298,12 +1303,17 @@ public static class CrossoverAutoSetup
             // not sprout a filter.
             double margin = Math.Pow(2.0, 1.0 / 12.0);
             CrossoverFilterFamily limitFamily = PreferredFamily();
-            int limitSlope = PreferredSlope(limitFamily);
             lowLimitEdge = options.MinCrossoverHz > bands[0].LowHz * margin
-                ? new CrossoverEdge(limitFamily, Math.Round(options.MinCrossoverHz), limitSlope)
+                ? new CrossoverEdge(
+                    limitFamily,
+                    Math.Round(options.MinCrossoverHz),
+                    forcedSlope ?? GentlestAdmissibleSlope(limitFamily, options.MinCrossoverHz))
                 : null;
             highLimitEdge = options.MaxCrossoverHz < bands[channelCount - 1].HighHz / margin
-                ? new CrossoverEdge(limitFamily, Math.Round(options.MaxCrossoverHz), limitSlope)
+                ? new CrossoverEdge(
+                    limitFamily,
+                    Math.Round(options.MaxCrossoverHz),
+                    forcedSlope ?? GentlestAdmissibleSlope(limitFamily, options.MaxCrossoverHz))
                 : null;
 
             // Flatness is only judged over the interior passband. The outermost
@@ -1536,7 +1546,6 @@ public static class CrossoverAutoSetup
         private void Initialize()
         {
             CrossoverFilterFamily family = PreferredFamily();
-            int slope = forcedSlope ?? PreferredSlope(family);
             for (int j = 0; j < channelCount - 1; j++)
             {
                 double fc = ProposeCrossoverFrequency(
@@ -1544,6 +1553,9 @@ public static class CrossoverAutoSetup
                 crossoverHz[j] = Math.Clamp(
                     RoundToLattice(fc), options.MinCrossoverHz, options.MaxCrossoverHz);
                 junctionFamily[j] = family;
+                // Seed the gentlest budget-admissible slope, not a fixed 24 that a
+                // very low junction's group delay might already blow.
+                int slope = forcedSlope ?? GentlestAdmissibleSlope(family, crossoverHz[j]);
                 lowerSlope[j] = slope;
                 upperSlope[j] = slope;
             }
@@ -1576,14 +1588,6 @@ public static class CrossoverAutoSetup
                 : options.Families[0];
         }
 
-        private static int PreferredSlope(CrossoverFilterFamily family)
-        {
-            IReadOnlyList<int> slopes = PracticalSlopes(family);
-            return slopes.Contains(CrossoverSlopeDbPerOctave)
-                ? CrossoverSlopeDbPerOctave
-                : slopes.MinBy(slope => Math.Abs(slope - CrossoverSlopeDbPerOctave));
-        }
-
         // The slopes the search may actually try at this junction frequency: the
         // family's practical slopes, minus any whose filter group delay exceeds
         // MaxCrossoverGroupDelaySeconds (which bites only low down, where a steep
@@ -1592,15 +1596,41 @@ public static class CrossoverAutoSetup
         private IReadOnlyList<int> AllowedSlopes(CrossoverFilterFamily family, double fcHz)
         {
             IReadOnlyList<int> slopes = PracticalSlopes(family);
-            if (forcedSlope is int locked)
+            if (slopes.Count == 0)
             {
-                return slopes.Contains(locked) ? [locked] : [];
+                return slopes;
             }
 
-            return slopes
-                .Where(slope => GroupDelaySeconds(family, slope, fcHz)
-                    <= MaxCrossoverGroupDelaySeconds)
-                .ToList();
+            int floor = slopes.Min();
+            bool WithinBudget(int slope) =>
+                GroupDelaySeconds(family, slope, fcHz) <= MaxCrossoverGroupDelaySeconds;
+
+            if (forcedSlope is int locked)
+            {
+                // The conventional run's forced slope is admitted on the same
+                // terms as the search: within the group-delay budget, or the
+                // practical floor (always admitted — see below).
+                return slopes.Contains(locked) && (WithinBudget(locked) || locked == floor)
+                    ? [locked]
+                    : [];
+            }
+
+            List<int> withinBudget = slopes.Where(WithinBudget).ToList();
+            // The practical floor (the gentlest slope) is always admitted even
+            // when its group delay exceeds the budget: a gentler crossover would
+            // break the overlap policy, so at a very low junction the floor's
+            // delay is inherent to crossing that low, not a policy bypass. The
+            // budget only bounds how much STEEPER than the floor the search goes.
+            return withinBudget.Count > 0 ? withinBudget : [floor];
+        }
+
+        // The gentlest slope the search seeds at this junction: the family's
+        // practical floor, which AllowedSlopes always admits (within the
+        // group-delay budget when it fits, and as the floor when it does not).
+        private int GentlestAdmissibleSlope(CrossoverFilterFamily family, double fcHz)
+        {
+            IReadOnlyList<int> allowed = AllowedSlopes(family, fcHz);
+            return allowed.Count > 0 ? allowed.Min() : PracticalSlopes(family).Min();
         }
 
         // Memoized peak group delay of one crossover filter. Group delay is the

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -47,9 +47,11 @@ public sealed record CrossoverProposal(
 /// scores that ranked it. <see cref="AchievabilityPenaltyDb"/> is the summed
 /// dip-penalized junction loss remaining after the best per-junction delay
 /// (measured on the impulse responses; null when no IRs were provided), and
-/// <see cref="IsConventional24"/> marks the all-24 dB/oct candidate that wins
-/// ties. Lower <see cref="TotalScore"/> is better; the list is returned best
-/// first.
+/// <see cref="IsConventional24"/> marks the one candidate built by the dedicated
+/// conventional run (every slope forced to 24 dB/oct, Linkwitz-Riley when the
+/// user allows it) — the engineering baseline that wins ties. A pool candidate
+/// that merely happens to use 24 dB/oct slopes is not conventional. Lower
+/// <see cref="TotalScore"/> is better; the list is returned best first.
 /// </summary>
 public sealed record RankedCrossoverProposal(
     IReadOnlyList<CrossoverProposal> Proposals,
@@ -468,6 +470,11 @@ public static class CrossoverAutoSetup
                 .ToArray();
         }
 
+        // Only the dedicated conventional run's candidate carries the flag —
+        // matched by signature, because a pool candidate that merely landed on
+        // all-24 dB/oct slopes (or a Butterworth/Bessel 24 mix) is not the
+        // LR24 baseline the tie preference is meant to protect.
+        string? conventionalSignature = conventional?.Signature;
         var ranked = pool
             .Select((candidate, index) =>
             {
@@ -477,7 +484,7 @@ public static class CrossoverAutoSetup
                     candidate.MagnitudeScore,
                     penalty,
                     candidate.MagnitudeScore + AchievabilityWeight * (penalty ?? 0),
-                    candidate.IsConventional24);
+                    candidate.Signature == conventionalSignature);
             })
             .OrderBy(candidate => candidate.TotalScore)
             .ToList();
@@ -628,7 +635,6 @@ public static class CrossoverAutoSetup
     internal sealed record PoolCandidate(
         IReadOnlyList<CrossoverProposal> Proposals,
         double MagnitudeScore,
-        bool IsConventional24,
         string Signature);
 
     /// <summary>
@@ -1017,9 +1023,11 @@ public static class CrossoverAutoSetup
         /// Runs the descent, then expands a pool of near-optimal states: per
         /// junction the best few (frequency, family, slope) options with the
         /// rest of the optimum fixed, crossed over the junctions (bounded),
-        /// each combination given one gain re-tune pass. Sorted by magnitude
-        /// score, deduplicated, at most <paramref name="poolSize"/> entries;
-        /// the descent winner is always included.
+        /// each combination given one gain re-tune pass. Combinations whose
+        /// junctions jointly land closer than the minimum separation are
+        /// rejected. Sorted by magnitude score, deduplicated, at most
+        /// <paramref name="poolSize"/> entries; the descent winner is always
+        /// included.
         /// </summary>
         public List<PoolCandidate> SolvePool(int poolSize)
         {
@@ -1034,8 +1042,7 @@ public static class CrossoverAutoSetup
                 string signature = SignatureOf(proposals);
                 if (seen.Add(signature))
                 {
-                    pool.Add(new PoolCandidate(
-                        proposals, Score(), IsConventional24(), signature));
+                    pool.Add(new PoolCandidate(proposals, Score(), signature));
                 }
             }
 
@@ -1091,6 +1098,14 @@ public static class CrossoverAutoSetup
             // full product exceeds the cap, the earliest (best-ranked) choices
             // are covered first.
             long combinations = Math.Min(totalCombinations, PoolMaxCombinations);
+            // Each junction's options were bounded against the descent optimum's
+            // NEIGHBOURS, so two junctions moved toward each other can jointly
+            // land closer than the minimum separation (or even swap order) —
+            // e.g. a peaked middle driver pulls both of its junctions inward.
+            // The small relative slack keeps float noise from rejecting a combo
+            // that sits exactly on a bound.
+            double minimumRatio =
+                Math.Pow(2.0, MinJunctionSeparationOctaves) * (1 - 1e-9);
             var indices = new int[junctions];
             for (long combo = 0; combo < combinations; combo++)
             {
@@ -1108,6 +1123,21 @@ public static class CrossoverAutoSetup
                     Set(j, choice.Family, choice.FrequencyHz, choice.LowerSlope, choice.UpperSlope);
                 }
 
+                bool separated = true;
+                for (int j = 1; j < junctions; j++)
+                {
+                    if (crossoverHz[j] < crossoverHz[j - 1] * minimumRatio)
+                    {
+                        separated = false;
+                        break;
+                    }
+                }
+
+                if (!separated)
+                {
+                    continue;
+                }
+
                 OptimizeGains();
                 Capture();
             }
@@ -1117,20 +1147,6 @@ public static class CrossoverAutoSetup
                 .OrderBy(candidate => candidate.MagnitudeScore)
                 .Take(poolSize)
                 .ToList();
-        }
-
-        private bool IsConventional24()
-        {
-            for (int j = 0; j < channelCount - 1; j++)
-            {
-                if (lowerSlope[j] != CrossoverSlopeDbPerOctave ||
-                    upperSlope[j] != CrossoverSlopeDbPerOctave)
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         private static string SignatureOf(IReadOnlyList<CrossoverProposal> proposals) =>

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -374,9 +374,8 @@ public static class CrossoverAutoSetup
         }
 
         options = Normalize(options);
-        IReadOnlyList<CrossoverProposal> proposals = options.IndependentSlopes
-            ? new Optimizer(channels, options).Solve()
-            : BestUniformSlopeCandidate(channels, options).Proposals;
+        IReadOnlyList<CrossoverProposal> proposals =
+            new Optimizer(channels, options).Solve();
 
         // The optimizer level-matched the drivers to flatten the sum, which is
         // right for choosing the crossovers but not the gains the user wants.
@@ -384,36 +383,6 @@ public static class CrossoverAutoSetup
         return ApplyTargetCurveGains(
             channels, proposals, options.SampleRateHz, options.SubElevationDb);
     }
-
-    // With independent slopes off, "matched" means ONE slope for the whole
-    // system: every junction (and both of its sides) uses the same dB/oct.
-    // A mixed 12/18 pair on one channel's two shoulders reads as broken to
-    // the user even though each junction is internally matched. Each
-    // feasible slope gets its own pinned descent; the best state wins.
-    private static PoolCandidate BestUniformSlopeCandidate(
-        IReadOnlyList<AutoSetupSource> channels,
-        CrossoverAutoSetupOptions options)
-    {
-        // Every family offers 24 dB/oct and slopes at or below the low-junction
-        // cap always pass the Capture guard, so at least one run produces a
-        // candidate.
-        return UniformSlopeCandidates(options.Families)
-            .Select(slope => new Optimizer(channels, options, forcedSlope: slope)
-                .SolvePool(1)
-                .FirstOrDefault())
-            .Where(candidate => candidate != null)
-            .MinBy(candidate => candidate!.MagnitudeScore)!;
-    }
-
-    // The system-wide slopes the matched-slopes mode may try: every practical
-    // slope some allowed family offers.
-    private static IReadOnlyList<int> UniformSlopeCandidates(
-        IReadOnlyList<CrossoverFilterFamily> families) =>
-        families
-            .SelectMany(PracticalSlopes)
-            .Distinct()
-            .OrderBy(slope => slope)
-            .ToList();
 
     // The slopes a family offers above the practical floor: an engineer does
     // not reach for a 6 dB/oct crossover — it protects nothing and leaves the
@@ -657,37 +626,7 @@ public static class CrossoverAutoSetup
         }
 
         options = Normalize(options);
-        List<PoolCandidate> pool;
-        if (options.IndependentSlopes)
-        {
-            pool = new Optimizer(channels, options).SolvePool(candidateCount);
-        }
-        else
-        {
-            // Matched slopes = one slope for the whole system (see
-            // BestUniformSlopeCandidate): one pinned pool per feasible slope,
-            // merged, so every candidate is internally uniform while the
-            // ranking still weighs the slopes against each other.
-            pool = new List<PoolCandidate>();
-            var poolSeen = new HashSet<string>();
-            foreach (int slope in UniformSlopeCandidates(options.Families))
-            {
-                foreach (PoolCandidate candidate in
-                    new Optimizer(channels, options, forcedSlope: slope)
-                        .SolvePool(candidateCount))
-                {
-                    if (poolSeen.Add(candidate.Signature))
-                    {
-                        pool.Add(candidate);
-                    }
-                }
-            }
-
-            pool = pool
-                .OrderBy(candidate => candidate.MagnitudeScore)
-                .Take(candidateCount)
-                .ToList();
-        }
+        List<PoolCandidate> pool = new Optimizer(channels, options).SolvePool(candidateCount);
 
         // The conventional candidate: every slope locked to 24 dB/oct,
         // Linkwitz-Riley when the user allows it — what an engineer reaches
@@ -1283,6 +1222,17 @@ public static class CrossoverAutoSetup
                     OptimizeJunction(j);
                 }
 
+                if (!options.IndependentSlopes)
+                {
+                    // Junction passes hold each channel's slope; this pass tunes
+                    // it (both shoulders together), so one driver never ends up
+                    // with a 12/18 split while the drivers still differ freely.
+                    for (int i = 0; i < channelCount; i++)
+                    {
+                        OptimizeChannelSlope(i);
+                    }
+                }
+
                 OptimizeGains();
 
                 double current = Score();
@@ -1313,20 +1263,6 @@ public static class CrossoverAutoSetup
             var seen = new HashSet<string>();
             void Capture()
             {
-                // A pinned steep slope can leave a low junction stranded at its
-                // seed frequency when no lattice point in its window allows the
-                // slope (AllowedSlopes empty) — such a state violates the
-                // low-junction cap and must not become a candidate.
-                for (int j = 0; j < channelCount - 1; j++)
-                {
-                    if (crossoverHz[j] < SteepSlopeMinimumJunctionHz &&
-                        (lowerSlope[j] > LowJunctionMaxSlopeDbPerOctave ||
-                            upperSlope[j] > LowJunctionMaxSlopeDbPerOctave))
-                    {
-                        return;
-                    }
-                }
-
                 NormalizeGainsCutOnly();
                 IReadOnlyList<CrossoverProposal> proposals = BuildProposals();
                 string signature = SignatureOf(proposals);
@@ -1454,15 +1390,6 @@ public static class CrossoverAutoSetup
         private void Initialize()
         {
             CrossoverFilterFamily family = PreferredFamily();
-            if (forcedSlope is int pinned && !PracticalSlopes(family).Contains(pinned))
-            {
-                // The preferred family may not offer the pinned slope (LR has
-                // no 18/36); seeding it anyway would ask CrossoverFilter for
-                // an unsupported cascade.
-                family = options.Families
-                    .FirstOrDefault(f => PracticalSlopes(f).Contains(pinned), family);
-            }
-
             int slope = forcedSlope ?? PreferredSlope(family);
             for (int j = 0; j < channelCount - 1; j++)
             {
@@ -1518,22 +1445,14 @@ public static class CrossoverAutoSetup
         private IReadOnlyList<int> AllowedSlopes(CrossoverFilterFamily family, double fcHz)
         {
             IReadOnlyList<int> slopes = PracticalSlopes(family);
-            if (fcHz < SteepSlopeMinimumJunctionHz)
-            {
-                // The group-delay cap binds the pinned runs too: a system-wide
-                // 36/48 dB/oct candidate is simply infeasible while it owns a
-                // junction below 300 Hz.
-                slopes = slopes
-                    .Where(slope => slope <= LowJunctionMaxSlopeDbPerOctave)
-                    .ToList();
-            }
-
             if (forcedSlope is int locked)
             {
                 return slopes.Contains(locked) ? [locked] : [];
             }
 
-            return slopes;
+            return fcHz < SteepSlopeMinimumJunctionHz
+                ? slopes.Where(slope => slope <= LowJunctionMaxSlopeDbPerOctave).ToList()
+                : slopes;
         }
 
         // Cut-only seed: bring every band down to the quietest, measured over the
@@ -1620,6 +1539,76 @@ public static class CrossoverAutoSetup
             Set(j, best.Family, best.FrequencyHz, best.LowerSlope, best.UpperSlope);
         }
 
+        // Channel i's single slope (both shoulders): its low-pass is the lower
+        // side of junction i, its high-pass the upper side of junction i-1.
+        private int ChannelSlope(int i) =>
+            i < channelCount - 1 ? lowerSlope[i] : upperSlope[i - 1];
+
+        // Writes one slope to both of channel i's shoulders, keeping the
+        // per-channel invariant (upperSlope[i-1] == lowerSlope[i]).
+        private void SetChannelSlope(int i, int slope)
+        {
+            if (i < channelCount - 1)
+            {
+                lowerSlope[i] = slope;
+            }
+
+            if (i > 0)
+            {
+                upperSlope[i - 1] = slope;
+            }
+        }
+
+        // The slopes channel i may take: allowed at every junction it touches
+        // (each junction's family and the low-frequency cap). An outer channel
+        // has one junction; an interior channel must satisfy both, so a slope
+        // one family offers but the neighbour's does not is excluded.
+        private IReadOnlyList<int> AllowedChannelSlopes(int i)
+        {
+            List<int>? allowed = null;
+            void Intersect(int junction)
+            {
+                IReadOnlyList<int> slopes =
+                    AllowedSlopes(junctionFamily[junction], crossoverHz[junction]);
+                allowed = allowed == null
+                    ? slopes.ToList()
+                    : allowed.Where(slopes.Contains).ToList();
+            }
+
+            if (i > 0)
+            {
+                Intersect(i - 1);
+            }
+
+            if (i < channelCount - 1)
+            {
+                Intersect(i);
+            }
+
+            return allowed ?? [];
+        }
+
+        // Coordinate step for one channel's slope (independent slopes off): the
+        // low-pass and high-pass move together, so the two shoulders can never
+        // disagree. Different channels remain free to pick different slopes.
+        private void OptimizeChannelSlope(int i)
+        {
+            int best = ChannelSlope(i);
+            double bestScore = Score();
+            foreach (int slope in AllowedChannelSlopes(i))
+            {
+                SetChannelSlope(i, slope);
+                double score = Score();
+                if (score < bestScore - 1e-9)
+                {
+                    bestScore = score;
+                    best = slope;
+                }
+            }
+
+            SetChannelSlope(i, best);
+        }
+
         internal readonly record struct JunctionOption(
             CrossoverFilterFamily Family,
             double FrequencyHz,
@@ -1627,10 +1616,13 @@ public static class CrossoverAutoSetup
             int UpperSlope,
             double Score);
 
-        // Scores every (lattice frequency × family × allowed slopes) choice for
-        // junction j with the rest of the state fixed. Shared by the descent
-        // (which keeps the minimum) and the ranked search's candidate pool
-        // (which keeps the top few). Restores the junction state afterward.
+        // Scores the (lattice frequency × family × slope) choices for junction j
+        // with the rest of the state fixed. With independent slopes ON, both
+        // sides of the junction are free. With it OFF, the slope is a property of
+        // the CHANNEL (its two shoulders share one slope, tuned separately in
+        // OptimizeChannelSlope), so the junction only varies frequency and
+        // family here and holds its two channels' current slopes — a family that
+        // cannot supply either held slope is skipped. Restores state afterward.
         private IEnumerable<JunctionOption> EnumerateJunctionOptions(
             int j,
             double low,
@@ -1647,9 +1639,9 @@ public static class CrossoverAutoSetup
                     foreach (CrossoverFilterFamily family in options.Families)
                     {
                         IReadOnlyList<int> slopes = AllowedSlopes(family, fc);
-                        foreach (int lower in slopes)
+                        if (options.IndependentSlopes)
                         {
-                            if (options.IndependentSlopes)
+                            foreach (int lower in slopes)
                             {
                                 foreach (int upper in slopes)
                                 {
@@ -1658,12 +1650,12 @@ public static class CrossoverAutoSetup
                                         family, fc, lower, upper, Score());
                                 }
                             }
-                            else
-                            {
-                                Set(j, family, fc, lower, lower);
-                                yield return new JunctionOption(
-                                    family, fc, lower, lower, Score());
-                            }
+                        }
+                        else if (slopes.Contains(savedLower) && slopes.Contains(savedUpper))
+                        {
+                            Set(j, family, fc, savedLower, savedUpper);
+                            yield return new JunctionOption(
+                                family, fc, savedLower, savedUpper, Score());
                         }
                     }
                 }

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -498,25 +498,10 @@ public static class CrossoverAutoSetup
 
     // The channels' measured IRs cut to one shared direct-sound window: the
     // post-check only ever evaluates the gated direct sound, so the candidate
-    // chains do not need the full capture. One shared offset keeps the
-    // inter-channel timing intact (verified bit-identical junction losses
-    // against full-length IRs on real measurements).
-    private static Complex[][] CropSharedDirectSoundWindow(Complex[][] impulseResponses)
-    {
-        int earliestPeak = impulseResponses.Min(VirtualCrossoverAnalysis.FindPeakIndex);
-        int start = Math.Max(0, earliestPeak - PostCheckCropPrePeakSamples);
-        var cropped = new Complex[impulseResponses.Length][];
-        for (int channel = 0; channel < impulseResponses.Length; channel++)
-        {
-            Complex[] ir = impulseResponses[channel];
-            int length = Math.Clamp(ir.Length - start, 1, PostCheckCropLength);
-            var slice = new Complex[length];
-            Array.Copy(ir, Math.Min(start, ir.Length - 1), slice, 0, length);
-            cropped[channel] = slice;
-        }
-
-        return cropped;
-    }
+    // chains do not need the full capture.
+    private static Complex[][] CropSharedDirectSoundWindow(Complex[][] impulseResponses) =>
+        VirtualCrossoverAnalysis.CropSharedDirectSoundWindow(
+            impulseResponses, PostCheckCropLength, PostCheckCropPrePeakSamples);
 
     // The raw channel's band-limited arrival in the given SHARED junction
     // band, cached across candidates. Arrivals from different measuring bands

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace Resonalyze.Dsp;
 
 /// <summary>
@@ -40,6 +42,22 @@ public sealed record CrossoverProposal(
     double GainDb);
 
 /// <summary>
+/// One entry of the ranked wizard search: the per-channel proposals plus the
+/// scores that ranked it. <see cref="AchievabilityPenaltyDb"/> is the summed
+/// dip-penalized junction loss remaining after the best per-junction delay
+/// (measured on the impulse responses; null when no IRs were provided), and
+/// <see cref="IsConventional24"/> marks the all-24 dB/oct candidate that wins
+/// ties. Lower <see cref="TotalScore"/> is better; the list is returned best
+/// first.
+/// </summary>
+public sealed record RankedCrossoverProposal(
+    IReadOnlyList<CrossoverProposal> Proposals,
+    double MagnitudeScore,
+    double? AchievabilityPenaltyDb,
+    double TotalScore,
+    bool IsConventional24);
+
+/// <summary>
 /// The choices the crossover wizard asks for before optimizing: which filter
 /// families the optimizer may pick from, the frequency window crossovers must
 /// fall inside, and whether the two sides of a junction may take different
@@ -75,11 +93,13 @@ public sealed record CrossoverAutoSetupOptions(
 /// <para>
 /// <see cref="Propose"/> searches per-junction crossover frequency, filter
 /// family and slope, plus per-channel cut-only gain, to make the summed magnitude
-/// response as flat as the drivers allow. The junctions are summed the way each
-/// family behaves acoustically once the alignment step has done its job: a
-/// Linkwitz-Riley or Bessel handover (both drivers roughly in phase at the corner)
-/// is an amplitude sum, a Butterworth handover (the drivers in quadrature) a power
-/// sum. That is what lets the optimizer compare families honestly.
+/// response as flat as the drivers allow. Channels are combined as a plain
+/// amplitude sum everywhere — the consistent expression of the design assumption
+/// that the later alignment step brings the junction to zero sum loss. How
+/// realistic that assumption is for a particular candidate is judged separately:
+/// <see cref="ProposeRanked"/> re-ranks the top candidates by the loss actually
+/// achievable after the best per-junction delay, measured on the channels'
+/// impulse responses with the production alignment search.
 /// </para>
 /// </summary>
 public static class CrossoverAutoSetup
@@ -96,10 +116,20 @@ public static class CrossoverAutoSetup
 
     private const int CrossoverSlopeDbPerOctave = 24;
 
-    // The log-frequency grid the optimizer scores flatness on, and the search
-    // resolution for each junction's crossover frequency.
+    /// <summary>
+    /// Below this junction frequency, slopes steeper than
+    /// <see cref="LowJunctionMaxSlopeDbPerOctave"/> are excluded from the
+    /// search: a steep low-frequency crossover carries a large group delay
+    /// (many periods of ringing at an already-long period), which is far more
+    /// audible than the protection it buys.
+    /// </summary>
+    public const double SteepSlopeMinimumJunctionHz = 300;
+
+    /// <summary>The steepest slope allowed for junctions below <see cref="SteepSlopeMinimumJunctionHz"/>.</summary>
+    public const int LowJunctionMaxSlopeDbPerOctave = 24;
+
+    // The log-frequency grid the optimizer scores flatness on.
     private const int GridPointsPerOctave = 24;
-    private const int CrossoverGridSteps = 21;
 
     // Adjacent crossovers keep at least this separation so a three-way search
     // cannot collapse two junctions onto the same frequency.
@@ -118,6 +148,88 @@ public static class CrossoverAutoSetup
     // A narrow suckout is far more audible than the same energy spread as ripple,
     // so the deepest dip below the mean is added to the RMS flatness score.
     private const double DipPenaltyWeight = 0.5;
+
+    // Ranked search (ProposeRanked): per junction this many of the best
+    // (frequency, family, slope) options seed the candidate pool; their cross
+    // combinations are scored (bounded) and the top of the pool goes to the
+    // impulse-response post-check.
+    private const int PoolOptionsPerJunction = 4;
+    private const int PoolMaxCombinations = 512;
+
+    // The achievability post-check works on the gated direct sound, so the
+    // chains run on a shared crop of the measured IRs instead of the full
+    // capture (verified against full-length IRs on real measurements: the
+    // 4096-sample evaluation gate sits at the shared peak anchor, so the crop
+    // does not change the junction losses).
+    private const int PostCheckCropLength = 32_768;
+    private const int PostCheckCropPrePeakSamples = 8_192;
+
+    // Per junction the alignment search runs in a window around the RAW
+    // channels' band-limited arrival difference (computed once — it is
+    // candidate-independent). The half-window absorbs the filter group delay
+    // any candidate can add, which scales as 1/fc (an LR24 at 40 Hz rings for
+    // ~10 ms, at 4 kHz for ~0.1 ms), so the window shrinks with the junction
+    // frequency — a wide window at a high junction would cost thousands of
+    // probe deltas across its short periods for nothing. A junction where the
+    // search finds no candidate at all is scored with a flat penalty instead
+    // of silently winning by absence.
+    private const double PostCheckWindowGroupDelayScaleHz = 1_200;
+    private const double PostCheckMinHalfWindowMs = 2.0;
+    private const double PostCheckMaxHalfWindowMs = 12.0;
+    private const double PostCheckMissingJunctionPenaltyDb = 6.0;
+
+    private static double PostCheckHalfWindowMs(double junctionHz) =>
+        Math.Clamp(
+            PostCheckWindowGroupDelayScaleHz / junctionHz,
+            PostCheckMinHalfWindowMs,
+            PostCheckMaxHalfWindowMs);
+
+    // How strongly the achievable post-alignment loss weighs against the
+    // magnitude flatness score in the final ranking, and how much worse (dB)
+    // a challenger must be before it loses to the conventional all-24 dB/oct
+    // candidate.
+    private const double AchievabilityWeight = 0.5;
+    private const double Conventional24PreferenceDb = 0.25;
+
+    /// <summary>
+    /// Snaps a crossover frequency to the lattice the wizard proposes on:
+    /// 5 Hz steps below 100 Hz, 10 Hz steps below 1 kHz, 50 Hz steps above.
+    /// The optimizer searches directly on this lattice, so the scored
+    /// frequency IS the proposed frequency.
+    /// </summary>
+    public static double RoundToLattice(double frequencyHz)
+    {
+        double step = LatticeStep(frequencyHz);
+        return Math.Max(20, Math.Round(frequencyHz / step) * step);
+    }
+
+    private static double LatticeStep(double frequencyHz) =>
+        frequencyHz < 100 ? 5 : frequencyHz < 1_000 ? 10 : 50;
+
+    // Every lattice frequency inside [low, high]; a window narrower than one
+    // lattice step collapses to its clamped, snapped midpoint so degenerate
+    // junction bounds still yield exactly one probe.
+    private static double[] LatticePoints(double low, double high)
+    {
+        var points = new List<double>();
+        double f = RoundToLattice(low);
+        if (f < low)
+        {
+            f += LatticeStep(f);
+        }
+        while (f <= high + 1e-9)
+        {
+            points.Add(f);
+            f += LatticeStep(f);
+        }
+
+        if (points.Count == 0)
+        {
+            points.Add(Math.Clamp(RoundToLattice(Math.Sqrt(low * high)), low, high));
+        }
+
+        return points.ToArray();
+    }
 
     // Pure magnitude flatness is blind to band overlap: shallow filters let
     // adjacent drivers overlap widely, which averages out each other's ripple and
@@ -256,11 +368,265 @@ public static class CrossoverAutoSetup
     }
 
     /// <summary>
+    /// The ranked wizard search: expands a pool of up to
+    /// <paramref name="candidateCount"/> near-optimal candidates (always
+    /// including a conventional all-24 dB/oct one), and — when the channels'
+    /// measured impulse responses are provided in the same order — re-ranks
+    /// them by the junction loss actually achievable after the best
+    /// per-junction delay, using the production alignment search on a shared
+    /// crop of the IRs. The conventional candidate wins unless a challenger
+    /// beats it by more than a small margin. Returns the candidates best
+    /// first; <c>[0].Proposals</c> is the recommended setup.
+    /// </summary>
+    public static IReadOnlyList<RankedCrossoverProposal> ProposeRanked(
+        IReadOnlyList<AutoSetupSource> channels,
+        CrossoverAutoSetupOptions options,
+        IReadOnlyList<Complex[]>? impulseResponses = null,
+        int candidateCount = 50)
+    {
+        ArgumentNullException.ThrowIfNull(channels);
+        ArgumentNullException.ThrowIfNull(options);
+        if (channels.Count < 2)
+        {
+            throw new ArgumentException(
+                "At least two channels are required.",
+                nameof(channels));
+        }
+        if (channels.Select(channel => channel.Type).Distinct().Count() != channels.Count)
+        {
+            throw new ArgumentException(
+                "Every channel needs a distinct driver type.",
+                nameof(channels));
+        }
+        if (impulseResponses != null &&
+            (impulseResponses.Count != channels.Count ||
+                impulseResponses.Any(ir => ir == null || ir.Length == 0)))
+        {
+            throw new ArgumentException(
+                "One non-empty impulse response is required per channel.",
+                nameof(impulseResponses));
+        }
+        if (candidateCount < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(candidateCount));
+        }
+
+        options = Normalize(options);
+        List<PoolCandidate> pool = new Optimizer(channels, options)
+            .SolvePool(candidateCount);
+
+        // The conventional candidate: every slope locked to 24 dB/oct,
+        // Linkwitz-Riley when the user allows it — what an engineer reaches
+        // for first, and the reference the challengers must beat.
+        CrossoverAutoSetupOptions conventionalOptions =
+            options.Families.Contains(CrossoverFilterFamily.LinkwitzRiley)
+                ? options with { Families = [CrossoverFilterFamily.LinkwitzRiley] }
+                : options;
+        PoolCandidate? conventional = new Optimizer(
+            channels, conventionalOptions, forcedSlope: CrossoverSlopeDbPerOctave)
+            .SolvePool(1)
+            .FirstOrDefault();
+        if (conventional != null &&
+            !pool.Any(entry => entry.Signature == conventional.Signature))
+        {
+            pool.Add(conventional);
+        }
+        pool = pool.OrderBy(candidate => candidate.MagnitudeScore).ToList();
+        if (pool.Count > candidateCount)
+        {
+            bool conventionalKept = conventional == null ||
+                pool.Take(candidateCount)
+                    .Any(entry => entry.Signature == conventional.Signature);
+            pool = pool.Take(candidateCount).ToList();
+            if (!conventionalKept)
+            {
+                // The conventional reference must always reach the post-check;
+                // it replaces the worst pool entry when truncation dropped it.
+                pool[^1] = conventional!;
+            }
+        }
+
+        double[]? penalties = null;
+        if (impulseResponses != null)
+        {
+            int sampleRate = (int)Math.Round(options.SampleRateHz);
+            int[] orderedIndex = Enumerable.Range(0, channels.Count)
+                .OrderBy(index => channels[index].Type)
+                .ToArray();
+            Complex[][] cropped = CropSharedDirectSoundWindow(
+                orderedIndex.Select(index => impulseResponses[index]).ToArray());
+            double[] junctionCenters = RawJunctionArrivalCentersMs(
+                cropped,
+                orderedIndex.Select(index => channels[index].MagnitudeDb).ToArray(),
+                sampleRate);
+            penalties = pool
+                .AsParallel().AsOrdered()
+                .Select(candidate => AchievabilityPenaltyDb(
+                    cropped,
+                    orderedIndex.Select(index => candidate.Proposals[index]).ToArray(),
+                    junctionCenters,
+                    sampleRate))
+                .ToArray();
+        }
+
+        var ranked = pool
+            .Select((candidate, index) =>
+            {
+                double? penalty = penalties?[index];
+                return new RankedCrossoverProposal(
+                    candidate.Proposals,
+                    candidate.MagnitudeScore,
+                    penalty,
+                    candidate.MagnitudeScore + AchievabilityWeight * (penalty ?? 0),
+                    candidate.IsConventional24);
+            })
+            .OrderBy(candidate => candidate.TotalScore)
+            .ToList();
+
+        // Ties (within the preference margin) go to the conventional candidate.
+        RankedCrossoverProposal? preferred = ranked
+            .FirstOrDefault(candidate => candidate.IsConventional24);
+        if (preferred != null &&
+            !ReferenceEquals(ranked[0], preferred) &&
+            preferred.TotalScore <= ranked[0].TotalScore + Conventional24PreferenceDb)
+        {
+            ranked.Remove(preferred);
+            ranked.Insert(0, preferred);
+        }
+
+        return ranked;
+    }
+
+    // The channels' measured IRs cut to one shared direct-sound window: the
+    // post-check only ever evaluates the gated direct sound, so the candidate
+    // chains do not need the full capture. One shared offset keeps the
+    // inter-channel timing intact (verified bit-identical junction losses
+    // against full-length IRs on real measurements).
+    private static Complex[][] CropSharedDirectSoundWindow(Complex[][] impulseResponses)
+    {
+        int earliestPeak = impulseResponses.Min(VirtualCrossoverAnalysis.FindPeakIndex);
+        int start = Math.Max(0, earliestPeak - PostCheckCropPrePeakSamples);
+        var cropped = new Complex[impulseResponses.Length][];
+        for (int channel = 0; channel < impulseResponses.Length; channel++)
+        {
+            Complex[] ir = impulseResponses[channel];
+            int length = Math.Clamp(ir.Length - start, 1, PostCheckCropLength);
+            var slice = new Complex[length];
+            Array.Copy(ir, Math.Min(start, ir.Length - 1), slice, 0, length);
+            cropped[channel] = slice;
+        }
+
+        return cropped;
+    }
+
+    // The search-window center per junction: the raw channels' band-limited
+    // arrival difference in each driver's OWN band, computed once for all
+    // candidates (a per-candidate arrival analysis was the dominant cost of
+    // the post-check — the Hilbert envelope per candidate per junction cost
+    // more than every alignment search combined).
+    private static double[] RawJunctionArrivalCentersMs(
+        Complex[][] croppedOrdered,
+        IReadOnlyList<SignalPoint>[] orderedCurves,
+        int sampleRate)
+    {
+        var arrivals = new double[croppedOrdered.Length];
+        var valid = new bool[croppedOrdered.Length];
+        for (int channel = 0; channel < croppedOrdered.Length; channel++)
+        {
+            DriverBandEstimate band = EstimateBand(orderedCurves[channel]);
+            TimeAlignmentAnalysisResult arrival =
+                VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                    croppedOrdered[channel], sampleRate, band.LowHz, band.HighHz);
+            arrivals[channel] = arrival.FirstArrivalDelayMilliseconds;
+            valid[channel] = arrival.IsValid;
+        }
+
+        var centers = new double[Math.Max(0, croppedOrdered.Length - 1)];
+        for (int j = 0; j < centers.Length; j++)
+        {
+            centers[j] = valid[j] && valid[j + 1]
+                ? arrivals[j] - arrivals[j + 1]
+                : 0;
+        }
+
+        return centers;
+    }
+
+    // The summed dip-penalized loss (positive dB, 0 = perfect handovers) that
+    // remains after the BEST per-junction delay for this candidate: each
+    // channel is processed with the candidate's filters and gain, then every
+    // adjacent junction runs the production alignment search in a window
+    // around the raw channels' arrival difference.
+    private static double AchievabilityPenaltyDb(
+        Complex[][] croppedOrdered,
+        CrossoverProposal[] orderedProposals,
+        double[] junctionCenters,
+        int sampleRate)
+    {
+        var processed = new Complex[croppedOrdered.Length][];
+        for (int channel = 0; channel < croppedOrdered.Length; channel++)
+        {
+            CrossoverProposal proposal = orderedProposals[channel];
+            processed[channel] = VirtualCrossoverAnalysis.ApplyChain(
+                croppedOrdered[channel],
+                new DspChannelChain(
+                    GainDb: proposal.GainDb,
+                    Crossover: new CrossoverSpec(
+                        proposal.Kind,
+                        proposal.LowPassEdge,
+                        proposal.HighPassEdge)),
+                sampleRate);
+        }
+
+        double penalty = 0;
+        for (int j = 0; j < processed.Length - 1; j++)
+        {
+            double? lowPassHz = orderedProposals[j].LowPassEdge?.FrequencyHz;
+            double? highPassHz = orderedProposals[j + 1].HighPassEdge?.FrequencyHz;
+            if (lowPassHz is not { } lp || highPassHz is not { } hp)
+            {
+                continue;
+            }
+
+            double bandLow = Math.Max(20, Math.Min(lp, hp) / 2);
+            double bandHigh = Math.Min(20_000, Math.Max(lp, hp) * 2);
+            double center = junctionCenters[j];
+            double halfWindow = PostCheckHalfWindowMs(Math.Min(lp, hp));
+
+            IReadOnlyList<AlignmentCandidate> found =
+                VirtualCrossoverAnalysis.FindAlignmentCandidates(
+                    processed[j + 1],
+                    [processed[j]],
+                    sampleRate,
+                    bandLow,
+                    bandHigh,
+                    center - halfWindow,
+                    center + halfWindow);
+            if (found.Count == 0)
+            {
+                penalty += PostCheckMissingJunctionPenaltyDb;
+                continue;
+            }
+
+            AlignmentCandidate best = found[0];
+            penalty += -(best.LossDb + DipPenaltyWeight * (best.DipDb - best.LossDb));
+        }
+
+        return penalty;
+    }
+
+    /// <summary>One entry of the optimizer's candidate pool.</summary>
+    internal sealed record PoolCandidate(
+        IReadOnlyList<CrossoverProposal> Proposals,
+        double MagnitudeScore,
+        bool IsConventional24,
+        string Signature);
+
+    /// <summary>
     /// The magnitude-domain summed response the wizard predicts for a proposal,
-    /// on the optimizer's own log grid. Each junction is combined the way its
-    /// family sums (amplitude for Linkwitz-Riley/Bessel, power for Butterworth),
-    /// so this is exactly the curve the optimizer scored. Used for the live
-    /// preview and by the tests.
+    /// on the optimizer's own log grid: a plain amplitude sum of the filtered
+    /// channels — exactly the curve the optimizer scored, under the same
+    /// ideal-alignment assumption. Used for the live preview and by the tests.
     /// </summary>
     public static IReadOnlyList<SignalPoint> SummedResponseDb(
         IReadOnlyList<AutoSetupSource> channels,
@@ -280,45 +646,26 @@ public static class CrossoverAutoSetup
             throw new ArgumentOutOfRangeException(nameof(sampleRateHz));
         }
 
-        var ordered = channels
-            .Select((channel, index) => (Channel: channel, Proposal: proposals[index]))
-            .OrderBy(item => item.Channel.Type)
-            .ToList();
         double[] grid = BuildGrid(sampleRateHz);
-
         double[] combined = new double[grid.Length];
-        bool first = true;
-        foreach ((AutoSetupSource channel, CrossoverProposal proposal) in ordered)
+        for (int channel = 0; channel < channels.Count; channel++)
         {
+            CrossoverProposal proposal = proposals[channel];
             double gainLinear = DataHelper.DecibelsToAmplitude(proposal.GainDb);
             var spec = new CrossoverSpec(
                 proposal.Kind,
                 proposal.LowPassEdge,
                 proposal.HighPassEdge);
-            bool power = proposal.HighPassEdge?.Family == CrossoverFilterFamily.Butterworth;
             for (int k = 0; k < grid.Length; k++)
             {
-                double driverDb = InterpolateDb(channel.MagnitudeDb, grid[k]);
-                double amplitude = double.IsFinite(driverDb)
-                    ? gainLinear
+                double driverDb = InterpolateDb(channels[channel].MagnitudeDb, grid[k]);
+                if (double.IsFinite(driverDb))
+                {
+                    combined[k] += gainLinear
                         * DataHelper.DecibelsToAmplitude(driverDb)
-                        * CrossoverFilter.Response(spec, grid[k], sampleRateHz).Magnitude
-                    : 0;
-                if (first)
-                {
-                    combined[k] = amplitude;
-                }
-                else if (power)
-                {
-                    combined[k] = Math.Sqrt(combined[k] * combined[k] + amplitude * amplitude);
-                }
-                else
-                {
-                    combined[k] += amplitude;
+                        * CrossoverFilter.Response(spec, grid[k], sampleRateHz).Magnitude;
                 }
             }
-
-            first = false;
         }
 
         var result = new SignalPoint[grid.Length];
@@ -517,12 +864,29 @@ public static class CrossoverAutoSetup
         private readonly int[] lowerSlope;
         private readonly int[] upperSlope;
 
+        // When set, every junction is locked to this slope (the conventional
+        // all-24 dB/oct candidate of the ranked search).
+        private readonly int? forcedSlope;
+
         private readonly Dictionary<(CrossoverFilterFamily, int, long, bool), double[]> magnitudeCache =
             new();
 
-        public Optimizer(IReadOnlyList<AutoSetupSource> channels, CrossoverAutoSetupOptions options)
+        // Unit-gain channel amplitudes (driver × its current edges, gain
+        // excluded) keyed by the edge choice, plus scratch buffers: scoring a
+        // trial allocates nothing, and the lattice-stable frequencies make the
+        // cache hit on almost every probe after the first pass.
+        private readonly Dictionary<(int Channel, long HighPassKey, long LowPassKey), double[]> unitCache =
+            new();
+        private readonly double[][] scratchUnits;
+        private readonly double[] scratchCombined;
+
+        public Optimizer(
+            IReadOnlyList<AutoSetupSource> channels,
+            CrossoverAutoSetupOptions options,
+            int? forcedSlope = null)
         {
             this.options = options;
+            this.forcedSlope = forcedSlope;
             channelCount = channels.Count;
 
             var ordered = channels
@@ -605,9 +969,18 @@ public static class CrossoverAutoSetup
             junctionFamily = new CrossoverFilterFamily[channelCount - 1];
             lowerSlope = new int[channelCount - 1];
             upperSlope = new int[channelCount - 1];
+            scratchUnits = new double[channelCount][];
+            scratchCombined = new double[grid.Length];
         }
 
         public IReadOnlyList<CrossoverProposal> Solve()
+        {
+            Descend();
+            NormalizeGainsCutOnly();
+            return BuildProposals();
+        }
+
+        private void Descend()
         {
             Initialize();
 
@@ -629,20 +1002,150 @@ public static class CrossoverAutoSetup
 
                 previous = current;
             }
-
-            NormalizeGainsCutOnly();
-            return BuildProposals();
         }
+
+        /// <summary>
+        /// Runs the descent, then expands a pool of near-optimal states: per
+        /// junction the best few (frequency, family, slope) options with the
+        /// rest of the optimum fixed, crossed over the junctions (bounded),
+        /// each combination given one gain re-tune pass. Sorted by magnitude
+        /// score, deduplicated, at most <paramref name="poolSize"/> entries;
+        /// the descent winner is always included.
+        /// </summary>
+        public List<PoolCandidate> SolvePool(int poolSize)
+        {
+            Descend();
+
+            var pool = new List<PoolCandidate>();
+            var seen = new HashSet<string>();
+            void Capture()
+            {
+                NormalizeGainsCutOnly();
+                IReadOnlyList<CrossoverProposal> proposals = BuildProposals();
+                string signature = SignatureOf(proposals);
+                if (seen.Add(signature))
+                {
+                    pool.Add(new PoolCandidate(
+                        proposals, Score(), IsConventional24(), signature));
+                }
+            }
+
+            Capture();
+            if (poolSize <= 1)
+            {
+                return pool;
+            }
+
+            int junctions = channelCount - 1;
+            var junctionChoices = new List<JunctionOption>[junctions];
+            for (int j = 0; j < junctions; j++)
+            {
+                (double low, double high) = JunctionSearchBounds(j);
+                junctionChoices[j] = EnumerateJunctionOptions(j, low, high)
+                    .GroupBy(option =>
+                        (option.Family, option.FrequencyHz, option.LowerSlope, option.UpperSlope))
+                    .Select(group => group.First())
+                    .OrderBy(option => option.Score)
+                    .Take(PoolOptionsPerJunction)
+                    .ToList();
+                if (junctionChoices[j].Count == 0)
+                {
+                    junctionChoices[j] =
+                    [
+                        new JunctionOption(
+                            junctionFamily[j], crossoverHz[j], lowerSlope[j], upperSlope[j], 0)
+                    ];
+                }
+            }
+
+            var savedGains = (double[])gainDb.Clone();
+            var savedFc = (double[])crossoverHz.Clone();
+            var savedFamilies = (CrossoverFilterFamily[])junctionFamily.Clone();
+            var savedLower = (int[])lowerSlope.Clone();
+            var savedUpper = (int[])upperSlope.Clone();
+            void Restore()
+            {
+                savedGains.CopyTo(gainDb, 0);
+                savedFc.CopyTo(crossoverHz, 0);
+                savedFamilies.CopyTo(junctionFamily, 0);
+                savedLower.CopyTo(lowerSlope, 0);
+                savedUpper.CopyTo(upperSlope, 0);
+            }
+
+            long totalCombinations = 1;
+            foreach (List<JunctionOption> choices in junctionChoices)
+            {
+                totalCombinations *= choices.Count;
+            }
+
+            // Mixed-radix enumeration over the per-junction choices; when the
+            // full product exceeds the cap, the earliest (best-ranked) choices
+            // are covered first.
+            long combinations = Math.Min(totalCombinations, PoolMaxCombinations);
+            var indices = new int[junctions];
+            for (long combo = 0; combo < combinations; combo++)
+            {
+                long remainder = combo;
+                for (int j = 0; j < junctions; j++)
+                {
+                    indices[j] = (int)(remainder % junctionChoices[j].Count);
+                    remainder /= junctionChoices[j].Count;
+                }
+
+                Restore();
+                for (int j = 0; j < junctions; j++)
+                {
+                    JunctionOption choice = junctionChoices[j][indices[j]];
+                    Set(j, choice.Family, choice.FrequencyHz, choice.LowerSlope, choice.UpperSlope);
+                }
+
+                OptimizeGains();
+                Capture();
+            }
+
+            Restore();
+            return pool
+                .OrderBy(candidate => candidate.MagnitudeScore)
+                .Take(poolSize)
+                .ToList();
+        }
+
+        private bool IsConventional24()
+        {
+            for (int j = 0; j < channelCount - 1; j++)
+            {
+                if (lowerSlope[j] != CrossoverSlopeDbPerOctave ||
+                    upperSlope[j] != CrossoverSlopeDbPerOctave)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static string SignatureOf(IReadOnlyList<CrossoverProposal> proposals) =>
+            string.Join(
+                "|",
+                proposals.Select(proposal =>
+                    $"{proposal.Kind}:{Describe(proposal.HighPassEdge)}:" +
+                    $"{Describe(proposal.LowPassEdge)}:{proposal.GainDb:0.0}"));
+
+        private static string Describe(CrossoverEdge? edge) =>
+            edge is { } value
+                ? $"{value.Family}/{value.FrequencyHz:0}/{value.SlopeDbPerOctave}"
+                : "-";
 
         private void Initialize()
         {
             CrossoverFilterFamily family = PreferredFamily();
-            int slope = PreferredSlope(family);
+            int slope = forcedSlope ?? PreferredSlope(family);
             for (int j = 0; j < channelCount - 1; j++)
             {
                 double fc = ProposeCrossoverFrequency(
                     curves[j], bands[j], types[j], curves[j + 1], bands[j + 1], types[j + 1]);
-                crossoverHz[j] = Math.Clamp(fc, options.MinCrossoverHz, options.MaxCrossoverHz);
+                crossoverHz[j] = Math.Clamp(
+                    RoundToLattice(fc), options.MinCrossoverHz, options.MaxCrossoverHz);
                 junctionFamily[j] = family;
                 lowerSlope[j] = slope;
                 upperSlope[j] = slope;
@@ -692,6 +1195,23 @@ public static class CrossoverAutoSetup
                 .Where(slope => slope >= MinPracticalSlopeDbPerOctave)
                 .ToList();
 
+        // The slopes the search may actually try at this junction frequency:
+        // the family's practical slopes, capped at 24 dB/oct below
+        // SteepSlopeMinimumJunctionHz (group delay), or pinned to the forced
+        // slope of the conventional-candidate run.
+        private IReadOnlyList<int> AllowedSlopes(CrossoverFilterFamily family, double fcHz)
+        {
+            IReadOnlyList<int> slopes = PracticalSlopes(family);
+            if (forcedSlope is int locked)
+            {
+                return slopes.Contains(locked) ? [locked] : [];
+            }
+
+            return fcHz < SteepSlopeMinimumJunctionHz
+                ? slopes.Where(slope => slope <= LowJunctionMaxSlopeDbPerOctave).ToList()
+                : slopes;
+        }
+
         // Cut-only seed: bring every band down to the quietest, measured over the
         // band it will actually cover with the seeded crossovers.
         private void InitializeGains()
@@ -717,20 +1237,19 @@ public static class CrossoverAutoSetup
             }
         }
 
-        private void OptimizeJunction(int j)
+        // The frequency window junction j may search: where both of its drivers
+        // actually produce output (inside the requested window), constrained to
+        // a band sensible for BOTH driver classes when their ranges overlap (a
+        // woofer must not cross up in its roll-off skirt at 850 Hz), and
+        // separated from the neighbouring junctions. Crossed bounds (an
+        // over-tight user window, a measured/class conflict, or neighbour
+        // separation) collapse to one sensible pinned frequency.
+        private (double Low, double High) JunctionSearchBounds(int j)
         {
-            // Keep the handover where both of its drivers actually produce output
-            // (inside the requested window), and separated from the neighbouring
-            // junctions.
             double separation = Math.Pow(2.0, MinJunctionSeparationOctaves);
             double low = Math.Max(options.MinCrossoverHz, bands[j + 1].LowHz);
             double high = Math.Min(options.MaxCrossoverHz, bands[j].HighHz);
 
-            // Constrain the handover to a band sensible for BOTH driver classes
-            // when their ranges overlap — a woofer must not cross up in its
-            // roll-off skirt at 850 Hz. Adjacent classes that do not overlap (e.g.
-            // a 2-way woofer + tweeter with no midrange between them) have no such
-            // band, so the measured overlap stands.
             (double typeLow, double typeHigh) = JunctionTypeBounds(types[j], types[j + 1]);
             if (typeLow <= typeHigh)
             {
@@ -750,10 +1269,6 @@ public static class CrossoverAutoSetup
 
             if (high < low)
             {
-                // Bounds crossed (an over-tight user window, a measured/class
-                // conflict, or neighbour separation): collapse to one sensible
-                // frequency — the class band's center when the classes overlap,
-                // otherwise the current seed — clamped to the requested window.
                 double pinned = typeLow <= typeHigh
                     ? Math.Sqrt(typeLow * typeHigh)
                     : crossoverHz[j];
@@ -761,55 +1276,78 @@ public static class CrossoverAutoSetup
                     pinned, options.MinCrossoverHz, options.MaxCrossoverHz);
             }
 
-            double[] fcGrid = LogSpace(low, high, CrossoverGridSteps);
+            return (low, high);
+        }
 
-            CrossoverFilterFamily bestFamily = junctionFamily[j];
-            int bestLower = lowerSlope[j];
-            int bestUpper = upperSlope[j];
-            double bestFc = crossoverHz[j];
-            double bestScore = Score();
+        private void OptimizeJunction(int j)
+        {
+            (double low, double high) = JunctionSearchBounds(j);
 
-            foreach (double fc in fcGrid)
+            JunctionOption best = new(
+                junctionFamily[j], crossoverHz[j], lowerSlope[j], upperSlope[j], Score());
+            foreach (JunctionOption option in EnumerateJunctionOptions(j, low, high))
             {
-                foreach (CrossoverFilterFamily family in options.Families)
+                if (option.Score < best.Score)
                 {
-                    IReadOnlyList<int> slopes = PracticalSlopes(family);
-                    foreach (int lower in slopes)
+                    best = option;
+                }
+            }
+
+            Set(j, best.Family, best.FrequencyHz, best.LowerSlope, best.UpperSlope);
+        }
+
+        internal readonly record struct JunctionOption(
+            CrossoverFilterFamily Family,
+            double FrequencyHz,
+            int LowerSlope,
+            int UpperSlope,
+            double Score);
+
+        // Scores every (lattice frequency × family × allowed slopes) choice for
+        // junction j with the rest of the state fixed. Shared by the descent
+        // (which keeps the minimum) and the ranked search's candidate pool
+        // (which keeps the top few). Restores the junction state afterward.
+        private IEnumerable<JunctionOption> EnumerateJunctionOptions(
+            int j,
+            double low,
+            double high)
+        {
+            CrossoverFilterFamily savedFamily = junctionFamily[j];
+            double savedFc = crossoverHz[j];
+            int savedLower = lowerSlope[j];
+            int savedUpper = upperSlope[j];
+            try
+            {
+                foreach (double fc in LatticePoints(low, high))
+                {
+                    foreach (CrossoverFilterFamily family in options.Families)
                     {
-                        if (options.IndependentSlopes)
+                        IReadOnlyList<int> slopes = AllowedSlopes(family, fc);
+                        foreach (int lower in slopes)
                         {
-                            foreach (int upper in slopes)
+                            if (options.IndependentSlopes)
                             {
-                                Set(j, family, fc, lower, upper);
-                                double score = Score();
-                                if (score < bestScore)
+                                foreach (int upper in slopes)
                                 {
-                                    bestScore = score;
-                                    bestFamily = family;
-                                    bestFc = fc;
-                                    bestLower = lower;
-                                    bestUpper = upper;
+                                    Set(j, family, fc, lower, upper);
+                                    yield return new JunctionOption(
+                                        family, fc, lower, upper, Score());
                                 }
                             }
-                        }
-                        else
-                        {
-                            Set(j, family, fc, lower, lower);
-                            double score = Score();
-                            if (score < bestScore)
+                            else
                             {
-                                bestScore = score;
-                                bestFamily = family;
-                                bestFc = fc;
-                                bestLower = lower;
-                                bestUpper = lower;
+                                Set(j, family, fc, lower, lower);
+                                yield return new JunctionOption(
+                                    family, fc, lower, lower, Score());
                             }
                         }
                     }
                 }
             }
-
-            Set(j, bestFamily, bestFc, bestLower, bestUpper);
+            finally
+            {
+                Set(j, savedFamily, savedFc, savedLower, savedUpper);
+            }
         }
 
         private void Set(
@@ -860,33 +1398,29 @@ public static class CrossoverAutoSetup
             }
         }
 
+        // Plain amplitude sum of the (unit-gain cached) channel responses with
+        // the gains applied inline — the ideal-alignment assumption, allocation
+        // free. The overlap penalty normalizes per channel, so it reads the
+        // unit responses directly and the gains drop out.
         private double Score()
         {
-            var amplitudes = new double[channelCount][];
             for (int i = 0; i < channelCount; i++)
             {
-                amplitudes[i] = ChannelAmplitude(i);
+                scratchUnits[i] = ChannelUnitAmplitude(i);
             }
 
-            return Flatness(Combine(amplitudes)) + OverlapPenalty(amplitudes);
-        }
-
-        private double[] Combine(double[][] amplitudes)
-        {
-            double[] combined = (double[])amplitudes[0].Clone();
-            for (int i = 1; i < channelCount; i++)
+            Array.Clear(scratchCombined);
+            for (int i = 0; i < channelCount; i++)
             {
-                double[] amplitude = amplitudes[i];
-                bool power = junctionFamily[i - 1] == CrossoverFilterFamily.Butterworth;
-                for (int k = 0; k < combined.Length; k++)
+                double gainLinear = DataHelper.DecibelsToAmplitude(gainDb[i]);
+                double[] unit = scratchUnits[i];
+                for (int k = 0; k < scratchCombined.Length; k++)
                 {
-                    combined[k] = power
-                        ? Math.Sqrt(combined[k] * combined[k] + amplitude[k] * amplitude[k])
-                        : combined[k] + amplitude[k];
+                    scratchCombined[k] += gainLinear * unit[k];
                 }
             }
 
-            return combined;
+            return Flatness(scratchCombined) + OverlapPenalty(scratchUnits);
         }
 
         // RMS deviation of the summed magnitude from its own mean over the interior
@@ -955,20 +1489,40 @@ public static class CrossoverAutoSetup
             return OverlapPenaltyDbPerOctave * total;
         }
 
-        private double[] ChannelAmplitude(int i)
+        // The channel's driver response × its current edges, WITHOUT the gain:
+        // memoized by the edge choice, so re-probing a lattice frequency (and
+        // every step of the gain search) reuses the array instead of
+        // recomputing the product.
+        private double[] ChannelUnitAmplitude(int i)
         {
-            double gainLinear = DataHelper.DecibelsToAmplitude(gainDb[i]);
-            double[]? highPass = i > 0
-                ? EdgeMagnitude(junctionFamily[i - 1], crossoverHz[i - 1], upperSlope[i - 1], highPass: true)
-                : lowLimitEdge is { } lowLimit ? EdgeMagnitude(lowLimit, highPass: true) : null;
-            double[]? lowPass = i < channelCount - 1
-                ? EdgeMagnitude(junctionFamily[i], crossoverHz[i], lowerSlope[i], highPass: false)
-                : highLimitEdge is { } highLimit ? EdgeMagnitude(highLimit, highPass: false) : null;
+            (CrossoverFilterFamily Family, double Fc, int Slope)? highPassEdge = i > 0
+                ? (junctionFamily[i - 1], crossoverHz[i - 1], upperSlope[i - 1])
+                : lowLimitEdge is { } lowLimit
+                    ? (lowLimit.Family, lowLimit.FrequencyHz, lowLimit.SlopeDbPerOctave)
+                    : null;
+            (CrossoverFilterFamily Family, double Fc, int Slope)? lowPassEdge = i < channelCount - 1
+                ? (junctionFamily[i], crossoverHz[i], lowerSlope[i])
+                : highLimitEdge is { } highLimit
+                    ? (highLimit.Family, highLimit.FrequencyHz, highLimit.SlopeDbPerOctave)
+                    : null;
+
+            var key = (i, EdgeKey(highPassEdge), EdgeKey(lowPassEdge));
+            if (unitCache.TryGetValue(key, out double[]? cached))
+            {
+                return cached;
+            }
+
+            double[]? highPass = highPassEdge is { } hp
+                ? EdgeMagnitude(hp.Family, hp.Fc, hp.Slope, highPass: true)
+                : null;
+            double[]? lowPass = lowPassEdge is { } lp
+                ? EdgeMagnitude(lp.Family, lp.Fc, lp.Slope, highPass: false)
+                : null;
 
             var amplitude = new double[grid.Length];
             for (int k = 0; k < grid.Length; k++)
             {
-                double value = gainLinear * driverAmplitude[i][k];
+                double value = driverAmplitude[i][k];
                 if (highPass != null)
                 {
                     value *= highPass[k];
@@ -981,11 +1535,21 @@ public static class CrossoverAutoSetup
                 amplitude[k] = value;
             }
 
+            unitCache[key] = amplitude;
             return amplitude;
         }
 
-        private double[] EdgeMagnitude(CrossoverEdge edge, bool highPass) =>
-            EdgeMagnitude(edge.Family, edge.FrequencyHz, edge.SlopeDbPerOctave, highPass);
+        private static long EdgeKey(
+            (CrossoverFilterFamily Family, double Fc, int Slope)? edge)
+        {
+            if (edge is not { } value)
+            {
+                return -1;
+            }
+
+            long frequencyKey = (long)Math.Round(value.Fc * 1000);
+            return frequencyKey * 1000 + value.Slope * 10 + (int)value.Family;
+        }
 
         private double[] EdgeMagnitude(
             CrossoverFilterFamily family,
@@ -1048,14 +1612,5 @@ public static class CrossoverAutoSetup
             return results;
         }
 
-        private static double[] LogSpace(double low, double high, int count)
-        {
-            if (high <= low)
-            {
-                return [low];
-            }
-
-            return EqualizationCurve.LogFrequencyGrid(low, high, count).ToArray();
-        }
     }
 }

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -120,6 +120,14 @@ public static class CrossoverAutoSetup
     // remaining room ripple of a 1/3-octave-smoothed in-room curve asks for.
     private const double BandEdgeDropDb = 8.0;
 
+    // The widest below-threshold gap EstimateBand bridges inside one band. A
+    // driver's own passband can have a narrow interference or room null that
+    // dips past the edge threshold for a fraction of an octave (a 1/3-octave-
+    // smoothed null lands around here); anything wider is a real dead zone that
+    // separates the usable band from an isolated resonance and must NOT be
+    // bridged, or a lone peak would stretch the band and mislabel the driver.
+    private const double MaxBandGapOctaves = 0.5;
+
     // The proposed crossover keeps at least this margin (octaves) above the
     // upper driver's low edge — the excursion protection — and below the lower
     // driver's high edge.
@@ -317,8 +325,31 @@ public static class CrossoverAutoSetup
         double reference = levels[(int)(levels.Count * 0.85)];
         double threshold = reference - BandEdgeDropDb;
 
-        double lowHz = double.NaN;
-        double highHz = double.NaN;
+        // Group the above-threshold points into contiguous segments, bridging a
+        // below-threshold gap only while it stays within MaxBandGapOctaves (a
+        // narrow interference/room null the driver's own band can have). The
+        // usable band is then the most PROMINENT segment — the one with the
+        // largest area above threshold, integrated over log-frequency — so an
+        // isolated resonance sitting past a deep dead gap cannot extend the band
+        // and mislabel the driver or skew the crossover bounds.
+        double bestLow = double.NaN;
+        double bestHigh = double.NaN;
+        double bestArea = double.NegativeInfinity;
+        double segLow = double.NaN;
+        double segHigh = double.NaN;
+        double segArea = 0.0;
+        double lastAboveHz = double.NaN;
+
+        void CloseSegment()
+        {
+            if (!double.IsNaN(segLow) && segHigh > segLow && segArea > bestArea)
+            {
+                bestArea = segArea;
+                bestLow = segLow;
+                bestHigh = segHigh;
+            }
+        }
+
         foreach (SignalPoint point in magnitudeDb)
         {
             if (!double.IsFinite(point.Y) || point.Y < threshold)
@@ -326,13 +357,28 @@ public static class CrossoverAutoSetup
                 continue;
             }
 
-            if (double.IsNaN(lowHz))
+            if (!double.IsNaN(lastAboveHz)
+                && Math.Log2(point.X / lastAboveHz) > MaxBandGapOctaves)
             {
-                lowHz = point.X;
+                // The dead gap since the last in-band point is too wide to
+                // bridge: close the open segment and start a fresh one here.
+                CloseSegment();
+                segLow = double.NaN;
+                segArea = 0.0;
             }
-            highHz = point.X;
-        }
 
+            if (double.IsNaN(segLow))
+            {
+                segLow = point.X;
+            }
+            segHigh = point.X;
+            segArea += point.Y - threshold;
+            lastAboveHz = point.X;
+        }
+        CloseSegment();
+
+        double lowHz = bestLow;
+        double highHz = bestHigh;
         if (double.IsNaN(lowHz) || highHz <= lowHz)
         {
             throw new ArgumentException(

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -149,16 +149,17 @@ public static class CrossoverAutoSetup
     private const int CrossoverSlopeDbPerOctave = 24;
 
     /// <summary>
-    /// Below this junction frequency, slopes steeper than
-    /// <see cref="LowJunctionMaxSlopeDbPerOctave"/> are excluded from the
-    /// search: a steep low-frequency crossover carries a large group delay
-    /// (many periods of ringing at an already-long period), which is far more
-    /// audible than the protection it buys.
+    /// A crossover slope is excluded from the search when the filter's peak group
+    /// delay exceeds this budget: a steep low-frequency crossover smears the
+    /// arrival by many periods, more than the protection it buys. The bound is on
+    /// the delay itself, not the frequency, so the same slope is allowed higher up
+    /// (a 48 dB/oct low-pass is fine at a 250 Hz woofer/mid handover, ~5 ms, but
+    /// not at a 75 Hz sub/woofer handover, ~17 ms). Group delay is the same for a
+    /// low-pass and a high-pass, so this bounds both shoulders identically; with
+    /// matched slopes a channel is still held to the gentler of its two junctions,
+    /// so a steep woofer low-pass with a gentle high-pass needs independent slopes.
     /// </summary>
-    public const double SteepSlopeMinimumJunctionHz = 300;
-
-    /// <summary>The steepest slope allowed for junctions below <see cref="SteepSlopeMinimumJunctionHz"/>.</summary>
-    public const int LowJunctionMaxSlopeDbPerOctave = 24;
+    public const double MaxCrossoverGroupDelaySeconds = 0.010;
 
     /// <summary>
     /// The mirror of the low-bass cap, for tweeters: a tweeter crossed below this
@@ -521,8 +522,8 @@ public static class CrossoverAutoSetup
     // they interfere; on a real system the summed dip that leaves is worse than
     // any group-delay a steeper filter costs, and Auto delay cannot align it
     // away — so the floor is 24 dB/oct, matching how these systems are tuned by
-    // hand. (Below SteepSlopeMinimumJunctionHz the slope is also capped at 24 for
-    // group delay, pinning low junctions to exactly 24.)
+    // hand. (A steeper slope is capped from above by the group-delay budget in
+    // AllowedSlopes, which bites only at low junction frequencies.)
     private static IReadOnlyList<int> PracticalSlopes(CrossoverFilterFamily family) =>
         CrossoverFilter.SupportedSlopes(family)
             .Where(slope => slope >= MinPracticalSlopeDbPerOctave)
@@ -1238,6 +1239,12 @@ public static class CrossoverAutoSetup
         private readonly Dictionary<(CrossoverFilterFamily, int, long, bool), double[]> magnitudeCache =
             new();
 
+        // Peak group delay (seconds) per (family, slope, rounded fc): computed
+        // from the exact biquad cascade, memoized because AllowedSlopes probes it
+        // on the same lattice frequencies across the whole search.
+        private readonly Dictionary<(CrossoverFilterFamily, int, long), double> groupDelayCache =
+            new();
+
         // Unit-gain channel amplitudes (driver × its current edges, gain
         // excluded) keyed by the edge choice, plus scratch buffers: scoring a
         // trial allocates nothing, and the lattice-stable frequencies make the
@@ -1577,10 +1584,11 @@ public static class CrossoverAutoSetup
                 : slopes.MinBy(slope => Math.Abs(slope - CrossoverSlopeDbPerOctave));
         }
 
-        // The slopes the search may actually try at this junction frequency:
-        // the family's practical slopes, capped at 24 dB/oct below
-        // SteepSlopeMinimumJunctionHz (group delay), or pinned to the forced
-        // slope of the conventional-candidate run.
+        // The slopes the search may actually try at this junction frequency: the
+        // family's practical slopes, minus any whose filter group delay exceeds
+        // MaxCrossoverGroupDelaySeconds (which bites only low down, where a steep
+        // slope smears the arrival), or pinned to the forced slope of the
+        // conventional-candidate run.
         private IReadOnlyList<int> AllowedSlopes(CrossoverFilterFamily family, double fcHz)
         {
             IReadOnlyList<int> slopes = PracticalSlopes(family);
@@ -1589,9 +1597,28 @@ public static class CrossoverAutoSetup
                 return slopes.Contains(locked) ? [locked] : [];
             }
 
-            return fcHz < SteepSlopeMinimumJunctionHz
-                ? slopes.Where(slope => slope <= LowJunctionMaxSlopeDbPerOctave).ToList()
-                : slopes;
+            return slopes
+                .Where(slope => GroupDelaySeconds(family, slope, fcHz)
+                    <= MaxCrossoverGroupDelaySeconds)
+                .ToList();
+        }
+
+        // Memoized peak group delay of one crossover filter. Group delay is the
+        // same for a low-pass and a high-pass, so the side is irrelevant here; the
+        // fc is rounded to the nearest Hz for the key (the lattice is coarser).
+        private double GroupDelaySeconds(CrossoverFilterFamily family, int slope, double fcHz)
+        {
+            var key = (family, slope, (long)Math.Round(fcHz));
+            if (!groupDelayCache.TryGetValue(key, out double delay))
+            {
+                delay = CrossoverFilter.MaxGroupDelaySeconds(
+                    new CrossoverEdge(family, fcHz, slope),
+                    highPass: false,
+                    options.SampleRateHz);
+                groupDelayCache[key] = delay;
+            }
+
+            return delay;
         }
 
         // The lowest slope a driver of this class may take at a handover of this

--- a/dsp/CrossoverFilter.cs
+++ b/dsp/CrossoverFilter.cs
@@ -82,6 +82,66 @@ public static class CrossoverFilter
         return response;
     }
 
+    /// <summary>
+    /// The peak group delay (seconds) this crossover edge adds, read from the
+    /// exact digital biquad cascade. Group delay τ(f) = −dφ/dω is sampled around
+    /// the corner — where a crossover's delay peaks — and the maximum returned:
+    /// the figure that bounds how much a steep low-frequency slope smears the
+    /// arrival. It scales as ≈ 1/f_c for a fixed order, and is the same for the
+    /// low-pass and high-pass sides, so callers may pass either.
+    /// </summary>
+    public static double MaxGroupDelaySeconds(
+        CrossoverEdge edge,
+        bool highPass,
+        double sampleRateHz)
+    {
+        if (sampleRateHz <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRateHz));
+        }
+        if (!(edge.FrequencyHz > 0))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(edge),
+                "The crossover corner frequency must be positive.");
+        }
+
+        CrossoverSpec spec = highPass
+            ? new CrossoverSpec(CrossoverKind.HighPass, HighPassEdge: edge)
+            : new CrossoverSpec(CrossoverKind.LowPass, LowPassEdge: edge);
+
+        // An octave-and-a-half either side of the corner captures the peak. The
+        // finite-difference step is small relative to the frequency, keeping the
+        // phase change per step well under π so no unwrapping is needed.
+        double nyquist = sampleRateHz / 2.0;
+        double lo = edge.FrequencyHz / 4.0;
+        double hi = Math.Min(edge.FrequencyHz * 4.0, nyquist * 0.99);
+        const int steps = 400;
+        double max = 0.0;
+        for (int i = 0; i <= steps; i++)
+        {
+            double f = lo * Math.Pow(hi / lo, (double)i / steps);
+            double delta = f * 1e-3;
+            if (f - delta <= 0 || f + delta >= nyquist)
+            {
+                continue;
+            }
+
+            Complex below = Response(spec, f - delta, sampleRateHz);
+            Complex above = Response(spec, f + delta, sampleRateHz);
+            // Arg(H(f−δ)·conj(H(f+δ))) = φ(f−δ) − φ(f+δ), the principal-value
+            // phase increase over 2·δ Hz; τ = that / (2π·2δ).
+            double phaseIncrease = (below * Complex.Conjugate(above)).Phase;
+            double groupDelay = phaseIncrease / (2.0 * Math.PI * 2.0 * delta);
+            if (groupDelay > max)
+            {
+                max = groupDelay;
+            }
+        }
+
+        return max;
+    }
+
     private static Complex EdgeResponse(
         CrossoverEdge edge,
         bool highPass,

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1049,6 +1049,42 @@ public static class VirtualCrossoverAnalysis
     }
 
     /// <summary>
+    /// Cuts a set of measured IRs to ONE shared direct-sound window: the same
+    /// offset (just before the earliest channel's peak) for every channel, so
+    /// the inter-channel timing survives intact. The alignment search, the
+    /// gated sum loss and the band-limited arrival detector all read the
+    /// direct sound near the peak, so running them on the crop instead of the
+    /// full capture produces the same results (verified bit-identical final
+    /// Auto delay cascades and junction losses on real measurements) at a
+    /// fraction of the FFT cost — the capture tail only matters for display.
+    /// </summary>
+    public static Complex[][] CropSharedDirectSoundWindow(
+        IReadOnlyList<Complex[]> impulseResponses,
+        int cropLength,
+        int prePeakSamples)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponses);
+        if (cropLength < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(cropLength));
+        }
+
+        int earliestPeak = impulseResponses.Min(FindPeakIndex);
+        int start = Math.Max(0, earliestPeak - Math.Max(0, prePeakSamples));
+        var cropped = new Complex[impulseResponses.Count][];
+        for (int channel = 0; channel < impulseResponses.Count; channel++)
+        {
+            Complex[] ir = impulseResponses[channel];
+            int length = Math.Clamp(ir.Length - start, 1, cropLength);
+            var slice = new Complex[length];
+            Array.Copy(ir, Math.Min(start, ir.Length - 1), slice, 0, length);
+            cropped[channel] = slice;
+        }
+
+        return cropped;
+    }
+
+    /// <summary>
     /// Measures the summation loss of already-settled responses without any
     /// search: the same gated, log-frequency-weighted average and 1/6-octave
     /// dip the alignment score reads, at the responses' current timing. Used

--- a/source/Tools/VirtualCrossoverAutoSetupDialog.Designer.cs
+++ b/source/Tools/VirtualCrossoverAutoSetupDialog.Designer.cs
@@ -165,6 +165,8 @@ namespace Resonalyze
             // independentSlopes
             //
             independentSlopes.AutoSize = true;
+            independentSlopes.Checked = true;
+            independentSlopes.CheckState = CheckState.Checked;
             independentSlopes.ForeColor = Color.White;
             independentSlopes.Location = new Point(12, 184);
             independentSlopes.Name = "independentSlopes";

--- a/source/Tools/VirtualCrossoverAutoSetupDialog.Designer.cs
+++ b/source/Tools/VirtualCrossoverAutoSetupDialog.Designer.cs
@@ -41,6 +41,9 @@ namespace Resonalyze
             maxCrossover = new DarkNumericUpDown();
             labelHz = new Label();
             independentSlopes = new CheckBox();
+            labelSubElevation = new Label();
+            subElevation = new DarkNumericUpDown();
+            labelSubElevationUnit = new Label();
             labelPreview = new Label();
             buttonApply = new Button();
             buttonCancel = new Button();
@@ -169,13 +172,46 @@ namespace Resonalyze
             independentSlopes.TabIndex = 19;
             independentSlopes.Text = "Independent slopes per side";
             //
+            // labelSubElevation
+            //
+            labelSubElevation.AutoSize = true;
+            labelSubElevation.ForeColor = Color.FromArgb(185, 190, 200);
+            labelSubElevation.Location = new Point(12, 214);
+            labelSubElevation.Name = "labelSubElevation";
+            labelSubElevation.Size = new Size(160, 15);
+            labelSubElevation.TabIndex = 20;
+            labelSubElevation.Text = "Sub level over mid/treble:";
+            //
+            // subElevation
+            //
+            subElevation.Location = new Point(196, 210);
+            subElevation.Minimum = 0m;
+            subElevation.Maximum = 60m;
+            subElevation.Increment = 1m;
+            subElevation.DecimalPlaces = 1;
+            subElevation.MinimumSize = new Size(36, 19);
+            subElevation.Name = "subElevation";
+            subElevation.Size = new Size(72, 21);
+            subElevation.TabIndex = 21;
+            subElevation.Value = 0m;
+            //
+            // labelSubElevationUnit
+            //
+            labelSubElevationUnit.AutoSize = true;
+            labelSubElevationUnit.ForeColor = Color.FromArgb(185, 190, 200);
+            labelSubElevationUnit.Location = new Point(276, 214);
+            labelSubElevationUnit.Name = "labelSubElevationUnit";
+            labelSubElevationUnit.Size = new Size(20, 15);
+            labelSubElevationUnit.TabIndex = 22;
+            labelSubElevationUnit.Text = "dB";
+            //
             // labelPreview
             //
             labelPreview.ForeColor = Color.FromArgb(230, 184, 0);
-            labelPreview.Location = new Point(12, 214);
+            labelPreview.Location = new Point(12, 240);
             labelPreview.Name = "labelPreview";
             labelPreview.Size = new Size(444, 62);
-            labelPreview.TabIndex = 20;
+            labelPreview.TabIndex = 23;
             labelPreview.Text = "—";
             //
             // buttonApply
@@ -185,10 +221,10 @@ namespace Resonalyze
             buttonApply.DialogResult = DialogResult.OK;
             buttonApply.FlatStyle = FlatStyle.Popup;
             buttonApply.ForeColor = Color.White;
-            buttonApply.Location = new Point(282, 284);
+            buttonApply.Location = new Point(282, 310);
             buttonApply.Name = "buttonApply";
             buttonApply.Size = new Size(84, 26);
-            buttonApply.TabIndex = 21;
+            buttonApply.TabIndex = 24;
             buttonApply.Text = "Apply";
             buttonApply.UseVisualStyleBackColor = false;
             //
@@ -198,10 +234,10 @@ namespace Resonalyze
             buttonCancel.DialogResult = DialogResult.Cancel;
             buttonCancel.FlatStyle = FlatStyle.Popup;
             buttonCancel.ForeColor = Color.White;
-            buttonCancel.Location = new Point(372, 284);
+            buttonCancel.Location = new Point(372, 310);
             buttonCancel.Name = "buttonCancel";
             buttonCancel.Size = new Size(84, 26);
-            buttonCancel.TabIndex = 22;
+            buttonCancel.TabIndex = 25;
             buttonCancel.Text = "Cancel";
             buttonCancel.UseVisualStyleBackColor = true;
             //
@@ -210,7 +246,7 @@ namespace Resonalyze
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(40, 44, 54);
-            ClientSize = new Size(468, 322);
+            ClientSize = new Size(468, 348);
             Controls.Add(labelHeader);
             Controls.Add(labelFilters);
             Controls.Add(checkButterworth);
@@ -222,6 +258,9 @@ namespace Resonalyze
             Controls.Add(maxCrossover);
             Controls.Add(labelHz);
             Controls.Add(independentSlopes);
+            Controls.Add(labelSubElevation);
+            Controls.Add(subElevation);
+            Controls.Add(labelSubElevationUnit);
             Controls.Add(labelPreview);
             Controls.Add(buttonApply);
             Controls.Add(buttonCancel);
@@ -251,6 +290,9 @@ namespace Resonalyze
         private DarkNumericUpDown maxCrossover;
         private Label labelHz;
         private CheckBox independentSlopes;
+        private Label labelSubElevation;
+        private DarkNumericUpDown subElevation;
+        private Label labelSubElevationUnit;
         private Label labelPreview;
         private Button buttonApply;
         private Button buttonCancel;

--- a/source/Tools/VirtualCrossoverAutoSetupDialog.cs
+++ b/source/Tools/VirtualCrossoverAutoSetupDialog.cs
@@ -17,6 +17,7 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
     private sealed record ChannelRow(
         string Name,
         IReadOnlyList<SignalPoint> MagnitudeDb,
+        IReadOnlyList<double>? Coherence,
         Label NameLabel,
         Label BandLabel,
         DarkComboBox TypeComboBox);
@@ -81,7 +82,7 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
     public void Init(
         double sampleRateHz,
         IReadOnlyList<(string Name, Color Accent, IReadOnlyList<SignalPoint> MagnitudeDb,
-            DriverBandEstimate Band)> channels,
+            IReadOnlyList<double>? Coherence, DriverBandEstimate Band)> channels,
         IReadOnlyList<Complex[]>? impulseResponses = null)
     {
         this.sampleRateHz = sampleRateHz;
@@ -104,7 +105,7 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
         for (int i = 0; i < channels.Count; i++)
         {
             (string name, Color accent, IReadOnlyList<SignalPoint> magnitude,
-                DriverBandEstimate band) = channels[i];
+                IReadOnlyList<double>? coherence, DriverBandEstimate band) = channels[i];
             int top = RowTop + i * RowStep;
 
             var nameLabel = new Label
@@ -146,7 +147,8 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
             Controls.Add(nameLabel);
             Controls.Add(bandLabel);
             Controls.Add(typeComboBox);
-            rows.Add(new ChannelRow(name, magnitude, nameLabel, bandLabel, typeComboBox));
+            rows.Add(new ChannelRow(
+                name, magnitude, coherence, nameLabel, bandLabel, typeComboBox));
         }
 
         int extraRows = Math.Max(0, channels.Count - DesignRowCount);
@@ -212,7 +214,8 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
 
     // One wizard source per channel row, in the row (Init) order.
     private List<AutoSetupSource> CurrentSources() =>
-        rows.Select(row => new AutoSetupSource(row.MagnitudeDb, TypeOf(row))).ToList();
+        rows.Select(row => new AutoSetupSource(row.MagnitudeDb, TypeOf(row), row.Coherence))
+            .ToList();
 
     private DriverType TypeOf(ChannelRow row) =>
         row.TypeComboBox.SelectedItem is DriverType type ? type : DriverType.Woofer;
@@ -310,10 +313,12 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
     private string FormatSummary(IReadOnlyList<CrossoverProposal> proposals)
     {
         List<AutoSetupSource> sources = CurrentSources();
+        AutoSetupSource lowSource = sources.OrderBy(source => source.Type).First();
+        AutoSetupSource highSource = sources.OrderBy(source => source.Type).Last();
         DriverBandEstimate low = CrossoverAutoSetup.EstimateBand(
-            sources.OrderBy(source => source.Type).First().MagnitudeDb);
+            lowSource.MagnitudeDb, lowSource.Coherence);
         DriverBandEstimate high = CrossoverAutoSetup.EstimateBand(
-            sources.OrderBy(source => source.Type).Last().MagnitudeDb);
+            highSource.MagnitudeDb, highSource.Coherence);
         double trim = Math.Pow(2.0, 0.5);
 
         var window = CrossoverAutoSetup

--- a/source/Tools/VirtualCrossoverAutoSetupDialog.cs
+++ b/source/Tools/VirtualCrossoverAutoSetupDialog.cs
@@ -308,6 +308,35 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
         return $"{family}{edge.SlopeDbPerOctave}";
     }
 
+    // Every control whose value feeds TryPropose()/CurrentOptions(). Frozen
+    // while the ranking task runs, so the applied result always matches the
+    // settings the user sees; their change handlers would otherwise re-enable
+    // Apply and overwrite the progress text mid-ranking.
+    private IEnumerable<Control> RankingInputControls()
+    {
+        foreach (ChannelRow row in rows)
+        {
+            yield return row.TypeComboBox;
+        }
+
+        foreach ((CheckBox box, CrossoverFilterFamily _) in familyBoxes)
+        {
+            yield return box;
+        }
+
+        yield return minCrossover;
+        yield return maxCrossover;
+        yield return independentSlopes;
+    }
+
+    private void SetRankingInputsEnabled(bool enabled)
+    {
+        foreach (Control control in RankingInputControls())
+        {
+            control.Enabled = enabled;
+        }
+    }
+
     private async void ApplyClick(object? sender, EventArgs e)
     {
         IReadOnlyList<CrossoverProposal>? quick = TryPropose();
@@ -335,6 +364,7 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
         IReadOnlyList<Complex[]> responses = impulseResponses;
         string previousPreview = labelPreview.Text;
         buttonApply.Enabled = false;
+        SetRankingInputsEnabled(false);
         labelPreview.Text = "Ranking candidates against the measured responses…";
         try
         {
@@ -359,6 +389,7 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
 
             labelPreview.Text = previousPreview;
             buttonApply.Enabled = true;
+            SetRankingInputsEnabled(true);
             System.Media.SystemSounds.Beep.Play();
         }
         catch (Exception exception)

--- a/source/Tools/VirtualCrossoverAutoSetupDialog.cs
+++ b/source/Tools/VirtualCrossoverAutoSetupDialog.cs
@@ -33,6 +33,10 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
     private readonly List<(CheckBox Box, CrossoverFilterFamily Family)> familyBoxes = new();
     private double sampleRateHz = 48_000;
     private bool initialized;
+    // The sub-elevation field is pre-filled once, from the first valid proposal's
+    // measured elevation (its default and upper limit). Until then options carry a
+    // null elevation so the DSP uses that measured default itself.
+    private bool subElevationInitialized;
     // The channels' measured transfer IRs (Init order). When present, Apply
     // re-ranks the top candidates by the junction loss achievable after the
     // best per-junction delay, instead of trusting the magnitude score alone.
@@ -156,7 +160,8 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
                      {
                          labelFilters, checkButterworth, checkLinkwitzRiley, checkBessel,
                          labelRange, minCrossover, labelDash, maxCrossover, labelHz,
-                         independentSlopes, labelPreview
+                         independentSlopes, labelSubElevation, subElevation,
+                         labelSubElevationUnit, labelPreview
                      })
             {
                 control.Top += rowShift;
@@ -187,13 +192,25 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
         minCrossover.ValueChanged += (_, _) => UpdatePreview();
         maxCrossover.ValueChanged += (_, _) => UpdatePreview();
         independentSlopes.CheckedChanged += (_, _) => UpdatePreview();
+        subElevation.ValueChanged += (_, _) => UpdatePreview();
         toolTip.SetToolTip(
             independentSlopes,
             "Let the low-pass and high-pass of a junction take different slopes\r\n" +
             "(they still share one crossover frequency), to compensate a driver's\r\n" +
             "own roll-off. Off makes the whole system use ONE slope — every\r\n" +
             "junction, both sides — the textbook crossover.");
+        toolTip.SetToolTip(
+            subElevation,
+            "How far the lowest driver sits above the levelled midrange/tweeter.\r\n" +
+            "Starts at (and is capped by) the measured elevation — the sub at its\r\n" +
+            "own level; lower it to flatten the bottom. The midrange/tweeter are\r\n" +
+            "levelled to each other and the remaining drivers are only cut, never\r\n" +
+            "boosted, onto the resulting target.");
     }
+
+    // One wizard source per channel row, in the row (Init) order.
+    private List<AutoSetupSource> CurrentSources() =>
+        rows.Select(row => new AutoSetupSource(row.MagnitudeDb, TypeOf(row))).ToList();
 
     private DriverType TypeOf(ChannelRow row) =>
         row.TypeComboBox.SelectedItem is DriverType type ? type : DriverType.Woofer;
@@ -207,7 +224,8 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
             (double)minCrossover.Value,
             (double)maxCrossover.Value,
             independentSlopes.Checked,
-            sampleRateHz);
+            sampleRateHz,
+            subElevationInitialized ? (double)subElevation.Value : null);
 
     private IReadOnlyList<CrossoverProposal>? TryPropose()
     {
@@ -216,16 +234,41 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
             return null;
         }
 
-        var sources = rows
-            .Select(row => new AutoSetupSource(row.MagnitudeDb, TypeOf(row)))
-            .ToList();
         try
         {
-            return CrossoverAutoSetup.Propose(sources, CurrentOptions());
+            return CrossoverAutoSetup.Propose(CurrentSources(), CurrentOptions());
         }
         catch (ArgumentException)
         {
             return null;
+        }
+    }
+
+    // Pre-fills the sub-elevation field once, the first time the driver types
+    // form a valid proposal: its default and upper limit are the measured
+    // elevation of the lowest driver over the levelled mid/tweeter reference.
+    private void TryInitializeSubElevation()
+    {
+        if (subElevationInitialized || SelectedFamilies().Count == 0)
+        {
+            return;
+        }
+
+        List<AutoSetupSource> sources = CurrentSources();
+        try
+        {
+            IReadOnlyList<CrossoverProposal> proposals =
+                CrossoverAutoSetup.Propose(sources, CurrentOptions());
+            double measured = CrossoverAutoSetup.MeasuredSubElevationDb(
+                sources, proposals, sampleRateHz);
+            decimal max = (decimal)Math.Max(0, Math.Round(measured, 1));
+            subElevation.Maximum = Math.Max(max, subElevation.Minimum);
+            subElevationInitialized = true;
+            subElevation.Value = max;
+        }
+        catch (ArgumentException)
+        {
+            // Types are not yet distinct; retry on the next change.
         }
     }
 
@@ -243,6 +286,7 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
             return;
         }
 
+        TryInitializeSubElevation();
         IReadOnlyList<CrossoverProposal>? proposals = TryPropose();
         buttonApply.Enabled = proposals != null;
         if (proposals == null)
@@ -254,18 +298,16 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
         var lines = rows
             .Select((row, index) => FormatProposal(row, proposals[index]))
             .ToList();
-        lines.Add(FormatFlatness(proposals));
+        lines.Add(FormatSummary(proposals));
         labelPreview.Text = string.Join(Environment.NewLine, lines);
     }
 
-    // The predicted flatness of the summed magnitude response over the interior
-    // passband — the quantity the optimizer minimizes, shown so the user can weigh
-    // the option choices.
-    private string FormatFlatness(IReadOnlyList<CrossoverProposal> proposals)
+    // The span of the predicted summed response and the sub elevation applied —
+    // with the target-curve gains the sum is an intentional downslope (bass
+    // lifted), not a flat line, so this reports the span rather than a defect.
+    private string FormatSummary(IReadOnlyList<CrossoverProposal> proposals)
     {
-        var sources = rows
-            .Select(row => new AutoSetupSource(row.MagnitudeDb, TypeOf(row)))
-            .ToList();
+        List<AutoSetupSource> sources = CurrentSources();
         DriverBandEstimate low = CrossoverAutoSetup.EstimateBand(
             sources.OrderBy(source => source.Type).First().MagnitudeDb);
         DriverBandEstimate high = CrossoverAutoSetup.EstimateBand(
@@ -277,9 +319,12 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
             .Where(point => point.X >= low.LowHz * trim && point.X <= high.HighHz / trim)
             .Select(point => point.Y)
             .ToList();
-        double ripple = window.Count > 0 ? window.Max() - window.Min() : 0;
-        return $"Predicted sum: ±{ripple / 2:0.0} dB over " +
-            $"{FormatHz(low.LowHz)}–{FormatHz(high.HighHz)}";
+        double span = window.Count > 0 ? window.Max() - window.Min() : 0;
+        string elevation = subElevationInitialized
+            ? $"  ·  sub +{(double)subElevation.Value:0.0} dB over mid/treble"
+            : string.Empty;
+        return $"Predicted sum spans {span:0.0} dB over " +
+            $"{FormatHz(low.LowHz)}–{FormatHz(high.HighHz)}{elevation}";
     }
 
     private static string FormatProposal(ChannelRow row, CrossoverProposal proposal)
@@ -328,6 +373,7 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
         yield return minCrossover;
         yield return maxCrossover;
         yield return independentSlopes;
+        yield return subElevation;
     }
 
     private void SetRankingInputsEnabled(bool enabled)
@@ -358,9 +404,7 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
         // measured IRs) runs off the UI thread; a couple of seconds on a
         // 4-way. The live preview keeps showing the fast magnitude-only
         // proposal until the ranking lands.
-        var sources = rows
-            .Select(row => new AutoSetupSource(row.MagnitudeDb, TypeOf(row)))
-            .ToList();
+        List<AutoSetupSource> sources = CurrentSources();
         CrossoverAutoSetupOptions options = CurrentOptions();
         IReadOnlyList<Complex[]> responses = impulseResponses;
         string previousPreview = labelPreview.Text;

--- a/source/Tools/VirtualCrossoverAutoSetupDialog.cs
+++ b/source/Tools/VirtualCrossoverAutoSetupDialog.cs
@@ -350,6 +350,8 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
         }
         catch (ArgumentException)
         {
+            // A user-input shape problem (duplicate types, unusable band):
+            // the same quiet signal the synchronous path gives.
             if (IsDisposed)
             {
                 return;
@@ -358,6 +360,26 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
             labelPreview.Text = previousPreview;
             buttonApply.Enabled = true;
             System.Media.SystemSounds.Beep.Play();
+        }
+        catch (Exception exception)
+        {
+            // An unhandled exception after an await in an async void handler
+            // would land in the WinForms synchronization context and kill the
+            // process; the ranking spans PLINQ, FFTs and the alignment search,
+            // so restore the dialog and report instead.
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            labelPreview.Text = previousPreview;
+            buttonApply.Enabled = true;
+            MessageBox.Show(
+                this,
+                $"Candidate ranking failed.\r\n\r\n{exception.Message}",
+                "Auto crossover",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
         }
     }
 

--- a/source/Tools/VirtualCrossoverAutoSetupDialog.cs
+++ b/source/Tools/VirtualCrossoverAutoSetupDialog.cs
@@ -191,9 +191,8 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
             independentSlopes,
             "Let the low-pass and high-pass of a junction take different slopes\r\n" +
             "(they still share one crossover frequency), to compensate a driver's\r\n" +
-            "own roll-off. Off keeps both sides of each junction matched, the\r\n" +
-            "textbook crossover — but different junctions may still pick\r\n" +
-            "different slopes, so a channel's two shoulders can differ.");
+            "own roll-off. Off makes the whole system use ONE slope — every\r\n" +
+            "junction, both sides — the textbook crossover.");
     }
 
     private DriverType TypeOf(ChannelRow row) =>

--- a/source/Tools/VirtualCrossoverAutoSetupDialog.cs
+++ b/source/Tools/VirtualCrossoverAutoSetupDialog.cs
@@ -197,8 +197,10 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
             independentSlopes,
             "Let the low-pass and high-pass of a junction take different slopes\r\n" +
             "(they still share one crossover frequency), to compensate a driver's\r\n" +
-            "own roll-off. Off makes the whole system use ONE slope — every\r\n" +
-            "junction, both sides — the textbook crossover.");
+            "own roll-off. Off ties each DRIVER's two shoulders (its high-pass and\r\n" +
+            "low-pass) to one slope, so no driver ends up steep on one side and\r\n" +
+            "shallow on the other; different drivers may still take different\r\n" +
+            "slopes — the textbook crossover.");
         toolTip.SetToolTip(
             subElevation,
             "How far the lowest driver sits above the levelled midrange/tweeter.\r\n" +

--- a/source/Tools/VirtualCrossoverAutoSetupDialog.cs
+++ b/source/Tools/VirtualCrossoverAutoSetupDialog.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Resonalyze.Dsp;
 
 namespace Resonalyze;
@@ -32,12 +33,19 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
     private readonly List<(CheckBox Box, CrossoverFilterFamily Family)> familyBoxes = new();
     private double sampleRateHz = 48_000;
     private bool initialized;
+    // The channels' measured transfer IRs (Init order). When present, Apply
+    // re-ranks the top candidates by the junction loss achievable after the
+    // best per-junction delay, instead of trusting the magnitude score alone.
+    private IReadOnlyList<Complex[]>? impulseResponses;
 
     public VirtualCrossoverAutoSetupDialog()
     {
         InitializeComponent();
         AcceptButton = buttonApply;
         CancelButton = buttonCancel;
+        // Apply ranks candidates asynchronously; the designer's automatic
+        // DialogResult would close the form at the first await instead.
+        buttonApply.DialogResult = DialogResult.None;
         buttonApply.Click += ApplyClick;
         WireOptionControls();
         // The designer file owns Dispose; the manually created tooltip is not in
@@ -69,9 +77,11 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
     public void Init(
         double sampleRateHz,
         IReadOnlyList<(string Name, Color Accent, IReadOnlyList<SignalPoint> MagnitudeDb,
-            DriverBandEstimate Band)> channels)
+            DriverBandEstimate Band)> channels,
+        IReadOnlyList<Complex[]>? impulseResponses = null)
     {
         this.sampleRateHz = sampleRateHz;
+        this.impulseResponses = impulseResponses;
         // Matches the optimizer's Nyquist ceiling; at 44.1 kHz this keeps the full
         // 20 kHz reachable instead of clamping to ~19.8 kHz.
         double ceiling = Math.Min(20_000, sampleRateHz * 0.49);
@@ -298,12 +308,55 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
         return $"{family}{edge.SlopeDbPerOctave}";
     }
 
-    private void ApplyClick(object? sender, EventArgs e)
+    private async void ApplyClick(object? sender, EventArgs e)
     {
-        Result = TryPropose();
-        if (Result == null)
+        IReadOnlyList<CrossoverProposal>? quick = TryPropose();
+        if (quick == null)
         {
-            DialogResult = DialogResult.None;
+            System.Media.SystemSounds.Beep.Play();
+            return;
+        }
+
+        if (impulseResponses == null)
+        {
+            Result = quick;
+            DialogResult = DialogResult.OK;
+            return;
+        }
+
+        // The ranked search (candidate pool + achievability post-check on the
+        // measured IRs) runs off the UI thread; a couple of seconds on a
+        // 4-way. The live preview keeps showing the fast magnitude-only
+        // proposal until the ranking lands.
+        var sources = rows
+            .Select(row => new AutoSetupSource(row.MagnitudeDb, TypeOf(row)))
+            .ToList();
+        CrossoverAutoSetupOptions options = CurrentOptions();
+        IReadOnlyList<Complex[]> responses = impulseResponses;
+        string previousPreview = labelPreview.Text;
+        buttonApply.Enabled = false;
+        labelPreview.Text = "Ranking candidates against the measured responses…";
+        try
+        {
+            IReadOnlyList<RankedCrossoverProposal> ranked = await Task.Run(
+                () => CrossoverAutoSetup.ProposeRanked(sources, options, responses));
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            Result = ranked[0].Proposals;
+            DialogResult = DialogResult.OK;
+        }
+        catch (ArgumentException)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            labelPreview.Text = previousPreview;
+            buttonApply.Enabled = true;
             System.Media.SystemSounds.Beep.Play();
         }
     }

--- a/source/Tools/VirtualCrossoverAutoSetupDialog.cs
+++ b/source/Tools/VirtualCrossoverAutoSetupDialog.cs
@@ -191,7 +191,9 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
             independentSlopes,
             "Let the low-pass and high-pass of a junction take different slopes\r\n" +
             "(they still share one crossover frequency), to compensate a driver's\r\n" +
-            "own roll-off. Off keeps both sides matched, the textbook crossover.");
+            "own roll-off. Off keeps both sides of each junction matched, the\r\n" +
+            "textbook crossover — but different junctions may still pick\r\n" +
+            "different slopes, so a channel's two shoulders can differ.");
     }
 
     private DriverType TypeOf(ChannelRow row) =>

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -1111,6 +1111,7 @@ public partial class VirtualCrossoverPanel : UserControl
         targetState.TransferPeakIndex = Math.Clamp(
             snapshot.TransferPeakIndex ?? 0, 0, transferIr.Length - 1);
         targetState.SampleRate = snapshot.SampleRate;
+        targetState.TransferCoherence = snapshot.TransferCoherence;
         targetSettings.DisplayName = displayName;
         targetSettings.SourceFilePath = sourceFilePath;
         targetSettings.HistoryEntryId = historyEntryId;
@@ -1222,6 +1223,7 @@ public partial class VirtualCrossoverPanel : UserControl
                 state.TransferPeakIndex = Math.Clamp(
                     snapshot.TransferPeakIndex ?? 0, 0, transferIr.Length - 1);
                 state.SampleRate = snapshot.SampleRate;
+                state.TransferCoherence = snapshot.TransferCoherence;
             }
         }
         catch (Exception exception) when (!showErrors)
@@ -3621,7 +3623,8 @@ public partial class VirtualCrossoverPanel : UserControl
         // 1/3-octave smoothing, independent of the display smoothing.
         var wizardOptions = new FrequencyResponseOptions { SmoothingInverseOctaves = 3 };
         var dialogChannels = new List<(string Name, Color Accent,
-            IReadOnlyList<SignalPoint> MagnitudeDb, DriverBandEstimate Band)>();
+            IReadOnlyList<SignalPoint> MagnitudeDb, IReadOnlyList<double>? Coherence,
+            DriverBandEstimate Band)>();
         try
         {
             foreach (ChannelRuntime channel in participating)
@@ -3633,12 +3636,20 @@ public partial class VirtualCrossoverPanel : UserControl
                         channel.SampleRate),
                     wizardOptions,
                     Calibration);
+                // When the source carried per-bin coherence, resample it onto the
+                // magnitude curve's log grid so the band read discounts the
+                // frequencies the measurement did not trust.
+                IReadOnlyList<double>? coherence =
+                    channel.TransferCoherence is { Length: > 1 } linear
+                        ? CoherencePerPoint(linear, curve.Points, channel.SampleRate)
+                        : null;
                 OxyColor accent = ChannelColors[channels.IndexOf(channel)];
                 dialogChannels.Add((
                     $"{channel.Control.ChannelName} — {channel.Settings.DisplayName}",
                     Color.FromArgb(accent.R, accent.G, accent.B),
                     curve.Points,
-                    CrossoverAutoSetup.EstimateBand(curve.Points)));
+                    coherence,
+                    CrossoverAutoSetup.EstimateBand(curve.Points, coherence)));
             }
         }
         catch (ArgumentException exception)
@@ -3691,6 +3702,40 @@ public partial class VirtualCrossoverPanel : UserControl
 
         ScheduleSave();
         RedrawAll();
+    }
+
+    // Averages a measurement's per-bin coherence (γ², a linear FFT grid over
+    // [0, Nyquist], bin k → k · rate / (2·(len−1))) over each magnitude point's
+    // 1/3-octave band, so the result lines up 1:1 with the wizard's magnitude
+    // curve (which is itself 1/3-octave smoothed) for EstimateBand to consume.
+    private static IReadOnlyList<double> CoherencePerPoint(
+        double[] coherence,
+        IReadOnlyList<SignalPoint> points,
+        int sampleRate)
+    {
+        int fftLength = 2 * (coherence.Length - 1);
+        double lowFactor = Math.Pow(2.0, -1.0 / 6.0);
+        double highFactor = Math.Pow(2.0, 1.0 / 6.0);
+        var values = new double[points.Count];
+        for (int i = 0; i < points.Count; i++)
+        {
+            double frequency = points[i].X;
+            int lo = Math.Max(0, (int)Math.Floor(frequency * lowFactor * fftLength / sampleRate));
+            int hi = Math.Min(
+                coherence.Length - 1,
+                (int)Math.Ceiling(frequency * highFactor * fftLength / sampleRate));
+            double sum = 0;
+            int count = 0;
+            for (int bin = lo; bin <= hi; bin++)
+            {
+                sum += coherence[bin];
+                count++;
+            }
+
+            values[i] = count > 0 ? sum / count : 1.0;
+        }
+
+        return values;
     }
 
     // ---------------------------------------------------------------- session
@@ -3832,6 +3877,13 @@ public partial class VirtualCrossoverPanel : UserControl
         public Complex[]? TransferImpulseResponse { get; set; }
         public int TransferPeakIndex { get; set; }
         public int SampleRate { get; set; }
+
+        // The measurement's per-bin coherence (γ²) on the linear FFT grid, when
+        // the source carried it. Only the auto-crossover wizard reads it, to
+        // discount frequencies the measurement did not trust when reading each
+        // driver's usable band; null when the source had none.
+        public double[]? TransferCoherence { get; set; }
+
         public ProcessedChannelCache? ProcessedCache { get; set; }
 
         // The band-limited envelope arrival and gated band level of this
@@ -3860,6 +3912,7 @@ public partial class VirtualCrossoverPanel : UserControl
             TransferImpulseResponse = null;
             TransferPeakIndex = 0;
             SampleRate = 0;
+            TransferCoherence = null;
             ProcessedCache = null;
             ArrivalCache = null;
             SourceRevision++;
@@ -3916,6 +3969,11 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             get => Active.TransferPeakIndex;
             set => Active.TransferPeakIndex = value;
+        }
+        public double[]? TransferCoherence
+        {
+            get => Active.TransferCoherence;
+            set => Active.TransferCoherence = value;
         }
         public int SampleRate
         {

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -89,6 +89,7 @@ public partial class VirtualCrossoverPanel : UserControl
     private bool redrawPending;
     private bool savePending;
     private bool autoDelayBusy;
+    private bool loadingProject;
 
     // Bumped whenever the displayed side (or the whole project) changes: a
     // redraw pass that started before the bump computed the OLD side's IRs,
@@ -252,6 +253,7 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
+        loadingProject = loading;
         UseWaitCursor = loading;
         Enabled = !loading;
         if (loading)
@@ -273,7 +275,13 @@ public partial class VirtualCrossoverPanel : UserControl
         }
         finally
         {
+            // Clear the loading state BEFORE the redraw so the final frame shows
+            // the real plot/metric, not the loading note — the bind's own
+            // interim redraws (e.g. the calibration combo refresh, which runs
+            // before the sources resolve) are what kept resetting the note back
+            // to the "no sources" hint.
             SetProjectLoading(false);
+            RedrawAll();
         }
     }
 
@@ -345,7 +353,8 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         UpdateSideRadioTexts();
-        RedrawAll();
+        // The final redraw is issued by ApplyProjectAsync after the loading
+        // state clears, so it draws the real plot instead of the loading note.
     }
 
     private void ScheduleSave()
@@ -1970,7 +1979,12 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         RemoveCurveSeries(model);
-        hintAnnotation.Text = processed.Count == 0 ? NoSourcesHint : string.Empty;
+        // While a session loads, interim redraws (the calibration combo refresh,
+        // etc.) run before the sources resolve, so processed is empty then; keep
+        // the loading note instead of flashing the "no sources" hint.
+        hintAnnotation.Text = loadingProject
+            ? LoadingHint
+            : processed.Count == 0 ? NoSourcesHint : string.Empty;
 
         // The processed magnitudes and the complex sum feed both the drawn
         // curves and the sum-loss metric, so they are built once here.

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -3483,7 +3483,10 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         using var dialog = new VirtualCrossoverAutoSetupDialog();
-        dialog.Init(participating[0].SampleRate, dialogChannels);
+        dialog.Init(
+            participating[0].SampleRate,
+            dialogChannels,
+            participating.Select(channel => channel.TransferImpulseResponse!).ToList());
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
             dialog.Result is not { } proposals)
         {

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -3660,19 +3660,33 @@ public partial class VirtualCrossoverPanel : UserControl
 
         for (int i = 0; i < participating.Count; i++)
         {
-            VirtualCrossoverChannelSettings settings = participating[i].Settings;
+            ChannelRuntime channel = participating[i];
             CrossoverProposal proposal = proposals[i];
-            settings.CrossoverKind = proposal.Kind;
-            if (proposal.HighPassEdge is { } highPass)
+            // A crossover is one electrical filter, so both sides of a stereo
+            // pair get the SAME frequencies, families and slopes (and the same
+            // wizard gain) — only delay and the scene-offset trim differ per
+            // side. A mono pair has just its one side.
+            foreach (bool rightSide in new[] { false, true })
             {
-                settings.HighPassEdge = highPass;
+                if (channel.Pair.Mono && rightSide)
+                {
+                    continue;
+                }
+
+                VirtualCrossoverChannelSettings settings = channel.SideSettings(rightSide);
+                settings.CrossoverKind = proposal.Kind;
+                if (proposal.HighPassEdge is { } highPass)
+                {
+                    settings.HighPassEdge = highPass;
+                }
+                if (proposal.LowPassEdge is { } lowPass)
+                {
+                    settings.LowPassEdge = lowPass;
+                }
+                settings.GainDb = proposal.GainDb;
             }
-            if (proposal.LowPassEdge is { } lowPass)
-            {
-                settings.LowPassEdge = lowPass;
-            }
-            settings.GainDb = proposal.GainDb;
-            ApplySettingsToControl(participating[i]);
+
+            ApplySettingsToControl(channel);
         }
 
         ScheduleSave();

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -1905,19 +1905,23 @@ public partial class VirtualCrossoverPanel : UserControl
 
         if (jobs.Count > 0)
         {
-            List<(PendingChannel Job, Complex[] Result, int Peak)> computed =
-                await Task.Run(() => jobs
-                    .Select(job =>
-                    {
-                        Complex[] result = VirtualCrossoverAnalysis.ApplyChain(
-                            job.TransferIr, job.Chain, job.SampleRate);
-                        int peak = VirtualCrossoverAnalysis.FindPeakIndex(result);
-                        return (job, result, peak);
-                    })
-                    .ToList());
-
-            foreach ((PendingChannel job, Complex[] result, int peak) in computed)
+            // One ApplyChain per channel — the full-length IR through the biquad
+            // cascade and its FFT — is the tool's heaviest math. They are pure
+            // and independent, so they run across cores; the cache write-back
+            // below stays on the UI thread after the await, so nothing races.
+            var computed = new (Complex[] Result, int Peak)[jobs.Count];
+            await Task.Run(() => Parallel.For(0, jobs.Count, j =>
             {
+                PendingChannel job = jobs[j];
+                Complex[] result = VirtualCrossoverAnalysis.ApplyChain(
+                    job.TransferIr, job.Chain, job.SampleRate);
+                computed[j] = (result, VirtualCrossoverAnalysis.FindPeakIndex(result));
+            }));
+
+            for (int j = 0; j < jobs.Count; j++)
+            {
+                PendingChannel job = jobs[j];
+                (Complex[] result, int peak) = computed[j];
                 job.State.ProcessedCache = new ProcessedChannelCache(job.Key, result, peak);
                 results[job.Index] = new ProcessedChannel(job.Channel, result, peak, job.Color);
             }
@@ -2401,7 +2405,13 @@ public partial class VirtualCrossoverPanel : UserControl
         // The summed envelope peak can sit between the arrivals or vanish under
         // cancellation, so the anchor is the earliest arrival, not the sum peak.
         int anchor = processed.Min(item => item.PeakIndex);
+        // One windowed FFT + resample per channel; GetPrimarySpectrum allocates
+        // its own buffers and reads only the (redraw-stable) options and
+        // calibration, so the channels' spectra compute across cores. AsOrdered
+        // keeps the result aligned with the channel list.
         List<AnalysisCurve> magnitudes = processed
+            .AsParallel()
+            .AsOrdered()
             .Select(item => BuildMagnitudeCurve(
                 item.ImpulseResponse, anchor, item.Channel.SampleRate))
             .ToList();

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -1710,8 +1710,7 @@ public partial class VirtualCrossoverPanel : UserControl
     }
 
     private List<ProcessedChannel> ProcessChannels(
-        IReadOnlyDictionary<ChannelRuntime, AlignmentOverride>? alignmentOverrides = null,
-        Dictionary<ChannelRuntime, ProcessedChannelCache>? searchCache = null)
+        IReadOnlyDictionary<ChannelRuntime, AlignmentOverride>? alignmentOverrides = null)
     {
         using var _ = AppProfiler.Zone("VirtualDSP.ProcessChannels");
         var processed = new List<ProcessedChannel>();
@@ -1756,14 +1755,14 @@ public partial class VirtualCrossoverPanel : UserControl
             }
 
             // The shared per-channel cache serves interactive redraws (UI thread
-            // only). The alignment search runs on a background thread, so it gets
-            // its own thread-confined cache instead — most channels keep a stable
-            // chain between junction searches, so they hit it, and the shared
-            // cache is never touched off the UI thread.
+            // only). The overrides path (Auto delay's pre-scan with zeroed
+            // delays) does not cache: the actual search runs its own cropped,
+            // thread-confined pipeline in ComputeAutoAlignment /
+            // ComputeStereoAlignment.
             var cacheKey = new ProcessedChannelCacheKey(ir, channel.SampleRate, chain);
             ProcessedChannelCache? cached = alignmentOverrides == null
                 ? channel.ProcessedCache
-                : searchCache?.GetValueOrDefault(channel);
+                : null;
             if (cached?.Key.Equals(cacheKey) == true)
             {
                 using (AppProfiler.Zone("VirtualDSP.ProcessChannels.CacheHit"))
@@ -1791,14 +1790,10 @@ public partial class VirtualCrossoverPanel : UserControl
                 peakIndex = VirtualCrossoverAnalysis.FindPeakIndex(result);
             }
 
-            var freshCache = new ProcessedChannelCache(cacheKey, result, peakIndex);
             if (alignmentOverrides == null)
             {
-                channel.ProcessedCache = freshCache;
-            }
-            else if (searchCache != null)
-            {
-                searchCache[channel] = freshCache;
+                channel.ProcessedCache = new ProcessedChannelCache(
+                    cacheKey, result, peakIndex);
             }
 
             using (AppProfiler.Zone("VirtualDSP.ProcessChannels.AddResult"))
@@ -2697,14 +2692,76 @@ public partial class VirtualCrossoverPanel : UserControl
         Dictionary<ChannelRuntime, AlignmentOverride> alignment,
         System.Text.StringBuilder log)
     {
-        var searchCache = new Dictionary<ChannelRuntime, ProcessedChannelCache>();
         List<ProcessedChannel> byBand = OrderByBand(processed);
         List<AdjacentPair> pairs = GetAdjacentPairs(byBand);
 
-        var snapshots = byBand.ToDictionary(
-            item => item.Channel,
-            item => new AlignmentSnapshot(
-                item.Channel, item.ImpulseResponse, item.PeakIndex));
+        // Same shared direct-sound crop + parallel cache-miss processing as
+        // the stereo run: identical final delays at a fraction of the FFT
+        // cost, because every search stage reads only the gated direct sound.
+        List<ChannelRuntime> ordered = byBand.Select(item => item.Channel).ToList();
+        Complex[][] croppedIrs = VirtualCrossoverAnalysis.CropSharedDirectSoundWindow(
+            ordered.Select(channel => channel.TransferImpulseResponse!).ToList(),
+            AutoDelaySearchCropLength,
+            AutoDelaySearchCropPrePeakSamples);
+        var searchIrs = new Dictionary<ChannelRuntime, Complex[]>();
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            searchIrs[ordered[i]] = croppedIrs[i];
+        }
+
+        var searchCache = new Dictionary<ChannelRuntime, ProcessedChannelCache>();
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides)
+        {
+            var results = new ProcessedChannelCache[ordered.Count];
+            var keys = new ProcessedChannelCacheKey[ordered.Count];
+            var chains = new DspChannelChain[ordered.Count];
+            var missing = new List<int>();
+            for (int i = 0; i < ordered.Count; i++)
+            {
+                ChannelRuntime channel = ordered[i];
+                AlignmentOverride over = overrides.GetValueOrDefault(channel);
+                chains[i] = channel.Settings.ToChain() with
+                {
+                    DelayMs = over.DelayMs,
+                    InvertPolarity = over.InvertPolarity
+                };
+                keys[i] = new ProcessedChannelCacheKey(
+                    searchIrs[channel], channel.SampleRate, chains[i]);
+                ProcessedChannelCache? cached = searchCache.GetValueOrDefault(channel);
+                if (cached?.Key.Equals(keys[i]) == true)
+                {
+                    results[i] = cached;
+                }
+                else
+                {
+                    missing.Add(i);
+                }
+            }
+
+            Parallel.ForEach(missing, i =>
+            {
+                Complex[] result = VirtualCrossoverAnalysis.ApplyChain(
+                    searchIrs[ordered[i]], chains[i], ordered[i].SampleRate);
+                results[i] = new ProcessedChannelCache(
+                    keys[i], result, VirtualCrossoverAnalysis.FindPeakIndex(result));
+            });
+            foreach (int i in missing)
+            {
+                searchCache[ordered[i]] = results[i];
+            }
+
+            return ordered
+                .Select((channel, i) => new AlignmentSnapshot(
+                    channel, results[i].ImpulseResponse, results[i].PeakIndex))
+                .ToList();
+        }
+
+        IReadOnlyList<AlignmentSnapshot> initial = Reprocess(
+            new Dictionary<IAlignmentChannel, AlignmentOverride>());
+        var snapshots = ordered
+            .Select((channel, i) => (channel, snapshot: initial[i]))
+            .ToDictionary(item => item.channel, item => item.snapshot);
         List<AlignmentJunction> junctions = pairs
             .Select(pair => new AlignmentJunction(
                 snapshots[pair.Lower.Channel],
@@ -2714,21 +2771,9 @@ public partial class VirtualCrossoverPanel : UserControl
                 pair.BandHighHz))
             .ToList();
 
-        IReadOnlyList<AlignmentSnapshot> Reprocess(
-            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides)
-        {
-            var mapped = overrides.ToDictionary(
-                entry => (ChannelRuntime)entry.Key,
-                entry => entry.Value);
-            return ProcessChannels(mapped, searchCache)
-                .Select(item => new AlignmentSnapshot(
-                    item.Channel, item.ImpulseResponse, item.PeakIndex))
-                .ToList();
-        }
-
         var engineAlignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
         AutoAlignmentEngine.Compute(
-            byBand.Select(item => snapshots[item.Channel]).ToList(),
+            ordered.Select(channel => snapshots[channel]).ToList(),
             junctions,
             Reprocess,
             engineAlignment,
@@ -2739,6 +2784,14 @@ public partial class VirtualCrossoverPanel : UserControl
             alignment[(ChannelRuntime)channel] = result;
         }
     }
+
+    // The Auto delay search reads only the gated direct sound, so it runs on
+    // a shared crop of the measured IRs (one offset for every channel keeps
+    // the inter-channel timing intact). 64k samples keep well over a second
+    // of decay at 44.1 kHz — conservative headroom over the 4096-sample
+    // evaluation gate and the low-band arrival envelopes.
+    private const int AutoDelaySearchCropLength = 65_536;
+    private const int AutoDelaySearchCropPrePeakSamples = 8_192;
 
     // The per-side participants of a stereo Auto delay run: every enabled
     // channel side with a resolved measurement. A mono pair contributes ONE
@@ -2909,37 +2962,86 @@ public partial class VirtualCrossoverPanel : UserControl
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         System.Text.StringBuilder log)
     {
-        var searchCache = new Dictionary<SideAlignmentChannel, ProcessedChannelCache>();
-        AlignmentSnapshot Process(SideAlignmentChannel side, AlignmentOverride over)
+        // The whole search runs on a shared direct-sound crop of the measured
+        // IRs: the engine only reads the gated direct sound and band-limited
+        // arrivals, so the final delays are identical to a full-length run
+        // (validated on real measurements) while every FFT in the cascade
+        // shrinks from the capture length to the crop.
+        Complex[][] croppedIrs = VirtualCrossoverAnalysis.CropSharedDirectSoundWindow(
+            union.Select(side => side.State.TransferImpulseResponse!).ToList(),
+            AutoDelaySearchCropLength,
+            AutoDelaySearchCropPrePeakSamples);
+        var searchIrs = new Dictionary<SideAlignmentChannel, Complex[]>();
+        for (int i = 0; i < union.Count; i++)
         {
-            Complex[] ir = side.State.TransferImpulseResponse!;
-            DspChannelChain chain = side.Settings.ToChain() with
-            {
-                DelayMs = over.DelayMs,
-                InvertPolarity = over.InvertPolarity
-            };
-            var key = new ProcessedChannelCacheKey(ir, side.State.SampleRate, chain);
-            ProcessedChannelCache? cached = searchCache.GetValueOrDefault(side);
-            if (cached?.Key.Equals(key) != true)
-            {
-                Complex[] result = VirtualCrossoverAnalysis.ApplyChain(
-                    ir, chain, side.State.SampleRate);
-                cached = new ProcessedChannelCache(
-                    key, result, VirtualCrossoverAnalysis.FindPeakIndex(result));
-                searchCache[side] = cached;
-            }
-
-            return new AlignmentSnapshot(side, cached.ImpulseResponse, cached.PeakIndex);
+            searchIrs[union[i]] = croppedIrs[i];
         }
 
-        IReadOnlyList<AlignmentSnapshot> Reprocess(
-            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
-            union
-                .Select(side => Process(side, overrides.GetValueOrDefault(side)))
-                .ToList();
+        var searchCache = new Dictionary<SideAlignmentChannel, ProcessedChannelCache>();
+        ProcessedChannelCache ComputeFresh(
+            SideAlignmentChannel side,
+            ProcessedChannelCacheKey key,
+            DspChannelChain chain)
+        {
+            Complex[] result = VirtualCrossoverAnalysis.ApplyChain(
+                searchIrs[side], chain, side.State.SampleRate);
+            return new ProcessedChannelCache(
+                key, result, VirtualCrossoverAnalysis.FindPeakIndex(result));
+        }
 
+        // Cache misses (all channels on the first call, usually one channel
+        // per cascade step afterwards) run in parallel: ApplyChain is pure
+        // FFT work on independent inputs, and the cache is written back on
+        // this (engine) thread only.
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides)
+        {
+            var results = new ProcessedChannelCache[union.Count];
+            var keys = new ProcessedChannelCacheKey[union.Count];
+            var chains = new DspChannelChain[union.Count];
+            var missing = new List<int>();
+            for (int i = 0; i < union.Count; i++)
+            {
+                SideAlignmentChannel side = union[i];
+                AlignmentOverride over = overrides.GetValueOrDefault(side);
+                chains[i] = side.Settings.ToChain() with
+                {
+                    DelayMs = over.DelayMs,
+                    InvertPolarity = over.InvertPolarity
+                };
+                keys[i] = new ProcessedChannelCacheKey(
+                    searchIrs[side], side.State.SampleRate, chains[i]);
+                ProcessedChannelCache? cached = searchCache.GetValueOrDefault(side);
+                if (cached?.Key.Equals(keys[i]) == true)
+                {
+                    results[i] = cached;
+                }
+                else
+                {
+                    missing.Add(i);
+                }
+            }
+
+            Parallel.ForEach(missing, i =>
+            {
+                results[i] = ComputeFresh(union[i], keys[i], chains[i]);
+            });
+            foreach (int i in missing)
+            {
+                searchCache[union[i]] = results[i];
+            }
+
+            return union
+                .Select((side, i) => new AlignmentSnapshot(
+                    side, results[i].ImpulseResponse, results[i].PeakIndex))
+                .ToList();
+        }
+
+        IReadOnlyList<AlignmentSnapshot> initialSnapshots = Reprocess(
+            new Dictionary<IAlignmentChannel, AlignmentOverride>());
         Dictionary<SideAlignmentChannel, AlignmentSnapshot> initial = union
-            .ToDictionary(side => side, side => Process(side, default));
+            .Select((side, i) => (side, snapshot: initialSnapshots[i]))
+            .ToDictionary(item => item.side, item => item.snapshot);
         List<AlignmentSnapshot> ByBand(List<SideAlignmentChannel> sides) => sides
             .OrderBy(side => VirtualCrossoverJunctions.BandCenterHz(side.Settings))
             .Select(side => initial[side])

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -236,9 +236,48 @@ public partial class VirtualCrossoverPanel : UserControl
             MessageBoxIcon.Information);
     }
 
+    private const string LoadingHint = "Loading the previous session…";
+
+    // Locks the panel while a project applies. Re-resolving every channel's
+    // source reads and reprocesses the stored transfer IRs, which takes several
+    // seconds; until this the panel sat enabled showing the "no sources" hint,
+    // so the last session looked lost right up until it snapped into place. The
+    // whole control tree is disabled (a load rebuilds the channel blocks, so
+    // covering not-yet-created controls means disabling the parent), the plot
+    // shows a loading note, and the cursor turns to a wait cursor.
+    private void SetProjectLoading(bool loading)
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        UseWaitCursor = loading;
+        Enabled = !loading;
+        if (loading)
+        {
+            hintAnnotation.Text = LoadingHint;
+            mainPlotView.InvalidatePlot(true);
+            MetricChanged?.Invoke("Loading\r\nsession…", string.Empty);
+        }
+    }
+
     // Binds a project (the internal autosave or an imported session) to the UI:
     // controls, view flags, and freshly re-resolved sources.
     private async Task ApplyProjectAsync(VirtualCrossoverProjectFile newProject)
+    {
+        SetProjectLoading(true);
+        try
+        {
+            await BindProjectAsync(newProject);
+        }
+        finally
+        {
+            SetProjectLoading(false);
+        }
+    }
+
+    private async Task BindProjectAsync(VirtualCrossoverProjectFile newProject)
     {
         project = newProject;
         displayRevision++;

--- a/tests/Resonalyze.Dsp.Tests/CropSharedWindowTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CropSharedWindowTests.cs
@@ -1,0 +1,39 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class CropSharedWindowTests
+{
+    [Fact]
+    public void Crop_KeepsTheInterChannelTimingIntact()
+    {
+        var early = new Complex[100_000];
+        var late = new Complex[100_000];
+        early[40_000] = Complex.One;
+        late[40_777] = Complex.One;
+
+        Complex[][] cropped = VirtualCrossoverAnalysis.CropSharedDirectSoundWindow(
+            [early, late], cropLength: 8_192, prePeakSamples: 1_000);
+
+        int earlyPeak = VirtualCrossoverAnalysis.FindPeakIndex(cropped[0]);
+        int latePeak = VirtualCrossoverAnalysis.FindPeakIndex(cropped[1]);
+        Assert.Equal(1_000, earlyPeak);
+        Assert.Equal(777, latePeak - earlyPeak);
+        Assert.All(cropped, ir => Assert.Equal(8_192, ir.Length));
+    }
+
+    [Fact]
+    public void Crop_ShortResponsesAndEarlyPeaksStayUsable()
+    {
+        var shortIr = new Complex[500];
+        shortIr[10] = Complex.One;
+
+        Complex[][] cropped = VirtualCrossoverAnalysis.CropSharedDirectSoundWindow(
+            [shortIr], cropLength: 8_192, prePeakSamples: 1_000);
+
+        // The peak sits before the pre-peak margin, so the crop starts at 0
+        // and the short capture comes back whole.
+        Assert.Equal(500, cropped[0].Length);
+        Assert.Equal(10, VirtualCrossoverAnalysis.FindPeakIndex(cropped[0]));
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/CrossoverAutoSetupTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverAutoSetupTests.cs
@@ -96,9 +96,45 @@ public sealed class CrossoverAutoSetupTests
         Assert.True(wooferToMid < midToTweeter);
         Assert.InRange(subToWoofer, 40, 80);
         Assert.InRange(wooferToMid, 250, 500);
-        Assert.InRange(midToTweeter, 2_000, 4_000);
+        // The placement heuristics cross the mid/tweeter as low as the tweeter's
+        // sensible floor (1.5 kHz) and its measured band allow, out of the 2–4 kHz
+        // ear-sensitivity band; a low tweeter handover must stay steep (>= 24).
+        Assert.InRange(midToTweeter, 1_500, 4_000);
+        if (midToTweeter < CrossoverAutoSetup.TweeterProtectionHz)
+        {
+            Assert.True(proposals[3].HighPassEdge!.Value.SlopeDbPerOctave >= 24);
+        }
         Assert.Null(proposals[3].LowPassEdge);
         Assert.True(SumRippleDb(sources, proposals) < 6.0);
+    }
+
+    [Fact]
+    public void Propose_CrossesACapableTweeterLowAndKeepsItSteep()
+    {
+        // A tweeter that measures clean down to ~1.2 kHz: the placement
+        // heuristics (avoid the 2–4 kHz ear band, cross a wide overlap low) pull
+        // its handover below the ear band, and the tweeter protection keeps that
+        // low handover steep (>= 24 dB/oct) so the tweeter is not overdriven.
+        var sources = new List<AutoSetupSource>
+        {
+            new(BandCurve(60, 900, 0), DriverType.Midbass),
+            new(BandCurve(250, 5_000, 0), DriverType.Midrange),
+            new(BandCurve(1_200, 20_000, 0), DriverType.Tweeter)
+        };
+
+        IReadOnlyList<CrossoverProposal> proposals =
+            CrossoverAutoSetup.Propose(sources, Options());
+
+        CrossoverEdge tweeterHighPass = proposals[2].HighPassEdge!.Value;
+        Assert.True(
+            tweeterHighPass.FrequencyHz < 2_000,
+            $"mid/tweeter handover {tweeterHighPass.FrequencyHz:0} Hz was not pulled below the ear band");
+        Assert.True(
+            tweeterHighPass.FrequencyHz >= 1_500,
+            $"handover {tweeterHighPass.FrequencyHz:0} Hz dropped below the tweeter floor");
+        Assert.True(
+            tweeterHighPass.SlopeDbPerOctave >= 24,
+            $"low tweeter handover slope {tweeterHighPass.SlopeDbPerOctave} is not steep");
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/CrossoverAutoSetupTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverAutoSetupTests.cs
@@ -95,7 +95,11 @@ public sealed class CrossoverAutoSetupTests
         Assert.True(subToWoofer < wooferToMid);
         Assert.True(wooferToMid < midToTweeter);
         Assert.InRange(subToWoofer, 40, 80);
-        Assert.InRange(wooferToMid, 250, 500);
+        // The placement heuristics cross the woofer/midrange handover as low as
+        // the midrange's sensible floor (200 Hz) allows — below its cone-breakup
+        // region — so the wide woofer/mid overlap does not linger up where it
+        // interferes; still gated by the measured midrange band.
+        Assert.InRange(wooferToMid, 200, 500);
         // The placement heuristics cross the mid/tweeter as low as the tweeter's
         // sensible floor (1.5 kHz) and its measured band allow, out of the 2–4 kHz
         // ear-sensitivity band; a low tweeter handover must stay steep (>= 24).

--- a/tests/Resonalyze.Dsp.Tests/CrossoverAutoSetupTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverAutoSetupTests.cs
@@ -191,6 +191,79 @@ public sealed class CrossoverAutoSetupTests
     }
 
     [Fact]
+    public void EstimateBand_IgnoresAnIsolatedResonancePastADeadGap()
+    {
+        // A woofer flat 40-400 Hz, then a deep dead gap, then a lone breakup
+        // resonance up near 3 kHz. The usable band must stay on the woofer: the
+        // isolated peak past the gap must not stretch HighHz and relabel the
+        // driver a midbass.
+        var points = new List<SignalPoint>();
+        foreach (double f in EqualizationCurve.LogFrequencyGrid(20, 20_000, 512))
+        {
+            double y;
+            if (f < 40)
+            {
+                y = -24.0 * Math.Log2(40 / f);
+            }
+            else if (f <= 400)
+            {
+                y = 0.0;
+            }
+            else
+            {
+                y = -24.0 * Math.Log2(f / 400); // deep roll-off above the band
+            }
+
+            if (f >= 2_700 && f <= 3_300)
+            {
+                y = 0.0; // an isolated resonance island past a dead gap
+            }
+
+            points.Add(new SignalPoint(f, y));
+        }
+
+        DriverBandEstimate band = CrossoverAutoSetup.EstimateBand(points);
+        Assert.InRange(band.HighHz, 400, 1_000); // the woofer edge, not the island
+        Assert.Equal(DriverType.Woofer, band.SuggestedType);
+    }
+
+    [Fact]
+    public void EstimateBand_BridgesANarrowInBandNull()
+    {
+        // A wide band (100 Hz - 2 kHz) with a single narrow deep null inside it
+        // (an interference or room dip). The narrow gap is bridged, so the band
+        // stays whole rather than splitting at the notch.
+        var points = new List<SignalPoint>();
+        foreach (double f in EqualizationCurve.LogFrequencyGrid(20, 20_000, 512))
+        {
+            double y;
+            if (f < 100)
+            {
+                y = -24.0 * Math.Log2(100 / f);
+            }
+            else if (f <= 2_000)
+            {
+                y = 0.0;
+            }
+            else
+            {
+                y = -24.0 * Math.Log2(f / 2_000);
+            }
+
+            if (f >= 560 && f <= 640)
+            {
+                y = -20.0; // a narrow deep null well within the passband
+            }
+
+            points.Add(new SignalPoint(f, y));
+        }
+
+        DriverBandEstimate band = CrossoverAutoSetup.EstimateBand(points);
+        Assert.InRange(band.LowHz, 70, 110);
+        Assert.InRange(band.HighHz, 2_000, 2_600);
+    }
+
+    [Fact]
     public void Propose_WooferToMidrange_KeepsTheCrossoverInTheWooferRange()
     {
         // Regression: a woofer whose measured response extends into the midband

--- a/tests/Resonalyze.Dsp.Tests/CrossoverAutoSetupTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverAutoSetupTests.cs
@@ -264,6 +264,63 @@ public sealed class CrossoverAutoSetupTests
     }
 
     [Fact]
+    public void EstimateBand_UsesCoherenceToRejectAnIncoherentRegion()
+    {
+        // A driver with a real, coherent passband (100-300 Hz) plus a broad,
+        // LOUD but incoherent region up high (2-8 kHz, γ² 0.2 — a rattle, buzz,
+        // or a channel picking up another driver). By magnitude area alone the
+        // loud broad region wins, so without coherence the band is read there.
+        // With coherence it is gated out and the real band is chosen.
+        var mag = new List<SignalPoint>();
+        var coh = new List<double>();
+        foreach (double f in EqualizationCurve.LogFrequencyGrid(20, 20_000, 512))
+        {
+            double y;
+            double g;
+            if (f is >= 100 and <= 300)
+            {
+                (y, g) = (0.0, 0.9);
+            }
+            else if (f is >= 2_000 and <= 8_000)
+            {
+                (y, g) = (3.0, 0.2);
+            }
+            else
+            {
+                (y, g) = (-40.0, 0.2);
+            }
+
+            mag.Add(new SignalPoint(f, y));
+            coh.Add(g);
+        }
+
+        DriverBandEstimate noCoh = CrossoverAutoSetup.EstimateBand(mag);
+        Assert.InRange(noCoh.LowHz, 1_900, 2_100); // the loud incoherent region wins
+
+        DriverBandEstimate withCoh = CrossoverAutoSetup.EstimateBand(mag, coh);
+        Assert.InRange(withCoh.LowHz, 90, 110);
+        Assert.InRange(withCoh.HighHz, 250, 350); // the real coherent band
+
+        // A mismatched-length coherence is ignored, not trusted.
+        DriverBandEstimate mismatched = CrossoverAutoSetup.EstimateBand(mag, new[] { 0.9 });
+        Assert.Equal(noCoh.HighHz, mismatched.HighHz);
+    }
+
+    [Fact]
+    public void EstimateBand_CoherenceDoesNotChopACoherentBand()
+    {
+        // Guard against over-tightening: a clean band whose γ² stays above the
+        // floor everywhere must read identically with and without coherence.
+        var mag = BandCurve(100, 2_000, 0);
+        var coh = Enumerable.Repeat(0.95, mag.Count).ToList();
+
+        DriverBandEstimate noCoh = CrossoverAutoSetup.EstimateBand(mag);
+        DriverBandEstimate withCoh = CrossoverAutoSetup.EstimateBand(mag, coh);
+        Assert.Equal(noCoh.LowHz, withCoh.LowHz);
+        Assert.Equal(noCoh.HighHz, withCoh.HighHz);
+    }
+
+    [Fact]
     public void Propose_WooferToMidrange_KeepsTheCrossoverInTheWooferRange()
     {
         // Regression: a woofer whose measured response extends into the midband

--- a/tests/Resonalyze.Dsp.Tests/CrossoverFilterTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverFilterTests.cs
@@ -30,6 +30,38 @@ public sealed class CrossoverFilterTests
         Assert.Equal(0.0, response.Imaginary, 12);
     }
 
+    [Fact]
+    public void MaxGroupDelay_GrowsWithOrderAndFallsWithFrequency()
+    {
+        var lr24At250 = new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 250, 24);
+        var lr48At250 = new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 250, 48);
+        var lr48At75 = new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 75, 48);
+
+        double gd24 = CrossoverFilter.MaxGroupDelaySeconds(lr24At250, highPass: false, SampleRate);
+        double gd48 = CrossoverFilter.MaxGroupDelaySeconds(lr48At250, highPass: false, SampleRate);
+        double gd48Low = CrossoverFilter.MaxGroupDelaySeconds(lr48At75, highPass: false, SampleRate);
+
+        // A steeper slope adds more delay; the same slope lower down adds much
+        // more (group delay scales ≈ 1/f_c, so 250 → 75 Hz is ≈ 3.3×).
+        Assert.True(gd48 > gd24);
+        Assert.True(gd48Low > gd48);
+        Assert.Equal(250.0 / 75.0, gd48Low / gd48, 1);
+
+        // Actual figures the auto-crossover budget is calibrated against.
+        Assert.InRange(gd48 * 1000, 4.0, 6.0);   // ~5 ms — fine at a woofer/mid handover
+        Assert.InRange(gd48Low * 1000, 15.0, 18.0); // ~17 ms — too much at a sub/woofer handover
+    }
+
+    [Fact]
+    public void MaxGroupDelay_IsTheSameForLowPassAndHighPass()
+    {
+        var edge = new CrossoverEdge(CrossoverFilterFamily.Butterworth, 300, 36);
+        double lowPass = CrossoverFilter.MaxGroupDelaySeconds(edge, highPass: false, SampleRate);
+        double highPass = CrossoverFilter.MaxGroupDelaySeconds(edge, highPass: true, SampleRate);
+
+        Assert.Equal(lowPass, highPass, 4);
+    }
+
     [Theory]
     [InlineData(6)]
     [InlineData(12)]

--- a/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
@@ -353,6 +353,74 @@ public sealed class CrossoverRankedProposalTests
         Assert.True(systemSlopes.Count > 1, "Expected more than one system slope in the pool.");
     }
 
+    // A synthetic 4-way with a hot bass, a rolled-off midbass, and a matched
+    // mid/tweeter: the target-curve fit should level the mid & tweeter to each
+    // other, keep the bass at its raw level by default, and leave the midbass
+    // alone when it already sits below the target line (cut-only).
+    private static List<AutoSetupSource> TargetCurveSources()
+    {
+        // Absolute levels: sub +6, midbass -6, mid/tweeter -18, tweeter a touch
+        // louder so it gets attenuated to the midrange.
+        List<SignalPoint> Shelf(double lowHz, double highHz, double levelDb) =>
+            BandCurve(lowHz, highHz).Select(p => new SignalPoint(p.X, p.Y + levelDb)).ToList();
+
+        return
+        [
+            new AutoSetupSource(Shelf(20, 90, 6), DriverType.Subwoofer),
+            new AutoSetupSource(Shelf(70, 400, -6), DriverType.Midbass),
+            new AutoSetupSource(Shelf(300, 5_000, -18), DriverType.Midrange),
+            new AutoSetupSource(Shelf(2_000, 20_000, -15), DriverType.Tweeter),
+        ];
+    }
+
+    [Fact]
+    public void ApplyTargetCurveGains_LevelsMidTweeterKeepsBassCutsOnlyDownward()
+    {
+        List<AutoSetupSource> sources = TargetCurveSources();
+        IReadOnlyList<CrossoverProposal> proposals =
+            CrossoverAutoSetup.Propose(sources, Options());
+
+        // Every gain is a cut (headroom-safe): the reference driver is at 0.
+        Assert.All(proposals, p => Assert.True(p.GainDb <= 0.0 + 1e-9, $"{p.GainDb} dB > 0"));
+        Assert.Contains(proposals, p => Math.Abs(p.GainDb) < 1e-9);
+
+        // The tweeter measured louder than the midrange, so it is attenuated to
+        // it; the midrange (the quieter reference member) stays at 0.
+        Assert.Equal(0.0, proposals[2].GainDb, precision: 6);
+        Assert.True(proposals[3].GainDb < -0.5, $"tweeter {proposals[3].GainDb} not attenuated");
+
+        // Default elevation keeps the bass at its raw level (gain ~0).
+        Assert.True(Math.Abs(proposals[0].GainDb) < 1.0, $"sub moved {proposals[0].GainDb} dB");
+    }
+
+    [Fact]
+    public void ApplyTargetCurveGains_TrimmingTheElevationCutsTheBass()
+    {
+        List<AutoSetupSource> sources = TargetCurveSources();
+        IReadOnlyList<CrossoverProposal> proposals =
+            CrossoverAutoSetup.Propose(sources, Options());
+        double measured = CrossoverAutoSetup.MeasuredSubElevationDb(
+            sources, proposals, SampleRate);
+        Assert.True(measured > 6, $"measured elevation {measured} unexpectedly small");
+
+        IReadOnlyList<CrossoverProposal> flat = CrossoverAutoSetup.ApplyTargetCurveGains(
+            sources, proposals, SampleRate, subElevationDb: 0);
+        IReadOnlyList<CrossoverProposal> half = CrossoverAutoSetup.ApplyTargetCurveGains(
+            sources, proposals, SampleRate, subElevationDb: measured / 2);
+
+        // Trimming the elevation only ever cuts the bass further; the reference
+        // members are unaffected.
+        Assert.True(flat[0].GainDb < half[0].GainDb, "flat sub not cut below half");
+        Assert.True(half[0].GainDb < proposals[0].GainDb + 1e-9, "half sub not cut below default");
+        Assert.Equal(proposals[2].GainDb, flat[2].GainDb, precision: 6);
+        // The elevation is clamped to the measured maximum: asking for more than
+        // measured cannot boost the bass above its raw level.
+        IReadOnlyList<CrossoverProposal> over = CrossoverAutoSetup.ApplyTargetCurveGains(
+            sources, proposals, SampleRate, subElevationDb: measured + 20);
+        Assert.Equal(proposals[0].GainDb, over[0].GainDb, precision: 6);
+        Assert.All(over, p => Assert.True(p.GainDb <= 0.0 + 1e-9));
+    }
+
     // With ideal impulse drivers a matched LR24 handover is losslessly
     // alignable, so the post-check must hand the win to the conventional
     // candidate with a near-zero penalty.

--- a/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
@@ -148,6 +148,66 @@ public sealed class CrossoverRankedProposalTests
             $"{groupDelay * 1000:0.0} ms group delay");
     }
 
+    // The budget caps steepness ABOVE the practical floor (24 dB/oct); the floor
+    // is always admitted. At a junction so low that even 24 dB/oct blows the
+    // budget, every candidate — the search seed, the descent result, AND the
+    // forced conventional baseline — uses exactly the floor there, never a
+    // steeper slope the budget forbids. This pins the two paths (Initialize and
+    // the conventional forced slope) that used to bypass the check entirely.
+    [Fact]
+    public void ProposeRanked_AtASubBudgetJunction_FallsBackToTheFloorConsistently()
+    {
+        var sources = new List<AutoSetupSource>
+        {
+            new(BandCurve(20, 35), DriverType.Subwoofer),
+            new(BandCurve(30, 500), DriverType.Woofer)
+        };
+        var options = new CrossoverAutoSetupOptions(
+            [CrossoverFilterFamily.LinkwitzRiley],
+            20,
+            20_000,
+            IndependentSlopes: true,
+            SampleRate);
+
+        IReadOnlyList<RankedCrossoverProposal> ranked =
+            CrossoverAutoSetup.ProposeRanked(sources, options, candidateCount: 50);
+
+        Assert.NotEmpty(ranked);
+        Assert.Contains(ranked, candidate => candidate.IsConventional24);
+
+        bool sawFloorAboveBudget = false;
+        foreach (RankedCrossoverProposal candidate in ranked)
+        {
+            foreach (CrossoverProposal proposal in candidate.Proposals)
+            {
+                foreach ((CrossoverEdge? edge, bool highPass) in new[]
+                    { (proposal.LowPassEdge, false), (proposal.HighPassEdge, true) })
+                {
+                    if (edge is not { } value)
+                    {
+                        continue;
+                    }
+
+                    double gd = CrossoverFilter.MaxGroupDelaySeconds(value, highPass, SampleRate);
+                    if (gd > CrossoverAutoSetup.MaxCrossoverGroupDelaySeconds)
+                    {
+                        // Tolerated only at the family's practical floor (the
+                        // gentlest slope it offers at or above 24 dB/oct).
+                        int floor = CrossoverFilter.SupportedSlopes(value.Family)
+                            .Where(slope => slope >= 24)
+                            .Min();
+                        Assert.Equal(floor, value.SlopeDbPerOctave);
+                        sawFloorAboveBudget = true;
+                    }
+                }
+            }
+        }
+
+        Assert.True(
+            sawFloorAboveBudget,
+            "Expected a junction low enough that even the floor slope exceeds the budget.");
+    }
+
     // Independent oracle for the summation rule: flat unit drivers make the
     // expected sum a pure amplitude sum of the exact digital filter
     // magnitudes, computed here WITHOUT SummedResponseDb's internals. A

--- a/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
@@ -201,6 +201,103 @@ public sealed class CrossoverRankedProposalTests
         Assert.All(ranked, candidate => Assert.Null(candidate.Proposals[2].LowPassEdge));
     }
 
+    private static List<SignalPoint> PeakedCurve(
+        double lowHz,
+        double highHz,
+        double peakHz,
+        double peakDb,
+        double widthOctaves)
+    {
+        var points = new List<SignalPoint>();
+        foreach (double frequency in EqualizationCurve.LogFrequencyGrid(20, 20_000, 512))
+        {
+            double y = peakDb * Math.Exp(
+                -Math.Pow(Math.Log2(frequency / peakHz) / widthOctaves, 2));
+            if (frequency < lowHz)
+            {
+                y -= 24.0 * Math.Log2(lowHz / frequency);
+            }
+            else if (frequency > highHz)
+            {
+                y -= 24.0 * Math.Log2(frequency / highHz);
+            }
+
+            points.Add(new SignalPoint(frequency, y));
+        }
+
+        return points;
+    }
+
+    // Per-junction pool options are each bounded against the descent optimum's
+    // neighbours; combined independently, two junctions moved toward each
+    // other can jointly break the half-octave minimum separation. A peaked
+    // middle driver pulls both of its junctions inward — without the joint
+    // check this configuration put an fc pair at ratio 1.375 (< sqrt 2) into
+    // the ranked list.
+    [Fact]
+    public void ProposeRanked_KeepsTheMinimumJunctionSeparationInEveryCandidate()
+    {
+        var sources = new List<AutoSetupSource>
+        {
+            new(BandCurve(20, 250), DriverType.Woofer),
+            new(PeakedCurve(60, 1_500, 220, 10, 0.5), DriverType.Midbass),
+            new(BandCurve(220, 20_000), DriverType.Midrange)
+        };
+
+        IReadOnlyList<RankedCrossoverProposal> ranked =
+            CrossoverAutoSetup.ProposeRanked(sources, Options(), candidateCount: 50);
+
+        double separation = Math.Pow(2.0, 0.5);
+        Assert.NotEmpty(ranked);
+        foreach (RankedCrossoverProposal candidate in ranked)
+        {
+            var crossovers = candidate.Proposals
+                .Take(candidate.Proposals.Count - 1)
+                .Select(proposal => proposal.LowPassEdge!.Value.FrequencyHz)
+                .ToList();
+            for (int j = 1; j < crossovers.Count; j++)
+            {
+                Assert.True(
+                    crossovers[j] >= crossovers[j - 1] * separation * (1 - 1e-9),
+                    $"fc {string.Join('/', crossovers)} breaks the separation.");
+            }
+        }
+    }
+
+    // The tie preference protects the ONE candidate the dedicated conventional
+    // run built (all slopes 24 dB/oct, Linkwitz-Riley when allowed) — a pool
+    // candidate that merely landed on all-24 slopes, or a Butterworth/Bessel
+    // 24 mix, must not carry the flag. Before the signature match this
+    // configuration flagged five candidates, one of them pure Butterworth.
+    [Fact]
+    public void ProposeRanked_FlagsOnlyTheDedicatedConventionalCandidate()
+    {
+        var sources = new List<AutoSetupSource>
+        {
+            new(BandCurve(20, 250), DriverType.Woofer),
+            new(PeakedCurve(60, 1_500, 260, 10, 0.3), DriverType.Midbass),
+            new(BandCurve(220, 20_000), DriverType.Midrange)
+        };
+
+        IReadOnlyList<RankedCrossoverProposal> ranked =
+            CrossoverAutoSetup.ProposeRanked(sources, Options(), candidateCount: 50);
+
+        RankedCrossoverProposal conventional =
+            Assert.Single(ranked, candidate => candidate.IsConventional24);
+        foreach (CrossoverProposal proposal in conventional.Proposals)
+        {
+            foreach (CrossoverEdge? edge in new[]
+                { proposal.LowPassEdge, proposal.HighPassEdge })
+            {
+                if (edge is { } value)
+                {
+                    Assert.Equal(CrossoverFilterFamily.LinkwitzRiley, value.Family);
+                    Assert.Equal(24, value.SlopeDbPerOctave);
+                }
+            }
+        }
+    }
+
     // With ideal impulse drivers a matched LR24 handover is losslessly
     // alignable, so the post-check must hand the win to the conventional
     // candidate with a near-zero penalty.

--- a/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
@@ -298,13 +298,13 @@ public sealed class CrossoverRankedProposalTests
         }
     }
 
-    // With independent slopes OFF, "matched" means one slope for the WHOLE
-    // system: every junction edge of every candidate uses the same dB/oct.
-    // Before this rule the search matched the two sides of each junction but
-    // let junctions differ, handing one channel a 12 dB/oct high-pass next to
-    // an 18 dB/oct low-pass.
+    // With independent slopes OFF, each DRIVER's two shoulders share one slope
+    // (no 12/18 split on a single channel) — but different drivers stay free to
+    // pick different slopes. The earlier bug let the per-junction pool combine
+    // slopes independently, so a middle driver's high-pass and low-pass drifted
+    // apart after Apply even though the panel preview looked matched.
     [Fact]
-    public void ProposeRanked_MatchedSlopesUseOneSlopeForTheWholeSystem()
+    public void ProposeRanked_MatchedSlopes_TieEachDriversTwoShoulders()
     {
         var sources = new List<AutoSetupSource>
         {
@@ -314,7 +314,7 @@ public sealed class CrossoverRankedProposalTests
             new(BandCurve(1_800, 20_000), DriverType.Tweeter)
         };
         var options = new CrossoverAutoSetupOptions(
-            [CrossoverFilterFamily.Butterworth],
+            [CrossoverFilterFamily.LinkwitzRiley, CrossoverFilterFamily.Butterworth],
             20,
             20_000,
             IndependentSlopes: false,
@@ -324,33 +324,57 @@ public sealed class CrossoverRankedProposalTests
             CrossoverAutoSetup.ProposeRanked(sources, options, candidateCount: 50);
 
         Assert.NotEmpty(ranked);
-        var systemSlopes = new HashSet<int>();
         foreach (RankedCrossoverProposal candidate in ranked)
         {
-            var slopes = new HashSet<int>();
-            for (int i = 0; i < candidate.Proposals.Count; i++)
+            foreach (CrossoverProposal proposal in candidate.Proposals)
             {
-                // The outer band-limit edges are protection filters, not
-                // junctions; only interior edges carry the system slope.
-                if (i > 0 && candidate.Proposals[i].HighPassEdge is { } highPass)
+                if (proposal.HighPassEdge is { } hp && proposal.LowPassEdge is { } lp)
                 {
-                    slopes.Add(highPass.SlopeDbPerOctave);
-                }
-                if (i < candidate.Proposals.Count - 1 &&
-                    candidate.Proposals[i].LowPassEdge is { } lowPass)
-                {
-                    slopes.Add(lowPass.SlopeDbPerOctave);
+                    Assert.Equal(hp.SlopeDbPerOctave, lp.SlopeDbPerOctave);
                 }
             }
+        }
+    }
 
-            int slope = Assert.Single(slopes);
-            systemSlopes.Add(slope);
+    // The per-channel tie must NOT collapse into one slope for the whole system:
+    // a sub junction below 300 Hz is capped at 24 dB/oct, but a tweeter far
+    // above it may still take a steeper slope, so the two drivers differ while
+    // each stays internally matched.
+    [Fact]
+    public void Propose_MatchedSlopes_LetDifferentDriversTakeDifferentSlopes()
+    {
+        // A tweeter whose passband has a rising skirt the optimizer tames with a
+        // steep high-pass, over a sub crossed low (its junction < 300 Hz, capped).
+        var sources = new List<AutoSetupSource>
+        {
+            new(BandCurve(20, 70), DriverType.Subwoofer),
+            new(PeakedCurve(120, 20_000, 1_600, 12, 0.6), DriverType.Midrange),
+            new(BandCurve(2_500, 20_000), DriverType.Tweeter)
+        };
+        var options = new CrossoverAutoSetupOptions(
+            [CrossoverFilterFamily.LinkwitzRiley],
+            20,
+            20_000,
+            IndependentSlopes: false,
+            SampleRate);
+
+        IReadOnlyList<CrossoverProposal> proposals =
+            CrossoverAutoSetup.Propose(sources, options);
+
+        // Each driver's shoulders still match…
+        foreach (CrossoverProposal proposal in proposals)
+        {
+            if (proposal.HighPassEdge is { } hp && proposal.LowPassEdge is { } lp)
+            {
+                Assert.Equal(hp.SlopeDbPerOctave, lp.SlopeDbPerOctave);
+            }
         }
 
-        // The merged pool still weighs different system slopes against each
-        // other — the uniformity must come from candidates, not from the
-        // search collapsing to a single slope.
-        Assert.True(systemSlopes.Count > 1, "Expected more than one system slope in the pool.");
+        // …and the sub junction (< 300 Hz) is capped at 24 while the tweeter,
+        // far above, is free to differ — the search is not one system slope.
+        Assert.True(
+            proposals[0].LowPassEdge!.Value.FrequencyHz < CrossoverAutoSetup.SteepSlopeMinimumJunctionHz);
+        Assert.True(proposals[0].LowPassEdge!.Value.SlopeDbPerOctave <= 24);
     }
 
     // A synthetic 4-way with a hot bass, a rolled-off midbass, and a matched

--- a/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
@@ -99,11 +99,12 @@ public sealed class CrossoverRankedProposalTests
         }
     }
 
-    // Below 300 Hz slopes steeper than 24 dB/oct are excluded (group delay);
-    // no candidate in the whole ranked pool may carry one, even with steep
-    // families available and independent slopes on.
+    // No candidate in the whole ranked pool may carry a slope whose filter group
+    // delay blows the budget — the low-frequency guard, now on the delay itself
+    // rather than a fixed frequency. Holds even with steep families and
+    // independent slopes on (a low sub junction still cannot go steep).
     [Fact]
-    public void ProposeRanked_NoSteepSlopesBelow300Hz()
+    public void ProposeRanked_KeepsEveryCrossoverWithinTheGroupDelayBudget()
     {
         var sources = new List<AutoSetupSource>
         {
@@ -125,20 +126,26 @@ public sealed class CrossoverRankedProposalTests
         {
             foreach (CrossoverProposal proposal in candidate.Proposals)
             {
-                foreach (CrossoverEdge? edge in new[]
-                    { proposal.LowPassEdge, proposal.HighPassEdge })
+                if (proposal.LowPassEdge is { } lp)
                 {
-                    if (edge is { } value &&
-                        value.FrequencyHz < CrossoverAutoSetup.SteepSlopeMinimumJunctionHz)
-                    {
-                        Assert.True(
-                            value.SlopeDbPerOctave <=
-                                CrossoverAutoSetup.LowJunctionMaxSlopeDbPerOctave,
-                            $"{value.SlopeDbPerOctave} dB/oct at {value.FrequencyHz} Hz");
-                    }
+                    AssertWithinGroupDelayBudget(lp, highPass: false);
+                }
+
+                if (proposal.HighPassEdge is { } hp)
+                {
+                    AssertWithinGroupDelayBudget(hp, highPass: true);
                 }
             }
         }
+    }
+
+    private static void AssertWithinGroupDelayBudget(CrossoverEdge edge, bool highPass)
+    {
+        double groupDelay = CrossoverFilter.MaxGroupDelaySeconds(edge, highPass, SampleRate);
+        Assert.True(
+            groupDelay <= CrossoverAutoSetup.MaxCrossoverGroupDelaySeconds + 1e-9,
+            $"{edge.SlopeDbPerOctave} dB/oct at {edge.FrequencyHz:0} Hz = " +
+            $"{groupDelay * 1000:0.0} ms group delay");
     }
 
     // Independent oracle for the summation rule: flat unit drivers make the
@@ -370,11 +377,15 @@ public sealed class CrossoverRankedProposalTests
             }
         }
 
-        // …and the sub junction (< 300 Hz) is capped at 24 while the tweeter,
-        // far above, is free to differ — the search is not one system slope.
+        // …and the sub junction sits low enough that a steeper slope would blow
+        // the group-delay budget, so it stays <= 24 while the tweeter, far above,
+        // is free to differ — the search is not one system slope.
+        CrossoverEdge subLowPass = proposals[0].LowPassEdge!.Value;
         Assert.True(
-            proposals[0].LowPassEdge!.Value.FrequencyHz < CrossoverAutoSetup.SteepSlopeMinimumJunctionHz);
-        Assert.True(proposals[0].LowPassEdge!.Value.SlopeDbPerOctave <= 24);
+            CrossoverFilter.MaxGroupDelaySeconds(
+                subLowPass with { SlopeDbPerOctave = 48 }, highPass: false, SampleRate)
+                > CrossoverAutoSetup.MaxCrossoverGroupDelaySeconds);
+        Assert.True(subLowPass.SlopeDbPerOctave <= 24);
     }
 
     // A synthetic 4-way with a hot bass, a rolled-off midbass, and a matched

--- a/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
@@ -1,0 +1,234 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class CrossoverRankedProposalTests
+{
+    private const double SampleRate = 48_000;
+
+    private static List<SignalPoint> FlatCurve(double levelDb = 0)
+    {
+        var points = new List<SignalPoint>();
+        foreach (double frequency in EqualizationCurve.LogFrequencyGrid(20, 20_000, 256))
+        {
+            points.Add(new SignalPoint(frequency, levelDb));
+        }
+
+        return points;
+    }
+
+    private static List<SignalPoint> BandCurve(double lowHz, double highHz)
+    {
+        var points = new List<SignalPoint>();
+        foreach (double frequency in EqualizationCurve.LogFrequencyGrid(20, 20_000, 512))
+        {
+            double y = 0;
+            if (frequency < lowHz)
+            {
+                y -= 24.0 * Math.Log2(lowHz / frequency);
+            }
+            else if (frequency > highHz)
+            {
+                y -= 24.0 * Math.Log2(frequency / highHz);
+            }
+
+            points.Add(new SignalPoint(frequency, y));
+        }
+
+        return points;
+    }
+
+    private static CrossoverAutoSetupOptions Options(
+        params CrossoverFilterFamily[] families) =>
+        new(
+            families.Length > 0
+                ? families
+                : [
+                    CrossoverFilterFamily.LinkwitzRiley,
+                    CrossoverFilterFamily.Butterworth,
+                    CrossoverFilterFamily.Bessel
+                ],
+            20,
+            20_000,
+            IndependentSlopes: false,
+            SampleRate);
+
+    [Theory]
+    [InlineData(83, 85)]
+    [InlineData(97, 95)]
+    [InlineData(100, 100)]
+    [InlineData(104, 100)]
+    [InlineData(996, 1_000)]
+    [InlineData(1_024, 1_000)]
+    [InlineData(1_730, 1_750)]
+    [InlineData(12, 20)]
+    [InlineData(6_420, 6_400)]
+    public void RoundToLattice_SnapsToTheHumanFriendlySteps(
+        double frequency,
+        double expected)
+    {
+        Assert.Equal(expected, CrossoverAutoSetup.RoundToLattice(frequency));
+    }
+
+    [Fact]
+    public void Propose_JunctionFrequenciesLandOnTheLattice()
+    {
+        var sources = new List<AutoSetupSource>
+        {
+            new(BandCurve(20, 100), DriverType.Subwoofer),
+            new(BandCurve(40, 500), DriverType.Woofer),
+            new(BandCurve(250, 4_500), DriverType.Midrange),
+            new(BandCurve(2_000, 20_000), DriverType.Tweeter)
+        };
+
+        IReadOnlyList<CrossoverProposal> proposals = CrossoverAutoSetup.Propose(
+            sources, Options());
+
+        foreach (CrossoverProposal proposal in proposals)
+        {
+            foreach (CrossoverEdge? edge in new[] { proposal.LowPassEdge, proposal.HighPassEdge })
+            {
+                if (edge is { } value)
+                {
+                    Assert.Equal(
+                        CrossoverAutoSetup.RoundToLattice(value.FrequencyHz),
+                        value.FrequencyHz,
+                        precision: 6);
+                }
+            }
+        }
+    }
+
+    // Below 300 Hz slopes steeper than 24 dB/oct are excluded (group delay);
+    // no candidate in the whole ranked pool may carry one, even with steep
+    // families available and independent slopes on.
+    [Fact]
+    public void ProposeRanked_NoSteepSlopesBelow300Hz()
+    {
+        var sources = new List<AutoSetupSource>
+        {
+            new(BandCurve(20, 100), DriverType.Subwoofer),
+            new(BandCurve(40, 500), DriverType.Woofer)
+        };
+        var options = new CrossoverAutoSetupOptions(
+            [CrossoverFilterFamily.LinkwitzRiley, CrossoverFilterFamily.Butterworth],
+            20,
+            20_000,
+            IndependentSlopes: true,
+            SampleRate);
+
+        IReadOnlyList<RankedCrossoverProposal> ranked =
+            CrossoverAutoSetup.ProposeRanked(sources, options, candidateCount: 50);
+
+        Assert.NotEmpty(ranked);
+        foreach (RankedCrossoverProposal candidate in ranked)
+        {
+            foreach (CrossoverProposal proposal in candidate.Proposals)
+            {
+                foreach (CrossoverEdge? edge in new[]
+                    { proposal.LowPassEdge, proposal.HighPassEdge })
+                {
+                    if (edge is { } value &&
+                        value.FrequencyHz < CrossoverAutoSetup.SteepSlopeMinimumJunctionHz)
+                    {
+                        Assert.True(
+                            value.SlopeDbPerOctave <=
+                                CrossoverAutoSetup.LowJunctionMaxSlopeDbPerOctave,
+                            $"{value.SlopeDbPerOctave} dB/oct at {value.FrequencyHz} Hz");
+                    }
+                }
+            }
+        }
+    }
+
+    // Independent oracle for the summation rule: flat unit drivers make the
+    // expected sum a pure amplitude sum of the exact digital filter
+    // magnitudes, computed here WITHOUT SummedResponseDb's internals. A
+    // power-sum regression (the old Butterworth branch) fails this by ~3 dB
+    // at the corner.
+    [Fact]
+    public void SummedResponseDb_IsThePlainAmplitudeSumOfTheFilteredChannels()
+    {
+        var channels = new List<AutoSetupSource>
+        {
+            new(FlatCurve(), DriverType.Woofer),
+            new(FlatCurve(), DriverType.Tweeter)
+        };
+        var lowPass = new CrossoverSpec(
+            CrossoverKind.LowPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 1_000, 24));
+        var highPass = new CrossoverSpec(
+            CrossoverKind.HighPass,
+            HighPassEdge: new CrossoverEdge(CrossoverFilterFamily.Butterworth, 1_000, 24));
+        var proposals = new List<CrossoverProposal>
+        {
+            new(CrossoverKind.LowPass, null, lowPass.LowPassEdge, GainDb: -2),
+            new(CrossoverKind.HighPass, highPass.HighPassEdge, null, GainDb: 0)
+        };
+
+        IReadOnlyList<SignalPoint> summed = CrossoverAutoSetup.SummedResponseDb(
+            channels, proposals, SampleRate);
+
+        foreach (SignalPoint point in summed)
+        {
+            double expected =
+                Math.Pow(10, -2 / 20.0)
+                    * CrossoverFilter.Response(lowPass, point.X, SampleRate).Magnitude
+                + CrossoverFilter.Response(highPass, point.X, SampleRate).Magnitude;
+            Assert.Equal(20 * Math.Log10(expected), point.Y, precision: 9);
+        }
+    }
+
+    [Fact]
+    public void ProposeRanked_AlwaysContainsTheConventional24Candidate()
+    {
+        var sources = new List<AutoSetupSource>
+        {
+            new(BandCurve(20, 120), DriverType.Subwoofer),
+            new(BandCurve(60, 900), DriverType.Midbass),
+            new(BandCurve(2_000, 20_000), DriverType.Tweeter)
+        };
+
+        IReadOnlyList<RankedCrossoverProposal> ranked =
+            CrossoverAutoSetup.ProposeRanked(sources, Options(), candidateCount: 50);
+
+        Assert.InRange(ranked.Count, 2, 50);
+        Assert.Contains(ranked, candidate => candidate.IsConventional24);
+        // Without IRs the penalty column stays empty and the ranking is the
+        // magnitude score alone.
+        Assert.All(ranked, candidate => Assert.Null(candidate.AchievabilityPenaltyDb));
+        // Proposals come back in input order: the tweeter is the last channel.
+        Assert.All(ranked, candidate => Assert.Null(candidate.Proposals[2].LowPassEdge));
+    }
+
+    // With ideal impulse drivers a matched LR24 handover is losslessly
+    // alignable, so the post-check must hand the win to the conventional
+    // candidate with a near-zero penalty.
+    [Fact]
+    public void ProposeRanked_WithImpulseResponsesPrefersAnAchievableHandover()
+    {
+        var sources = new List<AutoSetupSource>
+        {
+            new(FlatCurve(), DriverType.Woofer),
+            new(FlatCurve(), DriverType.Tweeter)
+        };
+        Complex[] MakeDelta()
+        {
+            var ir = new Complex[16_384];
+            ir[2_000] = Complex.One;
+            return ir;
+        }
+
+        IReadOnlyList<RankedCrossoverProposal> ranked = CrossoverAutoSetup.ProposeRanked(
+            sources,
+            Options(),
+            [MakeDelta(), MakeDelta()],
+            candidateCount: 20);
+
+        Assert.All(ranked, candidate => Assert.NotNull(candidate.AchievabilityPenaltyDb));
+        Assert.True(ranked[0].IsConventional24, "The conventional candidate should win on ideal drivers.");
+        Assert.True(
+            ranked[0].AchievabilityPenaltyDb < 1.0,
+            $"Achievability penalty {ranked[0].AchievabilityPenaltyDb:0.00} dB should be near zero.");
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
@@ -298,6 +298,61 @@ public sealed class CrossoverRankedProposalTests
         }
     }
 
+    // With independent slopes OFF, "matched" means one slope for the WHOLE
+    // system: every junction edge of every candidate uses the same dB/oct.
+    // Before this rule the search matched the two sides of each junction but
+    // let junctions differ, handing one channel a 12 dB/oct high-pass next to
+    // an 18 dB/oct low-pass.
+    [Fact]
+    public void ProposeRanked_MatchedSlopesUseOneSlopeForTheWholeSystem()
+    {
+        var sources = new List<AutoSetupSource>
+        {
+            new(BandCurve(20, 150), DriverType.Subwoofer),
+            new(BandCurve(50, 700), DriverType.Woofer),
+            new(BandCurve(250, 5_000), DriverType.Midrange),
+            new(BandCurve(1_800, 20_000), DriverType.Tweeter)
+        };
+        var options = new CrossoverAutoSetupOptions(
+            [CrossoverFilterFamily.Butterworth],
+            20,
+            20_000,
+            IndependentSlopes: false,
+            SampleRate);
+
+        IReadOnlyList<RankedCrossoverProposal> ranked =
+            CrossoverAutoSetup.ProposeRanked(sources, options, candidateCount: 50);
+
+        Assert.NotEmpty(ranked);
+        var systemSlopes = new HashSet<int>();
+        foreach (RankedCrossoverProposal candidate in ranked)
+        {
+            var slopes = new HashSet<int>();
+            for (int i = 0; i < candidate.Proposals.Count; i++)
+            {
+                // The outer band-limit edges are protection filters, not
+                // junctions; only interior edges carry the system slope.
+                if (i > 0 && candidate.Proposals[i].HighPassEdge is { } highPass)
+                {
+                    slopes.Add(highPass.SlopeDbPerOctave);
+                }
+                if (i < candidate.Proposals.Count - 1 &&
+                    candidate.Proposals[i].LowPassEdge is { } lowPass)
+                {
+                    slopes.Add(lowPass.SlopeDbPerOctave);
+                }
+            }
+
+            int slope = Assert.Single(slopes);
+            systemSlopes.Add(slope);
+        }
+
+        // The merged pool still weighs different system slopes against each
+        // other — the uniformity must come from candidates, not from the
+        // search collapsing to a single slope.
+        Assert.True(systemSlopes.Count > 1, "Expected more than one system slope in the pool.");
+    }
+
     // With ideal impulse drivers a matched LR24 handover is losslessly
     // alignable, so the post-check must hand the win to the conventional
     // candidate with a near-zero penalty.


### PR DESCRIPTION
Reworks the Auto crossover wizard around its design assumption — pick the crossover on magnitude, let Auto delay realize the alignment — and verifies that assumption per candidate before proposing.

## Scoring model made consistent

- Channels combine as a **plain amplitude sum everywhere** — the family-based amplitude-vs-power mix (and its non-associative 3+-channel ordering) is gone. This is the consistent expression of the ideal-alignment assumption the wizard already made.
- Crossover frequencies search directly on a **human-friendly lattice**: 5 Hz steps below 100 Hz, 10 Hz below 1 kHz, 50 Hz above. The scored frequency IS the proposed one; the stable lattice also makes the filter-magnitude cache hit, so the whole 50-candidate pool builds in ~0.4 s.
- **Junctions below 300 Hz never get slopes steeper than 24 dB/oct** — the group delay of a steep low-frequency crossover costs more than the protection it buys.

## Ranked search with an achievability post-check (`ProposeRanked`)

- Expands **~50 near-optimal candidates**: per-junction top options crossed over junctions (bounded at 512 combinations, one gain re-tune pass each), plus a **mandatory conventional all-LR24 run** whose slopes are locked and only frequencies/gains searched.
- Each candidate is re-ranked by the **junction loss actually achievable after the best per-junction delay** — the production alignment search (`FindAlignmentCandidates`) run on the channels' measured IRs over a shared 32k direct-sound crop, parallel over candidates. A candidate whose slopes cannot phase-align at a handover loses before Auto delay ever runs.
- Ties (within 0.25 dB) go to the conventional 24 dB/oct proposal.

## Performance

First end-to-end run on the real left 4-way cost 24.9 s; two cliffs found and fixed:

- per-candidate band-limited **arrival analyses** (Hilbert envelopes) → the search-window seeds are computed **once from the raw channels** (they are candidate-independent);
- a frequency-independent **search window** (±12 ms at a 4 kHz junction ≈ 1 s of probes) → the window now shrinks with the junction frequency, ±clamp(1200/fc, 2, 12) ms, matching the filter group delay it must absorb (∝ 1/fc).

Result: **50 candidates + post-check in 3.8 s on a 4-core container** (pool alone 0.4 s); scoring internals are allocation-free per trial (memoized unit-gain channel amplitudes).

## App wiring

The wizard dialog keeps the instant magnitude-only live preview; **Apply** runs the ranked search off the UI thread ("Ranking candidates…") when the panel hands it the channels' transfer IRs. The Apply button's designer `DialogResult` had to be disarmed — it would close the form at the first `await`.

## Testing

- 14 new dsp tests: an **independent amplitude-sum oracle** built from exact filter magnitudes (not `SummedResponseDb`'s internals), lattice rounding, the <300 Hz slope cap across the whole ranked pool, conventional-candidate presence, and a delta-IR ranking test where LR24 wins with a near-zero penalty.
- Validated end-to-end on the real left 4-way from `assets/test_data` (winner sanity, CONV24 preference, timings above).
- dsp suite **452/452**; full solution builds clean with `-p:EnableWindowsTargeting=true`.
- Needs one hands-on Windows check: the dialog's async Apply flow (Ranking… → dialog closes → winner applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP55go5gqByy6nRGAVAjGv)_