### PR TITLE
Auto delay: geometry-corroborated cross-side fallback when a pair's arrivals are modal-latched

### DIFF
--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1714,7 +1714,7 @@ public static class AutoAlignmentEngine
                     }
                 }
 
-                (double PathSplitMs, CrossSideLockTier Tier) resolved =
+                (double PathSplitMs, CrossSideLockTier Tier, int Corroborating) resolved =
                     ResolveLatchedPathSplit(
                         donorSplits.Select(item => item.SplitMs).ToList(),
                         CrossSideDonorAgreementMs);
@@ -1738,13 +1738,20 @@ public static class AutoAlignmentEngine
                 double latchedTarget =
                     leftDelayMs - resolved.PathSplitMs - plan.SceneOffsetMs;
                 bool tight = resolved.Tier == CrossSideLockTier.Tight;
+                // Name only the donors in the WINNING cluster — those within the
+                // agreement tolerance of the chosen split — not the outliers the
+                // resolver rejected.
+                string donorNames = string.Join(", ", donorSplits
+                    .Where(item => Math.Abs(item.SplitMs - resolved.PathSplitMs)
+                        <= CrossSideDonorAgreementMs)
+                    .Select(item => item.Names));
                 log.AppendLine(
                     $"  cross-side prior {rightChannel.Name}: target " +
                     $"{latchedTarget:0.000} ms — settled {link.Left.Name} shifted " +
-                    $"by the {(tight ? "corroborated" : "lone")} L/R arrival split " +
-                    $"{resolved.PathSplitMs:+0.000;-0.000} ms from " +
-                    $"{string.Join(", ", donorSplits.Select(item => item.Names))} " +
-                    $"(direct arrivals unmeasurable; {(tight ? "quarter" : "half")}-period lock)");
+                    $"by the {(tight ? $"{resolved.Corroborating}-pair corroborated" : "lone")} " +
+                    $"L/R arrival split {resolved.PathSplitMs:+0.000;-0.000} ms from " +
+                    $"{donorNames} (direct arrivals unmeasurable; " +
+                    $"{(tight ? "quarter" : "half")}-period lock)");
                 return (latchedTarget, true, tight);
             }
 
@@ -1970,43 +1977,67 @@ public static class AutoAlignmentEngine
     // deterministic so it is unit-tested directly, unlike the arrival detectors.
     internal enum CrossSideLockTier { None, Loose, Tight }
 
-    internal static (double PathSplitMs, CrossSideLockTier Tier) ResolveLatchedPathSplit(
-        IReadOnlyList<double> donorSplits, double agreementToleranceMs)
+    internal static (double PathSplitMs, CrossSideLockTier Tier, int Corroborating)
+        ResolveLatchedPathSplit(
+            IReadOnlyList<double> donorSplits, double agreementToleranceMs)
     {
         ArgumentNullException.ThrowIfNull(donorSplits);
         if (donorSplits.Count == 0)
         {
-            return (0.0, CrossSideLockTier.None);
+            return (0.0, CrossSideLockTier.None, 0);
         }
         if (donorSplits.Count == 1)
         {
-            return (donorSplits[0], CrossSideLockTier.Loose);
+            return (donorSplits[0], CrossSideLockTier.Loose, 1);
         }
 
-        // The largest set of splits mutually within tolerance of one member.
-        List<double> best = [donorSplits[0]];
-        foreach (double anchor in donorSplits)
+        // The largest window of splits MUTUALLY within tolerance (max − min ≤
+        // tolerance), not merely within tolerance of one anchor: a chain like
+        // 0.45 / 1.00 / 1.55 all sits within 0.6 of the middle yet spans 1.10,
+        // and must not read as one agreeing cluster. A two-pointer sweep over
+        // the sorted splits finds it in one pass.
+        double[] sorted = donorSplits.OrderBy(split => split).ToArray();
+        int bestCount = 0;
+        int bestStart = 0;
+        int windowsAtBest = 0;
+        int end = 0;
+        for (int start = 0; start < sorted.Length; start++)
         {
-            var cluster = donorSplits
-                .Where(split => Math.Abs(split - anchor) <= agreementToleranceMs)
-                .ToList();
-            if (cluster.Count > best.Count)
+            if (end < start)
             {
-                best = cluster;
+                end = start;
+            }
+            while (end + 1 < sorted.Length &&
+                sorted[end + 1] - sorted[start] <= agreementToleranceMs)
+            {
+                end++;
+            }
+
+            int count = end - start + 1;
+            if (count > bestCount)
+            {
+                bestCount = count;
+                bestStart = start;
+                windowsAtBest = 1;
+            }
+            else if (count == bestCount)
+            {
+                windowsAtBest++;
             }
         }
 
-        if (best.Count < 2)
+        // A lone corroborated cluster is the geometry; a lone unpaired split, or
+        // two equally-large clusters that disagree (windowsAtBest > 1), is not.
+        if (bestCount < 2 || windowsAtBest > 1)
         {
-            // Several donors, none corroborate: the geometry is ambiguous.
-            return (0.0, CrossSideLockTier.None);
+            return (0.0, CrossSideLockTier.None, 0);
         }
 
-        double[] sorted = best.OrderBy(split => split).ToArray();
-        double median = sorted.Length % 2 == 1
-            ? sorted[sorted.Length / 2]
-            : 0.5 * (sorted[sorted.Length / 2 - 1] + sorted[sorted.Length / 2]);
-        return (median, CrossSideLockTier.Tight);
+        double[] cluster = sorted[bestStart..(bestStart + bestCount)];
+        double median = cluster.Length % 2 == 1
+            ? cluster[cluster.Length / 2]
+            : 0.5 * (cluster[cluster.Length / 2 - 1] + cluster[cluster.Length / 2]);
+        return (median, CrossSideLockTier.Tight, bestCount);
     }
 
     // The lower edge of the localization region. Only the part of a pair's

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1498,10 +1498,12 @@ public static class AutoAlignmentEngine
         // band, low SNR) falls back to null and the search keeps its own-side
         // anchor.
         // Returns the delay that Δ-aligns the right channel to its left
