### PR TITLE
Transfer H1: relative regularization + explicit excitation edge

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,11 @@ Linux dev env where the work was done).
 - [ ] **GCC-PHAT alignment confidence line** renders in the Time Alignment
   panel ("Alignment: NN% (GCC-PHAT / envelope fallback)"); re-eyeball the fixed
   0.2 PHAT trust gate on real captures (coherence weighting shifts the peak).
+- [ ] **Excitation-masked H1** (relative regularization + explicit sweep-start
+  edge in `TransferFunction.ComputeAveragedRelativeIr`): re-measure and confirm
+  the transfer FR/IR look right; on reconstructed field captures the infrasonic
+  rumble that used to bias the loopback-referenced sub timing by up to ~0.34 ms
+  is gone, so a fresh sub measurement is the interesting one.
 - [ ] **Butterworth auto-delay polarity**: re-run the user's tune and confirm no
   channel is inverted on one side of a pair alone.
 - [ ] **Honest dBr/dBc axis + tracker labels** (FR plot title, distortion tracker
@@ -228,14 +233,6 @@ Linux dev env where the work was done).
   after wiring never get live-apply behavior. Deferred to a Windows session: the
   fix hooks `ControlAdded` recursively and re-enters the apply debounce, so it
   needs a live check that dynamically-added rows apply exactly once.
-
-## Measurement / transfer layer
-
-- [ ] **H1 has no excitation mask and an absolute epsilon.** Below the sweep band
-  `Gxy/Gxx` divides noise by noise and the garbage bins ring back through the
-  IFFT; the absolute epsilon's strength also varies with the average count. Fix:
-  relative regularization + a soft excitation taper at the sweep edges. Changes
-  every measured transfer IR — needs validation against fresh raw captures.
 
 ## EQ Wizard
 

--- a/dsp/TransferFunction.cs
+++ b/dsp/TransferFunction.cs
@@ -160,38 +160,50 @@ public static class TransferFunction
     // weights are real and Hermitian-symmetric (frequencies fold through
     // min(bin, N - bin); a real capture's power spectrum already is), so this
     // is zero-phase filtering: the inverse transform stays real and nothing
