### PR TITLE
Virtual DSP: track audition through the tune (WAV export)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,9 @@ file is provided with every release.
   tracking, a per-junction phase read-out (phase at the crossover, the
   coherence-maximizing delay fix and its lobe margin), per-pair Δ L−R timing,
   auto crossover proposals, a stereo-aware
-  auto delay with a scene offset, gated phase view, overlay capture, sessions,
-  and tuning-sheet export
+  auto delay with a scene offset, gated phase view, overlay capture, a
+  headphone track audition (your own music rendered through the tune to a WAV),
+  sessions, and tuning-sheet export
 - Live Spectrum: real-time loopback transfer function with selectable excitation
   (leakage-free periodic pink, pink, brown/red, white noise) and coherence
 - Frequency response, phase, group delay, waterfall, Burst Decay, and
@@ -1852,6 +1853,20 @@ it defaults to Off because the measurements are loopback-referenced.
 - **Capture to overlay** saves the predicted sum as a Captured overlay in
   Frequency Response — compare it against real measurements and target curves,
   or feed it onward to the EQ Wizard.
+- **Audition track…** renders a music file (wav/mp3/flac/m4a and friends)
+  through the tune and writes a stereo WAV: each program channel is convolved
+  with the summed processed response of its side — left sum to channel 1,
+  right sum to channel 2 — with the microphone calibration optionally baked in
+  as a linear-phase FIR, so what you hear matches the calibrated curves on
+  screen. The track is converted to the project's sample rate when needed (the
+  measured responses are never resampled), both channels share one
+  normalization gain so the L/R balance survives, and re-rendering with a
+  different calibration or after a settings tweak is one click — a quick A/B
+  between tune variants. Listen through **headphones only**: each ear gets the
+  measured acoustic path of its side at the microphone position (drivers,
+  cabin, and capsule included) — a stereo auralization of the two sides, not a
+  binaural head simulation — and playing it back through the car would
+  convolve the cabin twice.
 - **Export…** writes the whole setup as a tuning sheet (printable PDF or plain
   text): for every side of every pair (a mono pair prints once) the gain, delay
   in ms and mm, polarity, crossover filters, the all-pass stage, and PEQ bands —

--- a/audio/Contracts/AudioFileContent.cs
+++ b/audio/Contracts/AudioFileContent.cs
@@ -11,10 +11,6 @@ public sealed record AudioFileContent(float[][] Channels, int SampleRate)
     public int ChannelCount => Channels.Length;
 
     public int FrameCount => Channels.Length == 0 ? 0 : Channels[0].Length;
-
-    public TimeSpan Duration => SampleRate <= 0
-        ? TimeSpan.Zero
-        : TimeSpan.FromSeconds(FrameCount / (double)SampleRate);
 }
 
 /// <summary>

--- a/audio/Contracts/AudioFileContent.cs
+++ b/audio/Contracts/AudioFileContent.cs
@@ -1,0 +1,27 @@
+namespace Resonalyze.Audio;
+
+/// <summary>
+/// Deinterleaved PCM decoded from — or destined for — a media file: one
+/// <c>float[]</c> per channel, all of the same length, plus the rate they were
+/// sampled at. Backend-neutral like the rest of the contracts, so the decoder's
+/// NAudio/Media Foundation machinery stays inside this project.
+/// </summary>
+public sealed record AudioFileContent(float[][] Channels, int SampleRate)
+{
+    public int ChannelCount => Channels.Length;
+
+    public int FrameCount => Channels.Length == 0 ? 0 : Channels[0].Length;
+
+    public TimeSpan Duration => SampleRate <= 0
+        ? TimeSpan.Zero
+        : TimeSpan.FromSeconds(FrameCount / (double)SampleRate);
+}
+
+/// <summary>
+/// A media file's shape without its samples — what a picker can show the user
+/// before committing to a full decode.
+/// </summary>
+public sealed record AudioFileInfo(
+    int ChannelCount,
+    int SampleRate,
+    TimeSpan Duration);

--- a/audio/Files/AudioFileCodec.cs
+++ b/audio/Files/AudioFileCodec.cs
@@ -70,10 +70,11 @@ public static class AudioFileCodec
     /// frame alignment, so dropped channels cost decoding time but no memory.
     /// </param>
     /// <param name="maximumStoredBytes">
-    /// Hard cap on the KEPT samples' memory, checked after every decoder
-    /// block. The duration limit trusts the file to be what its header claims;
-    /// this one holds when it is not — a swapped file or a lying container
-    /// stops decoding at the budget instead of exhausting memory first.
+    /// Hard cap on the decode's PEAK memory — the kept samples plus the
+    /// assembly-time copy of one channel — checked after every decoder block.
+    /// The duration limit trusts the file to be what its header claims; this
+    /// one holds when it is not — a swapped file or a lying container stops
+    /// decoding at the budget instead of exhausting memory first.
     /// </param>
     public static AudioFileContent Read(
         string path,
@@ -155,7 +156,14 @@ public static class AudioFileCodec
                     $"The file is longer than {maximumDuration.TotalMinutes:0} " +
                     "minutes; use a shorter excerpt.");
             }
-            if (keptSamples * sizeof(float) > maximumStoredBytes)
+            // The budget bounds the decode's PEAK, not only the payload:
+            // while the first channel's final array fills during assembly,
+            // every chunk still exists, so the peak reaches
+            // payload + payload / keptChannels. Partial chunks and list
+            // overhead stay outside the count — a few chunk lengths at most,
+            // noise against any realistic budget.
+            long payloadBytes = keptSamples * sizeof(float);
+            if (payloadBytes + payloadBytes / keptChannels > maximumStoredBytes)
             {
                 throw new InvalidOperationException(
                     "The file decodes past the memory budget " +

--- a/audio/Files/AudioFileCodec.cs
+++ b/audio/Files/AudioFileCodec.cs
@@ -1,0 +1,201 @@
+using NAudio.Wave;
+
+namespace Resonalyze.Audio;
+
+/// <summary>
+/// Reads program material out of media files and writes rendered audio back as
+/// WAV. This is the only place file codecs live: decoding MP3/FLAC/M4A means
+/// NAudio and Media Foundation, and the app project cannot reference either.
+/// <para>
+/// Reading accepts whatever the platform can decode; writing is deliberately WAV
+/// only. Re-encoding a render to a lossy format would put codec artifacts inside
+/// the very thing being auditioned, and Windows does not guarantee an MP3 encoder
+/// is even installed.
+/// </para>
+/// </summary>
+public static class AudioFileCodec
+{
+    /// <summary>
+    /// The file dialog filter for material this decoder accepts. WAV, MP3 and
+    /// AIFF are decoded by NAudio itself; the rest go through Media Foundation,
+    /// which covers a stock Windows install's FLAC/M4A/WMA support.
+    /// </summary>
+    public const string ReadableFilesFilter =
+        "Audio files (*.wav;*.mp3;*.flac;*.m4a;*.aac;*.wma;*.aiff)" +
+        "|*.wav;*.mp3;*.flac;*.m4a;*.aac;*.wma;*.aiff;*.aif" +
+        "|All files (*.*)|*.*";
+
+    /// <summary>Bit depth of written files: transparent, and universally playable.</summary>
+    private const int WriteBitsPerSample = 24;
+
+    private const int WriteBytesPerSample = WriteBitsPerSample / 8;
+
+    // Frames pulled from the decoder per call. Large enough that the per-call
+    // overhead disappears, small enough that the copy churn stays bounded.
+    private const int ReadBlockFrames = 32_768;
+
+    /// <summary>
+    /// Reads a media file's format without decoding its samples, so a picker
+    /// can report (or refuse) the file the moment it is chosen.
+    /// </summary>
+    public static AudioFileInfo Probe(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        using var reader = new AudioFileReader(path);
+        return new AudioFileInfo(
+            reader.WaveFormat.Channels,
+            reader.WaveFormat.SampleRate,
+            reader.TotalTime);
+    }
+
+    /// <summary>
+    /// Decodes a media file to deinterleaved float PCM at its native rate.
+    /// </summary>
+    /// <param name="maximumDuration">
+    /// Refuses anything longer. A render holds the decoded material, its
+    /// resampled copy and the result in memory at once, so an unbounded file is
+    /// an out-of-memory crash rather than a slow operation.
+    /// </param>
+    public static AudioFileContent Read(
+        string path,
+        TimeSpan maximumDuration,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        using var reader = new AudioFileReader(path);
+        int channelCount = reader.WaveFormat.Channels;
+        int sampleRate = reader.WaveFormat.SampleRate;
+        if (channelCount <= 0 || sampleRate <= 0)
+        {
+            throw new InvalidOperationException(
+                "The file reports no audio channels.");
+        }
+
+        long maximumFrames = (long)Math.Ceiling(
+            maximumDuration.TotalSeconds * sampleRate);
+        var blocks = new List<float[]>();
+        var buffer = new float[channelCount * ReadBlockFrames];
+        long sampleCount = 0;
+        int read;
+        while ((read = reader.Read(buffer, 0, buffer.Length)) > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var block = new float[read];
+            Array.Copy(buffer, block, read);
+            blocks.Add(block);
+            sampleCount += read;
+            if (sampleCount / channelCount > maximumFrames)
+            {
+                throw new InvalidOperationException(
+                    $"The file is longer than {maximumDuration.TotalMinutes:0} " +
+                    "minutes; use a shorter excerpt.");
+            }
+        }
+
+        long frameCount = sampleCount / channelCount;
+        if (frameCount == 0)
+        {
+            throw new InvalidOperationException("The file decoded to no audio.");
+        }
+
+        var channels = new float[channelCount][];
+        for (int channel = 0; channel < channelCount; channel++)
+        {
+            channels[channel] = new float[frameCount];
+        }
+
+        // Deinterleave by a RUNNING index across block boundaries: a decoder is
+        // not contractually bound to return whole frames per call, and a
+        // per-block frame loop would silently drop a trailing partial frame and
+        // rotate every later sample's channel assignment (L/R swapped from that
+        // point on). A trailing partial frame at the END of the file, if any,
+        // falls outside frameCount and is dropped whole.
+        long flatIndex = 0;
+        foreach (float[] block in blocks)
+        {
+            foreach (float sample in block)
+            {
+                long frame = flatIndex / channelCount;
+                if (frame >= frameCount)
+                {
+                    break;
+                }
+
+                channels[flatIndex % channelCount][frame] = sample;
+                flatIndex++;
+            }
+        }
+
+        return new AudioFileContent(channels, sampleRate);
+    }
+
+    /// <summary>
+    /// Writes deinterleaved float PCM as a 24-bit WAV file. Samples outside
+    /// [-1, 1] are clipped rather than allowed to wrap into full-scale noise.
+    /// </summary>
+    public static void WriteWav(
+        string path,
+        AudioFileContent content,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(content);
+        if (content.ChannelCount == 0 || content.FrameCount == 0)
+        {
+            throw new ArgumentException("There is nothing to write.", nameof(content));
+        }
+        if (content.SampleRate <= 0)
+        {
+            throw new ArgumentException("The sample rate is invalid.", nameof(content));
+        }
+        // The interleaving loop below indexes every channel by the first one's
+        // frame count; a shorter channel would crash it mid-write and a longer
+        // one would be silently truncated, so refuse loudly instead.
+        foreach (float[] channel in content.Channels)
+        {
+            if (channel.Length != content.FrameCount)
+            {
+                throw new ArgumentException(
+                    "All channels must have the same length.", nameof(content));
+            }
+        }
+
+        int channelCount = content.ChannelCount;
+        int frameCount = content.FrameCount;
+        var format = new WaveFormat(content.SampleRate, WriteBitsPerSample, channelCount);
+        using var writer = new WaveFileWriter(path, format);
+
+        // Interleaving into a byte block and writing that beats WaveFileWriter's
+        // per-sample path, which allocates on every call — tens of millions of
+        // allocations over a full track.
+        int blockFrames = ReadBlockFrames;
+        var bytes = new byte[blockFrames * channelCount * WriteBytesPerSample];
+        for (int start = 0; start < frameCount; start += blockFrames)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int frames = Math.Min(blockFrames, frameCount - start);
+            int offset = 0;
+            for (int frame = 0; frame < frames; frame++)
+            {
+                for (int channel = 0; channel < channelCount; channel++)
+                {
+                    int value = ToInt24(content.Channels[channel][start + frame]);
+                    bytes[offset++] = (byte)value;
+                    bytes[offset++] = (byte)(value >> 8);
+                    bytes[offset++] = (byte)(value >> 16);
+                }
+            }
+
+            writer.Write(bytes, 0, offset);
+        }
+    }
+
+    private const int Int24Maximum = 0x7FFFFF;
+
+    private static int ToInt24(float sample)
+    {
+        double scaled = Math.Round(sample * Int24Maximum);
+        return (int)Math.Clamp(scaled, -Int24Maximum - 1, Int24Maximum);
+    }
+}

--- a/audio/Files/AudioFileCodec.cs
+++ b/audio/Files/AudioFileCodec.cs
@@ -49,19 +49,37 @@ public static class AudioFileCodec
     }
 
     /// <summary>
-    /// Decodes a media file to deinterleaved float PCM at its native rate.
+    /// Decodes a media file to deinterleaved float PCM at its native rate,
+    /// keeping only the first <paramref name="channelLimit"/> channels.
+    /// <para>
+    /// The stream is deinterleaved AS IT DECODES, into per-channel chunk lists:
+    /// no full interleaved copy ever exists beside the per-channel data, and
+    /// channels beyond the limit are never stored at all — a 7.1 file read for
+    /// a stereo render costs a quarter of its decoded size, not the whole of it
+    /// twice. The transient peak is the kept chunks plus one channel's final
+    /// array during assembly.
+    /// </para>
     /// </summary>
     /// <param name="maximumDuration">
     /// Refuses anything longer. A render holds the decoded material, its
     /// resampled copy and the result in memory at once, so an unbounded file is
     /// an out-of-memory crash rather than a slow operation.
     /// </param>
+    /// <param name="channelLimit">
+    /// How many leading channels to keep. The full channel layout still drives
+    /// frame alignment, so dropped channels cost decoding time but no memory.
+    /// </param>
     public static AudioFileContent Read(
         string path,
         TimeSpan maximumDuration,
+        int channelLimit = int.MaxValue,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        if (channelLimit <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channelLimit));
+        }
 
         using var reader = new AudioFileReader(path);
         int channelCount = reader.WaveFormat.Channels;
@@ -72,20 +90,53 @@ public static class AudioFileCodec
                 "The file reports no audio channels.");
         }
 
+        int keptChannels = Math.Min(channelCount, channelLimit);
         long maximumFrames = (long)Math.Ceiling(
             maximumDuration.TotalSeconds * sampleRate);
-        var blocks = new List<float[]>();
+
+        var chunks = new List<float[]>[keptChannels];
+        var current = new float[keptChannels][];
+        var fill = new int[keptChannels];
+        for (int channel = 0; channel < keptChannels; channel++)
+        {
+            chunks[channel] = new List<float[]>();
+            current[channel] = new float[ReadBlockFrames];
+        }
+
+        // The cursor walks the FULL channel layout by a running count across
+        // read boundaries: a decoder is not contractually bound to return whole
+        // frames per call, and restarting the channel assignment per block
+        // would rotate every later sample's channel (L/R swapped from that
+        // point on) if a call ever ended mid-frame.
         var buffer = new float[channelCount * ReadBlockFrames];
-        long sampleCount = 0;
+        long totalSamples = 0;
+        int channelCursor = 0;
         int read;
         while ((read = reader.Read(buffer, 0, buffer.Length)) > 0)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var block = new float[read];
-            Array.Copy(buffer, block, read);
-            blocks.Add(block);
-            sampleCount += read;
-            if (sampleCount / channelCount > maximumFrames)
+            for (int i = 0; i < read; i++)
+            {
+                if (channelCursor < keptChannels)
+                {
+                    float[] target = current[channelCursor];
+                    target[fill[channelCursor]] = buffer[i];
+                    if (++fill[channelCursor] == target.Length)
+                    {
+                        chunks[channelCursor].Add(target);
+                        current[channelCursor] = new float[ReadBlockFrames];
+                        fill[channelCursor] = 0;
+                    }
+                }
+
+                if (++channelCursor == channelCount)
+                {
+                    channelCursor = 0;
+                }
+            }
+
+            totalSamples += read;
+            if (totalSamples / channelCount > maximumFrames)
             {
                 throw new InvalidOperationException(
                     $"The file is longer than {maximumDuration.TotalMinutes:0} " +
@@ -93,38 +144,42 @@ public static class AudioFileCodec
             }
         }
 
-        long frameCount = sampleCount / channelCount;
+        long frameCount = totalSamples / channelCount;
         if (frameCount == 0)
         {
             throw new InvalidOperationException("The file decoded to no audio.");
         }
 
-        var channels = new float[channelCount][];
-        for (int channel = 0; channel < channelCount; channel++)
+        // Assemble channel by channel, releasing each channel's chunks as its
+        // final array fills, so the transient peak stays one channel wide. A
+        // kept channel may carry one sample past frameCount (a trailing partial
+        // frame at the end of the file); the copy bounds drop it.
+        var channels = new float[keptChannels][];
+        for (int channel = 0; channel < keptChannels; channel++)
         {
-            channels[channel] = new float[frameCount];
-        }
-
-        // Deinterleave by a RUNNING index across block boundaries: a decoder is
-        // not contractually bound to return whole frames per call, and a
-        // per-block frame loop would silently drop a trailing partial frame and
-        // rotate every later sample's channel assignment (L/R swapped from that
-        // point on). A trailing partial frame at the END of the file, if any,
-        // falls outside frameCount and is dropped whole.
-        long flatIndex = 0;
-        foreach (float[] block in blocks)
-        {
-            foreach (float sample in block)
+            var assembled = new float[frameCount];
+            long offset = 0;
+            foreach (float[] chunk in chunks[channel])
             {
-                long frame = flatIndex / channelCount;
-                if (frame >= frameCount)
+                long take = Math.Min(chunk.Length, frameCount - offset);
+                if (take <= 0)
                 {
                     break;
                 }
 
-                channels[flatIndex % channelCount][frame] = sample;
-                flatIndex++;
+                Array.Copy(chunk, 0, assembled, offset, take);
+                offset += take;
             }
+
+            long tail = Math.Min(fill[channel], frameCount - offset);
+            if (tail > 0)
+            {
+                Array.Copy(current[channel], 0, assembled, offset, tail);
+            }
+
+            chunks[channel].Clear();
+            current[channel] = Array.Empty<float>();
+            channels[channel] = assembled;
         }
 
         return new AudioFileContent(channels, sampleRate);

--- a/audio/Files/AudioFileCodec.cs
+++ b/audio/Files/AudioFileCodec.cs
@@ -69,16 +69,27 @@ public static class AudioFileCodec
     /// How many leading channels to keep. The full channel layout still drives
     /// frame alignment, so dropped channels cost decoding time but no memory.
     /// </param>
+    /// <param name="maximumStoredBytes">
+    /// Hard cap on the KEPT samples' memory, checked after every decoder
+    /// block. The duration limit trusts the file to be what its header claims;
+    /// this one holds when it is not — a swapped file or a lying container
+    /// stops decoding at the budget instead of exhausting memory first.
+    /// </param>
     public static AudioFileContent Read(
         string path,
         TimeSpan maximumDuration,
         int channelLimit = int.MaxValue,
+        long maximumStoredBytes = long.MaxValue,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
         if (channelLimit <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(channelLimit));
+        }
+        if (maximumStoredBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumStoredBytes));
         }
 
         using var reader = new AudioFileReader(path);
@@ -110,6 +121,7 @@ public static class AudioFileCodec
         // point on) if a call ever ended mid-frame.
         var buffer = new float[channelCount * ReadBlockFrames];
         long totalSamples = 0;
+        long keptSamples = 0;
         int channelCursor = 0;
         int read;
         while ((read = reader.Read(buffer, 0, buffer.Length)) > 0)
@@ -121,6 +133,7 @@ public static class AudioFileCodec
                 {
                     float[] target = current[channelCursor];
                     target[fill[channelCursor]] = buffer[i];
+                    keptSamples++;
                     if (++fill[channelCursor] == target.Length)
                     {
                         chunks[channelCursor].Add(target);
@@ -141,6 +154,13 @@ public static class AudioFileCodec
                 throw new InvalidOperationException(
                     $"The file is longer than {maximumDuration.TotalMinutes:0} " +
                     "minutes; use a shorter excerpt.");
+            }
+            if (keptSamples * sizeof(float) > maximumStoredBytes)
+            {
+                throw new InvalidOperationException(
+                    "The file decodes past the memory budget " +
+                    $"({maximumStoredBytes / 1_000_000} MB); use a shorter " +
+                    "excerpt.");
             }
         }
 

--- a/dsp/Auralization.cs
+++ b/dsp/Auralization.cs
@@ -116,7 +116,6 @@ public static class Auralization
 
         trim = new AuralizationTrim(
             length,
-            peakIndex,
             tail * 1000.0 / sampleRate,
             length < response.Length);
         return kernel;
@@ -289,12 +288,10 @@ public static class Auralization
 
 /// <summary>
 /// What <see cref="Auralization.TrimResponse"/> kept: the kernel length, the
-/// arrival it was measured from, the decay window past that arrival, and whether
-/// anything was actually cut.
+/// decay window past the arrival, and whether anything was actually cut.
 /// </summary>
 public readonly record struct AuralizationTrim(
     int Length,
-    int PeakIndex,
     double TailMilliseconds,
     bool Cut);
 

--- a/dsp/Auralization.cs
+++ b/dsp/Auralization.cs
@@ -152,17 +152,24 @@ public static class Auralization
         bool resampled = request.SourceSampleRate != request.KernelSampleRate;
         if (resampled)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            bool shared = ReferenceEquals(left, right);
