### PR TITLE
Add reliable WASAPI Shared and Exclusive audio backends

### DIFF
--- a/source/Audio/AudioBackend.cs
+++ b/source/Audio/AudioBackend.cs
@@ -4,5 +4,6 @@ public enum AudioBackend
 {
     Wave = 0,
     Asio = 1,
-    WasapiShared = 2
+    WasapiShared = 2,
+    WasapiExclusive = 3
 }

--- a/source/Audio/AudioBackend.cs
+++ b/source/Audio/AudioBackend.cs
@@ -3,5 +3,6 @@ namespace Resonalyze;
 public enum AudioBackend
 {
     Wave = 0,
-    Asio = 1
+    Asio = 1,
+    WasapiShared = 2
 }

--- a/source/Audio/AudioCaptureDataEventArgs.cs
+++ b/source/Audio/AudioCaptureDataEventArgs.cs
@@ -1,0 +1,14 @@
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+public sealed class AudioCaptureDataEventArgs : EventArgs
+{
+    public required ReadOnlyMemory<byte> Buffer { get; init; }
+    public required int BytesRecorded { get; init; }
+    public required WaveFormat Format { get; init; }
+    public long? DevicePositionFrames { get; init; }
+    public long? QpcPosition { get; init; }
+    public bool Discontinuity { get; init; }
+    public bool Silent { get; init; }
+}

--- a/source/Audio/AudioCaptureDataEventArgs.cs
+++ b/source/Audio/AudioCaptureDataEventArgs.cs
@@ -11,4 +11,5 @@ public sealed class AudioCaptureDataEventArgs : EventArgs
     public long? QpcPosition { get; init; }
     public bool Discontinuity { get; init; }
     public bool Silent { get; init; }
+    public bool TimestampError { get; init; }
 }

--- a/source/Audio/AudioDeviceStoppedEventArgs.cs
+++ b/source/Audio/AudioDeviceStoppedEventArgs.cs
@@ -1,0 +1,11 @@
+namespace Resonalyze;
+
+public sealed class AudioDeviceStoppedEventArgs : EventArgs
+{
+    public AudioDeviceStoppedEventArgs(Exception? exception = null)
+    {
+        Exception = exception;
+    }
+
+    public Exception? Exception { get; }
+}

--- a/source/Audio/AudioDeviceWarmup.cs
+++ b/source/Audio/AudioDeviceWarmup.cs
@@ -21,6 +21,12 @@ internal static class AudioDeviceWarmup
             return;
         }
 
+        if (settings.AudioBackend is AudioBackend.WasapiShared or AudioBackend.WasapiExclusive)
+        {
+            await WarmUpWasapiAsync(settings, cancellationToken);
+            return;
+        }
+
         await WarmUpWaveAsync(settings, cancellationToken);
     }
 
@@ -88,6 +94,56 @@ internal static class AudioDeviceWarmup
             expectedTotalSamples: prerollSamples + settings.SampleRate);
         await session.WaitForSamplesAsync(prerollSamples, linkedCancellation.Token);
         await session.StopAsync();
+    }
+
+    private static async Task WarmUpWasapiAsync(
+        MeasurementSettingsFile.SweepMeasurementSettings settings,
+        CancellationToken cancellationToken)
+    {
+        string captureEndpointId = settings.WasapiCaptureEndpointId ??
+            throw new InvalidOperationException("WASAPI capture endpoint is not selected.");
+        string renderEndpointId = settings.WasapiRenderEndpointId ??
+            throw new InvalidOperationException("WASAPI render endpoint is not selected.");
+        NAudio.CoreAudioApi.AudioClientShareMode shareMode =
+            settings.AudioBackend == AudioBackend.WasapiExclusive
+                ? NAudio.CoreAudioApi.AudioClientShareMode.Exclusive
+                : NAudio.CoreAudioApi.AudioClientShareMode.Shared;
+        int captureChannels = GetRequiredWaveInputChannelCount(settings);
+        int renderChannels = settings.PlaybackChannel == PlaybackChannel.Mono ? 1 : 2;
+        WaveFormat? captureFormat = shareMode == NAudio.CoreAudioApi.AudioClientShareMode.Exclusive
+            ? WasapiFormatSupport.CreateDeviceFormat(
+                settings.SampleRate,
+                settings.Bits,
+                captureChannels)
+            : null;
+        WaveFormat? renderFormat = shareMode == NAudio.CoreAudioApi.AudioClientShareMode.Exclusive
+            ? WasapiFormatSupport.CreateDeviceFormat(
+                settings.SampleRate,
+                settings.Bits,
+                renderChannels)
+            : null;
+        using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken);
+        linkedCancellation.CancelAfter(TimeSpan.FromSeconds(5));
+        await using var captureDevice = new WasapiCaptureDevice(
+            captureEndpointId,
+            settings.WasapiBufferMilliseconds,
+            shareMode,
+            captureFormat);
+        await using var playbackDevice = new WasapiPlaybackDevice(
+            renderEndpointId,
+            settings.WasapiBufferMilliseconds,
+            shareMode,
+            renderFormat);
+        await using var captureSession = new PcmCaptureSession(captureDevice);
+        float[] silence = new float[Math.Max(1, settings.SampleRate / 5)];
+        using var streams = new PcmStreamSet(silence, settings.SampleRate, settings.Bits);
+        WaveStream stream = streams.GetStream(settings.PlaybackChannel);
+
+        await captureSession.StartAsync(linkedCancellation.Token);
+        await playbackDevice.StartAsync(stream, linkedCancellation.Token);
+        await playbackDevice.WaitForPlaybackEndAsync(linkedCancellation.Token);
+        await captureSession.StopAsync();
     }
 
     private static float[] CreateAsioWarmupSignal(int sampleRate)

--- a/source/Audio/AudioPlaybackRunner.cs
+++ b/source/Audio/AudioPlaybackRunner.cs
@@ -1,0 +1,26 @@
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+internal static class AudioPlaybackRunner
+{
+    public static async Task PlayToEndAsync(
+        IAudioPlaybackDevice playback,
+        IWaveProvider source,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(playback);
+        ArgumentNullException.ThrowIfNull(source);
+
+        try
+        {
+            await playback.StartAsync(source, cancellationToken).ConfigureAwait(false);
+            await playback.WaitForPlaybackEndAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            await playback.StopAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+}

--- a/source/Audio/AudioRenderBufferReader.cs
+++ b/source/Audio/AudioRenderBufferReader.cs
@@ -1,0 +1,35 @@
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+internal static class AudioRenderBufferReader
+{
+    public static AudioRenderBufferRead Fill(IWaveProvider source, byte[] buffer)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(buffer);
+
+        Array.Clear(buffer);
+        int bytesRead = 0;
+        bool sourceEnded = false;
+        while (bytesRead < buffer.Length)
+        {
+            int read = source.Read(buffer, bytesRead, buffer.Length - bytesRead);
+            if (read == 0)
+            {
+                sourceEnded = true;
+                break;
+            }
+            if (read < 0 || read > buffer.Length - bytesRead)
+            {
+                throw new InvalidOperationException(
+                    "The audio source returned an invalid byte count.");
+            }
+            bytesRead += read;
+        }
+
+        return new AudioRenderBufferRead(bytesRead, sourceEnded);
+    }
+}
+
+internal readonly record struct AudioRenderBufferRead(int BytesRead, bool SourceEnded);

--- a/source/Audio/IAudioCaptureDevice.cs
+++ b/source/Audio/IAudioCaptureDevice.cs
@@ -1,0 +1,15 @@
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+public interface IAudioCaptureDevice : IAsyncDisposable
+{
+    event EventHandler<AudioCaptureDataEventArgs>? DataAvailable;
+    event EventHandler<AudioDeviceStoppedEventArgs>? Stopped;
+
+    WaveFormat CaptureFormat { get; }
+    int ChannelCount { get; }
+
+    Task StartAsync(CancellationToken cancellationToken);
+    Task StopAsync();
+}

--- a/source/Audio/IAudioPlaybackDevice.cs
+++ b/source/Audio/IAudioPlaybackDevice.cs
@@ -1,0 +1,12 @@
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+public interface IAudioPlaybackDevice : IAsyncDisposable
+{
+    WaveFormat PlaybackFormat { get; }
+
+    Task StartAsync(IWaveProvider source, CancellationToken cancellationToken);
+    Task WaitForPlaybackEndAsync(CancellationToken cancellationToken);
+    Task StopAsync();
+}

--- a/source/Audio/IInterleavedSampleDecoder.cs
+++ b/source/Audio/IInterleavedSampleDecoder.cs
@@ -1,0 +1,8 @@
+namespace Resonalyze;
+
+public interface IInterleavedSampleDecoder
+{
+    int ChannelCount { get; }
+
+    int Decode(ReadOnlySpan<byte> source, float[][] destination);
+}

--- a/source/Audio/InterleavedSampleDecoder.cs
+++ b/source/Audio/InterleavedSampleDecoder.cs
@@ -1,0 +1,136 @@
+using System.Buffers.Binary;
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+public static class InterleavedSampleDecoder
+{
+    private static readonly Guid PcmSubFormat =
+        new("00000001-0000-0010-8000-00aa00389b71");
+    private static readonly Guid FloatSubFormat =
+        new("00000003-0000-0010-8000-00aa00389b71");
+
+    public static IInterleavedSampleDecoder Create(WaveFormat format)
+    {
+        ArgumentNullException.ThrowIfNull(format);
+
+        bool isFloat = format.Encoding == WaveFormatEncoding.IeeeFloat ||
+            format is WaveFormatExtensible extensible &&
+            extensible.SubFormat == FloatSubFormat;
+        if (isFloat && format.BitsPerSample == 32)
+        {
+            return new Decoder(format.Channels, format.BlockAlign, 4, SampleEncoding.Float32);
+        }
+
+        bool isPcm = format.Encoding == WaveFormatEncoding.Pcm ||
+            format is WaveFormatExtensible pcmExtensible &&
+            pcmExtensible.SubFormat == PcmSubFormat;
+        if (!isPcm || format.BitsPerSample is not (16 or 24 or 32))
+        {
+            throw new NotSupportedException($"Unsupported capture format: {format}.");
+        }
+
+        SampleEncoding encoding = format.BitsPerSample switch
+        {
+            16 => SampleEncoding.Pcm16,
+            24 => SampleEncoding.Pcm24,
+            _ => SampleEncoding.Pcm32
+        };
+        return new Decoder(
+            format.Channels,
+            format.BlockAlign,
+            format.BitsPerSample / 8,
+            encoding);
+    }
+
+    private enum SampleEncoding
+    {
+        Pcm16,
+        Pcm24,
+        Pcm32,
+        Float32
+    }
+
+    private sealed class Decoder : IInterleavedSampleDecoder
+    {
+        private readonly int bytesPerFrame;
+        private readonly int bytesPerSample;
+        private readonly SampleEncoding encoding;
+
+        public Decoder(
+            int channelCount,
+            int bytesPerFrame,
+            int bytesPerSample,
+            SampleEncoding encoding)
+        {
+            ChannelCount = channelCount;
+            this.bytesPerFrame = bytesPerFrame;
+            this.bytesPerSample = bytesPerSample;
+            this.encoding = encoding;
+        }
+
+        public int ChannelCount { get; }
+
+        public int Decode(ReadOnlySpan<byte> source, float[][] destination)
+        {
+            ArgumentNullException.ThrowIfNull(destination);
+            if (destination.Length < ChannelCount)
+            {
+                throw new ArgumentException("A destination is required for every channel.", nameof(destination));
+            }
+
+            int frameCount = source.Length / bytesPerFrame;
+            for (int channel = 0; channel < ChannelCount; channel++)
+            {
+                if (destination[channel].Length < frameCount)
+                {
+                    throw new ArgumentException("Destination buffers are too short.", nameof(destination));
+                }
+            }
+
+            for (int frame = 0; frame < frameCount; frame++)
+            {
+                int frameOffset = frame * bytesPerFrame;
+                for (int channel = 0; channel < ChannelCount; channel++)
+                {
+                    int offset = frameOffset + channel * bytesPerSample;
+                    destination[channel][frame] = DecodeSample(source.Slice(offset, bytesPerSample));
+                }
+            }
+
+            return frameCount;
+        }
+
+        private float DecodeSample(ReadOnlySpan<byte> sample)
+        {
+            if (encoding == SampleEncoding.Float32)
+            {
+                float floatValue = BitConverter.Int32BitsToSingle(
+                    BinaryPrimitives.ReadInt32LittleEndian(sample));
+                return float.IsFinite(floatValue)
+                    ? Math.Clamp(floatValue, -1.0f, 1.0f)
+                    : 0.0f;
+            }
+
+            int value = encoding switch
+            {
+                SampleEncoding.Pcm16 => BinaryPrimitives.ReadInt16LittleEndian(sample),
+                SampleEncoding.Pcm24 => ReadPcm24(sample),
+                _ => BinaryPrimitives.ReadInt32LittleEndian(sample)
+            };
+            double scale = encoding switch
+            {
+                SampleEncoding.Pcm16 => 32768.0,
+                SampleEncoding.Pcm24 => 8388608.0,
+                _ => 2147483648.0
+            };
+            return (float)Math.Clamp(value / scale, -1.0, 1.0);
+        }
+
+        private static int ReadPcm24(ReadOnlySpan<byte> sample)
+        {
+            int value = sample[0] | sample[1] << 8 | sample[2] << 16;
+            return (value & 0x800000) == 0 ? value : value | unchecked((int)0xff000000);
+        }
+    }
+}

--- a/source/Audio/Mme/MmeCaptureDevice.cs
+++ b/source/Audio/Mme/MmeCaptureDevice.cs
@@ -1,0 +1,96 @@
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+public sealed class MmeCaptureDevice : IAudioCaptureDevice
+{
+    private readonly WaveInEvent source;
+    private TaskCompletionSource<bool>? stopped;
+    private bool disposed;
+
+    public MmeCaptureDevice(int deviceNumber, WaveFormat format)
+    {
+        CaptureFormat = format ?? throw new ArgumentNullException(nameof(format));
+        source = new WaveInEvent
+        {
+            DeviceNumber = deviceNumber,
+            WaveFormat = format
+        };
+        source.DataAvailable += HandleDataAvailable;
+        source.RecordingStopped += HandleRecordingStopped;
+    }
+
+    public event EventHandler<AudioCaptureDataEventArgs>? DataAvailable;
+    public event EventHandler<AudioDeviceStoppedEventArgs>? Stopped;
+
+    public WaveFormat CaptureFormat { get; }
+    public int ChannelCount => CaptureFormat.Channels;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        cancellationToken.ThrowIfCancellationRequested();
+        stopped = SampleWaiterRegistry.NewSignal();
+        source.StartRecording();
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync()
+    {
+        if (disposed || stopped == null)
+        {
+            return;
+        }
+
+        await AudioCaptureStop.StopAndWaitAsync(
+            source.StopRecording,
+            stopped,
+            stopped.Task,
+            "The MME audio input").ConfigureAwait(false);
+    }
+
+    private void HandleDataAvailable(object? sender, WaveInEventArgs args)
+    {
+        DataAvailable?.Invoke(
+            this,
+            new AudioCaptureDataEventArgs
+            {
+                Buffer = args.Buffer.AsMemory(0, args.BytesRecorded),
+                BytesRecorded = args.BytesRecorded,
+                Format = CaptureFormat
+            });
+    }
+
+    private void HandleRecordingStopped(object? sender, StoppedEventArgs args)
+    {
+        if (args.Exception == null)
+        {
+            stopped?.TrySetResult(true);
+        }
+        else
+        {
+            stopped?.TrySetException(args.Exception);
+        }
+        Stopped?.Invoke(this, new AudioDeviceStoppedEventArgs(args.Exception));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            await StopAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            disposed = true;
+            source.DataAvailable -= HandleDataAvailable;
+            source.RecordingStopped -= HandleRecordingStopped;
+            source.Dispose();
+        }
+    }
+}

