### PR TITLE
SPL: acoustic-calibrator calibration and a dB SPL frequency-response scale

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -304,6 +304,24 @@ Car / CarMild / XCurve presets cover it), and HP/LP filter types (crossover tool
 
 ## Live Spectrum / coherence
 
+- [ ] **RTA tone level is only accurate with a Flat Top window — periodic pink
+  forces rectangular, so it cannot carry dB SPL there.** RESOLVED for the general
+  case: Flat Top is a selectable Live Spectrum window and reads a tone at its true,
+  FFT-length-independent amplitude. Validated against the SPL calibrator on white
+  noise + Flat Top + smoothing OFF: the RTA read the 94 dB tone at −12.63 dB, the
+  flat-top calibration at −13 dBFS — 0.37 dB agreement, confirming the calibration
+  and the RTA are consistent end-to-end. (Two gotchas seen while validating, both
+  expected: a rectangular window scallops an off-bin tone ~2.4 dB low; and smoothing
+  dilutes a pure-tone spike more at finer resolution — 1024→−14.8, 2048→−19.6,
+  4096→−25.2 dB — so smoothing must be OFF to read a tone level.)
+  Residual: periodic pink pins the window to rectangular (leakage-free and correct
+  for the transfer function), and the RTA shares that windowed FFT, so it cannot use
+  Flat Top in that mode. If Live Spectrum ever gets its own dB SPL scale (as
+  Frequency Response now has) AND periodic-pink tone accuracy is wanted, decouple the
+  RTA window from the transfer: a separate flat-top mic FFT for the input magnitude
+  (computed only when the RTA is shown), leaving the transfer/coherence on
+  rectangular. Real swept measurements are unaffected either way (the deconvolved
+  transfer has no single-tone scalloping).
 - [ ] **EMA coherence has no effective average count** (overlap-correlated
   frames, alpha-dependent memory): expose K_eff ≈ (2−α)/α (reduced for overlap)
   alongside the curve and feed it to the same debias the sweep path uses.

--- a/dsp/DataHelper.Resampling.cs
+++ b/dsp/DataHelper.Resampling.cs
@@ -148,6 +148,205 @@ namespace Resonalyze.Dsp
             return output;
         }
 
+        /// <summary>
+        /// FFT-size-independent band levels for an RTA shown in absolute units, ABOVE the
+        /// FFT resolution limit. Where <see cref="LogarithmicResample"/> interpolates and
+        /// averages AMPLITUDE (correct for a relative / transfer trace), this integrates
+        /// POWER over each display band, so a broadband level does not shift with the FFT
+        /// length: the summed bin power in a fixed frequency band is invariant to N (at
+        /// higher N there are more, narrower bins, each carrying proportionally less
+        /// power). The summed power is divided by the window's equivalent noise bandwidth
+        /// so a noise band reads its true power rather than the coherent-gain (tone)
+        /// over-estimate, while a bin-centred full-scale tone under a rectangular
+        /// window still reads its calibrated level. Each bin contributes only the fraction
+        /// of its power overlapping the band, and no band is narrower than the window's
+        /// spectral main lobe, so the level is continuous (no jump as a bin centre crosses
+        /// a band edge), never sub-bin, and a tone keeps its whole main lobe.
+        /// <para>
+        /// The N-invariance holds only where the fixed <c>1/12</c>-octave reference band is
+        /// WIDER than that main lobe. Below the crossover (a low frequency, a long window
+        /// such as Flat Top, or a short FFT) the band is floored to the main lobe, whose
+        /// width in Hz — <c>mainLobeBins·Fs/N</c> — DOES shrink with N, so a broadband
+        /// level there drops ~3 dB per doubling of N. This is the unavoidable resolution
+        /// limit of a single FFT (the <c>1/12</c>-octave band is simply finer than the FFT
+        /// resolves), shared by every FFT RTA, and it is the deliberate cost of the
+        /// main-lobe floor: without it a coherent tone in that region would read low. Use a
+        /// longer FFT for finer low-frequency resolution.
+        /// </para>
+        /// The
+        /// integration band is a FIXED reference resolution, NOT the display smoothing:
+        /// because band power grows with bandwidth, tying it to smoothing would lift a
+        /// quiet spectrum by many dB. <paramref name="smoothingOctaves"/> instead applies
+        /// afterwards as a level-preserving dB average that only smooths scatter. The grid
+        /// is bounded so every emitted band fits WHOLE inside the resolved range: none
+        /// straddles Nyquist or DC (a half-empty band would show a false roll-off on a flat
+        /// input), and nothing above the last bin is synthesized from it.
+        /// <para>
+        /// Returns RELATIVE band levels in dB (<c>10·log10</c> of the band power); the
+        /// caller adds any microphone-calibration correction and the SPL offset.
+        /// </para>
+        /// </summary>
+        /// <param name="amplitudeSpectrum">
+        /// Tone-calibrated amplitude per bin (index = bin, 0..N/2), as produced by
+        /// <c>SpectrumAnalysis.ComputeInputMagnitudeSpectrum</c>.
+        /// </param>
+        public static List<SignalPoint> LogarithmicPowerBandResample(
+            IReadOnlyList<double> amplitudeSpectrum,
+            int fftLength,
+            int sampleRate,
+            double windowEnbwBins,
+            double windowMainLobeBins,
+            double start,
+            double stop,
+            int steps,
+            double smoothingOctaves)
+        {
+            ArgumentNullException.ThrowIfNull(amplitudeSpectrum);
+            if (steps < 2)
+            {
+                throw new ArgumentOutOfRangeException(nameof(steps));
+            }
+
+            var output = new List<SignalPoint>(steps);
+            double binWidth = fftLength > 0 ? (double)sampleRate / fftLength : 0.0;
+            int maxBin = Math.Min(amplitudeSpectrum.Count - 1, fftLength / 2);
+            if (binWidth <= 0.0 || maxBin < 1 || start <= 0.0 || stop <= start)
+            {
+                return output;
+            }
+
+            double enbw = windowEnbwBins > 0.0 ? windowEnbwBins : 1.0;
+
+            // The window's spectral resolution, in Hz: the main-lobe width, not the
+            // (narrower) equivalent NOISE bandwidth. A band is never integrated narrower
+            // than this, so a sub-bin band does not read a random fraction of a bin, and
+            // a coherent tone keeps its whole main lobe.
+            double mainLobeBins = windowMainLobeBins > 0.0 ? windowMainLobeBins : 1.0;
+            double resolutionHz = mainLobeBins * binWidth;
+
+            // The band the power is integrated over is a FIXED reference resolution — a
+            // fixed fractional octave, widened to the window main lobe or the grid cell
+            // where those are coarser — NOT the display smoothing. Tying the band to
+            // smoothing lifts the level, because band power grows with bandwidth: a wide
+            // smoothing swept ever more Hz into each band and raised a quiet spectrum by
+            // many dB at high frequencies. Smoothing is applied afterwards, as a
+            // level-preserving average that only smooths scatter.
+            const double referenceBandOctaves = 1.0 / 12.0;
+
+            double preliminaryStop = Math.Min(stop, maxBin * binWidth);
+            if (preliminaryStop <= start)
+            {
+                return output;
+            }
+
+            double gridHalfOctaves = 0.5 * Math.Log2(preliminaryStop / start) / (steps - 1);
+            double halfOctaves = Math.Max(gridHalfOctaves, referenceBandOctaves * 0.5);
+            double upperFactor = Math.Pow(2.0, halfOctaves);
+            double lowerFactor = 1.0 / upperFactor;
+
+            // Keep the WHOLE band inside the resolved spectrum, not just its centre. A
+            // band whose fractional-octave OR main-lobe width spilled past the last bin
+            // (near Nyquist) or below the first bin (near 20 Hz with a wide main lobe)
+            // would integrate a half-empty band and show a false roll-off on an input
+            // that is actually flat. Bound the centre so both the octave band
+            // [f/upperFactor, f·upperFactor] and the resolution band [f ± resolutionHz/2]
+            // fit within the resolved range [firstBinLowEdge, lastBinHighEdge].
+            double lowerEdge = 0.5 * binWidth;
+            double upperEdge = (maxBin + 0.5) * binWidth;
+            double effectiveStart = Math.Max(
+                start,
+                Math.Max(lowerEdge * upperFactor, lowerEdge + resolutionHz * 0.5));
+            double effectiveStop = Math.Min(
+                stop,
+                Math.Min(upperEdge / upperFactor, upperEdge - resolutionHz * 0.5));
+            if (effectiveStop <= effectiveStart)
+            {
+                return output;
+            }
+
+            // First pass: the fixed-resolution band POWER (linear) at each grid point.
+            var frequencies = new double[steps];
+            var bandPowers = new double[steps];
+            for (int i = 0; i < steps; i++)
+            {
+                double frequency = LogPositionToFrequency(i / (steps - 1.0), effectiveStart, effectiveStop);
+                frequencies[i] = frequency;
+                double lowFrequency = frequency * lowerFactor;
+                double highFrequency = frequency * upperFactor;
+                if (highFrequency - lowFrequency < resolutionHz)
+                {
+                    double half = resolutionHz * 0.5;
+                    lowFrequency = frequency - half;
+                    highFrequency = frequency + half;
+                }
+
+                // Integrate the fraction of every bin's power that overlaps the band —
+                // each bin owns the frequency interval [(k-½)·Δf, (k+½)·Δf], and only
+                // its overlap with the band counts — so the level is continuous as
+                // bins cross band edges instead of jumping when a centre lands inside.
+                // Dividing by the window ENBW turns the coherent-gain bin power into
+                // true band power (a rectangular-window tone still reads its level).
+                double bandPower = 0.0;
+                int firstBin = Math.Max(1, (int)Math.Ceiling(lowFrequency / binWidth - 0.5));
+                int lastBin = Math.Min(maxBin, (int)Math.Floor(highFrequency / binWidth + 0.5));
+                for (int bin = firstBin; bin <= lastBin; bin++)
+                {
+                    double binLow = (bin - 0.5) * binWidth;
+                    double binHigh = (bin + 0.5) * binWidth;
+                    double overlap =
+                        Math.Min(highFrequency, binHigh) - Math.Max(lowFrequency, binLow);
+                    if (overlap <= 0.0)
+                    {
+                        continue;
+                    }
+
+                    double amplitude = amplitudeSpectrum[bin];
+                    bandPower += amplitude * amplitude * (overlap / binWidth);
+                }
+
+                bandPowers[i] = bandPower / enbw;
+            }
+
+            // Second pass: display smoothing as a level-preserving moving MEAN of the
+            // band POWERS over the requested fractional octave. A mean (not a sum) leaves
+            // a flat or sloped spectrum's level unchanged and only smooths scatter; a
+            // tone is diluted toward the surrounding level, as any smoothing softens a
+            // spike. Averaging in the power domain (not dB) keeps a silent neighbour at
+            // zero power rather than -160 dB, so it does not swamp a nearby tone. It never
+            // lifts the level the way widening the integration band would.
+            double octavesPerStep = Math.Log2(effectiveStop / effectiveStart) / (steps - 1);
+            int smoothingHalfSteps = smoothingOctaves > 0.0 && octavesPerStep > 0.0
+                ? (int)Math.Round(smoothingOctaves * 0.5 / octavesPerStep)
+                : 0;
+
+            // 10·log10(power) == 20·log10(sqrt(power)); reuse the amplitude floor.
+            if (smoothingHalfSteps <= 0)
+            {
+                for (int i = 0; i < steps; i++)
+                {
+                    output.Add(new SignalPoint(frequencies[i], AmplitudeToDecibels(Math.Sqrt(bandPowers[i]))));
+                }
+
+                return output;
+            }
+
+            var prefix = new double[steps + 1];
+            for (int i = 0; i < steps; i++)
+            {
+                prefix[i + 1] = prefix[i] + bandPowers[i];
+            }
+
+            for (int i = 0; i < steps; i++)
+            {
+                int lowIndex = Math.Max(0, i - smoothingHalfSteps);
+                int highIndex = Math.Min(steps - 1, i + smoothingHalfSteps);
+                double mean = (prefix[highIndex + 1] - prefix[lowIndex]) / (highIndex - lowIndex + 1);
+                output.Add(new SignalPoint(frequencies[i], AmplitudeToDecibels(Math.Sqrt(mean))));
+            }
+
+            return output;
+        }
+
         public static List<SignalPoint> SmoothLinear(List<SignalPoint> input, double smoothingOctaves = 1.0 / 6.0)
         {
             if (input.Count < 2)

--- a/dsp/DataHelper.cs
+++ b/dsp/DataHelper.cs
@@ -13,6 +13,17 @@ namespace Resonalyze.Dsp
         Degrees90
     }
 
+    /// <summary>
+    /// The vertical scale of a frequency-response plot: the native
+    /// loopback-referenced dB (the default), or absolute dB SPL derived from the
+    /// microphone SPL calibration.
+    /// </summary>
+    public enum MagnitudeScale
+    {
+        Relative,
+        SoundPressureLevel
+    }
+
     public sealed class FrequencyResponseOptions
     {
         public int Window { get; set; } = 4096;
@@ -31,6 +42,11 @@ namespace Resonalyze.Dsp
                 ? MicrophoneCalibrationMode.Degrees0
                 : MicrophoneCalibrationMode.Off;
         }
+
+        // Whether the magnitude plot reads in native loopback-referenced dB or in
+        // absolute dB SPL. Presentation only: the curves are computed the same way,
+        // then shifted to SPL at draw time when a valid calibration is available.
+        public MagnitudeScale MagnitudeScale { get; set; } = MagnitudeScale.Relative;
 
         // Phase-mode windowing (milliseconds): the Tukey gate is left + plateau + right
         // with the peak at the fade-in/plateau boundary. PhaseDetrendMs is the τ used

--- a/dsp/SpectrumAnalysis.cs
+++ b/dsp/SpectrumAnalysis.cs
@@ -177,6 +177,42 @@ public static class SpectrumAnalysis
     }
 
     /// <summary>
+    /// The single-channel auto-power spectrum <c>|FFT(x·w)|²</c> of one captured
+    /// channel, one value per bin (0..N/2). This is exactly the target auto-power
+    /// <see cref="ComputeTransferSpectrumFrame"/> produces, but with a single FFT: a
+    /// reference-free RTA needs no cross-spectrum, reference power or coherence, so a
+    /// mic-only capture accumulates just this.
+    /// </summary>
+    public static double[] ComputeAutoPowerSpectrumFrame(
+        IReadOnlyList<float> samples,
+        WindowType windowType = WindowType.Hann)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        if (samples.Count == 0)
+        {
+            throw new ArgumentException("Samples must not be empty.", nameof(samples));
+        }
+
+        double[] window = Windowing.SharedAnalysisWindow(windowType, samples.Count);
+        var spectrum = new Complex[samples.Count];
+        for (int i = 0; i < samples.Count; i++)
+        {
+            spectrum[i] = new Complex(samples[i] * window[i], 0.0);
+        }
+
+        Fourier.Forward(spectrum, FourierOptions.Matlab);
+
+        int binCount = samples.Count / 2;
+        var power = new double[binCount];
+        for (int i = 0; i < binCount; i++)
+        {
+            power[i] = spectrum[i].Magnitude * spectrum[i].Magnitude;
+        }
+
+        return power;
+    }
+
+    /// <summary>
     /// Computes the magnitude-squared coherence γ² from averaged cross- and
     /// auto-spectra: |&lt;Sxy&gt;|² / (&lt;Sxx&gt;·&lt;Syy&gt;). The inputs must
     /// be accumulated over several frames; for a single frame coherence is

--- a/dsp/SplConversion.cs
+++ b/dsp/SplConversion.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// Places the loopback-referenced frequency-response curves on an absolute
+/// dB SPL axis.
+/// <para>
+/// The primary magnitude is a transfer function (microphone ÷ loopback), so its
+/// dB is relative (dBr); one per-measurement offset turns it into SPL:
+/// <c>K = loopbackPeakDbFs + calibrationOffsetDb</c>. The distortion and noise
+/// traces are ratios to the fundamental (dBc); adding the primary's own SPL at
+/// their frequency turns each ratio into an absolute level, so the whole plot
+/// reads in dB SPL. Any per-frequency microphone correction cancels: it is already
+/// in the displayed primary, so it rides along without entering <c>K</c>.
+/// </para>
+/// </summary>
+public static class SplConversion
+{
+    /// <summary>
+    /// Returns the curves converted to dB SPL using <paramref name="offsetDb"/>
+    /// (the measurement's <c>K</c>). The primary shifts by <c>K</c>; every
+    /// fundamental-relative curve is lifted by the primary's SPL at its own
+    /// frequency. Curves that carry no absolute reference and have no primary to
+    /// anchor to are returned unchanged — the caller decides whether SPL is
+    /// available at all.
+    /// </summary>
+    public static IReadOnlyList<AnalysisCurve> ToSoundPressureLevel(
+        IReadOnlyList<AnalysisCurve> curves,
+        double offsetDb)
+    {
+        ArgumentNullException.ThrowIfNull(curves);
+        if (!double.IsFinite(offsetDb))
+        {
+            throw new ArgumentOutOfRangeException(nameof(offsetDb));
+        }
+
+        IReadOnlyList<SignalPoint>? primary = null;
+        foreach (AnalysisCurve curve in curves)
+        {
+            if (curve.Kind == AnalysisCurveKind.Primary)
+            {
+                primary = curve.Points;
+                break;
+            }
+        }
+
+        var result = new List<AnalysisCurve>(curves.Count);
+        foreach (AnalysisCurve curve in curves)
+        {
+            if (curve.Kind == AnalysisCurveKind.Primary)
+            {
+                result.Add(curve with { Points = ShiftBy(curve.Points, offsetDb) });
+            }
+            else if (IsFundamentalRelative(curve.Kind) && primary is { Count: > 0 })
+            {
+                result.Add(curve with { Points = Lift(curve.Points, primary, offsetDb) });
+            }
+            else
+            {
+                result.Add(curve);
+            }
+        }
+
+        return result;
+    }
+
+    // The distortion and noise traces are all expressed relative to the
+    // fundamental, so each becomes an absolute level the same way.
+    private static bool IsFundamentalRelative(AnalysisCurveKind kind) => kind is
+        AnalysisCurveKind.SecondHarmonic or
+        AnalysisCurveKind.ThirdHarmonic or
+        AnalysisCurveKind.FourthHarmonic or
+        AnalysisCurveKind.ThdPlusNoise or
+        AnalysisCurveKind.NoiseFloor;
+
+    private static SignalPoint[] ShiftBy(IReadOnlyList<SignalPoint> points, double offsetDb)
+    {
+        var shifted = new SignalPoint[points.Count];
+        for (int i = 0; i < shifted.Length; i++)
+        {
+            SignalPoint point = points[i];
+            shifted[i] = point with { Y = point.Y + offsetDb };
+        }
+
+        return shifted;
+    }
+
+    // dBc(f) + primaryDbr(f) + K. The primary is sampled at the curve's own
+    // frequency (the distortion traces live on a different grid).
+    private static SignalPoint[] Lift(
+        IReadOnlyList<SignalPoint> points,
+        IReadOnlyList<SignalPoint> primaryDbr,
+        double offsetDb)
+    {
+        var lifted = new SignalPoint[points.Count];
+        for (int i = 0; i < lifted.Length; i++)
+        {
+            SignalPoint point = points[i];
+            double primaryAt = InterpolateDb(primaryDbr, point.X);
+            lifted[i] = point with { Y = point.Y + primaryAt + offsetDb };
+        }
+
+        return lifted;
+    }
+
+    // Linear interpolation of a frequency-ascending dB curve, clamped at the ends.
+    // The primary is smoothed and densely sampled on a log grid, so linear
+    // interpolation between neighbours sits well under the plotting resolution.
+    private static double InterpolateDb(IReadOnlyList<SignalPoint> curve, double x)
+    {
+        int count = curve.Count;
+        if (x <= curve[0].X)
+        {
+            return curve[0].Y;
+        }
+        if (x >= curve[count - 1].X)
+        {
+            return curve[count - 1].Y;
+        }
+
+        int low = 0;
+        int high = count - 1;
+        while (high - low > 1)
+        {
+            int mid = (low + high) >> 1;
+            if (curve[mid].X <= x)
+            {
+                low = mid;
+            }
+            else
+            {
+                high = mid;
+            }
+        }
+
+        SignalPoint left = curve[low];
+        SignalPoint right = curve[high];
+        double span = right.X - left.X;
+        if (span <= 0.0)
+        {
+            return left.Y;
+        }
+
+        double t = (x - left.X) / span;
+        return left.Y + t * (right.Y - left.Y);
+    }
+}

--- a/dsp/SplToneAnalysis.cs
+++ b/dsp/SplToneAnalysis.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// The pass/fail rule for detecting an acoustic calibrator's reference tone in a
+/// captured spectrum. A professional microphone calibrator emits one pure,
+/// dominant tone (nominally 1 kHz at 94/104/114 dB SPL); these thresholds decide
+/// whether what the microphone heard really is that tone and not room noise,
+/// mains hum, or a mis-seated coupler.
+/// </summary>
+/// <param name="TargetFrequencyHz">The calibrator's nominal tone frequency.</param>
+/// <param name="FrequencyToleranceHz">
+/// How far the observed peak may sit from <paramref name="TargetFrequencyHz"/>
+/// and still count as the reference tone. Generous by design: the calibrator's
+/// own tolerance is a percent or two and the soundcard clock adds well under
+/// that, so this is a sanity gate against locking onto an unrelated peak (mains
+/// harmonics, a different tone), not a precision measurement.
+/// </param>
+/// <param name="MinimumProminenceDb">
+/// How far the peak must stand above the spectrum's background for the tone to be
+/// called "clear". A calibrator at the capsule typically towers 40 dB or more
+/// over ambient; this floor rejects noise and hum while tolerating a merely
+/// quiet room.
+/// </param>
+/// <param name="MinimumAnalysisFrequencyHz">
+/// Bins below this are excluded from both the dominant-peak search and the
+/// background estimate, so low-frequency rumble and HVAC (which the coupler does
+/// not exclude and which carry no calibration information) cannot masquerade as
+/// the loudest tone or inflate the background.
+/// </param>
+public readonly record struct SplToneCriteria(
+    double TargetFrequencyHz,
+    double FrequencyToleranceHz,
+    double MinimumProminenceDb,
+    double MinimumAnalysisFrequencyHz)
+{
+    /// <summary>The standard IEC 60942 calibrator: a 1 kHz tone.</summary>
+    public static SplToneCriteria Default => new(
+        TargetFrequencyHz: 1_000.0,
+        FrequencyToleranceHz: 40.0,
+        MinimumProminenceDb: 20.0,
+        MinimumAnalysisFrequencyHz: 100.0);
+}
+
+/// <summary>
+/// What <see cref="SplToneAnalysis.Analyze"/> found: the dominant peak's
+/// frequency and level, how far it stood above the background, and whether it
+/// passes the criteria as the calibrator's reference tone.
+/// </summary>
+/// <param name="PeakFrequencyHz">Frequency of the loudest in-range bin.</param>
+/// <param name="LevelDbFs">
+/// The peak's level in dBFS. Because the spectrum is tone-calibrated (a
+/// full-scale sine reads amplitude 1.0), this is the microphone's digital level
+/// at the calibrator frequency — the raw number the SPL offset is anchored to.
+/// </param>
+/// <param name="ProminenceDb">The peak's level minus the background level.</param>
+/// <param name="WithinFrequencyTolerance">
+/// Whether the peak sits within the frequency tolerance of the target.
+/// </param>
+/// <param name="HasClearPeak">
+/// The overall verdict: a peak that is both on-frequency and prominent enough.
+/// This alone does not certify the calibration — the caller must also confirm the
+/// capture did not clip and the level was steady (see the listener).
+/// </param>
+public readonly record struct SplToneReading(
+    double PeakFrequencyHz,
+    double LevelDbFs,
+    double ProminenceDb,
+    bool WithinFrequencyTolerance,
+    bool HasClearPeak);
+
+/// <summary>
+/// Locates an acoustic calibrator's reference tone in an averaged, tone-calibrated
+/// power spectrum. Pure and backend-neutral: it consumes the spectrum produced by
+/// <see cref="SpectrumAnalysis.ComputePowerSpectrum"/> (evaluated with a
+/// <see cref="WindowType.FlatTop"/> window, whose amplitude flatness keeps the
+/// peak bin within hundredths of a dB of the true tone level wherever the tone
+/// falls between bins) and reports the peak, its prominence and the verdict.
+/// </summary>
+public static class SplToneAnalysis
+{
+    // The floor a bin's power is clamped to before the log so an empty or silent
+    // spectrum yields a very negative level instead of -infinity or NaN. -400 dBFS
+    // is far below any real capture yet stays finite.
+    private const double PowerFloor = 1e-40;
+
+    /// <summary>
+    /// Analyses <paramref name="averagedPowerSpectrum"/> — the single-sided,
+    /// coherent-gain-normalised power spectrum (amplit² per bin) from
+    /// <see cref="SpectrumAnalysis.ComputePowerSpectrum"/>, averaged over the
+    /// capture's frames — for the calibrator tone described by
+    /// <paramref name="criteria"/>. <paramref name="binWidthHz"/> is the spectrum's
+    /// frequency resolution (sample rate divided by the pre-FFT frame length).
+    /// </summary>
+    public static SplToneReading Analyze(
+        IReadOnlyList<double> averagedPowerSpectrum,
+        double binWidthHz,
+        SplToneCriteria criteria)
+    {
+        ArgumentNullException.ThrowIfNull(averagedPowerSpectrum);
+        if (!double.IsFinite(binWidthHz) || binWidthHz <= 0.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(binWidthHz));
+        }
+        if (!double.IsFinite(criteria.TargetFrequencyHz) || criteria.TargetFrequencyHz <= 0.0 ||
+            !double.IsFinite(criteria.FrequencyToleranceHz) || criteria.FrequencyToleranceHz < 0.0 ||
+            !double.IsFinite(criteria.MinimumProminenceDb) ||
+            !double.IsFinite(criteria.MinimumAnalysisFrequencyHz) ||
+            criteria.MinimumAnalysisFrequencyHz < 0.0)
+        {
+            throw new ArgumentException("The tone criteria contain an invalid value.", nameof(criteria));
+        }
+
+        int count = averagedPowerSpectrum.Count;
+        // Skip DC and everything below the analysis floor: rumble carries no
+        // calibration information and must not win the dominant-peak search.
+        int firstBin = Math.Max(1, (int)Math.Ceiling(criteria.MinimumAnalysisFrequencyHz / binWidthHz));
+        if (count < 2 || firstBin >= count)
+        {
+            return new SplToneReading(0.0, LevelToDecibels(0.0), 0.0, false, false);
+        }
+
+        int peakBin = firstBin;
+        double peakPower = averagedPowerSpectrum[firstBin];
+        for (int bin = firstBin + 1; bin < count; bin++)
+        {
+            double power = averagedPowerSpectrum[bin];
+            if (power > peakPower)
+            {
+                peakPower = power;
+                peakBin = bin;
+            }
+        }
+
+        double peakFrequencyHz = peakBin * binWidthHz;
+        double levelDbFs = LevelToDecibels(peakPower);
+        bool withinTolerance =
+            Math.Abs(peakFrequencyHz - criteria.TargetFrequencyHz) <= criteria.FrequencyToleranceHz;
+
+        double backgroundDb = EstimateBackgroundDb(
+            averagedPowerSpectrum, firstBin, peakBin, binWidthHz);
+        double prominenceDb = double.IsFinite(backgroundDb)
+            ? levelDbFs - backgroundDb
+            : 0.0;
+
+        bool clearPeak =
+            withinTolerance &&
+            peakPower > 0.0 &&
+            double.IsFinite(backgroundDb) &&
+            prominenceDb >= criteria.MinimumProminenceDb;
+
+        return new SplToneReading(
+            peakFrequencyHz,
+            levelDbFs,
+            prominenceDb,
+            withinTolerance,
+            clearPeak);
+    }
+
+    // The background level is the MEDIAN of the analysed bins, excluding a guard
+    // band around the peak so the tone's own main lobe (the flat-top lobe is
+    // several bins wide) does not lift the background it is measured against. The
+    // median — not the mean — keeps a second incidental tone or a spike from
+    // dragging the background up and masking a genuinely dominant calibrator tone.
+    private static double EstimateBackgroundDb(
+        IReadOnlyList<double> spectrum,
+        int firstBin,
+        int peakBin,
+        double binWidthHz)
+    {
+        // Wide enough to clear the flat-top main lobe and the calibrator's own
+        // frequency slop; 50 Hz is a handful of bins at measurement FFT lengths.
+        int guardBins = Math.Max(8, (int)Math.Ceiling(50.0 / binWidthHz));
+        int guardLow = peakBin - guardBins;
+        int guardHigh = peakBin + guardBins;
+
+        var background = new List<double>(spectrum.Count);
+        for (int bin = firstBin; bin < spectrum.Count; bin++)
+        {
+            if (bin >= guardLow && bin <= guardHigh)
+            {
+                continue;
+            }
+
+            background.Add(spectrum[bin]);
+        }
+
+        if (background.Count == 0)
+        {
+            return double.NaN;
+        }
+
+        background.Sort();
+        int middle = background.Count / 2;
+        double medianPower = background.Count % 2 == 1
+            ? background[middle]
+            : 0.5 * (background[middle - 1] + background[middle]);
+        return LevelToDecibels(medianPower);
+    }
+
+    // Power (amplitude²) to dBFS. The spectrum is amplitude-calibrated, so
+    // 10·log10(power) equals 20·log10(amplitude) — the microphone's dBFS level.
+    private static double LevelToDecibels(double power) =>
+        10.0 * Math.Log10(Math.Max(power, PowerFloor));
+}

--- a/dsp/Windowing.cs
+++ b/dsp/Windowing.cs
@@ -70,6 +70,54 @@ namespace Resonalyze.Dsp
             return copy;
         }
 
+        /// <summary>
+        /// The window's equivalent noise bandwidth, in FFT bins:
+        /// <c>ENBW = N·Σw² / (Σw)²</c>. It is the factor by which a windowed
+        /// periodogram over-states broadband noise power relative to the coherent
+        /// (tone) calibration, so dividing a band's summed bin power by it recovers
+        /// the true noise power. Rectangular is 1.0 (Hann ≈ 1.5, Blackman-Harris
+        /// ≈ 2.0, flat-top ≈ 3.77). Always ≥ 1.
+        /// </summary>
+        public static double EquivalentNoiseBandwidthBins(WindowType windowType, int length)
+        {
+            if (length <= 1)
+            {
+                return 1.0;
+            }
+
+            double[] window = SharedAnalysisWindow(windowType, length);
+            double sum = 0.0;
+            double sumOfSquares = 0.0;
+            for (int i = 0; i < window.Length; i++)
+            {
+                sum += window[i];
+                sumOfSquares += window[i] * window[i];
+            }
+
+            if (sum <= 0.0)
+            {
+                return 1.0;
+            }
+
+            return length * sumOfSquares / (sum * sum);
+        }
+
+        /// <summary>
+        /// The full width of the window's spectral main lobe, in FFT bins (twice the
+        /// first-null distance). Unlike the equivalent NOISE bandwidth, this bounds a
+        /// coherent tone's energy: a band at least this wide captures essentially the
+        /// whole main lobe, so summing its bin power and dividing by ENBW recovers the
+        /// tone's amplitude. Rectangular 2, Hann 4, Blackman-Harris 8, flat-top 10.
+        /// </summary>
+        public static int MainLobeWidthBins(WindowType windowType) => windowType switch
+        {
+            WindowType.Rectangular => 2,
+            WindowType.Hann => 4,
+            WindowType.BlackmanHarris => 8,
+            WindowType.FlatTop => 10,
+            _ => 4
+        };
+
         private static double AnalysisWindowValue(WindowType windowType, int index, int length)
         {
             if (length <= 1)

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -35,7 +35,9 @@ internal sealed class LiveSpectrumController : IDisposable
     private const long PeakHoldSuppressionMs = 1000;
     private bool disposed;
     private bool redrawInProgress;
-    private double[]? peakHoldMagnitude;
+    // The peak-hold envelope is held over the DISPLAYED band curve (freq, dB), not the
+    // raw FFT bins, so the SPL band power it shows is the peak of a real band level.
+    private List<SignalPoint>? peakHoldPoints;
     private long peakHoldResumeTick;
     private LiveSpectrumSnapshot? lastSnapshot;
     // The ~30 fps redraw reuses these series and refills their points in place;
@@ -83,6 +85,44 @@ internal sealed class LiveSpectrumController : IDisposable
     public bool InProgress => measurement.InProgress;
     public bool TimerEnabled => timer.Enabled;
 
+    // Whether the plot is currently rendering the absolute dB SPL (RTA) view. SPL is
+    // only effective when it is both selected and backed by a matching calibration,
+    // so this reflects what will actually be drawn — never a stale-calibration request.
+    private bool RenderingSpl =>
+        plotModelFactory.EffectiveLiveSpectrumScale == MagnitudeScale.SoundPressureLevel;
+
+    // The plot shows only the reference-free RTA (no transfer function or coherence)
+    // when the SPL view is active OR the capture has no loopback reference at all.
+    private bool RtaOnly => RenderingSpl || measurement.IsRtaCapture;
+
+    // The reference-free RTA is normally optional, but it IS the only curve in the
+    // RTA-only views, so it is always computed there even if its checkbox is off.
+    private bool NeedsInputMagnitude =>
+        liveSpectrumOptions.ShowInputMagnitude || RtaOnly;
+
+    // The display transform behind the peak-hold envelope at the last drawn frame.
+    // peakHoldPoints holds FINISHED display values, so any change to how a level maps
+    // to the display — the scale, the RTA-only shaping, the smoothing band width, the
+    // microphone-correction mode, or the SPL offset (e.g. a re-calibration to a new
+    // offset) — makes the old envelope incompatible; it must be dropped, not max-ed
+    // against the new values.
+    private readonly record struct PeakHoldDisplayKey(
+        MagnitudeScale Scale,
+        bool RtaOnly,
+        int SmoothingInverseOctaves,
+        MicrophoneCalibrationMode CalibrationMode,
+        double? SplOffsetDb);
+
+    private PeakHoldDisplayKey renderedPeakHoldKey;
+
+    private PeakHoldDisplayKey CurrentPeakHoldKey() => new(
+        RenderingSpl ? MagnitudeScale.SoundPressureLevel : MagnitudeScale.Relative,
+        RtaOnly,
+        liveSpectrumOptions.SmoothingInverseOctaves,
+        liveSpectrumOptions.CalibrationMode,
+        // The offset only shapes the display in SPL; in relative it is irrelevant.
+        RenderingSpl ? plotModelFactory.LiveSplOffsetDb : null);
+
     /// <summary>
     /// Clears the running average and peak-hold envelope without interrupting
     /// capture. Useful for the Infinite averaging preset.
@@ -103,7 +143,14 @@ internal sealed class LiveSpectrumController : IDisposable
 
         if (!liveSpectrumOptions.PeakHold)
         {
-            peakHoldMagnitude = null;
+            peakHoldPoints = null;
+        }
+
+        // Any change to the display transform (scale, smoothing, mic correction, SPL
+        // offset) makes the held display points incompatible; drop the envelope.
+        if (CurrentPeakHoldKey() != renderedPeakHoldKey)
+        {
+            SuspendPeakHold();
         }
 
         // Rebuild the model even while running: display options such as the coherence
@@ -116,7 +163,7 @@ internal sealed class LiveSpectrumController : IDisposable
     // the average ramps up from zero are not latched into the envelope.
     private void SuspendPeakHold()
     {
-        peakHoldMagnitude = null;
+        peakHoldPoints = null;
         peakHoldResumeTick = Environment.TickCount64 + PeakHoldSuppressionMs;
     }
 
@@ -158,6 +205,7 @@ internal sealed class LiveSpectrumController : IDisposable
             measurementSettings.WasapiCaptureEndpointId,
             measurementSettings.WasapiRenderEndpointId,
             measurementSettings.WasapiBufferMilliseconds);
