### PR TITLE
Gate offset Auto: robust IR-start detection replaces peak Fit

### DIFF
--- a/dsp/DataHelper.cs
+++ b/dsp/DataHelper.cs
@@ -62,6 +62,12 @@ namespace Resonalyze.Dsp
         public const double DefaultPhaseDetrendMs = 0.0;
         public const double DefaultPhaseSmoothingInverseOctaves = 12.0;
 
+        // Auto keeps the gate offset snapped to the estimated IR start
+        // (TransferIrDiagnostics.EstimateIrStart) whenever the measurement
+        // changes; off leaves the offset to the user. Default on: a first-run
+        // user should see a correctly gated phase without touching anything.
+        public bool PhaseGateAutoFit { get; set; } = true;
+
         public double PhaseGateOffsetMs { get; set; } = DefaultPhaseGateOffsetMs;
         public double PhaseLeftMs { get; set; } = DefaultPhaseLeftMs;
         public double PhasePlateauMs { get; set; } = DefaultPhasePlateauMs;
@@ -92,6 +98,9 @@ namespace Resonalyze.Dsp
         public const double DefaultGroupDelayPlateauMs = 10.0;
         public const double DefaultGroupDelayRightMs = 3.0;
         public const double DefaultGroupDelaySmoothingInverseOctaves = 12.0;
+
+        // The Group Delay twin of PhaseGateAutoFit.
+        public bool GroupDelayGateAutoFit { get; set; } = true;
 
         public double GroupDelayGateOffsetMs { get; set; } = DefaultGroupDelayGateOffsetMs;
         public double GroupDelayLeftMs { get; set; } = DefaultGroupDelayLeftMs;

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -253,8 +253,11 @@ public static class TransferIrDiagnostics
     /// usurp the front. Falls back to the full-band envelope when the
     /// dominant-band read is invalid (then a head artifact CAN poison it —
     /// <see cref="IrStartEstimate.DominantBandLimited"/> reports which path
-    /// answered); null when no credible arrival exists at all (empty, silent
-    /// or noise-only records) — the caller keeps whatever it used before.
+    /// answered); null when no credible arrival exists at all — empty, too
+    /// short or silent records, and noise-only records, which the envelope
+    /// SNR floor refuses (a noise envelope still has a "strongest peak" the
+    /// first-arrival search would fall back to, and only the peak-to-noise
+    /// grade exposes it). The caller keeps whatever figure it used before.
     /// Analysis is capped to the record's first <see cref="MaxAnalysisSamples"/>
     /// samples: the front lives there, and the cap keeps the per-refresh cost
     /// flat, the same convention as <see cref="DetectCrosstalkHead"/>.
@@ -264,7 +267,7 @@ public static class TransferIrDiagnostics
         int sampleRate)
     {
         ArgumentNullException.ThrowIfNull(impulseResponse);
-        if (impulseResponse.Count == 0 || sampleRate <= 0)
+        if (impulseResponse.Count < IrStartMinimumSamples || sampleRate <= 0)
         {
             return null;
         }
@@ -288,17 +291,32 @@ public static class TransferIrDiagnostics
                 BandpassPassOctaves = Math.Log2(band.HighHz / band.LowHz),
                 BandpassFadeOctaves = 0.25
             });
-        if (inBand.IsValid)
+        if (IsCredible(inBand))
         {
             return CrossingsOf(inBand, band, sampleRate, dominantBandLimited: true);
         }
 
         TimeAlignmentAnalysisResult fullBand = TimeAlignmentAnalysis.Analyze(
             impulseResponse, sampleRate, new TimeAlignmentAnalysisOptions());
-        return fullBand.IsValid
+        return IsCredible(fullBand)
             ? CrossingsOf(fullBand, band, sampleRate, dominantBandLimited: false)
             : null;
     }
+
+    // Below this length the spectral analysis behind the estimate is
+    // degenerate (no dominant band to speak of, no quantile noise floor).
+    private const int IrStartMinimumSamples = 256;
+
+    // The envelope peak-to-noise grade a record must clear before its front
+    // is trusted: IsValid alone only refuses flat-zero envelopes, so a
+    // noise-only record would otherwise "measure" a front at wherever its
+    // strongest random peak happens to sit. Same floor as the auto-delay
+    // onset lock (AutoAlignmentEngine.OnsetLockMinimumSnrDb, field-derived);
+    // clean cabin records grade 50+ dB, pure noise ~10-13 dB.
+    private const double IrStartMinimumSnrDb = 20;
+
+    private static bool IsCredible(TimeAlignmentAnalysisResult result) =>
+        result.IsValid && result.SignalToNoiseDecibels >= IrStartMinimumSnrDb;
 
     /// <summary>
     /// The <see cref="Complex"/> twin of the estimator above, for callers

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -21,6 +21,28 @@ public readonly record struct CrosstalkHeadGate(
     double BurstPeakDbReMax);
 
 /// <summary>
+/// The estimated start of a measured IR's honest acoustic content: the 25 %
+/// rising-front crossing (<see cref="StartMs"/>, the working figure) of the
+/// first credible arrival's envelope, read INSIDE the record's dominant band
+/// (see <see cref="TransferIrDiagnostics.EstimateIrStart"/>). The 10 %
+/// (<see cref="EarlyMs"/>) and 50 % (<see cref="LateMs"/>) crossings bound
+/// it; their spread is the front's sharpness — a direct sound keeps them
+/// within a fraction of a millisecond, a modal low-frequency build-up
+/// spreads them over milliseconds — and is the honesty figure a caller
+/// showing one number should surface. <see cref="DominantBandLimited"/> is
+/// false when the dominant-band read was invalid and the figures fall back
+/// to the full-band envelope (which a head artifact CAN poison — see the
+/// estimator's contract).
+/// </summary>
+public readonly record struct IrStartEstimate(
+    double StartMs,
+    double EarlyMs,
+    double LateMs,
+    double BandLowHz,
+    double BandHighHz,
+    bool DominantBandLimited);
+
+/// <summary>
 /// Record-hygiene diagnostics shared by the manual Time Alignment mode and
 /// the auto-delay launcher: where the driver's energy actually lives in
 /// frequency, and whether the record's head carries a playback-crosstalk
@@ -213,6 +235,131 @@ public static class TransferIrDiagnostics
         int high = Expand(peakIndex, +1);
 
         return new DominantBand(gridHz[low], gridHz[high], gridHz[peakIndex]);
+    }
+
+    /// <summary>
+    /// Estimates where the IR's honest acoustic content starts: the rising-
+    /// front crossings of the first credible arrival's Hilbert envelope, read
+    /// inside the record's DOMINANT band. The band-pass is what makes the
+    /// figure robust on real cabin records — a playback-crosstalk click or
+    /// other broadband head garbage carries almost no energy inside a
+    /// band-limited driver's working band, so the in-band envelope never sees
+    /// it, without any head-cleaning pass (field data, v3 cabin: the click at
+    /// ~0.5 ms poisons every full-band read of the midbass and subwoofer
+    /// records — 0.46-3.3 ms against fronts at 4.5-9 ms — while the in-band
+    /// read lands on the front on all seven records). The arrival itself is
+    /// the shared first-arrival physics (25 dB depth, noise gate, pre-ringing
+    /// rejection), so a stronger modal build-up peak seconds later cannot
+    /// usurp the front. Falls back to the full-band envelope when the
+    /// dominant-band read is invalid (then a head artifact CAN poison it —
+    /// <see cref="IrStartEstimate.DominantBandLimited"/> reports which path
+    /// answered); null when no credible arrival exists at all (empty, silent
+    /// or noise-only records) — the caller keeps whatever it used before.
+    /// Analysis is capped to the record's first <see cref="MaxAnalysisSamples"/>
+    /// samples: the front lives there, and the cap keeps the per-refresh cost
+    /// flat, the same convention as <see cref="DetectCrosstalkHead"/>.
+    /// </summary>
+    public static IrStartEstimate? EstimateIrStart(
+        IReadOnlyList<double> impulseResponse,
+        int sampleRate)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        if (impulseResponse.Count == 0 || sampleRate <= 0)
+        {
+            return null;
+        }
+
+        if (impulseResponse.Count > MaxAnalysisSamples)
+        {
+            var head = new double[MaxAnalysisSamples];
+            for (int i = 0; i < head.Length; i++)
+            {
+                head[i] = impulseResponse[i];
+            }
+            impulseResponse = head;
+        }
+
+        DominantBand band = DetectDominantBand(impulseResponse, sampleRate);
+        TimeAlignmentAnalysisResult inBand = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, sampleRate, new TimeAlignmentAnalysisOptions
+            {
+                UseBandpassWindow = true,
+                BandpassCenterHz = Math.Sqrt(band.LowHz * band.HighHz),
+                BandpassPassOctaves = Math.Log2(band.HighHz / band.LowHz),
+                BandpassFadeOctaves = 0.25
+            });
+        if (inBand.IsValid)
+        {
+            return CrossingsOf(inBand, band, sampleRate, dominantBandLimited: true);
+        }
+
+        TimeAlignmentAnalysisResult fullBand = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, sampleRate, new TimeAlignmentAnalysisOptions());
+        return fullBand.IsValid
+            ? CrossingsOf(fullBand, band, sampleRate, dominantBandLimited: false)
+            : null;
+    }
+
+    /// <summary>
+    /// The <see cref="Complex"/> twin of the estimator above, for callers
+    /// holding a transfer or processed IR in its FFT form.
+    /// </summary>
+    public static IrStartEstimate? EstimateIrStart(
+        IReadOnlyList<Complex> impulseResponse,
+        int sampleRate)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        int length = Math.Min(impulseResponse.Count, MaxAnalysisSamples);
+        var samples = new double[length];
+        for (int i = 0; i < length; i++)
+        {
+            samples[i] = impulseResponse[i].Real;
+        }
+        return EstimateIrStart(samples, sampleRate);
+    }
+
+    private static IrStartEstimate CrossingsOf(
+        TimeAlignmentAnalysisResult result,
+        DominantBand band,
+        int sampleRate,
+        bool dominantBandLimited)
+    {
+        double[] envelope = result.EnvelopeSamples;
+        int peakIndex = result.EnvelopePeakIndex;
+        double peak = envelope[peakIndex];
+        return new IrStartEstimate(
+            RisingFrontCrossingMs(envelope, peakIndex, 0.25 * peak, sampleRate),
+            RisingFrontCrossingMs(envelope, peakIndex, 0.10 * peak, sampleRate),
+            RisingFrontCrossingMs(envelope, peakIndex, 0.50 * peak, sampleRate),
+            band.LowHz,
+            band.HighHz,
+            dominantBandLimited);
+    }
+
+    // Walks backward down the arrival peak's own rising front to the first
+    // sample below the threshold and interpolates the crossing (sub-sample).
+    // Pinned to THAT front: an earlier, disjoint event past a dip never
+    // captures the crossing. Reaches 0.0 when the front starts at the record.
+    private static double RisingFrontCrossingMs(
+        IReadOnlyList<double> envelope,
+        int peakIndex,
+        double threshold,
+        int sampleRate)
+    {
+        int i = peakIndex;
+        while (i > 0 && envelope[i] > threshold)
+        {
+            i--;
+        }
+        if (i == peakIndex)
+        {
+            return peakIndex * 1_000.0 / sampleRate;
+        }
+
+        double below = envelope[i];
+        double above = envelope[i + 1];
+        double fraction = above > below ? (threshold - below) / (above - below) : 0.0;
+        return (i + fraction) * 1_000.0 / sampleRate;
     }
 
     // The widest spectral dip the dominant-band expansion steps across

