### PR TITLE
Add frequency-dependent windowing for phase analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Resonalyze is a Windows desktop application (WinForms, .NET 10) for acoustic measurements: impulse/frequency response, loopback-referenced time alignment, live transfer functions, EQ design, and virtual DSP crossover simulation. The SDK version is pinned in `global.json`.
+
+## Commands
+
+```powershell
+dotnet restore source/Resonalyze.sln
+dotnet build source/Resonalyze.sln --configuration Release
+dotnet run --project source/Resonalyze.csproj
+
+# All tests
+dotnet test source/Resonalyze.sln -c Release
+
+# One test project
+dotnet test tests/Resonalyze.Dsp.Tests/Resonalyze.Dsp.Tests.csproj
+
+# One test class or method
+dotnet test tests/Resonalyze.Dsp.Tests/Resonalyze.Dsp.Tests.csproj --filter "FullyQualifiedName~TransferFunctionTests"
+
+# Performance profiling build (defines TRACY_ENABLE, references Tracy-CSharp)
+dotnet run --project source/Resonalyze.csproj -c Tracy
+```
+
+Platform constraint: `source/` (the app) and `tests/Resonalyze.App.Tests/` target `net10.0-windows` and only build/run on Windows. `dsp/` and `tests/Resonalyze.Dsp.Tests/` target plain `net10.0` and are cross-platform — on a Linux environment, only the DSP library and its tests can be built and run.
+
+Test data: `assets/test_data` is a git submodule ([Resonalyze-test-data](https://github.com/DIMOSUS/Resonalyze-test-data), ~230 MB of real transfer IRs). Some dsp tests read it; run `git submodule update --init assets/test_data` once per clone, or those tests fail with a message pointing here.
+
+## Architecture
+
+Two projects, with a deliberate boundary:
+
+- **`dsp/Resonalyze.Dsp`** — pure, UI-free signal-processing library. Depends only on MathNet.Numerics and YamlDotNet. Contains FFT/spectrum analysis, windowing, transfer functions, minimum phase, excess delay, time-alignment analysis, biquad/crossover filters, the EQ auto-tuner, and PEQ profile import/export formats (Equalizer APO, REW, MiniDSP, CamillaDSP, EasyEffects, generic CSV — all implementing `IEqProfileFormat`). The app hands measurement data to this layer through `IImpulseMeasurement` (impulse response + peak index + sample rate).
+- **`source/Resonalyze`** — the WinForms app: audio device I/O, measurement lifecycle, and plotting.
+
+Inside `source/`, the flow is: signal generation and capture (`Measurements/` — `ExponentialSineSweep`, `NoiseSignal`, `SoundRecorder`; `Audio/` — NAudio Wave and ASIO backends; microphone and loopback are always channels of ONE input device, so timing stays sample-synchronous) → analysis via the Dsp library → plot presentation (`Plotting/` — `PlotModelFactory` builds OxyPlot models, `OxyPlotAdapter` hosts them).
+
+Key structural points:
+
+- **`Shell/Form1` is the hub**, split into partial classes by concern (`Form1.Measurement.cs`, `Form1.Plotting.cs`, `Form1.History.cs`, `Form1.Compare.cs`, etc.). The `Mode` enum in `Form1.cs` defines all analysis modes (frequency/phase/group delay/waterfall/burst decay/live spectrum/time alignment/EQ wizard/signal generator/virtual crossover); `ModeSwitching/ModeController` orchestrates tab switches.
+- **`Options/`** holds one settings panel per mode (`FROptions`, `IROpt`, `GDOpt`, ...), docked into the shell via `Shell/DockedModeSettingsHost`.
+- **`Tools/`** contains the larger feature panels: EQ Wizard, Signal Generator, Virtual DSP (`VirtualCrossoverPanel` + project file persistence), and PDF tuning-sheet export (PDFsharp/MigraDoc).
+- **`Overlays/`** manages persistent overlay slots and calculated (math) overlays; **`History/`** persists measurement snapshots with per-entry working state.
+- Update checking uses NetSparkle + `Settings/GitHubReleaseChecker`.
+
+## Testing Conventions
+
+Tests use xUnit. DSP tests are deterministic and synthetic: `tests/Resonalyze.Dsp.Tests/SyntheticMeasurement.cs` implements `IImpulseMeasurement` so analysis code is exercised against generated impulses/filters/delays rather than recordings. The exception is `RealMeasurementArrivalTests`, which pins field regressions against the real measurements in the `assets/test_data` submodule. App tests focus on file formats and non-UI logic (overlay files, impulse-response files, plot model construction, PDF sheets).
+
+## Code Style
+
+Enforced by `.editorconfig`; notable deviations from common C# defaults:
+
+- Private fields are `camelCase` with **no underscore prefix** (and no `this.` qualification except in constructor assignment).
+- `var` only when the type is apparent; explicit types otherwise, including built-ins.
+- CRLF line endings, 4-space indent, Allman braces, braces always.
+- New non-UI code uses file-scoped namespaces (see `Program.cs`, `ModeController.cs`).

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ file is provided with every release.
   low-coherence bands are bridged by a slope prediction instead of anchoring
   the unwrap, so one noisy bin can no longer throw the whole phase tail off by
   a multiple of 360°
+- Selectable phase windowing: the original fixed Tukey gate or a
+  frequency-dependent window (**FDW**, 4 / 6 / 8 cycles) that progressively
+  removes late reflections at mid and high frequencies while retaining the
+  fixed gate and useful resolution at low frequencies
 - Selectable microphone calibration profiles (**0°** / **90°**) applied per view,
   with lenient parsing of common `.txt` / `.cal` / `.frd` / `.csv` correction files
 - Time Alignment with sub-sample delay estimation from the transfer IR, refined
@@ -133,8 +137,9 @@ file is provided with every release.
 - Compare a second measurement (from a file or History) against the current one
   across Time Alignment, Phase, Group Delay, Frequency Response, and Impulse
   Response, with matching analysis settings and per-metric deltas
-- Minimum-phase / excess-phase decomposition with a millisecond gate, gate
-  offset, and a τ (delay) detrend for cross-measurement phase comparison
+- Minimum-phase / excess-phase decomposition from the same selected Fixed/FDW
+  spectrum, with **Off / Auto / Manual** τ detrending and one shared Auto
+  reference when Main and Compare are shown together
 - Per-curve visibility toggles in every analysis view; curves redraw on the fly
   with no separate draw/clear step
 - Harmonic distortion, THD, and THD+N analysis
@@ -474,13 +479,24 @@ both views need the common timing reference it provides, so they are only drawn
 when the active record contains a transfer IR. Without one, the plot says that
 loopback is required instead of showing a misleading curve.
 
-Both modes share a millisecond-based gate built from a left Tukey fade, a flat
-plateau, and a right Tukey fade. A **Gate offset** positions the end of the left
-fade inside the fixed analysis frame, and **Fit** snaps it to the transfer-IR
-peak. The docked preview draws the impulse response, the gate window, and a
-marker at the gate offset. A read-only readout shows the lowest reliable
+Both modes use a millisecond-based fixed gate built from a left Tukey fade, a
+flat plateau, and a right Tukey fade. A **Gate offset** positions the end of the
+left fade inside the analysis frame, and **Fit** snaps it to the transfer-IR
+peak. The docked preview draws the impulse response, the fixed gate, and a
+marker at the gate offset. A read-only readout shows its lowest reliable
 frequency (≈ 1 / gate length), so it is clear where the gated curve stops being
 trustworthy.
+
+Phase additionally offers **Window: Fixed / FDW**. Fixed reproduces the original
+single Tukey gate across the whole spectrum. **FDW** builds a small bank of
+time-aligned spectra whose effective right-side duration follows
+`cycles / frequency`: the fixed gate is the maximum, so low frequencies retain
+the long window, while mid and high frequencies progressively reject the late
+reflection tail. **FDW cycles** selects 4, 6, or 8 periods: 4 gives the strongest
+reflection suppression, 6 is the recommended balance, and 8 retains more late
+detail. Every bank spectrum is referenced to the same absolute sample origin
+before interpolation, so changing cycle count does not create an artificial
+time shift.
 
 The Phase view can show three independently toggled curves:
 
@@ -490,13 +506,20 @@ The Phase view can show three independently toggled curves:
 - **Excess phase** — measured minus minimum: the all-pass part (pure delay and
   reflections) that an equalizer cannot fix.
 
-A **τ** (delay) value detrends the linear-phase slope so the excess phase becomes
-readable. **Find τ** estimates it either from the first prominent arrival of the
-excess energy (peak — found with the same first-arrival detector Time Alignment
-uses, so a room mode ringing louder than the direct sound does not capture the
-reference) or from the energy-weighted average group delay (slope). Entering the
-same τ on two measurements lines up their phase for a direct comparison — for
-example, a midrange and a tweeter on the same axis.
+**Detrend** removes one constant delay before phase unwrapping:
+
+- **Auto** estimates the slope-based excess delay from the same Fixed/FDW
+  spectrum being displayed. The resolved read-only value appears directly in
+  **τ (ms)**.
+- **Manual** uses the editable τ value. Switching through Auto does not overwrite
+  the stored Manual value.
+- **Off** applies no additional detrend and keeps the absolute phase slope.
+
+When Main and Compare are displayed together, Auto is resolved once from Main
+and that common reference is applied to both measurements. Their real relative
+delay therefore remains visible as a linear phase difference instead of each
+curve being flattened independently. The same common reference is used for
+measured and excess phase.
 
 Unwrapped phase uses a **reliability-anchored** algorithm instead of naive
 bin-to-bin accumulation: each bin takes the 360° branch closest to a phase
@@ -511,6 +534,11 @@ turn count inside it is genuinely unknowable) is blanked instead of guessed,
 and the curve restarts as a fresh segment after it. On clean data the result
 is identical to the classic unwrap.
 
+Measured, minimum, and excess phase are internally consistent: minimum phase is
+derived from the magnitude of the selected Fixed/FDW analysis spectrum, and
+excess phase subtracts that curve from measured phase without smoothing across
+NaN segment breaks.
+
 Group Delay reads absolute delay referenced to the start of the transfer IR, so a
 peak well into the impulse response reports its true arrival time. The curve is
 computed energy-weighted: the numerator and the energy of the per-bin group-delay
@@ -520,6 +548,11 @@ no energy — follow the delay of the dominant energy instead of the singularity
 The smoothing window never narrows below the gate's own spectral resolution
 (features finer than 1/T cannot be resolved by a gate of duration T anyway), so
 interference-null spikes stay suppressed even with display smoothing off.
+FDW is deliberately not applied to Group Delay in this version: Group Delay
+continues to use the fixed Tukey gate. Consequently an FDW phase curve is a
+direct-sound-oriented representation and is not the exact integral of the
+currently displayed fixed-gate Group Delay. Selecting Fixed phase restores the
+mathematically compatible phase/group-delay pair.
 
 ## Audio Backends
 
@@ -807,8 +840,9 @@ current mode's settings so the two curves stay directly comparable:
   gains a second block whose every value shows the delta against the source in
   parentheses (for example `1.006 (+0.010)`).
 - **Phase** and **Group Delay** — the reference curves are computed with the
-  identical gate, τ detrend, and smoothing and drawn dashed and dimmed; the
-  gated IR preview in the settings panels shows the reference impulse as well.
+  identical gate/window and smoothing and drawn dashed and dimmed. Phase Auto
+  detrend is resolved once from Main and reused for Compare, preserving their
+  relative delay; the gated IR preview shows the reference impulse as well.
 - **Frequency Response** — the reference magnitude is overlaid (harmonics stay
   source-only to keep the plot readable).
 - **Impulse Response** — the reference impulse is drawn alongside the source
@@ -1372,10 +1406,14 @@ forth), and the **Sum loss** curve (blanked where every channel is filtered
 more than 40 dB below the loudest point — out there the "loss" would be the
 phase arithmetic of noise floors, not audible summation), with a **Phase view**
 toggle to check that
-the channels track each other through the crossover region. The Phase view has a
-manual **Gate...** dialog with an IR preview, Tukey left / plateau / right
-window controls, gate offset, and a shared τ detrend so reflections can be cut
-out without breaking relative phase. A second plot shows each DSP chain's own
+the channels track each other through the crossover region. Its **Gate...**
+dialog exposes **Fixed / FDW**, 4 / 6 / 8 cycles, and **Off / Auto / Manual**
+detrend alongside the IR preview, Tukey left / plateau / right controls, and
+gate offset. Virtual DSP deliberately keeps phase wrapped to -180..+180 degrees.
+Auto chooses one common reference channel, displays the resolved τ, and applies
+that exact value to every driver and the complex sum; it never independently
+flattens the channels, so their relative phase and timing remain intact. A
+second plot shows each DSP chain's own
 magnitude and phase (without the driver). A **Sum loss** read-out (avg / dip
 per junction plus a total) turns tuning into numbers you can minimize, and a
 **Δ L−R** block below it reports each stereo pair's final inter-side state:

--- a/dsp/DataHelper.Phase.cs
+++ b/dsp/DataHelper.Phase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using MathNet.Numerics.IntegralTransforms;
 
 namespace Resonalyze.Dsp
@@ -107,6 +108,239 @@ namespace Resonalyze.Dsp
                 out extractionStart);
             Fourier.Forward(spectrum, FourierOptions.Matlab);
             return spectrum;