--- a/source/Audio/Mme/MmePlaybackDevice.cs
+++ b/source/Audio/Mme/MmePlaybackDevice.cs
@@ -1,0 +1,88 @@
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+public sealed class MmePlaybackDevice : IAudioPlaybackDevice
+{
+    private readonly WaveOutEvent output;
+    private TaskCompletionSource<bool>? playbackEnded;
+    private IWaveProvider? initializedSource;
+    private bool disposed;
+
+    public MmePlaybackDevice(int deviceNumber)
+    {
+        output = new WaveOutEvent
+        {
+            DeviceNumber = deviceNumber
+        };
+        output.PlaybackStopped += HandlePlaybackStopped;
+    }
+
+    public WaveFormat PlaybackFormat { get; private set; } = null!;
+
+    public Task StartAsync(IWaveProvider source, CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        ArgumentNullException.ThrowIfNull(source);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (playbackEnded is { Task.IsCompleted: false })
+        {
+            throw new InvalidOperationException("Playback is already running.");
+        }
+
+        if (initializedSource != null && !ReferenceEquals(initializedSource, source))
+        {
+            throw new InvalidOperationException(
+                "This playback session is already initialized with another source.");
+        }
+        PlaybackFormat = source.WaveFormat;
+        playbackEnded = SampleWaiterRegistry.NewSignal();
+        if (initializedSource == null)
+        {
+            output.Init(source);
+            initializedSource = source;
+        }
+        output.Play();
+        return Task.CompletedTask;
+    }
+
+    public async Task WaitForPlaybackEndAsync(CancellationToken cancellationToken)
+    {
+        Task task = playbackEnded?.Task ??
+            throw new InvalidOperationException("Playback has not been started.");
+        await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task StopAsync()
+    {
+        if (!disposed && playbackEnded is { Task.IsCompleted: false })
+        {
+            output.Stop();
+        }
+        return Task.CompletedTask;
+    }
+
+    private void HandlePlaybackStopped(object? sender, StoppedEventArgs args)
+    {
+        if (args.Exception == null)
+        {
+            playbackEnded?.TrySetResult(true);
+        }
+        else
+        {
+            playbackEnded?.TrySetException(args.Exception);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (disposed)
+        {
+            return;
+        }
+        await StopAsync().ConfigureAwait(false);
+        disposed = true;
+        output.PlaybackStopped -= HandlePlaybackStopped;
+        output.Dispose();
+    }
+}

--- a/source/Audio/PcmCaptureSession.cs
+++ b/source/Audio/PcmCaptureSession.cs
@@ -1,6 +1,6 @@
 namespace Resonalyze;
 
-public sealed class PcmCaptureSession : IAsyncDisposable
+public sealed class PcmCaptureSession : IAsyncDisposable, ISweepCaptureSession
 {
     private readonly object sync = new();
     private readonly IAudioCaptureDevice device;

--- a/source/Audio/PcmCaptureSession.cs
+++ b/source/Audio/PcmCaptureSession.cs
@@ -27,10 +27,14 @@ public sealed class PcmCaptureSession : IAsyncDisposable
 
     public event Action<float[]>? SequenceReady;
     public event Action<float[][]>? SequenceChannelsReady;
+    public event Action? CaptureDiscontinuity;
     internal event Action<AudioChannelLevel[]>? LevelsAvailable;
 
     public int Sequence { get; set; }
     public int ReadSamples => accumulator.ReadSamples;
+    public long DiscontinuityCount { get; private set; }
+    public long SilentPacketCount { get; private set; }
+    public long TimestampErrorCount { get; private set; }
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
@@ -91,6 +95,19 @@ public sealed class PcmCaptureSession : IAsyncDisposable
 
     private void HandleDataAvailable(object? sender, AudioCaptureDataEventArgs args)
     {
+        if (args.Discontinuity)
+        {
+            DiscontinuityCount++;
+            CaptureDiscontinuity?.Invoke();
+        }
+        if (args.Silent)
+        {
+            SilentPacketCount++;
+        }
+        if (args.TimestampError)
+        {
+            TimestampErrorCount++;
+        }
         int frameCount = args.BytesRecorded / args.Format.BlockAlign;
         EnsureScratch(frameCount);
         int decodedFrames = decoder.Decode(args.Buffer.Span[..args.BytesRecorded], decodeScratch);

--- a/source/Audio/PcmCaptureSession.cs
+++ b/source/Audio/PcmCaptureSession.cs
@@ -12,6 +12,7 @@ public sealed class PcmCaptureSession : IAsyncDisposable, ISweepCaptureSession
     private double[] meterPeaks = Array.Empty<double>();
     private double[] meterSumSquares = Array.Empty<double>();
     private TaskCompletionSource<bool>? firstBufferReady;
+    private TaskCompletionSource<Exception?>? deviceStopped;
     private bool disposed;
 
     public PcmCaptureSession(IAudioCaptureDevice device, int sequence = 0, int expectedSamples = 0)
@@ -41,6 +42,8 @@ public sealed class PcmCaptureSession : IAsyncDisposable, ISweepCaptureSession
         ObjectDisposedException.ThrowIf(disposed, this);
         Reset();
         firstBufferReady = SampleWaiterRegistry.NewSignal();
+        deviceStopped = new TaskCompletionSource<Exception?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         try
         {
             await device.StartAsync(cancellationToken).ConfigureAwait(false);
@@ -56,6 +59,14 @@ public sealed class PcmCaptureSession : IAsyncDisposable, ISweepCaptureSession
     }
 
     public Task StopAsync() => device.StopAsync();
+
+    internal async Task WaitForStopAsync(CancellationToken cancellationToken)
+    {
+        Task<Exception?> task = deviceStopped?.Task ??
+            throw new InvalidOperationException("Capture has not been started.");
+        Exception? exception = await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        throw exception ?? new InvalidOperationException("The capture device stopped unexpectedly.");
+    }
 
     public Task WaitForSamplesAsync(int sampleCount, CancellationToken cancellationToken)
     {
@@ -163,6 +174,7 @@ public sealed class PcmCaptureSession : IAsyncDisposable, ISweepCaptureSession
     {
         Exception exception = args.Exception ?? new InvalidOperationException(
             "Recording stopped before the requested samples arrived.");
+        deviceStopped?.TrySetResult(args.Exception);
         firstBufferReady?.TrySetException(exception);
         lock (sync)
         {

--- a/source/Audio/PcmCaptureSession.cs
+++ b/source/Audio/PcmCaptureSession.cs
@@ -1,0 +1,171 @@
+namespace Resonalyze;
+
+public sealed class PcmCaptureSession : IAsyncDisposable
+{
+    private readonly object sync = new();
+    private readonly IAudioCaptureDevice device;
+    private readonly IInterleavedSampleDecoder decoder;
+    private readonly SampleWaiterRegistry sampleWaiters = new();
+    private readonly int expectedSamples;
+    private CaptureAccumulator accumulator;
+    private float[][] decodeScratch = Array.Empty<float[]>();
+    private double[] meterPeaks = Array.Empty<double>();
+    private double[] meterSumSquares = Array.Empty<double>();
+    private TaskCompletionSource<bool>? firstBufferReady;
+    private bool disposed;
+
+    public PcmCaptureSession(IAudioCaptureDevice device, int sequence = 0, int expectedSamples = 0)
+    {
+        this.device = device ?? throw new ArgumentNullException(nameof(device));
+        decoder = InterleavedSampleDecoder.Create(device.CaptureFormat);
+        Sequence = sequence;
+        this.expectedSamples = expectedSamples;
+        accumulator = CreateAccumulator();
+        device.DataAvailable += HandleDataAvailable;
+        device.Stopped += HandleStopped;
+    }
+
+    public event Action<float[]>? SequenceReady;
+    public event Action<float[][]>? SequenceChannelsReady;
+    internal event Action<AudioChannelLevel[]>? LevelsAvailable;
+
+    public int Sequence { get; set; }
+    public int ReadSamples => accumulator.ReadSamples;
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        Reset();
+        firstBufferReady = SampleWaiterRegistry.NewSignal();
+        try
+        {
+            await device.StartAsync(cancellationToken).ConfigureAwait(false);
+            using CancellationTokenRegistration registration = cancellationToken.Register(
+                () => firstBufferReady.TrySetCanceled(cancellationToken));
+            await firstBufferReady.Task.ConfigureAwait(false);
+        }
+        catch
+        {
+            await device.StopAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public Task StopAsync() => device.StopAsync();
+
+    public Task WaitForSamplesAsync(int sampleCount, CancellationToken cancellationToken)
+    {
+        if (sampleCount <= 0)
+        {
+            return Task.CompletedTask;
+        }
+        lock (sync)
+        {
+            return accumulator.ReadSamples >= sampleCount
+                ? Task.CompletedTask
+                : sampleWaiters.Add(sampleCount, cancellationToken);
+        }
+    }
+
+    public float[][] GetSamplesSnapshot()
+    {
+        lock (sync)
+        {
+            return accumulator.Snapshot();
+        }
+    }
+
+    public void Reset()
+    {
+        lock (sync)
+        {
+            accumulator = CreateAccumulator();
+            sampleWaiters.CancelAll();
+        }
+    }
+
+    private CaptureAccumulator CreateAccumulator() => new(
+        device.ChannelCount,
+        Sequence,
+        Math.Max(expectedSamples, device.CaptureFormat.SampleRate));
+
+    private void HandleDataAvailable(object? sender, AudioCaptureDataEventArgs args)
+    {
+        int frameCount = args.BytesRecorded / args.Format.BlockAlign;
+        EnsureScratch(frameCount);
+        int decodedFrames = decoder.Decode(args.Buffer.Span[..args.BytesRecorded], decodeScratch);
+        Array.Clear(meterPeaks);
+        Array.Clear(meterSumSquares);
+        for (int channel = 0; channel < device.ChannelCount; channel++)
+        {
+            for (int frame = 0; frame < decodedFrames; frame++)
+            {
+                float sample = decodeScratch[channel][frame];
+                meterPeaks[channel] = Math.Max(meterPeaks[channel], Math.Abs(sample));
+                meterSumSquares[channel] += sample * sample;
+            }
+        }
+
+        List<float[][]>? readySequences;
+        lock (sync)
+        {
+            accumulator.Append(decodeScratch, decodedFrames);
+            readySequences = accumulator.ExtractReadySequences();
+            sampleWaiters.CompleteUpTo(accumulator.ReadSamples);
+        }
+
+        firstBufferReady?.TrySetResult(true);
+        LevelsAvailable?.Invoke(
+            AudioLevelMetering.MeasureChannels(meterPeaks, meterSumSquares, decodedFrames));
+        if (readySequences == null)
+        {
+            return;
+        }
+        foreach (float[][] sequence in readySequences)
+        {
+            SequenceReady?.Invoke(sequence[0]);
+            SequenceChannelsReady?.Invoke(sequence);
+        }
+    }
+
+    private void EnsureScratch(int frames)
+    {
+        if (decodeScratch.Length == device.ChannelCount &&
+            decodeScratch.Length > 0 && decodeScratch[0].Length >= frames)
+        {
+            return;
+        }
+        decodeScratch = Enumerable.Range(0, device.ChannelCount)
+            .Select(_ => new float[frames])
+            .ToArray();
+        meterPeaks = new double[device.ChannelCount];
+        meterSumSquares = new double[device.ChannelCount];
+    }
+
+    private void HandleStopped(object? sender, AudioDeviceStoppedEventArgs args)
+    {
+        Exception exception = args.Exception ?? new InvalidOperationException(
+            "Recording stopped before the requested samples arrived.");
+        firstBufferReady?.TrySetException(exception);
+        lock (sync)
+        {
+            sampleWaiters.FaultAll(exception);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (disposed)
+        {
+            return;
+        }
+        disposed = true;
+        device.DataAvailable -= HandleDataAvailable;
+        device.Stopped -= HandleStopped;
+        lock (sync)
+        {
+            sampleWaiters.CancelAll();
+        }
+        await device.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/source/Audio/Wasapi/AudioEndpointInfo.cs
+++ b/source/Audio/Wasapi/AudioEndpointInfo.cs
@@ -1,0 +1,13 @@
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+public sealed record AudioEndpointInfo(
+    string Id,
+    string FriendlyName,
+    DataFlow Direction,
+    DeviceState State,
+    WaveFormat MixFormat,
+    int Channels,
+    bool IsDefault);

--- a/source/Audio/Wasapi/AudioEndpointInfo.cs
+++ b/source/Audio/Wasapi/AudioEndpointInfo.cs
@@ -10,4 +10,14 @@ public sealed record AudioEndpointInfo(
     DeviceState State,
     WaveFormat MixFormat,
     int Channels,
-    bool IsDefault);
+    bool IsDefault)
+{
+    public bool IsAvailable => State == DeviceState.Active;
+
+    public override string ToString()
+    {
+        string prefix = IsAvailable ? string.Empty : "[Unavailable] ";
+        string suffix = IsDefault ? " (Default)" : string.Empty;
+        return $"{prefix}{FriendlyName}{suffix}";
+    }
+}

--- a/source/Audio/Wasapi/AudioSessionDiagnostics.cs
+++ b/source/Audio/Wasapi/AudioSessionDiagnostics.cs
@@ -1,0 +1,17 @@
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+public sealed record AudioSessionDiagnostics(
+    string Backend,
+    string CaptureEndpointId,
+    string RenderEndpointId,
+    WaveFormat CaptureFormat,
+    WaveFormat RenderFormat,
+    int RequestedBufferMilliseconds,
+    long CapturePackets,
+    long RenderCallbacks,
+    long Discontinuities,
+    long SilentPackets,
+    long CaptureOverruns,
+    long RenderUnderruns);

--- a/source/Audio/Wasapi/AudioSessionDiagnostics.cs
+++ b/source/Audio/Wasapi/AudioSessionDiagnostics.cs
@@ -9,9 +9,11 @@ public sealed record AudioSessionDiagnostics(
     WaveFormat CaptureFormat,
     WaveFormat RenderFormat,
     int RequestedBufferMilliseconds,
+    int ActualBufferFrames,
     long CapturePackets,
     long RenderCallbacks,
     long Discontinuities,
     long SilentPackets,
+    long TimestampErrors,
     long CaptureOverruns,
     long RenderUnderruns);

--- a/source/Audio/Wasapi/WasapiCaptureDevice.cs
+++ b/source/Audio/Wasapi/WasapiCaptureDevice.cs
@@ -6,11 +6,9 @@ namespace Resonalyze;
 
 public sealed class WasapiCaptureDevice : IAudioCaptureDevice
 {
-    private const long ReferenceTimesPerMillisecond = 10_000;
-
     private readonly MMDeviceEnumerator enumerator;
     private readonly MMDevice endpoint;
-    private readonly AudioClient audioClient;
+    private AudioClient audioClient;
     private readonly EventWaitHandle packetReady = new(false, EventResetMode.AutoReset);
     private readonly string endpointId;
     private readonly string friendlyName;
@@ -30,22 +28,44 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(endpointId);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferMilliseconds);
-        enumerator = new MMDeviceEnumerator();
-        endpoint = enumerator.GetDevice(endpointId);
-        if (endpoint.DataFlow != DataFlow.Capture)
+        if (shareMode == AudioClientShareMode.Exclusive && requestedFormat == null)
         {
-            throw new ArgumentException("The endpoint is not a capture device.", nameof(endpointId));
-        }
-        this.endpointId = endpoint.ID;
-        friendlyName = endpoint.FriendlyName;
-        this.bufferMilliseconds = bufferMilliseconds;
-        audioClient = endpoint.AudioClient;
-        ShareMode = shareMode;
-        CaptureFormat = shareMode == AudioClientShareMode.Exclusive
-            ? requestedFormat ?? throw new ArgumentNullException(
+            throw new ArgumentNullException(
                 nameof(requestedFormat),
-                "WASAPI Exclusive capture requires an explicit format.")
-            : audioClient.MixFormat;
+                "WASAPI Exclusive capture requires an explicit format.");
+        }
+
+        var createdEnumerator = new MMDeviceEnumerator();
+        AudioClient? createdAudioClient = null;
+        try
+        {
+            MMDevice createdEndpoint = createdEnumerator.GetDevice(endpointId);
+            if (createdEndpoint.DataFlow != DataFlow.Capture)
+            {
+                throw new ArgumentException(
+                    "The endpoint is not a capture device.",
+                    nameof(endpointId));
+            }
+            createdAudioClient = createdEndpoint.AudioClient;
+            WaveFormat captureFormat = shareMode == AudioClientShareMode.Exclusive
+                ? requestedFormat!
+                : createdAudioClient.MixFormat;
+
+            enumerator = createdEnumerator;
+            endpoint = createdEndpoint;
+            audioClient = createdAudioClient;
+            this.endpointId = createdEndpoint.ID;
+            friendlyName = createdEndpoint.FriendlyName;
+            this.bufferMilliseconds = bufferMilliseconds;
+            ShareMode = shareMode;
+            CaptureFormat = captureFormat;
+        }
+        catch
+        {
+            createdAudioClient?.Dispose();
+            createdEnumerator.Dispose();
+            throw;
+        }
     }
 
     public event EventHandler<AudioCaptureDataEventArgs>? DataAvailable;
@@ -109,7 +129,8 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
         {
             return;
         }
-        long duration = bufferMilliseconds * ReferenceTimesPerMillisecond;
+        (long bufferDuration, long periodicity) =
+            WasapiStreamConfiguration.GetDurations(ShareMode, bufferMilliseconds);
         AudioClientStreamFlags flags = AudioClientStreamFlags.EventCallback;
         if (ShareMode == AudioClientShareMode.Shared)
         {
@@ -119,7 +140,33 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
         }
         else
         {
-            audioClient.Initialize(ShareMode, flags, duration, duration, CaptureFormat, Guid.Empty);
+            try
+            {
+                audioClient.Initialize(
+                    ShareMode,
+                    flags,
+                    bufferDuration,
+                    periodicity,
+                    CaptureFormat,
+                    Guid.Empty);
+            }
+            catch (COMException exception) when (
+                WasapiStreamConfiguration.IsBufferSizeNotAligned(exception))
+            {
+                int alignedFrames = audioClient.BufferSize;
+                long alignedDuration = WasapiStreamConfiguration.GetAlignedExclusiveDuration(
+                    alignedFrames,
+                    CaptureFormat.SampleRate);
+                audioClient.Dispose();
+                audioClient = endpoint.AudioClient;
+                audioClient.Initialize(
+                    ShareMode,
+                    flags,
+                    alignedDuration,
+                    alignedDuration,
+                    CaptureFormat,
+                    Guid.Empty);
+            }
         }
         audioClient.SetEventHandle(packetReady.SafeWaitHandle.DangerousGetHandle());
         initialized = true;

--- a/source/Audio/Wasapi/WasapiCaptureDevice.cs
+++ b/source/Audio/Wasapi/WasapiCaptureDevice.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using NAudio.CoreAudioApi;
 using NAudio.Wave;
 
@@ -5,12 +6,20 @@ namespace Resonalyze;
 
 public sealed class WasapiCaptureDevice : IAudioCaptureDevice
 {
+    private const long ReferenceTimesPerMillisecond = 10_000;
+
     private readonly MMDeviceEnumerator enumerator;
     private readonly MMDevice endpoint;
-    private readonly WasapiCapture capture;
+    private readonly AudioClient audioClient;
+    private readonly EventWaitHandle packetReady = new(false, EventResetMode.AutoReset);
     private readonly string endpointId;
     private readonly string friendlyName;
+    private readonly int bufferMilliseconds;
+    private Thread? captureThread;
     private TaskCompletionSource<bool>? stopped;
+    private volatile bool stopRequested;
+    private bool initialized;
+    private bool startedOnce;
     private bool disposed;
 
     public WasapiCaptureDevice(
@@ -29,20 +38,14 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
         }
         this.endpointId = endpoint.ID;
         friendlyName = endpoint.FriendlyName;
-
-        capture = new WasapiCapture(endpoint, useEventSync: true, bufferMilliseconds)
-        {
-            ShareMode = shareMode
-        };
-        if (shareMode == AudioClientShareMode.Exclusive)
-        {
-            capture.WaveFormat = requestedFormat ?? throw new ArgumentNullException(
+        this.bufferMilliseconds = bufferMilliseconds;
+        audioClient = endpoint.AudioClient;
+        ShareMode = shareMode;
+        CaptureFormat = shareMode == AudioClientShareMode.Exclusive
+            ? requestedFormat ?? throw new ArgumentNullException(
                 nameof(requestedFormat),
-                "WASAPI Exclusive capture requires an explicit format.");
-        }
-        capture.DataAvailable += HandleDataAvailable;
-        capture.RecordingStopped += HandleRecordingStopped;
-        CaptureFormat = capture.WaveFormat;
+                "WASAPI Exclusive capture requires an explicit format.")
+            : audioClient.MixFormat;
     }
 
     public event EventHandler<AudioCaptureDataEventArgs>? DataAvailable;
@@ -52,56 +55,171 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
     public int ChannelCount => CaptureFormat.Channels;
     public string EndpointId => endpointId;
     public string FriendlyName => friendlyName;
-    public AudioClientShareMode ShareMode => capture.ShareMode;
+    public AudioClientShareMode ShareMode { get; }
     public long CapturePackets { get; private set; }
+    public long Discontinuities { get; private set; }
+    public long SilentPackets { get; private set; }
+    public long TimestampErrors { get; private set; }
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(disposed, this);
         cancellationToken.ThrowIfCancellationRequested();
+        if (captureThread != null)
+        {
+            throw new InvalidOperationException("Capture is already running.");
+        }
+        if (startedOnce)
+        {
+            throw new InvalidOperationException(
+                "A WASAPI capture device cannot be restarted; keep it running and reset the session accumulator.");
+        }
+
+        Initialize();
+        startedOnce = true;
+        stopRequested = false;
         stopped = SampleWaiterRegistry.NewSignal();
         CapturePackets = 0;
-        capture.StartRecording();
+        Discontinuities = 0;
+        SilentPackets = 0;
+        TimestampErrors = 0;
+        captureThread = new Thread(CaptureLoop)
+        {
+            IsBackground = true,
+            Name = "Resonalyze WASAPI capture"
+        };
+        captureThread.Start();
         return Task.CompletedTask;
     }
 
     public async Task StopAsync()
     {
-        if (disposed || stopped == null || stopped.Task.IsCompleted)
+        if (disposed || captureThread == null || stopped == null)
         {
             return;
         }
-        await AudioCaptureStop.StopAndWaitAsync(
-            capture.StopRecording,
-            stopped,
-            stopped.Task,
-            $"WASAPI capture endpoint '{FriendlyName}'").ConfigureAwait(false);
+        stopRequested = true;
+        packetReady.Set();
+        await stopped.Task.WaitAsync(AudioCaptureStop.StopTimeout).ConfigureAwait(false);
     }
 
-    private void HandleDataAvailable(object? sender, WaveInEventArgs args)
+    private void Initialize()
     {
-        CapturePackets++;
-        DataAvailable?.Invoke(
-            this,
-            new AudioCaptureDataEventArgs
-            {
-                Buffer = args.Buffer.AsMemory(0, args.BytesRecorded),
-                BytesRecorded = args.BytesRecorded,
-                Format = CaptureFormat
-            });
-    }
-
-    private void HandleRecordingStopped(object? sender, StoppedEventArgs args)
-    {
-        if (args.Exception == null)
+        if (initialized)
         {
-            stopped?.TrySetResult(true);
+            return;
+        }
+        long duration = bufferMilliseconds * ReferenceTimesPerMillisecond;
+        AudioClientStreamFlags flags = AudioClientStreamFlags.EventCallback;
+        if (ShareMode == AudioClientShareMode.Shared)
+        {
+            flags |= AudioClientStreamFlags.AutoConvertPcm |
+                AudioClientStreamFlags.SrcDefaultQuality;
+            audioClient.Initialize(ShareMode, flags, 0, 0, CaptureFormat, Guid.Empty);
         }
         else
         {
-            stopped?.TrySetException(args.Exception);
+            audioClient.Initialize(ShareMode, flags, duration, duration, CaptureFormat, Guid.Empty);
         }
-        Stopped?.Invoke(this, new AudioDeviceStoppedEventArgs(args.Exception));
+        audioClient.SetEventHandle(packetReady.SafeWaitHandle.DangerousGetHandle());
+        initialized = true;
+    }
+
+    private void CaptureLoop()
+    {
+        Exception? failure = null;
+        try
+        {
+            AudioCaptureClient capture = audioClient.AudioCaptureClient;
+            audioClient.Start();
+            while (!stopRequested)
+            {
+                packetReady.WaitOne(bufferMilliseconds * 3);
+                if (!stopRequested)
+                {
+                    ReadAvailablePackets(capture);
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+        finally
+        {
+            try
+            {
+                audioClient.Stop();
+            }
+            catch (Exception exception)
+            {
+                failure ??= exception;
+            }
+            captureThread = null;
+            if (failure == null)
+            {
+                stopped?.TrySetResult(true);
+            }
+            else
+            {
+                stopped?.TrySetException(failure);
+            }
+            Stopped?.Invoke(this, new AudioDeviceStoppedEventArgs(failure));
+        }
+    }
+
+    private void ReadAvailablePackets(AudioCaptureClient capture)
+    {
+        while (capture.GetNextPacketSize() != 0)
+        {
+            IntPtr source = capture.GetBuffer(
+                out int frames,
+                out AudioClientBufferFlags flags,
+                out long devicePosition,
+                out long qpcPosition);
+            try
+            {
+                int byteCount = checked(frames * CaptureFormat.BlockAlign);
+                var buffer = new byte[byteCount];
+                bool silent = (flags & AudioClientBufferFlags.Silent) != 0;
+                bool discontinuity = (flags & AudioClientBufferFlags.DataDiscontinuity) != 0;
+                bool timestampError = (flags & AudioClientBufferFlags.TimestampError) != 0;
+                if (!silent)
+                {
+                    Marshal.Copy(source, buffer, 0, byteCount);
+                }
+                CapturePackets++;
+                if (silent)
+                {
+                    SilentPackets++;
+                }
+                if (discontinuity)
+                {
+                    Discontinuities++;
+                }
+                if (timestampError)
+                {
+                    TimestampErrors++;
+                }
+                DataAvailable?.Invoke(
+                    this,
+                    new AudioCaptureDataEventArgs
+                    {
+                        Buffer = buffer,
+                        BytesRecorded = byteCount,
+                        Format = CaptureFormat,
+                        DevicePositionFrames = devicePosition,
+                        QpcPosition = qpcPosition,
+                        Discontinuity = discontinuity,
+                        Silent = silent,
+                        TimestampError = timestampError
+                    });
+            }
+            finally
+            {
+                capture.ReleaseBuffer(frames);
+            }
+        }
     }
 
     public async ValueTask DisposeAsync()
@@ -117,12 +235,8 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
         finally
         {
             disposed = true;
-            capture.DataAvailable -= HandleDataAvailable;
-            capture.RecordingStopped -= HandleRecordingStopped;
-            capture.Dispose();
-            // MMDevice.Dispose forces ReleaseComObject. A later lookup of this
-            // endpoint can receive the disconnected cached RCW and fail with
-            // E_NOINTERFACE, so leave the lightweight endpoint wrapper to CLR.
+            packetReady.Dispose();
+            audioClient.Dispose();
             enumerator.Dispose();
         }
     }

--- a/source/Audio/Wasapi/WasapiCaptureDevice.cs
+++ b/source/Audio/Wasapi/WasapiCaptureDevice.cs
@@ -1,0 +1,109 @@
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+public sealed class WasapiCaptureDevice : IAudioCaptureDevice
+{
+    private readonly MMDeviceEnumerator enumerator;
+    private readonly MMDevice endpoint;
+    private readonly WasapiCapture capture;
+    private TaskCompletionSource<bool>? stopped;
+    private bool disposed;
+
+    public WasapiCaptureDevice(string endpointId, int bufferMilliseconds = 100)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(endpointId);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferMilliseconds);
+        enumerator = new MMDeviceEnumerator();
+        endpoint = enumerator.GetDevice(endpointId);
+        if (endpoint.DataFlow != DataFlow.Capture)
+        {
+            throw new ArgumentException("The endpoint is not a capture device.", nameof(endpointId));
+        }
+
+        capture = new WasapiCapture(endpoint, useEventSync: true, bufferMilliseconds);
+        capture.DataAvailable += HandleDataAvailable;
+        capture.RecordingStopped += HandleRecordingStopped;
+        CaptureFormat = capture.WaveFormat;
+    }
+
+    public event EventHandler<AudioCaptureDataEventArgs>? DataAvailable;
+    public event EventHandler<AudioDeviceStoppedEventArgs>? Stopped;
+
+    public WaveFormat CaptureFormat { get; }
+    public int ChannelCount => CaptureFormat.Channels;
+    public string EndpointId => endpoint.ID;
+    public string FriendlyName => endpoint.FriendlyName;
+    public long CapturePackets { get; private set; }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        cancellationToken.ThrowIfCancellationRequested();
+        stopped = SampleWaiterRegistry.NewSignal();
+        CapturePackets = 0;
+        capture.StartRecording();
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync()
+    {
+        if (disposed || stopped == null || stopped.Task.IsCompleted)
+        {
+            return;
+        }
+        await AudioCaptureStop.StopAndWaitAsync(
+            capture.StopRecording,
+            stopped,
+            stopped.Task,
+            $"WASAPI capture endpoint '{FriendlyName}'").ConfigureAwait(false);
+    }
+
+    private void HandleDataAvailable(object? sender, WaveInEventArgs args)
+    {
+        CapturePackets++;
+        DataAvailable?.Invoke(
+            this,
+            new AudioCaptureDataEventArgs
+            {
+                Buffer = args.Buffer.AsMemory(0, args.BytesRecorded),
+                BytesRecorded = args.BytesRecorded,
+                Format = CaptureFormat
+            });
+    }
+
+    private void HandleRecordingStopped(object? sender, StoppedEventArgs args)
+    {
+        if (args.Exception == null)
+        {
+            stopped?.TrySetResult(true);
+        }
+        else
+        {
+            stopped?.TrySetException(args.Exception);
+        }
+        Stopped?.Invoke(this, new AudioDeviceStoppedEventArgs(args.Exception));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (disposed)
+        {
+            return;
+        }
+        try
+        {
+            await StopAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            disposed = true;
+            capture.DataAvailable -= HandleDataAvailable;
+            capture.RecordingStopped -= HandleRecordingStopped;
+            capture.Dispose();
+            endpoint.Dispose();
+            enumerator.Dispose();
+        }
+    }
+}

--- a/source/Audio/Wasapi/WasapiCaptureDevice.cs
+++ b/source/Audio/Wasapi/WasapiCaptureDevice.cs
@@ -13,7 +13,11 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
     private TaskCompletionSource<bool>? stopped;
     private bool disposed;
 
-    public WasapiCaptureDevice(string endpointId, int bufferMilliseconds = 100)
+    public WasapiCaptureDevice(
+        string endpointId,
+        int bufferMilliseconds = 100,
+        AudioClientShareMode shareMode = AudioClientShareMode.Shared,
+        WaveFormat? requestedFormat = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(endpointId);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferMilliseconds);
@@ -26,7 +30,16 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
         this.endpointId = endpoint.ID;
         friendlyName = endpoint.FriendlyName;
 
-        capture = new WasapiCapture(endpoint, useEventSync: true, bufferMilliseconds);
+        capture = new WasapiCapture(endpoint, useEventSync: true, bufferMilliseconds)
+        {
+            ShareMode = shareMode
+        };
+        if (shareMode == AudioClientShareMode.Exclusive)
+        {
+            capture.WaveFormat = requestedFormat ?? throw new ArgumentNullException(
+                nameof(requestedFormat),
+                "WASAPI Exclusive capture requires an explicit format.");
+        }
         capture.DataAvailable += HandleDataAvailable;
         capture.RecordingStopped += HandleRecordingStopped;
         CaptureFormat = capture.WaveFormat;
@@ -39,6 +52,7 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
     public int ChannelCount => CaptureFormat.Channels;
     public string EndpointId => endpointId;
     public string FriendlyName => friendlyName;
+    public AudioClientShareMode ShareMode => capture.ShareMode;
     public long CapturePackets { get; private set; }
 
     public Task StartAsync(CancellationToken cancellationToken)

--- a/source/Audio/Wasapi/WasapiCaptureDevice.cs
+++ b/source/Audio/Wasapi/WasapiCaptureDevice.cs
@@ -8,6 +8,8 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
     private readonly MMDeviceEnumerator enumerator;
     private readonly MMDevice endpoint;
     private readonly WasapiCapture capture;
+    private readonly string endpointId;
+    private readonly string friendlyName;
     private TaskCompletionSource<bool>? stopped;
     private bool disposed;
 
@@ -21,6 +23,8 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
         {
             throw new ArgumentException("The endpoint is not a capture device.", nameof(endpointId));
         }
+        this.endpointId = endpoint.ID;
+        friendlyName = endpoint.FriendlyName;
 
         capture = new WasapiCapture(endpoint, useEventSync: true, bufferMilliseconds);
         capture.DataAvailable += HandleDataAvailable;
@@ -33,8 +37,8 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
 
     public WaveFormat CaptureFormat { get; }
     public int ChannelCount => CaptureFormat.Channels;
-    public string EndpointId => endpoint.ID;
-    public string FriendlyName => endpoint.FriendlyName;
+    public string EndpointId => endpointId;
+    public string FriendlyName => friendlyName;
     public long CapturePackets { get; private set; }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -102,7 +106,9 @@ public sealed class WasapiCaptureDevice : IAudioCaptureDevice
             capture.DataAvailable -= HandleDataAvailable;
             capture.RecordingStopped -= HandleRecordingStopped;
             capture.Dispose();
-            endpoint.Dispose();
+            // MMDevice.Dispose forces ReleaseComObject. A later lookup of this
+            // endpoint can receive the disconnected cached RCW and fail with
+            // E_NOINTERFACE, so leave the lightweight endpoint wrapper to CLR.
             enumerator.Dispose();
         }
     }

--- a/source/Audio/Wasapi/WasapiFormatSupport.cs
+++ b/source/Audio/Wasapi/WasapiFormatSupport.cs
@@ -1,0 +1,64 @@
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+public sealed record DuplexFormatSupport(
+    int SampleRate,
+    int BitsPerSample,
+    int CaptureChannels,
+    int RenderChannels,
+    bool CaptureSupported,
+    bool RenderSupported)
+{
+    public bool Supported => CaptureSupported && RenderSupported;
+}
+
+public static class WasapiFormatSupport
+{
+    public static DuplexFormatSupport CheckExclusive(
+        string captureEndpointId,
+        string renderEndpointId,
+        int sampleRate,
+        int bitsPerSample,
+        int captureChannels,
+        int renderChannels)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(captureEndpointId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(renderEndpointId);
+        WaveFormat captureFormat = CreateDeviceFormat(sampleRate, bitsPerSample, captureChannels);
+        WaveFormat renderFormat = CreateDeviceFormat(sampleRate, bitsPerSample, renderChannels);
+        using var enumerator = new MMDeviceEnumerator();
+        MMDevice capture = enumerator.GetDevice(captureEndpointId);
+        MMDevice render = enumerator.GetDevice(renderEndpointId);
+        bool captureSupported = capture.AudioClient.IsFormatSupported(
+            AudioClientShareMode.Exclusive,
+            captureFormat);
+        bool renderSupported = render.AudioClient.IsFormatSupported(
+            AudioClientShareMode.Exclusive,
+            renderFormat);
+        return new DuplexFormatSupport(
+            sampleRate,
+            bitsPerSample,
+            captureChannels,
+            renderChannels,
+            captureSupported,
+            renderSupported);
+    }
+
+    public static WaveFormat CreateDeviceFormat(int sampleRate, int bitsPerSample, int channels)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sampleRate);
+        if (bitsPerSample is not (16 or 24 or 32))
+        {
+            throw new ArgumentOutOfRangeException(nameof(bitsPerSample));
+        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(channels);
+        int channelMask = channels >= 31 ? 0 : (1 << channels) - 1;
+        return new WaveFormatExtensible(
+            sampleRate,
+            bitsPerSample,
+            channels,
+            channelMask);
+    }
+}

--- a/source/Audio/Wasapi/WasapiPlaybackDevice.cs
+++ b/source/Audio/Wasapi/WasapiPlaybackDevice.cs
@@ -1,0 +1,110 @@
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
+{
+    private readonly MMDeviceEnumerator enumerator;
+    private readonly MMDevice endpoint;
+    private readonly WasapiOut output;
+    private TaskCompletionSource<bool>? playbackEnded;
+    private IWaveProvider? initializedSource;
+    private bool disposed;
+
+    public WasapiPlaybackDevice(string endpointId, int bufferMilliseconds = 100)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(endpointId);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferMilliseconds);
+        enumerator = new MMDeviceEnumerator();
+        endpoint = enumerator.GetDevice(endpointId);
+        if (endpoint.DataFlow != DataFlow.Render)
+        {
+            throw new ArgumentException("The endpoint is not a render device.", nameof(endpointId));
+        }
+        output = new WasapiOut(
+            endpoint,
+            AudioClientShareMode.Shared,
+            useEventSync: true,
+            bufferMilliseconds);
+        output.PlaybackStopped += HandlePlaybackStopped;
+        PlaybackFormat = endpoint.AudioClient.MixFormat;
+    }
+
+    public WaveFormat PlaybackFormat { get; private set; }
+    public string EndpointId => endpoint.ID;
+    public string FriendlyName => endpoint.FriendlyName;
+
+    public Task StartAsync(IWaveProvider source, CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        ArgumentNullException.ThrowIfNull(source);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (playbackEnded is { Task.IsCompleted: false })
+        {
+            throw new InvalidOperationException("Playback is already running.");
+        }
+        if (source.WaveFormat.SampleRate != PlaybackFormat.SampleRate)
+        {
+            throw new InvalidOperationException(
+                $"WASAPI Shared requires the endpoint mix rate ({PlaybackFormat.SampleRate} Hz), " +
+                $"but the source is {source.WaveFormat.SampleRate} Hz.");
+        }
+        if (initializedSource != null && !ReferenceEquals(initializedSource, source))
+        {
+            throw new InvalidOperationException(
+                "This playback session is already initialized with another source.");
+        }
+
+        playbackEnded = SampleWaiterRegistry.NewSignal();
+        if (initializedSource == null)
+        {
+            output.Init(source);
+            initializedSource = source;
+        }
+        output.Play();
+        return Task.CompletedTask;
+    }
+
+    public async Task WaitForPlaybackEndAsync(CancellationToken cancellationToken)
+    {
+        Task task = playbackEnded?.Task ??
+            throw new InvalidOperationException("Playback has not been started.");
+        await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task StopAsync()
+    {
+        if (!disposed && playbackEnded is { Task.IsCompleted: false })
+        {
+            output.Stop();
+        }
+        return Task.CompletedTask;
+    }
+
+    private void HandlePlaybackStopped(object? sender, StoppedEventArgs args)
+    {
+        if (args.Exception == null)
+        {
+            playbackEnded?.TrySetResult(true);
+        }
+        else
+        {
+            playbackEnded?.TrySetException(args.Exception);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (disposed)
+        {
+            return;
+        }
+        await StopAsync().ConfigureAwait(false);
+        disposed = true;
+        output.PlaybackStopped -= HandlePlaybackStopped;
+        output.Dispose();
+        endpoint.Dispose();
+        enumerator.Dispose();
+    }
+}

--- a/source/Audio/Wasapi/WasapiPlaybackDevice.cs
+++ b/source/Audio/Wasapi/WasapiPlaybackDevice.cs
@@ -12,9 +12,14 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
     private readonly string friendlyName;
     private TaskCompletionSource<bool>? playbackEnded;
     private IWaveProvider? initializedSource;
+    private IWaveProvider? initializedProvider;
     private bool disposed;
 
-    public WasapiPlaybackDevice(string endpointId, int bufferMilliseconds = 100)
+    public WasapiPlaybackDevice(
+        string endpointId,
+        int bufferMilliseconds = 100,
+        AudioClientShareMode shareMode = AudioClientShareMode.Shared,
+        WaveFormat? requestedFormat = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(endpointId);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferMilliseconds);
@@ -28,16 +33,22 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
         friendlyName = endpoint.FriendlyName;
         output = new WasapiOut(
             endpoint,
-            AudioClientShareMode.Shared,
+            shareMode,
             useEventSync: true,
             bufferMilliseconds);
         output.PlaybackStopped += HandlePlaybackStopped;
-        PlaybackFormat = endpoint.AudioClient.MixFormat;
+        PlaybackFormat = shareMode == AudioClientShareMode.Exclusive
+            ? requestedFormat ?? throw new ArgumentNullException(
+                nameof(requestedFormat),
+                "WASAPI Exclusive playback requires an explicit format.")
+            : endpoint.AudioClient.MixFormat;
+        ShareMode = shareMode;
     }
 
     public WaveFormat PlaybackFormat { get; private set; }
     public string EndpointId => endpointId;
     public string FriendlyName => friendlyName;
+    public AudioClientShareMode ShareMode { get; }
 
     public Task StartAsync(IWaveProvider source, CancellationToken cancellationToken)
     {
@@ -51,8 +62,16 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
         if (source.WaveFormat.SampleRate != PlaybackFormat.SampleRate)
         {
             throw new InvalidOperationException(
-                $"WASAPI Shared requires the endpoint mix rate ({PlaybackFormat.SampleRate} Hz), " +
+                $"WASAPI {ShareMode} requires {PlaybackFormat.SampleRate} Hz, " +
                 $"but the source is {source.WaveFormat.SampleRate} Hz.");
+        }
+        if (ShareMode == AudioClientShareMode.Exclusive &&
+            (source.WaveFormat.BitsPerSample != PlaybackFormat.BitsPerSample ||
+                source.WaveFormat.Channels != PlaybackFormat.Channels))
+        {
+            throw new InvalidOperationException(
+                $"WASAPI Exclusive source format ({source.WaveFormat}) does not match " +
+                $"the requested endpoint format ({PlaybackFormat}).");
         }
         if (initializedSource != null && !ReferenceEquals(initializedSource, source))
         {
@@ -63,7 +82,10 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
         playbackEnded = SampleWaiterRegistry.NewSignal();
         if (initializedSource == null)
         {
-            output.Init(source);
+            initializedProvider = ShareMode == AudioClientShareMode.Exclusive
+                ? new WaveFormatOverrideProvider(source, PlaybackFormat)
+                : source;
+            output.Init(initializedProvider);
             initializedSource = source;
         }
         output.Play();
@@ -111,5 +133,21 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
         // See WasapiCaptureDevice: explicitly releasing this MMDevice can poison
         // a later RCW for the same endpoint identity.
         enumerator.Dispose();
+    }
+
+    private sealed class WaveFormatOverrideProvider : IWaveProvider
+    {
+        private readonly IWaveProvider source;
+
+        public WaveFormatOverrideProvider(IWaveProvider source, WaveFormat waveFormat)
+        {
+            this.source = source;
+            WaveFormat = waveFormat;
+        }
+
+        public WaveFormat WaveFormat { get; }
+
+        public int Read(byte[] buffer, int offset, int count) =>
+            source.Read(buffer, offset, count);
     }
 }

--- a/source/Audio/Wasapi/WasapiPlaybackDevice.cs
+++ b/source/Audio/Wasapi/WasapiPlaybackDevice.cs
@@ -7,11 +7,9 @@ namespace Resonalyze;
 
 public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
 {
-    private const long ReferenceTimesPerMillisecond = 10_000;
-
     private readonly MMDeviceEnumerator enumerator;
     private readonly MMDevice endpoint;
-    private readonly AudioClient audioClient;
+    private AudioClient audioClient;
     private readonly EventWaitHandle bufferReady = new(false, EventResetMode.AutoReset);
     private readonly string endpointId;
     private readonly string friendlyName;
@@ -33,22 +31,44 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(endpointId);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferMilliseconds);
-        enumerator = new MMDeviceEnumerator();
-        endpoint = enumerator.GetDevice(endpointId);
-        if (endpoint.DataFlow != DataFlow.Render)
+        if (shareMode == AudioClientShareMode.Exclusive && requestedFormat == null)
         {
-            throw new ArgumentException("The endpoint is not a render device.", nameof(endpointId));
-        }
-        this.endpointId = endpoint.ID;
-        friendlyName = endpoint.FriendlyName;
-        this.bufferMilliseconds = bufferMilliseconds;
-        audioClient = endpoint.AudioClient;
-        PlaybackFormat = shareMode == AudioClientShareMode.Exclusive
-            ? requestedFormat ?? throw new ArgumentNullException(
+            throw new ArgumentNullException(
                 nameof(requestedFormat),
-                "WASAPI Exclusive playback requires an explicit format.")
-            : audioClient.MixFormat;
-        ShareMode = shareMode;
+                "WASAPI Exclusive playback requires an explicit format.");
+        }
+
+        var createdEnumerator = new MMDeviceEnumerator();
+        AudioClient? createdAudioClient = null;
+        try
+        {
+            MMDevice createdEndpoint = createdEnumerator.GetDevice(endpointId);
+            if (createdEndpoint.DataFlow != DataFlow.Render)
+            {
+                throw new ArgumentException(
+                    "The endpoint is not a render device.",
+                    nameof(endpointId));
+            }
+            createdAudioClient = createdEndpoint.AudioClient;
+            WaveFormat playbackFormat = shareMode == AudioClientShareMode.Exclusive
+                ? requestedFormat!
+                : createdAudioClient.MixFormat;
+
+            enumerator = createdEnumerator;
+            endpoint = createdEndpoint;
+            audioClient = createdAudioClient;
+            this.endpointId = createdEndpoint.ID;
+            friendlyName = createdEndpoint.FriendlyName;
+            this.bufferMilliseconds = bufferMilliseconds;
+            PlaybackFormat = playbackFormat;
+            ShareMode = shareMode;
+        }
+        catch
+        {
+            createdAudioClient?.Dispose();
+            createdEnumerator.Dispose();
+            throw;
+        }
     }
 
     public WaveFormat PlaybackFormat { get; }
@@ -133,21 +153,62 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
         streamFormat = ShareMode == AudioClientShareMode.Exclusive
             ? PlaybackFormat
             : source.WaveFormat;
-        long duration = bufferMilliseconds * ReferenceTimesPerMillisecond;
+        (long bufferDuration, long periodicity) =
+            WasapiStreamConfiguration.GetDurations(ShareMode, bufferMilliseconds);
         AudioClientStreamFlags flags = AudioClientStreamFlags.EventCallback;
         if (ShareMode == AudioClientShareMode.Shared)
         {
             flags |= AudioClientStreamFlags.AutoConvertPcm |
                 AudioClientStreamFlags.SrcDefaultQuality;
-            audioClient.Initialize(ShareMode, flags, duration, 0, streamFormat, Guid.Empty);
+            audioClient.Initialize(
+                ShareMode,
+                flags,
+                bufferDuration,
+                periodicity,
+                streamFormat,
+                Guid.Empty);
         }
         else
         {
-            audioClient.Initialize(ShareMode, flags, duration, duration, streamFormat, Guid.Empty);
+            InitializeExclusive(flags, bufferDuration, periodicity);
         }
         audioClient.SetEventHandle(bufferReady.SafeWaitHandle.DangerousGetHandle());
         ActualBufferFrames = audioClient.BufferSize;
         initialized = true;
+    }
+
+    private void InitializeExclusive(
+        AudioClientStreamFlags flags,
+        long bufferDuration,
+        long periodicity)
+    {
+        try
+        {
+            audioClient.Initialize(
+                ShareMode,
+                flags,
+                bufferDuration,
+                periodicity,
+                streamFormat!,
+                Guid.Empty);
+        }
+        catch (COMException exception) when (
+            WasapiStreamConfiguration.IsBufferSizeNotAligned(exception))
+        {
+            int alignedFrames = audioClient.BufferSize;
+            long alignedDuration = WasapiStreamConfiguration.GetAlignedExclusiveDuration(
+                alignedFrames,
+                streamFormat!.SampleRate);
+            audioClient.Dispose();
+            audioClient = endpoint.AudioClient;
+            audioClient.Initialize(
+                ShareMode,
+                flags,
+                alignedDuration,
+                alignedDuration,
+                streamFormat,
+                Guid.Empty);
+        }
     }
 
     private void RenderLoop()
@@ -160,39 +221,13 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
             bool sourceEnded = !FillBuffer(render, ActualBufferFrames);
             audioClient.Start();
             clientStarted = true;
-            while (!stopRequested)
+            if (ShareMode == AudioClientShareMode.Exclusive)
             {
-                bufferReady.WaitOne(bufferMilliseconds * 3);
-                if (stopRequested)
-                {
-                    break;
-                }
-
-                int padding = audioClient.CurrentPadding;
-                if (sourceEnded)
-                {
-                    if (padding == 0)
-                    {
-                        break;
-                    }
-                    continue;
-                }
-                TimeSpan sinceLastFill = Stopwatch.GetElapsedTime(lastBufferFillTimestamp);
-                TimeSpan bufferDuration = TimeSpan.FromSeconds(
-                    (double)ActualBufferFrames / (streamFormat?.SampleRate ?? 1));
-                if (WasapiRenderTiming.IsUnderrun(
-                    padding,
-                    sourceEnded,
-                    sinceLastFill,
-                    bufferDuration))
-                {
-                    RenderUnderruns++;
-                }
-                int availableFrames = ActualBufferFrames - padding;
-                if (availableFrames > 0)
-                {
-                    sourceEnded = !FillBuffer(render, availableFrames);
-                }
+                RunExclusiveRenderLoop(render, sourceEnded);
+            }
+            else
+            {
+                RunSharedRenderLoop(render, sourceEnded);
             }
         }
         catch (Exception exception)
@@ -224,6 +259,80 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
             }
         }
     }
