### PR TITLE
Virtual DSP: envelope-first auto delay, impulse view, paired PDF export

### DIFF
--- a/dsp/AlignmentSelection.cs
+++ b/dsp/AlignmentSelection.cs
@@ -16,7 +16,7 @@ public static class AlignmentSelection
     /// tweeter cabin junction hands one +0.32 dB), while a genuinely flipped
     /// driver wins by the full arrival-prior penalty of its non-inverted
     /// impostors — several dB, not fractions. Same envelope-first principle
-    /// as the promotion distance ramp: a half-period flip hop must be
+    /// as the wide-window promotion margin: a half-period flip hop must be
     /// plainly better, not marginally.
     /// </summary>
     public const double DefaultInvertPreferenceMarginDb = 0.5;

--- a/dsp/AlignmentSelection.cs
+++ b/dsp/AlignmentSelection.cs
@@ -12,11 +12,14 @@ public static class AlignmentSelection
     /// <summary>
     /// An inverted winner must beat the best non-inverted candidate by this
     /// margin (dB): room reflections routinely hand a (flip + half-period
-    /// shift) impostor a few hundredths of a dB inside the pair band, while a
-    /// genuinely flipped driver wins by the full arrival-prior penalty of its
-    /// non-inverted impostors.
+    /// shift) impostor a few tenths of a dB inside the pair band (the r mid/
+    /// tweeter cabin junction hands one +0.32 dB), while a genuinely flipped
+    /// driver wins by the full arrival-prior penalty of its non-inverted
+    /// impostors — several dB, not fractions. Same envelope-first principle
+    /// as the promotion distance ramp: a half-period flip hop must be
+    /// plainly better, not marginally.
     /// </summary>
-    public const double DefaultInvertPreferenceMarginDb = 0.25;
+    public const double DefaultInvertPreferenceMarginDb = 0.5;
 
     /// <summary>
     /// Among same-polarity candidates within this score margin (dB), the one

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -863,7 +863,9 @@ public static class AutoAlignmentEngine
             IAlignmentChannel rightChannel,
             StereoPairLink link,
             double bandLowHz,
-            double bandHighHz)
+            double bandHighHz,
+            double fallbackLowHz,
+            double fallbackHighHz)
         {
             var searchAlignment =
                 new Dictionary<IAlignmentChannel, AlignmentOverride>(alignment);
@@ -873,75 +875,122 @@ public static class AutoAlignmentEngine
                 current.First(item => item.Channel == link.Left).ImpulseResponse;
             Complex[] rightIr =
                 current.First(item => item.Channel == rightChannel).ImpulseResponse;
-            TimeAlignmentAnalysisResult leftArrival =
-                VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
-                    leftIr, link.Left.SampleRate, bandLowHz, bandHighHz);
-            TimeAlignmentAnalysisResult rightRaw =
-                VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
-                    rightIr, rightChannel.SampleRate, bandLowHz, bandHighHz);
-            if (!leftArrival.IsValid || !rightRaw.IsValid ||
-                leftArrival.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
-                rightRaw.SignalToNoiseDecibels < MinimumArrivalSnrDb)
+
+            // Both sides measured in one band, with a modal-latch guard: the
+            // Latched flag separates "one side timed the wrong feature" (worth
+            // retrying one band up) from "the band cannot be measured at all"
+            // (silence or a too-narrow intersection — the link stays without a
+            // target, exactly as before the ladder existed).
+            // SAME driver measured in the band's upper half must agree with
+            // the full-band read to within the dispersion one direct wave
+            // packet can show (half a period at the probe's low edge). A
+            // full-band read landing far BEHIND its own upper-half read means
+            // the detector latched that side onto the in-room modal build-up
+            // instead of the direct rise (the under-seat midbass case:
+            // 21.2 ms in 80-200 Hz vs 13.9 ms one band up) — the two sides
+            // are then timing DIFFERENT features and their difference is
+            // garbage. The narrow upper half itself is NOT a substitute (at a
+            // low band it is an octave of mush that once dragged a woofer
+            // 6 ms off) — it only votes on the full band's honesty.
+            ((TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
+                Reads, bool Latched) MeasureConsistent(double lowHz, double highHz)
+            {
+                TimeAlignmentAnalysisResult left =
+                    VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                        leftIr, link.Left.SampleRate, lowHz, highHz);
+                TimeAlignmentAnalysisResult right =
+                    VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                        rightIr, rightChannel.SampleRate, lowHz, highHz);
+                if (!left.IsValid || !right.IsValid ||
+                    left.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
+                    right.SignalToNoiseDecibels < MinimumArrivalSnrDb)
+                {
+                    return (null, false);
+                }
+
+                double probeLowHz = Math.Sqrt(lowHz * highHz);
+                if (highHz <
+                    probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
+                {
+                    return ((left, right), false);
+                }
+
+                TimeAlignmentAnalysisResult leftProbe =
+                    VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                        leftIr, link.Left.SampleRate, probeLowHz, highHz);
+                TimeAlignmentAnalysisResult rightProbe =
+                    VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                        rightIr, rightChannel.SampleRate, probeLowHz, highHz);
+                if (!leftProbe.IsValid || !rightProbe.IsValid ||
+                    leftProbe.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
+                    rightProbe.SignalToNoiseDecibels < MinimumArrivalSnrDb)
+                {
+                    return ((left, right), false);
+                }
+
+                double toleranceMs = Math.Max(1.0, 500.0 / probeLowHz);
+                bool leftLatched = left.FirstArrivalDelayMilliseconds
+                    - leftProbe.FirstArrivalDelayMilliseconds > toleranceMs;
+                bool rightLatched = right.FirstArrivalDelayMilliseconds
+                    - rightProbe.FirstArrivalDelayMilliseconds > toleranceMs;
+                if (leftLatched || rightLatched)
+                {
+                    log.AppendLine(
+                        $"  cross-side link {rightChannel.Name}: " +
+                        $"{(leftLatched ? link.Left.Name : rightChannel.Name)}" +
+                        $" reads {(leftLatched ? left : right).FirstArrivalDelayMilliseconds:0.000} ms" +
+                        $" in {lowHz:0}-{highHz:0} Hz but " +
+                        $"{(leftLatched ? leftProbe : rightProbe).FirstArrivalDelayMilliseconds:0.000} ms" +
+                        $" in its {probeLowHz:0}-{highHz:0} Hz half " +
+                        "(modal latch: the sides time different features)");
+                    return (null, true);
+                }
+
+                return ((left, right), false);
+            }
+
+            // The consistency ladder: the pair's own shared band first; when a
+            // side LATCHED there, the channel's junction band — the engine
+            // already trusts it for junction work, and the direct rise that
+            // hid under a mode in the low link band is usually plain one
+            // octave up. An unmeasurable link band (silence, too narrow) does
+            // NOT ladder: the link was inadmissible, not mis-read. Only when
+            // both bands are poisoned is the prior withdrawn and the search
+            // keeps its own-side junction anchor.
+            double usedLowHz = bandLowHz;
+            double usedHighHz = bandHighHz;
+            ((TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
+                Reads, bool Latched) measured =
+                MeasureConsistent(bandLowHz, bandHighHz);
+            if (measured.Reads == null && measured.Latched &&
+                (fallbackLowHz != bandLowHz || fallbackHighHz != bandHighHz))
+            {
+                measured = MeasureConsistent(fallbackLowHz, fallbackHighHz);
+                if (measured.Reads != null)
+                {
+                    usedLowHz = fallbackLowHz;
+                    usedHighHz = fallbackHighHz;
+                }
+                else if (measured.Latched)
+                {
+                    log.AppendLine(
+                        $"  cross-side prior {rightChannel.Name}: withdrawn — " +
+                        "no band reads both sides' direct arrivals consistently");
+                }
+            }
+            if (measured.Reads is not { } arrivals)
             {
                 return null;
             }
 
-            // Modal-latch guard: the SAME driver measured in the band's upper
-            // half must agree with the full-band read to within the dispersion
-            // one direct wave packet can show (half a period at the probe's
-            // low edge). A full-band read landing far BEHIND its own upper-half
-            // read means the detector latched that side onto the in-room modal
-            // build-up instead of the direct rise (the under-seat midbass case:
-            // 21.2 ms in 80-200 Hz vs 15.2 ms one band up) — the two sides are
-            // then timing DIFFERENT features and their difference is garbage.
-            // The honest response is to withdraw the prior (the search keeps
-            // its own-side junction anchor), NOT to re-measure in the narrow
-            // upper half: at a low link band that probe is an octave of mush
-            // (~1/BW blur of many ms) that once dragged a woofer 6 ms off.
-            double probeLowHz = Math.Sqrt(bandLowHz * bandHighHz);
-            if (bandHighHz >=
-                probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
-            {
-                TimeAlignmentAnalysisResult leftProbe =
-                    VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
-                        leftIr, link.Left.SampleRate, probeLowHz, bandHighHz);
-                TimeAlignmentAnalysisResult rightProbe =
-                    VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
-                        rightIr, rightChannel.SampleRate, probeLowHz, bandHighHz);
-                double toleranceMs = Math.Max(1.0, 500.0 / probeLowHz);
-                if (leftProbe.IsValid && rightProbe.IsValid &&
-                    leftProbe.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
-                    rightProbe.SignalToNoiseDecibels >= MinimumArrivalSnrDb)
-                {
-                    bool leftLatched =
-                        leftArrival.FirstArrivalDelayMilliseconds
-                        - leftProbe.FirstArrivalDelayMilliseconds > toleranceMs;
-                    bool rightLatched =
-                        rightRaw.FirstArrivalDelayMilliseconds
-                        - rightProbe.FirstArrivalDelayMilliseconds > toleranceMs;
-                    if (leftLatched || rightLatched)
-                    {
-                        log.AppendLine(
-                            $"  cross-side prior {rightChannel.Name}: withdrawn — " +
-                            $"{(leftLatched ? link.Left.Name : rightChannel.Name)}" +
-                            $" reads {(leftLatched ? leftArrival : rightRaw).FirstArrivalDelayMilliseconds:0.000} ms" +
-                            $" in {bandLowHz:0}-{bandHighHz:0} Hz but " +
-                            $"{(leftLatched ? leftProbe : rightProbe).FirstArrivalDelayMilliseconds:0.000} ms" +
-                            $" in its {probeLowHz:0}-{bandHighHz:0} Hz half " +
-                            "(modal latch: the sides time different features)");
-                        return null;
-                    }
-                }
-            }
-
-            double target = leftArrival.FirstArrivalDelayMilliseconds
+            double target = arrivals.Left.FirstArrivalDelayMilliseconds
                 - plan.SceneOffsetMs
-                - rightRaw.FirstArrivalDelayMilliseconds;
+                - arrivals.Right.FirstArrivalDelayMilliseconds;
             log.AppendLine(
                 $"  cross-side prior {rightChannel.Name}: target {target:0.000} ms " +
-                $"(L arrival {leftArrival.FirstArrivalDelayMilliseconds:0.000}, " +
-                $"raw R {rightRaw.FirstArrivalDelayMilliseconds:0.000} ms " +
-                $"in {bandLowHz:0}-{bandHighHz:0} Hz)");
+                $"(L arrival {arrivals.Left.FirstArrivalDelayMilliseconds:0.000}, " +
+                $"raw R {arrivals.Right.FirstArrivalDelayMilliseconds:0.000} ms " +
+                $"in {usedLowHz:0}-{usedHighHz:0} Hz)");
             return target;
         }
 
@@ -974,9 +1023,15 @@ public static class AutoAlignmentEngine
             // The scene mandate: pairs reaching the localization region are
             // pinned to the cross-side target, which is then measured in the
             // localization sub-band alone — the low end of a wide shared band
-            // (soft envelopes, no localization) must not smear the pin. Pure
-            // low-frequency pairs keep the free joint-junction search with
-            // the full-band target as a gentle prior only.
+            // (soft envelopes, no localization) must not smear the pin. A
+            // pure low-frequency pair is pinned too, but only to the LOBE: an
+            // identical L/R driver pair's delay split is physical (path
+            // difference), and a junction comb whose lobes differ by a dB
+            // must not choose it — the field failure put one under-seat
+            // midbass at 0 and the other at 10.85 ms for exactly that. The
+            // lock tolerance is half the period of the tightest junction the
+            // channel searches against, so the sum keeps full authority
+            // inside the arrival's lobe and none across lobes.
             StereoPairLink? channelLink = plan.PairLinks?.FirstOrDefault(
                 item => item.Right == channel);
             bool lockable = channelLink != null && IsSceneLockable(channelLink);
@@ -988,10 +1043,16 @@ public static class AutoAlignmentEngine
                     lockable
                         ? Math.Max(channelLink.BandLowHz, SceneLockLocalizationLowHz)
                         : channelLink.BandLowHz,
-                    channelLink.BandHighHz);
-            double? sceneLock = lockable && crossTarget != null
-                ? SceneLockToleranceMs
-                : null;
+                    channelLink.BandHighHz,
+                    pair.BandLowHz,
+                    pair.BandHighHz);
+            double? sceneLock = crossTarget == null
+                ? null
+                : lockable
+                    ? SceneLockToleranceMs
+                    : 500.0 / Math.Max(
+                        pair.CrossoverHz,
+                        secondaryPair?.CrossoverHz ?? pair.CrossoverHz);
 
             // Polarity is a property of the DRIVER, not the side: a right channel
             // inherits the sign its left counterpart settled on (the two are the
@@ -1067,9 +1128,12 @@ public static class AutoAlignmentEngine
     // (the left counterpart's settled arrival minus the scene offset) and may
     // fine-tune its junction sum only within this tolerance — the stereo
     // image outranks the junction handover. Pairs living entirely below the
-    // localization region (the woofers) keep the free joint-junction search:
-    // the ear does not localize there, low-band envelope arrivals are soft,
-    // and the summation is what remains audible.
+    // localization region (the woofers) are pinned more loosely, to the
+    // arrival's LOBE (half the tightest adjacent junction period): the ear
+    // does not localize there, but an identical driver pair's delay split is
+    // still physical, and the junction comb must polish within that lobe,
+    // not choose one. With no reliable cross-side arrival at all the free
+    // joint-junction search remains.
     private const double SceneLockToleranceMs = 0.05;
 
     // The lower edge of the localization region. Only the part of a pair's
@@ -1180,8 +1244,11 @@ public static class AutoAlignmentEngine
             return;
         }
 
+        // Every linked pair participates: the scene-locked ones paid their
+        // junction sums to the stereo image, the low-frequency ones to the
+        // arrival-lobe pin — co-moving both sides by one delta repairs those
+        // junctions without touching what the pin bought.
         foreach (StereoPairLink link in plan.PairLinks
-            .Where(IsSceneLockable)
             .OrderByDescending(item => item.BandHighHz))
         {
             AlignmentOverride leftOverride = alignment.GetValueOrDefault(link.Left);
@@ -1196,6 +1263,18 @@ public static class AutoAlignmentEngine
                     pair.Upper.Channel == link.Right))
                 .ToList();
             if (adjacent.Count == 0)
+            {
+                continue;
+            }
+
+            // A pair bordering the shared mono channel is not co-moved: the
+            // mono is timed by the LEFT pass alone (a pinned invariant — the
+            // sub/left-woofer relation must match a left-only run exactly),
+            // and a shared shift of the pair would silently re-time the left
+            // side against it.
+            if (adjacent.Any(junction =>
+                plan.MonoChannels.Contains(junction.Lower.Channel) ||
+                plan.MonoChannels.Contains(junction.Upper.Channel)))
             {
                 continue;
             }

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -549,6 +549,13 @@ public static class AutoAlignmentEngine
                         $"dip {item.DipDb:0.0} dB)"))
                     : "none"));
 
+            // The arrival-anchored pick, captured BEFORE the edge-retry can move
+            // it: the promotion reach is measured from here, so a retry that
+            // legitimately widened the window (up to ~0.9 period) cannot stack
+            // with the promotion cap to let a comb alias land >2.5 periods off
+            // the envelope.
+            AlignmentCandidate arrivalPick = chosen;
+
             // A result pinned to the window edge means the optimum lies beyond
             // the coarse estimate's reach — retry once, widened but still short
             // of a full period so the search cannot land on the next lobe. The
@@ -593,12 +600,19 @@ public static class AutoAlignmentEngine
                 // score is a comb alias the summation cannot distinguish, so the
                 // envelope stays authoritative (see PromotionReachPeriods). Inside
                 // the reach, a hop onto another comb lobe must be plainly, not
-                // marginally, better (see WideWindowPromotionMarginDb).
+                // marginally, better (see WideWindowPromotionMarginDb). Both the
+                // reach (from the pre-retry arrival pick) and the gain (a
+                // prior-free acoustic score) are measured on quantities that do
+                // NOT depend on the search-window width — the wide diagnostic
+                // window carries a weaker arrival prior than the fine window, so
+                // comparing raw ScoreDb would credit a promotion for the prior
+                // relaxation alone.
                 double periodMs = 2.0 * halfPeriodMs;
                 double promotionReachMs = PromotionReachPeriods * periodMs;