+        NormalizeSilentSignal();
     }
 
     public async Task ToggleAsync()
@@ -195,7 +243,7 @@ internal sealed class LiveSpectrumController : IDisposable
     public void ForgetLastCurve()
     {
         lastSnapshot = null;
-        peakHoldMagnitude = null;
+        peakHoldPoints = null;
         RemoveOverloadAnnotation(plotView.Model);
     }
 
@@ -209,15 +257,139 @@ internal sealed class LiveSpectrumController : IDisposable
         RebuildModel();
     }
 
+    /// <summary>
+    /// Drops display state that is incompatible with any calibration change.
+    /// This must run even while another mode owns the visible plot.
+    /// </summary>
+    public void InvalidateCalibration()
+    {
+        SuspendPeakHold();
+    }
+
+    /// <summary>
+    /// Reacts to any calibration change — an SPL anchor added/cleared, its offset
+    /// re-measured, or a different microphone-correction file bound to the same mode.
+    /// This runs in EVERY app mode, not only while Live Spectrum is visible, because a
+    /// calibration change can force the signal either way — losing SPL normalizes a
+    /// <see cref="NoiseColor.Silent"/> RTA back to a real excitation, gaining it drops a
+    /// stale periodic-pink excitation back to Silent — and drops the now-incompatible
+    /// peak-hold envelope wherever the analyzer sits. It rebuilds the plot only when Live Spectrum is the visible
+    /// mode (a running one is restarted if a Silent capture must fall back; an idle one
+    /// simply re-renders). Returns whether the live signal type changed, so the caller
+    /// can persist the normalized options. Safe whether running or idle.
+    /// </summary>
+    public async Task<bool> RefreshCalibrationAsync()
+    {
+        InvalidateCalibration();
+
+        // A running capture whose signal no longer fits the effective scale must be
+        // restarted: a Silent RTA that lost SPL needs a real excitation, and a periodic
+        // pink capture that just gained SPL must drop its now-pointless excitation for
+        // the ambient mic-only RTA. Either way the playback and analysis path change, so
+        // stop it, normalize the signal, and restart on the corrected one.
+        bool restart = measurement.InProgress && SignalNeedsNormalization();
+        if (restart)
+        {
+            await StopAsync();
+        }
+
+        bool signalChanged = NormalizeSilentSignal();
+
+        if (restart && getCurrentMode() == Mode.LiveSpectrum)
+        {
+            await StartAsync();
+            return signalChanged;
+        }
+
+        // Only the VISIBLE Live Spectrum rebuilds its model here; in another mode the
+        // normalization above already removed the stale Silent, and the model is rebuilt
+        // when Live Spectrum next becomes visible (RestoreLastCurve).
+        if (getCurrentMode() == Mode.LiveSpectrum)
+        {
+            RebuildModel();
+        }
+
+        return signalChanged;
+    }
+
+    // Forces the runtime signal to one the effective scale actually offers, so the
+    // stored NoiseColor never diverges from what the panel and the playback show. The
+    // two scale-exclusive signals swap symmetrically: Silent (an ambient RTA with no
+    // excitation) is SPL-only, so off SPL it falls back to periodic pink; periodic pink
+    // (the transfer-function reference) is relative-only, so under the reference-free
+    // SPL RTA it falls back to Silent — which also restores the original signal after a
+    // Silent→pink calibration-loss round-trip. The shared Pink/Brown/White colours are
+    // valid on both scales and are never touched.
+    internal static bool NormalizeSignalType(
+        LiveSpectrumOptions options,
+        MagnitudeScale effectiveScale)
+    {
+        NoiseColor normalized = NormalizedSignalType(options.NoiseColor, effectiveScale);
+        if (normalized == options.NoiseColor)
+        {
+            return false;
+        }
+
+        options.NoiseColor = normalized;
+        return true;
+    }
+
+    private static NoiseColor NormalizedSignalType(
+        NoiseColor color,
+        MagnitudeScale effectiveScale)
+    {
+        bool spl = effectiveScale == MagnitudeScale.SoundPressureLevel;
+        if (color == NoiseColor.Silent && !spl)
+        {
+            return NoiseColor.PinkPeriodic;
+        }
+
+        if (color == NoiseColor.PinkPeriodic && spl)
+        {
+            return NoiseColor.Silent;
+        }
+
+        return color;
+    }
+
+    // Whether the current runtime signal is not valid for the effective scale and would
+    // be swapped by NormalizeSignalType. A running measurement must restart when it is,
+    // because either direction changes the playback (pink excitation ↔ zero) and the
+    // analysis path (transfer vs. mic-only RTA).
+    private bool SignalNeedsNormalization() =>
+        NormalizedSignalType(
+            liveSpectrumOptions.NoiseColor,
+            plotModelFactory.EffectiveLiveSpectrumScale) != liveSpectrumOptions.NoiseColor;
+
+    private bool NormalizeSilentSignal()
+    {
+        bool changed = NormalizeSignalType(
+            liveSpectrumOptions,
+            plotModelFactory.EffectiveLiveSpectrumScale);
+        if (changed)
+        {
+            measurement.RefreshPlaybackSignal();
+        }
+
+        return changed;
+    }
+
     // Recreates the plot model (and therefore its axes) from the current options, redraws
     // the last snapshot, and restores overlays. Safe to call while running: the next
     // TimerTick simply renders onto the fresh model.
     private void RebuildModel()
     {
         PlotModel model = plotModelFactory.CreateLiveSpectrum();
-        if (lastSnapshot != null)
+        // Prefer a freshly computed snapshot so a scale switch picks up curves the
+        // stored one may lack (e.g. the RTA when SPL is turned on): the accumulators
+        // survive a stop, so this still works when the analyzer is paused. Fall back
+        // to the last drawn snapshot when no accumulation is available.
+        LiveSpectrumSnapshot? snapshot =
+            measurement.GetAccumulatedSpectrumSnapshot(NeedsInputMagnitude) ?? lastSnapshot;
+        if (snapshot != null)
         {
-            AddLiveSpectrumSeries(model, lastSnapshot);
+            lastSnapshot = snapshot;
+            AddLiveSpectrumSeries(model, snapshot);
         }
 
         plotView.Model = model;
@@ -247,19 +419,12 @@ internal sealed class LiveSpectrumController : IDisposable
         {
             await selectLiveSpectrumAsync();
         }
-        if (!measurement.HasConfiguredLoopback)
-        {
-            MessageBox.Show(
-                owner,
-                "Live Transfer Function requires a configured loopback input.\r\n\r\n" +
-                "Open Record Settings and select a Wave or ASIO loopback channel.",
-                "Loopback required",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Information);
-            updateRecordButton();
-            return;
-        }
 
+        NormalizeSilentSignal();
+
+        // With no loopback the analyzer runs as a single-channel RTA (mic auto-power)
+        // instead of a dual-channel transfer function; both are valid, so starting is
+        // no longer gated on a configured loopback.
         SuspendPeakHold();
         lastSnapshot = null;
         plotView.Model = plotModelFactory.CreateLiveSpectrum();
@@ -273,7 +438,7 @@ internal sealed class LiveSpectrumController : IDisposable
     private async Task StopAsync()
     {
         LiveSpectrumSnapshot? finalSnapshot = measurement.GetAccumulatedSpectrumSnapshot(
-            liveSpectrumOptions.ShowInputMagnitude);
+            NeedsInputMagnitude);
         timer.Stop();
         await measurement.AbortAsync();
 
@@ -305,7 +470,7 @@ internal sealed class LiveSpectrumController : IDisposable
         try
         {
             LiveSpectrumSnapshot? snapshot = measurement.GetAccumulatedSpectrumSnapshot(
-                liveSpectrumOptions.ShowInputMagnitude);
+                NeedsInputMagnitude);
             PlotModel? model = plotView.Model;
             if (snapshot == null || model == null || getCurrentMode() != Mode.LiveSpectrum)
             {
@@ -338,25 +503,47 @@ internal sealed class LiveSpectrumController : IDisposable
         }
         attachedModel = model;
 
+        // The plot is the reference-free microphone (RTA) spectrum whenever the SPL
+        // view is active (the transfer function has no scalar SPL under noise) or the
+        // capture has no loopback at all (there is no transfer function to draw). In
+        // those RTA-only views the transfer function and coherence are hidden, the RTA
+        // is forced on, and the peak hold envelops it instead of the transfer curve.
+        bool rtaOnly = RtaOnly;
+        renderedPeakHoldKey = CurrentPeakHoldKey();
+
         if (liveSpectrumOptions.PeakHold)
         {
-            UpdatePeakHold(snapshot.Magnitude);
-            if (peakHoldMagnitude != null)
+            double[]? peakSource = rtaOnly ? snapshot.InputMagnitude : snapshot.Magnitude;
+            if (peakSource is { Length: > 0 })
+            {
+                // Envelope the DISPLAYED band curve, not the raw bins: in SPL the
+                // display sums bin powers per band, so per-bin peaks summed later
+                // would add maxima from different frames and overstate the band.
+                List<SignalPoint> current =
+                    plotModelFactory.BuildMainDisplayPoints(peakSource, rtaOnly);
+                UpdatePeakHold(current);
+            }
+            else
+            {
+                peakHoldPoints = null;
+            }
+
+            if (peakHoldPoints != null)
             {
                 if (peakHoldSeries == null)
                 {
-                    peakHoldSeries = plotModelFactory.BuildPeakHoldSeries(peakHoldMagnitude);
+                    peakHoldSeries = plotModelFactory.BuildPeakHoldSeries(peakHoldPoints);
                     peakHoldSeries.Tag = LiveSpectrumPeakHoldTag;
                 }
                 else
                 {
-                    plotModelFactory.UpdatePeakHoldSeries(peakHoldSeries, peakHoldMagnitude);
+                    plotModelFactory.UpdatePeakHoldSeries(peakHoldSeries, peakHoldPoints);
                 }
                 model.Series.Add(peakHoldSeries);
             }
         }
 
-        if (liveSpectrumOptions.ShowMainCurve)
+        if (!rtaOnly && liveSpectrumOptions.ShowMainCurve)
         {
             if (snapshot.Coherence != null &&
                 liveSpectrumOptions.CoherenceThresholdPercent > 0)
@@ -403,8 +590,10 @@ internal sealed class LiveSpectrumController : IDisposable
 
         // Reference-free RTA magnitude of the microphone input, overlaid on the
         // same dB axis. It is independent of coherence and the reference channel,
-        // so it is never split or dimmed by the coherence threshold.
-        if (snapshot.InputMagnitude != null && liveSpectrumOptions.ShowInputMagnitude)
+        // so it is never split or dimmed by the coherence threshold. In the RTA-only
+        // views it is the only trace, forced on (and lifted to dB SPL by the factory).
+        if (snapshot.InputMagnitude != null &&
+            (liveSpectrumOptions.ShowInputMagnitude || rtaOnly))
         {
             if (inputMagnitudeSeries == null)
             {
@@ -420,7 +609,9 @@ internal sealed class LiveSpectrumController : IDisposable
             model.Series.Add(inputMagnitudeSeries);
         }
 
-        if (snapshot.Coherence != null && liveSpectrumOptions.ShowCoherence)
+        // Coherence describes the transfer-function estimate, which the RTA-only
+        // views do not show, so it is drawn only alongside the transfer function.
+        if (!rtaOnly && snapshot.Coherence != null && liveSpectrumOptions.ShowCoherence)
         {
             if (coherenceSeries == null)
             {
@@ -435,25 +626,26 @@ internal sealed class LiveSpectrumController : IDisposable
         }
     }
 
-    private void UpdatePeakHold(double[] magnitude)
+    // Holds the per-band maximum of the displayed curve over time. The grid frequency
+    // per index is stable across ticks, so a per-index max of the dB level is the peak
+    // of the band level actually shown (a band level is monotone in its power).
+    private void UpdatePeakHold(List<SignalPoint> current)
     {
         if (Environment.TickCount64 < peakHoldResumeTick)
         {
             return;
         }
 
-        if (peakHoldMagnitude == null || peakHoldMagnitude.Length != magnitude.Length)
+        if (peakHoldPoints == null || peakHoldPoints.Count != current.Count)
         {
-            peakHoldMagnitude = (double[])magnitude.Clone();
+            peakHoldPoints = new List<SignalPoint>(current);
             return;
         }
 
-        for (int i = 0; i < peakHoldMagnitude.Length; i++)
+        for (int i = 0; i < current.Count; i++)
         {
-            if (magnitude[i] > peakHoldMagnitude[i])
-            {
-                peakHoldMagnitude[i] = magnitude[i];
-            }
+            double held = Math.Max(peakHoldPoints[i].Y, current[i].Y);
+            peakHoldPoints[i] = new SignalPoint(current[i].X, held);
         }
     }
 

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -78,6 +78,44 @@ namespace Resonalyze
         public int AverageRunCount { get; private set; } = 1;
         public int AcceptedAverageRunCount { get; private set; } = 1;
         public bool ConfirmEachAverageRun { get; private set; }
+        // The SPL calibration CONFIGURED for the next run (follows the settings /
+        // dialog). It is snapshotted into MeasurementSplCalibration when a run
+        // starts, so recalibrating afterwards never rewrites an existing result.
+        public SplCalibration? SplCalibration { get; set; }
+
+        // The SPL calibration that belongs to the CURRENT result: a snapshot taken
+        // when the sweep ran, or the calibration a loaded file carried. This — not
+        // the configured one — is what the plot reads and what a save stamps, so a
+        // later recalibration (or a preamp-gain change followed by one) cannot
+        // retroactively change the meaning of an already-measured impulse response.
+        public SplCalibration? MeasurementSplCalibration { get; set; }
+
+        // The input identity the CURRENT result was produced on: a snapshot of the
+        // input when the sweep ran, or the input a loaded file was measured on. The
+        // SPL anchor is validated against this, not the app's current configuration,
+        // so re-saving a loaded file cannot drop an anchor that was valid for it.
+        public MeasurementInputIdentity? MeasurementInput { get; set; }
+
+        /// <summary>
+        /// Whether <paramref name="calibration"/> was captured on the same digital
+        /// input that produced the current result. Both the live plot and the saved
+        /// file gate on this — the anchor is valid only for its own tract.
+        /// </summary>
+        public bool InputMatches(SplCalibration calibration)
+        {
+            ArgumentNullException.ThrowIfNull(calibration);
+            return MeasurementInput is { } identity && calibration.MatchesInput(identity);
+        }
+
+        private MeasurementInputIdentity CurrentInputIdentity() => new(
+            AudioBackend,
+            SampleRate,
+            Bits,
+            AudioBackend == AudioBackend.Asio ? AsioInputChannelOffset : WaveInputChannelOffset,
+            AudioBackend == AudioBackend.Wave ? InputDeviceNumber : null,
+            WasapiCaptureEndpointId,
+            AsioDriverName);
+
         // Per-run acceptance outcome of the last completed measurement; null until
         // a measurement ran (or when the result was restored from a file).
         internal SweepRunQualityReport? QualityReport { get; private set; }
@@ -136,6 +174,10 @@ namespace Resonalyze
             AsioOutputChannelOffset = audio.AsioOutputChannelOffset;
             sweepDeconvolutionResult = null;
             transferResult = null;
+            // The old result is gone; its calibration and input snapshots go with it.
+            // The next run re-snapshots the configured calibration and input.
+            MeasurementSplCalibration = null;
+            MeasurementInput = null;
             TransferCoherence = null;
             MicrophoneRecordedSamples = null;
             LoopbackRecordedSamples = null;
@@ -175,6 +217,11 @@ namespace Resonalyze
                 inProgress = true;
                 sweepDeconvolutionResult = null;
                 transferResult = null;
+                // Freeze the calibration and the input in effect at run start onto this
+                // result, so a later setting change cannot rewrite what it means or
+                // which input it is validated against.
+                MeasurementSplCalibration = SplCalibration;
+                MeasurementInput = CurrentInputIdentity();
                 TransferCoherence = null;
                 MicrophoneRecordedSamples = null;
                 LoopbackRecordedSamples = null;

--- a/source/Measurements/ImpulseResponseFile.cs
+++ b/source/Measurements/ImpulseResponseFile.cs
@@ -11,7 +11,7 @@ namespace Resonalyze;
 public sealed class ImpulseResponseFile
 {
     public const string CurrentFormat = "resonalyze-impulse-response";
-    public const int CurrentVersion = 6;
+    public const int CurrentVersion = 7;
 
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
@@ -41,6 +41,12 @@ public sealed class ImpulseResponseFile
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? TransferPeakIndex { get; set; }
+
+    // The SPL calibration in effect when the measurement ran. Its microphone-side
+    // offset, combined with this file's own loopback levels, is what later places
+    // the response on an SPL axis.
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SplCalibration? SplCalibration { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public LevelSnapshotFileEntry? MicrophoneLevels { get; set; }
@@ -92,6 +98,16 @@ public sealed class ImpulseResponseFile
         LevelSnapshotFileEntry? loopbackLevels =
             CreateLevelSnapshotFileEntry(levels.Loopback);
 
+        // Stamp the calibration frozen onto this result at run time (not the current
+        // configured one), and only when it belongs to this measurement's own input.
+        // A calibration left over from a different device/rate/bits/channel would
+        // otherwise be trusted on reload (loaded files skip the live match) and show
+        // a confidently wrong dB SPL offset.
+        SplCalibration? splCalibration =
+            measurement.MeasurementSplCalibration is { } anchor && measurement.InputMatches(anchor)
+                ? anchor
+                : null;
+
         return new ImpulseResponseFile
         {
             SavedAtUtc = DateTimeOffset.UtcNow,
@@ -104,6 +120,7 @@ public sealed class ImpulseResponseFile
             SweepDeconvolutionPeakIndex = sweepDeconvolution.PeakIndex,
             AverageRunCount = measurement.AverageRunCount,
             AcceptedAverageRunCount = measurement.AcceptedAverageRunCount,
+            SplCalibration = splCalibration,
             AudioSession = CreateAudioSessionFileEntry(
                 measurement.LastAudioSessionDiagnostics,
                 measurement.SampleRate,
@@ -374,6 +391,7 @@ public sealed class ImpulseResponseFile
         ValidateLevelEntry(LoopbackLevels, nameof(LoopbackLevels));
         ValidatePreview(PreviewFrequencyResponse);
         ValidateAudioSession(AudioSession);
+        SplCalibration?.Validate();
     }
 
     private static (double[] Real, double[]? Imaginary) ConvertSamples(

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -43,6 +43,7 @@ namespace Resonalyze
         private AveragingSpeed appliedAveragingSpeed;
         private volatile bool inProgress;
         private bool disposed;
+        private double playbackDuration = 60.0;
 
         public event Action<bool>? Completed;
         internal event Action<InputLevelMeterSnapshot>? LevelsAvailable;
@@ -80,6 +81,33 @@ namespace Resonalyze
                     AsioLoopbackInputChannelOffset.Value != AsioInputChannelOffset
                 : WaveLoopbackInputChannelOffset.HasValue &&
                     WaveLoopbackInputChannelOffset.Value != WaveInputChannelOffset;
+
+        /// <summary>
+        /// True when no loopback reference is configured, so the analyzer runs as a
+        /// single-channel RTA: it captures the microphone only and accumulates its
+        /// auto-power. There is no transfer function or coherence in this mode — only
+        /// the reference-free spectrum, which can still be shown relative or in dB SPL.
+        /// </summary>
+        public bool IsMicOnly => !HasConfiguredLoopback;
+
+        public bool IsRtaCapture =>
+            IsMicOnly || LiveSpectrumOptions.NoiseColor == NoiseColor.Silent;
+
+        /// <summary>
+        /// The digital identity of the microphone input this analyzer is configured
+        /// for, so an SPL calibration anchor can be validated against the live input
+        /// (the same way a completed sweep validates its own). Mirrors the sweep's
+        /// mapping: the microphone channel is the ASIO or Wave/WASAPI input offset,
+        /// and the device number is meaningful only for the Wave backend.
+        /// </summary>
+        public MeasurementInputIdentity CurrentInputIdentity() => new(
+            AudioBackend,
+            SampleRate,
+            Bits,
+            AudioBackend == AudioBackend.Asio ? AsioInputChannelOffset : WaveInputChannelOffset,
+            AudioBackend == AudioBackend.Wave ? InputDeviceNumber : null,
+            WasapiCaptureEndpointId,
+            AsioDriverName);
 
         public void Init(
             int sampleRate,
@@ -140,6 +168,19 @@ namespace Resonalyze
             WaveInputChannelOffset = normalizedWaveInputChannelOffset;
             WaveLoopbackInputChannelOffset = normalizedWaveLoopbackInputChannelOffset;
             LiveSpectrumOptions = liveSpectrumOptions ?? new LiveSpectrumOptions();
+            playbackDuration = requestedDuration;
+
+            RefreshPlaybackSignal();
+        }
+
+        public void RefreshPlaybackSignal()
+        {
+            ThrowIfDisposed();
+            if (InProgress)
+            {
+                throw new InvalidOperationException(
+                    "Cannot replace the playback signal during an active measurement.");
+            }
 
             signal?.Dispose();
             signal = new NoiseSignal();
@@ -152,13 +193,13 @@ namespace Resonalyze
             // first audio callbacks. Non-periodic colours still need the full
             // length (a short loop of aperiodic noise would seam audibly).
             double signalDuration =
-                LiveSpectrumOptions.NoiseColor == NoiseColor.PinkPeriodic
-                    ? SequenceLength / (double)sampleRate
-                    : requestedDuration;
+                LiveSpectrumOptions.NoiseColor is NoiseColor.PinkPeriodic or NoiseColor.Silent
+                    ? SequenceLength / (double)SampleRate
+                    : playbackDuration;
             signal.FillData(
                 signalDuration,
-                bits,
-                sampleRate,
+                Bits,
+                SampleRate,
                 LiveSpectrumOptions.NoiseColor,
                 SequenceLength);
         }
@@ -230,44 +271,56 @@ namespace Resonalyze
         public LiveSpectrumSnapshot? GetAccumulatedSpectrumSnapshot(
             bool includeInputMagnitude = true)
         {
-            Complex[] crossSpectrum;
-            double[] referencePowerSpectrum;
+            Complex[]? crossSpectrum;
+            double[]? referencePowerSpectrum;
             double[] targetPowerSpectrum;
             int frameCount;
             lock (dataSync)
             {
-                if (accumulatedCrossSpectrum == null ||
-                    accumulatedReferencePowerSpectrum == null ||
-                    accumulatedTargetPowerSpectrum == null)
+                // The mic auto-power is the one accumulator every mode fills; the
+                // cross-spectrum and reference power exist only for the dual-channel
+                // (loopback) transfer path. A reference-free (mic-only) capture has
+                // just the auto-power, and that alone drives the RTA.
+                if (accumulatedTargetPowerSpectrum == null)
                 {
                     return null;
                 }
 
-                crossSpectrum = (Complex[])accumulatedCrossSpectrum.Clone();
-                referencePowerSpectrum = (double[])accumulatedReferencePowerSpectrum.Clone();
                 targetPowerSpectrum = (double[])accumulatedTargetPowerSpectrum.Clone();
+                crossSpectrum = accumulatedCrossSpectrum != null
+                    ? (Complex[])accumulatedCrossSpectrum.Clone()
+                    : null;
+                referencePowerSpectrum = accumulatedReferencePowerSpectrum != null
+                    ? (double[])accumulatedReferencePowerSpectrum.Clone()
+                    : null;
                 frameCount = averagedFrameCount;
             }
 
-            double[] magnitude = SpectrumAnalysis.ComputeH1MagnitudeSpectrum(
-                crossSpectrum,
-                referencePowerSpectrum);
+            bool micOnly = crossSpectrum == null || referencePowerSpectrum == null;
+            // Without a reference channel there is no transfer function and no
+            // coherence; the RTA is the whole measurement.
+            double[] magnitude = micOnly
+                ? Array.Empty<double>()
+                : SpectrumAnalysis.ComputeH1MagnitudeSpectrum(
+                    crossSpectrum!,
+                    referencePowerSpectrum!);
             // γ² of a single frame is identically 1 in every energized bin
             // whatever the real relation between the channels, and the first
             // few EMA frames are barely better — the display would mark the
             // whole curve "trusted" exactly when no statistics exist yet. Until
             // a few frames have accumulated the coherence is UNKNOWN (null),
             // not perfect.
-            double[]? coherence = frameCount >= MinCoherenceFrames
+            double[]? coherence = !micOnly && frameCount >= MinCoherenceFrames
                 ? SpectrumAnalysis.ComputeCoherence(
-                    crossSpectrum,
-                    referencePowerSpectrum,
+                    crossSpectrum!,
+                    referencePowerSpectrum!,
                     targetPowerSpectrum)
                 : null;
             // The microphone auto-power is already accumulated for coherence. Only
             // normalize it into a reference-free RTA curve when the caller will show
-            // that curve; the transform otherwise adds avoidable UI snapshot work.
-            double[]? inputMagnitude = includeInputMagnitude
+            // that curve; the transform otherwise adds avoidable UI snapshot work. In
+            // mic-only mode the RTA is the only curve, so it is always computed.
+            double[]? inputMagnitude = includeInputMagnitude || micOnly
                 ? SpectrumAnalysis.ComputeInputMagnitudeSpectrum(
                     targetPowerSpectrum,
                     EffectiveWindowType,
@@ -524,7 +577,14 @@ namespace Resonalyze
 
                 foreach (float[][] frame in reframer.Push(sequence))
                 {
-                    AccumulateTransferSequence(frame);
+                    if (IsRtaCapture)
+                    {
+                        AccumulateMicOnlySequence(frame);
+                    }
+                    else
+                    {
+                        AccumulateTransferSequence(frame);
+                    }
                 }
             }
         }
@@ -615,6 +675,53 @@ namespace Resonalyze
             }
         }
 
+        // The single-channel path: only the microphone auto-power is captured and
+        // averaged, with the same settle/seed/EMA logic as the transfer path so the
+        // RTA converges identically. Cross- and reference-power stay null, which the
+        // snapshot reads as "mic only" (no transfer function, no coherence).
+        private void AccumulateMicOnlySequence(float[][] sequence)
+        {
+            int microphoneIndex = captureMicrophoneIndex;
+            if ((uint)microphoneIndex >= (uint)sequence.Length)
+            {
+                throw new InvalidOperationException(
+                    "Live RTA requires a microphone input.");
+            }
+
+            double[] targetPower = SpectrumAnalysis.ComputeAutoPowerSpectrumFrame(
+                sequence[microphoneIndex],
+                EffectiveWindowType);
+
+            lock (dataSync)
+            {
+                if (accumulatedTargetPowerSpectrum == null)
+                {
+                    if (sequencesCounter <= 2)
+                    {
+                        sequencesCounter++;
+                        return;
+                    }
+
+                    accumulatedTargetPowerSpectrum = targetPower;
+                    averagedFrameCount = 1;
+                    sequencesCounter++;
+                    return;
+                }
+
+                double alpha = infiniteAveraging
+                    ? 1.0 / (averagedFrameCount + 1)
+                    : transferAlpha;
+                for (int i = 0; i < accumulatedTargetPowerSpectrum.Length; i++)
+                {
+                    accumulatedTargetPowerSpectrum[i] =
+                        (1 - alpha) * accumulatedTargetPowerSpectrum[i] +
+                        alpha * targetPower[i];
+                }
+                averagedFrameCount++;
+                sequencesCounter++;
+            }
+        }
+
         private TransferSpectrumFrame ComputeTransferSpectrumFrame(float[][] sequence)
         {
             int microphoneIndex = captureMicrophoneIndex;
@@ -659,6 +766,8 @@ namespace Resonalyze
                 frame.TargetPowerSpectrum,
                 EffectiveWindowType,
                 SequenceLength);
+            // The mic-only RTA path uses a different (single-FFT) frame; warm it too.
+            _ = SpectrumAnalysis.ComputeAutoPowerSpectrumFrame(target, EffectiveWindowType);
         }
 
         // Periodic pink noise is exactly one FFT-length period, so every analysis block
@@ -668,6 +777,24 @@ namespace Resonalyze
             LiveSpectrumOptions.NoiseColor == NoiseColor.PinkPeriodic
                 ? WindowType.Rectangular
                 : LiveSpectrumOptions.WindowType;
+
+        /// <summary>
+        /// The equivalent noise bandwidth (in FFT bins) of the window actually used
+        /// for the live spectrum, so a power-integrated RTA can recover true band
+        /// power from the tone-calibrated amplitude spectrum. Reflects the periodic-pink
+        /// rectangular override (ENBW 1.0), not just the stored window choice.
+        /// </summary>
+        public double AnalysisWindowEnbwBins =>
+            Windowing.EquivalentNoiseBandwidthBins(EffectiveWindowType, SequenceLength);
+
+        /// <summary>
+        /// The spectral main-lobe width (in FFT bins) of the live window, so a
+        /// power-integrated RTA never draws a band narrower than the window can resolve
+        /// and keeps a tone's whole main lobe. Reflects the periodic-pink rectangular
+        /// override (2 bins), not just the stored window choice.
+        /// </summary>
+        public double AnalysisWindowMainLobeBins =>
+            Windowing.MainLobeWidthBins(EffectiveWindowType);
 
         private static int? NormalizeOptionalWaveChannel(int? channel) =>
             channel.HasValue

--- a/source/Measurements/NoiseSignal.cs
+++ b/source/Measurements/NoiseSignal.cs
@@ -61,6 +61,8 @@ public sealed class NoiseSignal : IDisposable
         var random = new Random(42);
         switch (noiseColor)
         {
+            case NoiseColor.Silent:
+                break;
             case NoiseColor.PinkPeriodic:
                 FillPinkPeriodic(random, periodLength);
                 break;

--- a/source/Measurements/SplCalibration.cs
+++ b/source/Measurements/SplCalibration.cs
@@ -1,0 +1,183 @@
+using System.Text.Json.Serialization;
+using Resonalyze.Audio;
+
+namespace Resonalyze;
+
+/// <summary>
+/// The digital identity of a capture input — backend, format and channel routing.
+/// A measurement carries one (a snapshot of the input it ran on, or the input a
+/// loaded file was measured on) so its SPL anchor is validated against the input
+/// that actually produced the result, not the app's current configuration.
+/// </summary>
+public readonly record struct MeasurementInputIdentity(
+    AudioBackend Backend,
+    int SampleRate,
+    int Bits,
+    int MicrophoneChannelOffset,
+    int? InputDeviceNumber,
+    string? WasapiCaptureEndpointId,
+    string? AsioDriverName);
+
+/// <summary>
+/// A sound-pressure-level calibration anchor: the fixed relationship between the
+/// microphone's digital level and absolute SPL, established by holding an acoustic
+/// calibrator (a known 94/104/114 dB tone at 1 kHz) over the capsule and reading
+/// the level it produces.
+/// <para>
+/// It stores the raw ingredients, not a pre-baked "shift the response by N dB"
+/// number. The displayed frequency response is a loopback-referenced transfer
+/// function (microphone ÷ loopback), so placing it on an SPL axis needs this
+/// microphone-side anchor <em>and</em> each measurement's own loopback level; the
+/// per-measurement combination is done where the curve is drawn, from these
+/// fields plus the impulse response's stored loopback levels.
+/// </para>
+/// <para>
+/// The anchor is valid only while the capture gain chain is unchanged. The digital
+/// half of that chain is recorded here so a mismatched input can be detected; the
+/// analog preamp gain cannot be seen from software, so the standing rule is to
+/// leave the input gain untouched between calibration and measurement.
+/// </para>
+/// </summary>
+public sealed class SplCalibration
+{
+    /// <summary>The reference levels a standard IEC 60942 calibrator emits, in dB SPL.</summary>
+    public static readonly double[] StandardReferenceLevelsDb = [94.0, 104.0, 114.0];
+
+    /// <summary>The calibrator's stated output level at the reference frequency, in dB SPL.</summary>
+    public double ReferenceLevelDbSpl { get; set; }
+
+    /// <summary>
+    /// The microphone level actually captured at the reference frequency, in dBFS.
+    /// The measured half of the anchor.
+    /// </summary>
+    public double MeasuredLevelDbFs { get; set; }
+
+    /// <summary>The calibrator's nominal tone frequency, in Hz (1 kHz for IEC 60942).</summary>
+    public double ReferenceFrequencyHz { get; set; } = 1_000.0;
+
+    /// <summary>The frequency the dominant peak was actually found at, in Hz (provenance).</summary>
+    public double MeasuredFrequencyHz { get; set; }
+
+    /// <summary>When the calibration was captured.</summary>
+    public DateTimeOffset CapturedAtUtc { get; set; }
+
+    // --- Capture identity: the digital half of the gain chain the anchor is
+    // pinned to, so a later measurement on a different input can be flagged. ---
+
+    public AudioBackend Backend { get; set; }
+    public int SampleRate { get; set; }
+    public int Bits { get; set; }
+    public int MicrophoneChannelOffset { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? InputDeviceNumber { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? WasapiCaptureEndpointId { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AsioDriverName { get; set; }
+
+    /// <summary>
+    /// The microphone-side offset that turns a captured dBFS level into dB SPL:
+    /// <c>SPL = dBFS + OffsetDb</c>. Derived, so it never disagrees with the stored
+    /// reference and measured levels.
+    /// </summary>
+    [JsonIgnore]
+    public double OffsetDb => ReferenceLevelDbSpl - MeasuredLevelDbFs;
+
+    /// <summary>
+    /// Whether this anchor was captured on the same digital input as the supplied
+    /// configuration. The analog preamp gain is invisible to software and is not
+    /// part of this check — the anchor can still be wrong if that knob moved.
+    /// </summary>
+    public bool MatchesInput(
+        AudioBackend backend,
+        int sampleRate,
+        int bits,
+        int microphoneChannelOffset,
+        int? inputDeviceNumber,
+        string? wasapiCaptureEndpointId,
+        string? asioDriverName)
+    {
+        if (Backend != backend ||
+            SampleRate != sampleRate ||
+            Bits != bits ||
+            MicrophoneChannelOffset != microphoneChannelOffset)
+        {
+            return false;
+        }
+
+        return backend switch
+        {
+            AudioBackend.Asio =>
+                string.Equals(AsioDriverName, asioDriverName, StringComparison.Ordinal),
+            AudioBackend.WasapiShared or AudioBackend.WasapiExclusive =>
+                string.Equals(WasapiCaptureEndpointId, wasapiCaptureEndpointId, StringComparison.Ordinal),
+            _ => InputDeviceNumber == inputDeviceNumber
+        };
+    }
+
+    /// <summary>Same check against an <see cref="MeasurementInputIdentity"/>.</summary>
+    public bool MatchesInput(MeasurementInputIdentity identity) =>
+        MatchesInput(
+            identity.Backend,
+            identity.SampleRate,
+            identity.Bits,
+            identity.MicrophoneChannelOffset,
+            identity.InputDeviceNumber,
+            identity.WasapiCaptureEndpointId,
+            identity.AsioDriverName);
+
+    /// <summary>
+    /// The input this calibration was captured on, as an identity. For a loaded
+    /// measurement (whose anchor was validated when its file was first saved) this
+    /// stands in for the result's own input identity.
+    /// </summary>
+    public MeasurementInputIdentity CaptureIdentity => new(
+        Backend,
+        SampleRate,
+        Bits,
+        MicrophoneChannelOffset,
+        InputDeviceNumber,
+        WasapiCaptureEndpointId,
+        AsioDriverName);
+
+    /// <summary>
+    /// Throws when the anchor is structurally invalid (used when loading a
+    /// persisted file). This is a sanity check on the stored numbers, not the
+    /// pass/fail policy of a live calibration.
+    /// </summary>
+    public void Validate()
+    {
+        if (!double.IsFinite(ReferenceLevelDbSpl) || ReferenceLevelDbSpl is < 0.0 or > 200.0)
+        {
+            throw new InvalidDataException("The SPL calibration reference level is out of range.");
+        }
+        if (!double.IsFinite(MeasuredLevelDbFs) || MeasuredLevelDbFs is < -250.0 or > 24.0)
+        {
+            throw new InvalidDataException("The SPL calibration measured level is out of range.");
+        }
+        if (!double.IsFinite(ReferenceFrequencyHz) || ReferenceFrequencyHz is <= 0.0 or > 200_000.0 ||
+            !double.IsFinite(MeasuredFrequencyHz) || MeasuredFrequencyHz < 0.0 || MeasuredFrequencyHz > 200_000.0)
+        {
+            throw new InvalidDataException("The SPL calibration frequency is out of range.");
+        }
+        if (!Enum.IsDefined(Backend))
+        {
+            throw new InvalidDataException("The SPL calibration backend is invalid.");
+        }
+        if (SampleRate is < 8_000 or > 768_000)
+        {
+            throw new InvalidDataException("The SPL calibration sample rate is out of range.");
+        }
+        if (Bits is not (16 or 24))
+        {
+            throw new InvalidDataException("The SPL calibration bit depth is unsupported.");
+        }
+        if (MicrophoneChannelOffset < 0)
+        {
+            throw new InvalidDataException("The SPL calibration microphone channel is invalid.");
+        }
+    }
+}

--- a/source/Measurements/SplCalibrationListener.cs
+++ b/source/Measurements/SplCalibrationListener.cs
@@ -1,0 +1,368 @@
+using System.Threading.Channels;
+using Resonalyze.Audio;
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>How a calibration capture failed, or <see cref="None"/> on success.</summary>
+public enum SplCalibrationFailure
+{
+    None,
+    // The capture barely ran — a device or driver problem, not a tone problem.
+    TooFewFrames,
+    // The input railed at full scale: the level is meaningless. Lower the gain.
+    Clipped,
+    // The loudest tone was not near the calibrator frequency.
+    OffFrequency,
+    // Nothing stood clearly above the noise: no calibrator tone, or it is buried.
+    NoClearPeak,
+    // A tone was found but its level drifted during the capture (coupler not
+    // seated, or being fitted/removed while listening).
+    Unstable,
+    // The processing pipeline could not keep up and capture frames were dropped, so
+    // the peak / clipping / stability checks may have missed the very frames that
+    // would have failed the calibration. The result cannot be trusted.
+    CaptureOverrun
+}
+
+/// <summary>
+/// The outcome of one calibration listen. Carries the raw facts; the pass/fail
+/// policy is <see cref="SplCalibrationListener.Evaluate"/>.
+/// </summary>
+/// <param name="Reading">The tone found in the averaged spectrum.</param>
+/// <param name="InputPeakDbFs">The loudest microphone sample of the whole capture, in dBFS.</param>
+/// <param name="Clipped">Whether any sample reached full scale.</param>
+/// <param name="LevelStabilityDb">
+/// The standard deviation of the per-frame tone level, in dB; a steady calibrator
+/// reads a small fraction of a dB. <see cref="double.NaN"/> if too few frames.
+/// </param>
+/// <param name="FramesAnalyzed">How many analysis frames were averaged.</param>
+/// <param name="Overran">
+/// Whether any capture frame was dropped before analysis. When true the peak,
+/// clipping and stability figures are computed over an incomplete capture and
+/// must not be trusted.
+/// </param>
+public readonly record struct SplCalibrationCaptureResult(
+    SplToneReading Reading,
+    double InputPeakDbFs,
+    bool Clipped,
+    double LevelStabilityDb,
+    int FramesAnalyzed,
+    bool Overran);
+
+/// <summary>A live progress update raised while a calibration listen runs.</summary>
+public readonly record struct SplCalibrationProgress(
+    SplToneReading Reading,
+    double InputPeakDbFs,
+    bool Clipped,
+    int FramesAnalyzed,
+    double ElapsedSeconds);
+
+/// <summary>
+/// Listens to the microphone alone — no reference, no meaningful playback — to
+/// measure the level of an acoustic calibrator's tone. It opens a streaming
+/// session (the only capturing session the audio layer offers) with a silent
+/// looping signal and reads just the microphone channel, accumulating a
+/// flat-top power spectrum whose peak bin gives the tone's level in dBFS to a
+/// fraction of a dB regardless of where the tone falls between bins.
+/// </summary>
+public sealed class SplCalibrationListener
+{
+    // A sample this close to full scale is treated as clipped: the true level is
+    // then unknowable and the calibration must be rejected. ~-0.009 dBFS.
+    private const float ClipThreshold = 0.999f;
+
+    // Below this the capture did not really run (device/driver failure); there is
+    // nothing to judge.
+    private const int MinimumFrames = 4;
+
+    // The first frames can catch the device still priming (a silent or partial
+    // block); they are scanned for clipping but kept out of the averaged spectrum
+    // and the stability estimate so a cold start does not skew the level.
+    private const int WarmupFrames = 2;
+
+    // A seated calibrator holds its level to hundredths of a dB; this tolerates
+    // normal capture jitter while rejecting a coupler that is drifting or being
+    // fitted mid-listen.
+    private const double MaximumLevelStabilityDb = 1.5;
+
+    private readonly IAudioSessionFactory audioSessionFactory;
+
+    public SplCalibrationListener(IAudioSessionFactory audioSessionFactory)
+    {
+        this.audioSessionFactory = audioSessionFactory ??
+            throw new ArgumentNullException(nameof(audioSessionFactory));
+    }
+
+    /// <summary>
+    /// Captures for up to <paramref name="duration"/> and returns the averaged
+    /// tone reading. Cancelling <paramref name="cancellationToken"/> aborts (throws
+    /// <see cref="OperationCanceledException"/>); reaching the duration completes
+    /// normally with whatever was captured.
+    /// </summary>
+    public async Task<SplCalibrationCaptureResult> CaptureAsync(
+        AudioSessionRequest request,
+        int frameLength,
+        SplToneCriteria criteria,
+        TimeSpan duration,
+        IProgress<SplCalibrationProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (frameLength < 2 || (frameLength & (frameLength - 1)) != 0)
+        {
+            throw new ArgumentException("Frame length must be a power of two.", nameof(frameLength));
+        }
+
+        double binWidthHz = (double)request.SampleRate / frameLength;
+        int targetBin = (int)Math.Round(criteria.TargetFrequencyHz / binWidthHz);
+        int toleranceBins = Math.Max(1, (int)Math.Ceiling(criteria.FrequencyToleranceHz / binWidthHz));
+
+        // Accumulated on the single processing task, so no locking is needed; the
+        // capture thread only enqueues raw frames.
+        double[]? accumulatedPower = null;
+        int frameCount = 0;
+        int rawFrameIndex = 0;
+        double inputPeak = 0.0;
+        bool clipped = false;
+        var perFrameLevels = new List<double>();
+        var frameBuffer = new float[frameLength];
+        int fill = 0;
+        long startTick = Environment.TickCount64;
+        // Incremented on the capture thread when a raw block is dropped because the
+        // processing task fell behind; any drop invalidates the whole capture.
+        int droppedFrames = 0;
+        // Set when the backend reports a capture packet discontinuity — loss BEFORE
+        // the bounded channel, which the drop counter above cannot see.
+        int captureDiscontinuities = 0;
+
+        var frames = Channel.CreateBounded<float[]>(
+            new BoundedChannelOptions(8)
+            {
+                SingleReader = true,
+                SingleWriter = true,
+                FullMode = BoundedChannelFullMode.DropOldest
+            },
+            _ => Interlocked.Increment(ref droppedFrames));
+
+        void ProcessFrame()
+        {
+            for (int i = 0; i < frameBuffer.Length; i++)
+            {
+                float magnitude = Math.Abs(frameBuffer[i]);
+                if (magnitude > inputPeak)
+                {
+                    inputPeak = magnitude;
+                }
+                if (magnitude >= ClipThreshold)
+                {
+                    clipped = true;
+                }
+            }
+
+            // Warm-up frames still count for clipping (the gain is wrong from the
+            // first sample) but not for the level, which the device may not have
+            // settled to yet.
+            if (rawFrameIndex++ < WarmupFrames)
+            {
+                return;
+            }
+
+            double[] power = SpectrumAnalysis.ComputePowerSpectrum(frameBuffer, WindowType.FlatTop);
+            accumulatedPower ??= new double[power.Length];
+            for (int i = 0; i < accumulatedPower.Length; i++)
+            {
+                accumulatedPower[i] += power[i];
+            }
+
+            frameCount++;
+            perFrameLevels.Add(PeakLevelNearTarget(power, targetBin, toleranceBins));
+
+            if (progress != null)
+            {
+                var averaged = new double[accumulatedPower.Length];
+                for (int i = 0; i < averaged.Length; i++)
+                {
+                    averaged[i] = accumulatedPower[i] / frameCount;
+                }
+
+                progress.Report(new SplCalibrationProgress(
+                    SplToneAnalysis.Analyze(averaged, binWidthHz, criteria),
+                    InputLevelToDbFs(inputPeak),
+                    clipped,
+                    frameCount,
+                    (Environment.TickCount64 - startTick) / 1000.0));
+            }
+        }
+
+        Task processing = Task.Run(async () =>
+        {
+            await foreach (float[] block in frames.Reader.ReadAllAsync())
+            {
+                int position = 0;
+                while (position < block.Length)
+                {
+                    int take = Math.Min(frameLength - fill, block.Length - position);
+                    Array.Copy(block, position, frameBuffer, fill, take);
+                    fill += take;
+                    position += take;
+                    if (fill == frameLength)
+                    {
+                        ProcessFrame();
+                        fill = 0;
+                    }
+                }
+            }
+        });
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(duration);
+
+        var silence = new AudioPlaybackSignal(
+            new float[request.SampleRate],
+            request.SampleRate,
+            request.BitsPerSample,
+            request.PlaybackChannel,
+            Loop: true);
+
+        IAudioStreamingSession? session = null;
+        void HandleFrame(AudioCaptureFrame frame)
+        {
+            int micIndex = frame.MicrophoneChannel;
+            if ((uint)micIndex < (uint)frame.Channels.Length)
+            {
+                frames.Writer.TryWrite(frame.Channels[micIndex]);
+            }
+        }
+
+        void HandleDiscontinuity() => Interlocked.Increment(ref captureDiscontinuities);
+
+        try
+        {
+            session = await audioSessionFactory
+                .OpenStreamingAsync(request, timeoutCts.Token).ConfigureAwait(false);
+            session.FrameAvailable += HandleFrame;
+            session.CaptureDiscontinuity += HandleDiscontinuity;
+            await session.RunAsync(silence, frameLength, timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Reaching the requested duration cancels the timeout token — the
+            // normal way this capture ends. A caller cancellation is re-thrown below.
+        }
+        finally
+        {
+            if (session != null)
+            {
+                session.FrameAvailable -= HandleFrame;
+                session.CaptureDiscontinuity -= HandleDiscontinuity;
+                await session.DisposeAsync().ConfigureAwait(false);
+            }
+
+            frames.Writer.TryComplete();
+            await processing.ConfigureAwait(false);
+        }
+
+        // A caller cancellation (not the duration timeout) is an abort, not a result.
+        cancellationToken.ThrowIfCancellationRequested();
+
+        double[] finalSpectrum = accumulatedPower ?? new double[frameLength / 2];
+        if (frameCount > 0)
+        {
+            for (int i = 0; i < finalSpectrum.Length; i++)
+            {
+                finalSpectrum[i] /= frameCount;
+            }
+        }
+
+        return new SplCalibrationCaptureResult(
+            SplToneAnalysis.Analyze(finalSpectrum, binWidthHz, criteria),
+            InputLevelToDbFs(inputPeak),
+            clipped,
+            StandardDeviationDb(perFrameLevels),
+            frameCount,
+            Volatile.Read(ref droppedFrames) > 0 ||
+                Volatile.Read(ref captureDiscontinuities) > 0);
+    }
+
+    /// <summary>
+    /// The pass/fail policy over a capture result. Checks are ordered by which
+    /// message is most useful to the user first.
+    /// </summary>
+    public static SplCalibrationFailure Evaluate(SplCalibrationCaptureResult result)
+    {
+        // A dropped frame means the clip / peak / stability checks ran over an
+        // incomplete capture — the missing frames could be the failing ones — so
+        // nothing else about the result can be trusted.
+        if (result.Overran)
+        {
+            return SplCalibrationFailure.CaptureOverrun;
+        }
+        if (result.FramesAnalyzed < MinimumFrames)
+        {
+            return SplCalibrationFailure.TooFewFrames;
+        }
+        if (result.Clipped)
+        {
+            return SplCalibrationFailure.Clipped;
+        }
+        if (!result.Reading.WithinFrequencyTolerance)
+        {
+            return SplCalibrationFailure.OffFrequency;
+        }
+        if (!result.Reading.HasClearPeak)
+        {
+            return SplCalibrationFailure.NoClearPeak;
+        }
+        if (!double.IsFinite(result.LevelStabilityDb) ||
+            result.LevelStabilityDb > MaximumLevelStabilityDb)
+        {
+            return SplCalibrationFailure.Unstable;
+        }
+
+        return SplCalibrationFailure.None;
+    }
+
+    private static double PeakLevelNearTarget(double[] power, int targetBin, int toleranceBins)
+    {
+        int low = Math.Max(1, targetBin - toleranceBins);
+        int high = Math.Min(power.Length - 1, targetBin + toleranceBins);
+        double peak = 0.0;
+        for (int bin = low; bin <= high; bin++)
+        {
+            if (power[bin] > peak)
+            {
+                peak = power[bin];
+            }
+        }
+
+        return 10.0 * Math.Log10(Math.Max(peak, 1e-40));
+    }
+
+    private static double StandardDeviationDb(IReadOnlyList<double> levels)
+    {
+        if (levels.Count < 2)
+        {
+            return double.NaN;
+        }
+
+        double mean = 0.0;
+        foreach (double level in levels)
+        {
+            mean += level;
+        }
+        mean /= levels.Count;
+
+        double variance = 0.0;
+        foreach (double level in levels)
+        {
+            double delta = level - mean;
+            variance += delta * delta;
+        }
+
+        return Math.Sqrt(variance / levels.Count);
+    }
+
+    private static double InputLevelToDbFs(double amplitude) =>
+        20.0 * Math.Log10(Math.Max(amplitude, 1e-10));
+}

--- a/source/Options/FROptions.Designer.cs
+++ b/source/Options/FROptions.Designer.cs
@@ -38,6 +38,9 @@ namespace Resonalyze.Options
             comboSmoothingInverseOctaves = new DarkComboBox();
             comboCalibration = new DarkComboBox();
             label2 = new Label();
+            labelScale = new Label();
+            radioMagnitudeRelative = new RadioButton();
+            radioMagnitudeSpl = new RadioButton();
             labelCurves = new Label();
             checkBoxShowPrimary = new CheckBox();
             checkBoxShowCoherence = new CheckBox();
@@ -176,11 +179,45 @@ namespace Resonalyze.Options
             label2.TabIndex = 46;
             label2.Text = "Calibration";
             //
+            // labelScale
+            //
+            labelScale.AutoSize = true;
+            labelScale.ForeColor = SystemColors.ControlLight;
+            labelScale.Location = new Point(12, 137);
+            labelScale.Name = "labelScale";
+            labelScale.Size = new Size(35, 15);
+            labelScale.TabIndex = 55;
+            labelScale.Text = "Scale";
+            //
+            // radioMagnitudeRelative
+            //
+            radioMagnitudeRelative.AutoSize = true;
+            radioMagnitudeRelative.Checked = true;
+            radioMagnitudeRelative.ForeColor = SystemColors.ControlLight;
+            radioMagnitudeRelative.Location = new Point(72, 135);
+            radioMagnitudeRelative.Name = "radioMagnitudeRelative";
+            radioMagnitudeRelative.Size = new Size(72, 19);
+            radioMagnitudeRelative.TabIndex = 56;
+            radioMagnitudeRelative.TabStop = true;
+            radioMagnitudeRelative.Text = "dBr/dBc";
+            radioMagnitudeRelative.UseVisualStyleBackColor = true;
+            //
+            // radioMagnitudeSpl
+            //
+            radioMagnitudeSpl.AutoSize = true;
+            radioMagnitudeSpl.ForeColor = SystemColors.ControlLight;
+            radioMagnitudeSpl.Location = new Point(153, 135);
+            radioMagnitudeSpl.Name = "radioMagnitudeSpl";
+            radioMagnitudeSpl.Size = new Size(66, 19);
+            radioMagnitudeSpl.TabIndex = 57;
+            radioMagnitudeSpl.Text = "dB SPL";
+            radioMagnitudeSpl.UseVisualStyleBackColor = true;
+            //
             // labelCurves
             //
             labelCurves.AutoSize = true;
             labelCurves.ForeColor = Color.FromArgb(150, 170, 205);
-            labelCurves.Location = new Point(12, 136);
+            labelCurves.Location = new Point(12, 165);
             labelCurves.Name = "labelCurves";
             labelCurves.Size = new Size(46, 15);
             labelCurves.TabIndex = 53;
@@ -190,7 +227,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowPrimary.AutoSize = true;
             checkBoxShowPrimary.ForeColor = SystemColors.ControlLight;
-            checkBoxShowPrimary.Location = new Point(12, 158);
+            checkBoxShowPrimary.Location = new Point(12, 187);
             checkBoxShowPrimary.Name = "checkBoxShowPrimary";
             checkBoxShowPrimary.Size = new Size(161, 19);
             checkBoxShowPrimary.TabIndex = 48;
@@ -201,7 +238,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowCoherence.AutoSize = true;
             checkBoxShowCoherence.ForeColor = SystemColors.ControlLight;
-            checkBoxShowCoherence.Location = new Point(12, 290);
+            checkBoxShowCoherence.Location = new Point(12, 319);
             checkBoxShowCoherence.Name = "checkBoxShowCoherence";
             checkBoxShowCoherence.Size = new Size(134, 19);
             checkBoxShowCoherence.TabIndex = 54;
@@ -212,7 +249,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowHd2.AutoSize = true;
             checkBoxShowHd2.ForeColor = SystemColors.ControlLight;
-            checkBoxShowHd2.Location = new Point(12, 180);
+            checkBoxShowHd2.Location = new Point(12, 209);
             checkBoxShowHd2.Name = "checkBoxShowHd2";
             checkBoxShowHd2.Size = new Size(81, 19);
             checkBoxShowHd2.TabIndex = 49;
@@ -223,7 +260,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowHd3.AutoSize = true;
             checkBoxShowHd3.ForeColor = SystemColors.ControlLight;
-            checkBoxShowHd3.Location = new Point(12, 202);
+            checkBoxShowHd3.Location = new Point(12, 231);
             checkBoxShowHd3.Name = "checkBoxShowHd3";
             checkBoxShowHd3.Size = new Size(81, 19);
             checkBoxShowHd3.TabIndex = 50;
@@ -234,7 +271,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowHd4.AutoSize = true;
             checkBoxShowHd4.ForeColor = SystemColors.ControlLight;
-            checkBoxShowHd4.Location = new Point(12, 224);
+            checkBoxShowHd4.Location = new Point(12, 253);
             checkBoxShowHd4.Name = "checkBoxShowHd4";
             checkBoxShowHd4.Size = new Size(81, 19);
             checkBoxShowHd4.TabIndex = 51;
@@ -245,7 +282,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowThdPlusNoise.AutoSize = true;
             checkBoxShowThdPlusNoise.ForeColor = SystemColors.ControlLight;
-            checkBoxShowThdPlusNoise.Location = new Point(12, 246);
+            checkBoxShowThdPlusNoise.Location = new Point(12, 275);
             checkBoxShowThdPlusNoise.Name = "checkBoxShowThdPlusNoise";
             checkBoxShowThdPlusNoise.Size = new Size(82, 19);
             checkBoxShowThdPlusNoise.TabIndex = 52;
@@ -256,7 +293,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowNoiseFloor.AutoSize = true;
             checkBoxShowNoiseFloor.ForeColor = SystemColors.ControlLight;
-            checkBoxShowNoiseFloor.Location = new Point(12, 268);
+            checkBoxShowNoiseFloor.Location = new Point(12, 297);
             checkBoxShowNoiseFloor.Name = "checkBoxShowNoiseFloor";
             checkBoxShowNoiseFloor.Size = new Size(114, 19);
             checkBoxShowNoiseFloor.TabIndex = 53;
@@ -266,7 +303,7 @@ namespace Resonalyze.Options
             // irPlotView
             //
             irPlotView.BackColor = Color.FromArgb(32, 36, 46);
-            irPlotView.Location = new Point(12, 316);
+            irPlotView.Location = new Point(12, 345);
             irPlotView.Name = "irPlotView";
             irPlotView.PanCursor = Cursors.Hand;
             irPlotView.Size = new Size(241, 300);
@@ -281,8 +318,11 @@ namespace Resonalyze.Options
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(45, 50, 60);
-            ClientSize = new Size(265, 623);
+            ClientSize = new Size(265, 652);
             Controls.Add(irPlotView);
+            Controls.Add(labelScale);
+            Controls.Add(radioMagnitudeRelative);
+            Controls.Add(radioMagnitudeSpl);
             Controls.Add(checkBoxShowNoiseFloor);
             Controls.Add(checkBoxShowThdPlusNoise);
             Controls.Add(checkBoxShowHd4);
@@ -326,6 +366,9 @@ namespace Resonalyze.Options
         private DarkComboBox comboSmoothingInverseOctaves;
         private DarkComboBox comboCalibration;
         private Label label2;
+        private Label labelScale;
+        private RadioButton radioMagnitudeRelative;
+        private RadioButton radioMagnitudeSpl;
         private Label labelCurves;
         private CheckBox checkBoxShowPrimary;
         private CheckBox checkBoxShowCoherence;

--- a/source/Options/FROptions.cs
+++ b/source/Options/FROptions.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Resonalyze.Dsp;
+using Resonalyze.Ui;
 
 namespace Resonalyze.Options
 {
@@ -49,6 +50,15 @@ namespace Resonalyze.Options
                 checkBoxShowHd4.Checked = visibility.ShowHd4;
                 checkBoxShowThdPlusNoise.Checked = visibility.ShowThdPlusNoise;
                 checkBoxShowNoiseFloor.Checked = visibility.ShowNoiseFloor;
+                // Keep the radio Enabled and mute it instead, so a disabled SPL choice
+                // renders in the theme's muted colour rather than the near-black system
+                // grey that WinForms would paint on the dark background.
+                bool splAvailable = IsSplAvailable();
+                UiStyle.SetTextEnabledLook(radioMagnitudeSpl, splAvailable, interactive: true);
+                bool spl = frequencyResponseOptions.MagnitudeScale == MagnitudeScale.SoundPressureLevel
+                    && splAvailable;
+                radioMagnitudeSpl.Checked = spl;
+                radioMagnitudeRelative.Checked = !spl;
                 UpdateTukeyWindowLimits();
             });
             UpdateIrPreview();
@@ -74,7 +84,44 @@ namespace Resonalyze.Options
             visibility.ShowHd4 = checkBoxShowHd4.Checked;
             visibility.ShowThdPlusNoise = checkBoxShowThdPlusNoise.Checked;
             visibility.ShowNoiseFloor = checkBoxShowNoiseFloor.Checked;
+            frequencyResponseOptions.MagnitudeScale = radioMagnitudeSpl.Checked
+                ? MagnitudeScale.SoundPressureLevel
+                : MagnitudeScale.Relative;
             UpdateIrPreview();
+        }
+
+        // SPL is offerable exactly when the plot can render it — mirror
+        // MeasurementPlotContext.SplOffsetDb: this measurement's own (snapshot)
+        // calibration, a captured loopback level, and an input that matches the anchor.
+        // Using the snapshot rather than the configured calibration keeps the panel in
+        // step with the plot for a completed run and for a loaded file (whose anchor is
+        // its own, not the app's currently configured one).
+        private bool IsSplAvailable() =>
+            Measurement is { } measurement &&
+            measurement.MeasurementSplCalibration is { } calibration &&
+            measurement.CurrentLevels.Loopback.Available &&
+            measurement.InputMatches(calibration);
+
+        /// <summary>
+        /// Re-evaluates whether dB SPL can be offered, without disturbing the current
+        /// selection. The panel can open before a measurement runs (no captured
+        /// loopback level yet), so the choice starts disabled; the host calls this once
+        /// a measurement or a loaded file provides the level, so the user can switch to
+        /// SPL without reopening the panel.
+        /// </summary>
+        public void RefreshSplAvailability()
+        {
+            bool available = IsSplAvailable();
+            UiStyle.SetTextEnabledLook(radioMagnitudeSpl, available, interactive: true);
+
+            // If SPL was the chosen scale but is no longer available (a run failed, or a
+            // file without a usable anchor was loaded), the plot already fell back to
+            // relative — move the selection with it so the checked radio does not
+            // contradict the axis.
+            if (!available && radioMagnitudeSpl.Checked)
+            {
+                radioMagnitudeRelative.Checked = true;
+            }
         }
 
         private void numericWindow_ValueChanged(object sender, EventArgs e)
@@ -132,6 +179,17 @@ namespace Resonalyze.Options
             toolTip.SetToolTip(
                 comboCalibration,
                 "Applies the selected microphone calibration file to the displayed frequency response.");
+            toolTip.SetToolTip(
+                labelScale,
+                "Vertical scale of the magnitude plot.");
+            toolTip.SetToolTip(
+                radioMagnitudeRelative,
+                "Native scale: the response in dBr (relative to the loopback reference), " +
+                "distortion and noise in dBc (relative to the fundamental).");
+            toolTip.SetToolTip(
+                radioMagnitudeSpl,
+                "Absolute dB SPL from the microphone SPL calibration. Available only when this " +
+                "measurement has a valid calibration and a captured loopback level.");
             toolTip.SetToolTip(
                 checkBoxShowPrimary,
                 "Shows the primary frequency-response curve.");

--- a/source/Options/LiveSpectrumOpt.Designer.cs
+++ b/source/Options/LiveSpectrumOpt.Designer.cs
@@ -49,6 +49,9 @@ namespace Resonalyze.Options
             label10 = new Label();
             coherenceLimitComboBox = new DarkComboBox();
             buttonResetAverage = new Button();
+            labelScale = new Label();
+            radioMagnitudeRelative = new RadioButton();
+            radioMagnitudeSpl = new RadioButton();
             labelCurves = new Label();
             labelMainCurve = new Label();
             checkMainCurve = new CheckBox();
@@ -207,7 +210,7 @@ namespace Resonalyze.Options
             //
             label8.AutoSize = true;
             label8.ForeColor = SystemColors.ControlLight;
-            label8.Location = new Point(12, 332);
+            label8.Location = new Point(12, 360);
             label8.Name = "label8";
             label8.Size = new Size(60, 15);
             label8.TabIndex = 59;
@@ -217,7 +220,7 @@ namespace Resonalyze.Options
             //
             checkPeakHold.AutoSize = true;
             checkPeakHold.ForeColor = SystemColors.ControlLight;
-            checkPeakHold.Location = new Point(238, 332);
+            checkPeakHold.Location = new Point(238, 360);
             checkPeakHold.Name = "checkPeakHold";
             checkPeakHold.Size = new Size(15, 14);
             checkPeakHold.TabIndex = 60;
@@ -227,7 +230,7 @@ namespace Resonalyze.Options
             //
             label9.AutoSize = true;
             label9.ForeColor = SystemColors.ControlLight;
-            label9.Location = new Point(12, 309);
+            label9.Location = new Point(12, 337);
             label9.Name = "label9";
             label9.Size = new Size(64, 15);
             label9.TabIndex = 62;
@@ -237,7 +240,7 @@ namespace Resonalyze.Options
             //
             checkCoherence.AutoSize = true;
             checkCoherence.ForeColor = SystemColors.ControlLight;
-            checkCoherence.Location = new Point(238, 309);
+            checkCoherence.Location = new Point(238, 337);
             checkCoherence.Name = "checkCoherence";
             checkCoherence.Size = new Size(15, 14);
             checkCoherence.TabIndex = 63;
@@ -269,18 +272,52 @@ namespace Resonalyze.Options
             buttonResetAverage.BackColor = Color.FromArgb(50, 55, 80);
             buttonResetAverage.FlatStyle = FlatStyle.Popup;
             buttonResetAverage.ForeColor = Color.White;
-            buttonResetAverage.Location = new Point(12, 358);
+            buttonResetAverage.Location = new Point(12, 386);
             buttonResetAverage.Name = "buttonResetAverage";
             buttonResetAverage.Size = new Size(241, 23);
             buttonResetAverage.TabIndex = 61;
             buttonResetAverage.Text = "Reset Average";
             buttonResetAverage.UseVisualStyleBackColor = false;
             //
+            // labelScale
+            //
+            labelScale.AutoSize = true;
+            labelScale.ForeColor = SystemColors.ControlLight;
+            labelScale.Location = new Point(12, 245);
+            labelScale.Name = "labelScale";
+            labelScale.Size = new Size(35, 15);
+            labelScale.TabIndex = 71;
+            labelScale.Text = "Scale";
+            //
+            // radioMagnitudeRelative
+            //
+            radioMagnitudeRelative.AutoSize = true;
+            radioMagnitudeRelative.Checked = true;
+            radioMagnitudeRelative.ForeColor = SystemColors.ControlLight;
+            radioMagnitudeRelative.Location = new Point(85, 243);
+            radioMagnitudeRelative.Name = "radioMagnitudeRelative";
+            radioMagnitudeRelative.Size = new Size(70, 19);
+            radioMagnitudeRelative.TabIndex = 72;
+            radioMagnitudeRelative.TabStop = true;
+            radioMagnitudeRelative.Text = "Relative";
+            radioMagnitudeRelative.UseVisualStyleBackColor = true;
+            //
+            // radioMagnitudeSpl
+            //
+            radioMagnitudeSpl.AutoSize = true;
+            radioMagnitudeSpl.ForeColor = SystemColors.ControlLight;
+            radioMagnitudeSpl.Location = new Point(168, 243);
+            radioMagnitudeSpl.Name = "radioMagnitudeSpl";
+            radioMagnitudeSpl.Size = new Size(66, 19);
+            radioMagnitudeSpl.TabIndex = 73;
+            radioMagnitudeSpl.Text = "dB SPL";
+            radioMagnitudeSpl.UseVisualStyleBackColor = true;
+            //
             // labelCurves
             //
             labelCurves.AutoSize = true;
             labelCurves.ForeColor = Color.FromArgb(150, 170, 205);
-            labelCurves.Location = new Point(12, 240);
+            labelCurves.Location = new Point(12, 268);
             labelCurves.Name = "labelCurves";
             labelCurves.Size = new Size(48, 15);
             labelCurves.TabIndex = 66;
@@ -290,7 +327,7 @@ namespace Resonalyze.Options
             //
             labelMainCurve.AutoSize = true;
             labelMainCurve.ForeColor = SystemColors.ControlLight;
-            labelMainCurve.Location = new Point(12, 263);
+            labelMainCurve.Location = new Point(12, 291);
             labelMainCurve.Name = "labelMainCurve";
             labelMainCurve.Size = new Size(67, 15);
             labelMainCurve.TabIndex = 67;
@@ -300,7 +337,7 @@ namespace Resonalyze.Options
             //
             checkMainCurve.AutoSize = true;
             checkMainCurve.ForeColor = SystemColors.ControlLight;
-            checkMainCurve.Location = new Point(238, 263);
+            checkMainCurve.Location = new Point(238, 291);
             checkMainCurve.Name = "checkMainCurve";
             checkMainCurve.Size = new Size(15, 14);
             checkMainCurve.TabIndex = 68;
@@ -310,7 +347,7 @@ namespace Resonalyze.Options
             //
             labelInputMagnitude.AutoSize = true;
             labelInputMagnitude.ForeColor = SystemColors.ControlLight;
-            labelInputMagnitude.Location = new Point(12, 286);
+            labelInputMagnitude.Location = new Point(12, 314);
             labelInputMagnitude.Name = "labelInputMagnitude";
             labelInputMagnitude.Size = new Size(67, 15);
             labelInputMagnitude.TabIndex = 69;
@@ -320,7 +357,7 @@ namespace Resonalyze.Options
             //
             checkInputMagnitude.AutoSize = true;
             checkInputMagnitude.ForeColor = SystemColors.ControlLight;
-            checkInputMagnitude.Location = new Point(238, 286);
+            checkInputMagnitude.Location = new Point(238, 314);
             checkInputMagnitude.Name = "checkInputMagnitude";
             checkInputMagnitude.Size = new Size(15, 14);
             checkInputMagnitude.TabIndex = 70;
@@ -331,9 +368,12 @@ namespace Resonalyze.Options
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(45, 50, 60);
-            ClientSize = new Size(265, 393);
+            ClientSize = new Size(265, 421);
             Controls.Add(signalTypeComboBox);
             Controls.Add(labelSignalType);
+            Controls.Add(labelScale);
+            Controls.Add(radioMagnitudeRelative);
+            Controls.Add(radioMagnitudeSpl);
             Controls.Add(checkInputMagnitude);
             Controls.Add(labelInputMagnitude);
             Controls.Add(checkMainCurve);
@@ -391,6 +431,9 @@ namespace Resonalyze.Options
         private Label label10;
         private DarkComboBox coherenceLimitComboBox;
         private Button buttonResetAverage;
+        private Label labelScale;
+        private RadioButton radioMagnitudeRelative;
+        private RadioButton radioMagnitudeSpl;
         private Label labelCurves;
         private Label labelMainCurve;
         private CheckBox checkMainCurve;

--- a/source/Options/LiveSpectrumOpt.cs
+++ b/source/Options/LiveSpectrumOpt.cs
@@ -1,4 +1,5 @@
 using Resonalyze.Dsp;
+using Resonalyze.Ui;
 
 namespace Resonalyze.Options
 {
@@ -16,6 +17,18 @@ namespace Resonalyze.Options
         private WindowType userWindowType = WindowType.Hann;
         private int userOverlapPercent = 50;
 
+        // The user's RTA (input magnitude) choice, tracked independently so the SPL
+        // mode — which forces the RTA on and locks its checkbox — can restore the
+        // real preference when the plot returns to the relative scale.
+        private bool userShowInputMagnitude;
+
+        // The user's last chosen signal, remembered so a scale switch keeps it when the
+        // new scale still offers it, and restores it on the way back. The two scales
+        // differ only by their exclusive signal: periodic pink (the transfer function's
+        // reference) is relative-only, Silent (an ambient RTA with no excitation) is
+        // SPL-only; the plain Pink/Brown/White excitations are shared.
+        private NoiseColor userSignalType = NoiseColor.PinkPeriodic;
+
         /// <summary>
         /// Raised when the user clicks Reset Average. Handled live (without an
         /// Apply / restart) so the Infinite averaging preset can be cleared.
@@ -27,9 +40,15 @@ namespace Resonalyze.Options
             InitializeComponent();
             SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
             buttonResetAverage.Click += (_, _) => ResetAverageRequested?.Invoke();
-            signalTypeComboBox.SelectionChangeCommitted += (_, _) => UpdatePeriodicPinkControls();
+            signalTypeComboBox.SelectionChangeCommitted += (_, _) =>
+            {
+                CaptureUserSignalType();
+                UpdatePeriodicPinkControls();
+            };
             windowComboBox.SelectionChangeCommitted += (_, _) => CaptureUserWindow();
             overlapComboBox.SelectionChangeCommitted += (_, _) => CaptureUserOverlap();
+            radioMagnitudeSpl.CheckedChanged += (_, _) => UpdateScaleDependentControls();
+            checkInputMagnitude.Click += (_, _) => CaptureUserInputMagnitude();
             InitializeToolTips();
             Disposed += (_, _) => toolTip.Dispose();
         }
@@ -37,16 +56,13 @@ namespace Resonalyze.Options
         public void Init(
             LiveSpectrumOptions options,
             bool hasZeroDegreeCalibration,
-            bool hasNinetyDegreeCalibration)
+            bool hasNinetyDegreeCalibration,
+            bool isSplAvailable)
         {
-            signalTypeComboBox.Items.Clear();
+            // The signal list is populated per scale in UpdateScaleDependentControls
+            // below; remember the stored signal so it survives a scale round-trip.
             signalTypeComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
-            signalTypeComboBox.Items.Add(
-                new NoiseColorOption(NoiseColor.PinkPeriodic, "Pink noise (periodic)"));
-            signalTypeComboBox.Items.Add(new NoiseColorOption(NoiseColor.Pink, "Pink noise"));
-            signalTypeComboBox.Items.Add(new NoiseColorOption(NoiseColor.Brown, "Brown / red noise"));
-            signalTypeComboBox.Items.Add(new NoiseColorOption(NoiseColor.White, "White noise"));
-            signalTypeComboBox.SelectedIndex = FindNoiseColorIndex(options.NoiseColor);
+            userSignalType = options.NoiseColor;
 
             sequenceLengthComboBox.Items.Clear();
             foreach (int sequenceLength in SequenceLengths)
@@ -76,7 +92,6 @@ namespace Resonalyze.Options
                 new WindowOption(WindowType.Rectangular, "Rectangular"));
             userWindowType = options.WindowType;
             windowComboBox.SelectedIndex = FindWindowIndex(options.WindowType);
-            UpdatePeriodicPinkControls();
 
             averagingComboBox.Items.Clear();
             averagingComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
@@ -97,8 +112,21 @@ namespace Resonalyze.Options
 
             checkMainCurve.Checked = options.ShowMainCurve;
             checkInputMagnitude.Checked = options.ShowInputMagnitude;
+            userShowInputMagnitude = options.ShowInputMagnitude;
             checkPeakHold.Checked = options.PeakHold;
             checkCoherence.Checked = options.ShowCoherence;
+
+            // SPL shows the microphone (RTA) spectrum in absolute dB SPL; it is
+            // offerable only when a matching SPL calibration is configured for the
+            // live input. A stale/absent calibration mutes the choice (kept Enabled so
+            // the dark theme's muted colour is used, not the near-black system grey).
+            UiStyle.SetTextEnabledLook(radioMagnitudeSpl, isSplAvailable, interactive: true);
+            bool spl = options.MagnitudeScale == MagnitudeScale.SoundPressureLevel
+                && isSplAvailable;
+            radioMagnitudeSpl.Checked = spl;
+            radioMagnitudeRelative.Checked = !spl;
+            UpdateScaleDependentControls();
+
             MicrophoneCalibrationComboHelper.Configure(
                 comboCalibration,
                 options.CalibrationMode,
@@ -132,13 +160,18 @@ namespace Resonalyze.Options
                     ? averagingOption.Speed
                     : AveragingSpeed.Medium;
             options.ShowMainCurve = checkMainCurve.Checked;
-            options.ShowInputMagnitude = checkInputMagnitude.Checked;
+            // Persist the user's real RTA choice, not the value forced (and locked) on
+            // while SPL mode is selected.
+            options.ShowInputMagnitude = userShowInputMagnitude;
             options.PeakHold = checkPeakHold.Checked;
             options.ShowCoherence = checkCoherence.Checked;
             options.CoherenceThresholdPercent =
                 coherenceLimitComboBox.SelectedItem is CoherenceLimitOption limitOption
                     ? limitOption.Percent
                     : CoherenceLimits[0];
+            options.MagnitudeScale = radioMagnitudeSpl.Checked
+                ? MagnitudeScale.SoundPressureLevel
+                : MagnitudeScale.Relative;
         }
 
         private static int FindCoherenceLimitIndex(int thresholdPercent) =>
@@ -195,6 +228,89 @@ namespace Resonalyze.Options
                 windowComboBox.SelectedIndex = FindWindowIndex(userWindowType);
                 overlapComboBox.Enabled = true;
                 overlapComboBox.SelectedIndex = FindOverlapIndex(userOverlapPercent);
+            }
+        }
+
+        // In SPL mode the plot is the absolute microphone (RTA) spectrum. The transfer
+        // function and coherence are dimensionless ratios with no SPL under noise
+        // excitation, so their curve controls are disabled. The RTA is the one shown
+        // curve, so it is forced on and locked; its relative-mode preference is kept in
+        // userShowInputMagnitude and restored when the scale returns to relative.
+        private void UpdateScaleDependentControls()
+        {
+            bool spl = radioMagnitudeSpl.Checked;
+            UpdateSignalTypesForScale(spl);
+
+            // Mute (rather than WinForms-disable) the transfer/coherence controls so
+            // they read as the theme's muted colour, not the near-black system grey.
+            UiStyle.SetTextEnabledLook(labelMainCurve, !spl);
+            UiStyle.SetTextEnabledLook(checkMainCurve, !spl, interactive: true);
+            UiStyle.SetTextEnabledLook(labelInputMagnitude, !spl);
+            UiStyle.SetTextEnabledLook(checkInputMagnitude, !spl, interactive: true);
+            UiStyle.SetTextEnabledLook(label9, !spl);
+            UiStyle.SetTextEnabledLook(checkCoherence, !spl, interactive: true);
+            UiStyle.SetTextEnabledLook(label10, !spl);
+            // The coherence-limit combo is a DarkComboBox, which mutes itself on Enabled.
+            coherenceLimitComboBox.Enabled = !spl;
+
+            checkInputMagnitude.Checked = spl || userShowInputMagnitude;
+        }
+
+        // The signal list follows the scale, differing only by the one scale-exclusive
+        // signal. SPL is a reference-free RTA, so periodic pink — which exists only to
+        // converge the transfer function fast — is dropped and Silent (an ambient RTA
+        // with no excitation) is offered alongside the plain Pink/Brown/White colours
+        // you can still play and measure the SPL of. The relative scale needs a known
+        // reference, so it drops Silent and offers periodic pink. The last signal is
+        // kept when the new scale still has it (Pink/Brown/White carry across), so a
+        // scale round-trip does not silently swap the excitation.
+        private void UpdateSignalTypesForScale(bool spl)
+        {
+            signalTypeComboBox.Items.Clear();
+            if (spl)
+            {
+                signalTypeComboBox.Items.Add(new NoiseColorOption(NoiseColor.Silent, "Silent"));
+            }
+            else
+            {
+                signalTypeComboBox.Items.Add(
+                    new NoiseColorOption(NoiseColor.PinkPeriodic, "Pink noise (periodic)"));
+            }
+
+            signalTypeComboBox.Items.Add(new NoiseColorOption(NoiseColor.Pink, "Pink noise"));
+            signalTypeComboBox.Items.Add(new NoiseColorOption(NoiseColor.Brown, "Brown / red noise"));
+            signalTypeComboBox.Items.Add(new NoiseColorOption(NoiseColor.White, "White noise"));
+
+            // Keep the remembered signal if this scale offers it; otherwise use the
+            // scale's exclusive default (Silent for SPL, periodic pink for relative).
+            int index = TryFindNoiseColorIndex(userSignalType);
+            if (index < 0)
+            {
+                index = FindNoiseColorIndex(spl ? NoiseColor.Silent : NoiseColor.PinkPeriodic);
+            }
+
+            signalTypeComboBox.SelectedIndex = index;
+            UpdatePeriodicPinkControls();
+        }
+
+        // Only a real user commit updates the remembered signal — never the programmatic
+        // re-selection above, which would pollute it with an auto-picked default.
+        private void CaptureUserSignalType()
+        {
+            if (signalTypeComboBox.SelectedItem is NoiseColorOption option)
+            {
+                userSignalType = option.NoiseColor;
+            }
+        }
+
+        // Only a real user toggle updates the remembered RTA preference. In SPL mode the
+        // checkbox is muted (AutoCheck off), so a click cannot change it — guard on that
+        // rather than Enabled, which stays true for the muted look.
+        private void CaptureUserInputMagnitude()
+        {
+            if (checkInputMagnitude.AutoCheck)
+            {
+                userShowInputMagnitude = checkInputMagnitude.Checked;
             }
         }
 
@@ -295,6 +411,12 @@ namespace Resonalyze.Options
 
         private int FindNoiseColorIndex(NoiseColor noiseColor)
         {
+            int index = TryFindNoiseColorIndex(noiseColor);
+            return index >= 0 ? index : 0;
+        }
+
+        private int TryFindNoiseColorIndex(NoiseColor noiseColor)
+        {
             for (int index = 0; index < signalTypeComboBox.Items.Count; index++)
             {
                 if (signalTypeComboBox.Items[index] is NoiseColorOption option &&
@@ -304,7 +426,7 @@ namespace Resonalyze.Options
                 }
             }
 
-            return 0;
+            return -1;
         }
 
         private sealed class NoiseColorOption
@@ -367,6 +489,18 @@ namespace Resonalyze.Options
             toolTip.SetToolTip(
                 comboCalibration,
                 "Applies the selected microphone calibration file to Live Spectrum.");
+            toolTip.SetToolTip(
+                labelScale,
+                "Vertical scale of the live plot.");
+            toolTip.SetToolTip(
+                radioMagnitudeRelative,
+                "Native scale: the transfer function and RTA in relative dB.");
+            toolTip.SetToolTip(
+                radioMagnitudeSpl,
+                "Absolute dB SPL. Shows the microphone (RTA) spectrum from the SPL "
+                + "calibration; the transfer function is a dimensionless ratio with no "
+                + "scalar SPL under noise, so it is hidden. Available only when a matching "
+                + "SPL calibration is configured for the live input.");
         }
     }
 }

--- a/source/Options/LiveSpectrumOptions.cs
+++ b/source/Options/LiveSpectrumOptions.cs
@@ -20,7 +20,8 @@ namespace Resonalyze.Options
         PinkPeriodic,
         Pink,
         Brown,
-        White
+        White,
+        Silent
     }
 
     /// <summary>
