### PR TITLE
Auto delay: low-overlap confidence gate + rate-independent alignment gate

### DIFF
--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1072,12 +1072,15 @@ public static class AutoAlignmentEngine
                 // the prior-laden score), so a margin computed over them
                 // could read "unrivaled" only because the rival was cut
                 // before the comparison.
+                double overlapOctaves = VirtualCrossoverAnalysis.EffectiveOverlapOctaves(
+                    variableIr, neighborIrs, channel.SampleRate, bandLowHz, bandHighHz);
                 decisions[channel] = BuildDecision(
                     chosen,
                     fineOptima.Concat(wideOptima).Concat(retriedOptima).ToList(),
                     halfPeriodMs, versus, wideSeed, edgeRetry, promoted,
                     onsetLocked: onsetAnchorMs != null,
-                    sceneLocked: sceneLockToleranceMs != null);
+                    sceneLocked: sceneLockToleranceMs != null,
+                    overlapOctaves);
             }
 
             if (onsetAnchorMs is { } settledAnchor)
@@ -1115,6 +1118,15 @@ public static class AutoAlignmentEngine
     // the arrival prior and the tie-breaks, not by the acoustics.
     private const double DecisionMediumMarginDb = 0.4;
 
+    // The genuine two-driver overlap (see
+    // VirtualCrossoverAnalysis.EffectiveOverlapOctaves) below which a junction
+    // delay, however cleanly its lobe won, rests on too little shared band to
+    // trust: the number is precise but barely observed. Healthy junctions run
+    // ~0.5 octave of overlap, so this only fires on a degenerate hand-over
+    // (a mis-set or extreme crossover where the drivers barely share a band) —
+    // it caps such a pick's reported confidence at Low and says why.
+    private const double MinTrustedOverlapOctaves = 0.25;
+
     // Condenses one junction search into the user-report decision: the
     // prior-free score margin of the chosen candidate over its best RIVAL —
     // another lobe (a quarter period away or more) or the opposite polarity;
@@ -1134,7 +1146,8 @@ public static class AutoAlignmentEngine
         bool edgeRetry,
         bool promoted,
         bool onsetLocked,
-        bool sceneLocked)
+        bool sceneLocked,
+        double overlapOctaves)
     {
         double rivalDistanceMs = 0.5 * halfPeriodMs;
         double chosenScore = AcousticScore(chosen);
@@ -1168,6 +1181,13 @@ public static class AutoAlignmentEngine
             {
                 level = AlignmentConfidence.Low;
             }
+            if (overlapOctaves < MinTrustedOverlapOctaves)
+            {
+                // A clean lobe over almost no shared band is precision without
+                // evidence: the rival margin cannot see how little the two
+                // drivers actually overlapped, so cap the trust here.
+                level = AlignmentConfidence.Low;
+            }
 
             confidence = level;
         }
@@ -1197,6 +1217,12 @@ public static class AutoAlignmentEngine
         if (edgeRetry)
         {
             detail += ", window-edge retry";
+        }
+        if (kind == AlignmentDecisionKind.Search &&
+            overlapOctaves < MinTrustedOverlapOctaves)
+        {
+            detail += FormattableString.Invariant(
+                $", low overlap ({overlapOctaves:0.00} oct)");
         }
 
         return new AlignmentDecision(kind, confidence, detail);

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1075,18 +1075,27 @@ public static class AutoAlignmentEngine
                 // Confidence overlap: the WEAKER of the per-neighbor overlaps
                 // (a two-neighbor search's good overlap with one settled
                 // neighbor must not mask near-none with the other; summing the
