### PR TITLE
Auto delay: modal-latch defenses — honesty probes, link witness, sub-band hop veto

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,11 @@ just a plot but the DSP settings themselves:
   flatten the summed magnitude (favoring tight, minimally overlapping splits),
   and **Auto delay** aligns each junction's delay and polarity against the
   phase-aware sum — across both stereo sides in one run, holding a
-  configurable L/R scene offset between the sides.
+  configurable L/R scene offset between the sides. The search level-matches
+  each junction internally, so the result does not follow the channel gains;
+  still, set the gains at least approximately first — past ±30 dB of in-band
+  imbalance the correction saturates and the log will ask you to level the
+  gains and re-run.
 - **Practical loudspeaker alignment**
   Time Alignment reports first arrival and strongest peak, each refined to
   sub-sample precision by a GCC-PHAT cross-correlation, plus distance at 20 °C,

--- a/dsp/AlignmentSelection.cs
+++ b/dsp/AlignmentSelection.cs
@@ -59,18 +59,27 @@ public static class AlignmentSelection
     /// first): first breaks near-ties of the score by closeness to
     /// <paramref name="baseDeltaMs"/> REGARDLESS of polarity (the envelope
     /// outranks fractions of a dB, and a flip partner is a lobe like any
-    /// other); then prefers a non-inverted candidate over an inverted winner
-    /// within the invert margin — but only one that does not sit more than
+    /// other); then prefers a RELATIVELY non-inverted candidate over a
+    /// relatively inverted winner within the invert margin — but only one
+    /// that does not sit more than
     /// <paramref name="invertPreferenceReachMs"/> farther from
     /// <paramref name="baseDeltaMs"/> than the winner it replaces — and
     /// finally re-breaks near-ties within the chosen polarity.
+    /// "Relatively" is against <paramref name="neighborInverted"/>, the
+    /// settled neighbor's polarity flag: polarity purity is a property of
+    /// the PAIR, not of one flag. With an inverted neighbor the pure choice
+    /// is the equally-inverted candidate — an absolute-flag preference there
+    /// used to "rescue" a mixed pair and pay for the cosmetics with a
+    /// quarter period of delay, dragging the tweeter off the onset line its
+    /// inverted twin sat on.
     /// </summary>
     public static AlignmentCandidate Select(
         IReadOnlyList<AlignmentCandidate> candidates,
         double baseDeltaMs,
         double invertPreferenceMarginDb = DefaultInvertPreferenceMarginDb,
         double invertPreferenceReachMs = DefaultInvertPreferenceReachMs,
-        double delayTieMarginDb = DefaultDelayTieMarginDb)
+        double delayTieMarginDb = DefaultDelayTieMarginDb,
+        bool neighborInverted = false)
     {
         ArgumentNullException.ThrowIfNull(candidates);
         if (candidates.Count == 0)
@@ -84,19 +93,19 @@ public static class AlignmentSelection
             .Where(item => item.ScoreDb >= candidates[0].ScoreDb - delayTieMarginDb)
             .OrderBy(item => Math.Abs(item.DelayMs - baseDeltaMs))
             .First();
-        if (best.InvertPolarity)
+        if (best.InvertPolarity ^ neighborInverted)
         {
             double bestDistanceMs = Math.Abs(best.DelayMs - baseDeltaMs);
-            AlignmentCandidate? bestNormal = candidates
-                .Where(item => !item.InvertPolarity &&
+            AlignmentCandidate? bestPure = candidates
+                .Where(item => item.InvertPolarity == neighborInverted &&
                     Math.Abs(item.DelayMs - baseDeltaMs) - bestDistanceMs <=
                         invertPreferenceReachMs)
                 .OrderByDescending(item => item.ScoreDb)
                 .FirstOrDefault();
-            if (bestNormal != null &&
-                bestNormal.ScoreDb >= best.ScoreDb - invertPreferenceMarginDb)
+            if (bestPure != null &&
+                bestPure.ScoreDb >= best.ScoreDb - invertPreferenceMarginDb)
             {
-                best = bestNormal;
+                best = bestPure;
             }
         }
 
@@ -119,7 +128,8 @@ public static class AlignmentSelection
         double baseDeltaMs,
         double invertPreferenceMarginDb = DefaultInvertPreferenceMarginDb,
         double invertPreferenceReachMs = DefaultInvertPreferenceReachMs,
-        double delayTieMarginDb = DefaultDelayTieMarginDb)
+        double delayTieMarginDb = DefaultDelayTieMarginDb,
+        bool neighborInverted = false)
     {
         ArgumentNullException.ThrowIfNull(candidates);
         if (candidates.Count == 0)
@@ -131,14 +141,14 @@ public static class AlignmentSelection
             .Where(item => item.ScoreDb >= candidates[0].ScoreDb - delayTieMarginDb)
             .OrderBy(item => Math.Abs(item.DelayMs - baseDeltaMs))
             .First();
-        if (!best.InvertPolarity)
+        if (best.InvertPolarity == neighborInverted)
         {
             return null;
         }
 
         double bestDistanceMs = Math.Abs(best.DelayMs - baseDeltaMs);
         List<AlignmentCandidate> inMargin = candidates
-            .Where(item => !item.InvertPolarity &&
+            .Where(item => item.InvertPolarity == neighborInverted &&
                 item.ScoreDb >= best.ScoreDb - invertPreferenceMarginDb)
             .ToList();
         return inMargin.Count == 0 || inMargin.Any(item =>
@@ -220,7 +230,8 @@ public static class AlignmentSelection
         Func<AlignmentCandidate, double> acousticScore,
         double anchorMs,
         double nearReachMs,
-        double lobeHopMarginDb)
+        double lobeHopMarginDb,
+        bool neighborInverted = false)
     {
         ArgumentNullException.ThrowIfNull(candidates);
         ArgumentNullException.ThrowIfNull(chosen);
@@ -238,7 +249,8 @@ public static class AlignmentSelection
             return chosen;
         }
 
-        AlignmentCandidate nearBest = Select(near, anchorMs);
+        AlignmentCandidate nearBest = Select(
+            near, anchorMs, neighborInverted: neighborInverted);
         return acousticScore(chosen) - acousticScore(nearBest) > lobeHopMarginDb
             ? chosen
             : nearBest;

--- a/dsp/AlignmentSelection.cs
+++ b/dsp/AlignmentSelection.cs
@@ -149,6 +149,54 @@ public static class AlignmentSelection
     }
 
     /// <summary>
+    /// The sub-precedence preference for a junction with the shared mono
+    /// sub: when <paramref name="chosen"/> leaves the sub TRAILING the rest
+    /// of the stack (its lead, signed by <paramref name="leadSign"/> and
+    /// measured from the envelope anchor, is below
+    /// −<paramref name="slackMs"/>), the nearest candidate on the LEADING
+    /// side whose prior-free score (via <paramref name="acousticScore"/>)
+    /// sits within <paramref name="marginDb"/> of the chosen's — and no
+    /// farther than <paramref name="reachMs"/> past the anchor, a sub
+    /// leading by whole periods being detached the other way — replaces it.
+    /// The psychoacoustics behind the asymmetry: the first wavefront binds
+    /// the bass to the localizable midbass transient (precedence effect), so
+    /// a slightly leading sub reads as "bass up front" while a trailing one
+    /// reads as sluggish, detached bass. Returns <paramref name="chosen"/>
+    /// unchanged when it already leads (or sits within the slack) or no
+    /// eligible leading candidate exists.
+    /// </summary>
+    public static AlignmentCandidate PreferSubLeading(
+        IEnumerable<AlignmentCandidate> pool,
+        AlignmentCandidate chosen,
+        Func<AlignmentCandidate, double> acousticScore,
+        double anchorMs,
+        double leadSign,
+        double marginDb,
+        double slackMs,
+        double reachMs)
+    {
+        ArgumentNullException.ThrowIfNull(pool);
+        ArgumentNullException.ThrowIfNull(chosen);
+        ArgumentNullException.ThrowIfNull(acousticScore);
+        if (leadSign * (chosen.DelayMs - anchorMs) >= -slackMs)
+        {
+            return chosen;
+        }
+
+        double chosenScore = acousticScore(chosen);
+        return pool
+            .Where(item =>
+            {
+                double leadMs = leadSign * (item.DelayMs - anchorMs);
+                return leadMs >= -slackMs && leadMs <= reachMs &&
+                    acousticScore(item) >= chosenScore - marginDb;
+            })
+            .OrderBy(item => Math.Abs(item.DelayMs - anchorMs))
+            .DefaultIfEmpty(chosen)
+            .First();
+    }
+
+    /// <summary>
     /// The envelope-first lobe gate for a WIDE-SEED fine window. An untrusted
     /// coarse seed widens the fine window toward a half period, so the window
     /// itself spans foreign comb lobes — territory that, under a trusted seed,

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1024,6 +1024,9 @@ public static class AutoAlignmentEngine
                     priorDelayMs: anchorMs,
                     priorSigmaMs: (windowHighMs - windowLowMs) / 4.0,
                     forcedPolarity: forcedPolarity,
+                    // Search-side level match: the lobe choice must not depend
+                    // on the channels' playback gains (see BuildAlignmentBins).
+                    levelMatch: true,
                     out IReadOnlyList<AlignmentCandidate> allOptima);
             return (candidates, allOptima, windowLowMs, windowHighMs);
         }
@@ -2726,7 +2729,8 @@ public static class AutoAlignmentEngine
                         new List<Complex[]> { IrOf(neighbor) },
                         mover.SampleRate,
                         junction.BandLowHz,
-                        junction.BandHighHz);
+                        junction.BandHighHz,
+                        levelMatch: true);
                 if (evaluator != null)
                 {
                     evaluators.Add(evaluator);
@@ -3029,7 +3033,8 @@ public static class AutoAlignmentEngine
                             new List<Complex[]> { IrOf(neighbor) },
                             mono.SampleRate,
                             lowHz,
-                            highHz);
+                            highHz,
+                            levelMatch: true);
                     if (loss is { } value)
                     {
                         total += value.LossDb +

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -661,12 +661,14 @@ public static class AutoAlignmentEngine
                         pair.BandHighHz,
                         pair.Upper.ValidRange);
                 double probeToleranceMs = Math.Max(1.0, 500.0 / probeLowHz);
+                ArrivalCertificate lowerCertificate =
+                    ClassifyArrival(lowerRead, lowerProbe, probeToleranceMs);
+                ArrivalCertificate upperCertificate =
+                    ClassifyArrival(upperRead, upperProbe, probeToleranceMs);
                 bool lowerLatched =
-                    ClassifyArrival(lowerRead, lowerProbe, probeToleranceMs) ==
-                        ArrivalCertificate.Latched;
+                    lowerCertificate == ArrivalCertificate.Latched;
                 bool upperLatched =
-                    ClassifyArrival(upperRead, upperProbe, probeToleranceMs) ==
-                        ArrivalCertificate.Latched;
+                    upperCertificate == ArrivalCertificate.Latched;
                 if (lowerLatched || upperLatched)
                 {
                     TimeAlignmentAnalysisResult latchedRead =
@@ -679,17 +681,20 @@ public static class AutoAlignmentEngine
                         $"{pair.BandLowHz:0}-{pair.BandHighHz:0} Hz but " +
                         $"{latchedProbe.FirstArrivalDelayMilliseconds:0.000} ms in its " +
                         $"{probeLowHz:0}-{pair.BandHighHz:0} Hz half (modal latch)");
-                    // Re-anchor only when BOTH sides measure in the half band —
-                    // mixing one half-band read with the other side's full-band
-                    // one would compare different wavefronts. A conviction
-                    // WITHOUT a usable replacement anchor changes nothing
-                    // below: the corrupted diff keeps centering the window,
-                    // and the reach veto stays armed — lifting it there would
-                    // trust an extremum measured around the very anchor the
-                    // probe just convicted (review find on the first cut).
-                    if (lowerProbe.IsValid && upperProbe.IsValid &&
-                        lowerProbe.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
-                        upperProbe.SignalToNoiseDecibels >= MinimumArrivalSnrDb)
+                    // Re-anchor only when BOTH probes read the same physics —
+                    // judged by the CERTIFICATES, not by bare validity: an
+                    // UNVERIFIED side either failed to measure or its probe
+                    // timed a far LATER feature than its own full band (a
+                    // late reflection the half band mistook for the front),
+                    // and either way its probe read is not the wavefront the
+                    // latched side's probe found. A conviction WITHOUT a
+                    // comparable replacement anchor changes nothing below:
+                    // the corrupted diff keeps centering the window, and the
+                    // reach veto stays armed — lifting it there would trust
+                    // an extremum measured around the very anchor the probe
+                    // just convicted (review finds, first and third cut).
+                    if (lowerCertificate != ArrivalCertificate.Unverified &&
+                        upperCertificate != ArrivalCertificate.Unverified)
                     {
                         lowerArrival = lowerProbe.FirstArrivalDelayMilliseconds;
                         upperArrival = upperProbe.FirstArrivalDelayMilliseconds;
@@ -3003,43 +3008,52 @@ public static class AutoAlignmentEngine
             }
 
             double framedMonoMs = framed[mono].DelayMs;