--- a/source/Measurements/TransferIrStartCache.cs
+++ b/source/Measurements/TransferIrStartCache.cs
@@ -1,0 +1,61 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// The shared "where does this transfer IR honestly start" answer behind every
+/// Auto gate-offset control (Phase, Group Delay) and the plot builds that
+/// consume it: <see cref="TransferIrDiagnostics.EstimateIrStart"/>, memoized
+/// per IR array so the dialogs and the plot factory read one figure computed
+/// once per measurement instead of re-running the band-limited analysis on
+/// every control change. Falls back to the transfer peak (the old Fit figure)
+/// when the estimator refuses the record, so Auto is never worse than Fit was.
+/// </summary>
+internal static class TransferIrStartCache
+{
+    private sealed record CachedStart(int SampleRate, double StartMs);
+
+    private static readonly ConditionalWeakTable<Complex[], CachedStart> cache = new();
+
+    /// <summary>
+    /// The estimated IR start (ms from the record start) of the measurement's
+    /// transfer IR; null when there is no transfer IR to read.
+    /// </summary>
+    public static double? ResolveStartMs(ExpSweepMeasurement measurement)
+    {
+        if (measurement.Transfer is not { ImpulseResponse.Length: > 0 } transfer ||
+            measurement.SampleRate <= 0)
+        {
+            return null;
+        }
+
+        return ResolveStartMs(
+            transfer.ImpulseResponse, measurement.SampleRate, transfer.PeakIndex);
+    }
+
+    /// <summary>
+    /// The same estimate for an IR held directly as an array (the Virtual DSP
+    /// processed channels); <paramref name="fallbackPeakIndex"/> answers when
+    /// the estimator refuses the record.
+    /// </summary>
+    public static double ResolveStartMs(
+        Complex[] impulseResponse,
+        int sampleRate,
+        int fallbackPeakIndex)
+    {
+        if (cache.TryGetValue(impulseResponse, out CachedStart? cached) &&
+            cached.SampleRate == sampleRate)
+        {
+            return cached.StartMs;
+        }
+
+        double startMs = TransferIrDiagnostics.EstimateIrStart(
+            impulseResponse, sampleRate) is { } estimate
+                ? estimate.StartMs
+                : fallbackPeakIndex * 1_000.0 / sampleRate;
+        cache.AddOrUpdate(impulseResponse, new CachedStart(sampleRate, startMs));
+        return startMs;
+    }
+}

--- a/source/Measurements/TransferIrStartCache.cs
+++ b/source/Measurements/TransferIrStartCache.cs
@@ -36,6 +36,22 @@ internal static class TransferIrStartCache
     }
 
     /// <summary>
+    /// The same estimate for any analysis-layer measurement view (the Compare
+    /// overlay); null without an impulse response.
+    /// </summary>
+    public static double? ResolveStartMs(IImpulseMeasurement measurement)
+    {
+        if (measurement.ImpulseResponse is not { Length: > 0 } impulseResponse ||
+            measurement.SampleRate <= 0)
+        {
+            return null;
+        }
+
+        return ResolveStartMs(
+            impulseResponse, measurement.SampleRate, measurement.PeakIndex);
+    }
+
+    /// <summary>
     /// The same estimate for an IR held directly as an array (the Virtual DSP
     /// processed channels); <paramref name="fallbackPeakIndex"/> answers when
     /// the estimator refuses the record.

--- a/source/Options/GDOpt.Designer.cs
+++ b/source/Options/GDOpt.Designer.cs
@@ -29,7 +29,7 @@ namespace Resonalyze.Options
         private void InitializeComponent()
         {
             labelGateOffset = new Label();
-            buttonFit = new Button();
+            checkAutoFit = new CheckBox();
             numericGateOffset = new DarkNumericUpDown();
             label9 = new Label();
             labelMinFrequency = new Label();
@@ -59,19 +59,22 @@ namespace Resonalyze.Options
             labelGateOffset.Size = new Size(91, 15);
             labelGateOffset.TabIndex = 60;
             labelGateOffset.Text = "Gate offset (ms)";
-            // 
-            // buttonFit
-            // 
-            buttonFit.BackColor = Color.FromArgb(55, 60, 72);
-            buttonFit.FlatStyle = FlatStyle.Flat;
-            buttonFit.ForeColor = Color.White;
-            buttonFit.Location = new Point(115, 11);
-            buttonFit.Name = "buttonFit";
-            buttonFit.Size = new Size(33, 21);
-            buttonFit.TabIndex = 61;
-            buttonFit.Text = "Fit";
-            buttonFit.UseCompatibleTextRendering = true;
-            buttonFit.UseVisualStyleBackColor = false;
+            //
+            // checkAutoFit
+            //
+            checkAutoFit.Appearance = Appearance.Button;
+            checkAutoFit.BackColor = Color.FromArgb(55, 60, 72);
+            checkAutoFit.FlatAppearance.CheckedBackColor = Color.FromArgb(80, 100, 140);
+            checkAutoFit.FlatStyle = FlatStyle.Flat;
+            checkAutoFit.ForeColor = Color.White;
+            checkAutoFit.Location = new Point(110, 11);
+            checkAutoFit.Name = "checkAutoFit";
+            checkAutoFit.Size = new Size(40, 21);
+            checkAutoFit.TabIndex = 61;
+            checkAutoFit.Text = "Auto";
+            checkAutoFit.TextAlign = ContentAlignment.MiddleCenter;
+            checkAutoFit.UseCompatibleTextRendering = true;
+            checkAutoFit.UseVisualStyleBackColor = false;
             // 
             // numericGateOffset
             // 
@@ -259,7 +262,7 @@ namespace Resonalyze.Options
             Controls.Add(checkBoxShowGroupDelay);
             Controls.Add(labelCurves);
             Controls.Add(numericGateOffset);
-            Controls.Add(buttonFit);
+            Controls.Add(checkAutoFit);
             Controls.Add(labelGateOffset);
             Controls.Add(labelMinFrequency);
             Controls.Add(label9);
@@ -288,7 +291,7 @@ namespace Resonalyze.Options
         #endregion
 
         private Label labelGateOffset;
-        private Button buttonFit;
+        private CheckBox checkAutoFit;
         private DarkNumericUpDown numericGateOffset;
         private Label label9;
         private Label labelMinFrequency;

--- a/source/Options/GDOpt.cs
+++ b/source/Options/GDOpt.cs
@@ -15,7 +15,7 @@ public partial class GDOpt : ImpulsePreviewOptionsForm
         numericLeftWindow.ValueChanged += Gate_ValueChanged;
         numericRightWindow.ValueChanged += Gate_ValueChanged;
         numericGateOffset.ValueChanged += (_, _) => UpdateIrPreview();
-        buttonFit.Click += buttonFit_Click;
+        checkAutoFit.CheckedChanged += (_, _) => AutoFitChanged();
         ConfigureResetDefaults();
         SmoothingPresetOptions.Configure(comboSmoothingInverseOctaves);
         InitializeToolTips();
@@ -32,6 +32,7 @@ public partial class GDOpt : ImpulsePreviewOptionsForm
         InitializeControls(() =>
         {
             numericGateOffset.Value = ClampToControl(numericGateOffset, opt.GroupDelayGateOffsetMs);
+            checkAutoFit.Checked = opt.GroupDelayGateAutoFit;
             numericWindow.Value = ClampToControl(numericWindow, opt.GroupDelayPlateauMs);
             numericLeftWindow.Value = ClampToControl(numericLeftWindow, opt.GroupDelayLeftMs);
             numericRightWindow.Value = ClampToControl(numericRightWindow, opt.GroupDelayRightMs);
@@ -43,11 +44,15 @@ public partial class GDOpt : ImpulsePreviewOptionsForm
         });
 
         UpdateMinFrequencyLabel();
+        // CheckedChanged only fires on a transition, so sync the offset
+        // field's enabled state for a false -> false init too.
+        numericGateOffset.Enabled = !checkAutoFit.Checked;
         UpdateIrPreview();
     }
 
     public void SetOptions(FrequencyResponseOptions opt, CurveVisibilityOptions visibility)
     {
+        opt.GroupDelayGateAutoFit = checkAutoFit.Checked;
         opt.GroupDelayGateOffsetMs = (double)numericGateOffset.Value;
         opt.GroupDelayPlateauMs = (double)numericWindow.Value;
         opt.GroupDelayLeftMs = (double)numericLeftWindow.Value;
@@ -73,19 +78,27 @@ public partial class GDOpt : ImpulsePreviewOptionsForm
                 FrequencyResponseOptions.DefaultGroupDelaySmoothingInverseOctaves);
     }
 
