### PR TITLE
Auto delay: honest PHAT seed gate, period-wide stage-1 correlation window

### DIFF
--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -149,6 +149,35 @@ public static class AutoAlignmentEngine
     private const double DiagnosticFineRangeMs = 3.0;
     private const double DiagnosticCorrelationRangeMs = 3.0;
 
+    // The wide diagnostic sweep must reach past the flip partner half a period
+    // out even at a LOW junction, where the fixed millisecond span above is
+    // sub-period — otherwise the [diag] line (and the promotion pool at
+    // un-locked junctions) simply cannot contain the true optimum it exists to
+    // surface. 1.25 half periods clears that partner with margin; mid/high
+    // junctions keep the fixed span, already many periods there.
+    private const double DiagnosticFineReachHalfPeriods = 1.25;
+
+    // The stage-1 correlation window in periods of the pair crossover. The
+    // peak-vs-trough dominance gate below is only meaningful when BOTH
+    // polarity partners are complete lobes inside the window, and the arrival
+    // estimate the window centers on can itself sit up to a half period off at
+    // a low junction — so the window must hold at least a full period to each
+    // side. Under the fixed ±3 ms window a field 85 Hz junction had its
+    // non-inverted rival lobe cut by the window edge: the truncated value
+    // understated the rival, the dominance gate passed on the corrupted
+    // number, and the timeline was seeded from the cut — a 3.6 ms miss the
+    // fine search could no longer reach. Mid/high junctions stay on the fixed
+    // floor (±3 ms already spans several periods there).
+    private const double SeedCorrelationWindowPeriods = 1.25;
+
+    // The stage-1 / diagnostic correlation half-window for a junction: the
+    // fixed floor, grown with the crossover period at low junctions so both
+    // polarity partners fit as whole lobes.
+    private static double SeedCorrelationRangeMs(double crossoverHz) =>
+        Math.Max(
+            DiagnosticCorrelationRangeMs,
+            SeedCorrelationWindowPeriods * 1000.0 / crossoverHz);
+
     // The minimum non-inverted PHAT peak correlation for its position to seed the
     // stage-2 window instead of the arrival envelope. Below it the peak is noise
     // (a low-frequency junction with too few in-band periods), and the arrival
@@ -393,12 +422,32 @@ public static class AutoAlignmentEngine
             // mid/high junction it lands the stage-2 window on the correct lobe
             // directly, sparing the wide-window recovery. Only the peak POSITION
             // is used (polarity and the final lobe stay with the loss search), and
-            // only when the peak carries a real correlation — otherwise the arrival
-            // envelope stands. The PHAT window is centered on the arrival estimate,
-            // so a trusted peak is by construction within reach of it. The timeline
-            // stores arrivals as (upper - lower); the PHAT peak is the delay to add
-            // to the upper channel, i.e. the same quantity negated.
+            // only when the peak is the honest winner of its window — otherwise
+            // the arrival envelope stands. Each distrust rule guards a distinct
+            // failure, checked in the order the earlier ones corrupt the later
+            // ones' inputs:
+            //  - an EDGE-PINNED extremum is a lobe cut by the window boundary,
+            //    so its position and magnitude (and hence every comparison
+            //    below) are artifacts of where the window ended;
+            //  - a DOMINANT INVERTED TROUGH means the correlation's strongest
+            //    alignment is the flipped one, and the non-inverted peak is a
+            //    half-period impostor — seeding from the loser would park the
+            //    fine window a fraction of a period off (the field failure:
+            //    trough −0.58 vs peak +0.46 at an 85 Hz junction, seeded from
+            //    the peak, 3.6 ms miss); near-ties fall under the dominance
+            //    floor below either way;
+            //  - a WEAK or BARELY-DOMINANT peak is lobe ambiguity, decided by
+            //    noise (see the two constants);
+            //  - a peak FARTHER FROM THE ARRIVAL than half a period (or the
+            //    fixed window floor, whichever is larger — the reach the fixed
+            //    window used to enforce by construction) is a cycle-skip
+            //    candidate the now period-wide window must not hand to the
+            //    timeline.
+            // The timeline stores arrivals as (upper - lower); the PHAT peak is
+            // the delay to add to the upper channel, i.e. the same quantity
+            // negated.
             double passOctaves = Math.Log2(pair.BandHighHz / pair.BandLowHz);
+            double centerLagMs = lowerArrival - upperArrival;
             CorrelationAlignmentResult phat =
                 VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
                     pair.Lower.ImpulseResponse,
@@ -406,12 +455,25 @@ public static class AutoAlignmentEngine
                     pair.Lower.Channel.SampleRate,
                     pair.CrossoverHz,
                     passOctaves,
-                    DiagnosticCorrelationRangeMs,
-                    centerLagMs: lowerArrival - upperArrival,
+                    SeedCorrelationRangeMs(pair.CrossoverHz),
+                    centerLagMs,
                     phaseTransform: true);