+
+    private void RunExclusiveRenderLoop(AudioRenderClient render, bool finalBufferQueued)
+    {
+        TimeSpan bufferDuration = GetBufferDuration();
+        while (!stopRequested)
+        {
+            bool signaled = bufferReady.WaitOne(bufferMilliseconds * 3);
+            if (stopRequested)
+            {
+                break;
+            }
+            if (!signaled)
+            {
+                RenderUnderruns++;
+                continue;
+            }
+            if (finalBufferQueued)
+            {
+                break;
+            }
+            if (Stopwatch.GetElapsedTime(lastBufferFillTimestamp) > bufferDuration * 1.5)
+            {
+                RenderUnderruns++;
+            }
+            finalBufferQueued = !FillBuffer(render, ActualBufferFrames);
+        }
+    }
+
+    private void RunSharedRenderLoop(AudioRenderClient render, bool sourceEnded)
+    {
+        TimeSpan bufferDuration = GetBufferDuration();
+        while (!stopRequested)
+        {
+            bool signaled = bufferReady.WaitOne(bufferMilliseconds * 3);
+            if (stopRequested)
+            {
+                break;
+            }
+            if (!signaled)
+            {
+                RenderUnderruns++;
+                continue;
+            }
+
+            int padding = audioClient.CurrentPadding;
+            if (sourceEnded)
+            {
+                if (padding == 0)
+                {
+                    break;
+                }
+                continue;
+            }
+            if (WasapiRenderTiming.IsUnderrun(
+                padding,
+                sourceEnded,
+                Stopwatch.GetElapsedTime(lastBufferFillTimestamp),
+                bufferDuration))
+            {
+                RenderUnderruns++;
+            }
+            int availableFrames = WasapiStreamConfiguration.GetRenderFrames(
+                ShareMode,
+                ActualBufferFrames,
+                padding);
+            if (availableFrames > 0)
+            {
+                sourceEnded = !FillBuffer(render, availableFrames);
+            }
+        }
+    }
+
+    private TimeSpan GetBufferDuration() => TimeSpan.FromSeconds(
+        (double)ActualBufferFrames / (streamFormat?.SampleRate ?? 1));
 
     private bool FillBuffer(AudioRenderClient render, int frames)
     {

--- a/source/Audio/Wasapi/WasapiPlaybackDevice.cs
+++ b/source/Audio/Wasapi/WasapiPlaybackDevice.cs
@@ -263,9 +263,10 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
     private void RunExclusiveRenderLoop(AudioRenderClient render, bool finalBufferQueued)
     {
         TimeSpan bufferDuration = GetBufferDuration();
+        int eventTimeoutMilliseconds = GetEventTimeoutMilliseconds();
         while (!stopRequested)
         {
-            bool signaled = bufferReady.WaitOne(bufferMilliseconds * 3);
+            bool signaled = bufferReady.WaitOne(eventTimeoutMilliseconds);
             if (stopRequested)
             {
                 break;
@@ -290,9 +291,10 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
     private void RunSharedRenderLoop(AudioRenderClient render, bool sourceEnded)
     {
         TimeSpan bufferDuration = GetBufferDuration();
+        int eventTimeoutMilliseconds = GetEventTimeoutMilliseconds();
         while (!stopRequested)
         {
-            bool signaled = bufferReady.WaitOne(bufferMilliseconds * 3);
+            bool signaled = bufferReady.WaitOne(eventTimeoutMilliseconds);
             if (stopRequested)
             {
                 break;
@@ -333,6 +335,11 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
 
     private TimeSpan GetBufferDuration() => TimeSpan.FromSeconds(
         (double)ActualBufferFrames / (streamFormat?.SampleRate ?? 1));
+
+    private int GetEventTimeoutMilliseconds() =>
+        WasapiStreamConfiguration.GetEventTimeoutMilliseconds(
+            ActualBufferFrames,
+            streamFormat?.SampleRate ?? 1);
 
     private bool FillBuffer(AudioRenderClient render, int frames)
     {

--- a/source/Audio/Wasapi/WasapiPlaybackDevice.cs
+++ b/source/Audio/Wasapi/WasapiPlaybackDevice.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using NAudio.CoreAudioApi;
 using NAudio.Wave;
 
@@ -5,15 +7,23 @@ namespace Resonalyze;
 
 public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
 {
+    private const long ReferenceTimesPerMillisecond = 10_000;
+
     private readonly MMDeviceEnumerator enumerator;
     private readonly MMDevice endpoint;
-    private readonly WasapiOut output;
+    private readonly AudioClient audioClient;
+    private readonly EventWaitHandle bufferReady = new(false, EventResetMode.AutoReset);
     private readonly string endpointId;
     private readonly string friendlyName;
+    private readonly int bufferMilliseconds;
+    private Thread? renderThread;
     private TaskCompletionSource<bool>? playbackEnded;
     private IWaveProvider? initializedSource;
-    private IWaveProvider? initializedProvider;
+    private WaveFormat? streamFormat;
+    private volatile bool stopRequested;
+    private bool initialized;
     private bool disposed;
+    private long lastBufferFillTimestamp;
 
     public WasapiPlaybackDevice(
         string endpointId,
@@ -31,64 +41,50 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
         }
         this.endpointId = endpoint.ID;
         friendlyName = endpoint.FriendlyName;
-        output = new WasapiOut(
-            endpoint,
-            shareMode,
-            useEventSync: true,
-            bufferMilliseconds);
-        output.PlaybackStopped += HandlePlaybackStopped;
+        this.bufferMilliseconds = bufferMilliseconds;
+        audioClient = endpoint.AudioClient;
         PlaybackFormat = shareMode == AudioClientShareMode.Exclusive
             ? requestedFormat ?? throw new ArgumentNullException(
                 nameof(requestedFormat),
                 "WASAPI Exclusive playback requires an explicit format.")
-            : endpoint.AudioClient.MixFormat;
+            : audioClient.MixFormat;
         ShareMode = shareMode;
     }
 
-    public WaveFormat PlaybackFormat { get; private set; }
+    public WaveFormat PlaybackFormat { get; }
     public string EndpointId => endpointId;
     public string FriendlyName => friendlyName;
     public AudioClientShareMode ShareMode { get; }
+    public long RenderCallbacks { get; private set; }
+    public long RenderUnderruns { get; private set; }
+    public int ActualBufferFrames { get; private set; }
 
     public Task StartAsync(IWaveProvider source, CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(disposed, this);
         ArgumentNullException.ThrowIfNull(source);
         cancellationToken.ThrowIfCancellationRequested();
-        if (playbackEnded is { Task.IsCompleted: false })
+        if (renderThread != null)
         {
             throw new InvalidOperationException("Playback is already running.");
         }
-        if (source.WaveFormat.SampleRate != PlaybackFormat.SampleRate)
-        {
-            throw new InvalidOperationException(
-                $"WASAPI {ShareMode} requires {PlaybackFormat.SampleRate} Hz, " +
-                $"but the source is {source.WaveFormat.SampleRate} Hz.");
-        }
-        if (ShareMode == AudioClientShareMode.Exclusive &&
-            (source.WaveFormat.BitsPerSample != PlaybackFormat.BitsPerSample ||
-                source.WaveFormat.Channels != PlaybackFormat.Channels))
-        {
-            throw new InvalidOperationException(
-                $"WASAPI Exclusive source format ({source.WaveFormat}) does not match " +
-                $"the requested endpoint format ({PlaybackFormat}).");
-        }
+        ValidateFormat(source.WaveFormat);
         if (initializedSource != null && !ReferenceEquals(initializedSource, source))
         {
             throw new InvalidOperationException(
                 "This playback session is already initialized with another source.");
         }
 
+        Initialize(source);
+        initializedSource = source;
+        stopRequested = false;
         playbackEnded = SampleWaiterRegistry.NewSignal();
-        if (initializedSource == null)
+        renderThread = new Thread(RenderLoop)
         {
-            initializedProvider = ShareMode == AudioClientShareMode.Exclusive
-                ? new WaveFormatOverrideProvider(source, PlaybackFormat)
-                : source;
-            output.Init(initializedProvider);
-            initializedSource = source;
-        }
-        output.Play();
+            IsBackground = true,
+            Name = "Resonalyze WASAPI render"
+        };
+        renderThread.Start();
         return Task.CompletedTask;
     }
 
@@ -99,25 +95,163 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
         await task.WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public Task StopAsync()
+    public async Task StopAsync()
     {
-        if (!disposed && playbackEnded is { Task.IsCompleted: false })
+        if (disposed || renderThread == null || playbackEnded == null)
         {
-            output.Stop();
+            return;
         }
-        return Task.CompletedTask;
+        stopRequested = true;
+        bufferReady.Set();
+        await playbackEnded.Task.WaitAsync(AudioCaptureStop.StopTimeout).ConfigureAwait(false);
     }
 
-    private void HandlePlaybackStopped(object? sender, StoppedEventArgs args)
+    private void ValidateFormat(WaveFormat sourceFormat)
     {
-        if (args.Exception == null)
+        if (sourceFormat.SampleRate != PlaybackFormat.SampleRate)
         {
-            playbackEnded?.TrySetResult(true);
+            throw new InvalidOperationException(
+                $"WASAPI {ShareMode} requires {PlaybackFormat.SampleRate} Hz, " +
+                $"but the source is {sourceFormat.SampleRate} Hz.");
+        }
+        if (ShareMode == AudioClientShareMode.Exclusive &&
+            (sourceFormat.BitsPerSample != PlaybackFormat.BitsPerSample ||
+                sourceFormat.Channels != PlaybackFormat.Channels))
+        {
+            throw new InvalidOperationException(
+                $"WASAPI Exclusive source format ({sourceFormat}) does not match " +
+                $"the requested endpoint format ({PlaybackFormat}).");
+        }
+    }
+
+    private void Initialize(IWaveProvider source)
+    {
+        if (initialized)
+        {
+            return;
+        }
+        streamFormat = ShareMode == AudioClientShareMode.Exclusive
+            ? PlaybackFormat
+            : source.WaveFormat;
+        long duration = bufferMilliseconds * ReferenceTimesPerMillisecond;
+        AudioClientStreamFlags flags = AudioClientStreamFlags.EventCallback;
+        if (ShareMode == AudioClientShareMode.Shared)
+        {
+            flags |= AudioClientStreamFlags.AutoConvertPcm |
+                AudioClientStreamFlags.SrcDefaultQuality;
+            audioClient.Initialize(ShareMode, flags, duration, 0, streamFormat, Guid.Empty);
         }
         else
         {
-            playbackEnded?.TrySetException(args.Exception);
+            audioClient.Initialize(ShareMode, flags, duration, duration, streamFormat, Guid.Empty);
         }
+        audioClient.SetEventHandle(bufferReady.SafeWaitHandle.DangerousGetHandle());
+        ActualBufferFrames = audioClient.BufferSize;
+        initialized = true;
+    }
+
+    private void RenderLoop()
+    {
+        Exception? failure = null;
+        bool clientStarted = false;
+        try
+        {
+            AudioRenderClient render = audioClient.AudioRenderClient;
+            bool sourceEnded = !FillBuffer(render, ActualBufferFrames);
+            audioClient.Start();
+            clientStarted = true;
+            while (!stopRequested)
+            {
+                bufferReady.WaitOne(bufferMilliseconds * 3);
+                if (stopRequested)
+                {
+                    break;
+                }
+
+                int padding = audioClient.CurrentPadding;
+                if (sourceEnded)
+                {
+                    if (padding == 0)
+                    {
+                        break;
+                    }
+                    continue;
+                }
+                TimeSpan sinceLastFill = Stopwatch.GetElapsedTime(lastBufferFillTimestamp);
+                TimeSpan bufferDuration = TimeSpan.FromSeconds(
+                    (double)ActualBufferFrames / (streamFormat?.SampleRate ?? 1));
+                if (WasapiRenderTiming.IsUnderrun(
+                    padding,
+                    sourceEnded,
+                    sinceLastFill,
+                    bufferDuration))
+                {
+                    RenderUnderruns++;
+                }
+                int availableFrames = ActualBufferFrames - padding;
+                if (availableFrames > 0)
+                {
+                    sourceEnded = !FillBuffer(render, availableFrames);
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+        finally
+        {
+            if (clientStarted)
+            {
+                try
+                {
+                    audioClient.Stop();
+                    audioClient.Reset();
+                }
+                catch (Exception exception)
+                {
+                    failure ??= exception;
+                }
+            }
+            renderThread = null;
+            if (failure == null)
+            {
+                playbackEnded?.TrySetResult(true);
+            }
+            else
+            {
+                playbackEnded?.TrySetException(failure);
+            }
+        }
+    }
+
+    private bool FillBuffer(AudioRenderClient render, int frames)
+    {
+        WaveFormat format = streamFormat ??
+            throw new InvalidOperationException("WASAPI render is not initialized.");
+        int byteCount = checked(frames * format.BlockAlign);
+        var buffer = new byte[byteCount];
+        int bytesRead = initializedSource?.Read(buffer, 0, byteCount) ?? 0;
+        IntPtr destination = render.GetBuffer(frames);
+        try
+        {
+            if (bytesRead > 0)
+            {
+                // The last source read can be shorter than the WASAPI buffer.
+                // Copy the zero-initialized tail too so no stale device-buffer
+                // contents are rendered after the final source frame.
+                Marshal.Copy(buffer, 0, destination, byteCount);
+            }
+            RenderCallbacks++;
+            lastBufferFillTimestamp = Stopwatch.GetTimestamp();
+        }
+        finally
+        {
+            render.ReleaseBuffer(
+                frames,
+                bytesRead == 0 ? AudioClientBufferFlags.Silent : AudioClientBufferFlags.None);
+        }
+        return bytesRead == byteCount;
     }
 
     public async ValueTask DisposeAsync()
@@ -126,28 +260,16 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
         {
             return;
         }
-        await StopAsync().ConfigureAwait(false);
-        disposed = true;
-        output.PlaybackStopped -= HandlePlaybackStopped;
-        output.Dispose();
-        // See WasapiCaptureDevice: explicitly releasing this MMDevice can poison
-        // a later RCW for the same endpoint identity.
-        enumerator.Dispose();
-    }
-
-    private sealed class WaveFormatOverrideProvider : IWaveProvider
-    {
-        private readonly IWaveProvider source;
-
-        public WaveFormatOverrideProvider(IWaveProvider source, WaveFormat waveFormat)
+        try
         {
-            this.source = source;
-            WaveFormat = waveFormat;
+            await StopAsync().ConfigureAwait(false);
         }
-
-        public WaveFormat WaveFormat { get; }
-
-        public int Read(byte[] buffer, int offset, int count) =>
-            source.Read(buffer, offset, count);
+        finally
+        {
+            disposed = true;
+            bufferReady.Dispose();
+            audioClient.Dispose();
+            enumerator.Dispose();
+        }
     }
 }

--- a/source/Audio/Wasapi/WasapiPlaybackDevice.cs
+++ b/source/Audio/Wasapi/WasapiPlaybackDevice.cs
@@ -231,11 +231,13 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
             throw new InvalidOperationException("WASAPI render is not initialized.");
         int byteCount = checked(frames * format.BlockAlign);
         var buffer = new byte[byteCount];
-        int bytesRead = initializedSource?.Read(buffer, 0, byteCount) ?? 0;
+        IWaveProvider source = initializedSource ??
+            throw new InvalidOperationException("WASAPI render source is not initialized.");
+        AudioRenderBufferRead read = AudioRenderBufferReader.Fill(source, buffer);
         IntPtr destination = render.GetBuffer(frames);
         try
         {
-            if (bytesRead > 0)
+            if (read.BytesRead > 0)
             {
                 // The last source read can be shorter than the WASAPI buffer.
                 // Copy the zero-initialized tail too so no stale device-buffer
@@ -249,9 +251,9 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
         {
             render.ReleaseBuffer(
                 frames,
-                bytesRead == 0 ? AudioClientBufferFlags.Silent : AudioClientBufferFlags.None);
+                read.BytesRead == 0 ? AudioClientBufferFlags.Silent : AudioClientBufferFlags.None);
         }
-        return bytesRead == byteCount;
+        return !read.SourceEnded;
     }
 
     public async ValueTask DisposeAsync()

--- a/source/Audio/Wasapi/WasapiPlaybackDevice.cs
+++ b/source/Audio/Wasapi/WasapiPlaybackDevice.cs
@@ -8,6 +8,8 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
     private readonly MMDeviceEnumerator enumerator;
     private readonly MMDevice endpoint;
     private readonly WasapiOut output;
+    private readonly string endpointId;
+    private readonly string friendlyName;
     private TaskCompletionSource<bool>? playbackEnded;
     private IWaveProvider? initializedSource;
     private bool disposed;
@@ -22,6 +24,8 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
         {
             throw new ArgumentException("The endpoint is not a render device.", nameof(endpointId));
         }
+        this.endpointId = endpoint.ID;
+        friendlyName = endpoint.FriendlyName;
         output = new WasapiOut(
             endpoint,
             AudioClientShareMode.Shared,
@@ -32,8 +36,8 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
     }
 
     public WaveFormat PlaybackFormat { get; private set; }
-    public string EndpointId => endpoint.ID;
-    public string FriendlyName => endpoint.FriendlyName;
+    public string EndpointId => endpointId;
+    public string FriendlyName => friendlyName;
 
     public Task StartAsync(IWaveProvider source, CancellationToken cancellationToken)
     {
@@ -104,7 +108,8 @@ public sealed class WasapiPlaybackDevice : IAudioPlaybackDevice
         disposed = true;
         output.PlaybackStopped -= HandlePlaybackStopped;
         output.Dispose();
-        endpoint.Dispose();
+        // See WasapiCaptureDevice: explicitly releasing this MMDevice can poison
+        // a later RCW for the same endpoint identity.
         enumerator.Dispose();
     }
 }

--- a/source/Audio/Wasapi/WasapiRenderTiming.cs
+++ b/source/Audio/Wasapi/WasapiRenderTiming.cs
@@ -1,0 +1,18 @@
+namespace Resonalyze;
+
+internal static class WasapiRenderTiming
+{
+    private const double MissedDeadlineFactor = 1.5;
+
+    public static bool IsUnderrun(
+        int currentPaddingFrames,
+        bool sourceEnded,
+        TimeSpan elapsedSinceFill,
+        TimeSpan bufferDuration)
+    {
+        return !sourceEnded &&
+            currentPaddingFrames == 0 &&
+            bufferDuration > TimeSpan.Zero &&
+            elapsedSinceFill > bufferDuration * MissedDeadlineFactor;
+    }
+}

--- a/source/Audio/Wasapi/WasapiStreamConfiguration.cs
+++ b/source/Audio/Wasapi/WasapiStreamConfiguration.cs
@@ -1,0 +1,45 @@
+using System.Runtime.InteropServices;
+using NAudio.CoreAudioApi;
+
+namespace Resonalyze;
+
+internal static class WasapiStreamConfiguration
+{
+    public const int BufferSizeNotAlignedHResult = unchecked((int)0x88890019);
+    private const long ReferenceTimesPerMillisecond = 10_000;
+    private const long ReferenceTimesPerSecond = 10_000_000;
+
+    public static (long BufferDuration, long Periodicity) GetDurations(
+        AudioClientShareMode shareMode,
+        int bufferMilliseconds)
+    {
+        if (shareMode == AudioClientShareMode.Shared)
+        {
+            return (0, 0);
+        }
+
+        long duration = checked(bufferMilliseconds * ReferenceTimesPerMillisecond);
+        return (duration, duration);
+    }
+
+    public static long GetAlignedExclusiveDuration(int bufferFrames, int sampleRate)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferFrames);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sampleRate);
+        return (long)Math.Ceiling(
+            (double)ReferenceTimesPerSecond * bufferFrames / sampleRate);
+    }
+
+    public static int GetRenderFrames(
+        AudioClientShareMode shareMode,
+        int bufferFrames,
+        int currentPaddingFrames)
+    {
+        return shareMode == AudioClientShareMode.Exclusive
+            ? bufferFrames
+            : Math.Max(0, bufferFrames - currentPaddingFrames);
+    }
+
+    public static bool IsBufferSizeNotAligned(COMException exception) =>
+        exception.HResult == BufferSizeNotAlignedHResult;
+}

--- a/source/Audio/Wasapi/WasapiStreamConfiguration.cs
+++ b/source/Audio/Wasapi/WasapiStreamConfiguration.cs
@@ -26,8 +26,17 @@ internal static class WasapiStreamConfiguration
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferFrames);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sampleRate);
-        return (long)Math.Ceiling(
-            (double)ReferenceTimesPerSecond * bufferFrames / sampleRate);
+        return checked(
+            (ReferenceTimesPerSecond * bufferFrames + sampleRate / 2) /
+            sampleRate);
+    }
+
+    public static int GetEventTimeoutMilliseconds(int bufferFrames, int sampleRate)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferFrames);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sampleRate);
+        double bufferMilliseconds = 1000.0 * bufferFrames / sampleRate;
+        return Math.Max(1, checked((int)Math.Ceiling(bufferMilliseconds * 3.0)));
     }
 
     public static int GetRenderFrames(

--- a/source/Audio/Wasapi/WindowsAudioEndpointService.cs
+++ b/source/Audio/Wasapi/WindowsAudioEndpointService.cs
@@ -1,0 +1,42 @@
+using NAudio.CoreAudioApi;
+
+namespace Resonalyze;
+
+public sealed class WindowsAudioEndpointService : IDisposable
+{
+    private readonly MMDeviceEnumerator enumerator = new();
+
+    public IReadOnlyList<AudioEndpointInfo> GetCaptureEndpoints() => GetEndpoints(DataFlow.Capture);
+
+    public IReadOnlyList<AudioEndpointInfo> GetRenderEndpoints() => GetEndpoints(DataFlow.Render);
+
+    private IReadOnlyList<AudioEndpointInfo> GetEndpoints(DataFlow direction)
+    {
+        string? defaultId = TryGetDefaultEndpointId(direction);
+        return enumerator
+            .EnumerateAudioEndPoints(direction, DeviceState.Active | DeviceState.Unplugged)
+            .Select(endpoint => new AudioEndpointInfo(
+                endpoint.ID,
+                endpoint.FriendlyName,
+                direction,
+                endpoint.State,
+                endpoint.AudioClient.MixFormat,
+                endpoint.AudioClient.MixFormat.Channels,
+                endpoint.ID == defaultId))
+            .ToArray();
+    }
+
+    private string? TryGetDefaultEndpointId(DataFlow direction)
+    {
+        try
+        {
+            return enumerator.GetDefaultAudioEndpoint(direction, Role.Multimedia).ID;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public void Dispose() => enumerator.Dispose();
+}

--- a/source/Audio/Wasapi/WindowsAudioEndpointService.cs
+++ b/source/Audio/Wasapi/WindowsAudioEndpointService.cs
@@ -1,10 +1,23 @@
+using System.Runtime.InteropServices;
 using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
 
 namespace Resonalyze;
 
 public sealed class WindowsAudioEndpointService : IDisposable
 {
     private readonly MMDeviceEnumerator enumerator = new();
+    private readonly EndpointNotificationClient notificationClient;
+    private bool disposed;
+
+    public WindowsAudioEndpointService()
+    {
+        notificationClient = new EndpointNotificationClient(this);
+        enumerator.RegisterEndpointNotificationCallback(notificationClient);
+    }
+
+    public event Action? EndpointsChanged;
+    public event Action<DataFlow, Role, string?>? DefaultEndpointChanged;
 
     public IReadOnlyList<AudioEndpointInfo> GetCaptureEndpoints() => GetEndpoints(DataFlow.Capture);
 
@@ -59,5 +72,59 @@ public sealed class WindowsAudioEndpointService : IDisposable
         }
     }
 
-    public void Dispose() => enumerator.Dispose();
+    private void NotifyEndpointsChanged() => EndpointsChanged?.Invoke();
+
+    private void NotifyDefaultEndpointChanged(DataFlow flow, Role role, string? endpointId)
+    {
+        DefaultEndpointChanged?.Invoke(flow, role, endpointId);
+        EndpointsChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+        disposed = true;
+        enumerator.UnregisterEndpointNotificationCallback(notificationClient);
+        enumerator.Dispose();
+    }
+
+    [ComVisible(true)]
+    private sealed class EndpointNotificationClient : IMMNotificationClient
+    {
+        private readonly WeakReference<WindowsAudioEndpointService> owner;
+
+        public EndpointNotificationClient(WindowsAudioEndpointService owner)
+        {
+            this.owner = new WeakReference<WindowsAudioEndpointService>(owner);
+        }
+
+        public void OnDeviceStateChanged(string deviceId, DeviceState newState) =>
+            NotifyChanged();
+
+        public void OnDeviceAdded(string pwstrDeviceId) => NotifyChanged();
+
+        public void OnDeviceRemoved(string deviceId) => NotifyChanged();
+
+        public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
+        {
+            if (owner.TryGetTarget(out WindowsAudioEndpointService? service))
+            {
+                service.NotifyDefaultEndpointChanged(flow, role, defaultDeviceId);
+            }
+        }
+
+        public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) =>
+            NotifyChanged();
+
+        private void NotifyChanged()
+        {
+            if (owner.TryGetTarget(out WindowsAudioEndpointService? service))
+            {
+                service.NotifyEndpointsChanged();
+            }
+        }
+    }
 }

--- a/source/Audio/Wasapi/WindowsAudioEndpointService.cs
+++ b/source/Audio/Wasapi/WindowsAudioEndpointService.cs
@@ -18,26 +18,28 @@ public sealed class WindowsAudioEndpointService : IDisposable
             direction,
             DeviceState.Active | DeviceState.Unplugged))
         {
-            using (endpoint)
+            // Do not explicitly dispose MMDevice wrappers here. Core Audio can
+            // return the same COM identity from a later GetDevice call; forcing
+            // ReleaseComObject through MMDevice.Dispose can leave the cached RCW
+            // disconnected and WasapiOut then fails to query IMMDevice with
+            // E_NOINTERFACE. The short-lived wrappers are released by the CLR.
+            NAudio.Wave.WaveFormat mixFormat;
+            try
             {
-                NAudio.Wave.WaveFormat mixFormat;
-                try
-                {
-                    mixFormat = endpoint.AudioClient.MixFormat;
-                }
-                catch
-                {
-                    mixFormat = new NAudio.Wave.WaveFormat(44_100, 16, 1);
-                }
-                endpoints.Add(new AudioEndpointInfo(
-                    endpoint.ID,
-                    endpoint.FriendlyName,
-                    direction,
-                    endpoint.State,
-                    mixFormat,
-                    endpoint.State == DeviceState.Active ? mixFormat.Channels : 0,
-                    endpoint.ID == defaultId));
+                mixFormat = endpoint.AudioClient.MixFormat;
             }
+            catch
+            {
+                mixFormat = new NAudio.Wave.WaveFormat(44_100, 16, 1);
+            }
+            endpoints.Add(new AudioEndpointInfo(
+                endpoint.ID,
+                endpoint.FriendlyName,
+                direction,
+                endpoint.State,
+                mixFormat,
+                endpoint.State == DeviceState.Active ? mixFormat.Channels : 0,
+                endpoint.ID == defaultId));
         }
         return endpoints;
     }
@@ -46,7 +48,7 @@ public sealed class WindowsAudioEndpointService : IDisposable
     {
         try
         {
-            using MMDevice endpoint = enumerator.GetDefaultAudioEndpoint(
+            MMDevice endpoint = enumerator.GetDefaultAudioEndpoint(
                 direction,
                 Role.Multimedia);
             return endpoint.ID;

--- a/source/Audio/Wasapi/WindowsAudioEndpointService.cs
+++ b/source/Audio/Wasapi/WindowsAudioEndpointService.cs
@@ -20,13 +20,22 @@ public sealed class WindowsAudioEndpointService : IDisposable
         {
             using (endpoint)
             {
+                NAudio.Wave.WaveFormat mixFormat;
+                try
+                {
+                    mixFormat = endpoint.AudioClient.MixFormat;
+                }
+                catch
+                {
+                    mixFormat = new NAudio.Wave.WaveFormat(44_100, 16, 1);
+                }
                 endpoints.Add(new AudioEndpointInfo(
-                endpoint.ID,
-                endpoint.FriendlyName,
-                direction,
-                endpoint.State,
-                endpoint.AudioClient.MixFormat,
-                endpoint.AudioClient.MixFormat.Channels,
+                    endpoint.ID,
+                    endpoint.FriendlyName,
+                    direction,
+                    endpoint.State,
+                    mixFormat,
+                    endpoint.State == DeviceState.Active ? mixFormat.Channels : 0,
                     endpoint.ID == defaultId));
             }
         }

--- a/source/Audio/Wasapi/WindowsAudioEndpointService.cs
+++ b/source/Audio/Wasapi/WindowsAudioEndpointService.cs
@@ -13,24 +13,34 @@ public sealed class WindowsAudioEndpointService : IDisposable
     private IReadOnlyList<AudioEndpointInfo> GetEndpoints(DataFlow direction)
     {
         string? defaultId = TryGetDefaultEndpointId(direction);
-        return enumerator
-            .EnumerateAudioEndPoints(direction, DeviceState.Active | DeviceState.Unplugged)
-            .Select(endpoint => new AudioEndpointInfo(
+        var endpoints = new List<AudioEndpointInfo>();
+        foreach (MMDevice endpoint in enumerator.EnumerateAudioEndPoints(
+            direction,
+            DeviceState.Active | DeviceState.Unplugged))
+        {
+            using (endpoint)
+            {
+                endpoints.Add(new AudioEndpointInfo(
                 endpoint.ID,
                 endpoint.FriendlyName,
                 direction,
                 endpoint.State,
                 endpoint.AudioClient.MixFormat,
                 endpoint.AudioClient.MixFormat.Channels,
-                endpoint.ID == defaultId))
-            .ToArray();
+                    endpoint.ID == defaultId));
+            }
+        }
+        return endpoints;
     }
 
     private string? TryGetDefaultEndpointId(DataFlow direction)
     {
         try
         {
-            return enumerator.GetDefaultAudioEndpoint(direction, Role.Multimedia).ID;
+            using MMDevice endpoint = enumerator.GetDefaultAudioEndpoint(
+                direction,
+                Role.Multimedia);
+            return endpoint.ID;
         }
         catch
         {

--- a/source/History/MeasurementHistoryService.cs
+++ b/source/History/MeasurementHistoryService.cs
@@ -232,6 +232,10 @@ internal sealed class MeasurementHistoryService
             TransferPeakIndex = transferResult?.PeakIndex,
             AverageRunCount = measurement.AverageRunCount,
             AcceptedAverageRunCount = measurement.AcceptedAverageRunCount,
+            AudioSession = ImpulseResponseFile.CreateAudioSessionFileEntry(
+                measurement.LastAudioSessionDiagnostics,
+                measurement.SampleRate,
+                measurement.Bits),
             SweepDeconvolutionImpulseResponse = sweep.ToArray(),
             TransferImpulseResponse = transfer,
             TransferCoherence = measurement.TransferCoherence?.ToArray(),
@@ -268,6 +272,7 @@ internal sealed class MeasurementHistoryService
             TransferPeakIndex = file.TransferPeakIndex,
             AverageRunCount = file.AverageRunCount,
             AcceptedAverageRunCount = file.AcceptedAverageRunCount,
+            AudioSession = file.AudioSession,
             SweepDeconvolutionImpulseResponse = sweep,
             TransferImpulseResponse = transfer,
             TransferCoherence = file.TransferCoherence?.ToArray(),

--- a/source/History/MeasurementHistorySnapshot.cs
+++ b/source/History/MeasurementHistorySnapshot.cs
@@ -14,6 +14,7 @@ internal sealed class MeasurementHistorySnapshot
     public int? TransferPeakIndex { get; init; }
     public int AverageRunCount { get; init; } = 1;
     public int AcceptedAverageRunCount { get; init; } = 1;
+    public ImpulseResponseFile.AudioSessionFileEntry? AudioSession { get; init; }
     public required Complex[] SweepDeconvolutionImpulseResponse { get; init; }
     public Complex[]? TransferImpulseResponse { get; init; }
     public double[]? TransferCoherence { get; init; }
@@ -38,6 +39,7 @@ internal sealed class MeasurementHistorySnapshot
             TransferPeakIndex = TransferPeakIndex,
             AverageRunCount = AverageRunCount,
             AcceptedAverageRunCount = AcceptedAverageRunCount,
+            AudioSession = AudioSession,
             SweepDeconvolutionRealSamples = SweepDeconvolutionImpulseResponse.Select(
                 sample => sample.Real).ToArray(),
             SweepDeconvolutionImaginarySamples = HasImaginarySamples(SweepDeconvolutionImpulseResponse)

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -154,7 +154,10 @@ internal sealed class LiveSpectrumController : IDisposable
             measurementSettings.WaveInputChannelOffset,
             measurementSettings.WaveLoopbackInputChannelOffset,
             measurementSettings.AsioLoopbackInputChannelOffset,
-            liveSpectrumOptions);
+            liveSpectrumOptions,
+            measurementSettings.WasapiCaptureEndpointId,
+            measurementSettings.WasapiRenderEndpointId,
+            measurementSettings.WasapiBufferMilliseconds);
     }
 
     public async Task ToggleAsync()

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -617,45 +617,90 @@ namespace Resonalyze
                         owner.Bits,
                         renderChannels);
                 }
-                captureDevice = new WasapiCaptureDevice(
-                    captureEndpointId,
-                    owner.WasapiBufferMilliseconds,
-                    shareMode,
-                    captureFormat);
-                playbackDevice = new WasapiPlaybackDevice(
-                    renderEndpointId,
-                    owner.WasapiBufferMilliseconds,
-                    shareMode,
-                    renderFormat);
+                WasapiCaptureDevice? createdCapture = null;
+                WasapiPlaybackDevice? createdPlayback = null;
+                PcmCaptureSession? createdSession = null;
+                try
+                {
+                    createdCapture = new WasapiCaptureDevice(
+                        captureEndpointId,
+                        owner.WasapiBufferMilliseconds,
+                        shareMode,
+                        captureFormat);
+                    createdPlayback = new WasapiPlaybackDevice(
+                        renderEndpointId,
+                        owner.WasapiBufferMilliseconds,
+                        shareMode,
+                        renderFormat);
+                    ValidateDevices(createdCapture, createdPlayback, shareMode, requiredChannels);
+                    createdSession = new PcmCaptureSession(
+                        createdCapture,
+                        expectedSamples: sweep.SweepSamples + owner.SampleRate * 2);
+                    createdSession.LevelsAvailable += channels => owner.RaiseLevels(
+                        owner.MapWaveLevels(channels));
+
+                    captureDevice = createdCapture;
+                    playbackDevice = createdPlayback;
+                    captureSession = createdSession;
+                    orchestrator = new SweepRunAudioOrchestrator(
+                        captureSession,
+                        playbackDevice);
+                }
+                catch
+                {
+                    DisposeFailedConstruction(createdPlayback);
+                    if (createdSession != null)
+                    {
+                        DisposeFailedConstruction(createdSession);
+                    }
+                    else
+                    {
+                        DisposeFailedConstruction(createdCapture);
+                    }
+                    throw;
+                }
+            }
+
+            private static void DisposeFailedConstruction(IAsyncDisposable? resource)
+            {
+                try
+                {
+                    resource?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                }
+                catch
+                {
+                }
+            }
+
+            private void ValidateDevices(
+                WasapiCaptureDevice createdCapture,
+                WasapiPlaybackDevice createdPlayback,
+                AudioClientShareMode shareMode,
+                int requiredChannels)
+            {
                 if (shareMode == AudioClientShareMode.Shared &&
-                    captureDevice.CaptureFormat.SampleRate != playbackDevice.PlaybackFormat.SampleRate)
+                    createdCapture.CaptureFormat.SampleRate !=
+                    createdPlayback.PlaybackFormat.SampleRate)
                 {
                     throw new InvalidOperationException(
                         "WASAPI Shared capture and render endpoints must use the same mix sample rate. " +
-                        $"Capture is {captureDevice.CaptureFormat.SampleRate} Hz and render is " +
-                        $"{playbackDevice.PlaybackFormat.SampleRate} Hz.");
+                        $"Capture is {createdCapture.CaptureFormat.SampleRate} Hz and render is " +
+                        $"{createdPlayback.PlaybackFormat.SampleRate} Hz.");
                 }
                 if (shareMode == AudioClientShareMode.Shared &&
-                    owner.SampleRate != captureDevice.CaptureFormat.SampleRate)
+                    owner.SampleRate != createdCapture.CaptureFormat.SampleRate)
                 {
                     throw new InvalidOperationException(
                         $"WASAPI Shared uses the endpoint mix rate " +
-                        $"({captureDevice.CaptureFormat.SampleRate} Hz). Update the measurement " +
+                        $"({createdCapture.CaptureFormat.SampleRate} Hz). Update the measurement " +
                         $"sample rate from {owner.SampleRate} Hz.");
                 }
-                if (captureDevice.ChannelCount < requiredChannels)
+                if (createdCapture.ChannelCount < requiredChannels)
                 {
                     throw new InvalidOperationException(
-                        $"The WASAPI capture endpoint exposes {captureDevice.ChannelCount} channel(s), " +
+                        $"The WASAPI capture endpoint exposes {createdCapture.ChannelCount} channel(s), " +
                         $"but the selected microphone and loopback routing requires {requiredChannels}.");
                 }
-
-                captureSession = new PcmCaptureSession(
-                    captureDevice,
-                    expectedSamples: sweep.SweepSamples + owner.SampleRate * 2);
-                captureSession.LevelsAvailable += channels => owner.RaiseLevels(
-                    owner.MapWaveLevels(channels));
-                orchestrator = new SweepRunAudioOrchestrator(captureSession, playbackDevice);
             }
 
             public async Task<CapturedSweepSamples> CaptureRunAsync(
@@ -706,7 +751,7 @@ namespace Resonalyze
                 catch (Exception exception) when (exception is not OperationCanceledException)
                 {
                     throw new InvalidOperationException(
-                        $"WASAPI Shared sweep run {currentRun} failed while {stage}.",
+                        $"{owner.AudioBackend} sweep run {currentRun} failed while {stage}.",
                         exception);
                 }
             }
@@ -895,15 +940,15 @@ namespace Resonalyze
         {
             float[][] sampleChannels = captured.SampleChannels;
             if (captured.ValidateSharedDeviceStereo &&
-                sampleChannels.Length > 1 &&
-                (WaveInputChannelOffset > 0 ||
-                    WaveLoopbackInputChannelOffset.HasValue))
+                captured.LoopbackIndex is int validationLoopbackIndex)
             {
                 RecordedChannelValidator.EnsureDifferentSignals(
                     sampleChannels,
-                    0,
-                    1,
-                    "Wave measurement");
+                    captured.MicrophoneIndex,
+                    validationLoopbackIndex,
+                    IsWasapiBackend(AudioBackend)
+                        ? "WASAPI measurement"
+                        : "Wave measurement");
             }
 
             float[] recorded = (uint)captured.MicrophoneIndex < (uint)sampleChannels.Length

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -565,6 +565,8 @@ namespace Resonalyze
             private readonly WasapiCaptureDevice captureDevice;
             private readonly WasapiPlaybackDevice playbackDevice;
             private readonly PcmCaptureSession captureSession;
+            private bool started;
+            private int runNumber;
 
             public WasapiSweepCapture(ExpSweepMeasurement owner, ExponentialSineSweep sweep)
             {
@@ -612,42 +614,76 @@ namespace Resonalyze
             public async Task<CapturedSweepSamples> CaptureRunAsync(
                 CancellationToken cancellationToken)
             {
-                await captureSession.StartAsync(cancellationToken).ConfigureAwait(false);
-                int recordingStart = captureSession.ReadSamples;
-                RawSourceWaveStream stream = sweep.GetStream(owner.PlaybackChannel);
-                stream.Position = 0;
-                await playbackDevice.StartAsync(stream, cancellationToken).ConfigureAwait(false);
-                await playbackDevice.WaitForPlaybackEndAsync(cancellationToken).ConfigureAwait(false);
+                int currentRun = ++runNumber;
+                string stage = "starting capture";
+                try
+                {
+                    if (!started)
+                    {
+                        await captureSession.StartAsync(cancellationToken).ConfigureAwait(false);
+                        started = true;
+                    }
+                    else
+                    {
+                        // WasapiCapture is not reliably restartable after StopRecording;
+                        // some drivers invalidate its MMDevice RCW. Keep capture alive
+                        // for the complete average and reset only the sample storage.
+                        captureSession.Reset();
+                    }
+                    int recordingStart = captureSession.ReadSamples;
+                    RawSourceWaveStream stream = sweep.GetStream(owner.PlaybackChannel);
+                    stream.Position = 0;
+                    stage = "starting playback";
+                    await playbackDevice.StartAsync(stream, cancellationToken).ConfigureAwait(false);
+                    stage = "waiting for playback completion";
+                    await playbackDevice.WaitForPlaybackEndAsync(cancellationToken).ConfigureAwait(false);
 
-                int requiredSamples = recordingStart + sweep.SweepSamples + owner.SampleRate;
-                await captureSession.WaitForSamplesAsync(requiredSamples, cancellationToken)
-                    .ConfigureAwait(false);
-                await captureSession.StopAsync().ConfigureAwait(false);
-                float[][] samples = captureSession.GetSamplesSnapshot();
-                owner.LastAudioSessionDiagnostics = new AudioSessionDiagnostics(
-                    nameof(AudioBackend.WasapiShared),
-                    captureDevice.EndpointId,
-                    playbackDevice.EndpointId,
-                    captureDevice.CaptureFormat,
-                    playbackDevice.PlaybackFormat,
-                    owner.WasapiBufferMilliseconds,
-                    captureDevice.CapturePackets,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0);
-                return new CapturedSweepSamples(
-                    samples,
-                    owner.WaveInputChannelOffset,
-                    owner.WaveLoopbackInputChannelOffset,
-                    ValidateSharedDeviceStereo: true);
+                    stage = "waiting for the captured tail";
+                    int requiredSamples = recordingStart + sweep.SweepSamples + owner.SampleRate;
+                    await captureSession.WaitForSamplesAsync(requiredSamples, cancellationToken)
+                        .ConfigureAwait(false);
+                    float[][] samples = captureSession.GetSamplesSnapshot();
+                    owner.LastAudioSessionDiagnostics = new AudioSessionDiagnostics(
+                        nameof(AudioBackend.WasapiShared),
+                        captureDevice.EndpointId,
+                        playbackDevice.EndpointId,
+                        captureDevice.CaptureFormat,
+                        playbackDevice.PlaybackFormat,
+                        owner.WasapiBufferMilliseconds,
+                        captureDevice.CapturePackets,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0);
+                    return new CapturedSweepSamples(
+                        samples,
+                        owner.WaveInputChannelOffset,
+                        owner.WaveLoopbackInputChannelOffset,
+                        ValidateSharedDeviceStereo: true);
+                }
+                catch (Exception exception) when (exception is not OperationCanceledException)
+                {
+                    throw new InvalidOperationException(
+                        $"WASAPI Shared sweep run {currentRun} failed while {stage}.",
+                        exception);
+                }
             }
 
             public async ValueTask DisposeAsync()
             {
-                await playbackDevice.DisposeAsync().ConfigureAwait(false);
-                await captureSession.DisposeAsync().ConfigureAwait(false);
+                try
+                {
+                    await playbackDevice.DisposeAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    if (started)
+                    {
+                        await captureSession.StopAsync().ConfigureAwait(false);
+                    }
+                    await captureSession.DisposeAsync().ConfigureAwait(false);
+                }
             }
         }
 

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -127,12 +127,20 @@ namespace Resonalyze
             LastAudioSessionDiagnostics = null;
             AudioBackend = audioBackend;
             AsioDriverName = asioDriverName;
-            WaveInputChannelOffset = IsWasapiBackend(audioBackend)
+            int normalizedWaveInputChannelOffset = IsWasapiBackend(audioBackend)
                 ? Math.Max(0, waveInputChannelOffset)
                 : Math.Clamp(waveInputChannelOffset, 0, 1);
-            WaveLoopbackInputChannelOffset = IsWasapiBackend(audioBackend)
+            int? normalizedWaveLoopbackInputChannelOffset = IsWasapiBackend(audioBackend)
                 ? NormalizeOptionalWasapiChannel(waveLoopbackInputChannelOffset)
                 : NormalizeOptionalWaveChannel(waveLoopbackInputChannelOffset);
+            if (audioBackend != AudioBackend.Asio &&
+                normalizedWaveLoopbackInputChannelOffset == normalizedWaveInputChannelOffset)
+            {
+                throw new InvalidOperationException(
+                    "Microphone and loopback inputs must use different channels.");
+            }
+            WaveInputChannelOffset = normalizedWaveInputChannelOffset;
+            WaveLoopbackInputChannelOffset = normalizedWaveLoopbackInputChannelOffset;
             AsioInputChannelOffset = asioInputChannelOffset;
             AsioLoopbackInputChannelOffset = asioLoopbackInputChannelOffset;
             AsioOutputChannelOffset = asioOutputChannelOffset;

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using NAudio.CoreAudioApi;
 using NAudio.Wave;
 using Resonalyze.Dsp;
 using static System.Math;
@@ -126,10 +127,10 @@ namespace Resonalyze
             LastAudioSessionDiagnostics = null;
             AudioBackend = audioBackend;
             AsioDriverName = asioDriverName;
-            WaveInputChannelOffset = audioBackend == AudioBackend.WasapiShared
+            WaveInputChannelOffset = IsWasapiBackend(audioBackend)
                 ? Math.Max(0, waveInputChannelOffset)
                 : Math.Clamp(waveInputChannelOffset, 0, 1);
-            WaveLoopbackInputChannelOffset = audioBackend == AudioBackend.WasapiShared
+            WaveLoopbackInputChannelOffset = IsWasapiBackend(audioBackend)
                 ? NormalizeOptionalWasapiChannel(waveLoopbackInputChannelOffset)
                 : NormalizeOptionalWaveChannel(waveLoopbackInputChannelOffset);
             AsioInputChannelOffset = asioInputChannelOffset;
@@ -367,7 +368,7 @@ namespace Resonalyze
                         .ConfigureAwait(false);
                 }
 
