### PR TITLE
Audition: subtract a typical cabin transfer function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1873,9 +1873,10 @@ it defaults to Off because the measurements are loopback-referenced.
   so both corrections cost one filter): the raw render reproduces the full
   in-car bass rise as headphone boom the in-car listener never perceives, while
   the subtracted render leaves this car's deviation from the typical curve
-  audible. Renders are peak-normalized, not loudness-matched, so an A/B between
-  cabin choices compares tone balance rather than level. Listen through
-  **headphones only**: each ear gets the
+  audible. The subtracted render is level-matched to the same tune without the
+  subtraction, so an A/B between cabin choices differs in tone, not loudness —
+  the removed bass reads as quieter bass, not a track the normalizer turned back
+  up. Listen through **headphones only**: each ear gets the
   measured acoustic path of its side at the microphone position (drivers,
   cabin, and capsule included) — a stereo auralization of the two sides, not a
   binaural head simulation — and playing it back through the car would

--- a/README.md
+++ b/README.md
@@ -1866,7 +1866,13 @@ it defaults to Off because the measurements are loopback-referenced.
   measured responses are never resampled), both channels share one
   normalization gain so the L/R balance survives, and re-rendering with a
   different calibration or after a settings tweak is one click — a quick A/B
-  between tune variants. Listen through **headphones only**: each ear gets the
+  between tune variants. **Subtract cabin** optionally removes a typical
+  body-style cabin transfer function (average sedan, hatchback, SUV, and
+  friends — the pressure-zone bass rise that reaches +15…+27 dB at 20 Hz) as
+  an inverse linear-phase FIR in both kernels: the raw render reproduces the
+  full in-car bass rise as headphone boom the in-car listener never perceives,
+  while the subtracted render leaves this car's deviation from the typical
+  curve audible. Listen through **headphones only**: each ear gets the
   measured acoustic path of its side at the microphone position (drivers,
   cabin, and capsule included) — a stereo auralization of the two sides, not a
   binaural head simulation — and playing it back through the car would

--- a/README.md
+++ b/README.md
@@ -1869,10 +1869,13 @@ it defaults to Off because the measurements are loopback-referenced.
   between tune variants. **Subtract cabin** optionally removes a typical
   body-style cabin transfer function (average sedan, hatchback, SUV, and
   friends — the pressure-zone bass rise that reaches +15…+27 dB at 20 Hz) as
-  an inverse linear-phase FIR in both kernels: the raw render reproduces the
-  full in-car bass rise as headphone boom the in-car listener never perceives,
-  while the subtracted render leaves this car's deviation from the typical
-  curve audible. Listen through **headphones only**: each ear gets the
+  an inverse linear-phase FIR in both kernels (folded into the calibration FIR,
+  so both corrections cost one filter): the raw render reproduces the full
+  in-car bass rise as headphone boom the in-car listener never perceives, while
+  the subtracted render leaves this car's deviation from the typical curve
+  audible. Renders are peak-normalized, not loudness-matched, so an A/B between
+  cabin choices compares tone balance rather than level. Listen through
+  **headphones only**: each ear gets the
   measured acoustic path of its side at the microphone position (drivers,
   cabin, and capsule included) — a stereo auralization of the two sides, not a
   binaural head simulation — and playing it back through the car would

--- a/dsp/Auralization.cs
+++ b/dsp/Auralization.cs
@@ -175,17 +175,49 @@ public static class Auralization
             right = convertedRight;
         }
 
+        // Reference kernels turn the normalization into a level-MATCHED one: the
+        // same source is convolved through a second pair of kernels (typically
+        // the tune WITHOUT the cabin subtraction) purely to read that render's
+        // peak. Rendered from the already-resampled source, so the material is
+        // converted only once. Their peak feeds the divisor below, so two renders
+        // that differ only by the reference (an A/B of cabin choices) come out at
+        // one shared gain and the difference stays audible instead of being
+        // normalized away. The reference outputs are read for their peak and
+        // dropped; only the real render is kept.
+        bool hasReference =
+            request.ReferenceLeftKernel != null && request.ReferenceRightKernel != null;
+        int convolvePasses = hasReference ? 4 : 2;
         double convolveShare = resampled ? 1.0 - ResampleProgressShare : 1.0;
         double convolveBase = resampled ? ResampleProgressShare : 0.0;
+        double passShare = convolveShare / convolvePasses;
+        int pass = 0;
+
+        double referencePeak = 0.0;
+        if (hasReference)
+        {
+            float[] referenceLeft = FastConvolution.Convolve(
+                left,
+                request.ReferenceLeftKernel!,
+                Scaled(progress, convolveBase + passShare * pass++, passShare),
+                cancellationToken);
+            float[] referenceRight = FastConvolution.Convolve(
+                right,
+                request.ReferenceRightKernel!,
+                Scaled(progress, convolveBase + passShare * pass++, passShare),
+                cancellationToken);
+            referencePeak = Math.Max(
+                AbsolutePeak(referenceLeft), AbsolutePeak(referenceRight));
+        }
+
         float[] renderedLeft = FastConvolution.Convolve(
             left,
             request.LeftKernel,
-            Scaled(progress, convolveBase, convolveShare / 2.0),
+            Scaled(progress, convolveBase + passShare * pass++, passShare),
             cancellationToken);
         float[] renderedRight = FastConvolution.Convolve(
             right,
             request.RightKernel,
-            Scaled(progress, convolveBase + convolveShare / 2.0, convolveShare / 2.0),
+            Scaled(progress, convolveBase + passShare * pass++, passShare),
             cancellationToken);
 
         // The kernels are trimmed per side, so the two convolutions come out at