-            bool trustPhat =
-                phat.PositivePeak.Coefficient >= PhatSeedMinCoefficient &&
-                phat.Confidence >= PhatSeedMinDominance;
+            double peakOffsetMs = phat.PositivePeak.DelayMs - centerLagMs;
+            double maxPeakOffsetMs = Math.Max(
+                DiagnosticCorrelationRangeMs, 500.0 / pair.CrossoverHz);
+            string? distrust =
+                phat.PositivePeak.EdgePinned || phat.NegativeTrough.EdgePinned
+                    ? "edge-pinned extremum"
+                    : phat.BestByMagnitude.InvertPolarity
+                        ? "inverted trough dominates"
+                        : phat.PositivePeak.Coefficient < PhatSeedMinCoefficient
+                            ? "peak too weak"
+                            : phat.Confidence < PhatSeedMinDominance
+                                ? "peak-trough near-tie"
+                                : Math.Abs(peakOffsetMs) > maxPeakOffsetMs
+                                    ? "peak beyond the arrival's reach"
+                                    : null;
+            bool trustPhat = distrust == null;
             double increment =
                 trustPhat ? -phat.PositivePeak.DelayMs : upperArrival - lowerArrival;
             timeline[pair.Upper.Channel] = timeline[pair.Lower.Channel] + increment;
@@ -440,7 +502,7 @@ public static class AutoAlignmentEngine
                 $"phat peak {phat.PositivePeak.DelayMs:+0.000;-0.000} ms " +
                 $"(r {phat.PositivePeak.Coefficient:+0.000;-0.000}, " +
                 $"dom {phat.Confidence:0.000}) -> seed " +
-                $"{(trustPhat ? "phat" : "arrival")}");
+                $"{(trustPhat ? "phat" : $"arrival ({distrust})")}");
         }
 
         return timeline;
@@ -688,9 +750,13 @@ public static class AutoAlignmentEngine
             // Wide sweep: the same junction searched across a much wider
             // window so lobes beyond the working range appear in the log.
             // At an un-locked junction the promotion below may adopt its
-            // winner; under a scene or onset lock it is log-only.
+            // winner; under a scene or onset lock it is log-only. At a low
+            // junction the fixed span is sub-period, so it grows to reach the
+            // flip partner half a period out (see DiagnosticFineReachHalfPeriods).
             (IReadOnlyList<AlignmentCandidate> wide, double wideLow, double wideHigh) =
-                SearchJunction(windowOverrideMs: DiagnosticFineRangeMs);
+                SearchJunction(windowOverrideMs: Math.Max(
+                    DiagnosticFineRangeMs,
+                    DiagnosticFineReachHalfPeriods * halfPeriodMs));
             log.AppendLine(
                 $"  [diag] wide {wideLow:0.000}..{wideHigh:0.000} ms: " +
                 (wide.Count > 0
@@ -1816,7 +1882,8 @@ public static class AutoAlignmentEngine
         log.AppendLine(
             "[corr] band-limited cross-correlation diagnostics " +
             "(full pair band, " +
-            $"window ±{DiagnosticCorrelationRangeMs:0.###} ms; " +
+            $"window ±max({DiagnosticCorrelationRangeMs:0.###} ms, " +
+            $"{SeedCorrelationWindowPeriods:0.##} fc periods); " +
             "[corr] raw amplitude, [phat] phase-transform / whitened)");
 
         foreach (AlignmentJunction pair in pairs)
@@ -1866,7 +1933,7 @@ public static class AutoAlignmentEngine
                 pair.Lower.Channel.SampleRate,
                 pair.CrossoverHz,
                 passOctaves,
-                DiagnosticCorrelationRangeMs,
+                SeedCorrelationRangeMs(pair.CrossoverHz),
                 centerLagMs,
                 phaseTransform);
         CorrelationDelayCandidate best = result.BestByMagnitude;
@@ -1876,6 +1943,7 @@ public static class AutoAlignmentEngine
             $"{pair.Upper.Channel.Name}: " +
             $"fc {result.CenterFrequencyHz:0} Hz, " +
             $"band {result.BandLowHz:0}-{result.BandHighHz:0} Hz, " +
+            $"window ±{result.SearchRangeMs:0.###} ms, " +
             $"delay to add to {pair.Upper.Channel.Name}: " +
             $"{best.DelayMs:+0.000;-0.000} ms, " +
             $"invert {(best.InvertPolarity ? "yes" : "no")}, " +
@@ -1883,8 +1951,10 @@ public static class AutoAlignmentEngine
             $"confidence {result.Confidence:0.000}");
         log.AppendLine(
             $"  [{tag}] peak {result.PositivePeak.DelayMs:+0.000;-0.000} ms " +
-            $"(r {result.PositivePeak.Coefficient:+0.000;-0.000}); " +
+            $"(r {result.PositivePeak.Coefficient:+0.000;-0.000}" +
+            $"{(result.PositivePeak.EdgePinned ? ", edge" : "")}); " +
             $"trough {result.NegativeTrough.DelayMs:+0.000;-0.000} ms " +
-            $"(r {result.NegativeTrough.Coefficient:+0.000;-0.000}, inv)");
+            $"(r {result.NegativeTrough.Coefficient:+0.000;-0.000}, inv" +
+            $"{(result.NegativeTrough.EdgePinned ? ", edge" : "")})");
     }
 }

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -178,6 +178,16 @@ public static class AutoAlignmentEngine
             DiagnosticCorrelationRangeMs,
             SeedCorrelationWindowPeriods * 1000.0 / crossoverHz);
 