-        // counterpart, and whether the target is COARSE (the energy-peak rung
-        // of the ladder, good to a fraction of a millisecond) — a coarse
-        // target may pin a lobe but never the tight scene tolerance.
-        (double TargetMs, bool Coarse)? CrossSideTargetMs(
+        // counterpart, whether the target is COARSE (good to a fraction of a
+        // millisecond — it may pin a lobe but never the tight scene tolerance),
+        // and whether BOTH sides were modal-LATCHED (the geometry-derived
+        // last-rung target, whose lock the caller tightens because the pair's
+        // own in-band sum is mode-shaped there).
+        (double TargetMs, bool Coarse, bool Latched)? CrossSideTargetMs(
             IAlignmentChannel rightChannel,
             StereoPairLink link,
             double bandLowHz,
@@ -1633,42 +1635,120 @@ public static class AutoAlignmentEngine
                 }
 
                 // The ladder's last rung: when no band reads both DIRECT rises
-                // consistently, the pair is timed by its processed IRs' energy
-                // peaks. For a band-passed channel that peak IS its in-band
-                // dominant packet (typically the modal build-up) — the same
-                // physical feature on both sides of one cabin, defined without
-                // any detector threshold. Its L/R difference tracks the true
-                // path split to a fraction of a millisecond — coarse against
-                // the tight scene pin, but the lobe lock only needs the target
-                // within half a junction period.
-                double leftPeakMs = leftSnapshot.PeakIndex
-                    * 1_000.0 / link.Left.SampleRate;
-                double rightPeakMs = rightSnapshot.PeakIndex
-                    * 1_000.0 / rightChannel.SampleRate;
-                // Guard the asymmetric-cabin case: if the two peaks sit farther
-                // apart than any real inter-side path, they are different room
-                // modes, not one shared feature, so their difference is not a
-                // usable L/R split. Withdraw the prior (free own-side search)
-                // rather than pin the pair to a fabricated target.
-                if (Math.Abs(leftPeakMs - rightPeakMs) > MaxInterSideDirectPathMs)
+                // consistently, both sides are modal-latched and every measured
+                // L/R timing figure ON THIS PAIR times room modes, not the
+                // drivers. This rung once used the processed IRs' energy-peak
+                // difference, trusting that the dominant packet is the same
+                // physical feature on both sides — but a field case (bad_plus:
+                // peaks 23.5 vs 17.9 ms, a 5.6 ms "path" no cabin geometry
+                // produces) showed the sides latching onto DIFFERENT modes and
+                // the fabricated target dragging the right midbass past the
+                // scene onto a junction notch. The pair itself is poisoned, but
+                // the cabin's L/R GEOMETRY is still measurable one band up:
+                // the nearest linked pair whose both sides read clean direct
+                // arrivals gives the raw path split the latched pair cannot
+                // (bad_plus: mids +1.37 ms, tweeters +1.41 ms — consistent),
+                // so aim the right delay at the settled left twin's, shifted by
+                // that split and the scene offset. No measurable neighbor
+                // degrades to plain symmetry (split 0: same mirrored hardware).
+                (double SplitMs, string Names)? NeighborRawSplit()
                 {
-                    log.AppendLine(
-                        $"  cross-side prior {rightChannel.Name}: withdrawn — " +
-                        $"energy peaks {leftPeakMs:0.000} / {rightPeakMs:0.000} ms " +
-                        "are too far apart to be one shared feature " +
-                        "(asymmetric modal dominance)");
+                    if (plan.PairLinks == null)
+                    {
+                        return null;
+                    }
+
+                    static double LinkCenterHz(StereoPairLink item) =>
+                        Math.Sqrt(item.BandLowHz * item.BandHighHz);
+                    double centerHz = LinkCenterHz(link);
+                    foreach (StereoPairLink other in plan.PairLinks
+                        .Where(item => item != link)
+                        .OrderBy(item =>
+                            Math.Abs(Math.Log(LinkCenterHz(item) / centerHz))))
+                    {
+                        AlignmentSnapshot? otherLeft = current.FirstOrDefault(
+                            item => item.Channel == other.Left);
+                        AlignmentSnapshot? otherRight = current.FirstOrDefault(
+                            item => item.Channel == other.Right);
+                        double lowHz2 = other.BandLowHz;
+                        double highHz2 = other.BandHighHz;
+                        if (otherLeft == null || otherRight == null ||
+                            highHz2 < lowHz2 *
+                                VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
+                        {
+                            continue;
+                        }
+
+                        TimeAlignmentAnalysisResult Read(
+                            AlignmentSnapshot side, double lo, double hi) =>
+                            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                                side.ImpulseResponse, side.Channel.SampleRate,
+                                lo, hi, side.ValidRange);
+                        TimeAlignmentAnalysisResult leftFull =
+                            Read(otherLeft, lowHz2, highHz2);
+                        TimeAlignmentAnalysisResult rightFull =
+                            Read(otherRight, lowHz2, highHz2);
+                        if (!leftFull.IsValid || !rightFull.IsValid ||
+                            leftFull.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
+                            rightFull.SignalToNoiseDecibels < MinimumArrivalSnrDb)
+                        {
+                            continue;
+                        }
+
+                        // The same honesty probe the pair itself gets: a full-
+                        // band read far behind its own upper half is a latch,
+                        // and a latched neighbor is no geometry reference.
+                        double probeLow2 = Math.Sqrt(lowHz2 * highHz2);
+                        if (highHz2 >= probeLow2 *
+                            VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
+                        {
+                            TimeAlignmentAnalysisResult leftProbe2 =
+                                Read(otherLeft, probeLow2, highHz2);
+                            TimeAlignmentAnalysisResult rightProbe2 =
+                                Read(otherRight, probeLow2, highHz2);
+                            double tolerance2 = Math.Max(1.0, 500.0 / probeLow2);
+                            bool Latches(
+                                TimeAlignmentAnalysisResult full,
+                                TimeAlignmentAnalysisResult probe) =>
+                                probe.IsValid &&
+                                probe.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
+                                full.FirstArrivalDelayMilliseconds -
+                                    probe.FirstArrivalDelayMilliseconds > tolerance2;
+                            if (Latches(leftFull, leftProbe2) ||
+                                Latches(rightFull, rightProbe2))
+                            {
+                                continue;
+                            }
+                        }
+
+                        // Raw = processed arrival minus the side's current DSP
+                        // delay; positive split = the right side sits farther.
+                        double rawLeft = leftFull.FirstArrivalDelayMilliseconds
+                            - alignment.GetValueOrDefault(other.Left).DelayMs;
+                        double rawRight = rightFull.FirstArrivalDelayMilliseconds
+                            - alignment.GetValueOrDefault(other.Right).DelayMs;
+                        return (rawRight - rawLeft,
+                            $"{other.Left.Name}/{other.Right.Name}");
+                    }
+
                     return null;
                 }
 
-                double peakTarget = leftPeakMs
-                    - plan.SceneOffsetMs
-                    - rightPeakMs;
+                double leftDelayMs =
+                    alignment.GetValueOrDefault(link.Left).DelayMs;
+                (double SplitMs, string Names)? proxy = NeighborRawSplit();
+                double pathSplitMs = proxy?.SplitMs ?? 0.0;
+                double latchedTarget =
+                    leftDelayMs - pathSplitMs - plan.SceneOffsetMs;
                 log.AppendLine(
                     $"  cross-side prior {rightChannel.Name}: target " +
-                    $"{peakTarget:0.000} ms from the processed IR energy peaks " +
-                    $"(L {leftPeakMs:0.000}, raw R {rightPeakMs:0.000} ms — " +
-                    "both sides' direct reads modal-latched)");
-                return (peakTarget, true);
+                    $"{latchedTarget:0.000} ms — settled {link.Left.Name} " +
+                    (proxy is { } source
+                        ? $"shifted by the {source.Names} raw path split " +
+                          $"{source.SplitMs:+0.000;-0.000} ms"
+                        : "mirrored symmetrically (no measurable neighbor pair)") +
+                    " (both sides' direct reads modal-latched)");
+                return (latchedTarget, true, true);
             }
 
             double target = arrivals.Left.FirstArrivalDelayMilliseconds
