### PR TITLE
Auto delay: honesty pass — no fabricated results, loud infeasibility, certified locks

### DIFF
--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -183,12 +183,13 @@ public static class AutoAlignmentEngine
     // AlignmentSelection tie-breaks, exactly as for any other admitted lobe.
     private const double LowJunctionReachFraction = 0.97;
 
-    // The delay ceiling a proposal may reach, mirroring the UI's per-channel
-    // delay limit — which itself mirrors real car DSP hardware: even top-end
-    // processors cap per-channel delay around 30 ms (~10 m of path), so a
-    // proposal past it could never be transferred to the device. Real cabin
-    // spans run well under 10 ms; the ceiling exists for the feasibility
-    // gate, not as an operating region.
+    // The delay ceiling an AUTO DELAY proposal may reach. Deliberately tighter
+    // than the manual UI range (100 ms — the Virtual DSP may model whatever
+    // hardware the user owns): even top-end car processors cap per-channel
+    // delay around 30 ms (~10 m of path), so an automatic proposal past it
+    // could never be transferred to a device. Real cabin spans run well under
+    // 10 ms; the ceiling exists for the feasibility gate, not as an operating
+    // region.
     private const double MaxDelayMs = 30;
 
     // A deliberately wide fine-search window (many periods at a high crossover,

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -359,9 +359,43 @@ public static class AutoAlignmentEngine
         AlignmentReprocessor reprocess,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         StringBuilder log,
-        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null) =>
+        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null)
+    {
+        ArgumentNullException.ThrowIfNull(channelsByBand);
+        ArgumentNullException.ThrowIfNull(alignment);
+        RequireOneSampleRate(channelsByBand);
+        // An absolute proposal, per the contract: stale entries would otherwise
+        // leak into the neighbor-base and reprocess reads and skew the result.
+        alignment.Clear();
+        decisions?.Clear();
         Compute(channelsByBand, pairs, reprocess, alignment, log,
             onsetLocks: null, decisions);
+        NormalizeAndVerifyFeasibility(channelsByBand.ToList(), alignment, log);
+    }
+
+    // Every cross-channel figure in the engine — correlation lags, junction
+    // bands, per-sample delays — assumes ONE sample rate: the searches read a
+    // neighbor's IR with the searched channel's rate, so mixed rates would
+    // silently misscale frequencies and delays rather than fail.
+    private static void RequireOneSampleRate(
+        IEnumerable<AlignmentSnapshot> channels)
+    {
+        int? sampleRate = null;
+        foreach (AlignmentSnapshot snapshot in channels)
+        {
+            if (sampleRate == null)
+            {
+                sampleRate = snapshot.Channel.SampleRate;
+            }
+            else if (snapshot.Channel.SampleRate != sampleRate)
+            {
+                throw new ArgumentException(
+                    "All channels must share one sample rate; " +
+                    $"found {sampleRate} and {snapshot.Channel.SampleRate} Hz. " +
+                    "Resample the measurements to a common rate first.");
+            }
+        }
+    }
 
     // One onset-locked junction: which channel the lock was applied to during
     // its fine search, how far the chosen delay landed from the onset-aligned
@@ -480,18 +514,53 @@ public static class AutoAlignmentEngine
         };
         foreach (AlignmentJunction pair in pairs)
         {
-            double lowerArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                pair.Lower.ImpulseResponse,
-                pair.Lower.Channel.SampleRate,
-                pair.BandLowHz,
-                pair.BandHighHz,
-                pair.Lower.ValidRange);
-            double upperArrival = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                pair.Upper.ImpulseResponse,
-                pair.Upper.Channel.SampleRate,
-                pair.BandLowHz,
-                pair.BandHighHz,
-                pair.Upper.ValidRange);
+            TimeAlignmentAnalysisResult lowerRead =
+                VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                    pair.Lower.ImpulseResponse,
+                    pair.Lower.Channel.SampleRate,
+                    pair.BandLowHz,
+                    pair.BandHighHz,
+                    pair.Lower.ValidRange);
+            TimeAlignmentAnalysisResult upperRead =
+                VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                    pair.Upper.ImpulseResponse,
+                    pair.Upper.Channel.SampleRate,
+                    pair.BandLowHz,
+                    pair.BandHighHz,
+                    pair.Upper.ValidRange);
+
+            // An invalid or near-noise arrival is NOT a time: treating it as
+            // one used to hand the timeline a fabricated 0 ms for a channel
+            // that was simply silent in the band, and the fine search then
+            // aligned the neighbor against that fiction. With no honest base
+            // the junction's offset is unknown: seed zero, mark the junction
+            // untrusted (the wide window), skip the PHAT refinement (its search
+            // window would be centered on the same fiction), and say so.
+            bool arrivalsMeasured =
+                lowerRead.IsValid && upperRead.IsValid &&
+                lowerRead.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
+                upperRead.SignalToNoiseDecibels >= MinimumArrivalSnrDb;
+            if (!arrivalsMeasured)
+            {
+                timeline[pair.Upper.Channel] = timeline[pair.Lower.Channel];
+                untrustedSeedJunctions.Add(pair);
+                string Describe(TimeAlignmentAnalysisResult read) =>
+                    !read.IsValid
+                        ? "unmeasurable"
+                        : $"SNR {read.SignalToNoiseDecibels:0.0} dB";
+                log.AppendLine(
+                    $"Pair {pair.Lower.Channel.Name}/" +
+                    $"{pair.Upper.Channel.Name}: " +
+                    $"fc {pair.CrossoverHz:0} Hz, " +
+                    $"band {pair.BandLowHz:0}-{pair.BandHighHz:0} Hz, " +
+                    $"arrivals {Describe(lowerRead)} / {Describe(upperRead)} " +
+                    $"(minimum {MinimumArrivalSnrDb:0} dB) — junction base " +
+                    "unknown, seeded at zero offset with the wide window");
+                continue;
+            }
+
+            double lowerArrival = lowerRead.FirstArrivalDelayMilliseconds;
+            double upperArrival = upperRead.FirstArrivalDelayMilliseconds;
 
             // Refine the coarse offset with the DOMINANT GCC-PHAT extremum of
             // either sign: at a mid/high junction it lands the stage-2 window
@@ -841,27 +910,27 @@ public static class AutoAlignmentEngine
                     $"(score {item.ScoreDb:0.00}, avg {item.LossDb:0.00}, " +
                     $"dip {item.DipDb:0.0} dB)")));
 
-            AlignmentCandidate chosen = candidates.Count > 0
+            AlignmentCandidate? selected = candidates.Count > 0
                 ? AlignmentSelection.Select(candidates, anchorMs)
-                : new AlignmentCandidate(anchorMs, forcedPolarity ?? false, 0);
-            if (candidates.Count > 0 && chosen != candidates[0])
+                : null;
+            if (selected is { } fineSelected && fineSelected != candidates[0])
             {
                 log.AppendLine(
-                    $"  preferred {chosen.DelayMs:0.000} ms" +
-                    $"{(chosen.InvertPolarity ? " inv" : "")} over " +
+                    $"  preferred {fineSelected.DelayMs:0.000} ms" +
+                    $"{(fineSelected.InvertPolarity ? " inv" : "")} over " +
                     $"{candidates[0].DelayMs:0.000} ms" +
                     $"{(candidates[0].InvertPolarity ? " inv" : "")} " +
-                    $"(margin {candidates[0].ScoreDb - chosen.ScoreDb:0.00} dB)");
+                    $"(margin {candidates[0].ScoreDb - fineSelected.ScoreDb:0.00} dB)");
             }
-            else if (candidates.Count > 0 && chosen.InvertPolarity &&
+            else if (selected is { InvertPolarity: true } keptInverted &&
                 AlignmentSelection.DeclinedInvertRescue(candidates, anchorMs)
                     is { } rescue)
             {
                 log.AppendLine(
-                    $"  kept {chosen.DelayMs:0.000} ms inv: rescue " +
+                    $"  kept {keptInverted.DelayMs:0.000} ms inv: rescue " +
                     $"{rescue.DelayMs:0.000} ms " +
-                    $"(margin {chosen.ScoreDb - rescue.ScoreDb:0.00} dB) is " +
-                    $"{Math.Abs(rescue.DelayMs - anchorMs) - Math.Abs(chosen.DelayMs - anchorMs):0.000} ms " +
+                    $"(margin {keptInverted.ScoreDb - rescue.ScoreDb:0.00} dB) is " +
+                    $"{Math.Abs(rescue.DelayMs - anchorMs) - Math.Abs(keptInverted.DelayMs - anchorMs):0.000} ms " +
                     "farther from the arrival (reach " +
                     $"{AlignmentSelection.DefaultInvertPreferenceReachMs:0.00} ms)");
             }
@@ -887,6 +956,42 @@ public static class AutoAlignmentEngine
                         $"(score {item.ScoreDb:0.00}, avg {item.LossDb:0.00}, " +
                         $"dip {item.DipDb:0.0} dB)"))
                     : "none"));
+
+            // An empty fine window is not yet "no evidence": the wide sweep
+            // covers several periods, so adopt its selection when it found
+            // structure the narrow window missed.
+            if (selected == null && wide.Count > 0)
+            {
+                selected = AlignmentSelection.Select(wide, anchorMs);
+                log.AppendLine(
+                    $"  fine window empty — adopted {selected.DelayMs:0.000} ms" +
+                    $"{(selected.InvertPolarity ? " inv" : "")} from the wide sweep");
+            }
+
+            // NO usable junction evidence at all (a channel silent in the band,
+            // a band the loss search finds no bins in). The engine used to
+            // fabricate a candidate at the coarse anchor here — a delay built on
+            // an unmeasured or even invalid arrival, applied as if it were a
+            // result. Refuse instead: the channel keeps its current (neutral)
+            // delay, and the report says why, in place of a confident number.
+            if (selected == null)
+            {
+                log.AppendLine(
+                    $"  NO junction evidence in {bandLowHz:0}-{bandHighHz:0} Hz — " +
+                    $"{channel.Name} left unchanged");
+                if (decisions != null)
+                {
+                    string versusRefused = neighborChannel.Name +
+                        (secondaryNeighbor != null ? $" + {secondaryNeighbor.Name}" : "");
+                    decisions[channel] = new AlignmentDecision(
+                        AlignmentDecisionKind.Search,
+                        AlignmentConfidence.Low,
+                        $"vs {versusRefused}: no junction evidence — not aligned");
+                }
+                return;
+            }
+
+            AlignmentCandidate chosen = selected;
 
             // The arrival-anchored pick, captured BEFORE the edge-retry can move
             // it: the promotion reach is measured from here, so a retry that
@@ -1059,8 +1164,11 @@ public static class AutoAlignmentEngine
                 newDelay = 0;
             }
 
+            // Unclamped above zero: a value past MaxDelayMs stays honest here —
+            // relations are what matter mid-run, and the final feasibility
+            // check refuses the proposal if the span truly does not fit.
             alignment[channel] = new AlignmentOverride(
-                Math.Clamp(Math.Round(newDelay, 2), 0, MaxDelayMs),
+                Math.Max(0, Math.Round(newDelay, 2)),
                 chosen.InvertPolarity);
 
             if (decisions != null)
@@ -1272,21 +1380,16 @@ public static class AutoAlignmentEngine
             {
                 AlignmentOverride currentAlignment =
                     alignment.GetValueOrDefault(item.Channel);
-                double shifted = currentAlignment.DelayMs + shiftMs;
-                if (shifted > MaxDelayMs)
-                {
-                    // The shift is only alignment-preserving while it is
-                    // uniform; a channel pinned at the ceiling breaks the
-                    // relative delays silently, so say so in the log.
-                    log.AppendLine(
-                        $"  WARNING: uniform shift +{shiftMs:0.000} ms pushes " +
-                        $"{item.Channel.Name} past the {MaxDelayMs:0} ms " +
-                        $"delay limit ({shifted:0.000} ms, clamped) — " +
-                        "the relative alignment is no longer preserved.");
-                }
+                // NO clamping here: the shift is only alignment-preserving
+                // while it is uniform, and a channel pinned at the ceiling
+                // would break the relative delays (and the stereo scene)
+                // SILENTLY. Transient out-of-range values are legal mid-run —
+                // only relations matter until the final normalization, and the
+                // feasibility check after it refuses a proposal whose span
+                // genuinely does not fit the DSP's delay range.
                 alignment[item.Channel] = currentAlignment with
                 {
-                    DelayMs = Math.Min(MaxDelayMs, shifted)
+                    DelayMs = currentAlignment.DelayMs + shiftMs
                 };
             }
         }