+        }
+
+        private const double FdwMinimumDurationSeconds = 0.0008;
+        private const double FdwCentersPerOctave = 3.0;
+        private static readonly ConditionalWeakTable<Complex[], PhaseSpectrumCache>
+            PhaseSpectrumCaches = new();
+
+        private sealed class PhaseSpectrumCache
+        {
+            public Dictionary<PhaseSpectrumCacheKey, CachedPhaseSpectrum> Entries { get; } = new();
+        }
+
+        private readonly record struct PhaseSpectrumCacheKey(
+            int SampleRate,
+            double GateOffsetMs,
+            double LeftMs,
+            double PlateauMs,
+            double RightMs,
+            PhaseWindowMode WindowMode,
+            int FdwCycles,
+            int FftLength);
+
+        private sealed record CachedPhaseSpectrum(Complex[] Spectrum, int ExtractionStart);
+
+        private sealed record FdwSpectrumEntry(
+            double CenterFrequencyHz,
+            int EffectiveGateSamples,
+            Complex[] Spectrum,
+            int ExtractionStart);
+
+        private static Complex[] BuildAnalysisSpectrum(
+            IImpulseMeasurement measurement,
+            PhaseAnalysisSettings settings,
+            out int extractionStart)
+        {
+            Complex[] impulse = measurement.ImpulseResponse
+                ?? throw new InvalidOperationException("Impulse response is not available.");
+            var key = new PhaseSpectrumCacheKey(
+                measurement.SampleRate,
+                settings.GateOffsetMs,
+                settings.LeftMs,
+                settings.PlateauMs,
+                settings.RightMs,
+                settings.WindowMode,
+                settings.ValidatedFdwCycles,
+                GatedFftLength);
+            PhaseSpectrumCache cache = PhaseSpectrumCaches.GetOrCreateValue(impulse);
+            lock (cache.Entries)
+            {
+                if (cache.Entries.TryGetValue(key, out CachedPhaseSpectrum? cached))
+                {
+                    extractionStart = cached.ExtractionStart;
+                    return cached.Spectrum;
+                }
+            }
+
+            Complex[] spectrum;
+            if (settings.WindowMode == PhaseWindowMode.Fixed)
+            {
+                spectrum = BuildPhaseSpectrum(
+                    measurement,
+                    settings.GateOffsetMs,
+                    settings.LeftMs,
+                    settings.PlateauMs,
+                    settings.RightMs,
+                    out extractionStart);
+            }
+            else
+            {
+                spectrum = BuildFdwSpectrum(measurement, settings, out extractionStart);
+            }
+            lock (cache.Entries)
+            {
+                cache.Entries[key] = new CachedPhaseSpectrum(spectrum, extractionStart);
+            }
+            return spectrum;
+        }
+
+        private static Complex[] BuildFdwSpectrum(
+            IImpulseMeasurement measurement,
+            PhaseAnalysisSettings settings,
+            out int extractionStart)
+        {
+            int sampleRate = measurement.SampleRate;
+            int left = MillisecondsToSamples(settings.LeftMs, sampleRate);
+            int plateau = MillisecondsToSamples(settings.PlateauMs, sampleRate);
+            int right = MillisecondsToSamples(settings.RightMs, sampleRate);
+            int fixedGate = Math.Clamp(left + plateau + right, 1, GatedFftLength);
+            // The left shoulder is the immutable temporal anchor. The 0.8 ms
+            // floor therefore applies to analysis time after that shoulder;
+            // otherwise a long configured fade could consume the whole shortest
+            // window and zero the direct arrival at its endpoint.
+            int minimumGate = Math.Clamp(
+                left + (int)Math.Round(FdwMinimumDurationSeconds * sampleRate),
+                1,
+                fixedGate);
+            int cycles = settings.ValidatedFdwCycles;
+            double binWidth = sampleRate / (double)GatedFftLength;
+            double nyquist = sampleRate / 2.0;
+            var entries = new List<FdwSpectrumEntry>();
+            int previousGate = -1;
+
+            for (double center = binWidth; center <= nyquist;
+                 center *= Math.Pow(2.0, 1.0 / FdwCentersPerOctave))
+            {
+                int effectiveGate = Math.Clamp(
+                    (int)Math.Round(cycles * sampleRate / center),
+                    minimumGate,
+                    fixedGate);
+                if (effectiveGate == previousGate)
+                {
+                    continue;
+                }
+
+                Complex[] spectrum = ExtractFdwWindowedImpulse(
+                    measurement,
+                    settings.GateOffsetMs,
+                    left,
+                    right,
+                    effectiveGate,
+                    out int start);
+                Fourier.Forward(spectrum, FourierOptions.Matlab);
+                entries.Add(new FdwSpectrumEntry(center, effectiveGate, spectrum, start));
+                previousGate = effectiveGate;
+            }
+
+            if (entries.Count == 0 || entries[^1].CenterFrequencyHz < nyquist)
+            {
+                int effectiveGate = minimumGate;
+                Complex[] spectrum = ExtractFdwWindowedImpulse(
+                    measurement,
+                    settings.GateOffsetMs,
+                    left,
+                    right,
+                    effectiveGate,
+                    out int start);
+                Fourier.Forward(spectrum, FourierOptions.Matlab);
+                if (entries.Count == 0 || entries[^1].EffectiveGateSamples != effectiveGate)
+                {
+                    entries.Add(new FdwSpectrumEntry(nyquist, effectiveGate, spectrum, start));
+                }
+            }
+
+            extractionStart = entries[0].ExtractionStart;
+            foreach (FdwSpectrumEntry entry in entries)
+            {
+                ApplyTimeReference(entry.Spectrum, entry.ExtractionStart, extractionStart);
+            }
+
+            var combined = new Complex[GatedFftLength];
+            int upperIndex = 0;
+            for (int bin = 0; bin <= combined.Length / 2; bin++)
+            {
+                double frequency = bin * binWidth;
+                while (upperIndex < entries.Count - 1 &&
+                       entries[upperIndex].CenterFrequencyHz < frequency)
+                {
+                    upperIndex++;
+                }
+
+                if (upperIndex == 0)
+                {
+                    combined[bin] = entries[0].Spectrum[bin];
+                    continue;
+                }
+
+                FdwSpectrumEntry lower = entries[upperIndex - 1];
+                FdwSpectrumEntry upper = entries[upperIndex];
+                double logFrequency = Math.Log(Math.Max(frequency, lower.CenterFrequencyHz));
+                double t = (logFrequency - Math.Log(lower.CenterFrequencyHz)) /
+                    (Math.Log(upper.CenterFrequencyHz) - Math.Log(lower.CenterFrequencyHz));
+                combined[bin] = InterpolateSpectrum(
+                    lower.Spectrum[bin], upper.Spectrum[bin], Math.Clamp(t, 0.0, 1.0));
+            }
+            for (int bin = 1; bin < combined.Length / 2; bin++)
+            {
+                combined[combined.Length - bin] = Complex.Conjugate(combined[bin]);
+            }
+
+            return combined;
+        }
+
+        private static Complex[] ExtractFdwWindowedImpulse(
+            IImpulseMeasurement measurement,
+            double gateOffsetMs,
+            int requestedLeft,
+            int requestedRight,
+            int gate,
+            out int extractionStart)
+        {
+            int left = Math.Min(requestedLeft, gate);
+            int right = Math.Min(requestedRight, gate - left);
+            double[] tukey = Windowing.TukeyWindow(
+                gate,
+                (double)left / gate * 2.0,
+                (double)right / gate * 2.0);
+            double[] window = new double[GatedFftLength];
+            Array.Copy(tukey, window, gate);
+            extractionStart = MillisecondsToSamples(gateOffsetMs, measurement.SampleRate) - left;
+            return ExtractWindow(measurement, extractionStart, GatedFftLength, window, wrap: true);
+        }
+
+        private static void ApplyTimeReference(
+            Complex[] spectrum,
+            int extractionStart,
+            double referenceSamples)
+        {
+            double shift = referenceSamples - extractionStart;
+            if (shift == 0.0)
+            {
+                return;
+            }
+
+            for (int bin = 0; bin < spectrum.Length; bin++)
+            {
+                spectrum[bin] *= Complex.FromPolarCoordinates(
+                    1.0,
+                    Math.Tau * bin * shift / spectrum.Length);
+            }
+        }
+
+        private static Complex InterpolateSpectrum(Complex lower, Complex upper, double t)
+        {
+            const double epsilon = 1e-300;
+            double lowerMagnitude = Math.Max(lower.Magnitude, epsilon);
+            double upperMagnitude = Math.Max(upper.Magnitude, epsilon);
+            double logMagnitude = Math.Log(lowerMagnitude) +
+                (Math.Log(upperMagnitude) - Math.Log(lowerMagnitude)) * t;
+            Complex rotation = upper / upperMagnitude * Complex.Conjugate(lower / lowerMagnitude);
+            double deltaPhase = Math.Atan2(rotation.Imaginary, rotation.Real);
+            return Complex.FromPolarCoordinates(
+                Math.Exp(logMagnitude),
+                lower.Phase + deltaPhase * t);
         }
 
         // Reliability gates for the unwrapped phase: bins this far below the LOCAL
@@ -371,6 +605,62 @@ namespace Resonalyze.Dsp
                 coherence);
         }
 
+        public static List<SignalPoint> GetGatedPhaseData(
+            IImpulseMeasurement measurement,
+            PhaseAnalysisSettings settings,
+            IReadOnlyList<double>? coherence = null)
+        {
+            Complex[] spectrum = BuildAnalysisSpectrum(measurement, settings, out int extractionStart);
+            double detrendMilliseconds = ResolveDetrendMilliseconds(
+                spectrum,
+                extractionStart,
+                measurement.SampleRate,
+                settings);
+            return BuildMeasuredPhase(
+                spectrum,
+                extractionStart,
+                detrendMilliseconds * measurement.SampleRate / 1000.0,
+                measurement.SampleRate,
+                settings.Unwrap,
+                coherence);
+        }
+
+        public static double ResolvePhaseDetrendMilliseconds(
+            IImpulseMeasurement measurement,
+            PhaseAnalysisSettings settings)
+        {
+            Complex[] spectrum = BuildAnalysisSpectrum(measurement, settings, out int extractionStart);
+            return ResolveDetrendMilliseconds(
+                spectrum,
+                extractionStart,
+                measurement.SampleRate,
+                settings);
+        }
+
+        /// <summary>
+        /// Resolves the one Auto reference that a multi-curve view must reuse for
+        /// every channel and sum. The reference measurement is intentionally the
+        /// only signal accepted, making per-channel auto-flattening a caller-visible
+        /// policy error rather than an accidental loop implementation.
+        /// </summary>
+        public static double ResolveCommonPhaseDetrendMilliseconds(
+            IImpulseMeasurement referenceMeasurement,
+            PhaseAnalysisSettings settings) =>
+            ResolvePhaseDetrendMilliseconds(referenceMeasurement, settings);
+
+        private static double ResolveDetrendMilliseconds(
+            Complex[] spectrum,
+            int extractionStart,
+            int sampleRate,
+            PhaseAnalysisSettings settings) => settings.DetrendMode switch
+            {
+                PhaseDetrendMode.Off => 0.0,
+                PhaseDetrendMode.Manual => settings.ManualDetrendMilliseconds,
+                PhaseDetrendMode.Auto => EstimatePhaseDetrend(
+                    spectrum, extractionStart, sampleRate).SlopeMilliseconds,
+                _ => 0.0
+            };
+
         public static AnalysisCurve GetPhase(
             IImpulseMeasurement measurement,
             double gateOffsetMs,
@@ -402,6 +692,22 @@ namespace Resonalyze.Dsp
                 "Phase",
                 smoothingInverseOctaves > 0
                     ? SmoothLinear(data, 1.0 / smoothingInverseOctaves)
+                    : data);
+        }
+
+        public static AnalysisCurve GetPhase(
+            IImpulseMeasurement measurement,
+            PhaseAnalysisSettings settings,
+            IReadOnlyList<double>? coherence = null)
+        {
+            List<SignalPoint> phase = GetGatedPhaseData(measurement, settings, coherence);
+            List<SignalPoint> data = phase
+                .Select(point => new SignalPoint(point.X, point.Y / Math.PI * 180.0))
+                .ToList();
+            return new AnalysisCurve(
+                "Phase",
+                settings.SmoothingInverseOctaves > 0
+                    ? SmoothLinear(data, 1.0 / settings.SmoothingInverseOctaves)
                     : data);
         }
 
@@ -446,6 +752,37 @@ namespace Resonalyze.Dsp
                 data.Add(new SignalPoint(f, minimumPhase[i] / Math.PI * 180.0));
             }
 
+            return new AnalysisCurve(
+                "Minimum Phase",
+                smoothingInverseOctaves > 0
+                    ? SmoothLinear(data, 1.0 / smoothingInverseOctaves)
+                    : data,
+                AnalysisCurveKind.MinimumPhase);
+        }
+
+        public static AnalysisCurve GetMinimumPhase(
+            IImpulseMeasurement measurement,
+            PhaseAnalysisSettings settings)
+        {
+            Complex[] spectrum = BuildAnalysisSpectrum(measurement, settings, out _);
+            return BuildMinimumPhaseCurve(
+                spectrum, measurement.SampleRate, settings.SmoothingInverseOctaves);
+        }
+
+        private static AnalysisCurve BuildMinimumPhaseCurve(
+            Complex[] spectrum,
+            int sampleRate,
+            double smoothingInverseOctaves)
+        {
+            double[] magnitude = spectrum.Select(value => value.Magnitude).ToArray();
+            double[] minimumPhase = MinimumPhase.FromMagnitude(magnitude);
+            var data = new List<SignalPoint>(spectrum.Length / 2);
+            for (int i = 1; i < spectrum.Length / 2; i++)
+            {
+                data.Add(new SignalPoint(
+                    i * sampleRate / (double)spectrum.Length,
+                    minimumPhase[i] / Math.PI * 180.0));
+            }
             return new AnalysisCurve(
                 "Minimum Phase",
                 smoothingInverseOctaves > 0
@@ -517,6 +854,39 @@ namespace Resonalyze.Dsp
                 AnalysisCurveKind.ExcessPhase);
         }
 
+        public static AnalysisCurve GetExcessPhase(
+            IImpulseMeasurement measurement,
+            PhaseAnalysisSettings settings,
+            IReadOnlyList<double>? coherence = null)
+        {
+            Complex[] spectrum = BuildAnalysisSpectrum(measurement, settings, out int extractionStart);
+            double detrendMilliseconds = ResolveDetrendMilliseconds(
+                spectrum, extractionStart, measurement.SampleRate, settings);
+            List<SignalPoint> measured = BuildMeasuredPhase(
+                spectrum,
+                extractionStart,
+                detrendMilliseconds * measurement.SampleRate / 1000.0,
+                measurement.SampleRate,
+                unwrap: true,
+                coherence);
+            double[] minimumPhase = MinimumPhase.FromMagnitude(
+                spectrum.Select(value => value.Magnitude).ToArray());
+            var data = new List<SignalPoint>(measured.Count);
+            for (int j = 0; j < measured.Count; j++)
+            {
+                double excess = double.IsNaN(measured[j].Y)
+                    ? double.NaN
+                    : measured[j].Y - minimumPhase[j + 1];
+                data.Add(new SignalPoint(measured[j].X, excess / Math.PI * 180.0));
+            }
+            return new AnalysisCurve(
+                "Excess Phase",
+                settings.SmoothingInverseOctaves > 0
+                    ? SmoothLinear(data, 1.0 / settings.SmoothingInverseOctaves)
+                    : data,
+                AnalysisCurveKind.ExcessPhase);
+        }
+
         /// <summary>
         /// Estimates the τ (in milliseconds) that flattens the excess phase, using the
         /// same window as the displayed curves. Returns both the energy-weighted
@@ -539,16 +909,27 @@ namespace Resonalyze.Dsp
                 rightMs,
                 out int extractionStart);
 
-            ExcessDelayResult result = ExcessDelay.Estimate(
-                spectrum,
-                measurement.SampleRate);
+            return EstimatePhaseDetrend(spectrum, extractionStart, measurement.SampleRate);
+        }
 
-            // ExcessDelay reports the delay relative to the window start; add the
-            // extraction start to get an absolute sample, then convert to ms.
-            double toMilliseconds = 1000.0 / measurement.SampleRate;
-            double slopeMs = (extractionStart + result.SlopeDelaySamples) * toMilliseconds;
-            double peakMs = (extractionStart + result.PeakDelaySamples) * toMilliseconds;
-            return (slopeMs, peakMs);
+        public static (double SlopeMilliseconds, double PeakMilliseconds) EstimatePhaseDetrend(
+            IImpulseMeasurement measurement,
+            PhaseAnalysisSettings settings)
+        {
+            Complex[] spectrum = BuildAnalysisSpectrum(measurement, settings, out int extractionStart);
+            return EstimatePhaseDetrend(spectrum, extractionStart, measurement.SampleRate);
+        }
+
+        private static (double SlopeMilliseconds, double PeakMilliseconds) EstimatePhaseDetrend(
+            Complex[] spectrum,
+            int extractionStart,
+            int sampleRate)
+        {
+            ExcessDelayResult result = ExcessDelay.Estimate(spectrum, sampleRate);
+            double toMilliseconds = 1000.0 / sampleRate;
+            return (
+                (extractionStart + result.SlopeDelaySamples) * toMilliseconds,
+                (extractionStart + result.PeakDelaySamples) * toMilliseconds);
         }
 
         // Minimal energy-weighted smoothing applied even when display smoothing is

--- a/dsp/DataHelper.cs
+++ b/dsp/DataHelper.cs
@@ -51,6 +51,22 @@ namespace Resonalyze.Dsp
         public double PhasePlateauMs { get; set; } = DefaultPhasePlateauMs;
         public double PhaseRightMs { get; set; } = DefaultPhaseRightMs;
         public double PhaseDetrendMs { get; set; } = DefaultPhaseDetrendMs;
+        public PhaseWindowMode PhaseWindowMode { get; set; } =
+            PhaseWindowMode.FrequencyDependent;
+        public int PhaseFdwCycles { get; set; } = PhaseAnalysisSettings.DefaultFdwCycles;
+        public PhaseDetrendMode PhaseDetrendMode { get; set; } = PhaseDetrendMode.Auto;
+
+        public PhaseAnalysisSettings CreatePhaseAnalysisSettings() => new(
+            PhaseWindowMode,
+            PhaseFdwCycles,
+            PhaseDetrendMode,
+            PhaseDetrendMs,
+            PhaseGateOffsetMs,
+            PhaseLeftMs,
+            PhasePlateauMs,
+            PhaseRightMs,
+            Unwrap,
+            SmoothingInverseOctaves);
 
         // Single source of truth for the group-delay gate defaults (ms). Group delay is
         // usually viewed a bit lower than the phase crossover region, so the gate is

--- a/dsp/PhaseAnalysisSettings.cs
+++ b/dsp/PhaseAnalysisSettings.cs
@@ -1,0 +1,33 @@
+namespace Resonalyze.Dsp;
+
+public enum PhaseWindowMode
+{
+    Fixed,
+    FrequencyDependent
+}
+
+public enum PhaseDetrendMode
+{
+    Off,
+    Auto,
+    Manual
+}
+
+public sealed record PhaseAnalysisSettings(
+    PhaseWindowMode WindowMode,
+    int FdwCycles,
+    PhaseDetrendMode DetrendMode,
+    double ManualDetrendMilliseconds,
+    double GateOffsetMs,
+    double LeftMs,
+    double PlateauMs,
+    double RightMs,
+    bool Unwrap,
+    double SmoothingInverseOctaves)
+{
+    public const int DefaultFdwCycles = 6;
+
+    public int ValidatedFdwCycles => FdwCycles is 4 or 6 or 8
+        ? FdwCycles
+        : DefaultFdwCycles;
+}