-                // fixed IRs would also let them cancel in-band), as a fraction
-                // of the band's nominal width so the threshold means the same
-                // across narrow and wide junction bands.
-                double nominalOctaves = Math.Log2(bandHighHz / bandLowHz);
-                double overlapOctaves = neighborIrs.Count == 0
-                    ? 0
-                    : neighborIrs.Min(neighbor =>
-                        VirtualCrossoverAnalysis.EffectiveOverlapOctaves(
-                            variableIr, [neighbor],
-                            channel.SampleRate, bandLowHz, bandHighHz));
-                double overlapFraction =
-                    nominalOctaves > 0 ? overlapOctaves / nominalOctaves : 0;
+                // fixed IRs would also let them cancel in-band). Each neighbor is
+                // measured in ITS OWN junction band and normalized to that band's
+                // width — not the union both searches span — so a low-junction
+                // partner (say 50-150 Hz) is not judged over five octaves it
+                // never overlaps. A fraction, not an octave count, so the
+                // threshold means the same across narrow and wide bands.
+                double OverlapFractionAgainst(AlignmentJunction junction, Complex[] neighborIr)
+                {
+                    double nominal = Math.Log2(junction.BandHighHz / junction.BandLowHz);
+                    double octaves = VirtualCrossoverAnalysis.EffectiveOverlapOctaves(
+                        variableIr, [neighborIr], channel.SampleRate,
+                        junction.BandLowHz, junction.BandHighHz);
+                    return nominal > 0 ? octaves / nominal : 0;
+                }
+                double overlapFraction = OverlapFractionAgainst(pair, neighborIrs[0]);
+                if (secondaryPair != null && neighborIrs.Count > 1)
+                {
+                    overlapFraction = Math.Min(
+                        overlapFraction,
+                        OverlapFractionAgainst(secondaryPair, neighborIrs[1]));
+                }
                 decisions[channel] = BuildDecision(
                     chosen,
                     fineOptima.Concat(wideOptima).Concat(retriedOptima).ToList(),
@@ -1137,10 +1146,10 @@ public static class AutoAlignmentEngine
     // its lobe won, rests on too little shared band to trust: precise but barely
     // observed. A fraction, not an absolute octave count, so it means the same
     // on a narrow steep-crossover band and a wide one. Healthy junctions share
-    // ~25-32% of the band (measured on the v3 cabin), so this only fires on a
-    // degenerate hand-over where the drivers barely share a band — it caps a
-    // Search pick's reported confidence at Low and annotates any decision (even
-    // a locked one) that hits it.
+    // ~19-25% of the band once the reliability gate is applied (measured on the
+    // v3 cabin), so this only fires on a degenerate hand-over where the drivers
+    // barely share a band — it caps a Search pick's reported confidence at Low
+    // and annotates any decision (even a locked one) that hits it.
     private const double MinTrustedOverlapFraction = 0.12;
 
     // Condenses one junction search into the user-report decision: the

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1072,15 +1072,28 @@ public static class AutoAlignmentEngine
                 // the prior-laden score), so a margin computed over them
                 // could read "unrivaled" only because the rival was cut
                 // before the comparison.
-                double overlapOctaves = VirtualCrossoverAnalysis.EffectiveOverlapOctaves(
-                    variableIr, neighborIrs, channel.SampleRate, bandLowHz, bandHighHz);
+                // Confidence overlap: the WEAKER of the per-neighbor overlaps
+                // (a two-neighbor search's good overlap with one settled
+                // neighbor must not mask near-none with the other; summing the
+                // fixed IRs would also let them cancel in-band), as a fraction
+                // of the band's nominal width so the threshold means the same
+                // across narrow and wide junction bands.
+                double nominalOctaves = Math.Log2(bandHighHz / bandLowHz);
+                double overlapOctaves = neighborIrs.Count == 0
+                    ? 0
+                    : neighborIrs.Min(neighbor =>
+                        VirtualCrossoverAnalysis.EffectiveOverlapOctaves(
+                            variableIr, [neighbor],
+                            channel.SampleRate, bandLowHz, bandHighHz));
+                double overlapFraction =
+                    nominalOctaves > 0 ? overlapOctaves / nominalOctaves : 0;
                 decisions[channel] = BuildDecision(
                     chosen,
                     fineOptima.Concat(wideOptima).Concat(retriedOptima).ToList(),
                     halfPeriodMs, versus, wideSeed, edgeRetry, promoted,
                     onsetLocked: onsetAnchorMs != null,
                     sceneLocked: sceneLockToleranceMs != null,
-                    overlapOctaves);
+                    overlapFraction);
             }
 
             if (onsetAnchorMs is { } settledAnchor)
@@ -1119,13 +1132,16 @@ public static class AutoAlignmentEngine
     private const double DecisionMediumMarginDb = 0.4;
 
     // The genuine two-driver overlap (see
-    // VirtualCrossoverAnalysis.EffectiveOverlapOctaves) below which a junction
-    // delay, however cleanly its lobe won, rests on too little shared band to
-    // trust: the number is precise but barely observed. Healthy junctions run
-    // ~0.5 octave of overlap, so this only fires on a degenerate hand-over
-    // (a mis-set or extreme crossover where the drivers barely share a band) —
-    // it caps such a pick's reported confidence at Low and says why.
-    private const double MinTrustedOverlapOctaves = 0.25;
+    // VirtualCrossoverAnalysis.EffectiveOverlapOctaves) as a FRACTION of the
+    // pair band's nominal width below which a junction delay, however cleanly
+    // its lobe won, rests on too little shared band to trust: precise but barely
+    // observed. A fraction, not an absolute octave count, so it means the same
+    // on a narrow steep-crossover band and a wide one. Healthy junctions share
+    // ~25-32% of the band (measured on the v3 cabin), so this only fires on a
+    // degenerate hand-over where the drivers barely share a band — it caps a
+    // Search pick's reported confidence at Low and annotates any decision (even
+    // a locked one) that hits it.
+    private const double MinTrustedOverlapFraction = 0.12;
 
     // Condenses one junction search into the user-report decision: the
     // prior-free score margin of the chosen candidate over its best RIVAL —