@@ -1679,7 +1759,7 @@ public static class AutoAlignmentEngine
                 $"(L arrival {arrivals.Left.FirstArrivalDelayMilliseconds:0.000}, " +
                 $"raw R {arrivals.Right.FirstArrivalDelayMilliseconds:0.000} ms " +
                 $"in {usedLowHz:0}-{usedHighHz:0} Hz)");
-            return (target, false);
+            return (target, false, false);
         }
 
         void AlignRight(int index, int neighborIndex, AlignmentJunction pair)
@@ -1723,7 +1803,7 @@ public static class AutoAlignmentEngine
             StereoPairLink? channelLink = plan.PairLinks?.FirstOrDefault(
                 item => item.Right == channel);
             bool lockable = channelLink != null && IsSceneLockable(channelLink);
-            (double TargetMs, bool Coarse)? cross = channelLink == null
+            (double TargetMs, bool Coarse, bool Latched)? cross = channelLink == null
                 ? null
                 : CrossSideTargetMs(
                     channel,
@@ -1735,11 +1815,19 @@ public static class AutoAlignmentEngine
                     pair.BandLowHz,
                     pair.BandHighHz);
             double? crossTarget = cross?.TargetMs;
+            // A double-latched pair gets a QUARTER-period lock instead of the
+            // usual half: the in-lobe authority the wide lock grants the
+            // junction sum assumes the sum measures direct-field summation,
+            // but under a double latch the same room modes that broke the
+            // arrival detectors shape the sum too — on bad_plus its in-band
+            // optimum sat 0.6 ms past every geometry-consistent point. Where
+            // the room owns the band, the geometry-derived target deserves
+            // the larger say; the sum still fine-tunes inside ±T/4.
             double? sceneLock = cross is not { } resolved
                 ? null
                 : lockable && !resolved.Coarse
                     ? SceneLockToleranceMs
-                    : 500.0 / Math.Max(
+                    : (resolved.Latched ? 250.0 : 500.0) / Math.Max(
                         pair.CrossoverHz,
                         secondaryPair?.CrossoverHz ?? pair.CrossoverHz);
 
@@ -1873,17 +1961,6 @@ public static class AutoAlignmentEngine
     // content to pin: the lock requires at least a third of an octave above
     // the edge, the same admission rule the arrival analysis itself applies.
     private const double SceneLockLocalizationLowHz = 300;
-
-    // The widest the two sides of one stereo pair can plausibly differ in
-    // direct-path time, measured from one listening position: a car cabin is
-    // at most a couple of metres across, so ~8 ms bounds any real path split
-    // with generous margin. The energy-peak fallback (below) trusts that both
-    // sides' dominant IR packets are the SAME physical feature; peaks farther
-    // apart than this are almost certainly DIFFERENT room modes dominating L
-    // vs R (an acoustically asymmetric install), so the peak difference is not
-    // a real L/R split and the pair falls back to its own-side junction search
-    // rather than pinning to a fabricated target.
-    private const double MaxInterSideDirectPathMs = 8.0;
 
     // Whether a linked pair reaches far enough into the localization region
     // for the scene to outrank its junction sums: locked in the descent,

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1714,7 +1714,8 @@ public static class AutoAlignmentEngine
                     }
                 }
 
-                (double PathSplitMs, CrossSideLockTier Tier, int Corroborating) resolved =
+                (double PathSplitMs, CrossSideLockTier Tier, int Corroborating,
+                    double ClusterLowMs, double ClusterHighMs) resolved =
                     ResolveLatchedPathSplit(
                         donorSplits.Select(item => item.SplitMs).ToList(),
                         CrossSideDonorAgreementMs);
@@ -1738,12 +1739,14 @@ public static class AutoAlignmentEngine
                 double latchedTarget =
                     leftDelayMs - resolved.PathSplitMs - plan.SceneOffsetMs;
                 bool tight = resolved.Tier == CrossSideLockTier.Tight;