--- a/source/Options/PROpt.cs
+++ b/source/Options/PROpt.cs
@@ -7,10 +7,11 @@ namespace Resonalyze.Options
     public partial class PROpt : ImpulsePreviewOptionsForm
     {
         private Func<CompareAnalysisSource?>? getCompare;
-        private readonly ComboBox comboWindowMode = new();
-        private readonly ComboBox comboFdwCycles = new();
-        private readonly ComboBox comboDetrendMode = new();
-        private readonly Label labelAutoDetrend = new();
+        private readonly DarkComboBox comboWindowMode = new();
+        private readonly DarkComboBox comboFdwCycles = new();
+        private readonly DarkComboBox comboDetrendMode = new();
+        private double manualDetrendMilliseconds;
+        private bool updatingDetrendDisplay;
 
         public PROpt()
         {
@@ -22,6 +23,14 @@ namespace Resonalyze.Options
             buttonFit.Click += buttonFit_Click;
             buttonTauSlope.Click += (_, _) => ApplyEstimatedTau(useSlope: true);
             buttonTauPeak.Click += (_, _) => ApplyEstimatedTau(useSlope: false);
+            numericOffset.ValueChanged += (_, _) =>
+            {
+                if (!updatingDetrendDisplay &&
+                    comboDetrendMode.SelectedIndex == (int)PhaseDetrendMode.Manual)
+                {
+                    manualDetrendMilliseconds = (double)numericOffset.Value;
+                }
+            };
             ConfigureResetDefaults();
             SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
             InitializeToolTips();
@@ -35,6 +44,7 @@ namespace Resonalyze.Options
         {
             AttachMeasurement(expSweepMeasurement);
             this.getCompare = getCompare;
+            manualDetrendMilliseconds = opt.PhaseDetrendMs;
             InitializeControls(() =>
             {
                 numericGateOffset.Value = ClampToControl(numericGateOffset, opt.PhaseGateOffsetMs);
@@ -70,7 +80,7 @@ namespace Resonalyze.Options
                 comboSmoothingInverseOctaves.SelectedItem is int inverseOctaves
                     ? inverseOctaves
                     : SmoothingPresetOptions.SupportedInverseOctaves[0];
-            opt.PhaseDetrendMs = (double)numericOffset.Value;
+            opt.PhaseDetrendMs = manualDetrendMilliseconds;
             opt.PhaseWindowMode = comboWindowMode.SelectedIndex == 0
                 ? PhaseWindowMode.Fixed
                 : PhaseWindowMode.FrequencyDependent;
@@ -104,17 +114,12 @@ namespace Resonalyze.Options
             comboFdwCycles.Items.AddRange([4, 6, 8]);
             AddModeControl("Detrend", comboDetrendMode, 62);
             comboDetrendMode.Items.AddRange(["Off", "Auto", "Manual"]);
-            labelAutoDetrend.AutoSize = true;
-            labelAutoDetrend.ForeColor = Color.Gainsboro;
-            labelAutoDetrend.Location = new Point(12, 84);
-            Controls.Add(labelAutoDetrend);
-
             comboWindowMode.SelectedIndexChanged += (_, _) => UpdatePhaseControlState();
             comboFdwCycles.SelectedIndexChanged += (_, _) => UpdatePhaseControlState();
             comboDetrendMode.SelectedIndexChanged += (_, _) => UpdatePhaseControlState();
         }
 
-        private void AddModeControl(string text, ComboBox combo, int top)
+        private void AddModeControl(string text, DarkComboBox combo, int top)
         {
             var label = new Label
             {
@@ -125,7 +130,7 @@ namespace Resonalyze.Options
             };
             combo.DropDownStyle = ComboBoxStyle.DropDownList;
             combo.Location = new Point(153, top);
-            combo.Size = new Size(100, 23);
+            combo.Size = new Size(100, 19);
             Controls.Add(label);
             Controls.Add(combo);
         }
@@ -137,19 +142,40 @@ namespace Resonalyze.Options
             numericOffset.Enabled = manual;
             buttonTauSlope.Enabled = manual;
             buttonTauPeak.Enabled = manual;
-            labelAutoDetrend.Text = comboDetrendMode.SelectedIndex == (int)PhaseDetrendMode.Auto
-                ? ResolveAutoDetrendLabel()
-                : string.Empty;
+            UpdateDetrendDisplay();
         }
 
-        private string ResolveAutoDetrendLabel()
+        private void UpdateDetrendDisplay()
         {
+            double displayed = comboDetrendMode.SelectedIndex switch
+            {
+                (int)PhaseDetrendMode.Off => 0.0,
+                (int)PhaseDetrendMode.Auto when TryResolveAutoDetrend(out double resolved) =>
+                    resolved,
+                (int)PhaseDetrendMode.Manual => manualDetrendMilliseconds,
+                _ => 0.0
+            };
+
+            updatingDetrendDisplay = true;
             try
             {
-                if (Measurement is not { InProgress: false } measurement ||
+                numericOffset.Value = ClampToControl(numericOffset, displayed);
+            }
+            finally
+            {
+                updatingDetrendDisplay = false;
+            }
+        }
+
+        private bool TryResolveAutoDetrend(out double resolved)
+        {
+            resolved = 0.0;
+            try
+            {
+                if (Measurement is not { } measurement ||
                     measurement.TransferImpulseResponse is not { Length: > 0 })
                 {
-                    return "Auto detrend: —";
+                    return false;
                 }
                 IImpulseMeasurement impulse =
                     new MeasurementPlotContext(measurement).CreatePrimaryMeasurement();
@@ -170,12 +196,12 @@ namespace Resonalyze.Options
                     comboSmoothingInverseOctaves.SelectedItem is int smoothing
                         ? smoothing
                         : FrequencyResponseOptions.DefaultPhaseSmoothingInverseOctaves);
-                double resolved = DataHelper.ResolvePhaseDetrendMilliseconds(impulse, settings);
-                return $"Auto detrend: {resolved:0.00} ms";
+                resolved = DataHelper.ResolvePhaseDetrendMilliseconds(impulse, settings);
+                return double.IsFinite(resolved);
             }
             catch (InvalidOperationException)
             {
-                return "Auto detrend: —";
+                return false;
             }
         }
 
@@ -269,6 +295,11 @@ namespace Resonalyze.Options
 
         protected override void RenderIrPreview()
         {
+            if (comboDetrendMode.SelectedIndex == (int)PhaseDetrendMode.Auto)
+            {
+                UpdateDetrendDisplay();
+            }
+
             if (Measurement == null || Measurement.SampleRate <= 0)
             {
                 return;
@@ -307,7 +338,7 @@ namespace Resonalyze.Options
                 "Applies octave smoothing to the phase traces.");
             numericOffset.ApplyToolTip(
                 toolTip,
-                "τ: linear-phase reference (delay) in milliseconds, removed to make the excess phase readable. Enter the same τ on two measurements to compare their relative phase.");
+                "τ: linear-phase reference in milliseconds. Auto shows the resolved read-only value here; Manual restores and edits the saved user value; Off shows zero.");
             toolTip.SetToolTip(
                 buttonTauSlope,
                 "Auto-find τ from the energy-weighted average group delay (flattens the excess-phase trend).");

--- a/source/Options/PROpt.cs
+++ b/source/Options/PROpt.cs
@@ -179,23 +179,8 @@ namespace Resonalyze.Options
                 }
                 IImpulseMeasurement impulse =
                     new MeasurementPlotContext(measurement).CreatePrimaryMeasurement();
-                var settings = new PhaseAnalysisSettings(
-                    comboWindowMode.SelectedIndex == 0
-                        ? PhaseWindowMode.Fixed
-                        : PhaseWindowMode.FrequencyDependent,
-                    comboFdwCycles.SelectedItem is int cycles
-                        ? cycles
-                        : PhaseAnalysisSettings.DefaultFdwCycles,
-                    PhaseDetrendMode.Auto,
-                    (double)numericOffset.Value,
-                    (double)numericGateOffset.Value,
-                    (double)numericLeftWindow.Value,
-                    (double)numericWindow.Value,
-                    (double)numericRightWindow.Value,
-                    checkBoxUnwrap.Checked,
-                    comboSmoothingInverseOctaves.SelectedItem is int smoothing
-                        ? smoothing
-                        : FrequencyResponseOptions.DefaultPhaseSmoothingInverseOctaves);
+                PhaseAnalysisSettings settings = CreateCurrentPhaseAnalysisSettings(
+                    PhaseDetrendMode.Auto);
                 resolved = DataHelper.ResolvePhaseDetrendMilliseconds(impulse, settings);
                 return double.IsFinite(resolved);
             }
@@ -204,6 +189,31 @@ namespace Resonalyze.Options
                 return false;
             }
         }
+
+        private PhaseAnalysisSettings CreateCurrentPhaseAnalysisSettings(
+            PhaseDetrendMode detrendMode) => new(
+                comboWindowMode.SelectedIndex == 0
+                    ? PhaseWindowMode.Fixed
+                    : PhaseWindowMode.FrequencyDependent,
+                comboFdwCycles.SelectedItem is int cycles
+                    ? cycles
+                    : PhaseAnalysisSettings.DefaultFdwCycles,
+                detrendMode,
+                manualDetrendMilliseconds,
+                (double)numericGateOffset.Value,
+                (double)numericLeftWindow.Value,
+                (double)numericWindow.Value,
+                (double)numericRightWindow.Value,
+                checkBoxUnwrap.Checked,
+                comboSmoothingInverseOctaves.SelectedItem is int smoothing
+                    ? smoothing
+                    : FrequencyResponseOptions.DefaultPhaseSmoothingInverseOctaves);
+
+        internal (double SlopeMilliseconds, double PeakMilliseconds)
+            EstimateCurrentPhaseDetrend(IImpulseMeasurement impulse) =>
+                DataHelper.EstimatePhaseDetrend(
+                    impulse,
+                    CreateCurrentPhaseAnalysisSettings(PhaseDetrendMode.Auto));
 
         // Points each field's "R" reset button at the built-in default values.
         private void ConfigureResetDefaults()
@@ -236,15 +246,11 @@ namespace Resonalyze.Options
             {
                 IImpulseMeasurement impulse =
                     new MeasurementPlotContext(measurement).CreatePrimaryMeasurement();
-                (double slopeMs, double peakMs) = DataHelper.EstimatePhaseDetrend(
-                    impulse,
-                    (double)numericGateOffset.Value,
-                    (double)numericLeftWindow.Value,
-                    (double)numericWindow.Value,
-                    (double)numericRightWindow.Value);
+                (double slopeMs, double peakMs) = EstimateCurrentPhaseDetrend(impulse);
                 numericOffset.Value = ClampToControl(
                     numericOffset,
                     useSlope ? slopeMs : peakMs);
+                manualDetrendMilliseconds = (double)numericOffset.Value;
             }
             catch (InvalidOperationException)
             {

--- a/source/Options/PROpt.cs
+++ b/source/Options/PROpt.cs
@@ -7,10 +7,15 @@ namespace Resonalyze.Options
     public partial class PROpt : ImpulsePreviewOptionsForm
     {
         private Func<CompareAnalysisSource?>? getCompare;
+        private readonly ComboBox comboWindowMode = new();
+        private readonly ComboBox comboFdwCycles = new();
+        private readonly ComboBox comboDetrendMode = new();
+        private readonly Label labelAutoDetrend = new();
 
         public PROpt()
         {
             InitializeComponent();
+            InitializePhaseAnalysisControls();
             numericLeftWindow.ValueChanged += Gate_ValueChanged;
             numericRightWindow.ValueChanged += Gate_ValueChanged;
             numericGateOffset.ValueChanged += (_, _) => UpdateIrPreview();
@@ -39,6 +44,11 @@ namespace Resonalyze.Options
                 comboSmoothingInverseOctaves.SelectedItem =
                     SmoothingPresetOptions.Normalize(opt.SmoothingInverseOctaves);
                 numericOffset.Value = ClampToControl(numericOffset, opt.PhaseDetrendMs);
+                comboWindowMode.SelectedItem = opt.PhaseWindowMode;
+                comboFdwCycles.SelectedItem = opt.PhaseFdwCycles is 4 or 6 or 8
+                    ? opt.PhaseFdwCycles
+                    : PhaseAnalysisSettings.DefaultFdwCycles;
+                comboDetrendMode.SelectedItem = opt.PhaseDetrendMode;
                 checkBoxUnwrap.Checked = opt.Unwrap;
                 checkBoxShowMeasured.Checked = visibility.ShowMeasuredPhase;
                 checkBoxShowMinimum.Checked = visibility.ShowMinimumPhase;
@@ -46,6 +56,7 @@ namespace Resonalyze.Options
                 checkBoxShowCoherence.Checked = visibility.ShowCoherence;
             });
             UpdateMinFrequencyLabel();
+            UpdatePhaseControlState();
             UpdateIrPreview();
         }
 
@@ -60,12 +71,112 @@ namespace Resonalyze.Options
                     ? inverseOctaves
                     : SmoothingPresetOptions.SupportedInverseOctaves[0];
             opt.PhaseDetrendMs = (double)numericOffset.Value;
+            opt.PhaseWindowMode = comboWindowMode.SelectedItem is PhaseWindowMode windowMode
+                ? windowMode
+                : PhaseWindowMode.FrequencyDependent;
+            opt.PhaseFdwCycles = comboFdwCycles.SelectedItem is int cycles
+                ? cycles
+                : PhaseAnalysisSettings.DefaultFdwCycles;
+            opt.PhaseDetrendMode = comboDetrendMode.SelectedItem is PhaseDetrendMode detrendMode
+                ? detrendMode
+                : PhaseDetrendMode.Auto;
             opt.Unwrap = checkBoxUnwrap.Checked;
             visibility.ShowMeasuredPhase = checkBoxShowMeasured.Checked;
             visibility.ShowMinimumPhase = checkBoxShowMinimum.Checked;
             visibility.ShowExcessPhase = checkBoxShowExcess.Checked;
             visibility.ShowCoherence = checkBoxShowCoherence.Checked;
             UpdateIrPreview();