-                double promotionStepMs = Math.Abs(wideChosen.DelayMs - chosen.DelayMs);
+                double promotionStepMs =
+                    Math.Abs(wideChosen.DelayMs - arrivalPick.DelayMs);
                 double periodsMoved = promotionStepMs / periodMs;
-                double gainDb = wideChosen.ScoreDb - chosen.ScoreDb;
+                double gainDb = AcousticScore(wideChosen) - AcousticScore(chosen);
                 if (gainDb > WideWindowPromotionMarginDb &&
                     promotionStepMs <= promotionReachMs)
                 {
@@ -616,7 +630,7 @@ public static class AutoAlignmentEngine
                     log.AppendLine(
                         $"  promotion declined: {wideChosen.DelayMs:0.000} ms is " +
                         $"{promotionStepMs:0.000} ms ({periodsMoved:0.0} " +
-                        $"periods) from the arrival pick {chosen.DelayMs:0.000} ms — " +
+                        $"periods) from the arrival pick {arrivalPick.DelayMs:0.000} ms — " +
                         "a comb alias beyond the envelope's reach.");
                 }
                 else if (gainDb > PromotionNoteworthyGainDb)
@@ -643,6 +657,17 @@ public static class AutoAlignmentEngine
                 chosen.InvertPolarity);
         }
     }
+
+    // A candidate's summation quality WITHOUT the arrival-prior penalty: the
+    // raw in-band average plus the same dip-excess term the candidate scores
+    // carry. The stored ScoreDb is this minus a prior penalty whose strength
+    // scales with the search window (priorSigma = window / 4), so ScoreDb is
+    // only comparable WITHIN one window; cross-window comparisons (the wide
+    // promotion vs the fine pick) must use this prior-free figure.
+    private static double AcousticScore(AlignmentCandidate candidate) =>
+        candidate.LossDb +
+        VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
+        (candidate.DipDb - candidate.LossDb);
 
     // A uniform delay shift of every channel in the scope but one: the standard
     // way to "advance" a channel that would otherwise need a negative delay.
@@ -1295,6 +1320,17 @@ public static class AutoAlignmentEngine
             return;
         }
 
+        // The co-move delta already applied to each channel, so a lower pair's
+        // reach is bounded relative to its already-settled neighbor — NOT
+        // relative to zero. Each per-pair move is capped at half a junction
+        // period, but two adjacent pairs moving that far in opposite directions
+        // would open a FULL period across their shared junction (a comb alias:
+        // the sum is back in phase, so the search sees no loss, yet the absolute
+        // alignment jumped a lobe). Constraining each pair's window around the
+        // neighbor's applied delta keeps the RELATIVE shift across every shared
+        // junction within half a period, which is what the reach cap must mean.
+        var comoveDeltas = new Dictionary<IAlignmentChannel, double>();
+
         // Every linked pair participates: the scene-locked ones paid their
         // junction sums to the stereo image, the low-frequency ones to the
         // arrival-lobe pin — co-moving both sides by one delta repairs those
@@ -1385,18 +1421,33 @@ public static class AutoAlignmentEngine
                 return total / evaluators.Count;
             }
 
-            // The tightest (highest-frequency) adjacent junction bounds the
-            // pair's reach: within half its period the junction sums are
-            // single-lobed, so the search can only polish the alignment the
-            // arrival-anchored walk chose. Past that lies the next comb lobe —
-            // and fractions of a dB of mean junction loss cannot choose a lobe
-            // (the same physics as the wide-window promotion reach cap). The
-            // flat window alone let a 0.1-0.2 dB "gain" walk the tweeter pair
-            // a whole period off its mid at a 2.3 kHz junction.
-            double tightestPeriodMs =
-                1_000.0 / adjacent.Max(junction => junction.CrossoverHz);
-            double reachMs = Math.Min(
-                PairComoveSearchRangeMs, 0.5 * tightestPeriodMs);
+            // Each adjacent junction bounds the pair's reach to within half its
+            // period OF THE NEIGHBOR'S ALREADY-APPLIED co-move delta: within
+            // half a period the junction sums are single-lobed, so the search
+            // can only polish the alignment the arrival-anchored walk chose.
+            // Past that lies the next comb lobe — and fractions of a dB of mean
+            // junction loss cannot choose a lobe (the same physics as the
+            // wide-window promotion reach cap). Centering on the neighbor's
+            // delta (0 for a channel that never co-moves — a mono/fixed
+            // neighbor) is what keeps the RELATIVE shift across the junction
+            // bounded even when the neighbor pair already moved; a flat ±half
+            // period around zero let two adjacent pairs drift a full period
+            // apart, and the flat window alone let a 0.1-0.2 dB "gain" walk the
+            // tweeter pair a whole period off its mid at a 2.3 kHz junction.
+            double lobeLowMs = -PairComoveSearchRangeMs;
+            double lobeHighMs = PairComoveSearchRangeMs;
+            foreach (AlignmentJunction junction in adjacent)
+            {
+                IAlignmentChannel neighbor =
+                    junction.Lower.Channel == link.Left ||
+                    junction.Lower.Channel == link.Right
+                        ? junction.Upper.Channel
+                        : junction.Lower.Channel;
+                double neighborDelta = comoveDeltas.GetValueOrDefault(neighbor);
+                double halfPeriodMs = 500.0 / junction.CrossoverHz;
+                lobeLowMs = Math.Max(lobeLowMs, neighborDelta - halfPeriodMs);
+                lobeHighMs = Math.Min(lobeHighMs, neighborDelta + halfPeriodMs);
+            }
 
             // Both bounds are fixed BEFORE the search so the winning delta
             // applies verbatim to both sides: negative deltas may not push
@@ -1404,18 +1455,24 @@ public static class AutoAlignmentEngine
             // past the delay ceiling. Clamping after the fact would move the
             // two sides unequally and silently bend the very scene this pass
             // exists to preserve.
-            double minDelta = -Math.Min(
-                Math.Min(leftOverride.DelayMs, rightOverride.DelayMs),
-                reachMs);
+            double minDelta = Math.Max(
+                lobeLowMs,
+                -Math.Min(leftOverride.DelayMs, rightOverride.DelayMs));
             double maxDelta = Math.Min(
-                reachMs,
+                lobeHighMs,
                 MaxDelayMs - Math.Max(leftOverride.DelayMs, rightOverride.DelayMs));
+            // The neighbor lobes can, in principle, exclude zero (a settled
+            // neighbor a hair over half a period away); never let the window
+            // invert or force a non-zero move — keeping the pair is always legal.
+            minDelta = Math.Min(minDelta, 0.0);
+            maxDelta = Math.Max(maxDelta, 0.0);
             double baseline = Score(0);
             double bestDelta = 0;
             double bestScore = baseline;
             // The coarse step scales down with the window so a tightly-capped
             // high-junction pair still gets a real grid before refinement.
-            double coarseStep = Math.Min(0.1, Math.Max(0.02, reachMs / 4.0));
+            double coarseStep = Math.Min(
+                0.1, Math.Max(0.02, (maxDelta - minDelta) / 8.0));
             for (double delta = minDelta; delta <= maxDelta + 1e-9; delta += coarseStep)
             {
                 double score = Score(delta);
@@ -1452,6 +1509,11 @@ public static class AutoAlignmentEngine
                 {
                     DelayMs = Math.Round(rightOverride.DelayMs + bestDelta, 2)
                 };
+                // Record the applied shift so a lower pair's reach is measured
+                // from here, keeping the relative shift across the shared
+                // junction within half a period.
+                comoveDeltas[link.Left] = bestDelta;
+                comoveDeltas[link.Right] = bestDelta;
                 log.AppendLine(
                     $"Co-move {link.Left.Name}+{link.Right.Name}: " +
                     $"{bestDelta:+0.00;-0.00} ms to both sides " +

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -170,8 +170,22 @@ public static class AutoAlignmentEngine
     // the coarse arrival, which at a high crossover can be a whole lobe off (its
     // period is a fraction of the arrival uncertainty); the promotion recovers
     // that lobe, while the margin keeps the physically-minimal arrival pick
-    // unless a distinctly better summation exists elsewhere.
+    // unless a distinctly better summation exists elsewhere. This flat floor
+    // governs sub-lobe moves; per-period hops pay the distance ramp below.
     private const double WideWindowPromotionMarginDb = 0.2;
+
+    // The distance ramp of the promotion margin: how much MORE the wide pick
+    // must win per crossover period it moves away from the arrival-anchored
+    // result. The envelope is the fundamental observation — on a healthy
+    // junction the summation surface is a comb whose lobes differ by mere
+    // fractions of a dB to ~1.4 dB (the head_90_grad cabin: a 1.40 dB "gain"
+    // 0.92 periods out walked the tweeter pair visibly ahead of its mid while
+    // the other side's junction got WORSE), so a hop must be justified by a
+    // gain that grows with the hop: one period costs 2 dB, two cost 4 dB. A
+    // genuine lobe recovery — the coarse arrival itself off by periods —
+    // shows up as a multi-dB gain (a misaligned junction combs across the
+    // whole overlap) and still clears the ramp.
+    private const double PromotionMarginPerPeriodDb = 2.0;
 
     // How far (in crossover periods) the promotion may move the pick away from
     // the arrival-anchored fine result. The promotion exists to recover a coarse
@@ -579,28 +593,46 @@ public static class AutoAlignmentEngine
                     AlignmentSelection.Select(wide, anchorMs);
                 // Only a lobe's reach from the arrival pick: past that the "better"
                 // score is a comb alias the summation cannot distinguish, so the
-                // envelope stays authoritative (see PromotionReachPeriods).
-                double promotionReachMs = PromotionReachPeriods * 2.0 * halfPeriodMs;
+                // envelope stays authoritative (see PromotionReachPeriods). Inside
+                // the reach, the required margin RAMPS with the distance in
+                // periods: the arrival is the fundamental observation, and a hop
+                // onto another comb lobe must be plainly, not marginally, better.
+                double periodMs = 2.0 * halfPeriodMs;
+                double promotionReachMs = PromotionReachPeriods * periodMs;
                 double promotionStepMs = Math.Abs(wideChosen.DelayMs - chosen.DelayMs);
-                if (wideChosen.ScoreDb > chosen.ScoreDb + WideWindowPromotionMarginDb &&
-                    promotionStepMs <= promotionReachMs)
+                double periodsMoved = promotionStepMs / periodMs;
+                double requiredMarginDb = Math.Max(
+                    WideWindowPromotionMarginDb,
+                    PromotionMarginPerPeriodDb * periodsMoved);
+                double gainDb = wideChosen.ScoreDb - chosen.ScoreDb;
+                if (gainDb > requiredMarginDb && promotionStepMs <= promotionReachMs)
                 {
                     log.AppendLine(
                         $"  promoted {wideChosen.DelayMs:0.000} ms" +
                         $"{(wideChosen.InvertPolarity ? " inv" : "")} " +
                         $"over {chosen.DelayMs:0.000} ms" +
                         $"{(chosen.InvertPolarity ? " inv" : "")} " +
-                        $"(gain {wideChosen.ScoreDb - chosen.ScoreDb:0.00} dB)");
+                        $"(gain {gainDb:0.00} dB, needed {requiredMarginDb:0.00} dB " +
+                        $"at {periodsMoved:0.0} periods)");
                     chosen = wideChosen;
                 }
-                else if (wideChosen.ScoreDb > chosen.ScoreDb + WideWindowPromotionMarginDb &&
+                else if (gainDb > WideWindowPromotionMarginDb &&
                     promotionStepMs > promotionReachMs)
                 {
                     log.AppendLine(
                         $"  promotion declined: {wideChosen.DelayMs:0.000} ms is " +
-                        $"{promotionStepMs:0.000} ms ({promotionStepMs / (2.0 * halfPeriodMs):0.0} " +
+                        $"{promotionStepMs:0.000} ms ({periodsMoved:0.0} " +
                         $"periods) from the arrival pick {chosen.DelayMs:0.000} ms — " +
                         "a comb alias beyond the envelope's reach.");
+                }
+                else if (gainDb > WideWindowPromotionMarginDb)
+                {
+                    log.AppendLine(
+                        $"  promotion declined: {wideChosen.DelayMs:0.000} ms" +
+                        $"{(wideChosen.InvertPolarity ? " inv" : "")} gains only " +
+                        $"{gainDb:0.00} dB over {chosen.DelayMs:0.000} ms — " +
+                        $"a {periodsMoved:0.0}-period hop off the arrival needs " +
+                        $"{requiredMarginDb:0.00} dB.");
                 }
             }
 

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -167,25 +167,23 @@ public static class AutoAlignmentEngine
 
     // How much better (in score dB) a wide-window optimum must be before it
     // unseats the arrival-anchored fine pick. The narrow window is centered on
-    // the coarse arrival, which at a high crossover can be a whole lobe off (its
-    // period is a fraction of the arrival uncertainty); the promotion recovers
-    // that lobe, while the margin keeps the physically-minimal arrival pick
-    // unless a distinctly better summation exists elsewhere. This flat floor
-    // governs sub-lobe moves; per-period hops pay the distance ramp below.
-    private const double WideWindowPromotionMarginDb = 0.2;
+    // the coarse arrival, which at a high crossover can be a whole lobe off
+    // (spread corners bias the two envelopes by more than a period); the
+    // promotion recovers that lobe, while the margin keeps the physically-
+    // minimal arrival pick unless a distinctly better summation exists
+    // elsewhere. Calibrated on two field runs of the same cabin: a FALSE hop
+    // (the tweeter pair walking visibly ahead of its mid while the other
+    // side's junction worsened) offered 1.40 dB, a GENUINE lobe recovery
+    // (the arrival lobe combing at dip -5.6 everywhere, the user's manual
+    // optimum two periods earlier at dip -1.6) offered 1.91 dB — comb noise
+    // between real lobes runs up to ~1.4 dB, a real envelope error shows as
+    // ~2 dB across the whole basin. A distance-scaled ramp cannot separate
+    // those two points at any slope; this flat threshold does.
+    private const double WideWindowPromotionMarginDb = 1.6;
 
-    // The distance ramp of the promotion margin: how much MORE the wide pick
-    // must win per crossover period it moves away from the arrival-anchored
-    // result. The envelope is the fundamental observation — on a healthy
-    // junction the summation surface is a comb whose lobes differ by mere
-    // fractions of a dB to ~1.4 dB (the head_90_grad cabin: a 1.40 dB "gain"
-    // 0.92 periods out walked the tweeter pair visibly ahead of its mid while
-    // the other side's junction got WORSE), so a hop must be justified by a
-    // gain that grows with the hop: one period costs 2 dB, two cost 4 dB. A
-    // genuine lobe recovery — the coarse arrival itself off by periods —
-    // shows up as a multi-dB gain (a misaligned junction combs across the
-    // whole overlap) and still clears the ramp.
-    private const double PromotionMarginPerPeriodDb = 2.0;
+    // The gain above which a declined promotion is worth a log line: below it
+    // the wide window merely confirmed the arrival pick.
+    private const double PromotionNoteworthyGainDb = 0.2;
 
     // How far (in crossover periods) the promotion may move the pick away from
     // the arrival-anchored fine result. The promotion exists to recover a coarse
@@ -594,29 +592,25 @@ public static class AutoAlignmentEngine
                 // Only a lobe's reach from the arrival pick: past that the "better"
                 // score is a comb alias the summation cannot distinguish, so the
                 // envelope stays authoritative (see PromotionReachPeriods). Inside
-                // the reach, the required margin RAMPS with the distance in
-                // periods: the arrival is the fundamental observation, and a hop
-                // onto another comb lobe must be plainly, not marginally, better.
+                // the reach, a hop onto another comb lobe must be plainly, not
+                // marginally, better (see WideWindowPromotionMarginDb).
                 double periodMs = 2.0 * halfPeriodMs;
                 double promotionReachMs = PromotionReachPeriods * periodMs;
                 double promotionStepMs = Math.Abs(wideChosen.DelayMs - chosen.DelayMs);
                 double periodsMoved = promotionStepMs / periodMs;
-                double requiredMarginDb = Math.Max(
-                    WideWindowPromotionMarginDb,
-                    PromotionMarginPerPeriodDb * periodsMoved);
                 double gainDb = wideChosen.ScoreDb - chosen.ScoreDb;
-                if (gainDb > requiredMarginDb && promotionStepMs <= promotionReachMs)
+                if (gainDb > WideWindowPromotionMarginDb &&
+                    promotionStepMs <= promotionReachMs)
                 {
                     log.AppendLine(
                         $"  promoted {wideChosen.DelayMs:0.000} ms" +
                         $"{(wideChosen.InvertPolarity ? " inv" : "")} " +
                         $"over {chosen.DelayMs:0.000} ms" +
                         $"{(chosen.InvertPolarity ? " inv" : "")} " +
-                        $"(gain {gainDb:0.00} dB, needed {requiredMarginDb:0.00} dB " +
-                        $"at {periodsMoved:0.0} periods)");
+                        $"(gain {gainDb:0.00} dB at {periodsMoved:0.0} periods)");
                     chosen = wideChosen;
                 }
