### PR TITLE
Centralize user data and group measurement configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,11 @@ Enforced by `.editorconfig`; notable deviations from common C# defaults:
 - `var` only when the type is apparent; explicit types otherwise, including built-ins.
 - CRLF line endings, 4-space indent, Allman braces, braces always.
 - New non-UI code uses file-scoped namespaces (see `Program.cs`, `ModeController.cs`).
+
+## User data paths
+
+Implicit user data (settings, history, overlays, Virtual DSP state and crash
+logs) is rooted by `ApplicationDataPaths`. Installed mode uses
+`%LocalAppData%\Resonalyze`; a `portable.flag` file beside the executable opts
+into portable storage beside the app. Do not introduce new direct
+`AppContext.BaseDirectory` persistence paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Key structural points:
 
 - **`Shell/Form1` is the hub**, split into partial classes by concern (`Form1.Measurement.cs`, `Form1.Plotting.cs`, `Form1.History.cs`, `Form1.Compare.cs`, etc.). The `Mode` enum in `Form1.cs` defines all analysis modes (frequency/phase/group delay/waterfall/burst decay/live spectrum/time alignment/EQ wizard/signal generator/virtual crossover); `ModeSwitching/ModeController` orchestrates tab switches.
 - **`Options/`** holds one settings panel per mode (`FROptions`, `IROpt`, `GDOpt`, ...), docked into the shell via `Shell/DockedModeSettingsHost`.
-- **`Tools/`** contains the larger feature panels: EQ Wizard, Signal Generator, Virtual DSP (`VirtualCrossoverPanel` + project file persistence), and PDF tuning-sheet export (PDFsharp/MigraDoc).
+- **`Tools/`** contains the larger feature panels: EQ Wizard, Signal Generator, Virtual DSP (`VirtualCrossoverPanel` + project file persistence), and PDF tuning-sheet export (PDFsharp/MigraDoc). `EqWizardPanel` is self-contained: it loads its own impulse response, computes its source FR with the selected microphone calibration, uses a mode-local target curve and persists through `MeasurementSettingsFile.EqWizard`; do not couple it to overlays or the current measurement.
 - **`Overlays/`** manages persistent overlay slots and calculated (math) overlays; **`History/`** persists measurement snapshots with per-entry working state.
 - Update checking uses NetSparkle + `Settings/GitHubReleaseChecker`.
 
@@ -60,6 +60,7 @@ Enforced by `.editorconfig`; notable deviations from common C# defaults:
 - `var` only when the type is apparent; explicit types otherwise, including built-ins.
 - CRLF line endings, 4-space indent, Allman braces, braces always.
 - New non-UI code uses file-scoped namespaces (see `Program.cs`, `ModeController.cs`).
+- Keep static WinForms controls in `.Designer.cs`. For genuinely dynamic controls, use a designer-defined `TableLayoutPanel` or `FlowLayoutPanel`; avoid absolute 96-DPI coordinates because controls created after `InitializeComponent` miss designer autoscaling.
 
 ## User data paths
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,4 +61,12 @@ Enforced by `.editorconfig`; notable deviations from common C# defaults:
 - `var` only when the type is apparent; explicit types otherwise, including built-ins.
 - CRLF line endings, 4-space indent, Allman braces, braces always.
 - New non-UI code uses file-scoped namespaces (see `Program.cs`, `ModeController.cs`).
+
+## User data paths
+
+Implicit user data (settings, history, overlays, Virtual DSP state and crash
+logs) is rooted by `ApplicationDataPaths`. Installed mode uses
+`%LocalAppData%\Resonalyze`; a `portable.flag` file beside the executable opts
+into portable storage beside the app. Do not introduce new direct
+`AppContext.BaseDirectory` persistence paths.
 - WinForms controls belong in the `.Designer.cs`, not created/positioned in code after `InitializeComponent`. `AutoScaleMode.Font` only scales controls present during `InitializeComponent`; anything added afterwards keeps its literal 96-DPI `Location`/`Size` and overlaps on high-DPI displays. For genuinely dynamic controls (variable count) add them to a designer-defined `TableLayoutPanel`/`FlowLayoutPanel` — never absolute `Point`s; any unavoidable code-side positioning must use measured device values (`.Bottom`, `Font.Height`, `LogicalToDeviceUnits`) in `OnLoad`, after scaling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,72 +1,7 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Read and follow [`AGENTS.md`](AGENTS.md), the single source of repository
+architecture, commands, testing conventions and code-style guidance.
 
-## Project Overview
-
-Resonalyze is a Windows desktop application (WinForms, .NET 10) for acoustic measurements: impulse/frequency response, loopback-referenced time alignment, live transfer functions, EQ design, and virtual DSP crossover simulation. The SDK version is pinned in `global.json`.
-
-## Commands
-
-```powershell
-dotnet restore source/Resonalyze.sln
-dotnet build source/Resonalyze.sln --configuration Release
-dotnet run --project source/Resonalyze.csproj
-
-# All tests
-dotnet test source/Resonalyze.sln -c Release
-
-# One test project
-dotnet test tests/Resonalyze.Dsp.Tests/Resonalyze.Dsp.Tests.csproj
-
-# One test class or method
-dotnet test tests/Resonalyze.Dsp.Tests/Resonalyze.Dsp.Tests.csproj --filter "FullyQualifiedName~TransferFunctionTests"
-
-# Performance profiling build (defines TRACY_ENABLE, references Tracy-CSharp)
-dotnet run --project source/Resonalyze.csproj -c Tracy
-```
-
-Platform constraint: `source/` (the app), `audio/Resonalyze.Audio`, `tests/Resonalyze.Audio.Tests/` and `tests/Resonalyze.App.Tests/` target `net10.0-windows` and only build/run on Windows (WASAPI/ASIO/MME are Windows-only). `dsp/` and `tests/Resonalyze.Dsp.Tests/` target plain `net10.0` and are cross-platform — on a Linux environment, only the DSP library and its tests can be built and run.
-
-Test data: `assets/test_data` is a git submodule ([Resonalyze-test-data](https://github.com/DIMOSUS/Resonalyze-test-data), ~230 MB of real transfer IRs). Some dsp tests read it; run `git submodule update --init assets/test_data` once per clone, or those tests fail with a message pointing here.
-
-## Architecture
-
-Three projects, with deliberate boundaries (`Dsp` ⟂ `Audio`; the app depends on both):
-
-- **`dsp/Resonalyze.Dsp`** — pure, UI-free signal-processing library. Depends only on MathNet.Numerics and YamlDotNet. Contains FFT/spectrum analysis, windowing, transfer functions, minimum phase, excess delay, time-alignment analysis, biquad/crossover filters, the EQ auto-tuner, and PEQ profile import/export formats (Equalizer APO, REW, MiniDSP, CamillaDSP, EasyEffects, generic CSV — all implementing `IEqProfileFormat`). The app hands measurement data to this layer through `IImpulseMeasurement` (impulse response + peak index + sample rate).
-- **`audio/Resonalyze.Audio`** — owns all audio drivers/devices (WASAPI Shared/Exclusive, ASIO, MME), format negotiation, capture/playback lifecycle, PCM decoding, diagnostics and warm-up. NAudio is confined here (declared `PrivateAssets="compile"` so `using NAudio` does not compile in the app). Low-level device types are `internal`; the measurement layer talks only to the neutral abstraction: `IAudioSessionFactory` + `IAudioDuplexSession`/`IAudioStreamingSession`/`IAudioPlaybackSession` and backend-neutral DTOs (`AudioSessionRequest`, `AudioPlaybackSignal`, `AudioCaptureResult`, `AudioSessionDiagnostics`, `AudioEndpointDescriptor`, `AudioFormat`, `PlaybackChannel`). Backends are chosen by the persisted `AudioBackend` enum inside `AudioBackendRegistry` (the only backend dispatch — no `switch (AudioBackend)` in `source/`).
-- **`source/Resonalyze`** — the WinForms app: composition root, measurement lifecycle, and plotting.
-
-Inside `source/`, the flow is: signal generation (`Measurements/` — `ExponentialSineSweep`, `NoiseSignal` produce float data only) → an audio session opened via `IAudioSessionFactory` (composition root in `Shell/Form1` builds `AudioBackendRegistry.CreateDefault()` and injects the factory into `ExpSweepMeasurement`, `NoiseMeasurement`, the signal generator and warm-up) → analysis via the Dsp library → plot presentation (`Plotting/` — `PlotModelFactory` builds OxyPlot models, `OxyPlotAdapter` hosts them). Microphone and loopback are always channels of ONE input device, so timing stays sample-synchronous.
-
-Key structural points:
-
-- **`Shell/Form1` is the hub**, split into partial classes by concern (`Form1.Measurement.cs`, `Form1.Plotting.cs`, `Form1.History.cs`, `Form1.Compare.cs`, etc.). The `Mode` enum in `Form1.cs` defines all analysis modes (frequency/phase/group delay/waterfall/burst decay/live spectrum/time alignment/EQ wizard/signal generator/virtual crossover); `ModeSwitching/ModeController` orchestrates tab switches.
-- **`Options/`** holds one settings panel per mode (`FROptions`, `IROpt`, `GDOpt`, ...), docked into the shell via `Shell/DockedModeSettingsHost`.
-- **`Tools/`** contains the larger feature panels: EQ Wizard, Signal Generator, Virtual DSP (`VirtualCrossoverPanel` + project file persistence), and PDF tuning-sheet export (PDFsharp/MigraDoc).
-  - **`EqWizardPanel` is self-contained** — it does not read overlays or the current measurement. It loads its own impulse response, computes the source FR in-panel via `DataHelper.GetSpectrum` (with the selected microphone calibration), corrects toward a mode-local target curve edited by reusing `OverlayTargetSettingsDialog` in its isolated mode, and persists its state in `MeasurementSettingsFile.EqWizard`.
-- **`Overlays/`** manages persistent overlay slots and calculated (math) overlays; **`History/`** persists measurement snapshots with per-entry working state.
-- Update checking uses NetSparkle + `Settings/GitHubReleaseChecker`.
-
-## Testing Conventions
-
-Tests use xUnit. DSP tests are deterministic and synthetic: `tests/Resonalyze.Dsp.Tests/SyntheticMeasurement.cs` implements `IImpulseMeasurement` so analysis code is exercised against generated impulses/filters/delays rather than recordings. The exception is `RealMeasurementArrivalTests`, which pins field regressions against the real measurements in the `assets/test_data` submodule. App tests focus on file formats and non-UI logic (overlay files, impulse-response files, plot model construction, PDF sheets) plus the measurement layer against a fake `IAudioSessionFactory` (`tests/Resonalyze.App.Tests/Fakes/`) — sweep/averaging/retry/cancellation/device-failure/live paths with no NAudio or hardware. `tests/Resonalyze.Audio.Tests/` exercises the audio internals directly (via `InternalsVisibleTo`): PCM decoding, accumulation, session reuse, WASAPI configuration. Hardware smoke tests are marked `[Trait("Category","Hardware")]` and excluded with `--filter "Category!=Hardware"`.
-
-## Code Style
-
-Enforced by `.editorconfig`; notable deviations from common C# defaults:
-
-- Private fields are `camelCase` with **no underscore prefix** (and no `this.` qualification except in constructor assignment).
-- `var` only when the type is apparent; explicit types otherwise, including built-ins.
-- CRLF line endings, 4-space indent, Allman braces, braces always.
-- New non-UI code uses file-scoped namespaces (see `Program.cs`, `ModeController.cs`).
-
-## User data paths
-
-Implicit user data (settings, history, overlays, Virtual DSP state and crash
-logs) is rooted by `ApplicationDataPaths`. Installed mode uses
-`%LocalAppData%\Resonalyze`; a `portable.flag` file beside the executable opts
-into portable storage beside the app. Do not introduce new direct
-`AppContext.BaseDirectory` persistence paths.
-- WinForms controls belong in the `.Designer.cs`, not created/positioned in code after `InitializeComponent`. `AutoScaleMode.Font` only scales controls present during `InitializeComponent`; anything added afterwards keeps its literal 96-DPI `Location`/`Size` and overlaps on high-DPI displays. For genuinely dynamic controls (variable count) add them to a designer-defined `TableLayoutPanel`/`FlowLayoutPanel` — never absolute `Point`s; any unavoidable code-side positioning must use measured device values (`.Bottom`, `Font.Height`, `LogicalToDeviceUnits`) in `OnLoad`, after scaling.
+Keep tool-specific notes here only when they do not apply to other coding
+agents; shared instructions belong in `AGENTS.md`.

--- a/TODO.md
+++ b/TODO.md
@@ -296,9 +296,6 @@ Linux dev env where the work was done).
   numbers into mutable global storage): restoring an old session shows whatever
   the slots hold TODAY. Store immutable overlay snapshots (content-addressed
   revisions) in the history entry.