@@ -1147,7 +1163,7 @@ public static class AutoAlignmentEngine
         bool promoted,
         bool onsetLocked,
         bool sceneLocked,
-        double overlapOctaves)
+        double overlapFraction)
     {
         double rivalDistanceMs = 0.5 * halfPeriodMs;
         double chosenScore = AcousticScore(chosen);
@@ -1181,7 +1197,7 @@ public static class AutoAlignmentEngine
             {
                 level = AlignmentConfidence.Low;
             }
-            if (overlapOctaves < MinTrustedOverlapOctaves)
+            if (overlapFraction < MinTrustedOverlapFraction)
             {
                 // A clean lobe over almost no shared band is precision without
                 // evidence: the rival margin cannot see how little the two
@@ -1218,11 +1234,13 @@ public static class AutoAlignmentEngine
         {
             detail += ", window-edge retry";
         }
-        if (kind == AlignmentDecisionKind.Search &&
-            overlapOctaves < MinTrustedOverlapOctaves)
+        // The low-overlap note is a diagnostic about the DATA, so it shows on
+        // every decision that hits it — including a locked one, whose confidence
+        // there is nothing to lower but whose junction is still barely observed.
+        if (overlapFraction < MinTrustedOverlapFraction)
         {
             detail += FormattableString.Invariant(
-                $", low overlap ({overlapOctaves:0.00} oct)");
+                $", low overlap ({overlapFraction * 100:0}% of band)");
         }
 
         return new AlignmentDecision(kind, confidence, detail);

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1346,6 +1346,60 @@ public static class VirtualCrossoverAnalysis
         return bins;
     }
 
+    /// <summary>
+    /// How many octaves of the pair band the two drivers GENUINELY share, as a
+    /// confidence figure for a junction delay: the integral of the per-bin
+    /// overlap O(f) = 2·min(|F|,|V|)/(|F|+|V|) over log-frequency, using the
+    /// same direct-sound gate and combined-fixed spectra as
+    /// <see cref="BuildAlignmentBins"/>. O(f) is 1 where the two contribute
+    /// equally and falls to 0 where one drowns the other, so this measures the
+    /// width of the region that actually informs the delay — not the nominal
+    /// band, most of which is one driver rolling off alone. A delay fitted over
+    /// a sliver of real overlap is a precise number resting on almost no
+    /// evidence; callers gate trust on this rather than report it as measured.
+    /// The delay SEARCH itself needs no such weight (the cross term conj(F)·V it
+    /// correlates already carries |F|·|V|, so a silent driver's bins vote near
+    /// zero), which is why this is a confidence read-out, not a search change.
+    /// </summary>
+    public static double EffectiveOverlapOctaves(
+        Complex[] variableImpulseResponse,
+        IReadOnlyList<Complex[]> fixedImpulseResponses,
+        int sampleRate,
+        double minFrequencyHz,
+        double maxFrequencyHz)
+    {
+        // The delay bounds only shape BuildAlignmentBins' argument validation
+        // (the bins themselves are delay-free); any valid span works, as in
+        // SumLossEvaluator.Create.
+        List<AlignmentBin> bins = BuildAlignmentBins(
+            variableImpulseResponse,
+            fixedImpulseResponses,
+            sampleRate,
+            minFrequencyHz,
+            maxFrequencyHz,
+            minDelayMs: -1,
+            maxDelayMs: 1);
+
+        double octaves = 0;
+        for (int i = 0; i < bins.Count - 1; i++)
+        {
+            AlignmentBin bin = bins[i];
+            double fixedMag = bin.FixedSum.Magnitude;
+            double variableMag = bin.Variable.Magnitude;
+            double sum = fixedMag + variableMag;
+            double overlap = sum > 0
+                ? 2.0 * Math.Min(fixedMag, variableMag) / sum
+                : 0.0;
+            // LogWeight is 1/f, so 1/LogWeight recovers the bin frequency; the
+            // step to the next retained bin is this stretch of log-frequency.
+            double frequency = 1.0 / bin.LogWeight;
+            double nextFrequency = 1.0 / bins[i + 1].LogWeight;
+            octaves += overlap * Math.Log2(nextFrequency / frequency);
+        }
+
+        return octaves;
+    }
+
     // The per-bin cross spectrum conj(F)·V for the correlation-based delay
     // search — <see cref="FindBestDelayMs"/> keeps the correlation objective
     // because without the polarity freedom the half-period impostor cannot win.

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1369,19 +1369,39 @@ public static class VirtualCrossoverAnalysis
     }
 
     /// <summary>