+    // How far from the arrival estimate a trusted seed peak may sit: half a
+    // period — the next same-polarity lobe is a full period out, so half a
+    // period is the no-cycle-skip bound — floored at the FIXED window span.
+    // The floor is deliberately the fixed ±3 ms, not the grown window: at a
+    // mid/high junction it keeps exactly the reach the fixed window used to
+    // enforce by construction, and at a low junction the grown window may SEE
+    // farther lobes but must never hand one to the timeline.
+    private static double SeedPeakReachMs(double crossoverHz) =>
+        Math.Max(DiagnosticCorrelationRangeMs, 500.0 / crossoverHz);
+
     // The minimum non-inverted PHAT peak correlation for its position to seed the
     // stage-2 window instead of the arrival envelope. Below it the peak is noise
     // (a low-frequency junction with too few in-band periods), and the arrival
@@ -459,20 +469,31 @@ public static class AutoAlignmentEngine
                     centerLagMs,
                     phaseTransform: true);
             double peakOffsetMs = phat.PositivePeak.DelayMs - centerLagMs;
-            double maxPeakOffsetMs = Math.Max(
-                DiagnosticCorrelationRangeMs, 500.0 / pair.CrossoverHz);
-            string? distrust =
-                phat.PositivePeak.EdgePinned || phat.NegativeTrough.EdgePinned
-                    ? "edge-pinned extremum"
-                    : phat.BestByMagnitude.InvertPolarity
-                        ? "inverted trough dominates"
-                        : phat.PositivePeak.Coefficient < PhatSeedMinCoefficient
-                            ? "peak too weak"
-                            : phat.Confidence < PhatSeedMinDominance
-                                ? "peak-trough near-tie"
-                                : Math.Abs(peakOffsetMs) > maxPeakOffsetMs
-                                    ? "peak beyond the arrival's reach"
-                                    : null;
+            string? Distrust()
+            {
+                if (phat.PositivePeak.EdgePinned || phat.NegativeTrough.EdgePinned)
+                {
+                    return "edge-pinned extremum";
+                }
+                if (phat.BestByMagnitude.InvertPolarity)
+                {
+                    return "inverted trough dominates";
+                }
+                if (phat.PositivePeak.Coefficient < PhatSeedMinCoefficient)
+                {
+                    return "peak too weak";
+                }
+                if (phat.Confidence < PhatSeedMinDominance)
+                {
+                    return "peak-trough near-tie";
+                }
+                if (Math.Abs(peakOffsetMs) > SeedPeakReachMs(pair.CrossoverHz))
+                {
+                    return "peak beyond the arrival's reach";
+                }
+                return null;
+            }
+            string? distrust = Distrust();
             bool trustPhat = distrust == null;
             double increment =
                 trustPhat ? -phat.PositivePeak.DelayMs : upperArrival - lowerArrival;

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -487,6 +487,18 @@ public static class AutoAlignmentEngine
                 {
                     return "peak-trough near-tie";
                 }
+                if (phat.PositiveRival is { } rival &&
+                    phat.PositivePeak.Coefficient - rival.Coefficient <
+                        PhatSeedMinDominance)
+                {
+                    // Confidence compares the peak against the TROUGH only; a
+                    // same-polarity lobe one period over is invisible to it. A
+                    // near-tie against that rival means the choice of lobe —
+                    // and with it a whole-period cycle skip — would be decided
+                    // by which reflection ran slightly hotter, so the seed
+                    // falls back to the polarity-blind arrival instead.
+                    return "same-polarity rival near-tie";
+                }
                 if (Math.Abs(peakOffsetMs) > SeedPeakReachMs(pair.CrossoverHz))
                 {
                     return "peak beyond the arrival's reach";
@@ -1976,6 +1988,11 @@ public static class AutoAlignmentEngine
             $"{(result.PositivePeak.EdgePinned ? ", edge" : "")}); " +
             $"trough {result.NegativeTrough.DelayMs:+0.000;-0.000} ms " +
             $"(r {result.NegativeTrough.Coefficient:+0.000;-0.000}, inv" +
-            $"{(result.NegativeTrough.EdgePinned ? ", edge" : "")})");
+            $"{(result.NegativeTrough.EdgePinned ? ", edge" : "")})" +
+            (result.PositiveRival is { } rival
+                ? $"; rival {rival.DelayMs:+0.000;-0.000} ms " +
+                    $"(r {rival.Coefficient:+0.000;-0.000}" +
+                    $"{(rival.EdgePinned ? ", edge" : "")})"
+                : ""));
     }
 }

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -702,12 +702,17 @@ public static class VirtualCrossoverAnalysis
             }
         }
 