-            double Score(
-                double deltaMs,
-                bool flip,
-                Func<AlignmentJunction, (double LowHz, double HighHz)>? bandOf = null)
+            IReadOnlyList<AlignmentSnapshot> Rendered(double deltaMs, bool flip) =>
+                reprocess(new Dictionary<IAlignmentChannel, AlignmentOverride>(framed)
+                {
+                    [mono] = new AlignmentOverride(
+                        Math.Round(framedMonoMs + deltaMs, 2),
+                        over.InvertPolarity ^ flip)
+                });
+            double? CellScore(
+                IReadOnlyList<AlignmentSnapshot> current,
+                AlignmentJunction junction,
+                double lowHz,
+                double highHz,
+                bool requireDelayEvidence)
             {
-                var trial =
-                    new Dictionary<IAlignmentChannel, AlignmentOverride>(framed)
-                    {
-                        [mono] = new AlignmentOverride(
-                            Math.Round(framedMonoMs + deltaMs, 2),
-                            over.InvertPolarity ^ flip)
-                    };
-                IReadOnlyList<AlignmentSnapshot> current = reprocess(trial);
                 Complex[] IrOf(IAlignmentChannel channel) =>
                     current.First(item => item.Channel == channel).ImpulseResponse;
+                IAlignmentChannel neighbor = junction.Lower.Channel == mono
+                    ? junction.Upper.Channel
+                    : junction.Lower.Channel;
+                (double LossDb, double DipDb)? loss =
+                    VirtualCrossoverAnalysis.MeasureSumLoss(
+                        IrOf(mono),
+                        new List<Complex[]> { IrOf(neighbor) },
+                        mono.SampleRate,
+                        lowHz,
+                        highHz,
+                        levelMatch: true,
+                        requireDelayEvidence);
+                return loss is { } value
+                    ? value.LossDb +
+                        VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
+                        (value.DipDb - value.LossDb)
+                    : null;
+            }
+            double Score(double deltaMs, bool flip)
+            {
+                IReadOnlyList<AlignmentSnapshot> current = Rendered(deltaMs, flip);
                 double total = 0;
                 int measured = 0;
                 foreach (AlignmentJunction junction in junctions)
                 {
-                    IAlignmentChannel neighbor = junction.Lower.Channel == mono
-                        ? junction.Upper.Channel
-                        : junction.Lower.Channel;
-                    (double lowHz, double highHz) = bandOf?.Invoke(junction)
-                        ?? (junction.BandLowHz, junction.BandHighHz);
-                    (double LossDb, double DipDb)? loss =
-                        VirtualCrossoverAnalysis.MeasureSumLoss(
-                            IrOf(mono),
-                            new List<Complex[]> { IrOf(neighbor) },
-                            mono.SampleRate,
-                            lowHz,
-                            highHz,
-                            levelMatch: true);
-                    if (loss is { } value)
+                    if (CellScore(current, junction, junction.BandLowHz,
+                        junction.BandHighHz, requireDelayEvidence: false)
+                        is { } cell)
                     {
-                        total += value.LossDb +
-                            VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
-                            (value.DipDb - value.LossDb);
+                        total += cell;
                         measured++;
                     }
                 }
@@ -3130,39 +3144,69 @@ public static class AutoAlignmentEngine
             {
                 // The sub-band consistency veto (see
                 // MonoComoveSubBandVetoMarginDb): a hop that cleared the
-                // margin must also HOLD each half of its junction bands —
-                // losing a half it can be measured in means the full-band
-                // gain came from a mode rewarding a comb impostor, not from
-                // a better alignment of the direct sound.
-                foreach (bool upperHalf in new[] { false, true })
+                // margin must also HOLD every (junction, half-band) CELL it
+                // can be measured in. Per cell, not per averaged half: a
+                // mean over the junctions would let a deficit on one side
+                // hide behind a surplus on the other (review find). And a
+                // cell casts a vote only where the delay is OBSERVABLE — the
+                // evidence gate refuses halves where one channel is just a
+                // filter tail, whose near-flat loss is noise the level match
+                // amplifies toward parity (review find). Losing a measurable
+                // cell means the full-band gain came from a mode rewarding a
+                // comb impostor, not from a better alignment of the direct
+                // sound.
+                IReadOnlyList<AlignmentSnapshot> hopRender =
+                    Rendered(bestDelta, bestFlip);
+                IReadOnlyList<AlignmentSnapshot> polishRender =
+                    Rendered(bestPolishDelta, false);
+                bool vetoed = false;
+                foreach (AlignmentJunction junction in junctions)
                 {
-                    (double LowHz, double HighHz) Half(AlignmentJunction junction) =>
-                        upperHalf
+                    foreach (bool upperHalf in new[] { false, true })
+                    {
+                        (double lowHz, double highHz) = upperHalf
                             ? (junction.CrossoverHz, junction.BandHighHz)
                             : (junction.BandLowHz, junction.CrossoverHz);
-                    double polishHalf = Score(bestPolishDelta, false, Half);
-                    if (double.IsNegativeInfinity(polishHalf))
-                    {
-                        continue;
-                    }
-                    double hopHalf = Score(bestDelta, bestFlip, Half);
-                    if (hopHalf >= polishHalf - MonoComoveSubBandVetoMarginDb)
-                    {
-                        continue;
-                    }
+                        double? polishCell = CellScore(
+                            polishRender, junction, lowHz, highHz,
+                            requireDelayEvidence: true);
+                        double? hopCell = CellScore(
+                            hopRender, junction, lowHz, highHz,
+                            requireDelayEvidence: true);
+                        if (polishCell is not { } polishCellScore ||
+                            hopCell is not { } hopCellScore ||
+                            hopCellScore >=
+                                polishCellScore - MonoComoveSubBandVetoMarginDb)
+                        {
+                            continue;
+                        }
 
-                    log.AppendLine(
-                        $"  mono lobe hop vetoed for {mono.Name}: " +
-                        $"{bestDelta:+0.00;-0.00} ms" +
-                        $"{(bestFlip ? " flipped" : "")} wins the full band " +
-                        $"by {bestScore - bestPolishScore:0.00} dB but loses " +
-                        $"the {(upperHalf ? "upper" : "lower")} half-band by " +
-                        $"{polishHalf - hopHalf:0.00} dB — a true lobe holds " +
-                        "every sub-band.");
+                        IAlignmentChannel neighbor =
+                            junction.Lower.Channel == mono
+                                ? junction.Upper.Channel
+                                : junction.Lower.Channel;
+                        log.AppendLine(
+                            $"  mono lobe hop vetoed for {mono.Name}: " +
+                            $"{bestDelta:+0.00;-0.00} ms" +
+                            $"{(bestFlip ? " flipped" : "")} wins the full band " +
+                            $"by {bestScore - bestPolishScore:0.00} dB but loses " +
+                            $"the {lowHz:0}-{highHz:0} Hz half vs " +
+                            $"{neighbor.Name} by " +
+                            $"{polishCellScore - hopCellScore:0.00} dB — a true " +
+                            "lobe holds every measurable sub-band.");
+                        vetoed = true;
+                        break;
+                    }
+                    if (vetoed)
+                    {
+                        break;
+                    }
+                }
+                if (vetoed)
+                {
                     bestScore = bestPolishScore;
                     bestDelta = bestPolishDelta;
                     bestFlip = false;
-                    break;
                 }
             }
 

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1517,12 +1517,15 @@ public static class AutoAlignmentEngine
                 {
                     // The report must say the objective was deliberately
                     // overridden: without this a negative rival margin reads
-                    // as an algorithm error, not a policy (review find).
+                    // as an algorithm error, not a policy (review find). The
+                    // figure is relative to the PRE-POLICY pick — itself
+                    // already shaped by the prior and the lobe gates, not
+                    // necessarily the global acoustic best.
                     AmendDecision(
                         decisions, channel,
                         "sub-precedence policy: the sub-leading lobe stands " +
-                        $"{precedenceBehindDb:0.00} dB behind the acoustic " +
-                        "best by design");
+                        $"{precedenceBehindDb:0.00} dB behind the pre-policy " +
+                        "pick by design");
                 }
             }
 
@@ -3243,9 +3246,6 @@ public static class AutoAlignmentEngine
                 int measured = 0;
                 foreach (AlignmentJunction junction in junctions)
                 {
-                    // Certified upfront to hold evidence at every junction;
-                    // the gate here is belt-and-suspenders on the same
-                    // delay-invariant read.
                     if (CellScore(current, junction, junction.BandLowHz,
                         junction.BandHighHz, requireDelayEvidence: true)
                         is { } cell)
@@ -3255,7 +3255,16 @@ public static class AutoAlignmentEngine
                     }
                 }
 
-                return measured > 0 ? total / measured : double.NegativeInfinity;
+                // FAIL-CLOSED, not an average of the survivors: the upfront
+                // certification ran on one render, but every probe re-gates
+                // the IRs and the direct-sound window shifts with the probed
+                // delay — a borderline junction can drop out mid-sweep, and a
+                // mean over the rest would be exactly the one-sided vote the
+                // certification exists to prevent (review find). A probe that
+                // cannot measure EVERY junction is not a candidate.
+                return measured == junctions.Count
+                    ? total / measured
+                    : double.NegativeInfinity;
             }
 
             double baseline = Score(0, flip: false);

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -981,6 +981,24 @@ public static class AutoAlignmentEngine
                 .First(item => item.Channel == secondaryNeighbor).ImpulseResponse);
         }
 
+        // The level match saturates at its cap; past it the residual
+        // imbalance shrinks the junction contrast again, so the user should
+        // level the gains and re-run — say so instead of degrading silently.
+        if (VirtualCrossoverAnalysis.MeasureInBandImbalanceDb(
+                variableIr, neighborIrs, channel.SampleRate, bandLowHz, bandHighHz)
+            is { } imbalanceDb &&
+            Math.Abs(imbalanceDb) > VirtualCrossoverAnalysis.LevelMatchCapDb)
+        {
+            log.AppendLine(
+                $"  WARNING: {channel.Name} sits " +
+                $"{Math.Abs(imbalanceDb):0} dB " +
+                $"{(imbalanceDb > 0 ? "under" : "over")} its neighbor(s) in " +
+                $"{bandLowHz:0}-{bandHighHz:0} Hz — past the " +
+                $"{VirtualCrossoverAnalysis.LevelMatchCapDb:0} dB level-match " +
+                "cap; level the channel gains and re-run for a trustworthy " +
+                "junction read.");
+        }
+
         // The onset lock (see the constants block): at a sharp-front junction
         // the search window is pinned to the broadband onset-aligned delay and
         // the arrival-anchored machinery below only polishes inside it. A
@@ -1391,6 +1409,7 @@ public static class AutoAlignmentEngine
                 }
             }
 
+            double? subPrecedenceBehindDb = null;
             // The sub-precedence preference (see SubPrecedenceMarginDb): at a
             // junction with the shared mono sub, a pick that leaves the sub
             // TRAILING the stack yields to the nearest candidate on the
@@ -1424,12 +1443,14 @@ public static class AutoAlignmentEngine
                         reachMs: 2.0 * halfPeriodMs);
                     if (leading != chosen)
                     {
+                        subPrecedenceBehindDb =
+                            AcousticScore(chosen) - AcousticScore(leading);
                         log.AppendLine(
                             $"  sub precedence: preferred {leading.DelayMs:0.000} ms" +
                             $"{(leading.InvertPolarity ? " inv" : "")} (the sub " +
                             $"leads the stack) over {chosen.DelayMs:0.000} ms" +
                             $"{(chosen.InvertPolarity ? " inv" : "")} — behind by " +
-                            $"{AcousticScore(chosen) - AcousticScore(leading):0.00} dB, " +
+                            $"{subPrecedenceBehindDb:0.00} dB, " +
                             $"within the {SubPrecedenceMarginDb:0.00} dB precedence margin.");
                         chosen = leading;
                     }
@@ -1492,6 +1513,17 @@ public static class AutoAlignmentEngine
                     onsetLocked: onsetAnchorMs != null,
                     sceneLocked: sceneLockToleranceMs != null,
                     overlapFraction);
+                if (subPrecedenceBehindDb is { } precedenceBehindDb)
+                {
+                    // The report must say the objective was deliberately
+                    // overridden: without this a negative rival margin reads
+                    // as an algorithm error, not a policy (review find).
+                    AmendDecision(
+                        decisions, channel,
+                        "sub-precedence policy: the sub-leading lobe stands " +
+                        $"{precedenceBehindDb:0.00} dB behind the acoustic " +
+                        "best by design");
+                }
             }
 
             if (onsetAnchorMs is { } settledAnchor)
@@ -2864,7 +2896,8 @@ public static class AutoAlignmentEngine
                         mover.SampleRate,
                         junction.BandLowHz,
                         junction.BandHighHz,
-                        levelMatch: true);
+                        levelMatch: true,
+                        requireDelayEvidence: true);
                 if (evaluator != null)
                 {
                     evaluators.Add(evaluator);
@@ -3093,6 +3126,38 @@ public static class AutoAlignmentEngine
                 continue;
             }
 