-    /// How many octaves of the pair band the two drivers GENUINELY share, as a
-    /// confidence figure for a junction delay: the integral of the per-bin
-    /// overlap O(f) = 2·min(|F|,|V|)/(|F|+|V|) over log-frequency, using the
-    /// same direct-sound gate and combined-fixed spectra as
-    /// <see cref="BuildAlignmentBins"/>. O(f) is 1 where the two contribute
-    /// equally and falls to 0 where one drowns the other, so this measures the
-    /// width of the region that actually informs the delay — not the nominal
-    /// band, most of which is one driver rolling off alone. A delay fitted over
-    /// a sliver of real overlap is a precise number resting on almost no
-    /// evidence; callers gate trust on this rather than report it as measured.
-    /// The delay SEARCH itself needs no such weight (the cross term conj(F)·V it
-    /// correlates already carries |F|·|V|, so a silent driver's bins vote near
-    /// zero), which is why this is a confidence read-out, not a search change.
+    /// How much of the effective bins below the in-band signal peak the
+    /// reliability gate keeps: a bin whose weaker channel sits more than this
+    /// far under the loudest combined level in the band is that driver's
+    /// roll-off tail, measurement noise or deconvolution residue — equal levels
+    /// there still read O(f)=1, so without the gate they inflate the overlap
+    /// with band that is not usable. A level gate, not an absolute SNR: matched
+    /// to the alignment loss's own -60 dB bin floor scale, generous enough to
+    /// keep a real hand-over's shoulders.
+    /// </summary>
+    private const double OverlapReliabilityGateDb = 30;
+
+    /// <summary>
+    /// How many octaves of the pair band the two drivers share at COMPARABLE,
+    /// USABLE level — a confidence figure for a junction delay: the integral of
+    /// the per-bin overlap O(f) = 2·min(|F|,|V|)/(|F|+|V|) over log-frequency,
+    /// using the same direct-sound gate and combined-fixed spectra as
+    /// <see cref="BuildAlignmentBins"/>, with a relative level gate (see
+    /// <see cref="OverlapReliabilityGateDb"/>) that drops bins where the weaker
+    /// channel is deep below the in-band signal. O(f) is 1 where the two
+    /// contribute equally and falls to 0 where one drowns the other, so this
+    /// measures the width of the region that actually informs the delay, not the
+    /// nominal band. It measures LEVEL BALANCE, not measurement reliability in
+    /// the coherence/SNR sense (the alignment spectra carry neither), so two
+    /// channels sitting TOGETHER in the noise floor would still read as overlap:
+    /// callers gate trust on it, but it is a coarse figure.
+    /// <para>
+    /// This is a confidence read-out, NOT a search weight. The fine selection
+    /// (<see cref="SearchAlignmentCandidatesByLoss"/>) scores each bin's
+    /// amplitude-NORMALIZED loss weighted only by 1/f, so it is not itself
+    /// amplitude-weighted — applying a per-bin reliability weight inside that
+    /// objective is a separate, unmeasured change, deliberately out of scope
+    /// here.
+    /// </para>
     /// </summary>
     public static double EffectiveOverlapOctaves(
         Complex[] variableImpulseResponse,
@@ -1401,6 +1421,21 @@ public static class VirtualCrossoverAnalysis
             maxFrequencyHz,
             minDelayMs: -1,
             maxDelayMs: 1);
+        if (bins.Count < 2)
+        {
+            return 0.0;
+        }
+
+        // The in-band peak of the COMBINED level is the signal reference; a bin
+        // whose weaker channel falls below reference·10^(-gate/20) is not usable
+        // shared band and contributes no overlap.
+        double signalPeak = 0;
+        foreach (AlignmentBin bin in bins)
+        {
+            signalPeak = Math.Max(signalPeak, bin.MagnitudeSum);
+        }
+        double reliabilityFloor =
+            signalPeak * Math.Pow(10.0, -OverlapReliabilityGateDb / 20.0);
 
         double octaves = 0;
         for (int i = 0; i < bins.Count - 1; i++)
@@ -1408,9 +1443,10 @@ public static class VirtualCrossoverAnalysis
             AlignmentBin bin = bins[i];
             double fixedMag = bin.FixedSum.Magnitude;
             double variableMag = bin.Variable.Magnitude;