-                // Name only the donors in the WINNING cluster — those within the
-                // agreement tolerance of the chosen split — not the outliers the
-                // resolver rejected.
+                // Name only the donors in the WINNING cluster — the resolver
+                // returns its [low, high] span, and a contiguous sorted window
+                // holds exactly the donors in that range, so this excludes the
+                // outliers the resolver rejected (unlike a distance-to-median
+                // test, which can catch a split just outside the cluster).
                 string donorNames = string.Join(", ", donorSplits
-                    .Where(item => Math.Abs(item.SplitMs - resolved.PathSplitMs)
-                        <= CrossSideDonorAgreementMs)
+                    .Where(item => item.SplitMs >= resolved.ClusterLowMs &&
+                        item.SplitMs <= resolved.ClusterHighMs)
                     .Select(item => item.Names));
                 log.AppendLine(
                     $"  cross-side prior {rightChannel.Name}: target " +
@@ -1977,18 +1980,20 @@ public static class AutoAlignmentEngine
     // deterministic so it is unit-tested directly, unlike the arrival detectors.
     internal enum CrossSideLockTier { None, Loose, Tight }
 
-    internal static (double PathSplitMs, CrossSideLockTier Tier, int Corroborating)
+    internal static (double PathSplitMs, CrossSideLockTier Tier, int Corroborating,
+        double ClusterLowMs, double ClusterHighMs)
         ResolveLatchedPathSplit(
             IReadOnlyList<double> donorSplits, double agreementToleranceMs)
     {
         ArgumentNullException.ThrowIfNull(donorSplits);
         if (donorSplits.Count == 0)
         {
-            return (0.0, CrossSideLockTier.None, 0);
+            return (0.0, CrossSideLockTier.None, 0, 0.0, 0.0);
         }
         if (donorSplits.Count == 1)
         {
-            return (donorSplits[0], CrossSideLockTier.Loose, 1);
+            return (donorSplits[0], CrossSideLockTier.Loose, 1,
+                donorSplits[0], donorSplits[0]);
         }
 
         // The largest window of splits MUTUALLY within tolerance (max − min ≤
@@ -2030,14 +2035,17 @@ public static class AutoAlignmentEngine
         // two equally-large clusters that disagree (windowsAtBest > 1), is not.
         if (bestCount < 2 || windowsAtBest > 1)
         {
-            return (0.0, CrossSideLockTier.None, 0);
+            return (0.0, CrossSideLockTier.None, 0, 0.0, 0.0);
         }
 
         double[] cluster = sorted[bestStart..(bestStart + bestCount)];
         double median = cluster.Length % 2 == 1
             ? cluster[cluster.Length / 2]
             : 0.5 * (cluster[cluster.Length / 2 - 1] + cluster[cluster.Length / 2]);
-        return (median, CrossSideLockTier.Tight, bestCount);
+        // The window is contiguous in the sorted splits, so [min, max] names its
+        // members exactly — the caller filters donors by this range, not by
+        // distance to the median (which can catch an out-of-cluster outlier).
+        return (median, CrossSideLockTier.Tight, bestCount, cluster[0], cluster[^1]);
     }
 
     // The lower edge of the localization region. Only the part of a pair's

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1500,10 +1500,11 @@ public static class AutoAlignmentEngine
         // Returns the delay that Δ-aligns the right channel to its left
         // counterpart, whether the target is COARSE (good to a fraction of a
         // millisecond — it may pin a lobe but never the tight scene tolerance),
-        // and whether BOTH sides were modal-LATCHED (the geometry-derived
-        // last-rung target, whose lock the caller tightens because the pair's
-        // own in-band sum is mode-shaped there).
-        (double TargetMs, bool Coarse, bool Latched)? CrossSideTargetMs(
+        // and whether it earns a TIGHT (quarter-period) lock — set only by the
+        // last rung when the pair's own arrivals were unmeasurable and CORROBO-
+        // RATED donor geometry replaced them, so the mode-shaped junction sum
+        // gets less in-lobe authority. Null when no target could be trusted.
+        (double TargetMs, bool Coarse, bool TightLock)? CrossSideTargetMs(
             IAlignmentChannel rightChannel,
             StereoPairLink link,
             double bandLowHz,
@@ -1634,30 +1635,29 @@ public static class AutoAlignmentEngine
                     return null;
                 }
 
-                // The ladder's last rung: when no band reads both DIRECT rises
-                // consistently, both sides are modal-latched and every measured
-                // L/R timing figure ON THIS PAIR times room modes, not the
-                // drivers. This rung once used the processed IRs' energy-peak
-                // difference, trusting that the dominant packet is the same
-                // physical feature on both sides — but a field case (bad_plus:
-                // peaks 23.5 vs 17.9 ms, a 5.6 ms "path" no cabin geometry
-                // produces) showed the sides latching onto DIFFERENT modes and
-                // the fabricated target dragging the right midbass past the
-                // scene onto a junction notch. The pair itself is poisoned, but
-                // the cabin's L/R GEOMETRY is still measurable one band up:
-                // the nearest linked pair whose both sides read clean direct
-                // arrivals gives the raw path split the latched pair cannot
-                // (bad_plus: mids +1.37 ms, tweeters +1.41 ms — consistent),
-                // so aim the right delay at the settled left twin's, shifted by
-                // that split and the scene offset. No measurable neighbor
-                // degrades to plain symmetry (split 0: same mirrored hardware).
-                (double SplitMs, string Names)? NeighborRawSplit()
+                // The ladder's last rung: no band read both DIRECT rises, so this
+                // pair's direct arrivals are UNMEASURABLE (a latch on at least
+                // one side under a room mode). This rung once used the processed
+                // IRs' energy-peak difference, trusting that the dominant packet
+                // is the same physical feature on both sides — but a field case
+                // (bad_plus: peaks 23.5 vs 17.9 ms, a 5.6 ms "path" no cabin
+                // geometry produces) showed the sides latching onto DIFFERENT
+                // modes and the fabricated target dragging the right midbass past
+                // the scene onto a junction notch. The pair is poisoned, but the
+                // cabin's L/R GEOMETRY is often measurable on OTHER linked pairs:
+                // each pair whose both sides read a clean direct arrival gives an
+                // L/R split, and where several agree (bad_plus: mids +1.37 ms,
+                // tweeters +1.41 — corroborated) that split is the cabin's L/R
+                // offset, so aim the right delay at the settled left twin's minus
+                // it and the scene. NOT clean geometry in isolation: each split
+                // also carries that donor pair's own L/R filter/driver asymmetry,
+                // which is why corroboration across pairs (not one nearest
+                // donor) earns the tight lock, a lone donor only a soft one, and
+                // no agreement no pin at all — a fabricated split hard-locked is
+                // the very failure this rung exists to avoid.
+                var donorSplits = new List<(double SplitMs, string Names)>();
+                if (plan.PairLinks != null)
                 {
-                    if (plan.PairLinks == null)
-                    {
-                        return null;
-                    }
-
                     static double LinkCenterHz(StereoPairLink item) =>
                         Math.Sqrt(item.BandLowHz * item.BandHighHz);
                     double centerHz = LinkCenterHz(link);
@@ -1672,8 +1672,9 @@ public static class AutoAlignmentEngine
                             item => item.Channel == other.Right);
                         double lowHz2 = other.BandLowHz;
                         double highHz2 = other.BandHighHz;
+                        double probeLow2 = Math.Sqrt(lowHz2 * highHz2);
                         if (otherLeft == null || otherRight == null ||
-                            highHz2 < lowHz2 *
+                            highHz2 < probeLow2 *
                                 VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
                         {
                             continue;
@@ -1684,71 +1685,67 @@ public static class AutoAlignmentEngine
                             VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
                                 side.ImpulseResponse, side.Channel.SampleRate,
                                 lo, hi, side.ValidRange);
-                        TimeAlignmentAnalysisResult leftFull =
-                            Read(otherLeft, lowHz2, highHz2);
-                        TimeAlignmentAnalysisResult rightFull =
-                            Read(otherRight, lowHz2, highHz2);
-                        if (!leftFull.IsValid || !rightFull.IsValid ||
-                            leftFull.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
-                            rightFull.SignalToNoiseDecibels < MinimumArrivalSnrDb)
-                        {
-                            continue;
-                        }
 
-                        // The same honesty probe the pair itself gets: a full-
-                        // band read far behind its own upper half is a latch,
-                        // and a latched neighbor is no geometry reference.
-                        double probeLow2 = Math.Sqrt(lowHz2 * highHz2);
-                        if (highHz2 >= probeLow2 *
-                            VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
+                        // A donor earns trust only if BOTH sides POSITIVELY read a
+                        // clean direct arrival — full band AND its upper half
+                        // valid, SNR-qualified, and agreeing. Absence of a proven
+                        // latch is NOT proof of a direct read: an unmeasurable or
+                        // low-SNR upper half leaves the split unverified, so skip.
+                        double tolerance2 = Math.Max(1.0, 500.0 / probeLow2);
+                        bool CleanDirect(AlignmentSnapshot side, out double rawMs)
                         {
-                            TimeAlignmentAnalysisResult leftProbe2 =
-                                Read(otherLeft, probeLow2, highHz2);
-                            TimeAlignmentAnalysisResult rightProbe2 =
-                                Read(otherRight, probeLow2, highHz2);
-                            double tolerance2 = Math.Max(1.0, 500.0 / probeLow2);
-                            bool Latches(
-                                TimeAlignmentAnalysisResult full,
-                                TimeAlignmentAnalysisResult probe) =>
-                                probe.IsValid &&
+                            TimeAlignmentAnalysisResult full = Read(side, lowHz2, highHz2);
+                            TimeAlignmentAnalysisResult probe = Read(side, probeLow2, highHz2);
+                            rawMs = full.FirstArrivalDelayMilliseconds
+                                - alignment.GetValueOrDefault(side.Channel).DelayMs;
+                            return full.IsValid && probe.IsValid &&
+                                full.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
                                 probe.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
                                 full.FirstArrivalDelayMilliseconds -
-                                    probe.FirstArrivalDelayMilliseconds > tolerance2;
-                            if (Latches(leftFull, leftProbe2) ||
-                                Latches(rightFull, rightProbe2))
-                            {
-                                continue;
-                            }
+                                    probe.FirstArrivalDelayMilliseconds <= tolerance2;
                         }
 
-                        // Raw = processed arrival minus the side's current DSP
-                        // delay; positive split = the right side sits farther.
-                        double rawLeft = leftFull.FirstArrivalDelayMilliseconds
-                            - alignment.GetValueOrDefault(other.Left).DelayMs;
-                        double rawRight = rightFull.FirstArrivalDelayMilliseconds
-                            - alignment.GetValueOrDefault(other.Right).DelayMs;
-                        return (rawRight - rawLeft,
-                            $"{other.Left.Name}/{other.Right.Name}");
+                        if (CleanDirect(otherLeft, out double rawLeft) &&
+                            CleanDirect(otherRight, out double rawRight))
+                        {
+                            donorSplits.Add((rawRight - rawLeft,
+                                $"{other.Left.Name}/{other.Right.Name}"));
+                        }
                     }
+                }
 
+                (double PathSplitMs, CrossSideLockTier Tier) resolved =
+                    ResolveLatchedPathSplit(
+                        donorSplits.Select(item => item.SplitMs).ToList(),
+                        CrossSideDonorAgreementMs);
+                if (resolved.Tier == CrossSideLockTier.None)
+                {
+                    // No corroborated geometry: fabricating one (symmetry or a
+                    // lone contradicted donor) and hard-locking to it is exactly
+                    // the confidently-wrong pin this rung must not create. Drop
+                    // the prior — the channel keeps its own-side junction search.
+                    log.AppendLine(
+                        $"  cross-side prior {rightChannel.Name}: withdrawn — " +
+                        "direct arrivals unmeasurable and no linked pair gives a " +
+                        (donorSplits.Count == 0
+                            ? "clean L/R geometry reference"
+                            : $"corroborated one ({donorSplits.Count} donor(s) disagree)"));
                     return null;
                 }
 
                 double leftDelayMs =
                     alignment.GetValueOrDefault(link.Left).DelayMs;
-                (double SplitMs, string Names)? proxy = NeighborRawSplit();
-                double pathSplitMs = proxy?.SplitMs ?? 0.0;
                 double latchedTarget =
-                    leftDelayMs - pathSplitMs - plan.SceneOffsetMs;
+                    leftDelayMs - resolved.PathSplitMs - plan.SceneOffsetMs;
+                bool tight = resolved.Tier == CrossSideLockTier.Tight;
                 log.AppendLine(
                     $"  cross-side prior {rightChannel.Name}: target " +
-                    $"{latchedTarget:0.000} ms — settled {link.Left.Name} " +
-                    (proxy is { } source
-                        ? $"shifted by the {source.Names} raw path split " +
-                          $"{source.SplitMs:+0.000;-0.000} ms"
-                        : "mirrored symmetrically (no measurable neighbor pair)") +
-                    " (both sides' direct reads modal-latched)");
-                return (latchedTarget, true, true);
+                    $"{latchedTarget:0.000} ms — settled {link.Left.Name} shifted " +
+                    $"by the {(tight ? "corroborated" : "lone")} L/R arrival split " +
+                    $"{resolved.PathSplitMs:+0.000;-0.000} ms from " +
+                    $"{string.Join(", ", donorSplits.Select(item => item.Names))} " +
+                    $"(direct arrivals unmeasurable; {(tight ? "quarter" : "half")}-period lock)");
+                return (latchedTarget, true, tight);
             }
 
             double target = arrivals.Left.FirstArrivalDelayMilliseconds
