### PR TITLE
Auto delay: fence the invert-preference swap by arrival reach

### DIFF
--- a/dsp/AlignmentSelection.cs
+++ b/dsp/AlignmentSelection.cs
@@ -17,9 +17,29 @@ public static class AlignmentSelection
     /// driver wins by the full arrival-prior penalty of its non-inverted
     /// impostors — several dB, not fractions. Same envelope-first principle
     /// as the wide-window promotion margin: a half-period flip hop must be
-    /// plainly better, not marginally.
+    /// plainly better, not marginally. That "several dB" premise only holds
+    /// near the arrival: a WIDE-SEED search dilutes the prior (sigma scales
+    /// with the window), so the margin is additionally fenced by
+    /// <see cref="DefaultInvertPreferenceReachMs"/>.
     /// </summary>
     public const double DefaultInvertPreferenceMarginDb = 0.5;
+
+    /// <summary>
+    /// How much farther from the arrival estimate (ms) a non-inverted rescue
+    /// may sit than the inverted winner it replaces. The invert margin's
+    /// rationale assumes the rescue IS the arrival-proximal candidate being
+    /// narrowly outscored by a flip impostor; when the best non-inverted
+    /// alternative instead lies a distant lobe away, swapping trades
+    /// milliseconds of envelope alignment for polarity cosmetics. The field
+    /// failure that pinned this: an 80 Hz sub/midbass junction where the
+    /// inverted winner sat 0.79 ms from the arrival and the margin (0.03 dB!)
+    /// handed the result to a non-inverted lobe 4.98 ms out — the sub started
+    /// 5 ms behind the midbass. The reach is absolute, not period-scaled,
+    /// because the audible cost (transient smear) is absolute: legitimate flip
+    /// rescues at mid/tweeter junctions sit within a fraction of a ms, while a
+    /// low junction's half-period hop costs several.
+    /// </summary>
+    public const double DefaultInvertPreferenceReachMs = 0.75;
 
     /// <summary>
     /// Among same-polarity candidates within this score margin (dB), the one
@@ -31,13 +51,17 @@ public static class AlignmentSelection
     /// <summary>
     /// Selects from <paramref name="candidates"/> (must be non-empty, best
     /// first): prefers a non-inverted candidate over an inverted winner within