@@ -197,7 +229,8 @@ public static class Auralization
         renderedRight = PadTo(renderedRight, commonLength);
 
         double gain = Normalize(
-            renderedLeft, renderedRight, request.PeakTargetDbfs, cancellationToken);
+            renderedLeft, renderedRight, referencePeak,
+            request.PeakTargetDbfs, cancellationToken);
         progress?.Report(1.0);
         return new AuralizationResult(
             [renderedLeft, renderedRight],
@@ -212,14 +245,21 @@ public static class Auralization
     private const double ResampleProgressShare = 0.2;
 
     // One gain for BOTH channels: scaling the sides independently would level the
-    // very inter-side balance the tune is being auditioned for.
+    // very inter-side balance the tune is being auditioned for. The divisor is
+    // the LARGEST peak in play — both channels and, when a level-matched render
+    // was asked for, the reference render's peak too. Dividing by the larger
+    // peak is the smaller of the two candidate gains: it cannot clip either
+    // render, and it pins this render to the reference's level so the two are
+    // directly comparable.
     private static double Normalize(
         float[] left,
         float[] right,
+        double referencePeak,
         double peakTargetDbfs,
         CancellationToken cancellationToken)
     {
-        double peak = Math.Max(AbsolutePeak(left), AbsolutePeak(right));
+        double peak = Math.Max(
+            Math.Max(AbsolutePeak(left), AbsolutePeak(right)), referencePeak);
         if (peak <= 0)
         {
             return 1.0;
@@ -319,6 +359,17 @@ public sealed record AuralizationRequest
 
     /// <summary>Trimmed summed response of the right side of the car.</summary>
     public required double[] RightKernel { get; init; }
+
+    /// <summary>
+    /// Optional left kernel of a REFERENCE render used only for level matching:
+    /// the source is convolved through it to read its peak, and the main render
+    /// is normalized to the larger of its own and this peak, so the two land at
+    /// one gain. Both reference kernels must be set together, or neither.
+    /// </summary>
+    public double[]? ReferenceLeftKernel { get; init; }
+
+    /// <summary>Right counterpart of <see cref="ReferenceLeftKernel"/>.</summary>
+    public double[]? ReferenceRightKernel { get; init; }
 
     /// <summary>The project's rate — both kernels share it, and the render adopts it.</summary>
     public required int KernelSampleRate { get; init; }

--- a/dsp/CabinTransferFunction.cs
+++ b/dsp/CabinTransferFunction.cs
@@ -1,0 +1,133 @@
+namespace Resonalyze.Dsp;
+
+/// <summary>Body styles with a bundled typical cabin transfer function.</summary>
+public enum CabinBodyStyle
+{
+    Sedan,
+    CompactSedan,
+    Hatchback,
+    Wagon,
+    Suv,
+    BmwF30SkiHatch
+}
+
+/// <summary>
+/// A TYPICAL cabin transfer function — the bass rise a car interior adds to a
+/// source's free-field response. Below the corner (the pressure-zone onset,
+/// c/2L for the cabin's longest dimension L) the cabin behaves like a sealed
+/// box around the listener and the gain climbs at a constant dB/octave with no
+/// saturation: published measurements reach +17 dB at 20 Hz for an averaged
+/// sedan, +23.5 dB for a hatchback, +27 dB for a compact sedan with the
+/// enclosure coupled straight into the cabin. This is deliberately NOT a
+/// target curve — targets sit far lower because the subwoofer's own
+/// low-frequency roll-off eats most of the cabin rise.
+/// <para>
+/// Most presets are the two-parameter pressure-zone shape (corner + slope with
+/// a soft knee). A trunk coupled through an opening does not fit it — the
+/// trunk-plus-hatch path behaves as an acoustic low-pass and the measured
+/// curve breaks over a steep cliff near the corner — so such presets are
+/// tabulated from an actual measurement instead.
+/// </para>
+/// <para>
+/// Either way the shape is the idealized envelope only. Real cabins ride
+/// modal peaks and nulls on top of it, and those stay in the audition on
+/// purpose: subtracting the typical envelope leaves exactly this car's
+/// deviation from it audible.
+/// </para>
+/// </summary>
+public sealed class CabinTransferFunction
+{
+    // Knee width of the parametric corner transition, chosen against the
+    // published averaged-sedan table (17/8/3/1.3 dB at 20/40/63/80 Hz for a
+    // 70 Hz corner): sharpness 3 reproduces those four anchors within ~0.5 dB.
+    private const double KneeSharpness = 3.0;
+
+    // Evaluation floor: the FIR design samples the curve at the 0 Hz bin,
+    // where the log-frequency slope has no value. Clamping to 1 Hz keeps DC
+    // finite while still attenuating it far below anything audible.
+    private const double MinimumFrequencyHz = 1.0;
+
+    private readonly Func<double, double> gainDb;
+
+    private CabinTransferFunction(Func<double, double> gainDb)
+    {
+        this.gainDb = gainDb;
+    }
+
+    /// <summary>
+    /// The typical curve for a body style. Corner tracks cabin length
+    /// (c/2L: lower for the long SUV cabin, higher for short ones); slope
+    /// tracks how directly the low-frequency source couples into how sealed a
+    /// volume (theory says 12 dB/oct for a perfectly tight cabin, leaky
+    /// trunk-isolated sedans measure nearer 9).
+    /// </summary>
+    public static CabinTransferFunction FromBodyStyle(CabinBodyStyle bodyStyle) =>
+        bodyStyle switch
+        {
+            CabinBodyStyle.Sedan => Sloped(cornerHz: 70, slopeDbPerOctave: 9),
+            CabinBodyStyle.CompactSedan => Sloped(80, 13.5),
+            CabinBodyStyle.Hatchback => Sloped(80, 12),
+            CabinBodyStyle.Wagon => Sloped(70, 11),
+            CabinBodyStyle.Suv => Sloped(55, 10),
+            // Read off an owner measurement (driver's seat vs nearfield at the
+            // sub, normalized to the 80–150 Hz shelf): ~11 dB/oct below 50 Hz,
+            // then a ~30 dB/oct cliff where the trunk-through-hatch coupling
+            // gives out.
+            CabinBodyStyle.BmwF30SkiHatch => Tabulated(
+                (20, 34.0),
+                (25, 30.0),
+                (31.5, 27.5),
+                (40, 23.5),
+                (50, 19.5),
+                (63, 11.0),
+                (70, 6.5),
+                (80, 1.0),
+                (95, 0.0)),
+            _ => throw new ArgumentOutOfRangeException(nameof(bodyStyle))
+        };
+
+    /// <summary>Cabin gain in dB at the given frequency (0 above the corner).</summary>
+    public double Evaluate(double frequencyHz) =>
+        gainDb(Math.Max(frequencyHz, MinimumFrequencyHz));
+
+    private static CabinTransferFunction Sloped(
+        double cornerHz, double slopeDbPerOctave) =>
+        new(frequencyHz =>
+            slopeDbPerOctave * SoftPlus(Math.Log2(cornerHz / frequencyHz)));
+
+    // Piecewise-linear in log-frequency over measured (Hz, dB) anchors, given
+    // in ascending frequency with the last gain 0: flat (0) above the last
+    // point, the first segment's slope extended below the first.
+    private static CabinTransferFunction Tabulated(
+        params (double FrequencyHz, double GainDb)[] points) =>
+        new(frequencyHz =>
+        {
+            if (frequencyHz >= points[^1].FrequencyHz)
+            {
+                return 0.0;
+            }
+
+            int upper = 1;
+            while (upper < points.Length - 1 &&
+                points[upper].FrequencyHz <= frequencyHz)
+            {
+                upper++;
+            }
+
+            (double lowHz, double lowDb) = points[upper - 1];
+            (double highHz, double highDb) = points[upper];
+            double position = Math.Log2(frequencyHz / lowHz) /
+                Math.Log2(highHz / lowHz);
+            return lowDb + (highDb - lowDb) * position;
+        });
+
+    // Softplus in octaves: → x well below the corner (constant dB/octave), → 0
+    // well above it, smooth at the knee. Written in the overflow-safe form —
+    // exp() only ever sees a non-positive argument.
+    private static double SoftPlus(double octaves)
+    {
+        double scaled = KneeSharpness * octaves;
+        return (Math.Max(scaled, 0) +
+            Math.Log(1 + Math.Exp(-Math.Abs(scaled)))) / KneeSharpness;
+    }
+}

--- a/dsp/CabinTransferFunction.cs
+++ b/dsp/CabinTransferFunction.cs
@@ -13,14 +13,21 @@ public enum CabinBodyStyle
 
 /// <summary>
 /// A TYPICAL cabin transfer function — the bass rise a car interior adds to a
-/// source's free-field response. Below the corner (the pressure-zone onset,
-/// c/2L for the cabin's longest dimension L) the cabin behaves like a sealed
-/// box around the listener and the gain climbs at a constant dB/octave with no
-/// saturation: published measurements reach +17 dB at 20 Hz for an averaged
-/// sedan, +23.5 dB for a hatchback, +27 dB for a compact sedan with the
-/// enclosure coupled straight into the cabin. This is deliberately NOT a
-/// target curve — targets sit far lower because the subwoofer's own
-/// low-frequency roll-off eats most of the cabin rise.
+/// source's free-field response. Below the corner the cabin behaves like a
+/// sealed box around the listener and the gain climbs at a constant dB/octave:
+/// published measurements reach +17 dB at 20 Hz for an averaged sedan, +23.5 dB
+/// for a hatchback, +27 dB for a compact sedan with the enclosure coupled
+/// straight into the cabin. This is deliberately NOT a target curve — targets
+/// sit far lower because the subwoofer's own low-frequency roll-off eats most
+/// of the cabin rise.
+/// <para>
+/// The "corner" is the KNEE CENTRE (near the pressure-zone onset c/2L for the
+/// cabin's longest dimension L), not a hard edge: the soft knee leaves a couple
+/// of dB still standing at the corner itself and has decayed to a fraction of a
+/// dB an octave above it. Below the audible band the rise is capped
+/// (<see cref="MaximumSubtractionDb"/>) rather than run to the tens of dB the
+/// slope would reach at DC — that region is unmeasured, and an unbounded notch
+/// there only buys the correction FIR deep, long infrasonic ringing.
 /// <para>
 /// Most presets are the two-parameter pressure-zone shape (corner + slope with
 /// a soft knee). A trunk coupled through an opening does not fit it — the
@@ -46,6 +53,14 @@ public sealed class CabinTransferFunction
     // where the log-frequency slope has no value. Clamping to 1 Hz keeps DC
     // finite while still attenuating it far below anything audible.
     private const double MinimumFrequencyHz = 1.0;
+
+    // The rise is measured/modeled only in the audible bass; below it the slope
+    // (or a table's steepest segment) would run to many tens of dB by DC, an
+    // unmeasured near-total notch whose only audible consequence is the
+    // correction FIR's infrasonic ringing. Cap the subtraction here — above
+    // every preset's deepest ANCHOR (the F30's +34 dB at 20 Hz), so no
+    // measured point is clipped, only the extrapolated tail.
+    private const double MaximumSubtractionDb = 40.0;
 
     private readonly Func<double, double> gainDb;
 
@@ -86,9 +101,15 @@ public sealed class CabinTransferFunction
             _ => throw new ArgumentOutOfRangeException(nameof(bodyStyle))
         };
 
-    /// <summary>Cabin gain in dB at the given frequency (0 above the corner).</summary>
+    /// <summary>
+    /// Cabin gain in dB at the given frequency: the pressure-zone rise below
+    /// the corner, decaying toward 0 above it, capped at
+    /// <see cref="MaximumSubtractionDb"/> in the infrasonic tail.
+    /// </summary>
     public double Evaluate(double frequencyHz) =>
-        gainDb(Math.Max(frequencyHz, MinimumFrequencyHz));
+        Math.Min(
+            gainDb(Math.Max(frequencyHz, MinimumFrequencyHz)),
+            MaximumSubtractionDb);
 
     private static CabinTransferFunction Sloped(
         double cornerHz, double slopeDbPerOctave) =>
@@ -97,7 +118,9 @@ public sealed class CabinTransferFunction
 
     // Piecewise-linear in log-frequency over measured (Hz, dB) anchors, given
     // in ascending frequency with the last gain 0: flat (0) above the last
-    // point, the first segment's slope extended below the first.
+    // point, and the FIRST anchor's value HELD below the first — the steep
+    // near-corner segment is not extrapolated into the infrasonic (it would
+    // run to tens of dB of unmeasured subtraction).
     private static CabinTransferFunction Tabulated(
         params (double FrequencyHz, double GainDb)[] points) =>
         new(frequencyHz =>
@@ -105,6 +128,10 @@ public sealed class CabinTransferFunction
             if (frequencyHz >= points[^1].FrequencyHz)
             {
                 return 0.0;
+            }
+            if (frequencyHz <= points[0].FrequencyHz)
+            {
+                return points[0].GainDb;
             }
 
             int upper = 1;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.Designer.cs
@@ -37,6 +37,8 @@ namespace Resonalyze
             labelTargetFile = new Label();
             labelCalibration = new Label();
             comboBoxCalibration = new DarkComboBox();
+            labelCabin = new Label();
+            comboBoxCabin = new DarkComboBox();
             buttonRender = new Button();
             progressBar = new ProgressBar();
             labelStatus = new Label();
@@ -127,39 +129,59 @@ namespace Resonalyze
             comboBoxCalibration.Location = new Point(104, 81);
             comboBoxCalibration.MinimumSize = new Size(36, 19);
             comboBoxCalibration.Name = "comboBoxCalibration";
-            comboBoxCalibration.Size = new Size(110, 19);
+            comboBoxCalibration.Size = new Size(200, 19);
             comboBoxCalibration.TabIndex = 7;
+            // 
+            // labelCabin
+            // 
+            labelCabin.AutoSize = true;
+            labelCabin.ForeColor = Color.FromArgb(185, 190, 200);
+            labelCabin.Location = new Point(12, 115);
+            labelCabin.Name = "labelCabin";
+            labelCabin.Size = new Size(86, 15);
+            labelCabin.TabIndex = 8;
+            labelCabin.Text = "Subtract cabin:";
+            // 
+            // comboBoxCabin
+            // 
+            comboBoxCabin.BackColor = Color.FromArgb(55, 60, 72);
+            comboBoxCabin.ForeColor = Color.White;
+            comboBoxCabin.Location = new Point(104, 113);
+            comboBoxCabin.MinimumSize = new Size(36, 19);
+            comboBoxCabin.Name = "comboBoxCabin";
+            comboBoxCabin.Size = new Size(200, 19);
+            comboBoxCabin.TabIndex = 9;
             // 
             // buttonRender
             // 
             buttonRender.BackColor = Color.FromArgb(46, 51, 67);
             buttonRender.FlatStyle = FlatStyle.Popup;
             buttonRender.ForeColor = Color.White;
-            buttonRender.Location = new Point(12, 112);
+            buttonRender.Location = new Point(12, 144);
             buttonRender.Name = "buttonRender";
             buttonRender.Size = new Size(120, 26);
-            buttonRender.TabIndex = 8;
+            buttonRender.TabIndex = 10;
             buttonRender.Text = "Render";
             buttonRender.UseVisualStyleBackColor = false;
             // 
             // progressBar
             // 
             progressBar.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
-            progressBar.Location = new Point(144, 112);
+            progressBar.Location = new Point(144, 144);
             progressBar.Maximum = 1000;
             progressBar.Name = "progressBar";
             progressBar.Size = new Size(440, 26);
             progressBar.Style = ProgressBarStyle.Continuous;
-            progressBar.TabIndex = 9;
+            progressBar.TabIndex = 11;
             // 
             // labelStatus
             // 
             labelStatus.AutoSize = true;
             labelStatus.ForeColor = Color.FromArgb(185, 190, 200);
-            labelStatus.Location = new Point(12, 146);
+            labelStatus.Location = new Point(12, 178);
             labelStatus.Name = "labelStatus";
             labelStatus.Size = new Size(0, 15);
-            labelStatus.TabIndex = 10;
+            labelStatus.TabIndex = 12;
             // 
             // textBoxReport
             // 
@@ -168,13 +190,13 @@ namespace Resonalyze
             textBoxReport.BorderStyle = BorderStyle.FixedSingle;
             textBoxReport.Font = new Font("Consolas", 9F);
             textBoxReport.ForeColor = Color.FromArgb(210, 214, 222);
-            textBoxReport.Location = new Point(12, 168);
+            textBoxReport.Location = new Point(12, 178);
             textBoxReport.Multiline = true;
             textBoxReport.Name = "textBoxReport";
             textBoxReport.ReadOnly = true;
             textBoxReport.ScrollBars = ScrollBars.Vertical;
-            textBoxReport.Size = new Size(572, 302);
-            textBoxReport.TabIndex = 11;
+            textBoxReport.Size = new Size(572, 324);
+            textBoxReport.TabIndex = 13;
             // 
             // buttonClose
             // 
@@ -182,10 +204,10 @@ namespace Resonalyze
             buttonClose.DialogResult = DialogResult.Cancel;
             buttonClose.FlatStyle = FlatStyle.Popup;
             buttonClose.ForeColor = Color.White;
-            buttonClose.Location = new Point(492, 480);
+            buttonClose.Location = new Point(492, 512);
             buttonClose.Name = "buttonClose";
             buttonClose.Size = new Size(92, 26);
-            buttonClose.TabIndex = 12;
+            buttonClose.TabIndex = 14;
             buttonClose.Text = "Close";
             buttonClose.UseVisualStyleBackColor = true;
             // 
@@ -195,7 +217,7 @@ namespace Resonalyze
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(40, 44, 54);
             CancelButton = buttonClose;
-            ClientSize = new Size(596, 518);
+            ClientSize = new Size(596, 550);
             Controls.Add(labelTrack);
             Controls.Add(buttonChooseSource);
             Controls.Add(labelSourceFile);
@@ -204,6 +226,8 @@ namespace Resonalyze
             Controls.Add(labelTargetFile);
             Controls.Add(labelCalibration);
             Controls.Add(comboBoxCalibration);
+            Controls.Add(labelCabin);
+            Controls.Add(comboBoxCabin);
             Controls.Add(buttonRender);
             Controls.Add(progressBar);
             Controls.Add(labelStatus);
@@ -212,7 +236,7 @@ namespace Resonalyze
             Font = new Font("Segoe UI", 9F);
             ForeColor = Color.White;
             MinimizeBox = false;
-            MinimumSize = new Size(560, 420);
+            MinimumSize = new Size(560, 452);
             Name = "VirtualCrossoverAuditionDialog";
             ShowInTaskbar = false;
             StartPosition = FormStartPosition.CenterParent;
@@ -231,6 +255,8 @@ namespace Resonalyze
         private Label labelTargetFile;
         private Label labelCalibration;
         private DarkComboBox comboBoxCalibration;
+        private Label labelCabin;
+        private DarkComboBox comboBoxCabin;
         private Button buttonRender;
         private ProgressBar progressBar;
         private Label labelStatus;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.Designer.cs
@@ -190,12 +190,12 @@ namespace Resonalyze
             textBoxReport.BorderStyle = BorderStyle.FixedSingle;
             textBoxReport.Font = new Font("Consolas", 9F);
             textBoxReport.ForeColor = Color.FromArgb(210, 214, 222);
-            textBoxReport.Location = new Point(12, 178);
+            textBoxReport.Location = new Point(12, 200);
             textBoxReport.Multiline = true;
             textBoxReport.Name = "textBoxReport";
             textBoxReport.ReadOnly = true;
             textBoxReport.ScrollBars = ScrollBars.Vertical;
-            textBoxReport.Size = new Size(572, 324);
+            textBoxReport.Size = new Size(572, 302);
             textBoxReport.TabIndex = 13;
             // 
             // buttonClose

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
@@ -44,11 +44,11 @@ internal sealed record VirtualCrossoverAuditionContext(
 /// inverse FIR in both kernels. The raw render carries the full in-car bass
 /// rise (+15…+27 dB at 20 Hz), which headphones reproduce as boom the in-car
 /// listener never perceives; with the typical rise subtracted, what remains
-/// audible at low frequencies is this car's deviation from it. The existing
-/// per-render peak normalization then rescales to the target PEAK — not to a
-/// matched loudness, so an A/B between two cabin choices is a tone-balance
-/// comparison, not a level-matched one (a bass-heavy variant loses the most
-/// headroom and comes back up the most).
+/// audible at low frequencies is this car's deviation from it. The subtracted
+/// render is level-matched to the same tune WITHOUT the subtraction (the
+/// reference kernels below), so an A/B between cabin choices differs in tone,
+/// not loudness — the removed bass reads as quieter bass rather than a track
+/// the normalizer turned back up.
 /// </para>
 /// </summary>
 internal sealed partial class VirtualCrossoverAuditionDialog : Form
@@ -559,17 +559,41 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         double[] rightKernel = Auralization.TrimResponse(
             context.RightSum, context.SampleRate, out AuralizationTrim rightTrim);
 
-        // ONE linear-phase correction FIR carries BOTH the microphone
-        // calibration and the cabin subtraction. Their dB corrections add, so a
-        // single design over the sum is the two applied in series but with half
-        // the taps, half the constant delay, one convolution pass per kernel and
-        // one truncation window. Design() negates the correction it is handed:
-        // the calibration's own correction and the cabin GAIN therefore both
-        // come out with the right sign — calibration applied, cabin rise
-        // subtracted. Baked into the KERNELS, not run over the track (two short
-        // double-precision convolutions instead of a third full-track pass), and
-        // identical on both sides so the inter-side scene is untouched; the
-        // normalization below then reads the corrected response.
+        // The mic calibration and the cabin subtraction go into the KERNELS as
+        // linear-phase FIRs (Design() negates the correction it is handed, so the
+        // calibration's correction and the cabin GAIN both come out right —
+        // calibration applied, cabin rise subtracted). The two combine into ONE
+        // FIR — their dB corrections add — so the OUTPUT kernels cost one
+        // convolution pass and one truncation window, not two, and add half the
+        // constant delay. Applied identically to both sides, so the inter-side
+        // scene is untouched.
+        //
+        // When the cabin is subtracted, a REFERENCE pair of kernels carries the
+        // calibration ALONE (the same tune with the cabin OFF). The render is
+        // level-matched against it below, so an A/B between cabin choices differs
+        // in tone, not loudness — the removed bass reads as quieter bass, not as
+        // a track the normalizer quietly turned back up. The reference is built
+        // BEFORE the combined FIR overwrites the kernels; Convolve returns fresh
+        // arrays, so the two pairs never alias.
+        double[]? referenceLeftKernel = null;
+        double[]? referenceRightKernel = null;
+        if (cabin != null)
+        {
+            if (calibration != null)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                double[] calFir = CalibrationFirFilter.Design(
+                    calibration.GetDecibelCorrection, context.SampleRate);
+                referenceLeftKernel = FastConvolution.Convolve(leftKernel, calFir);
+                referenceRightKernel = FastConvolution.Convolve(rightKernel, calFir);
+            }
+            else
+            {
+                referenceLeftKernel = leftKernel;
+                referenceRightKernel = rightKernel;
+            }
+        }
+
         int correctionFirTaps = 0;
         if (calibration != null || cabin != null)
         {
@@ -624,6 +648,8 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             {
                 LeftKernel = leftKernel,
                 RightKernel = rightKernel,
+                ReferenceLeftKernel = referenceLeftKernel,
+                ReferenceRightKernel = referenceRightKernel,
                 KernelSampleRate = context.SampleRate,
                 SourceChannels = material.Channels,
                 SourceSampleRate = material.SampleRate
@@ -748,7 +774,11 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
 
         section.AppendLine(
             $"Level: {rendered.AppliedGainDb:+0.0;-0.0} dB applied to both " +
-            $"channels (peak at {Auralization.DefaultPeakTarget:0.0} dBFS)");
+            (outcome.CabinApplied
+                ? "channels, matched to the no-cabin render (its peak at " +
+                    $"{Auralization.DefaultPeakTarget:0.0} dBFS) so the A/B is " +
+                    "level-honest"
+                : $"channels (peak at {Auralization.DefaultPeakTarget:0.0} dBFS)"));
         section.AppendLine(
             $"Written: {targetPath}");
         section.AppendLine(

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
@@ -45,7 +45,10 @@ internal sealed record VirtualCrossoverAuditionContext(
 /// rise (+15…+27 dB at 20 Hz), which headphones reproduce as boom the in-car
 /// listener never perceives; with the typical rise subtracted, what remains
 /// audible at low frequencies is this car's deviation from it. The existing
-/// peak normalization then restores the overall level.
+/// per-render peak normalization then rescales to the target PEAK — not to a
+/// matched loudness, so an A/B between two cabin choices is a tone-balance
+/// comparison, not a level-matched one (a bass-heavy variant loses the most
+/// headroom and comes back up the most).
 /// </para>
 /// </summary>
 internal sealed partial class VirtualCrossoverAuditionDialog : Form
@@ -556,31 +559,27 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         double[] rightKernel = Auralization.TrimResponse(
             context.RightSum, context.SampleRate, out AuralizationTrim rightTrim);
 
-        // The calibration FIR is baked into the KERNELS, not run over the track:
-        // two short double-precision convolutions instead of a third full-track
-        // pass, and the normalization below then reads the calibrated response.
-        int firTaps = 0;
-        if (calibration != null)
+        // ONE linear-phase correction FIR carries BOTH the microphone
+        // calibration and the cabin subtraction. Their dB corrections add, so a
+        // single design over the sum is the two applied in series but with half
+        // the taps, half the constant delay, one convolution pass per kernel and
+        // one truncation window. Design() negates the correction it is handed:
+        // the calibration's own correction and the cabin GAIN therefore both
+        // come out with the right sign — calibration applied, cabin rise
+        // subtracted. Baked into the KERNELS, not run over the track (two short
+        // double-precision convolutions instead of a third full-track pass), and
+        // identical on both sides so the inter-side scene is untouched; the
+        // normalization below then reads the corrected response.
+        int correctionFirTaps = 0;
+        if (calibration != null || cabin != null)
         {
             cancellationToken.ThrowIfCancellationRequested();
             double[] fir = CalibrationFirFilter.Design(
-                calibration.GetDecibelCorrection, context.SampleRate);
-            firTaps = fir.Length;
-            leftKernel = FastConvolution.Convolve(leftKernel, fir);
-            rightKernel = FastConvolution.Convolve(rightKernel, fir);
-        }
-
-        // The cabin subtraction is the calibration trick pointed the other way:
-        // Design() negates the curve it is given, so passing the cabin GAIN
-        // yields the inverse FIR — the typical bass rise applied as attenuation,
-        // identical in both kernels, leaving the inter-side scene untouched.
-        int cabinFirTaps = 0;
-        if (cabin != null)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            double[] fir = CalibrationFirFilter.Design(
-                cabin.Evaluate, context.SampleRate);
-            cabinFirTaps = fir.Length;
+                frequencyHz =>
+                    (calibration?.GetDecibelCorrection(frequencyHz) ?? 0.0) +
+                    (cabin?.Evaluate(frequencyHz) ?? 0.0),
+                context.SampleRate);
+            correctionFirTaps = fir.Length;
             leftKernel = FastConvolution.Convolve(leftKernel, fir);
             rightKernel = FastConvolution.Convolve(rightKernel, fir);
         }
@@ -644,9 +643,9 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             rightTrim,
             leftKernel.Length,
             rightKernel.Length,
-            firTaps,
+            correctionFirTaps,
             calibrationLabel,
-            cabinFirTaps,
+            cabin != null,
             cabinLabel,
             cabin?.Evaluate(20.0) ?? 0.0);
     }
@@ -723,13 +722,18 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             rendered.Channels[0].Length / (double)rendered.SampleRate;
         var section = new StringBuilder();
         section.AppendLine("== Result ==");
-        section.AppendLine($"Calibration: {outcome.CalibrationLabel}" +
-            (outcome.FirTaps > 0 ? $" (FIR {outcome.FirTaps} taps)" : string.Empty));
+        section.AppendLine($"Calibration: {outcome.CalibrationLabel}");
         section.AppendLine($"Cabin subtracted: {outcome.CabinLabel}" +
-            (outcome.CabinFirTaps > 0
-                ? $" (−{outcome.CabinTwentyHzDb:0.#} dB at 20 Hz, " +
-                    $"FIR {outcome.CabinFirTaps} taps)"
+            (outcome.CabinApplied
+                ? $" (−{outcome.CabinTwentyHzDb:0.#} dB at 20 Hz)"
                 : string.Empty));
+        if (outcome.CorrectionFirTaps > 0)
+        {
+            // One filter carries both corrections, so it is reported once.
+            section.AppendLine(
+                $"Correction FIR: {outcome.CorrectionFirTaps} taps, linear " +
+                "phase (calibration and cabin combined)");
+        }
         section.AppendLine(
             $"Kernels: {outcome.LeftKernelTaps} taps left, " +
             $"{outcome.RightKernelTaps} taps right; decay kept " +
@@ -751,7 +755,7 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             $"Stereo, {rendered.SampleRate} Hz, 24-bit, " +
             $"{FormatDuration(TimeSpan.FromSeconds(durationSeconds))}");
         section.AppendLine();
-        if (outcome.CabinFirTaps > 0)
+        if (outcome.CabinApplied)
         {
             section.AppendLine(
                 $"The typical {outcome.CabinLabel} bass rise was subtracted: " +
@@ -781,9 +785,9 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         AuralizationTrim RightTrim,
         int LeftKernelTaps,
         int RightKernelTaps,
-        int FirTaps,
+        int CorrectionFirTaps,
         string CalibrationLabel,
-        int CabinFirTaps,
+        bool CabinApplied,
         string CabinLabel,
         double CabinTwentyHzDb);
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAuditionDialog.cs
@@ -38,6 +38,15 @@ internal sealed record VirtualCrossoverAuditionContext(
 /// timing (the thing being auditioned) shifts by exactly the same constant on
 /// each channel.
 /// </para>
+/// <para>
+/// "Subtract cabin" optionally removes a typical body-style cabin transfer
+/// function (see <see cref="CabinTransferFunction"/>) the same way — an
+/// inverse FIR in both kernels. The raw render carries the full in-car bass
+/// rise (+15…+27 dB at 20 Hz), which headphones reproduce as boom the in-car
+/// listener never perceives; with the typical rise subtracted, what remains
+/// audible at low frequencies is this car's deviation from it. The existing
+/// peak normalization then restores the overall level.
+/// </para>
 /// </summary>
 internal sealed partial class VirtualCrossoverAuditionDialog : Form
 {
@@ -82,6 +91,23 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
     private static string? lastSourcePath;
     private static string? lastTargetPath;
     private static MicrophoneCalibrationMode? lastCalibrationMode;
+    // Seeded with the averaged sedan — the typical headphone listener wants
+    // the typical rise gone; "off (as measured)" stays one click away and is
+    // remembered like any other choice once picked.
+    private static CabinBodyStyle? lastCabinStyle = CabinBodyStyle.Sedan;
+
+    // "off" first so index 0 — the fallback everywhere — is the honest raw
+    // render; the styles follow the CabinTransferFunction presets.
+    private static readonly CabinOption[] CabinOptions =
+    [
+        new(null, "off (as measured)"),
+        new(CabinBodyStyle.Sedan, "average sedan"),
+        new(CabinBodyStyle.CompactSedan, "compact sedan"),
+        new(CabinBodyStyle.Hatchback, "hatchback"),
+        new(CabinBodyStyle.Wagon, "wagon"),
+        new(CabinBodyStyle.Suv, "SUV / crossover"),
+        new(CabinBodyStyle.BmwF30SkiHatch, "BMW F30, ski hatch open")
+    ];
 
     public VirtualCrossoverAuditionDialog(VirtualCrossoverAuditionContext context)
     {
@@ -109,6 +135,15 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             initialMode,
             context.HasZeroDegreeCalibration,
             context.HasNinetyDegreeCalibration);
+
+        comboBoxCabin.DropDownStyle = ComboBoxStyle.DropDownList;
+        foreach (CabinOption option in CabinOptions)
+        {
+            comboBoxCabin.Items.Add(option);
+        }
+
+        comboBoxCabin.SelectedIndex = Math.Max(
+            0, Array.FindIndex(CabinOptions, option => option.Style == lastCabinStyle));
 
         buttonChooseSource.Click += (_, _) => ChooseSource();
         buttonChooseTarget.Click += (_, _) => ChooseTarget();
@@ -155,6 +190,7 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         lastTargetPath = targetPath;
         lastCalibrationMode =
             MicrophoneCalibrationComboHelper.GetSelectedMode(comboBoxCalibration);
+        lastCabinStyle = SelectedCabinStyle;
         base.OnFormClosed(e);
     }
 
@@ -397,6 +433,13 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             calibration = null;
         }
 
+        CabinTransferFunction? cabin = SelectedCabinStyle is { } cabinStyle
+            ? CabinTransferFunction.FromBodyStyle(cabinStyle)
+            : null;
+        string cabinLabel = cabin == null
+            ? "off"
+            : comboBoxCabin.GetItemText(comboBoxCabin.SelectedItem);
+
         var cancellation = new CancellationTokenSource();
         activeRender = cancellation;
         SetRunning(true);
@@ -429,7 +472,7 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             RenderOutcome outcome = await Task.Run(
                 () => ExecuteRender(
                     context, source, target, calibration, calibrationLabel,
-                    progress, cancellation.Token),
+                    cabin, cabinLabel, progress, cancellation.Token),
                 cancellation.Token);
             resultSection = FormatResult(outcome, target);
             labelStatus.Text = "Finished.";
@@ -474,6 +517,7 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         buttonChooseSource.Enabled = !running;
         buttonChooseTarget.Enabled = !running;
         comboBoxCalibration.Enabled = !running && comboBoxCalibration.Items.Count > 1;
+        comboBoxCabin.Enabled = !running;
         buttonRender.Text = running ? "Cancel" : "Render";
         if (running)
         {
@@ -490,6 +534,9 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         buttonRender.Enabled =
             activeRender != null || (sourcePath != null && targetPath != null);
 
+    private CabinBodyStyle? SelectedCabinStyle =>
+        comboBoxCabin.SelectedItem is CabinOption option ? option.Style : null;
+
     // The whole pipeline on the worker thread: trim, calibrate, decode, render,
     // write. Static and argument-fed so it cannot touch a control.
     private static RenderOutcome ExecuteRender(
@@ -498,6 +545,8 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         string targetPath,
         CalibrationFile? calibration,
         string calibrationLabel,
+        CabinTransferFunction? cabin,
+        string cabinLabel,
         IProgress<AuditionProgress> progress,
         CancellationToken cancellationToken)
     {
@@ -517,6 +566,21 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             double[] fir = CalibrationFirFilter.Design(
                 calibration.GetDecibelCorrection, context.SampleRate);
             firTaps = fir.Length;
+            leftKernel = FastConvolution.Convolve(leftKernel, fir);
+            rightKernel = FastConvolution.Convolve(rightKernel, fir);
+        }
+
+        // The cabin subtraction is the calibration trick pointed the other way:
+        // Design() negates the curve it is given, so passing the cabin GAIN
+        // yields the inverse FIR — the typical bass rise applied as attenuation,
+        // identical in both kernels, leaving the inter-side scene untouched.
+        int cabinFirTaps = 0;
+        if (cabin != null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            double[] fir = CalibrationFirFilter.Design(
+                cabin.Evaluate, context.SampleRate);
+            cabinFirTaps = fir.Length;
             leftKernel = FastConvolution.Convolve(leftKernel, fir);
             rightKernel = FastConvolution.Convolve(rightKernel, fir);
         }
@@ -581,7 +645,10 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             leftKernel.Length,
             rightKernel.Length,
             firTaps,
-            calibrationLabel);
+            calibrationLabel,
+            cabinFirTaps,
+            cabinLabel,
+            cabin?.Evaluate(20.0) ?? 0.0);
     }
 
     // Through a temporary file beside the target: a cancel or a failure part-way
@@ -658,6 +725,11 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         section.AppendLine("== Result ==");
         section.AppendLine($"Calibration: {outcome.CalibrationLabel}" +
             (outcome.FirTaps > 0 ? $" (FIR {outcome.FirTaps} taps)" : string.Empty));
+        section.AppendLine($"Cabin subtracted: {outcome.CabinLabel}" +
+            (outcome.CabinFirTaps > 0
+                ? $" (−{outcome.CabinTwentyHzDb:0.#} dB at 20 Hz, " +
+                    $"FIR {outcome.CabinFirTaps} taps)"
+                : string.Empty));
         section.AppendLine(
             $"Kernels: {outcome.LeftKernelTaps} taps left, " +
             $"{outcome.RightKernelTaps} taps right; decay kept " +
@@ -679,6 +751,15 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
             $"Stereo, {rendered.SampleRate} Hz, 24-bit, " +
             $"{FormatDuration(TimeSpan.FromSeconds(durationSeconds))}");
         section.AppendLine();
+        if (outcome.CabinFirTaps > 0)
+        {
+            section.AppendLine(
+                $"The typical {outcome.CabinLabel} bass rise was subtracted: " +
+                "at low frequencies you are hearing this car's deviation from " +
+                "that typical curve, not the in-car level.");
+            section.AppendLine();
+        }
+
         section.Append(
             "Listen through headphones only. The left and right channels are " +
             "the measured acoustic response of the corresponding side at the " +
@@ -701,5 +782,13 @@ internal sealed partial class VirtualCrossoverAuditionDialog : Form
         int LeftKernelTaps,
         int RightKernelTaps,
         int FirTaps,
-        string CalibrationLabel);
+        string CalibrationLabel,
+        int CabinFirTaps,
+        string CabinLabel,
+        double CabinTwentyHzDb);
+
+    private sealed record CabinOption(CabinBodyStyle? Style, string Label)
+    {
+        public override string ToString() => Label;
+    }
 }