@@ -1803,7 +1800,7 @@ public static class AutoAlignmentEngine
             StereoPairLink? channelLink = plan.PairLinks?.FirstOrDefault(
                 item => item.Right == channel);
             bool lockable = channelLink != null && IsSceneLockable(channelLink);
-            (double TargetMs, bool Coarse, bool Latched)? cross = channelLink == null
+            (double TargetMs, bool Coarse, bool TightLock)? cross = channelLink == null
                 ? null
                 : CrossSideTargetMs(
                     channel,
@@ -1815,19 +1812,20 @@ public static class AutoAlignmentEngine
                     pair.BandLowHz,
                     pair.BandHighHz);
             double? crossTarget = cross?.TargetMs;
-            // A double-latched pair gets a QUARTER-period lock instead of the
-            // usual half: the in-lobe authority the wide lock grants the
-            // junction sum assumes the sum measures direct-field summation,
-            // but under a double latch the same room modes that broke the
-            // arrival detectors shape the sum too — on bad_plus its in-band
-            // optimum sat 0.6 ms past every geometry-consistent point. Where
-            // the room owns the band, the geometry-derived target deserves
-            // the larger say; the sum still fine-tunes inside ±T/4.
+            // A corroborated-geometry latched target (TightLock) gets a QUARTER-
+            // period lock instead of the usual half: the in-lobe authority the
+            // wide lock grants the junction sum assumes the sum measures direct-
+            // field summation, but where the pair's own direct arrivals were
+            // unmeasurable the same room modes shape the sum too — on bad_plus
+            // its in-band optimum sat 0.6 ms past every geometry-consistent
+            // point. There the multi-donor geometry deserves the larger say; the
+            // sum still fine-tunes inside ±T/4. A lone (uncorroborated) donor
+            // keeps the ordinary ±T/2.
             double? sceneLock = cross is not { } resolved
                 ? null
                 : lockable && !resolved.Coarse
                     ? SceneLockToleranceMs