@@ -98,5 +99,13 @@ namespace Resonalyze.Options
         /// Zero disables smoothing.
         /// </summary>
         public int SmoothingInverseOctaves { get; set; } = 6;
+
+        /// <summary>
+        /// Vertical scale of the live plot. In <see cref="MagnitudeScale.SoundPressureLevel"/>
+        /// the reference-free RTA (microphone) spectrum is shown in absolute dB SPL
+        /// (mic + calibration offset). The transfer function is a dimensionless ratio
+        /// with no scalar SPL under noise excitation, so it is not shown on the SPL axis.
+        /// </summary>
+        public MagnitudeScale MagnitudeScale { get; set; } = MagnitudeScale.Relative;
     }
 }

--- a/source/Options/MeasurementOptions.Designer.cs
+++ b/source/Options/MeasurementOptions.Designer.cs
@@ -56,6 +56,9 @@ namespace Resonalyze.Options
             labelCalibration90 = new Label();
             buttonCalibration90 = new Button();
             buttonClearCalibration90 = new Button();
+            labelSplCalibration = new Label();
+            buttonSplCalibration = new Button();
+            buttonClearSplCalibration = new Button();
             waveAudioBackendPanel = new WaveAudioBackendPanel();
             asioAudioBackendPanel = new AsioAudioBackendPanel();
             (numericUpDownRequestedDuration).BeginInit();