-- [ ] **Virtual DSP history-source loading has a stale-async race**
-  (`SelectHistoryEntryAsync` applies a slow snapshot over a newer selection):
-  per-channel source revision or CancellationTokenSource.
 
 ## Signal Generator / files / calibration / release
 

--- a/TODO.md
+++ b/TODO.md
@@ -296,11 +296,6 @@ Linux dev env where the work was done).
   numbers into mutable global storage): restoring an old session shows whatever
   the slots hold TODAY. Store immutable overlay snapshots (content-addressed
   revisions) in the history entry.
-- [ ] **History index lives beside the executable and dies silently**: no
-  write-permission handling (`Save()` throws unguarded in Program Files-style
-  installs), and any schema-version mismatch or parse error loads as an EMPTY
-  list with no backup/notification — mirror the project-file backup-on-invalid
-  policy, distinguish empty/unsupported/corrupted, and consider %LocalAppData%.
 - [ ] **Virtual DSP history-source loading has a stale-async race**
   (`SelectHistoryEntryAsync` applies a slow snapshot over a newer selection):
   per-channel source revision or CancellationTokenSource.

--- a/source/History/MeasurementHistoryPersistence.cs
+++ b/source/History/MeasurementHistoryPersistence.cs
@@ -116,14 +116,25 @@ internal sealed class MeasurementHistoryPersistence
                 return null;
             }
 
-            string backupPath = pathOnDisk + ".backup";
-            File.Move(pathOnDisk, backupPath, overwrite: true);
+            string backupPath = GetAvailableBackupPath();
+            File.Move(pathOnDisk, backupPath);
             return backupPath;
         }
         catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
         {
             return null;
         }
+    }
+
+    private string GetAvailableBackupPath()
+    {
+        string backupPath = pathOnDisk + ".backup";
+        for (int suffix = 1; File.Exists(backupPath); suffix++)
+        {
+            backupPath = pathOnDisk + $".backup.{suffix}";
+        }
+
+        return backupPath;
     }
 
     private sealed class StoreFile

--- a/source/History/MeasurementHistoryPersistence.cs
+++ b/source/History/MeasurementHistoryPersistence.cs
@@ -6,8 +6,6 @@ namespace Resonalyze.History;
 internal sealed class MeasurementHistoryPersistence
 {
     private const int CurrentSchemaVersion = 1;
-    private const string FileName = "measurement-history.json";
-
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
         WriteIndented = true,
@@ -18,14 +16,17 @@ internal sealed class MeasurementHistoryPersistence
 
     private readonly string pathOnDisk;
 
+    public string? LoadWarning { get; private set; }
+
     public MeasurementHistoryPersistence(string? pathOnDisk = null)
     {
         this.pathOnDisk = pathOnDisk
-            ?? Path.Combine(AppContext.BaseDirectory, FileName);
+            ?? ApplicationDataPaths.Current.HistoryFile;
     }
 
     public IReadOnlyList<MeasurementHistoryEntry> Load()
     {
+        LoadWarning = null;
         try
         {
             if (!File.Exists(pathOnDisk))
@@ -35,9 +36,14 @@ internal sealed class MeasurementHistoryPersistence
 
             using FileStream stream = File.OpenRead(pathOnDisk);
             StoreFile? file = JsonSerializer.Deserialize<StoreFile>(stream, SerializerOptions);
-            if (file?.SchemaVersion != CurrentSchemaVersion)
+            if (file == null)
             {
-                return Array.Empty<MeasurementHistoryEntry>();
+                throw new InvalidDataException("The history file is empty.");
+            }
+            if (file.SchemaVersion != CurrentSchemaVersion)
+            {
+                throw new InvalidDataException(
+                    $"History schema version {file.SchemaVersion} is not supported.");
             }
 
             return file.Entries
@@ -57,8 +63,13 @@ internal sealed class MeasurementHistoryPersistence
                 })
                 .ToArray();
         }
-        catch
+        catch (Exception exception)
         {
+            string? backupPath = BackupUnusableFile();
+            string preservation = backupPath == null
+                ? "The unusable file could not be backed up; check file permissions before saving history."
+                : $"The unusable file was preserved as '{backupPath}'.";
+            LoadWarning = $"Measurement history could not be loaded: {exception.Message}\r\n\r\n{preservation}";
             return Array.Empty<MeasurementHistoryEntry>();
         }
     }
@@ -83,8 +94,10 @@ internal sealed class MeasurementHistoryPersistence
                 .ToList()
         };
 