-                    : (resolved.Latched ? 250.0 : 500.0) / Math.Max(
+                    : (resolved.TightLock ? 250.0 : 500.0) / Math.Max(
                         pair.CrossoverHz,
                         secondaryPair?.CrossoverHz ?? pair.CrossoverHz);
 
@@ -1953,6 +1951,63 @@ public static class AutoAlignmentEngine
     // not choose one. With no reliable cross-side arrival at all the free
     // joint-junction search remains.
     private const double SceneLockToleranceMs = 0.05;
+
+    // How close two donor pairs' L/R arrival splits must sit to corroborate one
+    // another as the cabin's L/R path offset. Drivers at different positions do
+    // differ, so this is generous — the point is to reject a lone anomaly (a
+    // donor whose split is dominated by ITS filter/driver asymmetry, not the
+    // cabin geometry) while accepting the consistent offset genuinely shared
+    // pairs read (v3: mids +1.37, tweeters +1.41).
+    private const double CrossSideDonorAgreementMs = 0.6;
+
+    // How a latched pair's cross-side target is resolved from the clean donor
+    // pairs' L/R arrival splits (nearest-frequency first). Corroboration decides
+    // trust: two-plus splits agreeing within CrossSideDonorAgreementMs are the
+    // cabin's real L/R offset (tight quarter-period lock); a lone donor is one
+    // estimate carrying its own DSP asymmetry (loose half-period lock); zero
+    // donors or several that disagree mean the geometry is unknown and the pair
+    // must NOT be pinned (no target — the free own-side search stands). Pure and
+    // deterministic so it is unit-tested directly, unlike the arrival detectors.
+    internal enum CrossSideLockTier { None, Loose, Tight }
+
+    internal static (double PathSplitMs, CrossSideLockTier Tier) ResolveLatchedPathSplit(
+        IReadOnlyList<double> donorSplits, double agreementToleranceMs)
+    {
+        ArgumentNullException.ThrowIfNull(donorSplits);
+        if (donorSplits.Count == 0)
+        {
+            return (0.0, CrossSideLockTier.None);
+        }
+        if (donorSplits.Count == 1)
+        {
+            return (donorSplits[0], CrossSideLockTier.Loose);
+        }
+
+        // The largest set of splits mutually within tolerance of one member.
+        List<double> best = [donorSplits[0]];
+        foreach (double anchor in donorSplits)
+        {
+            var cluster = donorSplits
+                .Where(split => Math.Abs(split - anchor) <= agreementToleranceMs)
+                .ToList();
+            if (cluster.Count > best.Count)
+            {
+                best = cluster;
+            }
+        }
+
+        if (best.Count < 2)
+        {
+            // Several donors, none corroborate: the geometry is ambiguous.
+            return (0.0, CrossSideLockTier.None);
+        }
+
+        double[] sorted = best.OrderBy(split => split).ToArray();
+        double median = sorted.Length % 2 == 1
+            ? sorted[sorted.Length / 2]
+            : 0.5 * (sorted[sorted.Length / 2 - 1] + sorted[sorted.Length / 2]);
+        return (median, CrossSideLockTier.Tight);
+    }
 
     // The lower edge of the localization region. Only the part of a pair's
     // shared band ABOVE this edge carries scene information, so the lock's

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -814,4 +814,63 @@ public sealed class StereoAlignmentTests
         Assert.Contains("mono co-move", decision.Detail);
         Assert.Contains("reference", decision.Detail);
     }