@@ -1346,6 +1449,11 @@ public static class AutoAlignmentEngine
                 "Every mono channel must be part of the left walk that tunes it.",
                 nameof(plan));
         }
+        RequireOneSampleRate(plan.LeftChannelsByBand.Concat(rightByBand));
+        // An absolute proposal, per the contract (see Compute): stage L below
+        // uses the PRIVATE overload, so clear here.
+        alignment.Clear();
+        decisions?.Clear();
 
         // Onset-locked junctions accumulated across both sides: the co-move
         // must respect the front pins the fine searches honored.
@@ -1422,6 +1530,81 @@ public static class AutoAlignmentEngine
                 "Check the top pair's sources and crossover band.");
         }
 
+        // The same honesty certificate every cross-side read gets, on the one
+        // read that times a WHOLE side: each side's full-band arrival must
+        // agree with its own upper-half read to within the dispersion one
+        // wavefront can show. SNR alone proves a strong signal, not that both
+        // sides timed the same physical event — a strong early reflection on
+        // one side passes the SNR gate and would skew the entire right side.
+        // Disagreement is positive evidence of that and refuses the bridge; an
+        // unmeasurable upper half (a heavily rolled-off top end) cannot
+        // certify either way, so the bridge proceeds but its confidence is
+        // capped at Low below.
+        bool bridgeVerified = true;
+        double bridgeProbeLowHz =
+            Math.Sqrt(plan.BridgeBandLowHz * plan.BridgeBandHighHz);
+        if (plan.BridgeBandHighHz >= bridgeProbeLowHz *
+            VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
+        {
+            TimeAlignmentAnalysisResult leftProbe =
+                VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                    leftBridgeSnapshot.ImpulseResponse,
+                    plan.BridgeLeft.SampleRate,
+                    bridgeProbeLowHz,
+                    plan.BridgeBandHighHz,
+                    leftBridgeSnapshot.ValidRange);
+            TimeAlignmentAnalysisResult rightProbe =
+                VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                    rightBridgeSnapshot.ImpulseResponse,
+                    plan.BridgeRight.SampleRate,
+                    bridgeProbeLowHz,
+                    plan.BridgeBandHighHz,
+                    rightBridgeSnapshot.ValidRange);
+            double bridgeToleranceMs = Math.Max(1.0, 500.0 / bridgeProbeLowHz);
+            bool Certified(
+                TimeAlignmentAnalysisResult full,
+                TimeAlignmentAnalysisResult probe,
+                IAlignmentChannel channel)
+            {
+                if (!probe.IsValid ||
+                    probe.SignalToNoiseDecibels < MinimumArrivalSnrDb)
+                {
+                    bridgeVerified = false;
+                    return true;
+                }
+                double skewMs = full.FirstArrivalDelayMilliseconds -
+                    probe.FirstArrivalDelayMilliseconds;
+                if (skewMs > bridgeToleranceMs)
+                {
+                    // The full band times a LATER feature than its own upper
+                    // half — the arrival is not the direct front. Refuse.
+                    throw new InvalidOperationException(
+                        "The stereo bridge reads two different features on " +
+                        $"{channel.Name}: {full.FirstArrivalDelayMilliseconds:0.000} ms " +
+                        $"in {plan.BridgeBandLowHz:0}-{plan.BridgeBandHighHz:0} Hz but " +
+                        $"{probe.FirstArrivalDelayMilliseconds:0.000} ms in its " +
+                        $"{bridgeProbeLowHz:0}-{plan.BridgeBandHighHz:0} Hz half. " +
+                        "The arrival is not a clean direct front, so timing the " +
+                        "whole right side from it would be unreliable. Check the " +
+                        "top pair's measurements for early reflections.");
+                }
+                if (-skewMs > bridgeToleranceMs)
+                {
+                    // The upper half timed some LATER feature than the full
+                    // band's front — it cannot certify the read, but the full
+                    // read itself may still be the honest direct.
+                    bridgeVerified = false;
+                }
+                return true;
+            }
+            Certified(leftBridge, leftProbe, plan.BridgeLeft);
+            Certified(rightBridge, rightProbe, plan.BridgeRight);
+        }
+        else
+        {
+            bridgeVerified = false;
+        }
+
         double leftArrival = leftBridge.FirstArrivalDelayMilliseconds;
         double rightArrival = rightBridge.FirstArrivalDelayMilliseconds;
         double bridgeDelay = leftArrival - rightArrival - plan.SceneOffsetMs;
@@ -1445,8 +1628,10 @@ public static class AutoAlignmentEngine
                 $"  advanced via a uniform +{shift:0.000} ms shift " +
                 "of every settled channel");
         }
+        // Unclamped above zero (see the result write): the final feasibility
+        // check owns the delay-range verdict.
         alignment[plan.BridgeRight] = new AlignmentOverride(
-            Math.Clamp(Math.Round(bridgeDelay, 2), 0, MaxDelayMs), false);
+            Math.Max(0, Math.Round(bridgeDelay, 2)), false);
         if (decisions != null)
         {
             // The bridge is an envelope-arrival fit, not a candidate search:
@@ -1460,12 +1645,19 @@ public static class AutoAlignmentEngine
                 bridgeSnrDb >= BridgeHighSnrDb ? AlignmentConfidence.High
                 : bridgeSnrDb >= BridgeMediumSnrDb ? AlignmentConfidence.Medium
                 : AlignmentConfidence.Low;
+            if (!bridgeVerified)
+            {
+                // The honesty probe could not certify the arrivals as clean
+                // direct fronts — the bridge stands, but not with high trust.
+                bridgeConfidence = AlignmentConfidence.Low;
+            }
             string bridgeSnrText = FormattableString.Invariant(
                 $"{leftBridge.SignalToNoiseDecibels:0} / {rightBridge.SignalToNoiseDecibels:0} dB");
             decisions[plan.BridgeRight] = new AlignmentDecision(
                 AlignmentDecisionKind.Bridge,
                 bridgeConfidence,
-                $"bridge to {plan.BridgeLeft.Name}: arrival SNR {bridgeSnrText}");
+                $"bridge to {plan.BridgeLeft.Name}: arrival SNR {bridgeSnrText}" +
+                (bridgeVerified ? "" : ", honesty probe unavailable"));
         }
 
         // Polarity is a property of the DRIVER, not the side, and automatic delay
@@ -1534,13 +1726,19 @@ public static class AutoAlignmentEngine
             // full-band read landing far BEHIND its own upper-half read means
             // the detector latched that side onto the in-room modal build-up
             // instead of the direct rise (the under-seat midbass case:
-            // 21.2 ms in 80-200 Hz vs 13.9 ms one band up) — the two sides
-            // are then timing DIFFERENT features and their difference is
-            // garbage. The narrow upper half itself is NOT a substitute (at a
-            // low band it is an octave of mush that once dragged a woofer
-            // 6 ms off) — it only votes on the full band's honesty.
+            // 21.2 ms in 80-200 Hz vs 13.9 ms one band up); one landing far
+            // AHEAD means the upper half timed some later feature, so the two
+            // bands are not looking at one wavefront either — both directions
+            // fail the certification. The narrow upper half itself is NOT a
+            // substitute (at a low band it is an octave of mush that once
+            // dragged a woofer 6 ms off) — it only votes on the full band's
+            // honesty. Verified is the positive certificate: reads whose probe
+            // was unmeasurable (too-narrow band, silent or low-SNR upper half)
+            // are still usable but UNVERIFIED, and the caller must not grant
+            // them the tight scene lock an honest certificate earns.
             ((TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
-                Reads, bool Latched) MeasureConsistent(double lowHz, double highHz)
+                Reads, bool Latched, bool Verified) MeasureConsistent(
+                    double lowHz, double highHz)
             {
                 TimeAlignmentAnalysisResult left =
                     VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
@@ -1554,14 +1752,14 @@ public static class AutoAlignmentEngine
                     left.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
                     right.SignalToNoiseDecibels < MinimumArrivalSnrDb)
                 {
-                    return (null, false);
+                    return (null, false, false);
                 }
 
                 double probeLowHz = Math.Sqrt(lowHz * highHz);
                 if (highHz <
                     probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
                 {
-                    return ((left, right), false);
+                    return ((left, right), false, false);
                 }
 
                 TimeAlignmentAnalysisResult leftProbe =
@@ -1576,14 +1774,25 @@ public static class AutoAlignmentEngine
                     leftProbe.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
                     rightProbe.SignalToNoiseDecibels < MinimumArrivalSnrDb)
                 {
-                    return ((left, right), false);
+                    return ((left, right), false, false);
                 }
 
+                // The two disagreement directions mean different things. A full
+                // band LATE against its own upper half is the proven latch (the
+                // mode buried the direct; the read times the wrong feature and
+                // is garbage — replace it). A full band EARLY means the upper
+                // half could not see the front the full band did (weak in-band
+                // HF, a probe timing some later feature): the full read may
+                // still be the honest direct, but the probe cannot CERTIFY it —
+                // so the reads stay usable, only without the certificate (no
+                // tight scene lock, lobe pin only).
                 double toleranceMs = Math.Max(1.0, 500.0 / probeLowHz);
-                bool leftLatched = left.FirstArrivalDelayMilliseconds
-                    - leftProbe.FirstArrivalDelayMilliseconds > toleranceMs;
-                bool rightLatched = right.FirstArrivalDelayMilliseconds
-                    - rightProbe.FirstArrivalDelayMilliseconds > toleranceMs;
+                double leftSkewMs = left.FirstArrivalDelayMilliseconds
+                    - leftProbe.FirstArrivalDelayMilliseconds;
+                double rightSkewMs = right.FirstArrivalDelayMilliseconds
+                    - rightProbe.FirstArrivalDelayMilliseconds;
+                bool leftLatched = leftSkewMs > toleranceMs;
+                bool rightLatched = rightSkewMs > toleranceMs;
                 if (leftLatched || rightLatched)
                 {
                     log.AppendLine(
@@ -1594,10 +1803,14 @@ public static class AutoAlignmentEngine
                         $"{(leftLatched ? leftProbe : rightProbe).FirstArrivalDelayMilliseconds:0.000} ms" +
                         $" in its {probeLowHz:0}-{highHz:0} Hz half " +
                         "(modal latch: the sides time different features)");
-                    return (null, true);
+                    return (null, true, false);
+                }
+                if (-leftSkewMs > toleranceMs || -rightSkewMs > toleranceMs)
+                {
+                    return ((left, right), false, false);
                 }
 
-                return ((left, right), false);
+                return ((left, right), false, true);
             }
 
             // The consistency ladder: the pair's own shared band first; when a
@@ -1612,7 +1825,7 @@ public static class AutoAlignmentEngine
             double usedHighHz = bandHighHz;
             bool anyLatch;
             ((TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
-                Reads, bool Latched) measured =
+                Reads, bool Latched, bool Verified) measured =
                 MeasureConsistent(bandLowHz, bandHighHz);
             anyLatch = measured.Latched;
             if (measured.Reads == null && measured.Latched &&
@@ -1698,11 +1911,14 @@ public static class AutoAlignmentEngine
                             TimeAlignmentAnalysisResult probe = Read(side, probeLow2, highHz2);
                             rawMs = full.FirstArrivalDelayMilliseconds
                                 - alignment.GetValueOrDefault(side.Channel).DelayMs;
+                            // Two-sided: a full band far AHEAD of its upper half
+                            // means the bands time different features, just as a
+                            // late (latched) one does — neither certifies.
                             return full.IsValid && probe.IsValid &&
                                 full.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
                                 probe.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
-                                full.FirstArrivalDelayMilliseconds -
-                                    probe.FirstArrivalDelayMilliseconds <= tolerance2;
+                                Math.Abs(full.FirstArrivalDelayMilliseconds -
+                                    probe.FirstArrivalDelayMilliseconds) <= tolerance2;
                         }
 
                         if (CleanDirect(otherLeft, out double rawLeft) &&
@@ -1758,6 +1974,10 @@ public static class AutoAlignmentEngine
                 return (latchedTarget, true, tight);
             }
 