-        bool interior = Math.Abs(bestLag - centerLag) < rangeSamples;
-        bool edgePinned =
-            Math.Abs(bestLag - centerLag) >= rangeSamples - CorrelationEdgeGuardSamples;
-        double refinedLag = interior
-            ? TransferFunction.RefinePeakLag(correlation, bestLag, fftLength, sign)
-            : bestLag;
+        int distance = Math.Abs(bestLag - centerLag);
+        // The guard never consumes the whole window: a degenerate few-sample
+        // window keeps a non-edge center instead of flagging every lag.
+        int edgeGuard = Math.Min(CorrelationEdgeGuardSamples, rangeSamples - 1);
+        bool edgePinned = distance >= rangeSamples - edgeGuard;
+        // An edge-pinned extremum keeps its integer lag: sub-sample refinement
+        // on a cut lobe would drift the reported position toward the true
+        // extremum OUTSIDE the window, misstating what was measured.
+        double refinedLag = edgePinned
+            ? bestLag
+            : TransferFunction.RefinePeakLag(correlation, bestLag, fftLength, sign);
         return new CorrelationDelayCandidate(
             refinedLag * 1000.0 / sampleRate,
             normalizer > 0 ? sign * best / normalizer : 0,

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -70,6 +70,12 @@ public sealed record CorrelationDelayCandidate(
 /// Diagnostic result of a time-domain delay search around a crossover.
 /// <see cref="DelayMs"/> is the delay to add to the second impulse response
 /// passed to the search so it aligns with the first.
+/// <see cref="PositiveRival"/> is the strongest OTHER positive local maximum
+/// in the window, outside the main peak's own lobe — the same-polarity
+/// neighbor a period away that <see cref="Confidence"/> (peak vs trough)
+/// cannot see. A trust decision between two same-polarity lobes needs the
+/// peak to beat this rival too, or the choice of lobe is ambiguity, not
+/// measurement. Null when the window holds no separated positive structure.
 /// </summary>
 public sealed record CorrelationAlignmentResult(
     double CenterFrequencyHz,
@@ -77,7 +83,8 @@ public sealed record CorrelationAlignmentResult(
     double BandHighHz,
     double SearchRangeMs,
     CorrelationDelayCandidate PositivePeak,
-    CorrelationDelayCandidate NegativeTrough)
+    CorrelationDelayCandidate NegativeTrough,
+    CorrelationDelayCandidate? PositiveRival = null)
 {
     public CorrelationDelayCandidate BestByMagnitude =>
         Math.Abs(NegativeTrough.Coefficient) > Math.Abs(PositivePeak.Coefficient)
@@ -640,10 +647,13 @@ public static class VirtualCrossoverAnalysis
         int centerLag = (int)Math.Round(centerLagMs / 1000.0 * sampleRate);
         CorrelationDelayCandidate positive = FindCorrelationExtremum(
             correlation, centerLag, rangeSamples, normalizer, sampleRate,
-            findMaximum: true);
+            findMaximum: true, out int positiveLag);
         CorrelationDelayCandidate negative = FindCorrelationExtremum(
             correlation, centerLag, rangeSamples, normalizer, sampleRate,
-            findMaximum: false);
+            findMaximum: false, out _);
+        CorrelationDelayCandidate? positiveRival = FindPositiveRival(
+            correlation, centerLag, rangeSamples, positiveLag, normalizer,
+            sampleRate);
 
         return new CorrelationAlignmentResult(
             centerFrequencyHz,
@@ -651,7 +661,78 @@ public static class VirtualCrossoverAnalysis
             highHz,
             searchRangeMs,
             positive,
-            negative);
+            negative,
+            positiveRival);
+    }
+
+    // The strongest POSITIVE local maximum outside the main peak's own lobe —
+    // the contiguous positive region around it — i.e. the same-polarity rival
+    // one period over. A window boundary lag also qualifies when a
+    // non-positive gap separates it from the main lobe: a rival cut by the
+    // window still testifies, with its truncated value as a lower bound. Lags
+    // still connected to the main lobe never qualify, so the peak's own slope
+    // cannot masquerade as a rival. Null when the window holds no separated
+    // positive structure.
+    private static CorrelationDelayCandidate? FindPositiveRival(
+        double[] correlation,
+        int centerLag,
+        int rangeSamples,
+        int mainLag,
+        double normalizer,
+        int sampleRate)
+    {
+        int fftLength = correlation.Length;
+        double Value(int lag) =>
+            correlation[TransferFunction.WrapIndex(lag, fftLength)];
+
+        int windowLow = centerLag - rangeSamples;
+        int windowHigh = centerLag + rangeSamples;
+        int lobeLow = mainLag;
+        while (lobeLow > windowLow && Value(lobeLow - 1) > 0)
+        {
+            lobeLow--;
+        }
+        int lobeHigh = mainLag;
+        while (lobeHigh < windowHigh && Value(lobeHigh + 1) > 0)
+        {
+            lobeHigh++;
+        }
+
+        int bestLag = 0;
+        double best = 0;
+        for (int lag = windowLow; lag <= windowHigh; lag++)
+        {
+            if (lag >= lobeLow && lag <= lobeHigh)
+            {
+                continue;
+            }
+            double value = Value(lag);
+            if (value <= best)
+            {
+                continue;
+            }
+            bool boundary = lag == windowLow || lag == windowHigh;
+            if (boundary || (value >= Value(lag - 1) && value >= Value(lag + 1)))
+            {
+                best = value;
+                bestLag = lag;
+            }
+        }
+        if (best <= 0)
+        {
+            return null;
+        }
+
+        int edgeGuard = Math.Min(CorrelationEdgeGuardSamples, rangeSamples - 1);
+        bool edgePinned = Math.Abs(bestLag - centerLag) >= rangeSamples - edgeGuard;
+        double refinedLag = edgePinned
+            ? bestLag
+            : TransferFunction.RefinePeakLag(correlation, bestLag, fftLength, 1.0);
+        return new CorrelationDelayCandidate(
+            refinedLag * 1000.0 / sampleRate,
+            normalizer > 0 ? best / normalizer : 0,
+            InvertPolarity: false,
+            edgePinned);
     }
 
     // A smooth band-pass magnitude: a raised cosine over log frequency, one at