-        // Temp file + move keeps the store intact if the write is interrupted;
-        // a corrupted store silently wipes the whole history list on next load.
+        // Temp file + move keeps the store intact if the write is interrupted.
+        string directory = Path.GetDirectoryName(pathOnDisk)
+            ?? throw new InvalidOperationException("History directory cannot be resolved.");
+        Directory.CreateDirectory(directory);
         string tempPath = pathOnDisk + ".tmp";
         using (FileStream stream = File.Create(tempPath))
         {
@@ -92,6 +105,25 @@ internal sealed class MeasurementHistoryPersistence
         }
 
         File.Move(tempPath, pathOnDisk, overwrite: true);
+    }
+
+    private string? BackupUnusableFile()
+    {
+        try
+        {
+            if (!File.Exists(pathOnDisk))
+            {
+                return null;
+            }
+
+            string backupPath = pathOnDisk + ".backup";
+            File.Move(pathOnDisk, backupPath, overwrite: true);
+            return backupPath;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
     }
 
     private sealed class StoreFile

--- a/source/History/MeasurementHistoryService.cs
+++ b/source/History/MeasurementHistoryService.cs
@@ -18,6 +18,7 @@ internal sealed class MeasurementHistoryService
     public event Action? Changed;
 
     public IReadOnlyList<MeasurementHistoryEntry> Entries => entries;
+    public string? LoadWarning => persistence.LoadWarning;
 
     public Guid AddMeasurement(
         ExpSweepMeasurement measurement,

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -89,6 +89,11 @@ namespace Resonalyze
             private set => currentLevels = value;
         }
 
+        /// <summary>
+        /// Compatibility adapter for callers compiled against the original flat
+        /// parameter list. New code should use the grouped configuration overload.
+        /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void Init(
             int octaves,
             int sampleRate,
@@ -112,35 +117,68 @@ namespace Resonalyze
             string? wasapiCaptureEndpointName = null,
             string? wasapiRenderEndpointName = null)
         {
+            Init(new SweepMeasurementConfiguration(
+                new SweepSignalConfiguration(
+                    octaves,
+                    sampleRate,
+                    bits,
+                    requestedDuration,
+                    playbackChannel),
+                new SweepAudioConfiguration(
+                    audioBackend,
+                    outputDeviceNumber,
+                    inputDeviceNumber,
+                    waveInputChannelOffset,
+                    waveLoopbackInputChannelOffset,
+                    asioDriverName,
+                    asioInputChannelOffset,
+                    asioLoopbackInputChannelOffset,
+                    asioOutputChannelOffset,
+                    wasapiCaptureEndpointId,
+                    wasapiRenderEndpointId,
+                    wasapiCaptureEndpointName,
+                    wasapiRenderEndpointName,
+                    wasapiBufferMilliseconds),
+                new SweepAveragingConfiguration(
+                    averageRunCount,
+                    confirmEachAverageRun)));
+        }
+
+        public void Init(SweepMeasurementConfiguration configuration)
+        {
+            ArgumentNullException.ThrowIfNull(configuration);
             ThrowIfDisposed();
             if (InProgress)
             {
                 throw new InvalidOperationException("Cannot reinitialize an active measurement.");
             }
 
-            PlaybackChannel = Enum.IsDefined(playbackChannel)
-                ? playbackChannel
+            SweepSignalConfiguration signal = configuration.Signal;
+            SweepAudioConfiguration audio = configuration.Audio;
+            SweepAveragingConfiguration averaging = configuration.Averaging;
+            PlaybackChannel = Enum.IsDefined(signal.PlaybackChannel)
+                ? signal.PlaybackChannel
                 : PlaybackChannel.Mono;
-            SampleRate = sampleRate;
-            Bits = bits;
-            Octaves = octaves;
-            OutputDeviceNumber = outputDeviceNumber;
-            InputDeviceNumber = inputDeviceNumber;
-            WasapiCaptureEndpointId = wasapiCaptureEndpointId;
-            WasapiRenderEndpointId = wasapiRenderEndpointId;
-            WasapiCaptureEndpointName = wasapiCaptureEndpointName;
-            WasapiRenderEndpointName = wasapiRenderEndpointName;
-            WasapiBufferMilliseconds = Math.Clamp(wasapiBufferMilliseconds, 10, 100);
+            SampleRate = signal.SampleRate;
+            Bits = signal.Bits;
+            Octaves = signal.Octaves;
+            OutputDeviceNumber = audio.OutputDeviceNumber;
+            InputDeviceNumber = audio.InputDeviceNumber;
+            WasapiCaptureEndpointId = audio.WasapiCaptureEndpointId;
+            WasapiRenderEndpointId = audio.WasapiRenderEndpointId;
+            WasapiCaptureEndpointName = audio.WasapiCaptureEndpointName;
+            WasapiRenderEndpointName = audio.WasapiRenderEndpointName;
+            WasapiBufferMilliseconds = Math.Clamp(audio.WasapiBufferMilliseconds, 10, 100);
             LastAudioSessionDiagnostics = null;
-            AudioBackend = audioBackend;
-            AsioDriverName = asioDriverName;
-            int normalizedWaveInputChannelOffset = IsWasapiBackend(audioBackend)
-                ? Math.Max(0, waveInputChannelOffset)
-                : Math.Clamp(waveInputChannelOffset, 0, 1);
-            int? normalizedWaveLoopbackInputChannelOffset = IsWasapiBackend(audioBackend)
-                ? NormalizeOptionalWasapiChannel(waveLoopbackInputChannelOffset)
-                : NormalizeOptionalWaveChannel(waveLoopbackInputChannelOffset);
-            if (audioBackend != AudioBackend.Asio &&
+            AudioBackend = audio.Backend;
+            AsioDriverName = audio.AsioDriverName;
+            int normalizedWaveInputChannelOffset = IsWasapiBackend(audio.Backend)
+                ? Math.Max(0, audio.WaveInputChannelOffset)
+                : Math.Clamp(audio.WaveInputChannelOffset, 0, 1);
+            int? normalizedWaveLoopbackInputChannelOffset = IsWasapiBackend(audio.Backend)
+                ? NormalizeOptionalWasapiChannel(audio.WaveLoopbackInputChannelOffset)
+                : NormalizeOptionalWaveChannel(audio.WaveLoopbackInputChannelOffset);
+            if (audio.Backend != AudioBackend.Asio &&
                 normalizedWaveLoopbackInputChannelOffset == normalizedWaveInputChannelOffset)
             {
                 throw new InvalidOperationException(
@@ -148,25 +186,29 @@ namespace Resonalyze
             }
             WaveInputChannelOffset = normalizedWaveInputChannelOffset;
             WaveLoopbackInputChannelOffset = normalizedWaveLoopbackInputChannelOffset;
-            AsioInputChannelOffset = asioInputChannelOffset;
-            AsioLoopbackInputChannelOffset = asioLoopbackInputChannelOffset;
-            AsioOutputChannelOffset = asioOutputChannelOffset;
+            AsioInputChannelOffset = audio.AsioInputChannelOffset;
+            AsioLoopbackInputChannelOffset = audio.AsioLoopbackInputChannelOffset;
+            AsioOutputChannelOffset = audio.AsioOutputChannelOffset;
             sweepDeconvolutionResult = null;
             transferResult = null;
             TransferCoherence = null;
             MicrophoneRecordedSamples = null;
             LoopbackRecordedSamples = null;
             MeasurementMode = SweepMeasurementMode.SweepDeconvolution;
-            AverageRunCount = Math.Clamp(averageRunCount, 1, 64);
+            AverageRunCount = Math.Clamp(averaging.RunCount, 1, 64);
             AcceptedAverageRunCount = 0;
-            ConfirmEachAverageRun = confirmEachAverageRun;
+            ConfirmEachAverageRun = averaging.ConfirmEachRun;
             QualityReport = null;
             LastError = null;
             CurrentLevels = InputLevelMeterSnapshot.Empty;
 
             Sweep?.Dispose();
             Sweep = new ExponentialSineSweep();
-            Sweep.FillData(octaves, requestedDuration, bits, sampleRate);
+            Sweep.FillData(
+                signal.Octaves,
+                signal.RequestedDurationSeconds,
+                signal.Bits,
+                signal.SampleRate);
         }
 
         public Task<bool> RunAsync()
@@ -292,23 +334,31 @@ namespace Resonalyze
                 throw new ArgumentOutOfRangeException(nameof(transferPeakIndex));
             }
 
-            Init(
-                octaves,
-                sampleRate,
-                bits,
-                sweepDurationSeconds,
-                playChannel,
-                OutputDeviceNumber,
-                InputDeviceNumber,
-                AudioBackend,
-                AsioDriverName,
-                AsioInputChannelOffset,
-                AsioOutputChannelOffset,
-                WaveInputChannelOffset,
-                WaveLoopbackInputChannelOffset,
-                AsioLoopbackInputChannelOffset,
-                AverageRunCount,
-                ConfirmEachAverageRun);
+            Init(new SweepMeasurementConfiguration(
+                new SweepSignalConfiguration(
+                    octaves,
+                    sampleRate,
+                    bits,
+                    sweepDurationSeconds,
+                    playChannel),
+                new SweepAudioConfiguration(
+                    Backend: AudioBackend,
+                    OutputDeviceNumber: OutputDeviceNumber,
+                    InputDeviceNumber: InputDeviceNumber,
+                    WaveInputChannelOffset: WaveInputChannelOffset,
+                    WaveLoopbackInputChannelOffset: WaveLoopbackInputChannelOffset,
+                    AsioDriverName: AsioDriverName,
+                    AsioInputChannelOffset: AsioInputChannelOffset,
+                    AsioLoopbackInputChannelOffset: AsioLoopbackInputChannelOffset,
+                    AsioOutputChannelOffset: AsioOutputChannelOffset,
+                    WasapiCaptureEndpointId: WasapiCaptureEndpointId,
+                    WasapiRenderEndpointId: WasapiRenderEndpointId,
+                    WasapiCaptureEndpointName: WasapiCaptureEndpointName,
+                    WasapiRenderEndpointName: WasapiRenderEndpointName,
+                    WasapiBufferMilliseconds: WasapiBufferMilliseconds),
+                new SweepAveragingConfiguration(
+                    AverageRunCount,
+                    ConfirmEachAverageRun)));
             sweepDeconvolutionResult = new MeasurementImpulseResponse(
                 sweepDeconvolutionImpulseResponse.ToArray(),
                 sweepDeconvolutionPeakIndex);
@@ -327,7 +377,7 @@ namespace Resonalyze
                 1,
                 AverageRunCount);
             LastError = null;
-            ImpulseResponseChanged?.Invoke();
+            Publish(ImpulseResponseChanged);
         }
 
         internal void RestoreLevelSnapshot(InputLevelMeterSnapshot snapshot)