+            // An UNVERIFIED read (the honesty probe could not run — band too
+            // narrow, silent or low-SNR upper half) is still the best estimate
+            // but no certificate: it pins only the LOBE (Coarse), never the
+            // tight scene tolerance — the same standard the donor rung applies.
             double target = arrivals.Left.FirstArrivalDelayMilliseconds
                 - plan.SceneOffsetMs
                 - arrivals.Right.FirstArrivalDelayMilliseconds;
@@ -1765,8 +1985,9 @@ public static class AutoAlignmentEngine
                 $"  cross-side prior {rightChannel.Name}: target {target:0.000} ms " +
                 $"(L arrival {arrivals.Left.FirstArrivalDelayMilliseconds:0.000}, " +
                 $"raw R {arrivals.Right.FirstArrivalDelayMilliseconds:0.000} ms " +
-                $"in {usedLowHz:0}-{usedHighHz:0} Hz)");
-            return (target, false, false);
+                $"in {usedLowHz:0}-{usedHighHz:0} Hz" +
+                $"{(measured.Verified ? "" : "; honesty probe unavailable — lobe pin only")})");
+            return (target, !measured.Verified, false);
         }
 
         void AlignRight(int index, int neighborIndex, AlignmentJunction pair)
@@ -1881,15 +2102,32 @@ public static class AutoAlignmentEngine
         // vote on the mono channel at all.
         ComoveMonoChannels(plan, reprocess, alignment, log, allChannels, decisions);
 
-        // Final normalization: the smallest total latency that preserves every
-        // relation — the minimum proposed delay lands exactly at zero.
-        // (Channels without an entry sit at zero, so this only acts when a
-        // uniform shift raised the whole field.)
-        double minimum = allChannels.Min(
+        NormalizeAndVerifyFeasibility(allChannels, alignment, log);
+
+        // The invariant the user requires of automatic delay: no driver is ever
+        // inverted on one side of a pair alone.
+        EnforcePolaritySymmetry(plan, alignment, log, decisions);
+    }
+
+    // Final normalization + the single feasibility gate. Normalization: the
+    // smallest total latency that preserves every relation — the minimum
+    // proposed delay lands exactly at zero; lifting a NEGATIVE minimum is as
+    // legal as trimming a positive one (both are uniform), so transient
+    // out-of-range values from the shift passes settle here. Feasibility: a
+    // maximum past the DSP's delay ceiling after that means the proposal
+    // PHYSICALLY does not fit — clamping one channel would silently break the
+    // relative alignment (and the stereo scene), so the whole run refuses with
+    // the reason instead.
+    internal static void NormalizeAndVerifyFeasibility(
+        IReadOnlyList<AlignmentSnapshot> scope,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        StringBuilder log)
+    {
+        double minimum = scope.Min(
             item => alignment.GetValueOrDefault(item.Channel).DelayMs);
-        if (minimum > 0.005)
+        if (Math.Abs(minimum) > 0.005)
         {
-            foreach (AlignmentSnapshot item in allChannels)
+            foreach (AlignmentSnapshot item in scope)
             {
                 AlignmentOverride current = alignment.GetValueOrDefault(item.Channel);
                 alignment[item.Channel] = current with
@@ -1898,13 +2136,22 @@ public static class AutoAlignmentEngine
                 };
             }
             log.AppendLine(
-                $"Normalized: -{minimum:0.000} ms off every channel " +
+                $"Normalized: {-minimum:+0.000;-0.000} ms to every channel " +
                 "(minimum delay back to zero)");
         }
 
-        // The invariant the user requires of automatic delay: no driver is ever
-        // inverted on one side of a pair alone.
-        EnforcePolaritySymmetry(plan, alignment, log, decisions);
+        AlignmentSnapshot widest = scope.MaxBy(
+            item => alignment.GetValueOrDefault(item.Channel).DelayMs)!;
+        double widestDelayMs = alignment.GetValueOrDefault(widest.Channel).DelayMs;
+        if (widestDelayMs > MaxDelayMs + 0.005)
+        {
+            throw new InvalidOperationException(
+                "The proposed alignment does not fit the DSP delay range: " +
+                $"{widest.Channel.Name} needs {widestDelayMs:0.00} ms with the " +
+                $"earliest channel at 0, but the limit is {MaxDelayMs:0} ms. " +
+                "The measured spread between the earliest and latest channels " +
+                "is wider than the DSP can realize.");
+        }
     }
 
     // Post-pass bookkeeping for the user report: a pass that changes a

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -380,12 +380,12 @@ public static class AutoAlignmentEngine
     /// against the same record's upper-half read. LATCHED — the full band
     /// times a feature far LATER than its own upper half (the proven modal
     /// latch): the read times the wrong feature and is garbage. UNVERIFIED —
-    /// the probe cannot certify: its read is unmeasurable/low-SNR, or it
-    /// timed some feature far EARLIER... i.e. the full band leads it beyond
-    /// dispersion (weak in-band HF; the probe is blind to the front) — the
-    /// full read stays usable but earns no certificate (no tight scene lock).
-    /// VERIFIED — the two agree within the dispersion one wavefront can show.
-    /// One classification shared by the cross-side links, the donor
+    /// no certificate either way: the full read itself (or the probe) is
+    /// unmeasurable/low-SNR, or the PROBE timed some far LATER feature than
+    /// the full band's front (weak in-band HF leaves it blind to the front) —
+    /// the full read stays usable but earns no certificate (no tight scene
+    /// lock). VERIFIED — the two agree within the dispersion one wavefront
+    /// can show. One classification shared by the cross-side links, the donor
     /// certificates and the stereo bridge, so the three cannot drift apart.
     /// </summary>
     internal enum ArrivalCertificate
@@ -400,7 +400,9 @@ public static class AutoAlignmentEngine
         TimeAlignmentAnalysisResult probe,
         double toleranceMs)
     {
-        if (!probe.IsValid ||
+        if (!full.IsValid ||
+            full.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
+            !probe.IsValid ||
             probe.SignalToNoiseDecibels < MinimumArrivalSnrDb)
         {
             return ArrivalCertificate.Unverified;
@@ -575,34 +577,41 @@ public static class AutoAlignmentEngine
                     pair.BandHighHz,
                     pair.Upper.ValidRange);
 
-            // An invalid or near-noise arrival is NOT a time: treating it as
-            // one used to hand the timeline a fabricated 0 ms for a channel
-            // that was simply silent in the band, and the fine search then
-            // aligned the neighbor against that fiction. With no honest base
-            // the junction's offset is unknown: seed zero, mark the junction
-            // untrusted (the wide window), skip the PHAT refinement (its search
-            // window would be centered on the same fiction), and say so.
+            // An invalid or near-noise arrival is NOT a time — and, unlike a
+            // mis-TIMED one, it is not rescuable either: the envelope SNR
+            // grades the whole band against the record's own noise floor, so
+            // failing it means the channel has no measurable signal THERE at
+            // all — the junction search downstream would only shape a loss
+            // surface out of noise phases and let the prior pick a delay. The
+            // wide window rescues uncertain timing of a strong signal, never
+            // the absence of one. Refuse the run and point at the channel:
+            // this is a dead driver, a wrong source or a mis-set crossover,
+            // and the user must see that, not a proposal that pretends.
             bool arrivalsMeasured =
                 lowerRead.IsValid && upperRead.IsValid &&
                 lowerRead.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
                 upperRead.SignalToNoiseDecibels >= MinimumArrivalSnrDb;
             if (!arrivalsMeasured)
             {
-                timeline[pair.Upper.Channel] = timeline[pair.Lower.Channel];
-                untrustedSeedJunctions.Add(pair);
                 string Describe(TimeAlignmentAnalysisResult read) =>
                     !read.IsValid
                         ? "unmeasurable"
-                        : $"SNR {read.SignalToNoiseDecibels:0.0} dB";
+                        : $"near-noise (SNR {read.SignalToNoiseDecibels:0.0} dB, " +
+                          $"minimum {MinimumArrivalSnrDb:0})";
+                string lowerState = Describe(lowerRead);
+                string upperState = Describe(upperRead);
                 log.AppendLine(
                     $"Pair {pair.Lower.Channel.Name}/" +
                     $"{pair.Upper.Channel.Name}: " +
-                    $"fc {pair.CrossoverHz:0} Hz, " +
                     $"band {pair.BandLowHz:0}-{pair.BandHighHz:0} Hz, " +
-                    $"arrivals {Describe(lowerRead)} / {Describe(upperRead)} " +
-                    $"(minimum {MinimumArrivalSnrDb:0} dB) — junction base " +
-                    "unknown, seeded at zero offset with the wide window");
-                continue;
+                    $"arrivals {lowerState} / {upperState} — refusing the run");
+                throw new InvalidOperationException(
+                    $"No junction evidence between {pair.Lower.Channel.Name} " +
+                    $"and {pair.Upper.Channel.Name} in " +
+                    $"{pair.BandLowHz:0}-{pair.BandHighHz:0} Hz: " +
+                    $"{pair.Lower.Channel.Name} is {lowerState}, " +
+                    $"{pair.Upper.Channel.Name} is {upperState}. " +
+                    "Check the channels' sources and crossover settings.");
             }
 
             double lowerArrival = lowerRead.FirstArrivalDelayMilliseconds;

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -373,6 +373,50 @@ public static class AutoAlignmentEngine
         NormalizeAndVerifyFeasibility(channelsByBand.ToList(), alignment, log);
     }
 
+    /// <summary>
+    /// The verdict of the arrival honesty probe: a full-band read judged
+    /// against the same record's upper-half read. LATCHED — the full band
+    /// times a feature far LATER than its own upper half (the proven modal
+    /// latch): the read times the wrong feature and is garbage. UNVERIFIED —
+    /// the probe cannot certify: its read is unmeasurable/low-SNR, or it
+    /// timed some feature far EARLIER... i.e. the full band leads it beyond
+    /// dispersion (weak in-band HF; the probe is blind to the front) — the
+    /// full read stays usable but earns no certificate (no tight scene lock).
+    /// VERIFIED — the two agree within the dispersion one wavefront can show.
+    /// One classification shared by the cross-side links, the donor
+    /// certificates and the stereo bridge, so the three cannot drift apart.
+    /// </summary>
+    internal enum ArrivalCertificate
+    {
+        Unverified,
+        Latched,
+        Verified
+    }
+
+    internal static ArrivalCertificate ClassifyArrival(
+        TimeAlignmentAnalysisResult full,
+        TimeAlignmentAnalysisResult probe,
+        double toleranceMs)
+    {
+        if (!probe.IsValid ||
+            probe.SignalToNoiseDecibels < MinimumArrivalSnrDb)
+        {
+            return ArrivalCertificate.Unverified;
+        }
+
+        double skewMs = full.FirstArrivalDelayMilliseconds
+            - probe.FirstArrivalDelayMilliseconds;
+        if (skewMs > toleranceMs)
+        {
+            return ArrivalCertificate.Latched;
+        }
+        if (-skewMs > toleranceMs)
+        {
+            return ArrivalCertificate.Unverified;
+        }
+        return ArrivalCertificate.Verified;
+    }
+
     // Every cross-channel figure in the engine — correlation lags, junction
     // bands, per-sample delays — assumes ONE sample rate: the searches read a
     // neighbor's IR with the searched channel's rate, so mixed rates would
@@ -968,27 +1012,29 @@ public static class AutoAlignmentEngine
                     $"{(selected.InvertPolarity ? " inv" : "")} from the wide sweep");
             }
 