-    // moves in time. DC is excluded from the peak scan — at measurement FFT
-    // lengths a converter's static offset can rival the sweep bins and would
-    // drag both thresholds with it (bin 0 itself still passes through the
-    // same gates as any bin).
+    // moves in time. The peak scan that anchors the thresholds only looks at
+    // bins the excitation edge keeps: a bin the estimate discards must not
+    // scale the gate it is excluded from (a loud mains-adjacent hum below a
+    // narrow sweep's start, or DC — a converter's static offset can rival the
+    // sweep bins at measurement FFT lengths — would otherwise fade genuinely
+    // excited bins).
     private static Complex[] InverseExcitationGatedH1(
         Complex[] crossSpectrum,
         double[] referencePowerSpectrum,
         double excitationLowNyquistFraction)
     {
         int fftLength = crossSpectrum.Length;
+        int half = fftLength / 2;
+        double EdgeWeight(int bin)
+        {
+            if (excitationLowNyquistFraction <= 0.0)
+            {
+                return 1.0;
+            }
+
+            double nyquistFraction = Math.Min(bin, fftLength - bin) / (double)half;
+            return SoftGate(
+                nyquistFraction,
+                excitationLowNyquistFraction * 0.5,
+                excitationLowNyquistFraction);
+        }
+
         double maxReferencePower = 0;
         for (int bin = 1; bin < fftLength; bin++)
         {
-            maxReferencePower = Math.Max(maxReferencePower, referencePowerSpectrum[bin]);
+            if (EdgeWeight(bin) > 0)
+            {
+                maxReferencePower = Math.Max(maxReferencePower, referencePowerSpectrum[bin]);
+            }
         }
 
         double regularization = maxReferencePower * RelativeRegularization;
         double gateHigh = maxReferencePower * ExcitationGatePowerRatio;
         double gateLow = gateHigh * ExcitationGateFloorShare;
-        int half = fftLength / 2;
         var relative = new Complex[fftLength];
         for (int bin = 0; bin < fftLength; bin++)
         {
-            double weight = SoftGate(referencePowerSpectrum[bin], gateLow, gateHigh);
-            if (excitationLowNyquistFraction > 0.0 && weight > 0)
-            {
-                double nyquistFraction = Math.Min(bin, fftLength - bin) / (double)half;
-                weight *= SoftGate(
-                    nyquistFraction,
-                    excitationLowNyquistFraction * 0.5,
-                    excitationLowNyquistFraction);
-            }
+            double weight = SoftGate(referencePowerSpectrum[bin], gateLow, gateHigh)
+                * EdgeWeight(bin);
             if (weight > 0)
             {
                 relative[bin] = weight * crossSpectrum[bin]

--- a/dsp/TransferFunction.cs
+++ b/dsp/TransferFunction.cs
@@ -8,18 +8,51 @@ namespace Resonalyze.Dsp;
 /// </summary>
 public static class TransferFunction
 {
+    // H1 regularization relative to the strongest excitation bin. An absolute
+    // epsilon changes meaning with the record level and with the accumulated
+    // average count (the spectra below are unnormalized running sums), so its
+    // strength silently drifted between measurements; -100 dB of the peak bin
+    // is scale-invariant and sits far below the excitation-gate floor, so it
+    // only guards the truly degenerate zero-power bins.
+    private const double RelativeRegularization = 1e-10;
+
+    // The power gate: bins whose reference power sits more than 60 dB under
+    // the strongest excitation bin fade out over a raised cosine that reaches
+    // zero another 14 dB down. This is only a safety net for bins at the true
+    // capture noise floor (below -90 dB even for 16-bit loopbacks) — it
+    // deliberately canNOT mark the region below the sweep start, because at
+    // measurement FFT lengths the sweep's own spectral leakage skirts hold
+    // the reference power at just -40..-20 dB re max all the way down to DC
+    // (verified on reconstructed field captures), while genuinely excited
+    // bins reach -45 dB (~36 dB of 1/f tilt across 12 octaves plus the
+    // first-octave fade-in). Cutting below the sweep start is the caller's
+    // job via the explicit excitation edge — the sweep parameters are known,
+    // the spectrum alone cannot reveal them.
+    private const double ExcitationGatePowerRatio = 1e-6;
+    private const double ExcitationGateFloorShare = 0.04;
+
+    /// <param name="excitationLowNyquistFraction">
+    /// The excitation's low edge as a fraction of Nyquist (an exponential
+    /// sweep spanning N octaves starts at Nyquist / 2^N). Bins fade out over
+    /// a raised cosine between this frequency and half of it, and stay zero
+    /// below: the sweep never went there, so Gxy/Gxx is microphone rumble
+    /// divided by the reference's leakage skirt — garbage that used to ring
+    /// back through the IFFT across the whole IR. Zero (the default) disables
+    /// the edge for callers whose excitation genuinely covers DC.
+    /// </param>
     public static TransferEstimateResult ComputeAveragedRelativeIr(
         IReadOnlyList<TransferFunctionFrame> frames,
-        double epsilon = 1e-12)
+        double excitationLowNyquistFraction = 0.0)
     {
         ArgumentNullException.ThrowIfNull(frames);
         if (frames.Count == 0)
         {
             throw new ArgumentException("At least one transfer frame is required.", nameof(frames));
         }
-        if (!double.IsFinite(epsilon) || epsilon < 0)
+        if (!double.IsFinite(excitationLowNyquistFraction) ||
+            excitationLowNyquistFraction is < 0.0 or > 1.0)
         {
-            throw new ArgumentOutOfRangeException(nameof(epsilon));
+            throw new ArgumentOutOfRangeException(nameof(excitationLowNyquistFraction));
         }
 
         int sampleCount = frames.Min(frame => Math.Min(frame.Reference.Count, frame.Target.Count));
@@ -60,11 +93,10 @@ public static class TransferFunction
                     epsilon: 0.0)[..(fftLength / 2 + 1)],
             frames.Count);
 
-        Complex[] relative = InverseH1Response(
+        Complex[] relative = InverseExcitationGatedH1(
             crossSpectrum,
             referencePowerSpectrum,
-            epsilon,
-            filter: null);
+            excitationLowNyquistFraction);
 
         var impulseResponse = new double[fftLength];
         double peakMagnitude = 0;
@@ -118,6 +150,55 @@ public static class TransferFunction
                 targetPowerSpectrum[bin] += MagnitudeSquared(targetSpectrum[bin]);
             }
         }