-                if (AudioBackend == AudioBackend.WasapiShared)
+                if (IsWasapiBackend(AudioBackend))
                 {
                     wasapiCapture ??= new WasapiSweepCapture(this, sweep);
                     return await wasapiCapture.CaptureRunAsync(cancellationToken)
@@ -576,27 +577,64 @@ namespace Resonalyze
                     throw new InvalidOperationException("Select a WASAPI capture endpoint.");
                 string renderEndpointId = owner.WasapiRenderEndpointId ??
                     throw new InvalidOperationException("Select a WASAPI render endpoint.");
+                AudioClientShareMode shareMode = owner.AudioBackend == AudioBackend.WasapiExclusive
+                    ? AudioClientShareMode.Exclusive
+                    : AudioClientShareMode.Shared;
+                int requiredChannels = owner.GetRequiredWaveInputChannelCount();
+                int renderChannels = owner.PlaybackChannel == PlaybackChannel.Mono ? 1 : 2;
+                WaveFormat? captureFormat = null;
+                WaveFormat? renderFormat = null;
+                if (shareMode == AudioClientShareMode.Exclusive)
+                {
+                    DuplexFormatSupport support = WasapiFormatSupport.CheckExclusive(
+                        captureEndpointId,
+                        renderEndpointId,
+                        owner.SampleRate,
+                        owner.Bits,
+                        requiredChannels,
+                        renderChannels);
+                    if (!support.Supported)
+                    {
+                        throw new InvalidOperationException(
+                            $"WASAPI Exclusive format {owner.SampleRate} Hz / {owner.Bits}-bit " +
+                            $"is not supported by both endpoints (capture: " +
+                            $"{support.CaptureSupported}, render: {support.RenderSupported}).");
+                    }
+                    captureFormat = WasapiFormatSupport.CreateDeviceFormat(
+                        owner.SampleRate,
+                        owner.Bits,
+                        requiredChannels);
+                    renderFormat = WasapiFormatSupport.CreateDeviceFormat(
+                        owner.SampleRate,
+                        owner.Bits,
+                        renderChannels);
+                }
                 captureDevice = new WasapiCaptureDevice(
                     captureEndpointId,
-                    owner.WasapiBufferMilliseconds);
+                    owner.WasapiBufferMilliseconds,
+                    shareMode,
+                    captureFormat);
                 playbackDevice = new WasapiPlaybackDevice(
                     renderEndpointId,
-                    owner.WasapiBufferMilliseconds);
-                if (captureDevice.CaptureFormat.SampleRate != playbackDevice.PlaybackFormat.SampleRate)
+                    owner.WasapiBufferMilliseconds,
+                    shareMode,
+                    renderFormat);
+                if (shareMode == AudioClientShareMode.Shared &&
+                    captureDevice.CaptureFormat.SampleRate != playbackDevice.PlaybackFormat.SampleRate)
                 {
                     throw new InvalidOperationException(
                         "WASAPI Shared capture and render endpoints must use the same mix sample rate. " +
                         $"Capture is {captureDevice.CaptureFormat.SampleRate} Hz and render is " +
                         $"{playbackDevice.PlaybackFormat.SampleRate} Hz.");
                 }
-                if (owner.SampleRate != captureDevice.CaptureFormat.SampleRate)
+                if (shareMode == AudioClientShareMode.Shared &&
+                    owner.SampleRate != captureDevice.CaptureFormat.SampleRate)
                 {
                     throw new InvalidOperationException(
                         $"WASAPI Shared uses the endpoint mix rate " +
                         $"({captureDevice.CaptureFormat.SampleRate} Hz). Update the measurement " +
                         $"sample rate from {owner.SampleRate} Hz.");
                 }
-                int requiredChannels = owner.GetRequiredWaveInputChannelCount();
                 if (captureDevice.ChannelCount < requiredChannels)
                 {
                     throw new InvalidOperationException(
@@ -644,7 +682,7 @@ namespace Resonalyze
                         .ConfigureAwait(false);
                     float[][] samples = captureSession.GetSamplesSnapshot();
                     owner.LastAudioSessionDiagnostics = new AudioSessionDiagnostics(
-                        nameof(AudioBackend.WasapiShared),
+                        owner.AudioBackend.ToString(),
                         captureDevice.EndpointId,
                         playbackDevice.EndpointId,
                         captureDevice.CaptureFormat,
@@ -1193,6 +1231,9 @@ namespace Resonalyze
 
         private static int? NormalizeOptionalWasapiChannel(int? offset) =>
             offset.HasValue ? Math.Max(0, offset.Value) : null;
+
+        private static bool IsWasapiBackend(AudioBackend backend) =>
+            backend is AudioBackend.WasapiShared or AudioBackend.WasapiExclusive;
 
         private void ThrowIfDisposed()
         {

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -654,6 +654,9 @@ namespace Resonalyze
             {
                 int currentRun = ++runNumber;
                 string stage = "starting capture";
+                long discontinuitiesBefore = captureDevice.Discontinuities;
+                long timestampErrorsBefore = captureDevice.TimestampErrors;
+                long renderUnderrunsBefore = playbackDevice.RenderUnderruns;
                 try
                 {
                     if (!started)
@@ -688,17 +691,25 @@ namespace Resonalyze
                         captureDevice.CaptureFormat,
                         playbackDevice.PlaybackFormat,
                         owner.WasapiBufferMilliseconds,
+                        playbackDevice.ActualBufferFrames,
                         captureDevice.CapturePackets,
+                        playbackDevice.RenderCallbacks,
+                        captureDevice.Discontinuities,
+                        captureDevice.SilentPackets,
+                        captureDevice.TimestampErrors,
                         0,
-                        0,
-                        0,
-                        0,
-                        0);
+                        playbackDevice.RenderUnderruns);
                     return new CapturedSweepSamples(
                         samples,
                         owner.WaveInputChannelOffset,
                         owner.WaveLoopbackInputChannelOffset,
-                        ValidateSharedDeviceStereo: true);
+                        ValidateSharedDeviceStereo: true,
+                        CaptureDiscontinuity:
+                            captureDevice.Discontinuities > discontinuitiesBefore,
+                        CaptureTimestampError:
+                            captureDevice.TimestampErrors > timestampErrorsBefore,
+                        RenderUnderrun:
+                            playbackDevice.RenderUnderruns > renderUnderrunsBefore);
                 }
                 catch (Exception exception) when (exception is not OperationCanceledException)
                 {
@@ -870,10 +881,23 @@ namespace Resonalyze
                 (uint)loopbackIndex < (uint)channels.Length
                     ? channels[loopbackIndex]
                     : null;
-            return SweepRunQualityCheck.Assess(
+            var issues = SweepRunQualityCheck.Assess(
                 microphone,
                 loopback,
-                sweep.SweepSamples);
+                sweep.SweepSamples).ToList();
+            if (captured.CaptureDiscontinuity)
+            {
+                issues.Add("WASAPI reported a capture packet discontinuity.");
+            }
+            if (captured.CaptureTimestampError)
+            {
+                issues.Add("WASAPI reported an invalid capture timestamp.");
+            }
+            if (captured.RenderUnderrun)
+            {
+                issues.Add("WASAPI reported a render buffer underrun.");
+            }
+            return issues;
         }
 
         private SweepRunAnalysis AnalyzeCapturedRun(
@@ -1064,7 +1088,10 @@ namespace Resonalyze
             float[][] SampleChannels,
             int MicrophoneIndex,
             int? LoopbackIndex,
-            bool ValidateSharedDeviceStereo);
+            bool ValidateSharedDeviceStereo,
+            bool CaptureDiscontinuity = false,
+            bool CaptureTimestampError = false,
+            bool RenderUnderrun = false);
 
         private sealed record SweepRunAnalysis(
             Complex[] SweepImpulseResponse,

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -56,6 +56,8 @@ namespace Resonalyze
         public int InputDeviceNumber { get; private set; } = -1;
         public string? WasapiCaptureEndpointId { get; private set; }
         public string? WasapiRenderEndpointId { get; private set; }
+        public string? WasapiCaptureEndpointName { get; private set; }
+        public string? WasapiRenderEndpointName { get; private set; }
         public int WasapiBufferMilliseconds { get; private set; } = 100;
         public AudioSessionDiagnostics? LastAudioSessionDiagnostics { get; private set; }
         public string? AsioDriverName { get; private set; }
@@ -98,7 +100,9 @@ namespace Resonalyze
             bool confirmEachAverageRun = false,
             string? wasapiCaptureEndpointId = null,
             string? wasapiRenderEndpointId = null,
-            int wasapiBufferMilliseconds = 100)
+            int wasapiBufferMilliseconds = 100,
+            string? wasapiCaptureEndpointName = null,
+            string? wasapiRenderEndpointName = null)
         {
             ThrowIfDisposed();
             if (InProgress)
@@ -116,13 +120,18 @@ namespace Resonalyze
             InputDeviceNumber = inputDeviceNumber;
             WasapiCaptureEndpointId = wasapiCaptureEndpointId;
             WasapiRenderEndpointId = wasapiRenderEndpointId;
+            WasapiCaptureEndpointName = wasapiCaptureEndpointName;
+            WasapiRenderEndpointName = wasapiRenderEndpointName;
             WasapiBufferMilliseconds = Math.Clamp(wasapiBufferMilliseconds, 10, 100);
             LastAudioSessionDiagnostics = null;
             AudioBackend = audioBackend;
             AsioDriverName = asioDriverName;
-            WaveInputChannelOffset = Math.Clamp(waveInputChannelOffset, 0, 1);
-            WaveLoopbackInputChannelOffset = NormalizeOptionalWaveChannel(
-                waveLoopbackInputChannelOffset);
+            WaveInputChannelOffset = audioBackend == AudioBackend.WasapiShared
+                ? Math.Max(0, waveInputChannelOffset)
+                : Math.Clamp(waveInputChannelOffset, 0, 1);
+            WaveLoopbackInputChannelOffset = audioBackend == AudioBackend.WasapiShared
+                ? NormalizeOptionalWasapiChannel(waveLoopbackInputChannelOffset)
+                : NormalizeOptionalWaveChannel(waveLoopbackInputChannelOffset);
             AsioInputChannelOffset = asioInputChannelOffset;
             AsioLoopbackInputChannelOffset = asioLoopbackInputChannelOffset;
             AsioOutputChannelOffset = asioOutputChannelOffset;
@@ -1145,6 +1154,9 @@ namespace Resonalyze
                 ? Math.Clamp(offset.Value, 0, 1)
                 : null;
         }
+
+        private static int? NormalizeOptionalWasapiChannel(int? offset) =>
+            offset.HasValue ? Math.Max(0, offset.Value) : null;
 
         private void ThrowIfDisposed()
         {

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -54,6 +54,10 @@ namespace Resonalyze
         public AudioBackend AudioBackend { get; private set; } = AudioBackend.Wave;
         public int OutputDeviceNumber { get; private set; } = -1;
         public int InputDeviceNumber { get; private set; } = -1;
+        public string? WasapiCaptureEndpointId { get; private set; }
+        public string? WasapiRenderEndpointId { get; private set; }
+        public int WasapiBufferMilliseconds { get; private set; } = 100;
+        public AudioSessionDiagnostics? LastAudioSessionDiagnostics { get; private set; }
         public string? AsioDriverName { get; private set; }
         public int WaveInputChannelOffset { get; private set; }
         public int? WaveLoopbackInputChannelOffset { get; private set; }
@@ -91,7 +95,10 @@ namespace Resonalyze
             int? waveLoopbackInputChannelOffset = null,
             int? asioLoopbackInputChannelOffset = null,
             int averageRunCount = 1,
-            bool confirmEachAverageRun = false)
+            bool confirmEachAverageRun = false,
+            string? wasapiCaptureEndpointId = null,
+            string? wasapiRenderEndpointId = null,
+            int wasapiBufferMilliseconds = 100)
         {
             ThrowIfDisposed();
             if (InProgress)
@@ -107,6 +114,10 @@ namespace Resonalyze
             Octaves = octaves;
             OutputDeviceNumber = outputDeviceNumber;
             InputDeviceNumber = inputDeviceNumber;
+            WasapiCaptureEndpointId = wasapiCaptureEndpointId;
+            WasapiRenderEndpointId = wasapiRenderEndpointId;
+            WasapiBufferMilliseconds = Math.Clamp(wasapiBufferMilliseconds, 10, 100);
+            LastAudioSessionDiagnostics = null;
             AudioBackend = audioBackend;
             AsioDriverName = asioDriverName;
             WaveInputChannelOffset = Math.Clamp(waveInputChannelOffset, 0, 1);
@@ -336,6 +347,7 @@ namespace Resonalyze
             SoundRecorder recorder = soundRecorder!;
             bool success = false;
             AsioSweepCapture? asioCapture = null;
+            WasapiSweepCapture? wasapiCapture = null;
 
             async Task<CapturedSweepSamples> CaptureOneAsync()
             {
@@ -343,6 +355,13 @@ namespace Resonalyze
                 {
                     asioCapture ??= new AsioSweepCapture(this, sweep);
                     return await asioCapture.CaptureRunAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                if (AudioBackend == AudioBackend.WasapiShared)
+                {
+                    wasapiCapture ??= new WasapiSweepCapture(this, sweep);
+                    return await wasapiCapture.CaptureRunAsync(cancellationToken)
                         .ConfigureAwait(false);
                 }
 
@@ -429,6 +448,10 @@ namespace Resonalyze
                     if (asioCapture != null)
                     {
                         await asioCapture.DisposeAsync().ConfigureAwait(false);
+                    }
+                    if (wasapiCapture != null)
+                    {
+                        await wasapiCapture.DisposeAsync().ConfigureAwait(false);
                     }
                     await recorder.StopRecordingAsync().ConfigureAwait(false);
                 }
@@ -524,6 +547,99 @@ namespace Resonalyze
                 microphoneIndex,
                 loopbackIndex,
                 ValidateSharedDeviceStereo: true);
+        }
+
+        private sealed class WasapiSweepCapture : IAsyncDisposable
+        {
+            private readonly ExpSweepMeasurement owner;
+            private readonly ExponentialSineSweep sweep;
+            private readonly WasapiCaptureDevice captureDevice;
+            private readonly WasapiPlaybackDevice playbackDevice;
+            private readonly PcmCaptureSession captureSession;
+
+            public WasapiSweepCapture(ExpSweepMeasurement owner, ExponentialSineSweep sweep)
+            {
+                this.owner = owner;
+                this.sweep = sweep;
+                string captureEndpointId = owner.WasapiCaptureEndpointId ??
+                    throw new InvalidOperationException("Select a WASAPI capture endpoint.");
+                string renderEndpointId = owner.WasapiRenderEndpointId ??
+                    throw new InvalidOperationException("Select a WASAPI render endpoint.");
+                captureDevice = new WasapiCaptureDevice(
+                    captureEndpointId,
+                    owner.WasapiBufferMilliseconds);
+                playbackDevice = new WasapiPlaybackDevice(
+                    renderEndpointId,
+                    owner.WasapiBufferMilliseconds);
+                if (captureDevice.CaptureFormat.SampleRate != playbackDevice.PlaybackFormat.SampleRate)
+                {
+                    throw new InvalidOperationException(
+                        "WASAPI Shared capture and render endpoints must use the same mix sample rate. " +
+                        $"Capture is {captureDevice.CaptureFormat.SampleRate} Hz and render is " +
+                        $"{playbackDevice.PlaybackFormat.SampleRate} Hz.");
+                }
+                if (owner.SampleRate != captureDevice.CaptureFormat.SampleRate)
+                {
+                    throw new InvalidOperationException(
+                        $"WASAPI Shared uses the endpoint mix rate " +
+                        $"({captureDevice.CaptureFormat.SampleRate} Hz). Update the measurement " +
+                        $"sample rate from {owner.SampleRate} Hz.");
+                }
+                int requiredChannels = owner.GetRequiredWaveInputChannelCount();
+                if (captureDevice.ChannelCount < requiredChannels)
+                {
+                    throw new InvalidOperationException(
+                        $"The WASAPI capture endpoint exposes {captureDevice.ChannelCount} channel(s), " +
+                        $"but the selected microphone and loopback routing requires {requiredChannels}.");
+                }
+
+                captureSession = new PcmCaptureSession(
+                    captureDevice,
+                    expectedSamples: sweep.SweepSamples + owner.SampleRate * 2);
+                captureSession.LevelsAvailable += channels => owner.RaiseLevels(
+                    owner.MapWaveLevels(channels));
+            }
+
+            public async Task<CapturedSweepSamples> CaptureRunAsync(
+                CancellationToken cancellationToken)
+            {
+                await captureSession.StartAsync(cancellationToken).ConfigureAwait(false);
+                int recordingStart = captureSession.ReadSamples;
+                RawSourceWaveStream stream = sweep.GetStream(owner.PlaybackChannel);
+                stream.Position = 0;
+                await playbackDevice.StartAsync(stream, cancellationToken).ConfigureAwait(false);
+                await playbackDevice.WaitForPlaybackEndAsync(cancellationToken).ConfigureAwait(false);
+
+                int requiredSamples = recordingStart + sweep.SweepSamples + owner.SampleRate;
+                await captureSession.WaitForSamplesAsync(requiredSamples, cancellationToken)
+                    .ConfigureAwait(false);
+                await captureSession.StopAsync().ConfigureAwait(false);
+                float[][] samples = captureSession.GetSamplesSnapshot();
+                owner.LastAudioSessionDiagnostics = new AudioSessionDiagnostics(
+                    nameof(AudioBackend.WasapiShared),
+                    captureDevice.EndpointId,
+                    playbackDevice.EndpointId,
+                    captureDevice.CaptureFormat,
+                    playbackDevice.PlaybackFormat,
+                    owner.WasapiBufferMilliseconds,
+                    captureDevice.CapturePackets,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0);
+                return new CapturedSweepSamples(
+                    samples,
+                    owner.WaveInputChannelOffset,
+                    owner.WaveLoopbackInputChannelOffset,
+                    ValidateSharedDeviceStereo: true);
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await playbackDevice.DisposeAsync().ConfigureAwait(false);
+                await captureSession.DisposeAsync().ConfigureAwait(false);
+            }
         }
 
         // Owns the ASIO session for a whole measurement. The driver is opened

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -566,7 +566,7 @@ namespace Resonalyze
             private readonly WasapiCaptureDevice captureDevice;
             private readonly WasapiPlaybackDevice playbackDevice;
             private readonly PcmCaptureSession captureSession;
-            private bool started;
+            private readonly SweepRunAudioOrchestrator orchestrator;
             private int runNumber;
 
             public WasapiSweepCapture(ExpSweepMeasurement owner, ExponentialSineSweep sweep)
@@ -647,6 +647,7 @@ namespace Resonalyze
                     expectedSamples: sweep.SweepSamples + owner.SampleRate * 2);
                 captureSession.LevelsAvailable += channels => owner.RaiseLevels(
                     owner.MapWaveLevels(channels));
+                orchestrator = new SweepRunAudioOrchestrator(captureSession, playbackDevice);
             }
 
             public async Task<CapturedSweepSamples> CaptureRunAsync(
@@ -659,31 +660,14 @@ namespace Resonalyze
                 long renderUnderrunsBefore = playbackDevice.RenderUnderruns;
                 try
                 {
-                    if (!started)
-                    {
-                        await captureSession.StartAsync(cancellationToken).ConfigureAwait(false);
-                        started = true;
-                    }
-                    else
-                    {
-                        // WasapiCapture is not reliably restartable after StopRecording;
-                        // some drivers invalidate its MMDevice RCW. Keep capture alive
-                        // for the complete average and reset only the sample storage.
-                        captureSession.Reset();
-                    }
-                    int recordingStart = captureSession.ReadSamples;
                     RawSourceWaveStream stream = sweep.GetStream(owner.PlaybackChannel);
                     stream.Position = 0;
-                    stage = "starting playback";
-                    await playbackDevice.StartAsync(stream, cancellationToken).ConfigureAwait(false);
-                    stage = "waiting for playback completion";
-                    await playbackDevice.WaitForPlaybackEndAsync(cancellationToken).ConfigureAwait(false);
-
-                    stage = "waiting for the captured tail";
-                    int requiredSamples = recordingStart + sweep.SweepSamples + owner.SampleRate;
-                    await captureSession.WaitForSamplesAsync(requiredSamples, cancellationToken)
-                        .ConfigureAwait(false);
-                    float[][] samples = captureSession.GetSamplesSnapshot();
+                    stage = "running playback and capturing the tail";
+                    float[][] samples = await orchestrator.CaptureAsync(
+                        stream,
+                        sweep.SweepSamples,
+                        owner.SampleRate,
+                        cancellationToken).ConfigureAwait(false);
                     owner.LastAudioSessionDiagnostics = new AudioSessionDiagnostics(
                         owner.AudioBackend.ToString(),
                         captureDevice.EndpointId,
@@ -727,10 +711,6 @@ namespace Resonalyze
                 }
                 finally
                 {
-                    if (started)
-                    {
-                        await captureSession.StopAsync().ConfigureAwait(false);
-                    }
                     await captureSession.DisposeAsync().ConfigureAwait(false);
                 }
             }

--- a/source/Measurements/ImpulseResponseFile.cs
+++ b/source/Measurements/ImpulseResponseFile.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using NAudio.Wave;
 using Resonalyze.History;
 
 namespace Resonalyze;
@@ -11,7 +12,7 @@ namespace Resonalyze;
 public sealed class ImpulseResponseFile
 {
     public const string CurrentFormat = "resonalyze-impulse-response";
-    public const int CurrentVersion = 5;
+    public const int CurrentVersion = 6;
 
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
@@ -35,6 +36,9 @@ public sealed class ImpulseResponseFile
     public int SweepDeconvolutionPeakIndex { get; set; }
     public int AverageRunCount { get; set; } = 1;
     public int AcceptedAverageRunCount { get; set; } = 1;
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AudioSessionFileEntry? AudioSession { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? TransferPeakIndex { get; set; }
@@ -101,6 +105,10 @@ public sealed class ImpulseResponseFile
             SweepDeconvolutionPeakIndex = sweepDeconvolution.PeakIndex,
             AverageRunCount = measurement.AverageRunCount,
             AcceptedAverageRunCount = measurement.AcceptedAverageRunCount,
+            AudioSession = CreateAudioSessionFileEntry(
+                measurement.LastAudioSessionDiagnostics,
+                measurement.SampleRate,
+                measurement.Bits),
             TransferPeakIndex = transferPeakIndex,
             MicrophoneLevels = microphoneLevels,
             LoopbackLevels = loopbackLevels,
@@ -366,6 +374,7 @@ public sealed class ImpulseResponseFile
         ValidateLevelEntry(MicrophoneLevels, nameof(MicrophoneLevels));
         ValidateLevelEntry(LoopbackLevels, nameof(LoopbackLevels));
         ValidatePreview(PreviewFrequencyResponse);
+        ValidateAudioSession(AudioSession);
     }
 
     private static (double[] Real, double[]? Imaginary) ConvertSamples(
@@ -480,6 +489,74 @@ public sealed class ImpulseResponseFile
         };
     }
 
+    internal static AudioSessionFileEntry? CreateAudioSessionFileEntry(
+        AudioSessionDiagnostics? diagnostics,
+        int analysisSampleRate,
+        int analysisBits)
+    {
+        if (diagnostics == null)
+        {
+            return null;
+        }
+
+        return new AudioSessionFileEntry
+        {
+            Backend = diagnostics.Backend,
+            CaptureEndpointId = diagnostics.CaptureEndpointId,
+            RenderEndpointId = diagnostics.RenderEndpointId,
+            ShareMode = diagnostics.Backend.Contains("Exclusive", StringComparison.Ordinal)
+                ? "Exclusive"
+                : "Shared",
+            CaptureFormat = diagnostics.CaptureFormat.ToString(),
+            RenderFormat = diagnostics.RenderFormat.ToString(),
+            CaptureSampleRate = diagnostics.CaptureFormat.SampleRate,
+            RenderSampleRate = diagnostics.RenderFormat.SampleRate,
+            AnalysisSampleRate = analysisSampleRate,
+            FormatConversionOccurred =
+                diagnostics.Backend.Contains("Shared", StringComparison.Ordinal) &&
+                (diagnostics.RenderFormat.SampleRate != analysisSampleRate ||
+                    diagnostics.RenderFormat.Encoding != WaveFormatEncoding.Pcm ||
+                    diagnostics.RenderFormat.BitsPerSample != analysisBits),
+            RequestedBufferMilliseconds = diagnostics.RequestedBufferMilliseconds,
+            ActualBufferFrames = diagnostics.ActualBufferFrames,
+            CapturePackets = diagnostics.CapturePackets,
+            RenderCallbacks = diagnostics.RenderCallbacks,
+            Discontinuities = diagnostics.Discontinuities,
+            SilentPackets = diagnostics.SilentPackets,
+            TimestampErrors = diagnostics.TimestampErrors,
+            CaptureOverruns = diagnostics.CaptureOverruns,
+            RenderUnderruns = diagnostics.RenderUnderruns
+        };
+    }
+
+    private static void ValidateAudioSession(AudioSessionFileEntry? session)
+    {
+        if (session == null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(session.Backend) ||
+            string.IsNullOrWhiteSpace(session.CaptureEndpointId) ||
+            string.IsNullOrWhiteSpace(session.RenderEndpointId))
+        {
+            throw new InvalidDataException("Audio session endpoint metadata is incomplete.");
+        }
+        if (session.CaptureSampleRate <= 0 || session.RenderSampleRate <= 0 ||
+            session.AnalysisSampleRate <= 0 || session.RequestedBufferMilliseconds <= 0 ||
+            session.ActualBufferFrames <= 0)
+        {
+            throw new InvalidDataException("Audio session format metadata is invalid.");
+        }
+        if (session.CapturePackets < 0 || session.RenderCallbacks < 0 ||
+            session.Discontinuities < 0 || session.SilentPackets < 0 ||
+            session.TimestampErrors < 0 || session.CaptureOverruns < 0 ||
+            session.RenderUnderruns < 0)
+        {
+            throw new InvalidDataException("Audio session diagnostics cannot be negative.");
+        }
+    }
+
     private static InputLevelMeterEntry ToMeterEntry(LevelSnapshotFileEntry? entry)
     {
         if (entry == null)
@@ -556,5 +633,28 @@ public sealed class ImpulseResponseFile
         public int SmoothingInverseOctaves { get; set; }
         public double[] Frequencies { get; set; } = Array.Empty<double>();
         public double[] MagnitudesDb { get; set; } = Array.Empty<double>();
+    }
+
+    public sealed class AudioSessionFileEntry
+    {
+        public string Backend { get; set; } = string.Empty;
+        public string CaptureEndpointId { get; set; } = string.Empty;
+        public string RenderEndpointId { get; set; } = string.Empty;
+        public string ShareMode { get; set; } = string.Empty;
+        public string CaptureFormat { get; set; } = string.Empty;
+        public string RenderFormat { get; set; } = string.Empty;
+        public int CaptureSampleRate { get; set; }
+        public int RenderSampleRate { get; set; }
+        public int AnalysisSampleRate { get; set; }
+        public bool FormatConversionOccurred { get; set; }
+        public int RequestedBufferMilliseconds { get; set; }
+        public int ActualBufferFrames { get; set; }
+        public long CapturePackets { get; set; }
+        public long RenderCallbacks { get; set; }
+        public long Discontinuities { get; set; }
+        public long SilentPackets { get; set; }
+        public long TimestampErrors { get; set; }
+        public long CaptureOverruns { get; set; }
+        public long RenderUnderruns { get; set; }
     }
 }

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -113,12 +113,20 @@ namespace Resonalyze
             AsioInputChannelOffset = asioInputChannelOffset;
             AsioLoopbackInputChannelOffset = asioLoopbackInputChannelOffset;
             AsioOutputChannelOffset = asioOutputChannelOffset;
-            WaveInputChannelOffset = IsWasapiBackend(audioBackend)
+            int normalizedWaveInputChannelOffset = IsWasapiBackend(audioBackend)
                 ? Math.Max(0, waveInputChannelOffset)
                 : Math.Clamp(waveInputChannelOffset, 0, 1);
-            WaveLoopbackInputChannelOffset = IsWasapiBackend(audioBackend)
+            int? normalizedWaveLoopbackInputChannelOffset = IsWasapiBackend(audioBackend)
                 ? NormalizeOptionalWasapiChannel(waveLoopbackInputChannelOffset)
                 : NormalizeOptionalWaveChannel(waveLoopbackInputChannelOffset);
+            if (audioBackend != AudioBackend.Asio &&
+                normalizedWaveLoopbackInputChannelOffset == normalizedWaveInputChannelOffset)
+            {
+                throw new InvalidOperationException(
+                    "Microphone and loopback inputs must use different channels.");
+            }
+            WaveInputChannelOffset = normalizedWaveInputChannelOffset;
+            WaveLoopbackInputChannelOffset = normalizedWaveLoopbackInputChannelOffset;
             LiveSpectrumOptions = liveSpectrumOptions ?? new LiveSpectrumOptions();
 
             signal?.Dispose();
@@ -536,8 +544,12 @@ namespace Resonalyze
                 await captureSession.StartAsync(cancellationToken).ConfigureAwait(false);
                 await playbackDevice.StartAsync(loopingProvider, cancellationToken)
                     .ConfigureAwait(false);
-                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+                Task playbackEnded = playbackDevice.WaitForPlaybackEndAsync(cancellationToken);
+                Task captureStopped = captureSession.WaitForStopAsync(cancellationToken);
+                Task completed = await Task.WhenAny(playbackEnded, captureStopped)
                     .ConfigureAwait(false);