+        }
+
+        private void InitializePhaseAnalysisControls()
+        {
+            const int addedHeight = 92;
+            foreach (Control control in Controls.Cast<Control>().ToArray())
+            {
+                control.Top += addedHeight;
+            }
+            ClientSize = new Size(ClientSize.Width, ClientSize.Height + addedHeight);
+
+            AddModeControl("Window", comboWindowMode, 10);
+            comboWindowMode.DataSource = Enum.GetValues<PhaseWindowMode>();
+            AddModeControl("FDW cycles", comboFdwCycles, 36);
+            comboFdwCycles.Items.AddRange([4, 6, 8]);
+            AddModeControl("Detrend", comboDetrendMode, 62);
+            comboDetrendMode.DataSource = Enum.GetValues<PhaseDetrendMode>();
+            labelAutoDetrend.AutoSize = true;
+            labelAutoDetrend.ForeColor = Color.Gainsboro;
+            labelAutoDetrend.Location = new Point(12, 84);
+            Controls.Add(labelAutoDetrend);
+
+            comboWindowMode.SelectedIndexChanged += (_, _) => UpdatePhaseControlState();
+            comboFdwCycles.SelectedIndexChanged += (_, _) => UpdatePhaseControlState();
+            comboDetrendMode.SelectedIndexChanged += (_, _) => UpdatePhaseControlState();
+        }
+
+        private void AddModeControl(string text, ComboBox combo, int top)
+        {
+            var label = new Label
+            {
+                AutoSize = true,
+                ForeColor = Color.Gainsboro,
+                Location = new Point(12, top + 4),
+                Text = text
+            };
+            combo.DropDownStyle = ComboBoxStyle.DropDownList;
+            combo.Location = new Point(153, top);
+            combo.Size = new Size(100, 23);
+            Controls.Add(label);
+            Controls.Add(combo);
+        }
+
+        private void UpdatePhaseControlState()
+        {
+            comboFdwCycles.Enabled = comboWindowMode.SelectedItem is
+                PhaseWindowMode.FrequencyDependent;
+            bool manual = comboDetrendMode.SelectedItem is PhaseDetrendMode.Manual;
+            numericOffset.Enabled = manual;
+            buttonTauSlope.Enabled = manual;
+            buttonTauPeak.Enabled = manual;
+            labelAutoDetrend.Text = comboDetrendMode.SelectedItem is PhaseDetrendMode.Auto
+                ? ResolveAutoDetrendLabel()
+                : string.Empty;
+        }
+
+        private string ResolveAutoDetrendLabel()
+        {
+            try
+            {
+                if (Measurement is not { InProgress: false } measurement ||
+                    measurement.TransferImpulseResponse is not { Length: > 0 })
+                {
+                    return "Auto detrend: —";
+                }
+                IImpulseMeasurement impulse =
+                    new MeasurementPlotContext(measurement).CreatePrimaryMeasurement();
+                var settings = new PhaseAnalysisSettings(
+                    comboWindowMode.SelectedItem is PhaseWindowMode windowMode
+                        ? windowMode
+                        : PhaseWindowMode.FrequencyDependent,
+                    comboFdwCycles.SelectedItem is int cycles
+                        ? cycles
+                        : PhaseAnalysisSettings.DefaultFdwCycles,
+                    PhaseDetrendMode.Auto,
+                    (double)numericOffset.Value,
+                    (double)numericGateOffset.Value,
+                    (double)numericLeftWindow.Value,
+                    (double)numericWindow.Value,
+                    (double)numericRightWindow.Value,
+                    checkBoxUnwrap.Checked,
+                    comboSmoothingInverseOctaves.SelectedItem is int smoothing
+                        ? smoothing
+                        : FrequencyResponseOptions.DefaultPhaseSmoothingInverseOctaves);
+                double resolved = DataHelper.ResolvePhaseDetrendMilliseconds(impulse, settings);
+                return $"Auto detrend: {resolved:0.00} ms";
+            }
+            catch (InvalidOperationException)
+            {
+                return "Auto detrend: —";
+            }
         }
 
         // Points each field's "R" reset button at the built-in default values.
@@ -223,7 +334,16 @@ namespace Resonalyze.Options
                 "Lowest frequency the current gate can resolve (≈ 1 / gate length). Below it the curve is not reliable.");
             toolTip.SetToolTip(
                 irPlotView,
-                "Preview of the impulse response and the gate window used for phase calculation.");
+                "Preview of the impulse response and the gate window used for phase calculation. FDW phase uses shorter high-frequency windows; Group Delay remains fixed-gate and is not its exact integral.");
+            toolTip.SetToolTip(
+                comboWindowMode,
+                "Fixed uses one time gate for the entire spectrum. FDW shortens the analysis window as frequency rises to suppress late cabin reflections.");
+            toolTip.SetToolTip(
+                comboFdwCycles,
+                "Periods retained by FDW: 4 suppresses reflections most, 6 is recommended, and 8 retains more reflected detail.");
+            toolTip.SetToolTip(
+                comboDetrendMode,
+                "Removes a constant delay before unwrapping. Auto flattens excess phase, Manual uses the entered delay, and Off keeps the absolute phase slope.");
         }
     }
 }

--- a/source/Options/PROpt.cs
+++ b/source/Options/PROpt.cs
@@ -44,11 +44,11 @@ namespace Resonalyze.Options
                 comboSmoothingInverseOctaves.SelectedItem =
                     SmoothingPresetOptions.Normalize(opt.SmoothingInverseOctaves);
                 numericOffset.Value = ClampToControl(numericOffset, opt.PhaseDetrendMs);
-                comboWindowMode.SelectedItem = opt.PhaseWindowMode;
+                comboWindowMode.SelectedIndex = opt.PhaseWindowMode == PhaseWindowMode.Fixed ? 0 : 1;
                 comboFdwCycles.SelectedItem = opt.PhaseFdwCycles is 4 or 6 or 8
                     ? opt.PhaseFdwCycles
                     : PhaseAnalysisSettings.DefaultFdwCycles;
-                comboDetrendMode.SelectedItem = opt.PhaseDetrendMode;
+                comboDetrendMode.SelectedIndex = (int)opt.PhaseDetrendMode;
                 checkBoxUnwrap.Checked = opt.Unwrap;
                 checkBoxShowMeasured.Checked = visibility.ShowMeasuredPhase;
                 checkBoxShowMinimum.Checked = visibility.ShowMinimumPhase;
@@ -71,15 +71,16 @@ namespace Resonalyze.Options
                     ? inverseOctaves
                     : SmoothingPresetOptions.SupportedInverseOctaves[0];
             opt.PhaseDetrendMs = (double)numericOffset.Value;
-            opt.PhaseWindowMode = comboWindowMode.SelectedItem is PhaseWindowMode windowMode
-                ? windowMode
+            opt.PhaseWindowMode = comboWindowMode.SelectedIndex == 0
+                ? PhaseWindowMode.Fixed
                 : PhaseWindowMode.FrequencyDependent;
             opt.PhaseFdwCycles = comboFdwCycles.SelectedItem is int cycles
                 ? cycles
                 : PhaseAnalysisSettings.DefaultFdwCycles;
-            opt.PhaseDetrendMode = comboDetrendMode.SelectedItem is PhaseDetrendMode detrendMode
-                ? detrendMode
-                : PhaseDetrendMode.Auto;
+            opt.PhaseDetrendMode = Enum.IsDefined(
+                (PhaseDetrendMode)comboDetrendMode.SelectedIndex)
+                    ? (PhaseDetrendMode)comboDetrendMode.SelectedIndex
+                    : PhaseDetrendMode.Auto;
             opt.Unwrap = checkBoxUnwrap.Checked;
             visibility.ShowMeasuredPhase = checkBoxShowMeasured.Checked;
             visibility.ShowMinimumPhase = checkBoxShowMinimum.Checked;
@@ -98,11 +99,11 @@ namespace Resonalyze.Options
             ClientSize = new Size(ClientSize.Width, ClientSize.Height + addedHeight);
 
             AddModeControl("Window", comboWindowMode, 10);
-            comboWindowMode.DataSource = Enum.GetValues<PhaseWindowMode>();
+            comboWindowMode.Items.AddRange(["Fixed", "FDW"]);
             AddModeControl("FDW cycles", comboFdwCycles, 36);
             comboFdwCycles.Items.AddRange([4, 6, 8]);
             AddModeControl("Detrend", comboDetrendMode, 62);
-            comboDetrendMode.DataSource = Enum.GetValues<PhaseDetrendMode>();
+            comboDetrendMode.Items.AddRange(["Off", "Auto", "Manual"]);
             labelAutoDetrend.AutoSize = true;
             labelAutoDetrend.ForeColor = Color.Gainsboro;
             labelAutoDetrend.Location = new Point(12, 84);
@@ -131,13 +132,12 @@ namespace Resonalyze.Options
 
         private void UpdatePhaseControlState()
         {
-            comboFdwCycles.Enabled = comboWindowMode.SelectedItem is
-                PhaseWindowMode.FrequencyDependent;
-            bool manual = comboDetrendMode.SelectedItem is PhaseDetrendMode.Manual;
+            comboFdwCycles.Enabled = comboWindowMode.SelectedIndex == 1;
+            bool manual = comboDetrendMode.SelectedIndex == (int)PhaseDetrendMode.Manual;
             numericOffset.Enabled = manual;
             buttonTauSlope.Enabled = manual;
             buttonTauPeak.Enabled = manual;
-            labelAutoDetrend.Text = comboDetrendMode.SelectedItem is PhaseDetrendMode.Auto
+            labelAutoDetrend.Text = comboDetrendMode.SelectedIndex == (int)PhaseDetrendMode.Auto
                 ? ResolveAutoDetrendLabel()
                 : string.Empty;
         }