--- a/tests/Resonalyze.Dsp.Tests/AuralizationTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AuralizationTests.cs
@@ -103,6 +103,73 @@ public sealed class AuralizationTests
     }
 
     [Fact]
+    public void Render_LevelMatchesToTheReferenceKernels()
+    {
+        // The output kernel attenuates (as a cabin subtraction does); the
+        // reference kernel — the same tune without that subtraction — does not.
+        // The render must normalize to the LOUDER reference peak, so the output
+        // lands BELOW full scale by exactly the attenuation: the removed energy
+        // stays audibly removed instead of being normalized back up.
+        var source = new float[500];
+        source[0] = 1.0f;
+        double target = Math.Pow(10.0, Auralization.DefaultPeakTarget / 20.0);
+
+        AuralizationResult matched = Auralization.Render(new AuralizationRequest
+        {
+            LeftKernel = [0.5],
+            RightKernel = [0.5],
+            ReferenceLeftKernel = [1.0],
+            ReferenceRightKernel = [1.0],
+            KernelSampleRate = Rate,
+            SourceChannels = [source, source],
+            SourceSampleRate = Rate
+        });
+
+        // Reference peak 1.0 sets the gain; the 0.5 output rides at half of it,
+        // and the reported gain is the reference's own (−1 dBFS on its peak).
+        Assert.Equal(0.5 * target, matched.Channels[0].Max(Math.Abs), 4);
+        Assert.Equal(Auralization.DefaultPeakTarget, matched.AppliedGainDb, 2);
+
+        // Control: the SAME output kernel with NO reference normalizes to its
+        // own peak and reaches full scale — the difference the reference makes.
+        AuralizationResult unmatched = Auralization.Render(new AuralizationRequest
+        {
+            LeftKernel = [0.5],
+            RightKernel = [0.5],
+            KernelSampleRate = Rate,
+            SourceChannels = [source, source],
+            SourceSampleRate = Rate
+        });
+        Assert.Equal(target, unmatched.Channels[0].Max(Math.Abs), 4);
+    }
+
+    [Fact]
+    public void Render_ReferenceLouderOrQuieter_NeverClipsTheOutput()
+    {
+        // "Min of the two gains" = divide by the LARGER peak. Whichever of the
+        // output and the reference is louder, the output must stay at or below
+        // full scale — the divisor is never smaller than the output's own peak.
+        var source = new float[500];
+        source[0] = 1.0f;
+        double target = Math.Pow(10.0, Auralization.DefaultPeakTarget / 20.0);
+
+        AuralizationResult louderOutput = Auralization.Render(new AuralizationRequest
+        {
+            LeftKernel = [1.0],
+            RightKernel = [1.0],
+            ReferenceLeftKernel = [0.5],
+            ReferenceRightKernel = [0.5],
+            KernelSampleRate = Rate,
+            SourceChannels = [source, source],
+            SourceSampleRate = Rate
+        });
+
+        // Output peak 1.0 > reference 0.5, so the output itself sets the gain
+        // and reaches — but does not exceed — full scale.
+        Assert.Equal(target, louderOutput.Channels[0].Max(Math.Abs), 4);
+    }
+
+    [Fact]
     public void Render_MonoSourceFeedsBothSides()
     {
         double[] kernel = [1.0];

--- a/tests/Resonalyze.Dsp.Tests/CabinTransferFunctionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CabinTransferFunctionTests.cs
@@ -78,6 +78,33 @@ public sealed class CabinTransferFunctionTests
     }
 
     [Fact]