+                await completed.ConfigureAwait(false);
+                throw new InvalidOperationException("WASAPI live playback stopped unexpectedly.");
             }
             finally
             {

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -1,5 +1,6 @@
-using System.Threading.Channels;
 using System.Numerics;
+using System.Threading.Channels;
+using NAudio.CoreAudioApi;
 using NAudio.Wave;
 using Resonalyze.Dsp;
 using Resonalyze.Options;
@@ -49,6 +50,9 @@ namespace Resonalyze
         public AudioBackend AudioBackend { get; private set; } = AudioBackend.Wave;
         public int OutputDeviceNumber { get; private set; } = -1;
         public int InputDeviceNumber { get; private set; } = -1;
+        public string? WasapiCaptureEndpointId { get; private set; }
+        public string? WasapiRenderEndpointId { get; private set; }
+        public int WasapiBufferMilliseconds { get; private set; } = 100;
         public string? AsioDriverName { get; private set; }
         public int AsioInputChannelOffset { get; private set; }
         public int? AsioLoopbackInputChannelOffset { get; private set; }
@@ -59,11 +63,11 @@ namespace Resonalyze
         public LiveSpectrumOptions LiveSpectrumOptions { get; private set; } = new();
         public Exception? LastError { get; private set; }
         public bool HasConfiguredLoopback =>
-            AudioBackend == AudioBackend.Wave
-                ? WaveLoopbackInputChannelOffset.HasValue &&
-                    WaveLoopbackInputChannelOffset.Value != WaveInputChannelOffset
-                : AsioLoopbackInputChannelOffset.HasValue &&
-                    AsioLoopbackInputChannelOffset.Value != AsioInputChannelOffset;
+            AudioBackend == AudioBackend.Asio
+                ? AsioLoopbackInputChannelOffset.HasValue &&
+                    AsioLoopbackInputChannelOffset.Value != AsioInputChannelOffset
+                : WaveLoopbackInputChannelOffset.HasValue &&
+                    WaveLoopbackInputChannelOffset.Value != WaveInputChannelOffset;
 
         public void Init(
             int sampleRate,
@@ -80,7 +84,10 @@ namespace Resonalyze
             int waveInputChannelOffset = 0,
             int? waveLoopbackInputChannelOffset = null,
             int? asioLoopbackInputChannelOffset = null,
-            LiveSpectrumOptions? liveSpectrumOptions = null)
+            LiveSpectrumOptions? liveSpectrumOptions = null,
+            string? wasapiCaptureEndpointId = null,
+            string? wasapiRenderEndpointId = null,
+            int wasapiBufferMilliseconds = 100)
         {
             ThrowIfDisposed();
             if (InProgress)
@@ -99,13 +106,19 @@ namespace Resonalyze
             OutputDeviceNumber = outputDeviceNumber;
             InputDeviceNumber = inputDeviceNumber;
             AudioBackend = audioBackend;
+            WasapiCaptureEndpointId = wasapiCaptureEndpointId;
+            WasapiRenderEndpointId = wasapiRenderEndpointId;
+            WasapiBufferMilliseconds = Math.Clamp(wasapiBufferMilliseconds, 10, 100);
             AsioDriverName = asioDriverName;
             AsioInputChannelOffset = asioInputChannelOffset;
             AsioLoopbackInputChannelOffset = asioLoopbackInputChannelOffset;
             AsioOutputChannelOffset = asioOutputChannelOffset;
-            WaveInputChannelOffset = Math.Clamp(waveInputChannelOffset, 0, 1);
-            WaveLoopbackInputChannelOffset = NormalizeOptionalWaveChannel(
-                waveLoopbackInputChannelOffset);
+            WaveInputChannelOffset = IsWasapiBackend(audioBackend)
+                ? Math.Max(0, waveInputChannelOffset)
+                : Math.Clamp(waveInputChannelOffset, 0, 1);
+            WaveLoopbackInputChannelOffset = IsWasapiBackend(audioBackend)
+                ? NormalizeOptionalWasapiChannel(waveLoopbackInputChannelOffset)
+                : NormalizeOptionalWaveChannel(waveLoopbackInputChannelOffset);
             LiveSpectrumOptions = liveSpectrumOptions ?? new LiveSpectrumOptions();
 
             signal?.Dispose();
@@ -381,6 +394,10 @@ namespace Resonalyze
                 {
                     await RunAsioAsync(noiseSignal, cancellationToken).ConfigureAwait(false);
                 }
+                else if (IsWasapiBackend(AudioBackend))
+                {
+                    await RunWasapiAsync(stream, cancellationToken).ConfigureAwait(false);
+                }
                 else
                 {
                     await RunWaveAsync(stream, recorder, cancellationToken).ConfigureAwait(false);
@@ -454,6 +471,89 @@ namespace Resonalyze
             stream.Position = 0;
             player.Init(new LoopingWaveProvider(stream));
             await PlayUntilCancelledAsync(player, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task RunWasapiAsync(
+            RawSourceWaveStream stream,
+            CancellationToken cancellationToken)
+        {
+            string captureEndpointId = WasapiCaptureEndpointId ??
+                throw new InvalidOperationException("Select a WASAPI capture endpoint.");
+            string renderEndpointId = WasapiRenderEndpointId ??
+                throw new InvalidOperationException("Select a WASAPI render endpoint.");
+            AudioClientShareMode shareMode = AudioBackend == AudioBackend.WasapiExclusive
+                ? AudioClientShareMode.Exclusive
+                : AudioClientShareMode.Shared;
+            int captureChannels = GetRequiredWaveInputChannelCount();
+            int renderChannels = PlaybackChannel == PlaybackChannel.Mono ? 1 : 2;
+            WaveFormat? captureFormat = null;
+            WaveFormat? renderFormat = null;
+            if (shareMode == AudioClientShareMode.Exclusive)
+            {
+                DuplexFormatSupport support = WasapiFormatSupport.CheckExclusive(
+                    captureEndpointId,
+                    renderEndpointId,
+                    SampleRate,
+                    Bits,
+                    captureChannels,
+                    renderChannels);
+                if (!support.Supported)
+                {
+                    throw new InvalidOperationException(
+                        $"WASAPI Exclusive format {SampleRate} Hz / {Bits}-bit is not " +
+                        "supported by both live-spectrum endpoints.");
+                }
+                captureFormat = WasapiFormatSupport.CreateDeviceFormat(
+                    SampleRate,
+                    Bits,
+                    captureChannels);
+                renderFormat = WasapiFormatSupport.CreateDeviceFormat(
+                    SampleRate,
+                    Bits,
+                    renderChannels);
+            }
+
+            await using var captureDevice = new WasapiCaptureDevice(
+                captureEndpointId,
+                WasapiBufferMilliseconds,
+                shareMode,
+                captureFormat);
+            await using var playbackDevice = new WasapiPlaybackDevice(
+                renderEndpointId,
+                WasapiBufferMilliseconds,
+                shareMode,
+                renderFormat);
+            await using var captureSession = new PcmCaptureSession(
+                captureDevice,
+                SequenceLength);
+            captureSession.SequenceChannelsReady += ProcessSequenceChannels;
+            captureSession.LevelsAvailable += HandleWaveLevelsAvailable;
+            captureSession.CaptureDiscontinuity += HandleCaptureDiscontinuity;
+            try
+            {
+                stream.Position = 0;
+                var loopingProvider = new LoopingWaveProvider(stream);
+                await captureSession.StartAsync(cancellationToken).ConfigureAwait(false);
+                await playbackDevice.StartAsync(loopingProvider, cancellationToken)
+                    .ConfigureAwait(false);
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                captureSession.SequenceChannelsReady -= ProcessSequenceChannels;
+                captureSession.LevelsAvailable -= HandleWaveLevelsAvailable;
+                captureSession.CaptureDiscontinuity -= HandleCaptureDiscontinuity;
+                await playbackDevice.StopAsync().ConfigureAwait(false);
+                await captureSession.StopAsync().ConfigureAwait(false);
+            }
+        }
+
+        private void HandleCaptureDiscontinuity()
+        {
+            Interlocked.Increment(ref droppedFrameTotal);
+            Interlocked.Exchange(ref lastDropTickMs, Environment.TickCount64);
+            Interlocked.Increment(ref dropGeneration);
         }
 
         private static async Task PlayUntilCancelledAsync(
@@ -754,12 +854,12 @@ namespace Resonalyze
                 AsioLoopbackInputChannelOffset);
 
         private int GetMicrophoneSequenceIndex() =>
-            AudioBackend == AudioBackend.Wave
+            AudioBackend != AudioBackend.Asio
                 ? WaveInputChannelOffset
                 : AsioInputChannelOffset - GetAsioCaptureFirstInputOffset();
 
         private int? GetLoopbackSequenceIndex() =>
-            AudioBackend == AudioBackend.Wave
+            AudioBackend != AudioBackend.Asio
                 ? WaveLoopbackInputChannelOffset
                 : AsioLoopbackInputChannelOffset.HasValue
                     ? AsioLoopbackInputChannelOffset.Value - GetAsioCaptureFirstInputOffset()
@@ -769,6 +869,12 @@ namespace Resonalyze
             channel.HasValue
                 ? Math.Clamp(channel.Value, 0, 1)
                 : null;
+
+        private static int? NormalizeOptionalWasapiChannel(int? channel) =>
+            channel.HasValue ? Math.Max(0, channel.Value) : null;
+
+        private static bool IsWasapiBackend(AudioBackend backend) =>
+            backend is AudioBackend.WasapiShared or AudioBackend.WasapiExclusive;
 
         private void ThrowIfDisposed()
         {

--- a/source/Measurements/SoundRecorder.cs
+++ b/source/Measurements/SoundRecorder.cs
@@ -1,347 +1,107 @@
 using NAudio.Wave;
 
-namespace Resonalyze
+namespace Resonalyze;
+
+/// <summary>
+/// Compatibility facade for existing measurement callers. Device lifecycle and
+/// PCM processing are implemented by IAudioCaptureDevice and PcmCaptureSession.
+/// </summary>
+public sealed class SoundRecorder : IDisposable
 {
-    /// <summary>
-    /// Captures interleaved PCM input and exposes sample-count based asynchronous waits.
-    /// </summary>
-    public sealed class SoundRecorder : IDisposable
+    private PcmCaptureSession? session;
+    private bool disposed;
+    private int sequence;
+
+    public event Action<float[]>? SequenceReady;
+    public event Action<float[][]>? SequenceChannelsReady;
+    internal event Action<AudioChannelLevel[]>? LevelsAvailable;
+
+    public int Sequence
     {
-        private readonly object sync = new();
-        private readonly SampleWaiterRegistry sampleWaiters = new();
-        private WaveInEvent? waveSource;
-        private CaptureAccumulator? accumulator;
-        private float[][] decodeScratch = Array.Empty<float[]>();
-        private double[] meterPeaks = Array.Empty<double>();
-        private double[] meterSumSquares = Array.Empty<double>();
-        private int expectedTotalSamples;
-        private TaskCompletionSource<bool>? firstBufferReady;
-        private TaskCompletionSource<bool>? recordingStopped;
-        private bool disposed;
-
-        public event Action<float[]>? SequenceReady;
-        public event Action<float[][]>? SequenceChannelsReady;
-        internal event Action<AudioChannelLevel[]>? LevelsAvailable;
-
-        public int Sequence { get; set; }
-        public int ReadSamples => accumulator?.ReadSamples ?? 0;
-        public int SampleRate { get; private set; }
-        public int Bits { get; private set; }
-        public int ChannelCount { get; private set; }
-        public int InputDeviceNumber { get; private set; } = -1;
-
-        public void Init(
-            int sampleRate,
-            int bits,
-            int channelCount,
-            int inputDeviceNumber = -1,
-            int expectedSamples = 0)
+        get => sequence;
+        set
         {
-            ThrowIfDisposed();
-            if (bits is not (16 or 24))
+            sequence = value;
+            if (session != null)
             {
-                throw new NotSupportedException($"Unsupported sample size: {bits} bits.");
-            }
-            if (sampleRate <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(sampleRate));
-            }
-            if (channelCount <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(channelCount));
-            }
-
-            StopAndDisposeSource();
-            SampleRate = sampleRate;
-            Bits = bits;
-            ChannelCount = channelCount;
-            InputDeviceNumber = inputDeviceNumber;
-            expectedTotalSamples = expectedSamples;
-            ResetBuffers();
-        }
-
-        public async Task StartRecordingAsync(CancellationToken cancellationToken)
-        {
-            ThrowIfDisposed();
-            if (SampleRate == 0 || ChannelCount == 0)
-            {
-                throw new InvalidOperationException("Recorder is not initialized.");
-            }
-
-            StopAndDisposeSource();
-            ResetBuffers();
-
-            firstBufferReady = NewSignal();
-            recordingStopped = NewSignal();
-            waveSource = new WaveInEvent
-            {
-                DeviceNumber = InputDeviceNumber,
-                WaveFormat = new WaveFormat(SampleRate, Bits, ChannelCount)
-            };
-            waveSource.DataAvailable += ReceiveData;
-            waveSource.RecordingStopped += RecordingStopped;
-            try
-            {
-                waveSource.StartRecording();
-
-                using CancellationTokenRegistration registration =
-                    cancellationToken.Register(() => firstBufferReady.TrySetCanceled(cancellationToken));
-                await firstBufferReady.Task.ConfigureAwait(false);
-            }
-            catch
-            {
-                // If the device fails to start, stops before the first buffer,
-                // or the caller cancels while waiting for that first buffer, do
-                // not leave an active WaveInEvent (and its callbacks) behind.
-                StopAndDisposeSource();
-                throw;
+                session.Sequence = value;
             }
         }
+    }
 
-        public Task WaitForSamplesAsync(int sampleCount, CancellationToken cancellationToken)
+    public int ReadSamples => session?.ReadSamples ?? 0;
+    public int SampleRate { get; private set; }
+    public int Bits { get; private set; }
+    public int ChannelCount { get; private set; }
+    public int InputDeviceNumber { get; private set; } = -1;
+
+    public void Init(
+        int sampleRate,
+        int bits,
+        int channelCount,
+        int inputDeviceNumber = -1,
+        int expectedSamples = 0)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        if (bits is not (16 or 24 or 32))
         {
-            if (sampleCount <= 0)
-            {
-                return Task.CompletedTask;
-            }
-
-            lock (sync)
-            {
-                if (ReadSamples >= sampleCount)
-                {
-                    return Task.CompletedTask;
-                }
-
-                return sampleWaiters.Add(sampleCount, cancellationToken);
-            }
+            throw new NotSupportedException($"Unsupported sample size: {bits} bits.");
         }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sampleRate);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(channelCount);
 
-        public async Task StopRecordingAsync()
+        DisposeSession();
+        SampleRate = sampleRate;
+        Bits = bits;
+        ChannelCount = channelCount;
+        InputDeviceNumber = inputDeviceNumber;
+        var device = new MmeCaptureDevice(
+            inputDeviceNumber,
+            new WaveFormat(sampleRate, bits, channelCount));
+        session = new PcmCaptureSession(device, sequence, expectedSamples);
+        session.SequenceReady += HandleSequenceReady;
+        session.SequenceChannelsReady += HandleSequenceChannelsReady;
+        session.LevelsAvailable += HandleLevelsAvailable;
+    }
+
+    public Task StartRecordingAsync(CancellationToken cancellationToken) =>
+        GetSession().StartAsync(cancellationToken);
+
+    public Task WaitForSamplesAsync(int sampleCount, CancellationToken cancellationToken) =>
+        GetSession().WaitForSamplesAsync(sampleCount, cancellationToken);
+
+    public Task StopRecordingAsync() => GetSession().StopAsync();
+
+    public float[][] GetSamplesSnapshot() => GetSession().GetSamplesSnapshot();
+
+    private PcmCaptureSession GetSession() => session ??
+        throw new InvalidOperationException("Recorder is not initialized.");
+
+    private void HandleSequenceReady(float[] samples) => SequenceReady?.Invoke(samples);
+    private void HandleSequenceChannelsReady(float[][] samples) => SequenceChannelsReady?.Invoke(samples);
+    private void HandleLevelsAvailable(AudioChannelLevel[] levels) => LevelsAvailable?.Invoke(levels);
+
+    private void DisposeSession()
+    {
+        if (session == null)
         {
-            WaveInEvent? source;
-            TaskCompletionSource<bool>? stoppedSignal;
-            lock (sync)
-            {
-                source = waveSource;
-                stoppedSignal = recordingStopped;
-            }
-
-            if (source == null)
-            {
-                return;
-            }
-
-            try
-            {
-                await AudioCaptureStop.StopAndWaitAsync(
-                    source.StopRecording,
-                    stoppedSignal,
-                    stoppedSignal?.Task ?? Task.CompletedTask,
-                    "The audio input").ConfigureAwait(false);
-            }
-            finally
-            {
-                DetachAndDisposeSource(source);
-            }
+            return;
         }
+        session.SequenceReady -= HandleSequenceReady;
+        session.SequenceChannelsReady -= HandleSequenceChannelsReady;
+        session.LevelsAvailable -= HandleLevelsAvailable;
+        session.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        session = null;
+    }
 
-        // Meaningful only without sequence extraction (the accumulator drops the
-        // consumed prefix in sequence mode); no current caller mixes the two.
-        public float[][] GetSamplesSnapshot()
+    public void Dispose()
+    {
+        if (disposed)
         {
-            lock (sync)
-            {
-                return accumulator?.Snapshot() ?? Array.Empty<float[]>();
-            }
+            return;
         }
-
-        private void ReceiveData(object? sender, WaveInEventArgs args)
-        {
-            int bytesPerSample = Bits / 8;
-            int bytesPerFrame = bytesPerSample * ChannelCount;
-            int frameCount = args.BytesRecorded / bytesPerFrame;
-
-            // Decode and meter on reusable scratch outside the lock; only bounded
-            // array copies happen inside it (mirrors AsioFullDuplexSession).
-            EnsureScratch(frameCount);
-            double[] peaks = meterPeaks;
-            double[] sumSquares = meterSumSquares;
-            Array.Clear(peaks);
-            Array.Clear(sumSquares);
-            for (int frame = 0; frame < frameCount; frame++)
-            {
-                int frameOffset = frame * bytesPerFrame;
-                for (int channel = 0; channel < ChannelCount; channel++)
-                {
-                    int sampleOffset = frameOffset + channel * bytesPerSample;
-                    float sample = ReadPcmSample(args.Buffer, sampleOffset, bytesPerSample);
-                    decodeScratch[channel][frame] = sample;
-                    double magnitude = Math.Abs(sample);
-                    peaks[channel] = Math.Max(peaks[channel], magnitude);
-                    sumSquares[channel] += sample * sample;
-                }
-            }
-
-            List<float[][]>? readySequences;
-            lock (sync)
-            {
-                if (accumulator == null)
-                {
-                    return;
-                }
-
-                accumulator.Append(decodeScratch, frameCount);
-                readySequences = accumulator.ExtractReadySequences();
-                sampleWaiters.CompleteUpTo(accumulator.ReadSamples);
-            }
-
-            firstBufferReady?.TrySetResult(true);
-            LevelsAvailable?.Invoke(
-                AudioLevelMetering.MeasureChannels(peaks, sumSquares, frameCount));
-            if (readySequences == null)
-            {
-                return;
-            }
-
-            foreach (float[][] sequence in readySequences)
-            {
-                SequenceReady?.Invoke(sequence[0]);
-                SequenceChannelsReady?.Invoke(sequence);
-            }
-        }
-
-        private void EnsureScratch(int frames)
-        {
-            if (meterPeaks.Length != ChannelCount)
-            {
-                meterPeaks = new double[ChannelCount];
-                meterSumSquares = new double[ChannelCount];
-            }
-
-            if (decodeScratch.Length == ChannelCount &&
-                decodeScratch[0].Length >= frames)
-            {
-                return;
-            }
-
-            decodeScratch = new float[ChannelCount][];
-            for (int channel = 0; channel < ChannelCount; channel++)
-            {
-                decodeScratch[channel] = new float[frames];
-            }
-        }
-
-        private static float ReadPcmSample(byte[] buffer, int offset, int bytesPerSample)
-        {
-            int value = bytesPerSample == 2
-                ? (short)(buffer[offset] | buffer[offset + 1] << 8)
-                : buffer[offset] | buffer[offset + 1] << 8 | buffer[offset + 2] << 16;
-
-            if (bytesPerSample == 3 && (value & 0x800000) != 0)
-            {
-                value |= unchecked((int)0xff000000);
-            }
-
-            int maxValue = (1 << (bytesPerSample * 8 - 1)) - 1;
-            return Math.Clamp(value / (float)maxValue, -1.0f, 1.0f);
-        }
-
-        private void RecordingStopped(object? sender, StoppedEventArgs args)
-        {
-            if (args.Exception != null)
-            {
-                firstBufferReady?.TrySetException(args.Exception);
-                recordingStopped?.TrySetException(args.Exception);
-            }
-            else
-            {
-                firstBufferReady?.TrySetException(
-                    new InvalidOperationException("Recording stopped before the first audio buffer arrived."));
-                recordingStopped?.TrySetResult(true);
-            }
-
-            // A waiter blocked on a sample count that will never arrive (the
-            // device unplugged mid-capture) used to hang until a manual Abort:
-            // no more samples are coming, so fault every pending wait.
-            lock (sync)
-            {
-                sampleWaiters.FaultAll(
-                    args.Exception ??
-                    new InvalidOperationException(
-                        "Recording stopped before the requested samples arrived."));
-            }
-        }
-
-        private void ResetBuffers()
-        {
-            lock (sync)
-            {
-                // At least one second pre-allocated; a known recording length
-                // (e.g. the sweep) avoids growth re-allocations mid-capture.
-                accumulator = new CaptureAccumulator(
-                    ChannelCount,
-                    Sequence,
-                    Math.Max(expectedTotalSamples, SampleRate));
-
-                sampleWaiters.CancelAll();
-            }
-        }
-
-        private void StopAndDisposeSource()
-        {
-            WaveInEvent? source;
-            lock (sync)
-            {
-                source = waveSource;
-            }
-            if (source == null)
-            {
-                return;
-            }
-
-            DetachAndDisposeSource(source);
-        }
-
-        private void DetachAndDisposeSource(WaveInEvent source)
-        {
-            lock (sync)
-            {
-                if (ReferenceEquals(waveSource, source))
-                {
-                    waveSource = null;
-                }
-            }
-
-            source.DataAvailable -= ReceiveData;
-            source.RecordingStopped -= RecordingStopped;
-            source.Dispose();
-        }
-
-        private static TaskCompletionSource<bool> NewSignal() =>
-            SampleWaiterRegistry.NewSignal();
-
-        private void ThrowIfDisposed()
-        {
-            if (disposed)
-            {
-                throw new ObjectDisposedException(nameof(SoundRecorder));
-            }
-        }
-
-        public void Dispose()
-        {
-            if (disposed)
-            {
-                return;
-            }
-
-            disposed = true;
-            StopAndDisposeSource();
-            lock (sync)
-            {
-                sampleWaiters.CancelAll();
-            }
-            GC.SuppressFinalize(this);
-        }
+        disposed = true;
+        DisposeSession();
+        GC.SuppressFinalize(this);
     }
 }

--- a/source/Measurements/SweepRunAudioOrchestrator.cs
+++ b/source/Measurements/SweepRunAudioOrchestrator.cs
@@ -1,0 +1,56 @@
+using NAudio.Wave;
+
+namespace Resonalyze;
+
+internal interface ISweepCaptureSession
+{
+    int ReadSamples { get; }
+    Task StartAsync(CancellationToken cancellationToken);
+    void Reset();
+    Task WaitForSamplesAsync(int sampleCount, CancellationToken cancellationToken);
+    float[][] GetSamplesSnapshot();
+}
+
+internal sealed class SweepRunAudioOrchestrator
+{
+    private readonly ISweepCaptureSession capture;
+    private readonly IAudioPlaybackDevice playback;
+    private bool captureStarted;
+
+    public SweepRunAudioOrchestrator(
+        ISweepCaptureSession capture,
+        IAudioPlaybackDevice playback)
+    {
+        this.capture = capture;
+        this.playback = playback;
+    }
+
+    public async Task<float[][]> CaptureAsync(
+        IWaveProvider source,
+        int sweepSamples,
+        int tailSamples,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sweepSamples);
+        ArgumentOutOfRangeException.ThrowIfNegative(tailSamples);
+
+        if (!captureStarted)
+        {
+            await capture.StartAsync(cancellationToken).ConfigureAwait(false);
+            captureStarted = true;
+        }
+        else
+        {
+            capture.Reset();
+        }
+
+        int recordingStart = capture.ReadSamples;
+        await AudioPlaybackRunner.PlayToEndAsync(playback, source, cancellationToken)
+            .ConfigureAwait(false);
+        int requiredSamples = checked(recordingStart + sweepSamples + tailSamples);
+        await capture.WaitForSamplesAsync(requiredSamples, cancellationToken)
+            .ConfigureAwait(false);
+        return capture.GetSamplesSnapshot();
+    }
+}

--- a/source/Options/MeasurementOptions.Designer.cs
+++ b/source/Options/MeasurementOptions.Designer.cs
@@ -369,7 +369,7 @@ namespace Resonalyze.Options
             waveAudioBackendPanel.BackColor = Color.FromArgb(45, 50, 60);
             waveAudioBackendPanel.Location = new Point(12, 310);
             waveAudioBackendPanel.Name = "waveAudioBackendPanel";