-            // NO usable junction evidence at all (a channel silent in the band,
-            // a band the loss search finds no bins in). The engine used to
-            // fabricate a candidate at the coarse anchor here — a delay built on
-            // an unmeasured or even invalid arrival, applied as if it were a
-            // result. Refuse instead: the channel keeps its current (neutral)
-            // delay, and the report says why, in place of a confident number.
+            // NO usable junction evidence at all (a channel silent or buried in
+            // the band — the evidence gate returned no candidates in either
+            // window). The engine used to fabricate a candidate at the coarse
+            // anchor here — a delay built on an unmeasured or even invalid
+            // arrival, applied as if it were a result. A partial "skip this
+            // channel" is no better: earlier uniform shifts may already have
+            // written a delay into its override, later passes would shift it
+            // again, and the walk would align further channels against an
+            // unaligned neighbor. The only honest outcome is refusing the RUN,
+            // with the reason: an unmeasurable channel needs the user's
+            // attention (a dead driver, a wrong source, a mis-set crossover),
+            // not a proposal that quietly pretends it was aligned.
             if (selected == null)
             {
                 log.AppendLine(
                     $"  NO junction evidence in {bandLowHz:0}-{bandHighHz:0} Hz — " +
-                    $"{channel.Name} left unchanged");
-                if (decisions != null)
-                {
-                    string versusRefused = neighborChannel.Name +
-                        (secondaryNeighbor != null ? $" + {secondaryNeighbor.Name}" : "");
-                    decisions[channel] = new AlignmentDecision(
-                        AlignmentDecisionKind.Search,
-                        AlignmentConfidence.Low,
-                        $"vs {versusRefused}: no junction evidence — not aligned");
-                }
-                return;
+                    "refusing the run");
+                throw new InvalidOperationException(
+                    $"No junction evidence between {channel.Name} and " +
+                    $"{neighborChannel.Name} in " +
+                    $"{bandLowHz:0}-{bandHighHz:0} Hz: one of them is silent or " +
+                    "buried in the shared band, so no delay can be measured " +
+                    "there. Check the channel's source and crossover settings.");
             }
 
             AlignmentCandidate chosen = selected;
@@ -1561,44 +1607,32 @@ public static class AutoAlignmentEngine
                     plan.BridgeBandHighHz,
                     rightBridgeSnapshot.ValidRange);
             double bridgeToleranceMs = Math.Max(1.0, 500.0 / bridgeProbeLowHz);
-            bool Certified(
+            void Certify(
                 TimeAlignmentAnalysisResult full,
                 TimeAlignmentAnalysisResult probe,
                 IAlignmentChannel channel)
             {
-                if (!probe.IsValid ||
-                    probe.SignalToNoiseDecibels < MinimumArrivalSnrDb)
+                switch (ClassifyArrival(full, probe, bridgeToleranceMs))
                 {
-                    bridgeVerified = false;
-                    return true;
+                    case ArrivalCertificate.Latched:
+                        // The full band times a LATER feature than its own
+                        // upper half — the arrival is not the direct front.
+                        throw new InvalidOperationException(
+                            "The stereo bridge reads two different features on " +
+                            $"{channel.Name}: {full.FirstArrivalDelayMilliseconds:0.000} ms " +
+                            $"in {plan.BridgeBandLowHz:0}-{plan.BridgeBandHighHz:0} Hz but " +
+                            $"{probe.FirstArrivalDelayMilliseconds:0.000} ms in its " +
+                            $"{bridgeProbeLowHz:0}-{plan.BridgeBandHighHz:0} Hz half. " +
+                            "The arrival is not a clean direct front, so timing the " +
+                            "whole right side from it would be unreliable. Check the " +
+                            "top pair's measurements for early reflections.");
+                    case ArrivalCertificate.Unverified:
+                        bridgeVerified = false;
+                        break;
                 }
-                double skewMs = full.FirstArrivalDelayMilliseconds -
-                    probe.FirstArrivalDelayMilliseconds;
-                if (skewMs > bridgeToleranceMs)
-                {
-                    // The full band times a LATER feature than its own upper
-                    // half — the arrival is not the direct front. Refuse.
-                    throw new InvalidOperationException(
-                        "The stereo bridge reads two different features on " +
-                        $"{channel.Name}: {full.FirstArrivalDelayMilliseconds:0.000} ms " +
-                        $"in {plan.BridgeBandLowHz:0}-{plan.BridgeBandHighHz:0} Hz but " +
-                        $"{probe.FirstArrivalDelayMilliseconds:0.000} ms in its " +
-                        $"{bridgeProbeLowHz:0}-{plan.BridgeBandHighHz:0} Hz half. " +
-                        "The arrival is not a clean direct front, so timing the " +
-                        "whole right side from it would be unreliable. Check the " +
-                        "top pair's measurements for early reflections.");
-                }
-                if (-skewMs > bridgeToleranceMs)
-                {
-                    // The upper half timed some LATER feature than the full
-                    // band's front — it cannot certify the read, but the full
-                    // read itself may still be the honest direct.
-                    bridgeVerified = false;
-                }
-                return true;
             }
-            Certified(leftBridge, leftProbe, plan.BridgeLeft);
-            Certified(rightBridge, rightProbe, plan.BridgeRight);
+            Certify(leftBridge, leftProbe, plan.BridgeLeft);
+            Certify(rightBridge, rightProbe, plan.BridgeRight);
         }
         else
         {
@@ -1657,7 +1691,9 @@ public static class AutoAlignmentEngine
                 AlignmentDecisionKind.Bridge,
                 bridgeConfidence,
                 $"bridge to {plan.BridgeLeft.Name}: arrival SNR {bridgeSnrText}" +
-                (bridgeVerified ? "" : ", honesty probe unavailable"));
+                (bridgeVerified
+                    ? ""
+                    : ", arrival not certified by the upper-half probe"));
         }
 
         // Polarity is a property of the DRIVER, not the side, and automatic delay
@@ -1770,31 +1806,19 @@ public static class AutoAlignmentEngine
                     VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
                         rightIr, rightChannel.SampleRate, probeLowHz, highHz,
                         rightSnapshot.ValidRange);
-                if (!leftProbe.IsValid || !rightProbe.IsValid ||
-                    leftProbe.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
-                    rightProbe.SignalToNoiseDecibels < MinimumArrivalSnrDb)
-                {
-                    return ((left, right), false, false);
-                }
 
-                // The two disagreement directions mean different things. A full
-                // band LATE against its own upper half is the proven latch (the
-                // mode buried the direct; the read times the wrong feature and
-                // is garbage — replace it). A full band EARLY means the upper
-                // half could not see the front the full band did (weak in-band
-                // HF, a probe timing some later feature): the full read may
-                // still be the honest direct, but the probe cannot CERTIFY it —
-                // so the reads stay usable, only without the certificate (no
-                // tight scene lock, lobe pin only).
+                // See ClassifyArrival for the direction semantics: LATCHED
+                // poisons the read (ladder/donors), UNVERIFIED keeps it usable
+                // without the certificate, VERIFIED on both sides earns it.
                 double toleranceMs = Math.Max(1.0, 500.0 / probeLowHz);
-                double leftSkewMs = left.FirstArrivalDelayMilliseconds
-                    - leftProbe.FirstArrivalDelayMilliseconds;
-                double rightSkewMs = right.FirstArrivalDelayMilliseconds
-                    - rightProbe.FirstArrivalDelayMilliseconds;
-                bool leftLatched = leftSkewMs > toleranceMs;
-                bool rightLatched = rightSkewMs > toleranceMs;
-                if (leftLatched || rightLatched)
+                ArrivalCertificate leftCertificate =
+                    ClassifyArrival(left, leftProbe, toleranceMs);
+                ArrivalCertificate rightCertificate =
+                    ClassifyArrival(right, rightProbe, toleranceMs);
+                if (leftCertificate == ArrivalCertificate.Latched ||
+                    rightCertificate == ArrivalCertificate.Latched)
                 {
+                    bool leftLatched = leftCertificate == ArrivalCertificate.Latched;
                     log.AppendLine(
                         $"  cross-side link {rightChannel.Name}: " +
                         $"{(leftLatched ? link.Left.Name : rightChannel.Name)}" +
@@ -1805,12 +1829,10 @@ public static class AutoAlignmentEngine
                         "(modal latch: the sides time different features)");
                     return (null, true, false);
                 }
-                if (-leftSkewMs > toleranceMs || -rightSkewMs > toleranceMs)
-                {
-                    return ((left, right), false, false);
-                }
 
-                return ((left, right), false, true);
+                return ((left, right), false,
+                    leftCertificate == ArrivalCertificate.Verified &&
+                    rightCertificate == ArrivalCertificate.Verified);
             }
 
             // The consistency ladder: the pair's own shared band first; when a
@@ -1911,14 +1933,13 @@ public static class AutoAlignmentEngine
                             TimeAlignmentAnalysisResult probe = Read(side, probeLow2, highHz2);
                             rawMs = full.FirstArrivalDelayMilliseconds
                                 - alignment.GetValueOrDefault(side.Channel).DelayMs;
-                            // Two-sided: a full band far AHEAD of its upper half
-                            // means the bands time different features, just as a
-                            // late (latched) one does — neither certifies.
-                            return full.IsValid && probe.IsValid &&
+                            // A donor must be POSITIVELY clean: only a VERIFIED
+                            // certificate counts (unverified or latched reads
+                            // contribute no geometry).
+                            return full.IsValid &&
                                 full.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
-                                probe.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
-                                Math.Abs(full.FirstArrivalDelayMilliseconds -
-                                    probe.FirstArrivalDelayMilliseconds) <= tolerance2;
+                                ClassifyArrival(full, probe, tolerance2) ==
+                                    ArrivalCertificate.Verified;
                         }
 
                         if (CleanDirect(otherLeft, out double rawLeft) &&
@@ -1986,7 +2007,7 @@ public static class AutoAlignmentEngine
                 $"(L arrival {arrivals.Left.FirstArrivalDelayMilliseconds:0.000}, " +
                 $"raw R {arrivals.Right.FirstArrivalDelayMilliseconds:0.000} ms " +
                 $"in {usedLowHz:0}-{usedHighHz:0} Hz" +
-                $"{(measured.Verified ? "" : "; honesty probe unavailable — lobe pin only")})");
+                $"{(measured.Verified ? "" : "; arrival not certified by the upper-half probe — lobe pin only")})");
             return (target, !measured.Verified, false);
         }
 