@@ -169,7 +172,7 @@ namespace Resonalyze.Options
             button1.DialogResult = DialogResult.OK;
             button1.FlatStyle = FlatStyle.Popup;
             button1.ForeColor = Color.White;
-            button1.Location = new Point(12, 554);
+            button1.Location = new Point(12, 579);
             button1.Name = "button1";
             button1.Size = new Size(311, 23);
             button1.TabIndex = 12;
@@ -240,7 +243,7 @@ namespace Resonalyze.Options
             // 
             labelAudioBackend.AutoSize = true;
             labelAudioBackend.ForeColor = SystemColors.ControlLight;
-            labelAudioBackend.Location = new Point(12, 285);
+            labelAudioBackend.Location = new Point(12, 310);
             labelAudioBackend.Name = "labelAudioBackend";
             labelAudioBackend.Size = new Size(87, 15);
             labelAudioBackend.TabIndex = 23;
@@ -250,7 +253,7 @@ namespace Resonalyze.Options
             // 
             comboBoxAudioBackend.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxAudioBackend.ForeColor = Color.White;
-            comboBoxAudioBackend.Location = new Point(153, 277);
+            comboBoxAudioBackend.Location = new Point(153, 302);
             comboBoxAudioBackend.Margin = new Padding(0);
             comboBoxAudioBackend.MinimumSize = new Size(36, 19);
             comboBoxAudioBackend.Name = "comboBoxAudioBackend";
@@ -363,11 +366,45 @@ namespace Resonalyze.Options
             buttonClearCalibration90.Text = "X";
             buttonClearCalibration90.UseVisualStyleBackColor = true;
             buttonClearCalibration90.Click += buttonClearCalibration90_Click;
-            // 
+            //
+            // labelSplCalibration
+            //
+            labelSplCalibration.AutoSize = true;
+            labelSplCalibration.ForeColor = SystemColors.ControlLight;
+            labelSplCalibration.Location = new Point(12, 274);
+            labelSplCalibration.Name = "labelSplCalibration";
+            labelSplCalibration.Size = new Size(85, 15);
+            labelSplCalibration.TabIndex = 36;
+            labelSplCalibration.Text = "SPL calibration";
+            //
+            // buttonSplCalibration
+            //
+            buttonSplCalibration.FlatStyle = FlatStyle.Popup;
+            buttonSplCalibration.ForeColor = Color.White;
+            buttonSplCalibration.Location = new Point(153, 269);
+            buttonSplCalibration.Name = "buttonSplCalibration";
+            buttonSplCalibration.Size = new Size(143, 23);
+            buttonSplCalibration.TabIndex = 37;
+            buttonSplCalibration.Text = "Calibrate...";
+            buttonSplCalibration.UseVisualStyleBackColor = true;
+            buttonSplCalibration.Click += buttonSplCalibration_Click;
+            //
+            // buttonClearSplCalibration
+            //
+            buttonClearSplCalibration.FlatStyle = FlatStyle.Popup;
+            buttonClearSplCalibration.ForeColor = Color.White;
+            buttonClearSplCalibration.Location = new Point(299, 269);
+            buttonClearSplCalibration.Name = "buttonClearSplCalibration";
+            buttonClearSplCalibration.Size = new Size(24, 23);
+            buttonClearSplCalibration.TabIndex = 38;
+            buttonClearSplCalibration.Text = "X";
+            buttonClearSplCalibration.UseVisualStyleBackColor = true;
+            buttonClearSplCalibration.Click += buttonClearSplCalibration_Click;
+            //
             // waveAudioBackendPanel
-            // 
+            //
             waveAudioBackendPanel.BackColor = Color.FromArgb(45, 50, 60);
-            waveAudioBackendPanel.Location = new Point(12, 310);
+            waveAudioBackendPanel.Location = new Point(12, 335);
             waveAudioBackendPanel.Name = "waveAudioBackendPanel";
             waveAudioBackendPanel.Size = new Size(311, 213);
             waveAudioBackendPanel.TabIndex = 25;
@@ -375,7 +412,7 @@ namespace Resonalyze.Options
             // asioAudioBackendPanel
             // 
             asioAudioBackendPanel.BackColor = Color.FromArgb(45, 50, 60);
-            asioAudioBackendPanel.Location = new Point(12, 310);
+            asioAudioBackendPanel.Location = new Point(12, 335);
             asioAudioBackendPanel.Name = "asioAudioBackendPanel";
             asioAudioBackendPanel.Size = new Size(311, 213);
             asioAudioBackendPanel.TabIndex = 26;
@@ -385,9 +422,12 @@ namespace Resonalyze.Options
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(45, 50, 60);
-            ClientSize = new Size(334, 589);
+            ClientSize = new Size(334, 614);
             Controls.Add(asioAudioBackendPanel);
             Controls.Add(waveAudioBackendPanel);
+            Controls.Add(buttonClearSplCalibration);
+            Controls.Add(buttonSplCalibration);
+            Controls.Add(labelSplCalibration);
             Controls.Add(buttonClearCalibration90);
             Controls.Add(buttonCalibration90);
             Controls.Add(labelCalibration90);
@@ -452,6 +492,9 @@ namespace Resonalyze.Options
         private Label labelCalibration90;
         private Button buttonCalibration90;
         private Button buttonClearCalibration90;
+        private Label labelSplCalibration;
+        private Button buttonSplCalibration;
+        private Button buttonClearSplCalibration;
         private WaveAudioBackendPanel waveAudioBackendPanel;
         private AsioAudioBackendPanel asioAudioBackendPanel;
     }

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -16,6 +16,16 @@ namespace Resonalyze.Options
     public partial class MeasurementOptions : Form
     {
         private readonly ToolTip deviceToolTip = new();
+        // Raised the moment any calibration (microphone 0°/90° file or the SPL
+        // anchor) is selected, captured, or cleared, so the host can apply and
+        // persist it immediately instead of only when the panel is applied.
+        public event Action<CalibrationSelection>? CalibrationChanged;
+
+        /// <summary>A snapshot of the three calibrations the panel manages.</summary>
+        public sealed record CalibrationSelection(
+            string? MicrophoneCalibration0DegreesPath,
+            string? MicrophoneCalibration90DegreesPath,
+            SplCalibration? SplCalibration);
         private WindowsAudioEndpointService? endpointService;
         private Font? normalStatusFont;
         private Font? warningStatusFont;
@@ -29,6 +39,12 @@ namespace Resonalyze.Options
         private bool initializing;
         private string? microphoneCalibration0DegreesPath;
         private string? microphoneCalibration90DegreesPath;
+        // The SPL calibration anchor and the factory used to capture it. The
+        // factory is only present when the form is created for real use (the
+        // parameterless designer constructor leaves it null, which disables the
+        // Calibrate button).
+        private readonly IAudioSessionFactory? audioSessionFactory;
+        private SplCalibration? splCalibration;
         // Remembers the loopback channel choice while a mono or missing
         // recording device forces the combo to "None", so selecting a stereo
         // device again restores it instead of losing it on the next apply.
@@ -97,6 +113,13 @@ namespace Resonalyze.Options
             WireAudioBackendPanelEvents();
             TryStartEndpointMonitoring();
             Disposed += (_, _) => DisposeEndpointMonitoring();
+        }
+
+        public MeasurementOptions(IAudioSessionFactory audioSessionFactory)
+            : this()
+        {
+            this.audioSessionFactory = audioSessionFactory ??
+                throw new ArgumentNullException(nameof(audioSessionFactory));
         }
 
         private void TryStartEndpointMonitoring()
@@ -274,7 +297,10 @@ namespace Resonalyze.Options
             checkBoxConfirmEachAverageRun.Checked = settings.ConfirmEachAverageRun;
             microphoneCalibration0DegreesPath = settings.MicrophoneCalibration0DegreesPath;
             microphoneCalibration90DegreesPath = settings.MicrophoneCalibration90DegreesPath;
+            splCalibration = settings.SplCalibration;
             UpdateCalibrationButtons();
+            // The button's own refresh happens in the UpdateAudioBackendControls
+            // call at the end of Init, once the device/rate selections are settled.
             RefreshSampleRateOptions(settings.SampleRate);
             initializing = false;
             RefreshAsioDriverInfo(
@@ -292,6 +318,7 @@ namespace Resonalyze.Options
                 NormalizeCalibrationPath(microphoneCalibration0DegreesPath);
             settings.MicrophoneCalibration90DegreesPath =
                 NormalizeCalibrationPath(microphoneCalibration90DegreesPath);
+            settings.SplCalibration = splCalibration;
 
             int sampleRate = GetSelectedSampleRate();
             // Read the bit depth from the control, the single UI source of truth,
@@ -449,6 +476,10 @@ namespace Resonalyze.Options
             preferredWasapiRenderEndpointId = wasapiRenderEndpointId;
             preferredWasapiCaptureEndpointName = settings.WasapiCaptureEndpointName;
             preferredWasapiRenderEndpointName = settings.WasapiRenderEndpointName;
+
+            // Keep the live measurement's anchor in step with the applied settings,
+            // so a freshly captured impulse response stamps the current calibration.
+            expSweepMeasurement.SplCalibration = splCalibration;
         }
 
         private void buttonCalibration0_Click(object? sender, EventArgs e)
@@ -456,6 +487,7 @@ namespace Resonalyze.Options
             microphoneCalibration0DegreesPath =
                 SelectCalibrationFile(microphoneCalibration0DegreesPath);
             UpdateCalibrationButtons();
+            RaiseCalibrationChanged();
         }
 
         private void buttonCalibration90_Click(object? sender, EventArgs e)
@@ -463,18 +495,162 @@ namespace Resonalyze.Options
             microphoneCalibration90DegreesPath =
                 SelectCalibrationFile(microphoneCalibration90DegreesPath);
             UpdateCalibrationButtons();