-    // Snap the gate offset to the transfer IR peak (deterministic, gate-independent).
-    private void buttonFit_Click(object? sender, EventArgs e)
+    // Auto pressed: the offset field turns read-only and follows the
+    // estimated IR start; released: the field unlocks keeping the last
+    // value as the manual starting point.
+    private void AutoFitChanged()
     {
-        if (Measurement is not { } measurement ||
-            measurement.Transfer is not { ImpulseResponse.Length: > 0 } transfer ||
-            measurement.SampleRate <= 0)
+        numericGateOffset.Enabled = !checkAutoFit.Checked;
+        if (checkAutoFit.Checked)
         {
-            System.Media.SystemSounds.Beep.Play();
-            return;
+            ApplyAutoGateOffset();
         }
+    }
 
-        double onsetMs = transfer.PeakIndex * 1000.0 / measurement.SampleRate;
-        numericGateOffset.Value = ClampToControl(numericGateOffset, onsetMs);
+    // Snaps the gate offset to the estimated IR start (band-limited
+    // first-arrival front, memoized per IR in TransferIrStartCache).
+    private void ApplyAutoGateOffset()
+    {
+        if (Measurement is { } measurement &&
+            TransferIrStartCache.ResolveStartMs(measurement) is { } startMs)
+        {
+            numericGateOffset.Value = ClampToControl(numericGateOffset, startMs);
+        }
     }
 
     private void numericWindow_ValueChanged(object sender, EventArgs e)
@@ -116,6 +129,13 @@ public partial class GDOpt : ImpulsePreviewOptionsForm
 
     protected override void RenderIrPreview()
     {
+        // Auto mode re-snaps the offset whenever the preview refreshes —
+        // which includes every ImpulseResponseChanged of the measurement.
+        if (checkAutoFit.Checked)
+        {
+            ApplyAutoGateOffset();
+        }
+
         if (Measurement == null || Measurement.SampleRate <= 0)
         {
             return;
@@ -136,10 +156,10 @@ public partial class GDOpt : ImpulsePreviewOptionsForm
     {
         numericGateOffset.ApplyToolTip(
             toolTip,
-            "Gate position: time from the IR start to the end of the left Tukey shoulder. Use Fit to snap it to the transfer IR peak.");
+            "Gate position: time from the IR start to the end of the left Tukey shoulder. Auto keeps it snapped to the detected IR start.");
         toolTip.SetToolTip(
-            buttonFit,
-            "Snap the gate offset to the transfer IR peak.");
+            checkAutoFit,
+            "Keep the gate offset snapped to the detected IR start (band-limited first-arrival front), following every new measurement. Release to set the offset manually.");
         numericWindow.ApplyToolTip(
             toolTip,
             "Flat (weight 1) part of the gate after the peak, in milliseconds.");

--- a/source/Options/PROpt.Designer.cs
+++ b/source/Options/PROpt.Designer.cs
@@ -29,7 +29,7 @@ namespace Resonalyze.Options
         private void InitializeComponent()
         {
             labelGateOffset = new Label();
-            buttonFit = new Button();
+            checkAutoFit = new CheckBox();
             numericGateOffset = new DarkNumericUpDown();
             label9 = new Label();
             labelMinFrequency = new Label();
@@ -74,19 +74,22 @@ namespace Resonalyze.Options
             labelGateOffset.Size = new Size(91, 15);
             labelGateOffset.TabIndex = 60;
             labelGateOffset.Text = "Gate offset (ms)";
-            // 
-            // buttonFit
-            // 
-            buttonFit.BackColor = Color.FromArgb(55, 60, 72);
-            buttonFit.FlatStyle = FlatStyle.Flat;
-            buttonFit.ForeColor = Color.White;
-            buttonFit.Location = new Point(113, 103);
-            buttonFit.Name = "buttonFit";
-            buttonFit.Size = new Size(33, 21);
-            buttonFit.TabIndex = 61;
-            buttonFit.Text = "Fit";
-            buttonFit.UseCompatibleTextRendering = true;
-            buttonFit.UseVisualStyleBackColor = false;
+            //
+            // checkAutoFit
+            //
+            checkAutoFit.Appearance = Appearance.Button;
+            checkAutoFit.BackColor = Color.FromArgb(55, 60, 72);
+            checkAutoFit.FlatAppearance.CheckedBackColor = Color.FromArgb(80, 100, 140);
+            checkAutoFit.FlatStyle = FlatStyle.Flat;
+            checkAutoFit.ForeColor = Color.White;
+            checkAutoFit.Location = new Point(110, 103);
+            checkAutoFit.Name = "checkAutoFit";
+            checkAutoFit.Size = new Size(40, 21);
+            checkAutoFit.TabIndex = 61;
+            checkAutoFit.Text = "Auto";
+            checkAutoFit.TextAlign = ContentAlignment.MiddleCenter;
+            checkAutoFit.UseCompatibleTextRendering = true;
+            checkAutoFit.UseVisualStyleBackColor = false;
             // 
             // numericGateOffset
             // 
@@ -438,7 +441,7 @@ namespace Resonalyze.Options
             Controls.Add(irPlotView);
             Controls.Add(checkBoxShowCoherence);
             Controls.Add(numericGateOffset);
-            Controls.Add(buttonFit);
+            Controls.Add(checkAutoFit);
             Controls.Add(labelGateOffset);
             Controls.Add(labelMinFrequency);
             Controls.Add(labelCurves);
@@ -478,7 +481,7 @@ namespace Resonalyze.Options
         #endregion
 
         private Label labelGateOffset;
-        private Button buttonFit;
+        private CheckBox checkAutoFit;
         private DarkNumericUpDown numericGateOffset;
         private Label label9;
         private Label labelMinFrequency;

--- a/source/Options/PROpt.cs
+++ b/source/Options/PROpt.cs
@@ -19,7 +19,7 @@ namespace Resonalyze.Options
             numericLeftWindow.ValueChanged += Gate_ValueChanged;
             numericRightWindow.ValueChanged += Gate_ValueChanged;
             numericGateOffset.ValueChanged += (_, _) => UpdateIrPreview();
-            buttonFit.Click += buttonFit_Click;
+            checkAutoFit.CheckedChanged += (_, _) => AutoFitChanged();
             buttonTauSlope.Click += (_, _) => ApplyEstimatedTau(useSlope: true);
             buttonTauPeak.Click += (_, _) => ApplyEstimatedTau(useSlope: false);
             numericOffset.ValueChanged += (_, _) =>
@@ -47,6 +47,7 @@ namespace Resonalyze.Options
             InitializeControls(() =>
             {
                 numericGateOffset.Value = ClampToControl(numericGateOffset, opt.PhaseGateOffsetMs);
+                checkAutoFit.Checked = opt.PhaseGateAutoFit;
                 numericWindow.Value = ClampToControl(numericWindow, opt.PhasePlateauMs);
                 numericLeftWindow.Value = ClampToControl(numericLeftWindow, opt.PhaseLeftMs);
                 numericRightWindow.Value = ClampToControl(numericRightWindow, opt.PhaseRightMs);
@@ -67,11 +68,15 @@ namespace Resonalyze.Options
             });
             UpdateMinFrequencyLabel();
             UpdatePhaseControlState();
+            // CheckedChanged only fires on a transition, so sync the offset
+            // field's enabled state for a false -> false init too.
+            numericGateOffset.Enabled = !checkAutoFit.Checked;
             UpdateIrPreview();
         }
 
         public void SetOptions(FrequencyResponseOptions opt, CurveVisibilityOptions visibility)
         {
+            opt.PhaseGateAutoFit = checkAutoFit.Checked;
             opt.PhaseGateOffsetMs = (double)numericGateOffset.Value;
             opt.PhasePlateauMs = (double)numericWindow.Value;
             opt.PhaseLeftMs = (double)numericLeftWindow.Value;
@@ -222,19 +227,27 @@ namespace Resonalyze.Options
             }
         }
 
-        // Snap the gate offset to the transfer IR peak (deterministic, gate-independent).
-        private void buttonFit_Click(object? sender, EventArgs e)
+        // Auto pressed: the offset field turns read-only and follows the
+        // estimated IR start; released: the field unlocks keeping the last
+        // value as the manual starting point.
+        private void AutoFitChanged()
         {
-            if (Measurement is not { } measurement ||
-                measurement.Transfer is not { ImpulseResponse.Length: > 0 } transfer ||
-                measurement.SampleRate <= 0)
+            numericGateOffset.Enabled = !checkAutoFit.Checked;
+            if (checkAutoFit.Checked)
             {
-                System.Media.SystemSounds.Beep.Play();
-                return;
+                ApplyAutoGateOffset();
             }
+        }
 
-            double onsetMs = transfer.PeakIndex * 1000.0 / measurement.SampleRate;
-            numericGateOffset.Value = ClampToControl(numericGateOffset, onsetMs);
+        // Snaps the gate offset to the estimated IR start (band-limited
+        // first-arrival front, memoized per IR in TransferIrStartCache).
+        private void ApplyAutoGateOffset()
+        {
+            if (Measurement is { } measurement &&
+                TransferIrStartCache.ResolveStartMs(measurement) is { } startMs)
+            {
+                numericGateOffset.Value = ClampToControl(numericGateOffset, startMs);
+            }
         }
 
         private void numericWindow_ValueChanged(object sender, EventArgs e)