-    /// the invert margin, then breaks near-ties of the chosen polarity by
-    /// closeness to <paramref name="baseDeltaMs"/>.
+    /// the invert margin — but only a candidate that does not sit more than
+    /// <paramref name="invertPreferenceReachMs"/> farther from
+    /// <paramref name="baseDeltaMs"/> than the winner it replaces — then
+    /// breaks near-ties of the chosen polarity by closeness to
+    /// <paramref name="baseDeltaMs"/>.
     /// </summary>
     public static AlignmentCandidate Select(
         IReadOnlyList<AlignmentCandidate> candidates,
         double baseDeltaMs,
         double invertPreferenceMarginDb = DefaultInvertPreferenceMarginDb,
+        double invertPreferenceReachMs = DefaultInvertPreferenceReachMs,
         double delayTieMarginDb = DefaultDelayTieMarginDb)
     {
         ArgumentNullException.ThrowIfNull(candidates);
@@ -51,8 +75,11 @@ public static class AlignmentSelection
         AlignmentCandidate best = candidates[0];
         if (best.InvertPolarity)
         {
+            double bestDistanceMs = Math.Abs(best.DelayMs - baseDeltaMs);
             AlignmentCandidate? bestNormal = candidates
-                .Where(item => !item.InvertPolarity)
+                .Where(item => !item.InvertPolarity &&
+                    Math.Abs(item.DelayMs - baseDeltaMs) - bestDistanceMs <=
+                        invertPreferenceReachMs)
                 .OrderByDescending(item => item.ScoreDb)
                 .FirstOrDefault();
             if (bestNormal != null &&
@@ -67,6 +94,38 @@ public static class AlignmentSelection
                 item.ScoreDb >= best.ScoreDb - delayTieMarginDb)
             .OrderBy(item => Math.Abs(item.DelayMs - baseDeltaMs))
             .First();
+    }
+
+    /// <summary>
+    /// The non-inverted candidate the invert preference would have adopted
+    /// under the score margin alone, when the reach gate blocked every
+    /// eligible rescue — null when no rescue was in margin, or when one within
+    /// reach exists (so <see cref="Select"/> swapped instead of declining).
+    /// Purely diagnostic: lets the caller log WHY an inverted winner stood.
+    /// </summary>
+    public static AlignmentCandidate? DeclinedInvertRescue(
+        IReadOnlyList<AlignmentCandidate> candidates,
+        double baseDeltaMs,
+        double invertPreferenceMarginDb = DefaultInvertPreferenceMarginDb,
+        double invertPreferenceReachMs = DefaultInvertPreferenceReachMs)
+    {
+        ArgumentNullException.ThrowIfNull(candidates);
+        if (candidates.Count == 0 || !candidates[0].InvertPolarity)
+        {
+            return null;
+        }
+
+        AlignmentCandidate best = candidates[0];
+        double bestDistanceMs = Math.Abs(best.DelayMs - baseDeltaMs);
+        List<AlignmentCandidate> inMargin = candidates
+            .Where(item => !item.InvertPolarity &&
+                item.ScoreDb >= best.ScoreDb - invertPreferenceMarginDb)
+            .ToList();
+        return inMargin.Count == 0 || inMargin.Any(item =>
+                Math.Abs(item.DelayMs - baseDeltaMs) - bestDistanceMs <=
+                    invertPreferenceReachMs)
+            ? null
+            : inMargin.OrderByDescending(item => item.ScoreDb).First();
     }
 
     /// <summary>

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -779,6 +779,18 @@ public static class AutoAlignmentEngine
                     $"{(candidates[0].InvertPolarity ? " inv" : "")} " +
                     $"(margin {candidates[0].ScoreDb - chosen.ScoreDb:0.00} dB)");
             }
+            else if (candidates.Count > 0 && chosen.InvertPolarity &&
+                AlignmentSelection.DeclinedInvertRescue(candidates, anchorMs)
+                    is { } rescue)
+            {
+                log.AppendLine(
+                    $"  kept {chosen.DelayMs:0.000} ms inv: rescue " +
+                    $"{rescue.DelayMs:0.000} ms " +
+                    $"(margin {chosen.ScoreDb - rescue.ScoreDb:0.00} dB) is " +
+                    $"{Math.Abs(rescue.DelayMs - anchorMs) - Math.Abs(chosen.DelayMs - anchorMs):0.000} ms " +
+                    "farther from the arrival (reach " +
+                    $"{AlignmentSelection.DefaultInvertPreferenceReachMs:0.00} ms)");
+            }
 
             // Wide sweep: the same junction searched across a much wider
             // window so lobes beyond the working range appear in the log.

--- a/tests/Resonalyze.Dsp.Tests/AlignmentSelectionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AlignmentSelectionTests.cs
@@ -89,6 +89,77 @@ public sealed class AlignmentSelectionTests
         Assert.Equal(invertedFar, chosen);
     }
 
