### PR TITLE
Time Alignment honesty + band modes + crosstalk head gate

### DIFF
--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -388,8 +388,11 @@ public static class AutoAlignmentEngine
     /// lock). VERIFIED — the two agree within the dispersion one wavefront
     /// can show. One classification shared by the cross-side links, the donor
     /// certificates and the stereo bridge, so the three cannot drift apart.
+    /// Public because the manual Time Alignment mode surfaces the same
+    /// verdict on its bandpass-windowed reads (see
+    /// <see cref="TimeAlignmentAnalysis.ProbeArrivalHonesty"/>).
     /// </summary>
-    internal enum ArrivalCertificate
+    public enum ArrivalCertificate
     {
         Unverified,
         Latched,

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -56,6 +56,18 @@ public readonly record struct TimeAlignmentAnalysisResult(
     // result reports zeros and must not be shown as an alignment.
     bool IsValid = true);
 
+/// <summary>
+/// The verdict and figures of <see cref="TimeAlignmentAnalysis.ProbeArrivalHonesty"/>:
+/// the upper-half re-read ([ProbeLowHz, ProbeHighHz]) and the tolerance the
+/// full-band arrival was graded against.
+/// </summary>
+public readonly record struct TimeAlignmentArrivalProbe(
+    AutoAlignmentEngine.ArrivalCertificate Certificate,
+    TimeAlignmentAnalysisResult ProbeResult,
+    double ProbeLowHz,
+    double ProbeHighHz,
+    double ToleranceMs);
+
 public static class TimeAlignmentAnalysis
 {
     public static TimeAlignmentAnalysisResult Analyze(
@@ -206,6 +218,66 @@ public static class TimeAlignmentAnalysis
             firstArrival.RefinedByPhat,
             strongest.Confidence,
             strongest.RefinedByPhat);
+    }
+
+    /// <summary>
+    /// The arrival honesty probe for a bandpass-windowed manual measurement:
+    /// the same full-band-vs-upper-half check the auto-alignment engine runs
+    /// on every cross-side read. The upper half of the pass band is
+    /// re-analyzed with the SAME pipeline (only the lower edge rises; the top
+    /// edge and its fade stay put) and the full read is graded against it: a
+    /// full-band arrival far LATER than its own upper half is the proven
+    /// modal latch — the read times the band's late build-up (a room mode),
+    /// not the direct front. Returns null when no bandpass window is active,
+    /// or when the pass band is too narrow to carve a measurable upper half
+    /// (<see cref="VirtualCrossoverAnalysis.MinimumArrivalBandRatio"/>).
+    /// </summary>
+    public static TimeAlignmentArrivalProbe? ProbeArrivalHonesty(
+        IReadOnlyList<double> impulseResponse,
+        int sampleRate,
+        TimeAlignmentAnalysisOptions options,
+        TimeAlignmentAnalysisResult fullResult,
+        IReadOnlyList<double>? coherence = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (!options.UseBandpassWindow)
+        {
+            return null;
+        }
+
+        (_, double f2, double f3, _) = BandpassWindow.BandAround(
+            options.BandpassCenterHz,
+            options.BandpassPassOctaves,
+            options.BandpassFadeOctaves);
+        double probeLowHz = Math.Sqrt(f2 * f3);
+        if (f3 < probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
+        {
+            return null;
+        }
+
+        var probeOptions = new TimeAlignmentAnalysisOptions
+        {
+            UseBandpassWindow = true,
+            BandpassCenterHz = Math.Sqrt(probeLowHz * f3),
+            BandpassPassOctaves = Math.Log2(f3 / probeLowHz),
+            BandpassFadeOctaves = options.BandpassFadeOctaves,
+            FirstPeakThresholdBelowMaxDb = options.FirstPeakThresholdBelowMaxDb,
+            FirstPeakMinimumSnrDb = options.FirstPeakMinimumSnrDb,
+            PeakSearchWindowMilliseconds = options.PeakSearchWindowMilliseconds,
+            WrapPeakPositions = options.WrapPeakPositions
+        };
+        TimeAlignmentAnalysisResult probeResult = Analyze(
+            impulseResponse, sampleRate, probeOptions, coherence);
+        // The engine's bridge-probe allowance: the dispersion one wavefront
+        // can show across the band — half a period at the probe's lower edge,
+        // never tighter than 1 ms.
+        double toleranceMs = Math.Max(1.0, 500.0 / probeLowHz);
+        return new TimeAlignmentArrivalProbe(
+            AutoAlignmentEngine.ClassifyArrival(fullResult, probeResult, toleranceMs),
+            probeResult,
+            probeLowHz,
+            f3,
+            toleranceMs);
     }
 
     // The minimum normalized GCC-PHAT peak height for its refined lag to be

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -69,6 +69,12 @@ public static class TransferIrDiagnostics
     // a millisecond-scale event; anything longer is sound.
     private const double IslandCapSeconds = 0.010;
 
+    // How far below the in-band first-arrival peak the in-band envelope must
+    // stay over the whole gated stretch (the gate claims that stretch is
+    // pre-sound). Field margins: the click's in-band shadow reads ~-25 dB,
+    // a co-onset genuine rise ~-10 dB.
+    private const double InBandQuietBeforeGateDb = 15.0;
+
     // How much later the full-band first arrival must move after the trial
     // removal for the burst to be convicted (safely above the band-to-band
     // dispersion of one wavefront in a cabin, ~1-1.5 ms measured).
@@ -230,9 +236,12 @@ public static class TransferIrDiagnostics
     /// early arrival never trips this: its complement energy rises into the
     /// room decay (no island), it sits at the front rather than in the head
     /// (proportionality guard), and removing sound that IS the first
-    /// arrival of only one band cannot move the full-band read. Returns
-    /// null for full-range records (no complement to test — measured
-    /// harmless on the v3 field data: engine proposals move ≤ 0.01 ms) and
+    /// arrival of only one band cannot move the full-band read.
+    /// CONTRACT: this is a field-calibrated detector for BAND-LIMITED
+    /// records, not a universal crosstalk detector — a full-range record
+    /// offers no complement band to test and is always returned untouched
+    /// (null), even if its head carries a click (measured inert on the v3
+    /// field data: engine proposals move ≤ 0.01 ms). Null likewise
     /// whenever any of the guards is not met.
     /// </summary>
     public static CrosstalkHeadGate? DetectCrosstalkHead(
@@ -330,16 +339,37 @@ public static class TransferIrDiagnostics
         int gateEnd = islandEnd + fade;
 
         // Proportionality guard: the candidate must sit far ahead of the
-        // in-band front, and the gate may reach at most half-way to it. This
-        // is what protects genuine co-onset out-of-band content (its island
-        // sits AT the front, not in the head) — and it is deliberately not
-        // an onset-threshold walk, which the click's own in-band shadow and
-        // the window pre-ring ramp both poison (two field-tested failures).
+        // in-band front, and the gate may reach at most half-way from the
+        // candidate to it (midpoint, so an artifact that does not sit near
+        // sample zero is not penalized). This is what protects genuine
+        // co-onset out-of-band content (its island sits AT the front, not in
+        // the head) — and it is deliberately not an onset-threshold walk,
+        // which the click's own in-band shadow and the window pre-ring ramp
+        // both poison (two field-tested failures).
         int guard = (int)(sampleRate * PreFrontGuardSeconds);
         if (clickIndex + guard >= inBand.EnvelopePeakIndex ||
-            gateEnd > inBand.EnvelopePeakIndex / 2)
+            gateEnd > clickIndex + (inBand.EnvelopePeakIndex - clickIndex) / 2)
         {
             return null;
+        }
+
+        // The gate's own claim is "everything before it is pre-sound": the
+        // IN-BAND envelope must stay far below its first-arrival peak over
+        // the whole gated stretch. This is what refuses a co-onset genuine
+        // event (a driver's out-of-band burst travelling WITH a front whose
+        // envelope peaks much later) — there the in-band envelope is already
+        // rising where the island ends. The click's own in-band shadow sits
+        // ~25 dB down on the field records and clears the ceiling.
+        double[] inBandEnvelope = inBand.EnvelopeSamples;
+        double inBandFirstPeak = inBandEnvelope[inBand.EnvelopePeakIndex];
+        double quietCeiling =
+            inBandFirstPeak * Math.Pow(10, -InBandQuietBeforeGateDb / 20);
+        for (int i = 0; i < gateEnd && i < inBandEnvelope.Length; i++)
+        {
+            if (inBandEnvelope[i] > quietCeiling)
+            {
+                return null;
+            }
         }
 
         // The verdict is an experiment, not a threshold: trial-remove the

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -34,12 +34,15 @@ public static class TransferIrDiagnostics
 {
     /// <summary>
     /// How far below the smoothed spectrum's peak the dominant band extends.
-    /// Field calibration (v3 cabin, 7 records): 20 dB yields driver-shaped
-    /// bands on every record (sub 20-127, midbass 33-329, mid 71-6089,
-    /// tweeter 1016-20k); 25+ dB lets clean full-range records swallow the
-    /// whole audible range and the band loses its meaning.
+    /// Field calibration (v3 cabin, 7 records, threshold sweep 10/12/15/20):
+    /// 15 dB is the sweet spot — driver-shaped bands (sub 20-110, midbass
+    /// 78-320, mid 110-2560, tweeter 1108-20k) with arrivals intact. 20 dB
+    /// lets a mid record swallow 20 Hz-14 kHz (cabin gain and door leakage
+    /// keep its LF/HF shelves within 20 dB of the peak); 12 dB and tighter
+    /// squeezes the midbass band to 82-155 Hz and the band-limited arrival
+    /// read modal-latches (7.4 ms -> 15.3 ms).
     /// </summary>
-    public const double DominantBandThresholdDb = 20.0;
+    public const double DominantBandThresholdDb = 15.0;
 
     // Spectral analysis window: long enough to resolve 1/6 octave at 20 Hz,
     // short enough to keep the FFT cheap; the head artifact this feeds sits

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -65,6 +65,15 @@ public static class TransferIrDiagnostics
     // same time; only a non-acoustic event can be complement-early.
     private const double PreFrontGuardSeconds = 0.002;
 
+    // The island must close within this long of the candidate — a click is
+    // a millisecond-scale event; anything longer is sound.
+    private const double IslandCapSeconds = 0.010;
+
+    // How much later the full-band first arrival must move after the trial
+    // removal for the burst to be convicted (safely above the band-to-band
+    // dispersion of one wavefront in a cabin, ~1-1.5 ms measured).
+    private const double FirstArrivalJumpMs = 2.0;
+
     private const double FadeSeconds = 0.0004;
 
     public static DominantBand DetectDominantBand(
@@ -130,35 +139,101 @@ public static class TransferIrDiagnostics
             }
         }
 
+        // Expand from the peak, bridging dips narrower than
+        // MaxBridgedGapOctaves: an in-cabin cancellation notch is deep but
+        // narrow and must not cut the driver's working band in half, while
+        // a wide stretch of silence is a real band edge.
         double floorDb = gridDb[peakIndex] - thresholdDb;
-        int low = peakIndex;
-        int high = peakIndex;
-        while (low > 0 && gridDb[low - 1] >= floorDb)
+        int maxGapSteps = (int)Math.Round(MaxBridgedGapOctaves * 24);
+        int solidSteps = (int)Math.Round(MinSolidLandingOctaves * 24);
+        // A bridge must LAND on a solid stretch of band (≥ solidSteps
+        // consecutive points above the floor): real cancellation notches sit
+        // between solid regions, while broadband ripple hovering around the
+        // threshold offers only isolated spikes — chaining bridges through
+        // those would crawl the band arbitrarily far (measured on the field
+        // records: the midbass band tripled before this rule).
+        bool SolidAt(int start, int step)
         {
-            low--;
+            for (int i = 0; i < solidSteps; i++)
+            {
+                int index = start + step * i;
+                if (index < 0 || index >= gridDb.Count || gridDb[index] < floorDb)
+                {
+                    return false;
+                }
+            }
+            return true;
         }
-        while (high < gridDb.Count - 1 && gridDb[high + 1] >= floorDb)
+        int Expand(int from, int step)
         {
-            high++;
+            int edge = from;
+            while (true)
+            {
+                int next = edge + step;
+                if (next < 0 || next >= gridDb.Count)
+                {
+                    return edge;
+                }
+                if (gridDb[next] >= floorDb)
+                {
+                    edge = next;
+                    continue;
+                }
+                int across = -1;
+                for (int k = 2; k <= maxGapSteps; k++)
+                {
+                    int candidate = edge + step * k;
+                    if (candidate < 0 || candidate >= gridDb.Count)
+                    {
+                        break;
+                    }
+                    if (SolidAt(candidate, step))
+                    {
+                        across = candidate;
+                        break;
+                    }
+                }
+                if (across < 0)
+                {
+                    return edge;
+                }
+                edge = across;
+            }
         }
+        int low = Expand(peakIndex, -1);
+        int high = Expand(peakIndex, +1);
 
         return new DominantBand(gridHz[low], gridHz[high], gridHz[peakIndex]);
     }
 
+    // The widest spectral dip the dominant-band expansion steps across
+    // (interference notches); anything wider counts as the band's real edge.
+    private const double MaxBridgedGapOctaves = 0.5;
+
+    // A bridged gap must land on at least this much contiguous above-floor
+    // band on the far side.
+    private const double MinSolidLandingOctaves = 1.0 / 6.0;
+
     /// <summary>
-    /// Looks for a playback-crosstalk click in the record's head, defined by
-    /// physics rather than thresholds on raw samples: in the COMPLEMENT band
-    /// (half an octave above the dominant band's top, where the driver has
-    /// nothing to say) the first arrival must be a valley-separated island
-    /// (<see cref="TimeAlignmentAnalysisResult.StrongestPeakIsSeparateArrival"/> —
-    /// the same disjoint-event test the panel uses, sidelobe-rejected so
-    /// window pre-ring cannot masquerade as it) that PRECEDES the in-band
-    /// front. A genuine early arrival carries its out-of-band content along
-    /// with the in-band wavefront, so it reads the same time in both bands
-    /// and never trips this. Returns null when the record is full-range (no
-    /// complement to test — measured harmless on the v3 field data: engine
-    /// proposals move ≤ 0.01 ms), when the head is clean, or when the island
-    /// cannot be bounded safely away from the real sound.
+    /// Looks for a playback-crosstalk click in the record's head. The
+    /// candidate is the COMPLEMENT band's first arrival (half an octave
+    /// above the dominant band's top, where the driver has nothing to say;
+    /// sidelobe-rejected, so window pre-ring cannot masquerade as it), and
+    /// it must be a short ISLAND far ahead of the in-band front. The island
+    /// is judged on its own envelope, never against later complement
+    /// content: a click hotter than the driver's out-of-band tail — or one
+    /// that is the only complement event at all — is the MORE dangerous
+    /// artifact and must not detect worse than a faint one. The verdict is
+    /// an experiment rather than a threshold: the island is trial-removed
+    /// and the record's full-band first arrival re-read — only a jump well
+    /// past one wavefront's band-to-band dispersion convicts. A genuine
+    /// early arrival never trips this: its complement energy rises into the
+    /// room decay (no island), it sits at the front rather than in the head
+    /// (proportionality guard), and removing sound that IS the first
+    /// arrival of only one band cannot move the full-band read. Returns
+    /// null for full-range records (no complement to test — measured
+    /// harmless on the v3 field data: engine proposals move ≤ 0.01 ms) and
+    /// whenever any of the guards is not met.
     /// </summary>
     public static CrosstalkHeadGate? DetectCrosstalkHead(
         IReadOnlyList<double> impulseResponse,
@@ -199,7 +274,7 @@ public static class TransferIrDiagnostics
                 BandpassPassOctaves = Math.Log2(complementHigh / complementLow),
                 BandpassFadeOctaves = 0.25
             });