+            // Every junction must hold delay EVIDENCE on its own before the
+            // co-move may judge a compromise. The walk certified the LEFT
+            // junction individually, but the right sub junction never faced
+            // the structure gate alone — the descent searches a COMBINED band
+            // whose united fixed sum can hide an evidence-less sub junction
+            // behind a healthy upper one (review find). A co-move judged by
+            // the measurable side alone would merely re-optimize the left
+            // junction the walk already settled, so with any junction
+            // unmeasurable the whole co-move abstains and the walk's
+            // placement stands. Evidence is delay- and polarity-invariant
+            // (it reads magnitudes), so one certification on the current
+            // render covers every probe below.
+            IReadOnlyList<AlignmentSnapshot> certified = reprocess(alignment);
+            AlignmentJunction? unmeasurable = junctions.FirstOrDefault(
+                junction => CellScore(
+                    certified, junction, junction.BandLowHz, junction.BandHighHz,
+                    requireDelayEvidence: true) == null);
+            if (unmeasurable is { } silent)
+            {
+                IAlignmentChannel silentNeighbor =
+                    silent.Lower.Channel == mono
+                        ? silent.Upper.Channel
+                        : silent.Lower.Channel;
+                log.AppendLine(
+                    $"  mono co-move skipped for {mono.Name}: the junction vs " +
+                    $"{silentNeighbor.Name} in " +
+                    $"{silent.BandLowHz:0}-{silent.BandHighHz:0} Hz holds no " +
+                    "delay evidence — a compromise cannot be judged with one " +
+                    "side unmeasurable.");
+                continue;
+            }
+
             AlignmentOverride over = alignment.GetValueOrDefault(mono);
             double halfPeriodMs = junctions.Min(pair => 500.0 / pair.CrossoverHz);
             double reachMs = MonoComoveSearchHalfPeriods * halfPeriodMs;
@@ -3178,8 +3243,11 @@ public static class AutoAlignmentEngine
                 int measured = 0;
                 foreach (AlignmentJunction junction in junctions)
                 {
+                    // Certified upfront to hold evidence at every junction;
+                    // the gate here is belt-and-suspenders on the same
+                    // delay-invariant read.
                     if (CellScore(current, junction, junction.BandLowHz,
-                        junction.BandHighHz, requireDelayEvidence: false)
+                        junction.BandHighHz, requireDelayEvidence: true)
                         is { } cell)
                     {
                         total += cell;

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -398,6 +398,44 @@ public static class AutoAlignmentEngine
         Compute(channelsByBand, pairs, reprocess, alignment, log,
             onsetLocks: null, decisions);
         NormalizeAndVerifyFeasibility(channelsByBand.ToList(), alignment, log);
+        NormalizePolarityPresentation(channelsByBand, alignment, log);
+    }
+
+    // Presentation-only normalization: a GLOBAL polarity flip changes no
+    // relation — every junction, the scene and the sum see both of their ends
+    // flipped together — so when a proposal inverts MORE channels than it
+    // keeps, the whole field is flipped and the same physics reads as the
+    // minimal set of Invert switches. The field case: the sub-precedence
+    // lobe put the sub's relation to the stack inverted, which is presented
+    // as ONE inverted sub rather than three inverted stack channels (the
+    // owner's own hand tune of the same physics).
+    private static void NormalizePolarityPresentation(
+        IReadOnlyList<AlignmentSnapshot> scope,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        StringBuilder log)
+    {
+        List<IAlignmentChannel> channels = scope
+            .Select(item => item.Channel)
+            .Distinct()
+            .ToList();
+        int inverted = channels.Count(
+            channel => alignment.GetValueOrDefault(channel).InvertPolarity);
+        if (inverted * 2 <= channels.Count)
+        {
+            return;
+        }
+
+        foreach (IAlignmentChannel channel in channels)
+        {
+            AlignmentOverride over = alignment.GetValueOrDefault(channel);
+            alignment[channel] = over with
+            {
+                InvertPolarity = !over.InvertPolarity
+            };
+        }
+        log.AppendLine(
+            $"  polarity presentation: flipped every channel ({inverted} of " +
+            $"{channels.Count} were inverted) — a global flip changes no relation.");
     }
 
     /// <summary>
@@ -1091,8 +1129,16 @@ public static class AutoAlignmentEngine
                     $"(score {item.ScoreDb:0.00}, avg {item.LossDb:0.00}, " +
                     $"dip {item.DipDb:0.0} dB)")));
 
+            // Polarity purity is judged against the SETTLED primary neighbor:
+            // with an inverted neighbor the pure pair is the equally-inverted
+            // candidate, and an absolute-flag preference would "rescue" a
+            // mixed pair at the cost of a quarter period of delay (the field
+            // tweeter that slid off the onset line its inverted twin sat on).
+            bool neighborInverted =
+                alignment.GetValueOrDefault(neighborChannel).InvertPolarity;
             AlignmentCandidate? selected = candidates.Count > 0
-                ? AlignmentSelection.Select(candidates, anchorMs)
+                ? AlignmentSelection.Select(candidates, anchorMs,
+                    neighborInverted: neighborInverted)
                 : null;
             if (selected is { } fineSelected && fineSelected != candidates[0])
             {
@@ -1103,15 +1149,18 @@ public static class AutoAlignmentEngine
                     $"{(candidates[0].InvertPolarity ? " inv" : "")} " +
                     $"(margin {candidates[0].ScoreDb - fineSelected.ScoreDb:0.00} dB)");
             }
-            else if (selected is { InvertPolarity: true } keptInverted &&
-                AlignmentSelection.DeclinedInvertRescue(candidates, anchorMs)
+            else if (selected is { } keptPick &&
+                keptPick.InvertPolarity != neighborInverted &&
+                AlignmentSelection.DeclinedInvertRescue(candidates, anchorMs,
+                    neighborInverted: neighborInverted)
                     is { } rescue)
             {
                 log.AppendLine(
-                    $"  kept {keptInverted.DelayMs:0.000} ms inv: rescue " +
+                    $"  kept {keptPick.DelayMs:0.000} ms" +
+                    $"{(keptPick.InvertPolarity ? " inv" : "")}: rescue " +
                     $"{rescue.DelayMs:0.000} ms " +
-                    $"(margin {keptInverted.ScoreDb - rescue.ScoreDb:0.00} dB) is " +
-                    $"{Math.Abs(rescue.DelayMs - anchorMs) - Math.Abs(keptInverted.DelayMs - anchorMs):0.000} ms " +
+                    $"(margin {keptPick.ScoreDb - rescue.ScoreDb:0.00} dB) is " +
+                    $"{Math.Abs(rescue.DelayMs - anchorMs) - Math.Abs(keptPick.DelayMs - anchorMs):0.000} ms " +
                     "farther from the arrival (reach " +
                     $"{AlignmentSelection.DefaultInvertPreferenceReachMs:0.00} ms)");
             }
@@ -1143,7 +1192,8 @@ public static class AutoAlignmentEngine
             // structure the narrow window missed.
             if (selected == null && wide.Count > 0)
             {
-                selected = AlignmentSelection.Select(wide, anchorMs);
+                selected = AlignmentSelection.Select(wide, anchorMs,
+                    neighborInverted: neighborInverted);
                 log.AppendLine(
                     $"  fine window empty — adopted {selected.DelayMs:0.000} ms" +
                     $"{(selected.InvertPolarity ? " inv" : "")} from the wide sweep");
@@ -1207,7 +1257,8 @@ public static class AutoAlignmentEngine
                     // taking retried[0] raw would let the widened window hand
                     // the result to a (flip + half-period) impostor that the
                     // invert margin and the arrival tie-break exist to reject.
-                    chosen = AlignmentSelection.Select(retried, anchorMs);
+                    chosen = AlignmentSelection.Select(retried, anchorMs,
+                        neighborInverted: neighborInverted);
                 }
 
                 log.AppendLine(
@@ -1229,7 +1280,8 @@ public static class AutoAlignmentEngine
                     halfPeriodMs, MinFineAlignmentRangeMs, MaxFineAlignmentRangeMs);
                 AlignmentCandidate gated = AlignmentSelection.GateWideSeedLobe(
                     candidates, chosen, AcousticScore, anchorMs,
-                    trustedReachMs, WideWindowPromotionMarginDb);
+                    trustedReachMs, WideWindowPromotionMarginDb,
+                    neighborInverted);
                 if (gated != chosen)
                 {
                     log.AppendLine(
@@ -1261,7 +1313,8 @@ public static class AutoAlignmentEngine
                 onsetAnchorMs == null)
             {
                 AlignmentCandidate wideChosen =
-                    AlignmentSelection.Select(wide, anchorMs);
+                    AlignmentSelection.Select(wide, anchorMs,
+                        neighborInverted: neighborInverted);
                 // Only a lobe's reach from the arrival pick: past that the "better"
                 // score is a comb alias the summation cannot distinguish, so the
                 // envelope stays authoritative (see PromotionReachPeriods). Inside
@@ -2377,6 +2430,8 @@ public static class AutoAlignmentEngine
         // The invariant the user requires of automatic delay: no driver is ever
         // inverted on one side of a pair alone.
         EnforcePolaritySymmetry(plan, alignment, log, decisions);
+
+        NormalizePolarityPresentation(allChannels, alignment, log);
     }
 
     // Final normalization + the single feasibility gate. Normalization: the

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -621,6 +621,78 @@ public static class AutoAlignmentEngine
             double lowerArrival = lowerRead.FirstArrivalDelayMilliseconds;
             double upperArrival = upperRead.FirstArrivalDelayMilliseconds;
 
+            // The pair-band arrival honesty probe: the same full-band-vs-upper-
+            // half re-read (ClassifyArrival) the cross-side links, the donor
+            // certificates and the stereo bridge already run. A steep low-pass
+            // can concentrate the pair band's energy below the corner, where a
+            // channel's direct front hides under a late in-room modal build-up
+            // deeper than the envelope search depth — the full-band read then
+            // times the mode, whole periods late (field case: a midbass under
+            // LP 180 Hz/36 dB read 21.96 ms in 90-360 Hz against a 10.99 ms
+            // front in its own upper half — a 9.8 ms latch that seeded the
+            // stage-2 window a full period off and inverted the mids). A
+            // convicted latch does two things below: the pair re-anchors on
+            // the half-band reads where both measure (the same ladder the
+            // cross-side links climb), and the seed-reach veto is lifted — the
+            // reach rule measures the PHAT extremum against the arrival, so
+            // with the arrival convicted it would only enforce the very cycle
+            // skip it exists to prevent. The half-band read is a mushier
+            // anchor than an honest full-band one (an octave of HF mush once
+            // dragged a woofer 6 ms off on the cross-side ladder), so it only
+            // recenters the correlation window and the fallback diff; the
+            // trustworthy PHAT extremum, where present, still wins the seed.
+            double probeLowHz = Math.Sqrt(pair.BandLowHz * pair.BandHighHz);
+            bool arrivalLatched = false;
+            if (pair.BandHighHz >=
+                probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
+            {
+                TimeAlignmentAnalysisResult lowerProbe =
+                    VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                        pair.Lower.ImpulseResponse,
+                        pair.Lower.Channel.SampleRate,
+                        probeLowHz,
+                        pair.BandHighHz,
+                        pair.Lower.ValidRange);
+                TimeAlignmentAnalysisResult upperProbe =
+                    VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                        pair.Upper.ImpulseResponse,
+                        pair.Upper.Channel.SampleRate,
+                        probeLowHz,
+                        pair.BandHighHz,
+                        pair.Upper.ValidRange);
+                double probeToleranceMs = Math.Max(1.0, 500.0 / probeLowHz);
+                bool lowerLatched =
+                    ClassifyArrival(lowerRead, lowerProbe, probeToleranceMs) ==
+                        ArrivalCertificate.Latched;
+                bool upperLatched =
+                    ClassifyArrival(upperRead, upperProbe, probeToleranceMs) ==
+                        ArrivalCertificate.Latched;
+                arrivalLatched = lowerLatched || upperLatched;
+                if (arrivalLatched)
+                {
+                    TimeAlignmentAnalysisResult latchedRead =
+                        lowerLatched ? lowerRead : upperRead;
+                    TimeAlignmentAnalysisResult latchedProbe =
+                        lowerLatched ? lowerProbe : upperProbe;
+                    log.AppendLine(
+                        $"  {(lowerLatched ? pair.Lower : pair.Upper).Channel.Name}: " +
+                        $"{latchedRead.FirstArrivalDelayMilliseconds:0.000} ms in " +
+                        $"{pair.BandLowHz:0}-{pair.BandHighHz:0} Hz but " +
+                        $"{latchedProbe.FirstArrivalDelayMilliseconds:0.000} ms in its " +
+                        $"{probeLowHz:0}-{pair.BandHighHz:0} Hz half (modal latch)");
+                    // Re-anchor only when BOTH sides measure in the half band —
+                    // mixing one half-band read with the other side's full-band
+                    // one would compare different wavefronts.
+                    if (lowerProbe.IsValid && upperProbe.IsValid &&
+                        lowerProbe.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
+                        upperProbe.SignalToNoiseDecibels >= MinimumArrivalSnrDb)
+                    {
+                        lowerArrival = lowerProbe.FirstArrivalDelayMilliseconds;
+                        upperArrival = upperProbe.FirstArrivalDelayMilliseconds;
+                    }
+                }
+            }
+
             // Refine the coarse offset with the DOMINANT GCC-PHAT extremum of
             // either sign: at a mid/high junction it lands the stage-2 window
             // on the correct lobe directly, sparing the wide-window recovery.
@@ -691,7 +763,12 @@ public static class AutoAlignmentEngine
                 {
                     return "same-polarity rival near-tie";
                 }
-                if (Math.Abs(seedOffsetMs) > SeedReachMs(pair.CrossoverHz))
+                // The reach veto grades the extremum against the arrival, so
+                // it only means something while the arrival itself is honest:
+                // against a convicted modal latch it would enforce the very
+                // cycle skip it exists to prevent (see the probe above).
+                if (!arrivalLatched &&
+                    Math.Abs(seedOffsetMs) > SeedReachMs(pair.CrossoverHz))
                 {
                     return $"{seedLabel} beyond the arrival's reach";
                 }