+            double half = ResampleProgressShare / 2.0;
             float[] convertedLeft = SampleRateConverter.Resample(
-                left, request.SourceSampleRate, request.KernelSampleRate);
-            cancellationToken.ThrowIfCancellationRequested();
-            float[] convertedRight = ReferenceEquals(left, right)
+                left,
+                request.SourceSampleRate,
+                request.KernelSampleRate,
+                Scaled(progress, 0.0, shared ? ResampleProgressShare : half),
+                cancellationToken);
+            float[] convertedRight = shared
                 ? convertedLeft
                 : SampleRateConverter.Resample(
-                    right, request.SourceSampleRate, request.KernelSampleRate);
+                    right,
+                    request.SourceSampleRate,
+                    request.KernelSampleRate,
+                    Scaled(progress, half, half),
+                    cancellationToken);
             left = convertedLeft;
             right = convertedRight;
-            progress?.Report(ResampleProgressShare);
         }
 
         double convolveShare = resampled ? 1.0 - ResampleProgressShare : 1.0;
@@ -279,11 +286,17 @@ public static class Auralization
         return Math.Sqrt(sumSquares / (end - start));
     }
 
+    // Synchronous on purpose: Progress<T> created here — on a worker thread —
+    // would post every report to the thread pool, and two chained layers of
+    // that reorder freely (a left channel's report after the right's, a stage's
+    // update after the final status). Only the caller's outermost progress may
+    // hop threads.
     private static IProgress<double>? Scaled(
         IProgress<double>? progress, double offset, double share) =>
         progress == null
             ? null
-            : new Progress<double>(value => progress.Report(offset + value * share));
+            : new SynchronousProgress<double>(
+                value => progress.Report(offset + value * share));
 }
 
 /// <summary>

--- a/dsp/Auralization.cs
+++ b/dsp/Auralization.cs
@@ -6,11 +6,14 @@ namespace Resonalyze.Dsp;
 /// Renders program material through measured virtual-crossover responses, so a
 /// tune can be listened to instead of only read off a plot.
 /// <para>
-/// What the listener hears is what the MEASUREMENT MICROPHONE heard: the summed
-/// response carries the drivers, the cabin and the microphone as well as the DSP
-/// chain. It is an auralization of one point in the car, for headphones — not a
-/// preview of the electrical preset, and not a binaural rendering (one omni
-/// capsule is not two ears).
+/// The model is a HEADPHONE-ONLY stereo auralization of the measured left and
+/// right acoustic paths: each program channel is convolved with the summed
+/// response of its side (drivers, cabin and microphone capsule included, not
+/// only the DSP), and each side goes to its own ear. That preserves the tune's
+/// inter-side level and timing differences — the things being auditioned. It
+/// is NOT a binaural simulation of a listener's ears, and not literally what
+/// the microphone heard either: the capsule hears both sides SUMMED at one
+/// point, while the render keeps them separate so the balance stays audible.
 /// </para>
 /// </summary>
 public static class Auralization

--- a/dsp/Auralization.cs
+++ b/dsp/Auralization.cs
@@ -1,0 +1,326 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// Renders program material through measured virtual-crossover responses, so a
+/// tune can be listened to instead of only read off a plot.
+/// <para>
+/// What the listener hears is what the MEASUREMENT MICROPHONE heard: the summed
+/// response carries the drivers, the cabin and the microphone as well as the DSP
+/// chain. It is an auralization of one point in the car, for headphones — not a
+/// preview of the electrical preset, and not a binaural rendering (one omni
+/// capsule is not two ears).
+/// </para>
+/// </summary>
+public static class Auralization
+{
+    // The decay window the tail search reads. Five milliseconds is short enough
+    // to follow a cabin's decay (RT60 in a car is tens of milliseconds) and long
+    // enough that a single zero crossing cannot end the response early.
+    private const double DecayWindowMs = 5.0;
+
+    // Where the response stops being the car and starts being the measurement's
+    // own noise floor. Sixty dB below the arrival is past anything audible under
+    // program material, and a clean cabin sweep's floor sits above it.
+    private const double DecayFloorDb = 60.0;
+
+    // The tail is bounded both ways: too short truncates the cabin's decay into
+    // an audibly dry response, too long convolves the track with half a second
+    // of recorded hiss. A car's decay fits comfortably inside the upper bound.
+    private const double MinimumTailMs = 60.0;
+    private const double MaximumTailMs = 400.0;
+
+    // The kernel must not end on a step — that is a click on every sample of the
+    // program material, spread across the whole track by the convolution.
+    private const double FadeMs = 8.0;
+
+    /// <summary>
+    /// Peak target for the rendered file, dBFS. One dB of headroom leaves room
+    /// for the inter-sample overshoots any later lossy encode or resampler
+    /// introduces.
+    /// </summary>
+    public const double DefaultPeakTarget = -1.0;
+
+    /// <summary>
+    /// Cuts a processed virtual response down to the part worth convolving with,
+    /// and fades its end.
+    /// <para>
+    /// The response arrives as the tool's chain output: a power-of-two record
+    /// whose late region is the measurement's noise floor, the deconvolution's
+    /// numerical tail, and — for a negative chain delay — the samples the shift
+    /// wrapped past zero. Convolving music with all of that adds audible hiss and
+    /// a wrapped pre-echo, so the record is cut where the decay reaches the floor.
+    /// </para>
+    /// <para>
+    /// The cut is at the END only: sample 0 stays sample 0, so the measurement's
+    /// own propagation delay — and with it the difference between the two sides,
+    /// which is the whole point of the alignment being auditioned — survives
+    /// intact.
+    /// </para>
+    /// </summary>
+    public static double[] TrimResponse(
+        Complex[] response,
+        int sampleRate,
+        out AuralizationTrim trim)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        if (response.Length == 0)
+        {
+            throw new ArgumentException("The response is empty.", nameof(response));
+        }
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+
+        int peakIndex = VirtualCrossoverAnalysis.FindPeakIndex(response);
+        int windowLength = Math.Max(1, (int)Math.Round(DecayWindowMs * sampleRate / 1000.0));
+        int minimumTail = (int)Math.Round(MinimumTailMs * sampleRate / 1000.0);
+        int maximumTail = (int)Math.Round(MaximumTailMs * sampleRate / 1000.0);
+
+        double reference = WindowRms(response, peakIndex, windowLength);
+        double floor = reference * Math.Pow(10.0, -DecayFloorDb / 20.0);
+        int tail = maximumTail;
+        for (int start = peakIndex + windowLength;
+            start + windowLength <= response.Length;
+            start += windowLength)
+        {
+            if (start - peakIndex > maximumTail)
+            {
+                break;
+            }
+
+            if (WindowRms(response, start, windowLength) <= floor)
+            {
+                tail = start - peakIndex;
+                break;
+            }
+        }
+
+        tail = Math.Clamp(tail, minimumTail, maximumTail);
+        int length = Math.Min(response.Length, peakIndex + tail);
+        var kernel = new double[length];
+        for (int i = 0; i < length; i++)
+        {
+            kernel[i] = response[i].Real;
+        }
+
+        int fade = Math.Min(length, Math.Max(1, (int)Math.Round(FadeMs * sampleRate / 1000.0)));
+        for (int i = 0; i < fade; i++)
+        {
+            // Raised cosine from 1 down to 0 across the last `fade` samples.
+            double phase = Math.PI * (i + 1) / (fade + 1);
+            kernel[length - fade + i] *= 0.5 * (1.0 + Math.Cos(phase));
+        }
+
+        trim = new AuralizationTrim(
+            length,
+            peakIndex,
+            tail * 1000.0 / sampleRate,
+            length < response.Length);
+        return kernel;
+    }
+
+    /// <summary>
+    /// Runs the program material through the two side responses: channel 1 of the
+    /// source through the left kernel, channel 2 through the right. A mono source
+    /// feeds both sides; a source with more than two channels contributes its
+    /// first two, and the caller is expected to have said so.
+    /// </summary>
+    public static AuralizationResult Render(
+        AuralizationRequest request,
+        IProgress<double>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.SourceChannels.Length == 0)
+        {
+            throw new ArgumentException(
+                "The source has no channels.", nameof(request));
+        }
+
+        float[] left = request.SourceChannels[0];
+        float[] right = request.SourceChannels.Length > 1
+            ? request.SourceChannels[1]
+            : request.SourceChannels[0];
+
+        // The MATERIAL is converted to the response's rate, never the response to
+        // the material's. The kernels are the measurement — their timing and phase
+        // are the object under test, and a converter's own phase response would
+        // land inside the thing being auditioned. The rendered file therefore
+        // comes out at the project's rate.
+        bool resampled = request.SourceSampleRate != request.KernelSampleRate;
+        if (resampled)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            float[] convertedLeft = SampleRateConverter.Resample(
+                left, request.SourceSampleRate, request.KernelSampleRate);
+            cancellationToken.ThrowIfCancellationRequested();
+            float[] convertedRight = ReferenceEquals(left, right)
+                ? convertedLeft
+                : SampleRateConverter.Resample(
+                    right, request.SourceSampleRate, request.KernelSampleRate);
+            left = convertedLeft;
+            right = convertedRight;
+            progress?.Report(ResampleProgressShare);
+        }
+
+        double convolveShare = resampled ? 1.0 - ResampleProgressShare : 1.0;
+        double convolveBase = resampled ? ResampleProgressShare : 0.0;
+        float[] renderedLeft = FastConvolution.Convolve(
+            left,
+            request.LeftKernel,
+            Scaled(progress, convolveBase, convolveShare / 2.0),
+            cancellationToken);
+        float[] renderedRight = FastConvolution.Convolve(
+            right,
+            request.RightKernel,
+            Scaled(progress, convolveBase + convolveShare / 2.0, convolveShare / 2.0),
+            cancellationToken);
+
+        // The kernels are trimmed per side, so the two convolutions come out at
+        // DIFFERENT lengths (source + kernel − 1 each). A stereo file needs one
+        // frame count; the shorter side gets trailing zeros, which is exactly
+        // what it is — that side's response ended earlier.
+        int commonLength = Math.Max(renderedLeft.Length, renderedRight.Length);
+        renderedLeft = PadTo(renderedLeft, commonLength);
+        renderedRight = PadTo(renderedRight, commonLength);
+
+        double gain = Normalize(
+            renderedLeft, renderedRight, request.PeakTargetDbfs, cancellationToken);
+        progress?.Report(1.0);
+        return new AuralizationResult(
+            [renderedLeft, renderedRight],
+            request.KernelSampleRate,
+            DataHelper.AmplitudeToDecibels(gain),
+            resampled);
+    }
+
+    // Resampling is a single pass over the material against two block-FFT passes,
+    // so it is a modest slice of the whole job; the split only has to keep the
+    // bar moving at a believable rate.
+    private const double ResampleProgressShare = 0.2;
+
+    // One gain for BOTH channels: scaling the sides independently would level the
+    // very inter-side balance the tune is being auditioned for.
+    private static double Normalize(
+        float[] left,
+        float[] right,
+        double peakTargetDbfs,
+        CancellationToken cancellationToken)
+    {
+        double peak = Math.Max(AbsolutePeak(left), AbsolutePeak(right));
+        if (peak <= 0)
+        {
+            return 1.0;
+        }
+
+        // The summed transfer response has no absolute scale — it is
+        // loopback-referenced and then run through arbitrary gains and PEQ boosts
+        // — so the raw render lands anywhere from far below to far above full
+        // scale, and the factor is reported to the caller rather than hidden.
+        double gain = Math.Pow(10.0, peakTargetDbfs / 20.0) / peak;
+        cancellationToken.ThrowIfCancellationRequested();
+        Scale(left, gain);
+        Scale(right, gain);
+        return gain;
+    }
+
+    private static double AbsolutePeak(float[] samples)
+    {
+        double peak = 0;
+        foreach (float sample in samples)
+        {
+            double magnitude = Math.Abs(sample);
+            if (magnitude > peak)
+            {
+                peak = magnitude;
+            }
+        }
+
+        return peak;
+    }
+
+    private static float[] PadTo(float[] samples, int length)
+    {
+        if (samples.Length >= length)
+        {
+            return samples;
+        }
+
+        var padded = new float[length];
+        Array.Copy(samples, padded, samples.Length);
+        return padded;
+    }
+
+    private static void Scale(float[] samples, double gain)
+    {
+        for (int i = 0; i < samples.Length; i++)
+        {
+            samples[i] = (float)(samples[i] * gain);
+        }
+    }
+
+    private static double WindowRms(Complex[] response, int start, int length)
+    {
+        int end = Math.Min(response.Length, start + length);
+        if (start >= end)
+        {
+            return 0.0;
+        }
+
+        double sumSquares = 0;
+        for (int i = start; i < end; i++)
+        {
+            double value = response[i].Real;
+            sumSquares += value * value;
+        }
+
+        return Math.Sqrt(sumSquares / (end - start));
+    }
+
+    private static IProgress<double>? Scaled(
+        IProgress<double>? progress, double offset, double share) =>
+        progress == null
+            ? null
+            : new Progress<double>(value => progress.Report(offset + value * share));
+}
+
+/// <summary>
+/// What <see cref="Auralization.TrimResponse"/> kept: the kernel length, the
+/// arrival it was measured from, the decay window past that arrival, and whether
+/// anything was actually cut.
+/// </summary>
+public readonly record struct AuralizationTrim(
+    int Length,
+    int PeakIndex,
+    double TailMilliseconds,
+    bool Cut);
+
+/// <summary>The inputs of one auralization render.</summary>
+public sealed record AuralizationRequest
+{
+    /// <summary>Trimmed summed response of the left side of the car.</summary>
+    public required double[] LeftKernel { get; init; }
+
+    /// <summary>Trimmed summed response of the right side of the car.</summary>
+    public required double[] RightKernel { get; init; }
+
+    /// <summary>The project's rate — both kernels share it, and the render adopts it.</summary>
+    public required int KernelSampleRate { get; init; }
+
+    /// <summary>Deinterleaved program material.</summary>
+    public required float[][] SourceChannels { get; init; }
+
+    public required int SourceSampleRate { get; init; }
+
+    public double PeakTargetDbfs { get; init; } = Auralization.DefaultPeakTarget;
+}
+
+/// <summary>The rendered stereo pair and what the render had to do to it.</summary>
+public sealed record AuralizationResult(
+    float[][] Channels,
+    int SampleRate,
+    double AppliedGainDb,
+    bool Resampled);

--- a/dsp/CalibrationFirFilter.cs
+++ b/dsp/CalibrationFirFilter.cs
@@ -1,0 +1,89 @@
+using System.Numerics;
+using MathNet.Numerics.IntegralTransforms;
+
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// Designs a linear-phase FIR filter that APPLIES a microphone calibration to
+/// audio: its magnitude at every frequency is the inverse of the calibration
+/// correction (calibrated curve = raw − correction, so the filter's gain is
+/// 10^(−correction/20)), and its phase is exactly linear.
+/// <para>
+/// Linear phase is the point, not an implementation detail: the auralization
+/// convolves BOTH sides of the car with this one filter, and a linear-phase
+/// kernel delays both by the same constant regardless of frequency — the
+/// inter-side timing being auditioned survives to the sample. A minimum-phase
+/// design would add frequency-dependent group delay; small for smooth
+/// calibration curves, but not zero, and zero costs nothing here.
+/// </para>
+/// <para>
+/// Frequency-sampling design: the correction is sampled onto an FFT grid as a
+/// real zero-phase spectrum, inverted to time, rotated to centre, and shaped by
+/// a periodic Hann window. The window trades the truncation seam for roughly a
+/// two-bin smoothing of the response — calibration curves are smooth by nature,
+/// so nothing real is lost.
+/// </para>
+/// </summary>
+public static class CalibrationFirFilter
+{
+    // The FFT grid is sized for this resolution: fine enough that a mic's
+    // low-frequency deviation (the region car-audio tuning cares most about)
+    // is reproduced, coarse enough that the kernel stays a modest fraction of
+    // a second.
+    private const double TargetResolutionHz = 3.0;
+
+    private const int MinimumLength = 4_096;
+    private const int MaximumLength = 32_768;
+
+    /// <summary>
+    /// Designs the correction filter for the given sample rate.
+    /// <paramref name="correctionDb"/> is the calibration's correction in dB at
+    /// a frequency in Hz — pass <c>CalibrationFile.GetDecibelCorrection</c>.
+    /// The returned kernel is symmetric (linear-phase) with its peak at
+    /// <c>length / 2</c>, so it delays the signal by exactly that many samples.
+    /// </summary>
+    public static double[] Design(Func<double, double> correctionDb, int sampleRate)
+    {
+        ArgumentNullException.ThrowIfNull(correctionDb);
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+
+        int length = Math.Clamp(
+            DspMath.NextPowerOfTwo(
+                (int)Math.Ceiling(sampleRate / TargetResolutionHz)),
+            MinimumLength,
+            MaximumLength);
+
+        // A real, even spectrum (positive gains mirrored onto the negative
+        // bins) inverts to a real, zero-phase impulse response.
+        var spectrum = new Complex[length];
+        for (int bin = 0; bin <= length / 2; bin++)
+        {
+            double frequency = bin * (double)sampleRate / length;
+            double gain = Math.Pow(10.0, -correctionDb(frequency) / 20.0);
+            spectrum[bin] = gain;
+            if (bin > 0 && bin < length / 2)
+            {
+                spectrum[length - bin] = gain;
+            }
+        }
+
+        Fourier.Inverse(spectrum, FourierOptions.Matlab);
+
+        // Rotate the zero-phase response so its peak sits at the centre tap
+        // (zero phase → linear phase), then apply a PERIODIC Hann window —
+        // symmetric about the same centre, so the kernel stays exactly
+        // symmetric and the phase exactly linear.
+        int center = length / 2;
+        var kernel = new double[length];
+        for (int i = 0; i < length; i++)
+        {
+            double window = 0.5 * (1.0 - Math.Cos(2.0 * Math.PI * i / length));
+            kernel[i] = spectrum[(i + center) % length].Real * window;
+        }
+
+        return kernel;
+    }
+}

--- a/dsp/CalibrationFirFilter.cs
+++ b/dsp/CalibrationFirFilter.cs
@@ -9,12 +9,14 @@ namespace Resonalyze.Dsp;
 /// correction (calibrated curve = raw − correction, so the filter's gain is
 /// 10^(−correction/20)), and its phase is exactly linear.
 /// <para>
-/// Linear phase is the point, not an implementation detail: the auralization
-/// convolves BOTH sides of the car with this one filter, and a linear-phase
-/// kernel delays both by the same constant regardless of frequency — the
-/// inter-side timing being auditioned survives to the sample. A minimum-phase
-/// design would add frequency-dependent group delay; small for smooth
-/// calibration curves, but not zero, and zero costs nothing here.
+/// Linear phase is a CHOICE here, not a requirement. Any filter applied
+/// identically to both sides cancels out of the inter-side phase difference —
+/// arg(H_L·C) − arg(H_R·C) = arg(H_L) − arg(H_R) — so a minimum-phase design
+/// would preserve the auditioned scene just as well. Linear phase is kept
+/// because the designed magnitude is realized exactly and the kernel's
+/// symmetry is trivially verifiable; its price — a shared constant delay of
+/// half the kernel and a little pre-ringing — is invisible in an offline
+/// render of a smooth calibration curve.
 /// </para>
 /// <para>
 /// Frequency-sampling design: the correction is sampled onto an FFT grid as a

--- a/dsp/CalibrationFirFilter.cs
+++ b/dsp/CalibrationFirFilter.cs
@@ -41,8 +41,11 @@ public static class CalibrationFirFilter
     /// Designs the correction filter for the given sample rate.
     /// <paramref name="correctionDb"/> is the calibration's correction in dB at
     /// a frequency in Hz — pass <c>CalibrationFile.GetDecibelCorrection</c>.