-        if (!complement.IsValid || !complement.StrongestPeakIsSeparateArrival)
+        if (!complement.IsValid)
         {
             return null;
         }
@@ -217,23 +292,21 @@ public static class TransferIrDiagnostics
             return null;
         }
 
-        int guard = (int)(sampleRate * PreFrontGuardSeconds);
+        // The candidate: the complement's first arrival, and its island end —
+        // where the complement envelope falls well below the candidate's
+        // peak and stays there, within a short cap. A genuine early front's
+        // complement energy rises into the room decay instead of dropping,
+        // so no end is found.
         int clickIndex = complement.EnvelopePeakIndex;
-        if (clickIndex + guard >= inBand.EnvelopePeakIndex ||
-            clickIndex + guard >= complement.StrongestEnvelopePeakIndex)
-        {
-            return null;
-        }
-
-        // The island's end: where the complement envelope falls well below
-        // the click's peak and stays there.
         double[] envelope = complement.EnvelopeSamples;
         double clickPeak = envelope[clickIndex];
         double islandFloor = clickPeak * Math.Pow(10, -IslandEndBelowPeakDb / 20);
         int hold = Math.Max(1, (int)(sampleRate * IslandEndHoldSeconds));
+        int islandCap = Math.Min(
+            envelope.Length, clickIndex + (int)(sampleRate * IslandCapSeconds));
         int islandEnd = -1;
         int below = 0;
-        for (int i = clickIndex; i < complement.StrongestEnvelopePeakIndex; i++)
+        for (int i = clickIndex; i < islandCap; i++)
         {
             if (envelope[i] < islandFloor)
             {
@@ -253,11 +326,46 @@ public static class TransferIrDiagnostics
         {
             return null;
         }
-
         int fade = Math.Max(1, (int)(sampleRate * FadeSeconds));
         int gateEnd = islandEnd + fade;
-        if (gateEnd + guard >= inBand.EnvelopePeakIndex ||
-            gateEnd + guard >= complement.StrongestEnvelopePeakIndex)
+
+        // Proportionality guard: the candidate must sit far ahead of the
+        // in-band front, and the gate may reach at most half-way to it. This
+        // is what protects genuine co-onset out-of-band content (its island
+        // sits AT the front, not in the head) — and it is deliberately not
+        // an onset-threshold walk, which the click's own in-band shadow and
+        // the window pre-ring ramp both poison (two field-tested failures).
+        int guard = (int)(sampleRate * PreFrontGuardSeconds);
+        if (clickIndex + guard >= inBand.EnvelopePeakIndex ||
+            gateEnd > inBand.EnvelopePeakIndex / 2)
+        {
+            return null;
+        }
+
+        // The verdict is an experiment, not a threshold: trial-remove the
+        // island and re-read the FULL-BAND first arrival. If it jumps later
+        // by more than the dispersion tolerance, the record's first arrival
+        // WAS the head burst — a disjoint event ahead of all sound, i.e.
+        // crosstalk. If the read barely moves, the burst was not driving
+        // anything (measured inert on the field data) and the record is left
+        // alone.
+        var fullBandOptions = new TimeAlignmentAnalysisOptions();
+        TimeAlignmentAnalysisResult rawFull = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, sampleRate, fullBandOptions);
+        if (!rawFull.IsValid)
+        {
+            return null;
+        }
+        var gate = new CrosstalkHeadGate(gateEnd, 0, 0);
+        double[] trialCleaned = CleanCrosstalkHead(
+            impulseResponse is double[] array ? array : [.. impulseResponse],
+            sampleRate,
+            gate);
+        TimeAlignmentAnalysisResult cleanedFull = TimeAlignmentAnalysis.Analyze(
+            trialCleaned, sampleRate, fullBandOptions);
+        if (!cleanedFull.IsValid ||
+            cleanedFull.FirstArrivalDelayMilliseconds -
+            rawFull.FirstArrivalDelayMilliseconds < FirstArrivalJumpMs)
         {
             return null;
         }
@@ -294,6 +402,28 @@ public static class TransferIrDiagnostics
         {
             clean[i] = Complex.Zero;
         }
+        int fade = Math.Max(1, (int)(sampleRate * FadeSeconds));
+        for (int i = 0; i < fade && end + i < clean.Length; i++)
+        {
+            double w = 0.5 - 0.5 * Math.Cos(Math.PI * i / fade);
+            clean[end + i] *= w;
+        }
+        return clean;
+    }
+
+    /// <summary>
+    /// The real-valued twin of the gate above, for callers holding the
+    /// transfer IR as samples (the Time Alignment panel).
+    /// </summary>
+    public static double[] CleanCrosstalkHead(
+        double[] impulseResponse,
+        int sampleRate,
+        CrosstalkHeadGate gate)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        var clean = (double[])impulseResponse.Clone();
+        int end = Math.Min(gate.GateEndSample, clean.Length);
+        Array.Clear(clean, 0, end);
         int fade = Math.Max(1, (int)(sampleRate * FadeSeconds));
         for (int i = 0; i < fade && end + i < clean.Length; i++)
         {

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -1,0 +1,306 @@
+using System.Numerics;
+using MathNet.Numerics.IntegralTransforms;
+
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// The contiguous frequency region where a transfer IR actually carries the
+/// driver's energy: the 1/6-octave-smoothed magnitude spectrum's span within
+/// <see cref="TransferIrDiagnostics.DominantBandThresholdDb"/> of its peak.
+/// </summary>
+public readonly record struct DominantBand(double LowHz, double HighHz, double PeakHz);
+
+/// <summary>
+/// A detected pre-arrival crosstalk artifact and the head gate that removes
+/// it: zero everything before <see cref="GateEndSample"/> (with a short fade
+/// after it). Burst figures are diagnostics for the UI/log.
+/// </summary>
+public readonly record struct CrosstalkHeadGate(
+    int GateEndSample,
+    double BurstTimeMs,
+    double BurstPeakDbReMax);
+
+/// <summary>
+/// Record-hygiene diagnostics shared by the manual Time Alignment mode and
+/// the auto-delay launcher: where the driver's energy actually lives in
+/// frequency, and whether the record's head carries a playback-crosstalk
+/// click (field evidence: a broadband spike at one fixed sample in every
+/// record of a session — an electrical copy of the playback that lands
+/// before any physically possible acoustic arrival and, on band-limited
+/// low-frequency records, sits within the first-arrival detector's
+/// threshold).
+/// </summary>
+public static class TransferIrDiagnostics
+{
+    /// <summary>
+    /// How far below the smoothed spectrum's peak the dominant band extends.
+    /// Field calibration (v3 cabin, 7 records): 20 dB yields driver-shaped
+    /// bands on every record (sub 20-127, midbass 33-329, mid 71-6089,
+    /// tweeter 1016-20k); 25+ dB lets clean full-range records swallow the
+    /// whole audible range and the band loses its meaning.
+    /// </summary>
+    public const double DominantBandThresholdDb = 20.0;
+
+    // Spectral analysis window: long enough to resolve 1/6 octave at 20 Hz,
+    // short enough to keep the FFT cheap; the head artifact this feeds sits
+    // in the first milliseconds anyway.
+    private const int MaxAnalysisSamples = 65_536;
+
+    // The complement band (where the record has no driver energy) starts
+    // half an octave above the dominant band's top, and must span at least
+    // one octave to have any detection leverage — full-range records have no
+    // complement, and their head clicks measurably do not move the engine
+    // (v3: proposals shift ≤ 0.01 ms).
+    private const double ComplementGapOctaves = 0.5;
+    private const double ComplementMinimumOctaves = 1.0;
+
+    // The click island ends where the complement envelope falls this far
+    // below the click's own peak and stays there.
+    private const double IslandEndBelowPeakDb = 12.0;
+    private const double IslandEndHoldSeconds = 0.00025;
+
+    // The artifact must precede the in-band front by at least this much: a
+    // GENUINE early arrival carries the driver's out-of-band content along
+    // with the in-band front (same wavefront), so the two bands read the
+    // same time; only a non-acoustic event can be complement-early.
+    private const double PreFrontGuardSeconds = 0.002;
+
+    private const double FadeSeconds = 0.0004;
+
+    public static DominantBand DetectDominantBand(
+        IReadOnlyList<double> impulseResponse,
+        int sampleRate,
+        double thresholdDb = DominantBandThresholdDb)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        if (impulseResponse.Count == 0)
+        {
+            throw new ArgumentException(
+                "Impulse response must not be empty.", nameof(impulseResponse));
+        }
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+
+        int length = Math.Min(impulseResponse.Count, MaxAnalysisSamples);
+        var spectrum = new Complex[length];
+        for (int i = 0; i < length; i++)
+        {
+            spectrum[i] = impulseResponse[i];
+        }
+        Fourier.Forward(spectrum, FourierOptions.Matlab);
+
+        int half = length / 2;
+        double topHz = Math.Min(20_000, sampleRate * 0.45);
+
+        double SmoothedDb(double hz)
+        {
+            double lo = hz / Math.Pow(2.0, 1.0 / 12);
+            double hi = hz * Math.Pow(2.0, 1.0 / 12);
+            int i1 = Math.Max(1, (int)(lo * length / sampleRate));
+            int i2 = Math.Min(half - 1, (int)(hi * length / sampleRate));
+            if (i2 < i1)
+            {
+                i2 = i1;
+            }
+            double sum = 0;
+            for (int i = i1; i <= i2; i++)
+            {
+                sum += spectrum[i].Magnitude * spectrum[i].Magnitude;
+            }
+            return 10 * Math.Log10(Math.Max(1e-24, sum / (i2 - i1 + 1)));
+        }
+
+        // 1/24-octave log grid over the audible range.
+        var gridHz = new List<double>();
+        var gridDb = new List<double>();
+        for (double hz = 20; hz <= topHz; hz *= Math.Pow(2.0, 1.0 / 24))
+        {
+            gridHz.Add(hz);
+            gridDb.Add(SmoothedDb(hz));
+        }
+
+        int peakIndex = 0;
+        for (int i = 1; i < gridDb.Count; i++)
+        {
+            if (gridDb[i] > gridDb[peakIndex])
+            {
+                peakIndex = i;
+            }
+        }
+
+        double floorDb = gridDb[peakIndex] - thresholdDb;
+        int low = peakIndex;
+        int high = peakIndex;
+        while (low > 0 && gridDb[low - 1] >= floorDb)
+        {
+            low--;
+        }
+        while (high < gridDb.Count - 1 && gridDb[high + 1] >= floorDb)
+        {
+            high++;
+        }
+
+        return new DominantBand(gridHz[low], gridHz[high], gridHz[peakIndex]);
+    }
+
+    /// <summary>
+    /// Looks for a playback-crosstalk click in the record's head, defined by
+    /// physics rather than thresholds on raw samples: in the COMPLEMENT band
+    /// (half an octave above the dominant band's top, where the driver has
+    /// nothing to say) the first arrival must be a valley-separated island
+    /// (<see cref="TimeAlignmentAnalysisResult.StrongestPeakIsSeparateArrival"/> —
+    /// the same disjoint-event test the panel uses, sidelobe-rejected so
+    /// window pre-ring cannot masquerade as it) that PRECEDES the in-band
+    /// front. A genuine early arrival carries its out-of-band content along
+    /// with the in-band wavefront, so it reads the same time in both bands
+    /// and never trips this. Returns null when the record is full-range (no
+    /// complement to test — measured harmless on the v3 field data: engine
+    /// proposals move ≤ 0.01 ms), when the head is clean, or when the island
+    /// cannot be bounded safely away from the real sound.
+    /// </summary>
+    public static CrosstalkHeadGate? DetectCrosstalkHead(
+        IReadOnlyList<double> impulseResponse,
+        int sampleRate)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        if (impulseResponse.Count == 0 || sampleRate <= 0)
+        {
+            return null;
+        }
+
+        // The click and the front both live in the record's first second;
+        // capping the analysis keeps the per-refresh cost flat and the
+        // verdict identical between the panel, the engine and the probes.
+        if (impulseResponse.Count > MaxAnalysisSamples)
+        {
+            var head = new double[MaxAnalysisSamples];
+            for (int i = 0; i < head.Length; i++)
+            {
+                head[i] = impulseResponse[i];
+            }
+            impulseResponse = head;
+        }
+
+        DominantBand band = DetectDominantBand(impulseResponse, sampleRate);
+        double complementLow = band.HighHz * Math.Pow(2.0, ComplementGapOctaves);
+        double complementHigh = Math.Min(20_000, sampleRate * 0.45);
+        if (complementHigh < complementLow * Math.Pow(2.0, ComplementMinimumOctaves))
+        {
+            return null;
+        }
+
+        TimeAlignmentAnalysisResult complement = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, sampleRate, new TimeAlignmentAnalysisOptions
+            {
+                UseBandpassWindow = true,
+                BandpassCenterHz = Math.Sqrt(complementLow * complementHigh),
+                BandpassPassOctaves = Math.Log2(complementHigh / complementLow),
+                BandpassFadeOctaves = 0.25
+            });
+        if (!complement.IsValid || !complement.StrongestPeakIsSeparateArrival)
+        {
+            return null;
+        }
+
+        TimeAlignmentAnalysisResult inBand = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, sampleRate, new TimeAlignmentAnalysisOptions
+            {
+                UseBandpassWindow = true,
+                BandpassCenterHz = Math.Sqrt(band.LowHz * band.HighHz),
+                BandpassPassOctaves = Math.Log2(band.HighHz / band.LowHz),
+                BandpassFadeOctaves = 0.25
+            });
+        if (!inBand.IsValid)
+        {
+            return null;
+        }
+
+        int guard = (int)(sampleRate * PreFrontGuardSeconds);
+        int clickIndex = complement.EnvelopePeakIndex;
+        if (clickIndex + guard >= inBand.EnvelopePeakIndex ||
+            clickIndex + guard >= complement.StrongestEnvelopePeakIndex)
+        {
+            return null;
+        }
+
+        // The island's end: where the complement envelope falls well below
+        // the click's peak and stays there.
+        double[] envelope = complement.EnvelopeSamples;
+        double clickPeak = envelope[clickIndex];
+        double islandFloor = clickPeak * Math.Pow(10, -IslandEndBelowPeakDb / 20);
+        int hold = Math.Max(1, (int)(sampleRate * IslandEndHoldSeconds));
+        int islandEnd = -1;
+        int below = 0;
+        for (int i = clickIndex; i < complement.StrongestEnvelopePeakIndex; i++)
+        {
+            if (envelope[i] < islandFloor)
+            {
+                below++;
+                if (below >= hold)
+                {
+                    islandEnd = i - hold + 1;
+                    break;
+                }
+            }
+            else
+            {
+                below = 0;
+            }
+        }
+        if (islandEnd < 0)
+        {
+            return null;
+        }
+
+        int fade = Math.Max(1, (int)(sampleRate * FadeSeconds));
+        int gateEnd = islandEnd + fade;
+        if (gateEnd + guard >= inBand.EnvelopePeakIndex ||
+            gateEnd + guard >= complement.StrongestEnvelopePeakIndex)
+        {
+            return null;
+        }
+
+        double recordMax = 0;
+        int length = Math.Min(impulseResponse.Count, MaxAnalysisSamples);
+        for (int i = 0; i < length; i++)
+        {
+            recordMax = Math.Max(recordMax, Math.Abs(impulseResponse[i]));
+        }
+        return new CrosstalkHeadGate(
+            gateEnd,
+            clickIndex * 1000.0 / sampleRate,
+            recordMax > 0
+                ? 20 * Math.Log10(Math.Max(1e-12, clickPeak / recordMax))
+                : 0.0);
+    }
+
+    /// <summary>
+    /// Applies a head gate to a copy of the IR: zeros [0, GateEndSample) and
+    /// raised-cosine-fades the next <see cref="FadeSeconds"/> worth of
+    /// samples. The artifact is removed from the record before any linear
+    /// processing, so every downstream band-limited read is clean.
+    /// </summary>
+    public static Complex[] CleanCrosstalkHead(
+        Complex[] impulseResponse,
+        int sampleRate,
+        CrosstalkHeadGate gate)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        var clean = (Complex[])impulseResponse.Clone();
+        int end = Math.Min(gate.GateEndSample, clean.Length);
+        for (int i = 0; i < end; i++)
+        {
+            clean[i] = Complex.Zero;
+        }
+        int fade = Math.Max(1, (int)(sampleRate * FadeSeconds));
+        for (int i = 0; i < fade && end + i < clean.Length; i++)
+        {
+            double w = 0.5 - 0.5 * Math.Cos(Math.PI * i / fade);
+            clean[end + i] *= w;
+        }
+        return clean;
+    }
+
+}

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -734,7 +734,11 @@ internal sealed class MeasurementSettingsFile
         public int MicrophoneInputChannelOffset { get; set; }
         public int LoopbackInputChannelOffset { get; set; }
         public int AsioOutputChannelOffset { get; set; }