@@ -2123,18 +2144,27 @@ public static class AutoAlignmentEngine
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         StringBuilder log)
     {
+        // Always rebase (even a sub-hundredth minimum: a tiny negative left in
+        // the map would be an unrealizable delay), round onto the DSP's 0.01 ms
+        // grid, and only then judge the range on the values actually proposed.
+        // A channel with no entry and a zero result keeps NO entry — absence
+        // means "nothing proposed" (the reference), and the rebase must not
+        // manufacture zero-delay proposals for it.
         double minimum = scope.Min(
             item => alignment.GetValueOrDefault(item.Channel).DelayMs);
+        foreach (AlignmentSnapshot item in scope)
+        {
+            bool hasEntry = alignment.TryGetValue(
+                item.Channel, out AlignmentOverride current);
+            double rebasedMs = Math.Round(current.DelayMs - minimum, 2);
+            if (!hasEntry && rebasedMs == 0.0)
+            {
+                continue;
+            }
+            alignment[item.Channel] = current with { DelayMs = rebasedMs };
+        }
         if (Math.Abs(minimum) > 0.005)
         {
-            foreach (AlignmentSnapshot item in scope)
-            {
-                AlignmentOverride current = alignment.GetValueOrDefault(item.Channel);
-                alignment[item.Channel] = current with
-                {
-                    DelayMs = Math.Round(current.DelayMs - minimum, 2)
-                };
-            }
             log.AppendLine(
                 $"Normalized: {-minimum:+0.000;-0.000} ms to every channel " +
                 "(minimum delay back to zero)");
@@ -2594,17 +2624,36 @@ public static class AutoAlignmentEngine
             }
 
             // Both bounds are fixed BEFORE the search so the winning delta
-            // applies verbatim to both sides: negative deltas may not push
-            // either channel below zero, positive ones may not push either
-            // past the delay ceiling. Clamping after the fact would move the
-            // two sides unequally and silently bend the very scene this pass
-            // exists to preserve.
-            double minDelta = Math.Max(
-                lobeLowMs,
-                -Math.Min(leftOverride.DelayMs, rightOverride.DelayMs));
-            double maxDelta = Math.Min(
-                lobeHighMs,
-                MaxDelayMs - Math.Max(leftOverride.DelayMs, rightOverride.DelayMs));
+            // applies verbatim to both sides (clamping after the fact would
+            // move the two sides unequally and silently bend the very scene
+            // this pass exists to preserve). The move is RELATIVE — the pair
+            // against the rest of the field — so absolute positions are not
+            // walls: the same relative placement is reachable via a uniform
+            // rebase of everyone, and the bounds only close where the WHOLE
+            // field would run out of the DSP's range. Two plans differing by
+            // nothing but a global offset must co-move to the same relative
+            // answer (the mono co-move already works in this frame).
+            double pairMinMs = Math.Min(leftOverride.DelayMs, rightOverride.DelayMs);
+            double pairMaxMs = Math.Max(leftOverride.DelayMs, rightOverride.DelayMs);
+            List<IAlignmentChannel> fieldOthers = plan.LeftChannelsByBand
+                .Concat(plan.RightChannelsByBand)
+                .Select(item => item.Channel)
+                .Where(channel => channel != link.Left && channel != link.Right)
+                .Distinct()
+                .ToList();
+            double minDelta = lobeLowMs;
+            double maxDelta = lobeHighMs;
+            if (fieldOthers.Count > 0)
+            {
+                double maxOtherMs = fieldOthers.Max(
+                    channel => alignment.GetValueOrDefault(channel).DelayMs);
+                double minOtherMs = fieldOthers.Min(
+                    channel => alignment.GetValueOrDefault(channel).DelayMs);
+                minDelta = Math.Max(
+                    minDelta, -pairMinMs - (MaxDelayMs - maxOtherMs));
+                maxDelta = Math.Min(
+                    maxDelta, MaxDelayMs - pairMaxMs + minOtherMs);
+            }
             // The neighbor lobes can, in principle, exclude zero (a settled
             // neighbor a hair over half a period away); never let the window
             // invert or force a non-zero move — keeping the pair is always legal.

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -184,10 +184,12 @@ public static class AutoAlignmentEngine
     private const double LowJunctionReachFraction = 0.97;
 
     // The delay ceiling a proposal may reach, mirroring the UI's per-channel
-    // delay limit. Kept here so the uniform negative-delay shift can detect —
-    // and log — the rare case where clamping a pinned channel breaks the
-    // shift's alignment-preserving property.
-    private const double MaxDelayMs = 100;
+    // delay limit — which itself mirrors real car DSP hardware: even top-end
+    // processors cap per-channel delay around 30 ms (~10 m of path), so a
+    // proposal past it could never be transferred to the device. Real cabin
+    // spans run well under 10 ms; the ceiling exists for the feasibility
+    // gate, not as an operating region.
+    private const double MaxDelayMs = 30;
 
     // A deliberately wide fine-search window (many periods at a high crossover,
     // ~one at a low one). Its candidates are always logged, surfacing summation

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -462,6 +462,14 @@ public static class VirtualCrossoverAnalysis
     // noise from signal (two comparable noise floors pass a level test by
     // construction) — the engine's arrival-SNR refusal, which knows each
     // record's own noise floor, owns that judgement upstream.
+    /// <summary>
+    /// How many CONSECUTIVE evidence bins a qualifying run must hold besides
+    /// the octave width: at a low junction one coarse FFT cell can span a
+    /// sixth of an octave on its own, so width alone would let a lone bin —
+    /// or a gap credited to it — pass as broadband information.
+    /// </summary>
+    private const int MinEvidenceBins = 3;
+
     private static bool HoldsDelayEvidence(List<AlignmentBin> bins)
     {
         double signalPeak = 0;
@@ -472,28 +480,48 @@ public static class VirtualCrossoverAnalysis
         double levelFloor =
             signalPeak * Math.Pow(10.0, -EvidenceNoiseFloorGateDb / 20.0);
         double balanceRatio = Math.Pow(10.0, -OverlapReliabilityGateDb / 20.0);
-        double evidenceOctaves = 0;
-        for (int i = 0; i < bins.Count - 1; i++)
+        bool Evidence(AlignmentBin bin)
         {
-            AlignmentBin bin = bins[i];
             double weaker = Math.Min(
                 bin.FixedSum.Magnitude, bin.Variable.Magnitude);
             double stronger = Math.Max(
                 bin.FixedSum.Magnitude, bin.Variable.Magnitude);
-            if (bin.MagnitudeSum >= levelFloor &&
-                weaker >= stronger * balanceRatio)
+            return bin.MagnitudeSum >= levelFloor &&
+                weaker >= stronger * balanceRatio;
+        }
+
+        // The retained bins are a stride-decimated, zero-dropped sampling of
+        // the FFT grid, so consecutive list entries are not necessarily
+        // neighbors. Adjacency = the smallest FFT-index step present (the
+        // stride wherever any true neighbors survive); a run only accumulates
+        // across ADJACENT evidence pairs, so neither a dropped-bin gap nor a
+        // decimation hole can be credited to a lone lucky bin.
+        int minStep = int.MaxValue;
+        for (int i = 0; i + 1 < bins.Count; i++)
+        {
+            minStep = Math.Min(minStep, bins[i + 1].FftBin - bins[i].FftBin);
+        }
+
+        double runOctaves = 0;
+        int runBins = 1;
+        for (int i = 0; i + 1 < bins.Count; i++)
+        {
+            bool adjacent = bins[i + 1].FftBin - bins[i].FftBin == minStep;
+            if (adjacent && Evidence(bins[i]) && Evidence(bins[i + 1]))
             {
-                // LogWeight is 1/f; the step to the next bin is this stretch
-                // of log-frequency (the same accounting as the overlap
-                // read-out).
-                evidenceOctaves += Math.Log2(
-                    bins[i + 1].LogWeight > 0
-                        ? bin.LogWeight / bins[i + 1].LogWeight
-                        : 1.0);
-                if (evidenceOctaves >= MinEvidenceOctaves)
+                // LogWeight is 1/f, so the pair's stretch of log-frequency is
+                // log2(f[i+1]/f[i]).
+                runOctaves += Math.Log2(bins[i].LogWeight / bins[i + 1].LogWeight);
+                runBins++;
+                if (runOctaves >= MinEvidenceOctaves && runBins >= MinEvidenceBins)
                 {
                     return true;
                 }
+            }
+            else
+            {
+                runOctaves = 0;
+                runBins = 1;
             }
         }
         return false;
@@ -1313,7 +1341,11 @@ public static class VirtualCrossoverAnalysis
         Complex FixedSum,
         Complex Variable,
         double LogWeight,
-        double MagnitudeSum);
+        double MagnitudeSum,
+        // The source FFT bin index, so consumers can tell truly ADJACENT
+        // sampled bins from a gap where zero-magnitude bins were dropped —
+        // the evidence-width gate must not credit a gap to a lone bin.
+        int FftBin);
 
     // The direct-sound gate applied to every response before the alignment
     // spectra are taken: a cosine-faded Tukey window anchored one fade-length
@@ -1432,7 +1464,8 @@ public static class VirtualCrossoverAnalysis
                     fixedSpectrum[bin],
                     variableSpectrum[bin],
                     1.0 / frequencyHz,
-                    magnitudeSum));
+                    magnitudeSum,
+                    bin));
             }
         }
 

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -436,20 +436,32 @@ public static class VirtualCrossoverAnalysis
     /// </summary>
     private const double EvidenceNoiseFloorGateDb = 60;
 
-    // The delay-evidence gate: a delay is only OBSERVABLE where both sides
-    // genuinely radiate. With one side silent (or buried tens of dB under its
-    // partner everywhere — measurement noise, deconvolution residue) the loss
-    // |F+V|/(|F|+|V|) is flat at 0 dB for EVERY delay and polarity, so the
-    // search objective degenerates to the arrival prior alone and would
+    /// <summary>
+    /// The minimum integrated log-frequency width of balanced, above-floor
+    /// content the delay-evidence gate demands: a lobe-resolving broadband
+    /// delay cannot be read off a sliver (a lone lucky bin, a single shared
+    /// tone — whose delay is ambiguous modulo its own period). Healthy
+    /// junctions measure 0.4+ octaves of genuine overlap, so a sixth leaves
+    /// comfortable headroom while rejecting point coincidences.
+    /// </summary>
+    private const double MinEvidenceOctaves = 1.0 / 6.0;
+
+    // The delay-evidence STRUCTURE gate: a delay is only OBSERVABLE where both
+    // sides genuinely radiate over a usable width. With one side silent (or
+    // buried tens of dB under its partner everywhere — deconvolution residue)
+    // the loss |F+V|/(|F|+|V|) is flat at 0 dB for EVERY delay and polarity,
+    // so the search objective degenerates to the arrival prior alone and would
     // manufacture a confident "candidate" at the anchor out of nothing.