-    /// The returned kernel is symmetric (linear-phase) with its peak at
-    /// <c>length / 2</c>, so it delays the signal by exactly that many samples.
+    /// The returned kernel is an ODD-length Type-I FIR: exactly symmetric,
+    /// <c>h[n] = h[N−1−n]</c>, with its peak at the centre tap
+    /// <c>(N−1)/2</c> — the constant delay it adds. (An even-length kernel
+    /// symmetric about a single tap is only circularly symmetric; the edge tap
+    /// has no pair and the phase is not formally linear.)
     /// </summary>
     public static double[] Design(Func<double, double> correctionDb, int sampleRate)
     {
@@ -75,12 +78,15 @@ public static class CalibrationFirFilter
         Fourier.Inverse(spectrum, FourierOptions.Matlab);
 
         // Rotate the zero-phase response so its peak sits at the centre tap
-        // (zero phase → linear phase), then apply a PERIODIC Hann window —
-        // symmetric about the same centre, so the kernel stays exactly
-        // symmetric and the phase exactly linear.
+        // (zero phase → linear phase), then apply a PERIODIC Hann window
+        // symmetric about the same centre. One extra tap makes the kernel
+        // length + 1 — ODD — so tap i pairs with tap length − i exactly
+        // (the wrapped sample at each end is the same ifft value, and both
+        // carry the window's zero): a formal Type-I FIR, not merely a
+        // circularly symmetric one.
         int center = length / 2;
-        var kernel = new double[length];
-        for (int i = 0; i < length; i++)
+        var kernel = new double[length + 1];
+        for (int i = 0; i <= length; i++)
         {
             double window = 0.5 * (1.0 - Math.Cos(2.0 * Math.PI * i / length));
             kernel[i] = spectrum[(i + center) % length].Real * window;

--- a/dsp/FastConvolution.cs
+++ b/dsp/FastConvolution.cs
@@ -1,0 +1,145 @@
+using System.Numerics;
+using MathNet.Numerics.IntegralTransforms;
+
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// Linear convolution of a long signal with a fixed kernel, by overlap-add FFT.
+/// <para>
+/// The direct sum is not an option at this scale: a five-minute track at 48 kHz is
+/// ~14 million samples and an auralization kernel runs to tens of thousands of
+/// taps, which is ~10¹² multiply-adds. Overlap-add transforms the kernel once and
+/// then costs two transforms per block, bringing the same result to seconds.
+/// </para>
+/// <para>
+/// Blocks are formed so that each one's circular convolution IS its linear
+/// convolution — the hop leaves exactly <c>kernel.Length − 1</c> samples of room
+/// for the tail, which then adds into the following block. Nothing wraps.
+/// </para>
+/// </summary>
+public static class FastConvolution
+{
+    // The transform runs over this many times the kernel length. Larger blocks
+    // amortize the per-block transform better but waste more of it on the
+    // zero-padded tail; four is the usual sweet spot and keeps the working
+    // buffers small enough to stay in cache-friendly territory.
+    private const int BlockLengthFactor = 4;
+
+    private const int MinimumFftLength = 1024;
+
+    /// <summary>
+    /// Convolves <paramref name="signal"/> with <paramref name="kernel"/>,
+    /// returning <c>signal.Length + kernel.Length − 1</c> samples.
+    /// </summary>
+    /// <param name="progress">Receives 0..1 completion after each block.</param>
+    public static float[] Convolve(
+        float[] signal,
+        double[] kernel,
+        IProgress<double>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+        ArgumentNullException.ThrowIfNull(kernel);
+        if (kernel.Length == 0)
+        {
+            throw new ArgumentException("The kernel is empty.", nameof(kernel));
+        }
+        if (signal.Length == 0)
+        {
+            return Array.Empty<float>();
+        }
+
+        int fftLength = DspMath.NextPowerOfTwo(
+            Math.Max(MinimumFftLength, (int)Math.Min(
+                int.MaxValue / 2, (long)kernel.Length * BlockLengthFactor)));
+        int hop = fftLength - kernel.Length + 1;
+        if (hop <= 0)
+        {
+            throw new ArgumentException(
+                "The kernel is too long for the transform length.", nameof(kernel));
+        }
+
+        Complex[] kernelSpectrum = Transform(kernel, fftLength);
+        var output = new float[(long)signal.Length + kernel.Length - 1];
+        var block = new Complex[fftLength];
+        int blockCount = (signal.Length + hop - 1) / hop;
+        for (int blockIndex = 0; blockIndex < blockCount; blockIndex++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            int start = blockIndex * hop;
+            int count = Math.Min(hop, signal.Length - start);
+            Array.Clear(block);
+            for (int i = 0; i < count; i++)
+            {
+                block[i] = signal[start + i];
+            }
+
+            Fourier.Forward(block, FourierOptions.Matlab);
+            for (int bin = 0; bin < fftLength; bin++)
+            {
+                block[bin] *= kernelSpectrum[bin];
+            }
+            Fourier.Inverse(block, FourierOptions.Matlab);
+
+            // The block spans count + kernel.Length − 1 output samples, which is
+            // exactly what the padding left room for, so this never reads the
+            // wrapped region and never writes past the output.
+            int span = Math.Min(fftLength, output.Length - start);
+            for (int i = 0; i < span; i++)
+            {
+                output[start + i] += (float)block[i].Real;
+            }
+
+            progress?.Report((blockIndex + 1) / (double)blockCount);
+        }
+
+        return output;
+    }
+
+    /// <summary>
+    /// Linear convolution of two kernels, in double precision, by one transform
+    /// pair. For combining filter kernels (a trimmed room response with a
+    /// calibration FIR) — both fit a single FFT comfortably, and the result
+    /// stays in the double domain the analysis side works in.
+    /// </summary>
+    public static double[] Convolve(double[] first, double[] second)
+    {
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        if (first.Length == 0 || second.Length == 0)
+        {
+            throw new ArgumentException("Both kernels must be non-empty.");
+        }
+
+        int resultLength = first.Length + second.Length - 1;
+        int fftLength = DspMath.NextPowerOfTwo(resultLength);
+        Complex[] a = Transform(first, fftLength);
+        Complex[] b = Transform(second, fftLength);
+        for (int bin = 0; bin < fftLength; bin++)
+        {
+            a[bin] *= b[bin];
+        }
+
+        Fourier.Inverse(a, FourierOptions.Matlab);
+        var result = new double[resultLength];
+        for (int i = 0; i < resultLength; i++)
+        {
+            result[i] = a[i].Real;
+        }
+
+        return result;
+    }
+
+    private static Complex[] Transform(double[] kernel, int fftLength)
+    {
+        var spectrum = new Complex[fftLength];
+        for (int i = 0; i < kernel.Length; i++)
+        {
+            spectrum[i] = kernel[i];
+        }
+
+        Fourier.Forward(spectrum, FourierOptions.Matlab);
+        return spectrum;
+    }
+}

--- a/dsp/SampleRateConverter.cs
+++ b/dsp/SampleRateConverter.cs
@@ -96,32 +96,6 @@ public static class SampleRateConverter
         return output;
     }
 
-    /// <summary>
-    /// The length <see cref="Resample"/> produces, without doing the work — for
-    /// progress reporting and buffer budgeting.
-    /// </summary>
-    public static long ResampledLength(long inputLength, int fromRate, int toRate)
-    {
-        if (fromRate <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(fromRate));
-        }
-        if (toRate <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(toRate));
-        }
-
-        if (fromRate == toRate)
-        {
-            return inputLength;
-        }
-
-        int divisor = GreatestCommonDivisor(fromRate, toRate);
-        int up = toRate / divisor;
-        int down = fromRate / divisor;
-        return (inputLength * up + down - 1) / down;
-    }
-
     // The shared low-pass, designed in the interpolated domain: cutoff at the
     // lower of the two Nyquist limits, DC gain `up` over the whole kernel so the
     // every-up-th taps one output actually reads sum to unity.
@@ -139,7 +113,7 @@ public static class SampleRateConverter
         }
 
         double cutoff = 0.5 / factor;
-        double windowDenominator = BesselI0(KaiserBeta);
+        double windowDenominator = MathNet.Numerics.SpecialFunctions.BesselI0(KaiserBeta);
         var kernel = new double[length];
         for (int i = 0; i < kernel.Length; i++)
         {
@@ -148,34 +122,13 @@ public static class SampleRateConverter
                 ? 2.0 * cutoff
                 : Math.Sin(2.0 * Math.PI * cutoff * offset) / (Math.PI * offset);
             double ratio = offset / center;
-            double window = BesselI0(
+            double window = MathNet.Numerics.SpecialFunctions.BesselI0(
                 KaiserBeta * Math.Sqrt(Math.Max(0.0, 1.0 - ratio * ratio)))
                 / windowDenominator;
             kernel[i] = up * sinc * window;
         }
 
         return kernel;
-    }
-
-    // Zeroth-order modified Bessel function of the first kind, by its series.
-    // The terms fall factorially, so the loop exits on relative epsilon well
-    // before the iteration cap for any β this class uses.
-    private static double BesselI0(double x)
-    {
-        double sum = 1.0;
-        double term = 1.0;
-        for (int k = 1; k < 64; k++)
-        {
-            double factor = x / (2.0 * k);
-            term *= factor * factor;
-            sum += term;
-            if (term < sum * 1e-17)
-            {
-                break;
-            }
-        }
-
-        return sum;
     }
 
     private static int GreatestCommonDivisor(int a, int b)

--- a/dsp/SampleRateConverter.cs
+++ b/dsp/SampleRateConverter.cs
@@ -5,44 +5,57 @@ namespace Resonalyze.Dsp;
 /// <para>
 /// Every pair of integer rates is a rational ratio (44100 → 48000 is 160/147), so
 /// one anti-imaging/anti-aliasing kernel designed at the interpolated rate
-/// <c>up · fromRate</c> serves both directions: its cutoff sits at the LOWER of the
-/// two Nyquist limits, which removes the upsampler's images and the downsampler's
-/// aliases with the same taps. The zero-stuffed samples are never materialized —
-/// each output reads only the taps that land on real input samples, so the cost is
-/// ~2·<see cref="HalfLengthPerPhase"/> multiply-adds per output regardless of the
-/// ratio.
+/// <c>up · fromRate</c> serves both directions. The filter is specified the way
+/// any honest SRC must be: a passband reaching <see cref="PassbandFraction"/> of
+/// the LOWER of the two Nyquist limits (≈20.1 kHz for 44.1 kHz material), the
+/// full <see cref="StopbandAttenuationDb"/> reached AT that Nyquist — where
+/// aliasing actually begins — and the cutoff in the middle of the transition
+/// band between them. The Kaiser window's β and the kernel length follow from
+/// the attenuation and the transition width; a single cutoff at Nyquist would
+/// instead put the −6 dB point exactly where folding starts and leave content
+/// just above it only ~10 dB down.
 /// </para>
 /// <para>
-/// The kernel is symmetric and evaluated with its own group delay compensated, so
-/// the output is time-aligned with the input to a fraction of a sample. That
-/// matters here: the caller resamples MUSIC against measured impulse responses,
-/// and a converter that shifted the signal would move the very arrivals the
-/// measurement exists to place.
+/// The zero-stuffed samples are never materialized — each output reads only the
+/// taps that land on real input samples. The kernel is symmetric and evaluated
+/// with its own group delay compensated, so the output is time-aligned with the
+/// input to a fraction of a sample. That matters here: the caller resamples
+/// MUSIC against measured impulse responses, and a converter that shifted the
+/// signal would move the very arrivals the measurement exists to place.
 /// </para>
 /// </summary>
 public static class SampleRateConverter
 {
-    // Taps per polyphase branch, each side of the centre. Sixteen puts the
-    // transition band inside the last percent of the passband and the stopband
-    // under the Kaiser window's own floor — inaudible against any source
-    // material, and cheap enough to run over a whole track.
-    private const int HalfLengthPerPhase = 16;
+    // The passband keeps this fraction of the lower Nyquist: 91% is 20.07 kHz
+    // against a 44.1 kHz target — the top of the audible band survives, and the
+    // transition band that remains is wide enough to keep the kernel practical.
+    private const double PassbandFraction = 0.91;
 
-    // Kaiser β ≈ 8.6 gives roughly −90 dB stopband attenuation: below 16-bit
-    // material's own noise floor, so conversion artifacts cannot be the thing
-    // the listener hears.
-    private const double KaiserBeta = 8.6;
+    // Reached AT the lower Nyquist, i.e. at the first frequency that can fold
+    // back. Ninety dB is below 16-bit material's own noise floor.
+    private const double StopbandAttenuationDb = 90.0;
 
     // A sanity bound on pathological rate pairs. Rates that share no useful
-    // divisor (44100 → 48001) blow the kernel up to the interpolation factor
-    // itself; refuse rather than allocate hundreds of megabytes.
+    // divisor (44100 → 48001) push the transition width toward zero and the
+    // kernel toward millions of taps; refuse rather than allocate them.
     private const int MaximumKernelLength = 4 << 20;
+
+    // The inner loop is millions of iterations; the token is polled and the
+    // progress reported on power-of-two strides so the checks stay invisible
+    // next to the multiply-adds.
+    private const int CancellationCheckMask = 4_095;
+    private const int ProgressReportMask = (1 << 18) - 1;
 
     /// <summary>
     /// Resamples <paramref name="samples"/> from <paramref name="fromRate"/> to
     /// <paramref name="toRate"/>. Equal rates return a copy.
     /// </summary>
-    public static float[] Resample(float[] samples, int fromRate, int toRate)
+    public static float[] Resample(
+        float[] samples,
+        int fromRate,
+        int toRate,
+        IProgress<double>? progress = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(samples);
         if (fromRate <= 0)
@@ -73,6 +86,15 @@ public static class SampleRateConverter
         int lastInput = samples.Length - 1;
         for (long n = 0; n < outputLength; n++)
         {
+            if ((n & CancellationCheckMask) == 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+            if (n > 0 && (n & ProgressReportMask) == 0)
+            {
+                progress?.Report(n / (double)outputLength);
+            }
+
             // Output n represents input time n·down/up, i.e. position n·down in
             // the interpolated domain; the kernel is evaluated centred there,
             // and adding its own centre offset cancels the filter's group delay.
@@ -93,17 +115,29 @@ public static class SampleRateConverter
             output[n] = (float)sum;
         }
 
+        progress?.Report(1.0);
         return output;
     }
 
-    // The shared low-pass, designed in the interpolated domain: cutoff at the
-    // lower of the two Nyquist limits, DC gain `up` over the whole kernel so the
-    // every-up-th taps one output actually reads sum to unity.
+    // The shared low-pass in the interpolated domain, from the spec down: the
+    // stopband edge is the lower Nyquist, the passband edge its fraction, the
+    // cutoff halfway between, and Kaiser's published estimates turn the
+    // attenuation and transition width into β and the tap count
+    // (β = 0.1102·(A − 8.7), order ≈ (A − 7.95)/(2.285·Δω)). DC gain is `up`
+    // over the whole kernel so the every-up-th taps one output reads sum to
+    // unity.
     private static double[] BuildKernel(int up, int down, out int center)
     {
         int factor = Math.Max(up, down);
-        center = HalfLengthPerPhase * factor;
-        long length = 2L * center + 1;
+        double stopbandEdge = 0.5 / factor;
+        double transitionWidth = (1.0 - PassbandFraction) * stopbandEdge;
+        double cutoff = stopbandEdge - transitionWidth / 2.0;
+        double beta = 0.1102 * (StopbandAttenuationDb - 8.7);
+        int halfLength = (int)Math.Ceiling(
+            (StopbandAttenuationDb - 7.95) /
+            (2.0 * 2.285 * 2.0 * Math.PI * transitionWidth));
+        center = halfLength;
+        long length = 2L * halfLength + 1;
         if (length > MaximumKernelLength)
         {
             throw new NotSupportedException(
@@ -112,8 +146,7 @@ public static class SampleRateConverter
                 "resample efficiently.");
         }
 
-        double cutoff = 0.5 / factor;
-        double windowDenominator = MathNet.Numerics.SpecialFunctions.BesselI0(KaiserBeta);
+        double windowDenominator = MathNet.Numerics.SpecialFunctions.BesselI0(beta);
         var kernel = new double[length];
         for (int i = 0; i < kernel.Length; i++)
         {
@@ -123,7 +156,7 @@ public static class SampleRateConverter
                 : Math.Sin(2.0 * Math.PI * cutoff * offset) / (Math.PI * offset);
             double ratio = offset / center;
             double window = MathNet.Numerics.SpecialFunctions.BesselI0(
-                KaiserBeta * Math.Sqrt(Math.Max(0.0, 1.0 - ratio * ratio)))
+                beta * Math.Sqrt(Math.Max(0.0, 1.0 - ratio * ratio)))
                 / windowDenominator;
             kernel[i] = up * sinc * window;
         }

--- a/dsp/SampleRateConverter.cs
+++ b/dsp/SampleRateConverter.cs
@@ -1,0 +1,190 @@
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// Rational-ratio sample-rate conversion by polyphase windowed-sinc filtering.
+/// <para>
+/// Every pair of integer rates is a rational ratio (44100 → 48000 is 160/147), so
+/// one anti-imaging/anti-aliasing kernel designed at the interpolated rate
+/// <c>up · fromRate</c> serves both directions: its cutoff sits at the LOWER of the
+/// two Nyquist limits, which removes the upsampler's images and the downsampler's
+/// aliases with the same taps. The zero-stuffed samples are never materialized —
+/// each output reads only the taps that land on real input samples, so the cost is
+/// ~2·<see cref="HalfLengthPerPhase"/> multiply-adds per output regardless of the
+/// ratio.
+/// </para>
+/// <para>
+/// The kernel is symmetric and evaluated with its own group delay compensated, so
+/// the output is time-aligned with the input to a fraction of a sample. That
+/// matters here: the caller resamples MUSIC against measured impulse responses,
+/// and a converter that shifted the signal would move the very arrivals the
+/// measurement exists to place.
+/// </para>
+/// </summary>
+public static class SampleRateConverter
+{
+    // Taps per polyphase branch, each side of the centre. Sixteen puts the
+    // transition band inside the last percent of the passband and the stopband
+    // under the Kaiser window's own floor — inaudible against any source
+    // material, and cheap enough to run over a whole track.
+    private const int HalfLengthPerPhase = 16;
+
+    // Kaiser β ≈ 8.6 gives roughly −90 dB stopband attenuation: below 16-bit
+    // material's own noise floor, so conversion artifacts cannot be the thing
+    // the listener hears.
+    private const double KaiserBeta = 8.6;
+
+    // A sanity bound on pathological rate pairs. Rates that share no useful
+    // divisor (44100 → 48001) blow the kernel up to the interpolation factor
+    // itself; refuse rather than allocate hundreds of megabytes.
+    private const int MaximumKernelLength = 4 << 20;
+
+    /// <summary>
+    /// Resamples <paramref name="samples"/> from <paramref name="fromRate"/> to
+    /// <paramref name="toRate"/>. Equal rates return a copy.
+    /// </summary>
+    public static float[] Resample(float[] samples, int fromRate, int toRate)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        if (fromRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fromRate));
+        }
+        if (toRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(toRate));
+        }
+        if (fromRate == toRate)
+        {
+            return (float[])samples.Clone();
+        }
+        if (samples.Length == 0)
+        {
+            return Array.Empty<float>();
+        }
+
+        int divisor = GreatestCommonDivisor(fromRate, toRate);
+        int up = toRate / divisor;
+        int down = fromRate / divisor;
+        double[] kernel = BuildKernel(up, down, out int center);
+
+        long outputLength = ((long)samples.Length * up + down - 1) / down;
+        var output = new float[outputLength];
+        int kernelLength = kernel.Length;
+        int lastInput = samples.Length - 1;
+        for (long n = 0; n < outputLength; n++)
+        {
+            // Output n represents input time n·down/up, i.e. position n·down in
+            // the interpolated domain; the kernel is evaluated centred there,
+            // and adding its own centre offset cancels the filter's group delay.
+            long position = n * down + center;
+            // Tap j = position − i·up must land inside the kernel, which bounds
+            // the input samples this output reads.
+            long lowNumerator = position - kernelLength + 1;
+            int firstInput = lowNumerator <= 0
+                ? 0
+                : (int)((lowNumerator + up - 1) / up);
+            int finalInput = (int)Math.Min(lastInput, position / up);
+            double sum = 0;
+            for (int i = firstInput; i <= finalInput; i++)
+            {
+                sum += kernel[(int)(position - (long)i * up)] * samples[i];
+            }
+
+            output[n] = (float)sum;
+        }
+
+        return output;
+    }
+
+    /// <summary>
+    /// The length <see cref="Resample"/> produces, without doing the work — for
+    /// progress reporting and buffer budgeting.
+    /// </summary>
+    public static long ResampledLength(long inputLength, int fromRate, int toRate)
+    {
+        if (fromRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fromRate));
+        }
+        if (toRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(toRate));
+        }
+
+        if (fromRate == toRate)
+        {
+            return inputLength;
+        }
+
+        int divisor = GreatestCommonDivisor(fromRate, toRate);
+        int up = toRate / divisor;
+        int down = fromRate / divisor;
+        return (inputLength * up + down - 1) / down;
+    }
+
+    // The shared low-pass, designed in the interpolated domain: cutoff at the
+    // lower of the two Nyquist limits, DC gain `up` over the whole kernel so the
+    // every-up-th taps one output actually reads sum to unity.
+    private static double[] BuildKernel(int up, int down, out int center)
+    {
+        int factor = Math.Max(up, down);
+        center = HalfLengthPerPhase * factor;
+        long length = 2L * center + 1;
+        if (length > MaximumKernelLength)
+        {
+            throw new NotSupportedException(
+                $"Resampling by the ratio {up}/{down} needs a {length}-tap " +
+                "kernel; the two rates share too small a common divisor to " +
+                "resample efficiently.");
+        }
+
+        double cutoff = 0.5 / factor;
+        double windowDenominator = BesselI0(KaiserBeta);
+        var kernel = new double[length];
+        for (int i = 0; i < kernel.Length; i++)
+        {
+            double offset = i - center;
+            double sinc = offset == 0
+                ? 2.0 * cutoff
+                : Math.Sin(2.0 * Math.PI * cutoff * offset) / (Math.PI * offset);
+            double ratio = offset / center;
+            double window = BesselI0(
+                KaiserBeta * Math.Sqrt(Math.Max(0.0, 1.0 - ratio * ratio)))
+                / windowDenominator;
+            kernel[i] = up * sinc * window;
+        }
+
+        return kernel;
+    }
+
+    // Zeroth-order modified Bessel function of the first kind, by its series.
+    // The terms fall factorially, so the loop exits on relative epsilon well
+    // before the iteration cap for any β this class uses.
+    private static double BesselI0(double x)
+    {
+        double sum = 1.0;
+        double term = 1.0;
+        for (int k = 1; k < 64; k++)
+        {
+            double factor = x / (2.0 * k);
+            term *= factor * factor;
+            sum += term;
+            if (term < sum * 1e-17)
+            {
+                break;
+            }
+        }
+
+        return sum;
+    }
+
+    private static int GreatestCommonDivisor(int a, int b)
+    {
+        while (b != 0)
+        {
+            (a, b) = (b, a % b);
+        }
+
+        return a;
+    }
+}

--- a/dsp/SynchronousProgress.cs
+++ b/dsp/SynchronousProgress.cs
@@ -1,0 +1,22 @@
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// An <see cref="IProgress{T}"/> that invokes its handler synchronously on the
+/// reporting thread.
+/// <para>
+/// <see cref="Progress{T}"/> posts through the SynchronizationContext captured
+/// at construction; created on a worker thread that context is the thread pool,
+/// which means "some pool thread, later". Chain two of those and reports
+/// reorder freely — one stage's updates land after the next stage's, a progress
+/// bar walks backwards, a "running" status overwrites "finished". Every
+/// COMPOSITION layer must therefore relay inline with this type; only the one
+/// outermost progress, created on the UI thread, may hop threads.
+/// </para>
+/// </summary>
+public sealed class SynchronousProgress<T>(Action<T> handler) : IProgress<T>
+{
+    private readonly Action<T> handler =
+        handler ?? throw new ArgumentNullException(nameof(handler));
+
+    public void Report(T value) => handler(value);
+}