+        // Pre-band-mode files carry only this bool; BandMode is null there
+        // and the migration below keeps an explicit manual window, otherwise
+        // adopts the new AutoBand default.
         public bool UseBandpassWindow { get; set; }
+        public string? BandMode { get; set; }
         public double BandpassCenterHz { get; set; } = 1000;
         public double BandpassPassOctaves { get; set; } = 1;
         public double BandpassFadeOctaves { get; set; } = 0.5;
@@ -750,7 +754,8 @@ internal sealed class MeasurementSettingsFile
                 MicrophoneInputChannelOffset = options.MicrophoneInputChannelOffset,
                 LoopbackInputChannelOffset = options.LoopbackInputChannelOffset,
                 AsioOutputChannelOffset = options.AsioOutputChannelOffset,
-                UseBandpassWindow = options.UseBandpassWindow,
+                UseBandpassWindow = options.BandMode == TimeAlignmentBandMode.ManualBand,
+                BandMode = options.BandMode.ToString(),
                 BandpassCenterHz = options.BandpassCenterHz,
                 BandpassPassOctaves = options.BandpassPassOctaves,
                 BandpassFadeOctaves = options.BandpassFadeOctaves,
@@ -780,7 +785,11 @@ internal sealed class MeasurementSettingsFile
                     sampleRate,
                     AsioOutputChannelOffset,
                     input: false);
-            options.UseBandpassWindow = UseBandpassWindow;
+            options.BandMode = Enum.TryParse(BandMode, out TimeAlignmentBandMode mode)
+                ? mode
+                : UseBandpassWindow
+                    ? TimeAlignmentBandMode.ManualBand
+                    : TimeAlignmentBandMode.AutoBand;
             options.BandpassCenterHz = Math.Clamp(BandpassCenterHz, 20.0, 20_000.0);
             options.BandpassPassOctaves = Math.Clamp(BandpassPassOctaves, 0.0, 8.0);
             options.BandpassFadeOctaves = Math.Clamp(BandpassFadeOctaves, 0.0, 8.0);

--- a/source/TimeAlignment/TimeAlignmentOptions.cs
+++ b/source/TimeAlignment/TimeAlignmentOptions.cs
@@ -1,12 +1,24 @@
 namespace Resonalyze;
 
+/// <summary>
+/// How the Time Alignment analysis limits its frequency band: the raw
+/// record as-is, an automatic window around the driver's own dominant band
+/// (detected from the record's smoothed response), or a hand-set window.
+/// </summary>
+public enum TimeAlignmentBandMode
+{
+    FullBand,
+    AutoBand,
+    ManualBand
+}
+
 public sealed class TimeAlignmentOptions
 {
     public string? AsioDriverName { get; set; }
     public int MicrophoneInputChannelOffset { get; set; }
     public int LoopbackInputChannelOffset { get; set; }
     public int AsioOutputChannelOffset { get; set; }
-    public bool UseBandpassWindow { get; set; }
+    public TimeAlignmentBandMode BandMode { get; set; } = TimeAlignmentBandMode.AutoBand;
     public double BandpassCenterHz { get; set; } = 1000;
     public double BandpassPassOctaves { get; set; } = 1;
     public double BandpassFadeOctaves { get; set; } = 0.5;

--- a/source/TimeAlignment/TimeAlignmentPanel.Designer.cs
+++ b/source/TimeAlignment/TimeAlignmentPanel.Designer.cs
@@ -32,7 +32,10 @@ namespace Resonalyze
             var resources = new System.ComponentModel.ComponentResourceManager(typeof(TimeAlignmentPanel));
             helpLabel = new Label();
             sourceSummaryLabel = new Label();
-            bandpassCheckBox = new CheckBox();
+            bandModeFullRadio = new RadioButton();
+            bandModeAutoRadio = new RadioButton();
+            autoBandLabel = new Label();
+            bandModeManualRadio = new RadioButton();
             bandpassCenterLabel = new Label();
             bandpassCenterNumeric = new DarkNumericUpDown();
             bandpassPassOctavesLabel = new Label();
@@ -66,27 +69,63 @@ namespace Resonalyze
             sourceSummaryLabel.Size = new Size(500, 20);
             sourceSummaryLabel.TabIndex = 3;
             sourceSummaryLabel.Text = "Source: waiting for an impulse response.";
-            // 
-            // bandpassCheckBox
-            // 
-            bandpassCheckBox.AutoSize = true;
-            bandpassCheckBox.BackColor = Color.Transparent;
-            bandpassCheckBox.ForeColor = Color.FromArgb(210, 214, 222);
-            bandpassCheckBox.Location = new Point(18, 242);
-            bandpassCheckBox.Name = "bandpassCheckBox";
-            bandpassCheckBox.Size = new Size(143, 19);
-            bandpassCheckBox.TabIndex = 4;
-            bandpassCheckBox.Text = "Use bandpass window";
-            bandpassCheckBox.UseVisualStyleBackColor = false;
-            // 
+            //
+            // bandModeFullRadio
+            //
+            bandModeFullRadio.AutoSize = true;
+            bandModeFullRadio.BackColor = Color.Transparent;
+            bandModeFullRadio.ForeColor = Color.FromArgb(210, 214, 222);
+            bandModeFullRadio.Location = new Point(18, 234);
+            bandModeFullRadio.Name = "bandModeFullRadio";
+            bandModeFullRadio.Size = new Size(129, 19);
+            bandModeFullRadio.TabIndex = 4;
+            bandModeFullRadio.TabStop = true;
+            bandModeFullRadio.Text = "Full band (bypass)";
+            bandModeFullRadio.UseVisualStyleBackColor = false;
+            //
+            // bandModeAutoRadio
+            //
+            bandModeAutoRadio.AutoSize = true;
+            bandModeAutoRadio.BackColor = Color.Transparent;
+            bandModeAutoRadio.ForeColor = Color.FromArgb(210, 214, 222);
+            bandModeAutoRadio.Location = new Point(18, 256);
+            bandModeAutoRadio.Name = "bandModeAutoRadio";
+            bandModeAutoRadio.Size = new Size(233, 19);
+            bandModeAutoRadio.TabIndex = 5;
+            bandModeAutoRadio.TabStop = true;
+            bandModeAutoRadio.Text = "Auto band from the driver's response";
+            bandModeAutoRadio.UseVisualStyleBackColor = false;
+            //
+            // autoBandLabel
+            //
+            autoBandLabel.ForeColor = Color.FromArgb(150, 156, 168);
+            autoBandLabel.Location = new Point(38, 277);
+            autoBandLabel.Name = "autoBandLabel";
+            autoBandLabel.Size = new Size(280, 15);
+            autoBandLabel.TabIndex = 15;
+            autoBandLabel.Text = "-";
+            //
+            // bandModeManualRadio
+            //
+            bandModeManualRadio.AutoSize = true;
+            bandModeManualRadio.BackColor = Color.Transparent;
+            bandModeManualRadio.ForeColor = Color.FromArgb(210, 214, 222);
+            bandModeManualRadio.Location = new Point(18, 298);
+            bandModeManualRadio.Name = "bandModeManualRadio";
+            bandModeManualRadio.Size = new Size(165, 19);
+            bandModeManualRadio.TabIndex = 6;
+            bandModeManualRadio.TabStop = true;
+            bandModeManualRadio.Text = "Manual bandpass window";
+            bandModeManualRadio.UseVisualStyleBackColor = false;
+            //
             // bandpassCenterLabel
-            // 
+            //
             bandpassCenterLabel.AutoSize = true;
             bandpassCenterLabel.ForeColor = Color.FromArgb(210, 214, 222);
-            bandpassCenterLabel.Location = new Point(18, 276);
+            bandpassCenterLabel.Location = new Point(18, 330);
             bandpassCenterLabel.Name = "bandpassCenterLabel";
             bandpassCenterLabel.Size = new Size(118, 15);
-            bandpassCenterLabel.TabIndex = 5;
+            bandpassCenterLabel.TabIndex = 7;
             bandpassCenterLabel.Text = "Center frequency, Hz";
             // 
             // bandpassCenterNumeric
@@ -95,7 +134,7 @@ namespace Resonalyze
             bandpassCenterNumeric.DecimalPlaces = 0;
             bandpassCenterNumeric.ForeColor = Color.White;
             bandpassCenterNumeric.Increment = new decimal(new int[] { 10, 0, 0, 0 });
-            bandpassCenterNumeric.Location = new Point(180, 272);
+            bandpassCenterNumeric.Location = new Point(180, 326);
             bandpassCenterNumeric.Maximum = new decimal(new int[] { 20000, 0, 0, 0 });
             bandpassCenterNumeric.Minimum = new decimal(new int[] { 20, 0, 0, 0 });
             bandpassCenterNumeric.MinimumSize = new Size(36, 19);
@@ -110,7 +149,7 @@ namespace Resonalyze
             // 
             bandpassPassOctavesLabel.AutoSize = true;
             bandpassPassOctavesLabel.ForeColor = Color.FromArgb(210, 214, 222);
-            bandpassPassOctavesLabel.Location = new Point(18, 310);
+            bandpassPassOctavesLabel.Location = new Point(18, 364);
             bandpassPassOctavesLabel.Name = "bandpassPassOctavesLabel";
             bandpassPassOctavesLabel.Size = new Size(86, 15);
             bandpassPassOctavesLabel.TabIndex = 7;
@@ -122,7 +161,7 @@ namespace Resonalyze
             bandpassPassOctavesNumeric.DecimalPlaces = 1;
             bandpassPassOctavesNumeric.ForeColor = Color.White;
             bandpassPassOctavesNumeric.Increment = new decimal(new int[] { 1, 0, 0, 65536 });
-            bandpassPassOctavesNumeric.Location = new Point(180, 306);
+            bandpassPassOctavesNumeric.Location = new Point(180, 360);
             bandpassPassOctavesNumeric.Maximum = new decimal(new int[] { 8, 0, 0, 0 });
             bandpassPassOctavesNumeric.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
             bandpassPassOctavesNumeric.MinimumSize = new Size(36, 19);
@@ -137,7 +176,7 @@ namespace Resonalyze
             // 
             bandpassFadeOctavesLabel.AutoSize = true;
             bandpassFadeOctavesLabel.ForeColor = Color.FromArgb(210, 214, 222);
-            bandpassFadeOctavesLabel.Location = new Point(18, 344);
+            bandpassFadeOctavesLabel.Location = new Point(18, 398);
             bandpassFadeOctavesLabel.Name = "bandpassFadeOctavesLabel";
             bandpassFadeOctavesLabel.Size = new Size(88, 15);
             bandpassFadeOctavesLabel.TabIndex = 9;
@@ -149,7 +188,7 @@ namespace Resonalyze
             bandpassFadeOctavesNumeric.DecimalPlaces = 1;
             bandpassFadeOctavesNumeric.ForeColor = Color.White;
             bandpassFadeOctavesNumeric.Increment = new decimal(new int[] { 1, 0, 0, 65536 });
-            bandpassFadeOctavesNumeric.Location = new Point(180, 340);
+            bandpassFadeOctavesNumeric.Location = new Point(180, 394);
             bandpassFadeOctavesNumeric.Maximum = new decimal(new int[] { 8, 0, 0, 0 });
             bandpassFadeOctavesNumeric.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
             bandpassFadeOctavesNumeric.MinimumSize = new Size(36, 19);
@@ -197,7 +236,7 @@ namespace Resonalyze
             statusTextBox.Location = new Point(580, 18);
             statusTextBox.Name = "statusTextBox";
             statusTextBox.ReadOnly = true;
-            statusTextBox.ScrollBars = RichTextBoxScrollBars.None;
+            statusTextBox.ScrollBars = RichTextBoxScrollBars.Vertical;
             statusTextBox.Size = new Size(654, 415);
             statusTextBox.TabIndex = 13;
             statusTextBox.Text = "Run a loopback measurement or load an impulse response file with transfer IR.";
@@ -229,7 +268,10 @@ namespace Resonalyze
             Controls.Add(bandpassPassOctavesLabel);
             Controls.Add(bandpassCenterNumeric);
             Controls.Add(bandpassCenterLabel);
-            Controls.Add(bandpassCheckBox);
+            Controls.Add(bandModeManualRadio);
+            Controls.Add(autoBandLabel);
+            Controls.Add(bandModeAutoRadio);
+            Controls.Add(bandModeFullRadio);
             Controls.Add(sourceSummaryLabel);
             Controls.Add(helpLabel);
             Font = new Font("Segoe UI", 9F);
@@ -246,7 +288,10 @@ namespace Resonalyze
         #endregion
         private Label helpLabel;
         private Label sourceSummaryLabel;
-        private CheckBox bandpassCheckBox;
+        private RadioButton bandModeFullRadio;
+        private RadioButton bandModeAutoRadio;
+        private Label autoBandLabel;
+        private RadioButton bandModeManualRadio;
         private Label bandpassCenterLabel;
         private DarkNumericUpDown bandpassCenterNumeric;
         private Label bandpassPassOctavesLabel;

--- a/source/TimeAlignment/TimeAlignmentPanel.cs
+++ b/source/TimeAlignment/TimeAlignmentPanel.cs
@@ -13,7 +13,13 @@ public partial class TimeAlignmentPanel : UserControl
 
     internal Label CompareLabel => compareLabel;
 
-    internal CheckBox BandpassCheckBox => bandpassCheckBox;
+    internal RadioButton BandModeFullRadio => bandModeFullRadio;
+
+    internal RadioButton BandModeAutoRadio => bandModeAutoRadio;
+
+    internal RadioButton BandModeManualRadio => bandModeManualRadio;
+
+    internal Label AutoBandLabel => autoBandLabel;
 
     internal DarkNumericUpDown BandpassCenterNumeric => bandpassCenterNumeric;
 

--- a/source/TimeAlignment/TimeAlignmentPanel.resx
+++ b/source/TimeAlignment/TimeAlignmentPanel.resx
@@ -122,7 +122,7 @@
 Measures arrival time from the currently active loopback-based measurement record.
 
 How it works
-Resonalyze analyzes the active transfer IR immediately, optionally applies a bandpass window, then reports both First Arrival and Strongest Peak.
+Resonalyze analyzes the active transfer IR immediately — full band, auto-banded to the driver's own response, or through a manual bandpass window — then reports both First Arrival and Strongest Peak.
 
 Source selection
 This mode requires a transfer IR recorded with loopback enabled.</value>

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -925,8 +925,27 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         AppendLevelsLine(levels);
         AppendSeparator();
         AppendDelayTable(result, reference);
-        AppendStrongestPeakHint(result);
+        if (IsArrivalRecommendable(result, honestyProbe, options.BandMode, crosstalk != null))
+        {
+            AppendStrongestPeakHint(result);
+        }
     }