@@ -1865,16 +1942,46 @@ public static class AutoAlignmentEngine
                 Reads, bool Latched, bool Verified) measured =
                 MeasureConsistent(bandLowHz, bandHighHz);
             anyLatch = measured.Latched;
+            bool fallbackDiffers =
+                fallbackLowHz != bandLowHz || fallbackHighHz != bandHighHz;
+            // The junction band doubles as the LINK CERTIFICATE'S WITNESS: the
+            // link certificate can self-verify inside the modal region — the
+            // link band's upper half may still sit under the same mode, so
+            // full and probe agree on the mode and Verified is issued for a
+            // latched read (field case: a midbass link read 22.2 ms in
+            // 80-200 Hz, its 126-200 Hz half saw the same hump, and the
+            // fabricated -8.4 ms split — no cabin geometry produces one —
+            // was scene-locked onto the right midbass). A latch PROVEN one
+            // band up convicts the link read too: the junction band's full-
+            // vs-upper-half skew places the mode inside fc/2..fc, which the
+            // link band contains — so the link's split must not reach the
+            // scene lock, and the pair descends the same ladder a latched
+            // link band would.
+            ((TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
+                Reads, bool Latched, bool Verified)? junctionRung =
+                fallbackDiffers && (measured.Reads != null || measured.Latched)
+                    ? MeasureConsistent(fallbackLowHz, fallbackHighHz)
+                    : null;
             if (measured.Reads == null && measured.Latched &&
-                (fallbackLowHz != bandLowHz || fallbackHighHz != bandHighHz))
+                junctionRung is { } rung)
             {
-                measured = MeasureConsistent(fallbackLowHz, fallbackHighHz);
-                anyLatch |= measured.Latched;
+                measured = rung;
+                anyLatch |= rung.Latched;
                 if (measured.Reads != null)
                 {
                     usedLowHz = fallbackLowHz;
                     usedHighHz = fallbackHighHz;
                 }
+            }
+            else if (measured.Reads != null && junctionRung is { Latched: true })
+            {
+                log.AppendLine(
+                    $"  cross-side link {rightChannel.Name}: " +
+                    $"{bandLowHz:0}-{bandHighHz:0} Hz read discarded — the " +
+                    $"junction band {fallbackLowHz:0}-{fallbackHighHz:0} Hz " +
+                    "convicts a modal latch the link band's own probe cannot see");
+                measured = (null, true, false);
+                anyLatch = true;
             }
             if (measured.Reads is not { } arrivals)
             {
@@ -2393,6 +2500,23 @@ public static class AutoAlignmentEngine
     // the plain 0.05 dB threshold still applies.
     private const double MonoComoveLobeHopMarginDb = 0.1;
 
+    // The sub-band deficit that vetoes a mono lobe/polarity hop even after it
+    // cleared the margin above. The full-band mean cannot tell a genuine
+    // recovery from a comb impostor flattered by an in-room mode: a lobe a
+    // whole period off fits the phase only where its period matches the
+    // frequency, and a mode INSIDE the band can put more summed energy behind
+    // exactly that impostor than behind the direct sound. The cross-check
+    // every narrow-band ranging discipline converges on (sub-band GCC,
+    // multi-scale FWI, GPS widelane ambiguity resolution) is consistency
+    // ACROSS sub-bands: the true alignment holds in every half of the
+    // junction band, the impostor wins one half and loses the other. Field
+    // anchors (v3 cabin, 80 Hz sub junctions): the false full-period hop
+    // "gained" 1.43 dB full-band while losing the clean 40-80 Hz half by
+    // 0.29 dB; the genuine two-sided recovery's worst half-band deficit was
+    // 0.02 dB — the co-move's own noise-tie scale. 0.1 sits between, the
+    // same order-of-magnitude split as the hop margin itself.
+    private const double MonoComoveSubBandVetoMarginDb = 0.1;
+
     // The right bridge top inherits the left top's sign (set before the right walk,
     // so the right lowers align against a correctly-signed top). Automatic delay
     // never inverts one side of a pair alone — a driver's polarity is a property of
@@ -2830,7 +2954,10 @@ public static class AutoAlignmentEngine
             }
 
             double framedMonoMs = framed[mono].DelayMs;
-            double Score(double deltaMs, bool flip)
+            double Score(
+                double deltaMs,
+                bool flip,
+                Func<AlignmentJunction, (double LowHz, double HighHz)>? bandOf = null)
             {
                 var trial =
                     new Dictionary<IAlignmentChannel, AlignmentOverride>(framed)
@@ -2849,13 +2976,15 @@ public static class AutoAlignmentEngine
                     IAlignmentChannel neighbor = junction.Lower.Channel == mono
                         ? junction.Upper.Channel
                         : junction.Lower.Channel;
+                    (double lowHz, double highHz) = bandOf?.Invoke(junction)
+                        ?? (junction.BandLowHz, junction.BandHighHz);
                     (double LossDb, double DipDb)? loss =
                         VirtualCrossoverAnalysis.MeasureSumLoss(
                             IrOf(mono),
                             new List<Complex[]> { IrOf(neighbor) },
                             mono.SampleRate,
-                            junction.BandLowHz,
-                            junction.BandHighHz);
+                            lowHz,
+                            highHz);
                     if (loss is { } value)
                     {
                         total += value.LossDb +
@@ -2946,6 +3075,45 @@ public static class AutoAlignmentEngine
                 bestScore = bestPolishScore;
                 bestDelta = bestPolishDelta;
                 bestFlip = false;
+            }
+            else if (hop)
+            {
+                // The sub-band consistency veto (see
+                // MonoComoveSubBandVetoMarginDb): a hop that cleared the
+                // margin must also HOLD each half of its junction bands —
+                // losing a half it can be measured in means the full-band
+                // gain came from a mode rewarding a comb impostor, not from
+                // a better alignment of the direct sound.
+                foreach (bool upperHalf in new[] { false, true })
+                {
+                    (double LowHz, double HighHz) Half(AlignmentJunction junction) =>
+                        upperHalf
+                            ? (junction.CrossoverHz, junction.BandHighHz)
+                            : (junction.BandLowHz, junction.CrossoverHz);
+                    double polishHalf = Score(bestPolishDelta, false, Half);
+                    if (double.IsNegativeInfinity(polishHalf))
+                    {
+                        continue;
+                    }
+                    double hopHalf = Score(bestDelta, bestFlip, Half);
+                    if (hopHalf >= polishHalf - MonoComoveSubBandVetoMarginDb)
+                    {
+                        continue;
+                    }
+
+                    log.AppendLine(
+                        $"  mono lobe hop vetoed for {mono.Name}: " +
+                        $"{bestDelta:+0.00;-0.00} ms" +
+                        $"{(bestFlip ? " flipped" : "")} wins the full band " +
+                        $"by {bestScore - bestPolishScore:0.00} dB but loses " +
+                        $"the {(upperHalf ? "upper" : "lower")} half-band by " +
+                        $"{polishHalf - hopHalf:0.00} dB — a true lobe holds " +
+                        "every sub-band.");
+                    bestScore = bestPolishScore;
+                    bestDelta = bestPolishDelta;
+                    bestFlip = false;
+                    break;
+                }
             }
 
             if ((bestDelta != 0 || bestFlip) &&

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -261,6 +261,30 @@ public static class AutoAlignmentEngine
     // near-tie sends the seed back to the polarity-blind arrival envelope.
     private const double PhatSeedMinDominance = 0.1;
 
+    // The sub-precedence margin: at a junction with the shared mono sub, a
+    // near-tie between the comb lobe that leaves the sub TRAILING the stack
+    // and the one that leaves it LEADING is not acoustically resolvable —
+    // but it is perceptually one-sided. The first wavefront binds the bass
+    // to the localizable midbass transient (precedence effect), so a
+    // slightly leading sub reads as "bass up front" while a trailing one
+    // reads as sluggish, detached bass — the failure owners hand-tune away.
+    // The margin sits deliberately ABOVE the near-tie scale and just under
+    // the ~1.4 dB comb-noise ceiling the promotion margin's field
+    // calibration measured between real lobes: within that ceiling the
+    // summation cannot pick a lobe honestly anyway (an in-room mode can
+    // flatter either side by up to that much), so the psychoacoustics
+    // decide; beyond it the summation stands. Owner-calibrated on the v3
+    // cabin: the leading lobe measured 0.66-0.73 dB under the trailing pick
+    // on the prior-free level-matched score, yet the trailing tune was
+    // rejected by ear ("the bass lags") and the leading one localized the
+    // bass to the front stage.
+    private const double SubPrecedenceMarginDb = 1.0;
+
+    // Candidates within this of the envelope anchor count as neither leading
+    // nor trailing: the preference re-decides genuine lobe choices, not the
+    // sub-millisecond polish around the envelope-aligned point.
+    private const double SubPrecedenceSlackMs = 0.5;
+
     // How much better (in score dB) a wide-window optimum must be before it
     // unseats the arrival-anchored fine pick, at a junction the onset lock
     // does not govern (below its frequency gate, or a smeared front): there
@@ -466,7 +490,8 @@ public static class AutoAlignmentEngine
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         StringBuilder log,
         Dictionary<AlignmentJunction, OnsetLockState>? onsetLocks,
-        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null)
+        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null,
+        IReadOnlyCollection<IAlignmentChannel>? monoChannels = null)
     {
         ArgumentNullException.ThrowIfNull(channelsByBand);
         ArgumentNullException.ThrowIfNull(pairs);
@@ -523,7 +548,8 @@ public static class AutoAlignmentEngine
                 timeline, byBand, reprocess, alignment, log,
                 untrustedSeedJunctions: untrustedSeeds,
                 onsetLocks: onsetLocks,
-                decisions: decisions);
+                decisions: decisions,
+                monoChannels: monoChannels);
         }
         for (int i = referenceIndex + 1; i < byBand.Count; i++)
         {
@@ -532,7 +558,8 @@ public static class AutoAlignmentEngine
                 timeline, byBand, reprocess, alignment, log,
                 untrustedSeedJunctions: untrustedSeeds,
                 onsetLocks: onsetLocks,
-                decisions: decisions);
+                decisions: decisions,
+                monoChannels: monoChannels);
         }
     }
 
@@ -857,7 +884,8 @@ public static class AutoAlignmentEngine
         bool? forcedPolarity = null,
         IReadOnlySet<AlignmentJunction>? untrustedSeedJunctions = null,
         Dictionary<AlignmentJunction, OnsetLockState>? onsetLocks = null,
-        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null)
+        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null,
+        IReadOnlyCollection<IAlignmentChannel>? monoChannels = null)
     {
         // Widen the window when the coarse seed ACROSS this junction (or its
         // secondary, for a joint two-neighbour search) was the untrusted arrival
@@ -1310,6 +1338,51 @@ public static class AutoAlignmentEngine
                 }
             }
 
+            // The sub-precedence preference (see SubPrecedenceMarginDb): at a
+            // junction with the shared mono sub, a pick that leaves the sub
+            // TRAILING the stack yields to the nearest candidate on the
+            // LEADING side of the envelope anchor when the prior-free scores
+            // are within the precedence margin. The pool spans the fine and
+            // wide sets on the prior-free score — the arrival prior is
+            // exactly what keeps parking the result on the trailing lobe
+            // when the envelope-aligned point falls between two lobes.
+            // Bounded to one period past the anchor: a sub leading by whole
+            // periods is not "up front", it is detached the other way.
+            if (monoChannels != null &&
+                sceneLockToleranceMs == null && onsetAnchorMs == null)
+            {
+                bool subSearched = monoChannels.Contains(channel);
+                bool subNeighbor = secondaryNeighbor == null &&
+                    monoChannels.Contains(neighborChannel);
+                // With the STACK searched, delaying it beyond the anchor
+                // leaves the sub leading (+1); with the SUB searched the
+                // directions swap (-1).
+                double leadSign = subNeighbor ? 1.0 : -1.0;
+                if (subSearched ^ subNeighbor)
+                {
+                    AlignmentCandidate leading = AlignmentSelection.PreferSubLeading(
+                        candidates.Concat(wide),
+                        chosen,
+                        AcousticScore,
+                        anchorMs,
+                        leadSign,
+                        SubPrecedenceMarginDb,
+                        SubPrecedenceSlackMs,
+                        reachMs: 2.0 * halfPeriodMs);
+                    if (leading != chosen)
+                    {
+                        log.AppendLine(
+                            $"  sub precedence: preferred {leading.DelayMs:0.000} ms" +
+                            $"{(leading.InvertPolarity ? " inv" : "")} (the sub " +
+                            $"leads the stack) over {chosen.DelayMs:0.000} ms" +
+                            $"{(chosen.InvertPolarity ? " inv" : "")} — behind by " +
+                            $"{AcousticScore(chosen) - AcousticScore(leading):0.00} dB, " +
+                            $"within the {SubPrecedenceMarginDb:0.00} dB precedence margin.");
+                        chosen = leading;
+                    }
+                }
+            }
+
             double newDelay = chosen.DelayMs;
             if (newDelay < 0)
             {
@@ -1615,10 +1688,11 @@ public static class AutoAlignmentEngine
         var onsetLocks = new Dictionary<AlignmentJunction, OnsetLockState>(
             ReferenceEqualityComparer.Instance);
 
-        // Stage L: the left side, exactly like a mono run.
+        // Stage L: the left side, exactly like a mono run — plus the mono-set
+        // knowledge the sub-precedence preference needs.
         Compute(
             plan.LeftChannelsByBand, plan.LeftPairs, reprocess, alignment, log,
-            onsetLocks, decisions);
+            onsetLocks, decisions, plan.MonoChannels);
 
         // The union of both sides: the scope of every uniform shift from here
         // on. Shifting one side alone would silently break the inter-side