--- a/source/Tools/VirtualCrossover/ProcessedChannel.cs
+++ b/source/Tools/VirtualCrossover/ProcessedChannel.cs
@@ -16,6 +16,19 @@ internal sealed record ProcessedChannel(
     OxyColor Color);
 
 /// <summary>
+/// One side of the car summed: the complex sum of its participating channels'
+/// processed responses, the earliest arrival among them (the window anchor every
+/// curve built from this sum must share) and the project rate they were measured
+/// at. <see cref="ChannelCount"/> is how many channels went in, for read-outs
+/// that need to say so.
+/// </summary>
+internal sealed record VirtualCrossoverSideSum(
+    Complex[] ImpulseResponse,
+    int AnchorIndex,
+    int SampleRate,
+    int ChannelCount);
+
+/// <summary>
 /// Adjacent channels along the spectrum with their shared junction: the pair
 /// crossover frequency and the band (an octave to each side) where the two
 /// drivers genuinely overlap. This band is where coarse arrivals are compared,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.Designer.cs
@@ -43,9 +43,9 @@ namespace Resonalyze
             textBoxReport = new TextBox();
             buttonClose = new Button();
             SuspendLayout();
-            //
+            // 
             // labelTrack
-            //
+            // 
             labelTrack.AutoSize = true;
             labelTrack.ForeColor = Color.FromArgb(185, 190, 200);
             labelTrack.Location = new Point(12, 19);
@@ -53,9 +53,9 @@ namespace Resonalyze
             labelTrack.Size = new Size(38, 15);
             labelTrack.TabIndex = 0;
             labelTrack.Text = "Track:";
-            //
+            // 
             // buttonChooseSource
-            //
+            // 
             buttonChooseSource.BackColor = Color.FromArgb(46, 51, 67);
             buttonChooseSource.FlatStyle = FlatStyle.Popup;
             buttonChooseSource.ForeColor = Color.White;
@@ -65,9 +65,9 @@ namespace Resonalyze
             buttonChooseSource.TabIndex = 1;
             buttonChooseSource.Text = "Choose...";
             buttonChooseSource.UseVisualStyleBackColor = false;
-            //
+            // 
             // labelSourceFile
-            //
+            // 
             labelSourceFile.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             labelSourceFile.AutoEllipsis = true;
             labelSourceFile.ForeColor = Color.FromArgb(185, 190, 200);
@@ -76,9 +76,9 @@ namespace Resonalyze
             labelSourceFile.Size = new Size(360, 15);
             labelSourceFile.TabIndex = 2;
             labelSourceFile.Text = "no file chosen";
-            //
+            // 
             // labelOutput
-            //
+            // 
             labelOutput.AutoSize = true;
             labelOutput.ForeColor = Color.FromArgb(185, 190, 200);
             labelOutput.Location = new Point(12, 51);
@@ -86,9 +86,9 @@ namespace Resonalyze
             labelOutput.Size = new Size(48, 15);
             labelOutput.TabIndex = 3;
             labelOutput.Text = "Output:";
-            //
+            // 
             // buttonChooseTarget
-            //
+            // 
             buttonChooseTarget.BackColor = Color.FromArgb(46, 51, 67);
             buttonChooseTarget.FlatStyle = FlatStyle.Popup;
             buttonChooseTarget.ForeColor = Color.White;
@@ -98,9 +98,9 @@ namespace Resonalyze
             buttonChooseTarget.TabIndex = 4;
             buttonChooseTarget.Text = "Save as...";
             buttonChooseTarget.UseVisualStyleBackColor = false;
-            //
+            // 
             // labelTargetFile
-            //
+            // 
             labelTargetFile.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             labelTargetFile.AutoEllipsis = true;
             labelTargetFile.ForeColor = Color.FromArgb(185, 190, 200);
@@ -109,29 +109,29 @@ namespace Resonalyze
             labelTargetFile.Size = new Size(360, 15);
             labelTargetFile.TabIndex = 5;
             labelTargetFile.Text = "no file chosen";
-            //
+            // 
             // labelCalibration
-            //
+            // 
             labelCalibration.AutoSize = true;
             labelCalibration.ForeColor = Color.FromArgb(185, 190, 200);
             labelCalibration.Location = new Point(12, 83);
             labelCalibration.Name = "labelCalibration";
-            labelCalibration.Size = new Size(90, 15);
+            labelCalibration.Size = new Size(89, 15);
             labelCalibration.TabIndex = 6;
             labelCalibration.Text = "Mic calibration:";
-            //
+            // 
             // comboBoxCalibration
-            //
+            // 
             comboBoxCalibration.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxCalibration.ForeColor = Color.White;
-            comboBoxCalibration.Location = new Point(104, 80);
+            comboBoxCalibration.Location = new Point(104, 81);
             comboBoxCalibration.MinimumSize = new Size(36, 19);
             comboBoxCalibration.Name = "comboBoxCalibration";
-            comboBoxCalibration.Size = new Size(130, 19);
+            comboBoxCalibration.Size = new Size(110, 19);
             comboBoxCalibration.TabIndex = 7;
-            //
+            // 
             // buttonRender
-            //
+            // 
             buttonRender.BackColor = Color.FromArgb(46, 51, 67);
             buttonRender.FlatStyle = FlatStyle.Popup;
             buttonRender.ForeColor = Color.White;
@@ -141,9 +141,9 @@ namespace Resonalyze
             buttonRender.TabIndex = 8;
             buttonRender.Text = "Render";
             buttonRender.UseVisualStyleBackColor = false;
-            //
+            // 
             // progressBar
-            //
+            // 
             progressBar.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             progressBar.Location = new Point(144, 112);
             progressBar.Maximum = 1000;
@@ -151,18 +151,18 @@ namespace Resonalyze
             progressBar.Size = new Size(440, 26);
             progressBar.Style = ProgressBarStyle.Continuous;
             progressBar.TabIndex = 9;
-            //
+            // 
             // labelStatus
-            //
+            // 
             labelStatus.AutoSize = true;
             labelStatus.ForeColor = Color.FromArgb(185, 190, 200);
             labelStatus.Location = new Point(12, 146);
             labelStatus.Name = "labelStatus";
             labelStatus.Size = new Size(0, 15);
             labelStatus.TabIndex = 10;
-            //
+            // 
             // textBoxReport
-            //
+            // 
             textBoxReport.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             textBoxReport.BackColor = Color.FromArgb(33, 36, 45);
             textBoxReport.BorderStyle = BorderStyle.FixedSingle;
@@ -175,9 +175,9 @@ namespace Resonalyze
             textBoxReport.ScrollBars = ScrollBars.Vertical;
             textBoxReport.Size = new Size(572, 302);
             textBoxReport.TabIndex = 11;
-            //
+            // 
             // buttonClose
-            //
+            // 
             buttonClose.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
             buttonClose.DialogResult = DialogResult.Cancel;
             buttonClose.FlatStyle = FlatStyle.Popup;
@@ -188,9 +188,9 @@ namespace Resonalyze
             buttonClose.TabIndex = 12;
             buttonClose.Text = "Close";
             buttonClose.UseVisualStyleBackColor = true;
-            //
+            // 
             // VirtualCrossoverAuditionDialog
-            //
+            // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(40, 44, 54);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.Designer.cs
@@ -1,0 +1,240 @@
+namespace Resonalyze
+{
+    partial class VirtualCrossoverAuditionDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                components?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            labelTrack = new Label();
+            buttonChooseSource = new Button();
+            labelSourceFile = new Label();
+            labelOutput = new Label();
+            buttonChooseTarget = new Button();
+            labelTargetFile = new Label();
+            labelCalibration = new Label();
+            comboBoxCalibration = new DarkComboBox();
+            buttonRender = new Button();
+            progressBar = new ProgressBar();
+            labelStatus = new Label();
+            textBoxReport = new TextBox();
+            buttonClose = new Button();
+            SuspendLayout();
+            //
+            // labelTrack
+            //
+            labelTrack.AutoSize = true;
+            labelTrack.ForeColor = Color.FromArgb(185, 190, 200);
+            labelTrack.Location = new Point(12, 19);
+            labelTrack.Name = "labelTrack";
+            labelTrack.Size = new Size(38, 15);
+            labelTrack.TabIndex = 0;
+            labelTrack.Text = "Track:";
+            //
+            // buttonChooseSource
+            //
+            buttonChooseSource.BackColor = Color.FromArgb(46, 51, 67);
+            buttonChooseSource.FlatStyle = FlatStyle.Popup;
+            buttonChooseSource.ForeColor = Color.White;
+            buttonChooseSource.Location = new Point(104, 14);
+            buttonChooseSource.Name = "buttonChooseSource";
+            buttonChooseSource.Size = new Size(110, 26);
+            buttonChooseSource.TabIndex = 1;
+            buttonChooseSource.Text = "Choose...";
+            buttonChooseSource.UseVisualStyleBackColor = false;
+            //
+            // labelSourceFile
+            //
+            labelSourceFile.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            labelSourceFile.AutoEllipsis = true;
+            labelSourceFile.ForeColor = Color.FromArgb(185, 190, 200);
+            labelSourceFile.Location = new Point(224, 19);
+            labelSourceFile.Name = "labelSourceFile";
+            labelSourceFile.Size = new Size(360, 15);
+            labelSourceFile.TabIndex = 2;
+            labelSourceFile.Text = "no file chosen";
+            //
+            // labelOutput
+            //
+            labelOutput.AutoSize = true;
+            labelOutput.ForeColor = Color.FromArgb(185, 190, 200);
+            labelOutput.Location = new Point(12, 51);
+            labelOutput.Name = "labelOutput";
+            labelOutput.Size = new Size(48, 15);
+            labelOutput.TabIndex = 3;
+            labelOutput.Text = "Output:";
+            //
+            // buttonChooseTarget
+            //
+            buttonChooseTarget.BackColor = Color.FromArgb(46, 51, 67);
+            buttonChooseTarget.FlatStyle = FlatStyle.Popup;
+            buttonChooseTarget.ForeColor = Color.White;
+            buttonChooseTarget.Location = new Point(104, 46);
+            buttonChooseTarget.Name = "buttonChooseTarget";
+            buttonChooseTarget.Size = new Size(110, 26);
+            buttonChooseTarget.TabIndex = 4;
+            buttonChooseTarget.Text = "Save as...";
+            buttonChooseTarget.UseVisualStyleBackColor = false;
+            //
+            // labelTargetFile
+            //
+            labelTargetFile.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            labelTargetFile.AutoEllipsis = true;
+            labelTargetFile.ForeColor = Color.FromArgb(185, 190, 200);
+            labelTargetFile.Location = new Point(224, 51);
+            labelTargetFile.Name = "labelTargetFile";
+            labelTargetFile.Size = new Size(360, 15);
+            labelTargetFile.TabIndex = 5;
+            labelTargetFile.Text = "no file chosen";
+            //
+            // labelCalibration
+            //
+            labelCalibration.AutoSize = true;
+            labelCalibration.ForeColor = Color.FromArgb(185, 190, 200);
+            labelCalibration.Location = new Point(12, 83);
+            labelCalibration.Name = "labelCalibration";
+            labelCalibration.Size = new Size(90, 15);
+            labelCalibration.TabIndex = 6;
+            labelCalibration.Text = "Mic calibration:";
+            //
+            // comboBoxCalibration
+            //
+            comboBoxCalibration.BackColor = Color.FromArgb(55, 60, 72);
+            comboBoxCalibration.ForeColor = Color.White;
+            comboBoxCalibration.Location = new Point(104, 80);
+            comboBoxCalibration.MinimumSize = new Size(36, 19);
+            comboBoxCalibration.Name = "comboBoxCalibration";
+            comboBoxCalibration.Size = new Size(130, 19);
+            comboBoxCalibration.TabIndex = 7;
+            //
+            // buttonRender
+            //
+            buttonRender.BackColor = Color.FromArgb(46, 51, 67);
+            buttonRender.FlatStyle = FlatStyle.Popup;
+            buttonRender.ForeColor = Color.White;
+            buttonRender.Location = new Point(12, 112);
+            buttonRender.Name = "buttonRender";
+            buttonRender.Size = new Size(120, 26);
+            buttonRender.TabIndex = 8;
+            buttonRender.Text = "Render";
+            buttonRender.UseVisualStyleBackColor = false;
+            //
+            // progressBar
+            //
+            progressBar.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            progressBar.Location = new Point(144, 112);
+            progressBar.Maximum = 1000;
+            progressBar.Name = "progressBar";
+            progressBar.Size = new Size(440, 26);
+            progressBar.Style = ProgressBarStyle.Continuous;
+            progressBar.TabIndex = 9;
+            //
+            // labelStatus
+            //
+            labelStatus.AutoSize = true;
+            labelStatus.ForeColor = Color.FromArgb(185, 190, 200);
+            labelStatus.Location = new Point(12, 146);
+            labelStatus.Name = "labelStatus";
+            labelStatus.Size = new Size(0, 15);
+            labelStatus.TabIndex = 10;
+            //
+            // textBoxReport
+            //
+            textBoxReport.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            textBoxReport.BackColor = Color.FromArgb(33, 36, 45);
+            textBoxReport.BorderStyle = BorderStyle.FixedSingle;
+            textBoxReport.Font = new Font("Consolas", 9F);
+            textBoxReport.ForeColor = Color.FromArgb(210, 214, 222);
+            textBoxReport.Location = new Point(12, 168);
+            textBoxReport.Multiline = true;
+            textBoxReport.Name = "textBoxReport";
+            textBoxReport.ReadOnly = true;
+            textBoxReport.ScrollBars = ScrollBars.Vertical;
+            textBoxReport.Size = new Size(572, 302);
+            textBoxReport.TabIndex = 11;
+            //
+            // buttonClose
+            //
+            buttonClose.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            buttonClose.DialogResult = DialogResult.Cancel;
+            buttonClose.FlatStyle = FlatStyle.Popup;
+            buttonClose.ForeColor = Color.White;
+            buttonClose.Location = new Point(492, 480);
+            buttonClose.Name = "buttonClose";
+            buttonClose.Size = new Size(92, 26);
+            buttonClose.TabIndex = 12;
+            buttonClose.Text = "Close";
+            buttonClose.UseVisualStyleBackColor = true;
+            //
+            // VirtualCrossoverAuditionDialog
+            //
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            BackColor = Color.FromArgb(40, 44, 54);
+            CancelButton = buttonClose;
+            ClientSize = new Size(596, 518);
+            Controls.Add(labelTrack);
+            Controls.Add(buttonChooseSource);
+            Controls.Add(labelSourceFile);
+            Controls.Add(labelOutput);
+            Controls.Add(buttonChooseTarget);
+            Controls.Add(labelTargetFile);
+            Controls.Add(labelCalibration);
+            Controls.Add(comboBoxCalibration);
+            Controls.Add(buttonRender);
+            Controls.Add(progressBar);
+            Controls.Add(labelStatus);
+            Controls.Add(textBoxReport);
+            Controls.Add(buttonClose);
+            Font = new Font("Segoe UI", 9F);
+            ForeColor = Color.White;
+            MinimizeBox = false;
+            MinimumSize = new Size(560, 420);
+            Name = "VirtualCrossoverAuditionDialog";
+            ShowInTaskbar = false;
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "Audition track";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private Label labelTrack;
+        private Button buttonChooseSource;
+        private Label labelSourceFile;
+        private Label labelOutput;
+        private Button buttonChooseTarget;
+        private Label labelTargetFile;
+        private Label labelCalibration;
+        private DarkComboBox comboBoxCalibration;
+        private Button buttonRender;
+        private ProgressBar progressBar;
+        private Label labelStatus;
+        private TextBox textBoxReport;
+        private Button buttonClose;
+    }
+}

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
@@ -59,11 +59,12 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
     private string? sourcePath;
     private string? targetPath;
 
-    // Whether overwriting targetPath has been consented to IN THIS DIALOG: the
-    // SaveFileDialog's own prompt covers a picked path, but a path restored
-    // from the previous opening carries no such consent — the file sitting
-    // there is the PREVIOUS render, and silently replacing it would collapse
-    // an A/B pair into just B.
+    // Whether overwriting targetPath has been consented to IN THIS DIALOG.
+    // Only the SaveFileDialog's OverwritePrompt over an EXISTING file (or the
+    // render-time question below) grants it; a path restored from the
+    // previous opening and a freshly created new file both lack it — in
+    // either case the file on disk is the PREVIOUS render, and silently
+    // replacing it would collapse an A/B pair into just B.
     private bool targetOverwriteConfirmed;
     private string trackSection = string.Empty;
     private string resultSection = string.Empty;
@@ -308,10 +309,14 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             return;
         }
 
+        // Consent tracks what the SaveFileDialog actually asked. For an
+        // EXISTING file its OverwritePrompt just did. A NEW file had nothing
+        // to ask about — the first render creates it freely, and the next
+        // render in this same dialog finds it existing and unconfirmed, so it
+        // asks before replacing variant A with variant B.
+        targetOverwriteConfirmed = File.Exists(dialog.FileName);
         targetPath = dialog.FileName;
         labelTargetFile.Text = dialog.FileName;
-        // The SaveFileDialog's OverwritePrompt already asked if the file exists.
-        targetOverwriteConfirmed = true;
         RefreshRenderEnabled();
     }
 
@@ -360,10 +365,9 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         {
             DialogResult overwrite = MessageBox.Show(
                 this,
-                $"The output file already exists:\r\n{targetPath}\r\n\r\nIt was " +
-                "restored from the previous opening, so it holds that render. " +
-                "Overwrite it?\r\n\r\n(Choose No and Save as... to keep both " +
-                "variants for an A/B.)",
+                $"The output file already exists:\r\n{targetPath}\r\n\r\nIt " +
+                "holds the previous render. Overwrite it?\r\n\r\n(Choose No " +
+                "and Save as... to keep both variants for an A/B.)",
                 "Audition render",
                 MessageBoxButtons.YesNo,
                 MessageBoxIcon.Warning);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
@@ -562,10 +562,11 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             $"{FormatDuration(TimeSpan.FromSeconds(durationSeconds))}");
         section.AppendLine();
         section.Append(
-            "This is what the measurement microphone hears at its position — " +
-            "drivers, cabin and capsule included, not only the DSP. Listen on " +
-            "headphones: playing it back through the same system would convolve " +
-            "the car twice.");
+            "Listen through headphones only. The left and right channels are " +
+            "the measured acoustic response of the corresponding side at the " +
+            "microphone position — drivers, cabin and capsule included, not a " +
+            "binaural head simulation. Playing it back through the same system " +
+            "would convolve the car twice.");
         return section.ToString();
     }
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
@@ -64,6 +64,17 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
     private CancellationTokenSource? activeRender;
     private bool closeRequested;
 
+    // The last accepted inputs, remembered for the lifetime of the process: a
+    // tuning session renders the SAME track through several tune variants, and
+    // re-picking both files and the calibration on every opening made that
+    // loop needlessly slow. Deliberately not persisted to disk — a stale path
+    // from last week is noise, within one run it is the workflow. The source
+    // is re-probed on restore (the file may have changed or vanished since),
+    // so a dead path degrades to the usual refusal in the report.
+    private static string? lastSourcePath;
+    private static string? lastTargetPath;
+    private static MicrophoneCalibrationMode? lastCalibrationMode;
+
     public VirtualCrossoverAuditionDialog(VirtualCrossoverAuditionContext context)
     {
         this.context = context ?? throw new ArgumentNullException(nameof(context));
@@ -71,13 +82,23 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
 
         MicrophoneCalibrationComboHelper.Configure(
             comboBoxCalibration,
-            context.InitialCalibrationMode,
+            lastCalibrationMode ?? context.InitialCalibrationMode,
             context.HasZeroDegreeCalibration,
             context.HasNinetyDegreeCalibration);
 
         buttonChooseSource.Click += (_, _) => ChooseSource();
         buttonChooseTarget.Click += (_, _) => ChooseTarget();
         buttonRender.Click += async (_, _) => await OnRenderClickedAsync();
+
+        if (lastSourcePath != null)
+        {
+            ApplySourceSelection(lastSourcePath);
+        }
+        if (lastTargetPath != null)
+        {
+            targetPath = lastTargetPath;
+            labelTargetFile.Text = lastTargetPath;
+        }
 
         RefreshRenderEnabled();
         RefreshReport();
@@ -96,6 +117,18 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         }
 
         base.OnFormClosing(e);
+    }
+
+    // Unconditional on purpose: a restore that failed (the file vanished)
+    // leaves null here, and saving that null stops the next opening from
+    // retrying a dead path.
+    protected override void OnFormClosed(FormClosedEventArgs e)
+    {
+        lastSourcePath = sourcePath;
+        lastTargetPath = targetPath;
+        lastCalibrationMode =
+            MicrophoneCalibrationComboHelper.GetSelectedMode(comboBoxCalibration);
+        base.OnFormClosed(e);
     }
 
     // ---------------------------------------------------------------- pickers
@@ -127,16 +160,23 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             return;
         }
 
-        // Probe now, not at render time: an unreadable, over-long or over-sized
-        // file should say so the moment it is picked, in the report, with
-        // Render disabled.
+        ApplySourceSelection(dialog.FileName);
+    }
+
+    // Shared by the picker and the same-run restore: probes the file and
+    // either adopts it (path plus the track report section) or leaves the slot
+    // empty with the refusal in the report. Probing here, not at render time,
+    // means an unreadable, over-long or over-sized file says so the moment it
+    // enters, with Render disabled.
+    private void ApplySourceSelection(string fileName)
+    {
         try
         {
-            AudioFileInfo info = AudioFileCodec.Probe(dialog.FileName);
+            AudioFileInfo info = AudioFileCodec.Probe(fileName);
             long projectedBytes = ProjectedPipelineBytes(info, context.SampleRate);
             var section = new StringBuilder();
             section.AppendLine("== Track ==");
-            section.AppendLine(Path.GetFileName(dialog.FileName));
+            section.AppendLine(Path.GetFileName(fileName));
             section.AppendLine(
                 $"{info.ChannelCount} channel(s), {info.SampleRate} Hz, " +
                 $"{FormatDuration(info.Duration)}");
@@ -183,8 +223,8 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
                         "Only the first two channels will feed the two sides.");
                 }
 