+
+    // Whether the First Arrival may be RECOMMENDED as the alignment figure.
+    // The strongest-peak hint ends with "Use First Arrival for alignment",
+    // and that advice must never print next to a verdict that just
+    // disqualified the arrival: a modal latch, a near-noise record, or a
+    // full-band read over a record with detected crosstalk (the bypass mode
+    // analyzes it raw). The states are independent, so without this gate the
+    // status box could give two opposite instructions at once.
+    internal static bool IsArrivalRecommendable(
+        TimeAlignmentAnalysisResult result,
+        TimeAlignmentArrivalProbe? honestyProbe,
+        TimeAlignmentBandMode bandMode,
+        bool crosstalkDetected) =>
+        result.SignalToNoiseDecibels >= AutoAlignmentEngine.MinimumArrivalSnrDb &&
+        honestyProbe?.Certificate != AutoAlignmentEngine.ArrivalCertificate.Latched &&
+        !(bandMode == TimeAlignmentBandMode.FullBand && crosstalkDetected);
 
     // Field-proven failure (v3): an electrical copy of the playback lands at
     // a fixed early sample in every record of a session; on band-limited

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -21,7 +21,10 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     private readonly TimeAlignmentPanel panel;
     private readonly Label sourceSummaryLabel;
     private readonly Label compareLabel;
-    private readonly CheckBox bandpassCheckBox;
+    private readonly RadioButton bandModeFullRadio;
+    private readonly RadioButton bandModeAutoRadio;
+    private readonly RadioButton bandModeManualRadio;
+    private readonly Label autoBandLabel;
     private readonly DarkNumericUpDown bandpassCenterNumeric;
     private readonly DarkNumericUpDown bandpassPassOctavesNumeric;
     private readonly DarkNumericUpDown bandpassFadeOctavesNumeric;
@@ -29,7 +32,13 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     private readonly PlotView envelopePlotView;
     private readonly StatusRichTextBox statusTextBox;
     private readonly Font resultTableFont;
+    // The band detected for the Auto mode on the last refresh (null when no
+    // data or another mode is active); feeds the preview plot and the label.
+    private DominantBand? lastAutoBand;
     private bool disposed;
+
+    // The fade the Auto mode puts around the detected pass band.
+    private const double AutoBandFadeOctaves = 0.5;
 
     public TimeAlignmentPanelController(
         Form owner,
@@ -54,7 +63,10 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
         sourceSummaryLabel = panel.SourceSummaryLabel;
         compareLabel = panel.CompareLabel;
-        bandpassCheckBox = panel.BandpassCheckBox;
+        bandModeFullRadio = panel.BandModeFullRadio;
+        bandModeAutoRadio = panel.BandModeAutoRadio;
+        bandModeManualRadio = panel.BandModeManualRadio;
+        autoBandLabel = panel.AutoBandLabel;
         bandpassCenterNumeric = panel.BandpassCenterNumeric;
         bandpassPassOctavesNumeric = panel.BandpassPassOctavesNumeric;
         bandpassFadeOctavesNumeric = panel.BandpassFadeOctavesNumeric;
@@ -66,7 +78,6 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
         ApplyOptionsToControls();
         WireEvents();
-        UpdateBandpassPreview();
         RefreshAnalysis();
     }
 
@@ -88,7 +99,6 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
     public void RefreshConfiguration()
     {
-        UpdateBandpassPreview();
         RefreshAnalysis();
     }
 