@@ -2272,7 +2346,7 @@ public static class AutoAlignmentEngine
                 channel, neighbor, pair,
                 rightTimeline, allChannels, reprocess, alignment, log,
                 secondary, secondaryPair, crossTarget, sceneLock, inheritedPolarity,
-                rightUntrustedSeeds, onsetLocks, decisions);
+                rightUntrustedSeeds, onsetLocks, decisions, plan.MonoChannels);
         }
         for (int i = bridgeIndex - 1; i >= 0; i--)
         {

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -642,7 +642,7 @@ public static class AutoAlignmentEngine
             // recenters the correlation window and the fallback diff; the
             // trustworthy PHAT extremum, where present, still wins the seed.
             double probeLowHz = Math.Sqrt(pair.BandLowHz * pair.BandHighHz);
-            bool arrivalLatched = false;
+            bool arrivalReanchored = false;
             if (pair.BandHighHz >=
                 probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
             {
@@ -667,8 +667,7 @@ public static class AutoAlignmentEngine
                 bool upperLatched =
                     ClassifyArrival(upperRead, upperProbe, probeToleranceMs) ==
                         ArrivalCertificate.Latched;
-                arrivalLatched = lowerLatched || upperLatched;
-                if (arrivalLatched)
+                if (lowerLatched || upperLatched)
                 {
                     TimeAlignmentAnalysisResult latchedRead =
                         lowerLatched ? lowerRead : upperRead;
@@ -682,13 +681,19 @@ public static class AutoAlignmentEngine
                         $"{probeLowHz:0}-{pair.BandHighHz:0} Hz half (modal latch)");
                     // Re-anchor only when BOTH sides measure in the half band —
                     // mixing one half-band read with the other side's full-band
-                    // one would compare different wavefronts.
+                    // one would compare different wavefronts. A conviction
+                    // WITHOUT a usable replacement anchor changes nothing
+                    // below: the corrupted diff keeps centering the window,
+                    // and the reach veto stays armed — lifting it there would
+                    // trust an extremum measured around the very anchor the
+                    // probe just convicted (review find on the first cut).
                     if (lowerProbe.IsValid && upperProbe.IsValid &&
                         lowerProbe.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
                         upperProbe.SignalToNoiseDecibels >= MinimumArrivalSnrDb)
                     {
                         lowerArrival = lowerProbe.FirstArrivalDelayMilliseconds;
                         upperArrival = upperProbe.FirstArrivalDelayMilliseconds;
+                        arrivalReanchored = true;
                     }
                 }
             }
@@ -764,10 +769,14 @@ public static class AutoAlignmentEngine
                     return "same-polarity rival near-tie";
                 }
                 // The reach veto grades the extremum against the arrival, so
-                // it only means something while the arrival itself is honest:
-                // against a convicted modal latch it would enforce the very
-                // cycle skip it exists to prevent (see the probe above).
-                if (!arrivalLatched &&
+                // it is lifted only once the pair is RE-ANCHORED on honest
+                // half-band reads: against a convicted-and-replaced anchor it
+                // would enforce the very cycle skip it exists to prevent. A
+                // conviction without a replacement anchor keeps the veto —
+                // the window is still centered on the corrupted diff, and a
+                // strong distant modal peak found there is exactly the skip
+                // candidate the veto guards (see the probe above).
+                if (!arrivalReanchored &&
                     Math.Abs(seedOffsetMs) > SeedReachMs(pair.CrossoverHz))
                 {
                     return $"{seedLabel} beyond the arrival's reach";
@@ -1865,7 +1874,10 @@ public static class AutoAlignmentEngine
             // are still usable but UNVERIFIED, and the caller must not grant
             // them the tight scene lock an honest certificate earns.
             ((TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
-                Reads, bool Latched, bool Verified) MeasureConsistent(
+                Reads, bool Latched, bool Verified,
+                bool LeftLatched, bool RightLatched,
+                (TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
+                    FullReads) MeasureConsistent(
                     double lowHz, double highHz)
             {
                 TimeAlignmentAnalysisResult left =
@@ -1880,14 +1892,14 @@ public static class AutoAlignmentEngine
                     left.SignalToNoiseDecibels < MinimumArrivalSnrDb ||
                     right.SignalToNoiseDecibels < MinimumArrivalSnrDb)
                 {
-                    return (null, false, false);
+                    return (null, false, false, false, false, null);
                 }
 
                 double probeLowHz = Math.Sqrt(lowHz * highHz);
                 if (highHz <
                     probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
                 {
-                    return ((left, right), false, false);
+                    return ((left, right), false, false, false, false, (left, right));
                 }
 
                 TimeAlignmentAnalysisResult leftProbe =
@@ -1919,12 +1931,16 @@ public static class AutoAlignmentEngine
                         $"{(leftLatched ? leftProbe : rightProbe).FirstArrivalDelayMilliseconds:0.000} ms" +
                         $" in its {probeLowHz:0}-{highHz:0} Hz half " +
                         "(modal latch: the sides time different features)");
-                    return (null, true, false);
+                    return (null, true, false,
+                        leftLatched,
+                        rightCertificate == ArrivalCertificate.Latched,
+                        (left, right));
                 }
 
                 return ((left, right), false,
                     leftCertificate == ArrivalCertificate.Verified &&
-                    rightCertificate == ArrivalCertificate.Verified);
+                    rightCertificate == ArrivalCertificate.Verified,
+                    false, false, (left, right));
             }
 
             // The consistency ladder: the pair's own shared band first; when a
@@ -1939,7 +1955,10 @@ public static class AutoAlignmentEngine
             double usedHighHz = bandHighHz;
             bool anyLatch;
             ((TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
-                Reads, bool Latched, bool Verified) measured =
+                Reads, bool Latched, bool Verified,
+                bool LeftLatched, bool RightLatched,
+                (TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
+                    FullReads) measured =
                 MeasureConsistent(bandLowHz, bandHighHz);
             anyLatch = measured.Latched;
             bool fallbackDiffers =
@@ -1951,14 +1970,24 @@ public static class AutoAlignmentEngine
             // latched read (field case: a midbass link read 22.2 ms in
             // 80-200 Hz, its 126-200 Hz half saw the same hump, and the
             // fabricated -8.4 ms split — no cabin geometry produces one —
-            // was scene-locked onto the right midbass). A latch PROVEN one
-            // band up convicts the link read too: the junction band's full-
-            // vs-upper-half skew places the mode inside fc/2..fc, which the
-            // link band contains — so the link's split must not reach the
+            // was scene-locked onto the right midbass). The conviction does
+            // NOT transfer wholesale, though: the witness only proves a mode
+            // somewhere below its own probe half, which may lie below the
+            // link band entirely (review find on the first cut). So the
+            // witness convicts the link read only when the SAME-FEATURE test
+            // holds — the latched side's link read timed the very feature the
+            // witness convicted (the two reads agree within the wavefront
+            // tolerance; the bands overlap and both sit on one mode, so
+            // dispersion between them is small). A link read that timed an
+            // earlier, different feature stands: the mode is outside its
+            // band's reach. On conviction the link's split must not reach the
             // scene lock, and the pair descends the same ladder a latched
             // link band would.
             ((TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
-                Reads, bool Latched, bool Verified)? junctionRung =
+                Reads, bool Latched, bool Verified,
+                bool LeftLatched, bool RightLatched,
+                (TimeAlignmentAnalysisResult Left, TimeAlignmentAnalysisResult Right)?
+                    FullReads)? junctionRung =
                 fallbackDiffers && (measured.Reads != null || measured.Latched)
                     ? MeasureConsistent(fallbackLowHz, fallbackHighHz)
                     : null;
@@ -1973,15 +2002,31 @@ public static class AutoAlignmentEngine
                     usedHighHz = fallbackHighHz;
                 }
             }
-            else if (measured.Reads != null && junctionRung is { Latched: true })
+            else if (measured.Reads is { } linkReads &&
+                junctionRung is { Latched: true, FullReads: { } witnessReads } witness)
             {
-                log.AppendLine(
-                    $"  cross-side link {rightChannel.Name}: " +
-                    $"{bandLowHz:0}-{bandHighHz:0} Hz read discarded — the " +
-                    $"junction band {fallbackLowHz:0}-{fallbackHighHz:0} Hz " +
-                    "convicts a modal latch the link band's own probe cannot see");
-                measured = (null, true, false);
-                anyLatch = true;
+                double witnessProbeLowHz = Math.Sqrt(fallbackLowHz * fallbackHighHz);
+                double witnessToleranceMs = Math.Max(1.0, 500.0 / witnessProbeLowHz);
+                bool linkTimedTheConvictedFeature =
+                    (witness.LeftLatched && Math.Abs(
+                        linkReads.Left.FirstArrivalDelayMilliseconds -
+                        witnessReads.Left.FirstArrivalDelayMilliseconds) <=
+                            witnessToleranceMs) ||
+                    (witness.RightLatched && Math.Abs(
+                        linkReads.Right.FirstArrivalDelayMilliseconds -
+                        witnessReads.Right.FirstArrivalDelayMilliseconds) <=
+                            witnessToleranceMs);
+                if (linkTimedTheConvictedFeature)
+                {
+                    log.AppendLine(
+                        $"  cross-side link {rightChannel.Name}: " +
+                        $"{bandLowHz:0}-{bandHighHz:0} Hz read discarded — it timed " +
+                        $"the same feature the junction band " +
+                        $"{fallbackLowHz:0}-{fallbackHighHz:0} Hz convicts as a " +
+                        "modal latch the link band's own probe cannot see");
+                    measured = (null, true, false, false, false, null);
+                    anyLatch = true;
+                }
             }
             if (measured.Reads is not { } arrivals)
             {

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -2044,7 +2044,8 @@ public static class VirtualCrossoverAnalysis
         int sampleRate,
         double minFrequencyHz,
         double maxFrequencyHz,
-        bool levelMatch = false)
+        bool levelMatch = false,
+        bool requireDelayEvidence = false)
     {
         // The delay window only gates parameter validation here — the
         // measurement itself evaluates the responses exactly as given.
@@ -2057,6 +2058,18 @@ public static class VirtualCrossoverAnalysis
             minDelayMs: -1,
             maxDelayMs: 1,
             levelMatch);
+        // A caller COMPARING alignments across this band (rather than
+        // reporting what a sum happens to measure) must not read a verdict
+        // off a band where the delay is not observable: with one side only a
+        // filter tail or residue there, the loss is near-flat for every
+        // delay and a fraction-of-a-dB "difference" is noise — worse under
+        // the level match, which amplifies exactly such a tail toward
+        // parity. The same structure gate the candidate search runs.
+        if (requireDelayEvidence &&
+            (bins.Count == 0 || !HoldsDelayEvidence(bins)))
+        {
+            return null;
+        }
         if (bins.Count == 0)
         {
             return null;

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1400,12 +1400,56 @@ public static class VirtualCrossoverAnalysis
     // The per-bin spectra inside the frequency window, decimated to a bounded
     // bin count so the search stays fast for long IRs. The fixed channels act
     // as one combined source (superposition).
-    // The widest in-band level correction the search-side level match may
-    // apply, matched to OverlapReliabilityGateDb: a side sitting deeper than
-    // the reliability gate below its partner in the band is roll-off tail or
-    // deconvolution residue, and amplifying residue to parity would let the
-    // delay-evidence gate certify a junction that has no measurable overlap.
-    private const double LevelMatchCapDb = 30;
+    /// <summary>
+    /// The widest in-band level correction the search-side level match may
+    /// apply, matched to <see cref="OverlapReliabilityGateDb"/>: a side
+    /// sitting deeper than the reliability gate below its partner in the
+    /// band is roll-off tail or deconvolution residue, and amplifying
+    /// residue to parity would let the delay-evidence gate certify a
+    /// junction that has no measurable overlap. This bounds the search's
+    /// gain invariance: within ±30 dB of in-band imbalance the lobe choice
+    /// does not follow the channel gains; past the cap the residual
+    /// imbalance shrinks the junction contrast again, so the log tells the
+    /// user to level the gains first (see
+    /// <see cref="MeasureInBandImbalanceDb"/>).
+    /// </summary>
+    public const double LevelMatchCapDb = 30;
+
+    /// <summary>
+    /// The in-band level imbalance (dB) between the combined fixed channels
+    /// and the variable one, weighted exactly like the search-side level
+    /// match (log-frequency): positive when the variable channel is
+    /// quieter. Null when either side holds no in-band content. The
+    /// auto-delay log surfaces it when it exceeds
+    /// <see cref="LevelMatchCapDb"/> — the correction saturates there and
+    /// the junction read degrades, so the gains should be leveled first.
+    /// </summary>
+    public static double? MeasureInBandImbalanceDb(
+        Complex[] variableImpulseResponse,
+        IReadOnlyList<Complex[]> fixedImpulseResponses,
+        int sampleRate,
+        double minFrequencyHz,
+        double maxFrequencyHz)
+    {
+        List<AlignmentBin> bins = BuildAlignmentBins(
+            variableImpulseResponse,
+            fixedImpulseResponses,
+            sampleRate,
+            minFrequencyHz,
+            maxFrequencyHz,
+            minDelayMs: -1,
+            maxDelayMs: 1);
+        double variableLevel = 0;
+        double fixedLevel = 0;
+        foreach (AlignmentBin bin in bins)
+        {
+            variableLevel += bin.RawVariableMagnitude * bin.LogWeight;
+            fixedLevel += bin.FixedSum.Magnitude * bin.LogWeight;
+        }
+        return variableLevel > 0 && fixedLevel > 0
+            ? 20.0 * Math.Log10(fixedLevel / variableLevel)
+            : null;
+    }
 
     private static List<AlignmentBin> BuildAlignmentBins(
         Complex[] variableImpulseResponse,
@@ -2204,7 +2248,8 @@ public static class VirtualCrossoverAnalysis
             int sampleRate,
             double minFrequencyHz,
             double maxFrequencyHz,
-            bool levelMatch = false)
+            bool levelMatch = false,
+            bool requireDelayEvidence = false)
         {
             List<AlignmentBin> bins = BuildAlignmentBins(
                 variableImpulseResponse,
@@ -2215,7 +2260,8 @@ public static class VirtualCrossoverAnalysis
                 minDelayMs: -1,
                 maxDelayMs: 1,
                 levelMatch);
-            if (bins.Count == 0)
+            if (bins.Count == 0 ||
+                (requireDelayEvidence && !HoldsDelayEvidence(bins)))
             {
                 return null;
             }

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -475,10 +475,17 @@ public static class VirtualCrossoverAnalysis
 
     private static bool HoldsDelayEvidence(List<AlignmentBin> bins)
     {
+        // Observability is judged on the RAW magnitudes, before the
+        // search-side level match: the match may rescale the scoring frame,
+        // but it cannot manufacture a measurable overlap — a -60 dB filter
+        // tail amplified by the capped match would land exactly on the
+        // reliability gate and pass as "evidence" otherwise (review find).
         double signalPeak = 0;
         foreach (AlignmentBin bin in bins)
         {
-            signalPeak = Math.Max(signalPeak, bin.MagnitudeSum);
+            signalPeak = Math.Max(
+                signalPeak,
+                bin.FixedSum.Magnitude + bin.RawVariableMagnitude);
         }
         double levelFloor =
             signalPeak * Math.Pow(10.0, -EvidenceNoiseFloorGateDb / 20.0);
@@ -486,10 +493,10 @@ public static class VirtualCrossoverAnalysis
         bool Evidence(AlignmentBin bin)
         {
             double weaker = Math.Min(
-                bin.FixedSum.Magnitude, bin.Variable.Magnitude);
+                bin.FixedSum.Magnitude, bin.RawVariableMagnitude);
             double stronger = Math.Max(
-                bin.FixedSum.Magnitude, bin.Variable.Magnitude);
-            return bin.MagnitudeSum >= levelFloor &&
+                bin.FixedSum.Magnitude, bin.RawVariableMagnitude);
+            return bin.FixedSum.Magnitude + bin.RawVariableMagnitude >= levelFloor &&
                 weaker >= stronger * balanceRatio;
         }
 