+    [Fact]
+    public void Select_KeepsTheInvertedWinnerWhenTheRescueIsBeyondTheArrivalReach()
+    {
+        // The 80 Hz sub/midbass field failure verbatim: the inverted winner
+        // sits 0.79 ms from the arrival (the whitened correlation put its
+        // trough at r -0.97 there), while the best non-inverted candidate is a
+        // lobe 4.98 ms out that the WIDE-SEED-diluted prior let within
+        // 0.03 dB. Swapping parked the sub 5 ms behind the midbass; the reach
+        // gate must keep the inverted winner.
+        var inverted = new AlignmentCandidate(0.499, true, -1.06);
+        var normalFar = new AlignmentCandidate(-3.694, false, -1.10);
+        var normalWorse = new AlignmentCandidate(4.752, false, -2.49);
+
+        AlignmentCandidate chosen = AlignmentSelection.Select(
+            [inverted, normalFar, normalWorse], baseDeltaMs: 1.285);
+
+        Assert.Equal(inverted, chosen);
+    }
+
+    [Fact]
+    public void Select_SwapsToACloserRescueWhenTheBestNormalIsBeyondReach()
+    {
+        // The reach gate filters candidates, not the preference itself: with
+        // the best-scoring non-inverted lobe beyond reach, a lower-scoring one
+        // near the arrival still rescues the polarity.
+        var inverted = new AlignmentCandidate(0.5, true, -1.0);
+        var normalFar = new AlignmentCandidate(-3.7, false, -1.1);
+        var normalNear = new AlignmentCandidate(0.9, false, -1.45);
+
+        AlignmentCandidate chosen = AlignmentSelection.Select(
+            [inverted, normalFar, normalNear], baseDeltaMs: 1.285);
+
+        Assert.Equal(normalNear, chosen);
+    }
+
+    [Fact]
+    public void DeclinedInvertRescue_ReportsTheBlockedSwap()
+    {
+        var inverted = new AlignmentCandidate(0.499, true, -1.06);
+        var normalFar = new AlignmentCandidate(-3.694, false, -1.10);
+
+        AlignmentCandidate? declined = AlignmentSelection.DeclinedInvertRescue(
+            [inverted, normalFar], baseDeltaMs: 1.285);
+
+        Assert.Equal(normalFar, declined);
+    }
+
+    [Fact]
+    public void DeclinedInvertRescue_IsNullWhenAReachableRescueExists()
+    {
+        // A within-reach normal candidate means Select swapped rather than
+        // declined — nothing to report even though a farther one also sits in
+        // margin.
+        var inverted = new AlignmentCandidate(0.5, true, -1.0);
+        var normalFar = new AlignmentCandidate(-3.7, false, -1.1);
+        var normalNear = new AlignmentCandidate(0.9, false, -1.45);
+
+        Assert.Null(AlignmentSelection.DeclinedInvertRescue(
+            [inverted, normalFar, normalNear], baseDeltaMs: 1.285));
+    }
+
+    [Fact]
+    public void DeclinedInvertRescue_IsNullWithoutAMarginNormal()
+    {
+        var inverted = new AlignmentCandidate(0.5, true, -1.0);
+        var normalOutscored = new AlignmentCandidate(-3.7, false, -1.9);
+
+        Assert.Null(AlignmentSelection.DeclinedInvertRescue(
+            [inverted, normalOutscored], baseDeltaMs: 1.285));
+    }
+
     // AutoAlignmentEngine.AcousticScore: the prior-free figure the promotion
     // compares across search windows.
     private static double AcousticScore(AlignmentCandidate candidate) =>

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentRealDataTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentRealDataTests.cs
@@ -20,8 +20,8 @@ public sealed class StereoAlignmentRealDataTests
         Complex[] RawIr,
         DspChannelChain BaseChain) : IAlignmentChannel;
 
-    private static CrossoverEdge Bw(double frequencyHz) =>
-        new(CrossoverFilterFamily.Butterworth, frequencyHz, 24);
+    private static CrossoverEdge Bw(double frequencyHz, int slopeDbPerOctave = 24) =>
+        new(CrossoverFilterFamily.Butterworth, frequencyHz, slopeDbPerOctave);
 
     [Fact]
     public void ComputeStereo_RealCabin_BridgesTheTweetersAndKeepsTheMonoSub()
@@ -219,6 +219,111 @@ public sealed class StereoAlignmentRealDataTests
             final.First(item => item.Channel == rightTwr).ImpulseResponse,
             rightTwr.SampleRate, BridgeBandLowHz, BridgeBandHighHz);
         Assert.InRange(leftTwrArrival - rightTwrArrival, 0.15, 0.35);