-    // Evidence exists where some bin has (a) the weaker side within the
-    // reliability gate of the STRONGER SIDE IN THAT BIN — a per-bin balance,
-    // judged locally like the sum-loss level gate, because one global
-    // reference would let a subwoofer's cabin-gain peak veto a perfectly
-    // healthy hand-over region sitting 30 dB below it — and (b) the bin
-    // itself above the in-band noise floor, so two matched residue tails
-    // cannot fake balance. No such bin: the search returns empty and the
-    // caller refuses honestly.
+    // Evidence bins need (a) the weaker side within the reliability gate of
+    // the STRONGER SIDE IN THAT BIN — a per-bin balance, judged locally like
+    // the sum-loss level gate, because one global reference would let a
+    // subwoofer's cabin-gain peak veto a perfectly healthy hand-over region
+    // sitting 30 dB below it — and (b) the bin above the in-band level floor;
+    // their integrated width must reach MinEvidenceOctaves. This grades
+    // spectral STRUCTURE relative to the record itself: it cannot tell true
+    // noise from signal (two comparable noise floors pass a level test by
+    // construction) — the engine's arrival-SNR refusal, which knows each
+    // record's own noise floor, owns that judgement upstream.
     private static bool HoldsDelayEvidence(List<AlignmentBin> bins)
     {
         double signalPeak = 0;
@@ -457,19 +469,31 @@ public static class VirtualCrossoverAnalysis
         {
             signalPeak = Math.Max(signalPeak, bin.MagnitudeSum);
         }
-        double noiseFloor =
+        double levelFloor =
             signalPeak * Math.Pow(10.0, -EvidenceNoiseFloorGateDb / 20.0);
         double balanceRatio = Math.Pow(10.0, -OverlapReliabilityGateDb / 20.0);
-        foreach (AlignmentBin bin in bins)
+        double evidenceOctaves = 0;
+        for (int i = 0; i < bins.Count - 1; i++)
         {
+            AlignmentBin bin = bins[i];
             double weaker = Math.Min(
                 bin.FixedSum.Magnitude, bin.Variable.Magnitude);
             double stronger = Math.Max(
                 bin.FixedSum.Magnitude, bin.Variable.Magnitude);
-            if (bin.MagnitudeSum >= noiseFloor &&
+            if (bin.MagnitudeSum >= levelFloor &&
                 weaker >= stronger * balanceRatio)
             {
-                return true;
+                // LogWeight is 1/f; the step to the next bin is this stretch
+                // of log-frequency (the same accounting as the overlap
+                // read-out).
+                evidenceOctaves += Math.Log2(
+                    bins[i + 1].LogWeight > 0
+                        ? bin.LogWeight / bins[i + 1].LogWeight
+                        : 1.0);
+                if (evidenceOctaves >= MinEvidenceOctaves)
+                {
+                    return true;
+                }
             }
         }
         return false;

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -411,7 +411,7 @@ public static class VirtualCrossoverAnalysis
             maxFrequencyHz,
             minDelayMs,
             maxDelayMs);
-        if (bins.Count == 0)
+        if (bins.Count == 0 || !HoldsDelayEvidence(bins))
         {
             allOptima = Array.Empty<AlignmentCandidate>();
             return Array.Empty<AlignmentCandidate>();
@@ -426,6 +426,53 @@ public static class VirtualCrossoverAnalysis
             priorSigmaMs,
             forcedPolarity,
             out allOptima);
+    }
+
+    /// <summary>
+    /// How far below the in-band signal peak a bin may sit and still count as
+    /// measured content for the delay-evidence gate — the same scale as the
+    /// loss floor (<see cref="MinBinAmplitudeRatio"/>, −60 dB): below it the
+    /// "content" is measurement noise or deconvolution residue, not a driver.
+    /// </summary>
+    private const double EvidenceNoiseFloorGateDb = 60;
+
+    // The delay-evidence gate: a delay is only OBSERVABLE where both sides
+    // genuinely radiate. With one side silent (or buried tens of dB under its
+    // partner everywhere — measurement noise, deconvolution residue) the loss
+    // |F+V|/(|F|+|V|) is flat at 0 dB for EVERY delay and polarity, so the
+    // search objective degenerates to the arrival prior alone and would
+    // manufacture a confident "candidate" at the anchor out of nothing.
+    // Evidence exists where some bin has (a) the weaker side within the
+    // reliability gate of the STRONGER SIDE IN THAT BIN — a per-bin balance,
+    // judged locally like the sum-loss level gate, because one global
+    // reference would let a subwoofer's cabin-gain peak veto a perfectly
+    // healthy hand-over region sitting 30 dB below it — and (b) the bin
+    // itself above the in-band noise floor, so two matched residue tails
+    // cannot fake balance. No such bin: the search returns empty and the
+    // caller refuses honestly.
+    private static bool HoldsDelayEvidence(List<AlignmentBin> bins)
+    {
+        double signalPeak = 0;
+        foreach (AlignmentBin bin in bins)
+        {
+            signalPeak = Math.Max(signalPeak, bin.MagnitudeSum);
+        }
+        double noiseFloor =
+            signalPeak * Math.Pow(10.0, -EvidenceNoiseFloorGateDb / 20.0);
+        double balanceRatio = Math.Pow(10.0, -OverlapReliabilityGateDb / 20.0);
+        foreach (AlignmentBin bin in bins)
+        {
+            double weaker = Math.Min(
+                bin.FixedSum.Magnitude, bin.Variable.Magnitude);
+            double stronger = Math.Max(
+                bin.FixedSum.Magnitude, bin.Variable.Magnitude);
+            if (bin.MagnitudeSum >= noiseFloor &&
+                weaker >= stronger * balanceRatio)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     /// <summary>

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
@@ -145,7 +145,7 @@ namespace Resonalyze
             numericDelay.ForeColor = Color.White;
             numericDelay.Increment = new decimal(new int[] { 1, 0, 0, 131072 });
             numericDelay.Location = new Point(220, 33);
-            numericDelay.Maximum = new decimal(new int[] { 30, 0, 0, 0 });
+            numericDelay.Maximum = new decimal(new int[] { 100, 0, 0, 0 });
             numericDelay.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
             numericDelay.MinimumSize = new Size(36, 19);
             numericDelay.Name = "numericDelay";

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
@@ -145,7 +145,7 @@ namespace Resonalyze
             numericDelay.ForeColor = Color.White;
             numericDelay.Increment = new decimal(new int[] { 1, 0, 0, 131072 });
             numericDelay.Location = new Point(220, 33);
-            numericDelay.Maximum = new decimal(new int[] { 100, 0, 0, 0 });
+            numericDelay.Maximum = new decimal(new int[] { 30, 0, 0, 0 });
             numericDelay.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
             numericDelay.MinimumSize = new Size(36, 19);
             numericDelay.Name = "numericDelay";

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -504,31 +504,102 @@ public sealed class AutoAlignmentEngineTests
     }
 
     [Fact]
-    public void Compute_SilentJunction_RefusesInsteadOfFabricatingADelay()
+    public void Compute_SilentJunction_RefusesTheRunInsteadOfFabricatingADelay()
     {
-        // The B/C junction has NO evidence at all (both IRs empty in — indeed
-        // anywhere near — the band). The engine used to fabricate a candidate
-        // at the coarse anchor and apply it as a result; it must refuse and
-        // say so instead.
+        // The B/C junction has NO evidence at all (both IRs empty). The engine
+        // used to fabricate a candidate at the coarse anchor and apply it as a
+        // result; a partial skip would be no better (earlier uniform shifts
+        // could leave the channel a foreign delay). The whole run must refuse
+        // with the reason.
         var woofer = new TestChannel("A", DelayedImpulse(1.0));
         var silentB = new TestChannel("B", new Complex[IrLength]);
         var silentC = new TestChannel("C", new Complex[IrLength]);
         var log = new StringBuilder();
-        var decisions = new Dictionary<IAlignmentChannel, AlignmentDecision>();
 
-        Dictionary<IAlignmentChannel, AlignmentOverride> alignment = Run(
-            [woofer, silentB, silentC], [200, 1_000], log,
-            decisions: decisions);
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => Run([woofer, silentB, silentC], [200, 1_000], log));
 
-        string text = log.ToString();
-        Assert.Contains("junction base unknown", text);
-        Assert.Contains("NO junction evidence", text);
-        Assert.Contains("left unchanged", text);
-        // The silent channels must not have received a fabricated delay.
-        Assert.Equal(0.0, alignment.GetValueOrDefault(silentC).DelayMs);
-        if (decisions.TryGetValue(silentC, out AlignmentDecision? refused))
+        Assert.Contains("No junction evidence", error.Message);
+        Assert.Contains("junction base unknown", log.ToString());
+    }
+
+    [Fact]
+    public void Compute_ActiveFixedAndSilentVariable_RefusesTheRun()
+    {
+        // The reviewer's exact scenario: the FIXED neighbor radiates normally,
+        // the searched channel is silent. Bins then exist (the fixed side's
+        // energy), the loss is flat 0 dB for every delay, and the arrival
+        // prior alone used to manufacture a confident candidate at the anchor.
+        // The evidence gate must return no candidates and the run must refuse.
+        var woofer = new TestChannel("A", DelayedImpulse(1.0));
+        var silent = new TestChannel("B", new Complex[IrLength]);
+        var log = new StringBuilder();
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => Run([woofer, silent], [1_000], log));
+
+        Assert.Contains("No junction evidence", error.Message);
+    }
+
+    [Fact]
+    public void Compute_SilentFixedAndActiveVariable_RefusesTheRun()
+    {
+        // The mirror direction: the reference channel is the silent one.
+        var silent = new TestChannel("A", new Complex[IrLength]);
+        var tweeter = new TestChannel("B", DelayedImpulse(0.0));
+        var log = new StringBuilder();
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => Run([silent, tweeter], [1_000], log));
+
+        Assert.Contains("No junction evidence", error.Message);
+    }
+
+    private static TimeAlignmentAnalysisResult Read(
+        double arrivalMs, double snrDb = 40, bool valid = true) =>
+        default(TimeAlignmentAnalysisResult) with
         {
-            Assert.Contains("no junction evidence", refused.Detail);
+            FirstArrivalDelayMilliseconds = arrivalMs,
+            SignalToNoiseDecibels = snrDb,
+            IsValid = valid
+        };
+
+    // The single classification behind the cross-side links, the donor
+    // certificates and the stereo bridge — table-tested so the three
+    // consumers cannot drift apart. (An inline table rather than a Theory:
+    // the certificate enum is internal and must not appear in a public test
+    // signature.)
+    [Fact]
+    public void ClassifyArrival_GradesTheHonestyProbe()
+    {
+        var table = new (double FullMs, double ProbeMs, double ProbeSnrDb,
+            bool ProbeValid, AutoAlignmentEngine.ArrivalCertificate Expected)[]
+        {
+            // agreeing reads certify
+            (10.0, 10.4, 40.0, true, AutoAlignmentEngine.ArrivalCertificate.Verified),
+            // full far LATER than its upper half: the proven modal latch
+            (21.2, 13.9, 40.0, true, AutoAlignmentEngine.ArrivalCertificate.Latched),
+            // full far EARLIER: the probe is blind to the front — usable, uncertified
+            (8.0, 20.0, 40.0, true, AutoAlignmentEngine.ArrivalCertificate.Unverified),
+            // probe below the SNR floor cannot certify
+            (10.0, 10.1, 5.0, true, AutoAlignmentEngine.ArrivalCertificate.Unverified),
+            // invalid probe cannot certify
+            (10.0, 0.0, 40.0, false, AutoAlignmentEngine.ArrivalCertificate.Unverified),
+            // exactly at the tolerance edge still certifies
+            (12.0, 10.0, 40.0, true, AutoAlignmentEngine.ArrivalCertificate.Verified),
+        };
+
+        foreach (var row in table)
+        {
+            AutoAlignmentEngine.ArrivalCertificate actual =
+                AutoAlignmentEngine.ClassifyArrival(
+                    Read(row.FullMs),
+                    Read(row.ProbeMs, row.ProbeSnrDb, row.ProbeValid),
+                    toleranceMs: 2.0);
+            Assert.True(row.Expected == actual,
+                $"full {row.FullMs}, probe {row.ProbeMs} " +
+                $"(SNR {row.ProbeSnrDb}, valid {row.ProbeValid}): " +
+                $"expected {row.Expected}, got {actual}");
         }
     }
 

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -571,6 +571,36 @@ public sealed class AutoAlignmentEngineTests
         Assert.Contains("No junction evidence", error.Message);
     }
 
+    // A continuous shared spectral line: identical in both channels, so no
+    // per-bin level test can tell it from a real junction — but a line has no
+    // timeable front (its band-limited envelope is FLAT, reading ~-7 dB SNR
+    // against the 12 dB floor), which is exactly what the arrival-SNR
+    // evidence refusal measures. A single tone cannot resolve a broadband
+    // delay (it is ambiguous modulo its own period), so refusing is honest.
+    private static Complex[] SharedLineIr(double toneHz, double startMs)
+    {
+        var ir = new Complex[IrLength];
+        int start = BasePosition + (int)Math.Round(startMs / 1000.0 * SampleRate);
+        for (int i = 0; start + i < ir.Length; i++)
+        {
+            ir[start + i] = Math.Sin(Math.Tau * toneHz * i / SampleRate);
+        }
+        return ir;
+    }
+
+    [Fact]
+    public void Compute_SharedNarrowLineOnALowJunction_RefusesTheRun()
+    {
+        var lower = new TestChannel("A", SharedLineIr(120, 1.0));
+        var upper = new TestChannel("B", SharedLineIr(120, 1.2));
+        var log = new StringBuilder();
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => Run([lower, upper], [120], log, bands: [(80, 175)]));
+
+        Assert.Contains("No junction evidence", error.Message);
+    }
+
     [Fact]
     public void Compute_ActiveFixedAndSilentVariable_RefusesTheRun()
     {

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -64,7 +64,8 @@ public sealed class AutoAlignmentEngineTests
         double[] crossoversHz,
         StringBuilder log,
         (double LowHz, double HighHz)[]? bands = null,
-        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null)
+        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null,
+        Dictionary<IAlignmentChannel, AlignmentOverride>? alignment = null)
     {
         var snapshots = byBand.ToDictionary(
             channel => channel,
@@ -98,7 +99,7 @@ public sealed class AutoAlignmentEngineTests
                 })
                 .ToList();
 
-        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        alignment ??= new Dictionary<IAlignmentChannel, AlignmentOverride>();
         AutoAlignmentEngine.Compute(
             byBand.Select(channel => snapshots[channel]).ToList(),
             junctions,
@@ -448,5 +449,115 @@ public sealed class AutoAlignmentEngineTests
             Reprocess,
             new Dictionary<IAlignmentChannel, AlignmentOverride>(),
             new StringBuilder()));