-                else if (gainDb > WideWindowPromotionMarginDb &&
+                else if (gainDb > PromotionNoteworthyGainDb &&
                     promotionStepMs > promotionReachMs)
                 {
                     log.AppendLine(
@@ -625,14 +619,13 @@ public static class AutoAlignmentEngine
                         $"periods) from the arrival pick {chosen.DelayMs:0.000} ms — " +
                         "a comb alias beyond the envelope's reach.");
                 }
-                else if (gainDb > WideWindowPromotionMarginDb)
+                else if (gainDb > PromotionNoteworthyGainDb)
                 {
                     log.AppendLine(
                         $"  promotion declined: {wideChosen.DelayMs:0.000} ms" +
                         $"{(wideChosen.InvertPolarity ? " inv" : "")} gains only " +
                         $"{gainDb:0.00} dB over {chosen.DelayMs:0.000} ms — " +
-                        $"a {periodsMoved:0.0}-period hop off the arrival needs " +
-                        $"{requiredMarginDb:0.00} dB.");
+                        $"a lobe hop needs {WideWindowPromotionMarginDb:0.00} dB.");
                 }
             }
 

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -173,6 +173,23 @@ public static class AutoAlignmentEngine
     // unless a distinctly better summation exists elsewhere.
     private const double WideWindowPromotionMarginDb = 0.2;
 
+    // How far (in crossover periods) the promotion may move the pick away from
+    // the arrival-anchored fine result. The promotion exists to recover a coarse
+    // arrival that landed a lobe or two off at a degenerate junction (a spectral
+    // gap between the corners degrades the whitened correlation into near-equal
+    // lobes) — real data needs up to ~2 periods of reach for that (the r mid/
+    // tweeter cabin junction recovers the user's manual optimum ~1.8 periods off
+    // the fine pick). Beyond that the summation surface is a comb of near-equal
+    // minima spaced one period apart: which lobe is physically correct is set by
+    // the arrival, NOT by the sum (they differ by fractions of a dB). Without a
+    // cap the ±3 ms diagnostic window lets a marginally-better comb ALIAS three
+    // to four periods away unseat the envelope at a high crossover — the field
+    // failure where the tweeter walked ~1.7 ms (~3.9 periods) off its mid for a
+    // 0.25 dB "gain". 2.5 periods clears the legitimate ~1.8-period recovery and
+    // rejects the ~3.9-period alias. The wide window also scores under a weaker
+    // arrival prior, which inflates far aliases; the reach cap bounds that too.
+    private const double PromotionReachPeriods = 2.5;
+
     /// <summary>
     /// Runs the two-stage alignment. <paramref name="channelsByBand"/> holds
     /// the initial snapshots ordered along the spectrum;
@@ -560,7 +577,13 @@ public static class AutoAlignmentEngine
             {
                 AlignmentCandidate wideChosen =
                     AlignmentSelection.Select(wide, anchorMs);
-                if (wideChosen.ScoreDb > chosen.ScoreDb + WideWindowPromotionMarginDb)
+                // Only a lobe's reach from the arrival pick: past that the "better"
+                // score is a comb alias the summation cannot distinguish, so the
+                // envelope stays authoritative (see PromotionReachPeriods).
+                double promotionReachMs = PromotionReachPeriods * 2.0 * halfPeriodMs;
+                double promotionStepMs = Math.Abs(wideChosen.DelayMs - chosen.DelayMs);
+                if (wideChosen.ScoreDb > chosen.ScoreDb + WideWindowPromotionMarginDb &&
+                    promotionStepMs <= promotionReachMs)
                 {
                     log.AppendLine(
                         $"  promoted {wideChosen.DelayMs:0.000} ms" +
@@ -569,6 +592,15 @@ public static class AutoAlignmentEngine
                         $"{(chosen.InvertPolarity ? " inv" : "")} " +
                         $"(gain {wideChosen.ScoreDb - chosen.ScoreDb:0.00} dB)");
                     chosen = wideChosen;
+                }
+                else if (wideChosen.ScoreDb > chosen.ScoreDb + WideWindowPromotionMarginDb &&
+                    promotionStepMs > promotionReachMs)
+                {
+                    log.AppendLine(
+                        $"  promotion declined: {wideChosen.DelayMs:0.000} ms is " +
+                        $"{promotionStepMs:0.000} ms ({promotionStepMs / (2.0 * halfPeriodMs):0.0} " +
+                        $"periods) from the arrival pick {chosen.DelayMs:0.000} ms — " +
+                        "a comb alias beyond the envelope's reach.");
                 }
             }
 

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1010,6 +1010,10 @@ public static class AutoAlignmentEngine
     // the SAME delta (which leaves the pair's L-R timing untouched) to trade
     // junction loss between the sides. Bounded search, and a move must buy at
     // least the minimum gain in the mean adjacent-junction loss to apply.
+    // This range is additionally capped per pair to half the period of its
+    // tightest adjacent junction (see RebalancePairsKeepingScene): the flat
+    // window alone let fraction-of-a-dB "gains" walk a tweeter pair a whole
+    // comb lobe off its mid at a high junction.
     private const double PairComoveSearchRangeMs = 1.2;
     private const double PairComoveMinimumGainDb = 0.05;
 
@@ -1169,6 +1173,19 @@ public static class AutoAlignmentEngine
                 return total / evaluators.Count;
             }
 
+            // The tightest (highest-frequency) adjacent junction bounds the
+            // pair's reach: within half its period the junction sums are
+            // single-lobed, so the search can only polish the alignment the
+            // arrival-anchored walk chose. Past that lies the next comb lobe —
+            // and fractions of a dB of mean junction loss cannot choose a lobe
+            // (the same physics as the wide-window promotion reach cap). The
+            // flat window alone let a 0.1-0.2 dB "gain" walk the tweeter pair
+            // a whole period off its mid at a 2.3 kHz junction.
+            double tightestPeriodMs =
+                1_000.0 / adjacent.Max(junction => junction.CrossoverHz);
+            double reachMs = Math.Min(
+                PairComoveSearchRangeMs, 0.5 * tightestPeriodMs);
+
             // Both bounds are fixed BEFORE the search so the winning delta
             // applies verbatim to both sides: negative deltas may not push
             // either channel below zero, positive ones may not push either
@@ -1177,14 +1194,17 @@ public static class AutoAlignmentEngine
             // exists to preserve.
             double minDelta = -Math.Min(
                 Math.Min(leftOverride.DelayMs, rightOverride.DelayMs),
-                PairComoveSearchRangeMs);
+                reachMs);
             double maxDelta = Math.Min(
-                PairComoveSearchRangeMs,
+                reachMs,
                 MaxDelayMs - Math.Max(leftOverride.DelayMs, rightOverride.DelayMs));
             double baseline = Score(0);
             double bestDelta = 0;
             double bestScore = baseline;
-            for (double delta = minDelta; delta <= maxDelta + 1e-9; delta += 0.1)
+            // The coarse step scales down with the window so a tightly-capped
+            // high-junction pair still gets a real grid before refinement.
+            double coarseStep = Math.Min(0.1, Math.Max(0.02, reachMs / 4.0));
+            for (double delta = minDelta; delta <= maxDelta + 1e-9; delta += coarseStep)
             {
                 double score = Score(delta);
                 if (score > bestScore)
@@ -1193,8 +1213,8 @@ public static class AutoAlignmentEngine
                     bestDelta = delta;
                 }
             }
-            for (double delta = Math.Max(minDelta, bestDelta - 0.1);
-                delta <= Math.Min(maxDelta, bestDelta + 0.1) + 1e-9;
+            for (double delta = Math.Max(minDelta, bestDelta - coarseStep);
+                delta <= Math.Min(maxDelta, bestDelta + coarseStep) + 1e-9;
                 delta += 0.02)
             {
                 double score = Score(delta);

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -869,19 +869,69 @@ public static class AutoAlignmentEngine
                 new Dictionary<IAlignmentChannel, AlignmentOverride>(alignment);
             searchAlignment.Remove(rightChannel);
             IReadOnlyList<AlignmentSnapshot> current = reprocess(searchAlignment);
+            Complex[] leftIr =
+                current.First(item => item.Channel == link.Left).ImpulseResponse;
+            Complex[] rightIr =
+                current.First(item => item.Channel == rightChannel).ImpulseResponse;
             TimeAlignmentAnalysisResult leftArrival =
                 VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
-                    current.First(item => item.Channel == link.Left).ImpulseResponse,
-                    link.Left.SampleRate, bandLowHz, bandHighHz);
+                    leftIr, link.Left.SampleRate, bandLowHz, bandHighHz);
             TimeAlignmentAnalysisResult rightRaw =
                 VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
-                    current.First(item => item.Channel == rightChannel).ImpulseResponse,
-                    rightChannel.SampleRate, bandLowHz, bandHighHz);
+                    rightIr, rightChannel.SampleRate, bandLowHz, bandHighHz);
             if (!leftArrival.IsValid || !rightRaw.IsValid ||
                 leftArrival.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
                 rightRaw.SignalToNoiseDecibels < MinimumArrivalSnrDb)
             {
                 return null;
+            }
+
+            // Modal-latch guard: the SAME driver measured in the band's upper
+            // half must agree with the full-band read to within the dispersion
+            // one direct wave packet can show (half a period at the probe's
+            // low edge). A full-band read landing far BEHIND its own upper-half
+            // read means the detector latched that side onto the in-room modal
+            // build-up instead of the direct rise (the under-seat midbass case:
+            // 21.2 ms in 80-200 Hz vs 15.2 ms one band up) — the two sides are
+            // then timing DIFFERENT features and their difference is garbage.
+            // The honest response is to withdraw the prior (the search keeps
+            // its own-side junction anchor), NOT to re-measure in the narrow
+            // upper half: at a low link band that probe is an octave of mush
+            // (~1/BW blur of many ms) that once dragged a woofer 6 ms off.
+            double probeLowHz = Math.Sqrt(bandLowHz * bandHighHz);
+            if (bandHighHz >=
+                probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
+            {
+                TimeAlignmentAnalysisResult leftProbe =
+                    VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                        leftIr, link.Left.SampleRate, probeLowHz, bandHighHz);
+                TimeAlignmentAnalysisResult rightProbe =
+                    VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                        rightIr, rightChannel.SampleRate, probeLowHz, bandHighHz);
+                double toleranceMs = Math.Max(1.0, 500.0 / probeLowHz);
+                if (leftProbe.IsValid && rightProbe.IsValid &&
+                    leftProbe.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
+                    rightProbe.SignalToNoiseDecibels >= MinimumArrivalSnrDb)
+                {
+                    bool leftLatched =
+                        leftArrival.FirstArrivalDelayMilliseconds
+                        - leftProbe.FirstArrivalDelayMilliseconds > toleranceMs;
+                    bool rightLatched =
+                        rightRaw.FirstArrivalDelayMilliseconds
+                        - rightProbe.FirstArrivalDelayMilliseconds > toleranceMs;
+                    if (leftLatched || rightLatched)
+                    {
+                        log.AppendLine(
+                            $"  cross-side prior {rightChannel.Name}: withdrawn — " +
+                            $"{(leftLatched ? link.Left.Name : rightChannel.Name)}" +
+                            $" reads {(leftLatched ? leftArrival : rightRaw).FirstArrivalDelayMilliseconds:0.000} ms" +
+                            $" in {bandLowHz:0}-{bandHighHz:0} Hz but " +
+                            $"{(leftLatched ? leftProbe : rightProbe).FirstArrivalDelayMilliseconds:0.000} ms" +
+                            $" in its {probeLowHz:0}-{bandHighHz:0} Hz half " +
+                            "(modal latch: the sides time different features)");
+                        return null;
+                    }
+                }
             }
 
             double target = leftArrival.FirstArrivalDelayMilliseconds

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -859,7 +859,11 @@ public static class AutoAlignmentEngine
         // follows) rather than the full intersection. Unmeasurable (silent
         // band, low SNR) falls back to null and the search keeps its own-side
         // anchor.