@@ -686,7 +767,8 @@ public static class VirtualCrossoverAnalysis
         int rangeSamples,
         double normalizer,
         int sampleRate,
-        bool findMaximum)
+        bool findMaximum,
+        out int extremumLag)
     {
         int fftLength = correlation.Length;
         double sign = findMaximum ? 1.0 : -1.0;
@@ -702,6 +784,7 @@ public static class VirtualCrossoverAnalysis
             }
         }
 
+        extremumLag = bestLag;
         int distance = Math.Abs(bestLag - centerLag);
         // The guard never consumes the whole window: a degenerate few-sample
         // window keeps a non-edge center instead of flagging every lag.

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -54,11 +54,17 @@ public readonly record struct BroadbandOnsetEstimate(
 
 /// <summary>
 /// One extremum of a band-limited time-domain cross-correlation search.
+/// <see cref="EdgePinned"/> marks an extremum found on (or within a couple of
+/// samples of) the lag-window boundary: that is not a measured lobe but the
+/// window's cut through one whose true extremum can lie outside, so both the
+/// position and the magnitude are artifacts of where the window happened to
+/// end — callers gating on either must not trust an edge-pinned value.
 /// </summary>
 public sealed record CorrelationDelayCandidate(
     double DelayMs,
     double Coefficient,
-    bool InvertPolarity);
+    bool InvertPolarity,
+    bool EdgePinned = false);
 
 /// <summary>
 /// Diagnostic result of a time-domain delay search around a crossover.
@@ -663,6 +669,13 @@ public static class VirtualCrossoverAnalysis
         return 0.5 - 0.5 * Math.Cos(Math.Tau * position);
     }
 
+    // How close (in lag samples) to the search-window boundary an extremum may
+    // sit before it is flagged edge-pinned. A truncated lobe's argmax lands on
+    // the boundary itself or, after the discrete grid samples its slope, one
+    // sample inside — two samples covers both without reaching lag positions a
+    // genuinely interior lobe would occupy (windows are hundreds of samples).
+    private const int CorrelationEdgeGuardSamples = 2;
+
     // The extremum inside the lag window, refined to sub-sample precision with the
     // shared windowed-sinc interpolation (a plain 3-point parabola systematically
     // mislocates a sinc-shaped correlation peak). Positive lags are read at their
@@ -690,13 +703,16 @@ public static class VirtualCrossoverAnalysis
         }
 
         bool interior = Math.Abs(bestLag - centerLag) < rangeSamples;
+        bool edgePinned =
+            Math.Abs(bestLag - centerLag) >= rangeSamples - CorrelationEdgeGuardSamples;
         double refinedLag = interior
             ? TransferFunction.RefinePeakLag(correlation, bestLag, fftLength, sign)
             : bestLag;
         return new CorrelationDelayCandidate(
             refinedLag * 1000.0 / sampleRate,
             normalizer > 0 ? sign * best / normalizer : 0,
-            !findMaximum);
+            !findMaximum,
+            edgePinned);
     }
 
     // One spectrum bin of the alignment problem: the combined fixed spectrum,

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -62,7 +62,8 @@ public sealed class AutoAlignmentEngineTests
     private static Dictionary<IAlignmentChannel, AlignmentOverride> Run(
         TestChannel[] byBand,
         double[] crossoversHz,
-        StringBuilder log)
+        StringBuilder log,
+        (double LowHz, double HighHz)[]? bands = null)
     {
         var snapshots = byBand.ToDictionary(
             channel => channel,
@@ -75,8 +76,8 @@ public sealed class AutoAlignmentEngineTests
                 snapshots[byBand[i]],
                 snapshots[byBand[i + 1]],
                 fc,
-                Math.Max(20, fc / 2),
-                Math.Min(20_000, fc * 2)))
+                bands?[i].LowHz ?? Math.Max(20, fc / 2),
+                bands?[i].HighHz ?? Math.Min(20_000, fc * 2)))
             .ToList();
 
         IReadOnlyList<AlignmentSnapshot> Reprocess(
@@ -333,6 +334,34 @@ public sealed class AutoAlignmentEngineTests
         Assert.False(alignment.ContainsKey(midbass));
         Assert.Contains(
             "seed arrival (peak beyond the arrival's reach)",
+            TestLog.Line(text, "Pair B/C"));
+        Assert.Contains("WIDE SEED", TestLog.Line(text, "Channel C:"));
+    }
+
+    [Fact]
+    public void Compute_SamePolarityRivalNearTie_IsNotTrustedAsTheSeed()
+    {
+        // Two same-polarity correlation lobes a full period apart, the FAR
+        // one marginally stronger — the configuration peak-vs-trough
+        // Confidence cannot see (the second positive lobe is simply absent
+        // from it), so the far lobe used to seed as a confidently
+        // "unambiguous" peak: a silent whole-period cycle skip that stage 2
+        // could no longer recover (its window and the wide sweep both reach
+        // well under a period). The junction band is WIDE so the whitened
+        // kernel's own trough stays shallow — the trough rules must not be
+        // the ones refusing this seed; the rival rule must.
+        var midbass = new TestChannel("B", DelayedImpulse(15.0));
+        var mid = new TestChannel(
+            "C", ImpulseWithEcho(0.0, 0.97, 11.76, 1.0));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([midbass, mid], [85], log, bands: [(30, 340)]);
+
+        string text = log.ToString();
+        Assert.False(alignment.ContainsKey(midbass));
+        Assert.Contains(
+            "seed arrival (same-polarity rival near-tie)",
             TestLog.Line(text, "Pair B/C"));
         Assert.Contains("WIDE SEED", TestLog.Line(text, "Channel C:"));
     }

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -45,6 +45,23 @@ public sealed class AutoAlignmentEngineTests
             new DspChannelChain(DelayMs: delayMs, InvertPolarity: invert),
             SampleRate);
 