@@ -107,7 +117,18 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
     private void WireEvents()
     {
-        bandpassCheckBox.CheckedChanged += (_, _) => ApplyBandpassOptionChange();
+        // A radio switch fires CheckedChanged on both the leaving and the
+        // arriving button; reacting to the arriving one alone refreshes once.
+        void OnRadio(object? sender, EventArgs _)
+        {
+            if (sender is RadioButton { Checked: true })
+            {
+                ApplyBandpassOptionChange();
+            }
+        }
+        bandModeFullRadio.CheckedChanged += OnRadio;
+        bandModeAutoRadio.CheckedChanged += OnRadio;
+        bandModeManualRadio.CheckedChanged += OnRadio;
         bandpassCenterNumeric.ValueChanged += (_, _) => ApplyBandpassOptionChange();
         bandpassPassOctavesNumeric.ValueChanged += (_, _) => ApplyBandpassOptionChange();
         bandpassFadeOctavesNumeric.ValueChanged += (_, _) => ApplyBandpassOptionChange();
@@ -116,7 +137,6 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     private void ApplyBandpassOptionChange()
     {
         UpdateOptionsFromControls();
-        UpdateBandpassPreview();
         RefreshAnalysis();
         saveSettings();
     }
@@ -128,6 +148,9 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
         if (!TryGetMainSource(out TimeAlignmentAnalysisSource mainSource, out string noDataMessage))
         {
+            lastAutoBand = null;
+            UpdateAutoBandLabel();
+            UpdateBandpassPreview();
             SetStatusText(noDataMessage);
             ClearEnvelopePreview();
             return;
@@ -135,10 +158,18 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
         try
         {
+            // One options object per refresh: the Auto mode detects the band
+            // from the MAIN record and the Compare measurement is analyzed
+            // in the same band, so the delta column compares like with like.
+            TimeAlignmentAnalysisOptions analysisOptions =
+                CreateAnalysisOptions(mainSource, wrapPeakPositions: true);
+            UpdateAutoBandLabel();
+            UpdateBandpassPreview();
+
             TimeAlignmentAnalysisResult mainResult = TimeAlignmentAnalysis.Analyze(
                 mainSource.TransferImpulseResponse,
                 mainSource.SampleRate,
-                CreateAnalysisOptions(wrapPeakPositions: true),
+                analysisOptions,
                 mainSource.TransferCoherence);
             if (!mainResult.IsValid)
             {
@@ -154,25 +185,34 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             TimeAlignmentArrivalProbe? mainProbe = TimeAlignmentAnalysis.ProbeArrivalHonesty(
                 mainSource.TransferImpulseResponse,
                 mainSource.SampleRate,
-                CreateAnalysisOptions(wrapPeakPositions: true),
+                analysisOptions,
                 mainResult,
                 mainSource.TransferCoherence);
+            CrosstalkHeadGate? mainCrosstalk = DetectCrosstalk(
+                mainSource.TransferImpulseResponse, mainSource.SampleRate);
             TimeAlignmentCompareAnalysis? compareAnalysis =
-                AnalyzeCompare(mainSource, out string? compareWarning);
+                AnalyzeCompare(mainSource, analysisOptions, out string? compareWarning);
             TimeAlignmentArrivalProbe? compareProbe = compareAnalysis == null
                 ? null
                 : TimeAlignmentAnalysis.ProbeArrivalHonesty(
                     compareAnalysis.Value.Source.TransferImpulseResponse,
                     compareAnalysis.Value.Source.SampleRate,
-                    CreateAnalysisOptions(wrapPeakPositions: true),
+                    analysisOptions,
                     compareAnalysis.Value.Result,
                     compareAnalysis.Value.Source.TransferCoherence);
+            CrosstalkHeadGate? compareCrosstalk = compareAnalysis == null
+                ? null
+                : DetectCrosstalk(
+                    compareAnalysis.Value.Source.TransferImpulseResponse,
+                    compareAnalysis.Value.Source.SampleRate);
             SetMeasurementResultStatus(
                 mainSource,
                 mainResult,
                 mainProbe,
+                mainCrosstalk,
                 compareAnalysis,
                 compareProbe,
+                compareCrosstalk,
                 compareWarning);
             UpdateEnvelopePreview(
                 mainResult,
@@ -185,6 +225,14 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             ClearEnvelopePreview();
         }
     }
+
+    // The crosstalk check matters exactly where nothing filters the click
+    // out: the full-band mode. In the banded modes the window either kills
+    // it (auto/manual low bands) or the driver drowns it.
+    private CrosstalkHeadGate? DetectCrosstalk(double[] impulseResponse, int sampleRate) =>
+        options.BandMode == TimeAlignmentBandMode.FullBand
+            ? TransferIrDiagnostics.DetectCrosstalkHead(impulseResponse, sampleRate)
+            : null;
 
     private bool TryGetMainSource(
         out TimeAlignmentAnalysisSource source,
@@ -273,22 +321,42 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             snapshot.TransferCoherence,
             snapshot.MeterSnapshot);
 
-    private TimeAlignmentAnalysisOptions CreateAnalysisOptions(bool wrapPeakPositions) =>
-        new()
+    private TimeAlignmentAnalysisOptions CreateAnalysisOptions(
+        TimeAlignmentAnalysisSource source,
+        bool wrapPeakPositions)
+    {
+        double centerHz = options.BandpassCenterHz;
+        double passOctaves = options.BandpassPassOctaves;
+        double fadeOctaves = options.BandpassFadeOctaves;
+        lastAutoBand = null;
+        if (options.BandMode == TimeAlignmentBandMode.AutoBand)
         {
-            UseBandpassWindow = options.UseBandpassWindow,
-            BandpassCenterHz = options.BandpassCenterHz,
-            BandpassPassOctaves = options.BandpassPassOctaves,
-            BandpassFadeOctaves = options.BandpassFadeOctaves,
+            DominantBand band = TransferIrDiagnostics.DetectDominantBand(
+                source.TransferImpulseResponse, source.SampleRate);
+            lastAutoBand = band;
+            centerHz = Math.Sqrt(band.LowHz * band.HighHz);
+            passOctaves = Math.Log2(band.HighHz / band.LowHz);
+            fadeOctaves = AutoBandFadeOctaves;
+        }
+
+        return new TimeAlignmentAnalysisOptions
+        {
+            UseBandpassWindow = options.BandMode != TimeAlignmentBandMode.FullBand,
+            BandpassCenterHz = centerHz,
+            BandpassPassOctaves = passOctaves,
+            BandpassFadeOctaves = fadeOctaves,
             FirstPeakThresholdBelowMaxDb = options.FirstPeakThresholdBelowMaxDb,
             FirstPeakMinimumSnrDb = options.FirstPeakMinimumSnrDb,
             PeakSearchWindowMilliseconds = options.PeakSearchWindowMilliseconds,
             WrapPeakPositions = wrapPeakPositions
         };
+    }
 
     private void ApplyOptionsToControls()
     {
-        bandpassCheckBox.Checked = options.UseBandpassWindow;
+        bandModeFullRadio.Checked = options.BandMode == TimeAlignmentBandMode.FullBand;
+        bandModeAutoRadio.Checked = options.BandMode == TimeAlignmentBandMode.AutoBand;
+        bandModeManualRadio.Checked = options.BandMode == TimeAlignmentBandMode.ManualBand;
         bandpassCenterNumeric.Value =
             ClampDecimal(options.BandpassCenterHz, bandpassCenterNumeric);
         bandpassPassOctavesNumeric.Value =
@@ -300,7 +368,10 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
     private void UpdateOptionsFromControls()
     {
-        options.UseBandpassWindow = bandpassCheckBox.Checked;
+        options.BandMode =
+            bandModeAutoRadio.Checked ? TimeAlignmentBandMode.AutoBand
+            : bandModeManualRadio.Checked ? TimeAlignmentBandMode.ManualBand
+            : TimeAlignmentBandMode.FullBand;
         options.BandpassCenterHz = (double)bandpassCenterNumeric.Value;
         options.BandpassPassOctaves = (double)bandpassPassOctavesNumeric.Value;
         options.BandpassFadeOctaves = (double)bandpassFadeOctavesNumeric.Value;
@@ -309,14 +380,25 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
     private void UpdateBandpassControlStates()
     {
-        bandpassCenterNumeric.Enabled = bandpassCheckBox.Checked;
-        bandpassPassOctavesNumeric.Enabled = bandpassCheckBox.Checked;
-        bandpassFadeOctavesNumeric.Enabled = bandpassCheckBox.Checked;
+        bool manual = bandModeManualRadio.Checked;
+        bandpassCenterNumeric.Enabled = manual;
+        bandpassPassOctavesNumeric.Enabled = manual;
+        bandpassFadeOctavesNumeric.Enabled = manual;
+    }
+
+    private void UpdateAutoBandLabel()
+    {
+        autoBandLabel.Text = options.BandMode != TimeAlignmentBandMode.AutoBand
+            ? "-"
+            : lastAutoBand is { } band
+                ? $"detected: {band.LowHz:0}-{band.HighHz:0} Hz"
+                : "detected: waiting for a record";
     }
 
     private void UpdateBandpassPreview()
     {
-        bool addCurve = bandpassCheckBox.Checked;
+        bool addCurve = options.BandMode == TimeAlignmentBandMode.ManualBand ||
+            (options.BandMode == TimeAlignmentBandMode.AutoBand && lastAutoBand != null);
         PlotModel model = CreateBandpassPreviewModel(addCurve);
         bandpassPlotView.Model = model;
     }
@@ -352,10 +434,16 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             Color = OxyColor.FromRgb(255, 210, 80),
             StrokeThickness = 2
         };
-        (double f1, double f2, double f3, double f4) = BandpassWindow.BandAround(
-            (double)bandpassCenterNumeric.Value,
-            (double)bandpassPassOctavesNumeric.Value,
-            (double)bandpassFadeOctavesNumeric.Value);
+        (double f1, double f2, double f3, double f4) =
+            options.BandMode == TimeAlignmentBandMode.AutoBand && lastAutoBand is { } band
+                ? BandpassWindow.BandAround(
+                    Math.Sqrt(band.LowHz * band.HighHz),
+                    Math.Log2(band.HighHz / band.LowHz),
+                    AutoBandFadeOctaves)
+                : BandpassWindow.BandAround(
+                    (double)bandpassCenterNumeric.Value,
+                    (double)bandpassPassOctavesNumeric.Value,
+                    (double)bandpassFadeOctavesNumeric.Value);
         const int pointCount = 240;
         double minLog = Math.Log10(20);
         double maxLog = Math.Log10(maxFrequency);
@@ -376,6 +464,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
     private TimeAlignmentCompareAnalysis? AnalyzeCompare(
         TimeAlignmentAnalysisSource mainSource,
+        TimeAlignmentAnalysisOptions analysisOptions,
         out string? warning)
     {
         warning = null;
@@ -408,7 +497,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             TimeAlignmentAnalysisResult compareResult = TimeAlignmentAnalysis.Analyze(
                 compareSource.TransferImpulseResponse,
                 compareSource.SampleRate,
-                CreateAnalysisOptions(wrapPeakPositions: true),
+                analysisOptions,
                 compareSource.TransferCoherence);
             if (!compareResult.IsValid)
             {
@@ -746,16 +835,20 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentAnalysisSource mainSource,
         TimeAlignmentAnalysisResult mainResult,
         TimeAlignmentArrivalProbe? mainProbe,
+        CrosstalkHeadGate? mainCrosstalk,
         TimeAlignmentCompareAnalysis? compareAnalysis,
         TimeAlignmentArrivalProbe? compareProbe,
+        CrosstalkHeadGate? compareCrosstalk,
         string? compareWarning)
     {
         statusTextBox.BeginUpdate();
         try
         {
             statusTextBox.Clear();
-            AppendMeasurementResult("Main", mainSource.Levels, mainResult, mainProbe);
-            AppendCompareResult(mainResult, compareAnalysis, compareProbe, compareWarning);
+            AppendMeasurementResult(
+                "Main", mainSource.Levels, mainResult, mainProbe, mainCrosstalk);
+            AppendCompareResult(
+                mainResult, compareAnalysis, compareProbe, compareCrosstalk, compareWarning);
             statusTextBox.SelectionStart = 0;
             statusTextBox.SelectionLength = 0;
         }
@@ -769,6 +862,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentAnalysisResult mainResult,
         TimeAlignmentCompareAnalysis? compareAnalysis,
         TimeAlignmentArrivalProbe? compareProbe,
+        CrosstalkHeadGate? compareCrosstalk,
         string? warning)
     {
         if (compareAnalysis == null && warning == null)
@@ -791,6 +885,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             compareAnalysis!.Value.Source.Levels,
             compareAnalysis.Value.Result,
             compareProbe,
+            compareCrosstalk,
             mainResult);
     }
 
@@ -799,16 +894,36 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         InputLevelMeterSnapshot levels,
         TimeAlignmentAnalysisResult result,
         TimeAlignmentArrivalProbe? honestyProbe,
+        CrosstalkHeadGate? crosstalk,
         TimeAlignmentAnalysisResult? reference = null)
     {
         AppendSignalQuality(title, result);
         AppendAlignmentConfidence(result);
         AppendArrivalHonesty(result, honestyProbe);
-        AppendLevelLine("Mic", levels.Microphone);
-        AppendLevelLine("Loopback", levels.Loopback);
+        AppendCrosstalkFlag(crosstalk);
+        AppendLevelsLine(levels);
         AppendSeparator();
         AppendDelayTable(result, reference);
         AppendStrongestPeakHint(result);
+    }
+
+    // Field-proven failure (v3): an electrical copy of the playback lands at
+    // a fixed early sample in every record of a session; on band-limited
+    // drivers it sits within the first-peak threshold and the FULL-BAND
+    // First Arrival confidently times it instead of the sound.
+    private void AppendCrosstalkFlag(CrosstalkHeadGate? crosstalk)
+    {
+        if (crosstalk is not { } gate)
+        {
+            return;
+        }
+
+        AppendStatusText(
+            $"⚠ Playback crosstalk at {gate.BurstTimeMs:0.00} ms " +
+            $"({gate.BurstPeakDbReMax:0.0} dB re max) — an electrical copy of\r\n" +
+            "the playback, not the driver's sound; the full-band First Arrival\r\n" +
+            "may be timing it. Switch to Auto band.\r\n",
+            UiPalette.ErrorSoft);
     }
 
     // The auto-alignment engine's arrival honesty probe, surfaced on the
@@ -822,7 +937,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentAnalysisResult result,
         TimeAlignmentArrivalProbe? probe)
     {
-        if (!options.UseBandpassWindow)
+        if (options.BandMode == TimeAlignmentBandMode.FullBand)
         {
             return;
         }
@@ -847,14 +962,13 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                     UiPalette.SuccessGreenSoft);
                 break;
             case AutoAlignmentEngine.ArrivalCertificate.Latched:
-                AppendStatusText("MODAL LATCH\r\n", UiPalette.ErrorSoft);
                 AppendStatusText(
-                    $"⚠ First Arrival reads {result.FirstArrivalDelayMilliseconds:0.000} ms, " +
-                    $"but the {probeValue.ProbeLowHz:0}-{probeValue.ProbeHighHz:0} Hz upper half " +
-                    $"arrives at {probeValue.ProbeResult.FirstArrivalDelayMilliseconds:0.000} ms.\r\n" +
-                    "The full-band figure times the band's late build-up (a room\r\n" +
-                    "mode), not the direct sound — do not align by it. Move or\r\n" +
-                    "widen the band, or align by the upper-half arrival above.\r\n",
+                    $"MODAL LATCH — full band {result.FirstArrivalDelayMilliseconds:0.000} ms " +
+                    $"vs upper half {probeValue.ProbeResult.FirstArrivalDelayMilliseconds:0.000} ms\r\n",
+                    UiPalette.ErrorSoft);
+                AppendStatusText(
+                    "⚠ Not the direct front (modal build-up) — align by the " +
+                    "upper-half figure\r\n",
                     UiPalette.ErrorSoft);
                 break;
             default:
@@ -1050,16 +1164,27 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         string valueFormat) =>
         DelayTableText.FormatValueWithDelta(value, reference, valueFormat);
 
-    private void AppendLevelLine(string label, InputLevelMeterEntry entry)
+    // Mic and Loopback on one line: the status box holds two full measurement
+    // blocks plus their warnings, so every line of vertical budget counts.
+    private void AppendLevelsLine(InputLevelMeterSnapshot levels)
+    {
+        AppendStatusText("Levels (peak/RMS dBFS): ", UiPalette.TextPrimarySoft);
+        AppendLevelSegment("mic", levels.Microphone);
+        AppendStatusText(", ", UiPalette.TextPrimarySoft);
+        AppendLevelSegment("loop", levels.Loopback);
+        AppendStatusText("\r\n", UiPalette.TextPrimarySoft);
+    }
+
+    private void AppendLevelSegment(string label, InputLevelMeterEntry entry)
     {
         if (!entry.Available)
         {
-            AppendStatusText($"{label}: unavailable\r\n", UiPalette.TextSecondarySoft);
+            AppendStatusText($"{label} unavailable", UiPalette.TextSecondarySoft);
             return;
         }
 
         AppendStatusText(
-            $"{label}: peak {entry.PeakDbFs:0.0} dBFS, RMS {entry.RmsDbFs:0.0} dBFS",
+            $"{label} {entry.PeakDbFs:0.0}/{entry.RmsDbFs:0.0}",
             UiPalette.TextPrimarySoft);
         if (entry.Clipped)
         {
@@ -1069,8 +1194,6 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         {
             AppendStatusText(" FULL SCALE", UiPalette.TextSecondarySoft);
         }
-
-        AppendStatusText("\r\n", UiPalette.TextPrimarySoft);
     }
 
     private static string FormatDelayTableLine(

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -158,19 +158,31 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
         try
         {
+            // Crosstalk hygiene first: detection always runs on the RAW
+            // record, then the banded modes analyze the CLEANED record —
+            // the same order the Auto delay engine uses. A broadband click
+            // lands inside the analysis band and the upper-half probe
+            // alike, so analyzing the raw record could green-light
+            // ("verified") an arrival that times the click. The bypass mode
+            // keeps the raw record and flags the contamination instead.
+            CrosstalkHeadGate? mainCrosstalk = TransferIrDiagnostics.DetectCrosstalkHead(
+                mainSource.TransferImpulseResponse, mainSource.SampleRate);
+            TimeAlignmentAnalysisSource mainAnalysisSource =
+                CleanForAnalysis(mainSource, mainCrosstalk);
+
             // One options object per refresh: the Auto mode detects the band
             // from the MAIN record and the Compare measurement is analyzed
             // in the same band, so the delta column compares like with like.
             TimeAlignmentAnalysisOptions analysisOptions =
-                CreateAnalysisOptions(mainSource, wrapPeakPositions: true);
+                CreateAnalysisOptions(mainAnalysisSource, wrapPeakPositions: true);
             UpdateAutoBandLabel();
             UpdateBandpassPreview();
 
             TimeAlignmentAnalysisResult mainResult = TimeAlignmentAnalysis.Analyze(
-                mainSource.TransferImpulseResponse,
-                mainSource.SampleRate,
+                mainAnalysisSource.TransferImpulseResponse,
+                mainAnalysisSource.SampleRate,
                 analysisOptions,
-                mainSource.TransferCoherence);
+                mainAnalysisSource.TransferCoherence);
             if (!mainResult.IsValid)
             {
                 SetStatusText(
@@ -183,15 +195,16 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             }
 
             TimeAlignmentArrivalProbe? mainProbe = TimeAlignmentAnalysis.ProbeArrivalHonesty(
-                mainSource.TransferImpulseResponse,
-                mainSource.SampleRate,
+                mainAnalysisSource.TransferImpulseResponse,
+                mainAnalysisSource.SampleRate,
                 analysisOptions,
                 mainResult,
-                mainSource.TransferCoherence);
-            CrosstalkHeadGate? mainCrosstalk = DetectCrosstalk(
-                mainSource.TransferImpulseResponse, mainSource.SampleRate);
-            TimeAlignmentCompareAnalysis? compareAnalysis =
-                AnalyzeCompare(mainSource, analysisOptions, out string? compareWarning);
+                mainAnalysisSource.TransferCoherence);
+            TimeAlignmentCompareAnalysis? compareAnalysis = AnalyzeCompare(
+                mainSource,
+                analysisOptions,
+                out string? compareWarning,
+                out CrosstalkHeadGate? compareCrosstalk);
             TimeAlignmentArrivalProbe? compareProbe = compareAnalysis == null
                 ? null
                 : TimeAlignmentAnalysis.ProbeArrivalHonesty(
@@ -200,11 +213,6 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                     analysisOptions,
                     compareAnalysis.Value.Result,
                     compareAnalysis.Value.Source.TransferCoherence);
-            CrosstalkHeadGate? compareCrosstalk = compareAnalysis == null
-                ? null
-                : DetectCrosstalk(
-                    compareAnalysis.Value.Source.TransferImpulseResponse,
-                    compareAnalysis.Value.Source.SampleRate);
             SetMeasurementResultStatus(
                 mainSource,
                 mainResult,
@@ -226,13 +234,19 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         }
     }
 
-    // The crosstalk check matters exactly where nothing filters the click
-    // out: the full-band mode. In the banded modes the window either kills
-    // it (auto/manual low bands) or the driver drowns it.
-    private CrosstalkHeadGate? DetectCrosstalk(double[] impulseResponse, int sampleRate) =>
-        options.BandMode == TimeAlignmentBandMode.FullBand
-            ? TransferIrDiagnostics.DetectCrosstalkHead(impulseResponse, sampleRate)
-            : null;
+    // The banded modes analyze the record with the convicted click removed
+    // (band detection included); the bypass mode shows the record as-is and
+    // relies on the red flag instead.
+    private TimeAlignmentAnalysisSource CleanForAnalysis(
+        TimeAlignmentAnalysisSource source,
+        CrosstalkHeadGate? crosstalk) =>
+        options.BandMode != TimeAlignmentBandMode.FullBand && crosstalk is { } gate
+            ? source with
+            {
+                TransferImpulseResponse = TransferIrDiagnostics.CleanCrosstalkHead(
+                    source.TransferImpulseResponse, source.SampleRate, gate)
+            }
+            : source;
 
     private bool TryGetMainSource(
         out TimeAlignmentAnalysisSource source,
@@ -465,9 +479,11 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     private TimeAlignmentCompareAnalysis? AnalyzeCompare(
         TimeAlignmentAnalysisSource mainSource,
         TimeAlignmentAnalysisOptions analysisOptions,
-        out string? warning)
+        out string? warning,
+        out CrosstalkHeadGate? crosstalk)
     {
         warning = null;
+        crosstalk = null;
         TimeAlignmentCompareMeasurement? compare = getCompareMeasurement();
         if (compare == null)
         {
@@ -494,6 +510,11 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         {
             TimeAlignmentAnalysisSource compareSource =
                 CreateCompareSource(compareValue, snapshot);
+            // The Compare record gets the same hygiene as Main: its own
+            // detection on the raw IR, cleaned analysis in the banded modes.
+            crosstalk = TransferIrDiagnostics.DetectCrosstalkHead(
+                compareSource.TransferImpulseResponse, compareSource.SampleRate);
+            compareSource = CleanForAnalysis(compareSource, crosstalk);
             TimeAlignmentAnalysisResult compareResult = TimeAlignmentAnalysis.Analyze(
                 compareSource.TransferImpulseResponse,
                 compareSource.SampleRate,
@@ -918,12 +939,23 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             return;
         }
 
+        if (options.BandMode == TimeAlignmentBandMode.FullBand)
+        {
+            // Bypass shows the record as-is, so the figures above may time
+            // the click; the banded modes analyze it removed.
+            AppendStatusText(
+                $"⚠ Playback crosstalk at {gate.BurstTimeMs:0.00} ms " +
+                $"({gate.BurstPeakDbReMax:0.0} dB re max) — an electrical copy of\r\n" +
+                "the playback, not the driver's sound; the full-band First Arrival\r\n" +
+                "may be timing it. Switch to Auto band (analyzed with it removed).\r\n",
+                UiPalette.ErrorSoft);
+            return;
+        }
+
         AppendStatusText(
             $"⚠ Playback crosstalk at {gate.BurstTimeMs:0.00} ms " +
-            $"({gate.BurstPeakDbReMax:0.0} dB re max) — an electrical copy of\r\n" +
-            "the playback, not the driver's sound; the full-band First Arrival\r\n" +
-            "may be timing it. Switch to Auto band.\r\n",
-            UiPalette.ErrorSoft);
+            $"({gate.BurstPeakDbReMax:0.0} dB re max) removed from this analysis\r\n",
+            UiPalette.WarningAmber);
     }
 
     // The auto-alignment engine's arrival honesty probe, surfaced on the
@@ -962,13 +994,18 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                     UiPalette.SuccessGreenSoft);
                 break;
             case AutoAlignmentEngine.ArrivalCertificate.Latched:
+                // The upper-half figure is DIAGNOSTIC only: it proves the
+                // full-band read is not the direct front, but it is no
+                // alignment target itself (the engine's field case: an
+                // upper-half read walked a woofer 6 ms off).
                 AppendStatusText(
                     $"MODAL LATCH — full band {result.FirstArrivalDelayMilliseconds:0.000} ms " +
                     $"vs upper half {probeValue.ProbeResult.FirstArrivalDelayMilliseconds:0.000} ms\r\n",
                     UiPalette.ErrorSoft);
                 AppendStatusText(
-                    "⚠ Not the direct front (modal build-up) — align by the " +
-                    "upper-half figure\r\n",
+                    "⚠ Not the direct front (modal build-up) — do not align " +
+                    "from this arrival;\r\nchange the analysis band or check " +
+                    "the measurement.\r\n",
                     UiPalette.ErrorSoft);
                 break;
             default:
@@ -1063,6 +1100,14 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // honest "coarse alignment" signal rather than a trustworthy sub-sample number.
     private void AppendAlignmentConfidence(TimeAlignmentAnalysisResult result)
     {
+        // The near-noise state above already declared the figures
+        // non-evidence; a confident-looking percentage next to that verdict
+        // would read as a contradiction.
+        if (result.SignalToNoiseDecibels < AutoAlignmentEngine.MinimumArrivalSnrDb)
+        {
+            return;
+        }
+
         int percent = (int)Math.Round(
             Math.Clamp(result.FirstArrivalConfidence, 0.0, 1.0) * 100.0);
         string method = result.FirstArrivalRefinedByPhat

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -151,12 +151,28 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 return;
             }
 
+            TimeAlignmentArrivalProbe? mainProbe = TimeAlignmentAnalysis.ProbeArrivalHonesty(
+                mainSource.TransferImpulseResponse,
+                mainSource.SampleRate,
+                CreateAnalysisOptions(wrapPeakPositions: true),
+                mainResult,
+                mainSource.TransferCoherence);
             TimeAlignmentCompareAnalysis? compareAnalysis =
                 AnalyzeCompare(mainSource, out string? compareWarning);
+            TimeAlignmentArrivalProbe? compareProbe = compareAnalysis == null
+                ? null
+                : TimeAlignmentAnalysis.ProbeArrivalHonesty(
+                    compareAnalysis.Value.Source.TransferImpulseResponse,
+                    compareAnalysis.Value.Source.SampleRate,
+                    CreateAnalysisOptions(wrapPeakPositions: true),
+                    compareAnalysis.Value.Result,
+                    compareAnalysis.Value.Source.TransferCoherence);
             SetMeasurementResultStatus(
                 mainSource,
                 mainResult,
+                mainProbe,
                 compareAnalysis,
+                compareProbe,
                 compareWarning);
             UpdateEnvelopePreview(
                 mainResult,
@@ -729,15 +745,17 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     private void SetMeasurementResultStatus(
         TimeAlignmentAnalysisSource mainSource,
         TimeAlignmentAnalysisResult mainResult,
+        TimeAlignmentArrivalProbe? mainProbe,
         TimeAlignmentCompareAnalysis? compareAnalysis,
+        TimeAlignmentArrivalProbe? compareProbe,
         string? compareWarning)
     {
         statusTextBox.BeginUpdate();
         try
         {
             statusTextBox.Clear();
-            AppendMeasurementResult("Main", mainSource.Levels, mainResult);
-            AppendCompareResult(mainResult, compareAnalysis, compareWarning);
+            AppendMeasurementResult("Main", mainSource.Levels, mainResult, mainProbe);
+            AppendCompareResult(mainResult, compareAnalysis, compareProbe, compareWarning);
             statusTextBox.SelectionStart = 0;
             statusTextBox.SelectionLength = 0;
         }
@@ -750,6 +768,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     private void AppendCompareResult(
         TimeAlignmentAnalysisResult mainResult,
         TimeAlignmentCompareAnalysis? compareAnalysis,
+        TimeAlignmentArrivalProbe? compareProbe,
         string? warning)
     {
         if (compareAnalysis == null && warning == null)
@@ -771,6 +790,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             "Compare",
             compareAnalysis!.Value.Source.Levels,
             compareAnalysis.Value.Result,
+            compareProbe,
             mainResult);
     }
 
@@ -778,15 +798,72 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         string title,
         InputLevelMeterSnapshot levels,
         TimeAlignmentAnalysisResult result,
+        TimeAlignmentArrivalProbe? honestyProbe,
         TimeAlignmentAnalysisResult? reference = null)
     {
         AppendSignalQuality(title, result);
         AppendAlignmentConfidence(result);
+        AppendArrivalHonesty(result, honestyProbe);
         AppendLevelLine("Mic", levels.Microphone);
         AppendLevelLine("Loopback", levels.Loopback);
         AppendSeparator();
         AppendDelayTable(result, reference);
         AppendStrongestPeakHint(result);
+    }
+
+    // The auto-alignment engine's arrival honesty probe, surfaced on the
+    // manual table: with a bandpass window active, the full-band first
+    // arrival is re-checked against the band's upper half. A full-band read
+    // far LATER than its own upper half is the modal latch — the read times
+    // the band's late build-up (a room mode), not the direct sound — which
+    // produces a confident wrong number exactly where this tool is used most
+    // (subwoofer and midbass bands).
+    private void AppendArrivalHonesty(
+        TimeAlignmentAnalysisResult result,
+        TimeAlignmentArrivalProbe? probe)
+    {
+        if (!options.UseBandpassWindow)
+        {
+            return;
+        }
+
+        AppendStatusText("Arrival probe: ", UiPalette.TextPrimarySoft);
+        if (probe == null)
+        {
+            AppendStatusText(
+                "pass band too narrow for the upper-half check\r\n",
+                UiPalette.TextSecondarySoft);
+            return;
+        }
+
+        TimeAlignmentArrivalProbe probeValue = probe.Value;
+        switch (probeValue.Certificate)
+        {
+            case AutoAlignmentEngine.ArrivalCertificate.Verified:
+                AppendStatusText(
+                    $"verified — the {probeValue.ProbeLowHz:0}-{probeValue.ProbeHighHz:0} Hz " +
+                    "upper half agrees " +
+                    $"({probeValue.ProbeResult.FirstArrivalDelayMilliseconds:0.000} ms)\r\n",
+                    UiPalette.SuccessGreenSoft);
+                break;
+            case AutoAlignmentEngine.ArrivalCertificate.Latched:
+                AppendStatusText("MODAL LATCH\r\n", UiPalette.ErrorSoft);
+                AppendStatusText(
+                    $"⚠ First Arrival reads {result.FirstArrivalDelayMilliseconds:0.000} ms, " +
+                    $"but the {probeValue.ProbeLowHz:0}-{probeValue.ProbeHighHz:0} Hz upper half " +
+                    $"arrives at {probeValue.ProbeResult.FirstArrivalDelayMilliseconds:0.000} ms.\r\n" +
+                    "The full-band figure times the band's late build-up (a room\r\n" +
+                    "mode), not the direct sound — do not align by it. Move or\r\n" +
+                    "widen the band, or align by the upper-half arrival above.\r\n",
+                    UiPalette.ErrorSoft);
+                break;
+            default:
+                AppendStatusText(
+                    "not certified — the upper half is unmeasurable or does not " +
+                    "show the front\r\n",
+                    UiPalette.TextSecondarySoft);
+                break;
+        }
     }
 
     // A subwoofer or any narrowband/modal measurement can leave the strongest peak
@@ -816,8 +893,26 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // drag the signal grade down.
     private void AppendSignalQuality(string title, TimeAlignmentAnalysisResult result)
     {
-        string signalGrade = FormatConfidence(result.SignalToNoiseDecibels);
         AppendStatusText($"{title} Signal: ", UiPalette.TextPrimarySoft);
+
+        // Below the same SNR floor the auto-alignment engine refuses to
+        // measure at, the "arrival" is a bump in the noise (independent noise
+        // records read ~8 dB): the manual table still shows its figures, but
+        // graded as not-evidence rather than as a poor measurement.
+        if (result.SignalToNoiseDecibels < AutoAlignmentEngine.MinimumArrivalSnrDb)
+        {
+            AppendStatusText(
+                $"Unmeasurable ({result.SignalToNoiseDecibels:0.0} dB SNR, below " +
+                $"the {AutoAlignmentEngine.MinimumArrivalSnrDb:0} dB floor)\r\n",
+                UiPalette.ErrorSoft);
+            AppendStatusText(
+                "⚠ The arrival is not distinguishable from the record's noise\r\n" +
+                "floor — the delay figures below are noise, not measurements.\r\n",
+                UiPalette.ErrorSoft);
+            return;
+        }
+
+        string signalGrade = FormatConfidence(result.SignalToNoiseDecibels);
         AppendStatusText(
             $"{signalGrade} ({result.SignalToNoiseDecibels:0.0} dB SNR)\r\n",
             GetConfidenceColor(signalGrade));

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -2497,6 +2497,37 @@ public partial class VirtualCrossoverPanel : UserControl
         WriteAlignmentLog(result.Log.ToString());
     }
 
+    // The measured records may carry a playback-crosstalk click at one fixed
+    // early sample (an electrical copy of the playback, ahead of any acoustic
+    // arrival — seen in every record of the same session on the field data).
+    // Field-measured effect on the search: sub-sample GCC-PHAT bias on most
+    // configs and a wrong solution branch on gentle slopes. Head-gate every
+    // record the detector convicts before the search and name it in the log.
+    private static List<AlignmentReprocessInput> CleanCrosstalkHeads(
+        List<AlignmentReprocessInput> inputs,
+        System.Text.StringBuilder log) =>
+        inputs.Select(input =>
+        {
+            double[] real = Array.ConvertAll(
+                input.MeasuredImpulseResponse, sample => sample.Real);
+            CrosstalkHeadGate? gate = TransferIrDiagnostics.DetectCrosstalkHead(
+                real, input.SampleRate);
+            if (gate is not { } convicted)
+            {
+                return input;
+            }
+
+            log.AppendLine(
+                $"{input.Channel.Name}: playback-crosstalk click at " +
+                $"{convicted.BurstTimeMs:0.00} ms ({convicted.BurstPeakDbReMax:0.0} dB " +
+                "re max) removed from the record's head before the search");
+            return input with
+            {
+                MeasuredImpulseResponse = TransferIrDiagnostics.CleanCrosstalkHead(
+                    input.MeasuredImpulseResponse, input.SampleRate, convicted)
+            };
+        }).ToList();
+
     // Bridges the panel's channel model to the dsp AutoAlignmentEngine (where
     // the FFT-heavy alignment stages live, unit-tested): snapshots + junctions
     // in, an override map (plus the per-channel decisions for the report) out.
@@ -2523,11 +2554,13 @@ public partial class VirtualCrossoverPanel : UserControl
         // because every search stage reads only the gated direct sound. The crop
         // and every ApplyChain first run HERE, on the background thread.
         var reprocessor = new AlignmentReprocessor(
-            ordered.Select(channel => new AlignmentReprocessInput(
-                channel,
-                channel.TransferImpulseResponse!,
-                channel.SampleRate,
-                channel.Settings.ToChain())).ToList(),
+            CleanCrosstalkHeads(
+                ordered.Select(channel => new AlignmentReprocessInput(
+                    channel,
+                    channel.TransferImpulseResponse!,
+                    channel.SampleRate,
+                    channel.Settings.ToChain())).ToList(),
+                log),
             AutoDelaySearchCropLength,
             AutoDelaySearchCropPrePeakSamples);
 
@@ -2864,11 +2897,13 @@ public partial class VirtualCrossoverPanel : UserControl
         // (validated on real measurements) while every FFT in the cascade
         // shrinks from the capture length to the crop.
         var reprocessor = new AlignmentReprocessor(
-            union.Select(side => new AlignmentReprocessInput(
-                side,
-                side.State.TransferImpulseResponse!,
-                side.State.SampleRate,
-                side.Settings.ToChain())).ToList(),
+            CleanCrosstalkHeads(
+                union.Select(side => new AlignmentReprocessInput(
+                    side,
+                    side.State.TransferImpulseResponse!,
+                    side.State.SampleRate,
+                    side.Settings.ToChain())).ToList(),
+                log),
             AutoDelaySearchCropLength,
             AutoDelaySearchCropPrePeakSamples);
 

--- a/tests/Resonalyze.App.Tests/TimeAlignmentArrivalRecommendationTests.cs
+++ b/tests/Resonalyze.App.Tests/TimeAlignmentArrivalRecommendationTests.cs
@@ -1,0 +1,112 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+// The "Use First Arrival for alignment" hint and the disqualifying verdicts
+// (modal latch, near-noise, contaminated full-band) are independent states;
+// this contract pins that the recommendation is suppressed whenever any
+// verdict has just disqualified the arrival, so the status box can never
+// give two opposite instructions at once.
+public sealed class TimeAlignmentArrivalRecommendationTests
+{
+    private static TimeAlignmentAnalysisResult Result(
+        double snrDb,
+        bool strongestIsSeparateArrival = true) =>
+        new(
+            EnvelopeSamples: [],
+            EnvelopePeakIndex: 0,
+            EnvelopePeak: 1.0,
+            StrongestEnvelopePeakIndex: 0,
+            StrongestEnvelopePeak: 1.0,
+            SignalToNoiseDecibels: snrDb,
+            FirstArrivalProminenceDecibels: -10.0,
+            FirstArrivalPeakSample: 100.0,
+            FirstArrivalDelayMilliseconds: 2.0,
+            StrongestPeakSample: 700.0,
+            StrongestDelayMilliseconds: 14.0,
+            StrongestPeakSeparationMilliseconds: 12.0,
+            StrongestPeakIsSeparateArrival: strongestIsSeparateArrival,
+            FirstArrivalConfidence: 0.5,
+            FirstArrivalRefinedByPhat: true,
+            StrongestConfidence: 0.5,
+            StrongestRefinedByPhat: true);
+
+    private static TimeAlignmentArrivalProbe Probe(
+        AutoAlignmentEngine.ArrivalCertificate certificate) =>
+        new(certificate, Result(snrDb: 40), 1000, 1414, 1.0);
+
+    [Fact]
+    public void ModalLatchSuppressesTheFirstArrivalRecommendation()
+    {
+        // The exact contradiction from review: Latched + a separate late
+        // strongest peak — "do not align from this arrival" must not be
+        // followed by "Use First Arrival for alignment".
+        Assert.False(TimeAlignmentPanelController.IsArrivalRecommendable(
+            Result(snrDb: 40, strongestIsSeparateArrival: true),
+            Probe(AutoAlignmentEngine.ArrivalCertificate.Latched),
+            TimeAlignmentBandMode.ManualBand,
+            crosstalkDetected: false));
+    }
+
+    [Fact]
+    public void NearNoiseSuppressesTheFirstArrivalRecommendation()
+    {
+        Assert.False(TimeAlignmentPanelController.IsArrivalRecommendable(
+            Result(snrDb: 8),
+            honestyProbe: null,
+            TimeAlignmentBandMode.FullBand,
+            crosstalkDetected: false));
+    }
+
+    [Fact]
+    public void ContaminatedFullBandSuppressesTheFirstArrivalRecommendation()
+    {
+        // Bypass analyzes the raw record, so with detected crosstalk the
+        // First Arrival may be timing the click.
+        Assert.False(TimeAlignmentPanelController.IsArrivalRecommendable(
+            Result(snrDb: 40),
+            honestyProbe: null,
+            TimeAlignmentBandMode.FullBand,
+            crosstalkDetected: true));
+    }
+
+    [Fact]
+    public void CleanedBandedModeWithCrosstalkKeepsTheRecommendation()
+    {
+        // In the banded modes the analysis ran on the CLEANED record — the
+        // detected crosstalk is no longer in the figures.
+        Assert.True(TimeAlignmentPanelController.IsArrivalRecommendable(
+            Result(snrDb: 40),
+            Probe(AutoAlignmentEngine.ArrivalCertificate.Verified),
+            TimeAlignmentBandMode.AutoBand,
+            crosstalkDetected: true));
+    }
+
+    [Fact]
+    public void AHealthyReadKeepsTheRecommendation()
+    {
+        Assert.True(TimeAlignmentPanelController.IsArrivalRecommendable(
+            Result(snrDb: 40),
+            Probe(AutoAlignmentEngine.ArrivalCertificate.Verified),
+            TimeAlignmentBandMode.ManualBand,
+            crosstalkDetected: false));
+        Assert.True(TimeAlignmentPanelController.IsArrivalRecommendable(
+            Result(snrDb: 40),
+            honestyProbe: null,
+            TimeAlignmentBandMode.FullBand,
+            crosstalkDetected: false));
+    }
+
+    [Fact]
+    public void AnUnverifiedProbeAloneDoesNotSuppressTheRecommendation()
+    {
+        // Unverified = no certificate either way; the arrival stays usable
+        // (mirrors the engine: unverified reads keep working, just without
+        // a tight lock).
+        Assert.True(TimeAlignmentPanelController.IsArrivalRecommendable(
+            Result(snrDb: 40),
+            Probe(AutoAlignmentEngine.ArrivalCertificate.Unverified),
+            TimeAlignmentBandMode.AutoBand,
+            crosstalkDetected: false));
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
@@ -346,6 +346,165 @@ public sealed class TimeAlignmentAnalysisTests
         Assert.True(result.StrongestPeakIsSeparateArrival);
     }
 
+    // A Hann-windowed tone burst: band-limited content whose envelope peaks
+    // mid-burst, the building block of the honesty-probe scenarios below.
+    private static void AddToneBurst(
+        double[] impulseResponse,
+        double startMs,
+        double frequencyHz,
+        int periods,
+        double amplitude)
+    {
+        int start = (int)Math.Round(startMs * SampleRate / 1000.0);
+        int length = (int)Math.Round(periods * SampleRate / frequencyHz);
+        for (int i = 0; i < length && start + i < impulseResponse.Length; i++)
+        {
+            double hann = 0.5 - 0.5 * Math.Cos(Math.Tau * i / length);
+            impulseResponse[start + i] +=
+                amplitude * hann * Math.Sin(Math.Tau * frequencyHz * i / SampleRate);
+        }
+    }
+
+    private static TimeAlignmentAnalysisOptions OneOctaveAroundOneKilohertz => new()
+    {
+        UseBandpassWindow = true,
+        BandpassCenterHz = 1000,
+        BandpassPassOctaves = 1,
+        BandpassFadeOctaves = 0.5
+    };
+
+    [Fact]
+    public void ProbeArrivalHonesty_WithoutABandpassWindow_ReturnsNull()
+    {
+        var impulseResponse = new double[8_192];
+        impulseResponse[300] = 1.0;
+        var options = new TimeAlignmentAnalysisOptions();
+
+        TimeAlignmentAnalysisResult full = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, options);
+
+        Assert.Null(TimeAlignmentAnalysis.ProbeArrivalHonesty(
+            impulseResponse, SampleRate, options, full));
+    }
+
+    [Fact]
+    public void ProbeArrivalHonesty_PassBandTooNarrowForAnUpperHalf_ReturnsNull()
+    {
+        // Upper half spans passOctaves/2; MinimumArrivalBandRatio is 1/3
+        // octave, so anything under 2/3 octave of pass band cannot be probed.
+        var impulseResponse = new double[8_192];
+        impulseResponse[300] = 1.0;
+        var options = new TimeAlignmentAnalysisOptions
+        {
+            UseBandpassWindow = true,
+            BandpassCenterHz = 1000,
+            BandpassPassOctaves = 0.5,
+            BandpassFadeOctaves = 0.5
+        };
+
+        TimeAlignmentAnalysisResult full = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, options);
+
+        Assert.Null(TimeAlignmentAnalysis.ProbeArrivalHonesty(
+            impulseResponse, SampleRate, options, full));
+    }
+
+    [Fact]
+    public void ProbeArrivalHonesty_CleanImpulse_VerifiesTheArrival()
+    {
+        // A broadband impulse arrives at the same instant in every sub-band,
+        // so the upper-half re-read agrees and certifies the full-band figure.
+        var impulseResponse = new double[32_768];
+        impulseResponse[300] = 1.0;
+
+        TimeAlignmentAnalysisResult full = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, OneOctaveAroundOneKilohertz);
+        TimeAlignmentArrivalProbe? probe = TimeAlignmentAnalysis.ProbeArrivalHonesty(
+            impulseResponse, SampleRate, OneOctaveAroundOneKilohertz, full);
+
+        Assert.NotNull(probe);
+        Assert.Equal(
+            AutoAlignmentEngine.ArrivalCertificate.Verified,
+            probe.Value.Certificate);
+        // The probe band is the upper half of the 707-1414 Hz pass band:
+        // [center, f3].
+        Assert.Equal(1000.0, probe.Value.ProbeLowHz, precision: 6);
+        Assert.InRange(probe.Value.ProbeHighHz, 1414.0, 1414.5);
+        Assert.InRange(
+            Math.Abs(
+                probe.Value.ProbeResult.FirstArrivalDelayMilliseconds -
+                full.FirstArrivalDelayMilliseconds),
+            0.0,
+            probe.Value.ToleranceMs);
+    }
+
+    [Fact]
+    public void ProbeArrivalHonesty_LateFullBandArrival_FlagsTheModalLatch()
+    {
+        // The under-seat-midbass shape: the band's upper half carries a weak
+        // early direct front (-30 dB, below the full-band -25 dB first-peak
+        // threshold), while the band's lower edge carries the loud late
+        // build-up. The full band confidently times the late feature; only
+        // the upper-half re-read exposes that it is not the direct sound.
+        var impulseResponse = new double[32_768];
+        AddToneBurst(impulseResponse, startMs: 5.0, frequencyHz: 1200, periods: 5, amplitude: 0.0316);
+        AddToneBurst(impulseResponse, startMs: 12.0, frequencyHz: 800, periods: 20, amplitude: 1.0);
+
+        TimeAlignmentAnalysisResult full = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, OneOctaveAroundOneKilohertz);
+        TimeAlignmentArrivalProbe? probe = TimeAlignmentAnalysis.ProbeArrivalHonesty(
+            impulseResponse, SampleRate, OneOctaveAroundOneKilohertz, full);
+
+        Assert.NotNull(probe);
+        Assert.Equal(
+            AutoAlignmentEngine.ArrivalCertificate.Latched,
+            probe.Value.Certificate);
+        Assert.True(
+            full.FirstArrivalDelayMilliseconds -
+            probe.Value.ProbeResult.FirstArrivalDelayMilliseconds >
+            probe.Value.ToleranceMs,
+            $"full {full.FirstArrivalDelayMilliseconds:0.000} ms should read far " +
+            $"later than the probe {probe.Value.ProbeResult.FirstArrivalDelayMilliseconds:0.000} ms");
+    }
+
+    [Fact]
+    public void ProbeArrivalHonesty_NoiseFloorUpperHalf_ReturnsUnverified()
+    {
+        // All the signal sits below the probe band (a long 600 Hz burst
+        // against a 1000 Hz probe floor) over a -50 dB noise floor: the full
+        // band measures fine, but the upper half holds only noise (a pure
+        // digital-silence "upper half" is impossible in a synthetic — window
+        // leakage of the burst's edges reads as an early transient — the
+        // noise floor is what buries it, exactly as in a real record) and
+        // cannot certify either way: usable, no certificate.
+        var impulseResponse = new double[32_768];
+        var random = new Random(7);
+        for (int i = 0; i < impulseResponse.Length; i++)
+        {
+            impulseResponse[i] = 0.003 * (random.NextDouble() * 2.0 - 1.0);
+        }
+        AddToneBurst(impulseResponse, startMs: 10.0, frequencyHz: 600, periods: 60, amplitude: 1.0);
+
+        TimeAlignmentAnalysisResult full = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, OneOctaveAroundOneKilohertz);
+        TimeAlignmentArrivalProbe? probe = TimeAlignmentAnalysis.ProbeArrivalHonesty(
+            impulseResponse, SampleRate, OneOctaveAroundOneKilohertz, full);
+
+        Assert.True(full.IsValid);
+        Assert.True(
+            full.SignalToNoiseDecibels >= AutoAlignmentEngine.MinimumArrivalSnrDb,
+            $"full SNR {full.SignalToNoiseDecibels:0.0} dB should clear the floor");
+        Assert.NotNull(probe);
+        Assert.True(
+            probe.Value.ProbeResult.SignalToNoiseDecibels <
+                AutoAlignmentEngine.MinimumArrivalSnrDb,
+            $"probe SNR {probe.Value.ProbeResult.SignalToNoiseDecibels:0.0} dB " +
+            "should sit below the floor");
+        Assert.Equal(
+            AutoAlignmentEngine.ArrivalCertificate.Unverified,
+            probe.Value.Certificate);
+    }
+
     [Fact]
     public void Analyze_FlatUnityCoherence_ReproducesTheNullResultExactly()
     {

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -24,14 +24,19 @@ public sealed class TransferIrDiagnosticsTests
     // The field shape (v3 midbass records): a band-limited main arrival, the
     // driver's weak out-of-band content travelling WITH it, and a small
     // broadband click parked at a fixed early sample by the interface.
-    private static double[] CrosstalkRecord(bool withClick)
+    private static double[] CrosstalkRecord(
+        double clickAmplitude,
+        double outOfBandAmplitude = 0.05)
     {
         var impulseResponse = new double[32_768];
         AddToneBurst(impulseResponse, startMs: 40.0, frequencyHz: 300, periods: 30, amplitude: 1.0);
-        AddToneBurst(impulseResponse, startMs: 40.0, frequencyHz: 2000, periods: 40, amplitude: 0.05);
-        if (withClick)
+        if (outOfBandAmplitude > 0)
         {
-            impulseResponse[30] = 0.02;
+            AddToneBurst(impulseResponse, startMs: 40.0, frequencyHz: 2000, periods: 40, amplitude: outOfBandAmplitude);
+        }
+        if (clickAmplitude > 0)
+        {
+            impulseResponse[30] = clickAmplitude;
         }
         return impulseResponse;
     }
@@ -54,6 +59,39 @@ public sealed class TransferIrDiagnosticsTests
     }
 
     [Fact]