+    }
+
+    [Fact]
+    public void Compute_RealCabin_SubJunctionKeepsTheInvertedLobeNearTheArrival()
+    {
+        // The field failure of 2026-07-17 verbatim: the user's 4-way left side
+        // (sub LP 80 Bw24, woof 80 Bw24 / 220 Bw36, mid 200 Bw24 / 1500 Bw36
+        // at -3.5 dB, twr HP 1900 Bw36 at -7.5 dB). At the 80 Hz sub/woofer
+        // junction the whitened correlation is decisively inverted near the
+        // arrival (trough r -0.97 at -0.28 ms), and the fine search ranks that
+        // lobe first (0.499 ms inv). But the WIDE-SEED window dilutes the
+        // arrival prior enough that a non-inverted lobe 4.98 ms out came
+        // within 0.03 dB, and the invert preference swapped onto it — parking
+        // the sub 5 ms behind the woofer on the impulse view. The reach gate
+        // must decline that swap and keep the near-arrival inverted lobe.
+        Channel Load(string file, string name, DspChannelChain chain)
+        {
+            (int rate, Complex[] ir) = LoadTransferIr(file);
+            return new Channel(name, rate, ir, chain);
+        }
+
+        Channel sub = Load("sub woof closed window.json", "sub", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.LowPass, Bw(80))));
+        Channel woof = Load("l woof.json", "L woof", new DspChannelChain(
+            Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(220, 36), Bw(80))));
+        Channel mid = Load("l mid.json", "L mid", new DspChannelChain(
+            GainDb: -3.5,
+            Crossover: new CrossoverSpec(CrossoverKind.BandPass, Bw(1_500, 36), Bw(200))));
+        Channel twr = Load("l twr.json", "L twr", new DspChannelChain(
+            GainDb: -7.5,
+            Crossover: new CrossoverSpec(CrossoverKind.HighPass, HighPassEdge: Bw(1_900, 36))));
+
+        Channel[] byBand = [sub, woof, mid, twr];
+        var cache = new Dictionary<(Channel, double, bool), AlignmentSnapshot>();
+        AlignmentSnapshot Snapshot(Channel channel, AlignmentOverride over)
+        {
+            (Channel, double, bool) key = (channel, over.DelayMs, over.InvertPolarity);
+            if (!cache.TryGetValue(key, out AlignmentSnapshot? hit))
+            {
+                Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(
+                    channel.RawIr,
+                    channel.BaseChain with
+                    {
+                        DelayMs = over.DelayMs,
+                        InvertPolarity = over.InvertPolarity
+                    },
+                    channel.SampleRate);
+                hit = new AlignmentSnapshot(
+                    channel, processed, VirtualCrossoverAnalysis.FindPeakIndex(processed));
+                cache[key] = hit;
+            }
+
+            return hit;
+        }
+
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            byBand.Select(channel =>
+                Snapshot(channel, overrides.GetValueOrDefault(channel))).ToList();
+
+        List<AlignmentSnapshot> snapshots = byBand
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        double[] crossovers = [80, 220, 1_500];
+        List<AlignmentJunction> junctions = crossovers
+            .Select((fc, i) => new AlignmentJunction(
+                snapshots[i], snapshots[i + 1], fc,
+                Math.Max(20, fc / 2), Math.Min(20_000, fc * 2)))
+            .ToList();
+
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        var log = new StringBuilder();
+        AutoAlignmentEngine.Compute(snapshots, junctions, Reprocess, alignment, log);
+
+        // The declined swap leaves its trace: the rescue was in margin but
+        // beyond the arrival reach.
+        Assert.Contains("farther from the arrival", log.ToString());
+
+        // The sub junction flips (the woofer relative to the reference sub) —
+        // and the flip stays contained there: the cascade compensates the
+        // mid's polarity by delay, not by rippling the inversion upward.
+        Assert.True(
+            alignment.GetValueOrDefault(woof).InvertPolarity !=
+            alignment.GetValueOrDefault(sub).InvertPolarity,
+            "The sub/woofer junction lost its inverted near-arrival lobe.");
+        Assert.Equal(
+            alignment.GetValueOrDefault(mid).InvertPolarity,
+            alignment.GetValueOrDefault(sub).InvertPolarity);
+        Assert.Equal(
+            alignment.GetValueOrDefault(twr).InvertPolarity,
+            alignment.GetValueOrDefault(sub).InvertPolarity);
+
+        // THE regression: with the final delays applied, the sub's band-limited
+        // arrival stays within a cabin-width of the woofer's (the fix lands at
+        // +0.79 ms; the failure sat at +4.98, the mirrored lobe at -5.75).
+        IReadOnlyList<AlignmentSnapshot> final = Reprocess(alignment);
+        double subArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            final[0].ImpulseResponse, sub.SampleRate, 40, 160);
+        double woofArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            final[1].ImpulseResponse, woof.SampleRate, 40, 160);
+        Assert.InRange(subArrival - woofArrival, -2.5, 2.5);
+
+        // Still a physically realizable, normalized field.
+        Assert.All(byBand, channel =>
+            Assert.True(alignment.GetValueOrDefault(channel).DelayMs >= 0));
     }
 
     [Fact]