+    // A first arrival plus a competing later copy — the shape that splits the
+    // envelope arrival (reads the first copy) from the whitened-correlation
+    // peak (follows the stronger copy).
+    private static Complex[] ImpulseWithEcho(
+        double offsetMs, double amplitude, double echoMs, double echoAmplitude)
+    {
+        var ir = new Complex[IrLength];
+        ir[BasePosition + (int)Math.Round(offsetMs / 1000.0 * SampleRate)] =
+            amplitude;
+        ir[BasePosition + (int)Math.Round((offsetMs + echoMs) / 1000.0 * SampleRate)] +=
+            echoAmplitude;
+        return ir;
+    }
+
+    private static string LogLine(string log, string contains) =>
+        log.Split('\n').First(line => line.Contains(contains));
+
     private static Dictionary<IAlignmentChannel, AlignmentOverride> Run(
         TestChannel[] byBand,
         double[] crossoversHz,
@@ -263,6 +280,64 @@ public sealed class AutoAlignmentEngineTests
         Assert.DoesNotContain(
             "WARNING: fine result at the search edge", log.ToString());
         Assert.DoesNotContain("promoted", log.ToString());
+    }
+
+    [Fact]
+    public void Compute_TroughDominantLowJunction_SeedsFromTheArrivalAndFindsTheInvertedLobe()
+    {
+        // The field failure this pins (an 85 Hz junction): the upper channel
+        // is genuinely inverted and ~15 ms early, so the whitened
+        // correlation's strongest extremum is the inverted trough at the true
+        // offset while the non-inverted "peak" is only a half-period
+        // side-lobe of it. The old gate read the trough's dominance as
+        // confidence in that peak and seeded the timeline from the losing
+        // lobe, parking the fine window milliseconds short of the optimum. A
+        // trough-dominant junction must fall back to the arrival envelope,
+        // widen (WIDE SEED), and let the loss search take the inverted lobe.
+        var midbass = new TestChannel("B", DelayedImpulse(15.2));
+        var mid = new TestChannel("C", DelayedImpulse(0.0, invert: true));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([midbass, mid], [85], log);
+
+        string text = log.ToString();
+        Assert.False(alignment.ContainsKey(midbass));
+        AlignmentOverride result = alignment[mid];
+        Assert.True(result.InvertPolarity);
+        Assert.InRange(result.DelayMs, 15.0, 15.4);
+        Assert.Contains(
+            "seed arrival (inverted trough dominates)", LogLine(text, "Pair B/C"));
+        Assert.Contains("WIDE SEED", LogLine(text, "Channel C:"));
+    }
+
+    [Fact]
+    public void Compute_DominantPeakFarFromTheArrival_IsNotTrustedAsTheSeed()
+    {
+        // A low junction whose upper channel is a soft direct sound under a
+        // STRONG late reflection: the arrival detector honestly reads the
+        // direct copy (well inside its 25 dB search depth) while the whitened
+        // peak aligns the neighbor with the reflection, ~9 ms past it — a
+        // cycle-skip candidate. The fixed ±3 ms window used to exclude such a
+        // peak by construction; the period-wide window sees it, so the reach
+        // rule must refuse it and keep the TIMELINE on the arrival envelope,
+        // widened (WIDE SEED). What the loss search and the promotion then
+        // make of the deliberately ambiguous summation surface is their
+        // pinned-elsewhere business — this test pins the seed contract.
+        var midbass = new TestChannel("B", DelayedImpulse(15.0));
+        var mid = new TestChannel(
+            "C", ImpulseWithEcho(0.0, 0.35, 8.0, 1.0));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([midbass, mid], [85], log);
+
+        string text = log.ToString();
+        Assert.False(alignment.ContainsKey(midbass));
+        Assert.Contains(
+            "seed arrival (peak beyond the arrival's reach)",
+            LogLine(text, "Pair B/C"));
+        Assert.Contains("WIDE SEED", LogLine(text, "Channel C:"));
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -59,9 +59,6 @@ public sealed class AutoAlignmentEngineTests
         return ir;
     }
 
-    private static string LogLine(string log, string contains) =>
-        log.Split('\n').First(line => line.Contains(contains));
-
     private static Dictionary<IAlignmentChannel, AlignmentOverride> Run(
         TestChannel[] byBand,
         double[] crossoversHz,
@@ -307,8 +304,8 @@ public sealed class AutoAlignmentEngineTests
         Assert.True(result.InvertPolarity);
         Assert.InRange(result.DelayMs, 15.0, 15.4);
         Assert.Contains(
-            "seed arrival (inverted trough dominates)", LogLine(text, "Pair B/C"));
-        Assert.Contains("WIDE SEED", LogLine(text, "Channel C:"));
+            "seed arrival (inverted trough dominates)", TestLog.Line(text, "Pair B/C"));
+        Assert.Contains("WIDE SEED", TestLog.Line(text, "Channel C:"));
     }
 
     [Fact]