@@ -372,7 +422,7 @@ namespace Resonalyze
                 int requestedRuns = AverageRunCount;
                 for (int run = 1; run <= requestedRuns; run++)
                 {
-                    AverageProgressChanged?.Invoke(new SweepAverageProgress(
+                    Publish(AverageProgressChanged, new SweepAverageProgress(
                         run,
                         requestedRuns,
                         accumulator.AcceptedRuns,
@@ -384,7 +434,7 @@ namespace Resonalyze
                         // One automatic retry per bad run; a second failure skips
                         // the run so it cannot contaminate the average.
                         rejections.Add(new SweepRunRejection(run, Retried: false, issues));
-                        AverageProgressChanged?.Invoke(new SweepAverageProgress(
+                        Publish(AverageProgressChanged, new SweepAverageProgress(
                             run,
                             requestedRuns,
                             accumulator.AcceptedRuns,
@@ -461,14 +511,7 @@ namespace Resonalyze
                     averageConfirmation = null;
                     inProgress = false;
                 }
-                try
-                {
-                    Completed?.Invoke(success);
-                }
-                catch
-                {
-                    // UI subscribers must not break measurement cleanup.
-                }
+                Publish(Completed, success);
             }
 
             return success;
@@ -489,7 +532,7 @@ namespace Resonalyze
                 waitTask = averageConfirmation.Task;
             }
 
-            AverageProgressChanged?.Invoke(new SweepAverageProgress(
+            Publish(AverageProgressChanged, new SweepAverageProgress(
                 completedRun,
                 requestedRuns,
                 acceptedRuns,
@@ -652,7 +695,7 @@ namespace Resonalyze
             AcceptedAverageRunCount = result.AcceptedRunCount;
             CurrentLevels = result.Levels;
             RaiseLevels(result.Levels);
-            ImpulseResponseChanged?.Invoke();
+            Publish(ImpulseResponseChanged);
         }
 
         private bool TryBuildTransferFrame(
@@ -696,7 +739,7 @@ namespace Resonalyze
 
         private void RaiseLevels(InputLevelMeterSnapshot snapshot)
         {
-            LevelsAvailable?.Invoke(snapshot);
+            Publish(LevelsAvailable, snapshot);
         }
 
         private static int FindPeakIndex(IReadOnlyList<Complex> samples)
@@ -891,6 +934,47 @@ namespace Resonalyze
 
         private static bool IsWasapiBackend(AudioBackend backend) =>
             backend is AudioBackend.WasapiShared or AudioBackend.WasapiExclusive;
+
+        private static void Publish(Action? handlers)
+        {
+            if (handlers == null)
+            {
+                return;
+            }
+
+            foreach (Action handler in handlers.GetInvocationList().Cast<Action>())
+            {
+                try
+                {
+                    handler();
+                }
+                catch
+                {
+                    // Measurement notifications are observational. A broken UI
+                    // subscriber must not change the measurement outcome.
+                }
+            }
+        }
+
+        private static void Publish<T>(Action<T>? handlers, T value)
+        {
+            if (handlers == null)
+            {
+                return;
+            }
+
+            foreach (Action<T> handler in handlers.GetInvocationList().Cast<Action<T>>())
+            {
+                try
+                {
+                    handler(value);
+                }
+                catch
+                {
+                    // Continue with the remaining subscribers and cleanup.
+                }
+            }
+        }
 
         private void ThrowIfDisposed()
         {

--- a/source/Measurements/SweepMeasurementConfiguration.cs
+++ b/source/Measurements/SweepMeasurementConfiguration.cs
@@ -1,0 +1,33 @@
+namespace Resonalyze;
+
+public sealed record SweepMeasurementConfiguration(
+    SweepSignalConfiguration Signal,
+    SweepAudioConfiguration Audio,
+    SweepAveragingConfiguration Averaging);
+
+public sealed record SweepSignalConfiguration(
+    int Octaves,
+    int SampleRate,
+    int Bits,
+    double RequestedDurationSeconds,
+    PlaybackChannel PlaybackChannel);
+
+public sealed record SweepAudioConfiguration(
+    AudioBackend Backend = AudioBackend.Wave,
+    int OutputDeviceNumber = -1,
+    int InputDeviceNumber = -1,
+    int WaveInputChannelOffset = 0,
+    int? WaveLoopbackInputChannelOffset = null,
+    string? AsioDriverName = null,
+    int AsioInputChannelOffset = 0,
+    int? AsioLoopbackInputChannelOffset = null,
+    int AsioOutputChannelOffset = 0,
+    string? WasapiCaptureEndpointId = null,
+    string? WasapiRenderEndpointId = null,
+    string? WasapiCaptureEndpointName = null,
+    string? WasapiRenderEndpointName = null,
+    int WasapiBufferMilliseconds = 100);
+
+public sealed record SweepAveragingConfiguration(
+    int RunCount = 1,
+    bool ConfirmEachRun = false);

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -403,32 +403,37 @@ namespace Resonalyze.Options
                     "Microphone and loopback inputs must use different Wave channels.");
             }
 
-            expSweepMeasurement.Init(
-                octaves,
-                sampleRate,
-                bits,
-                requestedDuration,
-                playbackChannel,
-                outputDeviceNumber,
-                inputDeviceNumber,
-                audioBackend,
-                asioDriverName,
-                asioInputChannelOffset,
-                asioOutputChannelOffset,
-                waveInputChannelOffset,
-                waveLoopbackInputChannelOffset,
-                asioLoopbackInputChannelOffset,
-                averageRunCount,
-                confirmEachAverageRun,
-                wasapiCaptureEndpointId,
-                wasapiRenderEndpointId,
-                settings.WasapiBufferMilliseconds,
-                comboBoxRecordingDevice.SelectedItem is AudioEndpointDescriptor captureInfo
-                    ? captureInfo.DisplayName
-                    : preferredWasapiCaptureEndpointName,
-                comboBoxPlaybackDevice.SelectedItem is AudioEndpointDescriptor renderInfo
-                    ? renderInfo.DisplayName
-                    : preferredWasapiRenderEndpointName);
+            expSweepMeasurement.Init(new SweepMeasurementConfiguration(
+                new SweepSignalConfiguration(
+                    octaves,
+                    sampleRate,
+                    bits,
+                    requestedDuration,
+                    playbackChannel),
+                new SweepAudioConfiguration(
+                    Backend: audioBackend,
+                    OutputDeviceNumber: outputDeviceNumber,
+                    InputDeviceNumber: inputDeviceNumber,
+                    WaveInputChannelOffset: waveInputChannelOffset,
+                    WaveLoopbackInputChannelOffset: waveLoopbackInputChannelOffset,
+                    AsioDriverName: asioDriverName,
+                    AsioInputChannelOffset: asioInputChannelOffset,
+                    AsioLoopbackInputChannelOffset: asioLoopbackInputChannelOffset,
+                    AsioOutputChannelOffset: asioOutputChannelOffset,
+                    WasapiCaptureEndpointId: wasapiCaptureEndpointId,
+                    WasapiRenderEndpointId: wasapiRenderEndpointId,
+                    WasapiCaptureEndpointName:
+                        comboBoxRecordingDevice.SelectedItem is AudioEndpointDescriptor captureInfo
+                            ? captureInfo.DisplayName
+                            : preferredWasapiCaptureEndpointName,
+                    WasapiRenderEndpointName:
+                        comboBoxPlaybackDevice.SelectedItem is AudioEndpointDescriptor renderInfo
+                            ? renderInfo.DisplayName
+                            : preferredWasapiRenderEndpointName,
+                    WasapiBufferMilliseconds: settings.WasapiBufferMilliseconds),
+                new SweepAveragingConfiguration(
+                    averageRunCount,
+                    confirmEachAverageRun)));
 
             settings.WasapiCaptureEndpointId = wasapiCaptureEndpointId;
             settings.WasapiRenderEndpointId = wasapiRenderEndpointId;

--- a/source/Overlays/OverlayFile.cs
+++ b/source/Overlays/OverlayFile.cs
@@ -106,7 +106,7 @@ public sealed class OverlayFile
     {
         ValidateLocation(mode, slot);
         string root = rootDirectory
-            ?? Path.Combine(AppContext.BaseDirectory, "overlays");
+            ?? ApplicationDataPaths.Current.OverlaysDirectory;
         return Path.Combine(root, mode.ToString(), $"overlay-{slot:00}.json");
     }
 

--- a/source/Program.cs
+++ b/source/Program.cs
@@ -14,38 +14,54 @@ internal static class Program
             TryWriteCrashLog(args.ExceptionObject as Exception);
         Application.ThreadException += (_, args) =>
         {
-            TryWriteCrashLog(args.Exception);
+            string? crashLogPath = TryWriteCrashLog(args.Exception);
+            string logNotice = crashLogPath == null
+                ? "The crash log could not be written."
+                : $"Details were written to '{crashLogPath}'.";
             MessageBox.Show(
                 $"An unexpected error occurred.\r\n\r\n{args.Exception.Message}\r\n\r\n" +
-                $"Details were written to crash.log next to the application.",
+                logNotice,
                 "Resonalyze",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Error);
         };
 
         ApplicationConfiguration.Initialize();
+        IReadOnlyList<string> dataWarnings = ApplicationDataPaths.Current.Prepare();
+        if (dataWarnings.Count > 0)
+        {
+            MessageBox.Show(
+                "Some existing user data could not be prepared or migrated:\r\n\r\n" +
+                string.Join("\r\n\r\n", dataWarnings),
+                "Resonalyze user data",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning);
+        }
         AppProfiler.SetThreadName("UI");
         Application.Run(new Form1());
     }
 
-    private static void TryWriteCrashLog(Exception? exception)
+    private static string? TryWriteCrashLog(Exception? exception)
     {
         if (exception == null)
         {
-            return;
+            return null;
         }
 
         try
         {
-            string path = Path.Combine(AppContext.BaseDirectory, "crash.log");
+            string path = ApplicationDataPaths.Current.CrashLogFile;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             string entry = string.Create(
                 CultureInfo.InvariantCulture,
                 $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {exception}\r\n\r\n");
             File.AppendAllText(path, entry);
+            return path;
         }
         catch
         {
             // Logging must never make a crash worse.
+            return null;
         }
     }
 }

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -277,49 +277,52 @@ internal sealed class MeasurementSettingsFile
                 captureEndpointId,
                 renderEndpointId,
                 Clamp(SampleRate, 44_100, 384_000));
-            measurement.Init(
-                Clamp(Octaves, 1, 32),
-                sampleRate,
-                Bits is 16 or 24 ? Bits : 24,
-                Math.Clamp(RequestedDurationSeconds, 0.001, 100.0),
-                Enum.IsDefined(PlaybackChannel)
-                    ? PlaybackChannel
-                    : PlaybackChannel.Mono,
-                NormalizeDeviceNumber(
-                    AudioDeviceCatalog.GetPlaybackDevices(),
-                    OutputDeviceNumber),
-                NormalizeDeviceNumber(
-                    AudioDeviceCatalog.GetRecordingDevices(),
-                    InputDeviceNumber),
-                backend,
-                NormalizeAsioDriverName(AsioDriverName),
-                NormalizeAsioChannelOffset(
-                    AsioDriverName,
+            measurement.Init(new SweepMeasurementConfiguration(
+                new SweepSignalConfiguration(
+                    Clamp(Octaves, 1, 32),
                     sampleRate,
-                    AsioInputChannelOffset,
-                    input: true),
-                NormalizeAsioChannelOffset(
-                    AsioDriverName,
-                    sampleRate,
-                    AsioOutputChannelOffset,
-                    input: false),
-                IsWasapiBackend(backend)
-                    ? Math.Max(0, WaveInputChannelOffset)
-                    : NormalizeWaveChannelOffset(WaveInputChannelOffset),
-                IsWasapiBackend(backend)
-                    ? NormalizeOptionalWasapiChannelOffset(WaveLoopbackInputChannelOffset)
-                    : NormalizeOptionalWaveChannelOffset(WaveLoopbackInputChannelOffset),
-                NormalizeOptionalAsioChannelOffset(
-                    AsioDriverName,
-                    sampleRate,
-                    AsioLoopbackInputChannelOffset),
-                Clamp(AverageRunCount, 1, 64),
-                ConfirmEachAverageRun,
-                captureEndpointId,
-                renderEndpointId,
-                Clamp(WasapiBufferMilliseconds, 10, 100),
-                WasapiCaptureEndpointName,
-                WasapiRenderEndpointName);
+                    Bits is 16 or 24 ? Bits : 24,
+                    Math.Clamp(RequestedDurationSeconds, 0.001, 100.0),
+                    Enum.IsDefined(PlaybackChannel)
+                        ? PlaybackChannel
+                        : PlaybackChannel.Mono),
+                new SweepAudioConfiguration(
+                    Backend: backend,
+                    OutputDeviceNumber: NormalizeDeviceNumber(
+                        AudioDeviceCatalog.GetPlaybackDevices(),
+                        OutputDeviceNumber),
+                    InputDeviceNumber: NormalizeDeviceNumber(
+                        AudioDeviceCatalog.GetRecordingDevices(),
+                        InputDeviceNumber),
+                    WaveInputChannelOffset: IsWasapiBackend(backend)
+                        ? Math.Max(0, WaveInputChannelOffset)
+                        : NormalizeWaveChannelOffset(WaveInputChannelOffset),
+                    WaveLoopbackInputChannelOffset: IsWasapiBackend(backend)
+                        ? NormalizeOptionalWasapiChannelOffset(WaveLoopbackInputChannelOffset)
+                        : NormalizeOptionalWaveChannelOffset(WaveLoopbackInputChannelOffset),
+                    AsioDriverName: NormalizeAsioDriverName(AsioDriverName),
+                    AsioInputChannelOffset: NormalizeAsioChannelOffset(
+                        AsioDriverName,
+                        sampleRate,
+                        AsioInputChannelOffset,
+                        input: true),
+                    AsioLoopbackInputChannelOffset: NormalizeOptionalAsioChannelOffset(
+                        AsioDriverName,
+                        sampleRate,
+                        AsioLoopbackInputChannelOffset),
+                    AsioOutputChannelOffset: NormalizeAsioChannelOffset(
+                        AsioDriverName,
+                        sampleRate,
+                        AsioOutputChannelOffset,
+                        input: false),
+                    WasapiCaptureEndpointId: captureEndpointId,
+                    WasapiRenderEndpointId: renderEndpointId,
+                    WasapiCaptureEndpointName: WasapiCaptureEndpointName,
+                    WasapiRenderEndpointName: WasapiRenderEndpointName,
+                    WasapiBufferMilliseconds: Clamp(WasapiBufferMilliseconds, 10, 100)),
+                new SweepAveragingConfiguration(
+                    Clamp(AverageRunCount, 1, 64),
+                    ConfirmEachAverageRun)));
         }
     }
 

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -8,8 +8,6 @@ namespace Resonalyze;
 internal sealed class MeasurementSettingsFile
 {
     private const int CurrentSchemaVersion = 8;
-    private const string FileName = "measurement-settings.json";
-
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
         WriteIndented = true,
@@ -35,26 +33,33 @@ internal sealed class MeasurementSettingsFile
     [JsonIgnore]
     public bool LegacyDualDeviceLoopbackReset { get; private set; }
 
-    private static string PathOnDisk =>
-        Path.Combine(AppContext.BaseDirectory, FileName);
+    [JsonIgnore]
+    public string? LoadWarning { get; private set; }
 
-    public static MeasurementSettingsFile LoadOrDefault()
+    [JsonIgnore]
+    private string pathOnDisk = ApplicationDataPaths.Current.SettingsFile;
+
+    public static MeasurementSettingsFile LoadOrDefault(string? pathOnDisk = null)
     {
+        string path = pathOnDisk ?? ApplicationDataPaths.Current.SettingsFile;
         try
         {
-            if (!File.Exists(PathOnDisk))
+            if (!File.Exists(path))
             {
-                return new MeasurementSettingsFile();
+                return new MeasurementSettingsFile { pathOnDisk = path };
             }
 
-            using FileStream stream = File.OpenRead(PathOnDisk);
+            using FileStream stream = File.OpenRead(path);
             MeasurementSettingsFile? settings =
                 JsonSerializer.Deserialize<MeasurementSettingsFile>(
                     stream,
                     SerializerOptions);
             if (settings == null || settings.SchemaVersion is not (7 or CurrentSchemaVersion))
             {
-                return new MeasurementSettingsFile();
+                throw new InvalidDataException(
+                    settings == null
+                        ? "The settings file is empty."
+                        : $"Settings schema version {settings.SchemaVersion} is not supported.");
             }
 
             if (settings.SchemaVersion == 7)
@@ -69,11 +74,39 @@ internal sealed class MeasurementSettingsFile
             }
 
             settings.MigrateLegacyDualDeviceLoopback();
+            settings.pathOnDisk = path;
             return settings;
         }
-        catch
+        catch (Exception exception)
         {
-            return new MeasurementSettingsFile();
+            string? backupPath = BackupUnusableFile(path);
+            string preservation = backupPath == null
+                ? "The unusable file could not be backed up; check file permissions before saving new settings."
+                : $"The unusable file was preserved as '{backupPath}'.";
+            return new MeasurementSettingsFile
+            {
+                pathOnDisk = path,
+                LoadWarning = $"Settings could not be loaded: {exception.Message}\r\n\r\n{preservation}"
+            };
+        }
+    }
+
+    private static string? BackupUnusableFile(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            string backupPath = path + ".backup";
+            File.Move(path, backupPath, overwrite: true);
+            return backupPath;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return null;
         }
     }
 
@@ -100,15 +133,17 @@ internal sealed class MeasurementSettingsFile
     public void Save()
     {
         SchemaVersion = CurrentSchemaVersion;
-        // Temp file + move keeps the settings intact if the write is interrupted;
-        // a corrupted file silently loads as defaults.
-        string tempPath = PathOnDisk + ".tmp";
+        // Temp file + move keeps the settings intact if the write is interrupted.
+        string directory = Path.GetDirectoryName(pathOnDisk)
+            ?? throw new InvalidOperationException("Settings directory cannot be resolved.");
+        Directory.CreateDirectory(directory);
+        string tempPath = pathOnDisk + ".tmp";
         using (FileStream stream = File.Create(tempPath))
         {
             JsonSerializer.Serialize(stream, this, SerializerOptions);
         }
 
-        File.Move(tempPath, PathOnDisk, overwrite: true);
+        File.Move(tempPath, pathOnDisk, overwrite: true);
     }
 
     public void ApplyTo(

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -100,14 +100,25 @@ internal sealed class MeasurementSettingsFile
                 return null;
             }
 
-            string backupPath = path + ".backup";
-            File.Move(path, backupPath, overwrite: true);
+            string backupPath = GetAvailableBackupPath(path);
+            File.Move(path, backupPath);
             return backupPath;
         }
         catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
         {
             return null;
         }
+    }
+
+    private static string GetAvailableBackupPath(string path)
+    {
+        string backupPath = path + ".backup";
+        for (int suffix = 1; File.Exists(backupPath); suffix++)
+        {
+            backupPath = path + $".backup.{suffix}";
+        }
+
+        return backupPath;
     }
 
     // The separate-loopback-device capability was removed: microphone and

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -8,6 +8,8 @@ public partial class Form1
     private async void Form1_Shown(object? sender, EventArgs e)
     {
         StartStartupAudioWarmup();
+        NotifySettingsLoadProblem();
+        NotifyHistoryLoadProblem();
         NotifyLegacyDualDeviceLoopbackReset();
 
         if (updateCheckStarted)
@@ -35,6 +37,36 @@ public partial class Form1
         {
             // Update checks are best-effort only and must never affect startup.
         }
+    }
+
+    private void NotifySettingsLoadProblem()
+    {
+        if (string.IsNullOrWhiteSpace(measurementSettings.LoadWarning))
+        {
+            return;
+        }
+
+        MessageBox.Show(
+            this,
+            measurementSettings.LoadWarning,
+            "Settings recovery",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Warning);
+    }
+
+    private void NotifyHistoryLoadProblem()
+    {
+        if (string.IsNullOrWhiteSpace(measurementHistoryService.LoadWarning))
+        {
+            return;
+        }
+
+        MessageBox.Show(
+            this,
+            measurementHistoryService.LoadWarning,
+            "History recovery",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Warning);
     }
 
     public async Task ChangeModeAsync(Mode mode)

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -211,7 +211,8 @@ namespace Resonalyze
         {
             try
             {
-                string path = Path.Combine(AppContext.BaseDirectory, "measurement-error.log");
+                string path = ApplicationDataPaths.Current.MeasurementErrorLogFile;
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
                 File.AppendAllText(
                     path,
                     $"[{DateTimeOffset.Now:O}]\r\n{error}\r\n\r\n");

--- a/source/Storage/ApplicationDataPaths.cs
+++ b/source/Storage/ApplicationDataPaths.cs
@@ -10,6 +10,7 @@ internal sealed class ApplicationDataPaths
 {
     private const string ApplicationDirectoryName = "Resonalyze";
     private const string PortableMarkerFileName = "portable.flag";
+    private const string MigrationMarkerFileName = ".migration-v1-complete";
 
     public static ApplicationDataPaths Current { get; } = CreateDefault();
 
@@ -45,6 +46,8 @@ internal sealed class ApplicationDataPaths
         Path.Combine(RootDirectory, "measurement-error.log");
     public string VirtualDspAlignmentLogFile =>
         Path.Combine(ToolsDirectory, "virtual-dsp-align.log");
+    internal string MigrationMarkerFile =>
+        Path.Combine(RootDirectory, MigrationMarkerFileName);
 
     public IReadOnlyList<string> Prepare()
     {
@@ -60,15 +63,34 @@ internal sealed class ApplicationDataPaths
             return warnings;
         }
 
-        if (IsPortable || PathsEqual(RootDirectory, executableDirectory))
+        if (IsPortable ||
+            PathsEqual(RootDirectory, executableDirectory) ||
+            File.Exists(MigrationMarkerFile))
         {
             return warnings;
         }
 
         CopyLegacyFile("measurement-settings.json", SettingsFile, warnings);
         CopyLegacyFile("measurement-history.json", HistoryFile, warnings);
+        CopyLegacyFile("crash.log", CrashLogFile, warnings);
+        CopyLegacyFile("measurement-error.log", MeasurementErrorLogFile, warnings);
         CopyLegacyDirectory("overlays", OverlaysDirectory, warnings);
         CopyLegacyDirectory("tools", ToolsDirectory, warnings);
+
+        if (warnings.Count == 0)
+        {
+            try
+            {
+                File.WriteAllText(MigrationMarkerFile, string.Empty);
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                warnings.Add(
+                    $"Legacy data migration completed, but its marker '{MigrationMarkerFile}' " +
+                    $"could not be written: {exception.Message}");
+            }
+        }
+
         return warnings;
     }
 

--- a/source/Storage/ApplicationDataPaths.cs
+++ b/source/Storage/ApplicationDataPaths.cs
@@ -1,0 +1,144 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Owns every implicit application-data path. Installed builds use the current
+/// user's LocalAppData directory; placing <c>portable.flag</c> beside the
+/// executable keeps all data beside the application. Existing side-by-side
+/// data is copied forward once, without overwriting newer destination files.
+/// </summary>
+internal sealed class ApplicationDataPaths
+{
+    private const string ApplicationDirectoryName = "Resonalyze";
+    private const string PortableMarkerFileName = "portable.flag";
+
+    public static ApplicationDataPaths Current { get; } = CreateDefault();
+
+    private readonly string executableDirectory;
+
+    internal ApplicationDataPaths(
+        string executableDirectory,
+        string localApplicationDataDirectory,
+        bool? portable = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executableDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(localApplicationDataDirectory);
+
+        this.executableDirectory = Path.GetFullPath(executableDirectory);
+        IsPortable = portable ?? File.Exists(Path.Combine(
+            this.executableDirectory,
+            PortableMarkerFileName));
+        RootDirectory = IsPortable
+            ? this.executableDirectory
+            : Path.Combine(
+                Path.GetFullPath(localApplicationDataDirectory),
+                ApplicationDirectoryName);
+    }
+
+    public bool IsPortable { get; }
+    public string RootDirectory { get; }
+    public string SettingsFile => Path.Combine(RootDirectory, "measurement-settings.json");
+    public string HistoryFile => Path.Combine(RootDirectory, "measurement-history.json");
+    public string OverlaysDirectory => Path.Combine(RootDirectory, "overlays");
+    public string ToolsDirectory => Path.Combine(RootDirectory, "tools");
+    public string CrashLogFile => Path.Combine(RootDirectory, "crash.log");
+    public string MeasurementErrorLogFile =>
+        Path.Combine(RootDirectory, "measurement-error.log");
+    public string VirtualDspAlignmentLogFile =>
+        Path.Combine(ToolsDirectory, "virtual-dsp-align.log");
+
+    public IReadOnlyList<string> Prepare()
+    {
+        var warnings = new List<string>();
+        try
+        {
+            Directory.CreateDirectory(RootDirectory);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            warnings.Add(
+                $"The application data directory '{RootDirectory}' cannot be created: {exception.Message}");
+            return warnings;
+        }
+
+        if (IsPortable || PathsEqual(RootDirectory, executableDirectory))
+        {
+            return warnings;
+        }
+
+        CopyLegacyFile("measurement-settings.json", SettingsFile, warnings);
+        CopyLegacyFile("measurement-history.json", HistoryFile, warnings);
+        CopyLegacyDirectory("overlays", OverlaysDirectory, warnings);
+        CopyLegacyDirectory("tools", ToolsDirectory, warnings);
+        return warnings;
+    }
+
+    private void CopyLegacyFile(
+        string legacyRelativePath,
+        string destination,
+        List<string> warnings)
+    {
+        string source = Path.Combine(executableDirectory, legacyRelativePath);
+        if (!File.Exists(source) || File.Exists(destination))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+            File.Copy(source, destination, overwrite: false);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            warnings.Add(
+                $"Existing user data '{source}' could not be migrated to '{destination}': {exception.Message}");
+        }
+    }
+
+    private void CopyLegacyDirectory(
+        string legacyRelativePath,
+        string destination,
+        List<string> warnings)
+    {
+        string source = Path.Combine(executableDirectory, legacyRelativePath);
+        if (!Directory.Exists(source))
+        {
+            return;
+        }
+
+        try
+        {
+            foreach (string sourceFile in Directory.EnumerateFiles(
+                source,
+                "*",
+                SearchOption.AllDirectories))
+            {
+                string relativePath = Path.GetRelativePath(source, sourceFile);
+                string destinationFile = Path.Combine(destination, relativePath);
+                if (File.Exists(destinationFile))
+                {
+                    continue;
+                }
+
+                Directory.CreateDirectory(Path.GetDirectoryName(destinationFile)!);
+                File.Copy(sourceFile, destinationFile, overwrite: false);
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            warnings.Add(
+                $"Existing user data directory '{source}' could not be fully migrated to " +
+                $"'{destination}': {exception.Message}");
+        }
+    }
+
+    private static ApplicationDataPaths CreateDefault() => new(
+        AppContext.BaseDirectory,
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+
+    private static bool PathsEqual(string left, string right) =>
+        string.Equals(
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(left)),
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(right)),
+            StringComparison.OrdinalIgnoreCase);
+}

--- a/source/Tools/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossoverPanel.cs
@@ -3346,8 +3346,7 @@ public partial class VirtualCrossoverPanel : UserControl
     {
         try
         {
-            string path = Path.Combine(
-                AppContext.BaseDirectory, "tools", "virtual-dsp-align.log");
+            string path = ApplicationDataPaths.Current.VirtualDspAlignmentLogFile;
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             File.WriteAllText(path, text);
         }

--- a/source/Tools/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossoverProjectFile.cs
@@ -258,7 +258,7 @@ public sealed class VirtualCrossoverProjectFile
 
     public static string GetPath(string? rootDirectory = null) =>
         Path.Combine(
-            rootDirectory ?? Path.Combine(AppContext.BaseDirectory, "tools"),
+            rootDirectory ?? ApplicationDataPaths.Current.ToolsDirectory,
             FileName);
 
     public void Save(string? rootDirectory = null)

--- a/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
+++ b/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
@@ -40,6 +40,31 @@ public sealed class AbstractedMeasurementTests
     }
 
     [Fact]
+    public async Task SubscriberExceptions_DoNotChangeSuccessfulOutcomeOrSkipOthers()
+    {
+        var factory = new FakeAudioSessionFactory(
+            duplexFactory: (_, signal) => new RecordingDuplexSession(
+                signal,
+                (_, s, tail, _) => Task.FromResult(SyntheticCapture.Good(s, tail))));
+        using ExpSweepMeasurement measurement = CreateSweep(factory);
+        bool impulseObserverCalled = false;
+        bool completionObserverCalled = false;
+        measurement.ImpulseResponseChanged += () =>
+            throw new InvalidOperationException("broken impulse observer");
+        measurement.ImpulseResponseChanged += () => impulseObserverCalled = true;
+        measurement.Completed += _ =>
+            throw new InvalidOperationException("broken completion observer");
+        measurement.Completed += success => completionObserverCalled = success;
+
+        bool result = await measurement.RunAsync();
+
+        Assert.True(result);
+        Assert.Null(measurement.LastError);
+        Assert.True(impulseObserverCalled);
+        Assert.True(completionObserverCalled);
+    }
+
+    [Fact]
     public async Task AveragingReusesTheOpenSession()
     {
         RecordingDuplexSession? opened = null;

--- a/tests/Resonalyze.App.Tests/ApplicationDataPathsTests.cs
+++ b/tests/Resonalyze.App.Tests/ApplicationDataPathsTests.cs
@@ -43,6 +43,10 @@ public sealed class ApplicationDataPathsTests : IDisposable
         File.WriteAllText(
             Path.Combine(executable, "measurement-settings.json"),
             "legacy settings");
+        File.WriteAllText(Path.Combine(executable, "crash.log"), "legacy crash");
+        File.WriteAllText(
+            Path.Combine(executable, "measurement-error.log"),
+            "legacy measurement error");
         string legacyOverlay = Path.Combine(executable, "overlays", "FrequencyResponse");
         Directory.CreateDirectory(legacyOverlay);
         File.WriteAllText(Path.Combine(legacyOverlay, "overlay-01.json"), "legacy overlay");
@@ -60,6 +64,29 @@ public sealed class ApplicationDataPathsTests : IDisposable
                 paths.OverlaysDirectory,
                 "FrequencyResponse",
                 "overlay-01.json")));
+        Assert.Equal("legacy crash", File.ReadAllText(paths.CrashLogFile));
+        Assert.Equal(
+            "legacy measurement error",
+            File.ReadAllText(paths.MeasurementErrorLogFile));
+        Assert.True(File.Exists(paths.MigrationMarkerFile));
+        Assert.True(File.Exists(Path.Combine(executable, "measurement-settings.json")));
+    }
+
+    [Fact]
+    public void Prepare_DoesNotRestoreDeletedDataAfterMigrationCompleted()
+    {
+        string executable = CreateDirectory("app");
+        string local = CreateDirectory("local");
+        File.WriteAllText(
+            Path.Combine(executable, "measurement-settings.json"),
+            "legacy settings");
+        var paths = new ApplicationDataPaths(executable, local);
+
+        Assert.Empty(paths.Prepare());
+        File.Delete(paths.SettingsFile);
+
+        Assert.Empty(paths.Prepare());
+        Assert.False(File.Exists(paths.SettingsFile));
         Assert.True(File.Exists(Path.Combine(executable, "measurement-settings.json")));
     }
 