-            waveAudioBackendPanel.Size = new Size(311, 177);
+            waveAudioBackendPanel.Size = new Size(311, 213);
             waveAudioBackendPanel.TabIndex = 25;
             // 
             // asioAudioBackendPanel

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -174,8 +174,7 @@ namespace Resonalyze.Options
                 "analysis is derived from the transfer IR it produces.");
             deviceToolTip.SetToolTip(
                 buttonDeviceSettings,
-                "Opens the selected driver's control panel to change the hardware sample " +
-                "rate. Falls back to Windows Sound settings when no ASIO driver is selected.");
+                "Opens Windows Sound settings for the selected WASAPI endpoints.");
         }
 
         internal void Init(
@@ -321,9 +320,12 @@ namespace Resonalyze.Options
             {
                 ValidateSelectedAsioDriver(sampleRate);
             }
-            if (audioBackend == AudioBackend.Wave)
+            if (audioBackend != AudioBackend.Asio)
             {
                 ValidateSelectedWaveLoopback();
+            }
+            if (audioBackend == AudioBackend.Wave)
+            {
                 ValidateSelectedWaveSampleRate(sampleRate);
             }
             int asioInputChannelOffset =
@@ -816,21 +818,6 @@ namespace Resonalyze.Options
         {
             try
             {
-                int preferredSampleRate = GetSelectedSampleRate();
-                int preferredInputOffset = GetSelectedWaveInputChannelOffset();
-                int? preferredLoopbackOffset = GetSelectedWaveLoopbackChannelOffset();
-                if (comboBoxAsioDriver.SelectedItem is AsioDeviceInfo asioDriver)
-                {
-                    AsioDeviceCatalog.ShowControlPanel(asioDriver.DriverName);
-                    LoadWasapiEndpoints();
-                    PopulateDeviceControlsForSelectedBackend(
-                        preferredInputOffset,
-                        preferredLoopbackOffset);
-                    RefreshSampleRateOptions(preferredSampleRate);
-                    UpdateAudioBackendControls();
-                    return;
-                }
-
                 Process.Start(new ProcessStartInfo("control.exe", "mmsys.cpl")
                 {
                     UseShellExecute = true
@@ -1052,13 +1039,13 @@ namespace Resonalyze.Options
             return -1;
         }
 
-        private static AudioEndpointInfo CreateUnavailableEndpoint(
+        internal static AudioEndpointInfo CreateUnavailableEndpoint(
             string endpointId,
             string? friendlyName,
             NAudio.CoreAudioApi.DataFlow direction) =>
             new(
-                string.IsNullOrWhiteSpace(friendlyName) ? endpointId : friendlyName,
                 endpointId,
+                string.IsNullOrWhiteSpace(friendlyName) ? endpointId : friendlyName,
                 direction,
                 NAudio.CoreAudioApi.DeviceState.NotPresent,
                 new NAudio.Wave.WaveFormat(44_100, 16, 1),
@@ -1137,6 +1124,15 @@ namespace Resonalyze.Options
                 {
                     labelWaveLoopbackStatus.Text =
                         "⚠ A saved endpoint is unavailable. Reconnect it or select a replacement.";
+                    labelWaveLoopbackStatus.ForeColor = Color.Gold;
+                    return;
+                }
+                if (GetSelectedWaveLoopbackChannelOffset() == null)
+                {
+                    labelWaveLoopbackStatus.Font = WarningStatusFont;
+                    labelWaveLoopbackStatus.Text =
+                        "⚠ Loopback channel is REQUIRED. Select the physical input carrying " +
+                        "the playback reference.";
                     labelWaveLoopbackStatus.ForeColor = Color.Gold;
                     return;
                 }
@@ -1258,7 +1254,21 @@ namespace Resonalyze.Options
         {
             bool loopbackSelected =
                 comboBoxWaveLoopbackChannel.SelectedItem is InputChannelOption { Offset: not null };
-            if (loopbackSelected && !SelectedRecordingDeviceSupportsWaveLoopback())
+            ValidateRequiredWaveLoopback(
+                loopbackSelected,
+                SelectedRecordingDeviceSupportsWaveLoopback());
+        }
+
+        internal static void ValidateRequiredWaveLoopback(
+            bool loopbackSelected,
+            bool recordingDeviceSupportsLoopback)
+        {
+            if (!loopbackSelected)
+            {
+                throw new InvalidOperationException(
+                    "A loopback reference channel is required before measuring.");
+            }
+            if (!recordingDeviceSupportsLoopback)
             {
                 throw new InvalidOperationException(
                     "Wave loopback requires a selected stereo recording device.");

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -393,7 +393,7 @@ namespace Resonalyze.Options
                     sampleRate = captureEndpoint.MixFormat.SampleRate;
                 }
             }
-            if (IsWasapiBackend(audioBackend) &&
+            if (audioBackend != AudioBackend.Asio &&
                 waveLoopbackInputChannelOffset.HasValue &&
                 waveLoopbackInputChannelOffset.Value == waveInputChannelOffset)
             {

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -144,6 +144,7 @@ namespace Resonalyze.Options
                 {
                     AudioBackend.Wave => "MME Compatibility",
                     AudioBackend.WasapiShared => "WASAPI Shared",
+                    AudioBackend.WasapiExclusive => "WASAPI Exclusive",
                     _ => backend.ToString()
                 });
             }
@@ -295,7 +296,7 @@ namespace Resonalyze.Options
                 comboBoxPlaybackDevice.SelectedItem is AudioEndpointInfo renderSelection
                     ? renderSelection.Id
                     : preferredWasapiRenderEndpointId;
-            if (audioBackend == AudioBackend.WasapiShared)
+            if (IsWasapiBackend(audioBackend))
             {
                 using var endpointService = new WindowsAudioEndpointService();
                 AudioEndpointInfo captureEndpoint = SelectWasapiEndpoint(
@@ -311,7 +312,8 @@ namespace Resonalyze.Options
                     throw new InvalidOperationException(
                         "A selected WASAPI endpoint is unavailable. Reconnect it or select a replacement.");
                 }
-                if (captureEndpoint.MixFormat.SampleRate != renderEndpoint.MixFormat.SampleRate)
+                if (audioBackend == AudioBackend.WasapiShared &&
+                    captureEndpoint.MixFormat.SampleRate != renderEndpoint.MixFormat.SampleRate)
                 {
                     throw new InvalidOperationException(
                         "The default WASAPI capture and render endpoints use different mix rates. " +
@@ -319,9 +321,12 @@ namespace Resonalyze.Options
                 }
                 wasapiCaptureEndpointId = captureEndpoint.Id;
                 wasapiRenderEndpointId = renderEndpoint.Id;
-                sampleRate = captureEndpoint.MixFormat.SampleRate;
+                if (audioBackend == AudioBackend.WasapiShared)
+                {
+                    sampleRate = captureEndpoint.MixFormat.SampleRate;
+                }
             }
-            if (audioBackend is AudioBackend.Wave or AudioBackend.WasapiShared &&
+            if (IsWasapiBackend(audioBackend) &&
                 waveLoopbackInputChannelOffset.HasValue &&
                 waveLoopbackInputChannelOffset.Value == waveInputChannelOffset)
             {
@@ -612,8 +617,7 @@ namespace Resonalyze.Options
         {
             bool useAsio =
                 comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.Asio;
-            bool useWasapi =
-                comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiShared;
+            bool useWasapi = IsSelectedWasapiBackend();
             waveAudioBackendPanel.Visible = !useAsio;
             asioAudioBackendPanel.Visible = useAsio;
             comboBoxPlaybackDevice.Enabled = !useAsio;
@@ -848,7 +852,7 @@ namespace Resonalyze.Options
             initializing = true;
             try
             {
-                if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiShared)
+                if (IsSelectedWasapiBackend())
                 {
                     PopulateWasapiEndpointCombo(
                         comboBoxPlaybackDevice,
@@ -1010,7 +1014,7 @@ namespace Resonalyze.Options
                 return;
             }
 
-            if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiShared)
+            if (IsSelectedWasapiBackend())
             {
                 comboBoxWaveLoopbackChannel.Enabled = true;
                 labelWaveLoopbackStatus.Font = NormalStatusFont;
@@ -1021,6 +1025,27 @@ namespace Resonalyze.Options
                     labelWaveLoopbackStatus.Text =
                         "⚠ A saved endpoint is unavailable. Reconnect it or select a replacement.";
                     labelWaveLoopbackStatus.ForeColor = Color.Gold;
+                    return;
+                }
+                if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiExclusive)
+                {
+                    int selectedRate = GetSelectedSampleRate();
+                    int bits = (int)numericUpDownBits.Value;
+                    bool supported = IsExclusiveFormatSupported(
+                        capture.Id,
+                        render.Id,
+                        selectedRate,
+                        bits,
+                        Math.Max(
+                            GetSelectedWaveInputChannelOffset(),
+                            GetSelectedWaveLoopbackChannelOffset() ?? 0) + 1,
+                        GetSelectedPlaybackChannelCount());
+                    labelWaveLoopbackStatus.Text = supported
+                        ? $"Exclusive format: {selectedRate:N0} Hz / {bits}-bit, supported by both endpoints."
+                        : $"⚠ Exclusive format {selectedRate:N0} Hz / {bits}-bit is not supported by both endpoints.";
+                    labelWaveLoopbackStatus.ForeColor = supported
+                        ? Color.LightGray
+                        : Color.LightSalmon;
                     return;
                 }
                 string compatibility = capture.MixFormat.SampleRate == render.MixFormat.SampleRate
@@ -1347,14 +1372,35 @@ namespace Resonalyze.Options
                         : null);
             }
 
-            if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiShared)
+            if (IsSelectedWasapiBackend())
             {
                 AudioEndpointInfo? capture = comboBoxRecordingDevice.SelectedItem as AudioEndpointInfo;
                 AudioEndpointInfo? render = comboBoxPlaybackDevice.SelectedItem as AudioEndpointInfo;
-                return capture is { IsAvailable: true } && render is { IsAvailable: true } &&
-                    capture.MixFormat.SampleRate == render.MixFormat.SampleRate
+                if (capture is not { IsAvailable: true } || render is not { IsAvailable: true })
+                {
+                    return [];
+                }
+                if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiShared)
+                {
+                    return capture.MixFormat.SampleRate == render.MixFormat.SampleRate
                         ? [capture.MixFormat.SampleRate]
                         : [];
+                }
+
+                int captureChannels = Math.Max(
+                    GetSelectedWaveInputChannelOffset(),
+                    GetSelectedWaveLoopbackChannelOffset() ?? 0) + 1;
+                int renderChannels = GetSelectedPlaybackChannelCount();
+                int bits = (int)numericUpDownBits.Value;
+                return SampleRateCatalog.GetCandidateRates()
+                    .Where(rate => IsExclusiveFormatSupported(
+                        capture.Id,
+                        render.Id,
+                        rate,
+                        bits,
+                        captureChannels,
+                        renderChannels))
+                    .ToArray();
             }
 
             return AudioDeviceCatalog.GetSupportedWaveSampleRates(
@@ -1374,6 +1420,37 @@ namespace Resonalyze.Options
             comboBoxWaveLoopbackChannel.SelectedItem is InputChannelOption option
                 ? option.Offset
                 : null;
+
+        private static bool IsExclusiveFormatSupported(
+            string captureEndpointId,
+            string renderEndpointId,
+            int sampleRate,
+            int bits,
+            int captureChannels,
+            int renderChannels)
+        {
+            try
+            {
+                return WasapiFormatSupport.CheckExclusive(
+                    captureEndpointId,
+                    renderEndpointId,
+                    sampleRate,
+                    bits,
+                    captureChannels,
+                    renderChannels).Supported;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private bool IsSelectedWasapiBackend() =>
+            comboBoxAudioBackend.SelectedIndex is
+                (int)AudioBackend.WasapiShared or (int)AudioBackend.WasapiExclusive;
+
+        private static bool IsWasapiBackend(AudioBackend backend) =>
+            backend is AudioBackend.WasapiShared or AudioBackend.WasapiExclusive;
 
         private int GetSelectedSampleRate()
         {

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -20,6 +20,8 @@ namespace Resonalyze.Options
         private ExpSweepMeasurement? expSweepMeasurement;
         private IReadOnlyList<AudioDeviceInfo> playbackDevices = Array.Empty<AudioDeviceInfo>();
         private IReadOnlyList<AudioDeviceInfo> recordingDevices = Array.Empty<AudioDeviceInfo>();
+        private IReadOnlyList<AudioEndpointInfo> wasapiCaptureEndpoints = Array.Empty<AudioEndpointInfo>();
+        private IReadOnlyList<AudioEndpointInfo> wasapiRenderEndpoints = Array.Empty<AudioEndpointInfo>();
         private IReadOnlyList<AsioDeviceInfo> asioDrivers = Array.Empty<AsioDeviceInfo>();
         private AsioDriverInfo asioDriverInfo = AsioDeviceCatalog.EmptyDriverInfo;
         private bool initializing;
@@ -32,6 +34,10 @@ namespace Resonalyze.Options
         private bool updatingWaveLoopbackSelection;
         private string? preferredWasapiCaptureEndpointId;
         private string? preferredWasapiRenderEndpointId;
+        private string? preferredWasapiCaptureEndpointName;
+        private string? preferredWasapiRenderEndpointName;
+        private int preferredWavePlaybackDeviceNumber = -1;
+        private int preferredWaveRecordingDeviceNumber = -1;
 
         private DarkComboBox comboBoxPlaybackDevice => waveAudioBackendPanel.ComboBoxPlaybackDevice;
 
@@ -118,6 +124,10 @@ namespace Resonalyze.Options
             numericUpDownBits.Value = settings.Bits is 16 or 24 ? settings.Bits : 24;
             preferredWasapiCaptureEndpointId = settings.WasapiCaptureEndpointId;
             preferredWasapiRenderEndpointId = settings.WasapiRenderEndpointId;
+            preferredWasapiCaptureEndpointName = settings.WasapiCaptureEndpointName;
+            preferredWasapiRenderEndpointName = settings.WasapiRenderEndpointName;
+            preferredWavePlaybackDeviceNumber = settings.OutputDeviceNumber;
+            preferredWaveRecordingDeviceNumber = settings.InputDeviceNumber;
 
             comboBoxChannel.Items.Clear();
             foreach (PlaybackChannel channel in Enum.GetValues<PlaybackChannel>())
@@ -152,16 +162,8 @@ namespace Resonalyze.Options
             UpdateComboBoxToolTip(comboBoxPlaybackDevice);
 
             recordingDevices = AudioDeviceCatalog.GetRecordingDevices();
-            comboBoxRecordingDevice.Items.Clear();
-            comboBoxRecordingDevice.Items.AddRange(recordingDevices.Cast<object>().ToArray());
-            SelectDeviceOrShowMissing(
-                comboBoxRecordingDevice,
-                recordingDevices,
-                settings.InputDeviceNumber);
-            ConfigureDropDownWidth(comboBoxRecordingDevice);
-            UpdateComboBoxToolTip(comboBoxRecordingDevice);
-
-            FillWaveChannelControls(
+            LoadWasapiEndpoints();
+            PopulateDeviceControlsForSelectedBackend(
                 settings.WaveInputChannelOffset,
                 settings.WaveLoopbackInputChannelOffset);
 
@@ -233,9 +235,13 @@ namespace Resonalyze.Options
             PlaybackChannel playbackChannel = (PlaybackChannel)comboBoxChannel.SelectedIndex;
             double requestedDuration = (double)numericUpDownRequestedDuration.Value * 0.001;
             int octaves = (int)numericUpDownOctaves.Value;
-            int outputDeviceNumber = ((AudioDeviceInfo)comboBoxPlaybackDevice.SelectedItem!).DeviceNumber;
-            int inputDeviceNumber = ((AudioDeviceInfo)comboBoxRecordingDevice.SelectedItem!).DeviceNumber;
             AudioBackend audioBackend = (AudioBackend)comboBoxAudioBackend.SelectedIndex;
+            int outputDeviceNumber = comboBoxPlaybackDevice.SelectedItem is AudioDeviceInfo playbackDevice
+                ? playbackDevice.DeviceNumber
+                : preferredWavePlaybackDeviceNumber;
+            int inputDeviceNumber = comboBoxRecordingDevice.SelectedItem is AudioDeviceInfo recordingDevice
+                ? recordingDevice.DeviceNumber
+                : preferredWaveRecordingDeviceNumber;
             string? asioDriverName = comboBoxAsioDriver.SelectedItem is AsioDeviceInfo asioDriver
                 ? asioDriver.DriverName
                 : null;
@@ -281,8 +287,14 @@ namespace Resonalyze.Options
                     : null;
             int averageRunCount = (int)numericUpDownAverageRunCount.Value;
             bool confirmEachAverageRun = checkBoxConfirmEachAverageRun.Checked;
-            string? wasapiCaptureEndpointId = preferredWasapiCaptureEndpointId;
-            string? wasapiRenderEndpointId = preferredWasapiRenderEndpointId;
+            string? wasapiCaptureEndpointId =
+                comboBoxRecordingDevice.SelectedItem is AudioEndpointInfo captureSelection
+                    ? captureSelection.Id
+                    : preferredWasapiCaptureEndpointId;
+            string? wasapiRenderEndpointId =
+                comboBoxPlaybackDevice.SelectedItem is AudioEndpointInfo renderSelection
+                    ? renderSelection.Id
+                    : preferredWasapiRenderEndpointId;
             if (audioBackend == AudioBackend.WasapiShared)
             {
                 using var endpointService = new WindowsAudioEndpointService();
@@ -294,6 +306,11 @@ namespace Resonalyze.Options
                     endpointService.GetRenderEndpoints(),
                     wasapiRenderEndpointId,
                     "render");
+                if (!captureEndpoint.IsAvailable || !renderEndpoint.IsAvailable)
+                {
+                    throw new InvalidOperationException(
+                        "A selected WASAPI endpoint is unavailable. Reconnect it or select a replacement.");
+                }
                 if (captureEndpoint.MixFormat.SampleRate != renderEndpoint.MixFormat.SampleRate)
                 {
                     throw new InvalidOperationException(
@@ -331,12 +348,28 @@ namespace Resonalyze.Options
                 confirmEachAverageRun,
                 wasapiCaptureEndpointId,
                 wasapiRenderEndpointId,
-                settings.WasapiBufferMilliseconds);
+                settings.WasapiBufferMilliseconds,
+                comboBoxRecordingDevice.SelectedItem is AudioEndpointInfo captureInfo
+                    ? captureInfo.FriendlyName
+                    : preferredWasapiCaptureEndpointName,
+                comboBoxPlaybackDevice.SelectedItem is AudioEndpointInfo renderInfo
+                    ? renderInfo.FriendlyName
+                    : preferredWasapiRenderEndpointName);
 
             settings.WasapiCaptureEndpointId = wasapiCaptureEndpointId;
             settings.WasapiRenderEndpointId = wasapiRenderEndpointId;
+            settings.WasapiCaptureEndpointName =
+                comboBoxRecordingDevice.SelectedItem is AudioEndpointInfo selectedCapture
+                    ? selectedCapture.FriendlyName
+                    : preferredWasapiCaptureEndpointName;
+            settings.WasapiRenderEndpointName =
+                comboBoxPlaybackDevice.SelectedItem is AudioEndpointInfo selectedRender
+                    ? selectedRender.FriendlyName
+                    : preferredWasapiRenderEndpointName;
             preferredWasapiCaptureEndpointId = wasapiCaptureEndpointId;
             preferredWasapiRenderEndpointId = wasapiRenderEndpointId;
+            preferredWasapiCaptureEndpointName = settings.WasapiCaptureEndpointName;
+            preferredWasapiRenderEndpointName = settings.WasapiRenderEndpointName;
         }
 
         private void buttonCalibration0_Click(object? sender, EventArgs e)
@@ -486,6 +519,14 @@ namespace Resonalyze.Options
             }
 
             UpdateComboBoxToolTip(comboBoxPlaybackDevice);
+            if (comboBoxPlaybackDevice.SelectedItem is AudioEndpointInfo endpoint)
+            {
+                preferredWasapiRenderEndpointId = endpoint.Id;
+            }
+            else if (comboBoxPlaybackDevice.SelectedItem is AudioDeviceInfo device)
+            {
+                preferredWavePlaybackDeviceNumber = device.DeviceNumber;
+            }
             RefreshSampleRateOptions(GetSelectedSampleRate());
         }
 
@@ -497,6 +538,17 @@ namespace Resonalyze.Options
             }
 
             UpdateComboBoxToolTip(comboBoxRecordingDevice);
+            if (comboBoxRecordingDevice.SelectedItem is AudioEndpointInfo endpoint)
+            {
+                preferredWasapiCaptureEndpointId = endpoint.Id;
+                FillWasapiChannelControls(
+                    GetSelectedWaveInputChannelOffset(),
+                    GetSelectedWaveLoopbackChannelOffset());
+            }
+            else if (comboBoxRecordingDevice.SelectedItem is AudioDeviceInfo device)
+            {
+                preferredWaveRecordingDeviceNumber = device.DeviceNumber;
+            }
             UpdateWaveLoopbackControls();
             RefreshSampleRateOptions(GetSelectedSampleRate());
         }
@@ -564,8 +616,8 @@ namespace Resonalyze.Options
                 comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiShared;
             waveAudioBackendPanel.Visible = !useAsio;
             asioAudioBackendPanel.Visible = useAsio;
-            comboBoxPlaybackDevice.Enabled = !useAsio && !useWasapi;
-            comboBoxRecordingDevice.Enabled = !useAsio && !useWasapi;
+            comboBoxPlaybackDevice.Enabled = !useAsio;
+            comboBoxRecordingDevice.Enabled = !useAsio;
             comboBoxWaveInputChannel.Enabled = !useAsio;
             comboBoxWaveLoopbackChannel.Enabled = !useAsio &&
                 SelectedRecordingDeviceSupportsWaveLoopback();
@@ -598,10 +650,17 @@ namespace Resonalyze.Options
             labelAsioLoopbackChannel.Enabled = useAsio;
             if (useWasapi)
             {
-                labelWaveLoopbackStatus.Text =
-                    "WASAPI Shared uses the default Windows capture and render endpoints. " +
-                    "Their mix sample rates must match.";
-                labelWaveLoopbackStatus.ForeColor = Color.LightGray;
+                labelPlaybackDevice.Text = "Output endpoint";
+                labelRecordingDevice.Text = "Input endpoint";
+                labelWaveInputChannel.Text = "Microphone channel";
+                labelWaveLoopbackChannel.Text = "Loopback channel";
+            }
+            else
+            {
+                labelPlaybackDevice.Text = "Playback device";
+                labelRecordingDevice.Text = "Recording device";
+                labelWaveInputChannel.Text = "Wave input channel";
+                labelWaveLoopbackChannel.Text = "Wave loopback channel";
             }
             UpdateWaveLoopbackControls();
         }
@@ -766,6 +825,159 @@ namespace Resonalyze.Options
                 : (int)PlaybackChannel.Mono;
         }
 
+        private void LoadWasapiEndpoints()
+        {
+            try
+            {
+                using var endpointService = new WindowsAudioEndpointService();
+                wasapiCaptureEndpoints = endpointService.GetCaptureEndpoints();
+                wasapiRenderEndpoints = endpointService.GetRenderEndpoints();
+            }
+            catch
+            {
+                wasapiCaptureEndpoints = Array.Empty<AudioEndpointInfo>();
+                wasapiRenderEndpoints = Array.Empty<AudioEndpointInfo>();
+            }
+        }
+
+        private void PopulateDeviceControlsForSelectedBackend(
+            int preferredInputOffset,
+            int? preferredLoopbackOffset)
+        {
+            bool wasInitializing = initializing;
+            initializing = true;
+            try
+            {
+                if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiShared)
+                {
+                    PopulateWasapiEndpointCombo(
+                        comboBoxPlaybackDevice,
+                        wasapiRenderEndpoints,
+                        preferredWasapiRenderEndpointId,
+                        preferredWasapiRenderEndpointName,
+                        NAudio.CoreAudioApi.DataFlow.Render);
+                    PopulateWasapiEndpointCombo(
+                        comboBoxRecordingDevice,
+                        wasapiCaptureEndpoints,
+                        preferredWasapiCaptureEndpointId,
+                        preferredWasapiCaptureEndpointName,
+                        NAudio.CoreAudioApi.DataFlow.Capture);
+                    FillWasapiChannelControls(preferredInputOffset, preferredLoopbackOffset);
+                }
+                else
+                {
+                    comboBoxPlaybackDevice.Items.Clear();
+                    comboBoxPlaybackDevice.Items.AddRange(playbackDevices.Cast<object>().ToArray());
+                    SelectDeviceOrShowMissing(
+                        comboBoxPlaybackDevice,
+                        playbackDevices,
+                        preferredWavePlaybackDeviceNumber);
+                    comboBoxRecordingDevice.Items.Clear();
+                    comboBoxRecordingDevice.Items.AddRange(recordingDevices.Cast<object>().ToArray());
+                    SelectDeviceOrShowMissing(
+                        comboBoxRecordingDevice,
+                        recordingDevices,
+                        preferredWaveRecordingDeviceNumber);
+                    FillWaveChannelControls(preferredInputOffset, preferredLoopbackOffset);
+                }
+
+                ConfigureDropDownWidth(comboBoxPlaybackDevice);
+                ConfigureDropDownWidth(comboBoxRecordingDevice);
+                UpdateComboBoxToolTip(comboBoxPlaybackDevice);
+                UpdateComboBoxToolTip(comboBoxRecordingDevice);
+            }
+            finally
+            {
+                initializing = wasInitializing;
+            }
+        }
+
+        private static void PopulateWasapiEndpointCombo(
+            DarkComboBox comboBox,
+            IReadOnlyList<AudioEndpointInfo> endpoints,
+            string? preferredId,
+            string? preferredName,
+            NAudio.CoreAudioApi.DataFlow direction)
+        {
+            comboBox.Items.Clear();
+            comboBox.Items.AddRange(endpoints.Cast<object>().ToArray());
+            int index = FindWasapiEndpointIndex(endpoints, preferredId);
+            if (index < 0 && !string.IsNullOrWhiteSpace(preferredId))
+            {
+                comboBox.Items.Add(CreateUnavailableEndpoint(
+                    preferredId,
+                    preferredName,
+                    direction));
+                index = comboBox.Items.Count - 1;
+            }
+            if (index < 0)
+            {
+                index = endpoints.ToList().FindIndex(endpoint => endpoint.IsDefault);
+            }
+            if (index < 0 && comboBox.Items.Count > 0)
+            {
+                index = 0;
+            }
+            comboBox.SelectedIndex = index;
+        }
+
+        private static int FindWasapiEndpointIndex(
+            IReadOnlyList<AudioEndpointInfo> endpoints,
+            string? endpointId)
+        {
+            for (int i = 0; i < endpoints.Count; i++)
+            {
+                if (string.Equals(endpoints[i].Id, endpointId, StringComparison.Ordinal))
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        private static AudioEndpointInfo CreateUnavailableEndpoint(
+            string endpointId,
+            string? friendlyName,
+            NAudio.CoreAudioApi.DataFlow direction) =>
+            new(
+                string.IsNullOrWhiteSpace(friendlyName) ? endpointId : friendlyName,
+                endpointId,
+                direction,
+                NAudio.CoreAudioApi.DeviceState.NotPresent,
+                new NAudio.Wave.WaveFormat(44_100, 16, 1),
+                0,
+                false);
+
+        private void FillWasapiChannelControls(
+            int preferredInputOffset,
+            int? preferredLoopbackOffset)
+        {
+            int channelCount = comboBoxRecordingDevice.SelectedItem is AudioEndpointInfo endpoint
+                ? endpoint.Channels
+                : 0;
+            int preservedChannelCount = Math.Max(
+                preferredInputOffset + 1,
+                preferredLoopbackOffset.GetValueOrDefault(-1) + 1);
+            channelCount = Math.Max(channelCount, preservedChannelCount);
+            InputChannelOption[] channels = Enumerable.Range(0, channelCount)
+                .Select(index => new InputChannelOption(index, $"Input {index + 1}"))
+                .ToArray();
+
+            comboBoxWaveInputChannel.Items.Clear();
+            comboBoxWaveInputChannel.Items.AddRange(channels);
+            comboBoxWaveInputChannel.SelectedIndex = channelCount > 0
+                ? Math.Clamp(preferredInputOffset, 0, channelCount - 1)
+                : -1;
+            comboBoxWaveLoopbackChannel.Items.Clear();
+            comboBoxWaveLoopbackChannel.Items.Add(new InputChannelOption(null, "None"));
+            comboBoxWaveLoopbackChannel.Items.AddRange(channels);
+            comboBoxWaveLoopbackChannel.SelectedIndex = preferredLoopbackOffset is int offset &&
+                offset >= 0 && offset < channelCount
+                    ? offset + 1
+                    : 0;
+            preferredWaveLoopbackChannelOffset = preferredLoopbackOffset;
+        }
+
         private void FillWaveChannelControls(
             int preferredInputOffset,
             int? preferredLoopbackOffset)
@@ -802,9 +1014,25 @@ namespace Resonalyze.Options
             {
                 comboBoxWaveLoopbackChannel.Enabled = true;
                 labelWaveLoopbackStatus.Font = NormalStatusFont;
+                AudioEndpointInfo? capture = comboBoxRecordingDevice.SelectedItem as AudioEndpointInfo;
+                AudioEndpointInfo? render = comboBoxPlaybackDevice.SelectedItem as AudioEndpointInfo;
+                if (capture is not { IsAvailable: true } || render is not { IsAvailable: true })
+                {
+                    labelWaveLoopbackStatus.Text =
+                        "⚠ A saved endpoint is unavailable. Reconnect it or select a replacement.";
+                    labelWaveLoopbackStatus.ForeColor = Color.Gold;
+                    return;
+                }
+                string compatibility = capture.MixFormat.SampleRate == render.MixFormat.SampleRate
+                    ? ""
+                    : " — sample rates do not match";
                 labelWaveLoopbackStatus.Text =
-                    "WASAPI Shared uses the selected endpoint IDs and their mix sample rate.";
-                labelWaveLoopbackStatus.ForeColor = Color.LightGray;
+                    $"Shared mix format: {capture.MixFormat.SampleRate:N0} Hz / " +
+                    $"{capture.MixFormat.BitsPerSample}-bit capture, " +
+                    $"{render.MixFormat.BitsPerSample}-bit render{compatibility}.";
+                labelWaveLoopbackStatus.ForeColor = compatibility.Length == 0
+                    ? Color.LightGray
+                    : Color.LightSalmon;
                 return;
             }
 
@@ -883,7 +1111,8 @@ namespace Resonalyze.Options
             warningStatusFont ??= new Font(NormalStatusFont, FontStyle.Bold);
 
         private bool SelectedRecordingDeviceSupportsWaveLoopback() =>
-            comboBoxRecordingDevice.SelectedItem is AudioDeviceInfo { Channels: >= 2 };
+            comboBoxRecordingDevice.SelectedItem is AudioDeviceInfo { Channels: >= 2 } or
+                AudioEndpointInfo { Channels: >= 2, IsAvailable: true };
 
         private void ValidateSelectedWaveLoopback()
         {
@@ -1066,7 +1295,11 @@ namespace Resonalyze.Options
                 return;
             }
 
-            RefreshSampleRateOptions(GetSelectedSampleRate());
+            int preferredSampleRate = GetSelectedSampleRate();
+            PopulateDeviceControlsForSelectedBackend(
+                GetSelectedWaveInputChannelOffset(),
+                GetSelectedWaveLoopbackChannelOffset());
+            RefreshSampleRateOptions(preferredSampleRate);
             if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.Asio)
             {
                 // Opening the ASIO driver is a synchronous COM instantiation
@@ -1116,25 +1349,12 @@ namespace Resonalyze.Options
 
             if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiShared)
             {
-                try
-                {
-                    using var endpointService = new WindowsAudioEndpointService();
-                    AudioEndpointInfo capture = SelectWasapiEndpoint(
-                        endpointService.GetCaptureEndpoints(),
-                        preferredWasapiCaptureEndpointId,
-                        "capture");
-                    AudioEndpointInfo render = SelectWasapiEndpoint(
-                        endpointService.GetRenderEndpoints(),
-                        preferredWasapiRenderEndpointId,
-                        "render");
-                    return capture.MixFormat.SampleRate == render.MixFormat.SampleRate
+                AudioEndpointInfo? capture = comboBoxRecordingDevice.SelectedItem as AudioEndpointInfo;
+                AudioEndpointInfo? render = comboBoxPlaybackDevice.SelectedItem as AudioEndpointInfo;
+                return capture is { IsAvailable: true } && render is { IsAvailable: true } &&
+                    capture.MixFormat.SampleRate == render.MixFormat.SampleRate
                         ? [capture.MixFormat.SampleRate]
                         : [];
-                }
-                catch
-                {
-                    return [];
-                }
             }
 
             return AudioDeviceCatalog.GetSupportedWaveSampleRates(

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -30,6 +30,8 @@ namespace Resonalyze.Options
         // device again restores it instead of losing it on the next apply.
         private int? preferredWaveLoopbackChannelOffset;
         private bool updatingWaveLoopbackSelection;
+        private string? preferredWasapiCaptureEndpointId;
+        private string? preferredWasapiRenderEndpointId;
 
         private DarkComboBox comboBoxPlaybackDevice => waveAudioBackendPanel.ComboBoxPlaybackDevice;
 
@@ -114,6 +116,8 @@ namespace Resonalyze.Options
                 throw new InvalidOperationException("Sweep measurement is not initialized.");
             }
             numericUpDownBits.Value = settings.Bits is 16 or 24 ? settings.Bits : 24;
+            preferredWasapiCaptureEndpointId = settings.WasapiCaptureEndpointId;
+            preferredWasapiRenderEndpointId = settings.WasapiRenderEndpointId;
 
             comboBoxChannel.Items.Clear();
             foreach (PlaybackChannel channel in Enum.GetValues<PlaybackChannel>())
@@ -126,7 +130,12 @@ namespace Resonalyze.Options
             comboBoxAudioBackend.Items.Clear();
             foreach (AudioBackend backend in Enum.GetValues<AudioBackend>())
             {
-                comboBoxAudioBackend.Items.Add(backend.ToString());
+                comboBoxAudioBackend.Items.Add(backend switch
+                {
+                    AudioBackend.Wave => "MME Compatibility",
+                    AudioBackend.WasapiShared => "WASAPI Shared",
+                    _ => backend.ToString()
+                });
             }
             comboBoxAudioBackend.SelectedIndex = Enum.IsDefined(settings.AudioBackend)
                 ? (int)settings.AudioBackend
@@ -272,7 +281,30 @@ namespace Resonalyze.Options
                     : null;
             int averageRunCount = (int)numericUpDownAverageRunCount.Value;
             bool confirmEachAverageRun = checkBoxConfirmEachAverageRun.Checked;
-            if (audioBackend == AudioBackend.Wave &&
+            string? wasapiCaptureEndpointId = preferredWasapiCaptureEndpointId;
+            string? wasapiRenderEndpointId = preferredWasapiRenderEndpointId;
+            if (audioBackend == AudioBackend.WasapiShared)
+            {
+                using var endpointService = new WindowsAudioEndpointService();
+                AudioEndpointInfo captureEndpoint = SelectWasapiEndpoint(
+                    endpointService.GetCaptureEndpoints(),
+                    wasapiCaptureEndpointId,
+                    "capture");
+                AudioEndpointInfo renderEndpoint = SelectWasapiEndpoint(
+                    endpointService.GetRenderEndpoints(),
+                    wasapiRenderEndpointId,
+                    "render");
+                if (captureEndpoint.MixFormat.SampleRate != renderEndpoint.MixFormat.SampleRate)
+                {
+                    throw new InvalidOperationException(
+                        "The default WASAPI capture and render endpoints use different mix rates. " +
+                        "Choose endpoints with the same Windows audio format.");
+                }
+                wasapiCaptureEndpointId = captureEndpoint.Id;
+                wasapiRenderEndpointId = renderEndpoint.Id;
+                sampleRate = captureEndpoint.MixFormat.SampleRate;
+            }
+            if (audioBackend is AudioBackend.Wave or AudioBackend.WasapiShared &&
                 waveLoopbackInputChannelOffset.HasValue &&
                 waveLoopbackInputChannelOffset.Value == waveInputChannelOffset)
             {
@@ -296,7 +328,15 @@ namespace Resonalyze.Options
                 waveLoopbackInputChannelOffset,
                 asioLoopbackInputChannelOffset,
                 averageRunCount,
-                confirmEachAverageRun);
+                confirmEachAverageRun,
+                wasapiCaptureEndpointId,
+                wasapiRenderEndpointId,
+                settings.WasapiBufferMilliseconds);
+
+            settings.WasapiCaptureEndpointId = wasapiCaptureEndpointId;
+            settings.WasapiRenderEndpointId = wasapiRenderEndpointId;
+            preferredWasapiCaptureEndpointId = wasapiCaptureEndpointId;
+            preferredWasapiRenderEndpointId = wasapiRenderEndpointId;
         }
 
         private void buttonCalibration0_Click(object? sender, EventArgs e)
@@ -520,10 +560,12 @@ namespace Resonalyze.Options
         {
             bool useAsio =
                 comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.Asio;
+            bool useWasapi =
+                comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiShared;
             waveAudioBackendPanel.Visible = !useAsio;
             asioAudioBackendPanel.Visible = useAsio;
-            comboBoxPlaybackDevice.Enabled = !useAsio;
-            comboBoxRecordingDevice.Enabled = !useAsio;
+            comboBoxPlaybackDevice.Enabled = !useAsio && !useWasapi;
+            comboBoxRecordingDevice.Enabled = !useAsio && !useWasapi;
             comboBoxWaveInputChannel.Enabled = !useAsio;
             comboBoxWaveLoopbackChannel.Enabled = !useAsio &&
                 SelectedRecordingDeviceSupportsWaveLoopback();
@@ -554,7 +596,32 @@ namespace Resonalyze.Options
             labelWaveLoopbackChannel.Enabled = !useAsio;
             labelWaveLoopbackStatus.Enabled = !useAsio;
             labelAsioLoopbackChannel.Enabled = useAsio;
+            if (useWasapi)
+            {
+                labelWaveLoopbackStatus.Text =
+                    "WASAPI Shared uses the default Windows capture and render endpoints. " +
+                    "Their mix sample rates must match.";
+                labelWaveLoopbackStatus.ForeColor = Color.LightGray;
+            }
             UpdateWaveLoopbackControls();
+        }
+
+        private static AudioEndpointInfo SelectWasapiEndpoint(
+            IReadOnlyList<AudioEndpointInfo> endpoints,
+            string? preferredId,
+            string direction)
+        {
+            AudioEndpointInfo? endpoint = endpoints.FirstOrDefault(candidate =>
+                string.Equals(candidate.Id, preferredId, StringComparison.Ordinal));
+            if (!string.IsNullOrWhiteSpace(preferredId) && endpoint == null)
+            {
+                throw new InvalidOperationException(
+                    $"The saved WASAPI {direction} endpoint is unavailable. " +
+                    "Reconnect it or choose a replacement before applying settings.");
+            }
+            endpoint ??= endpoints.FirstOrDefault(candidate => candidate.IsDefault);
+            return endpoint ?? throw new InvalidOperationException(
+                $"No active WASAPI {direction} endpoint is available.");
         }
 
         private void ConfigureDropDownWidth(DarkComboBox comboBox)
@@ -728,6 +795,16 @@ namespace Resonalyze.Options
         {
             if (comboBoxWaveLoopbackChannel == null)
             {
+                return;
+            }
+
+            if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiShared)
+            {
+                comboBoxWaveLoopbackChannel.Enabled = true;
+                labelWaveLoopbackStatus.Font = NormalStatusFont;
+                labelWaveLoopbackStatus.Text =
+                    "WASAPI Shared uses the selected endpoint IDs and their mix sample rate.";
+                labelWaveLoopbackStatus.ForeColor = Color.LightGray;
                 return;
             }
 
@@ -1035,6 +1112,29 @@ namespace Resonalyze.Options
                     comboBoxAsioDriver.SelectedItem is AsioDeviceInfo asioDriver
                         ? asioDriver.DriverName
                         : null);
+            }
+
+            if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.WasapiShared)
+            {
+                try
+                {
+                    using var endpointService = new WindowsAudioEndpointService();
+                    AudioEndpointInfo capture = SelectWasapiEndpoint(
+                        endpointService.GetCaptureEndpoints(),
+                        preferredWasapiCaptureEndpointId,
+                        "capture");
+                    AudioEndpointInfo render = SelectWasapiEndpoint(
+                        endpointService.GetRenderEndpoints(),
+                        preferredWasapiRenderEndpointId,
+                        "render");
+                    return capture.MixFormat.SampleRate == render.MixFormat.SampleRate
+                        ? [capture.MixFormat.SampleRate]
+                        : [];
+                }
+                catch
+                {
+                    return [];
+                }
             }
 
             return AudioDeviceCatalog.GetSupportedWaveSampleRates(

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -15,6 +15,7 @@ namespace Resonalyze.Options
     public partial class MeasurementOptions : Form
     {
         private readonly ToolTip deviceToolTip = new();
+        private WindowsAudioEndpointService? endpointService;
         private Font? normalStatusFont;
         private Font? warningStatusFont;
         private ExpSweepMeasurement? expSweepMeasurement;
@@ -89,6 +90,62 @@ namespace Resonalyze.Options
         {
             InitializeComponent();
             WireAudioBackendPanelEvents();
+            TryStartEndpointMonitoring();
+            Disposed += (_, _) => DisposeEndpointMonitoring();
+        }
+
+        private void TryStartEndpointMonitoring()
+        {
+            try
+            {
+                endpointService = new WindowsAudioEndpointService();
+                endpointService.EndpointsChanged += HandleEndpointsChanged;
+            }
+            catch
+            {
+                endpointService = null;
+            }
+        }
+
+        private void DisposeEndpointMonitoring()
+        {
+            if (endpointService == null)
+            {
+                return;
+            }
+            endpointService.EndpointsChanged -= HandleEndpointsChanged;
+            endpointService.Dispose();
+            endpointService = null;
+        }
+
+        private void HandleEndpointsChanged()
+        {
+            if (IsDisposed || !IsHandleCreated)
+            {
+                return;
+            }
+            try
+            {
+                BeginInvoke((Action)(() =>
+                {
+                    if (IsDisposed)
+                    {
+                        return;
+                    }
+                    int inputOffset = GetSelectedWaveInputChannelOffset();
+                    int? loopbackOffset = GetSelectedWaveLoopbackChannelOffset();
+                    LoadWasapiEndpoints();
+                    if (IsSelectedWasapiBackend())
+                    {
+                        PopulateDeviceControlsForSelectedBackend(inputOffset, loopbackOffset);
+                        RefreshSampleRateOptions(GetSelectedSampleRate());
+                        UpdateAudioBackendControls();
+                    }
+                }));
+            }
+            catch (InvalidOperationException)
+            {
+            }
         }
 
         private void WireAudioBackendPanelEvents()
@@ -833,9 +890,17 @@ namespace Resonalyze.Options
         {
             try
             {
-                using var endpointService = new WindowsAudioEndpointService();
-                wasapiCaptureEndpoints = endpointService.GetCaptureEndpoints();
-                wasapiRenderEndpoints = endpointService.GetRenderEndpoints();
+                if (endpointService != null)
+                {
+                    wasapiCaptureEndpoints = endpointService.GetCaptureEndpoints();
+                    wasapiRenderEndpoints = endpointService.GetRenderEndpoints();
+                }
+                else
+                {
+                    using var temporaryService = new WindowsAudioEndpointService();
+                    wasapiCaptureEndpoints = temporaryService.GetCaptureEndpoints();
+                    wasapiRenderEndpoints = temporaryService.GetRenderEndpoints();
+                }
             }
             catch
             {
@@ -1041,7 +1106,8 @@ namespace Resonalyze.Options
                             GetSelectedWaveLoopbackChannelOffset() ?? 0) + 1,
                         GetSelectedPlaybackChannelCount());
                     labelWaveLoopbackStatus.Text = supported
-                        ? $"Exclusive format: {selectedRate:N0} Hz / {bits}-bit, supported by both endpoints."
+                        ? $"Exclusive: {selectedRate:N0} Hz / {bits}-bit opens directly " +
+                            "on both endpoints."
                         : $"⚠ Exclusive format {selectedRate:N0} Hz / {bits}-bit is not supported by both endpoints.";
                     labelWaveLoopbackStatus.ForeColor = supported
                         ? Color.LightGray
@@ -1054,7 +1120,8 @@ namespace Resonalyze.Options
                 labelWaveLoopbackStatus.Text =
                     $"Shared mix format: {capture.MixFormat.SampleRate:N0} Hz / " +
                     $"{capture.MixFormat.BitsPerSample}-bit capture, " +
-                    $"{render.MixFormat.BitsPerSample}-bit render{compatibility}.";
+                    $"{render.MixFormat.BitsPerSample}-bit render{compatibility}. " +
+                    "Windows may convert render audio; timing remains loopback-referenced.";
                 labelWaveLoopbackStatus.ForeColor = compatibility.Length == 0
                     ? Color.LightGray
                     : Color.LightSalmon;

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -57,6 +58,10 @@ namespace Resonalyze.Options
         private Label labelWaveLoopbackChannel => waveAudioBackendPanel.LabelWaveLoopbackChannel;
 
         private Label labelWaveLoopbackStatus => waveAudioBackendPanel.LabelWaveLoopbackStatus;
+
+        private Label labelDeviceSettings => waveAudioBackendPanel.LabelDeviceSettings;
+
+        private Button buttonDeviceSettings => waveAudioBackendPanel.ButtonDeviceSettings;
 
         private DarkComboBox comboBoxAsioDriver => asioAudioBackendPanel.ComboBoxAsioDriver;
 
@@ -157,6 +162,7 @@ namespace Resonalyze.Options
             comboBoxAsioDriver.SelectedIndexChanged += comboBoxAsioDriver_SelectedIndexChanged;
             buttonAsioInputProbe.Click += buttonAsioInputProbe_Click;
             buttonAsioControlPanel.Click += buttonAsioControlPanel_Click;
+            buttonDeviceSettings.Click += buttonDeviceSettings_Click;
 
             deviceToolTip.SetToolTip(
                 comboBoxWaveLoopbackChannel,
@@ -166,6 +172,10 @@ namespace Resonalyze.Options
                 comboBoxAsioLoopbackChannel,
                 "Required. ASIO input channel carrying the loopback reference signal; every " +
                 "analysis is derived from the transfer IR it produces.");
+            deviceToolTip.SetToolTip(
+                buttonDeviceSettings,
+                "Opens the selected driver's control panel to change the hardware sample " +
+                "rate. Falls back to Windows Sound settings when no ASIO driver is selected.");
         }
 
         internal void Init(
@@ -708,6 +718,9 @@ namespace Resonalyze.Options
             labelWaveInputChannel.Enabled = !useAsio;
             labelWaveLoopbackChannel.Enabled = !useAsio;
             labelWaveLoopbackStatus.Enabled = !useAsio;
+            labelDeviceSettings.Visible = useWasapi;
+            buttonDeviceSettings.Visible = useWasapi;
+            buttonDeviceSettings.Enabled = useWasapi;
             labelAsioLoopbackChannel.Enabled = useAsio;
             if (useWasapi)
             {
@@ -794,6 +807,41 @@ namespace Resonalyze.Options
                     this,
                     exception.Message,
                     "ASIO Control Panel",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
+        }
+
+        private void buttonDeviceSettings_Click(object? sender, EventArgs e)
+        {
+            try
+            {
+                int preferredSampleRate = GetSelectedSampleRate();
+                int preferredInputOffset = GetSelectedWaveInputChannelOffset();
+                int? preferredLoopbackOffset = GetSelectedWaveLoopbackChannelOffset();
+                if (comboBoxAsioDriver.SelectedItem is AsioDeviceInfo asioDriver)
+                {
+                    AsioDeviceCatalog.ShowControlPanel(asioDriver.DriverName);
+                    LoadWasapiEndpoints();
+                    PopulateDeviceControlsForSelectedBackend(
+                        preferredInputOffset,
+                        preferredLoopbackOffset);
+                    RefreshSampleRateOptions(preferredSampleRate);
+                    UpdateAudioBackendControls();
+                    return;
+                }
+
+                Process.Start(new ProcessStartInfo("control.exe", "mmsys.cpl")
+                {
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception exception)
+            {
+                MessageBox.Show(
+                    this,
+                    exception.Message,
+                    "Device Settings",
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Warning);
             }

--- a/source/Options/WaveAudioBackendPanel.Designer.cs
+++ b/source/Options/WaveAudioBackendPanel.Designer.cs
@@ -37,6 +37,8 @@ namespace Resonalyze.Options
             labelWaveLoopbackChannel = new Label();
             comboBoxWaveLoopbackChannel = new DarkComboBox();
             labelWaveLoopbackStatus = new Label();
+            labelDeviceSettings = new Label();
+            buttonDeviceSettings = new Button();
             SuspendLayout();
             //
             // labelPlaybackDevice
@@ -132,11 +134,32 @@ namespace Resonalyze.Options
             labelWaveLoopbackStatus.TabIndex = 42;
             labelWaveLoopbackStatus.Text = "-";
             //
+            // labelDeviceSettings
+            //
+            labelDeviceSettings.AutoSize = true;
+            labelDeviceSettings.ForeColor = SystemColors.ControlLight;
+            labelDeviceSettings.Location = new Point(0, 184);
+            labelDeviceSettings.Name = "labelDeviceSettings";
+            labelDeviceSettings.Size = new Size(91, 15);
+            labelDeviceSettings.TabIndex = 43;
+            labelDeviceSettings.Text = "Hardware clock";
+            //
+            // buttonDeviceSettings
+            //
+            buttonDeviceSettings.Location = new Point(141, 177);
+            buttonDeviceSettings.Name = "buttonDeviceSettings";
+            buttonDeviceSettings.Size = new Size(170, 29);
+            buttonDeviceSettings.TabIndex = 44;
+            buttonDeviceSettings.Text = "Open Device Settings";
+            buttonDeviceSettings.UseVisualStyleBackColor = true;
+            //
             // WaveAudioBackendPanel
             //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(45, 50, 60);
+            Controls.Add(buttonDeviceSettings);
+            Controls.Add(labelDeviceSettings);
             Controls.Add(labelWaveLoopbackStatus);
             Controls.Add(comboBoxWaveLoopbackChannel);
             Controls.Add(labelWaveLoopbackChannel);
@@ -147,7 +170,7 @@ namespace Resonalyze.Options
             Controls.Add(comboBoxPlaybackDevice);
             Controls.Add(labelPlaybackDevice);
             Name = "WaveAudioBackendPanel";
-            Size = new Size(311, 177);
+            Size = new Size(311, 213);
             ResumeLayout(false);
             PerformLayout();
         }
@@ -162,5 +185,7 @@ namespace Resonalyze.Options
         private Label labelWaveLoopbackChannel;
         private DarkComboBox comboBoxWaveLoopbackChannel;
         private Label labelWaveLoopbackStatus;
+        private Label labelDeviceSettings;
+        private Button buttonDeviceSettings;
     }
 }

--- a/source/Options/WaveAudioBackendPanel.cs
+++ b/source/Options/WaveAudioBackendPanel.cs
@@ -26,5 +26,9 @@ namespace Resonalyze.Options
         internal DarkComboBox ComboBoxWaveLoopbackChannel => comboBoxWaveLoopbackChannel;
 
         internal Label LabelWaveLoopbackStatus => labelWaveLoopbackStatus;
+
+        internal Label LabelDeviceSettings => labelDeviceSettings;
+
+        internal Button ButtonDeviceSettings => buttonDeviceSettings;
     }
 }

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -160,6 +160,9 @@ internal sealed class MeasurementSettingsFile
         public AudioBackend AudioBackend { get; set; } = AudioBackend.Wave;
         public int OutputDeviceNumber { get; set; } = -1;
         public int InputDeviceNumber { get; set; } = -1;
+        public string? WasapiCaptureEndpointId { get; set; }
+        public string? WasapiRenderEndpointId { get; set; }
+        public int WasapiBufferMilliseconds { get; set; } = 100;
         public string? AsioDriverName { get; set; }
         public int WaveInputChannelOffset { get; set; }
         public int? WaveLoopbackInputChannelOffset { get; set; }
@@ -196,6 +199,9 @@ internal sealed class MeasurementSettingsFile
                 AudioBackend = measurement.AudioBackend,
                 OutputDeviceNumber = measurement.OutputDeviceNumber,
                 InputDeviceNumber = measurement.InputDeviceNumber,
+                WasapiCaptureEndpointId = measurement.WasapiCaptureEndpointId,
+                WasapiRenderEndpointId = measurement.WasapiRenderEndpointId,
+                WasapiBufferMilliseconds = measurement.WasapiBufferMilliseconds,
                 AsioDriverName = measurement.AsioDriverName,
                 WaveInputChannelOffset = measurement.WaveInputChannelOffset,
                 WaveLoopbackInputChannelOffset = measurement.WaveLoopbackInputChannelOffset,
@@ -208,9 +214,21 @@ internal sealed class MeasurementSettingsFile
 
         public void ApplyTo(ExpSweepMeasurement measurement)
         {
+            AudioBackend backend = NormalizeAudioBackend(AudioBackend, AsioDriverName);
+            string? captureEndpointId = NormalizeWasapiEndpointId(
+                WasapiCaptureEndpointId,
+                capture: true);
+            string? renderEndpointId = NormalizeWasapiEndpointId(
+                WasapiRenderEndpointId,
+                capture: false);
+            int sampleRate = NormalizeWasapiSampleRate(
+                backend,
+                captureEndpointId,
+                renderEndpointId,
+                Clamp(SampleRate, 44_100, 384_000));
             measurement.Init(
                 Clamp(Octaves, 1, 32),
-                Clamp(SampleRate, 44_100, 384_000),
+                sampleRate,
                 Bits is 16 or 24 ? Bits : 24,
                 Math.Clamp(RequestedDurationSeconds, 0.001, 100.0),
                 Enum.IsDefined(PlaybackChannel)
@@ -222,26 +240,29 @@ internal sealed class MeasurementSettingsFile
                 NormalizeDeviceNumber(
                     AudioDeviceCatalog.GetRecordingDevices(),
                     InputDeviceNumber),
-                NormalizeAudioBackend(AudioBackend, AsioDriverName),
+                backend,
                 NormalizeAsioDriverName(AsioDriverName),
                 NormalizeAsioChannelOffset(
                     AsioDriverName,
-                    Clamp(SampleRate, 44_100, 384_000),
+                    sampleRate,
                     AsioInputChannelOffset,
                     input: true),
                 NormalizeAsioChannelOffset(
                     AsioDriverName,
-                    Clamp(SampleRate, 44_100, 384_000),
+                    sampleRate,
                     AsioOutputChannelOffset,
                     input: false),
                 NormalizeWaveChannelOffset(WaveInputChannelOffset),
                 NormalizeOptionalWaveChannelOffset(WaveLoopbackInputChannelOffset),
                 NormalizeOptionalAsioChannelOffset(
                     AsioDriverName,
-                    Clamp(SampleRate, 44_100, 384_000),
+                    sampleRate,
                     AsioLoopbackInputChannelOffset),
                 Clamp(AverageRunCount, 1, 64),
-                ConfirmEachAverageRun);
+                ConfirmEachAverageRun,
+                captureEndpointId,
+                renderEndpointId,
+                Clamp(WasapiBufferMilliseconds, 10, 100));
         }
     }
 
@@ -609,6 +630,58 @@ internal sealed class MeasurementSettingsFile
         }
 
         return backend;
+    }
+
+    private static string? NormalizeWasapiEndpointId(string? endpointId, bool capture)
+    {
+        try
+        {
+            using var service = new WindowsAudioEndpointService();
+            IReadOnlyList<AudioEndpointInfo> endpoints = capture
+                ? service.GetCaptureEndpoints()
+                : service.GetRenderEndpoints();
+            AudioEndpointInfo? exact = endpoints.FirstOrDefault(endpoint =>
+                string.Equals(endpoint.Id, endpointId, StringComparison.Ordinal));
+            if (!string.IsNullOrWhiteSpace(endpointId))
+            {
+                return exact?.Id ?? endpointId;
+            }
+            return endpoints.FirstOrDefault(endpoint => endpoint.IsDefault)?.Id;
+        }
+        catch
+        {
+            return endpointId;
+        }
+    }
+
+    private static int NormalizeWasapiSampleRate(
+        AudioBackend backend,
+        string? captureEndpointId,
+        string? renderEndpointId,
+        int fallback)
+    {
+        if (backend != AudioBackend.WasapiShared ||
+            captureEndpointId == null ||
+            renderEndpointId == null)
+        {
+            return fallback;
+        }
+        try
+        {
+            using var service = new WindowsAudioEndpointService();
+            AudioEndpointInfo? capture = service.GetCaptureEndpoints()
+                .FirstOrDefault(endpoint => endpoint.Id == captureEndpointId);
+            AudioEndpointInfo? render = service.GetRenderEndpoints()
+                .FirstOrDefault(endpoint => endpoint.Id == renderEndpointId);
+            return capture != null && render != null &&
+                capture.MixFormat.SampleRate == render.MixFormat.SampleRate
+                    ? capture.MixFormat.SampleRate
+                    : fallback;
+        }
+        catch
+        {
+            return fallback;
+        }
     }
 
     private static string? NormalizeAsioDriverName(string? asioDriverName)

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -162,6 +162,8 @@ internal sealed class MeasurementSettingsFile
         public int InputDeviceNumber { get; set; } = -1;
         public string? WasapiCaptureEndpointId { get; set; }
         public string? WasapiRenderEndpointId { get; set; }