+    public void DetectDominantBand_BridgesANarrowCancellationNotch()
+    {
+        // An in-cabin interference notch splits the driver's working band
+        // into two islands. The expansion must step across a deep-but-narrow
+        // dip instead of keeping only the island around the loudest room
+        // gain — the AutoBand default would otherwise throw away half the
+        // driver's real band.
+        var impulseResponse = new double[65_536];
+        for (int k = 0; k <= 15; k++)
+        {
+            if (k is 5 or 6)
+            {
+                continue; // the notch: ~356-400 Hz carved out
+            }
+            AddToneBurst(
+                impulseResponse,
+                startMs: 20.0,
+                frequencyHz: 200.0 * Math.Pow(2.0, k / 6.0),
+                periods: 60,
+                amplitude: 1.0);
+        }
+
+        DominantBand band = TransferIrDiagnostics.DetectDominantBand(impulseResponse, SampleRate);
+
+        Assert.True(
+            band.LowHz < 220,
+            $"low edge {band.LowHz:0} Hz should reach the 200 Hz component");
+        Assert.True(
+            band.HighHz > 1000,
+            $"high edge {band.HighHz:0} Hz should cross the notch to the upper island");
+    }
+
+    [Fact]
     public void DetectDominantBand_CoversABroadbandImpulse()
     {
         var impulseResponse = new double[32_768];
@@ -68,7 +106,10 @@ public sealed class TransferIrDiagnosticsTests
     [Fact]
     public void DetectCrosstalkHead_FindsTheEarlyBroadbandClick()
     {
-        double[] impulseResponse = CrosstalkRecord(withClick: true);
+        // -21 dB re the record's max — the field click's level, inside the
+        // full-band first-peak threshold, i.e. the click IS the full-band
+        // First Arrival until removed.
+        double[] impulseResponse = CrosstalkRecord(clickAmplitude: 0.09);
 
         CrosstalkHeadGate? gate = TransferIrDiagnostics.DetectCrosstalkHead(
             impulseResponse, SampleRate);
@@ -82,9 +123,42 @@ public sealed class TransferIrDiagnosticsTests
     }
 
     [Fact]
+    public void DetectCrosstalkHead_AClickHotterThanTheDriversTailIsStillFound()
+    {
+        // The MORE dangerous artifact: the click outguns the driver's
+        // out-of-band content, so it is the complement band's strongest
+        // event. A detector keyed on "the strongest peak comes later" would
+        // go blind exactly here.
+        double[] impulseResponse = CrosstalkRecord(clickAmplitude: 0.15);
+
+        CrosstalkHeadGate? gate = TransferIrDiagnostics.DetectCrosstalkHead(
+            impulseResponse, SampleRate);
+
+        Assert.NotNull(gate);
+        Assert.True(gate.Value.GateEndSample > 30);
+        Assert.True(gate.Value.GateEndSample < SampleRate * 30 / 1000);
+    }
+
+    [Fact]
+    public void DetectCrosstalkHead_AClickThatIsTheOnlyComplementEventIsFound()
+    {
+        // No driver out-of-band tail at all: the click is the complement
+        // band's only event, first and strongest at once.
+        double[] impulseResponse = CrosstalkRecord(
+            clickAmplitude: 0.09, outOfBandAmplitude: 0.0);
+
+        CrosstalkHeadGate? gate = TransferIrDiagnostics.DetectCrosstalkHead(
+            impulseResponse, SampleRate);
+
+        Assert.NotNull(gate);
+        Assert.True(gate.Value.GateEndSample > 30);
+        Assert.True(gate.Value.GateEndSample < SampleRate * 30 / 1000);
+    }
+
+    [Fact]
     public void DetectCrosstalkHead_CleanRecordYieldsNoGate()
     {
-        double[] impulseResponse = CrosstalkRecord(withClick: false);
+        double[] impulseResponse = CrosstalkRecord(clickAmplitude: 0.0);
 
         Assert.Null(TransferIrDiagnostics.DetectCrosstalkHead(impulseResponse, SampleRate));
     }
@@ -96,7 +170,7 @@ public sealed class TransferIrDiagnosticsTests
         // strong reflection cluster) has no complement island — the
         // complement carries sound only where the record's genuine
         // out-of-band content is, which travels with the arrivals.
-        double[] impulseResponse = CrosstalkRecord(withClick: false);
+        double[] impulseResponse = CrosstalkRecord(clickAmplitude: 0.0);
         AddToneBurst(impulseResponse, startMs: 5.0, frequencyHz: 300, periods: 10, amplitude: 0.1);
 
         Assert.Null(TransferIrDiagnostics.DetectCrosstalkHead(impulseResponse, SampleRate));
@@ -117,7 +191,7 @@ public sealed class TransferIrDiagnosticsTests
     [Fact]
     public void CleanCrosstalkHead_ZerosTheHeadAndKeepsTheRest()
     {
-        double[] impulseResponse = CrosstalkRecord(withClick: true);
+        double[] impulseResponse = CrosstalkRecord(clickAmplitude: 0.09);
         CrosstalkHeadGate? gate = TransferIrDiagnostics.DetectCrosstalkHead(
             impulseResponse, SampleRate);
         Assert.NotNull(gate);
@@ -140,6 +214,6 @@ public sealed class TransferIrDiagnosticsTests
             Assert.Equal(complexIr[i], clean[i]);
         }
         // And the original was not mutated.
-        Assert.Equal(0.02, impulseResponse[30]);
+        Assert.Equal(0.09, impulseResponse[30]);
     }
 }

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -1,0 +1,145 @@
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class TransferIrDiagnosticsTests
+{
+    private const int SampleRate = 48_000;
+
+    private static void AddToneBurst(
+        double[] impulseResponse,
+        double startMs,
+        double frequencyHz,
+        int periods,
+        double amplitude)
+    {
+        int start = (int)Math.Round(startMs * SampleRate / 1000.0);
+        int length = (int)Math.Round(periods * SampleRate / frequencyHz);
+        for (int i = 0; i < length && start + i < impulseResponse.Length; i++)
+        {
+            double hann = 0.5 - 0.5 * Math.Cos(Math.Tau * i / length);
+            impulseResponse[start + i] +=
+                amplitude * hann * Math.Sin(Math.Tau * frequencyHz * i / SampleRate);
+        }
+    }
+
+    // The field shape (v3 midbass records): a band-limited main arrival, the
+    // driver's weak out-of-band content travelling WITH it, and a small
+    // broadband click parked at a fixed early sample by the interface.
+    private static double[] CrosstalkRecord(bool withClick)
+    {
+        var impulseResponse = new double[32_768];
+        AddToneBurst(impulseResponse, startMs: 40.0, frequencyHz: 300, periods: 30, amplitude: 1.0);
+        AddToneBurst(impulseResponse, startMs: 40.0, frequencyHz: 2000, periods: 40, amplitude: 0.05);
+        if (withClick)
+        {
+            impulseResponse[30] = 0.02;
+        }
+        return impulseResponse;
+    }
+
+    [Fact]
+    public void DetectDominantBand_BracketsANarrowbandRecord()
+    {
+        var impulseResponse = new double[32_768];
+        AddToneBurst(impulseResponse, startMs: 20.0, frequencyHz: 500, periods: 40, amplitude: 1.0);
+
+        DominantBand band = TransferIrDiagnostics.DetectDominantBand(impulseResponse, SampleRate);
+
+        Assert.InRange(band.PeakHz, 400, 620);
+        Assert.True(band.LowHz < 500 && band.HighHz > 500);
+        // A 40-period Hann burst is spectrally tight: the -20 dB band must
+        // not swallow octaves of silence around it.
+        Assert.True(
+            Math.Log2(band.HighHz / band.LowHz) < 2.0,
+            $"band {band.LowHz:0}-{band.HighHz:0} Hz is too wide for a narrowband burst");
+    }
+
+    [Fact]
+    public void DetectDominantBand_CoversABroadbandImpulse()
+    {
+        var impulseResponse = new double[32_768];
+        impulseResponse[300] = 1.0;
+
+        DominantBand band = TransferIrDiagnostics.DetectDominantBand(impulseResponse, SampleRate);
+
+        Assert.True(band.LowHz <= 25);
+        Assert.True(band.HighHz >= 15_000);
+    }
+
+    [Fact]
+    public void DetectCrosstalkHead_FindsTheEarlyBroadbandClick()
+    {
+        double[] impulseResponse = CrosstalkRecord(withClick: true);
+
+        CrosstalkHeadGate? gate = TransferIrDiagnostics.DetectCrosstalkHead(
+            impulseResponse, SampleRate);
+
+        Assert.NotNull(gate);
+        // The gate covers the click (sample 30) and ends far before the
+        // 40 ms front.
+        Assert.True(gate.Value.GateEndSample > 30);
+        Assert.True(gate.Value.GateEndSample < SampleRate * 30 / 1000);
+        Assert.InRange(gate.Value.BurstTimeMs, 0.3, 1.1);
+    }
+
+    [Fact]
+    public void DetectCrosstalkHead_CleanRecordYieldsNoGate()
+    {
+        double[] impulseResponse = CrosstalkRecord(withClick: false);
+
+        Assert.Null(TransferIrDiagnostics.DetectCrosstalkHead(impulseResponse, SampleRate));
+    }
+
+    [Fact]
+    public void DetectCrosstalkHead_AGenuineWeakEarlyArrivalIsNotGated()
+    {
+        // A weak IN-BAND early arrival (a real direct front 35 ms before the
+        // strong reflection cluster) has no complement island — the
+        // complement carries sound only where the record's genuine
+        // out-of-band content is, which travels with the arrivals.
+        double[] impulseResponse = CrosstalkRecord(withClick: false);
+        AddToneBurst(impulseResponse, startMs: 5.0, frequencyHz: 300, periods: 10, amplitude: 0.1);
+
+        Assert.Null(TransferIrDiagnostics.DetectCrosstalkHead(impulseResponse, SampleRate));
+    }
+
+    [Fact]
+    public void DetectCrosstalkHead_AFullRangeRecordIsLeftAlone()
+    {
+        // A broadband record has no complement band to test — and the field
+        // data showed its head click is inert for the engine anyway.
+        var impulseResponse = new double[32_768];
+        impulseResponse[30] = 0.02;
+        impulseResponse[2_000] = 1.0;
+
+        Assert.Null(TransferIrDiagnostics.DetectCrosstalkHead(impulseResponse, SampleRate));
+    }
+
+    [Fact]
+    public void CleanCrosstalkHead_ZerosTheHeadAndKeepsTheRest()
+    {
+        double[] impulseResponse = CrosstalkRecord(withClick: true);
+        CrosstalkHeadGate? gate = TransferIrDiagnostics.DetectCrosstalkHead(
+            impulseResponse, SampleRate);
+        Assert.NotNull(gate);
+
+        var complexIr = Array.ConvertAll(
+            impulseResponse, v => new System.Numerics.Complex(v, 0.0));
+        System.Numerics.Complex[] clean = TransferIrDiagnostics.CleanCrosstalkHead(
+            complexIr, SampleRate, gate.Value);
+
+        Assert.Equal(complexIr.Length, clean.Length);
+        Assert.Equal(0.0, clean[30].Magnitude);
+        for (int i = 0; i < gate.Value.GateEndSample; i++)
+        {
+            Assert.Equal(0.0, clean[i].Magnitude);
+        }
+        // The main arrival region is untouched.
+        int front = SampleRate * 40 / 1000;
+        for (int i = front; i < front + 1000; i++)
+        {
+            Assert.Equal(complexIr[i], clean[i]);
+        }
+        // And the original was not mutated.
+        Assert.Equal(0.02, impulseResponse[30]);
+    }
+}