@@ -1348,7 +1355,14 @@ public static class VirtualCrossoverAnalysis
         // The source FFT bin index, so consumers can tell truly ADJACENT
         // sampled bins from a gap where zero-magnitude bins were dropped —
         // the evidence-width gate must not credit a gap to a lone bin.
-        int FftBin);
+        int FftBin,
+        // The variable channel's magnitude BEFORE the search-side level
+        // match. Observability is a property of the measurement, not of the
+        // scoring frame: the delay-evidence gate must judge the raw balance,
+        // or a -60 dB filter tail amplified by the (capped) level match
+        // lands exactly on the reliability gate and votes as "evidence"
+        // (review find). FixedSum is never scaled, so it needs no raw twin.
+        double RawVariableMagnitude);
 
     // The direct-sound gate applied to every response before the alignment
     // spectra are taken: a cosine-faded Tukey window anchored one fade-length
@@ -1509,7 +1523,8 @@ public static class VirtualCrossoverAnalysis
                     variableValue,
                     1.0 / frequencyHz,
                     magnitudeSum,
-                    bin));
+                    bin,
+                    variableSpectrum[bin].Magnitude));
             }
         }
 

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -375,11 +375,12 @@ public static class VirtualCrossoverAnalysis
         double maxDelayMs,
         double? priorDelayMs = null,
         double priorSigmaMs = 0,
-        bool? forcedPolarity = null) =>
+        bool? forcedPolarity = null,
+        bool levelMatch = false) =>
         FindAlignmentCandidates(
             variableImpulseResponse, fixedImpulseResponses, sampleRate,
             minFrequencyHz, maxFrequencyHz, minDelayMs, maxDelayMs,
-            priorDelayMs, priorSigmaMs, forcedPolarity, out _);
+            priorDelayMs, priorSigmaMs, forcedPolarity, levelMatch, out _);
 
     /// <summary>
     /// The overload that also reports EVERY refined local optimum (best
@@ -401,6 +402,7 @@ public static class VirtualCrossoverAnalysis
         double? priorDelayMs,
         double priorSigmaMs,
         bool? forcedPolarity,
+        bool levelMatch,
         out IReadOnlyList<AlignmentCandidate> allOptima)
     {
         List<AlignmentBin> bins = BuildAlignmentBins(
@@ -410,7 +412,8 @@ public static class VirtualCrossoverAnalysis
             minFrequencyHz,
             maxFrequencyHz,
             minDelayMs,
-            maxDelayMs);
+            maxDelayMs,
+            levelMatch);
         if (bins.Count == 0 || !HoldsDelayEvidence(bins))
         {
             allOptima = Array.Empty<AlignmentCandidate>();
@@ -1383,6 +1386,13 @@ public static class VirtualCrossoverAnalysis
     // The per-bin spectra inside the frequency window, decimated to a bounded
     // bin count so the search stays fast for long IRs. The fixed channels act
     // as one combined source (superposition).
+    // The widest in-band level correction the search-side level match may
+    // apply, matched to OverlapReliabilityGateDb: a side sitting deeper than
+    // the reliability gate below its partner in the band is roll-off tail or
+    // deconvolution residue, and amplifying residue to parity would let the
+    // delay-evidence gate certify a junction that has no measurable overlap.
+    private const double LevelMatchCapDb = 30;
+
     private static List<AlignmentBin> BuildAlignmentBins(
         Complex[] variableImpulseResponse,
         IReadOnlyList<Complex[]> fixedImpulseResponses,
@@ -1390,7 +1400,8 @@ public static class VirtualCrossoverAnalysis
         double minFrequencyHz,
         double maxFrequencyHz,
         double minDelayMs,
-        double maxDelayMs)
+        double maxDelayMs,
+        bool levelMatch = false)
     {
         ArgumentNullException.ThrowIfNull(variableImpulseResponse);
         ArgumentNullException.ThrowIfNull(fixedImpulseResponses);
@@ -1450,10 +1461,43 @@ public static class VirtualCrossoverAnalysis
         }
 
         int stride = Math.Max(1, (lastBin - firstBin + 1) / 4_096);
+
+        // The search-side level match: score the junction as if the two sides
+        // were gain-matched IN THIS BAND. The true inter-channel timing does
+        // not depend on playback level, but the loss surface's power to
+        // resolve it does — the anti-phase null (the contrast between lobes)
+        // only reaches full depth at equal levels, and a 10 dB imbalance
+        // flattens the landscape until near-tie gates flip on noise (field
+        // case: a sub tuned to -10 dB re the midbass picked a lobe a full
+        // period late that 0 dB resolved cleanly — the level-match-first
+        // discipline every phase-alignment workflow prescribes, applied
+        // internally). One scalar per channel set preserves the spectral
+        // shapes; only the balance moves. Reported losses elsewhere keep the
+        // real gains — this is for the SEARCH's eyes only.
+        double variableScale = 1.0;
+        if (levelMatch)
+        {
+            double variableLevel = 0;
+            double fixedLevel = 0;
+            for (int bin = firstBin; bin <= lastBin; bin += stride)
+            {
+                double frequencyHz = bin * (double)sampleRate / length;
+                variableLevel += variableSpectrum[bin].Magnitude / frequencyHz;
+                fixedLevel += fixedSpectrum[bin].Magnitude / frequencyHz;
+            }
+            if (variableLevel > 0 && fixedLevel > 0)
+            {
+                double cap = Math.Pow(10.0, LevelMatchCapDb / 20.0);
+                variableScale = Math.Clamp(
+                    fixedLevel / variableLevel, 1.0 / cap, cap);
+            }
+        }
+
         for (int bin = firstBin; bin <= lastBin; bin += stride)
         {
+            Complex variableValue = variableSpectrum[bin] * variableScale;
             double magnitudeSum =
-                fixedSpectrum[bin].Magnitude + variableSpectrum[bin].Magnitude;
+                fixedSpectrum[bin].Magnitude + variableValue.Magnitude;
             if (magnitudeSum > 0)
             {
                 double frequencyHz = bin * (double)sampleRate / length;
@@ -1462,7 +1506,7 @@ public static class VirtualCrossoverAnalysis
                 bins.Add(new AlignmentBin(
                     omegaMs,
                     fixedSpectrum[bin],
-                    variableSpectrum[bin],
+                    variableValue,
                     1.0 / frequencyHz,
                     magnitudeSum,
                     bin));
@@ -1999,7 +2043,8 @@ public static class VirtualCrossoverAnalysis
         IReadOnlyList<Complex[]> fixedImpulseResponses,
         int sampleRate,
         double minFrequencyHz,
-        double maxFrequencyHz)
+        double maxFrequencyHz,
+        bool levelMatch = false)
     {
         // The delay window only gates parameter validation here — the
         // measurement itself evaluates the responses exactly as given.
@@ -2010,7 +2055,8 @@ public static class VirtualCrossoverAnalysis
             minFrequencyHz,
             maxFrequencyHz,
             minDelayMs: -1,
-            maxDelayMs: 1);
+            maxDelayMs: 1,
+            levelMatch);
         if (bins.Count == 0)
         {
             return null;
@@ -2129,7 +2175,8 @@ public static class VirtualCrossoverAnalysis
             IReadOnlyList<Complex[]> fixedImpulseResponses,
             int sampleRate,
             double minFrequencyHz,
-            double maxFrequencyHz)
+            double maxFrequencyHz,
+            bool levelMatch = false)
         {
             List<AlignmentBin> bins = BuildAlignmentBins(
                 variableImpulseResponse,
@@ -2138,7 +2185,8 @@ public static class VirtualCrossoverAnalysis
                 minFrequencyHz,
                 maxFrequencyHz,
                 minDelayMs: -1,
-                maxDelayMs: 1);
+                maxDelayMs: 1,
+                levelMatch);
             if (bins.Count == 0)
             {
                 return null;

--- a/tests/Resonalyze.Dsp.Tests/AlignmentSelectionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AlignmentSelectionTests.cs
@@ -105,6 +105,24 @@ public sealed class AlignmentSelectionTests
     }
 
     [Fact]