+        public string? WasapiCaptureEndpointName { get; set; }
+        public string? WasapiRenderEndpointName { get; set; }
         public int WasapiBufferMilliseconds { get; set; } = 100;
         public string? AsioDriverName { get; set; }
         public int WaveInputChannelOffset { get; set; }
@@ -201,6 +203,8 @@ internal sealed class MeasurementSettingsFile
                 InputDeviceNumber = measurement.InputDeviceNumber,
                 WasapiCaptureEndpointId = measurement.WasapiCaptureEndpointId,
                 WasapiRenderEndpointId = measurement.WasapiRenderEndpointId,
+                WasapiCaptureEndpointName = measurement.WasapiCaptureEndpointName,
+                WasapiRenderEndpointName = measurement.WasapiRenderEndpointName,
                 WasapiBufferMilliseconds = measurement.WasapiBufferMilliseconds,
                 AsioDriverName = measurement.AsioDriverName,
                 WaveInputChannelOffset = measurement.WaveInputChannelOffset,
@@ -252,8 +256,12 @@ internal sealed class MeasurementSettingsFile
                     sampleRate,
                     AsioOutputChannelOffset,
                     input: false),
-                NormalizeWaveChannelOffset(WaveInputChannelOffset),
-                NormalizeOptionalWaveChannelOffset(WaveLoopbackInputChannelOffset),
+                backend == AudioBackend.WasapiShared
+                    ? Math.Max(0, WaveInputChannelOffset)
+                    : NormalizeWaveChannelOffset(WaveInputChannelOffset),
+                backend == AudioBackend.WasapiShared
+                    ? NormalizeOptionalWasapiChannelOffset(WaveLoopbackInputChannelOffset)
+                    : NormalizeOptionalWaveChannelOffset(WaveLoopbackInputChannelOffset),
                 NormalizeOptionalAsioChannelOffset(
                     AsioDriverName,
                     sampleRate,
@@ -262,7 +270,9 @@ internal sealed class MeasurementSettingsFile
                 ConfirmEachAverageRun,
                 captureEndpointId,
                 renderEndpointId,
-                Clamp(WasapiBufferMilliseconds, 10, 100));
+                Clamp(WasapiBufferMilliseconds, 10, 100),
+                WasapiCaptureEndpointName,
+                WasapiRenderEndpointName);
         }
     }
 
@@ -728,6 +738,9 @@ internal sealed class MeasurementSettingsFile
 
     private static int? NormalizeOptionalWaveChannelOffset(int? offset) =>
         offset.HasValue ? NormalizeWaveChannelOffset(offset.Value) : null;
+
+    private static int? NormalizeOptionalWasapiChannelOffset(int? offset) =>
+        offset.HasValue ? Math.Max(0, offset.Value) : null;
 
     private static int? NormalizeOptionalAsioChannelOffset(
         string? asioDriverName,

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -256,10 +256,10 @@ internal sealed class MeasurementSettingsFile
                     sampleRate,
                     AsioOutputChannelOffset,
                     input: false),
-                backend == AudioBackend.WasapiShared
+                IsWasapiBackend(backend)
                     ? Math.Max(0, WaveInputChannelOffset)
                     : NormalizeWaveChannelOffset(WaveInputChannelOffset),
-                backend == AudioBackend.WasapiShared
+                IsWasapiBackend(backend)
                     ? NormalizeOptionalWasapiChannelOffset(WaveLoopbackInputChannelOffset)
                     : NormalizeOptionalWaveChannelOffset(WaveLoopbackInputChannelOffset),
                 NormalizeOptionalAsioChannelOffset(
@@ -741,6 +741,9 @@ internal sealed class MeasurementSettingsFile
 
     private static int? NormalizeOptionalWasapiChannelOffset(int? offset) =>
         offset.HasValue ? Math.Max(0, offset.Value) : null;
+
+    private static bool IsWasapiBackend(AudioBackend backend) =>
+        backend is AudioBackend.WasapiShared or AudioBackend.WasapiExclusive;
 
     private static int? NormalizeOptionalAsioChannelOffset(
         string? asioDriverName,

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -185,12 +185,32 @@ namespace Resonalyze
                 return;
             }
 
+            string? logPath = TryWriteMeasurementErrorLog(error);
+            string logNotice = logPath == null
+                ? string.Empty
+                : $"\r\n\r\nFull details: {logPath}";
             MessageBox.Show(
                 this,
-                $"{summary}\r\n\r\n{error.Message}",
+                $"{summary}\r\n\r\n{error.Message}{logNotice}",
                 "Measurement",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Warning);
+        }
+
+        private static string? TryWriteMeasurementErrorLog(Exception error)
+        {
+            try
+            {
+                string path = Path.Combine(AppContext.BaseDirectory, "measurement-error.log");
+                File.AppendAllText(
+                    path,
+                    $"[{DateTimeOffset.Now:O}]\r\n{error}\r\n\r\n");
+                return path;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         // A configured calibration that fails to load must not silently produce

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -250,7 +250,10 @@ namespace Resonalyze
                 expSweepMeasurement.PlaybackChannel,
                 expSweepMeasurement.OutputDeviceNumber,
                 expSweepMeasurement.AsioDriverName,
-                expSweepMeasurement.AsioOutputChannelOffset);
+                expSweepMeasurement.AsioOutputChannelOffset,
+                expSweepMeasurement.WasapiRenderEndpointId,
+                expSweepMeasurement.WasapiRenderEndpointName,
+                expSweepMeasurement.WasapiBufferMilliseconds);
 
     }
 }

--- a/source/Tools/SignalGeneratorPanel.cs
+++ b/source/Tools/SignalGeneratorPanel.cs
@@ -11,13 +11,18 @@ internal sealed record SignalGeneratorPlaybackSettings(
     PlaybackChannel PlaybackChannel,
     int WaveOutputDeviceNumber,
     string? AsioDriverName,
-    int AsioOutputChannelOffset);
+    int AsioOutputChannelOffset,
+    string? WasapiRenderEndpointId,
+    string? WasapiRenderEndpointName,
+    int WasapiBufferMilliseconds);
 
 public partial class SignalGeneratorPanel : UserControl
 {
     private IWavePlayer? player;
     private WaveStream? playbackStream;
     private PcmStreamSet? pcmStreams;
+    private IAudioPlaybackDevice? audioPlaybackDevice;
+    private bool wasapiPlaying;
 
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -107,7 +112,7 @@ public partial class SignalGeneratorPanel : UserControl
                     settings.SampleRate,
                     settings.PlaybackChannel);
             }
-            else
+            else if (settings.Backend == AudioBackend.Wave)
             {
                 player = new WaveOutEvent
                 {
@@ -118,6 +123,40 @@ public partial class SignalGeneratorPanel : UserControl
                     settings.SampleRate,
                     settings.BitsPerSample);
                 playbackStream = pcmStreams.GetStream(settings.PlaybackChannel);
+            }
+            else
+            {
+                string endpointId = settings.WasapiRenderEndpointId ??
+                    throw new InvalidOperationException("WASAPI output endpoint is not selected.");
+                pcmStreams = new PcmStreamSet(
+                    monoSamples,
+                    settings.SampleRate,
+                    settings.BitsPerSample);
+                playbackStream = pcmStreams.GetStream(settings.PlaybackChannel);
+                NAudio.CoreAudioApi.AudioClientShareMode shareMode =
+                    settings.Backend == AudioBackend.WasapiExclusive
+                        ? NAudio.CoreAudioApi.AudioClientShareMode.Exclusive
+                        : NAudio.CoreAudioApi.AudioClientShareMode.Shared;
+                WaveFormat? requestedFormat = shareMode ==
+                    NAudio.CoreAudioApi.AudioClientShareMode.Exclusive
+                        ? WasapiFormatSupport.CreateDeviceFormat(
+                            settings.SampleRate,
+                            settings.BitsPerSample,
+                            playbackStream.WaveFormat.Channels)
+                        : null;
+                audioPlaybackDevice = new WasapiPlaybackDevice(
+                    endpointId,
+                    settings.WasapiBufferMilliseconds,
+                    shareMode,
+                    requestedFormat);
+                audioPlaybackDevice.StartAsync(playbackStream, CancellationToken.None)
+                    .GetAwaiter().GetResult();
+                wasapiPlaying = true;
+                _ = MonitorWasapiPlaybackAsync(audioPlaybackDevice);
+                buttonPlay.Enabled = false;
+                buttonStop.Enabled = true;
+                labelStatus.Text = "Playing";
+                return;
             }
 
             player.Init(playbackStream);
@@ -134,6 +173,43 @@ public partial class SignalGeneratorPanel : UserControl
             buttonStop.Enabled = false;
             labelStatus.Text = exception.Message;
         }
+    }
+
+    private async Task MonitorWasapiPlaybackAsync(IAudioPlaybackDevice playback)
+    {
+        Exception? error = null;
+        try
+        {
+            await playback.WaitForPlaybackEndAsync(CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            error = exception;
+        }
+
+        if (IsDisposed || !ReferenceEquals(audioPlaybackDevice, playback))
+        {
+            return;
+        }
+        try
+        {
+            BeginInvoke((Action)(() => CompleteWasapiPlayback(playback, error)));
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+
+    private void CompleteWasapiPlayback(IAudioPlaybackDevice playback, Exception? error)
+    {
+        if (!ReferenceEquals(audioPlaybackDevice, playback))
+        {
+            return;
+        }
+        DisposePlayback();
+        buttonPlay.Enabled = true;
+        buttonStop.Enabled = false;
+        labelStatus.Text = error?.Message ?? "Ready";
     }
 
     private AsioOut CreateAsioPlayer(SignalGeneratorPlaybackSettings settings)
@@ -246,6 +322,16 @@ public partial class SignalGeneratorPanel : UserControl
 
     private void StopPlayback()
     {
+        if (wasapiPlaying && audioPlaybackDevice != null)
+        {
+            wasapiPlaying = false;
+            audioPlaybackDevice.StopAsync().GetAwaiter().GetResult();
+            DisposePlayback();
+            buttonPlay.Enabled = true;
+            buttonStop.Enabled = false;
+            labelStatus.Text = "Ready";
+            return;
+        }
         if (player?.PlaybackState == PlaybackState.Playing)
         {
             player.Stop();
@@ -274,6 +360,12 @@ public partial class SignalGeneratorPanel : UserControl
         playbackStream = null;
         pcmStreams?.Dispose();
         pcmStreams = null;
+        if (audioPlaybackDevice != null)
+        {
+            audioPlaybackDevice.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            audioPlaybackDevice = null;
+        }
+        wasapiPlaying = false;
     }
 
     internal void RefreshAudioSettings()
@@ -290,10 +382,20 @@ public partial class SignalGeneratorPanel : UserControl
 
     private void RefreshAudioSettings(SignalGeneratorPlaybackSettings settings)
     {
-        string backend = settings.Backend == AudioBackend.Asio ? "ASIO" : "Wave";
-        string output = settings.Backend == AudioBackend.Asio
-            ? GetAsioOutputName(settings)
-            : GetWaveOutputName(settings.WaveOutputDeviceNumber);
+        string backend = settings.Backend switch
+        {
+            AudioBackend.Asio => "ASIO",
+            AudioBackend.WasapiShared => "WASAPI Shared",
+            AudioBackend.WasapiExclusive => "WASAPI Exclusive",
+            _ => "MME"
+        };
+        string output = settings.Backend switch
+        {
+            AudioBackend.Asio => GetAsioOutputName(settings),
+            AudioBackend.WasapiShared or AudioBackend.WasapiExclusive =>
+                settings.WasapiRenderEndpointName ?? "WASAPI endpoint",
+            _ => GetWaveOutputName(settings.WaveOutputDeviceNumber)
+        };
         labelAudioSettings.Text =
             $"{backend}: {settings.SampleRate} Hz, {settings.BitsPerSample}-bit, " +
             $"{settings.PlaybackChannel}, {output}";

--- a/tests/Resonalyze.App.Tests/AudioEndpointInfoTests.cs
+++ b/tests/Resonalyze.App.Tests/AudioEndpointInfoTests.cs
@@ -47,4 +47,17 @@ public sealed class AudioEndpointInfoTests
         Assert.Equal("[Unavailable] USB Audio", endpoint.ToString());
         Assert.False(endpoint.IsAvailable);
     }
+
+    [Fact]
+    public void MissingEndpointPlaceholderPreservesIdAndFriendlyName()
+    {
+        AudioEndpointInfo endpoint = Options.MeasurementOptions.CreateUnavailableEndpoint(
+            "endpoint-id",
+            "Focusrite USB",
+            DataFlow.Capture);
+
+        Assert.Equal("endpoint-id", endpoint.Id);
+        Assert.Equal("Focusrite USB", endpoint.FriendlyName);
+        Assert.Equal("[Unavailable] Focusrite USB", endpoint.ToString());
+    }
 }

--- a/tests/Resonalyze.App.Tests/AudioEndpointInfoTests.cs
+++ b/tests/Resonalyze.App.Tests/AudioEndpointInfoTests.cs
@@ -6,6 +6,17 @@ namespace Resonalyze.App.Tests;
 public sealed class AudioEndpointInfoTests
 {
     [Fact]
+    public void EndpointServiceRegistersAndUnregistersNotifications()
+    {
+        var service = new WindowsAudioEndpointService();
+
+        Assert.NotNull(service.GetCaptureEndpoints());
+        Assert.NotNull(service.GetRenderEndpoints());
+        service.Dispose();
+        service.Dispose();
+    }
+
+    [Fact]
     public void DisplayNameMarksDefaultActiveEndpoint()
     {
         var endpoint = new AudioEndpointInfo(

--- a/tests/Resonalyze.App.Tests/AudioEndpointInfoTests.cs
+++ b/tests/Resonalyze.App.Tests/AudioEndpointInfoTests.cs
@@ -1,0 +1,39 @@
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class AudioEndpointInfoTests
+{
+    [Fact]
+    public void DisplayNameMarksDefaultActiveEndpoint()
+    {
+        var endpoint = new AudioEndpointInfo(
+            "id",
+            "USB Audio",
+            DataFlow.Capture,
+            DeviceState.Active,
+            WaveFormat.CreateIeeeFloatWaveFormat(48_000, 8),
+            8,
+            true);
+
+        Assert.Equal("USB Audio (Default)", endpoint.ToString());
+        Assert.True(endpoint.IsAvailable);
+    }
+
+    [Fact]
+    public void DisplayNameMarksUnavailableEndpoint()
+    {
+        var endpoint = new AudioEndpointInfo(
+            "missing-id",
+            "USB Audio",
+            DataFlow.Capture,
+            DeviceState.NotPresent,
+            new WaveFormat(44_100, 16, 1),
+            0,
+            false);
+
+        Assert.Equal("[Unavailable] USB Audio", endpoint.ToString());
+        Assert.False(endpoint.IsAvailable);
+    }
+}

--- a/tests/Resonalyze.App.Tests/AudioPlaybackRunnerTests.cs
+++ b/tests/Resonalyze.App.Tests/AudioPlaybackRunnerTests.cs
@@ -1,0 +1,88 @@
+using NAudio.Wave;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class AudioPlaybackRunnerTests
+{
+    [Fact]
+    public async Task PlayToEnd_DoesNotCompleteBeforePlaybackEnds()
+    {
+        var playback = new FakePlaybackDevice();
+        Task run = AudioPlaybackRunner.PlayToEndAsync(
+            playback,
+            new SilenceProvider(new WaveFormat(48_000, 16, 1)),
+            CancellationToken.None);
+
+        Assert.False(run.IsCompleted);
+        playback.Complete();
+        await run;
+
+        Assert.Equal(1, playback.StartCount);
+        Assert.Equal(0, playback.StopCount);
+    }
+
+    [Fact]
+    public async Task PlayToEnd_CancellationStopsPlayback()
+    {
+        var playback = new FakePlaybackDevice();
+        using var cancellation = new CancellationTokenSource();
+        Task run = AudioPlaybackRunner.PlayToEndAsync(
+            playback,
+            new SilenceProvider(new WaveFormat(48_000, 16, 1)),
+            cancellation.Token);
+
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run);
+        Assert.Equal(1, playback.StopCount);
+    }
+
+    [Fact]
+    public async Task PlayToEnd_PlaybackFailureStopsAndPropagates()
+    {
+        var playback = new FakePlaybackDevice();
+        Task run = AudioPlaybackRunner.PlayToEndAsync(
+            playback,
+            new SilenceProvider(new WaveFormat(48_000, 16, 1)),
+            CancellationToken.None);
+        playback.Fail(new IOException("device lost"));
+
+        IOException exception = await Assert.ThrowsAsync<IOException>(() => run);
+
+        Assert.Equal("device lost", exception.Message);
+        Assert.Equal(1, playback.StopCount);
+    }
+
+    private sealed class FakePlaybackDevice : IAudioPlaybackDevice
+    {
+        private readonly TaskCompletionSource<bool> completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public WaveFormat PlaybackFormat { get; } = new(48_000, 16, 1);
+        public int StartCount { get; private set; }
+        public int StopCount { get; private set; }
+
+        public Task StartAsync(IWaveProvider source, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            StartCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task WaitForPlaybackEndAsync(CancellationToken cancellationToken) =>
+            completion.Task.WaitAsync(cancellationToken);
+
+        public Task StopAsync()
+        {
+            StopCount++;
+            completion.TrySetResult(true);
+            return Task.CompletedTask;
+        }
+
+        public void Complete() => completion.TrySetResult(true);
+
+        public void Fail(Exception exception) => completion.TrySetException(exception);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Resonalyze.App.Tests/AudioRenderBufferReaderTests.cs
+++ b/tests/Resonalyze.App.Tests/AudioRenderBufferReaderTests.cs
@@ -1,0 +1,89 @@
+using NAudio.Wave;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class AudioRenderBufferReaderTests
+{
+    [Fact]
+    public void Fill_ContinuesAfterShortReadsUntilBufferIsFull()
+    {
+        var source = new ChunkedWaveProvider([1, 2, 3, 4, 5, 6], chunkSize: 2);
+        var buffer = new byte[6];
+
+        AudioRenderBufferRead result = AudioRenderBufferReader.Fill(source, buffer);
+
+        Assert.Equal(6, result.BytesRead);
+        Assert.False(result.SourceEnded);
+        Assert.Equal([1, 2, 3, 4, 5, 6], buffer);
+    }
+
+    [Fact]
+    public void Fill_ZeroPadsFinalPartialBufferAndReportsEnd()
+    {
+        var source = new ChunkedWaveProvider([1, 2, 3], chunkSize: 2);
+        var buffer = Enumerable.Repeat((byte)0xCC, 6).ToArray();
+
+        AudioRenderBufferRead result = AudioRenderBufferReader.Fill(source, buffer);
+
+        Assert.Equal(3, result.BytesRead);
+        Assert.True(result.SourceEnded);
+        Assert.Equal([1, 2, 3, 0, 0, 0], buffer);
+    }
+
+    [Fact]
+    public void Fill_EmptySourceProducesSilentBuffer()
+    {
+        var source = new ChunkedWaveProvider([], chunkSize: 2);
+        var buffer = Enumerable.Repeat((byte)0xCC, 4).ToArray();
+
+        AudioRenderBufferRead result = AudioRenderBufferReader.Fill(source, buffer);
+
+        Assert.Equal(0, result.BytesRead);
+        Assert.True(result.SourceEnded);
+        Assert.Equal([0, 0, 0, 0], buffer);
+    }
+
+    [Fact]
+    public void RewoundSourceCanFillAnotherRun()
+    {
+        byte[] samples = [1, 2, 3, 4];
+        using var memory = new MemoryStream(samples, writable: false);
+        using var source = new RawSourceWaveStream(memory, new WaveFormat(48_000, 16, 1));
+        var first = new byte[4];
+        var second = new byte[4];
+
+        AudioRenderBufferReader.Fill(source, first);
+        source.Position = 0;
+        AudioRenderBufferReader.Fill(source, second);
+
+        Assert.Equal(first, second);
+        Assert.Equal(samples, second);
+    }
+
+    private sealed class ChunkedWaveProvider : IWaveProvider
+    {
+        private readonly byte[] data;
+        private readonly int chunkSize;
+        private int position;
+
+        public ChunkedWaveProvider(byte[] data, int chunkSize)
+        {
+            this.data = data;
+            this.chunkSize = chunkSize;
+        }
+
+        public WaveFormat WaveFormat { get; } = new(48_000, 16, 1);
+
+        public int Read(byte[] buffer, int offset, int count)
+        {
+            int available = Math.Min(data.Length - position, Math.Min(count, chunkSize));
+            if (available <= 0)
+            {
+                return 0;
+            }
+            Array.Copy(data, position, buffer, offset, available);
+            position += available;
+            return available;
+        }
+    }
+}

--- a/tests/Resonalyze.App.Tests/ImpulseResponseFileTests.cs
+++ b/tests/Resonalyze.App.Tests/ImpulseResponseFileTests.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using NAudio.Wave;
 
 namespace Resonalyze.App.Tests;
 
@@ -22,6 +23,23 @@ public sealed class ImpulseResponseFileTests
             SweepDeconvolutionPeakIndex = 2,
             AverageRunCount = 4,
             AcceptedAverageRunCount = 3,
+            AudioSession = new ImpulseResponseFile.AudioSessionFileEntry
+            {
+                Backend = "WasapiShared",
+                CaptureEndpointId = "capture-id",
+                RenderEndpointId = "render-id",
+                ShareMode = "Shared",
+                CaptureFormat = "32 bit float: 48kHz 2 channels",
+                RenderFormat = "32 bit float: 48kHz 2 channels",
+                CaptureSampleRate = 48_000,
+                RenderSampleRate = 48_000,
+                AnalysisSampleRate = 48_000,
+                FormatConversionOccurred = false,
+                RequestedBufferMilliseconds = 100,
+                ActualBufferFrames = 4_800,
+                CapturePackets = 123,
+                Discontinuities = 1
+            },
             MicrophoneLevels = new ImpulseResponseFile.LevelSnapshotFileEntry
             {
                 PeakDbFs = -6.5,
@@ -53,6 +71,7 @@ public sealed class ImpulseResponseFileTests
             Assert.Contains("\"sweepDeconvolutionPeakIndex\": 2", json);
             Assert.Contains("\"averageRunCount\": 4", json);
             Assert.Contains("\"acceptedAverageRunCount\": 3", json);
+            Assert.Contains("\"audioSession\"", json);
             Assert.Contains("\"transferPeakIndex\": 1", json);
             Assert.Contains("\"transferCoherence\"", json);
             Assert.Contains("\"microphoneLevels\"", json);
@@ -81,6 +100,11 @@ public sealed class ImpulseResponseFileTests
             Assert.Equal(2, loaded.SweepDeconvolutionPeakIndex);
             Assert.Equal(4, loaded.AverageRunCount);
             Assert.Equal(3, loaded.AcceptedAverageRunCount);
+            Assert.NotNull(loaded.AudioSession);
+            Assert.Equal("WasapiShared", loaded.AudioSession.Backend);
+            Assert.Equal("capture-id", loaded.AudioSession.CaptureEndpointId);
+            Assert.Equal(123, loaded.AudioSession.CapturePackets);
+            Assert.Equal(1, loaded.AudioSession.Discontinuities);
             Assert.NotNull(loaded.MicrophoneLevels);
             Assert.Equal(-6.5, loaded.MicrophoneLevels.PeakDbFs);
             Assert.Equal(-18.25, loaded.MicrophoneLevels.RmsDbFs);
@@ -113,6 +137,40 @@ public sealed class ImpulseResponseFileTests
         {
             File.Delete(path);
         }
+    }
+
+    [Fact]
+    public void AudioSessionEntry_CapturesWasapiDiagnostics()
+    {
+        var diagnostics = new AudioSessionDiagnostics(
+            "WasapiExclusive",
+            "capture-id",
+            "render-id",
+            WaveFormat.CreateCustomFormat(
+                WaveFormatEncoding.Pcm, 96_000, 2, 576_000, 6, 24),
+            WaveFormat.CreateCustomFormat(
+                WaveFormatEncoding.Pcm, 96_000, 2, 576_000, 6, 24),
+            40,
+            3_840,
+            50,
+            12,
+            2,
+            3,
+            4,
+            5,
+            6);
+
+        ImpulseResponseFile.AudioSessionFileEntry? entry =
+            ImpulseResponseFile.CreateAudioSessionFileEntry(diagnostics, 96_000, 24);
+
+        Assert.NotNull(entry);
+        Assert.Equal("Exclusive", entry.ShareMode);
+        Assert.Equal(96_000, entry.AnalysisSampleRate);
+        Assert.False(entry.FormatConversionOccurred);
+        Assert.Equal(50, entry.CapturePackets);
+        Assert.Equal(3_840, entry.ActualBufferFrames);
+        Assert.Equal(12, entry.RenderCallbacks);
+        Assert.Equal(6, entry.RenderUnderruns);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/InterleavedSampleDecoderTests.cs
+++ b/tests/Resonalyze.App.Tests/InterleavedSampleDecoderTests.cs
@@ -1,0 +1,82 @@
+using NAudio.Wave;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class InterleavedSampleDecoderTests
+{
+    [Fact]
+    public void Pcm16DecodesInterleavedChannelsAndIgnoresTrailingBytes()
+    {
+        IInterleavedSampleDecoder decoder = InterleavedSampleDecoder.Create(
+            new WaveFormat(48000, 16, 2));
+        byte[] source = [0x00, 0x80, 0xff, 0x7f, 0x00, 0x00, 0x34];
+        float[][] destination = [new float[2], new float[2]];
+
+        int frames = decoder.Decode(source, destination);
+
+        Assert.Equal(1, frames);
+        Assert.Equal(-1.0f, destination[0][0]);
+        Assert.InRange(destination[1][0], 0.9999f, 1.0f);
+    }
+
+    [Fact]
+    public void Pcm24SignExtendsNegativeSamples()
+    {
+        IInterleavedSampleDecoder decoder = InterleavedSampleDecoder.Create(
+            new WaveFormat(48000, 24, 1));
+        float[][] destination = [new float[3]];
+
+        int frames = decoder.Decode(
+            [0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0xff, 0xff, 0x7f],
+            destination);
+
+        Assert.Equal(3, frames);
+        Assert.Equal(-1.0f, destination[0][0]);
+        Assert.Equal(0.0f, destination[0][1]);
+        Assert.InRange(destination[0][2], 0.9999f, 1.0f);
+    }
+
+    [Fact]
+    public void Pcm32DecodesFullScaleValues()
+    {
+        IInterleavedSampleDecoder decoder = InterleavedSampleDecoder.Create(
+            new WaveFormat(48000, 32, 1));
+        float[][] destination = [new float[2]];
+
+        decoder.Decode([0, 0, 0, 0x80, 0xff, 0xff, 0xff, 0x7f], destination);
+
+        Assert.Equal(-1.0f, destination[0][0]);
+        Assert.InRange(destination[0][1], 0.9999f, 1.0f);
+    }
+
+    [Fact]
+    public void Float32ClampsAndReplacesNonFiniteValues()
+    {
+        IInterleavedSampleDecoder decoder = InterleavedSampleDecoder.Create(
+            WaveFormat.CreateIeeeFloatWaveFormat(48000, 1));
+        float[][] destination = [new float[4]];
+        byte[] source = new float[] { -2.0f, 0.25f, 2.0f, float.NaN }
+            .SelectMany(BitConverter.GetBytes)
+            .ToArray();
+
+        decoder.Decode(source, destination);
+
+        Assert.Equal([-1.0f, 0.25f, 1.0f, 0.0f], destination[0]);
+    }
+
+    [Fact]
+    public void DecodeSupportsEightChannels()
+    {
+        IInterleavedSampleDecoder decoder = InterleavedSampleDecoder.Create(
+            WaveFormat.CreateIeeeFloatWaveFormat(48000, 8));
+        float[] values = Enumerable.Range(0, 8).Select(index => index / 8.0f).ToArray();
+        byte[] source = values.SelectMany(BitConverter.GetBytes).ToArray();
+        float[][] destination = Enumerable.Range(0, 8).Select(_ => new float[1]).ToArray();
+
+        Assert.Equal(1, decoder.Decode(source, destination));
+        for (int channel = 0; channel < values.Length; channel++)
+        {
+            Assert.Equal(values[channel], destination[channel][0]);
+        }
+    }
+}

--- a/tests/Resonalyze.App.Tests/MeasurementChannelRoutingTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementChannelRoutingTests.cs
@@ -38,4 +38,15 @@ public sealed class MeasurementChannelRoutingTests
 
         Assert.Contains("different channels", exception.Message);
     }
+
+    [Fact]
+    public void OptionsRejectMissingWasapiLoopback()
+    {
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            Options.MeasurementOptions.ValidateRequiredWaveLoopback(
+                loopbackSelected: false,
+                recordingDeviceSupportsLoopback: true));
+
+        Assert.Contains("required", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/Resonalyze.App.Tests/MeasurementChannelRoutingTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementChannelRoutingTests.cs
@@ -1,0 +1,41 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class MeasurementChannelRoutingTests
+{
+    [Fact]
+    public void SweepRejectsSameMmeMicrophoneAndLoopbackChannel()
+    {
+        using var measurement = new ExpSweepMeasurement();
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            measurement.Init(
+                8,
+                48_000,
+                24,
+                0.25,
+                PlaybackChannel.Right,
+                audioBackend: AudioBackend.Wave,
+                waveInputChannelOffset: 0,
+                waveLoopbackInputChannelOffset: 0));
+
+        Assert.Contains("different channels", exception.Message);
+    }
+
+    [Fact]
+    public void LiveNoiseRejectsSameMmeMicrophoneAndLoopbackChannel()
+    {
+        using var measurement = new NoiseMeasurement();
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            measurement.Init(
+                48_000,
+                24,
+                1.0,
+                PlaybackChannel.Right,
+                audioBackend: AudioBackend.Wave,
+                waveInputChannelOffset: 1,
+                waveLoopbackInputChannelOffset: 1));
+
+        Assert.Contains("different channels", exception.Message);
+    }
+}

--- a/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
@@ -51,6 +51,32 @@ public sealed class MeasurementSettingsMigrationTests
         Assert.False(settings.LegacyDualDeviceLoopbackReset);
     }
 
+    [Fact]
+    public void WasapiEndpointIdsAndBufferAreCapturedWithoutOpeningHardware()
+    {
+        using var measurement = new ExpSweepMeasurement();
+        measurement.Init(
+            12,
+            48_000,
+            24,
+            1.0,
+            PlaybackChannel.Mono,
+            audioBackend: AudioBackend.WasapiShared,
+            waveInputChannelOffset: 0,
+            waveLoopbackInputChannelOffset: 1,
+            wasapiCaptureEndpointId: "capture-id",
+            wasapiRenderEndpointId: "render-id",
+            wasapiBufferMilliseconds: 40);
+
+        MeasurementSettingsFile.SweepMeasurementSettings captured =
+            MeasurementSettingsFile.SweepMeasurementSettings.Capture(measurement);
+
+        Assert.Equal(AudioBackend.WasapiShared, captured.AudioBackend);
+        Assert.Equal("capture-id", captured.WasapiCaptureEndpointId);
+        Assert.Equal("render-id", captured.WasapiRenderEndpointId);
+        Assert.Equal(40, captured.WasapiBufferMilliseconds);
+    }
+
     // The migration runs inside LoadOrDefault (which reads the real settings
     // path beside the executable), so the unit exercises it directly.
     private static void Migrate(MeasurementSettingsFile settings) =>

--- a/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
@@ -66,7 +66,9 @@ public sealed class MeasurementSettingsMigrationTests
             waveLoopbackInputChannelOffset: 1,
             wasapiCaptureEndpointId: "capture-id",
             wasapiRenderEndpointId: "render-id",
-            wasapiBufferMilliseconds: 40);
+            wasapiBufferMilliseconds: 40,
+            wasapiCaptureEndpointName: "USB Input",
+            wasapiRenderEndpointName: "USB Output");
 
         MeasurementSettingsFile.SweepMeasurementSettings captured =
             MeasurementSettingsFile.SweepMeasurementSettings.Capture(measurement);
@@ -75,6 +77,28 @@ public sealed class MeasurementSettingsMigrationTests
         Assert.Equal("capture-id", captured.WasapiCaptureEndpointId);
         Assert.Equal("render-id", captured.WasapiRenderEndpointId);
         Assert.Equal(40, captured.WasapiBufferMilliseconds);
+        Assert.Equal("USB Input", captured.WasapiCaptureEndpointName);
+        Assert.Equal("USB Output", captured.WasapiRenderEndpointName);
+    }
+
+    [Fact]
+    public void WasapiChannelOffsetsAreNotLimitedToStereo()
+    {
+        using var measurement = new ExpSweepMeasurement();
+        measurement.Init(
+            12,
+            48_000,
+            24,
+            1.0,
+            PlaybackChannel.Mono,
+            audioBackend: AudioBackend.WasapiShared,
+            waveInputChannelOffset: 5,
+            waveLoopbackInputChannelOffset: 7,
+            wasapiCaptureEndpointId: "capture-id",
+            wasapiRenderEndpointId: "render-id");
+
+        Assert.Equal(5, measurement.WaveInputChannelOffset);
+        Assert.Equal(7, measurement.WaveLoopbackInputChannelOffset);
     }
 
     // The migration runs inside LoadOrDefault (which reads the real settings

--- a/tests/Resonalyze.App.Tests/PcmCaptureSessionTests.cs
+++ b/tests/Resonalyze.App.Tests/PcmCaptureSessionTests.cs
@@ -50,6 +50,24 @@ public sealed class PcmCaptureSessionTests
         Assert.Empty(session.GetSamplesSnapshot()[0]);
     }
 
+    [Fact]
+    public async Task PacketFlagsAreCountedAndDiscontinuityIsPublished()
+    {
+        var device = new FakeCaptureDevice(new WaveFormat(48000, 16, 1));
+        await using var session = new PcmCaptureSession(device);
+        int notifications = 0;
+        session.CaptureDiscontinuity += () => notifications++;
+        Task start = session.StartAsync(CancellationToken.None);
+
+        device.Push([0, 0], discontinuity: true, silent: true, timestampError: true);
+        await start;
+
+        Assert.Equal(1, session.DiscontinuityCount);
+        Assert.Equal(1, session.SilentPacketCount);
+        Assert.Equal(1, session.TimestampErrorCount);
+        Assert.Equal(1, notifications);
+    }
+
     private sealed class FakeCaptureDevice : IAudioCaptureDevice
     {
         public FakeCaptureDevice(WaveFormat format)
@@ -71,7 +89,11 @@ public sealed class PcmCaptureSessionTests
 
         public Task StopAsync() => Task.CompletedTask;
 
-        public void Push(byte[] bytes)
+        public void Push(
+            byte[] bytes,
+            bool discontinuity = false,
+            bool silent = false,
+            bool timestampError = false)
         {
             DataAvailable?.Invoke(
                 this,
@@ -79,7 +101,10 @@ public sealed class PcmCaptureSessionTests
                 {
                     Buffer = bytes,
                     BytesRecorded = bytes.Length,
-                    Format = CaptureFormat
+                    Format = CaptureFormat,
+                    Discontinuity = discontinuity,
+                    Silent = silent,
+                    TimestampError = timestampError
                 });
         }
 

--- a/tests/Resonalyze.App.Tests/PcmCaptureSessionTests.cs
+++ b/tests/Resonalyze.App.Tests/PcmCaptureSessionTests.cs
@@ -1,0 +1,91 @@
+using NAudio.Wave;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class PcmCaptureSessionTests
+{
+    [Fact]
+    public async Task StartWaitsForFirstPacketAndSampleWaitCompletes()
+    {
+        var device = new FakeCaptureDevice(new WaveFormat(48000, 16, 1));
+        await using var session = new PcmCaptureSession(device);
+
+        Task start = session.StartAsync(CancellationToken.None);
+        Assert.False(start.IsCompleted);
+        device.Push([0, 0, 0xff, 0x7f]);
+        await start;
+
+        await session.WaitForSamplesAsync(2, CancellationToken.None);
+        Assert.Equal(2, session.ReadSamples);
+    }
+
+    [Fact]
+    public async Task UnexpectedStopFaultsPendingWaits()
+    {
+        var device = new FakeCaptureDevice(new WaveFormat(48000, 16, 1));
+        await using var session = new PcmCaptureSession(device);
+        Task start = session.StartAsync(CancellationToken.None);
+        device.Push([0, 0]);
+        await start;
+        Task wait = session.WaitForSamplesAsync(100, CancellationToken.None);
+
+        device.StopWithError(new IOException("Device unplugged."));
+
+        IOException exception = await Assert.ThrowsAsync<IOException>(() => wait);
+        Assert.Equal("Device unplugged.", exception.Message);
+    }
+
+    [Fact]
+    public async Task ResetRemovesSamplesFromPreviousRun()
+    {
+        var device = new FakeCaptureDevice(new WaveFormat(48000, 16, 1));
+        await using var session = new PcmCaptureSession(device);
+        Task start = session.StartAsync(CancellationToken.None);
+        device.Push([0xff, 0x7f]);
+        await start;
+        Assert.Single(session.GetSamplesSnapshot()[0]);
+
+        session.Reset();
+
+        Assert.Empty(session.GetSamplesSnapshot()[0]);
+    }
+
+    private sealed class FakeCaptureDevice : IAudioCaptureDevice
+    {
+        public FakeCaptureDevice(WaveFormat format)
+        {
+            CaptureFormat = format;
+        }
+
+        public event EventHandler<AudioCaptureDataEventArgs>? DataAvailable;
+        public event EventHandler<AudioDeviceStoppedEventArgs>? Stopped;
+
+        public WaveFormat CaptureFormat { get; }
+        public int ChannelCount => CaptureFormat.Channels;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync() => Task.CompletedTask;
+
+        public void Push(byte[] bytes)
+        {
+            DataAvailable?.Invoke(
+                this,
+                new AudioCaptureDataEventArgs
+                {
+                    Buffer = bytes,
+                    BytesRecorded = bytes.Length,
+                    Format = CaptureFormat
+                });
+        }
+
+        public void StopWithError(Exception exception) =>
+            Stopped?.Invoke(this, new AudioDeviceStoppedEventArgs(exception));
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Resonalyze.App.Tests/PcmCaptureSessionTests.cs
+++ b/tests/Resonalyze.App.Tests/PcmCaptureSessionTests.cs
@@ -36,6 +36,22 @@ public sealed class PcmCaptureSessionTests
     }
 
     [Fact]
+    public async Task UnexpectedStopIsObservableWithoutSampleWaiter()
+    {
+        var device = new FakeCaptureDevice(new WaveFormat(48000, 16, 1));
+        await using var session = new PcmCaptureSession(device);
+        Task start = session.StartAsync(CancellationToken.None);
+        device.Push([0, 0]);
+        await start;
+        Task stopped = session.WaitForStopAsync(CancellationToken.None);
+
+        device.StopWithError(new IOException("Device unplugged."));
+
+        IOException exception = await Assert.ThrowsAsync<IOException>(() => stopped);
+        Assert.Equal("Device unplugged.", exception.Message);
+    }
+
+    [Fact]
     public async Task ResetRemovesSamplesFromPreviousRun()
     {
         var device = new FakeCaptureDevice(new WaveFormat(48000, 16, 1));

--- a/tests/Resonalyze.App.Tests/RecordedChannelValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedChannelValidatorTests.cs
@@ -1,0 +1,36 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class RecordedChannelValidatorTests
+{
+    [Fact]
+    public void SelectedMultichannelInputsIgnoreUnselectedDuplicatePair()
+    {
+        float[][] channels = Enumerable.Range(0, 8)
+            .Select(_ => new float[32])
+            .ToArray();
+        channels[5] = Enumerable.Range(0, 32).Select(index => index / 32.0f).ToArray();
+        channels[7] = Enumerable.Range(0, 32).Select(index => -index / 32.0f).ToArray();
+
+        RecordedChannelValidator.EnsureDifferentSignals(
+            channels,
+            firstChannel: 5,
+            secondChannel: 7,
+            "WASAPI measurement");
+    }
+
+    [Fact]
+    public void SelectedMultichannelInputsRejectTheirOwnDuplicateSignals()
+    {
+        float[][] channels = Enumerable.Range(0, 8)
+            .Select(index => Enumerable.Repeat(index / 8.0f, 32).ToArray())
+            .ToArray();
+        channels[7] = channels[5].ToArray();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            RecordedChannelValidator.EnsureDifferentSignals(
+                channels,
+                firstChannel: 5,
+                secondChannel: 7,
+                "WASAPI measurement"));
+    }
+}

--- a/tests/Resonalyze.App.Tests/SweepRunAudioOrchestratorTests.cs
+++ b/tests/Resonalyze.App.Tests/SweepRunAudioOrchestratorTests.cs
@@ -1,0 +1,177 @@
+using NAudio.Wave;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class SweepRunAudioOrchestratorTests
+{
+    [Fact]
+    public async Task FirstRunStartsCaptureBeforePlaybackAndWaitsForTail()
+    {
+        List<string> calls = [];
+        var capture = new FakeCaptureSession(calls) { ReadSamples = 7 };
+        var playback = new CompletingPlaybackDevice(calls);
+        var orchestrator = new SweepRunAudioOrchestrator(capture, playback);
+
+        float[][] result = await orchestrator.CaptureAsync(
+            new SilenceProvider(new WaveFormat(48_000, 16, 1)),
+            sweepSamples: 100,
+            tailSamples: 25,
+            CancellationToken.None);
+
+        Assert.Equal(
+            ["capture-start", "playback-start", "playback-wait", "capture-wait", "snapshot"],
+            calls);
+        Assert.Equal(132, capture.RequiredSamples);
+        Assert.Same(capture.Snapshot, result);
+    }
+
+    [Fact]
+    public async Task SubsequentRunResetsCaptureWithoutRestartingDevice()
+    {
+        List<string> calls = [];
+        var capture = new FakeCaptureSession(calls);
+        var playback = new CompletingPlaybackDevice(calls);
+        var orchestrator = new SweepRunAudioOrchestrator(capture, playback);
+        var source = new SilenceProvider(new WaveFormat(48_000, 16, 1));
+
+        await orchestrator.CaptureAsync(source, 100, 25, CancellationToken.None);
+        calls.Clear();
+        await orchestrator.CaptureAsync(source, 100, 25, CancellationToken.None);
+
+        Assert.Equal(
+            ["capture-reset", "playback-start", "playback-wait", "capture-wait", "snapshot"],
+            calls);
+        Assert.Equal(1, capture.StartCount);
+        Assert.Equal(1, capture.ResetCount);
+        Assert.Equal(2, playback.StartCount);
+    }
+
+    [Fact]
+    public async Task PlaybackCancellationDoesNotWaitForCaptureTail()
+    {
+        List<string> calls = [];
+        var capture = new FakeCaptureSession(calls);
+        var playback = new BlockingPlaybackDevice(calls);
+        var orchestrator = new SweepRunAudioOrchestrator(capture, playback);
+        using var cancellation = new CancellationTokenSource();
+        Task<float[][]> run = orchestrator.CaptureAsync(
+            new SilenceProvider(new WaveFormat(48_000, 16, 1)),
+            100,
+            25,
+            cancellation.Token);
+
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run);
+        Assert.DoesNotContain("capture-wait", calls);
+        Assert.Contains("playback-stop", calls);
+    }
+
+    private sealed class FakeCaptureSession : ISweepCaptureSession
+    {
+        private readonly List<string> calls;
+
+        public FakeCaptureSession(List<string> calls)
+        {
+            this.calls = calls;
+        }
+
+        public int ReadSamples { get; set; }
+        public int RequiredSamples { get; private set; }
+        public int StartCount { get; private set; }
+        public int ResetCount { get; private set; }
+        public float[][] Snapshot { get; } = [[1.0f], [2.0f]];
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            calls.Add("capture-start");
+            StartCount++;
+            return Task.CompletedTask;
+        }
+
+        public void Reset()
+        {
+            calls.Add("capture-reset");
+            ResetCount++;
+            ReadSamples = 0;
+        }
+
+        public Task WaitForSamplesAsync(int sampleCount, CancellationToken cancellationToken)
+        {
+            calls.Add("capture-wait");
+            RequiredSamples = sampleCount;
+            return Task.CompletedTask;
+        }
+
+        public float[][] GetSamplesSnapshot()
+        {
+            calls.Add("snapshot");
+            return Snapshot;
+        }
+    }
+
+    private sealed class CompletingPlaybackDevice : IAudioPlaybackDevice
+    {
+        private readonly List<string> calls;
+
+        public CompletingPlaybackDevice(List<string> calls)
+        {
+            this.calls = calls;
+        }
+
+        public WaveFormat PlaybackFormat { get; } = new(48_000, 16, 1);
+        public int StartCount { get; private set; }
+
+        public Task StartAsync(IWaveProvider source, CancellationToken cancellationToken)
+        {
+            calls.Add("playback-start");
+            StartCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task WaitForPlaybackEndAsync(CancellationToken cancellationToken)
+        {
+            calls.Add("playback-wait");
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync() => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class BlockingPlaybackDevice : IAudioPlaybackDevice
+    {
+        private readonly List<string> calls;
+        private readonly TaskCompletionSource<bool> completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public BlockingPlaybackDevice(List<string> calls)
+        {
+            this.calls = calls;
+        }
+
+        public WaveFormat PlaybackFormat { get; } = new(48_000, 16, 1);
+
+        public Task StartAsync(IWaveProvider source, CancellationToken cancellationToken)
+        {
+            calls.Add("playback-start");
+            return Task.CompletedTask;
+        }
+
+        public Task WaitForPlaybackEndAsync(CancellationToken cancellationToken)
+        {
+            calls.Add("playback-wait");
+            return completion.Task.WaitAsync(cancellationToken);
+        }
+
+        public Task StopAsync()
+        {
+            calls.Add("playback-stop");
+            completion.TrySetResult(true);
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Resonalyze.App.Tests/WasapiFormatSupportTests.cs
+++ b/tests/Resonalyze.App.Tests/WasapiFormatSupportTests.cs
@@ -1,0 +1,31 @@
+using NAudio.Wave;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class WasapiFormatSupportTests
+{
+    [Theory]
+    [InlineData(16)]
+    [InlineData(24)]
+    [InlineData(32)]
+    public void CreateDeviceFormatPreservesRequestedShape(int bits)
+    {
+        WaveFormat format = WasapiFormatSupport.CreateDeviceFormat(96_000, bits, 8);
+
+        Assert.Equal(96_000, format.SampleRate);
+        Assert.Equal(bits, format.BitsPerSample);
+        Assert.Equal(8, format.Channels);
+        Assert.Equal(WaveFormatEncoding.Extensible, format.Encoding);
+        Guid expectedSubFormat = bits == 32
+            ? new Guid("00000003-0000-0010-8000-00aa00389b71")
+            : new Guid("00000001-0000-0010-8000-00aa00389b71");
+        Assert.Equal(expectedSubFormat, Assert.IsType<WaveFormatExtensible>(format).SubFormat);
+    }
+
+    [Fact]
+    public void CreateDeviceFormatRejectsUnsupportedBitDepth()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            WasapiFormatSupport.CreateDeviceFormat(48_000, 20, 2));
+    }
+}

--- a/tests/Resonalyze.App.Tests/WasapiHardwareSmokeTests.cs
+++ b/tests/Resonalyze.App.Tests/WasapiHardwareSmokeTests.cs
@@ -117,4 +117,48 @@ public sealed class WasapiHardwareSmokeTests
 
         Assert.True(succeeded, measurement.LastError?.ToString());
     }
+
+    [Fact]
+    [Trait("Category", "Hardware")]
+    public async Task ExclusiveSweepRunsOnAReportedDuplexFormat()
+    {
+        string? captureId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_CAPTURE_ENDPOINT_ID");
+        string? renderId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_RENDER_ENDPOINT_ID");
+        if (string.IsNullOrWhiteSpace(captureId) || string.IsNullOrWhiteSpace(renderId))
+        {
+            return;
+        }
+
+        DuplexFormatSupport? supported = SampleRateCatalog.GetCandidateRates()
+            .Select(rate => WasapiFormatSupport.CheckExclusive(
+                captureId,
+                renderId,
+                rate,
+                24,
+                2,
+                2))
+            .FirstOrDefault(format => format.Supported);
+        Assert.NotNull(supported);
+
+        using var measurement = new ExpSweepMeasurement();
+        measurement.Init(
+            8,
+            supported.SampleRate,
+            supported.BitsPerSample,
+            0.25,
+            PlaybackChannel.Right,
+            audioBackend: AudioBackend.WasapiExclusive,
+            waveInputChannelOffset: 0,
+            waveLoopbackInputChannelOffset: 1,
+            averageRunCount: 1,
+            wasapiCaptureEndpointId: captureId,
+            wasapiRenderEndpointId: renderId,
+            wasapiBufferMilliseconds: 100);
+
+        bool succeeded = await measurement.RunAsync();
+
+        Assert.True(succeeded, measurement.LastError?.ToString());
+    }
 }

--- a/tests/Resonalyze.App.Tests/WasapiHardwareSmokeTests.cs
+++ b/tests/Resonalyze.App.Tests/WasapiHardwareSmokeTests.cs
@@ -37,6 +37,73 @@ public sealed class WasapiHardwareSmokeTests
 
     [Fact]
     [Trait("Category", "Hardware")]
+    public async Task FailedDeviceConstructionReleasesComResources()
+    {
+        string? captureId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_CAPTURE_ENDPOINT_ID");
+        string? renderId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_RENDER_ENDPOINT_ID");
+        if (string.IsNullOrWhiteSpace(captureId) || string.IsNullOrWhiteSpace(renderId))
+        {
+            return;
+        }
+
+        Assert.Throws<ArgumentException>(() => new WasapiCaptureDevice(renderId));
+        Assert.Throws<ArgumentException>(() => new WasapiPlaybackDevice(captureId));
+
+        await using var capture = new WasapiCaptureDevice(captureId, 100);
+        await using var render = new WasapiPlaybackDevice(renderId, 100);
+        Assert.True(capture.ChannelCount > 0);
+        Assert.True(render.PlaybackFormat.SampleRate > 0);
+    }
+
+    [Fact]
+    [Trait("Category", "Hardware")]
+    public async Task FailedDuplexValidationReleasesBothEndpoints()
+    {
+        string? captureId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_CAPTURE_ENDPOINT_ID");
+        string? renderId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_RENDER_ENDPOINT_ID");
+        if (string.IsNullOrWhiteSpace(captureId) || string.IsNullOrWhiteSpace(renderId))
+        {
+            return;
+        }
+
+        int mixRate;
+        using (var service = new WindowsAudioEndpointService())
+        {
+            mixRate = Assert.Single(
+                service.GetCaptureEndpoints(), endpoint => endpoint.Id == captureId)
+                .MixFormat.SampleRate;
+        }
+        int wrongRate = mixRate == 48_000 ? 44_100 : 48_000;
+        using (var measurement = new ExpSweepMeasurement())
+        {
+            measurement.Init(
+                8,
+                wrongRate,
+                24,
+                0.25,
+                PlaybackChannel.Right,
+                audioBackend: AudioBackend.WasapiShared,
+                waveInputChannelOffset: 0,
+                waveLoopbackInputChannelOffset: 1,
+                wasapiCaptureEndpointId: captureId,
+                wasapiRenderEndpointId: renderId);
+
+            Assert.False(await measurement.RunAsync());
+            Assert.NotNull(measurement.LastError);
+        }
+
+        await using var capture = new WasapiCaptureDevice(captureId, 100);
+        await using var render = new WasapiPlaybackDevice(renderId, 100);
+        Assert.True(capture.ChannelCount > 0);
+        Assert.True(render.PlaybackFormat.SampleRate > 0);
+    }
+
+    [Fact]
+    [Trait("Category", "Hardware")]
     public async Task SelectedEndpointsSupportTwoCapturePlaybackRuns()
     {
         string? captureId = Environment.GetEnvironmentVariable(

--- a/tests/Resonalyze.App.Tests/WasapiHardwareSmokeTests.cs
+++ b/tests/Resonalyze.App.Tests/WasapiHardwareSmokeTests.cs
@@ -1,0 +1,120 @@
+using NAudio.Wave;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class WasapiHardwareSmokeTests
+{
+    [Fact]
+    [Trait("Category", "Hardware")]
+    public async Task SelectedEndpointsCanBeReopenedAfterEnumeration()
+    {
+        string? captureId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_CAPTURE_ENDPOINT_ID");
+        string? renderId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_RENDER_ENDPOINT_ID");
+        if (string.IsNullOrWhiteSpace(captureId) || string.IsNullOrWhiteSpace(renderId))
+        {
+            return;
+        }
+
+        // Enumerate first to reproduce the UI path. Explicitly releasing the
+        // returned MMDevice wrappers used to disconnect the cached COM RCW and
+        // make the following WasapiOut construction fail with E_NOINTERFACE.
+        using (var service = new WindowsAudioEndpointService())
+        {
+            Assert.Contains(service.GetCaptureEndpoints(), endpoint => endpoint.Id == captureId);
+            Assert.Contains(service.GetRenderEndpoints(), endpoint => endpoint.Id == renderId);
+        }
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        await using var capture = new WasapiCaptureDevice(captureId, 100);
+        await using var render = new WasapiPlaybackDevice(renderId, 100);
+        Assert.True(capture.ChannelCount > 0);
+        Assert.True(render.PlaybackFormat.SampleRate > 0);
+    }
+
+    [Fact]
+    [Trait("Category", "Hardware")]
+    public async Task SelectedEndpointsSupportTwoCapturePlaybackRuns()
+    {
+        string? captureId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_CAPTURE_ENDPOINT_ID");
+        string? renderId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_RENDER_ENDPOINT_ID");
+        if (string.IsNullOrWhiteSpace(captureId) || string.IsNullOrWhiteSpace(renderId))
+        {
+            return;
+        }
+
+        await using var captureDevice = new WasapiCaptureDevice(captureId, 100);
+        await using var playbackDevice = new WasapiPlaybackDevice(renderId, 100);
+        await using var captureSession = new PcmCaptureSession(captureDevice);
+        int sampleRate = playbackDevice.PlaybackFormat.SampleRate;
+        var format = new WaveFormat(sampleRate, 16, 2);
+        byte[] silence = new byte[sampleRate / 20 * format.BlockAlign];
+        using var memory = new MemoryStream(silence, writable: false);
+        using var stream = new RawSourceWaveStream(memory, format);
+
+        await captureSession.StartAsync(CancellationToken.None);
+        for (int run = 0; run < 2; run++)
+        {
+            if (run > 0)
+            {
+                captureSession.Reset();
+            }
+            stream.Position = 0;
+            await playbackDevice.StartAsync(stream, CancellationToken.None);
+            await playbackDevice.WaitForPlaybackEndAsync(CancellationToken.None);
+            await captureSession.WaitForSamplesAsync(
+                Math.Max(1, captureDevice.CaptureFormat.SampleRate / 20),
+                CancellationToken.None);
+        }
+        await captureSession.StopAsync();
+    }
+
+    [Fact]
+    [Trait("Category", "Hardware")]
+    public async Task FullSweepMeasurementSupportsFourRuns()
+    {
+        string? captureId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_CAPTURE_ENDPOINT_ID");
+        string? renderId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_RENDER_ENDPOINT_ID");
+        if (string.IsNullOrWhiteSpace(captureId) || string.IsNullOrWhiteSpace(renderId))
+        {
+            return;
+        }
+
+        int sampleRate;
+        using (var service = new WindowsAudioEndpointService())
+        {
+            AudioEndpointInfo capture = Assert.Single(
+                service.GetCaptureEndpoints(), endpoint => endpoint.Id == captureId);
+            AudioEndpointInfo render = Assert.Single(
+                service.GetRenderEndpoints(), endpoint => endpoint.Id == renderId);
+            Assert.Equal(capture.MixFormat.SampleRate, render.MixFormat.SampleRate);
+            sampleRate = capture.MixFormat.SampleRate;
+        }
+
+        using var measurement = new ExpSweepMeasurement();
+        measurement.Init(
+            12,
+            sampleRate,
+            24,
+            1.0,
+            PlaybackChannel.Right,
+            audioBackend: AudioBackend.WasapiShared,
+            waveInputChannelOffset: 0,
+            waveLoopbackInputChannelOffset: 1,
+            averageRunCount: 4,
+            wasapiCaptureEndpointId: captureId,
+            wasapiRenderEndpointId: renderId,
+            wasapiBufferMilliseconds: 100);
+
+        bool succeeded = await measurement.RunAsync();
+
+        Assert.True(succeeded, measurement.LastError?.ToString());
+    }
+}

--- a/tests/Resonalyze.App.Tests/WasapiHardwareSmokeTests.cs
+++ b/tests/Resonalyze.App.Tests/WasapiHardwareSmokeTests.cs
@@ -51,6 +51,13 @@ public sealed class WasapiHardwareSmokeTests
         await using var captureDevice = new WasapiCaptureDevice(captureId, 100);
         await using var playbackDevice = new WasapiPlaybackDevice(renderId, 100);
         await using var captureSession = new PcmCaptureSession(captureDevice);
+        long? lastDevicePosition = null;
+        long? lastQpcPosition = null;
+        captureDevice.DataAvailable += (_, packet) =>
+        {
+            lastDevicePosition = packet.DevicePositionFrames;
+            lastQpcPosition = packet.QpcPosition;
+        };
         int sampleRate = playbackDevice.PlaybackFormat.SampleRate;
         var format = new WaveFormat(sampleRate, 16, 2);
         byte[] silence = new byte[sampleRate / 20 * format.BlockAlign];
@@ -72,11 +79,14 @@ public sealed class WasapiHardwareSmokeTests
                 CancellationToken.None);
         }
         await captureSession.StopAsync();
+        Assert.True(captureDevice.CapturePackets > 0);
+        Assert.NotNull(lastDevicePosition);
+        Assert.NotNull(lastQpcPosition);
     }
 
     [Fact]
     [Trait("Category", "Hardware")]
-    public async Task FullSweepMeasurementSupportsFourRuns()
+    public async Task FullSweepMeasurementSupportsEightRuns()
     {
         string? captureId = Environment.GetEnvironmentVariable(
             "RESONALYZE_WASAPI_CAPTURE_ENDPOINT_ID");
@@ -108,7 +118,7 @@ public sealed class WasapiHardwareSmokeTests
             audioBackend: AudioBackend.WasapiShared,
             waveInputChannelOffset: 0,
             waveLoopbackInputChannelOffset: 1,
-            averageRunCount: 4,
+            averageRunCount: 8,
             wasapiCaptureEndpointId: captureId,
             wasapiRenderEndpointId: renderId,
             wasapiBufferMilliseconds: 100);
@@ -116,6 +126,17 @@ public sealed class WasapiHardwareSmokeTests
         bool succeeded = await measurement.RunAsync();
 
         Assert.True(succeeded, measurement.LastError?.ToString());
+        Assert.Equal(8, measurement.AverageRunCount);
+        Assert.Equal(8, measurement.AcceptedAverageRunCount);
+        Assert.NotNull(measurement.LastAudioSessionDiagnostics);
+        Assert.True(measurement.LastAudioSessionDiagnostics.CapturePackets > 0);
+        Assert.True(measurement.LastAudioSessionDiagnostics.RenderCallbacks > 0);
+        Assert.True(measurement.LastAudioSessionDiagnostics.ActualBufferFrames > 0);
+        // Some drivers mark the first packet after AudioClient.Start as a
+        // discontinuity. Per-run baselines still reject any discontinuity
+        // occurring during an accepted sweep.
+        Assert.Equal(0, measurement.LastAudioSessionDiagnostics.TimestampErrors);
+        Assert.Equal(0, measurement.LastAudioSessionDiagnostics.RenderUnderruns);
     }
 
     [Fact]
@@ -160,5 +181,119 @@ public sealed class WasapiHardwareSmokeTests
         bool succeeded = await measurement.RunAsync();
 
         Assert.True(succeeded, measurement.LastError?.ToString());
+    }
+
+    [Theory]
+    [InlineData(AudioBackend.WasapiShared)]
+    [InlineData(AudioBackend.WasapiExclusive)]
+    [Trait("Category", "Hardware")]
+    public async Task LiveNoiseProducesSpectrum(AudioBackend backend)
+    {
+        string? captureId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_CAPTURE_ENDPOINT_ID");
+        string? renderId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_RENDER_ENDPOINT_ID");
+        if (string.IsNullOrWhiteSpace(captureId) || string.IsNullOrWhiteSpace(renderId))
+        {
+            return;
+        }
+
+        int sampleRate;
+        if (backend == AudioBackend.WasapiExclusive)
+        {
+            DuplexFormatSupport? supported = SampleRateCatalog.GetCandidateRates()
+                .Select(rate => WasapiFormatSupport.CheckExclusive(
+                    captureId,
+                    renderId,
+                    rate,
+                    24,
+                    2,
+                    2))
+                .FirstOrDefault(format => format.Supported);
+            Assert.NotNull(supported);
+            sampleRate = supported.SampleRate;
+        }
+        else
+        {
+            using var service = new WindowsAudioEndpointService();
+            AudioEndpointInfo capture = Assert.Single(
+                service.GetCaptureEndpoints(), endpoint => endpoint.Id == captureId);
+            sampleRate = capture.MixFormat.SampleRate;
+        }
+
+        using var measurement = new NoiseMeasurement();
+        measurement.Init(
+            sampleRate,
+            24,
+            2.0,
+            PlaybackChannel.Right,
+            sequenceLength: 2048,
+            audioBackend: backend,
+            waveInputChannelOffset: 0,
+            waveLoopbackInputChannelOffset: 1,
+            wasapiCaptureEndpointId: captureId,
+            wasapiRenderEndpointId: renderId,
+            wasapiBufferMilliseconds: 100);
+
+        Task<bool> running = measurement.RunAsync();
+        await Task.Delay(1500);
+        await measurement.AbortAsync();
+
+        Assert.True(await running, measurement.LastError?.ToString());
+        Assert.NotNull(measurement.GetAccumulatedSpectrumSnapshot());
+    }
+
+    [Theory]
+    [InlineData(AudioBackend.WasapiShared)]
+    [InlineData(AudioBackend.WasapiExclusive)]
+    [Trait("Category", "Hardware")]
+    public async Task AudioWarmupCompletes(AudioBackend backend)
+    {
+        string? captureId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_CAPTURE_ENDPOINT_ID");
+        string? renderId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_RENDER_ENDPOINT_ID");
+        if (string.IsNullOrWhiteSpace(captureId) || string.IsNullOrWhiteSpace(renderId))
+        {
+            return;
+        }
+
+        int sampleRate;
+        if (backend == AudioBackend.WasapiExclusive)
+        {
+            DuplexFormatSupport? supported = SampleRateCatalog.GetCandidateRates()
+                .Select(rate => WasapiFormatSupport.CheckExclusive(
+                    captureId,
+                    renderId,
+                    rate,
+                    24,
+                    2,
+                    2))
+                .FirstOrDefault(format => format.Supported);
+            Assert.NotNull(supported);
+            sampleRate = supported.SampleRate;
+        }
+        else
+        {
+            using var service = new WindowsAudioEndpointService();
+            sampleRate = Assert.Single(
+                service.GetCaptureEndpoints(), endpoint => endpoint.Id == captureId)
+                .MixFormat.SampleRate;
+        }
+
+        var settings = new MeasurementSettingsFile.SweepMeasurementSettings
+        {
+            AudioBackend = backend,
+            SampleRate = sampleRate,
+            Bits = 24,
+            PlaybackChannel = PlaybackChannel.Right,
+            WaveInputChannelOffset = 0,
+            WaveLoopbackInputChannelOffset = 1,
+            WasapiCaptureEndpointId = captureId,
+            WasapiRenderEndpointId = renderId,
+            WasapiBufferMilliseconds = 100
+        };
+
+        await AudioDeviceWarmup.WarmUpAsync(settings);
     }
 }