+    }
+
+    // A channel whose sample rate differs from the harness default, for the
+    // mixed-rate rejection below.
+    private sealed class OddRateChannel(string name, Complex[] ir) : IAlignmentChannel
+    {
+        public string Name { get; } = name;
+        public int SampleRate => 44_100;
+        public Complex[] Ir { get; } = ir;
+    }
+
+    [Fact]
+    public void Compute_RejectsMixedSampleRates()
+    {
+        // Every cross-channel figure assumes ONE rate; mixed rates would
+        // silently misscale frequencies and delays rather than fail.
+        var woofer = new TestChannel("W", DelayedImpulse(1.0));
+        var odd = new OddRateChannel("T", DelayedImpulse(0.0));
+        var wooferSnapshot = new AlignmentSnapshot(
+            woofer, woofer.InitialIr, BasePosition);
+        var oddSnapshot = new AlignmentSnapshot(odd, odd.Ir, BasePosition);
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            [wooferSnapshot, oddSnapshot];
+
+        ArgumentException error = Assert.Throws<ArgumentException>(
+            () => AutoAlignmentEngine.Compute(
+                [wooferSnapshot, oddSnapshot],
+                [new AlignmentJunction(wooferSnapshot, oddSnapshot, 1_000, 500, 2_000)],
+                Reprocess,
+                new Dictionary<IAlignmentChannel, AlignmentOverride>(),
+                new StringBuilder()));
+        Assert.Contains("sample rate", error.Message);
+    }
+
+    [Fact]
+    public void Compute_ClearsAStaleAlignmentMap()
+    {
+        // The contract promises an ABSOLUTE proposal: stale entries (a repeat
+        // call with the same dictionary) must not leak into the neighbor bases.
+        var woofer = new TestChannel("W", DelayedImpulse(1.0));
+        var tweeter = new TestChannel("T", DelayedImpulse(0.0));
+        var stale = new TestChannel("stale", DelayedImpulse(0.0));
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [stale] = new AlignmentOverride(42.0, true)
+        };
+        var log = new StringBuilder();
+
+        Run([woofer, tweeter], [1_000], log, alignment: alignment);
+
+        Assert.False(alignment.ContainsKey(stale));
+    }
+
+    [Fact]
+    public void Compute_SilentJunction_RefusesInsteadOfFabricatingADelay()
+    {
+        // The B/C junction has NO evidence at all (both IRs empty in — indeed
+        // anywhere near — the band). The engine used to fabricate a candidate
+        // at the coarse anchor and apply it as a result; it must refuse and
+        // say so instead.
+        var woofer = new TestChannel("A", DelayedImpulse(1.0));
+        var silentB = new TestChannel("B", new Complex[IrLength]);
+        var silentC = new TestChannel("C", new Complex[IrLength]);
+        var log = new StringBuilder();
+        var decisions = new Dictionary<IAlignmentChannel, AlignmentDecision>();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment = Run(
+            [woofer, silentB, silentC], [200, 1_000], log,
+            decisions: decisions);
+
+        string text = log.ToString();
+        Assert.Contains("junction base unknown", text);
+        Assert.Contains("NO junction evidence", text);
+        Assert.Contains("left unchanged", text);
+        // The silent channels must not have received a fabricated delay.
+        Assert.Equal(0.0, alignment.GetValueOrDefault(silentC).DelayMs);
+        if (decisions.TryGetValue(silentC, out AlignmentDecision? refused))
+        {
+            Assert.Contains("no junction evidence", refused.Detail);
+        }
+    }
+
+    [Fact]
+    public void NormalizeAndVerifyFeasibility_LiftsTheFieldAndRefusesAWideSpan()
+    {
+        var early = new TestChannel("E", DelayedImpulse(0.0));
+        var late = new TestChannel("L", DelayedImpulse(1.0));
+        var earlySnapshot = new AlignmentSnapshot(early, early.InitialIr, BasePosition);
+        var lateSnapshot = new AlignmentSnapshot(late, late.InitialIr, BasePosition);
+
+        // A field of 20..90 normalizes to 0..70 (a uniform trim, relations kept).
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [early] = new AlignmentOverride(20.0, false),
+            [late] = new AlignmentOverride(90.0, false)
+        };
+        AutoAlignmentEngine.NormalizeAndVerifyFeasibility(
+            [earlySnapshot, lateSnapshot], alignment, new StringBuilder());
+        Assert.Equal(0.0, alignment[early].DelayMs, 2);
+        Assert.Equal(70.0, alignment[late].DelayMs, 2);
+
+        // A span wider than the DSP's 100 ms range cannot be realized by any
+        // uniform shift: the proposal must refuse loudly, not clamp silently.
+        alignment[early] = new AlignmentOverride(0.0, false);
+        alignment[late] = new AlignmentOverride(150.0, false);
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => AutoAlignmentEngine.NormalizeAndVerifyFeasibility(
+                [earlySnapshot, lateSnapshot], alignment, new StringBuilder()));
+        Assert.Contains("does not fit", error.Message);
     }
 }

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -520,7 +520,55 @@ public sealed class AutoAlignmentEngineTests
             () => Run([woofer, silentB, silentC], [200, 1_000], log));
 
         Assert.Contains("No junction evidence", error.Message);
-        Assert.Contains("junction base unknown", log.ToString());
+        Assert.Contains("refusing the run", log.ToString());
+    }
+
+    // Deterministic seeded noise: a dead channel in the field is noise, not
+    // digital zeros. Its band-limited envelope SNR reads ~8 dB (a flat record
+    // has no quiet quarter), comfortably under the 12 dB floor — the arrival
+    // detector's own noise reference is what tells noise from signal, which
+    // per-bin spectral levels alone cannot.
+    private static Complex[] NoiseIr(int seed, double amplitude)
+    {
+        var random = new Random(seed);
+        var ir = new Complex[IrLength];
+        for (int i = 0; i < ir.Length; i++)
+        {
+            ir[i] = amplitude * (random.NextDouble() * 2.0 - 1.0);
+        }
+        return ir;
+    }
+
+    [Fact]
+    public void Compute_IndependentEqualLevelNoise_RefusesTheRun()
+    {
+        // Two comparable noise channels pass any per-bin level balance by
+        // construction; the loss surface is noise phases and the prior would
+        // pick a delay. The arrival-SNR evidence gate must refuse the run.
+        var noiseA = new TestChannel("A", NoiseIr(1, 1.0));
+        var noiseB = new TestChannel("B", NoiseIr(2, 1.0));
+        var log = new StringBuilder();
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => Run([noiseA, noiseB], [1_000], log));
+
+        Assert.Contains("No junction evidence", error.Message);
+    }
+
+    [Fact]
+    public void Compute_ActiveAndLowLevelNoise_RefusesTheRun()
+    {
+        // A live neighbor plus a channel that is only -40 dB measurement
+        // noise: bins exist and the noise even "balances" some of them, but
+        // the noise channel's own arrival SNR exposes it.
+        var woofer = new TestChannel("A", DelayedImpulse(1.0));
+        var noise = new TestChannel("B", NoiseIr(3, 0.01));
+        var log = new StringBuilder();
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => Run([woofer, noise], [1_000], log));
+
+        Assert.Contains("No junction evidence", error.Message);
     }
 
     [Fact]
@@ -601,6 +649,18 @@ public sealed class AutoAlignmentEngineTests
                 $"(SNR {row.ProbeSnrDb}, valid {row.ProbeValid}): " +
                 $"expected {row.Expected}, got {actual}");
         }
+
+        // The classifier is self-sufficient: an unmeasurable or near-noise
+        // FULL read cannot be certified (or latched) either — no hidden
+        // caller-side precondition.
+        Assert.Equal(
+            AutoAlignmentEngine.ArrivalCertificate.Unverified,
+            AutoAlignmentEngine.ClassifyArrival(
+                Read(10.0, valid: false), Read(10.2), toleranceMs: 2.0));
+        Assert.Equal(
+            AutoAlignmentEngine.ArrivalCertificate.Unverified,
+            AutoAlignmentEngine.ClassifyArrival(
+                Read(10.0, snrDb: 5.0), Read(10.2), toleranceMs: 2.0));
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -611,21 +611,22 @@ public sealed class AutoAlignmentEngineTests
         var earlySnapshot = new AlignmentSnapshot(early, early.InitialIr, BasePosition);
         var lateSnapshot = new AlignmentSnapshot(late, late.InitialIr, BasePosition);
 
-        // A field of 20..90 normalizes to 0..70 (a uniform trim, relations kept).
+        // A field of 8..28 normalizes to 0..20 (a uniform trim, relations kept).
         var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
         {
-            [early] = new AlignmentOverride(20.0, false),
-            [late] = new AlignmentOverride(90.0, false)
+            [early] = new AlignmentOverride(8.0, false),
+            [late] = new AlignmentOverride(28.0, false)
         };
         AutoAlignmentEngine.NormalizeAndVerifyFeasibility(
             [earlySnapshot, lateSnapshot], alignment, new StringBuilder());
         Assert.Equal(0.0, alignment[early].DelayMs, 2);
-        Assert.Equal(70.0, alignment[late].DelayMs, 2);
+        Assert.Equal(20.0, alignment[late].DelayMs, 2);
 
-        // A span wider than the DSP's 100 ms range cannot be realized by any
-        // uniform shift: the proposal must refuse loudly, not clamp silently.
+        // A span wider than the DSP's 30 ms delay range (real car processors
+        // cap there) cannot be realized by any uniform shift: the proposal
+        // must refuse loudly, not clamp silently.
         alignment[early] = new AlignmentOverride(0.0, false);
-        alignment[late] = new AlignmentOverride(150.0, false);
+        alignment[late] = new AlignmentOverride(45.0, false);
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(
             () => AutoAlignmentEngine.NormalizeAndVerifyFeasibility(
                 [earlySnapshot, lateSnapshot], alignment, new StringBuilder()));

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -86,25 +86,32 @@ public sealed class StereoAlignmentTests
             double rightMidEchoMs = 0,
             double leftLateMs = 0,
             double rightMidAmplitude = 1.0,
-            int[]? reprocessCount = null)
+            int[]? reprocessCount = null,
+            double globalLateMs = 0)
     {
-        var sub = new TestChannel("sub", ImpulseAtMs(2.0 + leftLateMs));
-        var leftWoof = new TestChannel("L woof", ImpulseAtMs(1.0 + leftLateMs));
-        var leftMid = new TestChannel("L mid", ImpulseAtMs(0.4 + leftLateMs));
+        var sub = new TestChannel(
+            "sub", ImpulseAtMs(2.0 + leftLateMs + globalLateMs));
+        var leftWoof = new TestChannel(
+            "L woof", ImpulseAtMs(1.0 + leftLateMs + globalLateMs));
+        var leftMid = new TestChannel(
+            "L mid", ImpulseAtMs(0.4 + leftLateMs + globalLateMs));
         var leftTwr = new TestChannel(
-            "L twr", ImpulseAtMs(0.0 + leftLateMs, leftTopAmplitude));
-        var rightWoof = new TestChannel("R woof", ImpulseAtMs(1.0 + rightLateMs));
+            "L twr", ImpulseAtMs(0.0 + leftLateMs + globalLateMs, leftTopAmplitude));
+        var rightWoof = new TestChannel(
+            "R woof", ImpulseAtMs(1.0 + rightLateMs + globalLateMs));
         Complex[] rightMidIr = ImpulseAtMs(
-            0.4 + rightLateMs, rightMidEchoMs > 0 ? 0.6 : rightMidAmplitude);
+            0.4 + rightLateMs + globalLateMs,
+            rightMidEchoMs > 0 ? 0.6 : rightMidAmplitude);
         if (rightMidEchoMs > 0)
         {
             int echoPosition = BasePosition + (int)Math.Round(
-                (0.4 + rightLateMs + rightMidEchoMs) / 1000.0 * SampleRate);
+                (0.4 + rightLateMs + globalLateMs + rightMidEchoMs)
+                    / 1000.0 * SampleRate);
             rightMidIr[echoPosition] += Complex.One;
         }
         var rightMid = new TestChannel("R mid", rightMidIr);
         var rightTwr = new TestChannel(
-            "R twr", ImpulseAtMs(0.0 + rightLateMs, rightTopAmplitude));
+            "R twr", ImpulseAtMs(0.0 + rightLateMs + globalLateMs, rightTopAmplitude));
 
         TestChannel[] leftByBand = [sub, leftWoof, leftMid, leftTwr];
         TestChannel[] rightByBand = [sub, rightWoof, rightMid, rightTwr];
@@ -793,6 +800,38 @@ public sealed class StereoAlignmentTests
         Assert.NotNull(decision.Confidence);
         Assert.Contains("mono co-move", decision.Detail);
         Assert.Contains("reference", decision.Detail);