+    }
+
+    // The H1 estimate cross / (auto + λ), gated by the known excitation low
+    // edge and by a power-floor safety net read from the reference's own
+    // accumulated spectrum, transformed back to the time domain. All gate
+    // weights are real and Hermitian-symmetric (frequencies fold through
+    // min(bin, N - bin); a real capture's power spectrum already is), so this
+    // is zero-phase filtering: the inverse transform stays real and nothing
+    // moves in time. DC is excluded from the peak scan — at measurement FFT
+    // lengths a converter's static offset can rival the sweep bins and would
+    // drag both thresholds with it (bin 0 itself still passes through the
+    // same gates as any bin).
+    private static Complex[] InverseExcitationGatedH1(
+        Complex[] crossSpectrum,
+        double[] referencePowerSpectrum,
+        double excitationLowNyquistFraction)
+    {
+        int fftLength = crossSpectrum.Length;
+        double maxReferencePower = 0;
+        for (int bin = 1; bin < fftLength; bin++)
+        {
+            maxReferencePower = Math.Max(maxReferencePower, referencePowerSpectrum[bin]);
+        }
+
+        double regularization = maxReferencePower * RelativeRegularization;
+        double gateHigh = maxReferencePower * ExcitationGatePowerRatio;
+        double gateLow = gateHigh * ExcitationGateFloorShare;
+        int half = fftLength / 2;
+        var relative = new Complex[fftLength];
+        for (int bin = 0; bin < fftLength; bin++)
+        {
+            double weight = SoftGate(referencePowerSpectrum[bin], gateLow, gateHigh);
+            if (excitationLowNyquistFraction > 0.0 && weight > 0)
+            {
+                double nyquistFraction = Math.Min(bin, fftLength - bin) / (double)half;
+                weight *= SoftGate(
+                    nyquistFraction,
+                    excitationLowNyquistFraction * 0.5,
+                    excitationLowNyquistFraction);
+            }
+            if (weight > 0)
+            {
+                relative[bin] = weight * crossSpectrum[bin]
+                    / (referencePowerSpectrum[bin] + regularization);
+            }
+        }
+
+        Fourier.Inverse(relative, FourierOptions.Matlab);
+        return relative;
     }
 
     // The H1 estimate cross / (auto + eps), optionally shaped by a spectral

--- a/dsp/TransferFunction.cs
+++ b/dsp/TransferFunction.cs
@@ -39,8 +39,11 @@ public static class TransferFunction
     /// a raised cosine between this frequency and half of it, and stay zero
     /// below: the sweep never went there, so Gxy/Gxx is microphone rumble
     /// divided by the reference's leakage skirt — garbage that used to ring
-    /// back through the IFFT across the whole IR. Zero (the default) disables
-    /// the edge for callers whose excitation genuinely covers DC.
+    /// back through the IFFT across the whole IR. The returned coherence
+    /// carries the same validity: the leakage is deterministic across runs,
+    /// so raw γ² reads ~1 exactly where the estimate is zeroed as unexcited.
+    /// Zero (the default) disables the edge for callers whose excitation
+    /// genuinely covers DC.
     /// </param>
     public static TransferEstimateResult ComputeAveragedRelativeIr(
         IReadOnlyList<TransferFunctionFrame> frames,
@@ -86,6 +89,10 @@ public static class TransferFunction
         // at 2-4 averages the raw MSC of pure noise reads 1/K (0.5 at K=2 —
         // straddling the very thresholds the unwrap and the PHAT weighting
         // trust), which is estimator bias, not information.
+        (double[] gateWeights, double regularization) = BuildExcitationGate(
+            referencePowerSpectrum,
+            excitationLowNyquistFraction);
+
         double[] coherence = SpectrumAnalysis.DebiasCoherence(
             SpectrumAnalysis
                 .ComputeCoherence(
@@ -95,10 +102,22 @@ public static class TransferFunction
                     epsilon: 0.0)[..(fftLength / 2 + 1)],
             frames.Count);
 
-        Complex[] relative = InverseExcitationGatedH1(
+        // The gate is the estimate's validity, and the coherence must carry
+        // it too: below the sweep start the sweep's own deterministic leakage
+        // repeats across runs, so raw γ² reads ~1 exactly where H1 is zeroed
+        // as unexcited — and downstream consumers (the phase unwrap's trust
+        // gate, the PHAT weighting, the plotted coherence curve) would keep
+        // presenting those bins as reliable.
+        for (int bin = 0; bin < coherence.Length; bin++)
+        {
+            coherence[bin] *= gateWeights[bin];
+        }
+
+        Complex[] relative = InverseGatedH1(
             crossSpectrum,
             referencePowerSpectrum,
-            excitationLowNyquistFraction);
+            gateWeights,
+            regularization);
 
         var impulseResponse = new double[fftLength];
         double peakMagnitude = 0;
@@ -154,59 +173,71 @@ public static class TransferFunction
         }
     }
 