-        double? CrossSideTargetMs(
+        // Returns the delay that Δ-aligns the right channel to its left
+        // counterpart, and whether the target is COARSE (the energy-peak rung
+        // of the ladder, good to a fraction of a millisecond) — a coarse
+        // target may pin a lobe but never the tight scene tolerance.
+        (double TargetMs, bool Coarse)? CrossSideTargetMs(
             IAlignmentChannel rightChannel,
             StereoPairLink link,
             double bandLowHz,
@@ -871,10 +875,12 @@ public static class AutoAlignmentEngine
                 new Dictionary<IAlignmentChannel, AlignmentOverride>(alignment);
             searchAlignment.Remove(rightChannel);
             IReadOnlyList<AlignmentSnapshot> current = reprocess(searchAlignment);
-            Complex[] leftIr =
-                current.First(item => item.Channel == link.Left).ImpulseResponse;
-            Complex[] rightIr =
-                current.First(item => item.Channel == rightChannel).ImpulseResponse;
+            AlignmentSnapshot leftSnapshot =
+                current.First(item => item.Channel == link.Left);
+            AlignmentSnapshot rightSnapshot =
+                current.First(item => item.Channel == rightChannel);
+            Complex[] leftIr = leftSnapshot.ImpulseResponse;
+            Complex[] rightIr = rightSnapshot.ImpulseResponse;
 
             // Both sides measured in one band, with a modal-latch guard: the
             // Latched flag separates "one side timed the wrong feature" (worth
@@ -959,28 +965,53 @@ public static class AutoAlignmentEngine
             // keeps its own-side junction anchor.
             double usedLowHz = bandLowHz;
             double usedHighHz = bandHighHz;
+            bool anyLatch;
             ((TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
                 Reads, bool Latched) measured =
                 MeasureConsistent(bandLowHz, bandHighHz);
+            anyLatch = measured.Latched;
             if (measured.Reads == null && measured.Latched &&
                 (fallbackLowHz != bandLowHz || fallbackHighHz != bandHighHz))
             {
                 measured = MeasureConsistent(fallbackLowHz, fallbackHighHz);
+                anyLatch |= measured.Latched;
                 if (measured.Reads != null)
                 {
                     usedLowHz = fallbackLowHz;
                     usedHighHz = fallbackHighHz;
                 }
-                else if (measured.Latched)
-                {
-                    log.AppendLine(
-                        $"  cross-side prior {rightChannel.Name}: withdrawn — " +
-                        "no band reads both sides' direct arrivals consistently");
-                }
             }
             if (measured.Reads is not { } arrivals)
             {
-                return null;
+                if (!anyLatch)
+                {
+                    // The link band itself was inadmissible (silent or too
+                    // narrow): no target, exactly as before the ladder.
+                    return null;
+                }
+
+                // The ladder's last rung: when no band reads both DIRECT rises
+                // consistently, the pair is timed by its processed IRs' energy
+                // peaks. For a band-passed channel that peak IS its in-band
+                // dominant packet (typically the modal build-up) — the same
+                // physical feature on both sides of one cabin, defined without
+                // any detector threshold. Its L/R difference tracks the true
+                // path split to a fraction of a millisecond — coarse against
+                // the tight scene pin, but the lobe lock only needs the target
+                // within half a junction period.
+                double leftPeakMs = leftSnapshot.PeakIndex
+                    * 1_000.0 / link.Left.SampleRate;
+                double rightPeakMs = rightSnapshot.PeakIndex
+                    * 1_000.0 / rightChannel.SampleRate;
+                double peakTarget = leftPeakMs
+                    - plan.SceneOffsetMs
+                    - rightPeakMs;
+                log.AppendLine(
+                    $"  cross-side prior {rightChannel.Name}: target " +
+                    $"{peakTarget:0.000} ms from the processed IR energy peaks " +
+                    $"(L {leftPeakMs:0.000}, raw R {rightPeakMs:0.000} ms — " +
+                    "both sides' direct reads modal-latched)");
+                return (peakTarget, true);
             }
 
             double target = arrivals.Left.FirstArrivalDelayMilliseconds
@@ -991,7 +1022,7 @@ public static class AutoAlignmentEngine
                 $"(L arrival {arrivals.Left.FirstArrivalDelayMilliseconds:0.000}, " +
                 $"raw R {arrivals.Right.FirstArrivalDelayMilliseconds:0.000} ms " +
                 $"in {usedLowHz:0}-{usedHighHz:0} Hz)");
-            return target;
+            return (target, false);
         }
 
         void AlignRight(int index, int neighborIndex, AlignmentJunction pair)
@@ -1035,7 +1066,7 @@ public static class AutoAlignmentEngine
             StereoPairLink? channelLink = plan.PairLinks?.FirstOrDefault(
                 item => item.Right == channel);
             bool lockable = channelLink != null && IsSceneLockable(channelLink);
-            double? crossTarget = channelLink == null
+            (double TargetMs, bool Coarse)? cross = channelLink == null
                 ? null
                 : CrossSideTargetMs(
                     channel,
@@ -1046,9 +1077,10 @@ public static class AutoAlignmentEngine
                     channelLink.BandHighHz,
                     pair.BandLowHz,
                     pair.BandHighHz);
-            double? sceneLock = crossTarget == null
+            double? crossTarget = cross?.TargetMs;
+            double? sceneLock = cross is not { } resolved
                 ? null
-                : lockable
+                : lockable && !resolved.Coarse
                     ? SceneLockToleranceMs
                     : 500.0 / Math.Max(
                         pair.CrossoverHz,

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -996,6 +996,21 @@ public static class AutoAlignmentEngine
                     * 1_000.0 / link.Left.SampleRate;
                 double rightPeakMs = rightSnapshot.PeakIndex
                     * 1_000.0 / rightChannel.SampleRate;
+                // Guard the asymmetric-cabin case: if the two peaks sit farther
+                // apart than any real inter-side path, they are different room
+                // modes, not one shared feature, so their difference is not a
+                // usable L/R split. Withdraw the prior (free own-side search)
+                // rather than pin the pair to a fabricated target.
+                if (Math.Abs(leftPeakMs - rightPeakMs) > MaxInterSideDirectPathMs)
+                {
+                    log.AppendLine(
+                        $"  cross-side prior {rightChannel.Name}: withdrawn — " +
+                        $"energy peaks {leftPeakMs:0.000} / {rightPeakMs:0.000} ms " +
+                        "are too far apart to be one shared feature " +
+                        "(asymmetric modal dominance)");
+                    return null;
+                }
+
                 double peakTarget = leftPeakMs
                     - plan.SceneOffsetMs
                     - rightPeakMs;
@@ -1168,6 +1183,17 @@ public static class AutoAlignmentEngine
     // content to pin: the lock requires at least a third of an octave above
     // the edge, the same admission rule the arrival analysis itself applies.
     private const double SceneLockLocalizationLowHz = 300;
+
+    // The widest the two sides of one stereo pair can plausibly differ in
+    // direct-path time, measured from one listening position: a car cabin is
+    // at most a couple of metres across, so ~8 ms bounds any real path split
+    // with generous margin. The energy-peak fallback (below) trusts that both
+    // sides' dominant IR packets are the SAME physical feature; peaks farther
+    // apart than this are almost certainly DIFFERENT room modes dominating L
+    // vs R (an acoustically asymmetric install), so the peak difference is not
+    // a real L/R split and the pair falls back to its own-side junction search
+    // rather than pinning to a fabricated target.
+    private const double MaxInterSideDirectPathMs = 8.0;
 
     // Whether a linked pair reaches far enough into the localization region
     // for the scene to outrank its junction sums: locked in the descent,

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -147,13 +147,32 @@ public static class TimeAlignmentAnalysis
         // not, and a genuine second arrival must be separated by a real valley:
         // a band-limited low-frequency driver's direct sound keeps rising for
         // milliseconds, and an early shoulder of that one wave packet peaking
-        // later must not be called a reflection.
+        // later must not be called a reflection. In a band-limited analysis the
+        // envelope's time resolution is ~1/bandwidth, so within that blur a
+        // separation is the same wave packet's interference structure, not two
+        // events — unless the valley between them is deep enough to prove the
+        // events resolved anyway (destructive interference can resolve faster
+        // than the nominal 1/BW).
         double separationMilliseconds =
             (strongestPeakIndex - envelopePeakIndex) * 1000.0 / sampleRate;
+        double valleyDepthDb = ValleyDepthDb(
+            envelope, envelopePeakIndex, strongestPeakIndex);
+        double blurMilliseconds = SeparateArrivalThresholdMilliseconds;
+        if (options.UseBandpassWindow)
+        {
+            double bandwidthHz = options.BandpassCenterHz * (
+                Math.Pow(2.0, options.BandpassPassOctaves / 2.0)
+                - Math.Pow(2.0, -options.BandpassPassOctaves / 2.0));
+            blurMilliseconds = Math.Max(
+                SeparateArrivalThresholdMilliseconds,
+                1_000.0 / Math.Max(1e-9, bandwidthHz));
+        }
         bool strongestIsSeparateArrival =
             strongestPeakIndex != envelopePeakIndex &&
             separationMilliseconds >= SeparateArrivalThresholdMilliseconds &&
-            HasValleyBetween(envelope, envelopePeakIndex, strongestPeakIndex);
+            valleyDepthDb >= SeparateArrivalValleyDb &&
+            (separationMilliseconds >= blurMilliseconds ||
+                valleyDepthDb >= SeparateArrivalResolvedValleyDb);
 
         if (options.WrapPeakPositions)
         {
@@ -204,7 +223,14 @@ public static class TimeAlignmentAnalysis
     // rise does not.
     private const double SeparateArrivalValleyDb = 6.0;
 
-    private static bool HasValleyBetween(
+    // A valley this deep proves the two events resolved even when their
+    // separation sits inside the analysis band's nominal ~1/BW blur —
+    // destructive interference nulls faster than the envelope's rise time.
+    private const double SeparateArrivalResolvedValleyDb = 20.0;
+
+    // The envelope dip between the two peaks, in dB below the LOWER of them
+    // (>= 0; 0 when the envelope never dips).
+    private static double ValleyDepthDb(
         IReadOnlyList<double> envelope,
         int firstIndex,
         int secondIndex)
@@ -218,8 +244,12 @@ public static class TimeAlignmentAnalysis
         }
 
         double reference = Math.Min(envelope[firstIndex], envelope[secondIndex]);
-        return valley <= reference *
-            Math.Pow(10.0, -SeparateArrivalValleyDb / 20.0);
+        if (reference <= 0.0 || valley <= 0.0)
+        {
+            return valley <= 0.0 && reference > 0.0 ? double.PositiveInfinity : 0.0;
+        }
+
+        return Math.Max(0.0, DataHelper.AmplitudeToDecibels(reference / valley));
     }
 
     // A short refinement window (~0.1 ms) around the envelope peak: wide enough to

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -358,9 +358,13 @@ public static class VirtualCrossoverAnalysis
             samples[i] = impulseResponse[i].Real;
         }
 
-        // Gentle spectral fades and a moderate threshold: the zero-phase bandpass
-        // rings symmetrically around the arrival, and steep edges plus a deep
-        // threshold would let the detector fire on a pre-ringing lobe.
+        // Gentle spectral fades keep the zero-phase bandpass ringing tame, and
+        // the kernel-envelope sidelobe rejection inside the peak search tells
+        // that ringing from a genuine early arrival by physics, so the search
+        // depth matches the analyzer's default 25 dB. The old, shallower 15 dB
+        // missed a soft direct rise sitting under a strong in-room modal
+        // build-up (the under-seat midbass in its 80-200 Hz pair band) and
+        // latched the arrival onto the mode, milliseconds late.
         return TimeAlignmentAnalysis.Analyze(
             samples,
             sampleRate,
@@ -369,8 +373,7 @@ public static class VirtualCrossoverAnalysis
                 UseBandpassWindow = true,
                 BandpassCenterHz = Math.Sqrt(low * high),
                 BandpassPassOctaves = Math.Log2(high / low),
-                BandpassFadeOctaves = 1.0,
-                FirstPeakThresholdBelowMaxDb = 15
+                BandpassFadeOctaves = 1.0
             });
     }
 

--- a/source/Options/ImpulseWindowPreview.cs
+++ b/source/Options/ImpulseWindowPreview.cs
@@ -39,13 +39,38 @@ internal static class ImpulseWindowPreview
     {
         var model = CreatePreviewPlotModel("IR Gate");
 
+        (double StartMs, double EndMs)? window = AddGatedTraceSeries(
+            model, traces, sampleRate, gateOffsetMs, leftMs, plateauMs, rightMs);
+
+        model.Axes.Add(window is { } bounds
+            ? CreateTimeAxis(bounds.StartMs, bounds.EndMs)
+            : CreateTimeAxis(-10, 10));
+        model.Axes.Add(CreateAmplitudeAxis());
+
+        plotView.Model = model;
+        plotView.InvalidatePlot(true);
+    }
+
+    // The shared body of the gated multi-trace view: each trace normalized to
+    // its own in-window peak, the Tukey gate outline, and a vertical mark at
+    // the gate offset. Used by the gate dialog's preview and the Virtual DSP
+    // impulse view alike, so the two renderings cannot drift apart. Everything
+    // added carries seriesTag so a host redrawing an existing model can find
+    // and remove it. Returns the display window bounds (ms), or null when
+    // there is nothing to draw.
+    public static (double StartMs, double EndMs)? AddGatedTraceSeries(
+        PlotModel model,
+        IReadOnlyList<IrPreviewTrace> traces,
+        int sampleRate,
+        double gateOffsetMs,
+        double leftMs,
+        double plateauMs,
+        double rightMs,
+        object? seriesTag = null)
+    {
         if (traces.Count == 0 || sampleRate <= 0)
         {
-            model.Axes.Add(CreateTimeAxis(-10, 10));
-            model.Axes.Add(CreateAmplitudeAxis());
-            plotView.Model = model;
-            plotView.InvalidatePlot(true);
-            return;
+            return null;
         }
 
         int gateOffset = MillisecondsToSamples(gateOffsetMs, sampleRate);
@@ -83,6 +108,7 @@ internal static class ImpulseWindowPreview
                 Color = trace.Color,
                 StrokeThickness = 1.2,
                 Title = trace.Title,
+                Tag = seriesTag,
                 TrackerFormatString = "{0}\n{2:0.000} ms\n{4:0.000}"
             };
             for (int s = displayStart; s <= displayEnd; s++)
@@ -100,6 +126,7 @@ internal static class ImpulseWindowPreview
         {
             Color = OxyColor.FromRgb(50, 210, 120),
             StrokeThickness = 1.5,
+            Tag = seriesTag,
             TrackerFormatString = "{0}\n{2:0.000} ms\n{4:0.000}"
         };
         for (int s = displayStart; s <= displayEnd; s++)
@@ -109,22 +136,19 @@ internal static class ImpulseWindowPreview
         }
         model.Series.Add(windowSeries);
 
-        model.Axes.Add(CreateTimeAxis(
-            displayStart * 1000.0 / sampleRate,
-            displayEnd * 1000.0 / sampleRate));
-        model.Axes.Add(CreateAmplitudeAxis());
-
         model.Annotations.Add(new LineAnnotation
         {
             Type = LineAnnotationType.Vertical,
             X = gateOffsetMs,
             Color = OxyColor.FromArgb(127, 80, 150, 255),
             LineStyle = LineStyle.Dot,
-            StrokeThickness = 1.0
+            StrokeThickness = 1.0,
+            Tag = seriesTag
         });
 
-        plotView.Model = model;
-        plotView.InvalidatePlot(true);
+        return (
+            displayStart * 1000.0 / sampleRate,
+            displayEnd * 1000.0 / sampleRate);
     }
 
     public static void Update(

--- a/source/Tools/PdfSheet.cs
+++ b/source/Tools/PdfSheet.cs
@@ -26,6 +26,10 @@ internal sealed class PdfSheet : IDisposable
 
     public Section Section { get; }
 
+    // The built MigraDoc model, for tests that assert the layout before it is
+    // rendered to a PDF.
+    internal Document Document => document;
+
     public PdfSheet(string title, string subtitleText)
     {
         document = new Document();

--- a/source/Tools/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossoverPanel.Designer.cs
@@ -46,6 +46,7 @@ namespace Resonalyze
             checkBoxShowLoss = new CheckBox();
             radioViewMagnitude = new RadioButton();
             radioViewPhase = new RadioButton();
+            radioViewImpulse = new RadioButton();
             labelSmoothing = new Label();
             comboBoxSmoothing = new DarkComboBox();
             buttonAutoDelay = new Button();
@@ -288,12 +289,24 @@ namespace Resonalyze
             radioViewPhase.Text = "Phase";
             radioViewPhase.UseVisualStyleBackColor = true;
             // 
+            // radioViewImpulse
+            // 
+            radioViewImpulse.AutoSize = true;
+            radioViewImpulse.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            radioViewImpulse.ForeColor = Color.FromArgb(210, 214, 222);
+            radioViewImpulse.Location = new Point(702, 411);
+            radioViewImpulse.Name = "radioViewImpulse";
+            radioViewImpulse.Size = new Size(68, 19);
+            radioViewImpulse.TabIndex = 11;
+            radioViewImpulse.Text = "Impulse";
+            radioViewImpulse.UseVisualStyleBackColor = true;
+            // 
             // labelSmoothing
             // 
             labelSmoothing.AutoSize = true;
             labelSmoothing.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             labelSmoothing.ForeColor = Color.FromArgb(210, 214, 222);
-            labelSmoothing.Location = new Point(707, 414);
+            labelSmoothing.Location = new Point(779, 414);
             labelSmoothing.Name = "labelSmoothing";
             labelSmoothing.Size = new Size(67, 15);
             labelSmoothing.TabIndex = 10;
@@ -303,7 +316,7 @@ namespace Resonalyze
             // 
             comboBoxSmoothing.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxSmoothing.ForeColor = Color.White;
-            comboBoxSmoothing.Location = new Point(781, 412);
+            comboBoxSmoothing.Location = new Point(853, 412);
             comboBoxSmoothing.MinimumSize = new Size(36, 19);
             comboBoxSmoothing.Name = "comboBoxSmoothing";
             comboBoxSmoothing.Size = new Size(90, 19);
@@ -359,7 +372,7 @@ namespace Resonalyze
             // 
             buttonPhaseGate.FlatStyle = FlatStyle.Popup;
             buttonPhaseGate.ForeColor = Color.White;
-            buttonPhaseGate.Location = new Point(877, 410);
+            buttonPhaseGate.Location = new Point(949, 410);
             buttonPhaseGate.Name = "buttonPhaseGate";
             buttonPhaseGate.Size = new Size(80, 24);
             buttonPhaseGate.TabIndex = 16;
@@ -370,7 +383,7 @@ namespace Resonalyze
             // 
             comboBoxCalibration.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxCalibration.ForeColor = Color.White;
-            comboBoxCalibration.Location = new Point(965, 413);
+            comboBoxCalibration.Location = new Point(1037, 413);
             comboBoxCalibration.MinimumSize = new Size(36, 19);
             comboBoxCalibration.Name = "comboBoxCalibration";
             comboBoxCalibration.Size = new Size(110, 19);
@@ -481,6 +494,7 @@ namespace Resonalyze
             Controls.Add(checkBoxShowLoss);
             Controls.Add(radioViewMagnitude);
             Controls.Add(radioViewPhase);
+            Controls.Add(radioViewImpulse);
             Controls.Add(labelSmoothing);
             Controls.Add(comboBoxSmoothing);
             Controls.Add(buttonAutoDelay);
@@ -533,6 +547,7 @@ namespace Resonalyze
         private CheckBox checkBoxShowLoss;
         private RadioButton radioViewMagnitude;
         private RadioButton radioViewPhase;
+        private RadioButton radioViewImpulse;
         private Label labelSmoothing;
         private DarkComboBox comboBoxSmoothing;
         private Button buttonAutoDelay;

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -824,6 +824,9 @@ public partial class VirtualCrossoverPanel : UserControl
     {
         ConfigureMainValueAxis();
         UpdateGateButtonAvailability();
+        // Fractional-octave smoothing shapes only the frequency-domain curves;
+        // grey it out in the impulse view where it has no effect.
+        comboBoxSmoothing.Enabled = !radioViewImpulse.Checked;
         OnViewChanged();
     }
 

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -2149,46 +2149,69 @@ public partial class VirtualCrossoverPanel : UserControl
         double LowHz,
         double HighHz,
         SideProcessJob Left,
-        SideProcessJob Right);
+        SideProcessJob Right,
+        bool Mono = false)
+    {
+        // A mono job's Left and Right are the same instance; iterate the left
+        // slot alone so the shared response is processed once.
+        public IEnumerable<SideProcessJob> Sides =>
+            Mono ? new[] { Left } : new[] { Left, Right };
+    }
 
     /// <summary>
     /// The final per-pair L−R timing: both sides' fully processed responses
     /// (current delays included) get their band-limited envelope arrival read
     /// in the pair's shared band, and the difference (positive: right leads —