@@ -265,6 +278,13 @@ namespace Resonalyze.Options
 
         protected override void RenderIrPreview()
         {
+            // Auto mode re-snaps the offset whenever the preview refreshes —
+            // which includes every ImpulseResponseChanged of the measurement.
+            if (checkAutoFit.Checked)
+            {
+                ApplyAutoGateOffset();
+            }
+
             if (comboDetrendMode.SelectedIndex == (int)PhaseDetrendMode.Auto)
             {
                 UpdateDetrendDisplay();
@@ -290,10 +310,10 @@ namespace Resonalyze.Options
         {
             numericGateOffset.ApplyToolTip(
                 toolTip,
-                "Gate position: time from the IR start to the end of the left Tukey shoulder. Use Fit to snap it to the transfer IR peak.");
+                "Gate position: time from the IR start to the end of the left Tukey shoulder. Auto keeps it snapped to the detected IR start.");
             toolTip.SetToolTip(
-                buttonFit,
-                "Snap the gate offset to the transfer IR peak.");
+                checkAutoFit,
+                "Keep the gate offset snapped to the detected IR start (band-limited first-arrival front), following every new measurement. Release to set the offset manually.");
             numericWindow.ApplyToolTip(
                 toolTip,
                 "Flat (weight 1) part of the gate after the peak, in milliseconds.");

--- a/source/Plotting/MeasurementPlotContext.cs
+++ b/source/Plotting/MeasurementPlotContext.cs
@@ -37,6 +37,14 @@ internal sealed class MeasurementPlotContext
         expSweepMeasurement.TransferImpulseResponse is { Length: > 0 };
 
     /// <summary>
+    /// The estimated honest start of the transfer IR (ms) for the Auto gate
+    /// offset; null without a transfer IR. Memoized per IR in
+    /// <see cref="TransferIrStartCache"/>, shared with the options dialogs.
+    /// </summary>
+    public double? ResolveAutoGateOffsetMs() =>
+        TransferIrStartCache.ResolveStartMs(expSweepMeasurement);
+
+    /// <summary>
     /// The offset K that turns the loopback-referenced magnitude (dBr) into dB SPL:
     /// <c>K = loopbackPeakDbFs + calibrationOffsetDb</c>. Null when SPL cannot be
     /// shown — no calibration, no captured loopback level, or a calibration that does

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -314,6 +314,16 @@ internal sealed class PlotModelFactory
             IImpulseMeasurement primaryMeasurement =
                 measurementContext.CreatePrimaryMeasurement();
             var compare = TryCreateCompareMeasurement();
+            // Auto gate: re-snap the offset to the current measurement's IR
+            // start before reading the settings, so a fresh measurement is
+            // gated correctly even while the options dialog is closed. The
+            // options object is updated (not just a local copy) so the dialog
+            // and the persisted settings show the value the plot used.
+            if (phaseResponseOptions.PhaseGateAutoFit &&
+                measurementContext.ResolveAutoGateOffsetMs() is { } phaseStartMs)
+            {
+                phaseResponseOptions.PhaseGateOffsetMs = phaseStartMs;
+            }
             PhaseAnalysisSettings phaseSettings =
                 phaseResponseOptions.CreatePhaseAnalysisSettings();
             if (phaseSettings.DetrendMode == PhaseDetrendMode.Auto && compare != null)
@@ -504,6 +514,13 @@ internal sealed class PlotModelFactory
             (groupDelayVisibility.ShowGroupDelay || groupDelayVisibility.ShowCoherence))
         {
             const string groupDelayTrackerFormat = "{0}\n{2:0.0} Hz\n{4:0.000} ms";
+            // Auto gate: same contract as the phase plot — re-snap the offset
+            // to the current measurement's IR start in the shared options.
+            if (groupDelayOptions.GroupDelayGateAutoFit &&
+                measurementContext.ResolveAutoGateOffsetMs() is { } gdStartMs)
+            {
+                groupDelayOptions.GroupDelayGateOffsetMs = gdStartMs;
+            }
             if (groupDelayVisibility.ShowGroupDelay)
             {
                 // The gate is positioned by its Gate offset (left-shoulder-end) within the

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -393,15 +393,27 @@ internal sealed class PlotModelFactory
                     phaseUnwrapped: true);
             }
 