@@ -154,8 +154,8 @@ namespace Resonalyze.Options
                 IImpulseMeasurement impulse =
                     new MeasurementPlotContext(measurement).CreatePrimaryMeasurement();
                 var settings = new PhaseAnalysisSettings(
-                    comboWindowMode.SelectedItem is PhaseWindowMode windowMode
-                        ? windowMode
+                    comboWindowMode.SelectedIndex == 0
+                        ? PhaseWindowMode.Fixed
                         : PhaseWindowMode.FrequencyDependent,
                     comboFdwCycles.SelectedItem is int cycles
                         ? cycles

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -173,13 +173,30 @@ internal sealed class PlotModelFactory
             measurementContext.HasTransferImpulseResponse)
         {
             const string phaseTrackerFormat = "{0}\n{2:0.0} Hz\n{4:0.0}\u00B0";
+            IImpulseMeasurement primaryMeasurement =
+                measurementContext.CreatePrimaryMeasurement();
+            var compare = TryCreateCompareMeasurement();
             PhaseAnalysisSettings phaseSettings =
                 phaseResponseOptions.CreatePhaseAnalysisSettings();
+            if (phaseSettings.DetrendMode == PhaseDetrendMode.Auto && compare != null)
+            {
+                // A comparison is meaningful only with one common time reference.
+                // Resolve Auto from Main once, then reuse it as Manual for Main,
+                // Compare and both excess curves so their relative delay survives.
+                double commonDetrend = DataHelper.ResolvePhaseDetrendMilliseconds(
+                    primaryMeasurement,
+                    phaseSettings);
+                phaseSettings = phaseSettings with
+                {
+                    DetrendMode = PhaseDetrendMode.Manual,
+                    ManualDetrendMilliseconds = commonDetrend
+                };
+            }
 
             if (phaseResponseVisibility.ShowMeasuredPhase)
             {
                 AnalysisCurve curve = DataHelper.GetPhase(
-                    measurementContext.CreatePrimaryMeasurement(),
+                    primaryMeasurement,
                     phaseSettings,
                     expSweepMeasurement.TransferCoherence);
 
@@ -197,7 +214,7 @@ internal sealed class PlotModelFactory
             if (phaseResponseVisibility.ShowMinimumPhase)
             {
                 AnalysisCurve minimumPhaseCurve = DataHelper.GetMinimumPhase(
-                    measurementContext.CreatePrimaryMeasurement(),
+                    primaryMeasurement,
                     phaseSettings);
 
                 // Minimum phase is continuous (unwrapped) by construction.
@@ -213,7 +230,7 @@ internal sealed class PlotModelFactory
             if (phaseResponseVisibility.ShowExcessPhase)
             {
                 AnalysisCurve excessPhaseCurve = DataHelper.GetExcessPhase(
-                    measurementContext.CreatePrimaryMeasurement(),
+                    primaryMeasurement,
                     phaseSettings,
                     expSweepMeasurement.TransferCoherence);
 
@@ -230,19 +247,19 @@ internal sealed class PlotModelFactory
 
             // Overlay the Compare measurement with the identical gate / detrend /
             // smoothing so the two responses can be read on the same terms.
-            if (TryCreateCompareMeasurement() is { } compare)
+            if (compare is { } compareData)
             {
                 if (phaseResponseVisibility.ShowMeasuredPhase)
                 {
                     AnalysisCurve compareCurve = DataHelper.GetPhase(
-                        compare.Measurement,
+                        compareData.Measurement,
                         phaseSettings,
-                        compare.Coherence);
+                        compareData.Coherence);
                     AddCompareLineSeries(
                         model,
                         compareCurve,
                         phaseTrackerFormat,
-                        compare.DisplayName,
+                        compareData.DisplayName,
                         Mode.PhaseResponse,
                         phaseResponseOptions.Unwrap);
                 }
@@ -250,13 +267,13 @@ internal sealed class PlotModelFactory
                 if (phaseResponseVisibility.ShowMinimumPhase)
                 {
                     AnalysisCurve compareCurve = DataHelper.GetMinimumPhase(
-                        compare.Measurement,
+                        compareData.Measurement,
                         phaseSettings);
                     AddCompareLineSeries(
                         model,
                         compareCurve,
                         phaseTrackerFormat,
-                        compare.DisplayName,
+                        compareData.DisplayName,
                         Mode.PhaseResponse,
                         phaseUnwrapped: true);
                 }
@@ -264,14 +281,14 @@ internal sealed class PlotModelFactory
                 if (phaseResponseVisibility.ShowExcessPhase)
                 {
                     AnalysisCurve compareCurve = DataHelper.GetExcessPhase(
-                        compare.Measurement,
+                        compareData.Measurement,
                         phaseSettings,
-                        compare.Coherence);
+                        compareData.Coherence);
                     AddCompareLineSeries(
                         model,
                         compareCurve,
                         phaseTrackerFormat,
-                        compare.DisplayName,
+                        compareData.DisplayName,
                         Mode.PhaseResponse,
                         phaseUnwrapped: true);
                 }

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -173,18 +173,14 @@ internal sealed class PlotModelFactory
             measurementContext.HasTransferImpulseResponse)
         {
             const string phaseTrackerFormat = "{0}\n{2:0.0} Hz\n{4:0.0}\u00B0";
+            PhaseAnalysisSettings phaseSettings =
+                phaseResponseOptions.CreatePhaseAnalysisSettings();
 
             if (phaseResponseVisibility.ShowMeasuredPhase)
             {
                 AnalysisCurve curve = DataHelper.GetPhase(
                     measurementContext.CreatePrimaryMeasurement(),
-                    phaseResponseOptions.PhaseGateOffsetMs,
-                    phaseResponseOptions.PhaseLeftMs,
-                    phaseResponseOptions.PhasePlateauMs,
-                    phaseResponseOptions.PhaseRightMs,
-                    phaseResponseOptions.PhaseDetrendMs,
-                    phaseResponseOptions.SmoothingInverseOctaves,
-                    phaseResponseOptions.Unwrap,
+                    phaseSettings,
                     expSweepMeasurement.TransferCoherence);
 
                 // Measured phase can be either representation; tag it so overlay
@@ -202,11 +198,7 @@ internal sealed class PlotModelFactory
             {
                 AnalysisCurve minimumPhaseCurve = DataHelper.GetMinimumPhase(
                     measurementContext.CreatePrimaryMeasurement(),
-                    phaseResponseOptions.PhaseGateOffsetMs,
-                    phaseResponseOptions.PhaseLeftMs,
-                    phaseResponseOptions.PhasePlateauMs,
-                    phaseResponseOptions.PhaseRightMs,
-                    phaseResponseOptions.SmoothingInverseOctaves);
+                    phaseSettings);
 
                 // Minimum phase is continuous (unwrapped) by construction.
                 AddLineSeries(
@@ -222,12 +214,7 @@ internal sealed class PlotModelFactory
             {
                 AnalysisCurve excessPhaseCurve = DataHelper.GetExcessPhase(
                     measurementContext.CreatePrimaryMeasurement(),
-                    phaseResponseOptions.PhaseGateOffsetMs,
-                    phaseResponseOptions.PhaseLeftMs,
-                    phaseResponseOptions.PhasePlateauMs,
-                    phaseResponseOptions.PhaseRightMs,
-                    phaseResponseOptions.PhaseDetrendMs,
-                    phaseResponseOptions.SmoothingInverseOctaves,
+                    phaseSettings,
                     expSweepMeasurement.TransferCoherence);
 
                 // Excess phase stays continuous (unwrapped) regardless of the detrend
@@ -249,13 +236,7 @@ internal sealed class PlotModelFactory
                 {
                     AnalysisCurve compareCurve = DataHelper.GetPhase(
                         compare.Measurement,
-                        phaseResponseOptions.PhaseGateOffsetMs,
-                        phaseResponseOptions.PhaseLeftMs,
-                        phaseResponseOptions.PhasePlateauMs,
-                        phaseResponseOptions.PhaseRightMs,
-                        phaseResponseOptions.PhaseDetrendMs,
-                        phaseResponseOptions.SmoothingInverseOctaves,
-                        phaseResponseOptions.Unwrap,
+                        phaseSettings,
                         compare.Coherence);
                     AddCompareLineSeries(
                         model,
@@ -270,11 +251,7 @@ internal sealed class PlotModelFactory
                 {
                     AnalysisCurve compareCurve = DataHelper.GetMinimumPhase(
                         compare.Measurement,
-                        phaseResponseOptions.PhaseGateOffsetMs,
-                        phaseResponseOptions.PhaseLeftMs,
-                        phaseResponseOptions.PhasePlateauMs,
-                        phaseResponseOptions.PhaseRightMs,
-                        phaseResponseOptions.SmoothingInverseOctaves);
+                        phaseSettings);
                     AddCompareLineSeries(
                         model,
                         compareCurve,
@@ -288,12 +265,7 @@ internal sealed class PlotModelFactory
                 {
                     AnalysisCurve compareCurve = DataHelper.GetExcessPhase(
                         compare.Measurement,
-                        phaseResponseOptions.PhaseGateOffsetMs,
-                        phaseResponseOptions.PhaseLeftMs,
-                        phaseResponseOptions.PhasePlateauMs,
-                        phaseResponseOptions.PhaseRightMs,
-                        phaseResponseOptions.PhaseDetrendMs,
-                        phaseResponseOptions.SmoothingInverseOctaves,
+                        phaseSettings,
                         compare.Coherence);
                     AddCompareLineSeries(
                         model,

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -7,7 +7,7 @@ namespace Resonalyze;
 
 internal sealed class MeasurementSettingsFile
 {
-    private const int CurrentSchemaVersion = 7;
+    private const int CurrentSchemaVersion = 8;
     private const string FileName = "measurement-settings.json";
 
     private static readonly JsonSerializerOptions SerializerOptions = new()
@@ -51,9 +51,20 @@ internal sealed class MeasurementSettingsFile
                 JsonSerializer.Deserialize<MeasurementSettingsFile>(
                     stream,
                     SerializerOptions);
-            if (settings?.SchemaVersion != CurrentSchemaVersion)
+            if (settings == null || settings.SchemaVersion is not (7 or CurrentSchemaVersion))
             {
                 return new MeasurementSettingsFile();
+            }
+
+            if (settings.SchemaVersion == 7)
+            {
+                settings.PhaseResponse.PhaseWindowMode =
+                    Resonalyze.Dsp.PhaseWindowMode.Fixed;
+                settings.PhaseResponse.PhaseDetrendMode =
+                    Resonalyze.Dsp.PhaseDetrendMode.Manual;
+                settings.PhaseResponse.PhaseFdwCycles =
+                    PhaseAnalysisSettings.DefaultFdwCycles;
+                settings.SchemaVersion = CurrentSchemaVersion;
             }
 
             settings.MigrateLegacyDualDeviceLoopback();
@@ -302,6 +313,11 @@ internal sealed class MeasurementSettingsFile
         public double PhasePlateauMs { get; set; } = FrequencyResponseOptions.DefaultPhasePlateauMs;
         public double PhaseRightMs { get; set; } = FrequencyResponseOptions.DefaultPhaseRightMs;
         public double PhaseDetrendMs { get; set; } = FrequencyResponseOptions.DefaultPhaseDetrendMs;
+        public PhaseWindowMode? PhaseWindowMode { get; set; } =
+            Resonalyze.Dsp.PhaseWindowMode.FrequencyDependent;
+        public int PhaseFdwCycles { get; set; } = PhaseAnalysisSettings.DefaultFdwCycles;
+        public PhaseDetrendMode? PhaseDetrendMode { get; set; } =
+            Resonalyze.Dsp.PhaseDetrendMode.Auto;
         public double GroupDelayGateOffsetMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayGateOffsetMs;
         public double GroupDelayLeftMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayLeftMs;
         public double GroupDelayPlateauMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayPlateauMs;
@@ -336,6 +352,9 @@ internal sealed class MeasurementSettingsFile
                 PhasePlateauMs = options.PhasePlateauMs,
                 PhaseRightMs = options.PhaseRightMs,
                 PhaseDetrendMs = options.PhaseDetrendMs,
+                PhaseWindowMode = options.PhaseWindowMode,
+                PhaseFdwCycles = options.PhaseFdwCycles,
+                PhaseDetrendMode = options.PhaseDetrendMode,
                 GroupDelayGateOffsetMs = options.GroupDelayGateOffsetMs,
                 GroupDelayLeftMs = options.GroupDelayLeftMs,
                 GroupDelayPlateauMs = options.GroupDelayPlateauMs,
@@ -371,6 +390,19 @@ internal sealed class MeasurementSettingsFile
             options.PhasePlateauMs = ClampMilliseconds(PhasePlateauMs, 0.0, 1000.0);
             options.PhaseRightMs = ClampMilliseconds(PhaseRightMs, 0.0, 1000.0);
             options.PhaseDetrendMs = ClampMilliseconds(PhaseDetrendMs, -2000.0, 2000.0);
+            // Missing fields identify the pre-FDW format: retain its Fixed/manual
+            // representation rather than silently changing existing projects.
+            options.PhaseWindowMode = PhaseWindowMode is { } windowMode &&
+                Enum.IsDefined(windowMode)
+                    ? windowMode
+                    : Resonalyze.Dsp.PhaseWindowMode.Fixed;
+            options.PhaseFdwCycles = PhaseFdwCycles is 4 or 6 or 8
+                ? PhaseFdwCycles
+                : PhaseAnalysisSettings.DefaultFdwCycles;
+            options.PhaseDetrendMode = PhaseDetrendMode is { } detrendMode &&
+                Enum.IsDefined(detrendMode)
+                    ? detrendMode
+                    : Resonalyze.Dsp.PhaseDetrendMode.Manual;
             options.GroupDelayGateOffsetMs = ClampMilliseconds(GroupDelayGateOffsetMs, 0.0, 2000.0);
             options.GroupDelayLeftMs = ClampMilliseconds(GroupDelayLeftMs, 0.0, 1000.0);
             options.GroupDelayPlateauMs = ClampMilliseconds(GroupDelayPlateauMs, 0.0, 1000.0);

--- a/source/Tools/VirtualCrossoverGateDialog.cs
+++ b/source/Tools/VirtualCrossoverGateDialog.cs
@@ -35,11 +35,19 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
     [System.ComponentModel.Browsable(false)]
     [System.ComponentModel.DesignerSerializationVisibility(
         System.ComponentModel.DesignerSerializationVisibility.Hidden)]
-    public Action<double, double, double, double, double>? PreviewChanged { get; set; }
+    public Action<double, double, double, double, PhaseWindowMode, int,
+        PhaseDetrendMode, double, bool>? PreviewChanged { get; set; }
+
+    private readonly ComboBox comboWindowMode = new();
+    private readonly ComboBox comboFdwCycles = new();
+    private readonly ComboBox comboDetrendMode = new();
+    private readonly CheckBox checkBoxUnwrap = new();
+    private readonly Label labelAutoDetrend = new();
 
     public VirtualCrossoverGateDialog()
     {
         InitializeComponent();
+        InitializePhaseControls();
         numericGateOffset.ValueChanged += (_, _) => OnGateChanged();
         numericLeft.ValueChanged += (_, _) => OnGateChanged();
         numericPlateau.ValueChanged += (_, _) => OnGateChanged();
@@ -62,6 +70,17 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
     public double PlateauMs => (double)numericPlateau.Value;
     public double RightMs => (double)numericRight.Value;
     public double DetrendMs => (double)numericTau.Value;
+    public PhaseWindowMode WindowMode => comboWindowMode.SelectedIndex == 0
+        ? PhaseWindowMode.Fixed
+        : PhaseWindowMode.FrequencyDependent;
+    public int FdwCycles => comboFdwCycles.SelectedItem is int cycles
+        ? cycles
+        : PhaseAnalysisSettings.DefaultFdwCycles;
+    public PhaseDetrendMode DetrendMode =>
+        Enum.IsDefined((PhaseDetrendMode)comboDetrendMode.SelectedIndex)
+            ? (PhaseDetrendMode)comboDetrendMode.SelectedIndex
+            : PhaseDetrendMode.Auto;
+    public bool Unwrap => checkBoxUnwrap.Checked;
 
     /// <summary>
     /// Seeds the dialog: the processed channel IRs to preview (absolute
@@ -76,6 +95,10 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         double plateauMs,
         double rightMs,
         double detrendMs,
+        PhaseWindowMode windowMode,
+        int fdwCycles,
+        PhaseDetrendMode detrendMode,
+        bool unwrap,
         double fitToMs)
     {
         traces = previewTraces;
@@ -87,6 +110,12 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         numericPlateau.Value = Clamp(numericPlateau, plateauMs);
         numericRight.Value = Clamp(numericRight, rightMs);
         numericTau.Value = Clamp(numericTau, detrendMs);
+        comboWindowMode.SelectedIndex = windowMode == PhaseWindowMode.Fixed ? 0 : 1;
+        comboFdwCycles.SelectedItem = fdwCycles is 4 or 6 or 8
+            ? fdwCycles
+            : PhaseAnalysisSettings.DefaultFdwCycles;
+        comboDetrendMode.SelectedIndex = (int)detrendMode;
+        checkBoxUnwrap.Checked = unwrap;
 
         initialized = true;
         OnGateChanged();
@@ -110,8 +139,10 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
             earliest.Samples,
             VirtualCrossoverAnalysis.FindPeakIndex(earliest.Samples),
             sampleRate);
-        (double slopeMs, double peakMs) = DataHelper.EstimatePhaseDetrend(
-            view, GateOffsetMs, LeftMs, PlateauMs, RightMs);
+        var settings = new PhaseAnalysisSettings(
+            WindowMode, FdwCycles, PhaseDetrendMode.Auto, DetrendMs,
+            GateOffsetMs, LeftMs, PlateauMs, RightMs, Unwrap, 0.0);
+        (double slopeMs, double peakMs) = DataHelper.EstimatePhaseDetrend(view, settings);
         numericTau.Value = Clamp(numericTau, useSlope ? slopeMs : peakMs);
     }
 
@@ -124,7 +155,91 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
 
         UpdateMinFrequencyLabel();
         UpdatePreview();
-        PreviewChanged?.Invoke(GateOffsetMs, LeftMs, PlateauMs, RightMs, DetrendMs);
+        UpdatePhaseControlState();
+        PreviewChanged?.Invoke(
+            GateOffsetMs, LeftMs, PlateauMs, RightMs, WindowMode, FdwCycles,
+            DetrendMode, DetrendMs, Unwrap);
+    }
+
+    private void InitializePhaseControls()
+    {
+        const int addedHeight = 62;
+        irPlotView.Top += addedHeight;
+        buttonSave.Top += addedHeight;
+        buttonCancel.Top += addedHeight;
+        ClientSize = new Size(ClientSize.Width, ClientSize.Height + addedHeight);
+
+        AddCombo("Window", comboWindowMode, 102, 112);
+        comboWindowMode.Items.AddRange(["Fixed", "FDW"]);
+        AddCombo("FDW cycles", comboFdwCycles, 102, 322);
+        comboFdwCycles.Items.AddRange([4, 6, 8]);
+        AddCombo("Detrend", comboDetrendMode, 132, 112);
+        comboDetrendMode.Items.AddRange(["Off", "Auto", "Manual"]);
+
+        checkBoxUnwrap.AutoSize = true;
+        checkBoxUnwrap.ForeColor = Color.White;
+        checkBoxUnwrap.Location = new Point(414, 106);
+        checkBoxUnwrap.Text = "Unwrap";
+        Controls.Add(checkBoxUnwrap);
+        labelAutoDetrend.AutoSize = true;
+        labelAutoDetrend.ForeColor = Color.FromArgb(210, 214, 222);
+        labelAutoDetrend.Location = new Point(262, 136);
+        Controls.Add(labelAutoDetrend);
+
+        comboWindowMode.SelectedIndexChanged += (_, _) => OnGateChanged();
+        comboFdwCycles.SelectedIndexChanged += (_, _) => OnGateChanged();
+        comboDetrendMode.SelectedIndexChanged += (_, _) => OnGateChanged();
+        checkBoxUnwrap.CheckedChanged += (_, _) => OnGateChanged();
+    }
+
+    private void AddCombo(string text, ComboBox combo, int top, int left)
+    {
+        var label = new Label
+        {
+            AutoSize = true,
+            Font = new Font("Segoe UI Semibold", 9F),
+            ForeColor = Color.FromArgb(210, 214, 222),
+            Location = new Point(left - 100, top + 4),
+            Text = text
+        };
+        combo.DropDownStyle = ComboBoxStyle.DropDownList;
+        combo.Location = new Point(left, top);
+        combo.Size = new Size(126, 23);
+        Controls.Add(label);
+        Controls.Add(combo);
+    }
+
+    private void UpdatePhaseControlState()
+    {
+        comboFdwCycles.Enabled = WindowMode == PhaseWindowMode.FrequencyDependent;
+        bool manual = DetrendMode == PhaseDetrendMode.Manual;
+        numericTau.Enabled = manual;
+        buttonTauSlope.Enabled = manual;
+        buttonTauPeak.Enabled = manual;
+        labelAutoDetrend.Text = DetrendMode == PhaseDetrendMode.Auto
+            ? ResolveAutoDetrendLabel()
+            : string.Empty;
+    }
+
+    private string ResolveAutoDetrendLabel()
+    {
+        IrPreviewTrace? reference = traces
+            .OrderBy(trace => VirtualCrossoverAnalysis.FindPeakIndex(trace.Samples))
+            .FirstOrDefault();
+        if (reference == null || sampleRate <= 0)
+        {
+            return "Auto detrend: —";
+        }
+
+        var view = new ImpulseMeasurementView(
+            reference.Samples,
+            VirtualCrossoverAnalysis.FindPeakIndex(reference.Samples),
+            sampleRate);
+        var settings = new PhaseAnalysisSettings(
+            WindowMode, FdwCycles, PhaseDetrendMode.Auto, DetrendMs,
+            GateOffsetMs, LeftMs, PlateauMs, RightMs, Unwrap, 0.0);
+        double resolved = DataHelper.ResolveCommonPhaseDetrendMilliseconds(view, settings);
+        return $"Auto detrend: {resolved:0.00} ms, reference: {reference.Title}";
     }
 
     private void UpdateMinFrequencyLabel()
@@ -231,5 +346,13 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
             irPlotView,
             "Preview of every channel's processed impulse response\r\n" +
             "and the gate window used for the phase view.");
+        toolTip.SetToolTip(comboWindowMode,
+            "Fixed uses one gate. FDW shortens the window as frequency rises.");
+        toolTip.SetToolTip(comboFdwCycles,
+            "4 cycles suppresses reflections most; 6 is recommended; 8 retains more detail.");
+        toolTip.SetToolTip(comboDetrendMode,
+            "Auto uses one common reference for every curve, preserving relative timing.");
+        toolTip.SetToolTip(checkBoxUnwrap,
+            "Uses the reliability-aware segmented unwrap and preserves unreliable gaps.");
     }
 }

--- a/source/Tools/VirtualCrossoverGateDialog.cs
+++ b/source/Tools/VirtualCrossoverGateDialog.cs
@@ -36,12 +36,11 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
     [System.ComponentModel.DesignerSerializationVisibility(
         System.ComponentModel.DesignerSerializationVisibility.Hidden)]
     public Action<double, double, double, double, PhaseWindowMode, int,
-        PhaseDetrendMode, double, bool>? PreviewChanged { get; set; }
+        PhaseDetrendMode, double>? PreviewChanged { get; set; }
 
     private readonly DarkComboBox comboWindowMode = new();
     private readonly DarkComboBox comboFdwCycles = new();
     private readonly DarkComboBox comboDetrendMode = new();
-    private readonly CheckBox checkBoxUnwrap = new();
     private readonly Label labelAutoDetrend = new();
 
     public VirtualCrossoverGateDialog()
@@ -80,8 +79,6 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         Enum.IsDefined((PhaseDetrendMode)comboDetrendMode.SelectedIndex)
             ? (PhaseDetrendMode)comboDetrendMode.SelectedIndex
             : PhaseDetrendMode.Auto;
-    public bool Unwrap => checkBoxUnwrap.Checked;
-
     /// <summary>
     /// Seeds the dialog: the processed channel IRs to preview (absolute
     /// timeline), the current gate values, and the offset the Fit button snaps
@@ -98,7 +95,6 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         PhaseWindowMode windowMode,
         int fdwCycles,
         PhaseDetrendMode detrendMode,
-        bool unwrap,
         double fitToMs)
     {
         traces = previewTraces;
@@ -115,8 +111,6 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
             ? fdwCycles
             : PhaseAnalysisSettings.DefaultFdwCycles;
         comboDetrendMode.SelectedIndex = (int)detrendMode;
-        checkBoxUnwrap.Checked = unwrap;
-
         initialized = true;
         OnGateChanged();
     }
@@ -141,7 +135,7 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
             sampleRate);
         var settings = new PhaseAnalysisSettings(
             WindowMode, FdwCycles, PhaseDetrendMode.Auto, DetrendMs,
-            GateOffsetMs, LeftMs, PlateauMs, RightMs, Unwrap, 0.0);
+            GateOffsetMs, LeftMs, PlateauMs, RightMs, Unwrap: false, 0.0);
         (double slopeMs, double peakMs) = DataHelper.EstimatePhaseDetrend(view, settings);
         numericTau.Value = Clamp(numericTau, useSlope ? slopeMs : peakMs);
     }
@@ -158,16 +152,18 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         UpdatePhaseControlState();
         PreviewChanged?.Invoke(
             GateOffsetMs, LeftMs, PlateauMs, RightMs, WindowMode, FdwCycles,
-            DetrendMode, DetrendMs, Unwrap);
+            DetrendMode, DetrendMs);
     }
 
     private void InitializePhaseControls()
     {
         const int addedHeight = 62;
-        irPlotView.Top += addedHeight;
-        buttonSave.Top += addedHeight;
-        buttonCancel.Top += addedHeight;
         ClientSize = new Size(ClientSize.Width, ClientSize.Height + addedHeight);
+        // Resizing already moves bottom-anchored buttons and stretches the
+        // top+bottom-anchored plot. Move only the plot's top edge into the new
+        // controls area and give back the automatically added height.
+        irPlotView.Top += addedHeight;
+        irPlotView.Height -= addedHeight;
 
         AddCombo("Window", comboWindowMode, 102, 12, 112, 126);
         comboWindowMode.Items.AddRange(["Fixed", "FDW"]);
@@ -176,11 +172,6 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         AddCombo("Detrend", comboDetrendMode, 132, 12, 112, 126);
         comboDetrendMode.Items.AddRange(["Off", "Auto", "Manual"]);
 
-        checkBoxUnwrap.AutoSize = true;
-        checkBoxUnwrap.ForeColor = Color.White;
-        checkBoxUnwrap.Location = new Point(452, 104);
-        checkBoxUnwrap.Text = "Unwrap";
-        Controls.Add(checkBoxUnwrap);
         labelAutoDetrend.AutoSize = true;
         labelAutoDetrend.ForeColor = Color.FromArgb(210, 214, 222);
         labelAutoDetrend.Location = new Point(262, 134);
@@ -189,7 +180,6 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         comboWindowMode.SelectedIndexChanged += (_, _) => OnGateChanged();
         comboFdwCycles.SelectedIndexChanged += (_, _) => OnGateChanged();
         comboDetrendMode.SelectedIndexChanged += (_, _) => OnGateChanged();
-        checkBoxUnwrap.CheckedChanged += (_, _) => OnGateChanged();
     }
 
     private void AddCombo(
@@ -243,7 +233,7 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
             sampleRate);
         var settings = new PhaseAnalysisSettings(
             WindowMode, FdwCycles, PhaseDetrendMode.Auto, DetrendMs,
-            GateOffsetMs, LeftMs, PlateauMs, RightMs, Unwrap, 0.0);
+            GateOffsetMs, LeftMs, PlateauMs, RightMs, Unwrap: false, 0.0);
         double resolved = DataHelper.ResolveCommonPhaseDetrendMilliseconds(view, settings);
         return $"Auto detrend: {resolved:0.00} ms, reference: {reference.Title}";
     }