+            double weaker = Math.Min(fixedMag, variableMag);
             double sum = fixedMag + variableMag;
-            double overlap = sum > 0
-                ? 2.0 * Math.Min(fixedMag, variableMag) / sum
+            double overlap = sum > 0 && weaker >= reliabilityFloor
+                ? 2.0 * weaker / sum
                 : 0.0;
             // LogWeight is 1/f, so 1/LogWeight recovers the bin frequency; the
             // step to the next retained bin is this stretch of log-frequency.

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1245,17 +1245,37 @@ public static class VirtualCrossoverAnalysis
         double MagnitudeSum);
 
     // The direct-sound gate applied to every response before the alignment
-    // spectra are taken: the same shape as the panel's default frequency-
-    // response window (4096 samples, 256-sample cosine fades, anchored one
-    // fade-length before the earliest channel peak). Reading the full IR
-    // instead would fold the entire room decay into every bin — hundreds of
-    // milliseconds of reverberation whose comb structure the alignment cannot
-    // change — so the search would optimize (and be misled by) reflections
-    // while the panel displays the gated direct sound. One gate shared by all
-    // channels, like the metric's shared anchor, so the loss keeps its 0 dB
-    // ceiling.
-    private const int AlignmentGateLengthSamples = 4096;
-    private const int AlignmentGateFadeSamples = 256;
+    // spectra are taken: a cosine-faded Tukey window anchored one fade-length
+    // before the earliest channel peak. Reading the full IR instead would fold
+    // the entire room decay into every bin — hundreds of milliseconds of
+    // reverberation whose comb structure the alignment cannot change — so the
+    // search would optimize (and be misled by) reflections while the panel
+    // displays the gated direct sound. One gate shared by all channels, like
+    // the metric's shared anchor, so the loss keeps its 0 dB ceiling.
+    //
+    // The window is sized in TIME, not samples: historically it was a fixed
+    // 4096 samples, which is ~85 ms at 48 kHz but only 43 ms at 96 kHz and
+    // 21 ms at 192 kHz — the higher the rate, the shorter the physical window.
+    // The delay estimate is flat for any window past ~40 ms and drifts only
+    // below it, so a sample-fixed gate quietly changes the answer at high rates;
+    // pinning the duration (and the fade) keeps every rate on that plateau. The
+    // reference figures reproduce the historical 4096-sample / 256-fade window
+    // EXACTLY at 48 kHz. The analyzed span is then zero-padded to a power-of-two
+    // FFT length sized per rate — window and FFT length kept separate so the
+    // physical window cannot jump across a power-of-two boundary (the same split
+    // as JunctionPhaseAlignment's analysis window).
+    private const int AlignmentGateReferenceRate = 48_000;
+    private const int AlignmentGateReferenceSamples = 4096;
+    private const int AlignmentGateReferenceFadeSamples = 256;
+
+    private static int AlignmentGateSamples(int sampleRate) => (int)Math.Round(
+        (double)AlignmentGateReferenceSamples * sampleRate / AlignmentGateReferenceRate);
+
+    private static int AlignmentGateFadeSamples(int sampleRate) => (int)Math.Round(
+        (double)AlignmentGateReferenceFadeSamples * sampleRate / AlignmentGateReferenceRate);
+
+    private static int AlignmentFftLength(int sampleRate) =>
+        DspMath.NextPowerOfTwo(AlignmentGateSamples(sampleRate));
 
     // The per-bin spectra inside the frequency window, decimated to a bounded
     // bin count so the search stays fast for long IRs. The fixed channels act
@@ -1295,14 +1315,16 @@ public static class VirtualCrossoverAnalysis
         // the fade-in: a fade would attenuate the channels' arrivals unequally
         // (they sit at different fade depths) and bias the loss. When the peak
         // sits closer to the start than a full fade, the fade shrinks to fit.
-        int leftFadeSamples = Math.Min(AlignmentGateFadeSamples, anchor);
+        int gateSamples = AlignmentGateSamples(sampleRate);
+        int fadeSamples = AlignmentGateFadeSamples(sampleRate);
+        int leftFadeSamples = Math.Min(fadeSamples, anchor);
         int gateStart = anchor - leftFadeSamples;
         double[] gate = Windowing.TukeyWindow(
-            AlignmentGateLengthSamples,
-            2.0 * leftFadeSamples / AlignmentGateLengthSamples,
-            2.0 * AlignmentGateFadeSamples / AlignmentGateLengthSamples);
+            gateSamples,
+            2.0 * leftFadeSamples / gateSamples,
+            2.0 * fadeSamples / gateSamples);
 