+
+    // ---- the pure latched-fallback donor resolver (unit-tested directly, since
+    //      driving the modal-latch detectors synthetically is threshold-brittle) ----
+
+    [Fact]
+    public void ResolveLatchedPathSplit_NoDonors_YieldsNoTarget()
+    {
+        var (split, tier) = AutoAlignmentEngine.ResolveLatchedPathSplit([], 0.6);
+
+        // No geometry reference at all: the caller must NOT fabricate one.
+        Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.None, tier);
+        Assert.Equal(0.0, split);
+    }
+
+    [Fact]
+    public void ResolveLatchedPathSplit_LoneDonor_IsATrustedButLooseEstimate()
+    {
+        var (split, tier) = AutoAlignmentEngine.ResolveLatchedPathSplit([1.37], 0.6);
+
+        // One donor is a usable estimate but carries its own DSP asymmetry, so
+        // it only earns the loose lock — never the tight one.
+        Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.Loose, tier);
+        Assert.Equal(1.37, split, 6);
+    }
+
+    [Fact]
+    public void ResolveLatchedPathSplit_AgreeingDonors_CorroborateForTheTightLock()
+    {
+        // The v3 case: mids +1.37 and tweeters +1.41 agree, so the cabin's L/R
+        // offset is corroborated and pinned tightly at their median.
+        var (split, tier) = AutoAlignmentEngine.ResolveLatchedPathSplit(
+            [1.37, 1.41], 0.6);
+
+        Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.Tight, tier);
+        Assert.Equal(1.39, split, 6);
+    }
+
+    [Fact]
+    public void ResolveLatchedPathSplit_TwoDisagreeingDonors_YieldNoTarget()
+    {
+        // Two donors, no corroboration: the geometry is ambiguous, so the pair
+        // must not be pinned rather than gamble on one.
+        var (_, tier) = AutoAlignmentEngine.ResolveLatchedPathSplit([0.4, 1.5], 0.6);
+
+        Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.None, tier);
+    }
+
+    [Fact]
+    public void ResolveLatchedPathSplit_MajorityCluster_RejectsTheOutlier()
+    {
+        // The reviewer's anomaly case: a nearest donor of +0.40 must NOT win
+        // over two corroborating +1.4-ish donors. The majority cluster's median
+        // is taken and the outlier dropped.
+        var (split, tier) = AutoAlignmentEngine.ResolveLatchedPathSplit(
+            [0.40, 1.50, 1.40], 0.6);
+
+        Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.Tight, tier);
+        Assert.Equal(1.45, split, 6);
+    }
 }

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -821,7 +821,7 @@ public sealed class StereoAlignmentTests
     [Fact]
     public void ResolveLatchedPathSplit_NoDonors_YieldsNoTarget()
     {
-        var (split, tier, corroborating) =
+        var (split, tier, corroborating, _, _) =
             AutoAlignmentEngine.ResolveLatchedPathSplit([], 0.6);
 
         // No geometry reference at all: the caller must NOT fabricate one.
@@ -833,7 +833,7 @@ public sealed class StereoAlignmentTests
     [Fact]
     public void ResolveLatchedPathSplit_LoneDonor_IsATrustedButLooseEstimate()
     {
-        var (split, tier, corroborating) =
+        var (split, tier, corroborating, low, high) =
             AutoAlignmentEngine.ResolveLatchedPathSplit([1.37], 0.6);
 
         // One donor is a usable estimate but carries its own DSP asymmetry, so
@@ -841,6 +841,8 @@ public sealed class StereoAlignmentTests
         Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.Loose, tier);
         Assert.Equal(1.37, split, 6);
         Assert.Equal(1, corroborating);
+        Assert.Equal(1.37, low, 6);
+        Assert.Equal(1.37, high, 6);
     }
 
     [Fact]
@@ -848,12 +850,14 @@ public sealed class StereoAlignmentTests
     {
         // The v3 case: mids +1.37 and tweeters +1.41 agree, so the cabin's L/R
         // offset is corroborated and pinned tightly at their median.
-        var (split, tier, corroborating) =
+        var (split, tier, corroborating, low, high) =
             AutoAlignmentEngine.ResolveLatchedPathSplit([1.37, 1.41], 0.6);
 
         Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.Tight, tier);
         Assert.Equal(1.39, split, 6);
         Assert.Equal(2, corroborating);
+        Assert.Equal(1.37, low, 6);
+        Assert.Equal(1.41, high, 6);
     }
 
     [Fact]
@@ -861,7 +865,8 @@ public sealed class StereoAlignmentTests
     {
         // Two donors, no corroboration: the geometry is ambiguous, so the pair
         // must not be pinned rather than gamble on one.
-        var (_, tier, _) = AutoAlignmentEngine.ResolveLatchedPathSplit([0.4, 1.5], 0.6);
+        var (_, tier, _, _, _) =
+            AutoAlignmentEngine.ResolveLatchedPathSplit([0.4, 1.5], 0.6);
 
         Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.None, tier);
     }
@@ -871,13 +876,36 @@ public sealed class StereoAlignmentTests
     {
         // The reviewer's anomaly case: a nearest donor of +0.40 must NOT win
         // over two corroborating +1.4-ish donors. The majority cluster's median
-        // is taken and the outlier dropped.
-        var (split, tier, corroborating) =
+        // is taken, the outlier dropped, and the reported [low, high] span
+        // excludes it so the log names only the true cluster members.
+        var (split, tier, corroborating, low, high) =
             AutoAlignmentEngine.ResolveLatchedPathSplit([0.40, 1.50, 1.40], 0.6);
 
         Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.Tight, tier);
         Assert.Equal(1.45, split, 6);
         Assert.Equal(2, corroborating);
+        Assert.Equal(1.40, low, 6);
+        Assert.Equal(1.50, high, 6);
+    }
+
+    [Fact]
+    public void ResolveLatchedPathSplit_ClusterSpanExcludesADonorNearTheMedian()
+    {
+        // The winning cluster is [1.00, 1.05, 1.45, 1.50] (median 1.25); the
+        // 0.70 donor sits 0.55 from that median — inside the tolerance — yet is
+        // NOT in the cluster (1.50 − 0.70 = 0.80 > 0.60). The returned [low,
+        // high] span, not a distance-to-median test, is what keeps it out of
+        // the log.
+        var (split, tier, corroborating, low, high) =
+            AutoAlignmentEngine.ResolveLatchedPathSplit(
+                [0.70, 1.00, 1.05, 1.45, 1.50], 0.60);
+
+        Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.Tight, tier);
+        Assert.Equal(4, corroborating);
+        Assert.Equal(1.00, low, 6);
+        Assert.Equal(1.50, high, 6);
+        Assert.True(0.70 < low, "the 0.70 donor must fall outside the cluster span");
+        Assert.Equal(1.25, split, 6);
     }
 
     [Fact]
@@ -888,7 +916,7 @@ public sealed class StereoAlignmentTests
         // Anchoring on the middle would fake one 3-way cluster; the mutual-span
         // rule instead sees two equally-large disagreeing 2-clusters and refuses
         // to pin — no confidently-wrong tight lock from bridged measurements.
-        var (_, tier, _) =
+        var (_, tier, _, _, _) =
             AutoAlignmentEngine.ResolveLatchedPathSplit([0.45, 1.00, 1.55], 0.60);
 
         Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.None, tier);

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -821,22 +821,26 @@ public sealed class StereoAlignmentTests
     [Fact]
     public void ResolveLatchedPathSplit_NoDonors_YieldsNoTarget()
     {
-        var (split, tier) = AutoAlignmentEngine.ResolveLatchedPathSplit([], 0.6);
+        var (split, tier, corroborating) =
+            AutoAlignmentEngine.ResolveLatchedPathSplit([], 0.6);
 
         // No geometry reference at all: the caller must NOT fabricate one.
         Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.None, tier);
         Assert.Equal(0.0, split);