### PR DESCRIPTION
Two related honesty upgrades for the manual Time Alignment mode, plus a field-driven artifact detector that also protects the Auto delay engine.

## 1. Arrival honesty probe + near-noise state (first commit)

Ports the #48 honesty ideas into the manual mode:

- With a band-limited analysis, the full-band first arrival is re-checked against the **upper half of the pass band** (`TimeAlignmentAnalysis.ProbeArrivalHonesty`, reusing the engine's `ClassifyArrival` / `ArrivalCertificate` — now public — with the same bridge-probe tolerance). The panel shows `Arrival probe:` per measurement: **verified** (green) / **not certified** (grey) / **MODAL LATCH** (red, both figures, do-not-align-by-it warning).
- A record whose SNR sits below the engine's 12 dB arrival floor is graded **Unmeasurable** in red — the figures stay visible but are labeled noise, not measurements.

## 2. Band modes + playback-crosstalk detection (second commit)

Field finding on the v3 records: **every record of the session carries an electrical playback-crosstalk click at one fixed early sample** (0.567 ms; sub-sample identical across independent records — 25.15 vs 25.18 smp; broadband, 16 kHz content in midbass records). Consequences, measured:

- the full-band First Arrival confidently times the click on band-limited drivers (0.576 ms instead of ~6.5 — a physically impossible 0.2 m);
- the Auto delay engine takes sub-sample GCC-PHAT bias on most of the 13-config matrix and a **wrong solution branch on gentle slopes** (LR 12 dB/oct: R sub-mb junction −0.86 vs −0.43 dB, midbass scene split +0.07 vs the +0.26 ms target).

What ships:

- **`dsp/TransferIrDiagnostics`** — `DetectDominantBand` (1/6-oct smoothed spectrum, contiguous −20 dB region; field-calibrated: 25+ dB lets clean full-range records swallow the whole audible range) and `DetectCrosstalkHead`/`CleanCrosstalkHead`. The artifact is defined by physics, not sample thresholds: **the complement band's first arrival is a valley-separated island preceding the in-band front**. It reuses `Analyze` + the separate-arrival test, so window pre-ring cannot masquerade as a click, and a genuine early arrival — which carries its out-of-band content along with the in-band wavefront — reads the same time in both bands and never trips it. (Two hand-rolled envelope-threshold detectors failed on the field data before this formulation.)
- **Time Alignment: three band modes** instead of the bandpass checkbox — `Full band (bypass)`, `Auto band from the driver's response` (**default**; detected band shown next to the radio and drawn in the preview; Compare is analyzed in the Main band so the delta column compares like with like), `Manual bandpass window`. Full-band mode flags detected crosstalk in red with the figures and points at Auto band. Settings migrate: an explicit manual window is kept, everything else adopts AutoBand.
- **Auto delay head gate** — convicted records are cleaned before both runs (single-side and stereo) and named in the log. Validated over the 13-config matrix: detector cleaning reproduces the fully-cleaned baseline (12/13 bit-identical or ≤0.02 ms; the gentle-slope config recovers the correct branch, modulo an acoustically-identical global polarity flip).
- **Status readout fits the box again**: modal-latch warning compacted to 2 lines, mic/loopback merged into one `Levels` line, vertical scrollbar only on overflow.

## Tests

12 new dsp tests (5 probe + 7 diagnostics). Suites green: **794 dsp + 497 app**. Detector verdicts on v3: l/r midbass and r mid convicted (the exact records whose cleaning fixes the engine); sub/l mid/tweeter clicks measured inert (≤0.01 ms) and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