-        int length = AlignmentGateLengthSamples;
+        int length = AlignmentFftLength(sampleRate);
         Complex[] variableSpectrum = ForwardSpectrum(
             GateDirectSound(variableImpulseResponse, gateStart, gate), length);
         var fixedSpectrum = new Complex[length];
@@ -1902,12 +1924,14 @@ public static class VirtualCrossoverAnalysis
         }
 
         int anchor = FindPeakIndex(impulseResponse);
-        int leftFade = Math.Min(AlignmentGateFadeSamples, anchor);
+        int gateSamples = AlignmentGateSamples(sampleRate);
+        int fadeSamples = AlignmentGateFadeSamples(sampleRate);
+        int leftFade = Math.Min(fadeSamples, anchor);
         double[] gate = Windowing.TukeyWindow(
-            AlignmentGateLengthSamples,
-            2.0 * leftFade / AlignmentGateLengthSamples,
-            2.0 * AlignmentGateFadeSamples / AlignmentGateLengthSamples);
-        int length = AlignmentGateLengthSamples;
+            gateSamples,
+            2.0 * leftFade / gateSamples,
+            2.0 * fadeSamples / gateSamples);
+        int length = AlignmentFftLength(sampleRate);
         Complex[] spectrum = ForwardSpectrum(
             GateDirectSound(impulseResponse, anchor - leftFade, gate), length);
 

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -68,6 +68,83 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void EffectiveOverlapOctaves_IdenticalBroadbandDriversSpanTheWholeBand()
+    {
+        Complex[] a = UnitImpulse(4_096, 100);
+        Complex[] b = UnitImpulse(4_096, 100);
+
+        double octaves = VirtualCrossoverAnalysis.EffectiveOverlapOctaves(
+            b, [a], SampleRate, 500, 2_000);
+
+        // Two flat, equal spectra overlap perfectly (O=1) across the entire
+        // band, whose nominal width is log2(2000/500) = 2 octaves.
+        Assert.InRange(octaves, 1.7, 2.05);
+    }
+
+    [Fact]
+    public void EffectiveOverlapOctaves_DisjointDriversBarelyOverlap()
+    {
+        // The fixed driver rolls off almost two octaves below the band; the
+        // variable is flat. Across 500-2000 Hz only one driver radiates, so
+        // the genuinely shared band collapses toward zero — the degenerate
+        // hand-over the engine's trust floor is there to catch.
+        Complex[] fixedIr = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(4_096, 100),
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.LowPass,
+                LowPassEdge: new CrossoverEdge(
+                    CrossoverFilterFamily.Butterworth, 125, 36))),
+            SampleRate);
+        Complex[] variableIr = UnitImpulse(4_096, 100);
+
+        double octaves = VirtualCrossoverAnalysis.EffectiveOverlapOctaves(
+            variableIr, [fixedIr], SampleRate, 500, 2_000);
+
+        Assert.True(octaves < 0.1, $"expected near-zero overlap, got {octaves:0.000}");
+    }
+
+    [Fact]
+    public void EffectiveOverlapOctaves_CrossoverPairKeepsAFractionOfTheBand()
+    {
+        // A real hand-over: a low-pass and a high-pass sharing a 1 kHz corner.
+        // The two genuinely overlap around the corner but each rolls off alone
+        // toward the band edges, so the effective overlap is a healthy fraction
+        // of the nominal 2 octaves — comfortably above the trust floor and well
+        // clear of the disjoint case.
+        Complex[] lower = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(4_096, 100),
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.LowPass,
+                LowPassEdge: new CrossoverEdge(
+                    CrossoverFilterFamily.LinkwitzRiley, 1_000, 24))),
+            SampleRate);
+        Complex[] upper = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(4_096, 100),
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.HighPass,
+                HighPassEdge: new CrossoverEdge(
+                    CrossoverFilterFamily.LinkwitzRiley, 1_000, 24))),
+            SampleRate);
+
+        double octaves = VirtualCrossoverAnalysis.EffectiveOverlapOctaves(
+            upper, [lower], SampleRate, 500, 2_000);
+
+        Assert.InRange(octaves, 0.3, 1.4);
+    }
+
+    [Fact]
+    public void EffectiveOverlapOctaves_SilentVariableHasNoOverlap()
+    {
+        Complex[] fixedIr = UnitImpulse(4_096, 100);
+        var silent = new Complex[4_096];
+
+        double octaves = VirtualCrossoverAnalysis.EffectiveOverlapOctaves(
+            silent, [fixedIr], SampleRate, 500, 2_000);
+
+        Assert.Equal(0.0, octaves, 6);
+    }
+
+    [Fact]
     public void ApplyChain_IdentityKeepsTheImpulse()
     {
         Complex[] ir = UnitImpulse(2_048, 100);

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -82,6 +82,30 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void EffectiveOverlapOctaves_GatesBandWhereBothChannelsAreFarBelowSignal()
+    {
+        // Both channels are the SAME steep band-pass, so O(f)=1 across the whole
+        // 500-2000 Hz band — yet outside the 500-700 Hz pass-band both fall far
+        // below the in-band peak. Equal levels there are not usable shared band,
+        // so the reliability gate drops them: the overlap reads the pass-band
+        // alone (~1 oct), not the full ~2 that ungated equal levels would count.
+        Complex[] bandPass = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(8_192, 100),
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.BandPass,
+                LowPassEdge: new CrossoverEdge(
+                    CrossoverFilterFamily.LinkwitzRiley, 700, 48),
+                HighPassEdge: new CrossoverEdge(
+                    CrossoverFilterFamily.LinkwitzRiley, 500, 48))),
+            SampleRate);
+
+        double octaves = VirtualCrossoverAnalysis.EffectiveOverlapOctaves(
+            bandPass, [bandPass], SampleRate, 500, 2_000);
+
+        Assert.InRange(octaves, 0.7, 1.4);
+    }
+
+    [Fact]
     public void EffectiveOverlapOctaves_DisjointDriversBarelyOverlap()
     {
         // The fixed driver rolls off almost two octaves below the band; the

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -132,6 +132,61 @@ public sealed class VirtualCrossoverAnalysisTests
         Assert.InRange(octaves, 0.3, 1.4);
     }
 