@@ -358,7 +348,5 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
             "4 cycles suppresses reflections most; 6 is recommended; 8 retains more detail.");
         toolTip.SetToolTip(comboDetrendMode,
             "Auto uses one common reference for every curve, preserving relative timing.");
-        toolTip.SetToolTip(checkBoxUnwrap,
-            "Uses the reliability-aware segmented unwrap and preserves unreliable gaps.");
     }
 }

--- a/source/Tools/VirtualCrossoverGateDialog.cs
+++ b/source/Tools/VirtualCrossoverGateDialog.cs
@@ -38,9 +38,9 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
     public Action<double, double, double, double, PhaseWindowMode, int,
         PhaseDetrendMode, double, bool>? PreviewChanged { get; set; }
 
-    private readonly ComboBox comboWindowMode = new();
-    private readonly ComboBox comboFdwCycles = new();
-    private readonly ComboBox comboDetrendMode = new();
+    private readonly DarkComboBox comboWindowMode = new();
+    private readonly DarkComboBox comboFdwCycles = new();
+    private readonly DarkComboBox comboDetrendMode = new();
     private readonly CheckBox checkBoxUnwrap = new();
     private readonly Label labelAutoDetrend = new();
 
@@ -169,21 +169,21 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         buttonCancel.Top += addedHeight;
         ClientSize = new Size(ClientSize.Width, ClientSize.Height + addedHeight);
 
-        AddCombo("Window", comboWindowMode, 102, 112);
+        AddCombo("Window", comboWindowMode, 102, 12, 112, 126);
         comboWindowMode.Items.AddRange(["Fixed", "FDW"]);
-        AddCombo("FDW cycles", comboFdwCycles, 102, 322);
+        AddCombo("FDW cycles", comboFdwCycles, 102, 262, 342, 74);
         comboFdwCycles.Items.AddRange([4, 6, 8]);
-        AddCombo("Detrend", comboDetrendMode, 132, 112);
+        AddCombo("Detrend", comboDetrendMode, 132, 12, 112, 126);
         comboDetrendMode.Items.AddRange(["Off", "Auto", "Manual"]);
 
         checkBoxUnwrap.AutoSize = true;
         checkBoxUnwrap.ForeColor = Color.White;
-        checkBoxUnwrap.Location = new Point(414, 106);
+        checkBoxUnwrap.Location = new Point(452, 104);
         checkBoxUnwrap.Text = "Unwrap";
         Controls.Add(checkBoxUnwrap);
         labelAutoDetrend.AutoSize = true;
         labelAutoDetrend.ForeColor = Color.FromArgb(210, 214, 222);
-        labelAutoDetrend.Location = new Point(262, 136);
+        labelAutoDetrend.Location = new Point(262, 134);
         Controls.Add(labelAutoDetrend);
 
         comboWindowMode.SelectedIndexChanged += (_, _) => OnGateChanged();
@@ -192,19 +192,25 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         checkBoxUnwrap.CheckedChanged += (_, _) => OnGateChanged();
     }
 
-    private void AddCombo(string text, ComboBox combo, int top, int left)
+    private void AddCombo(
+        string text,
+        DarkComboBox combo,
+        int top,
+        int labelLeft,
+        int controlLeft,
+        int width)
     {
         var label = new Label
         {
             AutoSize = true,
             Font = new Font("Segoe UI Semibold", 9F),
             ForeColor = Color.FromArgb(210, 214, 222),
-            Location = new Point(left - 100, top + 4),
+            Location = new Point(labelLeft, top + 2),
             Text = text
         };
         combo.DropDownStyle = ComboBoxStyle.DropDownList;
-        combo.Location = new Point(left, top);
-        combo.Size = new Size(126, 23);
+        combo.Location = new Point(controlLeft, top);
+        combo.Size = new Size(width, 19);
         Controls.Add(label);
         Controls.Add(combo);
     }

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -75,7 +75,7 @@ public partial class VirtualCrossoverPanel : UserControl
     // project, Cancel reverts by simply dropping them).
     private (double OffsetMs, double LeftMs, double PlateauMs, double RightMs,
         PhaseWindowMode WindowMode, int FdwCycles, PhaseDetrendMode DetrendMode,
-        double DetrendMs, bool Unwrap)? gatePreview;
+        double DetrendMs)? gatePreview;
     private PlotWatermarkAnnotation hintAnnotation = null!;
     private LinearAxis mainValueAxis = null!;
     private PlotLabelsPanelController plotLabels = null!;
@@ -3379,7 +3379,7 @@ public partial class VirtualCrossoverPanel : UserControl
             gatePreview?.LeftMs ?? project.PhaseGateLeftMs,
             gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs,
             gatePreview?.RightMs ?? project.PhaseGateRightMs,
-            Unwrap: gatePreview?.Unwrap ?? project.PhaseUnwrap,
+            Unwrap: false,
             SmoothingInverseOctaves: 0.0);
 
     private List<SignalPoint> BuildPhasePoints(
@@ -3450,16 +3450,15 @@ public partial class VirtualCrossoverPanel : UserControl
             project.PhaseWindowMode,
             project.PhaseFdwCycles,
             project.PhaseDetrendMode,
-            project.PhaseUnwrap,
             fitOffsetMs);
         // The callback is wired after Init so seeding the controls does not
         // trigger a redundant redraw; from here every dialog change repaints the
         // phase plot immediately.
         dialog.PreviewChanged = (offsetMs, leftMs, plateauMs, rightMs, windowMode,
-            fdwCycles, detrendMode, detrendMs, unwrap) =>
+            fdwCycles, detrendMode, detrendMs) =>
         {
             gatePreview = (offsetMs, leftMs, plateauMs, rightMs, windowMode,
-                fdwCycles, detrendMode, detrendMs, unwrap);
+                fdwCycles, detrendMode, detrendMs);
             RequestRedraw();
         };
 
@@ -3475,7 +3474,6 @@ public partial class VirtualCrossoverPanel : UserControl
                 project.PhaseWindowMode = dialog.WindowMode;
                 project.PhaseFdwCycles = dialog.FdwCycles;
                 project.PhaseDetrendMode = dialog.DetrendMode;
-                project.PhaseUnwrap = dialog.Unwrap;
                 ScheduleSave();
             }
         }

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -3295,8 +3295,7 @@ public partial class VirtualCrossoverPanel : UserControl
         int sampleRate = processed[0].Channel.SampleRate;
         double gateOffsetMs = gatePreview?.OffsetMs
             ?? ResolveGateOffsetMs(reference, sampleRate);
-        double detrendMs = gatePreview?.DetrendMs
-            ?? ResolveDetrendMs(reference, sampleRate);
+        double detrendMs = ResolveCommonDetrendMs(processed, gateOffsetMs, sampleRate);
 
         foreach (ProcessedChannel item in processed)
         {
@@ -3340,6 +3339,50 @@ public partial class VirtualCrossoverPanel : UserControl
     private double ResolveDetrendMs(int referenceSample, int sampleRate) =>
         project.PhaseDetrendMs ?? referenceSample * 1_000.0 / sampleRate;
 
+    private double ResolveCommonDetrendMs(
+        List<ProcessedChannel> processed,
+        double gateOffsetMs,
+        int sampleRate)
+    {
+        if (gatePreview is { } preview)
+        {
+            return preview.DetrendMs;
+        }
+        if (frequencyResponseOptions.PhaseDetrendMode == PhaseDetrendMode.Off)
+        {
+            return 0.0;
+        }
+        if (frequencyResponseOptions.PhaseDetrendMode == PhaseDetrendMode.Manual)
+        {
+            return frequencyResponseOptions.PhaseDetrendMs;
+        }
+
+        // Estimate once from the existing common anchor (earliest processed
+        // arrival), then apply that exact value to every driver and the sum.
+        ProcessedChannel anchor = processed.MinBy(item => item.PeakIndex)!;
+        var view = new ImpulseMeasurementView(anchor.ImpulseResponse, 0, sampleRate);
+        PhaseAnalysisSettings settings = CreateVirtualPhaseSettings(
+            gateOffsetMs,
+            PhaseDetrendMode.Auto,
+            manualDetrendMilliseconds: 0.0);
+        return DataHelper.ResolveCommonPhaseDetrendMilliseconds(view, settings);
+    }
+
+    private PhaseAnalysisSettings CreateVirtualPhaseSettings(
+        double gateOffsetMs,
+        PhaseDetrendMode detrendMode,
+        double manualDetrendMilliseconds) => new(
+            frequencyResponseOptions.PhaseWindowMode,
+            frequencyResponseOptions.PhaseFdwCycles,
+            detrendMode,
+            manualDetrendMilliseconds,
+            gateOffsetMs,
+            gatePreview?.LeftMs ?? project.PhaseGateLeftMs,
+            gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs,
+            gatePreview?.RightMs ?? project.PhaseGateRightMs,
+            Unwrap: false,
+            SmoothingInverseOctaves: 0.0);
+
     private List<SignalPoint> BuildPhasePoints(
         Complex[] impulseResponse,
         int sampleRate,
@@ -3353,14 +3396,11 @@ public partial class VirtualCrossoverPanel : UserControl
         // fractional-sample phase reference; every curve built with the same τ
         // is directly comparable regardless of where its gate sits.
         var view = new ImpulseMeasurementView(impulseResponse, 0, sampleRate);
-        List<SignalPoint> phase = DataHelper.GetGatedPhaseData(
-            view,
+        PhaseAnalysisSettings settings = CreateVirtualPhaseSettings(
             gateOffsetMs,
-            gatePreview?.LeftMs ?? project.PhaseGateLeftMs,
-            gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs,
-            gatePreview?.RightMs ?? project.PhaseGateRightMs,
-            referenceSamples: detrendMs / 1_000.0 * sampleRate,
-            unwrap: false);
+            PhaseDetrendMode.Manual,
+            detrendMs);
+        List<SignalPoint> phase = DataHelper.GetGatedPhaseData(view, settings);
 
         var points = new List<SignalPoint>(phase.Count);
         foreach (SignalPoint point in phase)
@@ -3498,11 +3538,11 @@ public partial class VirtualCrossoverPanel : UserControl
         PreparedDspResponse response,
         double frequency,
         DspPlotMode mode) => mode switch
-    {
-        DspPlotMode.Phase => response.Response(frequency).Phase / Math.PI * 180.0,
-        DspPlotMode.GroupDelay => response.GroupDelayMs(frequency),
-        _ => DataHelper.AmplitudeToDecibels(response.Response(frequency).Magnitude)
-    };
+        {
+            DspPlotMode.Phase => response.Response(frequency).Phase / Math.PI * 180.0,
+            DspPlotMode.GroupDelay => response.GroupDelayMs(frequency),
+            _ => DataHelper.AmplitudeToDecibels(response.Response(frequency).Magnitude)
+        };
 
     // ------------------------------------------------------- capture / export
 
@@ -3959,7 +3999,8 @@ public partial class VirtualCrossoverPanel : UserControl
         // entry: it is measured over the same band from the same response.
         public (Complex[] ProcessedIr, double LowHz, double HighHz,
             TimeAlignmentAnalysisResult Result, double? LevelDb)?
-            ArrivalCache { get; set; }
+            ArrivalCache
+        { get; set; }
 
         // Invalidation counter for in-flight asynchronous source loads: a
         // load captures the revision when it starts (BeginSourceLoad, which

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -74,7 +74,8 @@ public partial class VirtualCrossoverPanel : UserControl
     // tracks the dialog live; null once it closes (Save committed them to the
     // project, Cancel reverts by simply dropping them).
     private (double OffsetMs, double LeftMs, double PlateauMs, double RightMs,
-        double DetrendMs)? gatePreview;
+        PhaseWindowMode WindowMode, int FdwCycles, PhaseDetrendMode DetrendMode,
+        double DetrendMs, bool Unwrap)? gatePreview;
     private PlotWatermarkAnnotation hintAnnotation = null!;
     private LinearAxis mainValueAxis = null!;
     private PlotLabelsPanelController plotLabels = null!;