+            RaiseCalibrationChanged();
         }
 
         private void buttonClearCalibration0_Click(object? sender, EventArgs e)
         {
             microphoneCalibration0DegreesPath = null;
             UpdateCalibrationButtons();
+            RaiseCalibrationChanged();
         }
 
         private void buttonClearCalibration90_Click(object? sender, EventArgs e)
         {
             microphoneCalibration90DegreesPath = null;
             UpdateCalibrationButtons();
+            RaiseCalibrationChanged();
+        }
+
+        private void RaiseCalibrationChanged() =>
+            CalibrationChanged?.Invoke(new CalibrationSelection(
+                NormalizeCalibrationPath(microphoneCalibration0DegreesPath),
+                NormalizeCalibrationPath(microphoneCalibration90DegreesPath),
+                splCalibration));
+
+        private void buttonSplCalibration_Click(object? sender, EventArgs e)
+        {
+            if (audioSessionFactory == null)
+            {
+                return;
+            }
+
+            AudioSessionRequest request;
+            try
+            {
+                request = BuildCalibrationCaptureRequest();
+            }
+            catch (Exception exception)
+            {
+                MessageBox.Show(
+                    this,
+                    exception.Message,
+                    "SPL calibration",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+                return;
+            }
+
+            using var dialog = new SplCalibrationDialog(audioSessionFactory, request, splCalibration);
+            if (dialog.ShowDialog(this) == DialogResult.OK && dialog.Result != null)
+            {
+                splCalibration = dialog.Result;
+                UpdateSplCalibrationButton();
+                // A completed physical calibration is not a tentative edit: persist
+                // it now instead of waiting for an Apply that the user may never
+                // make (the panel only applies on the Apply button, not on close).
+                RaiseCalibrationChanged();
+            }
+        }
+
+        private void buttonClearSplCalibration_Click(object? sender, EventArgs e)
+        {
+            splCalibration = null;
+            UpdateSplCalibrationButton();
+            RaiseCalibrationChanged();
+        }
+
+        // The capture side of the currently selected audio configuration, with no
+        // loopback: the SPL calibration listens to the microphone alone against an
+        // external calibrator. Playback is silent, so the render selection only
+        // needs to be openable.
+        private AudioSessionRequest BuildCalibrationCaptureRequest()
+        {
+            var backend = (AudioBackend)comboBoxAudioBackend.SelectedIndex;
+            PlaybackChannel playbackChannel = comboBoxChannel.SelectedIndex >= 0
+                ? (PlaybackChannel)comboBoxChannel.SelectedIndex
+                : PlaybackChannel.Mono;
+            return AudioSessionRequestBuilder.Build(
+                backend,
+                GetSelectedSampleRate(),
+                (int)numericUpDownBits.Value,
+                playbackChannel,
+                waveInputChannelOffset: GetSelectedWaveInputChannelOffset(),
+                waveLoopbackInputChannelOffset: null,
+                asioInputChannelOffset: GetSelectedAsioInputChannelOffset(),
+                asioLoopbackInputChannelOffset: null,
+                asioOutputChannelOffset: GetSelectedAsioOutputChannelOffset(),
+                outputDeviceNumber: GetSelectedPlaybackDeviceNumber(),
+                inputDeviceNumber: GetSelectedRecordingDeviceNumber(),
+                wasapiCaptureEndpointId:
+                    comboBoxRecordingDevice.SelectedItem is AudioEndpointDescriptor capture
+                        ? capture.Id
+                        : null,
+                wasapiRenderEndpointId:
+                    comboBoxPlaybackDevice.SelectedItem is AudioEndpointDescriptor render
+                        ? render.Id
+                        : null,
+                asioDriverName:
+                    comboBoxAsioDriver.SelectedItem is AsioDeviceInfo asio
+                        ? asio.DriverName
+                        : null,
+                bufferMilliseconds: 100,
+                expectedCaptureSamples: 0);
+        }
+
+        private void UpdateSplCalibrationButton()
+        {
+            buttonSplCalibration.Enabled = audioSessionFactory != null;
+            buttonClearSplCalibration.Enabled = splCalibration != null;
+
+            if (splCalibration == null)
+            {
+                buttonSplCalibration.Text = "Calibrate...";
+                buttonSplCalibration.ForeColor = Color.White;
+                deviceToolTip.SetToolTip(
+                    buttonSplCalibration,
+                    audioSessionFactory != null
+                        ? "Measure the offset from a 1 kHz acoustic calibrator so measurements " +
+                            "can be shown in dB SPL. Uses the currently selected input."
+                        : "SPL calibration is unavailable.");
+                deviceToolTip.SetToolTip(buttonClearSplCalibration, "No SPL calibration.");
+                return;
+            }
+
+            buttonSplCalibration.Text =
+                $"{splCalibration.ReferenceLevelDbSpl:0} dB · {splCalibration.OffsetDb:+0.0;-0.0;0.0} dB";
+            bool stale = !CurrentInputMatches(splCalibration);
+            buttonSplCalibration.ForeColor = stale ? Color.Gold : Color.White;
+            string detail =
+                $"Measured {splCalibration.MeasuredLevelDbFs:0.0} dBFS at " +
+                $"{splCalibration.MeasuredFrequencyHz:0} Hz " +
+                $"({splCalibration.ReferenceLevelDbSpl:0} dB SPL reference).\r\n" +
+                $"Offset {splCalibration.OffsetDb:+0.0;-0.0;0.0} dB · " +
+                $"{splCalibration.CapturedAtUtc.ToLocalTime():g}.";
+            if (stale)
+            {
+                detail += "\r\n⚠ The current input differs from the calibrated one — recalibrate.";
+            }
+            deviceToolTip.SetToolTip(buttonSplCalibration, detail);
+            deviceToolTip.SetToolTip(buttonClearSplCalibration, "Clear the SPL calibration.");
+        }
+
+        private bool CurrentInputMatches(SplCalibration calibration)
+        {
+            var backend = (AudioBackend)comboBoxAudioBackend.SelectedIndex;
+            int microphoneChannelOffset = backend == AudioBackend.Asio
+                ? GetSelectedAsioInputChannelOffset()
+                : GetSelectedWaveInputChannelOffset();
+            return calibration.MatchesInput(
+                backend,
+                GetSelectedSampleRate(),
+                (int)numericUpDownBits.Value,
+                microphoneChannelOffset,
+                backend == AudioBackend.Wave ? GetSelectedRecordingDeviceNumber() : null,
+                comboBoxRecordingDevice.SelectedItem is AudioEndpointDescriptor capture
+                    ? capture.Id
+                    : null,
+                comboBoxAsioDriver.SelectedItem is AsioDeviceInfo asio ? asio.DriverName : null);
         }
 
         private string? SelectCalibrationFile(string? currentPath)
@@ -729,6 +905,9 @@ namespace Resonalyze.Options
             buttonDeviceSettings.Visible = useWasapi;
             buttonDeviceSettings.Enabled = useWasapi;
             labelAsioLoopbackChannel.Enabled = useAsio;
+            // Refresh the stale marker: the calibration is pinned to one input, so
+            // switching backend/device must flag it if it no longer matches.
+            UpdateSplCalibrationButton();
             if (useWasapi)
             {
                 labelPlaybackDevice.Text = "Output endpoint";

--- a/source/Options/SplCalibrationDialog.Designer.cs
+++ b/source/Options/SplCalibrationDialog.Designer.cs
@@ -1,0 +1,166 @@
+namespace Resonalyze.Options
+{
+    partial class SplCalibrationDialog
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            labelInstruction = new Label();
+            labelReference = new Label();
+            comboBoxReference = new DarkComboBox();
+            labelGainWarning = new Label();
+            buttonStart = new Button();
+            progressBar = new ProgressBar();
+            labelStatus = new Label();
+            buttonSave = new Button();
+            buttonCancel = new Button();
+            SuspendLayout();
+            //
+            // labelInstruction
+            //
+            labelInstruction.ForeColor = SystemColors.ControlLight;
+            labelInstruction.Location = new Point(16, 16);
+            labelInstruction.Name = "labelInstruction";
+            labelInstruction.Size = new Size(398, 36);
+            labelInstruction.TabIndex = 0;
+            labelInstruction.Text = "Fit the acoustic calibrator over the microphone capsule and select the reference level it is set to.";
+            //
+            // labelReference
+            //
+            labelReference.AutoSize = true;
+            labelReference.ForeColor = SystemColors.ControlLight;
+            labelReference.Location = new Point(16, 64);
+            labelReference.Name = "labelReference";
+            labelReference.Size = new Size(89, 15);
+            labelReference.TabIndex = 1;
+            labelReference.Text = "Reference level";
+            //
+            // comboBoxReference
+            //
+            comboBoxReference.BackColor = Color.FromArgb(55, 60, 72);
+            comboBoxReference.ForeColor = Color.White;
+            comboBoxReference.Location = new Point(140, 60);
+            comboBoxReference.Margin = new Padding(0);
+            comboBoxReference.MinimumSize = new Size(36, 19);
+            comboBoxReference.Name = "comboBoxReference";
+            comboBoxReference.Size = new Size(130, 23);
+            comboBoxReference.TabIndex = 2;
+            //
+            // labelGainWarning
+            //
+            labelGainWarning.ForeColor = Color.Gold;
+            labelGainWarning.Location = new Point(16, 92);
+            labelGainWarning.Name = "labelGainWarning";
+            labelGainWarning.Size = new Size(398, 48);
+            labelGainWarning.TabIndex = 3;
+            labelGainWarning.Text = "⚠ Calibrate at the input gain you measure with, then leave the preamp untouched. A moved gain knob silently invalidates the SPL scale — software cannot detect it.";
+            //
+            // buttonStart
+            //
+            buttonStart.FlatStyle = FlatStyle.Popup;
+            buttonStart.ForeColor = Color.White;
+            buttonStart.Location = new Point(16, 150);
+            buttonStart.Name = "buttonStart";
+            buttonStart.Size = new Size(398, 28);
+            buttonStart.TabIndex = 4;
+            buttonStart.Text = "Start calibration";
+            buttonStart.UseVisualStyleBackColor = true;
+            buttonStart.Click += buttonStart_Click;
+            //
+            // progressBar
+            //
+            progressBar.Location = new Point(16, 186);
+            progressBar.Name = "progressBar";
+            progressBar.Size = new Size(398, 8);
+            progressBar.Style = ProgressBarStyle.Continuous;
+            progressBar.TabIndex = 5;
+            progressBar.Visible = false;
+            //
+            // labelStatus
+            //
+            labelStatus.ForeColor = SystemColors.ControlLight;
+            labelStatus.Location = new Point(16, 204);
+            labelStatus.Name = "labelStatus";
+            labelStatus.Size = new Size(398, 64);
+            labelStatus.TabIndex = 6;
+            labelStatus.Text = "Idle.";
+            //
+            // buttonSave
+            //
+            buttonSave.DialogResult = DialogResult.OK;
+            buttonSave.Enabled = false;
+            buttonSave.FlatStyle = FlatStyle.Popup;
+            buttonSave.ForeColor = Color.White;
+            buttonSave.Location = new Point(204, 282);
+            buttonSave.Name = "buttonSave";
+            buttonSave.Size = new Size(130, 30);
+            buttonSave.TabIndex = 7;
+            buttonSave.Text = "Save calibration";
+            buttonSave.UseVisualStyleBackColor = true;
+            //
+            // buttonCancel
+            //
+            buttonCancel.DialogResult = DialogResult.Cancel;
+            buttonCancel.FlatStyle = FlatStyle.Popup;
+            buttonCancel.ForeColor = Color.White;
+            buttonCancel.Location = new Point(338, 282);
+            buttonCancel.Name = "buttonCancel";
+            buttonCancel.Size = new Size(76, 30);
+            buttonCancel.TabIndex = 8;
+            buttonCancel.Text = "Cancel";
+            buttonCancel.UseVisualStyleBackColor = true;
+            //
+            // SplCalibrationDialog
+            //
+            AcceptButton = buttonSave;
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            BackColor = Color.FromArgb(45, 50, 60);
+            CancelButton = buttonCancel;
+            ClientSize = new Size(430, 328);
+            Controls.Add(labelInstruction);
+            Controls.Add(labelReference);
+            Controls.Add(comboBoxReference);
+            Controls.Add(labelGainWarning);
+            Controls.Add(buttonStart);
+            Controls.Add(progressBar);
+            Controls.Add(labelStatus);
+            Controls.Add(buttonSave);
+            Controls.Add(buttonCancel);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "SplCalibrationDialog";
+            ShowInTaskbar = false;
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "SPL calibration";
+            FormClosing += SplCalibrationDialog_FormClosing;
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private Label labelInstruction;
+        private Label labelReference;
+        private DarkComboBox comboBoxReference;
+        private Label labelGainWarning;
+        private Button buttonStart;
+        private ProgressBar progressBar;
+        private Label labelStatus;
+        private Button buttonSave;
+        private Button buttonCancel;
+    }
+}

--- a/source/Options/SplCalibrationDialog.cs
+++ b/source/Options/SplCalibrationDialog.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Drawing;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Resonalyze.Audio;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.Options
+{
+    /// <summary>
+    /// Modal SPL calibration: the user fits an acoustic calibrator over the
+    /// microphone, picks its reference level, and listens for the tone. On success
+    /// the dialog exposes an <see cref="SplCalibration"/> anchor; the caller is
+    /// responsible for persisting it. Capture runs on the same input the caller is
+    /// configuring, so the anchor is pinned to that digital tract.
+    /// </summary>
+    internal sealed partial class SplCalibrationDialog : Form
+    {
+        // A power-of-two block; ~5.9 Hz bins at 48 kHz, which is ample to isolate
+        // the 1 kHz tone while leaving room for enough frames in a few seconds.
+        private const int FrameLength = 8_192;
+        private static readonly TimeSpan CaptureDuration = TimeSpan.FromSeconds(4);
+        private static readonly SplToneCriteria Criteria = SplToneCriteria.Default;
+
+        private readonly IAudioSessionFactory audioSessionFactory;
+        private readonly AudioSessionRequest request;
+
+        private CancellationTokenSource? cancellation;
+        private bool running;
+        private bool pendingClose;
+
+        /// <summary>The captured calibration anchor, or null until one succeeds.</summary>
+        public SplCalibration? Result { get; private set; }
+
+        public SplCalibrationDialog(
+            IAudioSessionFactory audioSessionFactory,
+            AudioSessionRequest request,
+            SplCalibration? existing = null)
+        {
+            this.audioSessionFactory = audioSessionFactory ??
+                throw new ArgumentNullException(nameof(audioSessionFactory));
+            this.request = request ?? throw new ArgumentNullException(nameof(request));
+
+            InitializeComponent();
+
+            foreach (double level in SplCalibration.StandardReferenceLevelsDb)
+            {
+                comboBoxReference.Items.Add($"{level:0} dB SPL");
+            }
+
+            int preselect = existing != null
+                ? Math.Max(0, Array.IndexOf(
+                    SplCalibration.StandardReferenceLevelsDb, existing.ReferenceLevelDbSpl))
+                : 0;
+            comboBoxReference.SelectedIndex = preselect;
+        }
+
+        private double SelectedReferenceLevelDbSpl
+        {
+            get
+            {
+                int index = Math.Clamp(
+                    comboBoxReference.SelectedIndex,
+                    0,
+                    SplCalibration.StandardReferenceLevelsDb.Length - 1);
+                return SplCalibration.StandardReferenceLevelsDb[index];
+            }
+        }
+
+        private async void buttonStart_Click(object? sender, EventArgs e)
+        {
+            if (running)
+            {
+                // The button doubles as Stop while a capture is in flight.
+                cancellation?.Cancel();
+                return;
+            }
+
+            double reference = SelectedReferenceLevelDbSpl;
+            BeginRunningState();
+
+            using var runCancellation = new CancellationTokenSource();
+            cancellation = runCancellation;
+            var progress = new Progress<SplCalibrationProgress>(ReportProgress);
+
+            SplCalibrationCaptureResult? capture = null;
+            string? error = null;
+            bool cancelled = false;
+            try
+            {
+                capture = await new SplCalibrationListener(audioSessionFactory)
+                    .CaptureAsync(request, FrameLength, Criteria, CaptureDuration, progress, runCancellation.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                cancelled = true;
+            }
+            catch (Exception exception)
+            {
+                error = exception.Message;
+            }
+            finally
+            {
+                cancellation = null;
+                running = false;
+            }
+
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            EndRunningState();
+
+            if (cancelled)
+            {
+                SetStatus("Calibration cancelled.", SystemColors.ControlLight);
+            }
+            else if (error != null)
+            {
+                SetStatus(
+                    $"Could not open the input for calibration:\r\n{error}",
+                    Color.LightSalmon);
+            }
+            else if (capture is { } result)
+            {
+                ApplyResult(result, reference);
+            }
+
+            if (pendingClose)
+            {
+                Close();
+            }
+        }
+
+        private void BeginRunningState()
+        {
+            running = true;
+            Result = null;
+            buttonSave.Enabled = false;
+            buttonCancel.Enabled = false;
+            comboBoxReference.Enabled = false;
+            buttonStart.Text = "Stop";
+            progressBar.Value = 0;
+            progressBar.Visible = true;
+            SetStatus("Listening for the calibrator tone…", SystemColors.ControlLight);
+        }
+
+        private void EndRunningState()
+        {
+            buttonStart.Text = "Start calibration";
+            progressBar.Visible = false;
+            comboBoxReference.Enabled = true;
+            buttonCancel.Enabled = true;
+        }
+
+        private void ReportProgress(SplCalibrationProgress progress)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            int percent = (int)Math.Clamp(
+                progress.ElapsedSeconds / CaptureDuration.TotalSeconds * 100.0, 0, 100);
+            progressBar.Value = percent;
+
+            string tone = progress.Reading.PeakFrequencyHz > 0
+                ? $"{progress.Reading.PeakFrequencyHz:0} Hz at {progress.Reading.LevelDbFs:0.0} dBFS"
+                : "—";
+            string clip = progress.Clipped ? "   ⚠ CLIPPING — lower the input gain" : "";
+            SetStatus(
+                $"Listening…   input peak {progress.InputPeakDbFs:0.0} dBFS\r\n" +
+                $"Loudest tone: {tone}\r\n" +
+                $"Prominence: {progress.Reading.ProminenceDb:0.0} dB{clip}",
+                progress.Clipped ? Color.LightSalmon : SystemColors.ControlLight);
+        }
+
+        private void ApplyResult(SplCalibrationCaptureResult result, double reference)
+        {
+            SplCalibrationFailure failure = SplCalibrationListener.Evaluate(result);
+            if (failure != SplCalibrationFailure.None)
+            {
+                Result = null;
+                buttonSave.Enabled = false;
+                SetStatus(DescribeFailure(failure, result), Color.LightSalmon);
+                return;
+            }
+
+            Result = new SplCalibration
+            {
+                ReferenceLevelDbSpl = reference,
+                MeasuredLevelDbFs = result.Reading.LevelDbFs,
+                ReferenceFrequencyHz = Criteria.TargetFrequencyHz,
+                MeasuredFrequencyHz = result.Reading.PeakFrequencyHz,
+                CapturedAtUtc = DateTimeOffset.UtcNow,
+                Backend = request.Backend,
+                SampleRate = request.SampleRate,
+                Bits = request.BitsPerSample,
+                MicrophoneChannelOffset = request.Routing.MicrophoneChannel,
+                InputDeviceNumber = request.Backend == AudioBackend.Wave
+                    ? request.WaveInputDeviceNumber
+                    : null,
+                WasapiCaptureEndpointId = request.WasapiCaptureEndpointId,
+                AsioDriverName = request.AsioDriverName
+            };
+
+            buttonSave.Enabled = true;
+            SetStatus(
+                $"Calibration successful.\r\n" +
+                $"{result.Reading.PeakFrequencyHz:0} Hz measured at {result.Reading.LevelDbFs:0.0} dBFS.\r\n" +
+                $"Offset {Result.OffsetDb:+0.0;-0.0;0.0} dB at {reference:0} dB SPL reference.",
+                Color.LightGreen);
+        }
+
+        private static string DescribeFailure(
+            SplCalibrationFailure failure,
+            SplCalibrationCaptureResult result) => failure switch
+        {
+            SplCalibrationFailure.TooFewFrames =>
+                "The capture did not run long enough. Check the input device and try again.",
+            SplCalibrationFailure.Clipped =>
+                $"The input clipped (peak {result.InputPeakDbFs:0.0} dBFS). Lower the input " +
+                "gain and calibrate again.",
+            SplCalibrationFailure.OffFrequency =>
+                $"The loudest tone was at {result.Reading.PeakFrequencyHz:0} Hz, not " +
+                $"{Criteria.TargetFrequencyHz:0} Hz. Check the calibrator is set to 1 kHz and " +
+                "seated on the capsule.",
+            SplCalibrationFailure.NoClearPeak =>
+                $"No clear {Criteria.TargetFrequencyHz:0} Hz tone stood out from the noise " +
+                $"(prominence {result.Reading.ProminenceDb:0.0} dB). Seat the calibrator firmly " +
+                "and reduce ambient noise.",
+            SplCalibrationFailure.Unstable =>
+                $"The level was unsteady ({result.LevelStabilityDb:0.0} dB variation). Make sure " +
+                "the calibrator is fully seated and held still.",
+            SplCalibrationFailure.CaptureOverrun =>
+                "The capture dropped frames (processing overload), so the result cannot be " +
+                "trusted. Close other work and calibrate again.",
+            _ => "Calibration failed."
+        };
+
+        private void SetStatus(string text, Color color)
+        {
+            labelStatus.ForeColor = color;
+            labelStatus.Text = text;
+        }
+
+        private void SplCalibrationDialog_FormClosing(object? sender, FormClosingEventArgs e)
+        {
+            // A capture is in flight: cancel it and defer the close until it
+            // unwinds, so the background task never touches a disposed form.
+            if (running)
+            {
+                pendingClose = true;
+                cancellation?.Cancel();
+                e.Cancel = true;
+            }
+        }
+    }
+}

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -12,6 +12,7 @@ public sealed class OverlayCollection
 {
     private readonly List<Overlay> overlays = new();
     private readonly Action notifyPlotChanged;
+    private Func<MagnitudeScale>? getCurrentMagnitudeScale;
 
     public OverlayCollection(
         Form1 form,
@@ -95,6 +96,15 @@ public sealed class OverlayCollection
     public OxyPlot.WindowsForms.PlotView PlotView { get; }
     public Form1 Form { get; }
 
+    // The magnitude scale the plot is currently drawn in, so a captured overlay is
+    // tagged with its unit and only shown again on a matching axis. Defaults to
+    // Relative until the shell provides the live value.
+    public void SetMagnitudeScaleProvider(Func<MagnitudeScale> provider) =>
+        getCurrentMagnitudeScale = provider;
+
+    public MagnitudeScale CurrentMagnitudeScale =>
+        getCurrentMagnitudeScale?.Invoke() ?? MagnitudeScale.Relative;
+
     // Lands any debounced offset saves immediately; the shell calls this on
     // close so an offset changed within the debounce window still persists.
     public void FlushPendingSaves()
@@ -122,12 +132,24 @@ public sealed class OverlayCollection
 
     public void Show(Mode mode)
     {
+        Mode overlayMode = OverlayModeFor(mode);
+        MagnitudeScale scale = CurrentMagnitudeScale;
         foreach (Overlay overlay in overlays)
         {
-            if (overlay.Checked && overlay.SeriesMode == OverlayModeFor(mode))
+            if (!overlay.Checked || overlay.SeriesMode != overlayMode)
             {
-                overlay.Show();
+                continue;
             }
+
+            // In the magnitude mode an overlay shows only on the axis it was captured
+            // on: dBr/dBc overlays in Relative, dB SPL overlays in SPL.
+            if (overlayMode == Mode.FrequencyResponse &&
+                overlay.CapturedMagnitudeScale != scale)
+            {
+                continue;
+            }
+
+            overlay.Show();
         }
 
         notifyPlotChanged();
@@ -438,6 +460,9 @@ public sealed class Overlay
     private DataPoint[]? sourcePoints;
     private DataPoint[]? drawPoints;
     private string? capturedYAxisKey;
+    // The magnitude scale this slot was captured in (meaningful for a captured
+    // FR curve; Relative for every other kind). Gates which magnitude mode shows it.
+    private MagnitudeScale capturedMagnitudeScale = MagnitudeScale.Relative;
     // Phase representation of a captured curve: true unwrapped, false wrapped, null
     // unknown. Drives the wrapped-difference choice in phase overlay operations.
     private bool? phaseUnwrapped;
@@ -537,6 +562,8 @@ public sealed class Overlay
     public Mode SeriesMode { get; private set; }
     public bool Checked => checkBox.Checked;
     public OverlayKind Kind => kind;
+
+    public MagnitudeScale CapturedMagnitudeScale => capturedMagnitudeScale;
     public bool HasCaptureData => sourcePoints is { Length: > 1 };
 
     // The overlay mode for the current view; Frequency Response and Live Spectrum
@@ -1245,6 +1272,8 @@ public sealed class Overlay
         kind = OverlayKind.Captured;
         operationConfigured = false;
         sourcePoints = points;
+        // The curve was drawn in the plot's current scale, so it carries that unit.
+        capturedMagnitudeScale = collection.CurrentMagnitudeScale;
         capturedYAxisKey = string.IsNullOrEmpty(selected.YAxisKey)
             ? null
             : selected.YAxisKey;
@@ -1302,6 +1331,8 @@ public sealed class Overlay
         targetConfigured = false;
         // Imported text gives no wrap/unwrap hint; leave it unknown.
         phaseUnwrapped = null;
+        // Imported points are assumed to be in the current view's unit.
+        capturedMagnitudeScale = collection.CurrentMagnitudeScale;
         capturedYAxisKey = null;
         sourcePoints = imported
             .Select(point => new DataPoint(point.X, point.Y))
@@ -1545,6 +1576,9 @@ public sealed class Overlay
         Hide();
         kind = OverlayKind.Target;
         capturedYAxisKey = null;
+        // Targets and operations are defined in relative dB; they belong to the
+        // Relative axis until an SPL-native form exists.
+        capturedMagnitudeScale = MagnitudeScale.Relative;
         Title = dialog.OverlayName;
         targetSourceSlot = dialog.SourceSlot;
         targetPreset = dialog.Preset;
@@ -1686,6 +1720,7 @@ public sealed class Overlay
         Hide();
         kind = OverlayKind.Operation;
         capturedYAxisKey = null;
+        capturedMagnitudeScale = MagnitudeScale.Relative;
         Title = dialog.OverlayName;
         sourceSlotA = dialog.SourceSlotA;
         sourceSlotB = dialog.SourceSlotB;
@@ -1798,7 +1833,11 @@ public sealed class Overlay
 
         if (checkBox.Checked)
         {
-            if (SeriesMode == CurrentOverlayMode)
+            // Show only on a matching mode and — in the magnitude mode — a matching
+            // scale, so an SPL overlay is not drawn on the dBr axis or vice versa.
+            if (SeriesMode == CurrentOverlayMode &&
+                (SeriesMode != Mode.FrequencyResponse ||
+                 capturedMagnitudeScale == collection.CurrentMagnitudeScale))
             {
                 Show();
             }
@@ -1818,6 +1857,7 @@ public sealed class Overlay
         SeriesMode = file.Mode;
         kind = file.Kind;
         Title = file.Title;
+        capturedMagnitudeScale = file.CapturedMagnitudeScale;
         strokeThickness = file.StrokeThickness;
         lineStyle = file.LineStyle;
         opacityPercent = file.OpacityPercent;
@@ -1925,6 +1965,7 @@ public sealed class Overlay
             Slot = Index,
             Kind = kind,
             Title = Title,
+            CapturedMagnitudeScale = capturedMagnitudeScale,
             Offset = (double)offsetControl.Value,
             ColorArgb = panel.BackColor.ToArgb(),
             StrokeThickness = strokeThickness,

--- a/source/Overlays/OverlayFile.cs
+++ b/source/Overlays/OverlayFile.cs
@@ -59,6 +59,14 @@ public sealed class OverlayFile
     // default axis, older app builds ignore this property.
     public string? CapturedYAxisKey { get; set; }
 
+    // The magnitude scale the samples were captured in: dBr/dBc (Relative) or
+    // dB SPL. An SPL overlay only makes sense on an SPL axis and vice versa, so this
+    // gates which magnitude mode shows it. Additive with a safe default, so it needs
+    // no file version bump: older files deserialize to Relative and older app builds
+    // ignore the unknown property.
+    public Resonalyze.Dsp.MagnitudeScale CapturedMagnitudeScale { get; set; } =
+        Resonalyze.Dsp.MagnitudeScale.Relative;
+
     // Captured phase curves only: true if the samples are an unwrapped (continuous)
     // representation, false if wrapped (-180..180), null if unknown (e.g. imported text
     // or a non-phase mode). Additive and nullable, so it needs no file version bump:

--- a/source/Plotting/MeasurementPlotContext.cs
+++ b/source/Plotting/MeasurementPlotContext.cs
@@ -36,6 +36,41 @@ internal sealed class MeasurementPlotContext
     public bool HasTransferImpulseResponse =>
         expSweepMeasurement.TransferImpulseResponse is { Length: > 0 };
 
+    /// <summary>
+    /// The offset K that turns the loopback-referenced magnitude (dBr) into dB SPL:
+    /// <c>K = loopbackPeakDbFs + calibrationOffsetDb</c>. Null when SPL cannot be
+    /// shown — no calibration, no captured loopback level, or a calibration that does
+    /// not belong to the input that produced this result.
+    /// </summary>
+    public double? SplOffsetDb
+    {
+        get
+        {
+            // The result's own frozen calibration, not the configured one, so a live
+            // recalibration does not retroactively rescale the measurement on screen.
+            if (expSweepMeasurement.MeasurementSplCalibration is not { } calibration)
+            {
+                return null;
+            }
+
+            InputLevelMeterEntry loopback = expSweepMeasurement.CurrentLevels.Loopback;
+            if (!loopback.Available)
+            {
+                return null;
+            }
+
+            // Validate against the result's own input identity (a live snapshot, or a
+            // loaded file's). A loaded file's anchor matches its own identity, so it is
+            // trusted; a live anchor from a different input is refused.
+            if (!expSweepMeasurement.InputMatches(calibration))
+            {
+                return null;
+            }
+
+            return loopback.PeakDbFs + calibration.OffsetDb;
+        }
+    }
+
     // All analysis (magnitude, phase, group delay, impulse, decays) is derived from the
     // loopback transfer IR, which is now mandatory for every measurement. Callers must gate
     // on HasTransferImpulseResponse; the sweep deconvolution is reserved for harmonics/noise.

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -80,6 +80,69 @@ internal sealed class PlotModelFactory
     public void SetCompareSourceProvider(Func<CompareAnalysisSource?> provider) =>
         getCompareSource = provider;
 
+    /// <summary>
+    /// The scale the Frequency Response plot actually renders in — SPL only when it
+    /// is both selected and available, matching <c>renderSpl</c> in
+    /// <see cref="CreateFrequencyResponse"/>. Overlays gate on this, not on the
+    /// requested scale, so a stale-calibration fallback to dBr does not mis-tag or
+    /// mis-show overlays.
+    /// </summary>
+    public MagnitudeScale EffectiveFrequencyResponseScale =>
+        frequencyResponseOptions.MagnitudeScale == MagnitudeScale.SoundPressureLevel &&
+        measurementContext.SplOffsetDb.HasValue
+            ? MagnitudeScale.SoundPressureLevel
+            : MagnitudeScale.Relative;
+
+    /// <summary>
+    /// The offset that turns the reference-free live RTA magnitude (raw microphone
+    /// dBFS) into dB SPL: <c>SPL = mic + calibration.OffsetDb</c>. Unlike the swept
+    /// frequency response there is NO loopback term — the RTA is already the plain
+    /// microphone spectrum, not a loopback-referenced transfer. Null when SPL cannot
+    /// be shown: no configured SPL calibration, or one captured on a different digital
+    /// input than the live analyzer is running on.
+    /// </summary>
+    public double? LiveSplOffsetDb
+    {
+        get
+        {
+            // Live analysis is always "now", so it reads the configured calibration
+            // (the one set for the next run), not a frozen measurement snapshot.
+            if (expSweepMeasurement.SplCalibration is not { } calibration)
+            {
+                return null;
+            }
+
+            // Validate against the live input, not the app's saved sweep input, so a
+            // calibration from a different device does not scale the live RTA.
+            if (!calibration.MatchesInput(noiseMeasurement.CurrentInputIdentity()))
+            {
+                return null;
+            }
+
+            return calibration.OffsetDb;
+        }
+    }
+
+    /// <summary>
+    /// The scale the Live Spectrum plot actually renders in — SPL only when it is
+    /// both selected and available. The live controller and overlays gate on this,
+    /// not on the requested scale, so a missing/mismatched calibration falls back to
+    /// the native dB view instead of an empty SPL plot.
+    /// </summary>
+    public MagnitudeScale EffectiveLiveSpectrumScale =>
+        liveSpectrumOptions.MagnitudeScale == MagnitudeScale.SoundPressureLevel &&
+        LiveSplOffsetDb.HasValue
+            ? MagnitudeScale.SoundPressureLevel
+            : MagnitudeScale.Relative;
+
+    // The dB offset applied to the live RTA / peak-hold curves when the plot is in
+    // SPL mode; zero in the native (relative) view. The transfer function is never
+    // shifted — it is a dimensionless ratio, not an absolute level.
+    private double LiveSplRenderOffset =>
+        EffectiveLiveSpectrumScale == MagnitudeScale.SoundPressureLevel
+            ? LiveSplOffsetDb ?? 0.0
+            : 0.0;
+
     private CalibrationFile? GetCalibration(FrequencyResponseOptions options) =>
         options.CalibrationMode == MicrophoneCalibrationMode.Off
             ? null
@@ -95,6 +158,13 @@ internal sealed class PlotModelFactory
         PlotModel model = PlotModelStyle.CreateTitledModel(
             measurementContext.CreateTitle("Frequency Response"));
 
+        // dB SPL is available only with a valid calibration and loopback level for
+        // this measurement; otherwise the plot stays in native loopback-referenced dB.
+        bool splRequested =
+            frequencyResponseOptions.MagnitudeScale == MagnitudeScale.SoundPressureLevel;
+        double? splOffset = splRequested ? measurementContext.SplOffsetDb : null;
+        bool renderSpl = splOffset.HasValue;
+
         // Magnitude is derived from the loopback transfer IR, which is required.
         if (measurementContext.CanIncludeCurves(includeCurves) &&
             measurementContext.HasTransferImpulseResponse)
@@ -103,19 +173,26 @@ internal sealed class PlotModelFactory
                 frequencyResponseOptions,
                 GetCalibration(frequencyResponseOptions),
                 frequencyResponseVisibility.ToSpectrumCurves());
+            if (renderSpl)
+            {
+                curves = SplConversion.ToSoundPressureLevel(curves, splOffset!.Value);
+            }
+
             foreach (AnalysisCurve curve in curves)
             {
                 AddLineSeries(
                     model,
                     curve,
-                    DistortionTrackerFormat(curve.Kind),
+                    renderSpl ? SplTrackerFormat : DistortionTrackerFormat(curve.Kind),
                     Mode.FrequencyResponse,
                     DecibelAxisKey);
             }
 
             // Overlay the Compare magnitude (primary only; harmonics stay Main-only to
             // keep the plot readable), computed with the identical options/calibration.
-            if (TryCreateCompareMeasurement() is { } compare)
+            // The Compare source carries no loopback level or calibration, so it has no
+            // absolute reference; it is omitted in SPL mode rather than drawn as dBr.
+            if (!renderSpl && TryCreateCompareMeasurement() is { } compare)
             {
                 IReadOnlyList<AnalysisCurve> compareCurves = DataHelper.GetSpectrum(
                     compare.Measurement,
@@ -139,6 +216,13 @@ internal sealed class PlotModelFactory
                 frequencyResponseVisibility.ShowCoherence);
 
             AddHiddenHarmonicAnnotation(model, curves);
+
+            // The user asked for SPL but this measurement cannot supply it (no
+            // calibration, no loopback level, or a calibration from another input).
+            if (splRequested && !renderSpl)
+            {
+                AddSplUnavailableAnnotation(model);
+            }
         }
         else if (measurementContext.CanIncludeCurves(includeCurves) &&
                  !measurementContext.HasTransferImpulseResponse)
@@ -147,12 +231,31 @@ internal sealed class PlotModelFactory
         }
 
         PlotModelStyle.AddFrequencyAxis(model);
-        // The primary response is the loopback-referenced transfer magnitude (dBr,
-        // relative to the reference); the harmonic / THD / noise curves are ratios to
-        // the fundamental (dBc, relative to H1). The axis names both.
-        PlotModelStyle.AddDecibelAxis(model, "dBr/dBc");
+        // In SPL mode the whole plot is absolute dB SPL, which needs a different
+        // default window and clamps (curves sit near 40–110 dB, far above the dBr
+        // ceiling). Otherwise the primary is the loopback-referenced transfer
+        // magnitude (dBr) and the harmonic / THD / noise curves are ratios to the
+        // fundamental (dBc); the axis names both.
+        if (renderSpl)
+        {
+            PlotModelStyle.AddDecibelAxis(
+                model,
+                "dB SPL",
+                PlotModelStyle.SplDecibelMinimum,
+                PlotModelStyle.SplDecibelMaximum,
+                PlotModelStyle.SplDecibelAbsoluteMinimum,
+                PlotModelStyle.SplDecibelAbsoluteMaximum);
+        }
+        else
+        {
+            PlotModelStyle.AddDecibelAxis(model, "dBr/dBc");
+        }
+
         return model;
     }
+
+    // In SPL mode every trace is an absolute level; the tracker reads dB SPL.
+    private const string SplTrackerFormat = "{0}\n{2:0.0} Hz\n{4:0.00} dB SPL";
 
     // The tracker unit for a frequency-response curve: the primary is the transfer
     // magnitude relative to the loopback reference (dBr), every distortion curve
@@ -616,19 +719,57 @@ internal sealed class PlotModelFactory
         return model;
     }
 
+    // The reference-free RTA is the only trace when the plot is in SPL, or when the
+    // capture has no loopback reference to form a transfer function from.
+    private bool LiveRtaOnly =>
+        EffectiveLiveSpectrumScale == MagnitudeScale.SoundPressureLevel ||
+        noiseMeasurement.IsMicOnly;
+
     public PlotModel CreateLiveSpectrum()
     {
-        PlotModel model = PlotModelStyle.CreateTitledModel("Live Transfer Function");
+        // In SPL mode the whole plot is the absolute microphone (RTA) spectrum in
+        // dB SPL; a mic-only capture shows the RTA in the native scale. Either way the
+        // transfer function and its coherence are absent, so the title, axis and
+        // (absent) coherence axis follow the RTA.
+        bool renderSpl =
+            EffectiveLiveSpectrumScale == MagnitudeScale.SoundPressureLevel;
+        bool rtaOnly = LiveRtaOnly;
+        PlotModel model = PlotModelStyle.CreateTitledModel(
+            renderSpl
+                ? "Live Spectrum — dB SPL"
+                : rtaOnly
+                    ? "Live Spectrum (RTA)"
+                    : "Live Transfer Function");
 
         PlotModelStyle.AddFrequencyAxis(model);
-        PlotModelStyle.AddDecibelAxis(model);
-        if (liveSpectrumOptions.ShowCoherence)
+        if (renderSpl)
         {
-            AddCoherenceAxis(model);
+            PlotModelStyle.AddDecibelAxis(
+                model,
+                "dB SPL",
+                PlotModelStyle.SplDecibelMinimum,
+                PlotModelStyle.SplDecibelMaximum,
+                PlotModelStyle.SplDecibelAbsoluteMinimum,
+                PlotModelStyle.SplDecibelAbsoluteMaximum);
+        }
+        else
+        {
+            PlotModelStyle.AddDecibelAxis(model);
+            if (!rtaOnly && liveSpectrumOptions.ShowCoherence)
+            {
+                AddCoherenceAxis(model);
+            }
         }
 
         return model;
     }
+
+    // The live magnitude tracker unit: absolute dB SPL when the RTA is shown on the
+    // SPL axis, otherwise the native relative dB.
+    private string LiveMagnitudeTracker() =>
+        EffectiveLiveSpectrumScale == MagnitudeScale.SoundPressureLevel
+            ? "{0}\n{2:0.0} Hz\n{4:0.00} dB SPL"
+            : "{0}\n{2:0.0} Hz\n{4:0.00} dB";
 
     public LineSeries BuildNoiseSeries(double[] accumulatedData)
     {
@@ -653,32 +794,90 @@ internal sealed class PlotModelFactory
         var series = new LineSeries
         {
             Color = OxyColor.FromRgb(80, 170, 255),
-            Title = "Input Spectrum (RTA)",
-            TrackerFormatString = "{0}\n{2:0.0} Hz\n{4:0.00} dB"
+            Title = "Input Spectrum (RTA)"
         };
         UpdateInputMagnitudeSeries(series, inputMagnitude);
         return series;
     }
 
-    public void UpdateInputMagnitudeSeries(LineSeries series, double[] inputMagnitude) =>
-        FillPoints(series, ResampleLiveSpectrumMagnitude(inputMagnitude));
+    // The RTA is the raw microphone spectrum, so it is the one live curve with an
+    // honest absolute level: in SPL mode it is lifted by the microphone SPL offset,
+    // AND integrated as power per band so the absolute level is FFT-size-independent.
+    public void UpdateInputMagnitudeSeries(LineSeries series, double[] inputMagnitude)
+    {
+        series.TrackerFormatString = LiveMagnitudeTracker();
+        FillPoints(series, ResampleLiveRta(inputMagnitude));
+    }
 
-    public LineSeries BuildPeakHoldSeries(double[] peakHoldData)
+    // The current main trace as displayed points: the RTA (power-integrated in SPL)
+    // when the RTA is the shown curve, the transfer function otherwise. The peak-hold
+    // envelope is accumulated over THESE points, not the raw bins — in SPL the display
+    // sums bin powers per band, so a per-bin peak then summed would add maxima from
+    // different frames and overstate the band's true peak power.
+    public List<SignalPoint> BuildMainDisplayPoints(double[] magnitude, bool rtaOnly) =>
+        rtaOnly
+            ? ResampleLiveRta(magnitude)
+            : ResampleLiveSpectrumMagnitude(magnitude, 0.0);
+
+    public LineSeries BuildPeakHoldSeries(List<SignalPoint> peakHoldPoints)
     {
         var series = new LineSeries
         {
             Color = OxyColor.FromAColor(170, OxyColor.FromRgb(255, 196, 0)),
             LineStyle = LineStyle.Solid,
             StrokeThickness = 1.0,
-            Title = "Peak Hold",
-            TrackerFormatString = "{0}\n{2:0.0} Hz\n{4:0.00} dB"
+            Title = "Peak Hold"
         };
-        UpdatePeakHoldSeries(series, peakHoldData);
+        UpdatePeakHoldSeries(series, peakHoldPoints);
         return series;
     }
 
-    public void UpdatePeakHoldSeries(LineSeries series, double[] peakHoldData) =>
-        FillPoints(series, ResampleLiveSpectrumMagnitude(peakHoldData));
+    // The envelope is already in display points (band levels in SPL, amplitude dB
+    // otherwise); just draw it with the matching tracker unit.
+    public void UpdatePeakHoldSeries(LineSeries series, List<SignalPoint> peakHoldPoints)
+    {
+        series.TrackerFormatString = LiveMagnitudeTracker();
+        FillPoints(series, peakHoldPoints);
+    }
+
+    // The RTA trace. In SPL mode it is a true, FFT-size-independent band level: bin
+    // power is integrated per display band, the microphone calibration is applied per
+    // band, and the SPL offset lifts it to dB SPL. In the native (relative) view it
+    // stays the amplitude-averaged spectrum in dB.
+    private List<SignalPoint> ResampleLiveRta(double[] amplitudeSpectrum)
+    {
+        if (EffectiveLiveSpectrumScale != MagnitudeScale.SoundPressureLevel)
+        {
+            return ResampleLiveSpectrumMagnitude(amplitudeSpectrum, 0.0);
+        }
+
+        double smoothingOctaves = liveSpectrumOptions.SmoothingInverseOctaves > 0
+            ? 1.0 / liveSpectrumOptions.SmoothingInverseOctaves
+            : 0.0;
+        List<SignalPoint> bands = DataHelper.LogarithmicPowerBandResample(
+            amplitudeSpectrum,
+            noiseMeasurement.SequenceLength,
+            noiseMeasurement.SampleRate,
+            noiseMeasurement.AnalysisWindowEnbwBins,
+            noiseMeasurement.AnalysisWindowMainLobeBins,
+            20,
+            20000,
+            1024,
+            smoothingOctaves);
+
+        double offsetDb = LiveSplRenderOffset;
+        CalibrationFile? calibration = GetCalibration(liveSpectrumOptions);
+        for (int i = 0; i < bands.Count; i++)
+        {
+            // The microphone correction is a per-frequency dB gain (same sign
+            // convention as LogarithmicResample); it applies identically to a power
+            // level, so subtract it at the band centre, then lift to dB SPL.
+            double correction = calibration?.GetDecibelCorrection(bands[i].X) ?? 0.0;
+            bands[i] = new SignalPoint(bands[i].X, bands[i].Y - correction + offsetDb);
+        }
+
+        return bands;
+    }
 
     private static void FillPoints(LineSeries series, List<SignalPoint> points)
     {
@@ -689,7 +888,9 @@ internal sealed class PlotModelFactory
         }
     }
 