-                sourcePath = dialog.FileName;
-                labelSourceFile.Text = dialog.FileName;
+                sourcePath = fileName;
+                labelSourceFile.Text = fileName;
             }
 
             trackSection = section.ToString().TrimEnd();
@@ -195,7 +235,7 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             labelSourceFile.Text = "no file chosen";
             trackSection =
                 "== Track ==\r\n" +
-                $"{Path.GetFileName(dialog.FileName)}\r\n" +
+                $"{Path.GetFileName(fileName)}\r\n" +
                 $"UNREADABLE: {exception.Message}";
         }
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
@@ -43,8 +43,11 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
 {
     // A render holds the decoded material, its resampled copy and the result in
     // memory at once, so length is bounded rather than left to fail as an
-    // out-of-memory crash deep in a background task.
+    // out-of-memory crash deep in a background task. The duration cap alone is
+    // not a memory cap — ten minutes at 192 kHz is six times ten minutes at
+    // 32 kHz — so the pipeline's projected bytes are bounded separately.
     private const int MaximumTrackMinutes = 10;
+    private const long MaximumPipelineBytes = 1_000_000_000;
 
     // Progress budget: decoding and writing are single passes over the material
     // against the render's block transforms, so they get the ends of the bar.
@@ -112,11 +115,25 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             return;
         }
 
-        // Probe now, not at render time: an unreadable or over-long file should
-        // say so the moment it is picked, in the report, with Render disabled.
+        if (PathsEqual(dialog.FileName, targetPath))
+        {
+            MessageBox.Show(
+                this,
+                "This file is already chosen as the OUTPUT. Rendering a file " +
+                "onto itself would destroy the source.",
+                "Audition render",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
+        }
+
+        // Probe now, not at render time: an unreadable, over-long or over-sized
+        // file should say so the moment it is picked, in the report, with
+        // Render disabled.
         try
         {
             AudioFileInfo info = AudioFileCodec.Probe(dialog.FileName);
+            long projectedBytes = ProjectedPipelineBytes(info, context.SampleRate);
             var section = new StringBuilder();
             section.AppendLine("== Track ==");
             section.AppendLine(Path.GetFileName(dialog.FileName));
@@ -128,6 +145,23 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
                 section.Append(
                     $"REFUSED: longer than {MaximumTrackMinutes} minutes — " +
                     "use a shorter excerpt.");
+                sourcePath = null;
+                labelSourceFile.Text = "no file chosen";
+            }
+            else if (projectedBytes > MaximumPipelineBytes)
+            {
+                // The duration alone does not bound memory: the render keeps the
+                // decoded stereo source, its resampled copy and both rendered
+                // sides alive at its peak, and that scales with the rates.
+                double allowedMinutes = MaximumPipelineBytes
+                    / (ProjectedPipelineBytes(
+                        info with { Duration = TimeSpan.FromMinutes(1) },
+                        context.SampleRate) * 1.0);
+                section.Append(
+                    $"REFUSED: rendering this would hold ~" +
+                    $"{projectedBytes / 1_000_000} MB of audio in memory " +
+                    $"(bound {MaximumPipelineBytes / 1_000_000} MB). At these " +
+                    $"rates keep the excerpt under ~{allowedMinutes:0} minutes.");
                 sourcePath = null;
                 labelSourceFile.Text = "no file chosen";
             }
@@ -194,9 +228,44 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             return;
         }
 
+        // Writing onto the source would destroy it on the first render — and
+        // the advertised A/B re-render would then process the processed file.
+        if (PathsEqual(dialog.FileName, sourcePath))
+        {
+            MessageBox.Show(
+                this,
+                "This is the source track itself. Choose a different output " +
+                "file — rendering onto the source would destroy it.",
+                "Audition render",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
+        }
+
         targetPath = dialog.FileName;
         labelTargetFile.Text = dialog.FileName;
         RefreshRenderEnabled();
+    }
+
+    private static bool PathsEqual(string? first, string? second) =>
+        first != null && second != null &&
+        string.Equals(
+            Path.GetFullPath(first),
+            Path.GetFullPath(second),
+            StringComparison.OrdinalIgnoreCase);
+
+    // The render's peak working set: the decoded stereo source, its resampled
+    // copy (absent when the rates already match) and the two rendered sides,
+    // all float32 and all alive at once. Channels beyond two are never stored
+    // (the decoder is told to keep two), so two is the multiplier even for
+    // multichannel files.
+    private static long ProjectedPipelineBytes(AudioFileInfo info, int projectRate)
+    {
+        double seconds = info.Duration.TotalSeconds;
+        long sourceFrames = (long)Math.Ceiling(seconds * info.SampleRate);
+        long renderedFrames = (long)Math.Ceiling(seconds * projectRate);
+        long resampledFrames = info.SampleRate == projectRate ? 0 : renderedFrames;
+        return 4L * 2L * (sourceFrames + resampledFrames + renderedFrames);
     }
 
     // ----------------------------------------------------------------- render
@@ -208,7 +277,7 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             RequestCancel();
             return;
         }
-        if (sourcePath == null || targetPath == null)
+        if (sourcePath == null || targetPath == null || PathsEqual(sourcePath, targetPath))
         {
             return;
         }
@@ -237,9 +306,18 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         resultSection = string.Empty;
         RefreshReport();
 