+    public void Select_JudgesPolarityPurityAgainstTheNeighbor()
+    {
+        // With an INVERTED settled neighbor the pure pair is the
+        // equally-inverted candidate: an absolute-flag preference used to
+        // "rescue" the mixed pair here and pay a quarter period of delay for
+        // the cosmetics (the field tweeter that slid off the onset line its
+        // inverted twin sat on).
+        var mixedNormal = new AlignmentCandidate(1.6, false, -0.50);
+        var pureInverted = new AlignmentCandidate(2.0, true, -0.60);
+
+        AlignmentCandidate chosen = AlignmentSelection.Select(
+            [mixedNormal, pureInverted], baseDeltaMs: 2.0,
+            neighborInverted: true);
+
+        Assert.Equal(pureInverted, chosen);
+    }
+
+    [Fact]
     public void Select_PrefersNonInvertedWithinMargin()
     {
         // The inverted impostor wins by less than the invert margin, so the

--- a/tests/Resonalyze.Dsp.Tests/AlignmentSelectionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AlignmentSelectionTests.cs
@@ -2,6 +2,91 @@ namespace Resonalyze.Dsp.Tests;
 
 public sealed class AlignmentSelectionTests
 {
+    // PreferSubLeading scores through LossDb so the tests control the
+    // prior-free figure directly (the engine passes its dip-penalized
+    // AcousticScore the same way).
+    private static double Score(AlignmentCandidate candidate) => candidate.LossDb;
+
+    [Fact]
+    public void PreferSubLeading_TrailingPickYieldsToLeadingLobeWithinMargin()
+    {
+        // The field shape (an 80 Hz sub junction, leadSign +1: the stack is
+        // searched, larger delay = sub leads): the chosen candidate leaves
+        // the sub trailing by ~1.8 ms and the leading lobe sits 0.7 dB down
+        // — inside the precedence margin, so psychoacoustics decide.
+        var trailing = new AlignmentCandidate(0.1, false, -0.8, LossDb: -0.7);
+        var leading = new AlignmentCandidate(5.8, true, -1.8, LossDb: -1.4);
+
+        AlignmentCandidate chosen = AlignmentSelection.PreferSubLeading(
+            [trailing, leading], trailing, Score,
+            anchorMs: 1.9, leadSign: 1.0,
+            marginDb: 1.0, slackMs: 0.5, reachMs: 12.5);
+
+        Assert.Equal(leading, chosen);
+    }
+
+    [Fact]
+    public void PreferSubLeading_KeepsTheTrailingPickBeyondTheMargin()
+    {
+        var trailing = new AlignmentCandidate(0.1, false, -0.8, LossDb: -0.7);
+        var leading = new AlignmentCandidate(5.8, true, -1.8, LossDb: -2.0);
+
+        AlignmentCandidate chosen = AlignmentSelection.PreferSubLeading(
+            [trailing, leading], trailing, Score,
+            anchorMs: 1.9, leadSign: 1.0,
+            marginDb: 1.0, slackMs: 0.5, reachMs: 12.5);
+
+        Assert.Equal(trailing, chosen);
+    }
+
+    [Fact]
+    public void PreferSubLeading_InertWhenTheChosenAlreadyLeads()
+    {
+        // Already on the leading side (and even inside the slack): nothing
+        // to re-decide, whatever else the pool holds.
+        var chosenLead = new AlignmentCandidate(2.1, false, -0.8, LossDb: -0.9);
+        var deeperLead = new AlignmentCandidate(4.5, false, -0.7, LossDb: -0.5);
+
+        AlignmentCandidate chosen = AlignmentSelection.PreferSubLeading(
+            [chosenLead, deeperLead], chosenLead, Score,
+            anchorMs: 1.9, leadSign: 1.0,
+            marginDb: 1.0, slackMs: 0.5, reachMs: 12.5);
+
+        Assert.Equal(chosenLead, chosen);
+    }
+
+    [Fact]
+    public void PreferSubLeading_IgnoresLeadsBeyondTheReach()
+    {
+        // A sub leading by whole periods is detached the other way: the only
+        // "leading" candidate sits past the reach, so the trailing pick stands.
+        var trailing = new AlignmentCandidate(0.1, false, -0.8, LossDb: -0.7);
+        var farLead = new AlignmentCandidate(16.0, false, -1.0, LossDb: -0.8);
+
+        AlignmentCandidate chosen = AlignmentSelection.PreferSubLeading(
+            [trailing, farLead], trailing, Score,
+            anchorMs: 1.9, leadSign: 1.0,
+            marginDb: 1.0, slackMs: 0.5, reachMs: 12.5);
+
+        Assert.Equal(trailing, chosen);
+    }
+
+    [Fact]
+    public void PreferSubLeading_LeadSignFlipsWhenTheSubItselfIsSearched()
+    {
+        // With the SUB searched (leadSign -1), the sub leads where its OWN
+        // delay is smaller than the anchor.
+        var trailing = new AlignmentCandidate(3.6, false, -0.8, LossDb: -0.7);
+        var leading = new AlignmentCandidate(-2.1, true, -1.8, LossDb: -1.2);
+
+        AlignmentCandidate chosen = AlignmentSelection.PreferSubLeading(
+            [trailing, leading], trailing, Score,
+            anchorMs: 1.9, leadSign: -1.0,
+            marginDb: 1.0, slackMs: 0.5, reachMs: 12.5);
+
+        Assert.Equal(leading, chosen);
+    }
+
     [Fact]
     public void Select_SingleCandidateIsReturned()
     {

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -439,6 +439,74 @@ public sealed class AutoAlignmentEngineTests
         Assert.InRange(alignment[mid].DelayMs, 3.0, 9.0);
     }
 
+    // The upper channel of the incomparable-probe case: its full band reads
+    // the (low-passed) direct front, but its upper half is owned by a strong
+    // high-passed late reflection — the half-band probe times a feature far
+    // LATER than the channel's own full-band front, so its certificate is
+    // UNVERIFIED: the probe is valid and clean, yet not the wavefront a
+    // latched partner's probe found.
+    private static Complex[] FrontWithLateHighReflection(
+        double frontMs, double reflectionMs, double reflectionGainDb)
+    {
+        Complex[] ir = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(BasePosition),
+            new DspChannelChain(
+                DelayMs: frontMs,
+                Crossover: new CrossoverSpec(
+                    CrossoverKind.LowPass,
+                    new CrossoverEdge(
+                        CrossoverFilterFamily.Butterworth, 150, 36))),
+            SampleRate);
+        Complex[] late = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(BasePosition),
+            new DspChannelChain(
+                GainDb: reflectionGainDb,
+                DelayMs: reflectionMs,
+                Crossover: new CrossoverSpec(
+                    CrossoverKind.HighPass,
+                    HighPassEdge: new CrossoverEdge(
+                        CrossoverFilterFamily.Butterworth, 220, 36))),
+            SampleRate);
+        for (int i = 0; i < ir.Length; i++)
+        {
+            ir[i] += late[i];
+        }
+        return ir;
+    }
+
+    [Fact]
+    public void Compute_ModalLatchWithIncomparableProbe_KeepsTheFullBandAnchor()
+    {
+        // One side convicted (its half-band probe found the true early
+        // front), the other UNVERIFIED: its probe timed a late high-passed
+        // reflection far behind its own full-band front. The two probes then
+        // time DIFFERENT physical events, so the pair must not re-anchor on
+        // them — the Pair line keeps the full-band arrivals and the reach
+        // veto stays armed (re-anchoring on incomparable probes was the
+        // review find on the second cut).
+        var midbass = new TestChannel("B", FrontUnderLateMode(5.0, 15.0, 2.0));
+        var mid = new TestChannel("C", FrontWithLateHighReflection(0.0, 8.0, 8));
+        var log = new StringBuilder();
+
+        try
+        {
+            Run([midbass, mid], [180], log);
+        }
+        catch (InvalidOperationException)
+        {
+            // A refused run (infeasible spread) is an acceptable outcome for
+            // this deliberately poisoned pair; the seed contract under test
+            // was logged before the refusal.
+        }
+
+        string text = log.ToString();
+        Assert.Contains("(modal latch)", text);
+        string pairLine = TestLog.Line(text, "Pair B/C");
+        // The latched side's full-band anchor (~37 ms) stands — no re-anchor
+        // onto the probes' mismatched wavefronts.
+        Assert.Contains("arrivals 37", pairLine);
+    }
+
     [Fact]
     public void Compute_SamePolarityRivalNearTie_IsNotTrustedAsTheSeed()
     {

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -409,6 +409,79 @@ public sealed class AutoAlignmentEngineTests
         Assert.Contains("WIDE SEED", TestLog.Line(text, "Channel C:"));
     }
 
+    // A channel whose LOW band arrives late and HIGH band early: two
+    // competing alignment lobes living in different halves of the pair band,
+    // the shape that makes the search's gain (in)variance measurable.
+    private static Complex[] SplitBandArrivals()
+    {
+        Complex[] low = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(BasePosition),
+            new DspChannelChain(
+                GainDb: 6,
+                DelayMs: 10.0,
+                Crossover: new CrossoverSpec(
+                    CrossoverKind.LowPass,
+                    new CrossoverEdge(
+                        CrossoverFilterFamily.Butterworth, 180, 36))),
+            SampleRate);
+        Complex[] high = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(BasePosition),
+            new DspChannelChain(
+                GainDb: -14,
+                DelayMs: 2.0,
+                Crossover: new CrossoverSpec(
+                    CrossoverKind.HighPass,
+                    HighPassEdge: new CrossoverEdge(
+                        CrossoverFilterFamily.Butterworth, 280, 36))),
+            SampleRate);
+        for (int i = 0; i < low.Length; i++)
+        {
+            low[i] += high[i];
+        }
+        return low;
+    }
+
+    [Fact]
+    public void FindAlignmentCandidates_LevelMatch_PinsTheWinnerAcrossGains()
+    {
+        // The discrimination weight of each bin rides the LEVEL BALANCE
+        // between the channels, so with two lobes living in different halves
+        // of the band the winner follows the variable channel's gain: at
+        // 0 dB the louder low half rules (align with the late low arrival),
+        // at -20 dB the equal-level region migrates into the quiet high half
+        // (align with the early high arrival). The precondition below proves
+        // this synthetic genuinely discriminates — without it a clean
+        // impulse pair stays green even with the level match broken. The
+        // level match must then pin ONE winner across 0/-10/-20 dB.
+        Complex[] fixedIr = SplitBandArrivals();
+        double WinnerMs(double gain, bool levelMatch)
+        {
+            Complex[] variable = UnitImpulse(BasePosition)
+                .Select(value => value * gain)
+                .ToArray();
+            IReadOnlyList<AlignmentCandidate> candidates =
+                VirtualCrossoverAnalysis.FindAlignmentCandidates(
+                    variable, [fixedIr], SampleRate, 90, 360, -1, 13,
+                    levelMatch: levelMatch);
+            Assert.NotEmpty(candidates);
+            return candidates[0].DelayMs;
+        }
+
+        double unmatchedLoud = WinnerMs(1.0, levelMatch: false);
+        double unmatchedQuiet = WinnerMs(0.1, levelMatch: false);
+        Assert.True(
+            Math.Abs(unmatchedLoud - unmatchedQuiet) > 2.0,
+            "the synthetic must discriminate: unmatched winners " +
+            $"{unmatchedLoud:0.000} vs {unmatchedQuiet:0.000} ms");
+
+        double matched = WinnerMs(1.0, levelMatch: true);
+        foreach (double gain in new[] { 0.316, 0.1 })
+        {
+            double winner = WinnerMs(gain, levelMatch: true);
+            Assert.InRange(winner, matched - 0.35, matched + 0.35);
+        }
+    }
+
     [Fact]
     public void Compute_ModalLatchOnTheArrival_ReanchorsOnTheHalfBandReads()
     {

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -59,6 +59,45 @@ public sealed class AutoAlignmentEngineTests
         return ir;
     }
 
+    // A SOFT band-limited front under a strong late resonant build-up BELOW
+    // the pair band — the field shape of the modal latch. The front is an
+    // impulse smeared by a band-pass (a real driver through its crossover has
+    // no sharp click), so in the full pair band its low envelope hides below
+    // the 25 dB arrival search depth under the modes' bulk; the band's UPPER
+    // half sits past the modes, where the front stands alone. Causal decaying
+    // sines keep the record's tail (and with it the SNR grade) clean, unlike
+    // a windowed tone burst whose spectral leakage rings across the record.
+    private static Complex[] FrontUnderLateMode(
+        double frontMs, double modeMs, double modeAmplitude)
+    {
+        Complex[] ir = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(BasePosition),
+            new DspChannelChain(
+                DelayMs: frontMs,
+                Crossover: new CrossoverSpec(
+                    CrossoverKind.BandPass,
+                    new CrossoverEdge(CrossoverFilterFamily.Butterworth, 800, 24),
+                    new CrossoverEdge(CrossoverFilterFamily.Butterworth, 80, 24))),
+            SampleRate);
+        int start = BasePosition + (int)Math.Round(modeMs / 1000.0 * SampleRate);
+        // A smooth attack keeps the build-up's onset out of the band's upper
+        // half — an abruptly switched sine is itself a broadband click there.
+        const double AttackSeconds = 0.008;
+        const double DecaySeconds = 0.1;
+        foreach (double modeHz in new[] { 65.0, 72.0, 80.0 })
+        {
+            for (int i = start; i < ir.Length; i++)
+            {
+                double t = (i - start) / (double)SampleRate;
+                ir[i] += modeAmplitude *
+                    (1 - Math.Exp(-t / AttackSeconds)) *
+                    Math.Exp(-t / DecaySeconds) *
+                    Math.Sin(2 * Math.PI * modeHz * t);
+            }
+        }
+        return ir;
+    }
+
     private static Dictionary<IAlignmentChannel, AlignmentOverride> Run(
         TestChannel[] byBand,
         double[] crossoversHz,
@@ -368,6 +407,36 @@ public sealed class AutoAlignmentEngineTests
             "seed arrival (peak beyond the arrival's reach)",
             TestLog.Line(text, "Pair B/C"));
         Assert.Contains("WIDE SEED", TestLog.Line(text, "Channel C:"));
+    }
+
+    [Fact]
+    public void Compute_ModalLatchOnTheArrival_ReanchorsOnTheHalfBandReads()
+    {
+        // The field failure this pins (a 180 Hz midbass/mid junction under a
+        // steep LP): the lower channel's soft direct front hides below the
+        // 25 dB envelope search depth under a strong late resonant build-up
+        // below the band, so the full-band arrival reads the build-up at
+        // ~37 ms, over 20 ms late — while the band's upper half still reads
+        // the front at ~15 ms. The honesty probe must convict that latch and
+        // the pair must re-anchor on the half-band reads: the timeline then
+        // seeds near the true ~5.6 ms relation instead of parking a channel
+        // tens of ms off (the field run inverted the mids a full period out).
+        var midbass = new TestChannel(
+            "B", FrontUnderLateMode(5.0, 15.0, 2.0));
+        var mid = new TestChannel("C", DelayedImpulse(0.0));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([midbass, mid], [180], log);
+
+        string text = log.ToString();
+        Assert.False(alignment.ContainsKey(midbass));
+        Assert.Contains("(modal latch)", text);
+        // Re-anchored on the half-band front (~15 ms), not the ~37 ms mode.
+        Assert.Contains("arrivals 15", TestLog.Line(text, "Pair B/C"));
+        // The mid lands near its true relation to the front — the latched
+        // read would have based the search two dozen ms away.
+        Assert.InRange(alignment[mid].DelayMs, 3.0, 9.0);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -747,6 +747,75 @@ public sealed class StereoAlignmentTests
     }
 
     [Fact]