### PR DESCRIPTION
## Field failure

The 2026-07-17 run (sub LP 80 Bw24, woof 80 Bw24 / 220 Bw36, mid 200 Bw24 / 1500 Bw36, twr 1900 Bw36) parked the sub ~5 ms behind the midbass. The engine actually found the correct alignment — the whitened correlation is decisively inverted near the arrival (trough r −0.97 at −0.28 ms) and the fine search ranked that lobe first (`0.499 ms inv`) — but the invert-preference swap handed the result to a non-inverted lobe 4.98 ms out that the WIDE-SEED window's diluted prior (sigma scales with the window) let within 0.03 dB.

## Fix

The invert preference's own rationale assumes the rescue is the arrival-proximal candidate being narrowly outscored by a flip impostor. `AlignmentSelection.Select` now only swaps to a non-inverted candidate sitting at most `DefaultInvertPreferenceReachMs` (0.75 ms) farther from the arrival estimate than the inverted winner it replaces. The reach is absolute rather than period-scaled: the audible cost (transient smear) is absolute, and legitimate flip rescues at mid/tweeter junctions sit within a fraction of a ms.

A declined swap leaves a trace (`kept 0.499 ms inv: rescue -3.694 ms (margin 0.03 dB) is 4.193 ms farther from the arrival`), reported via the new diagnostic `AlignmentSelection.DeclinedInvertRescue`.

## Validation on the real cabin IRs

- Reproduced the field run number-for-number from `assets/test_data` (same candidates, same 0.03 dB margin); pre-fix sub↔woofer arrival gap **+4.98 ms**, post-fix **+0.79 ms**, with the inversion contained at the sub junction (the mid compensates by delay, not by rippling the flip upward).
- Legitimate swaps survive: the C/D junction swap (0.27 ms) and both pre-existing real-cabin stereo regressions (`BridgesTheTweetersAndKeepsTheMonoSub`, `LowJunctionSeedDoesNotFlipTheWoofers`) pass unchanged.

## Tests

656/656 DSP tests green, 6 new:
- `AlignmentSelectionTests`: the field numbers verbatim (keep the inverted winner beyond reach; swap to a closer in-margin rescue; `DeclinedInvertRescue` reporting contract).
- `StereoAlignmentRealDataTests.Compute_RealCabin_SubJunctionKeepsTheInvertedLobeNearTheArrival`: the field config on the real measurements — declined-swap log marker, inversion only at the sub junction, sub arrival within a cabin-width of the woofer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeEcKvVjJbNntVcqfiCrJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeEcKvVjJbNntVcqfiCrJZ)_