+        Assert.Equal(0, corroborating);
     }
 
     [Fact]
     public void ResolveLatchedPathSplit_LoneDonor_IsATrustedButLooseEstimate()
     {
-        var (split, tier) = AutoAlignmentEngine.ResolveLatchedPathSplit([1.37], 0.6);
+        var (split, tier, corroborating) =
+            AutoAlignmentEngine.ResolveLatchedPathSplit([1.37], 0.6);
 
         // One donor is a usable estimate but carries its own DSP asymmetry, so
         // it only earns the loose lock — never the tight one.
         Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.Loose, tier);
         Assert.Equal(1.37, split, 6);
+        Assert.Equal(1, corroborating);
     }
 
     [Fact]
@@ -844,11 +848,12 @@ public sealed class StereoAlignmentTests
     {
         // The v3 case: mids +1.37 and tweeters +1.41 agree, so the cabin's L/R
         // offset is corroborated and pinned tightly at their median.
-        var (split, tier) = AutoAlignmentEngine.ResolveLatchedPathSplit(
-            [1.37, 1.41], 0.6);
+        var (split, tier, corroborating) =
+            AutoAlignmentEngine.ResolveLatchedPathSplit([1.37, 1.41], 0.6);
 
         Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.Tight, tier);
         Assert.Equal(1.39, split, 6);
+        Assert.Equal(2, corroborating);
     }
 
     [Fact]
@@ -856,7 +861,7 @@ public sealed class StereoAlignmentTests
     {
         // Two donors, no corroboration: the geometry is ambiguous, so the pair
         // must not be pinned rather than gamble on one.
-        var (_, tier) = AutoAlignmentEngine.ResolveLatchedPathSplit([0.4, 1.5], 0.6);
+        var (_, tier, _) = AutoAlignmentEngine.ResolveLatchedPathSplit([0.4, 1.5], 0.6);
 
         Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.None, tier);
     }
@@ -867,10 +872,25 @@ public sealed class StereoAlignmentTests
         // The reviewer's anomaly case: a nearest donor of +0.40 must NOT win
         // over two corroborating +1.4-ish donors. The majority cluster's median
         // is taken and the outlier dropped.
-        var (split, tier) = AutoAlignmentEngine.ResolveLatchedPathSplit(
-            [0.40, 1.50, 1.40], 0.6);
+        var (split, tier, corroborating) =
+            AutoAlignmentEngine.ResolveLatchedPathSplit([0.40, 1.50, 1.40], 0.6);
 
         Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.Tight, tier);
         Assert.Equal(1.45, split, 6);
+        Assert.Equal(2, corroborating);
+    }
+
+    [Fact]
+    public void ResolveLatchedPathSplit_BridgedDonorsDoNotFormOneTightCluster()
+    {
+        // A chain where consecutive pairs agree but the extremes do not: each of
+        // 0.45/1.00/1.55 is within 0.6 of the middle, yet the extremes span 1.10.
+        // Anchoring on the middle would fake one 3-way cluster; the mutual-span
+        // rule instead sees two equally-large disagreeing 2-clusters and refuses
+        // to pin — no confidently-wrong tight lock from bridged measurements.
+        var (_, tier, _) =
+            AutoAlignmentEngine.ResolveLatchedPathSplit([0.45, 1.00, 1.55], 0.60);
+
+        Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.None, tier);
     }
 }


### PR DESCRIPTION
Fixes a field failure (`bad_plus.json`) where Auto delay put the right midbass on a badly-timed delay. Root-caused and validated offline against the real v3 cabin, then hardened over two review rounds.

## The bug

When a linked pair's direct arrivals are **unmeasurable** — a weak direct buried under a huge late room-mode build-up, which the arrival detector's own upper-half honesty probe flags (a latch on either side) — the cross-side ladder's last rung timed the right channel from the **processed-IR energy-peak difference**. But the two sides can latch onto *different* room modes: on `bad_plus` the peaks read 23.5 vs 17.9 ms, a 5.6 ms "path split" no cabin geometry produces. That fabricated target dragged the right midbass ~1 ms past the scene onto a deep junction notch.

## The fix

The pair itself is poisoned, but the cabin's L/R geometry is usually measurable on **other** linked pairs. The rung now:

- Collects the L/R arrival split of **every** linked pair that reads a positively-clean direct arrival on both sides — full band **and** upper-half probe valid, SNR-qualified, and agreeing. (Absence of a proven latch is not taken as proof of a clean read.)
- Feeds those splits to `ResolveLatchedPathSplit`, a pure, unit-tested selector that tiers trust by **corroboration**: two-plus splits **mutually** within 0.6 ms (a real cluster, not an anchor-bridged chain) are the cabin's L/R offset — tight quarter-period lock, at their median; a lone donor is one estimate carrying its own DSP asymmetry — loose half-period lock; zero donors, or clusters that disagree, yield **no target**, and the pair keeps its free own-side search rather than be pinned to a fabricated split.
- Targets the settled left twin's delay minus that split and the scene offset. The old `MaxInterSideDirectPathMs` guard goes with the peak arithmetic it guarded.

The split is a donor pair's arrival difference, which also carries that donor's own L/R filter/driver asymmetry — corroboration **across** pairs (not one nearest donor) is what promotes it to the tight lock.

## Validation (offline, real v3 data)

- **The field failure is fixed:** `bad_plus` pins from the corroborated mids (+1.37) + tweeters (+1.41) split (+1.389 ms, quarter-period lock) → the right midbass lands **1.68 ms ahead** of the left, matching the physical ideal of **1.64 ms** (owner-confirmed 30–50 cm curved-path difference under the front seats). The engine's own sub↔midbass junction read improves from −1.64 dB / −7.6 dB dip (field) to −0.69 / −2.1.
- **No regression:** the 12 other stereo crossover configs (corners/slopes/families) are **bit-identical** — the rung only fires when a pair's direct arrivals are unmeasurable, which they aren't.
- 769 dsp + 497 app tests green; solution builds.

## Testing

The pure selector `ResolveLatchedPathSplit` is unit-tested directly (no donors → no target; lone donor → loose; agreeing pair → tight; disagreeing pair → none; majority cluster rejects an outlier; a bridged chain does not form one tight cluster). Driving the modal-latch detectors synthetically is threshold-brittle, so the end-to-end rung is validated by the offline stereo probe against `bad_plus.json` in `D:\hobby\AMP\v3` rather than a brittle unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