+    }
+
+    [Fact]
+    public void ComputeStereo_IsInvariantToAGlobalTimeOffset()
+    {
+        // Two systems differing by nothing but a uniform acoustic offset are
+        // the SAME system: every relative quantity — the walk's bases, the
+        // scene, and above all the co-move windows (which once bounded by
+        // absolute [0, ceiling] positions and so depended on the transient
+        // global offset) — must produce the identical normalized proposal.
+        (TestChannel _, TestChannel[] leftA, TestChannel[] rightA,
+            Dictionary<IAlignmentChannel, AlignmentOverride> baseline, _) =
+            RunStereo(sceneOffsetMs: 0.25, linkBands: UserLinkBands);
+        (TestChannel _, TestChannel[] leftB, TestChannel[] rightB,
+            Dictionary<IAlignmentChannel, AlignmentOverride> offset, _) =
+            RunStereo(
+                sceneOffsetMs: 0.25,
+                linkBands: UserLinkBands,
+                globalLateMs: 15.0);
+
+        TestChannel[] channelsA = [leftA[0], leftA[1], leftA[2], rightA[0], rightA[1], rightA[2]];
+        TestChannel[] channelsB = [leftB[0], leftB[1], leftB[2], rightB[0], rightB[1], rightB[2]];
+        for (int i = 0; i < channelsA.Length; i++)
+        {
+            Assert.Equal(
+                baseline.GetValueOrDefault(channelsA[i]).DelayMs,
+                offset.GetValueOrDefault(channelsB[i]).DelayMs,
+                2);
+            Assert.Equal(
+                baseline.GetValueOrDefault(channelsA[i]).InvertPolarity,
+                offset.GetValueOrDefault(channelsB[i]).InvertPolarity);
+        }
     }
 
     // ---- the pure latched-fallback donor resolver (unit-tested directly, since

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -573,58 +573,38 @@ public sealed class StereoAlignmentTests
     [Fact]
     public void ComputeStereo_NearTheDelayCeilingTheSceneSurvives()
     {
-        // The left side is 99.2 ms late, parking the whole right side just
-        // under the 100 ms delay ceiling. Every pass that adds delay from
-        // here — the co-move above all — must bound its window by the ceiling
-        // UP FRONT: clamping one side after the fact would move the two sides
+        // The left side is 26 ms late, parking the whole right side just
+        // under the 30 ms delay ceiling (real car DSPs cap per-channel delay
+        // around 30 ms — the ceiling is the transferable range, not an
+        // operating region). Every pass that adds delay from here — the
+        // co-move above all — must bound its window by the remaining span UP
+        // FRONT: clamping one side after the fact would move the two sides
         // unequally and silently bend the scene. Both linked pairs must still
         // read the scene offset at the end and nothing may exceed the limit.
+        // (At this realistic lateness the impulses sit well inside the
+        // detector's linear range, so the scene is measured directly on the
+        // final proposal — the normalization is uniform and scene-invariant.)
         (TestChannel sub, TestChannel[] left, TestChannel[] right,
             Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
             StringBuilder log) = RunStereo(
                 sceneOffsetMs: 0.25,
                 rightLateMs: 0,
                 linkBands: UserLinkBands,
-                leftLateMs: 99.2);
+                leftLateMs: 26.0);
 
         Assert.Contains("Co-move", log.ToString());
         Assert.All(
             new[] { sub, left[0], left[1], left[2], right[0], right[1], right[2] },
             channel => Assert.True(
-                alignment.GetValueOrDefault(channel).DelayMs is >= 0 and <= 100));
+                alignment.GetValueOrDefault(channel).DelayMs is >= 0 and <= 30));
 
-        // At this lateness the impulses sit ~110 ms into the record — beyond
-        // the band-arrival detector's search reach, where its read is a
-        // nonlinear function of absolute position. A uniform shift (the final
-        // normalization, which the mono co-move can re-trigger by lifting the
-        // minimum delay) is scene-invariant by definition but moves those
-        // saturated reads unequally, so the scene is measured at the
-        // PRE-normalization positions: the normalization amount added back to
-        // every channel identically, restoring the exact positions the walk
-        // and the co-moves actually balanced.
-        double normalizedMs = 0;
-        Match normalized = Regex.Match(
-            log.ToString(), @"Normalized: -([\d.,]+) ms");
-        if (normalized.Success)
-        {
-            normalizedMs = double.Parse(
-                normalized.Groups[1].Value, CultureInfo.CurrentCulture);
-        }
-
-        Dictionary<IAlignmentChannel, AlignmentOverride> preNormalization =
-            alignment.ToDictionary(
-                item => item.Key,
-                item => item.Value with
-                {
-                    DelayMs = item.Value.DelayMs + normalizedMs
-                });
         double twrDelta =
-            FinalBandArrivalMs(left[2], preNormalization, 2_500, 12_000) -
-            FinalBandArrivalMs(right[2], preNormalization, 2_500, 12_000);
+            FinalBandArrivalMs(left[2], alignment, 2_500, 12_000) -
+            FinalBandArrivalMs(right[2], alignment, 2_500, 12_000);
         Assert.InRange(twrDelta, 0.15, 0.35);
         double midDelta =
-            FinalBandArrivalMs(left[1], preNormalization, 400, 2_500) -
-            FinalBandArrivalMs(right[1], preNormalization, 400, 2_500);
+            FinalBandArrivalMs(left[1], alignment, 400, 2_500) -
+            FinalBandArrivalMs(right[1], alignment, 400, 2_500);
         Assert.InRange(midDelta, 0.15, 0.35);
     }
 

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -219,6 +219,28 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void FindAlignmentCandidates_OneSidedSilence_ReturnsEmpty()
+    {
+        // With one side silent the loss |F+V|/(|F|+|V|) is flat 0 dB for every
+        // delay and polarity — no delay evidence exists, and returning
+        // prior-shaped "candidates" would let a caller fabricate an alignment.
+        Complex[] active = UnitImpulse(4_096, 100);
+        var silent = new Complex[4_096];
+
+        IReadOnlyList<AlignmentCandidate> silentVariable =
+            VirtualCrossoverAnalysis.FindAlignmentCandidates(
+                silent, [active], SampleRate, 500, 2_000, -3, 3,
+                priorDelayMs: 0.5, priorSigmaMs: 1.0);
+        IReadOnlyList<AlignmentCandidate> silentFixed =
+            VirtualCrossoverAnalysis.FindAlignmentCandidates(
+                active, [silent], SampleRate, 500, 2_000, -3, 3,
+                priorDelayMs: 0.5, priorSigmaMs: 1.0);
+
+        Assert.Empty(silentVariable);
+        Assert.Empty(silentFixed);
+    }
+
+    [Fact]
     public void EffectiveOverlapOctaves_SilentVariableHasNoOverlap()
     {
         Complex[] fixedIr = UnitImpulse(4_096, 100);


### PR DESCRIPTION
Follow-up to a full static audit of `AutoAlignmentEngine`. The audit's central finding: the engine's remaining risk is that it doesn't say **"I don't know"** often enough — absence of data could become a confident delay. This pass closes the confirmed P1/P2 paths where that happened.

## What changed

**No fabricated results (audit P1, hardened per review).** `BuildArrivalTimeline` used `FindBandLimitedArrivalMs`, which discards `IsValid`/SNR — an unmeasurable band silently became a 0 ms "arrival" anchoring the fine search. Now the full analysis is read and gated: an unmeasurable junction base is declared unknown (zero seed + the wide/untrusted window, PHAT skipped since its search window would center on the same fiction) and logged. The review then showed the fabrication also survived *implicitly*: with one side silent, bins still exist (the live side's energy), the loss is flat 0 dB, and the arrival prior alone manufactured a candidate at the anchor. `FindAlignmentCandidates` now holds a **delay-evidence gate** — empty unless a **contiguous run of adjacent bins** (per FFT index — a dropped-bin gap cannot be credited to a lone bin), at least three bins and a sixth of an octave wide, has the weaker side within the reliability gate of the stronger side *in each bin* (a local, per-bin balance: a global reference let a subwoofer's cabin-gain peak veto a healthy hand-over 30 dB below it, caught by the config matrix) above the in-band −60 dB level floor. The structure gate cannot tell true noise from signal (matched levels pass any level test); that judgement is the **arrival-SNR evidence refusal** in the timeline, which knows each record's own noise floor — seeded noise reads ~8 dB and a shared spectral line (no timeable front) ~−7 dB against the 12 dB floor, both refused deterministically and pinned by engine tests. With no evidence in either window the **run refuses** with the reason — a partial "skip this channel" could leave it a delay from earlier uniform shifts, so an unmeasurable channel aborts the proposal and points the user at the dead driver / wrong source / mis-set crossover.

**Loud infeasibility (audit P1).** Every mid-run delay clamp is gone: a per-channel clamp after a uniform shift silently broke the relative delays and the stereo scene while the proposal still looked normal. Transient out-of-range values are legal (only relations matter mid-run); the final normalization lifts/trims uniformly, and a single feasibility gate then **throws** when the measured spread exceeds the proposal's delay range — the dialog surfaces it as a failed run with the reason. That range is **30 ms**: real car processors cap per-channel delay there, so an automatic proposal past it could never be transferred to a device. The *manual* UI keeps its 100 ms range (the Virtual DSP may model whatever hardware the user owns) — lowering it broke old-project consistency (model 50 ms / display 30 ms) and was reverted per review.

**Bridge honesty probe (audit P1/P2).** The bridge — one read per side timing the whole right side — passed on `IsValid` + SNR alone. It now gets the same full-band vs upper-half agreement check as every cross-side read: a full band timing *later* than its own upper half (not a direct front) **refuses the bridge**; an uncertifiable probe lets it proceed with confidence capped at Low.

**One arrival classifier (review P2).** The full-vs-upper-half semantics (Latched / Unverified / Verified) are now a single internal `ClassifyArrival` helper feeding the cross-side links, the donor certificates and the bridge — table-tested so the three cannot drift apart.

**Coordinate-invariant pair co-move (review P2).** The pair co-move bounded its window by absolute [0, 100 ms] positions, so two states differing only by a global offset co-moved differently; it now bounds by the field span, as the mono co-move already did. Normalization always rebases onto the 0.01 ms grid and judges the range on the rounded values.

**Direction-aware honesty gate (audit P1/P2).** The cross-side gate only rejected a full-band read that was *late* against its upper half. It is now direction-aware: **full-late** = the proven latch (the read times the wrong feature — garbage; ladder/donor substitution as before); **full-early** = the probe is blind to the front (the read stands, but earns **no certificate** — lobe pin only, never the tight ±0.05 scene lock). Validation showed why a plain `Abs()` (the audit's literal suggestion) is wrong: in the near-ceiling regime it poisoned *self-consistent* reads and substituted cross-band donors, bending the scene by 8 ms — the asymmetric form is the physically-motivated version of the same requirement, which the audit explicitly allowed. Donor certification stays strictly two-sided (a donor must be *positively* clean). An invalid/low-SNR upper half likewise no longer counts as "no latch = clean": such reads are usable but unverified → coarse lock.

**Entry validation (audit P2).** Mixed channel sample rates throw with a clear message (every cross-channel figure assumes one rate); a non-empty `alignment`/`decisions` map is cleared on the public entry points, honoring the documented absolute-proposal contract.

## Deliberately out of scope (per the agreed triage)

Reliability weighting inside the loss objective, separate two-neighbour junction objectives, exhaustive plan-topology validation, rounded-delay rescoring, and the perf items — each deferred with its own rationale (measure-first for the first two).

## Validation (real v3 data + suites)

- `bad_plus` and **10/12** stereo crossover configs are **bit-identical** to `main`.
- The **2/12** changed configs are the intended semantics: their 300–400 Hz localization band is too narrow for the honesty probe, so their previously **uncertified** tight ±0.05 lock degrades to the coarse lobe lock; the scene stays within ±0.2 ms of target.
- 778 dsp + 497 app tests green (new: mixed-rate rejection, stale-map clearing, one-sided silence in both directions at the dsp and engine level, the `ClassifyArrival` table, the feasibility gate directly).
- Round-2 note: the first evidence-gate draft used a global level reference and wrongly refused the BW 50/500 config's sub↔midbass junction — the config matrix caught it before commit; the shipped gate judges per-bin balance locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