+    public void ComoveMonoChannels_SubBandInconsistentHop_IsVetoed()
+    {
+        // The field failure this pins (an 80 Hz sub junction): both woofers
+        // carry a strong inverted narrowband build-up in the junction band's
+        // UPPER half, half a period behind their direct front. Through the
+        // full-band mean the sub then "gains" by flipping onto that build-up
+        // (a comb impostor the margin gate cannot refuse), while the clean
+        // LOWER half — direct sound only — plainly loses. The sub-band
+        // consistency veto is the cross-check narrow-band ranging disciplines
+        // converge on: a true lobe holds every half of the band, an impostor
+        // wins one half and loses the other.
+        Complex[] WooferIr()
+        {
+            Complex[] ir = ImpulseAtMs(8.0);
+            Complex[] mode = VirtualCrossoverAnalysis.ApplyChain(
+                ImpulseAtMs(8.0 + 6.25, -10.0),
+                new DspChannelChain(Crossover: new CrossoverSpec(
+                    CrossoverKind.BandPass,
+                    new CrossoverEdge(CrossoverFilterFamily.Butterworth, 150, 36),
+                    new CrossoverEdge(CrossoverFilterFamily.Butterworth, 100, 36))),
+                SampleRate);
+            for (int i = 0; i < ir.Length; i++)
+            {
+                ir[i] += mode[i];
+            }
+            return ir;
+        }
+        var sub = new TestChannel("sub", ImpulseAtMs(8.0));
+        var leftWoof = new TestChannel("L woof", WooferIr());
+        var rightWoof = new TestChannel("R woof", WooferIr());
+        TestChannel[] all = [sub, leftWoof, rightWoof];
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            all.Select(channel =>
+                Snapshot(channel, overrides.GetValueOrDefault(channel))).ToList();
+        List<AlignmentSnapshot> snapshots = all
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        var plan = new StereoAlignmentPlan(
+            [snapshots[0], snapshots[1]],
+            [Junction(snapshots[0], snapshots[1], 80)],
+            [snapshots[0], snapshots[2]],
+            [Junction(snapshots[0], snapshots[2], 80)],
+            new HashSet<IAlignmentChannel> { sub },
+            leftWoof,
+            rightWoof,
+            40,
+            160,
+            SceneOffsetMs: 0);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [sub] = new(0, false),
+            [leftWoof] = new(0, false),
+            [rightWoof] = new(0, false)
+        };
+        var log = new StringBuilder();
+
+        AutoAlignmentEngine.ComoveMonoChannels(
+            plan, Reprocess, alignment, log, snapshots);
+
+        Assert.Contains("mono lobe hop vetoed for sub", log.ToString());
+        // The sub stays on the direct-sound lobe: no flip, at most an in-lobe
+        // polish away from the aligned position.
+        Assert.False(alignment[sub].InvertPolarity);
+        Assert.InRange(
+            alignment[sub].DelayMs - alignment[leftWoof].DelayMs, -2.5, 2.5);
+    }
+
+    [Fact]
     public void ComoveMonoChannels_RefreshesTheStaleDecision()
     {
         // The same system as the invariance test above: both woofers want the

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -816,6 +816,54 @@ public sealed class StereoAlignmentTests
     }
 
     [Fact]
+    public void ComoveMonoChannels_UnmeasurableRightJunction_AbstainsEntirely()
+    {
+        // The right sub junction never faced the walk's structure gate on
+        // its own (the descent certifies a COMBINED band), so the co-move
+        // certifies every junction itself — and with the right woofer only a
+        // -60 dB residue, the whole co-move must abstain rather than move
+        // the sub judged by the healthy left junction alone: that would
+        // merely re-optimize what the walk already settled (review find).
+        var sub = new TestChannel("sub", ImpulseAtMs(10.0));
+        var leftWoof = new TestChannel("L woof", ImpulseAtMs(8.0));
+        var rightWoof = new TestChannel("R woof", ImpulseAtMs(7.5, 0.001));
+        TestChannel[] all = [sub, leftWoof, rightWoof];
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            all.Select(channel =>
+                Snapshot(channel, overrides.GetValueOrDefault(channel))).ToList();
+        List<AlignmentSnapshot> snapshots = all
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        var plan = new StereoAlignmentPlan(
+            [snapshots[0], snapshots[1]],
+            [Junction(snapshots[0], snapshots[1], 80)],
+            [snapshots[0], snapshots[2]],
+            [Junction(snapshots[0], snapshots[2], 80)],
+            new HashSet<IAlignmentChannel> { sub },
+            leftWoof,
+            rightWoof,
+            40,
+            160,
+            SceneOffsetMs: 0);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [sub] = new(0, false),
+            [leftWoof] = new(1.0, false),
+            [rightWoof] = new(1.0, false)
+        };
+        var log = new StringBuilder();
+
+        AutoAlignmentEngine.ComoveMonoChannels(
+            plan, Reprocess, alignment, log, snapshots);
+
+        Assert.Contains("mono co-move skipped for sub", log.ToString());
+        Assert.DoesNotContain("Co-move sub:", log.ToString());
+        Assert.Equal(0, alignment[sub].DelayMs);
+        Assert.False(alignment[sub].InvertPolarity);
+    }
+
+    [Fact]
     public void ComoveMonoChannels_RefreshesTheStaleDecision()
     {
         // The same system as the invariance test above: both woofers want the

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -15,6 +15,26 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void MeasureSumLoss_LevelMatchedMinus60DbTail_HasNoDelayEvidence()
+    {
+        // A variable channel that is only a -60 dB residue of the fixed one:
+        // the capped (+30 dB) search-side level match lifts it to exactly
+        // the -30 dB reliability gate, where a matched-magnitude evidence
+        // read would pass it as measurable overlap. Observability must be
+        // judged on the RAW balance — the level match rescales the scoring
+        // frame, it cannot manufacture a measurable delay.
+        Complex[] fixedIr = UnitImpulse(4_096, 100);
+        var tail = new Complex[4_096];
+        tail[120] = 0.001; // -60 dB, same broadband spectral shape.
+
+        (double LossDb, double DipDb)? loss = VirtualCrossoverAnalysis.MeasureSumLoss(
+            tail, [fixedIr], SampleRate, 500, 2_000,
+            levelMatch: true, requireDelayEvidence: true);
+
+        Assert.Null(loss);
+    }
+
+    [Fact]
     public void PredictedAverageSumLossDb_AlignedImpulsesSumWithoutLoss()
     {
         Complex[] a = UnitImpulse(4_096, 100);

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -35,6 +35,33 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void FindAlignmentCandidates_LevelMatch_CandidatesAreGainInvariant()
+    {
+        // The same physical pair at 0, -10 and -20 dB of variable-channel
+        // gain must produce the same lobe choices: the level match rescales
+        // the scoring frame, so within its documented ±30 dB cap the search
+        // cannot follow the playback gains.
+        Complex[] fixedIr = UnitImpulse(4_096, 100);
+        Complex[] reference = UnitImpulse(4_096, 120);
+        double? baselineDelayMs = null;
+        foreach (double gain in new[] { 1.0, 0.316, 0.1 })
+        {
+            Complex[] variable = reference.Select(value => value * gain).ToArray();
+            IReadOnlyList<AlignmentCandidate> candidates =
+                VirtualCrossoverAnalysis.FindAlignmentCandidates(
+                    variable, [fixedIr], SampleRate, 500, 2_000, -2, 2,
+                    levelMatch: true);
+            Assert.NotEmpty(candidates);
+            baselineDelayMs ??= candidates[0].DelayMs;
+            Assert.InRange(
+                candidates[0].DelayMs,
+                baselineDelayMs.Value - 0.005,
+                baselineDelayMs.Value + 0.005);
+            Assert.False(candidates[0].InvertPolarity);
+        }
+    }
+
+    [Fact]
     public void PredictedAverageSumLossDb_AlignedImpulsesSumWithoutLoss()
     {
         Complex[] a = UnitImpulse(4_096, 100);

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -35,33 +35,6 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
-    public void FindAlignmentCandidates_LevelMatch_CandidatesAreGainInvariant()
-    {
-        // The same physical pair at 0, -10 and -20 dB of variable-channel
-        // gain must produce the same lobe choices: the level match rescales
-        // the scoring frame, so within its documented ±30 dB cap the search
-        // cannot follow the playback gains.
-        Complex[] fixedIr = UnitImpulse(4_096, 100);
-        Complex[] reference = UnitImpulse(4_096, 120);
-        double? baselineDelayMs = null;
-        foreach (double gain in new[] { 1.0, 0.316, 0.1 })
-        {
-            Complex[] variable = reference.Select(value => value * gain).ToArray();
-            IReadOnlyList<AlignmentCandidate> candidates =
-                VirtualCrossoverAnalysis.FindAlignmentCandidates(
-                    variable, [fixedIr], SampleRate, 500, 2_000, -2, 2,
-                    levelMatch: true);
-            Assert.NotEmpty(candidates);
-            baselineDelayMs ??= candidates[0].DelayMs;
-            Assert.InRange(
-                candidates[0].DelayMs,
-                baselineDelayMs.Value - 0.005,
-                baselineDelayMs.Value + 0.005);
-            Assert.False(candidates[0].InvertPolarity);
-        }
-    }
-
-    [Fact]
     public void PredictedAverageSumLossDb_AlignedImpulsesSumWithoutLoss()
     {
         Complex[] a = UnitImpulse(4_096, 100);


### PR DESCRIPTION
## Summary

A field series against one root cause — a 90–180 Hz cabin mode overpowering the direct front under steep low-frequency crossover slopes — that grew, through three review rounds and an owner listening test, into a coherent set of auto-delay defenses plus two search-policy changes. Every step was validated by replaying the real cabin sessions headlessly and by a 16-config midbass/mid crossover matrix.

### Modal-latch defenses

1. **Pair-seed honesty probe** (`BuildArrivalTimeline`): the direct front can hide below the 25 dB envelope search depth under a late modal build-up, so the arrival reads the mode ~10 ms late and the seed-reach rule then vetoes the *honest* GCC-PHAT extremum. The timeline now probes both pair arrivals (full band vs upper half, the shared `ClassifyArrival`); a convicted latch re-anchors the pair on the half-band reads — only when both sides' certificates are comparable (not `Unverified`) — and only an actually re-anchored pair lifts the reach veto.
2. **Cross-side link witness**: the link certificate can self-verify when the mode covers the link band's upper half; a fabricated −8.4 ms L/R split then scene-locks the right midbass ~11 ms early. The junction band now doubles as the link certificate's witness, with a same-feature test (the link read must have timed the very feature the witness convicted); a convicted link descends the existing ladder to the corroborated donor splits.
3. **Sub-band consistency veto** for the mono co-move: a lobe/polarity hop that clears the margin must also hold every measurable `(junction, half-band)` cell — an in-room mode can flatter a comb impostor through the full-band mean while the clean half plainly loses. Cells vote only where delay evidence exists, judged on **raw** (pre-level-match) magnitudes; the co-move abstains entirely when any of its junctions holds no evidence (the right sub junction is never certified individually by the walk).

### Search-policy changes

4. **Level-matched junction scoring**: the anti-phase null — the loss surface's contrast between lobes — only reaches full depth at equal levels, so a −10 dB sub gain used to flip the chosen lobe a full period (owner heard the bass lagging). Every junction is now scored as if gain-matched in that band (one scalar, spectral shape preserved, capped at 30 dB); reported losses, the metric panel and gain balance keep the real gains. Candidates are gain-invariant within the cap; past it the log asks to level the gains first.
5. **Sub-precedence preference**: between the comb lobe that leaves the mono sub trailing the stack and the one that leaves it leading, the summation is not an honest judge (comb noise between real lobes runs to ~1.4 dB) but perception is one-sided — the first wavefront binds the bass to the localizable midbass transient. Within a 1.0 dB prior-free margin the leading lobe wins. Owner-calibrated (A/B listening: the trailing tune "lags", the leading one localizes the bass to the front stage); the decision report explicitly states when this policy overrode the acoustic best.
6. **Pairwise polarity purity + minimal-flip presentation**: the invert preference now judges candidates against the settled neighbor's polarity (purity is a property of the pair — the absolute-flag rescue used to produce mixed mid/tweeter pairs a quarter period off the onset line), and a final global flip presents the result with the minimal set of Invert switches (a global flip changes no relation).

## Validation

- Field sessions and the validation harness are **published** at [Resonalyze-test-data](https://github.com/DIMOSUS/Resonalyze-test-data): both cabins' records, the failure sessions (`v3/virtual-dsp-session_bad.json`, `_bad2.json`), the ear-validated reference (`v3/session_validated.json`) and `harness/RealDataAlignmentHarness.cs` (drop into `tests/Resonalyze.App.Tests/`, point `RESONALYZE_FIELD_DATA_V3`/`_V2` at the checkout — CI-safe, returns silently without the data). Both failing sessions repaired; the ear-validated session reproduces the owner's hand tune (sub inverted, clean stack, C–D paired, all IR onsets on one line) identically at −10 and 0 dB sub gain; the reference `head_90_grad` cabin stays bit-identical through every defense.
- 16-config crossover matrix: pre-series, all four LP 180/36 configs stranded 9–12 ms off every landscape lobe; post-series every config sits on a real lobe.
- Suites: Dsp 845, App 509. Each defense carries a synthetic regression that fails without it, including the review sketches (`MeasureSumLoss_LevelMatchedMinus60DbTail_HasNoDelayEvidence`, comparable-probe re-anchor, co-move abstention, gain-invariance at 0/−10/−20 dB).

## Known limits (documented, deferred)

- Gain invariance is bounded by the 30 dB level-match cap (the underlying post-gain evidence read predates this PR); the log now warns past the cap.
- The pair honesty probe can in principle self-verify a mode that covers the upper half of a *pair* band (the link-band analogue is fixed here); a conflict-triggered deeper probe rung is a follow-up task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