-    private List<SignalPoint> ResampleLiveSpectrumMagnitude(double[] magnitude)
+    private List<SignalPoint> ResampleLiveSpectrumMagnitude(
+        double[] magnitude,
+        double offsetDb = 0.0)
     {
         int length = noiseMeasurement.SequenceLength;
         int binCount = Math.Min(length / 2, magnitude.Length);
@@ -699,7 +900,7 @@ internal sealed class PlotModelFactory
         {
             double frequency =
                 i * ((double)noiseMeasurement.SampleRate / length);
-            double decibels = DataHelper.AmplitudeToDecibels(magnitude[i]);
+            double decibels = DataHelper.AmplitudeToDecibels(magnitude[i]) + offsetDb;
             data.Add(new DataPoint(frequency, decibels));
         }
 
@@ -1285,6 +1486,19 @@ internal sealed class PlotModelFactory
             TextFlowDirection = TextFlowDirection.TopDown,
             FontSize = 13,
             TextColor = OxyColors.Gray,
+            TextHorizontalAlignment = OxyPlot.HorizontalAlignment.Center
+        });
+    }
+
+    private static void AddSplUnavailableAnnotation(PlotModel model)
+    {
+        model.Annotations.Add(new OverlayTextAnnotation
+        {
+            Text = "No SPL calibration for this measurement — showing dBr/dBc",
+            TextPosition = new DataPoint(0.5, 3),
+            TextFlowDirection = TextFlowDirection.TopDown,
+            FontSize = 12,
+            TextColor = OxyColor.FromRgb(255, 170, 0),
             TextHorizontalAlignment = OxyPlot.HorizontalAlignment.Center
         });
     }

--- a/source/Plotting/PlotModelStyle.cs
+++ b/source/Plotting/PlotModelStyle.cs
@@ -27,17 +27,38 @@ internal static class PlotModelStyle
         });
     }
 
-    public static void AddDecibelAxis(PlotModel model, string title = "dB")
+    // Default view and hard clamps for the loopback-referenced (dBr/dBc) axis.
+    public const double RelativeDecibelMinimum = -90;
+    public const double RelativeDecibelMaximum = 0;
+    public const double RelativeDecibelAbsoluteMinimum = -120;
+    public const double RelativeDecibelAbsoluteMaximum = 10;
+
+    // Default view and hard clamps for the absolute dB SPL axis. The window frames
+    // a typical in-cabin response (noise floor to peaks); the clamp ceiling sits at
+    // loud/painful levels (car audio can get there) but well short of anything
+    // physically absurd — 120 dB is already the threshold of pain.
+    public const double SplDecibelMinimum = 0;
+    public const double SplDecibelMaximum = 120;
+    public const double SplDecibelAbsoluteMinimum = -20;
+    public const double SplDecibelAbsoluteMaximum = 150;
+
+    public static void AddDecibelAxis(
+        PlotModel model,
+        string title = "dB",
+        double minimum = RelativeDecibelMinimum,
+        double maximum = RelativeDecibelMaximum,
+        double absoluteMinimum = RelativeDecibelAbsoluteMinimum,
+        double absoluteMaximum = RelativeDecibelAbsoluteMaximum)
     {
         model.Axes.Insert(0, new LinearAxis
         {
             Key = PlotModelFactory.DecibelAxisKey,
             Position = AxisPosition.Left,
-            AbsoluteMinimum = -120,
-            AbsoluteMaximum = 10,
+            AbsoluteMinimum = absoluteMinimum,
+            AbsoluteMaximum = absoluteMaximum,
             MajorStep = 10,
-            Minimum = -90,
-            Maximum = 0,
+            Minimum = minimum,
+            Maximum = maximum,
             MajorGridlineStyle = LineStyle.Solid,
             MinorGridlineStyle = LineStyle.Dot,
             Title = title,

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -7,7 +7,7 @@ namespace Resonalyze;
 
 internal sealed class MeasurementSettingsFile
 {
-    private const int CurrentSchemaVersion = 8;
+    private const int CurrentSchemaVersion = 9;
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
         WriteIndented = true,
@@ -59,7 +59,7 @@ internal sealed class MeasurementSettingsFile
                 JsonSerializer.Deserialize<MeasurementSettingsFile>(
                     stream,
                     SerializerOptions);
-            if (settings == null || settings.SchemaVersion is not (7 or CurrentSchemaVersion))
+            if (settings == null || settings.SchemaVersion is < 7 or > CurrentSchemaVersion)
             {
                 throw new InvalidDataException(
                     settings == null
@@ -75,9 +75,21 @@ internal sealed class MeasurementSettingsFile
                     Resonalyze.Dsp.PhaseDetrendMode.Manual;
                 settings.PhaseResponse.PhaseFdwCycles =
                     PhaseAnalysisSettings.DefaultFdwCycles;
-                settings.SchemaVersion = CurrentSchemaVersion;
             }
 
+            // Version 9 added the SPL calibration; 7 and 8 files simply carry none.
+            // A structurally broken anchor drops to null rather than failing the
+            // whole settings load — the measurement configuration is the value here.
+            try
+            {
+                settings.Measurement.SplCalibration?.Validate();
+            }
+            catch (InvalidDataException)
+            {
+                settings.Measurement.SplCalibration = null;
+            }
+
+            settings.SchemaVersion = CurrentSchemaVersion;
             settings.MigrateLegacyDualDeviceLoopback();
             settings.pathOnDisk = path;
             return settings;
@@ -267,6 +279,7 @@ internal sealed class MeasurementSettingsFile
         public bool ConfirmEachAverageRun { get; set; }
         public string? MicrophoneCalibration0DegreesPath { get; set; }
         public string? MicrophoneCalibration90DegreesPath { get; set; }
+        public SplCalibration? SplCalibration { get; set; }
 
         // A loopback reference channel is mandatory: every analysis mode is derived from the
         // transfer IR, which only exists when the loopback is captured alongside the microphone.
@@ -299,7 +312,8 @@ internal sealed class MeasurementSettingsFile
                 AsioLoopbackInputChannelOffset = measurement.AsioLoopbackInputChannelOffset,
                 AsioOutputChannelOffset = measurement.AsioOutputChannelOffset,
                 AverageRunCount = measurement.AverageRunCount,
-                ConfirmEachAverageRun = measurement.ConfirmEachAverageRun
+                ConfirmEachAverageRun = measurement.ConfirmEachAverageRun,
+                SplCalibration = measurement.SplCalibration
             };
 
         public void ApplyTo(ExpSweepMeasurement measurement)
@@ -362,6 +376,8 @@ internal sealed class MeasurementSettingsFile
                 new SweepAveragingConfiguration(
                     Clamp(AverageRunCount, 1, 64),
                     ConfirmEachAverageRun)));
+            // Metadata, applied after Init (which does not touch it).
+            measurement.SplCalibration = SplCalibration;
         }
     }
 
@@ -375,6 +391,7 @@ internal sealed class MeasurementSettingsFile
         public bool Unwrap { get; set; } = true;
         public bool UseCalibration { get; set; } = true;
         public MicrophoneCalibrationMode? CalibrationMode { get; set; }
+        public MagnitudeScale MagnitudeScale { get; set; } = MagnitudeScale.Relative;
         public bool ShowCoherence { get; set; } = true;
         public bool ShowMeasuredPhase { get; set; } = true;
         public bool ShowMinimumPhase { get; set; } = true;
@@ -414,6 +431,7 @@ internal sealed class MeasurementSettingsFile
                 Unwrap = options.Unwrap,
                 UseCalibration = options.UseCalibration,
                 CalibrationMode = options.CalibrationMode,
+                MagnitudeScale = options.MagnitudeScale,
                 ShowCoherence = visibility.ShowCoherence,
                 ShowMeasuredPhase = visibility.ShowMeasuredPhase,
                 ShowMinimumPhase = visibility.ShowMinimumPhase,
@@ -452,6 +470,9 @@ internal sealed class MeasurementSettingsFile
             options.Offset = Clamp(Offset, -32768, 32768);
             options.Unwrap = Unwrap;
             options.CalibrationMode = NormalizeCalibrationMode(CalibrationMode, UseCalibration);
+            options.MagnitudeScale = Enum.IsDefined(MagnitudeScale)
+                ? MagnitudeScale
+                : MagnitudeScale.Relative;
             visibility.ShowCoherence = ShowCoherence;
             visibility.ShowMeasuredPhase = ShowMeasuredPhase;
             visibility.ShowMinimumPhase = ShowMinimumPhase;
@@ -616,6 +637,7 @@ internal sealed class MeasurementSettingsFile
         public bool PeakHold { get; set; }
         public bool ShowCoherence { get; set; } = true;
         public int CoherenceThresholdPercent { get; set; } = 25;
+        public MagnitudeScale MagnitudeScale { get; set; } = MagnitudeScale.Relative;
 
         public static LiveSpectrumSettings Capture(
             LiveSpectrumOptions options) =>
@@ -641,7 +663,8 @@ internal sealed class MeasurementSettingsFile
                 PeakHold = options.PeakHold,
                 ShowCoherence = options.ShowCoherence,
                 CoherenceThresholdPercent =
-                    NormalizeCoherenceThreshold(options.CoherenceThresholdPercent)
+                    NormalizeCoherenceThreshold(options.CoherenceThresholdPercent),
+                MagnitudeScale = options.MagnitudeScale
             };
 
         public void ApplyTo(LiveSpectrumOptions options)
@@ -666,6 +689,9 @@ internal sealed class MeasurementSettingsFile
             options.ShowCoherence = ShowCoherence;
             options.CoherenceThresholdPercent =
                 NormalizeCoherenceThreshold(CoherenceThresholdPercent);
+            options.MagnitudeScale = Enum.IsDefined(MagnitudeScale)
+                ? MagnitudeScale
+                : MagnitudeScale.Relative;
         }
 
         private static int NormalizeCoherenceThreshold(int thresholdPercent) =>

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -126,8 +126,20 @@ public partial class Form1
                     file.AverageRunCount,
                     file.AcceptedAverageRunCount);
                 expSweepMeasurement.RestoreLevelSnapshot(file.GetMeterSnapshot());
+                // The loaded file's own calibration is this result's snapshot (what
+                // it was measured under), so it can be shown in dB SPL. The configured
+                // calibration for the next new run is left untouched. Its capture
+                // identity stands in for the result's input, so re-saving the file
+                // validates the anchor against the input it was measured on — not the
+                // app's current device — and keeps it.
+                expSweepMeasurement.MeasurementSplCalibration = file.SplCalibration;
+                expSweepMeasurement.MeasurementInput = file.SplCalibration?.CaptureIdentity;
                 ApplyLoadedImpulseResponseState(dialog.FileName);
                 sessionTracker.MarkLoadedFile(dialog.FileName, file);
+                // A loaded file carries its own SPL calibration and loopback level, so
+                // an open Frequency Response panel can now offer dB SPL for it.
+                dockedModeSettingsHost.InvokeIfOpen<Options.FROptions>(
+                    panel => panel.RefreshSplAvailability());
             }
             catch (Exception exception)
             {

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -224,6 +224,13 @@ public partial class Form1
                 DrawSelectedMode(true);
             }
 
+            // The Frequency Response panel evaluates dB SPL availability only when it
+            // opens; a run changes it in both directions (a good run captures the
+            // loopback level SPL needs; a failed/aborted run clears the level snapshot),
+            // so re-offer or withdraw SPL after EVERY completion, not just success.
+            dockedModeSettingsHost.InvokeIfOpen<Options.FROptions>(
+                panel => panel.RefreshSplAvailability());
+
             if (success)
             {
                 NotifyDegradedSweepAverage();

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -196,6 +196,54 @@ public partial class Form1
         expSweepMeasurement.InProgress &&
         expSweepMeasurement.AverageRunCount > 1;
 
+    // Commit a calibration change (microphone 0°/90° file or the SPL anchor) the
+    // moment it happens: into the settings and to disk (debounced, flushed on
+    // close), onto the live measurement so the next impulse response stamps the SPL
+    // anchor, and onto the plot so a microphone calibration shows at once. None of
+    // it needs an Apply-settings click — a completed calibration is not a tentative
+    // edit, and losing it because Apply was not pressed is the whole bug here.
+    private async void PersistCalibration(MeasurementOptions.CalibrationSelection selection)
+    {
+        measurementSettings.Measurement.MicrophoneCalibration0DegreesPath =
+            selection.MicrophoneCalibration0DegreesPath;
+        measurementSettings.Measurement.MicrophoneCalibration90DegreesPath =
+            selection.MicrophoneCalibration90DegreesPath;
+        measurementSettings.Measurement.SplCalibration = selection.SplCalibration;
+        expSweepMeasurement.SplCalibration = selection.SplCalibration;
+        RefreshCalibrationConsumers();
+        // Persist the calibration itself up front so it survives even if the redraw
+        // below fails; the normalized live options are re-saved afterwards.
+        ScheduleMeasurementSettingsSave();
+
+        IReadOnlyList<AxisViewport> viewports = CaptureAxisViewports();
+        try
+        {
+            // Normalize Live Spectrum for the calibration change in EVERY mode — drop
+            // its stale peak hold, and fall a Silent RTA back to a real excitation once
+            // SPL is gone — not only while it is the visible mode; it rebuilds its own
+            // model only when visible, so any other mode still refreshes below.
+            bool liveSignalChanged = await liveSpectrumController.RefreshCalibrationAsync();
+
+            // If the live signal was normalized (Silent → periodic pink), capture the
+            // options so the change reaches disk: a plain schedule serializes the
+            // un-captured LiveSpectrum settings and would keep the stale Silent.
+            if (liveSignalChanged)
+            {
+                SaveMeasurementSettings();
+            }
+
+            if (CurrentMode != Mode.LiveSpectrum)
+            {
+                await RefreshCurrentModePlotAsync(viewports);
+            }
+        }
+        catch (Exception exception)
+        {
+            // The calibration is already saved and applied; only the redraw failed.
+            ShowMeasurementError("Failed to redraw after a calibration change.", exception);
+        }
+    }
+
     private void buttonRecordOpt_Click(object sender, EventArgs e)
     {
         if (dockedMeasurementSettingsHost.IsOpen)
@@ -208,7 +256,12 @@ public partial class Form1
         dockedHistoryHost.Close();
         dockedMeasurementSettingsHost.Toggle(
             "measurement-settings",
-            () => new MeasurementOptions(),
+            () =>
+            {
+                var options = new MeasurementOptions(audioSessionFactory);
+                options.CalibrationChanged += PersistCalibration;
+                return options;
+            },
             dialog => dialog.Init(expSweepMeasurement, measurementSettings.Measurement),
             async dialog =>
             {

--- a/source/Shell/Form1.ModeCatalog.cs
+++ b/source/Shell/Form1.ModeCatalog.cs
@@ -47,7 +47,10 @@ public partial class Form1
                         frequencyResponseVisibility,
                         microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees0),
                         microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees90)),
-                    opt => opt.SetOptions(frequencyResponseOptions, frequencyResponseVisibility))),
+                    opt => opt.SetOptions(frequencyResponseOptions, frequencyResponseVisibility),
+                    // Switching dBr <-> SPL rescales the axis, so the old zoom is
+                    // meaningless: refit instead of restoring it.
+                    viewResetKey: () => frequencyResponseOptions.MagnitudeScale)),
             [ModeTab.Phase] = new(
                 ModeTab.Phase,
                 Mode.PhaseResponse,

--- a/source/Shell/Form1.ModeSettings.cs
+++ b/source/Shell/Form1.ModeSettings.cs
@@ -139,7 +139,8 @@ public partial class Form1
                 opt.Init(
                     liveSpectrumOptions,
                     microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees0),
-                    microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees90));
+                    microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees90),
+                    plotModelFactory.LiveSplOffsetDb.HasValue);
                 opt.ResetAverageRequested += liveSpectrumController.ResetAverage;
             },
             ApplyLiveSpectrumOptionsAsync,

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -133,6 +133,20 @@ namespace Resonalyze
             overlayCollection = dependencies.OverlayCollection;
             plotLabelsPanelController = dependencies.PlotLabelsPanelController;
             plotModelFactory = dependencies.PlotModelFactory;
+            // Overlays are tagged with, and gated by, the magnitude scale the plot is
+            // ACTUALLY rendered in — SPL only when the plot is showing SPL (selected and
+            // available). Live Spectrum shares Frequency Response's overlay slots, so it
+            // must report its OWN effective scale here; otherwise a Live SPL plot would
+            // gate overlays as Relative and show dBr overlays on the dB SPL axis. Every
+            // other mode, and any dBr fallback, is Relative. Wired after plotModelFactory
+            // is assigned (the lambda reads it).
+            overlayCollection.SetMagnitudeScaleProvider(
+                () => CurrentMode switch
+                {
+                    Mode.FrequencyResponse => plotModelFactory.EffectiveFrequencyResponseScale,
+                    Mode.LiveSpectrum => plotModelFactory.EffectiveLiveSpectrumScale,
+                    _ => Dsp.MagnitudeScale.Relative
+                });
             liveSpectrumController = dependencies.LiveSpectrumController;
             modeController = dependencies.ModeController;
             commandController = dependencies.CommandController;

--- a/source/Ui/Controls/DarkComboBox.cs
+++ b/source/Ui/Controls/DarkComboBox.cs
@@ -445,6 +445,26 @@ public sealed class DarkComboBox : UserControl
         LayoutInnerControls();
     }
 
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        base.OnHandleCreated(e);
+        // DeviceDpi is only final once the handle exists in its monitor's context, and
+        // the drop-down button column is positioned from it. A control created at
+        // runtime (e.g. an added Virtual DSP channel) lays out at the default 96 DPI in
+        // the constructor; re-run it here so the button and text are not left offset on
+        // a higher-DPI display. Designer-placed instances are covered by the form's
+        // startup scale pass; runtime-added ones are not.
+        LayoutInnerControls();
+        Invalidate();
+    }
+
+    protected override void OnDpiChangedAfterParent(EventArgs e)
+    {
+        base.OnDpiChangedAfterParent(e);
+        LayoutInnerControls();
+        Invalidate();
+    }
+
     protected override void OnLayout(LayoutEventArgs e)
     {
         base.OnLayout(e);

--- a/source/Ui/Controls/DarkNumericUpDown.cs
+++ b/source/Ui/Controls/DarkNumericUpDown.cs
@@ -712,6 +712,25 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
         LayoutEditor();
     }
 
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        base.OnHandleCreated(e);
+        // DeviceDpi is only final once the handle exists in its monitor's context.
+        // A control created at runtime (e.g. an added Virtual DSP channel) lays its
+        // editor out at the default 96 DPI in the constructor, so without this the
+        // text stays offset inside a higher-DPI field. Designer-placed instances are
+        // masked by the form's startup scale pass; runtime-added ones are not.
+        LayoutEditor();
+    }
+
+    protected override void OnDpiChangedAfterParent(EventArgs e)
+    {
+        base.OnDpiChangedAfterParent(e);
+        // Moving the window to a monitor at another scale re-fires this; the inner
+        // editor must be re-laid-out for the new DeviceDpi.
+        LayoutEditor();
+    }
+
     private void EditorKeyDown(object? sender, KeyEventArgs e)
     {
         if (e.KeyCode == Keys.Enter)

--- a/source/Ui/UiStyle.cs
+++ b/source/Ui/UiStyle.cs
@@ -9,11 +9,12 @@ internal static class UiStyle
     // muted pass, keyed weakly so controls are not kept alive.
     private static readonly ConditionalWeakTable<Control, object> enabledForeColors = new();
 
-    // Standard Label/CheckBox controls paint disabled text with a dark emboss (Label) or a
-    // low-contrast system grey (CheckBox), which reads as near-black on the dark theme. Rather
-    // than letting WinForms disable them, keep them Enabled and mute the text colour instead —
-    // matching how DarkComboBox/DarkNumericUpDown render their own disabled state. Pass
-    // interactive:true for check boxes so the muted look also stops them toggling or taking focus.
+    // Standard Label/CheckBox/RadioButton controls paint disabled text with a dark emboss
+    // (Label) or a low-contrast system grey (CheckBox/RadioButton), which reads as near-black
+    // on the dark theme. Rather than letting WinForms disable them, keep them Enabled and mute
+    // the text colour instead — matching how DarkComboBox/DarkNumericUpDown render their own
+    // disabled state. Pass interactive:true for check boxes and radio buttons so the muted look
+    // also stops them toggling or taking focus.
     public static void SetTextEnabledLook(Control control, bool enabled, bool interactive = false)
     {
         if (enabled)
@@ -33,10 +34,24 @@ internal static class UiStyle
             control.ForeColor = UiPalette.TextMuted;
         }
 
-        if (interactive && control is CheckBox checkBox)
+        if (!interactive)
         {
-            checkBox.AutoCheck = enabled;
-            checkBox.TabStop = enabled;
+            return;
+        }
+
+        // RadioButton and CheckBox both expose AutoCheck/TabStop but share no common
+        // property for them, so switch on the concrete type. AutoCheck:false makes a
+        // click leave the state untouched, matching a disabled control's behaviour.
+        switch (control)
+        {
+            case RadioButton radioButton:
+                radioButton.AutoCheck = enabled;
+                radioButton.TabStop = enabled;
+                break;
+            case CheckBox checkBox:
+                checkBox.AutoCheck = enabled;
+                checkBox.TabStop = enabled;
+                break;
         }
     }
 

--- a/tests/Resonalyze.App.Tests/Fakes/RecordingSessions.cs
+++ b/tests/Resonalyze.App.Tests/Fakes/RecordingSessions.cs
@@ -96,10 +96,12 @@ internal sealed class RecordingStreamingSession : IAudioStreamingSession
     public event Action? CaptureDiscontinuity;
 
     public bool Disposed { get; private set; }
+    public AudioPlaybackSignal? LastPlaybackSignal { get; private set; }
 
     public async Task RunAsync(
         AudioPlaybackSignal loopingSignal, int sequenceLength, CancellationToken cancellationToken)
     {
+        LastPlaybackSignal = loopingSignal;
         _ = CaptureDiscontinuity;
         for (int f = 0; f < framesToRaise; f++)
         {

--- a/tests/Resonalyze.App.Tests/LiveSpectrumControllerTests.cs
+++ b/tests/Resonalyze.App.Tests/LiveSpectrumControllerTests.cs
@@ -1,0 +1,105 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Resonalyze.Dsp;
+using Resonalyze.Options;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class LiveSpectrumControllerTests
+{
+    [Fact]
+    public void MissingEffectiveSplCalibration_NormalizesSilentToPeriodicPink()
+    {
+        var options = new LiveSpectrumOptions
+        {
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel,
+            NoiseColor = NoiseColor.Silent
+        };
+
+        bool changed = LiveSpectrumController.NormalizeSignalType(
+            options,
+            MagnitudeScale.Relative);
+
+        Assert.True(changed);
+        Assert.Equal(NoiseColor.PinkPeriodic, options.NoiseColor);
+    }
+
+    [Fact]
+    public void NormalizeSignalType_KeepsSilentWhileSplIsEffective()
+    {
+        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.Silent };
+
+        bool changed = LiveSpectrumController.NormalizeSignalType(
+            options,
+            MagnitudeScale.SoundPressureLevel);
+
+        Assert.False(changed);
+        Assert.Equal(NoiseColor.Silent, options.NoiseColor);
+    }
+
+    [Fact]
+    public void NormalizeSignalType_LeavesANonSilentSignalUntouched()
+    {
+        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.Pink };
+
+        bool changed = LiveSpectrumController.NormalizeSignalType(
+            options,
+            MagnitudeScale.Relative);
+
+        Assert.False(changed);
+        Assert.Equal(NoiseColor.Pink, options.NoiseColor);
+    }
+
+    [Fact]
+    public void RestoredEffectiveSpl_NormalizesPeriodicPinkBackToSilent()
+    {
+        // The symmetric half of the fallback: after a Silent→pink calibration-loss the
+        // stored signal is periodic pink while the requested scale is still SPL. When SPL
+        // becomes effective again, periodic pink is invalid there (it is the transfer
+        // reference, pointless in the reference-free RTA), so it must swap back to Silent
+        // — never left playing an excitation the SPL panel cannot even display.
+        var options = new LiveSpectrumOptions
+        {
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel,
+            NoiseColor = NoiseColor.PinkPeriodic
+        };
+
+        bool changed = LiveSpectrumController.NormalizeSignalType(
+            options,
+            MagnitudeScale.SoundPressureLevel);
+
+        Assert.True(changed);
+        Assert.Equal(NoiseColor.Silent, options.NoiseColor);
+    }
+
+    [Fact]
+    public void NormalizeSignalType_KeepsPeriodicPinkOnTheRelativeScale()
+    {
+        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.PinkPeriodic };
+
+        bool changed = LiveSpectrumController.NormalizeSignalType(
+            options,
+            MagnitudeScale.Relative);
+
+        Assert.False(changed);
+        Assert.Equal(NoiseColor.PinkPeriodic, options.NoiseColor);
+    }
+
+    [Fact]
+    public void CalibrationInvalidatedOutsideLiveSpectrum_DropsPeakHoldBeforeRestore()
+    {
+        var controller = (LiveSpectrumController)RuntimeHelpers.GetUninitializedObject(
+            typeof(LiveSpectrumController));
+        FieldInfo peakHoldField = typeof(LiveSpectrumController).GetField(
+            "peakHoldPoints",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        peakHoldField.SetValue(
+            controller,
+            new List<SignalPoint> { new(1000.0, 85.0) });
+
+        // PersistCalibration invokes this even when another mode owns the plot.
+        controller.InvalidateCalibration();
+
+        Assert.Null(peakHoldField.GetValue(controller));
+    }
+}

--- a/tests/Resonalyze.App.Tests/NoiseSignalTests.cs
+++ b/tests/Resonalyze.App.Tests/NoiseSignalTests.cs
@@ -1,0 +1,21 @@
+using Resonalyze.Options;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class NoiseSignalTests
+{
+    [Fact]
+    public void FillData_Silent_CreatesZeroPlaybackBuffer()
+    {
+        using var signal = new NoiseSignal();
+
+        signal.FillData(
+            requestedDuration: 2048.0 / 48_000,
+            sampleRate: 48_000,
+            noiseColor: NoiseColor.Silent,
+            periodLength: 2048);
+
+        Assert.Equal(2048, signal.FloatData.Length);
+        Assert.All(signal.FloatData, sample => Assert.Equal(0.0f, sample));
+    }
+}

--- a/tests/Resonalyze.App.Tests/OverlayFileTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlayFileTests.cs
@@ -1,9 +1,41 @@
 using System.Drawing;