-        // Progress<T> posts to the UI synchronization context captured here.
+        // The ONE asynchronous hop in the whole progress chain: created here on
+        // the UI thread, so Progress<T> posts to the UI context — in order.
+        // Every layer below it relays synchronously (SynchronousProgress); a
+        // worker-created Progress<T> would post to the thread pool and reorder.
+        // The IsDisposed guard covers reports still queued when the form goes.
         var progress = new Progress<AuditionProgress>(update =>
         {
+            if (IsDisposed)
+            {
+                return;
+            }
+
             labelStatus.Text = update.Status;
             progressBar.Value = (int)Math.Clamp(
                 Math.Round(update.Fraction * progressBar.Maximum),
@@ -347,12 +425,16 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         }
 
         progress.Report(new AuditionProgress("Decoding the track…", 0.01));
+        // Only the first two channels are kept — the render feeds channel 1 to
+        // the left side and channel 2 to the right, and storing a 7.1 layout
+        // would quadruple the decoded footprint for nothing.
         AudioFileContent material = AudioFileCodec.Read(
             sourcePath,
             TimeSpan.FromMinutes(MaximumTrackMinutes),
+            channelLimit: 2,
             cancellationToken);
 
-        var renderProgress = new Progress<double>(value =>
+        var renderProgress = new SynchronousProgress<double>(value =>
             progress.Report(new AuditionProgress(
                 "Rendering through the tune…",
                 DecodeShare + value * RenderShare)));

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
@@ -259,14 +259,20 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
     // all float32 and all alive at once. Channels beyond two are never stored
     // (the decoder is told to keep two), so two is the multiplier even for
     // multichannel files.
-    private static long ProjectedPipelineBytes(AudioFileInfo info, int projectRate)
+    private static long ProjectedPipelineBytes(
+        long sourceFrames, int sourceRate, int projectRate)
     {
-        double seconds = info.Duration.TotalSeconds;
-        long sourceFrames = (long)Math.Ceiling(seconds * info.SampleRate);
-        long renderedFrames = (long)Math.Ceiling(seconds * projectRate);
-        long resampledFrames = info.SampleRate == projectRate ? 0 : renderedFrames;
+        long renderedFrames = (long)Math.Ceiling(
+            sourceFrames * (double)projectRate / sourceRate);
+        long resampledFrames = sourceRate == projectRate ? 0 : renderedFrames;
         return 4L * 2L * (sourceFrames + resampledFrames + renderedFrames);
     }
+
+    private static long ProjectedPipelineBytes(AudioFileInfo info, int projectRate) =>
+        ProjectedPipelineBytes(
+            (long)Math.Ceiling(info.Duration.TotalSeconds * info.SampleRate),
+            info.SampleRate,
+            projectRate);
 
     // ----------------------------------------------------------------- render
 
@@ -433,6 +439,22 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             TimeSpan.FromMinutes(MaximumTrackMinutes),
             channelLimit: 2,
             cancellationToken);
+
+        // The pick-time budget was a preflight over the container's CLAIMED
+        // duration; the decode is the truth — the file may have been replaced
+        // since the pick, or the header may simply lie — so the same bound is
+        // enforced again on the actual frame count, before the resampled and
+        // rendered buffers come into existence.
+        long actualBytes = ProjectedPipelineBytes(
+            material.FrameCount, material.SampleRate, context.SampleRate);
+        if (actualBytes > MaximumPipelineBytes)
+        {
+            throw new InvalidOperationException(
+                $"The decoded track is larger than its header promised: " +
+                $"rendering would hold ~{actualBytes / 1_000_000} MB of audio " +
+                $"in memory (bound {MaximumPipelineBytes / 1_000_000} MB). " +
+                "Use a shorter excerpt.");
+        }
 
         var renderProgress = new SynchronousProgress<double>(value =>
             progress.Report(new AuditionProgress(

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
@@ -374,7 +374,6 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         progress.Report(new AuditionProgress("Finished", 1.0));
 
         return new RenderOutcome(
-            material.ChannelCount,
             material.SampleRate,
             rendered,
             leftTrim,
@@ -494,7 +493,6 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         $"{(int)duration.TotalMinutes}:{duration.Seconds:00}";
 
     private sealed record RenderOutcome(
-        int SourceChannelCount,
         int SourceSampleRate,
         AuralizationResult Rendered,
         AuralizationTrim LeftTrim,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
@@ -1,0 +1,506 @@
+using System.Numerics;
+using System.Text;
+using Resonalyze.Dsp;
+using Resonalyze.Options;
+
+namespace Resonalyze;
+
+/// <summary>One step of a running audition render, for the progress read-out.</summary>
+internal readonly record struct AuditionProgress(string Status, double Fraction);
+
+/// <summary>
+/// Everything the audition dialog needs from the panel, captured at the moment
+/// the button was pressed: the two sides' summed responses (immutable
+/// snapshots), the project rate, and the microphone-calibration sources the
+/// panel itself uses for its curves.
+/// </summary>
+internal sealed record VirtualCrossoverAuditionContext(
+    Complex[] LeftSum,
+    Complex[] RightSum,
+    int SampleRate,
+    int LeftChannelCount,
+    int RightChannelCount,
+    string? BorrowedSide,
+    Func<MicrophoneCalibrationMode, CalibrationFile?>? CalibrationResolver,
+    bool HasZeroDegreeCalibration,
+    bool HasNinetyDegreeCalibration,
+    MicrophoneCalibrationMode InitialCalibrationMode);
+
+/// <summary>
+/// The Virtual DSP audition dialog: pick a track and a destination, optionally a
+/// microphone calibration, render, and read what happened. The render runs on a
+/// worker task behind the progress bar and stays cancellable; the report block
+/// accumulates the input file's shape, the tune's responses and the result.
+/// <para>
+/// The chosen calibration becomes a linear-phase FIR baked into BOTH side
+/// kernels before the track convolution — one filter, both sides, so the
+/// magnitude matches the calibrated on-screen curves while the inter-side
+/// timing (the thing being auditioned) shifts by exactly the same constant on
+/// each channel.
+/// </para>
+/// </summary>
+internal sealed partial class VirtualCrossoverAuditionDialog : Form
+{
+    // A render holds the decoded material, its resampled copy and the result in
+    // memory at once, so length is bounded rather than left to fail as an
+    // out-of-memory crash deep in a background task.
+    private const int MaximumTrackMinutes = 10;
+
+    // Progress budget: decoding and writing are single passes over the material
+    // against the render's block transforms, so they get the ends of the bar.
+    private const double DecodeShare = 0.06;
+    private const double RenderShare = 0.86;
+
+    private readonly VirtualCrossoverAuditionContext context;
+
+    private string? sourcePath;
+    private string? targetPath;
+    private string trackSection = string.Empty;
+    private string resultSection = string.Empty;
+
+    private CancellationTokenSource? activeRender;
+    private bool closeRequested;
+
+    public VirtualCrossoverAuditionDialog(VirtualCrossoverAuditionContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException(nameof(context));
+        InitializeComponent();
+
+        MicrophoneCalibrationComboHelper.Configure(
+            comboBoxCalibration,
+            context.InitialCalibrationMode,
+            context.HasZeroDegreeCalibration,
+            context.HasNinetyDegreeCalibration);
+
+        buttonChooseSource.Click += (_, _) => ChooseSource();
+        buttonChooseTarget.Click += (_, _) => ChooseTarget();
+        buttonRender.Click += async (_, _) => await OnRenderClickedAsync();
+
+        RefreshRenderEnabled();
+        RefreshReport();
+    }
+
+    // The dialog cannot close while a render is writing: cancel it and let the
+    // completion path below close the form once the worker has unwound.
+    protected override void OnFormClosing(FormClosingEventArgs e)
+    {
+        if (activeRender != null)
+        {
+            e.Cancel = true;
+            closeRequested = true;
+            RequestCancel();
+            return;
+        }
+
+        base.OnFormClosing(e);
+    }
+
+    // ---------------------------------------------------------------- pickers
+
+    private void ChooseSource()
+    {
+        using var dialog = new OpenFileDialog
+        {
+            CheckFileExists = true,
+            Filter = AudioFileCodec.ReadableFilesFilter,
+            Multiselect = false,
+            RestoreDirectory = true,
+            Title = "Choose a track to audition"
+        };
+        if (dialog.ShowDialog(this) != DialogResult.OK)
+        {
+            return;
+        }
+
+        // Probe now, not at render time: an unreadable or over-long file should
+        // say so the moment it is picked, in the report, with Render disabled.
+        try
+        {
+            AudioFileInfo info = AudioFileCodec.Probe(dialog.FileName);
+            var section = new StringBuilder();
+            section.AppendLine("== Track ==");
+            section.AppendLine(Path.GetFileName(dialog.FileName));
+            section.AppendLine(
+                $"{info.ChannelCount} channel(s), {info.SampleRate} Hz, " +
+                $"{FormatDuration(info.Duration)}");
+            if (info.Duration > TimeSpan.FromMinutes(MaximumTrackMinutes))
+            {
+                section.Append(
+                    $"REFUSED: longer than {MaximumTrackMinutes} minutes — " +
+                    "use a shorter excerpt.");
+                sourcePath = null;
+                labelSourceFile.Text = "no file chosen";
+            }
+            else
+            {
+                if (info.SampleRate != context.SampleRate)
+                {
+                    section.AppendLine(
+                        $"Will be converted to the project's {context.SampleRate} Hz " +
+                        "(the measured responses are never resampled).");
+                }
+                if (info.ChannelCount == 1)
+                {
+                    section.AppendLine("Mono: the same signal will feed both sides.");
+                }
+                else if (info.ChannelCount > 2)
+                {
+                    section.AppendLine(
+                        "Only the first two channels will feed the two sides.");
+                }
+
+                sourcePath = dialog.FileName;
+                labelSourceFile.Text = dialog.FileName;
+            }
+
+            trackSection = section.ToString().TrimEnd();
+        }
+        catch (Exception exception)
+        {
+            sourcePath = null;
+            labelSourceFile.Text = "no file chosen";
+            trackSection =
+                "== Track ==\r\n" +
+                $"{Path.GetFileName(dialog.FileName)}\r\n" +
+                $"UNREADABLE: {exception.Message}";
+        }
+
+        resultSection = string.Empty;
+        RefreshRenderEnabled();
+        RefreshReport();
+    }
+
+    // WAV only, and deliberately so: re-encoding to a lossy format would put
+    // codec artifacts inside the very thing being auditioned, and Windows does
+    // not guarantee an MP3 encoder is installed at all.
+    private void ChooseTarget()
+    {
+        using var dialog = new SaveFileDialog
+        {
+            AddExtension = true,
+            DefaultExt = "wav",
+            FileName = sourcePath == null
+                ? "audition_processed.wav"
+                : Path.GetFileNameWithoutExtension(sourcePath) + "_processed.wav",
+            Filter = "WAV audio (*.wav)|*.wav",
+            InitialDirectory = sourcePath == null
+                ? null
+                : Path.GetDirectoryName(sourcePath),
+            OverwritePrompt = true,
+            Title = "Save the auditioned track"
+        };
+        if (dialog.ShowDialog(this) != DialogResult.OK)
+        {
+            return;
+        }
+
+        targetPath = dialog.FileName;
+        labelTargetFile.Text = dialog.FileName;
+        RefreshRenderEnabled();
+    }
+
+    // ----------------------------------------------------------------- render
+
+    private async Task OnRenderClickedAsync()
+    {
+        if (activeRender != null)
+        {
+            RequestCancel();
+            return;
+        }
+        if (sourcePath == null || targetPath == null)
+        {
+            return;
+        }
+
+        // Resolved on the UI thread: the combo and the resolver belong here.
+        // A configured-but-unreadable file degrades to Off, called out in the
+        // result rather than silently.
+        MicrophoneCalibrationMode mode =
+            MicrophoneCalibrationComboHelper.GetSelectedMode(comboBoxCalibration);
+        CalibrationFile? calibration = mode == MicrophoneCalibrationMode.Off
+            ? null
+            : context.CalibrationResolver?.Invoke(mode);
+        string calibrationLabel = mode == MicrophoneCalibrationMode.Off
+            ? "off"
+            : calibration is { HasData: true }
+                ? comboBoxCalibration.GetItemText(comboBoxCalibration.SelectedItem)
+                : "off (the calibration file could not be read)";
+        if (calibration is not { HasData: true })
+        {
+            calibration = null;
+        }
+
+        var cancellation = new CancellationTokenSource();
+        activeRender = cancellation;
+        SetRunning(true);
+        resultSection = string.Empty;
+        RefreshReport();
+
+        // Progress<T> posts to the UI synchronization context captured here.
+        var progress = new Progress<AuditionProgress>(update =>
+        {
+            labelStatus.Text = update.Status;
+            progressBar.Value = (int)Math.Clamp(
+                Math.Round(update.Fraction * progressBar.Maximum),
+                0,
+                progressBar.Maximum);
+        });
+
+        string source = sourcePath;
+        string target = targetPath;
+        try
+        {
+            RenderOutcome outcome = await Task.Run(
+                () => ExecuteRender(
+                    context, source, target, calibration, calibrationLabel,
+                    progress, cancellation.Token),
+                cancellation.Token);
+            resultSection = FormatResult(outcome, target);
+            labelStatus.Text = "Finished.";
+        }
+        catch (OperationCanceledException)
+        {
+            resultSection = "== Result ==\r\nCancelled; nothing was written.";
+            labelStatus.Text = "Cancelled.";
+            progressBar.Value = 0;
+        }
+        catch (Exception exception)
+        {
+            resultSection = $"== Result ==\r\nFAILED: {exception.Message}";
+            labelStatus.Text = "Failed.";
+            progressBar.Value = 0;
+        }
+        finally
+        {
+            activeRender = null;
+            cancellation.Dispose();
+            SetRunning(false);
+            RefreshReport();
+            if (closeRequested)
+            {
+                Close();
+            }
+        }
+    }
+
+    private void RequestCancel()
+    {
+        if (activeRender is { IsCancellationRequested: false } cancellation)
+        {
+            cancellation.Cancel();
+            buttonRender.Enabled = false;
+            labelStatus.Text = "Cancelling…";
+        }
+    }
+
+    private void SetRunning(bool running)
+    {
+        buttonChooseSource.Enabled = !running;
+        buttonChooseTarget.Enabled = !running;
+        comboBoxCalibration.Enabled = !running && comboBoxCalibration.Items.Count > 1;
+        buttonRender.Text = running ? "Cancel" : "Render";
+        if (running)
+        {
+            progressBar.Value = 0;
+            buttonRender.Enabled = true;
+        }
+        else
+        {
+            RefreshRenderEnabled();
+        }
+    }
+
+    private void RefreshRenderEnabled() =>
+        buttonRender.Enabled =
+            activeRender != null || (sourcePath != null && targetPath != null);
+
+    // The whole pipeline on the worker thread: trim, calibrate, decode, render,
+    // write. Static and argument-fed so it cannot touch a control.
+    private static RenderOutcome ExecuteRender(
+        VirtualCrossoverAuditionContext context,
+        string sourcePath,
+        string targetPath,
+        CalibrationFile? calibration,
+        string calibrationLabel,
+        IProgress<AuditionProgress> progress,
+        CancellationToken cancellationToken)
+    {
+        progress.Report(new AuditionProgress("Preparing the responses…", 0));
+        double[] leftKernel = Auralization.TrimResponse(
+            context.LeftSum, context.SampleRate, out AuralizationTrim leftTrim);
+        double[] rightKernel = Auralization.TrimResponse(
+            context.RightSum, context.SampleRate, out AuralizationTrim rightTrim);
+
+        // The calibration FIR is baked into the KERNELS, not run over the track:
+        // two short double-precision convolutions instead of a third full-track
+        // pass, and the normalization below then reads the calibrated response.
+        int firTaps = 0;
+        if (calibration != null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            double[] fir = CalibrationFirFilter.Design(
+                calibration.GetDecibelCorrection, context.SampleRate);
+            firTaps = fir.Length;
+            leftKernel = FastConvolution.Convolve(leftKernel, fir);
+            rightKernel = FastConvolution.Convolve(rightKernel, fir);
+        }
+
+        progress.Report(new AuditionProgress("Decoding the track…", 0.01));
+        AudioFileContent material = AudioFileCodec.Read(
+            sourcePath,
+            TimeSpan.FromMinutes(MaximumTrackMinutes),
+            cancellationToken);
+
+        var renderProgress = new Progress<double>(value =>
+            progress.Report(new AuditionProgress(
+                "Rendering through the tune…",
+                DecodeShare + value * RenderShare)));
+        AuralizationResult rendered = Auralization.Render(
+            new AuralizationRequest
+            {
+                LeftKernel = leftKernel,
+                RightKernel = rightKernel,
+                KernelSampleRate = context.SampleRate,
+                SourceChannels = material.Channels,
+                SourceSampleRate = material.SampleRate
+            },
+            renderProgress,
+            cancellationToken);
+
+        progress.Report(new AuditionProgress(
+            "Writing the WAV file…", DecodeShare + RenderShare));
+        WriteRenderedTrack(targetPath, rendered, cancellationToken);
+        progress.Report(new AuditionProgress("Finished", 1.0));
+
+        return new RenderOutcome(
+            material.ChannelCount,
+            material.SampleRate,
+            rendered,
+            leftTrim,
+            rightTrim,
+            leftKernel.Length,
+            rightKernel.Length,
+            firTaps,
+            calibrationLabel);
+    }
+
+    // Through a temporary file beside the target: a cancel or a failure part-way
+    // through a multi-hundred-megabyte write must not leave a truncated WAV
+    // where the user's chosen file — possibly one they asked to overwrite —
+    // used to be.
+    private static void WriteRenderedTrack(
+        string targetPath,
+        AuralizationResult result,
+        CancellationToken cancellationToken)
+    {
+        string temporaryPath = targetPath + ".partial";
+        try
+        {
+            AudioFileCodec.WriteWav(
+                temporaryPath,
+                new AudioFileContent(result.Channels, result.SampleRate),
+                cancellationToken);
+            File.Move(temporaryPath, targetPath, overwrite: true);
+        }
+        catch
+        {
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch (IOException)
+            {
+                // Losing the temporary file matters less than the original error.
+            }
+
+            throw;
+        }
+    }
+
+    // ----------------------------------------------------------------- report
+
+    private void RefreshReport()
+    {
+        var report = new StringBuilder();
+        report.AppendLine("== Tune ==");
+        report.AppendLine($"Project rate: {context.SampleRate} Hz");
+        report.AppendLine($"Left side:  {context.LeftChannelCount} channel(s)");
+        report.AppendLine($"Right side: {context.RightChannelCount} channel(s)");
+        if (context.BorrowedSide != null)
+        {
+            report.AppendLine(
+                $"WARNING: the {context.BorrowedSide} side has no sources — both " +
+                "ears will render from the other one and the image will sound " +
+                "perfectly centred. That is the missing measurement, not the tune.");
+        }
+
+        if (trackSection.Length > 0)
+        {
+            report.AppendLine();
+            report.AppendLine(trackSection);
+        }
+
+        if (resultSection.Length > 0)
+        {
+            report.AppendLine();
+            report.AppendLine(resultSection);
+        }
+
+        textBoxReport.Text = report.ToString().TrimEnd();
+    }
+
+    private static string FormatResult(RenderOutcome outcome, string targetPath)
+    {
+        AuralizationResult rendered = outcome.Rendered;
+        double durationSeconds =
+            rendered.Channels[0].Length / (double)rendered.SampleRate;
+        var section = new StringBuilder();
+        section.AppendLine("== Result ==");
+        section.AppendLine($"Calibration: {outcome.CalibrationLabel}" +
+            (outcome.FirTaps > 0 ? $" (FIR {outcome.FirTaps} taps)" : string.Empty));
+        section.AppendLine(
+            $"Kernels: {outcome.LeftKernelTaps} taps left, " +
+            $"{outcome.RightKernelTaps} taps right; decay kept " +
+            $"{outcome.LeftTrim.TailMilliseconds:0} / " +
+            $"{outcome.RightTrim.TailMilliseconds:0} ms");
+        if (rendered.Resampled)
+        {
+            section.AppendLine(
+                $"Track converted {outcome.SourceSampleRate} → " +
+                $"{rendered.SampleRate} Hz (the responses were left untouched).");
+        }
+
+        section.AppendLine(
+            $"Level: {rendered.AppliedGainDb:+0.0;-0.0} dB applied to both " +
+            $"channels (peak at {Auralization.DefaultPeakTarget:0.0} dBFS)");
+        section.AppendLine(
+            $"Written: {targetPath}");
+        section.AppendLine(
+            $"Stereo, {rendered.SampleRate} Hz, 24-bit, " +
+            $"{FormatDuration(TimeSpan.FromSeconds(durationSeconds))}");
+        section.AppendLine();
+        section.Append(
+            "This is what the measurement microphone hears at its position — " +
+            "drivers, cabin and capsule included, not only the DSP. Listen on " +
+            "headphones: playing it back through the same system would convolve " +
+            "the car twice.");
+        return section.ToString();
+    }
+
+    // Total minutes, not the minutes component: a refused over-an-hour file
+    // must not display as its remainder ("1:02:03" as "2:03").
+    private static string FormatDuration(TimeSpan duration) =>
+        $"{(int)duration.TotalMinutes}:{duration.Seconds:00}";
+
+    private sealed record RenderOutcome(
+        int SourceChannelCount,
+        int SourceSampleRate,
+        AuralizationResult Rendered,
+        AuralizationTrim LeftTrim,
+        AuralizationTrim RightTrim,
+        int LeftKernelTaps,
+        int RightKernelTaps,
+        int FirTaps,
+        string CalibrationLabel);
+}

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
@@ -58,6 +58,13 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
 
     private string? sourcePath;
     private string? targetPath;
+
+    // Whether overwriting targetPath has been consented to IN THIS DIALOG: the
+    // SaveFileDialog's own prompt covers a picked path, but a path restored
+    // from the previous opening carries no such consent — the file sitting
+    // there is the PREVIOUS render, and silently replacing it would collapse
+    // an A/B pair into just B.
+    private bool targetOverwriteConfirmed;
     private string trackSection = string.Empty;
     private string resultSection = string.Empty;
 
@@ -80,9 +87,25 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         this.context = context ?? throw new ArgumentNullException(nameof(context));
         InitializeComponent();
 
+        // The remembered mode wins only when its profile is configured NOW:
+        // a 90° choice remembered from another project must not seed a
+        // project set up for 0° with "90 degrees (file missing)" — which would
+        // silently render as Off — so anything unavailable falls back to the
+        // panel's own setting.
+        MicrophoneCalibrationMode initialMode = lastCalibrationMode switch
+        {
+            MicrophoneCalibrationMode.Degrees0
+                when context.HasZeroDegreeCalibration =>
+                MicrophoneCalibrationMode.Degrees0,
+            MicrophoneCalibrationMode.Degrees90
+                when context.HasNinetyDegreeCalibration =>
+                MicrophoneCalibrationMode.Degrees90,
+            MicrophoneCalibrationMode.Off => MicrophoneCalibrationMode.Off,
+            _ => context.InitialCalibrationMode
+        };
         MicrophoneCalibrationComboHelper.Configure(
             comboBoxCalibration,
-            lastCalibrationMode ?? context.InitialCalibrationMode,
+            initialMode,
             context.HasZeroDegreeCalibration,
             context.HasNinetyDegreeCalibration);
 
@@ -96,8 +119,11 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         }
         if (lastTargetPath != null)
         {
+            // Restored WITHOUT overwrite consent: the file at this path is the
+            // previous opening's render, and Render asks before replacing it.
             targetPath = lastTargetPath;
             labelTargetFile.Text = lastTargetPath;
+            targetOverwriteConfirmed = false;
         }
 
         RefreshRenderEnabled();
@@ -284,6 +310,8 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
 
         targetPath = dialog.FileName;
         labelTargetFile.Text = dialog.FileName;
+        // The SaveFileDialog's OverwritePrompt already asked if the file exists.
+        targetOverwriteConfirmed = true;
         RefreshRenderEnabled();
     }
 
@@ -326,6 +354,25 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         if (sourcePath == null || targetPath == null || PathsEqual(sourcePath, targetPath))
         {
             return;
+        }
+
+        if (File.Exists(targetPath) && !targetOverwriteConfirmed)
+        {
+            DialogResult overwrite = MessageBox.Show(
+                this,
+                $"The output file already exists:\r\n{targetPath}\r\n\r\nIt was " +
+                "restored from the previous opening, so it holds that render. " +
+                "Overwrite it?\r\n\r\n(Choose No and Save as... to keep both " +
+                "variants for an A/B.)",
+                "Audition render",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning);
+            if (overwrite != DialogResult.Yes)
+            {
+                return;
+            }
+
+            targetOverwriteConfirmed = true;
         }
 
         // Resolved on the UI thread: the combo and the resolver belong here.
@@ -474,10 +521,15 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         // Only the first two channels are kept — the render feeds channel 1 to
         // the left side and channel 2 to the right, and storing a 7.1 layout
         // would quadruple the decoded footprint for nothing.
+        // The byte cap makes the budget hold DURING the decode as well: a file
+        // swapped after the pick or a container lying about its duration stops
+        // at the budget instead of exhausting memory before the post-decode
+        // check below ever runs.
         AudioFileContent material = AudioFileCodec.Read(
             sourcePath,
             TimeSpan.FromMinutes(MaximumTrackMinutes),
             channelLimit: 2,
+            MaximumPipelineBytes,
             cancellationToken);
 
         // The pick-time budget was a preflight over the container's CLAIMED

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.resx
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -452,14 +452,36 @@ internal sealed class VirtualCrossoverMetrics
         bool oppositeRight,
         long revision)
     {
+        VirtualCrossoverSideSum? side = await ComputeSideSumAsync(
+            channels, oppositeRight, revision, minimumChannels: 2);
+        return side == null
+            ? null
+            : buildMagnitudeCurve(
+                side.ImpulseResponse, side.AnchorIndex, side.SampleRate);
+    }
+
+    /// <summary>
+    /// The complex sum of one side's participating channels, processed through
+    /// their chains. Mono channels contribute their single response to both
+    /// sides, exactly as they do physically. Null when the side has fewer than
+    /// <paramref name="minimumChannels"/> participating channels, or when the
+    /// render went stale. Uses the coordinator cache, so it shares processed
+    /// responses and staleness handling with the main redraw.
+    /// </summary>
+    public async Task<VirtualCrossoverSideSum?> ComputeSideSumAsync(
+        IReadOnlyList<VirtualCrossoverChannel> channels,
+        bool rightSide,
+        long revision,
+        int minimumChannels)
+    {
         var jobs = new List<SideProcessJob>();
         int nextId = 0;
         for (int channelIndex = 0; channelIndex < channels.Count; channelIndex++)
         {
             VirtualCrossoverChannel channel = channels[channelIndex];
             VirtualCrossoverChannelSettings settings =
-                channel.SideSettings(oppositeRight);
-            VirtualCrossoverChannelState state = channel.SideState(oppositeRight);
+                channel.SideSettings(rightSide);
+            VirtualCrossoverChannelState state = channel.SideState(rightSide);
             if (!settings.Enabled ||
                 state.ProcessingSource is not { } source)
             {
@@ -474,7 +496,7 @@ internal sealed class VirtualCrossoverMetrics
                 Id = nextId++,
                 SlotId = new ProcessingSlotId(
                     channelIndex,
-                    !channel.Pair.Mono && oppositeRight),
+                    !channel.Pair.Mono && rightSide),
                 State = state,
                 Source = source,
                 SampleRate = state.SampleRate,
@@ -482,7 +504,7 @@ internal sealed class VirtualCrossoverMetrics
             });
         }
 
-        if (jobs.Count < 2)
+        if (jobs.Count < minimumChannels)
         {
             return null;
         }
@@ -512,8 +534,11 @@ internal sealed class VirtualCrossoverMetrics
 
         Complex[] sum = VirtualCrossoverAnalysis.SumImpulseResponses(
             jobs.Select(side => side.ProcessedIr!).ToList());
-        int anchor = jobs.Min(side => side.ProcessedPeak);
-        return buildMagnitudeCurve(sum, anchor, jobs[0].SampleRate);
+        return new VirtualCrossoverSideSum(
+            sum,
+            jobs.Min(side => side.ProcessedPeak),
+            jobs[0].SampleRate,
+            jobs.Count);
     }
 
     // One channel side snapshotted on the UI thread for background processing

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Audition.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Audition.cs
@@ -1,0 +1,98 @@
+namespace Resonalyze;
+
+/// <summary>
+/// The Virtual DSP "Audition track" command: sums both sides of the tune and
+/// hands them to <see cref="VirtualCrossoverAuditionDialog"/>, where the user
+/// picks a music file, a destination and a microphone calibration, and renders
+/// the track through the tune. The result is an auralization of the MEASUREMENT
+/// MICROPHONE's position — drivers, cabin and capsule included — meant for
+/// headphones; played back through the same system it would convolve the car
+/// twice.
+/// </summary>
+public partial class VirtualCrossoverPanel
+{
+    // Reentrancy guard: the side summing below awaits with the button still
+    // enabled, so a double-click would otherwise start two interleaved flows.
+    private bool auditionInFlight;
+
+    private async Task AuditionTrackAsync()
+    {
+        if (auditionInFlight)
+        {
+            return;
+        }
+
+        auditionInFlight = true;
+        try
+        {
+            await RunAuditionFlowAsync();
+        }
+        finally
+        {
+            auditionInFlight = false;
+        }
+    }
+
+    private async Task RunAuditionFlowAsync()
+    {
+        // Both sides are summed from the SAME coordinator revision, so the two
+        // ears are rendered from one consistent state of the tune.
+        long revision = processingCoordinator.CurrentRevision;
+        VirtualCrossoverSideSum? leftSide = await metrics.ComputeSideSumAsync(
+            channels, rightSide: false, revision, minimumChannels: 1);
+        VirtualCrossoverSideSum? rightSide = await metrics.ComputeSideSumAsync(
+            channels, rightSide: true, revision, minimumChannels: 1);
+        // Staleness first: a mid-flight settings change nulls whichever sum ran
+        // second, and that null must not masquerade as a missing side below.
+        if (!processingCoordinator.IsCurrent(revision))
+        {
+            ShowError(
+                "The tune changed while the sides were being summed.",
+                "Nothing was rendered; press Audition track again.");
+            return;
+        }
+
+        if (leftSide == null && rightSide == null)
+        {
+            ShowError(
+                "No channel has a source on either side.",
+                "Pick measurements for at least one channel (Source...) before " +
+                "auditioning a track.");
+            return;
+        }
+
+        // Half a tune is the normal mid-session state, so a missing side renders
+        // from the other one instead of refusing; the dialog's report carries
+        // the warning, in view the whole time the user sets the render up.
+        string? borrowedSide = leftSide == null ? "left" : rightSide == null ? "right" : null;
+        leftSide ??= rightSide;
+        rightSide ??= leftSide;
+        VirtualCrossoverSideSum left = leftSide!;
+        VirtualCrossoverSideSum right = rightSide!;
+        if (left.SampleRate != right.SampleRate)
+        {
+            // The project format admits one rate, so this is a guard rather than
+            // a case: a mixed-rate pair would render the two ears on different
+            // time bases.
+            ShowError(
+                $"The two sides were measured at different rates " +
+                $"({left.SampleRate} Hz and {right.SampleRate} Hz).",
+                "All channels in a Virtual DSP project must share one sample rate.");
+            return;
+        }
+
+        using var dialog = new VirtualCrossoverAuditionDialog(
+            new VirtualCrossoverAuditionContext(
+                left.ImpulseResponse,
+                right.ImpulseResponse,
+                left.SampleRate,
+                left.ChannelCount,
+                right.ChannelCount,
+                borrowedSide,
+                calibrationResolver,
+                hasZeroDegreeCalibration,
+                hasNinetyDegreeCalibration,
+                project.CalibrationMode));
+        dialog.ShowDialog(FindForm());
+    }
+}

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Audition.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Audition.cs
@@ -4,10 +4,11 @@ namespace Resonalyze;
 /// The Virtual DSP "Audition track" command: sums both sides of the tune and
 /// hands them to <see cref="VirtualCrossoverAuditionDialog"/>, where the user
 /// picks a music file, a destination and a microphone calibration, and renders
-/// the track through the tune. The result is an auralization of the MEASUREMENT
-/// MICROPHONE's position — drivers, cabin and capsule included — meant for
-/// headphones; played back through the same system it would convolve the car
-/// twice.
+/// the track through the tune. The result is a headphone-only stereo
+/// auralization of the measured left and right acoustic paths at the
+/// microphone position — drivers, cabin and capsule included, but not a
+/// binaural head simulation; played back through the same system it would
+/// convolve the car twice.
 /// </summary>
 public partial class VirtualCrossoverPanel
 {

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
@@ -55,6 +55,7 @@ namespace Resonalyze
             comboBoxCalibration = new DarkComboBox();
             buttonSessionImport = new Button();
             buttonSessionExport = new Button();
+            buttonAudition = new Button();
             labelCrossoverWarning = new Label();
             dspModePanel = new Panel();
             labelDspMode = new Label();
@@ -371,9 +372,20 @@ namespace Resonalyze
             buttonSessionImport.TabIndex = 17;
             buttonSessionImport.Text = "Load session...";
             buttonSessionImport.UseVisualStyleBackColor = true;
-            // 
+            //
+            // buttonAudition
+            //
+            buttonAudition.FlatStyle = FlatStyle.Popup;
+            buttonAudition.ForeColor = Color.White;
+            buttonAudition.Location = new Point(358, 612);
+            buttonAudition.Name = "buttonAudition";
+            buttonAudition.Size = new Size(125, 24);
+            buttonAudition.TabIndex = 21;
+            buttonAudition.Text = "Audition track...";
+            buttonAudition.UseVisualStyleBackColor = true;
+            //
             // buttonSessionExport
-            // 
+            //
             buttonSessionExport.FlatStyle = FlatStyle.Popup;
             buttonSessionExport.ForeColor = Color.White;
             buttonSessionExport.Location = new Point(358, 642);
@@ -521,6 +533,7 @@ namespace Resonalyze
             Controls.Add(comboBoxCalibration);
             Controls.Add(buttonSessionImport);
             Controls.Add(buttonSessionExport);
+            Controls.Add(buttonAudition);
             Controls.Add(labelCrossoverWarning);
             Controls.Add(dspModePanel);
             Controls.Add(channelListPanel);
@@ -573,6 +586,7 @@ namespace Resonalyze
         private DarkComboBox comboBoxCalibration;
         private Button buttonSessionImport;
         private Button buttonSessionExport;
+        private Button buttonAudition;
         private Label labelCrossoverWarning;
         private Panel dspModePanel;
         private Label labelDspMode;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -130,6 +130,7 @@ public partial class VirtualCrossoverPanel : UserControl
         buttonPhaseGate.Click += async (_, _) => await OpenPhaseGateDialogAsync();
         buttonSessionImport.Click += async (_, _) => await ImportSessionAsync();
         buttonSessionExport.Click += (_, _) => ExportSession();
+        buttonAudition.Click += async (_, _) => await AuditionTrackAsync();
         buttonAddChannel.Click += (_, _) => AddChannel();
         buttonRemoveChannel.Click += (_, _) => RemoveChannel();
         buttonCopyLeftToRight.Click += (_, _) => CopySideSettings(fromRight: false);
@@ -1639,6 +1640,18 @@ public partial class VirtualCrossoverPanel : UserControl
             buttonSessionImport,
             "Load a saved session file, replacing the current state.\r\n" +
             "Sources are re-resolved from history or their file paths.");
+        toolTip.SetToolTip(
+            buttonAudition,
+            "Render a music file through the current tune and save it\r\n" +
+            "as a WAV: the left side's summed response on channel 1,\r\n" +
+            "the right side's on channel 2. Microphone calibration can\r\n" +
+            "be applied as a linear-phase FIR baked into both sides.\r\n" +
+            "What you hear is the MICROPHONE's position — drivers, cabin\r\n" +
+            "and capsule included, not only the DSP — so listen on\r\n" +
+            "headphones. Played back through the same system it would\r\n" +
+            "convolve the car twice.\r\n" +
+            "A track at another sample rate is converted to the project's;\r\n" +
+            "the measured responses are never resampled.");
         // The per-channel block tooltips are applied in CreateChannel, so every
         // block — including ones added after construction — carries them.
     }
@@ -1699,6 +1712,9 @@ public partial class VirtualCrossoverPanel : UserControl
             || redrawTask is { IsCompleted: false };
         buttonAutoSetup.Enabled = !busy;
         buttonAutoDelay.Enabled = !busy;
+        // The audition sums both sides through the coordinator at one revision;
+        // starting it mid-redraw would race the invalidation and render nothing.
+        buttonAudition.Enabled = !busy;
     }
 
     // The redraw loop coalesces edits into one trailing pass. Snapshot revision,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -1646,10 +1646,10 @@ public partial class VirtualCrossoverPanel : UserControl
             "as a WAV: the left side's summed response on channel 1,\r\n" +
             "the right side's on channel 2. Microphone calibration can\r\n" +
             "be applied as a linear-phase FIR baked into both sides.\r\n" +
-            "What you hear is the MICROPHONE's position — drivers, cabin\r\n" +
-            "and capsule included, not only the DSP — so listen on\r\n" +
-            "headphones. Played back through the same system it would\r\n" +
-            "convolve the car twice.\r\n" +
+            "Listen through HEADPHONES only: each ear gets its side's\r\n" +
+            "measured acoustic path (drivers, cabin, capsule) at the mic\r\n" +
+            "position — not a binaural head simulation. Played through\r\n" +
+            "the same system it would convolve the car twice.\r\n" +
             "A track at another sample rate is converted to the project's;\r\n" +
             "the measured responses are never resampled.");
         // The per-channel block tooltips are applied in CreateChannel, so every

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -199,6 +199,69 @@ public sealed class VirtualCrossoverMetricsTests
     }
 
     [Fact]