@@ -3344,17 +3345,15 @@ public partial class VirtualCrossoverPanel : UserControl
         double gateOffsetMs,
         int sampleRate)
     {
-        if (gatePreview is { } preview)
-        {
-            return preview.DetrendMs;
-        }
-        if (frequencyResponseOptions.PhaseDetrendMode == PhaseDetrendMode.Off)
+        PhaseDetrendMode detrendMode = gatePreview?.DetrendMode ?? project.PhaseDetrendMode;
+        if (detrendMode == PhaseDetrendMode.Off)
         {
             return 0.0;
         }
-        if (frequencyResponseOptions.PhaseDetrendMode == PhaseDetrendMode.Manual)
+        if (detrendMode == PhaseDetrendMode.Manual)
         {
-            return frequencyResponseOptions.PhaseDetrendMs;
+            return gatePreview?.DetrendMs ?? ResolveDetrendMs(
+                processed.Min(item => item.PeakIndex), sampleRate);
         }
 
         // Estimate once from the existing common anchor (earliest processed
@@ -3372,15 +3371,15 @@ public partial class VirtualCrossoverPanel : UserControl
         double gateOffsetMs,
         PhaseDetrendMode detrendMode,
         double manualDetrendMilliseconds) => new(
-            frequencyResponseOptions.PhaseWindowMode,
-            frequencyResponseOptions.PhaseFdwCycles,
+            gatePreview?.WindowMode ?? project.PhaseWindowMode,
+            gatePreview?.FdwCycles ?? project.PhaseFdwCycles,
             detrendMode,
             manualDetrendMilliseconds,
             gateOffsetMs,
             gatePreview?.LeftMs ?? project.PhaseGateLeftMs,
             gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs,
             gatePreview?.RightMs ?? project.PhaseGateRightMs,
-            Unwrap: false,
+            Unwrap: gatePreview?.Unwrap ?? project.PhaseUnwrap,
             SmoothingInverseOctaves: 0.0);
 
     private List<SignalPoint> BuildPhasePoints(
@@ -3448,13 +3447,19 @@ public partial class VirtualCrossoverPanel : UserControl
             project.PhaseGatePlateauMs,
             project.PhaseGateRightMs,
             ResolveDetrendMs(reference, sampleRate),
+            project.PhaseWindowMode,
+            project.PhaseFdwCycles,
+            project.PhaseDetrendMode,
+            project.PhaseUnwrap,
             fitOffsetMs);
         // The callback is wired after Init so seeding the controls does not
         // trigger a redundant redraw; from here every dialog change repaints the
         // phase plot immediately.
-        dialog.PreviewChanged = (offsetMs, leftMs, plateauMs, rightMs, detrendMs) =>
+        dialog.PreviewChanged = (offsetMs, leftMs, plateauMs, rightMs, windowMode,
+            fdwCycles, detrendMode, detrendMs, unwrap) =>
         {
-            gatePreview = (offsetMs, leftMs, plateauMs, rightMs, detrendMs);
+            gatePreview = (offsetMs, leftMs, plateauMs, rightMs, windowMode,
+                fdwCycles, detrendMode, detrendMs, unwrap);
             RequestRedraw();
         };
 
@@ -3467,6 +3472,10 @@ public partial class VirtualCrossoverPanel : UserControl
                 project.PhaseGatePlateauMs = dialog.PlateauMs;
                 project.PhaseGateRightMs = dialog.RightMs;
                 project.PhaseDetrendMs = dialog.DetrendMs;
+                project.PhaseWindowMode = dialog.WindowMode;
+                project.PhaseFdwCycles = dialog.FdwCycles;
+                project.PhaseDetrendMode = dialog.DetrendMode;
+                project.PhaseUnwrap = dialog.Unwrap;
                 ScheduleSave();
             }
         }

--- a/source/Tools/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossoverProjectFile.cs
@@ -250,7 +250,6 @@ public sealed class VirtualCrossoverProjectFile
         PhaseWindowMode.FrequencyDependent;
     public int PhaseFdwCycles { get; set; } = PhaseAnalysisSettings.DefaultFdwCycles;
     public PhaseDetrendMode PhaseDetrendMode { get; set; } = PhaseDetrendMode.Auto;
-    public bool PhaseUnwrap { get; set; } = true;
 
     public static string GetPath(string? rootDirectory = null) =>
         Path.Combine(
@@ -356,8 +355,6 @@ public sealed class VirtualCrossoverProjectFile
         }
         if (file.Version == 3)
         {
-            // v3 always rendered Virtual DSP phase wrapped in code.
-            file.PhaseUnwrap = false;
             file.Version = 4;
         }
     }

--- a/source/Tools/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossoverProjectFile.cs
@@ -166,7 +166,7 @@ public sealed class VirtualCrossoverProjectFile
     // step in Migrate below. Files from a NEWER version (a downgraded app)
     // are never migrated: LoadOrDefault backs them up and starts fresh,
     // LoadFrom rejects them with an explicit error.
-    public const int CurrentVersion = 2;
+    public const int CurrentVersion = 3;
     public const int MaximumChannelCount = 8;
     private const string FileName = "virtual-crossover.json";
 
@@ -246,6 +246,10 @@ public sealed class VirtualCrossoverProjectFile
     // readable while their relative phase is preserved. Null follows the
     // earliest processed arrival automatically.
     public double? PhaseDetrendMs { get; set; }
+    public PhaseWindowMode PhaseWindowMode { get; set; } =
+        PhaseWindowMode.FrequencyDependent;
+    public int PhaseFdwCycles { get; set; } = PhaseAnalysisSettings.DefaultFdwCycles;
+    public PhaseDetrendMode PhaseDetrendMode { get; set; } = PhaseDetrendMode.Auto;
 
     public static string GetPath(string? rootDirectory = null) =>
         Path.Combine(
@@ -340,6 +344,14 @@ public sealed class VirtualCrossoverProjectFile
                 .ToList();
             file.Channels = new List<VirtualCrossoverChannelSettings>();
             file.Version = 2;
+        }
+        if (file.Version == 2)
+        {
+            // v2 only had a fixed gate and a numeric common detrend.
+            file.PhaseWindowMode = PhaseWindowMode.Fixed;
+            file.PhaseFdwCycles = PhaseAnalysisSettings.DefaultFdwCycles;
+            file.PhaseDetrendMode = PhaseDetrendMode.Manual;
+            file.Version = 3;
         }
     }
 
@@ -448,6 +460,14 @@ public sealed class VirtualCrossoverProjectFile
         {
             throw new InvalidDataException(
                 "The virtual crossover DSP plot mode is invalid.");
+        }
+        if (!Enum.IsDefined(PhaseWindowMode) || !Enum.IsDefined(PhaseDetrendMode))
+        {
+            throw new InvalidDataException("The phase analysis mode is invalid.");
+        }
+        if (PhaseFdwCycles is not (4 or 6 or 8))
+        {
+            PhaseFdwCycles = PhaseAnalysisSettings.DefaultFdwCycles;
         }
         if (PhaseGateOffsetMs is { } gateOffset &&
             (!double.IsFinite(gateOffset) || gateOffset is < 0 or > 10_000))

--- a/source/Tools/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossoverProjectFile.cs
@@ -166,7 +166,7 @@ public sealed class VirtualCrossoverProjectFile
     // step in Migrate below. Files from a NEWER version (a downgraded app)
     // are never migrated: LoadOrDefault backs them up and starts fresh,
     // LoadFrom rejects them with an explicit error.
-    public const int CurrentVersion = 3;
+    public const int CurrentVersion = 4;
     public const int MaximumChannelCount = 8;
     private const string FileName = "virtual-crossover.json";
 
@@ -250,6 +250,7 @@ public sealed class VirtualCrossoverProjectFile
         PhaseWindowMode.FrequencyDependent;
     public int PhaseFdwCycles { get; set; } = PhaseAnalysisSettings.DefaultFdwCycles;
     public PhaseDetrendMode PhaseDetrendMode { get; set; } = PhaseDetrendMode.Auto;
+    public bool PhaseUnwrap { get; set; } = true;
 
     public static string GetPath(string? rootDirectory = null) =>
         Path.Combine(
@@ -352,6 +353,12 @@ public sealed class VirtualCrossoverProjectFile
             file.PhaseFdwCycles = PhaseAnalysisSettings.DefaultFdwCycles;
             file.PhaseDetrendMode = PhaseDetrendMode.Manual;
             file.Version = 3;
+        }
+        if (file.Version == 3)
+        {
+            // v3 always rendered Virtual DSP phase wrapped in code.
+            file.PhaseUnwrap = false;
+            file.Version = 4;
         }
     }
 

--- a/tests/Resonalyze.App.Tests/PROptTests.cs
+++ b/tests/Resonalyze.App.Tests/PROptTests.cs
@@ -1,0 +1,74 @@
+using System.Numerics;
+using Resonalyze.Dsp;
+using Resonalyze.Options;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class PROptTests
+{
+    [Fact]
+    public void ManualTauEstimate_UsesSelectedFdwSpectrum()
+    {
+        const int sampleRate = 48_000;
+        const int directSample = 1_440;
+        var impulse = new Complex[4_096];
+        impulse[directSample] = Complex.One;
+        impulse[directSample + 480] = new Complex(0.8, 0.0);
+
+        using var measurement = new ExpSweepMeasurement();
+        measurement.RestoreImpulseResponse(
+            octaves: 12,
+            sampleRate,
+            bits: 24,
+            sweepDurationSeconds: 1.0,
+            playChannel: PlaybackChannel.Mono,
+            sweepDeconvolutionImpulseResponse: impulse,
+            sweepDeconvolutionPeakIndex: directSample,
+            measurementMode: SweepMeasurementMode.LoopbackTransfer,
+            transferImpulseResponse: impulse,
+            transferPeakIndex: directSample);
+
+        var options = new FrequencyResponseOptions
+        {
+            PhaseWindowMode = PhaseWindowMode.FrequencyDependent,
+            PhaseFdwCycles = 4,
+            PhaseDetrendMode = PhaseDetrendMode.Manual,
+            PhaseGateOffsetMs = directSample * 1_000.0 / sampleRate,
+            PhaseLeftMs = 1.0,
+            PhasePlateauMs = 4.0,
+            PhaseRightMs = 15.0,
+            Unwrap = true
+        };
+        using var panel = new PROpt();
+        panel.Init(measurement, options, new CurveVisibilityOptions());
+
+        IImpulseMeasurement view =
+            new MeasurementPlotContext(measurement).CreatePrimaryMeasurement();
+        var fdwSettings = new PhaseAnalysisSettings(
+            options.PhaseWindowMode,
+            options.PhaseFdwCycles,
+            PhaseDetrendMode.Auto,
+            options.PhaseDetrendMs,
+            options.PhaseGateOffsetMs,
+            options.PhaseLeftMs,
+            options.PhasePlateauMs,
+            options.PhaseRightMs,
+            options.Unwrap,
+            options.SmoothingInverseOctaves);
+
+        (double expectedSlope, double expectedPeak) =
+            DataHelper.EstimatePhaseDetrend(view, fdwSettings);
+        (double actualSlope, double actualPeak) = panel.EstimateCurrentPhaseDetrend(view);
+
+        Assert.Equal(expectedSlope, actualSlope, tolerance: 1e-9);
+        Assert.Equal(expectedPeak, actualPeak, tolerance: 1e-9);
+
+        (double fixedSlope, _) = DataHelper.EstimatePhaseDetrend(
+            view,
+            options.PhaseGateOffsetMs,
+            options.PhaseLeftMs,
+            options.PhasePlateauMs,
+            options.PhaseRightMs);
+        Assert.NotEqual(fixedSlope, actualSlope, tolerance: 0.00001);
+    }
+}

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -237,6 +237,104 @@ public sealed class PlotModelFactoryTests
                 .CreatePhaseResponse(includeCurves: true)));
     }
 
+    [Fact]
+    public void PhaseResponse_AutoDetrendPreservesMainCompareRelativeDelay()
+    {
+        const int sampleRate = 44_100;
+        const int mainSample = 64;
+        const int compareSample = 86;
+        using var measurement = CreateTransferMeasurement();
+        using var noiseMeasurement = new NoiseMeasurement();
+        var phaseOptions = new FrequencyResponseOptions
+        {
+            PhaseGateOffsetMs = mainSample * 1_000.0 / sampleRate,
+            PhaseWindowMode = PhaseWindowMode.Fixed,
+            PhaseFdwCycles = 6,
+            PhaseDetrendMode = PhaseDetrendMode.Auto,
+            Unwrap = true,
+            SmoothingInverseOctaves = 0.0
+        };
+        var visibility = PhaseAllOff();
+        visibility.ShowMeasuredPhase = true;
+        visibility.ShowExcessPhase = true;
+        PlotModelFactory factory = CreateFactory(
+            measurement,
+            noiseMeasurement,
+            phaseResponseOptions: phaseOptions,
+            phaseResponseVisibility: visibility);
+        var compareImpulse = new Complex[2048];
+        compareImpulse[compareSample] = Complex.One;
+        factory.SetCompareSourceProvider(() => new CompareAnalysisSource(
+            "Delayed reference", sampleRate, compareImpulse, compareSample));
+
+        List<LineSeries> series = factory.CreatePhaseResponse(includeCurves: true)
+            .Series.OfType<LineSeries>().ToList();
+        double expectedChange = -360.0 * (compareSample - mainSample) /
+            sampleRate * 1_000.0;
+        AssertRelativePhaseSlope(series, AnalysisCurveKind.Primary, expectedChange);
+
+        IImpulseMeasurement mainView =
+            new MeasurementPlotContext(measurement).CreatePrimaryMeasurement();
+        var compareView = new ImpulseMeasurementView(
+            compareImpulse, compareSample, sampleRate);
+        PhaseAnalysisSettings autoSettings = phaseOptions.CreatePhaseAnalysisSettings();
+        double commonDetrend = DataHelper.ResolvePhaseDetrendMilliseconds(
+            mainView, autoSettings);
+        PhaseAnalysisSettings commonSettings = autoSettings with
+        {
+            DetrendMode = PhaseDetrendMode.Manual,
+            ManualDetrendMilliseconds = commonDetrend
+        };
+        AnalysisCurve expectedExcess = DataHelper.GetExcessPhase(
+            compareView, commonSettings);
+        LineSeries compareExcess = series.Single(item => item.Tag is CurveTag
+        {
+            Kind: AnalysisCurveKind.ExcessPhase,
+            Source: CurveSource.Compare
+        });
+        AssertCurveValueAt(compareExcess, expectedExcess, 500.0);
+        AssertCurveValueAt(compareExcess, expectedExcess, 1_500.0);
+    }
+
+    private static void AssertCurveValueAt(
+        LineSeries actual,
+        AnalysisCurve expected,
+        double frequency)
+    {
+        OxyPlot.DataPoint actualPoint = actual.Points.MinBy(point =>
+            Math.Abs(point.X - frequency));
+        SignalPoint expectedPoint = expected.Points.MinBy(point =>
+            Math.Abs(point.X - frequency));
+        Assert.Equal(expectedPoint.Y, actualPoint.Y, tolerance: 1e-9);
+    }
+
+    private static void AssertRelativePhaseSlope(
+        IEnumerable<LineSeries> series,
+        AnalysisCurveKind kind,
+        double expectedChange)
+    {
+        List<LineSeries> matching = series.Where(item => item.Tag is CurveTag tag &&
+            tag.Mode == Mode.PhaseResponse && tag.Kind == kind).ToList();
+        LineSeries main = matching.Single(item =>
+            ((CurveTag)item.Tag!).Source == CurveSource.Main);
+        LineSeries compare = matching.Single(item =>
+            ((CurveTag)item.Tag!).Source == CurveSource.Compare);
+        double differenceAt500 = PhaseDifferenceAt(main, compare, 500.0);
+        double differenceAt1500 = PhaseDifferenceAt(main, compare, 1_500.0);
+        Assert.Equal(expectedChange, differenceAt1500 - differenceAt500, tolerance: 2.0);
+    }
+
+    private static double PhaseDifferenceAt(
+        LineSeries main,
+        LineSeries compare,
+        double frequency)
+    {
+        int index = main.Points
+            .Select((point, i) => (Distance: Math.Abs(point.X - frequency), Index: i))
+            .MinBy(candidate => candidate.Distance).Index;
+        return compare.Points[index].Y - main.Points[index].Y;
+    }
+
     private static CurveVisibilityOptions PhaseAllOff() => new()
     {
         ShowMeasuredPhase = false,
@@ -561,6 +659,7 @@ public sealed class PlotModelFactoryTests
         NoiseMeasurement noiseMeasurement,
         ImpulseResponseOptions? impulseOptions = null,
         FrequencyResponseOptions? groupDelayOptions = null,
+        FrequencyResponseOptions? phaseResponseOptions = null,
         CurveVisibilityOptions? frequencyResponseVisibility = null,
         CurveVisibilityOptions? phaseResponseVisibility = null,
         CurveVisibilityOptions? groupDelayVisibility = null)
@@ -574,7 +673,7 @@ public sealed class PlotModelFactoryTests
             noiseMeasurement,
             mode => new CalibrationFile(calibrationPath),
             new FrequencyResponseOptions(),