+using Resonalyze.Dsp;
 
 namespace Resonalyze.App.Tests;
 
 public sealed class OverlayFileTests
 {
+    [Fact]
+    public void SaveAndLoad_RoundTripsCapturedMagnitudeScale()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var original = new OverlayFile
+            {
+                SavedAtUtc = DateTimeOffset.UtcNow,
+                Mode = Mode.FrequencyResponse,
+                Slot = 2,
+                Title = "SPL overlay",
+                ColorArgb = Color.Orange.ToArgb(),
+                CapturedMagnitudeScale = MagnitudeScale.SoundPressureLevel,
+                Points = [new OverlayPoint(20, 80), new OverlayPoint(20_000, 70)]
+            };
+
+            original.Save(root);
+            OverlayFile? loaded = OverlayFile.Load(Mode.FrequencyResponse, 2, root);
+
+            Assert.NotNull(loaded);
+            Assert.Equal(MagnitudeScale.SoundPressureLevel, loaded!.CapturedMagnitudeScale);
+            // A file written before the field existed defaults to Relative.
+            Assert.Equal(MagnitudeScale.Relative, new OverlayFile().CapturedMagnitudeScale);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     [Fact]
     public void SaveAndLoad_RoundTripsOverlayData()
     {

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -594,6 +594,67 @@ public sealed class PlotModelFactoryTests
         Assert.NotEmpty(factory.CreateFrequencyResponse(includeCurves: true).Series);
     }
 
+    [Fact]
+    public void CreateFrequencyResponse_InSplMode_UsesTheSplAxisAndLimits()
+    {
+        ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        // The result's own frozen calibration (matching the default Wave input) plus
+        // its input identity and a captured loopback level are the ingredients of K.
+        var anchor = new SplCalibration
+        {
+            ReferenceLevelDbSpl = 94,
+            MeasuredLevelDbFs = -20,
+            Backend = Resonalyze.Audio.AudioBackend.Wave,
+            SampleRate = 44_100,
+            Bits = 24,
+            MicrophoneChannelOffset = 0,
+            InputDeviceNumber = -1
+        };
+        measurement.MeasurementSplCalibration = anchor;
+        measurement.MeasurementInput = anchor.CaptureIdentity;
+        measurement.RestoreLevelSnapshot(new InputLevelMeterSnapshot(
+            new InputLevelMeterEntry(true, -3, -6, false, false),
+            new InputLevelMeterEntry(true, -6, -9, false, true)));
+        using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+
+        var splOptions = new FrequencyResponseOptions
+        {
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel
+        };
+        OxyPlot.PlotModel model = CreateFactory(
+                measurement, noise, frequencyResponseOptions: splOptions)
+            .CreateFrequencyResponse(includeCurves: true);
+
+        var dbAxis = (OxyPlot.Axes.LinearAxis)model.Axes.First(
+            axis => axis.Key == PlotModelFactory.DecibelAxisKey);
+        Assert.Equal("dB SPL", dbAxis.Title);
+        // Curves sit near 40–110 dB, so the axis must reach well above the dBr
+        // ceiling of 10 or the plot would be blank.
+        Assert.Equal(PlotModelStyle.SplDecibelMaximum, dbAxis.Maximum);
+        Assert.Equal(PlotModelStyle.SplDecibelAbsoluteMaximum, dbAxis.AbsoluteMaximum);
+    }
+
+    [Fact]
+    public void CreateFrequencyResponse_WithoutCalibration_StaysOnTheRelativeAxis()
+    {
+        ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+        var splOptions = new FrequencyResponseOptions
+        {
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel
+        };
+
+        OxyPlot.PlotModel model = CreateFactory(
+                measurement, noise, frequencyResponseOptions: splOptions)
+            .CreateFrequencyResponse(includeCurves: true);
+
+        // SPL was requested but no calibration is available: fall back to dBr/dBc.
+        var dbAxis = (OxyPlot.Axes.LinearAxis)model.Axes.First(
+            axis => axis.Key == PlotModelFactory.DecibelAxisKey);
+        Assert.Equal("dBr/dBc", dbAxis.Title);
+        Assert.Equal(PlotModelStyle.RelativeDecibelMaximum, dbAxis.Maximum);
+    }
+
     private static ExpSweepMeasurement CreateSweepOnlyMeasurement()
     {
         var sweep = new Complex[2048];
@@ -662,7 +723,9 @@ public sealed class PlotModelFactoryTests
         FrequencyResponseOptions? phaseResponseOptions = null,
         CurveVisibilityOptions? frequencyResponseVisibility = null,
         CurveVisibilityOptions? phaseResponseVisibility = null,
-        CurveVisibilityOptions? groupDelayVisibility = null)
+        CurveVisibilityOptions? groupDelayVisibility = null,
+        FrequencyResponseOptions? frequencyResponseOptions = null,
+        LiveSpectrumOptions? liveSpectrumOptions = null)
     {
         string calibrationPath = Path.Combine(
             Path.GetTempPath(),
@@ -672,15 +735,216 @@ public sealed class PlotModelFactoryTests
             measurement,
             noiseMeasurement,
             mode => new CalibrationFile(calibrationPath),
-            new FrequencyResponseOptions(),
+            frequencyResponseOptions ?? new FrequencyResponseOptions(),
             phaseResponseOptions ?? new FrequencyResponseOptions(),
             groupDelayOptions ?? new FrequencyResponseOptions(),
             frequencyResponseVisibility ?? new CurveVisibilityOptions(),
             phaseResponseVisibility ?? new CurveVisibilityOptions(),
             groupDelayVisibility ?? new CurveVisibilityOptions(),
             impulseOptions ?? new ImpulseResponseOptions(),
-            new LiveSpectrumOptions(),
+            liveSpectrumOptions ?? new LiveSpectrumOptions(),
             new WaterfallGenerateOptions(),
             new WaterfallGenerateOptions());
+    }
+
+    // A live analyzer configured for the default Wave input, so it produces a
+    // concrete input identity an SPL anchor can be pinned to.
+    private static NoiseMeasurement CreateLiveAnalyzer()
+    {
+        var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+        noise.Init(
+            44_100,
+            24,
+            60,
+            PlaybackChannel.Mono,
+            sequenceLength: 2048,
+            waveInputChannelOffset: 0,
+            waveLoopbackInputChannelOffset: 1);
+        return noise;
+    }
+
+    // An SPL anchor captured on the input the live analyzer runs on, so it validates.
+    private static SplCalibration LiveAnchorMatching(
+        NoiseMeasurement noise,
+        double referenceLevelDbSpl,
+        double measuredLevelDbFs)
+    {
+        MeasurementInputIdentity id = noise.CurrentInputIdentity();
+        return new SplCalibration
+        {
+            ReferenceLevelDbSpl = referenceLevelDbSpl,
+            MeasuredLevelDbFs = measuredLevelDbFs,
+            Backend = id.Backend,
+            SampleRate = id.SampleRate,
+            Bits = id.Bits,
+            MicrophoneChannelOffset = id.MicrophoneChannelOffset,
+            InputDeviceNumber = id.InputDeviceNumber,
+            WasapiCaptureEndpointId = id.WasapiCaptureEndpointId,
+            AsioDriverName = id.AsioDriverName
+        };
+    }
+
+    [Fact]
+    public void CreateLiveSpectrum_InSplMode_UsesTheSplAxis()
+    {
+        using ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        using NoiseMeasurement noise = CreateLiveAnalyzer();
+        // Live uses the CONFIGURED calibration (there is no frozen snapshot), validated
+        // against the live input.
+        measurement.SplCalibration = LiveAnchorMatching(noise, 94, -16);
+        var options = new LiveSpectrumOptions
+        {
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel
+        };
+
+        PlotModelFactory factory =
+            CreateFactory(measurement, noise, liveSpectrumOptions: options);
+
+        Assert.Equal(MagnitudeScale.SoundPressureLevel, factory.EffectiveLiveSpectrumScale);
+        Assert.Equal(94 - (-16), factory.LiveSplOffsetDb!.Value, precision: 9);
+
+        OxyPlot.PlotModel model = factory.CreateLiveSpectrum();
+        var dbAxis = (OxyPlot.Axes.LinearAxis)model.Axes.First(
+            axis => axis.Key == PlotModelFactory.DecibelAxisKey);
+        Assert.Equal("dB SPL", dbAxis.Title);
+        Assert.Equal(PlotModelStyle.SplDecibelMaximum, dbAxis.Maximum);
+        Assert.Contains("SPL", model.Title);
+    }
+
+    [Fact]
+    public void LiveSplOffset_UnavailableWithoutOrWithMismatchedCalibration()
+    {
+        using ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        using NoiseMeasurement noise = CreateLiveAnalyzer();
+        var options = new LiveSpectrumOptions
+        {
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel
+        };
+        PlotModelFactory factory =
+            CreateFactory(measurement, noise, liveSpectrumOptions: options);
+
+        // No configured calibration: SPL requested but unavailable, stay on native dB.
+        Assert.Null(factory.LiveSplOffsetDb);
+        Assert.Equal(MagnitudeScale.Relative, factory.EffectiveLiveSpectrumScale);
+        var dbAxis = (OxyPlot.Axes.LinearAxis)factory.CreateLiveSpectrum().Axes.First(
+            axis => axis.Key == PlotModelFactory.DecibelAxisKey);
+        Assert.Equal("dB", dbAxis.Title);
+
+        // A calibration captured on a different digital input (sample rate) does not
+        // apply to this live input.
+        SplCalibration mismatched = LiveAnchorMatching(noise, 94, -16);
+        mismatched.SampleRate = 48_000;
+        measurement.SplCalibration = mismatched;
+        Assert.Null(factory.LiveSplOffsetDb);
+        Assert.Equal(MagnitudeScale.Relative, factory.EffectiveLiveSpectrumScale);
+    }
+
+    [Fact]
+    public void LiveSplPeakHold_HoldsBandPowerNotTheSumOfPerBinMaxima()
+    {
+        // Finding: two frames whose energy sits in different bins of one band must not
+        // peak-hold to the SUM of their bin maxima (+3 dB over any real band level).
+        // The controller holds the max of BuildMainDisplayPoints (already band powers),
+        // so the held level is one frame's band, not both bins added.
+        using ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        using NoiseMeasurement noise = CreateLiveAnalyzer();
+        measurement.SplCalibration = LiveAnchorMatching(noise, 94, -16);
+        var options = new LiveSpectrumOptions
+        {
+            CalibrationMode = MicrophoneCalibrationMode.Off,
+            SmoothingInverseOctaves = 6,
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel
+        };
+        PlotModelFactory factory =
+            CreateFactory(measurement, noise, liveSpectrumOptions: options);
+
+        int binCount = noise.SequenceLength / 2;
+        // Two adjacent bins near 1 kHz (44100/2048 ≈ 21.5 Hz/bin, ~5 bins per 1/6 oct).
+        const int binA = 47;
+        const int binB = 48;
+        var frameA = new double[binCount];
+        var frameB = new double[binCount];
+        var frameBoth = new double[binCount];
+        frameA[binA] = 1.0;
+        frameB[binB] = 1.0;
+        frameBoth[binA] = 1.0;
+        frameBoth[binB] = 1.0;
+
+        List<SignalPoint> bandA = factory.BuildMainDisplayPoints(frameA, rtaOnly: true);
+        List<SignalPoint> bandB = factory.BuildMainDisplayPoints(frameB, rtaOnly: true);
+        List<SignalPoint> bandBoth = factory.BuildMainDisplayPoints(frameBoth, rtaOnly: true);
+
+        // The peak band across the two single-bin frames (what a correct peak hold shows).
+        int peak = 0;
+        for (int i = 1; i < bandBoth.Count; i++)
+        {
+            if (bandBoth[i].Y > bandBoth[peak].Y)
+            {
+                peak = i;
+            }
+        }
+
+        double held = Math.Max(bandA[peak].Y, bandB[peak].Y);
+        // Both bins present in one frame is ~3 dB above either alone; the peak hold of
+        // the two single-bin frames must stay near a single band, well below that sum.
+        Assert.True(
+            bandBoth[peak].Y - held > 2.0,
+            $"peak hold {held:0.00} dB reached the summed band {bandBoth[peak].Y:0.00} dB");
+    }
+
+    [Fact]
+    public void CreateLiveSpectrum_MicOnly_ShowsTheRtaWithNoCoherenceAxis()
+    {
+        using ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+        // No loopback configured: the analyzer is a single-channel RTA.
+        noise.Init(44_100, 24, 60, PlaybackChannel.Mono, sequenceLength: 2048, waveInputChannelOffset: 0);
+        Assert.True(noise.IsMicOnly);
+
+        var options = new LiveSpectrumOptions { ShowCoherence = true };
+        PlotModelFactory factory =
+            CreateFactory(measurement, noise, liveSpectrumOptions: options);
+
+        OxyPlot.PlotModel model = factory.CreateLiveSpectrum();
+
+        Assert.Contains("RTA", model.Title);
+        // There is no transfer function, so no coherence axis even though the
+        // coherence curve is requested.
+        Assert.DoesNotContain(model.Axes, axis => axis.Key == PlotModelFactory.CoherenceAxisKey);
+    }
+
+    [Fact]
+    public void LiveRta_InSplMode_IsLiftedByTheCalibrationOffset()
+    {
+        using ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        using NoiseMeasurement noise = CreateLiveAnalyzer();
+
+        // The SPL RTA is power-integrated (not a constant shift of the amplitude
+        // trace), so isolate the OFFSET: two calibrations differing only in offset
+        // must move the identical power-band curve by exactly the offset difference.
+        var options = new LiveSpectrumOptions
+        {
+            CalibrationMode = MicrophoneCalibrationMode.Off,
+            SmoothingInverseOctaves = 0,
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel
+        };
+        PlotModelFactory factory =
+            CreateFactory(measurement, noise, liveSpectrumOptions: options);
+
+        var magnitude = new double[noise.SequenceLength / 2];
+        Array.Fill(magnitude, 0.1);
+
+        measurement.SplCalibration = LiveAnchorMatching(noise, 94, -16);  // offset 110
+        LineSeries lower = factory.BuildInputMagnitudeSeries(magnitude);
+        measurement.SplCalibration = LiveAnchorMatching(noise, 104, -16); // offset 120
+        LineSeries higher = factory.BuildInputMagnitudeSeries(magnitude);
+
+        Assert.Equal(lower.Points.Count, higher.Points.Count);
+        Assert.NotEmpty(lower.Points);
+        for (int i = 0; i < lower.Points.Count; i++)
+        {
+            Assert.Equal(lower.Points[i].X, higher.Points[i].X, precision: 9);
+            Assert.Equal(lower.Points[i].Y + 10.0, higher.Points[i].Y, precision: 6);
+        }
     }
 }

--- a/tests/Resonalyze.App.Tests/SilentLiveSpectrumTests.cs
+++ b/tests/Resonalyze.App.Tests/SilentLiveSpectrumTests.cs
@@ -1,0 +1,101 @@
+using Resonalyze.Dsp;
+using Resonalyze.Options;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class SilentLiveSpectrumTests
+{
+    [Fact]
+    public async Task EffectiveSplFallback_RebuildsPlaybackAsPeriodicPink()
+    {
+        RecordingStreamingSession? session = null;
+        var factory = new FakeAudioSessionFactory(
+            streamingFactory: _ => session = new RecordingStreamingSession(
+                framesToRaise: 1,
+                failAfterFrames: false));
+        using var measurement = new NoiseMeasurement(factory);
+        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.Silent };
+        measurement.Init(
+            44_100,
+            24,
+            0.5,
+            PlaybackChannel.Mono,
+            sequenceLength: 1024,
+            liveSpectrumOptions: options);
+
+        Assert.True(LiveSpectrumController.NormalizeSignalType(
+            options,
+            MagnitudeScale.Relative));
+        measurement.RefreshPlaybackSignal();
+
+        Task<bool> running = measurement.RunAsync();
+        for (int attempt = 0;
+            attempt < 100 && session?.LastPlaybackSignal == null;
+            attempt++)
+        {
+            await Task.Delay(10);
+        }
+        await measurement.AbortAsync();
+
+        Assert.True(await running, measurement.LastError?.ToString());
+        Assert.Equal(NoiseColor.PinkPeriodic, options.NoiseColor);
+        Assert.Contains(
+            session!.LastPlaybackSignal!.MonoSamples,
+            sample => sample != 0.0f);
+    }
+
+    [Fact]
+    public void NormalizedSilentSignal_IsCapturedAsPeriodicPinkForPersistence()
+    {
+        // The persistence follow-up: once the runtime signal is normalized away from
+        // Silent (SPL lost), capturing the live options for the settings file must
+        // record the normalized value, so a stale Silent cannot return on next launch.
+        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.Silent };
+        LiveSpectrumController.NormalizeSignalType(options, MagnitudeScale.Relative);
+
+        MeasurementSettingsFile.LiveSpectrumSettings captured =
+            MeasurementSettingsFile.LiveSpectrumSettings.Capture(options);
+
+        Assert.Equal(NoiseColor.PinkPeriodic, captured.NoiseColor);
+    }
+
+    [Fact]
+    public async Task SilentWithLoopback_UsesMicrophoneOnlyAnalysisAndZeroPlayback()
+    {
+        RecordingStreamingSession? session = null;
+        var factory = new FakeAudioSessionFactory(
+            streamingFactory: _ => session = new RecordingStreamingSession(
+                framesToRaise: 20,
+                failAfterFrames: false));
+        using var measurement = new NoiseMeasurement(factory);
+        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.Silent };
+        measurement.Init(
+            44_100,
+            24,
+            0.5,
+            PlaybackChannel.Mono,
+            sequenceLength: 1024,
+            waveInputChannelOffset: 0,
+            waveLoopbackInputChannelOffset: 1,
+            liveSpectrumOptions: options);
+
+        Task<bool> running = measurement.RunAsync();
+        LiveSpectrumSnapshot? snapshot = null;
+        for (int attempt = 0; attempt < 100 && snapshot == null; attempt++)
+        {
+            await Task.Delay(10);
+            snapshot = measurement.GetAccumulatedSpectrumSnapshot();
+        }
+        await measurement.AbortAsync();
+
+        Assert.True(await running, measurement.LastError?.ToString());
+        Assert.NotNull(snapshot);
+        Assert.Empty(snapshot.Magnitude);
+        Assert.Null(snapshot.Coherence);
+        Assert.NotNull(snapshot.InputMagnitude);
+        Assert.NotNull(session?.LastPlaybackSignal);
+        Assert.All(
+            session!.LastPlaybackSignal!.MonoSamples,
+            sample => Assert.Equal(0.0f, sample));
+    }
+}