@@ -336,8 +333,8 @@ public sealed class AutoAlignmentEngineTests
         Assert.False(alignment.ContainsKey(midbass));
         Assert.Contains(
             "seed arrival (peak beyond the arrival's reach)",
-            LogLine(text, "Pair B/C"));
-        Assert.Contains("WIDE SEED", LogLine(text, "Channel C:"));
+            TestLog.Line(text, "Pair B/C"));
+        Assert.Contains("WIDE SEED", TestLog.Line(text, "Channel C:"));
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -43,9 +43,6 @@ public sealed class StereoAlignmentTests
         return ir;
     }
 
-    private static string LogLine(string log, string contains) =>
-        log.Split('\n').First(line => line.Contains(contains));
-
     private static AlignmentSnapshot Snapshot(
         TestChannel channel, AlignmentOverride over)
     {
@@ -656,12 +653,12 @@ public sealed class StereoAlignmentTests
 
         string text = log.ToString();
         // The premise: exactly the low junction fell back to the arrival seed.
-        Assert.Contains("seed arrival", LogLine(text, "Pair sub/woof"));
-        Assert.Contains("seed phat", LogLine(text, "Pair woof/mid"));
+        Assert.Contains("seed arrival", TestLog.Line(text, "Pair sub/woof"));
+        Assert.Contains("seed phat", TestLog.Line(text, "Pair woof/mid"));
 
         // Issue 1: the untrusted junction widens on the descending search of its lower
         // channel. Issue 2: the trusted junction is not polluted by its shared channel.
-        Assert.Contains("WIDE SEED", LogLine(text, "Channel sub:"));
-        Assert.DoesNotContain("WIDE SEED", LogLine(text, "Channel woof:"));
+        Assert.Contains("WIDE SEED", TestLog.Line(text, "Channel sub:"));
+        Assert.DoesNotContain("WIDE SEED", TestLog.Line(text, "Channel woof:"));
     }
 }