-            new FrequencyResponseOptions(),
+            phaseResponseOptions ?? new FrequencyResponseOptions(),
             groupDelayOptions ?? new FrequencyResponseOptions(),
             frequencyResponseVisibility ?? new CurveVisibilityOptions(),
             phaseResponseVisibility ?? new CurveVisibilityOptions(),

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverGateDialogLayoutTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverGateDialogLayoutTests.cs
@@ -1,0 +1,21 @@
+using System.Windows.Forms;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class VirtualCrossoverGateDialogLayoutTests
+{
+    [Fact]
+    public void ActionButtonsRemainInsideTheClientArea()
+    {
+        using var dialog = new VirtualCrossoverGateDialog();
+        Button save = dialog.Controls.OfType<Button>()
+            .Single(button => button.Text == "Save");
+        Button cancel = dialog.Controls.OfType<Button>()
+            .Single(button => button.Text == "Cancel");
+
+        Assert.True(save.Bottom <= dialog.ClientSize.Height);
+        Assert.True(cancel.Bottom <= dialog.ClientSize.Height);
+        Assert.True(save.Top >= 0);
+        Assert.True(cancel.Top >= 0);
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -19,7 +19,11 @@ public sealed class VirtualCrossoverProjectFileTests
                 PhaseGateLeftMs = 0.25,
                 PhaseGatePlateauMs = 6.5,
                 PhaseGateRightMs = 2.0,
-                PhaseDetrendMs = 13.07
+                PhaseDetrendMs = 13.07,
+                PhaseWindowMode = PhaseWindowMode.FrequencyDependent,
+                PhaseFdwCycles = 8,
+                PhaseDetrendMode = PhaseDetrendMode.Manual,
+                PhaseUnwrap = false
             };
             original.StereoSceneOffsetMs = -0.4;
             original.ActiveSideRight = true;
@@ -56,6 +60,10 @@ public sealed class VirtualCrossoverProjectFileTests
             Assert.Equal(original.PhaseGatePlateauMs, loaded.PhaseGatePlateauMs);
             Assert.Equal(original.PhaseGateRightMs, loaded.PhaseGateRightMs);
             Assert.Equal(original.PhaseDetrendMs, loaded.PhaseDetrendMs);
+            Assert.Equal(original.PhaseWindowMode, loaded.PhaseWindowMode);
+            Assert.Equal(original.PhaseFdwCycles, loaded.PhaseFdwCycles);
+            Assert.Equal(original.PhaseDetrendMode, loaded.PhaseDetrendMode);
+            Assert.Equal(original.PhaseUnwrap, loaded.PhaseUnwrap);
             Assert.Equal(original.StereoSceneOffsetMs, loaded.StereoSceneOffsetMs);
             Assert.Equal(original.ActiveSideRight, loaded.ActiveSideRight);
             Assert.Equal(original.Pairs.Count, loaded.Pairs.Count);
@@ -405,6 +413,33 @@ public sealed class VirtualCrossoverProjectFileTests
                 VirtualCrossoverProjectFile.LoadOrDefault(root);
             Assert.Equal(2, reloaded.Pairs.Count);
             Assert.Equal("woofer.json", reloaded.Pairs[0].Left.DisplayName);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadOrDefault_MigratesVersion3ToWrappedPhase()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var project = new VirtualCrossoverProjectFile { PhaseUnwrap = true };
+            project.Save(root);
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            string json = File.ReadAllText(path)
+                .Replace($"\"version\": {VirtualCrossoverProjectFile.CurrentVersion}",
+                    "\"version\": 3")
+                .Replace("\"phaseUnwrap\": true", "\"phaseUnwrap\": false");
+            File.WriteAllText(path, json);
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.Equal(VirtualCrossoverProjectFile.CurrentVersion, loaded.Version);
+            Assert.False(loaded.PhaseUnwrap);
         }
         finally
         {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -22,8 +22,7 @@ public sealed class VirtualCrossoverProjectFileTests
                 PhaseDetrendMs = 13.07,
                 PhaseWindowMode = PhaseWindowMode.FrequencyDependent,
                 PhaseFdwCycles = 8,
-                PhaseDetrendMode = PhaseDetrendMode.Manual,
-                PhaseUnwrap = false
+                PhaseDetrendMode = PhaseDetrendMode.Manual
             };
             original.StereoSceneOffsetMs = -0.4;
             original.ActiveSideRight = true;
@@ -63,7 +62,6 @@ public sealed class VirtualCrossoverProjectFileTests
             Assert.Equal(original.PhaseWindowMode, loaded.PhaseWindowMode);
             Assert.Equal(original.PhaseFdwCycles, loaded.PhaseFdwCycles);
             Assert.Equal(original.PhaseDetrendMode, loaded.PhaseDetrendMode);
-            Assert.Equal(original.PhaseUnwrap, loaded.PhaseUnwrap);
             Assert.Equal(original.StereoSceneOffsetMs, loaded.StereoSceneOffsetMs);
             Assert.Equal(original.ActiveSideRight, loaded.ActiveSideRight);
             Assert.Equal(original.Pairs.Count, loaded.Pairs.Count);
@@ -413,33 +411,6 @@ public sealed class VirtualCrossoverProjectFileTests
                 VirtualCrossoverProjectFile.LoadOrDefault(root);
             Assert.Equal(2, reloaded.Pairs.Count);
             Assert.Equal("woofer.json", reloaded.Pairs[0].Left.DisplayName);
-        }
-        finally
-        {
-            Directory.Delete(root, recursive: true);
-        }
-    }
-
-    [Fact]
-    public void LoadOrDefault_MigratesVersion3ToWrappedPhase()
-    {
-        string root = CreateTemporaryDirectory();
-        try
-        {
-            var project = new VirtualCrossoverProjectFile { PhaseUnwrap = true };
-            project.Save(root);
-            string path = VirtualCrossoverProjectFile.GetPath(root);
-            string json = File.ReadAllText(path)
-                .Replace($"\"version\": {VirtualCrossoverProjectFile.CurrentVersion}",
-                    "\"version\": 3")
-                .Replace("\"phaseUnwrap\": true", "\"phaseUnwrap\": false");
-            File.WriteAllText(path, json);
-
-            VirtualCrossoverProjectFile loaded =
-                VirtualCrossoverProjectFile.LoadOrDefault(root);
-
-            Assert.Equal(VirtualCrossoverProjectFile.CurrentVersion, loaded.Version);
-            Assert.False(loaded.PhaseUnwrap);
         }
         finally
         {

--- a/tests/Resonalyze.Dsp.Tests/DataHelperResampleTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/DataHelperResampleTests.cs
@@ -72,6 +72,25 @@ public sealed class DataHelperResampleTests
         Assert.All(output, point => Assert.Equal(-3.0, point.Y, precision: 6));
     }
 
+    [Fact]
+    public void SmoothLinear_PreservesNaNSegmentBreakWithoutBlendingAcrossIt()
+    {
+        var input = new List<SignalPoint>();
+        for (int i = 1; i <= 80; i++)
+        {
+            double value = i is >= 35 and <= 45
+                ? double.NaN
+                : i < 35 ? 10.0 : 100.0;
+            input.Add(new SignalPoint(i * 10.0, value));
+        }
+
+        List<SignalPoint> output = DataHelper.SmoothLinear(input, 1.0 / 3.0);
+
+        Assert.All(output.Skip(34).Take(11), point => Assert.True(double.IsNaN(point.Y)));
+        Assert.Equal(10.0, output[33].Y, tolerance: 1e-9);
+        Assert.Equal(100.0, output[45].Y, tolerance: 1e-9);
+    }
+
     private static List<SignalPoint> BuildLinearGrid(
         double startHz,
         double stepHz,

--- a/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
@@ -1,0 +1,179 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class FrequencyDependentPhaseTests
+{
+    private const int SampleRate = 48_000;
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(6)]
+    [InlineData(8)]
+    public void PureDelay_AutoDetrendIsFlat(int cycles)
+    {
+        SyntheticMeasurement measurement = DelayedImpulse(960);
+        PhaseAnalysisSettings settings = Settings(
+            PhaseWindowMode.FrequencyDependent,
+            cycles,
+            PhaseDetrendMode.Auto,
+            gateOffsetMs: 20.0);
+
+        double resolved = DataHelper.ResolvePhaseDetrendMilliseconds(measurement, settings);
+        List<SignalPoint> phase = DataHelper.GetGatedPhaseData(measurement, settings);
+
+        Assert.Equal(20.0, resolved, tolerance: 0.06);
+        Assert.All(
+            phase.Where(point => point.X is >= 100 and <= 15_000),
+            point => Assert.True(Math.Abs(point.Y) < 1e-5,
+                $"Residual {point.Y:e} rad at {point.X:0.#} Hz."));
+    }
+
+    [Fact]
+    public void Fdw_InvalidCyclesFallsBackToSix()
+    {
+        SyntheticMeasurement measurement = ReflectedImpulse();
+        List<SignalPoint> invalid = DataHelper.GetGatedPhaseData(
+            measurement,
+            Settings(PhaseWindowMode.FrequencyDependent, 123, PhaseDetrendMode.Manual));
+        List<SignalPoint> six = DataHelper.GetGatedPhaseData(
+            measurement,
+            Settings(PhaseWindowMode.FrequencyDependent, 6, PhaseDetrendMode.Manual));
+
+        Assert.Equal(six, invalid);
+    }
+
+    [Fact]
+    public void Fdw_WhenEveryWindowIsClamped_MatchesFixed()
+    {
+        SyntheticMeasurement measurement = DelayedImpulse(480);
+        PhaseAnalysisSettings fixedSettings = Settings(
+            PhaseWindowMode.Fixed, 6, PhaseDetrendMode.Manual) with
+        {
+            LeftMs = 0.5,
+            PlateauMs = 0.4,
+            RightMs = 0.1
+        };
+        PhaseAnalysisSettings fdwSettings = fixedSettings with
+        {
+            WindowMode = PhaseWindowMode.FrequencyDependent
+        };
+
+        List<SignalPoint> fixedPhase = DataHelper.GetGatedPhaseData(measurement, fixedSettings);
+        List<SignalPoint> fdwPhase = DataHelper.GetGatedPhaseData(measurement, fdwSettings);
+
+        Assert.Equal(fixedPhase.Count, fdwPhase.Count);
+        foreach ((SignalPoint expected, SignalPoint actual) in fixedPhase.Zip(fdwPhase))
+        {
+            Assert.Equal(expected.X, actual.X, precision: 12);
+            double error = Math.IEEERemainder(actual.Y - expected.Y, Math.Tau);
+            Assert.True(Math.Abs(error) < 1e-10);
+        }
+    }
+
+    [Fact]
+    public void CommonDetrendPreservesRelativePhase()
+    {
+        SyntheticMeasurement first = DelayedImpulse(480);
+        SyntheticMeasurement second = DelayedImpulse(504);
+        PhaseAnalysisSettings settings = Settings(
+            PhaseWindowMode.FrequencyDependent,
+            6,
+            PhaseDetrendMode.Manual,
+            manualMs: 10.0);
+        List<SignalPoint> firstPhase = DataHelper.GetGatedPhaseData(first, settings);
+        List<SignalPoint> secondPhase = DataHelper.GetGatedPhaseData(second, settings);
+
+        foreach ((SignalPoint a, SignalPoint b) in firstPhase.Zip(secondPhase)
+                     .Where(pair => pair.First.X is >= 200 and <= 10_000))
+        {
+            double expected = -Math.Tau * a.X * 24 / SampleRate;
+            double actual = Math.IEEERemainder(b.Y - a.Y, Math.Tau);
+            double error = Math.IEEERemainder(actual - expected, Math.Tau);
+            Assert.True(Math.Abs(error) < 1e-5,
+                $"Relative-phase error {error:e} at {a.X:0.#} Hz.");
+        }
+    }
+
+    [Fact]
+    public void CommonAutoDetrend_DoesNotIndependentlyFlattenOtherChannels()
+    {
+        SyntheticMeasurement anchor = DelayedImpulse(480);
+        SyntheticMeasurement later = DelayedImpulse(504);
+        PhaseAnalysisSettings auto = Settings(
+            PhaseWindowMode.FrequencyDependent,
+            6,
+            PhaseDetrendMode.Auto);
+        double common = DataHelper.ResolveCommonPhaseDetrendMilliseconds(anchor, auto);
+        PhaseAnalysisSettings shared = auto with
+        {
+            DetrendMode = PhaseDetrendMode.Manual,
+            ManualDetrendMilliseconds = common
+        };
+
+        List<SignalPoint> anchorPhase = DataHelper.GetGatedPhaseData(anchor, shared);
+        List<SignalPoint> laterPhase = DataHelper.GetGatedPhaseData(later, shared);
+        double anchorEnergy = MeanAbsoluteAngle(anchorPhase, 500, 5_000);
+        double laterEnergy = MeanAbsoluteAngle(laterPhase, 500, 5_000);
+
+        Assert.True(anchorEnergy < 1e-5);
+        Assert.True(laterEnergy > 0.2,
+            "The later channel was independently flattened instead of using the common reference.");
+    }
+
+    [Fact]
+    public void FdwSuppressesLateReflectionMoreAtHighFrequency()
+    {
+        SyntheticMeasurement measurement = ReflectedImpulse();
+        List<SignalPoint> fixedPhase = DataHelper.GetGatedPhaseData(
+            measurement,
+            Settings(PhaseWindowMode.Fixed, 6, PhaseDetrendMode.Manual));
+        List<SignalPoint> fdwPhase = DataHelper.GetGatedPhaseData(
+            measurement,
+            Settings(PhaseWindowMode.FrequencyDependent, 4, PhaseDetrendMode.Manual));
+
+        double fixedHigh = MeanAbsoluteAngle(fixedPhase, 8_000, 15_000);
+        double fdwHigh = MeanAbsoluteAngle(fdwPhase, 8_000, 15_000);
+        Assert.True(fdwHigh < fixedHigh * 0.7,
+            $"FDW {fdwHigh:0.###} rad, fixed {fixedHigh:0.###} rad.");
+    }
+
+    private static double MeanAbsoluteAngle(
+        IEnumerable<SignalPoint> points,
+        double low,
+        double high) => points
+        .Where(point => point.X >= low && point.X <= high)
+        .Average(point => Math.Abs(Math.IEEERemainder(point.Y, Math.Tau)));
+
+    private static PhaseAnalysisSettings Settings(
+        PhaseWindowMode windowMode,
+        int cycles,
+        PhaseDetrendMode detrendMode,
+        double manualMs = 10.0,
+        double gateOffsetMs = 10.0) => new(
+            windowMode,
+            cycles,
+            detrendMode,
+            manualMs,
+            GateOffsetMs: gateOffsetMs,
+            LeftMs: 1.0,
+            PlateauMs: 3.0,
+            RightMs: 12.0,
+            Unwrap: false,
+            SmoothingInverseOctaves: 0.0);
+
+    private static SyntheticMeasurement DelayedImpulse(int sample)
+    {
+        var impulse = new Complex[4_096];
+        impulse[sample] = Complex.One;
+        return new SyntheticMeasurement(impulse, SampleRate, sample);
+    }
+
+    private static SyntheticMeasurement ReflectedImpulse()
+    {
+        var impulse = new Complex[4_096];
+        impulse[480] = Complex.One;
+        impulse[576] = new Complex(0.4, 0.0); // 2 ms late reflection
+        return new SyntheticMeasurement(impulse, SampleRate, 480);
+    }
+}


### PR DESCRIPTION
## Summary

- add a shared Fixed/FDW phase-analysis pipeline with 4, 6, and 8-cycle windows
- support Auto, Manual, and Off detrend modes while preserving the existing reliability-aware unwrap
- use the selected spectrum consistently for measured, minimum, and excess phase
- share phase settings and one common Auto detrend reference with Virtual DSP
- migrate existing settings and projects without changing their Fixed/manual phase representation
- cache reusable phase spectra and add FDW, relative-phase, clamp-equivalence, and NaN-smoothing regressions

## Why

Frequency-dependent windowing suppresses late reflection energy at mid and high frequencies, producing a cleaner and more readable measured-phase graph in difficult acoustic environments such as car cabins. Low frequencies retain the existing longer gate, while Fixed mode remains available for compatibility.

## Validation

- `dotnet test source/Resonalyze.sln -c Release --no-restore`
  - 525 DSP tests passed
  - 402 app tests passed
- `dotnet build source/Resonalyze.sln -c Release --no-restore`
- focused FDW regression suite passed
- `git diff --check`