+    public void Evaluate_HoldsATabulatedCurveConstantBelowItsFirstAnchor()
+    {
+        CabinTransferFunction cabin =
+            CabinTransferFunction.FromBodyStyle(CabinBodyStyle.BmwF30SkiHatch);
+
+        // The 20 Hz anchor is +34 dB; below it the steep near-corner segment is
+        // NOT extrapolated — every infrasonic frequency holds that same value
+        // rather than climbing to the tens of dB the segment slope would reach.
+        double atFirstAnchor = cabin.Evaluate(20.0);
+        Assert.Equal(atFirstAnchor, cabin.Evaluate(10.0), 6);
+        Assert.Equal(atFirstAnchor, cabin.Evaluate(1.0), 6);
+    }
+
+    [Fact]
+    public void Evaluate_CapsTheInfrasonicSubtraction()
+    {
+        // The compact-sedan slope (13.5 dB/oct) would pass 40 dB well into the
+        // infrasonic; the cap holds it there so the correction FIR never carves
+        // a near-total notch — but a MEASURED anchor is never clipped by it.
+        CabinTransferFunction cabin =
+            CabinTransferFunction.FromBodyStyle(CabinBodyStyle.CompactSedan);
+
+        Assert.InRange(cabin.Evaluate(1.0), 39.99, 40.01);
+        Assert.InRange(cabin.Evaluate(20.0), 26.0, 28.0);
+    }
+
+    [Fact]
     public void Design_SubtractsTheCabinRiseWhenUsedAsACorrection()
     {
         // The audition feeds Evaluate straight into the calibration FIR

--- a/tests/Resonalyze.Dsp.Tests/CabinTransferFunctionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CabinTransferFunctionTests.cs
@@ -1,0 +1,111 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The cabin curves are anchored to published or owner measurements, not
+/// invented: the averaged-sedan table (Autozvuk 2000/08), a measured hatchback
+/// (+23.5 dB at 20 Hz), a compact sedan with the enclosure coupled into the
+/// cabin (+27 dB at 20 Hz) and the owner-measured BMW F30 with the ski hatch
+/// open. The tests hold the presets to those anchors and hold the shape to the
+/// model: rising toward low frequencies below the corner, nothing above it.
+/// </summary>
+public sealed class CabinTransferFunctionTests
+{
+    private const int Rate = 48_000;
+
+    [Theory]
+    [InlineData(CabinBodyStyle.Sedan, 20.0, 15.5, 17.5)]
+    [InlineData(CabinBodyStyle.Sedan, 40.0, 7.0, 8.5)]
+    [InlineData(CabinBodyStyle.Sedan, 63.0, 2.3, 3.5)]
+    [InlineData(CabinBodyStyle.Sedan, 80.0, 0.8, 1.9)]
+    [InlineData(CabinBodyStyle.Hatchback, 20.0, 23.0, 25.0)]
+    [InlineData(CabinBodyStyle.CompactSedan, 20.0, 26.0, 28.0)]
+    [InlineData(CabinBodyStyle.Suv, 20.0, 13.5, 15.5)]
+    [InlineData(CabinBodyStyle.Wagon, 20.0, 19.0, 21.0)]
+    [InlineData(CabinBodyStyle.BmwF30SkiHatch, 20.0, 33.5, 34.5)]
+    [InlineData(CabinBodyStyle.BmwF30SkiHatch, 50.0, 19.0, 20.0)]
+    [InlineData(CabinBodyStyle.BmwF30SkiHatch, 70.0, 6.0, 7.0)]
+    [InlineData(CabinBodyStyle.BmwF30SkiHatch, 100.0, 0.0, 0.0)]
+    public void Evaluate_MatchesTheMeasuredAnchors(
+        CabinBodyStyle bodyStyle, double frequencyHz, double minDb, double maxDb)
+    {
+        CabinTransferFunction cabin = CabinTransferFunction.FromBodyStyle(bodyStyle);
+
+        Assert.InRange(cabin.Evaluate(frequencyHz), minDb, maxDb);
+    }
+
+    [Theory]
+    [InlineData(CabinBodyStyle.Sedan, 140.0)]
+    [InlineData(CabinBodyStyle.CompactSedan, 160.0)]
+    [InlineData(CabinBodyStyle.Hatchback, 160.0)]
+    [InlineData(CabinBodyStyle.Wagon, 140.0)]
+    [InlineData(CabinBodyStyle.Suv, 110.0)]
+    [InlineData(CabinBodyStyle.BmwF30SkiHatch, 95.0)]
+    public void Evaluate_IsFlatAboveTheCornerAndMonotonicBelow(
+        CabinBodyStyle bodyStyle, double flatFromHz)
+    {
+        CabinTransferFunction cabin = CabinTransferFunction.FromBodyStyle(bodyStyle);
+
+        // An octave above the corner the knee has decayed to a fraction of a
+        // dB, and midband/treble carry nothing at all.
+        Assert.InRange(cabin.Evaluate(flatFromHz), 0.0, 0.6);
+        Assert.InRange(cabin.Evaluate(1_000.0), 0.0, 0.01);
+        Assert.InRange(cabin.Evaluate(16_000.0), 0.0, 0.01);
+
+        double previous = double.MaxValue;
+        for (double frequency = 10; frequency <= 20_000; frequency *= 1.1)
+        {
+            double gain = cabin.Evaluate(frequency);
+            Assert.True(
+                gain <= previous + 1e-12,
+                $"Gain rose with frequency at {frequency:0.0} Hz");
+            previous = gain;
+        }
+    }
+
+    [Fact]
+    public void Evaluate_ReachesTheNominalSlopeBelowTheKnee()
+    {
+        // The hatchback preset is the theoretical fully-sealed cabin:
+        // 12 dB/oct. Two octaves under the corner the softplus knee is spent,
+        // so one more octave down must add almost exactly that.
+        CabinTransferFunction cabin =
+            CabinTransferFunction.FromBodyStyle(CabinBodyStyle.Hatchback);
+
+        double perOctave = cabin.Evaluate(10.0) - cabin.Evaluate(20.0);
+        Assert.InRange(perOctave, 11.8, 12.01);
+    }
+
+    [Fact]
+    public void Design_SubtractsTheCabinRiseWhenUsedAsACorrection()
+    {
+        // The audition feeds Evaluate straight into the calibration FIR
+        // designer, whose kernel gain is the NEGATED correction: the cabin's
+        // +24 dB at 20 Hz must come out as −24 dB of attenuation, and the
+        // midband must stay untouched.
+        CabinTransferFunction cabin =
+            CabinTransferFunction.FromBodyStyle(CabinBodyStyle.Hatchback);
+        double[] kernel = CalibrationFirFilter.Design(cabin.Evaluate, Rate);
+
+        Assert.InRange(MagnitudeDbAt(kernel, 20.0), -25.0, -23.0);
+        Assert.InRange(MagnitudeDbAt(kernel, 40.0), -13.0, -11.0);
+        Assert.InRange(MagnitudeDbAt(kernel, 1_000.0), -0.3, 0.3);
+        Assert.InRange(MagnitudeDbAt(kernel, 10_000.0), -0.3, 0.3);
+    }
+
+    // The filter's frequency response probed directly: |Σ h[n]·e^(−j2πfn/fs)|.
+    private static double MagnitudeDbAt(double[] kernel, double frequencyHz)
+    {
+        double real = 0;
+        double imaginary = 0;
+        for (int n = 0; n < kernel.Length; n++)
+        {
+            double phase = -2.0 * Math.PI * frequencyHz * n / Rate;
+            real += kernel[n] * Math.Cos(phase);
+            imaginary += kernel[n] * Math.Sin(phase);
+        }
+
+        return 20.0 * Math.Log10(Math.Sqrt(real * real + imaginary * imaginary));
+    }
+}


### PR DESCRIPTION
## What

Adds a **"Subtract cabin"** option to the Virtual DSP *Audition track…* dialog: the render can now remove a typical body-style cabin transfer function, so the headphone auralization stops carrying the in-car bass rise the in-car listener never consciously perceives. What remains audible at low frequencies is this car's deviation from the typical curve — exactly the thing worth auditioning.

## Why a cabin curve, not a target curve

The subtracted shape is a *physical* cabin transfer function — flat above the pressure-zone corner (c/2L), a constant dB/octave climb below it, reaching +15…+27 dB at 20 Hz. Target curves sit far lower because the subwoofer's own low-frequency roll-off eats most of the cabin rise, so subtracting a target would badly under-compensate.

## Model and presets (`dsp/CabinTransferFunction.cs`)

Two-parameter shape (corner + slope, softplus knee calibrated against the published averaged-sedan table to ~0.5 dB), plus tabulated curves for measured cars that the parametric shape cannot fit:

| Preset | Corner | Slope | @ 20 Hz | Anchor |
|---|---|---|---|---|
| average sedan (default) | 70 Hz | 9 dB/oct | +16.4 | Autozvuk 2000/08 averaged table |
| compact sedan | 80 | 13.5 | +27 | measured VAZ 2110, box coupled into the cabin |
| hatchback | 80 | 12 | +24 | measured Mitsubishi Eclipse (+23.5) |
| wagon | 70 | 11 | +20 | sedan↔hatch interpolation |
| SUV / crossover | 55 | 10 | +14.6 | longer cabin, leakier |
| BMW F30, ski hatch open | table | — | +34 | owner measurement; ~30 dB/oct trunk-coupling cliff at 50–80 Hz |

## How it is applied

The curve is fed to the existing `CalibrationFirFilter.Design` (which negates it), giving an inverse linear-phase FIR convolved into **both** side kernels — same mechanism as the mic calibration, so the inter-side scene is untouched and the existing peak normalization restores the overall level. The report names the preset, its 20 Hz depth and FIR taps, and adds an honesty note about what the subtracted render represents. The choice defaults to the averaged sedan and is remembered for the app session.

## Tests

- `CabinTransferFunctionTests`: every preset held to its measured anchors, shape flat above the corner and monotonic below, nominal 12 dB/oct reached under the knee, and an end-to-end FIR check (−24 dB at 20 Hz for the hatchback, midband untouched).
- Full suites green: Dsp 865/865, App 506/506 (App run in Debug — the Release output dir was locked by a running app instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