-            // Overlay the Compare measurement with the identical gate / detrend /
-            // smoothing so the two responses can be read on the same terms.
+            // Overlay the Compare measurement with the identical gate LENGTH,
+            // window mode, detrend and smoothing so the two responses read on
+            // the same terms. The gate's PLACEMENT is per-curve under Auto:
+            // the two records' fronts sit at different times, and one shared
+            // offset would cut the earlier record's direct arrival into the
+            // left shoulder. The extraction re-references every spectrum to
+            // absolute time and both curves share the one τ resolved above,
+            // so their relative phase/delay survives the differing windows.
             if (compare is { } compareData)
             {
+                PhaseAnalysisSettings comparePhaseSettings =
+                    phaseResponseOptions.PhaseGateAutoFit &&
+                    TransferIrStartCache.ResolveStartMs(compareData.Measurement)
+                        is { } compareStartMs
+                        ? phaseSettings with { GateOffsetMs = compareStartMs }
+                        : phaseSettings;
                 if (phaseResponseVisibility.ShowMeasuredPhase)
                 {
                     AnalysisCurve compareCurve = DataHelper.GetPhase(
                         compareData.Measurement,
-                        phaseSettings,
+                        comparePhaseSettings,
                         compareData.Coherence);
                     AddCompareLineSeries(
                         model,
@@ -416,7 +428,7 @@ internal sealed class PlotModelFactory
                 {
                     AnalysisCurve compareCurve = DataHelper.GetMinimumPhase(
                         compareData.Measurement,
-                        phaseSettings);
+                        comparePhaseSettings);
                     AddCompareLineSeries(
                         model,
                         compareCurve,
@@ -430,7 +442,7 @@ internal sealed class PlotModelFactory
                 {
                     AnalysisCurve compareCurve = DataHelper.GetExcessPhase(
                         compareData.Measurement,
-                        phaseSettings,
+                        comparePhaseSettings,
                         compareData.Coherence);
                     AddCompareLineSeries(
                         model,
@@ -537,12 +549,22 @@ internal sealed class PlotModelFactory
                 AddLineSeries(model, curve, groupDelayTrackerFormat, Mode.GroupDelay, GroupDelayAxisKey);
                 UpdateGroupDelayRange(curve, ref minimum, ref maximum, ref hasValidData);
 
-                // Overlay the Compare measurement with the identical gate / smoothing.
+                // Overlay the Compare measurement with the identical gate
+                // length / smoothing. Under Auto the gate PLACEMENT is
+                // per-curve (each record's own IR start): group delay reads
+                // absolute from the IR start, so differently placed windows
+                // stay directly comparable while both direct arrivals survive.
                 if (TryCreateCompareMeasurement() is { } compare)
                 {
+                    double compareGateOffsetMs =
+                        groupDelayOptions.GroupDelayGateAutoFit &&
+                        TransferIrStartCache.ResolveStartMs(compare.Measurement)
+                            is { } compareStartMs
+                            ? compareStartMs
+                            : groupDelayOptions.GroupDelayGateOffsetMs;
                     AnalysisCurve compareCurve = DataHelper.GetGroupDelay(
                         compare.Measurement,
-                        groupDelayOptions.GroupDelayGateOffsetMs,
+                        compareGateOffsetMs,
                         groupDelayOptions.GroupDelayLeftMs,
                         groupDelayOptions.GroupDelayPlateauMs,
                         groupDelayOptions.GroupDelayRightMs,

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -403,9 +403,11 @@ internal sealed class MeasurementSettingsFile
         public bool ShowThdPlusNoise { get; set; } = true;
         public bool ShowNoiseFloor { get; set; } = true;
         public bool ShowGroupDelay { get; set; } = true;
-        // Nullable so a pre-Auto file (v <= 9, field absent) is
-        // distinguishable from a stored choice — see ApplyTo.
-        public bool? PhaseGateAutoFit { get; set; } = true;
+        // Nullable and deliberately WITHOUT an initializer: System.Text.Json
+        // never assigns a missing property, so an initializer value would
+        // survive deserialization and a pre-Auto file (v <= 9, field absent)
+        // would be indistinguishable from a stored true — see ApplyTo.
+        public bool? PhaseGateAutoFit { get; set; }
         public double PhaseGateOffsetMs { get; set; } = FrequencyResponseOptions.DefaultPhaseGateOffsetMs;
         public double PhaseLeftMs { get; set; } = FrequencyResponseOptions.DefaultPhaseLeftMs;
         public double PhasePlateauMs { get; set; } = FrequencyResponseOptions.DefaultPhasePlateauMs;
@@ -416,7 +418,7 @@ internal sealed class MeasurementSettingsFile
         public int PhaseFdwCycles { get; set; } = PhaseAnalysisSettings.DefaultFdwCycles;
         public PhaseDetrendMode? PhaseDetrendMode { get; set; } =
             Resonalyze.Dsp.PhaseDetrendMode.Auto;
-        public bool? GroupDelayGateAutoFit { get; set; } = true;
+        public bool? GroupDelayGateAutoFit { get; set; }
         public double GroupDelayGateOffsetMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayGateOffsetMs;
         public double GroupDelayLeftMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayLeftMs;
         public double GroupDelayPlateauMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayPlateauMs;

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -403,6 +403,7 @@ internal sealed class MeasurementSettingsFile
         public bool ShowThdPlusNoise { get; set; } = true;
         public bool ShowNoiseFloor { get; set; } = true;
         public bool ShowGroupDelay { get; set; } = true;
+        public bool PhaseGateAutoFit { get; set; } = true;
         public double PhaseGateOffsetMs { get; set; } = FrequencyResponseOptions.DefaultPhaseGateOffsetMs;
         public double PhaseLeftMs { get; set; } = FrequencyResponseOptions.DefaultPhaseLeftMs;
         public double PhasePlateauMs { get; set; } = FrequencyResponseOptions.DefaultPhasePlateauMs;
@@ -413,6 +414,7 @@ internal sealed class MeasurementSettingsFile
         public int PhaseFdwCycles { get; set; } = PhaseAnalysisSettings.DefaultFdwCycles;
         public PhaseDetrendMode? PhaseDetrendMode { get; set; } =
             Resonalyze.Dsp.PhaseDetrendMode.Auto;
+        public bool GroupDelayGateAutoFit { get; set; } = true;
         public double GroupDelayGateOffsetMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayGateOffsetMs;
         public double GroupDelayLeftMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayLeftMs;
         public double GroupDelayPlateauMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayPlateauMs;
@@ -443,6 +445,7 @@ internal sealed class MeasurementSettingsFile
                 ShowThdPlusNoise = visibility.ShowThdPlusNoise,
                 ShowNoiseFloor = visibility.ShowNoiseFloor,
                 ShowGroupDelay = visibility.ShowGroupDelay,
+                PhaseGateAutoFit = options.PhaseGateAutoFit,
                 PhaseGateOffsetMs = options.PhaseGateOffsetMs,
                 PhaseLeftMs = options.PhaseLeftMs,
                 PhasePlateauMs = options.PhasePlateauMs,
@@ -451,6 +454,7 @@ internal sealed class MeasurementSettingsFile
                 PhaseWindowMode = options.PhaseWindowMode,
                 PhaseFdwCycles = options.PhaseFdwCycles,
                 PhaseDetrendMode = options.PhaseDetrendMode,
+                GroupDelayGateAutoFit = options.GroupDelayGateAutoFit,
                 GroupDelayGateOffsetMs = options.GroupDelayGateOffsetMs,
                 GroupDelayLeftMs = options.GroupDelayLeftMs,
                 GroupDelayPlateauMs = options.GroupDelayPlateauMs,
@@ -484,6 +488,7 @@ internal sealed class MeasurementSettingsFile
             visibility.ShowThdPlusNoise = ShowThdPlusNoise;
             visibility.ShowNoiseFloor = ShowNoiseFloor;
             visibility.ShowGroupDelay = ShowGroupDelay;
+            options.PhaseGateAutoFit = PhaseGateAutoFit;
             options.PhaseGateOffsetMs = ClampMilliseconds(PhaseGateOffsetMs, 0.0, 2000.0);
             options.PhaseLeftMs = ClampMilliseconds(PhaseLeftMs, 0.0, 1000.0);
             options.PhasePlateauMs = ClampMilliseconds(PhasePlateauMs, 0.0, 1000.0);
@@ -502,6 +507,7 @@ internal sealed class MeasurementSettingsFile
                 Enum.IsDefined(detrendMode)
                     ? detrendMode
                     : Resonalyze.Dsp.PhaseDetrendMode.Manual;
+            options.GroupDelayGateAutoFit = GroupDelayGateAutoFit;
             options.GroupDelayGateOffsetMs = ClampMilliseconds(GroupDelayGateOffsetMs, 0.0, 2000.0);
             options.GroupDelayLeftMs = ClampMilliseconds(GroupDelayLeftMs, 0.0, 1000.0);
             options.GroupDelayPlateauMs = ClampMilliseconds(GroupDelayPlateauMs, 0.0, 1000.0);

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -403,7 +403,9 @@ internal sealed class MeasurementSettingsFile
         public bool ShowThdPlusNoise { get; set; } = true;
         public bool ShowNoiseFloor { get; set; } = true;
         public bool ShowGroupDelay { get; set; } = true;
-        public bool PhaseGateAutoFit { get; set; } = true;
+        // Nullable so a pre-Auto file (v <= 9, field absent) is
+        // distinguishable from a stored choice — see ApplyTo.
+        public bool? PhaseGateAutoFit { get; set; } = true;
         public double PhaseGateOffsetMs { get; set; } = FrequencyResponseOptions.DefaultPhaseGateOffsetMs;
         public double PhaseLeftMs { get; set; } = FrequencyResponseOptions.DefaultPhaseLeftMs;
         public double PhasePlateauMs { get; set; } = FrequencyResponseOptions.DefaultPhasePlateauMs;
@@ -414,7 +416,7 @@ internal sealed class MeasurementSettingsFile
         public int PhaseFdwCycles { get; set; } = PhaseAnalysisSettings.DefaultFdwCycles;
         public PhaseDetrendMode? PhaseDetrendMode { get; set; } =
             Resonalyze.Dsp.PhaseDetrendMode.Auto;
-        public bool GroupDelayGateAutoFit { get; set; } = true;
+        public bool? GroupDelayGateAutoFit { get; set; } = true;
         public double GroupDelayGateOffsetMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayGateOffsetMs;
         public double GroupDelayLeftMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayLeftMs;
         public double GroupDelayPlateauMs { get; set; } = FrequencyResponseOptions.DefaultGroupDelayPlateauMs;
@@ -488,7 +490,12 @@ internal sealed class MeasurementSettingsFile
             visibility.ShowThdPlusNoise = ShowThdPlusNoise;
             visibility.ShowNoiseFloor = ShowNoiseFloor;
             visibility.ShowGroupDelay = ShowGroupDelay;
-            options.PhaseGateAutoFit = PhaseGateAutoFit;
+            // Absent in a pre-Auto file: enable Auto only when the stored
+            // offset is the untouched default. A deliberately fitted/typed
+            // gate must stay manual — the Auto re-snap would silently
+            // overwrite the user's placement and persist over it.
+            options.PhaseGateAutoFit = PhaseGateAutoFit ??
+                PhaseGateOffsetMs == FrequencyResponseOptions.DefaultPhaseGateOffsetMs;
             options.PhaseGateOffsetMs = ClampMilliseconds(PhaseGateOffsetMs, 0.0, 2000.0);
             options.PhaseLeftMs = ClampMilliseconds(PhaseLeftMs, 0.0, 1000.0);
             options.PhasePlateauMs = ClampMilliseconds(PhasePlateauMs, 0.0, 1000.0);
@@ -507,7 +514,8 @@ internal sealed class MeasurementSettingsFile
                 Enum.IsDefined(detrendMode)
                     ? detrendMode
                     : Resonalyze.Dsp.PhaseDetrendMode.Manual;
-            options.GroupDelayGateAutoFit = GroupDelayGateAutoFit;
+            options.GroupDelayGateAutoFit = GroupDelayGateAutoFit ??
+                GroupDelayGateOffsetMs == FrequencyResponseOptions.DefaultGroupDelayGateOffsetMs;
             options.GroupDelayGateOffsetMs = ClampMilliseconds(GroupDelayGateOffsetMs, 0.0, 2000.0);
             options.GroupDelayLeftMs = ClampMilliseconds(GroupDelayLeftMs, 0.0, 1000.0);
             options.GroupDelayPlateauMs = ClampMilliseconds(GroupDelayPlateauMs, 0.0, 1000.0);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverGateDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverGateDialog.Designer.cs
@@ -32,7 +32,7 @@ namespace Resonalyze
         {
             labelGateOffset = new Label();
             numericGateOffset = new DarkNumericUpDown();
-            buttonFit = new Button();
+            checkAutoOffset = new CheckBox();
             labelLeft = new Label();
             numericLeft = new DarkNumericUpDown();
             labelPlateau = new Label();
@@ -88,17 +88,22 @@ namespace Resonalyze
             numericGateOffset.TextAlign = HorizontalAlignment.Right;
             numericGateOffset.ThousandsSeparator = false;
             numericGateOffset.Value = new decimal(new int[] { 0, 0, 0, 0 });
-            // 
-            // buttonFit
-            // 
-            buttonFit.FlatStyle = FlatStyle.Popup;
-            buttonFit.ForeColor = Color.White;
-            buttonFit.Location = new Point(198, 10);
-            buttonFit.Name = "buttonFit";
-            buttonFit.Size = new Size(40, 23);
-            buttonFit.TabIndex = 2;
-            buttonFit.Text = "Fit";
-            buttonFit.UseVisualStyleBackColor = true;
+            //
+            // checkAutoOffset
+            //
+            checkAutoOffset.Appearance = Appearance.Button;
+            checkAutoOffset.BackColor = Color.FromArgb(55, 60, 72);
+            checkAutoOffset.FlatAppearance.CheckedBackColor = Color.FromArgb(80, 100, 140);
+            checkAutoOffset.FlatStyle = FlatStyle.Flat;
+            checkAutoOffset.ForeColor = Color.White;
+            checkAutoOffset.Location = new Point(198, 10);
+            checkAutoOffset.Name = "checkAutoOffset";
+            checkAutoOffset.Size = new Size(44, 23);
+            checkAutoOffset.TabIndex = 2;
+            checkAutoOffset.Text = "Auto";
+            checkAutoOffset.TextAlign = ContentAlignment.MiddleCenter;
+            checkAutoOffset.UseCompatibleTextRendering = true;
+            checkAutoOffset.UseVisualStyleBackColor = false;
             // 
             // labelLeft
             // 
@@ -367,7 +372,7 @@ namespace Resonalyze
             ClientSize = new Size(620, 512);
             Controls.Add(labelGateOffset);
             Controls.Add(numericGateOffset);
-            Controls.Add(buttonFit);
+            Controls.Add(checkAutoOffset);
             Controls.Add(labelLeft);
             Controls.Add(numericLeft);
             Controls.Add(labelPlateau);
@@ -411,7 +416,7 @@ namespace Resonalyze
 
         private Label labelGateOffset;
         private DarkNumericUpDown numericGateOffset;
-        private Button buttonFit;
+        private CheckBox checkAutoOffset;
         private Label labelLeft;
         private DarkNumericUpDown numericLeft;
         private Label labelPlateau;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverGateDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverGateDialog.cs
@@ -49,8 +49,14 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         comboWindowMode.SelectedIndexChanged += (_, _) => OnGateChanged();
         comboFdwCycles.SelectedIndexChanged += (_, _) => OnGateChanged();
         comboDetrendMode.SelectedIndexChanged += (_, _) => OnGateChanged();
-        buttonFit.Click += (_, _) =>
-            numericGateOffset.Value = Clamp(numericGateOffset, fitOffsetMs);
+        checkAutoOffset.CheckedChanged += (_, _) =>
+        {
+            numericGateOffset.Enabled = !checkAutoOffset.Checked;
+            if (checkAutoOffset.Checked)
+            {
+                numericGateOffset.Value = Clamp(numericGateOffset, fitOffsetMs);
+            }
+        };
         buttonTauSlope.Click += (_, _) => ApplyEstimatedTau(useSlope: true);
         buttonTauPeak.Click += (_, _) => ApplyEstimatedTau(useSlope: false);
         buttonSave.Click += (_, _) => CommitGateEditors();
@@ -62,6 +68,12 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
     }
 
     public double GateOffsetMs => (double)numericGateOffset.Value;
+
+    /// <summary>
+    /// Auto pressed: the offset is not pinned — the caller stores null and the
+    /// gate keeps following the earliest estimated channel IR start.
+    /// </summary>
+    public bool AutoOffset => checkAutoOffset.Checked;
     public double LeftMs => (double)numericLeft.Value;
     public double PlateauMs => (double)numericPlateau.Value;
     public double RightMs => (double)numericRight.Value;
@@ -78,8 +90,9 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
             : PhaseDetrendMode.Auto;
     /// <summary>
     /// Seeds the dialog: the processed channel IRs to preview (absolute
-    /// timeline), the current gate values, and the offset the Fit button snaps
-    /// to (the earliest processed arrival).
+    /// timeline), the current gate values, the offset Auto snaps to (the
+    /// earliest estimated channel IR start) and whether the offset is
+    /// currently unpinned (Auto pressed).
     /// </summary>
     public void Init(
         IReadOnlyList<IrPreviewTrace> previewTraces,
@@ -92,13 +105,19 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         PhaseWindowMode windowMode,
         int fdwCycles,
         PhaseDetrendMode detrendMode,
-        double fitToMs)
+        double fitToMs,
+        bool autoOffset)
     {
         traces = previewTraces;
         sampleRate = previewSampleRate;
         fitOffsetMs = fitToMs;
 
         numericGateOffset.Value = Clamp(numericGateOffset, gateOffsetMs);
+        // After the offset: a false -> true transition re-snaps the value to
+        // fitOffsetMs (already seeded) and disables the field; false -> false
+        // never fires CheckedChanged, so sync the enabled state explicitly.
+        checkAutoOffset.Checked = autoOffset;
+        numericGateOffset.Enabled = !autoOffset;
         numericLeft.Value = Clamp(numericLeft, leftMs);
         numericPlateau.Value = Clamp(numericPlateau, plateauMs);
         numericRight.Value = Clamp(numericRight, rightMs);
@@ -249,11 +268,12 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
             toolTip,
             "Gate position: time from the IR start to the end\r\n" +
             "of the left Tukey shoulder.\r\n" +
-            "Use Fit to snap it to the earliest channel arrival.");
+            "Auto keeps it on the earliest channel IR start.");
         toolTip.SetToolTip(
-            buttonFit,
-            "Snap the gate offset to the earliest processed\r\n" +
-            "channel arrival.");
+            checkAutoOffset,
+            "Keep the gate offset on the earliest processed channel's\r\n" +
+            "detected IR start, following source and delay changes.\r\n" +
+            "Release to pin the offset manually.");
         numericLeft.ApplyToolTip(
             toolTip,
             "Tukey fade-in before the arrival, in milliseconds.\r\n" +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3021,10 +3021,9 @@ public partial class VirtualCrossoverPanel : UserControl
         // One shared absolute reference (the earliest arrival) keeps the curves'
         // relative phase intact — that relative alignment through the crossover
         // region is exactly what this view is for.
-        int reference = processed.Min(item => item.PeakIndex);
         int sampleRate = processed[0].Channel.SampleRate;
         double gateOffsetMs = gatePreview?.OffsetMs
-            ?? ResolveGateOffsetMs(reference, sampleRate);
+            ?? ResolveGateOffsetMs(processed, sampleRate);
         double detrendMs = ResolveCommonDetrendMs(processed, gateOffsetMs, sampleRate);
 
         // Read the gate and project state ONCE, here on the UI thread: every curve gets
@@ -3088,10 +3087,9 @@ public partial class VirtualCrossoverPanel : UserControl
             return null;
         }
 
-        int reference = shown.Min(item => item.PeakIndex);
         int sampleRate = shown[0].Channel.SampleRate;
         double gateOffsetMs = gatePreview?.OffsetMs
-            ?? ResolveGateOffsetMs(reference, sampleRate);
+            ?? ResolveGateOffsetMs(shown, sampleRate);
 
         var traces = shown
             .Select(item => new IrPreviewTrace(
@@ -3115,11 +3113,23 @@ public partial class VirtualCrossoverPanel : UserControl
     private VirtualCrossoverPhaseGateSettings ActiveGate =>
         project.PhaseGateFor(project.ActiveSideRight);
 
-    // A stored gate offset is used as-is; an unconfigured side follows the
-    // earliest processed arrival, so the gate tracks source and delay changes
-    // until the user pins it in the gate dialog.
-    private double ResolveGateOffsetMs(int referenceSample, int sampleRate) =>
-        ActiveGate.OffsetMs ?? referenceSample * 1_000.0 / sampleRate;
+    // A stored gate offset is used as-is; an unconfigured side (Auto) follows
+    // the earliest ESTIMATED IR START of the processed channels — the
+    // band-limited first-arrival front, robust to head garbage that poisons a
+    // bare peak read — so the gate tracks source and delay changes until the
+    // user pins it in the gate dialog.
+    private double ResolveGateOffsetMs(
+        IReadOnlyList<ProcessedChannel> processed,
+        int sampleRate) =>
+        ActiveGate.OffsetMs ?? EarliestStartMs(processed, sampleRate);
+
+    // The Auto gate anchor: the earliest estimated IR start across the
+    // processed channels (memoized per IR in TransferIrStartCache).
+    private static double EarliestStartMs(
+        IReadOnlyList<ProcessedChannel> processed,
+        int sampleRate) =>
+        processed.Min(item => TransferIrStartCache.ResolveStartMs(
+            item.ImpulseResponse, sampleRate, item.PeakIndex));
 
     // The τ detrend follows the same pattern: unconfigured projects reference
     // the earliest arrival. One τ serves every curve, so their relative phase —
@@ -3231,7 +3241,7 @@ public partial class VirtualCrossoverPanel : UserControl
 
         int sampleRate = processed[0].Channel.SampleRate;
         int reference = processed.Min(item => item.PeakIndex);
-        double fitOffsetMs = reference * 1_000.0 / sampleRate;
+        double fitOffsetMs = EarliestStartMs(processed, sampleRate);
 
         var traces = processed
             .Select(item => new IrPreviewTrace(
@@ -3244,7 +3254,7 @@ public partial class VirtualCrossoverPanel : UserControl
         dialog.Init(
             traces,
             sampleRate,
-            ResolveGateOffsetMs(reference, sampleRate),
+            ResolveGateOffsetMs(processed, sampleRate),
             project.PhaseGateLeftMs,
             project.PhaseGatePlateauMs,
             project.PhaseGateRightMs,
@@ -3252,7 +3262,8 @@ public partial class VirtualCrossoverPanel : UserControl
             project.PhaseWindowMode,
             project.PhaseFdwCycles,
             project.PhaseDetrendMode,
-            fitOffsetMs);
+            fitOffsetMs,
+            autoOffset: ActiveGate.OffsetMs == null);
         // The callback is wired after Init so seeding the controls does not
         // trigger a redundant redraw; from here every dialog change repaints the
         // phase plot immediately.
@@ -3272,7 +3283,9 @@ public partial class VirtualCrossoverPanel : UserControl
                 // lengths and the analysis modes are project-wide, so both sides keep
                 // reading the phase at the same resolution and by the same method.
                 VirtualCrossoverPhaseGateSettings gate = ActiveGate;
-                gate.OffsetMs = dialog.GateOffsetMs;
+                // Auto pressed = unpinned: store null so this side's gate
+                // keeps following the earliest estimated channel IR start.
+                gate.OffsetMs = dialog.AutoOffset ? null : dialog.GateOffsetMs;
                 gate.DetrendMs = dialog.DetrendMs;
                 project.PhaseGateLeftMs = dialog.LeftMs;
                 project.PhaseGatePlateauMs = dialog.PlateauMs;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3060,12 +3060,33 @@ public partial class VirtualCrossoverPanel : UserControl
         return jobs
             .AsParallel()
             .AsOrdered()
-            .Select(job => new AcousticCurve(
-                job.Title,
-                BuildPhasePoints(job.Ir, sampleRate, settings),
-                job.Color,
-                job.Thickness,
-                LineStyle.Solid))
+            .SelectMany(job =>
+            {
+                (List<SignalPoint> points, List<SignalPoint> wrapSegments) =
+                    BuildPhasePoints(job.Ir, sampleRate, settings);
+                var curves = new List<AcousticCurve>(2);
+                // The ±360° wrap verticals: the channel's color faded and
+                // thinned well below the curve, dashed, drawn first (i.e.
+                // under the solid curve) — visible as wraps without competing
+                // with the phase traces. The empty title keeps them out of
+                // the plot-labels panel.
+                if (wrapSegments.Count > 0)
+                {
+                    curves.Add(new AcousticCurve(
+                        string.Empty,
+                        wrapSegments,
+                        OxyColor.FromAColor(110, job.Color),
+                        job.Thickness * 0.4,
+                        LineStyle.Dash));
+                }
+                curves.Add(new AcousticCurve(
+                    job.Title,
+                    points,
+                    job.Color,
+                    job.Thickness,
+                    LineStyle.Solid));
+                return curves;
+            })
             .ToList();
     }
 
@@ -3182,10 +3203,11 @@ public partial class VirtualCrossoverPanel : UserControl
     // Static on purpose: the caller reads the gate and project state once on the UI
     // thread and hands the settings down, so this runs on a pool thread without the
     // compiler letting it reach back into a control.
-    private static List<SignalPoint> BuildPhasePoints(
-        Complex[] impulseResponse,
-        int sampleRate,
-        PhaseAnalysisSettings settings)
+    private static (List<SignalPoint> Points, List<SignalPoint> WrapSegments)
+        BuildPhasePoints(
+            Complex[] impulseResponse,
+            int sampleRate,
+            PhaseAnalysisSettings settings)
     {
         // The gate construction is shared with the Phase mode (DataHelper's
         // gated extraction): a Tukey window of left + plateau + right whose
@@ -3196,11 +3218,14 @@ public partial class VirtualCrossoverPanel : UserControl
         var view = new ImpulseMeasurementView(impulseResponse, 0, sampleRate);
         List<SignalPoint> phase = DataHelper.GetGatedPhaseData(view, settings);
 
-        // Wrapped phase jumps from +180° to −180° between adjacent bins; a NaN
-        // break keeps the plot from drawing that wrap as a vertical line that
-        // reads like a real phase transition.
+        // Wrapped phase jumps from +180° to −180° between adjacent bins. The
+        // main curve breaks at the wrap (NaN) so the jump does not read as a
+        // real phase transition drawn at full stroke; the jump itself goes
+        // into WrapSegments — NaN-separated two-point verticals the caller
+        // draws as a thinner dashed twin, keeping the wrap visible.
         var points = new List<SignalPoint>(phase.Count);
-        double previous = double.NaN;
+        var wrapSegments = new List<SignalPoint>();
+        SignalPoint? previous = null;
         foreach (SignalPoint point in phase)
         {
             if (point.X is < 20 or > 20_000)
@@ -3208,18 +3233,25 @@ public partial class VirtualCrossoverPanel : UserControl
                 continue;
             }
 
-            double degrees = point.Y / Math.PI * 180.0;
-            if (!double.IsNaN(previous) && !double.IsNaN(degrees) &&
-                Math.Abs(degrees - previous) > 180.0)
+            var current = new SignalPoint(point.X, point.Y / Math.PI * 180.0);
+            if (previous is { } before && !double.IsNaN(before.Y) &&
+                !double.IsNaN(current.Y) &&
+                Math.Abs(current.Y - before.Y) > 180.0)
             {
                 points.Add(new SignalPoint(point.X, double.NaN));
+                // Strictly vertical, halfway between the two bins (geometric
+                // mean = the visual midpoint on the log-frequency axis).
+                double wrapHz = Math.Sqrt(before.X * current.X);
+                wrapSegments.Add(new SignalPoint(wrapHz, before.Y));
+                wrapSegments.Add(new SignalPoint(wrapHz, current.Y));
+                wrapSegments.Add(new SignalPoint(wrapHz, double.NaN));
             }
 
-            points.Add(new SignalPoint(point.X, degrees));
-            previous = degrees;
+            points.Add(current);
+            previous = current;
         }
 
-        return points;
+        return (points, wrapSegments);
     }
 
     // Opens the manual phase-gate dialog: the gate offset and Tukey shoulders

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -37,8 +37,9 @@ public enum DspPlotMode
 public sealed class VirtualCrossoverPhaseGateSettings
 {
     /// <summary>
-    /// Null follows this side's earliest processed arrival automatically, so the gate
-    /// tracks source and delay changes until the user pins it in the gate dialog.
+    /// Null (the gate dialog's Auto) follows this side's earliest estimated
+    /// channel IR start automatically, so the gate tracks source and delay
+    /// changes until the user pins it in the gate dialog.
     /// </summary>
     public double? OffsetMs { get; set; }
 

--- a/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
@@ -1,3 +1,6 @@
+using Resonalyze.Dsp;
+using Resonalyze.Options;
+
 namespace Resonalyze.App.Tests;
 
 // The separate-loopback-device capability was removed; a settings file
@@ -144,6 +147,69 @@ public sealed class MeasurementSettingsMigrationTests
 
         Assert.Equal(5, measurement.WaveInputChannelOffset);
         Assert.Equal(7, measurement.WaveLoopbackInputChannelOffset);
+    }
+
+    // A pre-Auto file (v <= 9) has no PhaseGateAutoFit/GroupDelayGateAutoFit
+    // fields — the nullable stays null after deserialization. A deliberately
+    // fitted/typed gate offset must stay manual (Auto would silently re-snap
+    // and persist over it); an untouched default offset gets the new Auto.
+    [Fact]
+    public void PreAutoFileWithACustomGateOffsetStaysManual()
+    {
+        var settings = new MeasurementSettingsFile.FrequencyResponseSettings
+        {
+            PhaseGateAutoFit = null,
+            PhaseGateOffsetMs = 6.5,
+            GroupDelayGateAutoFit = null,
+            GroupDelayGateOffsetMs = 12.25
+        };
+        var options = new FrequencyResponseOptions();
+
+        settings.ApplyTo(options, new CurveVisibilityOptions());
+
+        Assert.False(options.PhaseGateAutoFit);
+        Assert.Equal(6.5, options.PhaseGateOffsetMs);
+        Assert.False(options.GroupDelayGateAutoFit);
+        Assert.Equal(12.25, options.GroupDelayGateOffsetMs);
+    }
+
+    [Fact]
+    public void PreAutoFileWithTheDefaultGateOffsetGetsAuto()
+    {
+        var settings = new MeasurementSettingsFile.FrequencyResponseSettings
+        {
+            PhaseGateAutoFit = null,
+            PhaseGateOffsetMs = FrequencyResponseOptions.DefaultPhaseGateOffsetMs,
+            GroupDelayGateAutoFit = null,
+            GroupDelayGateOffsetMs =
+                FrequencyResponseOptions.DefaultGroupDelayGateOffsetMs
+        };
+        var options = new FrequencyResponseOptions();
+
+        settings.ApplyTo(options, new CurveVisibilityOptions());
+
+        Assert.True(options.PhaseGateAutoFit);
+        Assert.True(options.GroupDelayGateAutoFit);
+    }
+
+    [Fact]
+    public void StoredAutoFitChoiceIsAppliedAsIs()
+    {
+        var settings = new MeasurementSettingsFile.FrequencyResponseSettings
+        {
+            // An explicitly released Auto with the default offset must not be
+            // re-enabled by the missing-field heuristic.
+            PhaseGateAutoFit = false,
+            PhaseGateOffsetMs = FrequencyResponseOptions.DefaultPhaseGateOffsetMs,
+            GroupDelayGateAutoFit = true,
+            GroupDelayGateOffsetMs = 12.25
+        };
+        var options = new FrequencyResponseOptions();
+
+        settings.ApplyTo(options, new CurveVisibilityOptions());
+
+        Assert.False(options.PhaseGateAutoFit);
+        Assert.True(options.GroupDelayGateAutoFit);
     }
 
     // The migration runs inside LoadOrDefault (which reads the real settings

--- a/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
@@ -150,19 +150,19 @@ public sealed class MeasurementSettingsMigrationTests
     }
 
     // A pre-Auto file (v <= 9) has no PhaseGateAutoFit/GroupDelayGateAutoFit
-    // fields — the nullable stays null after deserialization. A deliberately
-    // fitted/typed gate offset must stay manual (Auto would silently re-snap
-    // and persist over it); an untouched default offset gets the new Auto.
+    // fields. These tests deserialize REAL JSON without the fields — the
+    // failure mode they guard is exactly a property initializer surviving
+    // deserialization (System.Text.Json never assigns a missing property),
+    // which a hand-built object with an explicit null cannot catch. A
+    // deliberately fitted/typed gate offset must stay manual (Auto would
+    // silently re-snap and persist over it); an untouched default offset
+    // gets the new Auto.
     [Fact]
     public void PreAutoFileWithACustomGateOffsetStaysManual()
     {
-        var settings = new MeasurementSettingsFile.FrequencyResponseSettings
-        {
-            PhaseGateAutoFit = null,
-            PhaseGateOffsetMs = 6.5,
-            GroupDelayGateAutoFit = null,
-            GroupDelayGateOffsetMs = 12.25
-        };
+        MeasurementSettingsFile.FrequencyResponseSettings settings =
+            DeserializeFrequencyResponse(
+                """{"PhaseGateOffsetMs": 6.5, "GroupDelayGateOffsetMs": 12.25}""");
         var options = new FrequencyResponseOptions();
 
         settings.ApplyTo(options, new CurveVisibilityOptions());
@@ -176,14 +176,8 @@ public sealed class MeasurementSettingsMigrationTests
     [Fact]
     public void PreAutoFileWithTheDefaultGateOffsetGetsAuto()
     {
-        var settings = new MeasurementSettingsFile.FrequencyResponseSettings
-        {
-            PhaseGateAutoFit = null,
-            PhaseGateOffsetMs = FrequencyResponseOptions.DefaultPhaseGateOffsetMs,
-            GroupDelayGateAutoFit = null,
-            GroupDelayGateOffsetMs =
-                FrequencyResponseOptions.DefaultGroupDelayGateOffsetMs
-        };
+        MeasurementSettingsFile.FrequencyResponseSettings settings =
+            DeserializeFrequencyResponse("""{"PhasePlateauMs": 4.0}""");
         var options = new FrequencyResponseOptions();
 
         settings.ApplyTo(options, new CurveVisibilityOptions());
@@ -195,15 +189,14 @@ public sealed class MeasurementSettingsMigrationTests
     [Fact]
     public void StoredAutoFitChoiceIsAppliedAsIs()
     {
-        var settings = new MeasurementSettingsFile.FrequencyResponseSettings
-        {
-            // An explicitly released Auto with the default offset must not be
-            // re-enabled by the missing-field heuristic.
-            PhaseGateAutoFit = false,
-            PhaseGateOffsetMs = FrequencyResponseOptions.DefaultPhaseGateOffsetMs,
-            GroupDelayGateAutoFit = true,
-            GroupDelayGateOffsetMs = 12.25
-        };
+        // An explicitly released Auto with the default offset must not be
+        // re-enabled by the missing-field heuristic.
+        MeasurementSettingsFile.FrequencyResponseSettings settings =
+            DeserializeFrequencyResponse(
+                """
+                {"PhaseGateAutoFit": false,
+                 "GroupDelayGateAutoFit": true, "GroupDelayGateOffsetMs": 12.25}
+                """);
         var options = new FrequencyResponseOptions();
 
         settings.ApplyTo(options, new CurveVisibilityOptions());
@@ -211,6 +204,11 @@ public sealed class MeasurementSettingsMigrationTests
         Assert.False(options.PhaseGateAutoFit);
         Assert.True(options.GroupDelayGateAutoFit);
     }
+
+    private static MeasurementSettingsFile.FrequencyResponseSettings
+        DeserializeFrequencyResponse(string json) =>
+        System.Text.Json.JsonSerializer
+            .Deserialize<MeasurementSettingsFile.FrequencyResponseSettings>(json)!;
 
     // The migration runs inside LoadOrDefault (which reads the real settings
     // path beside the executable), so the unit exercises it directly.

--- a/tests/Resonalyze.App.Tests/PROptTests.cs
+++ b/tests/Resonalyze.App.Tests/PROptTests.cs
@@ -33,6 +33,9 @@ public sealed class PROptTests
             PhaseWindowMode = PhaseWindowMode.FrequencyDependent,
             PhaseFdwCycles = 4,
             PhaseDetrendMode = PhaseDetrendMode.Manual,
+            // The test pins the gate manually; the Auto default would re-snap
+            // the offset to the estimated IR start and shift the τ estimates.
+            PhaseGateAutoFit = false,
             PhaseGateOffsetMs = directSample * 1_000.0 / sampleRate,
             PhaseLeftMs = 1.0,
             PhasePlateauMs = 4.0,

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -188,6 +188,75 @@ public sealed class TransferIrDiagnosticsTests
         Assert.Null(TransferIrDiagnostics.DetectCrosstalkHead(impulseResponse, SampleRate));
     }
 
+    [Theory]
+    [InlineData(0.09)]
+    [InlineData(0.15)]
+    public void EstimateIrStart_LandsOnTheFrontDespiteTheHeadClick(
+        double clickAmplitude)
+    {
+        // The field failure the estimator exists for: the broadband click at
+        // sample 30 IS the full-band first arrival, but carries no energy
+        // inside the driver's 300 Hz band — the in-band read must walk the
+        // genuine front at 40 ms instead, at both field click levels.
+        double[] impulseResponse = CrosstalkRecord(clickAmplitude);
+
+        IrStartEstimate? start = TransferIrDiagnostics.EstimateIrStart(
+            impulseResponse, SampleRate);
+
+        Assert.NotNull(start);
+        Assert.True(start.Value.DominantBandLimited);
+        // On the front's rise (40 ms + a fraction of the 100 ms Hann rise),
+        // far past the click at 0.6 ms.
+        Assert.InRange(start.Value.StartMs, 40.0, 65.0);
+        Assert.True(start.Value.EarlyMs <= start.Value.StartMs);
+        Assert.True(start.Value.StartMs <= start.Value.LateMs);
+    }
+
+    [Fact]
+    public void EstimateIrStart_ReadsASharpBroadbandFrontTightly()
+    {
+        var impulseResponse = new double[32_768];
+        int front = SampleRate * 20 / 1000;
+        impulseResponse[front] = 1.0;
+
+        IrStartEstimate? start = TransferIrDiagnostics.EstimateIrStart(
+            impulseResponse, SampleRate);
+
+        Assert.NotNull(start);
+        // A delta's envelope rises within the Hilbert skirt: the crossing
+        // sits within a fraction of a millisecond of the front, and the
+        // 10-vs-50 % spread stays tight.
+        Assert.InRange(start.Value.StartMs, 19.5, 20.05);
+        Assert.InRange(
+            start.Value.LateMs - start.Value.EarlyMs, 0.0, 0.5);
+    }
+
+    [Fact]
+    public void EstimateIrStart_ComplexOverloadMatchesTheRealOne()
+    {
+        double[] impulseResponse = CrosstalkRecord(clickAmplitude: 0.09);
+        var complexIr = Array.ConvertAll(
+            impulseResponse, v => new System.Numerics.Complex(v, 0.0));
+
+        IrStartEstimate? fromReal = TransferIrDiagnostics.EstimateIrStart(
+            impulseResponse, SampleRate);
+        IrStartEstimate? fromComplex = TransferIrDiagnostics.EstimateIrStart(
+            complexIr, SampleRate);
+
+        Assert.Equal(fromReal, fromComplex);
+    }
+
+    [Fact]
+    public void EstimateIrStart_RefusesSilenceAndDegenerateInput()
+    {
+        Assert.Null(TransferIrDiagnostics.EstimateIrStart(
+            new double[16_384], SampleRate));
+        Assert.Null(TransferIrDiagnostics.EstimateIrStart(
+            Array.Empty<double>(), SampleRate));
+        Assert.Null(TransferIrDiagnostics.EstimateIrStart(
+            new double[] { 1.0 }, sampleRate: 0));
+    }
+
     [Fact]
     public void CleanCrosstalkHead_ZerosTheHeadAndKeepsTheRest()
     {

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -253,8 +253,40 @@ public sealed class TransferIrDiagnosticsTests
             new double[16_384], SampleRate));
         Assert.Null(TransferIrDiagnostics.EstimateIrStart(
             Array.Empty<double>(), SampleRate));
+        // Too short for any spectral analysis — refused BEFORE the FFT, even
+        // at a valid sample rate.
+        Assert.Null(TransferIrDiagnostics.EstimateIrStart(
+            new double[] { 1.0 }, SampleRate));
         Assert.Null(TransferIrDiagnostics.EstimateIrStart(
             new double[] { 1.0 }, sampleRate: 0));
+    }
+
+    [Fact]
+    public void EstimateIrStart_RefusesANoiseOnlyRecord()
+    {
+        // A noise envelope still has a strongest peak the first-arrival
+        // search falls back to; only the SNR floor exposes that there is no
+        // front to measure. Deterministic LCG noise (approx. Gaussian via a
+        // sum of uniforms) so the test never flakes.
+        var impulseResponse = new double[65_536];
+        uint state = 12_345;
+        double NextUniform()
+        {
+            state = state * 1_664_525u + 1_013_904_223u;
+            return state / 4_294_967_296.0;
+        }
+        for (int i = 0; i < impulseResponse.Length; i++)
+        {
+            double sum = 0;
+            for (int k = 0; k < 12; k++)
+            {
+                sum += NextUniform();
+            }
+            impulseResponse[i] = sum - 6.0;
+        }
+
+        Assert.Null(TransferIrDiagnostics.EstimateIrStart(
+            impulseResponse, SampleRate));
     }
 
     [Fact]


### PR DESCRIPTION
## What

Replaces the one-shot **Fit** button (snap gate offset to the transfer IR's global peak) with a latching **Auto** toggle in the Phase and Group Delay option dialogs and the Virtual DSP phase-gate dialog. While pressed (the default), the gate offset stays snapped to the *estimated IR start* and follows every new measurement; released, the field unlocks with the last value as the manual starting point.

## Why

On real cabin records the global peak is not the IR start: midbass/sub records peak on a modal build-up 5–8 ms after the honest front, and every v3 record carries a playback-crosstalk click in its head that poisons naive first-arrival reads.

## How

New `TransferIrDiagnostics.EstimateIrStart` (dsp): dominant band of the record → Hilbert envelope *inside that band* → first credible arrival (shared Time Alignment physics: 25 dB depth, noise gate, pre-ringing rejection) → 25 % rising-front crossing (10/50 % as bounds/honesty spread). The band-pass makes the read blind to broadband head garbage without any cleaning pass. Fallbacks: full-band first arrival → stored peak index (never worse than old Fit).

Validated on all 7 v3 cabin records (d:\hobby\AMP\v3): mids/tweeters land within ~0.3 ms of the old peak; midbass reads 4.5/6.9 ms instead of 12.6/13.7 (modal horn) or 0.5 ms (click); subwoofer 6.8 ms instead of 12.8/3.3.

- Auto also re-snaps at plot build (`PlotModelFactory`), so a fresh measurement is gated correctly while the options dialog is closed; estimates are memoized per IR array (`TransferIrStartCache`), one computation per measurement across all consumers.
- Persisted as `PhaseGateAutoFit` / `GroupDelayGateAutoFit` (default on — first-run users see a correctly gated phase/GD immediately; FDW 6 cycles + Auto detrend were already the defaults).
- Virtual DSP: Auto maps onto the existing `OffsetMs == null` auto-follow; the follow anchor switches from `min(PeakIndex)` to the earliest robust IR start across processed channels.
- Virtual DSP phase view: ±360° wraps are drawn again — strictly vertical thin dashed segments (0.4× stroke, alpha 110, geometric-mean bin midpoint) instead of bare NaN breaks.

## Tests

5 new synthetic dsp tests (click ahead of a band-limited front at both field click levels, sharp broadband front, Complex-overload equivalence, silence/degenerate refusal); `ManualTauEstimate_UsesSelectedFdwSpectrum` now pins the gate manually (opts out of the Auto default). Full suite: 1417 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)