+    public async Task ComputeSideSumAsync_HonorsTheMinimumChannelCount()
+    {
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        long revision = coordinator.Invalidate();
+
+        // One resolved channel: enough for the audition (minimum 1), not for
+        // the opposite-side overlay (minimum 2).
+        VirtualCrossoverSideSum? forAudition = await metrics.ComputeSideSumAsync(
+            [ResolvedChannel("A", 48_000)], rightSide: false, revision,
+            minimumChannels: 1);
+        VirtualCrossoverSideSum? forOverlay = await metrics.ComputeSideSumAsync(
+            [ResolvedChannel("A", 48_000)], rightSide: false, revision,
+            minimumChannels: 2);
+
+        Assert.NotNull(forAudition);
+        Assert.Equal(1, forAudition.ChannelCount);
+        Assert.Equal(48_000, forAudition.SampleRate);
+        Assert.Null(forOverlay);
+    }
+
+    [Fact]
+    public async Task ComputeSideSumAsync_MonoChannelContributesToBothSidesAtFullLevel()
+    {
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        // A mono channel (a sub) resolved on its single slot: program material
+        // routes it into BOTH ears at full level, so both side sums must carry
+        // its response unattenuated.
+        VirtualCrossoverChannel mono = ResolvedChannel("Sub", 48_000);
+        mono.Pair.Mono = true;
+        long revision = coordinator.Invalidate();
+
+        VirtualCrossoverSideSum? left = await metrics.ComputeSideSumAsync(
+            [mono], rightSide: false, revision, minimumChannels: 1);
+        VirtualCrossoverSideSum? right = await metrics.ComputeSideSumAsync(
+            [mono], rightSide: true, revision, minimumChannels: 1);
+
+        Assert.NotNull(left);
+        Assert.NotNull(right);
+        Assert.Equal(left.ImpulseResponse.Length, right.ImpulseResponse.Length);
+        for (int i = 0; i < left.ImpulseResponse.Length; i++)
+        {
+            Assert.Equal(left.ImpulseResponse[i], right.ImpulseResponse[i]);
+        }
+    }
+
+    [Fact]
+    public async Task ComputeSideSumAsync_ReturnsNullForAStaleRevision()
+    {
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        long revision = coordinator.Invalidate();
+        coordinator.Invalidate();
+
+        VirtualCrossoverSideSum? result = await metrics.ComputeSideSumAsync(
+            [ResolvedChannel("A", 48_000)], rightSide: false, revision,
+            minimumChannels: 1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
     public async Task ComputeStereoDeltasAsync_SkipsAStereoPairWithOnlyOneSideResolved()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();

--- a/tests/Resonalyze.Audio.Tests/AudioFileCodecTests.cs
+++ b/tests/Resonalyze.Audio.Tests/AudioFileCodecTests.cs
@@ -1,0 +1,101 @@
+namespace Resonalyze.Audio.Tests;
+
+public sealed class AudioFileCodecTests : IDisposable
+{
+    private readonly string directory = Path.Combine(
+        Path.GetTempPath(), "resonalyze-codec-tests-" + Guid.NewGuid().ToString("N"));
+
+    public AudioFileCodecTests()
+    {
+        Directory.CreateDirectory(directory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Temp cleanup is best-effort.
+        }
+    }
+
+    private string PathFor(string name) => Path.Combine(directory, name);
+
+    [Fact]
+    public void WriteWav_ReadBack_RoundTripsWithin24BitPrecision()
+    {
+        const int Rate = 48_000;
+        var left = new float[Rate / 10];
+        var right = new float[left.Length];
+        for (int i = 0; i < left.Length; i++)
+        {
+            left[i] = (float)(0.8 * Math.Sin(2.0 * Math.PI * 440.0 * i / Rate));
+            right[i] = (float)(0.5 * Math.Sin(2.0 * Math.PI * 1_000.0 * i / Rate));
+        }
+        string path = PathFor("roundtrip.wav");
+
+        AudioFileCodec.WriteWav(path, new AudioFileContent([left, right], Rate));
+        AudioFileContent read = AudioFileCodec.Read(
+            path, TimeSpan.FromMinutes(1));
+
+        Assert.Equal(2, read.ChannelCount);
+        Assert.Equal(Rate, read.SampleRate);
+        Assert.Equal(left.Length, read.FrameCount);
+        double quantum = 1.0 / (1 << 23);
+        for (int i = 0; i < left.Length; i++)
+        {
+            Assert.True(Math.Abs(read.Channels[0][i] - left[i]) <= 2 * quantum);
+            Assert.True(Math.Abs(read.Channels[1][i] - right[i]) <= 2 * quantum);
+        }
+    }
+
+    [Fact]
+    public void WriteWav_ClipsOutOfRangeSamplesInsteadOfWrapping()
+    {
+        float[] channel = [2.0f, -3.0f, 0.5f];
+        string path = PathFor("clipped.wav");
+
+        AudioFileCodec.WriteWav(path, new AudioFileContent([channel], 48_000));
+        AudioFileContent read = AudioFileCodec.Read(path, TimeSpan.FromMinutes(1));
+
+        // A wrapped +2.0 would come back near -1; clipping keeps the signs.
+        Assert.True(read.Channels[0][0] > 0.99f);
+        Assert.True(read.Channels[0][1] < -0.99f);
+        Assert.Equal(0.5f, read.Channels[0][2], 3);
+    }
+
+    [Fact]
+    public void Read_RefusesMaterialLongerThanTheBound()
+    {
+        const int Rate = 8_000;
+        var channel = new float[Rate * 3];
+        string path = PathFor("long.wav");
+        AudioFileCodec.WriteWav(path, new AudioFileContent([channel], Rate));
+
+        Assert.Throws<InvalidOperationException>(() =>
+            AudioFileCodec.Read(path, TimeSpan.FromSeconds(2)));
+    }
+
+    [Fact]
+    public void WriteWav_RefusesEmptyContent()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            AudioFileCodec.WriteWav(
+                PathFor("empty.wav"),
+                new AudioFileContent(Array.Empty<float[]>(), 48_000)));
+    }
+
+    [Fact]
+    public void WriteWav_RefusesMismatchedChannelLengths()
+    {
+        // The interleaver indexes every channel by the first one's frame count;
+        // a shorter channel used to crash it mid-write with an index error.
+        Assert.Throws<ArgumentException>(() =>
+            AudioFileCodec.WriteWav(
+                PathFor("mismatched.wav"),
+                new AudioFileContent([new float[300], new float[100]], 48_000)));
+    }
+}

--- a/tests/Resonalyze.Audio.Tests/AudioFileCodecTests.cs
+++ b/tests/Resonalyze.Audio.Tests/AudioFileCodecTests.cs
@@ -139,14 +139,19 @@ public sealed class AudioFileCodecTests : IDisposable
             AudioFileCodec.Read(path, TimeSpan.FromSeconds(2)));
     }
 
-    [Fact]
-    public void Read_RefusesMaterialPastTheByteBudget()
+    // One second of mono 8 kHz float is a 32 kB payload, but the decode's
+    // PEAK is twice that: while the final array fills, every chunk still
+    // exists. 20 kB fails on the payload alone; 50 kB fits the payload and
+    // must still be refused for the assembly peak (64 kB).
+    [Theory]
+    [InlineData(20_000)]
+    [InlineData(50_000)]
+    public void Read_RefusesMaterialPastTheByteBudget(long budget)
     {
         // The duration bound trusts the header; the byte bound holds when the
-        // header lies or the file was swapped after probing. One second of
-        // mono 8 kHz float is 32 kB — a 20 kB budget must stop the decode.
+        // header lies or the file was swapped after probing.
         const int Rate = 8_000;
-        string path = PathFor("oversized.wav");
+        string path = PathFor($"oversized-{budget}.wav");
         AudioFileCodec.WriteWav(
             path, new AudioFileContent([new float[Rate]], Rate));
 
@@ -155,7 +160,7 @@ public sealed class AudioFileCodecTests : IDisposable
                 path,
                 TimeSpan.FromMinutes(1),
                 channelLimit: int.MaxValue,
-                maximumStoredBytes: 20_000));
+                maximumStoredBytes: budget));
     }
 
     [Fact]

--- a/tests/Resonalyze.Audio.Tests/AudioFileCodecTests.cs
+++ b/tests/Resonalyze.Audio.Tests/AudioFileCodecTests.cs
@@ -67,6 +67,66 @@ public sealed class AudioFileCodecTests : IDisposable
         Assert.Equal(0.5f, read.Channels[0][2], 3);
     }
 
+    // Unique per channel AND per position: a channel rotation, a swap, or a
+    // one-frame slip each break the equality somewhere. The inter-channel step
+    // (0.004) is far above the 24-bit round-trip tolerance.
+    private static float MultichannelSample(int channel, int frame) =>
+        (frame % 997 - 498) / 1_000f + channel * 0.004f;
+
+    [Fact]
+    public void Read_ChannelLimitKeepsExactlyTheLeadingChannels()
+    {
+        // Four channels over MORE frames than one decoder block (32768), so
+        // the running channel cursor crosses several Read calls — the place a
+        // per-block restart would rotate the channel assignment. A WAV reader
+        // always returns whole frames, so the mid-frame boundary itself cannot
+        // be staged here; the cursor continuity across calls is what this
+        // exercises.
+        const int Rate = 48_000;
+        const int Frames = 70_000;
+        const int ChannelCount = 4;
+        var channels = new float[ChannelCount][];
+        for (int c = 0; c < ChannelCount; c++)
+        {
+            channels[c] = new float[Frames];
+            for (int i = 0; i < Frames; i++)
+            {
+                channels[c][i] = MultichannelSample(c, i);
+            }
+        }
+        string path = PathFor("multichannel.wav");
+        AudioFileCodec.WriteWav(path, new AudioFileContent(channels, Rate));
+
+        AudioFileContent limited = AudioFileCodec.Read(
+            path, TimeSpan.FromMinutes(1), channelLimit: 2);
+
+        Assert.Equal(2, limited.ChannelCount);
+        Assert.Equal(Frames, limited.FrameCount);
+        double quantum = 1.0 / (1 << 23);
+        for (int c = 0; c < 2; c++)
+        {
+            for (int i = 0; i < Frames; i++)
+            {
+                Assert.True(
+                    Math.Abs(limited.Channels[c][i] - MultichannelSample(c, i))
+                        <= 2 * quantum,
+                    $"Channel {c} drifted at frame {i}");
+            }
+        }
+
+        // Without a limit the same file yields every channel, and the LAST one
+        // carries its own signal — the limited read kept the right two, not
+        // just any two.
+        AudioFileContent full = AudioFileCodec.Read(path, TimeSpan.FromMinutes(1));
+        Assert.Equal(ChannelCount, full.ChannelCount);
+        for (int i = 0; i < Frames; i += 1_000)
+        {
+            Assert.True(
+                Math.Abs(full.Channels[3][i] - MultichannelSample(3, i))
+                    <= 2 * quantum);
+        }
+    }
+
     [Fact]
     public void Read_RefusesMaterialLongerThanTheBound()
     {

--- a/tests/Resonalyze.Audio.Tests/AudioFileCodecTests.cs
+++ b/tests/Resonalyze.Audio.Tests/AudioFileCodecTests.cs
@@ -140,6 +140,25 @@ public sealed class AudioFileCodecTests : IDisposable
     }
 
     [Fact]