--- a/tests/Resonalyze.Dsp.Tests/TestLog.cs
+++ b/tests/Resonalyze.Dsp.Tests/TestLog.cs
@@ -1,0 +1,12 @@
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// Shared log-text lookups for the alignment engine test classes, which pin
+/// diagnostic markers to specific lines of the engine's run log.
+/// </summary>
+internal static class TestLog
+{
+    /// <summary>The first log line containing <paramref name="contains"/>.</summary>
+    internal static string Line(string log, string contains) =>
+        log.Split('\n').First(line => line.Contains(contains));
+}

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -969,6 +969,37 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void FindBandLimitedCorrelationDelay_FlagsWindowEdgeExtremaAsEdgePinned()
+    {
+        // The true peak sits ~4.1 ms out while the window reaches 3 ms: the
+        // argmax lands on (or one grid sample inside) the boundary — a cut
+        // through the rising lobe, not a measured extremum, so its position
+        // AND magnitude are artifacts of where the window ended. The flag is
+        // the honest signal callers gate on; re-centering the window on the
+        // true lag clears it.
+        Complex[] first = UnitImpulse(8_192, 2_000);
+        Complex[] second = UnitImpulse(8_192, 2_000 - 197);
+        const double offsetMs = 197.0 / SampleRate * 1_000.0;
+
+        CorrelationAlignmentResult pinned =
+            VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
+                first, second, SampleRate,
+                centerFrequencyHz: 100, passOctaves: 1, searchRangeMs: 3,
+                phaseTransform: true);
+        CorrelationAlignmentResult centered =
+            VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
+                first, second, SampleRate,
+                centerFrequencyHz: 100, passOctaves: 1, searchRangeMs: 3,
+                centerLagMs: offsetMs, phaseTransform: true);
+
+        Assert.True(pinned.PositivePeak.EdgePinned);
+        Assert.False(centered.PositivePeak.EdgePinned);
+        // Sub-sample refinement may move the interior peak a hair off the
+        // sample grid; the point here is the flag, not the position.
+        Assert.InRange(centered.PositivePeak.DelayMs, offsetMs - 0.05, offsetMs + 0.05);
+    }
+
+    [Fact]
     public void EstimatePolarity_ReadsTheFirstSignificantExcursion()
     {
         Complex[] positive = UnitImpulse(256, 50);

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -1000,6 +1000,38 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void FindBandLimitedCorrelationDelay_ReportsTheSamePolarityRival()
+    {
+        // Two positive copies ~a period apart in the second channel produce
+        // two same-polarity alignment lobes. The strongest OTHER lobe must
+        // come back as PositiveRival — the ambiguity peak-vs-trough
+        // Confidence cannot see — while a clean single-copy pair reports no
+        // comparable rival (kernel side structure only).
+        Complex[] first = UnitImpulse(8_192, 2_000);
+        var second = new Complex[8_192];
+        second[1_800] = 0.97;
+        second[1_236] = 1.0;
+        double centerMs = 200.0 / SampleRate * 1_000.0;
+
+        CorrelationAlignmentResult result =
+            VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
+                first, second, SampleRate,
+                centerFrequencyHz: 85, passOctaves: 3.5, searchRangeMs: 15,
+                centerLagMs: centerMs, phaseTransform: true);
+
+        Assert.NotNull(result.PositiveRival);
+        Assert.False(result.PositiveRival!.InvertPolarity);
+        Assert.True(result.PositiveRival.Coefficient > 0);
+        // The two lobes sit the copies' spacing apart and carry comparable
+        // whitened correlation — the near-tie the seed gate must refuse.
+        Assert.InRange(
+            Math.Abs(result.PositivePeak.DelayMs - result.PositiveRival.DelayMs),
+            10.0, 13.5);
+        Assert.True(
+            result.PositivePeak.Coefficient - result.PositiveRival.Coefficient < 0.2);
+    }
+
+    [Fact]
     public void EstimatePolarity_ReadsTheFirstSignificantExcursion()
     {
         Complex[] positive = UnitImpulse(256, 50);


### PR DESCRIPTION
## Why

On a real tune the Auto delay result pushed the B channel far forward on the impulse response: a 60/85 Hz crossover with heavily overlapping pair bands (30–120 / 43–170 Hz), where the B/C junction settled ~3.6 ms short and un-inverted even though **both** correlators agreed on ~15.8–16 ms **with inversion** (`invert yes`, trough −0.58 dominating peak +0.46).

Root cause: two coupled defects in the stage-1 PHAT seed.

1. **Fixed ±3 ms correlation window.** At 85 Hz the period is 11.8 ms, so ±3 ms is sub-period — it cannot hold even one full peak+trough pair. The non-inverted rival lobe was cut by the window edge; its truncated magnitude understated the rival, and the peak-vs-trough dominance was computed against that corrupted number.
2. **Trust gate blind to a dominant inverted trough.** `Confidence` picks the strongest extremum *by magnitude* (the inverted trough) but the seed always took `PositivePeak.DelayMs`. So the more convincingly the data pointed at the inverted lobe, the more confidently the engine seeded from the *losing* non-inverted one (a "flip + half-period" impostor). The seeded timeline landed a whole lobe off, and the fixed stage-2 window could no longer reach the truth.

The user's own manual fit (invert B, delay to match the sub) independently confirmed the inversion the correlators saw and the automatic run dropped.

## What changed

**`dsp/AutoAlignmentEngine.cs`**
- Stage-1 correlation window is now adaptive: `±max(3 ms, 1.25 × period(fc))` (`SeedCorrelationRangeMs`). Mid/high junctions keep the ±3 ms floor (already many periods there); low junctions grow so both polarity partners appear as whole lobes and dominance becomes meaningful.
- The seed trust gate is an ordered set of guard clauses, each returning a logged reason, checked in the order earlier ones corrupt later inputs: `edge-pinned extremum` → `inverted trough dominates` → `peak too weak` → `peak-trough near-tie` → `peak beyond the arrival's reach`. Any distrust falls back to the arrival envelope and marks the junction WIDE SEED (widening stage-2 to admit the true lobe), exactly the existing low-junction recovery path.
- The seed-peak reach bound is a named helper `SeedPeakReachMs` = `max(3 ms, ½ period)` — the no-cycle-skip half period, floored at the *fixed* window span so a grown window may *see* farther lobes but never hands one to the timeline.
- Wide diagnostic sweep grows to `1.25 × halfPeriod` at low junctions so the `[diag]` log line can actually surface the optimum it exists to show.

**`dsp/VirtualCrossoverAnalysis.cs`**
- `CorrelationDelayCandidate` gains an `EdgePinned` flag, set when an extremum sits within a couple of samples of the lag-window boundary (a cut through a lobe, not a measured extremum). Edge-pinned extrema keep their integer lag (no sub-sample refinement of a truncated lobe) and are distrusted by the seed gate. The guard floors so a degenerate few-sample window can't flag its own center.
- Diagnostic log prints the window width and an `edge` marker.

## Behavior change

Auto delay proposals shift for **low crossovers with wide overlapping bands** where the old fixed window mis-seeded — the intended fix. The regression suite (including the real-cabin measurements in the `assets/test_data` submodule) pins that the corrected junctions stay on the direct-arrival lobe and that mid/high junctions are unaffected (they already spanned several periods). Log format is additive; no `source/` UI parses it.

## Tests

- `Compute_TroughDominantLowJunction_SeedsFromTheArrivalAndFindsTheInvertedLobe` — mirror of the field failure (85 Hz, inverted upper channel): now seeds from the arrival, widens, and lands on the inverted lobe.
- `Compute_DominantPeakFarFromTheArrival_IsNotTrustedAsTheSeed` — a strong reflection past the arrival's reach is refused as a cycle-skip seed.
- `FindBandLimitedCorrelationDelay_FlagsWindowEdgeExtremaAsEdgePinned` — the edge flag is set for a truncated lobe and cleared when the window re-centers.
- Shared `TestLog.Line` helper deduplicates the per-class log-line lookup.

Full solution builds (`-p:EnableWindowsTargeting=true`); **648/648** DSP tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeEcKvVjJbNntVcqfiCrJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeEcKvVjJbNntVcqfiCrJZ)_