--- a/tests/Resonalyze.App.Tests/ApplicationDataPathsTests.cs
+++ b/tests/Resonalyze.App.Tests/ApplicationDataPathsTests.cs
@@ -1,0 +1,83 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class ApplicationDataPathsTests : IDisposable
+{
+    private readonly string root = Path.Combine(
+        Path.GetTempPath(),
+        $"resonalyze-paths-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void InstalledMode_UsesLocalApplicationData()
+    {
+        string executable = CreateDirectory("app");
+        string local = CreateDirectory("local");
+
+        var paths = new ApplicationDataPaths(executable, local);
+
+        Assert.False(paths.IsPortable);
+        Assert.Equal(Path.Combine(local, "Resonalyze"), paths.RootDirectory);
+        Assert.Equal(
+            Path.Combine(local, "Resonalyze", "measurement-settings.json"),
+            paths.SettingsFile);
+    }
+
+    [Fact]
+    public void PortableMarker_KeepsDataBesideExecutable()
+    {
+        string executable = CreateDirectory("app");
+        string local = CreateDirectory("local");
+        File.WriteAllText(Path.Combine(executable, "portable.flag"), string.Empty);
+
+        var paths = new ApplicationDataPaths(executable, local);
+
+        Assert.True(paths.IsPortable);
+        Assert.Equal(executable, paths.RootDirectory);
+        Assert.Empty(paths.Prepare());
+    }
+
+    [Fact]
+    public void Prepare_CopiesLegacyFilesAndDirectoriesWithoutOverwriting()
+    {
+        string executable = CreateDirectory("app");
+        string local = CreateDirectory("local");
+        File.WriteAllText(
+            Path.Combine(executable, "measurement-settings.json"),
+            "legacy settings");
+        string legacyOverlay = Path.Combine(executable, "overlays", "FrequencyResponse");
+        Directory.CreateDirectory(legacyOverlay);
+        File.WriteAllText(Path.Combine(legacyOverlay, "overlay-01.json"), "legacy overlay");
+        var paths = new ApplicationDataPaths(executable, local);
+        Directory.CreateDirectory(paths.RootDirectory);
+        File.WriteAllText(paths.SettingsFile, "current settings");
+
+        IReadOnlyList<string> warnings = paths.Prepare();
+
+        Assert.Empty(warnings);
+        Assert.Equal("current settings", File.ReadAllText(paths.SettingsFile));
+        Assert.Equal(
+            "legacy overlay",
+            File.ReadAllText(Path.Combine(
+                paths.OverlaysDirectory,
+                "FrequencyResponse",
+                "overlay-01.json")));
+        Assert.True(File.Exists(Path.Combine(executable, "measurement-settings.json")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private string CreateDirectory(string name)
+    {
+        string path = Path.Combine(root, name);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/tests/Resonalyze.App.Tests/MeasurementHistoryPersistenceTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementHistoryPersistenceTests.cs
@@ -16,6 +16,19 @@ public sealed class MeasurementHistoryPersistenceTests : IDisposable
         storePath = Path.Combine(directory, "measurement-history.json");
     }
 
+    [Fact]
+    public void Load_PreservesEarlierBackupOnRepeatedCorruption()
+    {
+        File.WriteAllText(storePath + ".backup", "earlier corruption");
+        File.WriteAllText(storePath, "{ later corruption");
+        var persistence = new MeasurementHistoryPersistence(storePath);
+
+        persistence.Load();
+
+        Assert.Equal("earlier corruption", File.ReadAllText(storePath + ".backup"));
+        Assert.Equal("{ later corruption", File.ReadAllText(storePath + ".backup.1"));
+    }
+
     public void Dispose()
     {
         try

--- a/tests/Resonalyze.App.Tests/MeasurementHistoryPersistenceTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementHistoryPersistenceTests.cs
@@ -78,6 +78,20 @@ public sealed class MeasurementHistoryPersistenceTests : IDisposable
         var persistence = new MeasurementHistoryPersistence(storePath);
 
         Assert.Empty(persistence.Load());
+        Assert.NotNull(persistence.LoadWarning);
+        Assert.False(File.Exists(storePath));
+        Assert.True(File.Exists(storePath + ".backup"));
+    }
+
+    [Fact]
+    public void Load_ReportsAndBacksUpUnsupportedStore()
+    {
+        File.WriteAllText(storePath, "{ \"schemaVersion\": 999, \"entries\": [] }");
+        var persistence = new MeasurementHistoryPersistence(storePath);
+
+        Assert.Empty(persistence.Load());
+        Assert.Contains("version 999 is not supported", persistence.LoadWarning);
+        Assert.True(File.Exists(storePath + ".backup"));
     }
 
     internal static MeasurementHistoryEntry CreateEntry(string? sourceFilePath) =>

--- a/tests/Resonalyze.App.Tests/MeasurementSettingsFileRecoveryTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementSettingsFileRecoveryTests.cs
@@ -22,6 +22,20 @@ public sealed class MeasurementSettingsFileRecoveryTests : IDisposable
     }
 
     [Fact]
+    public void LoadOrDefault_PreservesEarlierBackupOnRepeatedCorruption()
+    {
+        string path = Path.Combine(directory, "measurement-settings.json");
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(path + ".backup", "earlier corruption");
+        File.WriteAllText(path, "{ later corruption");
+
+        MeasurementSettingsFile.LoadOrDefault(path);
+
+        Assert.Equal("earlier corruption", File.ReadAllText(path + ".backup"));
+        Assert.Equal("{ later corruption", File.ReadAllText(path + ".backup.1"));
+    }
+
+    [Fact]
     public void LoadOrDefault_UnsupportedVersionIsBackedUpAndReported()
     {
         Directory.CreateDirectory(directory);

--- a/tests/Resonalyze.App.Tests/MeasurementSettingsFileRecoveryTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementSettingsFileRecoveryTests.cs
@@ -1,0 +1,47 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class MeasurementSettingsFileRecoveryTests : IDisposable
+{
+    private readonly string directory = Path.Combine(
+        Path.GetTempPath(),
+        $"resonalyze-settings-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void LoadOrDefault_CorruptFileIsBackedUpAndReported()
+    {
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "measurement-settings.json");
+        File.WriteAllText(path, "{ not json");
+
+        MeasurementSettingsFile settings = MeasurementSettingsFile.LoadOrDefault(path);
+
+        Assert.NotNull(settings.LoadWarning);
+        Assert.Contains("could not be loaded", settings.LoadWarning);
+        Assert.False(File.Exists(path));
+        Assert.True(File.Exists(path + ".backup"));
+    }
+
+    [Fact]
+    public void LoadOrDefault_UnsupportedVersionIsBackedUpAndReported()
+    {
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "measurement-settings.json");
+        File.WriteAllText(path, "{ \"SchemaVersion\": 999 }");
+
+        MeasurementSettingsFile settings = MeasurementSettingsFile.LoadOrDefault(path);
+
+        Assert.Contains("version 999 is not supported", settings.LoadWarning);
+        Assert.True(File.Exists(path + ".backup"));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+}

--- a/tests/Resonalyze.App.Tests/SweepMeasurementConfigurationTests.cs
+++ b/tests/Resonalyze.App.Tests/SweepMeasurementConfigurationTests.cs
@@ -1,0 +1,37 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class SweepMeasurementConfigurationTests
+{
+    [Fact]
+    public void Init_AppliesGroupedSignalAudioAndAveragingConfiguration()
+    {
+        using var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        var configuration = new SweepMeasurementConfiguration(
+            new SweepSignalConfiguration(
+                10,
+                96_000,
+                24,
+                0.25,
+                PlaybackChannel.Right),
+            new SweepAudioConfiguration(
+                Backend: AudioBackend.Asio,
+                AsioDriverName: "Test ASIO",
+                AsioInputChannelOffset: 4,
+                AsioLoopbackInputChannelOffset: 5,
+                AsioOutputChannelOffset: 2),
+            new SweepAveragingConfiguration(3, ConfirmEachRun: true));
+
+        measurement.Init(configuration);
+
+        Assert.Equal(10, measurement.Octaves);
+        Assert.Equal(96_000, measurement.SampleRate);
+        Assert.Equal(PlaybackChannel.Right, measurement.PlaybackChannel);
+        Assert.Equal(AudioBackend.Asio, measurement.AudioBackend);
+        Assert.Equal("Test ASIO", measurement.AsioDriverName);
+        Assert.Equal(4, measurement.AsioInputChannelOffset);
+        Assert.Equal(5, measurement.AsioLoopbackInputChannelOffset);
+        Assert.Equal(2, measurement.AsioOutputChannelOffset);
+        Assert.Equal(3, measurement.AverageRunCount);
+        Assert.True(measurement.ConfirmEachAverageRun);
+    }
+}


### PR DESCRIPTION
## Summary

- centralize installed and portable user-data paths
- migrate legacy settings, history, overlays, Virtual DSP sessions, and logs without silently treating access or parsing failures as empty state
- retain atomic writes and back up corrupt or unsupported files before recovery
- replace the long sweep initializer argument list with grouped configuration records
- keep subscriber failures from changing successful measurement completion or breaking cleanup
- refresh agent guidance and remove stale technical-debt documentation

## Compatibility

- installed mode uses `%LocalAppData%\Resonalyze`
- `portable.flag` beside the executable retains storage beside the application
- existing file formats remain readable and legacy data is migrated

## Validation

- `dotnet test source\Resonalyze.sln -c Release --no-restore --filter "Category!=Hardware"`
  - Audio: 75 passed
  - App: 349 passed
  - DSP: 536 passed
  - Total: 960 passed
- added path-selection/migration, settings recovery, history recovery, and grouped measurement-configuration tests
- `git diff --check`

## Manual checks

- installed and portable builds on Windows
- migration from an existing beside-exe profile
- read-only/access-denied paths and recovery-warning UX

Split from #35 to isolate persistence and measurement-configuration compatibility risk.