+    public void Read_RefusesMaterialPastTheByteBudget()
+    {
+        // The duration bound trusts the header; the byte bound holds when the
+        // header lies or the file was swapped after probing. One second of
+        // mono 8 kHz float is 32 kB — a 20 kB budget must stop the decode.
+        const int Rate = 8_000;
+        string path = PathFor("oversized.wav");
+        AudioFileCodec.WriteWav(
+            path, new AudioFileContent([new float[Rate]], Rate));
+
+        Assert.Throws<InvalidOperationException>(() =>
+            AudioFileCodec.Read(
+                path,
+                TimeSpan.FromMinutes(1),
+                channelLimit: int.MaxValue,
+                maximumStoredBytes: 20_000));
+    }
+
+    [Fact]
     public void WriteWav_RefusesEmptyContent()
     {
         Assert.Throws<ArgumentException>(() =>

--- a/tests/Resonalyze.Dsp.Tests/AuralizationTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AuralizationTests.cs
@@ -1,0 +1,229 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class AuralizationTests
+{
+    private const int Rate = 48_000;
+
+    // A synthetic cabin-like response: an arrival at `peakIndex` followed by an
+    // exponential decay, sitting in a record padded with numerical noise far
+    // below it — the shape TrimResponse exists to cut.
+    private static Complex[] DecayingResponse(
+        int length, int peakIndex, double decayPerSample, double noiseFloor)
+    {
+        var random = new Random(11);
+        var response = new Complex[length];
+        for (int i = 0; i < length; i++)
+        {
+            response[i] = noiseFloor * (random.NextDouble() * 2.0 - 1.0);
+        }
+
+        double amplitude = 1.0;
+        for (int i = peakIndex; i < length; i++)
+        {
+            response[i] += amplitude * Math.Cos(0.3 * (i - peakIndex));
+            amplitude *= decayPerSample;
+        }
+
+        return response;
+    }
+
+    [Fact]
+    public void TrimResponse_CutsTheNoiseTailButKeepsTheArrival()
+    {
+        // 200 ms of record; the decay reaches −60 dB after ~70 ms.
+        int length = Rate / 5;
+        const int PeakIndex = 480;
+        double decay = Math.Pow(10.0, -60.0 / 20.0 / (0.07 * Rate));
+        Complex[] response = DecayingResponse(length, PeakIndex, decay, 1e-6);
+
+        double[] kernel = Auralization.TrimResponse(
+            response, Rate, out AuralizationTrim trim);
+
+        Assert.True(trim.Cut);
+        Assert.Equal(kernel.Length, trim.Length);
+        Assert.Equal(PeakIndex, trim.PeakIndex);
+        // The head is untouched: sample 0 stays sample 0, so the measured
+        // propagation delay survives.
+        Assert.Equal(response[PeakIndex].Real, kernel[PeakIndex], 10);
+        // The cut lands after the decay reached the floor but well before the
+        // record's end.
+        Assert.True(kernel.Length < length);
+        Assert.True(trim.TailMilliseconds >= 60.0);
+        // The kernel ends faded to zero, not on a step.
+        Assert.Equal(0.0, Math.Abs(kernel[^1]), 3);
+    }
+
+    [Fact]
+    public void TrimResponse_ShortCleanResponseIsKeptWhole()
+    {
+        // A response shorter than the minimum tail has nothing to cut.
+        var response = new Complex[1_024];
+        response[100] = 1.0;
+
+        double[] kernel = Auralization.TrimResponse(
+            response, Rate, out AuralizationTrim trim);
+
+        Assert.False(trim.Cut);
+        Assert.Equal(response.Length, kernel.Length);
+    }
+
+    [Fact]
+    public void Render_AppliesTheSideKernelsAndSharesOneGain()
+    {
+        // Left kernel: unit impulse. Right kernel: half-amplitude impulse. The
+        // rendered channels must keep that 2:1 ratio — normalization is one
+        // shared gain, never per channel — and peak at the target.
+        double[] leftKernel = [1.0];
+        double[] rightKernel = [0.5];
+        var source = new float[Rate];
+        for (int i = 0; i < source.Length; i++)
+        {
+            source[i] = (float)(0.25 * Math.Sin(2.0 * Math.PI * 440.0 * i / Rate));
+        }
+
+        AuralizationResult result = Auralization.Render(new AuralizationRequest
+        {
+            LeftKernel = leftKernel,
+            RightKernel = rightKernel,
+            KernelSampleRate = Rate,
+            SourceChannels = [source, source],
+            SourceSampleRate = Rate
+        });
+
+        Assert.False(result.Resampled);
+        Assert.Equal(Rate, result.SampleRate);
+        float leftPeak = result.Channels[0].Max(Math.Abs);
+        float rightPeak = result.Channels[1].Max(Math.Abs);
+        double target = Math.Pow(10.0, Auralization.DefaultPeakTarget / 20.0);
+        Assert.Equal(target, leftPeak, 3);
+        Assert.Equal(0.5, rightPeak / leftPeak, 3);
+        // The applied gain is reported: 0.25 source peak → −1 dBFS is ~+11.5 dB.
+        Assert.InRange(result.AppliedGainDb, 10.0, 13.0);
+    }
+
+    [Fact]
+    public void Render_MonoSourceFeedsBothSides()
+    {
+        double[] kernel = [1.0];
+        var source = new float[1_000];
+        source[100] = 0.5f;
+
+        AuralizationResult result = Auralization.Render(new AuralizationRequest
+        {
+            LeftKernel = kernel,
+            RightKernel = kernel,
+            KernelSampleRate = Rate,
+            SourceChannels = [source],
+            SourceSampleRate = Rate
+        });
+
+        Assert.Equal(result.Channels[0].Length, result.Channels[1].Length);
+        for (int i = 0; i < result.Channels[0].Length; i++)
+        {
+            Assert.Equal(result.Channels[0][i], result.Channels[1][i]);
+        }
+    }
+
+    [Fact]
+    public void Render_ResamplesTheMaterialToTheKernelRate()
+    {
+        double[] kernel = [1.0];
+        var source = new float[44_100];
+        for (int i = 0; i < source.Length; i++)
+        {
+            source[i] = (float)(0.5 * Math.Sin(2.0 * Math.PI * 1_000.0 * i / 44_100));
+        }
+
+        AuralizationResult result = Auralization.Render(new AuralizationRequest
+        {
+            LeftKernel = kernel,
+            RightKernel = kernel,
+            KernelSampleRate = Rate,
+            SourceChannels = [source, source],
+            SourceSampleRate = 44_100
+        });
+
+        Assert.True(result.Resampled);
+        Assert.Equal(Rate, result.SampleRate);
+        // One second of material stays one second at the new rate.
+        Assert.InRange(result.Channels[0].Length, Rate - 10, Rate + 10);
+    }
+
+    [Fact]
+    public void Render_DelayDifferenceBetweenSidesSurvives()
+    {
+        // The left kernel arrives 48 samples (1 ms) later than the right: the
+        // rendered channels must carry exactly that inter-side lag, because the
+        // lag IS the alignment being auditioned.
+        var leftKernel = new double[128];
+        var rightKernel = new double[128];
+        leftKernel[58] = 1.0;
+        rightKernel[10] = 1.0;
+        var source = new float[500];
+        source[0] = 1.0f;
+
+        AuralizationResult result = Auralization.Render(new AuralizationRequest
+        {
+            LeftKernel = leftKernel,
+            RightKernel = rightKernel,
+            KernelSampleRate = Rate,
+            SourceChannels = [source, source],
+            SourceSampleRate = Rate
+        });
+
+        int leftPeak = IndexOfPeak(result.Channels[0]);
+        int rightPeak = IndexOfPeak(result.Channels[1]);
+        Assert.Equal(48, leftPeak - rightPeak);
+    }
+
+    [Fact]
+    public void Render_PadsTheSidesToOneLength_WhenTheKernelsDiffer()
+    {
+        // TrimResponse trims each side by its own peak and decay, so unequal
+        // kernel lengths are the NORMAL case — and each convolution's length is
+        // source + kernel − 1. A stereo file has one frame count, so the render
+        // must equalize the channels; the first release crashed the WAV writer
+        // on exactly this (right side shorter → index out of bounds).
+        double[] leftKernel = new double[300];
+        double[] rightKernel = new double[100];
+        leftKernel[0] = 1.0;
+        rightKernel[0] = 1.0;
+        var source = new float[500];
+        source[0] = 1.0f;
+
+        AuralizationResult result = Auralization.Render(new AuralizationRequest
+        {
+            LeftKernel = leftKernel,
+            RightKernel = rightKernel,
+            KernelSampleRate = Rate,
+            SourceChannels = [source, source],
+            SourceSampleRate = Rate
+        });
+
+        Assert.Equal(source.Length + leftKernel.Length - 1, result.Channels[0].Length);
+        Assert.Equal(result.Channels[0].Length, result.Channels[1].Length);
+        // The shorter side's extension is silence, not garbage.
+        for (int i = source.Length + rightKernel.Length - 1;
+            i < result.Channels[1].Length;
+            i++)
+        {
+            Assert.Equal(0.0f, result.Channels[1][i]);
+        }
+    }
+
+    private static int IndexOfPeak(float[] samples)
+    {
+        int index = 0;
+        for (int i = 1; i < samples.Length; i++)
+        {
+            if (Math.Abs(samples[i]) > Math.Abs(samples[index]))
+            {
+                index = i;
+            }
+        }
+
+        return index;
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/AuralizationTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AuralizationTests.cs
@@ -43,7 +43,6 @@ public sealed class AuralizationTests
 
         Assert.True(trim.Cut);
         Assert.Equal(kernel.Length, trim.Length);
-        Assert.Equal(PeakIndex, trim.PeakIndex);
         // The head is untouched: sample 0 stays sample 0, so the measured
         // propagation delay survives.
         Assert.Equal(response[PeakIndex].Real, kernel[PeakIndex], 10);

--- a/tests/Resonalyze.Dsp.Tests/CalibrationFirFilterTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CalibrationFirFilterTests.cs
@@ -60,21 +60,22 @@ public sealed class CalibrationFirFilterTests
     [Fact]
     public void Design_IsExactlyLinearPhase()
     {
-        // Linear phase = symmetric kernel. Not required for the inter-side
-        // scene (any shared filter cancels out of the phase difference), but
-        // it is what this design promises — exact magnitude, constant delay —
-        // so hold it to that.
+        // Linear phase = the STANDARD FIR symmetry h[n] == h[N−1−n] over an
+        // odd length (Type I) — every tap has a pair, including the edges. Not
+        // required for the inter-side scene (any shared filter cancels out of
+        // the phase difference), but it is what this design promises — exact
+        // magnitude, constant delay — so hold it to exactly that.
         double[] kernel = CalibrationFirFilter.Design(
             frequency => 3.0 * Math.Sin(frequency / 700.0), Rate);
 
-        int center = kernel.Length / 2;
+        Assert.True(kernel.Length % 2 == 1, "A Type-I FIR has odd length");
         double peak = kernel.Max(Math.Abs);
-        for (int offset = 1; offset < center; offset++)
+        for (int i = 0; i < kernel.Length / 2; i++)
         {
             Assert.True(
-                Math.Abs(kernel[center + offset] - kernel[center - offset]) <
+                Math.Abs(kernel[i] - kernel[kernel.Length - 1 - i]) <
                     peak * 1e-9,
-                $"Asymmetric at offset {offset}");
+                $"Asymmetric at tap {i}");
         }
     }
 

--- a/tests/Resonalyze.Dsp.Tests/CalibrationFirFilterTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CalibrationFirFilterTests.cs
@@ -1,0 +1,98 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The calibration FIR must do exactly two things: reproduce the calibration's
+/// magnitude inverted (the correction the curves subtract, applied as a filter)
+/// and stay strictly linear-phase, because the auralization runs it over BOTH
+/// sides of the car and any phase behavior must cancel in the inter-side
+/// comparison.
+/// </summary>
+public sealed class CalibrationFirFilterTests
+{
+    private const int Rate = 48_000;
+
+    // The filter's frequency response probed directly: |Σ h[n]·e^(−j2πfn/fs)|.
+    private static double MagnitudeDbAt(double[] kernel, double frequencyHz)
+    {
+        double real = 0;
+        double imaginary = 0;
+        for (int n = 0; n < kernel.Length; n++)
+        {
+            double phase = -2.0 * Math.PI * frequencyHz * n / Rate;
+            real += kernel[n] * Math.Cos(phase);
+            imaginary += kernel[n] * Math.Sin(phase);
+        }
+
+        return 20.0 * Math.Log10(Math.Sqrt(real * real + imaginary * imaginary));
+    }
+
+    [Fact]
+    public void Design_InvertsAFlatCorrection()
+    {
+        // A microphone reading +6 dB hot everywhere: the filter must sit at
+        // −6 dB everywhere, so the calibrated render matches the calibrated
+        // on-screen curves.
+        double[] kernel = CalibrationFirFilter.Design(_ => 6.0, Rate);
+
+        foreach (double frequency in new[] { 40.0, 300.0, 1_000.0, 8_000.0, 16_000.0 })
+        {
+            Assert.InRange(MagnitudeDbAt(kernel, frequency), -6.2, -5.8);
+        }
+    }
+
+    [Fact]
+    public void Design_TracksAShelfAwayFromItsEdge()
+    {
+        // A +6 dB high shelf above 1 kHz. The frequency-sampling design smooths
+        // the step over a couple of grid bins, so the assertion stays away from
+        // the edge itself.
+        double[] kernel = CalibrationFirFilter.Design(
+            frequency => frequency >= 1_000.0 ? 6.0 : 0.0, Rate);
+
+        Assert.InRange(MagnitudeDbAt(kernel, 100.0), -0.3, 0.3);
+        Assert.InRange(MagnitudeDbAt(kernel, 250.0), -0.3, 0.3);
+        Assert.InRange(MagnitudeDbAt(kernel, 4_000.0), -6.3, -5.7);
+        Assert.InRange(MagnitudeDbAt(kernel, 12_000.0), -6.3, -5.7);
+    }
+
+    [Fact]
+    public void Design_IsExactlyLinearPhase()
+    {
+        // Linear phase = symmetric kernel. The auralization applies one filter
+        // to both sides, and only a constant, frequency-independent delay keeps
+        // the inter-side timing intact — that is this symmetry.
+        double[] kernel = CalibrationFirFilter.Design(
+            frequency => 3.0 * Math.Sin(frequency / 700.0), Rate);
+
+        int center = kernel.Length / 2;
+        double peak = kernel.Max(Math.Abs);
+        for (int offset = 1; offset < center; offset++)
+        {
+            Assert.True(
+                Math.Abs(kernel[center + offset] - kernel[center - offset]) <
+                    peak * 1e-9,
+                $"Asymmetric at offset {offset}");
+        }
+    }
+
+    [Fact]
+    public void Design_DelaysByExactlyHalfItsLength()
+    {
+        // The peak of a near-flat filter sits at the centre tap: the constant
+        // group delay both sides share.
+        double[] kernel = CalibrationFirFilter.Design(_ => 0.0, Rate);
+
+        int peakIndex = 0;
+        for (int i = 1; i < kernel.Length; i++)
+        {
+            if (Math.Abs(kernel[i]) > Math.Abs(kernel[peakIndex]))
+            {
+                peakIndex = i;
+            }
+        }
+
+        Assert.Equal(kernel.Length / 2, peakIndex);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/CalibrationFirFilterTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CalibrationFirFilterTests.cs
@@ -60,9 +60,10 @@ public sealed class CalibrationFirFilterTests
     [Fact]
     public void Design_IsExactlyLinearPhase()
     {
-        // Linear phase = symmetric kernel. The auralization applies one filter
-        // to both sides, and only a constant, frequency-independent delay keeps
-        // the inter-side timing intact — that is this symmetry.
+        // Linear phase = symmetric kernel. Not required for the inter-side
+        // scene (any shared filter cancels out of the phase difference), but
+        // it is what this design promises — exact magnitude, constant delay —
+        // so hold it to that.
         double[] kernel = CalibrationFirFilter.Design(
             frequency => 3.0 * Math.Sin(frequency / 700.0), Rate);
 

--- a/tests/Resonalyze.Dsp.Tests/FastConvolutionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FastConvolutionTests.cs
@@ -1,0 +1,154 @@
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class FastConvolutionTests
+{
+    [Fact]
+    public void ConvolveDoubles_MatchesTheDirectSum()
+    {
+        var random = new Random(11);
+        var first = new double[600];
+        var second = new double[145];
+        for (int i = 0; i < first.Length; i++)
+        {
+            first[i] = random.NextDouble() * 2.0 - 1.0;
+        }
+        for (int i = 0; i < second.Length; i++)
+        {
+            second[i] = random.NextDouble() * 2.0 - 1.0;
+        }
+
+        double[] fast = FastConvolution.Convolve(first, second);
+
+        Assert.Equal(first.Length + second.Length - 1, fast.Length);
+        for (int n = 0; n < fast.Length; n++)
+        {
+            double direct = 0;
+            for (int k = Math.Max(0, n - first.Length + 1);
+                k <= Math.Min(n, second.Length - 1);
+                k++)
+            {
+                direct += second[k] * first[n - k];
+            }
+
+            Assert.True(
+                Math.Abs(fast[n] - direct) < 1e-9,
+                $"Mismatch at {n}: fast {fast[n]}, direct {direct}");
+        }
+    }
+
+    [Fact]
+    public void Convolve_MatchesTheDirectSum()
+    {
+        var random = new Random(7);
+        var signal = new float[5_000];
+        for (int i = 0; i < signal.Length; i++)
+        {
+            signal[i] = (float)(random.NextDouble() * 2.0 - 1.0);
+        }
+
+        var kernel = new double[257];
+        for (int i = 0; i < kernel.Length; i++)
+        {
+            kernel[i] = random.NextDouble() * 2.0 - 1.0;
+        }
+
+        float[] fast = FastConvolution.Convolve(signal, kernel);
+
+        Assert.Equal(signal.Length + kernel.Length - 1, fast.Length);
+        // The WHOLE output against the O(N·K) definition — cheap at this size,
+        // and it covers every overlap-add block boundary wherever the block
+        // length lands, instead of guessing positions.
+        for (int n = 0; n < fast.Length; n++)
+        {
+            double direct = 0;
+            for (int k = Math.Max(0, n - signal.Length + 1);
+                k <= Math.Min(n, kernel.Length - 1);
+                k++)
+            {
+                direct += kernel[k] * signal[n - k];
+            }
+
+            Assert.True(
+                Math.Abs(fast[n] - direct) < 1e-4,
+                $"Mismatch at {n}: fast {fast[n]}, direct {direct}");
+        }
+    }
+
+    [Fact]
+    public void Convolve_IdentityKernelReturnsTheSignal()
+    {
+        float[] signal = [1f, -2f, 3f, 0.5f];
+        double[] kernel = [1.0];
+
+        float[] output = FastConvolution.Convolve(signal, kernel);
+
+        Assert.Equal(signal.Length, output.Length);
+        for (int i = 0; i < signal.Length; i++)
+        {
+            Assert.Equal(signal[i], output[i], 5);
+        }
+    }
+
+    [Fact]
+    public void Convolve_DelayKernelShiftsTheSignal()
+    {
+        var signal = new float[100];
+        signal[10] = 1.0f;
+        var kernel = new double[40];
+        kernel[25] = 1.0;
+
+        float[] output = FastConvolution.Convolve(signal, kernel);
+
+        int peakIndex = 0;
+        for (int i = 1; i < output.Length; i++)
+        {
+            if (Math.Abs(output[i]) > Math.Abs(output[peakIndex]))
+            {
+                peakIndex = i;
+            }
+        }
+
+        Assert.Equal(35, peakIndex);
+        Assert.Equal(1.0f, output[peakIndex], 5);
+    }
+
+    [Fact]
+    public void Convolve_ReportsMonotonicProgressEndingAtOne()
+    {
+        var signal = new float[100_000];
+        signal[0] = 1.0f;
+        var kernel = new double[2_048];
+        kernel[0] = 1.0;
+        var reports = new List<double>();
+        var progress = new SynchronousProgress(reports.Add);
+
+        FastConvolution.Convolve(signal, kernel, progress);
+
+        Assert.NotEmpty(reports);
+        Assert.Equal(1.0, reports[^1], 10);
+        for (int i = 1; i < reports.Count; i++)
+        {
+            Assert.True(reports[i] >= reports[i - 1]);
+        }
+    }
+
+    [Fact]
+    public void Convolve_CancellationStopsTheWork()
+    {
+        var signal = new float[500_000];
+        var kernel = new double[8_192];
+        kernel[0] = 1.0;
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            FastConvolution.Convolve(signal, kernel, null, cancellation.Token));
+    }
+
+    // Progress<T> posts through a synchronization context, which the test must
+    // not depend on; this reports inline on the calling thread.
+    private sealed class SynchronousProgress(Action<double> handler) : IProgress<double>
+    {
+        public void Report(double value) => handler(value);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/FastConvolutionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FastConvolutionTests.cs
@@ -120,7 +120,7 @@ public sealed class FastConvolutionTests
         var kernel = new double[2_048];
         kernel[0] = 1.0;
         var reports = new List<double>();
-        var progress = new SynchronousProgress(reports.Add);
+        var progress = new SynchronousProgress<double>(reports.Add);
 
         FastConvolution.Convolve(signal, kernel, progress);
 
@@ -143,12 +143,5 @@ public sealed class FastConvolutionTests
 
         Assert.Throws<OperationCanceledException>(() =>
             FastConvolution.Convolve(signal, kernel, null, cancellation.Token));
-    }
-
-    // Progress<T> posts through a synchronization context, which the test must
-    // not depend on; this reports inline on the calling thread.
-    private sealed class SynchronousProgress(Action<double> handler) : IProgress<double>
-    {
-        public void Report(double value) => handler(value);
     }
 }

--- a/tests/Resonalyze.Dsp.Tests/SampleRateConverterTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SampleRateConverterTests.cs
@@ -1,0 +1,115 @@
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class SampleRateConverterTests
+{
+    [Fact]
+    public void Resample_EqualRatesReturnsACopy()
+    {
+        float[] input = [0.1f, -0.5f, 0.9f];
+
+        float[] output = SampleRateConverter.Resample(input, 48_000, 48_000);
+
+        Assert.Equal(input, output);
+        Assert.NotSame(input, output);
+    }
+
+    [Fact]
+    public void Resample_EmptyInputStaysEmpty()
+    {
+        Assert.Empty(SampleRateConverter.Resample(
+            Array.Empty<float>(), 44_100, 48_000));
+    }
+
+    [Theory]
+    [InlineData(44_100, 48_000)]
+    [InlineData(48_000, 44_100)]
+    [InlineData(96_000, 48_000)]
+    [InlineData(48_000, 96_000)]
+    public void Resample_PreservesAMidbandTone(int fromRate, int toRate)
+    {
+        // A 1 kHz tone sits far below either Nyquist, so it must pass with its
+        // amplitude and phase intact — the whole point of the converter being
+        // time-aligned. The edges carry the kernel's ramp-in, so the check reads
+        // the interior.
+        const double Frequency = 1_000.0;
+        int length = fromRate / 2;
+        var input = new float[length];
+        for (int i = 0; i < length; i++)
+        {
+            input[i] = (float)Math.Sin(2.0 * Math.PI * Frequency * i / fromRate);
+        }
+
+        float[] output = SampleRateConverter.Resample(input, fromRate, toRate);
+
+        Assert.Equal(
+            SampleRateConverter.ResampledLength(length, fromRate, toRate),
+            output.Length);
+        int margin = toRate / 20;
+        double maxError = 0;
+        for (int i = margin; i < output.Length - margin; i++)
+        {
+            double expected = Math.Sin(2.0 * Math.PI * Frequency * i / toRate);
+            maxError = Math.Max(maxError, Math.Abs(output[i] - expected));
+        }
+
+        // −60 dB against a full-scale tone: far beyond audibility and well
+        // inside the kernel's design stopband.
+        Assert.True(
+            maxError < 1e-3,
+            $"Tone error after {fromRate} -> {toRate}: {maxError:E2}");
+    }
+
+    [Fact]
+    public void Resample_RejectsAToneAboveTheTargetNyquist()
+    {
+        // Downsampling 96 kHz material carrying a 30 kHz tone to 48 kHz must
+        // suppress it (24 kHz Nyquist), not fold it into the audible band.
+        const int FromRate = 96_000;
+        const int ToRate = 48_000;
+        const double Frequency = 30_000.0;
+        int length = FromRate / 2;
+        var input = new float[length];
+        for (int i = 0; i < length; i++)
+        {
+            input[i] = (float)Math.Sin(2.0 * Math.PI * Frequency * i / FromRate);
+        }
+
+        float[] output = SampleRateConverter.Resample(input, FromRate, ToRate);
+
+        int margin = ToRate / 20;
+        double peak = 0;
+        for (int i = margin; i < output.Length - margin; i++)
+        {
+            peak = Math.Max(peak, Math.Abs(output[i]));
+        }
+
+        Assert.True(peak < 1e-3, $"Alias residue: {peak:E2}");
+    }
+
+    [Fact]
+    public void Resample_KeepsAnImpulseWhereItWas()
+    {
+        // The converter must not shift the material against the (untouched)
+        // impulse responses it will be convolved with: an impulse at a known
+        // time must come out at the same time in the new rate.
+        const int FromRate = 44_100;
+        const int ToRate = 48_000;
+        var input = new float[FromRate / 4];
+        int inputIndex = input.Length / 2;
+        input[inputIndex] = 1.0f;
+
+        float[] output = SampleRateConverter.Resample(input, FromRate, ToRate);
+
+        int peakIndex = 0;
+        for (int i = 1; i < output.Length; i++)
+        {
+            if (Math.Abs(output[i]) > Math.Abs(output[peakIndex]))
+            {
+                peakIndex = i;
+            }
+        }
+
+        double expectedIndex = inputIndex * (double)ToRate / FromRate;
+        Assert.InRange(peakIndex, expectedIndex - 1.0, expectedIndex + 1.0);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/SampleRateConverterTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SampleRateConverterTests.cs
@@ -88,6 +88,100 @@ public sealed class SampleRateConverterTests
     }
 
     [Fact]
+    public void Resample_KeepsTheTopOfTheAudibleBand()
+    {
+        // 48 → 44.1: a 20 kHz tone sits inside the design's passband (91% of
+        // the 22.05 kHz Nyquist ≈ 20.07 kHz) and must survive at full level.
+        // A single-cutoff kernel with its −6 dB point AT Nyquist was ~2 dB
+        // down here — audibly shaving the top of real material.
+        const int FromRate = 48_000;
+        const int ToRate = 44_100;
+        const double Frequency = 20_000.0;
+        int length = FromRate / 2;
+        var input = new float[length];
+        for (int i = 0; i < length; i++)
+        {
+            input[i] = (float)Math.Sin(2.0 * Math.PI * Frequency * i / FromRate);
+        }
+
+        float[] output = SampleRateConverter.Resample(input, FromRate, ToRate);
+
+        int margin = ToRate / 20;
+        double sumSquares = 0;
+        int count = 0;
+        for (int i = margin; i < output.Length - margin; i++)
+        {
+            sumSquares += (double)output[i] * output[i];
+            count++;
+        }
+
+        // A unit sine's RMS is 1/√2; allow ±0.26 dB for passband ripple and
+        // the finite measurement window.
+        double rms = Math.Sqrt(sumSquares / count);
+        Assert.InRange(rms, 0.97 / Math.Sqrt(2.0), 1.03 / Math.Sqrt(2.0));
+    }
+
+    [Theory]
+    [InlineData(22_500.0)]
+    [InlineData(23_000.0)]
+    public void Resample_SuppressesContentJustAboveTheTargetNyquist(double frequency)
+    {
+        // 48 → 44.1: content just past the 22.05 kHz target Nyquist is exactly
+        // what folds back into the audible band, so the full stopband
+        // attenuation must hold THERE — not only deep inside the stopband.
+        // The previous design left 22.5 kHz only ~9 dB down (aliased to
+        // 21.6 kHz).
+        const int FromRate = 48_000;
+        const int ToRate = 44_100;
+        int length = FromRate / 2;
+        var input = new float[length];
+        for (int i = 0; i < length; i++)
+        {
+            input[i] = (float)Math.Sin(2.0 * Math.PI * frequency * i / FromRate);
+        }
+
+        float[] output = SampleRateConverter.Resample(input, FromRate, ToRate);
+
+        int margin = ToRate / 20;
+        double peak = 0;
+        for (int i = margin; i < output.Length - margin; i++)
+        {
+            peak = Math.Max(peak, Math.Abs(output[i]));
+        }
+
+        Assert.True(peak < 1e-3, $"Alias residue at {frequency} Hz: {peak:E2}");
+    }
+
+    [Fact]
+    public void Resample_HonorsCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.ThrowsAny<OperationCanceledException>(() =>
+            SampleRateConverter.Resample(
+                new float[48_000], 48_000, 44_100,
+                progress: null, cancellation.Token));
+    }
+
+    [Fact]
+    public void Resample_ReportsForwardOnlyProgressEndingAtOne()
+    {
+        var reports = new List<double>();
+        var progress = new SynchronousProgress<double>(reports.Add);
+
+        SampleRateConverter.Resample(
+            new float[400_000], 44_100, 48_000, progress);
+
+        Assert.NotEmpty(reports);
+        Assert.Equal(1.0, reports[^1]);
+        for (int i = 1; i < reports.Count; i++)
+        {
+            Assert.True(reports[i] >= reports[i - 1], "Progress went backwards");
+        }
+    }
+
+    [Fact]
     public void Resample_KeepsAnImpulseWhereItWas()
     {
         // The converter must not shift the material against the (untouched)

--- a/tests/Resonalyze.Dsp.Tests/SampleRateConverterTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SampleRateConverterTests.cs
@@ -41,8 +41,9 @@ public sealed class SampleRateConverterTests
 
         float[] output = SampleRateConverter.Resample(input, fromRate, toRate);
 
+        // ceil(length · to / from): one second of material stays one second.
         Assert.Equal(
-            SampleRateConverter.ResampledLength(length, fromRate, toRate),
+            ((long)length * toRate + fromRate - 1) / fromRate,
             output.Length);
         int margin = toRate / 20;
         double maxError = 0;


### PR DESCRIPTION
## What

A new **Audition track...** button in the Virtual DSP tool renders a music file through the two sides' summed processed responses and writes a stereo WAV — a headphone-only stereo auralization of the measured left and right acoustic paths at the microphone position (drivers, cabin and capsule included; each program channel through its side's summed response, each side to its own ear — not a binaural head simulation). Channel 1 carries the left side's sum, channel 2 the right side's.

## How

**Audition dialog** (designer-based, dark theme): track/destination pickers with an instant probe report (format, duration, resample/mono/multichannel notes; unreadable or over-10-minute files refused at pick time), a mic-calibration selector (Off / 0° / 90°, seeded from this run's last audition when that profile is still configured, otherwise from the panel's selection), a cancellable progress render, and a report block accumulating the tune's shape, the input file and the result (kernel taps, decay kept, applied gain, destination). Re-rendering with a different calibration is one click — convenient for A/B.

**Calibration** is applied as a **linear-phase FIR** (frequency-sampling design, ~3 Hz resolution, periodic Hann window) baked into BOTH side kernels before the track convolution: the magnitude matches the calibrated on-screen curves, while both channels shift by exactly the same constant — the inter-side timing being auditioned is untouched. Exact kernel symmetry is test-enforced.

**New DSP primitives** (`dsp/`, all cross-platform and unit-tested):
- `SampleRateConverter` — polyphase windowed-sinc rational-ratio SRC (Kaiser β≈8.6, ~−90 dB stopband, group delay compensated). The material is always converted to the project rate; the measured responses are never resampled.
- `FastConvolution` — overlap-add FFT convolution (float track × double kernel) plus a double/double single-transform overload for kernel combination.
- `Auralization` — response trimming (decay-tracked tail cut with an end fade, head kept so inter-side arrival differences survive), render orchestration, side-length equalization, single shared normalization gain (−1 dBFS peak).
- `CalibrationFirFilter` — the FIR design.

**New audio-layer codec** (`audio/Files/`, NAudio stays behind the boundary): decode wav/mp3/flac/m4a/wma/aiff, probe without decoding, write 24-bit WAV. Deinterleaving is robust to partial frames at decoder block boundaries; mismatched channel lengths are refused loudly. Output goes through a `.partial` temp file so a cancel or failure never leaves a truncated WAV at the user's chosen path.

**Panel plumbing**: `VirtualCrossoverMetrics.ComputeSideSumAsync` generalizes the opposite-side sum (shared coordinator cache and staleness guard); mono channels contribute to both sides at full level, matching how program material routes them.

## Tests

All three suites pass (Dsp / App / Audio). Coverage: SRC identity/ratio/timing, Nyquist-edge passband and near-Nyquist alias suppression, SRC cancellation and monotonic progress; convolution vs the direct sum over the whole output; response trim/fade/head-preservation, side-length padding, shared normalization gain; calibration FIR magnitude/symmetry/delay; codec round-trip, refusals, and channel-limited multichannel decode; side-sum gating/staleness/mono behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