-    // The H1 estimate cross / (auto + λ), gated by the known excitation low
-    // edge and by a power-floor safety net read from the reference's own
-    // accumulated spectrum, transformed back to the time domain. All gate
-    // weights are real and Hermitian-symmetric (frequencies fold through
-    // min(bin, N - bin); a real capture's power spectrum already is), so this
-    // is zero-phase filtering: the inverse transform stays real and nothing
-    // moves in time. The peak scan that anchors the thresholds only looks at
-    // bins the excitation edge keeps: a bin the estimate discards must not
-    // scale the gate it is excluded from (a loud mains-adjacent hum below a
-    // narrow sweep's start, or DC — a converter's static offset can rival the
-    // sweep bins at measurement FFT lengths — would otherwise fade genuinely
-    // excited bins).
-    private static Complex[] InverseExcitationGatedH1(
-        Complex[] crossSpectrum,
+    // The validity of every bin of the H1 estimate: the excitation edge from
+    // the caller's known sweep start times the power-floor safety net read
+    // from the reference's own accumulated spectrum. The weights are real and
+    // Hermitian-symmetric (frequencies fold through min(bin, N - bin); a real
+    // capture's power spectrum already is), so applying them is zero-phase
+    // filtering: nothing moves in time. The peak scan that anchors the power
+    // thresholds and the regularization only looks at bins at FULL edge
+    // weight: a bin the estimate discards or attenuates must not scale the
+    // gate it is excluded from — a loud mains-adjacent hum below (or inside
+    // the ramp of) a narrow sweep's start, or DC, whose converter-offset
+    // splatter can rival the sweep bins at measurement FFT lengths, would
+    // otherwise fade genuinely excited bins.
+    private static (double[] Weights, double Regularization) BuildExcitationGate(
         double[] referencePowerSpectrum,
         double excitationLowNyquistFraction)
     {
-        int fftLength = crossSpectrum.Length;
+        int fftLength = referencePowerSpectrum.Length;
         int half = fftLength / 2;
-        double EdgeWeight(int bin)
-        {
-            if (excitationLowNyquistFraction <= 0.0)
-            {
-                return 1.0;
-            }
-
-            double nyquistFraction = Math.Min(bin, fftLength - bin) / (double)half;
-            return SoftGate(
-                nyquistFraction,
-                excitationLowNyquistFraction * 0.5,
-                excitationLowNyquistFraction);
-        }
+        double NyquistFraction(int bin) =>
+            Math.Min(bin, fftLength - bin) / (double)half;
 
         double maxReferencePower = 0;
         for (int bin = 1; bin < fftLength; bin++)
         {
-            if (EdgeWeight(bin) > 0)
+            if (excitationLowNyquistFraction <= 0.0 ||
+                NyquistFraction(bin) >= excitationLowNyquistFraction)
             {
                 maxReferencePower = Math.Max(maxReferencePower, referencePowerSpectrum[bin]);
             }
         }
 
-        double regularization = maxReferencePower * RelativeRegularization;
         double gateHigh = maxReferencePower * ExcitationGatePowerRatio;
         double gateLow = gateHigh * ExcitationGateFloorShare;
+        var weights = new double[fftLength];
+        for (int bin = 0; bin < fftLength; bin++)
+        {
+            double weight = SoftGate(referencePowerSpectrum[bin], gateLow, gateHigh);
+            if (excitationLowNyquistFraction > 0.0 && weight > 0)
+            {
+                weight *= SoftGate(
+                    NyquistFraction(bin),
+                    excitationLowNyquistFraction * 0.5,
+                    excitationLowNyquistFraction);
+            }
+            weights[bin] = weight;
+        }
+
+        return (weights, maxReferencePower * RelativeRegularization);
+    }
+
+    // The H1 estimate cross / (auto + λ), shaped by the validity weights and
+    // transformed back to the time domain.
+    private static Complex[] InverseGatedH1(
+        Complex[] crossSpectrum,
+        double[] referencePowerSpectrum,
+        double[] weights,
+        double regularization)
+    {
+        int fftLength = crossSpectrum.Length;
         var relative = new Complex[fftLength];
         for (int bin = 0; bin < fftLength; bin++)
         {
-            double weight = SoftGate(referencePowerSpectrum[bin], gateLow, gateHigh)
-                * EdgeWeight(bin);
-            if (weight > 0)
+            if (weights[bin] > 0)
             {
-                relative[bin] = weight * crossSpectrum[bin]
+                relative[bin] = weights[bin] * crossSpectrum[bin]
                     / (referencePowerSpectrum[bin] + regularization);
             }
         }

--- a/dsp/TransferFunction.cs
+++ b/dsp/TransferFunction.cs
@@ -12,8 +12,10 @@ public static class TransferFunction
     // epsilon changes meaning with the record level and with the accumulated
     // average count (the spectra below are unnormalized running sums), so its
     // strength silently drifted between measurements; -100 dB of the peak bin
-    // is scale-invariant and sits far below the excitation-gate floor, so it
-    // only guards the truly degenerate zero-power bins.
+    // is scale-invariant. Note it does no gating work of its own: any bin the
+    // gates let through already has at least gateLow (-74 dB re max) in the
+    // denominator, so λ biases it by under 0.25% — it only keeps the division
+    // Tikhonov-safe should the gate constants ever loosen.
     private const double RelativeRegularization = 1e-10;
 
     // The power gate: bins whose reference power sits more than 60 dB under

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -363,7 +363,11 @@ namespace Resonalyze
                     return result;
                 }
 
-                var accumulator = new SweepAverageAccumulator();
+                // The sweep spans Octaves octaves up to Nyquist, so its low
+                // edge is Nyquist / 2^Octaves — the transfer estimator masks
+                // the never-excited bins below it.
+                var accumulator = new SweepAverageAccumulator(
+                    Math.Pow(2.0, -sweep.Octaves));
                 var rejections = new List<SweepRunRejection>();
                 int requestedRuns = AverageRunCount;
                 for (int run = 1; run <= requestedRuns; run++)
@@ -734,6 +738,7 @@ namespace Resonalyze
 
         private sealed class SweepAverageAccumulator
         {
+            private readonly double excitationLowNyquistFraction;
             private readonly List<TransferFunctionFrame> transferFrames = new();
             private readonly ChannelLevelAccumulator microphoneLevels = new(fullScaleReference: false);
             private readonly ChannelLevelAccumulator loopbackLevels = new(fullScaleReference: true);
@@ -741,6 +746,11 @@ namespace Resonalyze
             private int referencePeakIndex;
             private float[]? lastMicrophoneSamples;
             private float[]? lastLoopbackSamples;
+
+            public SweepAverageAccumulator(double excitationLowNyquistFraction)
+            {
+                this.excitationLowNyquistFraction = excitationLowNyquistFraction;
+            }
 
             public int AcceptedRuns { get; private set; }
 
@@ -805,7 +815,8 @@ namespace Resonalyze
                 if (transferFrames.Count == AcceptedRuns)
                 {
                     TransferEstimateResult transfer = TransferFunction.ComputeAveragedRelativeIr(
-                        transferFrames);
+                        transferFrames,
+                        excitationLowNyquistFraction);
                     transferImpulseResponse = Array.ConvertAll(
                         transfer.ImpulseResponse,
                         sample => new Complex(sample, 0.0));

--- a/tests/Resonalyze.Dsp.Tests/TransferFunctionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferFunctionTests.cs
@@ -242,6 +242,169 @@ public sealed class TransferFunctionTests
     }
 
     [Fact]
+    public void ComputeAveragedRelativeIr_GatesOutBinsAtTheReferenceNoiseFloor()
+    {
+        // The power-floor safety net: where the reference truly carries
+        // nothing but its (tiny, electrical) noise, Gxy/Gxx is a noise ratio
+        // of order target/reference — orders of magnitude above the in-band
+        // response — and with the absolute epsilon it rang back through the
+        // IFFT as broadband time-domain garbage. Those bins must read zero:
+        // the recovered IR is then a clean band-limited pulse at the true
+        // delay instead of noise swamping it.
+        const int delay = 25;
+        double[] sweep = MiniSweep(4096, octaves: 5);
+        double[] reference = AddNoise(sweep, 1e-6, seed: 1);
+        double[] target = AddNoise(Delay(sweep, delay), 1e-3, seed: 2);
+
+        TransferEstimateResult result = TransferFunction.ComputeAveragedRelativeIr(
+            [new TransferFunctionFrame(reference, target)]);
+
+        Assert.Equal(delay, result.PeakIndex);
+        Assert.InRange(result.ImpulseResponse[delay], 0.8, 1.05);
+        Assert.True(
+            WorstOutsideWindow(result.ImpulseResponse, delay, 64) < 0.02,
+            "Reference-noise-floor bins leaked into the IR.");
+    }
+
+    [Fact]
+    public void ComputeAveragedRelativeIr_ExcitationEdgeCutsRumbleTheFloorGateCannot()
+    {
+        // The field failure mode on real capture lengths: the sweep's own
+        // leakage skirts hold the reference power at only -40..-20 dB re max
+        // all the way below the sweep start, so no data-driven floor gate can
+        // mark that region — while the microphone picks up strong infrasonic
+        // rumble there (vibration, wind) that the loopback never sees.
+        // Gxy/Gxx then reads rumble-over-skirt, far above the honest in-band
+        // response. Model the skirt as a reference tone below the sweep start
+        // — well above the floor gate yet far below the passband — and the
+        // rumble as a 40 dB louder target tone at the same frequency: only
+        // the explicit excitation edge can cut it. Both tones are Hann-shaped
+        // so their own leakage stays as compact relative to the edge as real
+        // capture-length rumble is.
+        const int delay = 25;
+        const int octaves = 3; // sweep spans Nyquist/8..Nyquist
+        double[] sweep = MiniSweep(4096, octaves);
+        double[] reference = AddNoise(sweep, 1e-6, seed: 5);
+        double[] target = AddNoise(Delay(sweep, delay), 1e-5, seed: 6);
+        for (int i = 0; i < reference.Length; i++)
+        {
+            // Nyquist/64 — below the sweep start and below the edge's ramp.
+            double phase = 2.0 * Math.PI * i / 128.0;
+            double window = 0.5 - 0.5 * Math.Cos(2.0 * Math.PI * i / reference.Length);
+            reference[i] += 0.0005 * window * Math.Sin(phase);
+            target[i] += 0.05 * window * Math.Sin(phase + 1.0);
+        }
+        var frames = new[] { new TransferFunctionFrame(reference, target) };
+
+        TransferEstimateResult unmasked = TransferFunction.ComputeAveragedRelativeIr(frames);
+        TransferEstimateResult masked = TransferFunction.ComputeAveragedRelativeIr(
+            frames, excitationLowNyquistFraction: Math.Pow(2.0, -octaves));
+
+        // The rumble tone spreads as a sinusoid across the whole IR while the
+        // pulse's own band-edge ringing decays away from it, so far-field RMS
+        // separates the two. Without the edge the rumble-over-skirt garbage
+        // dominates it (~0.09 here)...
+        Assert.True(
+            RmsOutsideWindow(unmasked.ImpulseResponse, delay, 256) > 0.03,
+            "Test setup lost its teeth: the floor gate alone already cut the rumble.");
+        // ...with it the pulse comes back clean, in place and full-size.
+        Assert.Equal(delay, masked.PeakIndex);
+        Assert.InRange(masked.ImpulseResponse[delay], 0.8, 1.05);
+        Assert.True(
+            RmsOutsideWindow(masked.ImpulseResponse, delay, 256) < 0.005,
+            "Sub-excitation rumble leaked past the excitation edge.");
+    }
+
+    [Fact]
+    public void ComputeAveragedRelativeIr_EstimateDoesNotDependOnTheAverageCount()
+    {
+        // The cross- and auto-spectra are accumulated without normalization, so
+        // an absolute epsilon regularized four accumulated runs four times more
+        // weakly than one. The relative regularization scales with the sums:
+        // repeating the identical frame must reproduce the identical estimate.
+        double[] sweep = MiniSweep(2048, octaves: 4);
+        double[] reference = AddNoise(sweep, 1e-6, seed: 3);
+        double[] target = AddNoise(Delay(sweep, 40), 1e-4, seed: 4);
+        var frame = new TransferFunctionFrame(reference, target);
+
+        TransferEstimateResult once = TransferFunction.ComputeAveragedRelativeIr([frame]);
+        TransferEstimateResult four = TransferFunction.ComputeAveragedRelativeIr(
+            [frame, frame, frame, frame]);
+
+        Assert.Equal(once.PeakIndex, four.PeakIndex);
+        for (int i = 0; i < once.ImpulseResponse.Length; i++)
+        {
+            Assert.Equal(once.ImpulseResponse[i], four.ImpulseResponse[i], precision: 12);
+        }
+    }
+
+    // The app's exponential sweep in miniature: <paramref name="octaves"/>
+    // octaves ending exactly at Nyquist, amplitude faded in linearly over the
+    // first octave — so the spectrum has the same shape the excitation gates
+    // see in a real loopback capture, leakage skirts below the start
+    // frequency included.
+    private static double[] MiniSweep(int length, int octaves)
+    {
+        double frequencyRatio = Math.Pow(2.0, octaves);
+        double logarithmicRatio = Math.Log(frequencyRatio);
+        double phaseFactor = (Math.PI / frequencyRatio) / logarithmicRatio;
+        double octaveLength = length / (double)octaves;
+        var sweep = new double[length];
+        for (int i = 0; i < length; i++)
+        {
+            double exponentialPosition = Math.Exp(i / (double)length * logarithmicRatio);
+            sweep[i] = Math.Sin(phaseFactor * length * exponentialPosition)
+                * Math.Min(i / octaveLength, 1.0);
+        }
+
+        return sweep;
+    }
+
+    private static double WorstOutsideWindow(double[] ir, int center, int halfWidth)
+    {
+        double worst = 0;
+        for (int i = 0; i < ir.Length; i++)
+        {
+            if (Math.Abs(i - center) > halfWidth)
+            {
+                worst = Math.Max(worst, Math.Abs(ir[i]));
+            }
+        }
+
+        return worst;
+    }
+
+    private static double RmsOutsideWindow(double[] ir, int center, int halfWidth)
+    {
+        double sum = 0;
+        int count = 0;
+        for (int i = 0; i < ir.Length; i++)
+        {
+            if (Math.Abs(i - center) > halfWidth)
+            {
+                sum += ir[i] * ir[i];
+                count++;
+            }
+        }
+
+        return Math.Sqrt(sum / Math.Max(1, count));
+    }
+
+    private static double[] AddNoise(double[] signal, double amplitude, int seed)
+    {
+        var noisy = new double[signal.Length];
+        for (int i = 0; i < signal.Length; i++)
+        {
+            // Deterministic pseudo-noise, decorrelated across seeds.
+            noisy[i] = signal[i] + amplitude
+                * Math.Sin(i * (12.9898 + seed * 3.7) + seed * 78.233)
+                * Math.Sin(i * 0.7301 + seed);
+        }
+
+        return noisy;
+    }
+
+    [Fact]
     public void RefineAround_DegenerateCorrelationReportsNoRefinementWithoutNaN()
     {
         // An all-zero IR whitens to an empty band (weightSum 0, normalizer 0), so the

--- a/tests/Resonalyze.Dsp.Tests/TransferFunctionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferFunctionTests.cs
@@ -319,13 +319,14 @@ public sealed class TransferFunctionTests
     public void ComputeAveragedRelativeIr_MaskedBinsDoNotScaleTheGateThresholds()
     {
         // PR-review finding: the peak scan anchoring gateHigh and λ used to
-        // include bins the excitation edge later zeroes. A loud sub-edge
-        // reference component (hum below a narrow sweep's start) then scaled
-        // the power gate from an artifact excluded from the estimate, fading
-        // the genuinely excited bins. The hum here is deliberately absurd —
-        // 60+ dB over the sweep bins, enough to zero the whole passband
-        // through the old scan — so the pin is decisive: with the scan
-        // restricted to edge-eligible bins the pulse must come back intact.
+        // include bins the excitation edge later zeroes or attenuates. A loud
+        // sub-edge reference component (hum below — or in the ramp of — a
+        // narrow sweep's start) then scaled the power gate from an artifact
+        // excluded from the estimate, fading the genuinely excited bins. The
+        // hums here are deliberately absurd — 60+ dB over the sweep bins,
+        // enough to zero the whole passband through the old scan — so the pin
+        // is decisive: with the scan restricted to bins at FULL edge weight
+        // the pulse must come back intact.
         const int delay = 25;
         const int octaves = 3; // sweep spans Nyquist/8..Nyquist
         double[] sweep = MiniSweep(4096, octaves);
@@ -333,9 +334,12 @@ public sealed class TransferFunctionTests
         double[] target = AddNoise(Delay(sweep, delay), 1e-5, seed: 8);
         for (int i = 0; i < reference.Length; i++)
         {
-            // Nyquist/64 — below the excitation edge's ramp.
             double window = 0.5 - 0.5 * Math.Cos(2.0 * Math.PI * i / reference.Length);
+            // Nyquist/64 — below the excitation edge's ramp.
             reference[i] += 1000.0 * window * Math.Sin(2.0 * Math.PI * i / 128.0);
+            // Nyquist * 3/32 — inside the edge's ramp (Nyquist/16..Nyquist/8),
+            // where the bin is attenuated but not zeroed.
+            reference[i] += 1000.0 * window * Math.Sin(2.0 * Math.PI * 3.0 * i / 64.0);
         }
 
         TransferEstimateResult result = TransferFunction.ComputeAveragedRelativeIr(
@@ -344,6 +348,46 @@ public sealed class TransferFunctionTests
 
         Assert.Equal(delay, result.PeakIndex);
         Assert.InRange(result.ImpulseResponse[delay], 0.8, 1.05);
+    }
+
+    [Fact]
+    public void ComputeAveragedRelativeIr_CoherenceIsUntrustedWhereTheEstimateIsMasked()
+    {
+        // PR-review finding: coherence used to be returned unmasked. Below
+        // the sweep start the sweep's own leakage — and any stationary rumble
+        // — is deterministic across runs, so raw γ² reads ~1 exactly where
+        // the estimate zeroes the bins as unexcited, and the consumers that
+        // treat coherence as a reliability gate (phase unwrap, PHAT
+        // weighting, the plotted curve) kept trusting them. Three identical
+        // frames make raw γ² exactly 1 everywhere; the returned coherence
+        // must still read the masked region as untrusted and keep full
+        // in-band trust.
+        const int octaves = 3; // sweep spans Nyquist/8..Nyquist
+        double[] sweep = MiniSweep(4096, octaves);
+        double[] reference = AddNoise(sweep, 1e-6, seed: 9);
+        double[] target = AddNoise(Delay(sweep, 25), 1e-6, seed: 10);
+        for (int i = 0; i < target.Length; i++)
+        {
+            // Deterministic rumble at Nyquist/64, below the edge's ramp.
+            target[i] += 0.05 * Math.Sin(2.0 * Math.PI * i / 128.0);
+        }
+        var frame = new TransferFunctionFrame(reference, target);
+
+        TransferEstimateResult result = TransferFunction.ComputeAveragedRelativeIr(
+            [frame, frame, frame],
+            excitationLowNyquistFraction: Math.Pow(2.0, -octaves));
+
+        // Coherence covers 0..Nyquist in fftLength / 2 + 1 = 4097 bins; the
+        // rumble sits at bin 64, the edge's ramp spans bins 256..512.
+        Assert.NotNull(result.Coherence);
+        Assert.Equal(4097, result.Coherence!.Length);
+        Assert.Equal(0.0, result.Coherence[64]);
+        for (int bin = 0; bin < 256; bin++)
+        {
+            Assert.Equal(0.0, result.Coherence[bin]);
+        }
+        Assert.InRange(result.Coherence[1024], 0.999, 1.0 + 1e-9);
+        Assert.InRange(result.Coherence[2048], 0.999, 1.0 + 1e-9);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/TransferFunctionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferFunctionTests.cs
@@ -316,6 +316,37 @@ public sealed class TransferFunctionTests
     }
 
     [Fact]
+    public void ComputeAveragedRelativeIr_MaskedBinsDoNotScaleTheGateThresholds()
+    {
+        // PR-review finding: the peak scan anchoring gateHigh and λ used to
+        // include bins the excitation edge later zeroes. A loud sub-edge
+        // reference component (hum below a narrow sweep's start) then scaled
+        // the power gate from an artifact excluded from the estimate, fading
+        // the genuinely excited bins. The hum here is deliberately absurd —
+        // 60+ dB over the sweep bins, enough to zero the whole passband
+        // through the old scan — so the pin is decisive: with the scan
+        // restricted to edge-eligible bins the pulse must come back intact.
+        const int delay = 25;
+        const int octaves = 3; // sweep spans Nyquist/8..Nyquist
+        double[] sweep = MiniSweep(4096, octaves);
+        double[] reference = AddNoise(sweep, 1e-6, seed: 7);
+        double[] target = AddNoise(Delay(sweep, delay), 1e-5, seed: 8);
+        for (int i = 0; i < reference.Length; i++)
+        {
+            // Nyquist/64 — below the excitation edge's ramp.
+            double window = 0.5 - 0.5 * Math.Cos(2.0 * Math.PI * i / reference.Length);
+            reference[i] += 1000.0 * window * Math.Sin(2.0 * Math.PI * i / 128.0);
+        }
+
+        TransferEstimateResult result = TransferFunction.ComputeAveragedRelativeIr(
+            [new TransferFunctionFrame(reference, target)],
+            excitationLowNyquistFraction: Math.Pow(2.0, -octaves));
+
+        Assert.Equal(delay, result.PeakIndex);
+        Assert.InRange(result.ImpulseResponse[delay], 0.8, 1.05);
+    }
+
+    [Fact]
     public void ComputeAveragedRelativeIr_EstimateDoesNotDependOnTheAverageCount()
     {
         // The cross- and auto-spectra are accumulated without normalization, so


### PR DESCRIPTION
## Problem

`TransferFunction.ComputeAveragedRelativeIr` — the H1 estimator behind every loopback-referenced transfer IR — had two long-standing issues (TODO: "H1 has no excitation mask and an absolute epsilon"):

1. **Absolute epsilon (1e-12).** The cross/auto spectra are accumulated without normalization, so N averaged runs were regularized N times more weakly than one, and the effective strength followed the record level.
2. **No excitation mask.** Below the sweep start `Gxy/Gxx` divides microphone rumble by the reference's leakage skirt, and the garbage rings back through the IFFT across the whole IR — it even leaks into the whitened GCC-PHAT correlation that Time Alignment and Auto delay trust.

## Fix

- **Relative regularization**: λ = −100 dB of the strongest excitation bin — scale- and average-count-invariant.
- **Power-floor soft gate** (−60 dB re max, raised cosine to −74 dB) zeroes bins at the true capture noise floor.
- **Explicit excitation edge**: the key design finding is that no data-driven gate can mark the sub-sweep region — on real capture lengths the sweep's own leakage skirts hold Gxx at −40..−20 dB re max all the way down to DC (verified on reconstructed field captures), while genuine in-band tilt already spans ~36 dB. The sweep's band is known instead: it always ends at Nyquist and spans `Octaves` octaves, so `ExpSweepMeasurement` passes `2^-Octaves` and the estimator fades bins out between that fraction of Nyquist and half of it.

All gate weights are real and Hermitian-symmetric — zero-phase filtering, nothing moves in time.

## Validation on real measurements

No raw captures are stored, so the harness reconstructed them: each field measurement's Farina sweep-deconvolution IR (which embeds the real room, noise and harmonics) reconvolved with the app's exact sweep = microphone; the sweep itself + electrical noise + converter offset = loopback; plus realistic infrasonic rumble (0.7–6.5 Hz, non-repeating across runs) that an in-car mic sees and the loopback never does. Across `l woof` / `r twr` / `sub woof`:

- in-band magnitude identical to the old estimator within **1e-6 dB**; agreement with each measurement's stored transfer unchanged (0.01–0.20 dB);
- sub-band garbage down **~35 dB** (the sub's used to sit +21 dB *above* its in-band response);
- rumble used to drag the GCC-PHAT sub timing **0.34 ms early** with a falsely inflated correlation; with the edge the estimate matches the rumble-free reference exactly.

## Tests

- 3 new pins: average-count invariance (bit-level), noise-floor gate, and the explicit edge cutting rumble the floor gate provably cannot (the test asserts the unmasked estimate is polluted first, so it cannot go vacuous).
- Full suite green: 534 dsp / 349 app / 78 audio.

TODO item removed; a live re-measure note (the sub is the interesting one) added to the pending checks section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