+    // A low-frequency junction scene at an arbitrary sample rate: a direct
+    // arrival plus an early reflection ~30 ms later (inside the ~85 ms gate at
+    // every rate, but outside the 21 ms window a fixed 4096-sample gate would
+    // give at 192 kHz), band-limited to the 80 Hz overlap so window duration —
+    // hence frequency resolution — actually bears on the recovered delay.
+    private static Complex[] LowJunctionArrival(int sampleRate, double arrivalMs)
+    {
+        int length = sampleRate / 2; // 0.5 s, room for the gate at any rate
+        var ir = new Complex[length];
+        int direct = (int)Math.Round(arrivalMs / 1000.0 * sampleRate);
+        int reflection = (int)Math.Round((arrivalMs + 30.0) / 1000.0 * sampleRate);
+        ir[direct] = Complex.One;
+        if (reflection < length)
+        {
+            ir[reflection] += 0.5;
+        }
+        return VirtualCrossoverAnalysis.ApplyChain(
+            ir,
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.BandPass,
+                LowPassEdge: new CrossoverEdge(
+                    CrossoverFilterFamily.LinkwitzRiley, 160, 24),
+                HighPassEdge: new CrossoverEdge(
+                    CrossoverFilterFamily.LinkwitzRiley, 40, 24))),
+            sampleRate);
+    }
+
+    private static double RecoveredJunctionDelayMs(int sampleRate, double knownDelayMs)
+    {
+        // The variable arrives knownDelayMs LATER, so the delay that realigns
+        // it is the negative of that (delay to ADD to the variable).
+        Complex[] fixedIr = LowJunctionArrival(sampleRate, 10.0);
+        Complex[] variableIr = LowJunctionArrival(sampleRate, 10.0 + knownDelayMs);
+        IReadOnlyList<AlignmentCandidate> candidates =
+            VirtualCrossoverAnalysis.FindAlignmentCandidates(
+                variableIr, [fixedIr], sampleRate, 40, 160, -2.0, 2.0);
+        return AlignmentSelection.Select(candidates, 0.0).DelayMs;
+    }
+
+    [Fact]
+    public void FindAlignmentCandidates_RecoversTheSameDelayAcrossSampleRates()
+    {
+        // The gate is sized in time, so the same physical scene must yield the
+        // same delay whatever the sample rate; a sample-fixed gate would shrink
+        // the window at 96 kHz and drift the estimate.
+        const double knownDelayMs = 0.30;
+        double at48k = RecoveredJunctionDelayMs(48_000, knownDelayMs);
+        double at96k = RecoveredJunctionDelayMs(96_000, knownDelayMs);
+
+        Assert.Equal(-knownDelayMs, at48k, 1);
+        Assert.Equal(-knownDelayMs, at96k, 1);
+        Assert.True(Math.Abs(at48k - at96k) < 0.05,
+            $"rate-dependent delay: 48k={at48k:0.000} ms, 96k={at96k:0.000} ms");
+    }
+
     [Fact]
     public void EffectiveOverlapOctaves_SilentVariableHasNoOverlap()
     {

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -175,14 +175,21 @@ public sealed class VirtualCrossoverAnalysisTests
     public void FindAlignmentCandidates_RecoversTheSameDelayAcrossSampleRates()
     {
         // The gate is sized in time, so the same physical scene must yield the
-        // same delay whatever the sample rate; a sample-fixed gate would shrink
-        // the window at 96 kHz and drift the estimate.
+        // same delay whatever the sample rate. 192 kHz is the discriminating
+        // case: a fixed 4096-sample gate is only 21 ms there, so it CUTS the
+        // 30 ms reflection this scene carries and drifts the estimate — the old
+        // implementation fails this assertion while 48 and 96 kHz (85 / 43 ms
+        // windows, both past the ~40 ms plateau) would pass either way.
         const double knownDelayMs = 0.30;
         double at48k = RecoveredJunctionDelayMs(48_000, knownDelayMs);
         double at96k = RecoveredJunctionDelayMs(96_000, knownDelayMs);
+        double at192k = RecoveredJunctionDelayMs(192_000, knownDelayMs);
 
         Assert.Equal(-knownDelayMs, at48k, 1);
         Assert.Equal(-knownDelayMs, at96k, 1);
+        Assert.Equal(-knownDelayMs, at192k, 1);
+        Assert.True(Math.Abs(at48k - at192k) < 0.05,
+            $"rate-dependent delay: 48k={at48k:0.000} ms, 192k={at192k:0.000} ms");
         Assert.True(Math.Abs(at48k - at96k) < 0.05,
             $"rate-dependent delay: 48k={at48k:0.000} ms, 96k={at96k:0.000} ms");
     }


### PR DESCRIPTION
Two offline-validated correctness improvements to the Auto delay engine, plus review-driven hardening (validated against the v3 cabin; no behaviour change on the common 48 kHz path).

## 1. Size the alignment gate in time, not samples

The direct-sound gate for the alignment spectra was a fixed 4096 samples — ~85 ms at 48 kHz but only 43 ms at 96 kHz and 21 ms at 192 kHz. The delay estimate is flat for any window past ~40 ms and drifts only below it (verified on v3), so a sample-fixed gate quietly changes the answer at high sample rates. The window (and its fade) are now sized in **time**, reproducing the historical 4096/256 window **exactly at 48 kHz**, and the span is zero-padded to a per-rate power-of-two FFT length — the physical-window / FFT-length split already used by `JunctionPhaseAlignment`. Behaviour is unchanged at 48 kHz; only higher rates move, onto the stable plateau.

## 2. Low-overlap confidence read-out (informative only)

A junction delay can win its lobe cleanly yet rest on almost no shared band. `VirtualCrossoverAnalysis.EffectiveOverlapOctaves` integrates the per-bin overlap `O(f) = 2·min(|F|,|V|)/(|F|+|V|)` over log-frequency, on the same gate/spectra as the aligner, with a **relative level gate** that drops bins where the weaker channel is >30 dB below the in-band signal peak (roll-off tails, noise, deconvolution residue). It measures **level balance, not coherence/SNR** — two channels together in the noise floor would still read as overlap — so it is used as a coarse confidence figure, not a hard gate.

A Search decision whose overlap is below **12% of the band's nominal width** is capped to **Low** confidence and annotated (`low overlap (N% of band)`); the annotation also shows on locked decisions (whose confidence there is nothing to lower). In a two-neighbour search each neighbour is measured in its **own** junction band and the **weaker** fraction is taken. The delay **search is untouched** — this is a read-out.

Note: the fine selection (`SearchAlignmentCandidatesByLoss`) scores each bin's amplitude-**normalised** loss weighted only by 1/f, so it is *not* itself amplitude-weighted. Applying a per-bin reliability weight inside that objective — and refusing to auto-apply a Low-confidence delay — are deliberately **out of scope** here (each its own measure-first change).

## Tests

- `FindAlignmentCandidates_RecoversTheSameDelayAcrossSampleRates`: same physical scene recovers the same delay at 48/96/**192 kHz** (192 kHz is the discriminating case — the old 21 ms gate cuts the scene's 30 ms reflection; verified the test fails on the pre-fix gate).
- `EffectiveOverlapOctaves`: full-overlap ≈ 2 oct; disjoint drivers < 0.1 oct; identical steep band-passes read only the ~1-oct pass-band, not the ungated ~2 (verified fails with the level gate disabled); real LP/HP crossover 0.3–1.4 oct; silent channel = 0. Healthy v3 junctions read ~19–25% of band, clear of the 12% gate.
- Full suite green: 763 dsp + 495 app; solution builds. 48 kHz behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