--- a/tests/Resonalyze.App.Tests/SplCalibrationTests.cs
+++ b/tests/Resonalyze.App.Tests/SplCalibrationTests.cs
@@ -1,0 +1,387 @@
+using System.Numerics;
+using Resonalyze.Audio;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The SPL calibration anchor and its persistence into the settings and impulse
+/// response files. The anchor is stored as raw ingredients (reference level,
+/// measured level, capture identity); these tests hold that they round-trip and
+/// that a broken anchor never takes a whole file down with it.
+/// </summary>
+public sealed class SplCalibrationTests
+{
+    private static SplCalibration ValidAnchor() => new()
+    {
+        ReferenceLevelDbSpl = 94.0,
+        MeasuredLevelDbFs = -20.5,
+        ReferenceFrequencyHz = 1_000.0,
+        MeasuredFrequencyHz = 1_001.0,
+        CapturedAtUtc = new DateTimeOffset(2026, 7, 17, 12, 0, 0, TimeSpan.Zero),
+        Backend = AudioBackend.WasapiShared,
+        SampleRate = 48_000,
+        Bits = 24,
+        MicrophoneChannelOffset = 0,
+        WasapiCaptureEndpointId = "capture-id"
+    };
+
+    [Fact]
+    public void OffsetDb_IsReferenceMinusMeasured()
+    {
+        SplCalibration anchor = ValidAnchor();
+
+        Assert.Equal(114.5, anchor.OffsetDb, 9);
+    }
+
+    [Fact]
+    public void Validate_RejectsOutOfRangeValues()
+    {
+        Assert.Throws<InvalidDataException>(() =>
+            new SplCalibration { ReferenceLevelDbSpl = 5_000, MeasuredLevelDbFs = -20, Bits = 24, SampleRate = 48_000 }.Validate());
+        Assert.Throws<InvalidDataException>(() =>
+            new SplCalibration { ReferenceLevelDbSpl = 94, MeasuredLevelDbFs = double.NaN, Bits = 24, SampleRate = 48_000 }.Validate());
+        Assert.Throws<InvalidDataException>(() =>
+            new SplCalibration { ReferenceLevelDbSpl = 94, MeasuredLevelDbFs = -20, Bits = 20, SampleRate = 48_000 }.Validate());
+    }
+
+    [Fact]
+    public void MatchesInput_TrueOnlyForTheSameDigitalTract()
+    {
+        SplCalibration anchor = ValidAnchor();
+
+        Assert.True(anchor.MatchesInput(
+            AudioBackend.WasapiShared, 48_000, 24, 0, null, "capture-id", null));
+        // A different endpoint, rate, bits, or channel each break the match.
+        Assert.False(anchor.MatchesInput(
+            AudioBackend.WasapiShared, 48_000, 24, 0, null, "other-id", null));
+        Assert.False(anchor.MatchesInput(
+            AudioBackend.WasapiShared, 44_100, 24, 0, null, "capture-id", null));
+        Assert.False(anchor.MatchesInput(
+            AudioBackend.WasapiShared, 48_000, 16, 0, null, "capture-id", null));
+        Assert.False(anchor.MatchesInput(
+            AudioBackend.WasapiShared, 48_000, 24, 1, null, "capture-id", null));
+        Assert.False(anchor.MatchesInput(
+            AudioBackend.Wave, 48_000, 24, 0, 1, null, null));
+    }
+
+    [Fact]
+    public async Task ImpulseResponseFile_RoundTripsTheAnchor()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"resonalyze-ir-{Guid.NewGuid():N}.json");
+        var file = new ImpulseResponseFile
+        {
+            SavedAtUtc = DateTimeOffset.UtcNow,
+            SampleRate = 48_000,
+            Bits = 24,
+            Octaves = 10,
+            SweepDurationSeconds = 1.0,
+            PlayChannel = PlaybackChannel.Mono,
+            SweepDeconvolutionPeakIndex = 1,
+            SweepDeconvolutionRealSamples = [0.0, 1.0, 0.0],
+            SplCalibration = ValidAnchor()
+        };
+
+        try
+        {
+            await file.SaveAsync(path);
+
+            string json = await File.ReadAllTextAsync(path);
+            Assert.Contains("\"splCalibration\"", json);
+            // The derived offset is never written; it is recomputed on load.
+            Assert.DoesNotContain("\"offsetDb\"", json);
+
+            ImpulseResponseFile loaded = await ImpulseResponseFile.LoadAsync(path);
+            Assert.NotNull(loaded.SplCalibration);
+            Assert.Equal(94.0, loaded.SplCalibration.ReferenceLevelDbSpl);
+            Assert.Equal(-20.5, loaded.SplCalibration.MeasuredLevelDbFs);
+            Assert.Equal(1_001.0, loaded.SplCalibration.MeasuredFrequencyHz);
+            Assert.Equal(AudioBackend.WasapiShared, loaded.SplCalibration.Backend);
+            Assert.Equal("capture-id", loaded.SplCalibration.WasapiCaptureEndpointId);
+            Assert.Equal(114.5, loaded.SplCalibration.OffsetDb, 9);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task ImpulseResponseFile_LoadsVersion6WithoutAnAnchor()
+    {
+        // The version bump (6 -> 7) must not reject a file written before the
+        // anchor existed; it simply carries none.
+        string path = Path.Combine(Path.GetTempPath(), $"resonalyze-ir-{Guid.NewGuid():N}.json");
+        const string json = """
+            {
+              "format": "resonalyze-impulse-response",
+              "version": 6,
+              "sampleRate": 48000,
+              "bits": 24,
+              "octaves": 10,
+              "sweepDurationSeconds": 1.0,
+              "playChannel": "Mono",
+              "measurementMode": "SweepDeconvolution",
+              "sweepDeconvolutionPeakIndex": 0,
+              "sweepDeconvolutionRealSamples": [1.0]
+            }
+            """;
+
+        try
+        {
+            await File.WriteAllTextAsync(path, json);
+
+            ImpulseResponseFile loaded = await ImpulseResponseFile.LoadAsync(path);
+
+            Assert.Null(loaded.SplCalibration);
+            Assert.Equal(48_000, loaded.SampleRate);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // Matches the default (Wave, 44.1 kHz, 24-bit, channel 0) input a restored
+    // measurement carries, so the anchor is stamped rather than dropped.
+    private static SplCalibration MatchingWaveAnchor() => new()
+    {
+        ReferenceLevelDbSpl = 94.0,
+        MeasuredLevelDbFs = -20.5,
+        Backend = AudioBackend.Wave,
+        SampleRate = 44_100,
+        Bits = 24,
+        MicrophoneChannelOffset = 0,
+        InputDeviceNumber = -1
+    };
+
+    // The default Wave 44.1 kHz / 24-bit / channel-0 input a fresh restored
+    // measurement represents.
+    private static readonly MeasurementInputIdentity WaveInput =
+        new(AudioBackend.Wave, 44_100, 24, 0, -1, null, null);
+
+    private static ExpSweepMeasurement RestoredMeasurement(
+        SplCalibration? anchor, MeasurementInputIdentity? input = null)
+    {
+        var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        measurement.RestoreImpulseResponse(
+            octaves: 12,
+            sampleRate: 44_100,
+            bits: 24,
+            sweepDurationSeconds: 1.0,
+            playChannel: PlaybackChannel.Right,
+            sweepDeconvolutionImpulseResponse: [Complex.Zero, Complex.One, Complex.Zero],
+            sweepDeconvolutionPeakIndex: 1);
+        // The result's own frozen calibration and input identity (Restore clears both
+        // via Init); Capture stamps and validates against these, not the configured
+        // calibration or the app's current device.
+        measurement.MeasurementSplCalibration = anchor;
+        measurement.MeasurementInput = input ?? WaveInput;
+        return measurement;
+    }
+
+    [Fact]
+    public void Capture_StampsTheMeasurementsActiveAnchor()
+    {
+        using ExpSweepMeasurement measurement = RestoredMeasurement(MatchingWaveAnchor());
+
+        ImpulseResponseFile file = ImpulseResponseFile.Capture(measurement);
+
+        Assert.NotNull(file.SplCalibration);
+        Assert.Equal(94.0, file.SplCalibration.ReferenceLevelDbSpl);
+        Assert.Equal(114.5, file.SplCalibration.OffsetDb, 9);
+    }
+
+    [Fact]
+    public async Task Capture_RejectsABackendDiscontinuityEvenWithACleanTone()
+    {
+        const int sampleRate = 48_000;
+        var factory = new FakeAudioSessionFactory(
+            streamingFactory: _ => new ToneWithDiscontinuitySession(sampleRate));
+        var request = new AudioSessionRequest(
+            AudioBackend.Wave, sampleRate, 24, PlaybackChannel.Mono,
+            new AudioCaptureRouting(0, null));
+
+        SplCalibrationCaptureResult result = await new SplCalibrationListener(factory)
+            .CaptureAsync(
+                request,
+                frameLength: 2048,
+                SplToneCriteria.Default,
+                TimeSpan.FromMilliseconds(300),
+                progress: null,
+                CancellationToken.None);
+
+        // The tone itself is clean, but a single backend discontinuity (loss before
+        // the FFT queue) must still reject the capture.
+        Assert.True(result.Reading.HasClearPeak);
+        Assert.True(result.Overran);
+        Assert.Equal(
+            SplCalibrationFailure.CaptureOverrun, SplCalibrationListener.Evaluate(result));
+    }
+
+    // Delivers a clean, continuous 1 kHz tone and raises CaptureDiscontinuity once.
+    private sealed class ToneWithDiscontinuitySession : IAudioStreamingSession
+    {
+        private readonly int sampleRate;
+
+        public ToneWithDiscontinuitySession(int sampleRate) => this.sampleRate = sampleRate;
+
+        public event Action<AudioCaptureFrame>? FrameAvailable;
+        public event Action<AudioInputLevels>? InputLevelsAvailable { add { } remove { } }
+        public event Action? CaptureDiscontinuity;
+
+        public async Task RunAsync(
+            AudioPlaybackSignal loopingSignal, int sequenceLength, CancellationToken cancellationToken)
+        {
+            double phase = 0.0;
+            double delta = 2.0 * Math.PI * 1_000.0 / sampleRate;
+
+            // Deliver a fixed, small number of frames (within the listener's bounded
+            // channel capacity, so none is dropped by flooding), raise one backend
+            // discontinuity, then return to end the capture. No wall-clock delay: the
+            // test must be deterministic on a loaded CI runner, not race the capture
+            // duration (paced frames vs a fixed timeout previously flaked here).
+            for (int frame = 0; frame < 8 && !cancellationToken.IsCancellationRequested; frame++)
+            {
+                var block = new float[sequenceLength];
+                for (int i = 0; i < block.Length; i++)
+                {
+                    block[i] = (float)(0.2 * Math.Sin(phase));
+                    phase += delta;
+                }
+
+                FrameAvailable?.Invoke(new AudioCaptureFrame([block], 0, null));
+                if (frame == 5)
+                {
+                    CaptureDiscontinuity?.Invoke();
+                }
+
+                // Yield so the processing task drains the channel between frames,
+                // keeping the queue well under capacity regardless of scheduling.
+                await Task.Yield();
+            }
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public void Evaluate_RejectsAnOverrunEvenWhenTheToneLooksPerfect()
+    {
+        var clearTone = new SplToneReading(
+            PeakFrequencyHz: 1_000,
+            LevelDbFs: -13,
+            ProminenceDb: 60,
+            WithinFrequencyTolerance: true,
+            HasClearPeak: true);
+        var overran = new SplCalibrationCaptureResult(
+            clearTone, InputPeakDbFs: -3, Clipped: false, LevelStabilityDb: 0.1,
+            FramesAnalyzed: 20, Overran: true);
+        var clean = overran with { Overran = false };
+
+        Assert.Equal(SplCalibrationFailure.CaptureOverrun, SplCalibrationListener.Evaluate(overran));
+        Assert.Equal(SplCalibrationFailure.None, SplCalibrationListener.Evaluate(clean));
+    }
+
+    [Fact]
+    public void Capture_DropsAnAnchorCapturedOnADifferentInput()
+    {
+        // ValidAnchor is a WASAPI 48 kHz calibration; the measurement ran on the
+        // default Wave 44.1 kHz input. A mismatched anchor must not ride along, or a
+        // reopened file would show a confidently wrong dB SPL offset.
+        using ExpSweepMeasurement measurement = RestoredMeasurement(ValidAnchor());
+
+        ImpulseResponseFile file = ImpulseResponseFile.Capture(measurement);
+
+        Assert.Null(file.SplCalibration);
+    }
+
+    [Fact]
+    public void Capture_KeepsALoadedFilesAnchorWhenReSavedOnAnotherDevice()
+    {
+        // A file measured on WASAPI, reopened while the app is configured for Wave.
+        // Its result identity is the file's own input (the anchor's capture identity),
+        // so re-saving validates the anchor against that — not the current Wave device
+        // — and keeps it. Without this, Save would silently drop the calibration.
+        SplCalibration anchor = ValidAnchor();
+        using ExpSweepMeasurement measurement =
+            RestoredMeasurement(anchor, anchor.CaptureIdentity);
+
+        ImpulseResponseFile file = ImpulseResponseFile.Capture(measurement);
+
+        Assert.NotNull(file.SplCalibration);
+        Assert.Equal(114.5, file.SplCalibration.OffsetDb, 9);
+    }
+
+    [Fact]
+    public void SettingsFile_RoundTripsTheAnchor()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"resonalyze-settings-{Guid.NewGuid():N}.json");
+        try
+        {
+            MeasurementSettingsFile settings = MeasurementSettingsFile.LoadOrDefault(path);
+            settings.Measurement.SplCalibration = ValidAnchor();
+            settings.Save();
+
+            MeasurementSettingsFile loaded = MeasurementSettingsFile.LoadOrDefault(path);
+
+            Assert.NotNull(loaded.Measurement.SplCalibration);
+            Assert.Equal(94.0, loaded.Measurement.SplCalibration.ReferenceLevelDbSpl);
+            Assert.Equal(-20.5, loaded.Measurement.SplCalibration.MeasuredLevelDbFs);
+            Assert.Equal("capture-id", loaded.Measurement.SplCalibration.WasapiCaptureEndpointId);
+            Assert.Equal(114.5, loaded.Measurement.SplCalibration.OffsetDb, 9);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SettingsFile_Version8LoadsWithoutAnAnchorAndUpgrades()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"resonalyze-settings-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(path, "{\"SchemaVersion\":8}");
+
+            MeasurementSettingsFile loaded = MeasurementSettingsFile.LoadOrDefault(path);
+
+            Assert.Null(loaded.Measurement.SplCalibration);
+            Assert.Null(loaded.LoadWarning);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SettingsFile_DropsABrokenAnchorInsteadOfFailingTheWholeLoad()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"resonalyze-settings-{Guid.NewGuid():N}.json");
+        try
+        {
+            MeasurementSettingsFile settings = MeasurementSettingsFile.LoadOrDefault(path);
+            settings.Measurement.SplCalibration = new SplCalibration
+            {
+                ReferenceLevelDbSpl = 5_000, // out of range
+                MeasuredLevelDbFs = -20.0,
+                Backend = AudioBackend.Wave,
+                SampleRate = 48_000,
+                Bits = 24
+            };
+            settings.Save();
+
+            MeasurementSettingsFile loaded = MeasurementSettingsFile.LoadOrDefault(path);
+
+            Assert.Null(loaded.Measurement.SplCalibration);
+            // The rest of the settings survived — no backup, no fresh-start warning.
+            Assert.Null(loaded.LoadWarning);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/LogarithmicPowerBandResampleTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/LogarithmicPowerBandResampleTests.cs
@@ -1,0 +1,421 @@
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class LogarithmicPowerBandResampleTests
+{
+    private const int SampleRate = 48_000;
+
+    [Fact]
+    public void PowerBandLevels_AreFftLengthInvariant_ForTheSameNoise()
+    {
+        // The whole point of the power-integrated RTA: the same acoustic noise must
+        // read the same absolute band level whatever the FFT size. The old amplitude
+        // path dropped a broadband level ~3.01 dB per doubling of N; this must not.
+        float[] signal = WhiteNoise(2_048 * 200, seed: 20260718);
+
+        List<SignalPoint> bands2048 = BandLevels(signal, 2_048);
+        List<SignalPoint> bands4096 = BandLevels(signal, 4_096);
+
+        // The two FFT sizes clamp their grids to their own resolved range, so the log
+        // grids no longer share a frequency per index — compare at matching frequencies
+        // (nearest point in each), over a mid band where every band holds several bins
+        // so the estimate is stable and the comparison is about scale, not variance.
+        double sum2048 = 0.0;
+        double sum4096 = 0.0;
+        double maxAbsDiff = 0.0;
+        int count = 0;
+        // Compare from 1 kHz up, where the fixed 1/12-octave band is wider than the
+        // rectangular main lobe at both FFT sizes, so the band (and level) is
+        // FFT-independent rather than resolution-limited.
+        for (double frequency = 1_000.0; frequency <= 6_000.0; frequency *= 1.05)
+        {
+            double level2048 = NearestLevel(bands2048, frequency);
+            double level4096 = NearestLevel(bands4096, frequency);
+            sum2048 += level2048;
+            sum4096 += level4096;
+            maxAbsDiff = Math.Max(maxAbsDiff, Math.Abs(level2048 - level4096));
+            count++;
+        }
+
+        double meanDiff = Math.Abs(sum2048 / count - sum4096 / count);
+        // A 3 dB FFT-size error would blow straight past this; 0.5 dB leaves room for
+        // the finite-average estimation scatter of two independent noise runs.
+        Assert.True(meanDiff < 0.5, $"mean band level differed by {meanDiff:0.000} dB across FFT sizes");
+        Assert.True(maxAbsDiff < 2.0, $"a band differed by {maxAbsDiff:0.000} dB across FFT sizes");
+    }
+
+    [Theory]
+    // Above each window's main-lobe crossover (where the fixed 1/12-octave band already
+    // exceeds the lobe at BOTH FFT sizes) the band is FFT-independent. The lower bound is
+    // the N=2048 crossover with margin: Hann (4-bin lobe) ~1.6 kHz, Flat Top (10-bin lobe)
+    // ~4.1 kHz. The old invariance test only exercised Rectangular from 1 kHz, whose lobe
+    // crosses at ~0.97 kHz, so it never caught a wide-lobe window in its resolved region.
+    [InlineData(WindowType.Hann, 1_800.0)]
+    [InlineData(WindowType.FlatTop, 4_400.0)]
+    public void PowerBandLevels_AreFftLengthInvariant_AboveResolution_ForWideLobeWindows(
+        WindowType windowType,
+        double lowerFrequency)
+    {
+        float[] signal = WhiteNoise(4_096 * 220, seed: 909_090);
+
+        List<SignalPoint> bands2048 = BandLevels(signal, 2_048, windowType);
+        List<SignalPoint> bands4096 = BandLevels(signal, 4_096, windowType);
+
+        double sum2048 = 0.0;
+        double sum4096 = 0.0;
+        double maxAbsDiff = 0.0;
+        int count = 0;
+        for (double frequency = lowerFrequency; frequency <= 8_000.0; frequency *= 1.05)
+        {
+            double level2048 = NearestLevel(bands2048, frequency);
+            double level4096 = NearestLevel(bands4096, frequency);
+            sum2048 += level2048;
+            sum4096 += level4096;
+            maxAbsDiff = Math.Max(maxAbsDiff, Math.Abs(level2048 - level4096));
+            count++;
+        }
+
+        double meanDiff = Math.Abs(sum2048 / count - sum4096 / count);
+        Assert.True(meanDiff < 0.5, $"{windowType}: mean band level differed by {meanDiff:0.000} dB across FFT sizes");
+        Assert.True(maxAbsDiff < 2.0, $"{windowType}: a band differed by {maxAbsDiff:0.000} dB across FFT sizes");
+    }
+
+    [Fact]
+    public void PowerBandLevels_AreResolutionLimited_BelowTheMainLobeCrossover()
+    {
+        // The documented cost of the main-lobe floor: below the crossover the band width
+        // IS the main lobe (mainLobeBins·Fs/N), which halves when N doubles, so a broadband
+        // level drops ~3 dB per doubling — the resolution limit of a single FFT, not a bug.
+        // Pin it so a future change cannot silently claim invariance it does not have here.
+        // At 300 Hz the Hann lobe (~94 Hz at 2048, ~47 Hz at 4096) dwarfs the 1/12-octave
+        // band (~17 Hz), so both FFT sizes are floored to their lobe.
+        float[] signal = WhiteNoise(4_096 * 220, seed: 515_151);
+
+        double level2048 = NearestLevel(BandLevels(signal, 2_048, WindowType.Hann), 300.0);
+        double level4096 = NearestLevel(BandLevels(signal, 4_096, WindowType.Hann), 300.0);
+
+        double drop = level2048 - level4096;
+        Assert.True(
+            drop is > 1.5 and < 4.5,
+            $"expected a ~3 dB resolution-limited drop below the crossover, got {drop:0.00} dB");
+    }
+
+    [Fact]
+    public void PowerBandLevel_ReadsAFullScaleToneAtItsCalibratedLevel()
+    {
+        // A power sum over a band containing a full-scale on-bin tone (rectangular,
+        // leakage-free, ENBW 1) must still read 0 dBFS — the same level the tone
+        // calibration is anchored to, so the SPL offset stays valid for tones.
+        const int length = 2_048;
+        const int bin = 256; // 256 * 48000 / 2048 = 6000 Hz
+        double toneFrequency = (double)bin * SampleRate / length;
+
+        // Smoothing off, so the tone reads its band level directly; smoothing would
+        // (correctly) dilute a spike toward the surrounding silence.
+        List<SignalPoint> bands = BandLevels(
+            CreateSine(length, bin), length, smoothingOctaves: 0.0);
+
+        double peak = double.NegativeInfinity;
+        foreach (SignalPoint point in bands)
+        {
+            if (point.X >= toneFrequency * 0.98 && point.X <= toneFrequency * 1.02)
+            {
+                peak = Math.Max(peak, point.Y);
+            }
+        }
+
+        Assert.InRange(peak, -0.3, 0.3);
+    }
+
+    [Fact]
+    public void PowerBandLevel_WindowEnbwRemovesTheNoiseOverEstimate()
+    {
+        // Under a Hann window the coherent-gain-normalized bin power over-states a
+        // noise band by the window ENBW (~1.5). Dividing by ENBW must bring the Hann
+        // band level back onto the rectangular one for the same noise.
+        float[] signal = WhiteNoise(4_096 * 120, seed: 4242);
+
+        double rectangular = MeanBandLevel(BandLevels(signal, 4_096, WindowType.Rectangular));
+        double hann = MeanBandLevel(BandLevels(signal, 4_096, WindowType.Hann));
+
+        Assert.True(
+            Math.Abs(rectangular - hann) < 0.75,
+            $"Hann vs rectangular mid-band level differed by {Math.Abs(rectangular - hann):0.000} dB");
+    }
+
+    [Fact]
+    public void PowerBandLevels_SmoothingDoesNotLiftTheLevel()
+    {
+        // The bug: smoothing was the integration band width, so wider smoothing swept
+        // more power into each band and lifted the whole curve (up to ~20 dB on a quiet
+        // signal). With a fixed reference band and level-preserving averaging, the mid
+        // band level must stay put from Smoothing Off through the widest setting.
+        float[] signal = WhiteNoise(2_048 * 250, seed: 33_221);
+
+        double off = MeanBandLevel(BandLevels(signal, 2_048, smoothingOctaves: 0.0));
+        double sixth = MeanBandLevel(BandLevels(signal, 2_048, smoothingOctaves: 1.0 / 6.0));
+        double wide = MeanBandLevel(BandLevels(signal, 2_048, smoothingOctaves: 1.0));
+
+        Assert.True(Math.Abs(off - sixth) < 1.0, $"1/6-octave smoothing shifted the level {off - sixth:0.00} dB");
+        Assert.True(Math.Abs(off - wide) < 1.0, $"1-octave smoothing shifted the level {off - wide:0.00} dB");
+    }
+
+    [Fact]
+    public void PowerBandLevels_DoNotRollOffAtTheTopEdgeOnAFlatSpectrum()
+    {
+        // At 32 kHz the 20 kHz request sits above Nyquist, so the grid clamps below it.
+        // For a perfectly flat spectrum the 1/6-octave band power rises monotonically
+        // with frequency (wider bands hold more power), so the last emitted band must be
+        // ABOVE the band an octave below it. A band straddling Nyquist would instead be
+        // half-empty and dip below it — the roll-off artifact.
+        const int sampleRate = 32_000;
+        const int fftLength = 2_048;
+        var amplitude = new double[fftLength / 2];
+        Array.Fill(amplitude, 0.1);
+
+        List<SignalPoint> bands = DataHelper.LogarithmicPowerBandResample(
+            amplitude,
+            fftLength,
+            sampleRate,
+            windowEnbwBins: 1.0,
+            windowMainLobeBins: 2.0,
+            start: 20,
+            stop: 20_000,
+            steps: 1024,
+            smoothingOctaves: 1.0 / 6.0);
+
+        double top = bands[^1].Y;
+        double octaveBelow = NearestLevel(bands, bands[^1].X / 2.0);
+        Assert.True(
+            top >= octaveBelow,
+            $"top band {top:0.00} dB dipped below the octave-below {octaveBelow:0.00} dB");
+    }
+
+    [Fact]
+    public void PowerBandLevels_HaveNoAlignmentJumpBelowTheFftResolution()
+    {
+        // With smoothing off, the 1024-point log grid is far finer than the FFT bins
+        // near 1 kHz. The old whole-bin-or-fraction rule made a band that caught a bin
+        // centre read ~5.4 dB above its neighbour that did not. Fractional-overlap
+        // integration plus the resolution floor must keep adjacent bands within a
+        // fraction of that, dominated only by the noise estimate's own scatter.
+        float[] signal = WhiteNoise(2_048 * 300, seed: 71755);
+        List<SignalPoint> bands = BandLevels(signal, 2_048, smoothingOctaves: 0.0);
+
+        double maxAdjacentJump = 0.0;
+        for (int i = 1; i < bands.Count; i++)
+        {
+            if (bands[i].X is >= 800.0 and <= 1_200.0)
+            {
+                maxAdjacentJump = Math.Max(
+                    maxAdjacentJump,
+                    Math.Abs(bands[i].Y - bands[i - 1].Y));
+            }
+        }
+
+        Assert.True(maxAdjacentJump < 2.0, $"adjacent sub-bin bands jumped {maxAdjacentJump:0.00} dB");
+    }
+
+    [Fact]
+    public void PowerBandLevels_StopAtNyquist_AndDoNotFabricateAboveTheLastBin()
+    {
+        // At a 32 kHz sample rate Nyquist is 16 kHz, but the plot still asks for 20 kHz.
+        // The grid must stop at the highest resolved bin instead of reusing it to
+        // invent a 16–20 kHz region.
+        const int sampleRate = 32_000;
+        const int fftLength = 2_048;
+        double nyquist = (fftLength / 2 - 1) * ((double)sampleRate / fftLength);
+
+        var amplitude = new double[fftLength / 2];
+        Array.Fill(amplitude, 0.1);
+
+        List<SignalPoint> bands = DataHelper.LogarithmicPowerBandResample(
+            amplitude,
+            fftLength,
+            sampleRate,
+            windowEnbwBins: 1.0,
+            windowMainLobeBins: 2.0,
+            start: 20,
+            stop: 20_000,
+            steps: 1024,
+            smoothingOctaves: 1.0 / 6.0);
+
+        Assert.NotEmpty(bands);
+        Assert.All(bands, point => Assert.True(
+            point.X <= nyquist + 1e-6,
+            $"band at {point.X:0} Hz is above Nyquist {nyquist:0} Hz"));
+        // The grid should actually reach up toward Nyquist, not stop far short.
+        Assert.True(bands[^1].X > nyquist * 0.9);
+    }
+
+    [Theory]
+    [InlineData(WindowType.Hann, 0.0, 6_000.0)]        // Hann, smoothing off, on-bin
+    [InlineData(WindowType.FlatTop, 0.0, 6_000.0)]     // Flat Top, smoothing off
+    [InlineData(WindowType.FlatTop, 1.0 / 48.0, 6_000.0)] // Flat Top, 1/48 octave
+    [InlineData(WindowType.Hann, 0.0, 1_000.0)]        // Hann, off-bin (~42.7) near 1 kHz
+    public void PowerBandLevel_ReadsAToneAcrossWindowsAndFineSmoothing(
+        WindowType windowType,
+        double smoothingOctaves,
+        double frequencyHz)
+    {
+        // The resolution floor is the window's main lobe, not its ENBW, so a full-scale
+        // tone keeps its whole main lobe and reads its calibrated 0 dBFS level even with
+        // narrow smoothing and a wide-lobe window — an ENBW floor left a bin-centred Hann
+        // tone ~1.25 dB low.
+        double peak = TonePeakLevel(frequencyHz, windowType, smoothingOctaves, fftLength: 2_048);
+        Assert.InRange(peak, -1.0, 0.4);
+    }
+
+    private static double TonePeakLevel(
+        double frequencyHz,
+        WindowType windowType,
+        double smoothingOctaves,
+        int fftLength)
+    {
+        var sine = new float[fftLength];
+        for (int i = 0; i < fftLength; i++)
+        {
+            sine[i] = (float)Math.Sin(2.0 * Math.PI * frequencyHz * i / SampleRate);
+        }
+
+        double[] amplitude = SpectrumAnalysis.ComputeInputMagnitudeSpectrum(
+            SpectrumAnalysis.ComputeAutoPowerSpectrumFrame(sine, windowType),
+            windowType,
+            fftLength);
+        List<SignalPoint> bands = DataHelper.LogarithmicPowerBandResample(
+            amplitude,
+            fftLength,
+            SampleRate,
+            Windowing.EquivalentNoiseBandwidthBins(windowType, fftLength),
+            Windowing.MainLobeWidthBins(windowType),
+            start: 20,
+            stop: 20_000,
+            steps: 1024,
+            smoothingOctaves: smoothingOctaves);
+
+        double peak = double.NegativeInfinity;
+        foreach (SignalPoint point in bands)
+        {
+            if (point.X >= frequencyHz * 0.98 && point.X <= frequencyHz * 1.02)
+            {
+                peak = Math.Max(peak, point.Y);
+            }
+        }
+
+        return peak;
+    }
+
+    // Mean over 1–5 kHz, where the fixed 1/12-octave reference band is wider than any
+    // window's main lobe, so every window integrates the same band (isolating the ENBW
+    // correction / smoothing under test from the low-frequency resolution limit).
+    private static double MeanBandLevel(List<SignalPoint> bands)
+    {
+        double sum = 0.0;
+        int count = 0;
+        foreach (SignalPoint point in bands)
+        {
+            if (point.X is >= 1_000.0 and <= 5_000.0)
+            {
+                sum += point.Y;
+                count++;
+            }
+        }
+
+        return sum / count;
+    }
+
+    private static List<SignalPoint> BandLevels(
+        float[] signal,
+        int fftLength,
+        WindowType windowType = WindowType.Rectangular,
+        double smoothingOctaves = 1.0 / 6.0) =>
+        BandLevelsAt(signal, fftLength, SampleRate, windowType, smoothingOctaves);
+
+    private static List<SignalPoint> BandLevelsAt(
+        float[] signal,
+        int fftLength,
+        int sampleRate,
+        WindowType windowType = WindowType.Rectangular,
+        double smoothingOctaves = 1.0 / 6.0)
+    {
+        double[] targetPower = AccumulateTargetPower(signal, fftLength, windowType);
+        double[] amplitude = SpectrumAnalysis.ComputeInputMagnitudeSpectrum(
+            targetPower, windowType, fftLength);
+        return DataHelper.LogarithmicPowerBandResample(
+            amplitude,
+            fftLength,
+            sampleRate,
+            Windowing.EquivalentNoiseBandwidthBins(windowType, fftLength),
+            Windowing.MainLobeWidthBins(windowType),
+            start: 20,
+            stop: 20_000,
+            steps: 1024,
+            smoothingOctaves: smoothingOctaves);
+    }
+
+    private static double NearestLevel(List<SignalPoint> bands, double frequency)
+    {
+        double bestDistance = double.MaxValue;
+        double level = double.NaN;
+        foreach (SignalPoint point in bands)
+        {
+            double distance = Math.Abs(point.X - frequency);
+            if (distance < bestDistance)
+            {
+                bestDistance = distance;
+                level = point.Y;
+            }
+        }
+
+        return level;
+    }
+
+    // Averages the mic auto-power over non-overlapping frames, matching the live
+    // analyzer's accumulation, so the amplitude spectrum is a stable noise estimate.
+    private static double[] AccumulateTargetPower(float[] signal, int fftLength, WindowType windowType)
+    {
+        int frames = signal.Length / fftLength;
+        double[]? accumulated = null;
+        var frame = new float[fftLength];
+        for (int f = 0; f < frames; f++)
+        {
+            Array.Copy(signal, f * fftLength, frame, 0, fftLength);
+            TransferSpectrumFrame spectrum =
+                SpectrumAnalysis.ComputeTransferSpectrumFrame(frame, frame, windowType);
+            accumulated ??= new double[spectrum.TargetPowerSpectrum.Length];
+            for (int i = 0; i < accumulated.Length; i++)
+            {
+                accumulated[i] += spectrum.TargetPowerSpectrum[i];
+            }
+        }
+
+        for (int i = 0; i < accumulated!.Length; i++)
+        {
+            accumulated[i] /= frames;
+        }
+
+        return accumulated;
+    }
+
+    private static float[] CreateSine(int length, int bin)
+    {
+        var samples = new float[length];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            samples[i] = (float)Math.Sin(2.0 * Math.PI * bin * i / length);
+        }
+
+        return samples;
+    }
+
+    private static float[] WhiteNoise(int length, int seed)
+    {
+        var rng = new Random(seed);
+        var samples = new float[length];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            samples[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        }
+
+        return samples;
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/SpectrumAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SpectrumAnalysisTests.cs
@@ -423,6 +423,35 @@ public sealed class SpectrumAnalysisTests
             SpectrumAnalysis.ComputeInputMagnitudeSpectrum([1.0], WindowType.Hann, 1));
     }
 
+    [Theory]
+    [InlineData(WindowType.Hann)]
+    [InlineData(WindowType.Rectangular)]
+    public void ComputeAutoPowerSpectrumFrame_MatchesTheTransferFrameTargetPower(WindowType windowType)
+    {
+        // The mic-only RTA path accumulates ComputeAutoPowerSpectrumFrame; it must
+        // produce exactly the target auto-power the dual-channel transfer frame does,
+        // so a reference-free capture reads the same RTA as one with a loopback.
+        const int length = 512;
+        float[] signal = CreateSine(length, bin: 40);
+
+        double[] autoPower = SpectrumAnalysis.ComputeAutoPowerSpectrumFrame(signal, windowType);
+        TransferSpectrumFrame frame =
+            SpectrumAnalysis.ComputeTransferSpectrumFrame(signal, signal, windowType);
+
+        Assert.Equal(frame.TargetPowerSpectrum.Length, autoPower.Length);
+        for (int i = 0; i < autoPower.Length; i++)
+        {
+            Assert.Equal(frame.TargetPowerSpectrum[i], autoPower[i], precision: 9);
+        }
+    }
+
+    [Fact]
+    public void ComputeAutoPowerSpectrumFrame_RejectsEmpty()
+    {
+        Assert.Throws<ArgumentException>(
+            () => SpectrumAnalysis.ComputeAutoPowerSpectrumFrame(Array.Empty<float>()));
+    }
+
     private static float[] CreateImpulse(int length)
     {
         var impulse = new float[length];

--- a/tests/Resonalyze.Dsp.Tests/SplConversionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SplConversionTests.cs
@@ -1,0 +1,105 @@
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// SPL conversion turns the loopback-referenced curves into an absolute dB SPL
+/// axis: the primary shifts by K, and every fundamental-relative trace is lifted
+/// by the primary's own SPL at its frequency so a ratio becomes a level.
+/// </summary>
+public sealed class SplConversionTests
+{
+    private static AnalysisCurve Curve(AnalysisCurveKind kind, params (double X, double Y)[] points) =>
+        new(kind.ToString(), points.Select(p => new SignalPoint(p.X, p.Y)).ToArray(), kind);
+
+    [Fact]
+    public void Primary_ShiftsByOffsetAndKeepsIdentity()
+    {
+        AnalysisCurve primary = Curve(
+            AnalysisCurveKind.Primary, (100, -30), (1_000, -10), (10_000, -20));
+
+        AnalysisCurve result = SplConversion
+            .ToSoundPressureLevel([primary], offsetDb: 100.0)[0];
+
+        Assert.Equal(AnalysisCurveKind.Primary, result.Kind);
+        Assert.Equal(primary.Name, result.Name);
+        Assert.Equal([70.0, 90.0, 80.0], result.Points.Select(p => p.Y));
+        Assert.Equal([100.0, 1_000.0, 10_000.0], result.Points.Select(p => p.X));
+    }
+
+    [Fact]
+    public void Harmonic_LiftedByFlatPrimary()
+    {
+        // primary flat at -10 dBr, K = 100 -> primary SPL = 90 everywhere.
+        // A -50 dBc harmonic becomes 90 + (-50) = 40 dB SPL.
+        AnalysisCurve primary = Curve(AnalysisCurveKind.Primary, (100, -10), (10_000, -10));
+        AnalysisCurve hd2 = Curve(AnalysisCurveKind.SecondHarmonic, (100, -50), (10_000, -50));
+
+        IReadOnlyList<AnalysisCurve> result =
+            SplConversion.ToSoundPressureLevel([primary, hd2], offsetDb: 100.0);
+
+        Assert.All(result[1].Points, point => Assert.Equal(40.0, point.Y, 9));
+    }
+
+    [Fact]
+    public void Harmonic_LiftedBySlopedPrimaryWithInterpolation()
+    {
+        // primary: 0 dBr at 100 Hz, -20 dBr at 1000 Hz. At 550 Hz (halfway in
+        // frequency) the interpolated primary is -10 dBr. With K = 90 that point's
+        // primary SPL is 80; a -40 dBc harmonic there reads 80 + (-40) = 40.
+        AnalysisCurve primary = Curve(AnalysisCurveKind.Primary, (100, 0), (1_000, -20));
+        AnalysisCurve hd3 = Curve(AnalysisCurveKind.ThirdHarmonic, (550, -40));
+
+        AnalysisCurve result =
+            SplConversion.ToSoundPressureLevel([primary, hd3], offsetDb: 90.0)[1];
+
+        Assert.Equal(40.0, result.Points[0].Y, 9);
+    }
+
+    [Fact]
+    public void EveryFundamentalRelativeTraceIsLifted()
+    {
+        AnalysisCurve primary = Curve(AnalysisCurveKind.Primary, (100, 0), (10_000, 0));
+        AnalysisCurveKind[] relative =
+        [
+            AnalysisCurveKind.SecondHarmonic,
+            AnalysisCurveKind.ThirdHarmonic,
+            AnalysisCurveKind.FourthHarmonic,
+            AnalysisCurveKind.ThdPlusNoise,
+            AnalysisCurveKind.NoiseFloor
+        ];
+        var curves = new List<AnalysisCurve> { primary };
+        curves.AddRange(relative.Select(kind => Curve(kind, (1_000, -60))));
+
+        IReadOnlyList<AnalysisCurve> result =
+            SplConversion.ToSoundPressureLevel(curves, offsetDb: 100.0);
+
+        // primary SPL at 1 kHz is 0 + 100; each -60 dBc trace becomes 40 dB SPL.
+        foreach (AnalysisCurve curve in result.Where(c => c.Kind != AnalysisCurveKind.Primary))
+        {
+            Assert.Equal(40.0, curve.Points[0].Y, 9);
+        }
+    }
+
+    [Fact]
+    public void MissingPrimary_LeavesFundamentalRelativeUnchanged()
+    {
+        // With nothing to anchor to, a ratio cannot become a level; leave it as-is
+        // (the caller only enters SPL mode when a primary and a valid K exist).
+        AnalysisCurve hd2 = Curve(AnalysisCurveKind.SecondHarmonic, (1_000, -60));
+
+        AnalysisCurve result =
+            SplConversion.ToSoundPressureLevel([hd2], offsetDb: 100.0)[0];
+
+        Assert.Equal(-60.0, result.Points[0].Y, 9);
+    }
+
+    [Fact]
+    public void RejectsInvalidArguments()
+    {
+        AnalysisCurve primary = Curve(AnalysisCurveKind.Primary, (100, 0));
+
+        Assert.Throws<ArgumentNullException>(
+            () => SplConversion.ToSoundPressureLevel(null!, 100.0));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => SplConversion.ToSoundPressureLevel([primary], double.NaN));
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/SplToneAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SplToneAnalysisTests.cs
@@ -1,0 +1,174 @@
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The SPL calibration listens for an acoustic calibrator's reference tone and
+/// anchors the whole SPL scale to the level it reads there, so two things must
+/// hold: the tone level must be accurate to a fraction of a dB wherever the tone
+/// falls between bins (why the flat-top window is used), and the verdict must
+/// reject anything that is not a clean, dominant tone at the target frequency.
+/// </summary>
+public sealed class SplToneAnalysisTests
+{
+    private const int SampleRate = 48_000;
+    private const int FrameLength = 16_384;
+    private const double BinWidthHz = (double)SampleRate / FrameLength;
+
+    private static readonly SplToneCriteria Criteria = SplToneCriteria.Default;
+
+    [Fact]
+    public void Analyze_CleanTone_IsClearAndOnFrequency()
+    {
+        double[] spectrum = PowerSpectrumOf(Tone(frequencyHz: 1_000.0, amplitude: 0.1));
+
+        SplToneReading reading = SplToneAnalysis.Analyze(spectrum, BinWidthHz, Criteria);
+
+        Assert.True(reading.HasClearPeak, $"prominence {reading.ProminenceDb:0.0} dB");
+        Assert.True(reading.WithinFrequencyTolerance);
+        Assert.Equal(1_000.0, reading.PeakFrequencyHz, BinWidthHz);
+        Assert.Equal(-20.0, reading.LevelDbFs, 0.3); // 0.1 amplitude = -20 dBFS
+        Assert.True(reading.ProminenceDb > 40.0, $"prominence {reading.ProminenceDb:0.0} dB");
+    }
+
+    [Theory]
+    // Bin-centred, and three tones that fall progressively further between bins
+    // (bin width ~2.93 Hz). A Hann or rectangular window would read 1.4–3.9 dB
+    // low here; the flat-top window is what keeps every one within a fraction of
+    // a dB — this is the test that pins that choice.
+    [InlineData(1_000.0)]
+    [InlineData(1_000.7)]
+    [InlineData(1_001.5)]
+    [InlineData(999.3)]
+    public void Analyze_ToneLevelIsAccurateAcrossSubBinOffsets(double frequencyHz)
+    {
+        const double amplitude = 0.25; // -12.04 dBFS
+        double expectedDbFs = 20.0 * Math.Log10(amplitude);
+
+        double[] spectrum = PowerSpectrumOf(Tone(frequencyHz, amplitude));
+        SplToneReading reading = SplToneAnalysis.Analyze(spectrum, BinWidthHz, Criteria);
+
+        Assert.True(reading.HasClearPeak);
+        Assert.Equal(expectedDbFs, reading.LevelDbFs, 0.3);
+    }
+
+    [Fact]
+    public void Analyze_MeasuredLevelTracksTheReferenceOffset()
+    {
+        // The number the whole feature depends on: two calibrator levels 20 dB
+        // apart must read 20 dB apart, so ref - measured is a stable offset.
+        double quiet = SplToneAnalysis.Analyze(
+            PowerSpectrumOf(Tone(1_000.0, 0.02)), BinWidthHz, Criteria).LevelDbFs;
+        double loud = SplToneAnalysis.Analyze(
+            PowerSpectrumOf(Tone(1_000.0, 0.2)), BinWidthHz, Criteria).LevelDbFs;
+
+        Assert.Equal(20.0, loud - quiet, 0.1);
+    }
+
+    [Fact]
+    public void Analyze_NoiseOnly_HasNoClearPeak()
+    {
+        // Broadband noise averaged over many frames is flat: no bin stands 20 dB
+        // above the background, so there is no calibrator tone to lock onto.
+        double[] spectrum = AveragedPowerSpectrum(
+            frameCount: 32, frame => Noise(seed: frame, amplitude: 0.05));
+
+        SplToneReading reading = SplToneAnalysis.Analyze(spectrum, BinWidthHz, Criteria);
+
+        Assert.False(reading.HasClearPeak, $"prominence {reading.ProminenceDb:0.0} dB");
+    }
+
+    [Fact]
+    public void Analyze_OffFrequencyTone_FailsTolerance()
+    {
+        // A clean tone, but at 1.5 kHz: prominent, yet not the calibrator's tone.
+        double[] spectrum = PowerSpectrumOf(Tone(frequencyHz: 1_500.0, amplitude: 0.1));
+
+        SplToneReading reading = SplToneAnalysis.Analyze(spectrum, BinWidthHz, Criteria);
+
+        Assert.False(reading.WithinFrequencyTolerance);
+        Assert.False(reading.HasClearPeak);
+        Assert.Equal(1_500.0, reading.PeakFrequencyHz, BinWidthHz);
+    }
+
+    [Fact]
+    public void Analyze_LowFrequencyRumbleDoesNotOutrankTheTone()
+    {
+        // A large sub-100 Hz rumble sits below the analysis floor, so the 1 kHz
+        // calibrator tone still wins the dominant-peak search even though the
+        // rumble carries far more energy.
+        float[] rumbleAndTone = Sum(
+            Tone(frequencyHz: 50.0, amplitude: 0.8),
+            Tone(frequencyHz: 1_000.0, amplitude: 0.1));
+
+        SplToneReading reading = SplToneAnalysis.Analyze(
+            PowerSpectrumOf(rumbleAndTone), BinWidthHz, Criteria);
+
+        Assert.True(reading.HasClearPeak);
+        Assert.Equal(1_000.0, reading.PeakFrequencyHz, BinWidthHz);
+    }
+
+    [Fact]
+    public void Analyze_RejectsInvalidArguments()
+    {
+        double[] spectrum = PowerSpectrumOf(Tone(1_000.0, 0.1));
+
+        Assert.Throws<ArgumentNullException>(
+            () => SplToneAnalysis.Analyze(null!, BinWidthHz, Criteria));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => SplToneAnalysis.Analyze(spectrum, 0.0, Criteria));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => SplToneAnalysis.Analyze(spectrum, double.NaN, Criteria));
+    }
+
+    private static double[] PowerSpectrumOf(float[] samples) =>
+        SpectrumAnalysis.ComputePowerSpectrum(samples, WindowType.FlatTop);
+
+    private static double[] AveragedPowerSpectrum(int frameCount, Func<int, float[]> buildFrame)
+    {
+        double[]? accumulated = null;
+        for (int frame = 0; frame < frameCount; frame++)
+        {
+            double[] power = PowerSpectrumOf(buildFrame(frame));
+            accumulated ??= new double[power.Length];
+            for (int i = 0; i < power.Length; i++)
+            {
+                accumulated[i] += power[i] / frameCount;
+            }
+        }
+
+        return accumulated!;
+    }
+
+    private static float[] Tone(double frequencyHz, double amplitude)
+    {
+        var samples = new float[FrameLength];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            samples[i] = (float)(amplitude * Math.Sin(2.0 * Math.PI * frequencyHz * i / SampleRate));
+        }
+
+        return samples;
+    }
+
+    private static float[] Noise(int seed, double amplitude)
+    {
+        var random = new Random(seed + 1);
+        var samples = new float[FrameLength];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            samples[i] = (float)(amplitude * (random.NextDouble() * 2.0 - 1.0));
+        }
+
+        return samples;
+    }
+
+    private static float[] Sum(float[] a, float[] b)
+    {
+        var samples = new float[a.Length];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            samples[i] = a[i] + b[i];
+        }
+
+        return samples;
+    }
+}


### PR DESCRIPTION
Adds absolute sound-pressure-level support, in two commits.

## SPL calibration (`7b9b1ea`)

A **Calibrate** button in Record Settings listens to an external acoustic calibrator
(94/104/114 dB at 1 kHz) and records the microphone's digital level there, anchoring
dBFS to dB SPL. The listen is capture-only (a silent streaming session, microphone
channel only), and the tone level is read from a flat-top spectrum whose peak bin holds
the true amplitude within hundredths of a dB wherever the tone lands between bins. The
verdict rejects clipping, an off-frequency or non-dominant peak, and an unsteady level.

The anchor stores its *ingredients* (reference level, measured level, capture identity)
— not a baked offset — in the settings file and on every captured impulse response. All
three calibrations (microphone 0°/90° files and the SPL anchor) now persist the instant
they change, not only when Record Settings is applied.

## dB SPL frequency-response scale (`b71efa9`)

A **Relative / dB SPL** radio in the Frequency Response settings. In SPL mode the whole
magnitude plot reads in absolute dB SPL.

The displayed magnitude is a loopback-referenced transfer function (dBr), so a single
per-measurement offset `K = loopbackPeakDbFs + calibrationOffsetDb` turns it into SPL:
the primary shifts by K, and every fundamental-relative trace (HDn, THD, noise floor) is
lifted by the primary's SPL at its own frequency, so a ratio becomes an absolute level.
Any microphone-correction file cancels (it is already in the primary). K comes from the
active calibration + current loopback level for a live measurement, or from a loaded
file's own stored calibration + loopback level; a live calibration captured on a
different input is refused. SPL is offered only when a calibration and loopback level
exist; otherwise the plot stays dBr/dBc. The Compare overlay has no absolute reference
and is omitted in SPL mode.

Overlays are tagged with the scale they were captured in and shown only on a matching
axis. The dB axis gets an SPL-appropriate window (0..120 dB, clamped -20..150), and
switching scale refits the view rather than restoring the now-meaningless dBr zoom.

## Validation

The offset is analytically exact given the loopback level, and was checked end-to-end
against the calibrator: the flat-top calibration reads the 94 dB tone accurately. The
couple-dB shortfall seen when *re-measuring* the calibrator with a sweep or the RTA is
window scalloping on a steady off-bin tone (997.6 Hz sits ~0.4 of a bin below 1 kHz),
which real swept measurements do not have. One check remains before fully trusting the
absolute numbers — a calibrated sound-level meter on a real speaker (tracked in
`TODO.md`).

## Tests

DSP and App suites green (SPL tone analysis, SPL conversion, per-measurement offset +
axis, settings/IR/overlay round-trips and migrations); Debug/Release/Tracy build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