--- a/tests/Resonalyze.App.Tests/WasapiHardwareSmokeTests.cs
+++ b/tests/Resonalyze.App.Tests/WasapiHardwareSmokeTests.cs
@@ -183,6 +183,57 @@ public sealed class WasapiHardwareSmokeTests
         Assert.True(succeeded, measurement.LastError?.ToString());
     }
 
+    [Fact]
+    [Trait("Category", "Hardware")]
+    public async Task AbortedSweepReleasesEndpointsForImmediateReuse()
+    {
+        string? captureId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_CAPTURE_ENDPOINT_ID");
+        string? renderId = Environment.GetEnvironmentVariable(
+            "RESONALYZE_WASAPI_RENDER_ENDPOINT_ID");
+        if (string.IsNullOrWhiteSpace(captureId) || string.IsNullOrWhiteSpace(renderId))
+        {
+            return;
+        }
+
+        int sampleRate;
+        using (var service = new WindowsAudioEndpointService())
+        {
+            sampleRate = Assert.Single(
+                service.GetCaptureEndpoints(), endpoint => endpoint.Id == captureId)
+                .MixFormat.SampleRate;
+        }
+
+        using (var measurement = new ExpSweepMeasurement())
+        {
+            measurement.Init(
+                16,
+                sampleRate,
+                24,
+                5.0,
+                PlaybackChannel.Right,
+                audioBackend: AudioBackend.WasapiShared,
+                waveInputChannelOffset: 0,
+                waveLoopbackInputChannelOffset: 1,
+                wasapiCaptureEndpointId: captureId,
+                wasapiRenderEndpointId: renderId,
+                wasapiBufferMilliseconds: 100);
+
+            Task<bool> running = measurement.RunAsync();
+            await Task.Delay(500);
+            await measurement.AbortAsync();
+
+            Assert.False(await running);
+            Assert.Null(measurement.LastError);
+            Assert.False(measurement.InProgress);
+        }
+
+        await using var capture = new WasapiCaptureDevice(captureId, 100);
+        await using var render = new WasapiPlaybackDevice(renderId, 100);
+        Assert.True(capture.ChannelCount > 0);
+        Assert.True(render.PlaybackFormat.SampleRate > 0);
+    }
+
     [Theory]
     [InlineData(AudioBackend.WasapiShared)]
     [InlineData(AudioBackend.WasapiExclusive)]

--- a/tests/Resonalyze.App.Tests/WasapiRenderTimingTests.cs
+++ b/tests/Resonalyze.App.Tests/WasapiRenderTimingTests.cs
@@ -1,0 +1,54 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class WasapiRenderTimingTests
+{
+    private static readonly TimeSpan BufferDuration = TimeSpan.FromMilliseconds(40);
+
+    [Fact]
+    public void EmptyPaddingAtNormalExclusiveCallbackIsNotUnderrun()
+    {
+        bool underrun = WasapiRenderTiming.IsUnderrun(
+            currentPaddingFrames: 0,
+            sourceEnded: false,
+            elapsedSinceFill: TimeSpan.FromMilliseconds(40),
+            BufferDuration);
+
+        Assert.False(underrun);
+    }
+
+    [Fact]
+    public void EmptyPaddingAfterMissedDeadlineIsUnderrun()
+    {
+        bool underrun = WasapiRenderTiming.IsUnderrun(
+            currentPaddingFrames: 0,
+            sourceEnded: false,
+            elapsedSinceFill: TimeSpan.FromMilliseconds(61),
+            BufferDuration);
+
+        Assert.True(underrun);
+    }
+
+    [Fact]
+    public void BufferedAudioIsNotUnderrunAfterDelayedCallback()
+    {
+        bool underrun = WasapiRenderTiming.IsUnderrun(
+            currentPaddingFrames: 1,
+            sourceEnded: false,
+            elapsedSinceFill: TimeSpan.FromMilliseconds(80),
+            BufferDuration);
+
+        Assert.False(underrun);
+    }
+
+    [Fact]
+    public void DrainedCompletedSourceIsNotUnderrun()
+    {
+        bool underrun = WasapiRenderTiming.IsUnderrun(
+            currentPaddingFrames: 0,
+            sourceEnded: true,
+            elapsedSinceFill: TimeSpan.FromMilliseconds(80),
+            BufferDuration);
+
+        Assert.False(underrun);
+    }
+}

--- a/tests/Resonalyze.App.Tests/WasapiStreamConfigurationTests.cs
+++ b/tests/Resonalyze.App.Tests/WasapiStreamConfigurationTests.cs
@@ -47,14 +47,30 @@ public sealed class WasapiStreamConfigurationTests
         Assert.Equal(360, frames);
     }
 
-    [Fact]
-    public void AlignedExclusiveDurationRoundsUpToReferenceTimeUnit()
+    [Theory]
+    [InlineData(512, 48_000, 106_667)]
+    [InlineData(256, 48_000, 53_333)]
+    [InlineData(64, 44_100, 14_512)]
+    public void AlignedExclusiveDurationRoundsToNearestReferenceTimeUnit(
+        int bufferFrames,
+        int sampleRate,
+        long expectedDuration)
     {
         long duration = WasapiStreamConfiguration.GetAlignedExclusiveDuration(
-            bufferFrames: 512,
+            bufferFrames,
+            sampleRate);
+
+        Assert.Equal(expectedDuration, duration);
+    }
+
+    [Fact]
+    public void EventTimeoutUsesActualAlignedBufferSize()
+    {
+        int timeout = WasapiStreamConfiguration.GetEventTimeoutMilliseconds(
+            bufferFrames: 1_920,
             sampleRate: 48_000);
 
-        Assert.Equal(106_667, duration);
+        Assert.Equal(120, timeout);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/WasapiStreamConfigurationTests.cs
+++ b/tests/Resonalyze.App.Tests/WasapiStreamConfigurationTests.cs
@@ -1,0 +1,69 @@
+using System.Runtime.InteropServices;
+using NAudio.CoreAudioApi;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class WasapiStreamConfigurationTests
+{
+    [Fact]
+    public void SharedEventDrivenInitializationUsesZeroDurations()
+    {
+        (long bufferDuration, long periodicity) =
+            WasapiStreamConfiguration.GetDurations(AudioClientShareMode.Shared, 100);
+
+        Assert.Equal(0, bufferDuration);
+        Assert.Equal(0, periodicity);
+    }
+
+    [Fact]
+    public void ExclusiveEventDrivenInitializationUsesEqualDurations()
+    {
+        (long bufferDuration, long periodicity) =
+            WasapiStreamConfiguration.GetDurations(AudioClientShareMode.Exclusive, 40);
+
+        Assert.Equal(400_000, bufferDuration);
+        Assert.Equal(bufferDuration, periodicity);
+    }
+
+    [Fact]
+    public void ExclusiveRenderAlwaysRequestsFullEndpointBuffer()
+    {
+        int frames = WasapiStreamConfiguration.GetRenderFrames(
+            AudioClientShareMode.Exclusive,
+            bufferFrames: 480,
+            currentPaddingFrames: 120);
+
+        Assert.Equal(480, frames);
+    }
+
+    [Fact]
+    public void SharedRenderRequestsOnlyAvailableFrames()
+    {
+        int frames = WasapiStreamConfiguration.GetRenderFrames(
+            AudioClientShareMode.Shared,
+            bufferFrames: 480,
+            currentPaddingFrames: 120);
+
+        Assert.Equal(360, frames);
+    }
+
+    [Fact]
+    public void AlignedExclusiveDurationRoundsUpToReferenceTimeUnit()
+    {
+        long duration = WasapiStreamConfiguration.GetAlignedExclusiveDuration(
+            bufferFrames: 512,
+            sampleRate: 48_000);
+
+        Assert.Equal(106_667, duration);
+    }
+
+    [Fact]
+    public void BufferAlignmentErrorIsRecognizedByHResult()
+    {
+        var exception = new COMException(
+            "not aligned",
+            WasapiStreamConfiguration.BufferSizeNotAlignedHResult);
+
+        Assert.True(WasapiStreamConfiguration.IsBufferSizeNotAligned(exception));
+    }
+}


### PR DESCRIPTION
## Summary

- introduce reusable capture and playback abstractions while retaining MME Compatibility as a permanent diagnostic fallback
- add WASAPI Shared and Exclusive measurement paths backed by stable MMDevice endpoint IDs
- reuse capture and render sessions across averaged sweep runs
- migrate sweep, noise/live spectrum, signal generator, and device warmup workflows
- add endpoint hot-plug monitoring and a device-settings shortcut for changing the hardware clock
- collect capture timestamps, discontinuities, silent packets, render callbacks, and underrun diagnostics
- reject and retry sweep runs affected by capture or render glitches
- persist audio-session formats and diagnostics in impulse-response files
- harden playback EOF, cancellation, rewind, tail capture, and abort behavior

## Why

The legacy Wave/MME path could silently resample and identified devices by unstable numeric indices. The new WASAPI backends provide stable endpoint selection, an explicit Shared compatibility mode, and an Exclusive path that opens the current hardware format directly. ASIO remains the preferred backend for interfaces whose WDM driver exposes only the current hardware clock; MME remains available for diagnosing unusual user systems.

## User impact

Users can select WASAPI capture and render endpoints, use multi-channel microphone and physical-loopback routing, run repeated averaged measurements without reopening devices, and inspect whether a result encountered packet or render glitches. The WASAPI settings panel can open the selected vendor driver control panel so the hardware sample rate can be changed before refreshing supported Exclusive formats.

## Validation

- `dotnet test source/Resonalyze.sln -c Debug --no-restore`
  - 383 App tests passed
  - 468 DSP tests passed
- `dotnet test source/Resonalyze.sln -c Release --no-restore`
  - 383 App tests passed
  - 468 DSP tests passed
- Focusrite hardware matrix: 9/9 passed in Release
  - Shared and Exclusive endpoint opening
  - repeated capture/playback
  - eight averaged sweeps
  - sweep abort and immediate endpoint reuse
  - Shared/Exclusive live noise
  - Shared/Exclusive warmup
- `git diff --check`

## Notes

Cross-device unplug, sleep/resume, Realtek/Bluetooth/HDMI, and comparative ASIO/WASAPI acoustic measurements remain manual hardware validation tasks.