-    /// the scene-offset convention) feeds the metric read-out. Only complete
-    /// stereo pairs measure: mono pairs have one response, bypassed or muted
-    /// sides are not a final tune. Heavy work runs off the UI thread and both
-    /// the processed IRs and the arrivals are cached per side, so an unchanged
-    /// configuration costs nothing on redraw.
+    /// the scene-offset convention) feeds the metric read-out. A mono channel
+    /// (the shared sub) has one response, so it reports that single arrival in
+    /// its own band with "—" for the right side and the delta; a stereo pair
+    /// needs both sides present and unbypassed. Heavy work runs off the UI
+    /// thread and both the processed IRs and the arrivals are cached per side,
+    /// so an unchanged configuration costs nothing on redraw.
     /// </summary>
     private async Task<List<VirtualCrossoverMetric.StereoDelta>> ComputeStereoDeltasAsync()
     {
         var jobs = new List<StereoDeltaJob>();
         foreach (ChannelRuntime channel in channels)
         {
-            if (channel.Pair.Mono)
+            // A mono channel (the shared sub) has one physical response and no
+            // L/R timing to compare, but its own arrival is still worth showing:
+            // it reads in its own band on the left slot and prints "—" for R and
+            // the delta. A stereo pair needs both sides present and unbypassed.
+            bool mono = channel.Pair.Mono;
+
+            VirtualCrossoverChannelSettings leftSettings = channel.SideSettings(false);
+            ChannelSideState leftState = channel.PhysicalSideState(false);
+            if (!leftSettings.Enabled || leftSettings.Bypass ||
+                leftState.TransferImpulseResponse is not { } leftIr)
             {
                 continue;
             }
 
-            VirtualCrossoverChannelSettings leftSettings = channel.SideSettings(false);
             VirtualCrossoverChannelSettings rightSettings = channel.SideSettings(true);
-            ChannelSideState leftState = channel.PhysicalSideState(false);
             ChannelSideState rightState = channel.PhysicalSideState(true);
-            if (!leftSettings.Enabled || !rightSettings.Enabled ||
-                leftSettings.Bypass || rightSettings.Bypass ||
-                leftState.TransferImpulseResponse is not { } leftIr ||
-                rightState.TransferImpulseResponse is not { } rightIr)
+            if (!mono &&
+                (!rightSettings.Enabled || rightSettings.Bypass ||
+                    rightState.TransferImpulseResponse is not { }))
             {
                 continue;
             }
 
             (double leftLow, double leftHigh) =
                 VirtualCrossoverJunctions.GetChannelBand(leftSettings);
-            (double rightLow, double rightHigh) =
-                VirtualCrossoverJunctions.GetChannelBand(rightSettings);
-            double lowHz = Math.Max(leftLow, rightLow);
-            double highHz = Math.Min(leftHigh, rightHigh);
+            double lowHz, highHz;
+            if (mono)
+            {
+                lowHz = leftLow;
+                highHz = leftHigh;
+            }
+            else
+            {
+                (double rightLow, double rightHigh) =
+                    VirtualCrossoverJunctions.GetChannelBand(rightSettings);
+                lowHz = Math.Max(leftLow, rightLow);
+                highHz = Math.Min(leftHigh, rightHigh);
+            }
             if (highHz < lowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
             {
                 // The arrival analysis refuses a band this narrow (it is not
@@ -2231,23 +2254,30 @@ public partial class VirtualCrossoverPanel : UserControl
                 return side;
             }
 
+            SideProcessJob leftJob = Snapshot(leftState, leftSettings, leftIr);
+            SideProcessJob rightJob = mono
+                ? leftJob
+                : Snapshot(
+                    rightState,
+                    rightSettings,
+                    rightState.TransferImpulseResponse!);
             jobs.Add(new StereoDeltaJob(
                 channel.Control.ChannelName,
                 lowHz,
                 highHz,
-                Snapshot(leftState, leftSettings, leftIr),
-                Snapshot(rightState, rightSettings, rightIr)));
+                leftJob,
+                rightJob,
+                mono));
         }
 
-        bool anyWork = jobs.Any(job =>
-            job.Left.Arrival == null || job.Right.Arrival == null);
+        bool anyWork = jobs.Any(job => job.Sides.Any(side => side.Arrival == null));
         if (anyWork)
         {
             await Task.Run(() =>
             {
                 foreach (StereoDeltaJob job in jobs)
                 {
-                    foreach (SideProcessJob side in new[] { job.Left, job.Right })
+                    foreach (SideProcessJob side in job.Sides)
                     {
                         if (side.ProcessedIr == null)
                         {
@@ -2274,7 +2304,7 @@ public partial class VirtualCrossoverPanel : UserControl
             // in this panel.
             foreach (StereoDeltaJob job in jobs)
             {
-                foreach (SideProcessJob side in new[] { job.Left, job.Right })
+                foreach (SideProcessJob side in job.Sides)
                 {
                     if (!side.ProcessedFromCache)
                     {
@@ -2306,12 +2336,23 @@ public partial class VirtualCrossoverPanel : UserControl
             .Select(job =>
             {
                 TimeAlignmentAnalysisResult left = job.Left.Arrival!.Value;
-                TimeAlignmentAnalysisResult right = job.Right.Arrival!.Value;
                 bool leftReliable = Reliable(left);
+                double? leftMs = leftReliable
+                    ? left.FirstArrivalDelayMilliseconds
+                    : null;
+                if (job.Mono)
+                {
+                    // One physical response: show its arrival on the left slot;
+                    // the right and the L−R delta have no meaning here ("—").
+                    return new VirtualCrossoverMetric.StereoDelta(
+                        job.Channel, leftMs, null, job.LowHz, job.HighHz, null);
+                }
+
+                TimeAlignmentAnalysisResult right = job.Right.Arrival!.Value;
                 bool rightReliable = Reliable(right);
                 return new VirtualCrossoverMetric.StereoDelta(
                     job.Channel,
-                    leftReliable ? left.FirstArrivalDelayMilliseconds : null,
+                    leftMs,
                     rightReliable ? right.FirstArrivalDelayMilliseconds : null,
                     job.LowHz,
                     job.HighHz,

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -78,6 +78,12 @@ public partial class VirtualCrossoverPanel : UserControl
         double DetrendMs)? gatePreview;
     private PlotWatermarkAnnotation hintAnnotation = null!;
     private LinearAxis mainValueAxis = null!;
+    // The main plot's two bottom axes: the shared log-frequency axis for the
+    // magnitude/phase views and a linear ms axis for the impulse view. Only
+    // one is in the model at a time (ConfigureMainBottomAxis swaps them), so
+    // the untagged curve series always bind to the active one.
+    private LogarithmicAxis mainFrequencyAxis = null!;
+    private LinearAxis mainTimeAxis = null!;
     private PlotLabelsPanelController plotLabels = null!;
     private bool initialized;
     private bool suppressProjectEvents;
@@ -300,8 +306,11 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             checkBoxShowSum.Checked = project.ShowSumCurve;
             checkBoxShowLoss.Checked = project.ShowLossCurve;
-            radioViewPhase.Checked = project.ShowPhaseView;
-            radioViewMagnitude.Checked = !project.ShowPhaseView;
+            radioViewImpulse.Checked = project.ShowImpulseView;
+            radioViewPhase.Checked =
+                !project.ShowImpulseView && project.ShowPhaseView;
+            radioViewMagnitude.Checked =
+                !project.ShowImpulseView && !project.ShowPhaseView;
             radioSideRight.Checked = project.ActiveSideRight;
             radioSideLeft.Checked = !project.ActiveSideRight;
             numericSceneOffset.Value = Clamp(
@@ -461,9 +470,21 @@ public partial class VirtualCrossoverPanel : UserControl
     {
         checkBoxShowSum.CheckedChanged += (_, _) => OnViewChanged();
         checkBoxShowLoss.CheckedChanged += (_, _) => OnViewChanged();
-        // In a two-radio group every toggle flips radioViewPhase, so listening
-        // to it alone reacts exactly once per mode switch.
-        radioViewPhase.CheckedChanged += (_, _) => OnViewModeChanged();
+        // Three-radio group: each fires on both the check and the uncheck, so
+        // act only on the one that became checked to run the switch exactly
+        // once per mode change.
+        radioViewMagnitude.CheckedChanged += (_, _) =>
+        {
+            if (radioViewMagnitude.Checked) OnViewModeChanged();
+        };
+        radioViewPhase.CheckedChanged += (_, _) =>
+        {
+            if (radioViewPhase.Checked) OnViewModeChanged();
+        };
+        radioViewImpulse.CheckedChanged += (_, _) =>
+        {
+            if (radioViewImpulse.Checked) OnViewModeChanged();
+        };
         comboBoxSmoothing.SelectedIndexChanged += (_, _) => OnViewChanged();
         comboBoxCalibration.SelectedIndexChanged += (_, _) => OnCalibrationChanged();
         // Three-radio group: each fires on both the check and the uncheck, so act
@@ -806,10 +827,10 @@ public partial class VirtualCrossoverPanel : UserControl
         OnViewChanged();
     }
 
-    // The gate only shapes the phase view; grey the button out elsewhere so it
-    // does not suggest an effect on the magnitude curves.
+    // The gate shapes the phase and impulse views; grey the button out on the
+    // magnitude view so it does not suggest an effect on those curves.
     private void UpdateGateButtonAvailability() =>
-        buttonPhaseGate.Enabled = radioViewPhase.Checked;
+        buttonPhaseGate.Enabled = !radioViewMagnitude.Checked;
 
     private void OnViewChanged()
     {
@@ -821,6 +842,7 @@ public partial class VirtualCrossoverPanel : UserControl
         project.ShowSumCurve = checkBoxShowSum.Checked;
         project.ShowLossCurve = checkBoxShowLoss.Checked;
         project.ShowPhaseView = radioViewPhase.Checked;
+        project.ShowImpulseView = radioViewImpulse.Checked;
         project.SmoothingInverseOctaves = comboBoxSmoothing.SelectedItem is int value
             ? value
             : 12;
@@ -1327,8 +1349,22 @@ public partial class VirtualCrossoverPanel : UserControl
     {
         var model = new PlotModel();
         PlotModelStyle.AddFrequencyAxis(model);
+        mainFrequencyAxis = (LogarithmicAxis)model.Axes[^1];
+        // The impulse view runs on an absolute-time axis; its range follows
+        // the gate window on every impulse redraw, so it is static like the
+        // gate dialog's preview instead of pannable.
+        mainTimeAxis = new LinearAxis
+        {
+            Position = AxisPosition.Bottom,
+            Title = "ms",
+            MajorGridlineStyle = LineStyle.Solid,
+            MinorGridlineStyle = LineStyle.Dot,
+            IsPanEnabled = false,
+            IsZoomEnabled = false
+        };
         // The absolute pan/zoom limits live in ConfigureMainValueAxis: they
-        // differ between the magnitude (dB) and phase (deg) views.
+        // differ between the magnitude (dB), phase (deg) and impulse
+        // (normalized) views.
         mainValueAxis = new LinearAxis
         {
             Position = AxisPosition.Left,
@@ -1361,10 +1397,22 @@ public partial class VirtualCrossoverPanel : UserControl
     }
 
     // Magnitude and phase reuse one axis object so pan/zoom of the frequency
-    // axis survives the toggle; only the value scale is re-armed.
+    // axis survives the toggle; only the value scale is re-armed. The impulse
+    // view additionally swaps the bottom axis to the linear ms one.
     private void ConfigureMainValueAxis()
     {
-        if (radioViewPhase.Checked)
+        if (radioViewImpulse.Checked)
+        {
+            // Every trace is normalized to its own peak, exactly like the IR
+            // Gate preview, so the scale is unitless.
+            mainValueAxis.Title = string.Empty;
+            mainValueAxis.AbsoluteMinimum = -1.05;
+            mainValueAxis.AbsoluteMaximum = 1.05;
+            mainValueAxis.Minimum = -1.05;
+            mainValueAxis.Maximum = 1.05;
+            mainValueAxis.MajorStep = 0.5;
+        }
+        else if (radioViewPhase.Checked)
         {
             mainValueAxis.Title = "deg";
             mainValueAxis.AbsoluteMinimum = -180;
@@ -1383,8 +1431,29 @@ public partial class VirtualCrossoverPanel : UserControl
             mainValueAxis.MajorStep = double.NaN;
         }
 
+        ConfigureMainBottomAxis();
         mainValueAxis.Reset();
         mainPlotView.InvalidatePlot(false);
+    }
+
+    // Keeps exactly one bottom axis in the model: the log-frequency axis for
+    // the magnitude/phase views, the linear ms axis for the impulse view.
+    // Swapping whole axis objects (instead of reconfiguring one) preserves
+    // each view's own range across toggles.
+    private void ConfigureMainBottomAxis()
+    {
+        if (mainPlotView.Model is not { } model)
+        {
+            return;
+        }
+
+        Axis wanted = radioViewImpulse.Checked ? mainTimeAxis : mainFrequencyAxis;
+        Axis retired = radioViewImpulse.Checked ? mainFrequencyAxis : mainTimeAxis;
+        if (!model.Axes.Contains(wanted))
+        {
+            model.Axes.Remove(retired);
+            model.Axes.Add(wanted);
+        }
     }
 
     private void InitializeDspPlot()
@@ -1519,6 +1588,11 @@ public partial class VirtualCrossoverPanel : UserControl
             "Show the phase of the processed channels and the sum.\r\n" +
             "Well-aligned channels track each other through\r\n" +
             "the crossover region.");
+        toolTip.SetToolTip(
+            radioViewImpulse,
+            "Show each channel's processed impulse response around\r\n" +
+            "the phase gate, every trace normalized to its own peak.\r\n" +
+            "Well-aligned drivers start together.");
         toolTip.SetToolTip(
             comboBoxSmoothing,
             "Fractional-octave smoothing of the magnitude curves.");
@@ -1975,7 +2049,7 @@ public partial class VirtualCrossoverPanel : UserControl
         List<VirtualCrossoverMetric.StereoDelta> stereoDeltas =
             await ComputeStereoDeltasAsync();
         AnalysisCurve? oppositeSum =
-            checkBoxShowSum.Checked && !radioViewPhase.Checked
+            checkBoxShowSum.Checked && radioViewMagnitude.Checked
                 ? await ComputeOppositeSumCurveAsync()
                 : null;
         if (mainPlotView.IsDisposed || revision != displayRevision)
@@ -2004,6 +2078,10 @@ public partial class VirtualCrossoverPanel : UserControl
             if (radioViewPhase.Checked)
             {
                 DrawPhaseCurves(model, processed);
+            }
+            else if (radioViewImpulse.Checked)
+            {
+                DrawImpulseCurves(model, processed);
             }
             else
             {
@@ -3369,6 +3447,50 @@ public partial class VirtualCrossoverPanel : UserControl
         }
     }
 
+    // The impulse view is the gate dialog's IR preview promoted to the main
+    // plot: every processed channel IR (crossover/PEQ/gain/delay/polarity
+    // applied) on the shared absolute timeline, each normalized to its own
+    // in-window peak, with the phase-gate Tukey window drawn where it sits.
+    // Well-aligned drivers visibly start together.
+    private void DrawImpulseCurves(PlotModel model, List<ProcessedChannel> processed)
+    {
+        int reference = processed.Min(item => item.PeakIndex);
+        int sampleRate = processed[0].Channel.SampleRate;
+        double gateOffsetMs = gatePreview?.OffsetMs
+            ?? ResolveGateOffsetMs(reference, sampleRate);
+
+        var traces = processed
+            .Where(item => item.Channel.Settings.ShowProcessedCurve)
+            .Select(item => new IrPreviewTrace(
+                item.ImpulseResponse,
+                item.Channel.Control.ChannelName,
+                item.Color))
+            .ToList();
+
+        (double StartMs, double EndMs)? window =
+            ImpulseWindowPreview.AddGatedTraceSeries(
+                model,
+                traces,
+                sampleRate,
+                gateOffsetMs,
+                gatePreview?.LeftMs ?? project.PhaseGateLeftMs,
+                gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs,
+                gatePreview?.RightMs ?? project.PhaseGateRightMs,
+                CurveSeriesTag);
+        if (window is not { } bounds)
+        {
+            return;
+        }
+
+        // The axis is static (no pan/zoom), so simply re-arm it to the display
+        // window the series were built for.
+        mainTimeAxis.AbsoluteMinimum = bounds.StartMs;
+        mainTimeAxis.AbsoluteMaximum = bounds.EndMs;
+        mainTimeAxis.Minimum = bounds.StartMs;
+        mainTimeAxis.Maximum = bounds.EndMs;
+        mainTimeAxis.Reset();
+    }
+
     // A stored gate offset is used as-is; an unconfigured project follows the
     // earliest processed arrival, so the gate tracks source and delay changes
     // until the user pins it in the gate dialog.
@@ -3954,6 +4076,16 @@ public partial class VirtualCrossoverPanel : UserControl
             if (Equals(model.Series[index].Tag, CurveSeriesTag))
             {
                 model.Series.RemoveAt(index);
+            }
+        }
+
+        // The impulse view marks its gate-offset annotation with the same tag,
+        // so a redraw sweeps it together with the curves.
+        for (int index = model.Annotations.Count - 1; index >= 0; index--)
+        {
+            if (Equals(model.Annotations[index].Tag, CurveSeriesTag))
+            {
+                model.Annotations.RemoveAt(index);
             }
         }
     }

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -3457,13 +3457,22 @@ public partial class VirtualCrossoverPanel : UserControl
     // Well-aligned drivers visibly start together.
     private void DrawImpulseCurves(PlotModel model, List<ProcessedChannel> processed)
     {
-        int reference = processed.Min(item => item.PeakIndex);
-        int sampleRate = processed[0].Channel.SampleRate;
+        // Only the shown traces set the gate offset and the ms-axis window, so
+        // an auto gate never centers on a channel whose curve is hidden.
+        List<ProcessedChannel> shown = processed
+            .Where(item => item.Channel.Settings.ShowProcessedCurve)
+            .ToList();
+        if (shown.Count == 0)
+        {
+            return;
+        }
+
+        int reference = shown.Min(item => item.PeakIndex);
+        int sampleRate = shown[0].Channel.SampleRate;
         double gateOffsetMs = gatePreview?.OffsetMs
             ?? ResolveGateOffsetMs(reference, sampleRate);
 
-        var traces = processed
-            .Where(item => item.Channel.Settings.ShowProcessedCurve)
+        var traces = shown
             .Select(item => new IrPreviewTrace(
                 item.ImpulseResponse,
                 item.Channel.Control.ChannelName,

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -1657,9 +1657,9 @@ public partial class VirtualCrossoverPanel : UserControl
             "Run Auto delay afterward to phase-align the result.");
         toolTip.SetToolTip(
             buttonPhaseGate,
-            "Configure the phase-view gate: offset and Tukey fades,\r\n" +
-            "with an IR preview — cut the window before the first\r\n" +
-            "reflection for clean phase traces.");
+            "Configure the gate for the phase and impulse views:\r\n" +
+            "offset and Tukey fades, with an IR preview — cut the\r\n" +
+            "window before the first reflection for clean traces.");
         toolTip.SetToolTip(
             buttonSessionExport,
             "Save the whole session (sources, DSP chains, gate, view)\r\n" +

--- a/source/Tools/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossoverProjectFile.cs
@@ -217,6 +217,11 @@ public sealed class VirtualCrossoverProjectFile
     public bool ShowSumCurve { get; set; } = true;
     public bool ShowLossCurve { get; set; }
     public bool ShowPhaseView { get; set; }
+    // The main plot's impulse view (the gated IR preview promoted to the main
+    // plot). Additive: older files lack it, and when set it wins over
+    // ShowPhaseView. Kept as a second flag so files written by this version
+    // still open in older builds (which fall back to magnitude/phase).
+    public bool ShowImpulseView { get; set; }
     public int SmoothingInverseOctaves { get; set; } = 12;
 
     // Which curve the per-channel DSP chain plot shows. Additive: older files lack

--- a/source/Tools/VirtualCrossoverSheetPdf.cs
+++ b/source/Tools/VirtualCrossoverSheetPdf.cs
@@ -38,6 +38,19 @@ internal static class VirtualCrossoverSheetPdf
         string? metricLine,
         int sampleRate)
     {
+        using PdfSheet sheet = Build(project, metricLine, sampleRate);
+        sheet.Save(filePath);
+    }
+
+    // Builds the sheet without rendering it, so a test can walk the MigraDoc
+    // document model (section tables, rows, cells) and assert the layout — a
+    // stereo pair as one L/R table, a mono/one-sided pair as a single column —
+    // without parsing a rendered PDF. The caller owns disposal.
+    internal static PdfSheet Build(
+        VirtualCrossoverProjectFile project,
+        string? metricLine,
+        int sampleRate)
+    {
         ArgumentNullException.ThrowIfNull(project);
 
         string subtitleText =
@@ -47,7 +60,7 @@ internal static class VirtualCrossoverSheetPdf
             subtitleText += $"   ·   {metricLine}";
         }
 
-        using var sheet = new PdfSheet("Virtual DSP", subtitleText);
+        var sheet = new PdfSheet("Virtual DSP", subtitleText);
 
         // Both sides of every pair print in one sheet; a mono pair prints
         // once. On the graph the right side reuses the pair's hue dashed.
@@ -97,7 +110,7 @@ internal static class VirtualCrossoverSheetPdf
             }
         }
 
-        sheet.Save(filePath);
+        return sheet;
     }
 
     private static void AddPairSection(

--- a/source/Tools/VirtualCrossoverSheetPdf.cs
+++ b/source/Tools/VirtualCrossoverSheetPdf.cs
@@ -12,7 +12,9 @@ namespace Resonalyze;
 // Renders the Virtual DSP settings as a phone-friendly "tuning sheet" PDF
 // (MigraDoc / PDFsharp, same style as TuningSheetPdf): the product banner, the
 // title, a combined graph of every channel's DSP chain, and one section per
-// channel with the values to dial into the DSP plus its PEQ band cards.
+// channel PAIR with the values to dial into the DSP plus the PEQ band cards —
+// a stereo pair prints its L and R values side by side in one table, a mono
+// pair (or a pair with one loaded side) prints the single-channel layout.
 // The shared layout (scaffold, images, filter cards) lives in PdfSheet.
 internal static class VirtualCrossoverSheetPdf
 {
@@ -72,13 +74,127 @@ internal static class VirtualCrossoverSheetPdf
                 Unit.FromCentimeter(17));
         }
 
-        foreach ((int index, string sideSuffix, _, VirtualCrossoverChannelSettings channel)
-            in participating)
+        // A stereo pair with both sides loaded prints as ONE section with an
+        // L/R value table — the two sides of a pair are dialed in together,
+        // so their numbers belong side by side. A mono pair (or a pair with
+        // one loaded side) keeps the single-channel layout.
+        for (int i = 0; i < project.Pairs.Count; i++)
         {
-            AddChannelSection(sheet, index, sideSuffix, channel);
+            VirtualCrossoverChannelPairSettings pair = project.Pairs[i];
+            if (!pair.Mono && pair.Left.HasSource && pair.Right.HasSource)
+            {
+                AddPairSection(sheet, i, pair.Left, pair.Right);
+                continue;
+            }
+
+            foreach ((VirtualCrossoverChannelSettings channel, string sideSuffix)
+                in VirtualCrossoverSheet.SideSections(pair))
+            {
+                if (channel.HasSource)
+                {
+                    AddChannelSection(sheet, i, sideSuffix, channel);
+                }
+            }
         }
 
         sheet.Save(filePath);
+    }
+
+    private static void AddPairSection(
+        PdfSheet sheet,
+        int index,
+        VirtualCrossoverChannelSettings left,
+        VirtualCrossoverChannelSettings right)
+    {
+        Section section = sheet.Section;
+        Paragraph heading = section.AddParagraph(
+            $"Channel {VirtualCrossoverSheet.ChannelName(index)}");
+        heading.Format.Font.Bold = true;
+        heading.Format.Font.Size = 15;
+        heading.Format.SpaceBefore = Unit.FromMillimeter(5);
+        heading.Format.SpaceAfter = Unit.FromMillimeter(1);
+
+        var table = section.AddTable();
+        table.Borders.Width = 0.5;
+        table.Borders.Color = PdfSheet.CardBorderColor;
+        Column labelColumn = table.AddColumn(Unit.FromCentimeter(3.0));
+        labelColumn.LeftPadding = Unit.FromMillimeter(2);
+        for (int side = 0; side < 2; side++)
+        {
+            Column sideColumn = table.AddColumn(Unit.FromCentimeter(5.5));
+            sideColumn.LeftPadding = Unit.FromMillimeter(2);
+        }
+
+        Row header = table.AddRow();
+        header.Cells[1].AddParagraph("L").Format.Font.Bold = true;
+        header.Cells[2].AddParagraph("R").Format.Font.Bold = true;
+
+        AddPairRow(table, "Source", left.DisplayName, right.DisplayName);
+        AddPairRow(table, "Gain",
+            $"{Signed(left.GainDb)} dB",
+            $"{Signed(right.GainDb)} dB");
+        AddPairRow(table, "Delay", PairDelayText(left), PairDelayText(right));
+        AddPairRow(table, "Polarity", PolarityText(left), PolarityText(right));
+        AddPairRow(table, "Crossover",
+            VirtualCrossoverSheet.DescribeCrossover(left),
+            VirtualCrossoverSheet.DescribeCrossover(right));
+        if (HasPeq(left) || HasPeq(right))
+        {
+            AddPairRow(table, "PEQ", PeqSummary(left), PeqSummary(right));
+        }
+
+        AddPeqCards(
+            sheet, $"PEQ {VirtualCrossoverSheet.ChannelName(index)} L", left);
+        AddPeqCards(
+            sheet, $"PEQ {VirtualCrossoverSheet.ChannelName(index)} R", right);
+    }
+
+    private static string PairDelayText(VirtualCrossoverChannelSettings channel) =>
+        $"{Number(channel.DelayMs, "0.00")} ms " +
+        $"(= {Number(channel.DelayMs * Acoustics.SpeedOfSoundAt20CMetersPerSecond, "0.#")} mm)";
+
+    private static string PolarityText(VirtualCrossoverChannelSettings channel) =>
+        channel.InvertPolarity ? "Inverted" : "Normal";
+
+    private static bool HasPeq(VirtualCrossoverChannelSettings channel) =>
+        channel.PeqBands.Count > 0 || channel.PeqPreampDb != 0;
+
+    private static string PeqSummary(VirtualCrossoverChannelSettings channel) =>
+        HasPeq(channel)
+            ? $"{channel.PeqSourceName ?? "custom"}, " +
+              $"preamp {Signed(channel.PeqPreampDb)} dB"
+            : "—";
+
+    // The pair table names each side's PEQ in one summary row; the band cards
+    // print below it per side, captioned, so the two sides cannot be mixed up.
+    private static void AddPeqCards(
+        PdfSheet sheet,
+        string caption,
+        VirtualCrossoverChannelSettings channel)
+    {
+        if (channel.PeqBands.Count == 0)
+        {
+            return;
+        }
+
+        Paragraph paragraph = sheet.Section.AddParagraph(caption);
+        paragraph.Format.Font.Bold = true;
+        paragraph.Format.Font.Size = 12;
+        paragraph.Format.SpaceBefore = Unit.FromMillimeter(2);
+        sheet.AddFilterCards(channel.PeqBands);
+    }
+
+    private static void AddPairRow(
+        Table table,
+        string label,
+        string leftValue,
+        string rightValue)
+    {
+        Row row = table.AddRow();
+        Paragraph caption = row.Cells[0].AddParagraph(label);
+        caption.Format.Font.Color = PdfSheet.CaptionColor;
+        row.Cells[1].AddParagraph(leftValue).Format.Font.Bold = true;
+        row.Cells[2].AddParagraph(rightValue).Format.Font.Bold = true;
     }
 
     private static void AddChannelSection(

--- a/source/Tools/VirtualCrossoverSheetPdf.cs
+++ b/source/Tools/VirtualCrossoverSheetPdf.cs
@@ -107,18 +107,10 @@ internal static class VirtualCrossoverSheetPdf
         VirtualCrossoverChannelSettings right)
     {
         Section section = sheet.Section;
-        Paragraph heading = section.AddParagraph(
-            $"Channel {VirtualCrossoverSheet.ChannelName(index)}");
-        heading.Format.Font.Bold = true;
-        heading.Format.Font.Size = 15;
-        heading.Format.SpaceBefore = Unit.FromMillimeter(5);
-        heading.Format.SpaceAfter = Unit.FromMillimeter(1);
+        AddSectionHeading(
+            section, $"Channel {VirtualCrossoverSheet.ChannelName(index)}");
 
-        var table = section.AddTable();
-        table.Borders.Width = 0.5;
-        table.Borders.Color = PdfSheet.CardBorderColor;
-        Column labelColumn = table.AddColumn(Unit.FromCentimeter(3.0));
-        labelColumn.LeftPadding = Unit.FromMillimeter(2);
+        Table table = AddValueTable(section);
         for (int side = 0; side < 2; side++)
         {
             Column sideColumn = table.AddColumn(Unit.FromCentimeter(5.5));
@@ -133,7 +125,7 @@ internal static class VirtualCrossoverSheetPdf
         AddPairRow(table, "Gain",
             $"{Signed(left.GainDb)} dB",
             $"{Signed(right.GainDb)} dB");
-        AddPairRow(table, "Delay", PairDelayText(left), PairDelayText(right));
+        AddPairRow(table, "Delay", DelayText(left), DelayText(right));
         AddPairRow(table, "Polarity", PolarityText(left), PolarityText(right));
         AddPairRow(table, "Crossover",
             VirtualCrossoverSheet.DescribeCrossover(left),
@@ -149,9 +141,11 @@ internal static class VirtualCrossoverSheetPdf
             sheet, $"PEQ {VirtualCrossoverSheet.ChannelName(index)} R", right);
     }
 
-    private static string PairDelayText(VirtualCrossoverChannelSettings channel) =>
+    // The value strings shared by the pair table and the single-channel
+    // section, so the two layouts cannot print the same field differently.
+    private static string DelayText(VirtualCrossoverChannelSettings channel) =>
         $"{Number(channel.DelayMs, "0.00")} ms " +
-        $"(= {Number(channel.DelayMs * Acoustics.SpeedOfSoundAt20CMetersPerSecond, "0.#")} mm)";
+        $"(= {Number(channel.DelayMs * Acoustics.SpeedOfSoundAt20CMetersPerSecond, "0.#")} mm in air)";
 
     private static string PolarityText(VirtualCrossoverChannelSettings channel) =>
         channel.InvertPolarity ? "Inverted" : "Normal";
@@ -204,39 +198,46 @@ internal static class VirtualCrossoverSheetPdf
         VirtualCrossoverChannelSettings channel)
     {
         Section section = sheet.Section;
-        Paragraph heading = section.AddParagraph(
+        AddSectionHeading(
+            section,
             $"Channel {VirtualCrossoverSheet.ChannelName(index)}{sideSuffix} — " +
             channel.DisplayName);
-        heading.Format.Font.Bold = true;
-        heading.Format.Font.Size = 15;
-        heading.Format.SpaceBefore = Unit.FromMillimeter(5);
-        heading.Format.SpaceAfter = Unit.FromMillimeter(1);
 
-        var table = section.AddTable();
-        table.Borders.Width = 0.5;
-        table.Borders.Color = PdfSheet.CardBorderColor;
-        Column labelColumn = table.AddColumn(Unit.FromCentimeter(3.0));
-        labelColumn.LeftPadding = Unit.FromMillimeter(2);
+        Table table = AddValueTable(section);
         Column valueColumn = table.AddColumn(Unit.FromCentimeter(11.0));
         valueColumn.LeftPadding = Unit.FromMillimeter(2);
 
         AddRow(table, "Gain", $"{Signed(channel.GainDb)} dB");
-        AddRow(
-            table,
-            "Delay",
-            $"{Number(channel.DelayMs, "0.00")} ms   " +
-            $"(= {Number(channel.DelayMs * Acoustics.SpeedOfSoundAt20CMetersPerSecond, "0.#")} mm in air)");
-        AddRow(table, "Polarity", channel.InvertPolarity ? "Inverted" : "Normal");
+        AddRow(table, "Delay", DelayText(channel));
+        AddRow(table, "Polarity", PolarityText(channel));
         AddRow(table, "Crossover", VirtualCrossoverSheet.DescribeCrossover(channel));
-        if (channel.PeqBands.Count > 0 || channel.PeqPreampDb != 0)
+        if (HasPeq(channel))
         {
-            AddRow(
-                table,
-                "PEQ",
-                $"{channel.PeqSourceName ?? "custom"}, preamp {Signed(channel.PeqPreampDb)} dB");
+            AddRow(table, "PEQ", PeqSummary(channel));
         }
 
         sheet.AddFilterCards(channel.PeqBands);
+    }
+
+    // The section heading and the label-column value table shared by the pair
+    // and single-channel layouts; the caller adds the value column(s) it needs.
+    private static void AddSectionHeading(Section section, string title)
+    {
+        Paragraph heading = section.AddParagraph(title);
+        heading.Format.Font.Bold = true;
+        heading.Format.Font.Size = 15;
+        heading.Format.SpaceBefore = Unit.FromMillimeter(5);
+        heading.Format.SpaceAfter = Unit.FromMillimeter(1);
+    }
+
+    private static Table AddValueTable(Section section)
+    {
+        Table table = section.AddTable();
+        table.Borders.Width = 0.5;
+        table.Borders.Color = PdfSheet.CardBorderColor;
+        Column labelColumn = table.AddColumn(Unit.FromCentimeter(3.0));
+        labelColumn.LeftPadding = Unit.FromMillimeter(2);
+        return table;
     }
 
     private static void AddRow(Table table, string label, string value)

--- a/tests/Resonalyze.App.Tests/ImpulseWindowPreviewTests.cs
+++ b/tests/Resonalyze.App.Tests/ImpulseWindowPreviewTests.cs
@@ -1,0 +1,82 @@
+using System.Numerics;
+using OxyPlot;
+using OxyPlot.Annotations;
+using OxyPlot.Series;
+using Resonalyze.Options;
+
+namespace Resonalyze.App.Tests;
+
+// Pins the shared gated-IR rendering used by both the gate dialog's preview
+// and the Virtual DSP impulse view: per-trace normalization, the Tukey gate
+// outline, the gate-offset mark, and the tag the host sweeps on redraw.
+public sealed class ImpulseWindowPreviewTests
+{
+    private const int SampleRate = 48_000;
+    private const string Tag = "test-tag";
+
+    [Fact]
+    public void AddGatedTraceSeries_NoTraces_AddsNothingAndReturnsNull()
+    {
+        var model = new PlotModel();
+
+        (double, double)? window = ImpulseWindowPreview.AddGatedTraceSeries(
+            model, [], SampleRate,
+            gateOffsetMs: 10, leftMs: 0.5, plateauMs: 15, rightMs: 5);
+
+        Assert.Null(window);
+        Assert.Empty(model.Series);
+        Assert.Empty(model.Annotations);
+    }
+
+    [Fact]
+    public void AddGatedTraceSeries_NormalizesEachTraceAndTagsEverything()
+    {
+        var model = new PlotModel();
+        // Two arrivals 10 ms apart with very different amplitudes: independent
+        // normalization must bring BOTH peaks to ±1 so each stays visible.
+        IrPreviewTrace loud = MakeTrace("A", peakSample: 480, amplitude: 0.5);
+        IrPreviewTrace quiet = MakeTrace("B", peakSample: 960, amplitude: -0.02);
+
+        (double StartMs, double EndMs)? window =
+            ImpulseWindowPreview.AddGatedTraceSeries(
+                model, [loud, quiet], SampleRate,
+                gateOffsetMs: 10, leftMs: 0.5, plateauMs: 15, rightMs: 5, Tag);
+
+        Assert.NotNull(window);
+        // The display window covers the whole gate (9.5 ms to 30.5 ms) plus
+        // context on both sides.
+        Assert.True(window.Value.StartMs < 9.5);
+        Assert.True(window.Value.EndMs > 30.5);
+
+        List<LineSeries> series = model.Series
+            .OfType<LineSeries>()
+            .Where(item => Equals(item.Tag, Tag))
+            .ToList();
+        // Two traces plus the untitled gate-window outline.
+        Assert.Equal(3, series.Count);
+        Assert.Equal("A", series[0].Title);
+        Assert.Equal("B", series[1].Title);
+        Assert.Null(series[2].Title);
+
+        Assert.Equal(1.0, series[0].Points.Max(point => Math.Abs(point.Y)), 12);
+        Assert.Equal(1.0, series[1].Points.Max(point => Math.Abs(point.Y)), 12);
+        // The Tukey gate plateau reaches weight 1 and never leaves [0, 1].
+        Assert.Equal(1.0, series[2].Points.Max(point => point.Y), 12);
+        Assert.True(series[2].Points.All(point => point.Y is >= 0 and <= 1));
+
+        LineAnnotation mark = Assert.IsType<LineAnnotation>(
+            Assert.Single(model.Annotations));
+        Assert.Equal(Tag, mark.Tag);
+        Assert.Equal(10.0, mark.X, 12);
+    }
+
+    private static IrPreviewTrace MakeTrace(
+        string title,
+        int peakSample,
+        double amplitude)
+    {
+        var samples = new Complex[SampleRate / 10];
+        samples[peakSample] = amplitude;
+        return new IrPreviewTrace(samples, title, OxyColors.White);
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -89,6 +89,33 @@ public sealed class VirtualCrossoverMetricTests
     }
 
     [Fact]
+    public void FormatStereoDeltasCompact_MonoSubShowsItsArrivalAndDashesRightAndDelta()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            // The shared mono sub carries a single arrival on the left slot; the
+            // right side and the L−R delta have no meaning and read "—".
+            string text = VirtualCrossoverMetric.FormatStereoDeltasCompact(
+            [
+                new VirtualCrossoverMetric.StereoDelta("A", 22.39, null, 20, 80),
+                new VirtualCrossoverMetric.StereoDelta(
+                    "B", 16.78, 17.18, 40, 160, LevelDeltaDb: 3.4)
+            ]);
+
+            Assert.Equal(
+                "Arrival (ms)\r\n" +
+                "         L      R  Δ L−R\r\n" +
+                "A    22.39      —      —\r\n" +
+                "B    16.78  17.18  -0.40\r\n" +
+                "\r\n" +
+                "Level Δ L−R (dB)\r\n" +
+                "A        —\r\n" +
+                "B     +3.4",
+                text);
+        });
+    }
+
+    [Fact]
     public void FormatStereoDeltasCompact_EmptyListRendersNothing()
     {
         Assert.Equal(

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
@@ -1,3 +1,6 @@
+using System.Text;
+using MigraDoc.DocumentObjectModel;
+using MigraDoc.DocumentObjectModel.Tables;
 using Resonalyze;
 using Resonalyze.Dsp;
 
@@ -5,6 +8,116 @@ namespace Resonalyze.App.Tests;
 
 public sealed class VirtualCrossoverSheetPdfTests
 {
+    [Fact]
+    public void Build_StereoPair_RendersOneLeftRightTable()
+    {
+        var project = new VirtualCrossoverProjectFile();
+        project.Pairs[1].Left.SourceFilePath = "l.json";
+        project.Pairs[1].Left.DisplayName = "L woof";
+        project.Pairs[1].Left.DelayMs = 4.82;
+        project.Pairs[1].Left.GainDb = -1.5;
+        project.Pairs[1].Right.SourceFilePath = "r.json";
+        project.Pairs[1].Right.DisplayName = "R woof";
+        project.Pairs[1].Right.DelayMs = 3.18;
+        project.Pairs[1].Right.InvertPolarity = true;
+
+        using PdfSheet sheet = VirtualCrossoverSheetPdf.Build(project, null, 48_000);
+        Table pairTable = PairTables(sheet.Document).Single();
+
+        // A pair table is three columns (label + L + R) with an L/R header row.
+        Assert.Equal(3, pairTable.Columns.Count);
+        Assert.Equal("L", CellText(pairTable.Rows[0].Cells[1]));
+        Assert.Equal("R", CellText(pairTable.Rows[0].Cells[2]));
+
+        // Both sides' values sit side by side in one row each.
+        Assert.Equal("L woof", RowValue(pairTable, "Source", left: true));
+        Assert.Equal("R woof", RowValue(pairTable, "Source", left: false));
+        Assert.Contains("-1.5 dB", RowValue(pairTable, "Gain", left: true));
+        Assert.Contains("4.82 ms", RowValue(pairTable, "Delay", left: true));
+        Assert.Contains("mm in air", RowValue(pairTable, "Delay", left: true));
+        Assert.Contains("mm in air", RowValue(pairTable, "Delay", left: false));
+        Assert.Equal("Normal", RowValue(pairTable, "Polarity", left: true));
+        Assert.Equal("Inverted", RowValue(pairTable, "Polarity", left: false));
+    }
+
+    [Fact]
+    public void Build_MonoPairAndOneSidedPair_UseSingleColumnTables()
+    {
+        var project = new VirtualCrossoverProjectFile();
+        project.Pairs[0].Mono = true;
+        project.Pairs[0].Left.SourceFilePath = "sub.json";
+        project.Pairs[0].Left.DisplayName = "Sub";
+        // A stereo pair with only the left side loaded is NOT a pair table.
+        project.Pairs[1].Left.SourceFilePath = "half.json";
+        project.Pairs[1].Left.DisplayName = "Half";
+
+        using PdfSheet sheet = VirtualCrossoverSheetPdf.Build(project, null, 48_000);
+
+        // No three-column pair table — every section is a single-channel table.
+        Assert.Empty(PairTables(sheet.Document));
+    }
+
+    private static IEnumerable<Table> PairTables(Document document)
+    {
+        DocumentElements elements = document.LastSection.Elements;
+        for (int i = 0; i < elements.Count; i++)
+        {
+            if (elements[i] is Table { Columns.Count: 3 } table)
+            {
+                yield return table;
+            }
+        }
+    }
+
+    // The bold value cell (L or R) of the row whose label matches.
+    private static string RowValue(Table table, string label, bool left)
+    {
+        for (int r = 0; r < table.Rows.Count; r++)
+        {
+            if (CellText(table.Rows[r].Cells[0]) == label)
+            {
+                return CellText(table.Rows[r].Cells[left ? 1 : 2]);
+            }
+        }
+
+        throw new InvalidOperationException($"No row labelled '{label}'.");
+    }
+
+    private static string CellText(Cell cell)
+    {
+        var builder = new StringBuilder();
+        AppendText(cell.Elements, builder);
+        return builder.ToString();
+    }
+
+    private static void AppendText(DocumentElements elements, StringBuilder builder)
+    {
+        for (int i = 0; i < elements.Count; i++)
+        {
+            if (elements[i] is Paragraph paragraph)
+            {
+                for (int j = 0; j < paragraph.Elements.Count; j++)
+                {
+                    switch (paragraph.Elements[j])
+                    {
+                        case Text text:
+                            builder.Append(text.Content);
+                            break;
+                        case FormattedText formatted:
+                            for (int k = 0; k < formatted.Elements.Count; k++)
+                            {
+                                if (formatted.Elements[k] is Text inner)
+                                {
+                                    builder.Append(inner.Content);
+                                }
+                            }
+                            break;
+                    }
+                }
+            }
+        }
+    }
+
     [Fact]
     public void Export_WritesAValidPdfFile()
     {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
@@ -22,6 +22,10 @@ public sealed class VirtualCrossoverSheetPdfTests
         project.Pairs[1].Right.SourceFilePath = "top r.json";
         project.Pairs[1].Right.DisplayName = "Top R";
         project.Pairs[1].Right.CrossoverKind = CrossoverKind.HighPass;
+        // A stereo pair with ONE loaded side falls back to the single-channel
+        // layout instead of an L/R table with an empty column.
+        project.Pairs[2].Right.SourceFilePath = "half.json";
+        project.Pairs[2].Right.DisplayName = "Half";
 
         string path = Path.Combine(Path.GetTempPath(), $"vdsp_{Guid.NewGuid():N}.pdf");
         try

--- a/tests/Resonalyze.Dsp.Tests/AlignmentSelectionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AlignmentSelectionTests.cs
@@ -38,7 +38,7 @@ public sealed class AlignmentSelectionTests
     {
         // A genuinely flipped driver wins by more than the margin and stays.
         var inverted = new AlignmentCandidate(2.0, true, -0.50);
-        var normal = new AlignmentCandidate(1.4, false, -0.90);
+        var normal = new AlignmentCandidate(1.4, false, -1.10);
 
         AlignmentCandidate chosen = AlignmentSelection.Select(
             [inverted, normal], baseDeltaMs: 1.4);
@@ -81,7 +81,7 @@ public sealed class AlignmentSelectionTests
         // participate.
         var inverted = new AlignmentCandidate(2.0, true, -0.50);
         var invertedFar = new AlignmentCandidate(4.0, true, -0.58);
-        var normal = new AlignmentCandidate(1.0, false, -0.90);
+        var normal = new AlignmentCandidate(1.0, false, -1.10);
 
         AlignmentCandidate chosen = AlignmentSelection.Select(
             [inverted, invertedFar, normal], baseDeltaMs: 3.8);

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -220,17 +220,21 @@ public sealed class AutoAlignmentEngineTests
     {
         // A 2 kHz junction: the fine window is ±0.5 ms and the retry reach is
         // ±0.45 ms (1.8 half-periods), while the search-time optimum sits at
-        // +2.5 ms — 1.5 ms past the stage-1 seed. Only the ±3 ms diagnostic
-        // sweep reaches it, and its clearly better summation must be promoted.
+        // +2.0 ms — 1.0 ms (two periods) past the stage-1 seed. Only the ±3 ms
+        // diagnostic sweep reaches it; its clearly better summation is within
+        // the promotion reach cap (2.5 periods), so it must be promoted. A more
+        // distant optimum would be a comb alias the arrival, not the sum, must
+        // resolve — the reach cap declines those (pinned on real data in
+        // PromotionReachTests / RealMeasurementArrivalTests).
         var woofer = new TestChannel("W", DelayedImpulse(1.0));
         var tweeter = new TestChannel(
-            "T", DelayedImpulse(0.0), reprocessIr: DelayedImpulse(-1.5));
+            "T", DelayedImpulse(0.0), reprocessIr: DelayedImpulse(-1.0));
         var log = new StringBuilder();
 
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
             Run([woofer, tweeter], [2_000], log);
 
-        Assert.InRange(alignment[tweeter].DelayMs, 2.4, 2.6);
+        Assert.InRange(alignment[tweeter].DelayMs, 1.9, 2.1);
         Assert.Contains("promoted", log.ToString());
     }
 

--- a/tests/Resonalyze.Dsp.Tests/PromotionReachTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/PromotionReachTests.cs
@@ -1,0 +1,223 @@
+using System.Numerics;
+using System.Text;
+using System.Text.Json;
+using Xunit.Abstractions;
+
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The field regression the user hit on the real cabin measurements with an
+/// auto-crossover that split mid/tweeter at 2300 Hz: the wide-window promotion
+/// unseated the tweeter's arrival-anchored pick with a comb ALIAS ~1.7 ms
+/// (nearly four crossover periods) away for a 0.25 dB summation "gain", so the
+/// left tweeter arrived a couple of periods off its own mid and the mid IR read
+/// as lagging on the plot. The promotion reach cap keeps the pick within a lobe
+/// of the arrival, so mid and tweeter stay on the SAME summation lobe (their
+/// band-limited arrivals within one crossover period of each other — the
+/// residual is the crossover's own per-driver group delay, not a misalignment).
+/// </summary>
+public sealed class PromotionReachTests
+{
+    private readonly ITestOutputHelper output;
+
+    public PromotionReachTests(ITestOutputHelper output) => this.output = output;
+
+    private sealed record Channel(
+        string Name,
+        int SampleRate,
+        Complex[] RawIr,
+        DspChannelChain BaseChain) : IAlignmentChannel;
+
+    private static CrossoverEdge Bw(double frequencyHz) =>
+        new(CrossoverFilterFamily.Butterworth, frequencyHz, 24);
+
+    [Fact]
+    public void ComputeStereo_RealCabin_PromotionKeepsMidAndTweeterOnOneLobe()
+    {
+        Channel Load(string file, string name, DspChannelChain chain)
+        {
+            (int rate, Complex[] ir) = LoadTransferIr(file);
+            return new Channel(name, rate, ir, chain);
+        }
+
+        const double WoofMidHz = 200;
+        const double MidTwrHz = 2_300;
+        Channel sub = Load("sub woof closed window.json", "sub", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.LowPass, Bw(80))));
+        Channel leftWoof = Load("l woof.json", "L woof", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(WoofMidHz), Bw(80))));
+        Channel leftMid = Load("l mid.json", "L mid", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(MidTwrHz), Bw(WoofMidHz))));
+        Channel leftTwr = Load("l twr.json", "L twr", new DspChannelChain(
+            GainDb: -5,
+            Crossover: new CrossoverSpec(CrossoverKind.HighPass, HighPassEdge: Bw(MidTwrHz))));
+        Channel rightWoof = Load("r woof.json", "R woof", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(WoofMidHz), Bw(80))));
+        Channel rightMid = Load("r mid.json", "R mid", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(MidTwrHz), Bw(WoofMidHz))));
+        Channel rightTwr = Load("r twr.json", "R twr", new DspChannelChain(
+            GainDb: -5,
+            Crossover: new CrossoverSpec(CrossoverKind.HighPass, HighPassEdge: Bw(MidTwrHz))));
+
+        Channel[] all = [sub, leftWoof, leftMid, leftTwr, rightWoof, rightMid, rightTwr];
+        Channel[] leftByBand = [sub, leftWoof, leftMid, leftTwr];
+        Channel[] rightByBand = [sub, rightWoof, rightMid, rightTwr];
+
+        var cache = new Dictionary<(Channel, double, bool), AlignmentSnapshot>();
+        AlignmentSnapshot Snapshot(Channel channel, AlignmentOverride over)
+        {
+            (Channel, double, bool) key = (channel, over.DelayMs, over.InvertPolarity);
+            if (!cache.TryGetValue(key, out AlignmentSnapshot? hit))
+            {
+                Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(
+                    channel.RawIr,
+                    channel.BaseChain with
+                    {
+                        DelayMs = over.DelayMs,
+                        InvertPolarity = over.InvertPolarity
+                    },
+                    channel.SampleRate);
+                hit = new AlignmentSnapshot(
+                    channel, processed, VirtualCrossoverAnalysis.FindPeakIndex(processed));
+                cache[key] = hit;
+            }
+
+            return hit;
+        }
+
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            all.Select(channel =>
+                Snapshot(channel, overrides.GetValueOrDefault(channel))).ToList();
+
+        List<AlignmentSnapshot> leftSnapshots = leftByBand
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        List<AlignmentSnapshot> rightSnapshots = rightByBand
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        AlignmentJunction Junction(
+            AlignmentSnapshot lower, AlignmentSnapshot upper, double fc) =>
+            new(lower, upper, fc, Math.Max(20, fc / 2), Math.Min(20_000, fc * 2));
+        double[] crossovers = [80, WoofMidHz, MidTwrHz];
+        List<AlignmentJunction> leftPairs = crossovers
+            .Select((fc, i) => Junction(leftSnapshots[i], leftSnapshots[i + 1], fc))
+            .ToList();
+        List<AlignmentJunction> rightPairs = crossovers
+            .Select((fc, i) => Junction(rightSnapshots[i], rightSnapshots[i + 1], fc))
+            .ToList();
+
+        const double SceneOffsetMs = 0.25;
+        const double BridgeBandLowHz = 2_300;
+        const double BridgeBandHighHz = 20_000;
+        List<StereoPairLink> pairLinks =
+        [
+            new(leftWoof, rightWoof, 80, WoofMidHz),
+            new(leftMid, rightMid, WoofMidHz, MidTwrHz),
+            new(leftTwr, rightTwr, BridgeBandLowHz, BridgeBandHighHz)
+        ];
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        var log = new StringBuilder();
+        AutoAlignmentEngine.ComputeStereo(
+            new StereoAlignmentPlan(
+                leftSnapshots,
+                leftPairs,
+                rightSnapshots,
+                rightPairs,
+                new HashSet<IAlignmentChannel> { sub },
+                leftTwr,
+                rightTwr,
+                BridgeBandLowHz,
+                BridgeBandHighHz,
+                SceneOffsetMs,
+                pairLinks),
+            Reprocess,
+            alignment,
+            log);
+
+        output.WriteLine(log.ToString());
+
+        IReadOnlyList<AlignmentSnapshot> final = Reprocess(alignment);
+        double MidTwrArrival(Channel mid, Channel twr, out double midMs, out double twrMs)
+        {
+            midMs = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+                final.First(item => item.Channel == mid).ImpulseResponse,
+                mid.SampleRate, 1_150, 4_600);
+            twrMs = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+                final.First(item => item.Channel == twr).ImpulseResponse,
+                twr.SampleRate, 1_150, 4_600);
+            return midMs - twrMs;
+        }
+
+        double leftGap = MidTwrArrival(leftMid, leftTwr, out double lMid, out double lTwr);
+        double rightGap = MidTwrArrival(rightMid, rightTwr, out double rMid, out double rTwr);
+        output.WriteLine(
+            $"LEFT  mid {lMid:0.000} / twr {lTwr:0.000} ms -> C/D gap {leftGap:+0.000;-0.000} ms");
+        output.WriteLine(
+            $"RIGHT mid {rMid:0.000} / twr {rTwr:0.000} ms -> C/D gap {rightGap:+0.000;-0.000} ms");
+        output.WriteLine(
+            $"delays: L mid {alignment.GetValueOrDefault(leftMid).DelayMs:0.00} " +
+            $"L twr {alignment.GetValueOrDefault(leftTwr).DelayMs:0.00} | " +
+            $"R mid {alignment.GetValueOrDefault(rightMid).DelayMs:0.00} " +
+            $"R twr {alignment.GetValueOrDefault(rightTwr).DelayMs:0.00}");
+
+        // The contract: mid and tweeter land on the SAME summation lobe, i.e.
+        // their band-limited arrivals sit within one crossover period of each
+        // other (1000/2300 ≈ 0.43 ms). The bug promoted the tweeter a couple of
+        // periods off, opening a >0.7 ms cross-lobe gap. The residual inside one
+        // period is the crossover's inherent per-driver group delay, not a
+        // misalignment.
+        const double OnePeriodMs = 1_000.0 / MidTwrHz;
+        Assert.InRange(Math.Abs(leftGap), 0, OnePeriodMs);
+        Assert.InRange(Math.Abs(rightGap), 0, OnePeriodMs);
+
+        // The promotion must not have walked the tweeter off the envelope: the
+        // declined-alias diagnostic fires only when the reach cap rejects a
+        // multi-period comb alias, which is exactly this cabin's failure mode.
+        Assert.Contains("promotion declined", log.ToString());
+    }
+
+    private static (int SampleRate, Complex[] Ir) LoadTransferIr(string fileName)
+    {
+        string path = Path.Combine(FindTestDataDirectory(), fileName);
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException(
+                $"{fileName} is missing - initialize the measurement-data " +
+                "submodule with 'git submodule update --init assets/test_data'.",
+                path);
+        }
+
+        using FileStream stream = File.OpenRead(path);
+        using JsonDocument document = JsonDocument.Parse(stream);
+        JsonElement root = document.RootElement;
+        int sampleRate = root.GetProperty("sampleRate").GetInt32();
+        JsonElement samples = root.GetProperty("transferRealSamples");
+        var impulseResponse = new Complex[samples.GetArrayLength()];
+        int index = 0;
+        foreach (JsonElement sample in samples.EnumerateArray())
+        {
+            impulseResponse[index++] = new Complex(sample.GetDouble(), 0.0);
+        }
+
+        return (sampleRate, impulseResponse);
+    }
+
+    private static string FindTestDataDirectory()
+    {
+        DirectoryInfo? current = new(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            string candidate = Path.Combine(current.FullName, "assets", "test_data");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "assets/test_data was not found above the test binary.");
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/PromotionReachTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/PromotionReachTests.cs
@@ -6,14 +6,17 @@ using Xunit.Abstractions;
 namespace Resonalyze.Dsp.Tests;
 
 /// <summary>
-/// The field regression the user hit on the real cabin measurements with an
-/// auto-crossover that split mid/tweeter at 2300 Hz: the wide-window promotion
-/// unseated the tweeter's arrival-anchored pick with a comb ALIAS ~1.7 ms
-/// (nearly four crossover periods) away for a 0.25 dB summation "gain", so the
-/// left tweeter arrived a couple of periods off its own mid and the mid IR read
-/// as lagging on the plot. The promotion reach cap keeps the pick within a lobe
-/// of the arrival, so mid and tweeter stay on the SAME summation lobe (their
-/// band-limited arrivals within one crossover period of each other — the
+/// The field regressions the user hit on the real cabin measurements with an
+/// auto-crossover that split mid/tweeter at 2300 Hz — two doors into the same
+/// failure: (a) the wide-window promotion unseated the tweeter's
+/// arrival-anchored pick with a comb ALIAS ~1.7 ms (nearly four crossover
+/// periods) away for a 0.25 dB summation "gain"; (b) with the promotion capped,
+/// the scene-preserving co-move walked the tweeter pair up to a period off its
+/// mid through its flat ±1.2 ms window for 0.1-1 dB of mean junction loss. Both
+/// are the same physics: on a high junction the summation surface is a comb of
+/// near-equal minima and fractions of a dB cannot choose a lobe — the arrival
+/// can. With both reach caps, mid and tweeter stay on the SAME summation lobe
+/// (band-limited arrivals within one crossover period of each other — the
 /// residual is the crossover's own per-driver group delay, not a misalignment).
 /// </summary>
 public sealed class PromotionReachTests
@@ -31,8 +34,13 @@ public sealed class PromotionReachTests
     private static CrossoverEdge Bw(double frequencyHz) =>
         new(CrossoverFilterFamily.Butterworth, frequencyHz, 24);
 
-    [Fact]
-    public void ComputeStereo_RealCabin_PromotionKeepsMidAndTweeterOnOneLobe()
+    // Both tweeter gains are real field configs: -5 dB exposed the promotion
+    // alias, 0 dB exposed the co-move door once the promotion was capped.
+    [Theory]
+    [InlineData(-5.0)]
+    [InlineData(0.0)]
+    public void ComputeStereo_RealCabin_PromotionKeepsMidAndTweeterOnOneLobe(
+        double tweeterGainDb)
     {
         Channel Load(string file, string name, DspChannelChain chain)
         {
@@ -49,14 +57,14 @@ public sealed class PromotionReachTests
         Channel leftMid = Load("l mid.json", "L mid", new DspChannelChain(
             Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(MidTwrHz), Bw(WoofMidHz))));
         Channel leftTwr = Load("l twr.json", "L twr", new DspChannelChain(
-            GainDb: -5,
+            GainDb: tweeterGainDb,
             Crossover: new CrossoverSpec(CrossoverKind.HighPass, HighPassEdge: Bw(MidTwrHz))));
         Channel rightWoof = Load("r woof.json", "R woof", new DspChannelChain(
             Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(WoofMidHz), Bw(80))));
         Channel rightMid = Load("r mid.json", "R mid", new DspChannelChain(
             Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(MidTwrHz), Bw(WoofMidHz))));
         Channel rightTwr = Load("r twr.json", "R twr", new DspChannelChain(
-            GainDb: -5,
+            GainDb: tweeterGainDb,
             Crossover: new CrossoverSpec(CrossoverKind.HighPass, HighPassEdge: Bw(MidTwrHz))));
 
         Channel[] all = [sub, leftWoof, leftMid, leftTwr, rightWoof, rightMid, rightTwr];

--- a/tests/Resonalyze.Dsp.Tests/PromotionReachTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/PromotionReachTests.cs
@@ -149,10 +149,10 @@ public sealed class PromotionReachTests
         double MidTwrArrival(Channel mid, Channel twr, out double midMs, out double twrMs)
         {
             midMs = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                final.First(item => item.Channel == mid).ImpulseResponse,
+                final.First(item => ReferenceEquals(item.Channel, mid)).ImpulseResponse,
                 mid.SampleRate, 1_150, 4_600);
             twrMs = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                final.First(item => item.Channel == twr).ImpulseResponse,
+                final.First(item => ReferenceEquals(item.Channel, twr)).ImpulseResponse,
                 twr.SampleRate, 1_150, 4_600);
             return midMs - twrMs;
         }

--- a/tests/Resonalyze.Dsp.Tests/RealMeasurementArrivalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/RealMeasurementArrivalTests.cs
@@ -90,10 +90,14 @@ public sealed class RealMeasurementArrivalTests
         // -5 dB) leaves a spectral gap between the corners, so the whitened
         // pair correlation degenerates into near-equal lobes. The field failure:
         // its peak (r 0.47, but peak-vs-trough dominance only 0.02) was trusted
-        // as the stage-2 seed and sat two 1300 Hz periods off the arrival — Auto
-        // delay proposed 2.22 ms for the mid where the summation optimum (the
-        // user's manual pick) sits near 0.68 ms. The seed dominance gate plus
-        // the direct-sound-gated loss must keep the result on the arrival lobe.
+        // as the stage-2 seed and sat two 1300 Hz periods off the arrival. The
+        // seed dominance gate must keep the search on the arrival lobe, and the
+        // envelope-first margins (the promotion distance ramp, the invert
+        // preference) must keep the result there: this junction's comb offers a
+        // (flip + half-period) impostor +0.32 dB over the honest arrival pick
+        // and a 1.8-period-away lobe another 0.27 dB up — noise-level "gains"
+        // that used to walk the tweeter visibly off its mid (the 2026-07-13
+        // field verdict on the successor measurement set).
         (int midRate, Complex[] midIr) = LoadTransferIr("r mid.json");
         (int twrRate, Complex[] twrIr) = LoadTransferIr("r twr.json");
         var midChain = new DspChannelChain(Crossover: new CrossoverSpec(
@@ -145,10 +149,12 @@ public sealed class RealMeasurementArrivalTests
             new StringBuilder());
 
         // A uniform shift of both channels is the same alignment, so the pin is
-        // the net mid-vs-tweeter delay: the arrival lobe, not 2 periods later.
+        // the net mid-vs-tweeter delay: the arrival-matched offset (the raw
+        // band arrivals differ by -0.54 ms) within a fraction of the 1300 Hz
+        // period, on the honest non-inverted lobe.
         double netDelayMs = alignment.GetValueOrDefault(mid).DelayMs
             - alignment.GetValueOrDefault(twr).DelayMs;
-        Assert.InRange(netDelayMs, 0.3, 1.0);
+        Assert.InRange(netDelayMs, -0.8, -0.3);
         Assert.False(alignment.GetValueOrDefault(mid).InvertPolarity);
         Assert.False(alignment.GetValueOrDefault(twr).InvertPolarity);
     }

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -520,12 +520,17 @@ public sealed class StereoAlignmentTests
     }
 
     [Fact]
-    public void ComputeStereo_PureLowBandPairKeepsTheFreeSearch()
+    public void ComputeStereo_PureLowBandPairIsLockedToItsArrivalLobe()
     {
         // The woofer link's shared band (80-175 Hz) never reaches the
-        // localization region, so the scene mandate does not apply: the pair
-        // keeps the free joint-junction search and the cross-side target
-        // stays a gentle prior only. The mid link (400-2500 Hz) is locked.
+        // localization region, so the tight scene pin does not apply — but an
+        // identical L/R driver pair's delay split is still physical, and the
+        // junction comb (lobes a dB apart at a low junction) must not choose
+        // it: the field failure parked one under-seat midbass at 0 and the
+        // other at 10.85 ms. The pair is locked to the cross-side arrival's
+        // LOBE (half the tightest adjacent junction period), inside which the
+        // junction sum keeps full authority. The mid link (400-2500 Hz) keeps
+        // the tight scene lock.
         (TestChannel _, TestChannel[] _, TestChannel[] _,
             Dictionary<IAlignmentChannel, AlignmentOverride> _,
             StringBuilder log) = RunStereo(
@@ -536,8 +541,8 @@ public sealed class StereoAlignmentTests
         string woofLine = Array.Find(lines,
             line => line.StartsWith("Channel R woof:"))!;
         Assert.NotNull(woofLine);
-        Assert.DoesNotContain("SCENE-LOCKED", woofLine);
         Assert.Contains("(cross-side)", woofLine);
+        Assert.Contains("SCENE-LOCKED", woofLine);
         string midLine = Array.Find(lines,
             line => line.StartsWith("Channel R mid:"))!;
         Assert.NotNull(midLine);


### PR DESCRIPTION
## Summary

Two threads of work on the Virtual DSP tool, both driven by real cabin measurements (`head_90_grad` field set):

### Auto delay — envelope-first alignment
A field session surfaced the auto-tuner walking drivers onto the wrong summation lobe (tweeters ahead of mids, an under-seat midbass pair split 0 vs 10.85 ms). The fix establishes the **band-limited arrival envelope as the fundamental observation**, with the junction sum only polishing within a lobe:

- **Promotion margin**, field-calibrated to a flat 1.6 dB: comb noise between real lobes runs up to ~1.4 dB, a genuine envelope error shows as ~2 dB, and the same cabin provided both calibration points. Replaces an earlier distance ramp that no slope could make separate the two.
- **Invert-preference margin** raised 0.25 → 0.5 dB — a half-period flip impostor must be plainly, not marginally, better.
- **Modal-latch hardening**: the arrival detector now searches to 25 dB depth (kernel-envelope sidelobe rejection already guards the pre-ring), a consistency ladder times a fully modal-latched pair by its processed-IR energy peaks, and low-frequency pairs lock to the arrival lobe. Closes the long-deferred adaptive modal-flag threshold (now ~1/BW).

Every change is pinned against the real `assets/test_data` measurements.

### Virtual DSP UI/export
- **Impulse view**: a third Magnitude/Phase/**Impulse** radio on the acoustic plot shows each processed channel's IR exactly like the gate dialog's preview (shared rendering, so they can't drift). The smoothing combo greys out there.
- **PDF export**: stereo pairs now print as one L/R table instead of two separate sections; mono pairs keep the single-channel layout.
- **Metric**: the mono sub's arrival row now appears in the read-out.

## Test plan
- Full DSP suite green (531 tests), including new `PromotionReachTests` and updated real-data pins.
- App tests green (339), including new `ImpulseWindowPreviewTests` and the PDF pair-table case.
- Auto-delay results validated offline against both field configs; the left-tweeter recovery lands on the user's manual optimum to the hundredth of a ms.
- PDF layout verified by rendering a sample sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
