### PR TITLE
Auto delay: an explicit L-R level field replaces the derived tilt

### DIFF
--- a/dsp/GainBalanceEngine.cs
+++ b/dsp/GainBalanceEngine.cs
@@ -45,8 +45,8 @@ public sealed record GainBalanceResult(
 /// so narrow interference dips barely register and band width does not bias
 /// the figure), measured at 0 dB gain by subtracting the current gain from the
 /// chain-applied response. Every eligible left channel is levelled to one
-/// target, every eligible right channel to that target plus the scene tilt
-/// derived from the stereo scene offset; the shared target sits as high as the
+/// target, every eligible right channel to that target MINUS the L-R level
+/// difference the caller asks for; the shared target sits as high as the
 /// cut-only constraint allows (the quietest channel ends at 0 dB of cut).
 /// </summary>
 public static class GainBalanceEngine
@@ -65,14 +65,14 @@ public static class GainBalanceEngine
     /// </summary>
     public const double EligibilityMinOctaveFraction = 1.0 / 3.0;
 
-    // The time-intensity trading anchor: a 0.27 ms scene offset (image at the
-    // cabin center for a left-seated listener) maps to the near side sitting
-    // 2 dB below the far side — ~135 µs/dB, inside the psychoacoustic trading
-    // range. Interpolated linearly and clamped: the offset control reaches
-    // ±5 ms, and extrapolating the trade that far would demand ±37 dB.
-    public const double SceneTiltReferenceMs = 0.27;
-    public const double SceneTiltReferenceDb = 2.0;
-    public const double MaxSceneTiltDb = 6.0;
+    /// <summary>
+    /// The range of the intentional L-R level difference the caller may ask
+    /// for. The tilt is the tuner's decision, not a derived figure — but past
+    /// this magnitude a "level difference" stops being an image placement and
+    /// becomes one side switched off, so the engine treats a larger request as
+    /// a typo and clamps it.
+    /// </summary>
+    public const double MaxLevelDifferenceDb = 6.0;
 
     // Confidence thresholds on the robust in-band spread of the smoothed
     // level (or of the L−R difference): a flat relation means the single
@@ -122,16 +122,18 @@ public static class GainBalanceEngine
     public const double MaxProposedCutDb = DspChannelChain.MaximumGainDb;
 
     /// <summary>
-    /// The intentional L/R level tilt (dB) for a stereo scene offset (ms):
-    /// positive means the RIGHT side plays louder — the same "image toward
-    /// the dash center for a left-seated listener" convention as the delay
-    /// offset itself. Clamped to <see cref="MaxSceneTiltDb"/>.
+    /// The intentional L-R level difference (dB) as the balance will apply
+    /// it: LEFT minus RIGHT, so a positive value means the left side plays
+    /// louder and a negative one asks for the near side of a left-seated
+    /// listener to sit below the far side (the level half of the same image
+    /// placement the delay scene offset makes in time). Clamped to
+    /// <see cref="MaxLevelDifferenceDb"/>, and a non-finite request reads as
+    /// no tilt at all.
     /// </summary>
-    public static double SceneTiltDb(double sceneOffsetMs) =>
-        Math.Clamp(
-            sceneOffsetMs / SceneTiltReferenceMs * SceneTiltReferenceDb,
-            -MaxSceneTiltDb,
-            MaxSceneTiltDb);
+    public static double LevelDifferenceDb(double requestedDb) =>
+        double.IsFinite(requestedDb)
+            ? Math.Clamp(requestedDb, -MaxLevelDifferenceDb, MaxLevelDifferenceDb)
+            : 0;
 
     /// <summary>
     /// Why a channel's gain is left alone, or null when it is adjustable.
@@ -168,24 +170,27 @@ public static class GainBalanceEngine
     }
 
     /// <summary>
-    /// Computes the cut-only gain proposal for every channel. The scene offset
-    /// only matters when right-side channels participate; pass 0 for a
-    /// single-side run.
+    /// Computes the cut-only gain proposal for every channel. The requested
+    /// L-R level difference only matters when right-side channels
+    /// participate; pass 0 for a single-side run.
     /// </summary>
     public static IReadOnlyList<GainBalanceResult> Compute(
         IReadOnlyList<GainBalanceInput> channels,
-        double sceneOffsetMs,
+        double levelDifferenceDb,
         StringBuilder log)
     {
         ArgumentNullException.ThrowIfNull(channels);
         ArgumentNullException.ThrowIfNull(log);
 
-        double tiltDb = channels.Any(input => input.RightSide)
-            ? SceneTiltDb(sceneOffsetMs)
+        double differenceDb = channels.Any(input => input.RightSide)
+            ? LevelDifferenceDb(levelDifferenceDb)
             : 0;
+        // The request is L-R while every target below is expressed relative to
+        // the LEFT board, so the right side's own offset is its negation.
+        double tiltDb = -differenceDb;
         log.AppendLine(
-            $"Gain balance: scene tilt {tiltDb:+0.00;-0.00} dB " +
-            "(positive: right side louder), cut-only");
+            $"Gain balance: L-R level difference {differenceDb:+0.00;-0.00} dB " +
+            "(positive: left side louder), cut-only");
 
         var spectra = new Dictionary<IAlignmentChannel, (double[] Power, double BinWidthHz)>();
         var levels = new Dictionary<IAlignmentChannel, double>();

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
@@ -35,6 +35,7 @@ namespace Resonalyze
             checkBoxGains = new CheckBox();
             labelLevelDifference = new Label();
             numericLevelDifference = new DarkNumericUpDown();
+            labelLevelDifferenceHint = new Label();
             buttonRun = new Button();
             labelStatus = new Label();
             textBoxReport = new TextBox();
@@ -50,9 +51,9 @@ namespace Resonalyze
             labelSceneOffset.ForeColor = Color.FromArgb(185, 190, 200);
             labelSceneOffset.Location = new Point(12, 16);
             labelSceneOffset.Name = "labelSceneOffset";
-            labelSceneOffset.Size = new Size(83, 15);
+            labelSceneOffset.Size = new Size(61, 15);
             labelSceneOffset.TabIndex = 0;
-            labelSceneOffset.Text = "L/R offset, ms:";
+            labelSceneOffset.Text = "L/R offset:";
             // 
             // numericSceneOffset
             // 
@@ -60,16 +61,17 @@ namespace Resonalyze
             numericSceneOffset.DecimalPlaces = 2;
             numericSceneOffset.ForeColor = Color.White;
             numericSceneOffset.Increment = new decimal(new int[] { 5, 0, 0, 131072 });
-            numericSceneOffset.Location = new Point(104, 12);
+            numericSceneOffset.Location = new Point(84, 12);
             numericSceneOffset.Maximum = new decimal(new int[] { 5, 0, 0, 0 });
             numericSceneOffset.Minimum = new decimal(new int[] { 5, 0, 0, int.MinValue });
             numericSceneOffset.MinimumSize = new Size(36, 19);
             numericSceneOffset.Name = "numericSceneOffset";
-            numericSceneOffset.Size = new Size(72, 21);
+            numericSceneOffset.Size = new Size(92, 21);
             numericSceneOffset.TabIndex = 1;
             numericSceneOffset.TextAlign = HorizontalAlignment.Right;
             numericSceneOffset.ThousandsSeparator = false;
             numericSceneOffset.Value = new decimal(new int[] { 27, 0, 0, 131072 });
+            numericSceneOffset.ValueSuffix = "ms";
             // 
             // checkBoxGains
             // 
@@ -82,24 +84,24 @@ namespace Resonalyze
             checkBoxGains.Size = new Size(199, 19);
             checkBoxGains.TabIndex = 2;
             checkBoxGains.Text = "Balance channel gains (cut-only)";
-            //
+            // 
             // labelLevelDifference
-            //
+            // 
             labelLevelDifference.AutoSize = true;
             labelLevelDifference.ForeColor = Color.FromArgb(185, 190, 200);
-            labelLevelDifference.Location = new Point(411, 16);
+            labelLevelDifference.Location = new Point(403, 16);
             labelLevelDifference.Name = "labelLevelDifference";
-            labelLevelDifference.Size = new Size(80, 15);
+            labelLevelDifference.Size = new Size(55, 15);
             labelLevelDifference.TabIndex = 3;
-            labelLevelDifference.Text = "L-R level, dB:";
-            //
+            labelLevelDifference.Text = "L-R level:";
+            // 
             // numericLevelDifference
-            //
+            // 
             numericLevelDifference.BackColor = Color.FromArgb(55, 60, 72);
             numericLevelDifference.DecimalPlaces = 1;
             numericLevelDifference.ForeColor = Color.White;
             numericLevelDifference.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
-            numericLevelDifference.Location = new Point(500, 12);
+            numericLevelDifference.Location = new Point(463, 12);
             numericLevelDifference.Maximum = new decimal(new int[] { 6, 0, 0, 0 });
             numericLevelDifference.Minimum = new decimal(new int[] { 6, 0, 0, int.MinValue });
             numericLevelDifference.MinimumSize = new Size(36, 19);
@@ -109,27 +111,38 @@ namespace Resonalyze
             numericLevelDifference.TextAlign = HorizontalAlignment.Right;
             numericLevelDifference.ThousandsSeparator = false;
             numericLevelDifference.Value = new decimal(new int[] { 1, 0, 0, int.MinValue });
-            //
+            numericLevelDifference.ValueSuffix = "dB";
+            // 
+            // labelLevelDifferenceHint
+            // 
+            labelLevelDifferenceHint.AutoSize = true;
+            labelLevelDifferenceHint.ForeColor = Color.FromArgb(120, 125, 135);
+            labelLevelDifferenceHint.Location = new Point(543, 16);
+            labelLevelDifferenceHint.Name = "labelLevelDifferenceHint";
+            labelLevelDifferenceHint.Size = new Size(137, 15);
+            labelLevelDifferenceHint.TabIndex = 5;
+            labelLevelDifferenceHint.Text = "LHD -1…-2 ; RHD +1…+2";
+            // 
             // buttonRun
-            //
+            // 
             buttonRun.BackColor = Color.FromArgb(46, 51, 67);
             buttonRun.FlatStyle = FlatStyle.Popup;
             buttonRun.ForeColor = Color.White;
             buttonRun.Location = new Point(12, 44);
             buttonRun.Name = "buttonRun";
             buttonRun.Size = new Size(120, 26);
-            buttonRun.TabIndex = 5;
+            buttonRun.TabIndex = 6;
             buttonRun.Text = "Run";
             buttonRun.UseVisualStyleBackColor = false;
-            //
+            // 
             // labelStatus
-            //
+            // 
             labelStatus.AutoSize = true;
             labelStatus.ForeColor = Color.FromArgb(185, 190, 200);
             labelStatus.Location = new Point(144, 50);
             labelStatus.Name = "labelStatus";
             labelStatus.Size = new Size(0, 15);
-            labelStatus.TabIndex = 6;
+            labelStatus.TabIndex = 7;
             // 
             // textBoxReport
             // 
@@ -144,7 +157,7 @@ namespace Resonalyze
             textBoxReport.ReadOnly = true;
             textBoxReport.ScrollBars = ScrollBars.Vertical;
             textBoxReport.Size = new Size(700, 553);
-            textBoxReport.TabIndex = 7;
+            textBoxReport.TabIndex = 8;
             // 
             // buttonApply
             // 
@@ -156,7 +169,7 @@ namespace Resonalyze
             buttonApply.Location = new Point(538, 643);
             buttonApply.Name = "buttonApply";
             buttonApply.Size = new Size(84, 26);
-            buttonApply.TabIndex = 8;
+            buttonApply.TabIndex = 9;
             buttonApply.Text = "Apply";
             buttonApply.UseVisualStyleBackColor = false;
             // 
@@ -169,7 +182,7 @@ namespace Resonalyze
             buttonCancel.Location = new Point(628, 643);
             buttonCancel.Name = "buttonCancel";
             buttonCancel.Size = new Size(84, 26);
-            buttonCancel.TabIndex = 9;
+            buttonCancel.TabIndex = 10;
             buttonCancel.Text = "Discard";
             buttonCancel.UseVisualStyleBackColor = true;
             // 
@@ -184,6 +197,7 @@ namespace Resonalyze
             Controls.Add(checkBoxGains);
             Controls.Add(labelLevelDifference);
             Controls.Add(numericLevelDifference);
+            Controls.Add(labelLevelDifferenceHint);
             Controls.Add(buttonRun);
             Controls.Add(labelStatus);
             Controls.Add(textBoxReport);
@@ -210,6 +224,7 @@ namespace Resonalyze
         private CheckBox checkBoxGains;
         private Label labelLevelDifference;
         private DarkNumericUpDown numericLevelDifference;
+        private Label labelLevelDifferenceHint;
         private Button buttonRun;
         private Label labelStatus;
         private TextBox textBoxReport;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
@@ -33,12 +33,15 @@ namespace Resonalyze
             labelSceneOffset = new Label();
             numericSceneOffset = new DarkNumericUpDown();
             checkBoxGains = new CheckBox();
+            labelLevelDifference = new Label();
+            numericLevelDifference = new DarkNumericUpDown();
             buttonRun = new Button();
             labelStatus = new Label();
             textBoxReport = new TextBox();
             buttonApply = new Button();
             buttonCancel = new Button();
             (numericSceneOffset).BeginInit();
+            (numericLevelDifference).BeginInit();
             SuspendLayout();
             // 
             // labelSceneOffset
@@ -79,27 +82,54 @@ namespace Resonalyze
             checkBoxGains.Size = new Size(199, 19);
             checkBoxGains.TabIndex = 2;
             checkBoxGains.Text = "Balance channel gains (cut-only)";
-            // 
+            //
+            // labelLevelDifference
+            //
+            labelLevelDifference.AutoSize = true;
+            labelLevelDifference.ForeColor = Color.FromArgb(185, 190, 200);
+            labelLevelDifference.Location = new Point(411, 16);
+            labelLevelDifference.Name = "labelLevelDifference";
+            labelLevelDifference.Size = new Size(80, 15);
+            labelLevelDifference.TabIndex = 3;
+            labelLevelDifference.Text = "L-R level, dB:";
+            //
+            // numericLevelDifference
+            //
+            numericLevelDifference.BackColor = Color.FromArgb(55, 60, 72);
+            numericLevelDifference.DecimalPlaces = 1;
+            numericLevelDifference.ForeColor = Color.White;
+            numericLevelDifference.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
+            numericLevelDifference.Location = new Point(500, 12);
+            numericLevelDifference.Maximum = new decimal(new int[] { 6, 0, 0, 0 });
+            numericLevelDifference.Minimum = new decimal(new int[] { 6, 0, 0, int.MinValue });
+            numericLevelDifference.MinimumSize = new Size(36, 19);
+            numericLevelDifference.Name = "numericLevelDifference";
+            numericLevelDifference.Size = new Size(72, 21);
+            numericLevelDifference.TabIndex = 4;
+            numericLevelDifference.TextAlign = HorizontalAlignment.Right;
+            numericLevelDifference.ThousandsSeparator = false;
+            numericLevelDifference.Value = new decimal(new int[] { 1, 0, 0, int.MinValue });
+            //
             // buttonRun
-            // 
+            //
             buttonRun.BackColor = Color.FromArgb(46, 51, 67);
             buttonRun.FlatStyle = FlatStyle.Popup;
             buttonRun.ForeColor = Color.White;
             buttonRun.Location = new Point(12, 44);
             buttonRun.Name = "buttonRun";
             buttonRun.Size = new Size(120, 26);
-            buttonRun.TabIndex = 3;
+            buttonRun.TabIndex = 5;
             buttonRun.Text = "Run";
             buttonRun.UseVisualStyleBackColor = false;
-            // 
+            //
             // labelStatus
-            // 
+            //
             labelStatus.AutoSize = true;
             labelStatus.ForeColor = Color.FromArgb(185, 190, 200);
             labelStatus.Location = new Point(144, 50);
             labelStatus.Name = "labelStatus";
             labelStatus.Size = new Size(0, 15);
-            labelStatus.TabIndex = 4;
+            labelStatus.TabIndex = 6;
             // 
             // textBoxReport
             // 
@@ -114,7 +144,7 @@ namespace Resonalyze
             textBoxReport.ReadOnly = true;
             textBoxReport.ScrollBars = ScrollBars.Vertical;
             textBoxReport.Size = new Size(700, 553);
-            textBoxReport.TabIndex = 5;
+            textBoxReport.TabIndex = 7;
             // 
             // buttonApply
             // 
@@ -126,7 +156,7 @@ namespace Resonalyze
             buttonApply.Location = new Point(538, 643);
             buttonApply.Name = "buttonApply";
             buttonApply.Size = new Size(84, 26);
-            buttonApply.TabIndex = 6;
+            buttonApply.TabIndex = 8;
             buttonApply.Text = "Apply";
             buttonApply.UseVisualStyleBackColor = false;
             // 
@@ -139,7 +169,7 @@ namespace Resonalyze
             buttonCancel.Location = new Point(628, 643);
             buttonCancel.Name = "buttonCancel";
             buttonCancel.Size = new Size(84, 26);
-            buttonCancel.TabIndex = 7;
+            buttonCancel.TabIndex = 9;
             buttonCancel.Text = "Discard";
             buttonCancel.UseVisualStyleBackColor = true;
             // 
@@ -152,6 +182,8 @@ namespace Resonalyze
             Controls.Add(labelSceneOffset);
             Controls.Add(numericSceneOffset);
             Controls.Add(checkBoxGains);
+            Controls.Add(labelLevelDifference);
+            Controls.Add(numericLevelDifference);
             Controls.Add(buttonRun);
             Controls.Add(labelStatus);
             Controls.Add(textBoxReport);
@@ -166,6 +198,7 @@ namespace Resonalyze
             StartPosition = FormStartPosition.CenterParent;
             Text = "Auto delay";
             (numericSceneOffset).EndInit();
+            (numericLevelDifference).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -175,6 +208,8 @@ namespace Resonalyze
         private Label labelSceneOffset;
         private DarkNumericUpDown numericSceneOffset;
         private CheckBox checkBoxGains;
+        private Label labelLevelDifference;
+        private DarkNumericUpDown numericLevelDifference;
         private Button buttonRun;
         private Label labelStatus;
         private TextBox textBoxReport;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
@@ -140,6 +140,7 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
         bool enabled = stereo && checkBoxGains.Checked;
         labelLevelDifference.Enabled = enabled;
         numericLevelDifference.Enabled = enabled;
+        labelLevelDifferenceHint.Enabled = enabled;
     }
 
     // Once a proposal exists, any input change makes it stale: Apply must
@@ -193,6 +194,7 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
         checkBoxGains.Enabled = false;
         labelLevelDifference.Enabled = false;
         numericLevelDifference.Enabled = false;
+        labelLevelDifferenceHint.Enabled = false;
         SetStatus("Aligning…", StatusNeutral);
         UseWaitCursor = true;
         try

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
@@ -25,7 +25,7 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
     private static readonly Color StatusWarning = Color.FromArgb(230, 184, 0);
     private static readonly Color StatusError = Color.FromArgb(240, 100, 110);
 
-    private Func<double, bool, Task<AutoDelayRunResult>>? runner;
+    private Func<double, bool, double, Task<AutoDelayRunResult>>? runner;
     private bool stereo;
     private bool running;
 
@@ -36,7 +36,12 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
         buttonApply.Enabled = false;
         buttonRun.Click += async (_, _) => await RunAsync();
         numericSceneOffset.ValueChanged += (_, _) => InvalidateResult();
-        checkBoxGains.CheckedChanged += (_, _) => InvalidateResult();
+        numericLevelDifference.ValueChanged += (_, _) => InvalidateResult();
+        checkBoxGains.CheckedChanged += (_, _) =>
+        {
+            UpdateLevelDifferenceEnabled();
+            InvalidateResult();
+        };
         toolTip.SetToolTip(
             numericSceneOffset,
             "Stereo scene offset (ms).\r\n" +
@@ -44,17 +49,26 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
             "pulling the image from the driver's axis toward the\r\n" +
             "dash center on a left-hand-drive car. Typical: 0.2–0.3 ms.\r\n" +
             "Right-hand drive: enter a negative value.\r\n" +
-            "0 = image centered on the measurement position.\r\n" +
-            "With gain balancing on, the same offset also sets the\r\n" +
-            "L/R level tilt (0.27 ms ≈ 2 dB, clamped at ±6 dB).");
+            "0 = image centered on the measurement position.");
         toolTip.SetToolTip(
             checkBoxGains,
             "Starting-point level balance, cut-only: channels whose band\r\n" +
             "meaningfully reaches above 300 Hz are levelled by their\r\n" +
-            "per-octave band energy — the board to one target, right vs\r\n" +
-            "left honoring the scene offset. Subwoofers, mono channels\r\n" +
+            "per-octave band energy — the board to one target, left vs\r\n" +
+            "right offset by the L-R level below. Subwoofers, mono channels\r\n" +
             "and channels without a crossover keep their gain. This is a\r\n" +
             "starting balance, not a final tonal decision.");
+        numericLevelDifference.ApplyToolTip(
+            toolTip,
+            "The intentional level difference (dB) the balance aims for,\r\n" +
+            "read as LEFT minus RIGHT.\r\n" +
+            "Negative: the left side plays quieter by this much, pulling\r\n" +
+            "the image away from the driver's axis toward the dash center\r\n" +
+            "on a left-hand-drive car — the same placement as the offset\r\n" +
+            "above, traded as level instead of time. Typical: -1 to -2 dB.\r\n" +
+            "Right-hand drive: a positive value.\r\n" +
+            "0 = both sides levelled to the same target.\r\n" +
+            "Cut-only: the tilt is produced by attenuating the near side.");
         // The designer's Dispose releases the tooltip; no Disposed handler.
     }
 
@@ -62,16 +76,18 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
     public AutoDelayRunResult? Result { get; private set; }
 
     /// <summary>
-    /// Seeds the dialog: the run mode (a single-side run has no L/R offset to
-    /// honor), the persisted scene offset, and the panel's compute delegate
-    /// (scene offset ms, balance gains) -> proposal.
+    /// Seeds the dialog: the run mode (a single-side run has no L/R relation
+    /// to honor), the persisted scene offset and L-R level difference, and the
+    /// panel's compute delegate (scene offset ms, balance gains, L-R level
+    /// difference dB) -> proposal.
     /// <paramref name="polarityWarning"/> is a non-empty red heads-up shown at
     /// launch when a driver's left and right measured polarities disagree.
     /// </summary>
     public void Init(
         bool stereo,
         double sceneOffsetMs,
-        Func<double, bool, Task<AutoDelayRunResult>> runner,
+        double levelDifferenceDb,
+        Func<double, bool, double, Task<AutoDelayRunResult>> runner,
         string? polarityWarning = null)
     {
         this.stereo = stereo;
@@ -80,6 +96,11 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
             (decimal)sceneOffsetMs,
             numericSceneOffset.Minimum,
             numericSceneOffset.Maximum);
+        numericLevelDifference.Value = Math.Clamp(
+            (decimal)levelDifferenceDb,
+            numericLevelDifference.Minimum,
+            numericLevelDifference.Maximum);
+        UpdateLevelDifferenceEnabled();
         if (!stereo)
         {
             labelSceneOffset.Enabled = false;
@@ -88,6 +109,10 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
                 numericSceneOffset,
                 "Only one side is measured, so this run aligns a single\r\n" +
                 "side and the L/R scene offset does not apply.");
+            numericLevelDifference.ApplyToolTip(
+                toolTip,
+                "Only one side is measured, so there is no L/R relation to\r\n" +
+                "tilt: the gain balance levels this side's board alone.");
         }
 
         textBoxReport.Text =
@@ -104,6 +129,17 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
         {
             SetStatus(polarityWarning, StatusError);
         }
+    }
+
+    // The L-R level difference is an input to the gain balance only: with the
+    // checkbox off no gain is written at all, and a single-side run has no L/R
+    // relation to tilt. Kept visible-but-disabled either way, so the value the
+    // next stereo run would use stays readable.
+    private void UpdateLevelDifferenceEnabled()
+    {
+        bool enabled = stereo && checkBoxGains.Checked;
+        labelLevelDifference.Enabled = enabled;
+        numericLevelDifference.Enabled = enabled;
     }
 
     // Once a proposal exists, any input change makes it stale: Apply must
@@ -155,12 +191,16 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
         buttonCancel.Enabled = false;
         numericSceneOffset.Enabled = false;
         checkBoxGains.Enabled = false;
+        labelLevelDifference.Enabled = false;
+        numericLevelDifference.Enabled = false;
         SetStatus("Aligning…", StatusNeutral);
         UseWaitCursor = true;
         try
         {
             AutoDelayRunResult result = await runner(
-                (double)numericSceneOffset.Value, checkBoxGains.Checked);
+                (double)numericSceneOffset.Value,
+                checkBoxGains.Checked,
+                (double)numericLevelDifference.Value);
             if (IsDisposed)
             {
                 return;
@@ -195,6 +235,7 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
                 buttonCancel.Enabled = true;
                 numericSceneOffset.Enabled = stereo;
                 checkBoxGains.Enabled = true;
+                UpdateLevelDifferenceEnabled();
                 UseWaitCursor = false;
             }
         }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayReport.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayReport.cs
@@ -45,6 +45,7 @@ internal sealed record AutoDelayRunResult(
     bool Stereo,
     double SceneOffsetMs,
     bool GainsRequested,
+    double LevelDifferenceDb,
     string ReportText,
     StringBuilder Log);
 
@@ -60,6 +61,7 @@ internal static class VirtualCrossoverAutoDelayReport
         bool stereo,
         double sceneOffsetMs,
         bool gainsRequested,
+        double levelDifferenceDb,
         AutoDelaySumLossForecast? leftSumLoss = null,
         AutoDelaySumLossForecast? rightSumLoss = null)
     {
@@ -76,7 +78,8 @@ internal static class VirtualCrossoverAutoDelayReport
                 "(positive: right side leads)" +
                 (gainsRequested
                     ? FormattableString.Invariant(
-                        $", gain tilt {GainBalanceEngine.SceneTiltDb(sceneOffsetMs):+0.0;-0.0;0.0} dB")
+                        $", L-R level {GainBalanceEngine.LevelDifferenceDb(levelDifferenceDb):+0.0;-0.0;0.0} dB") +
+                      " (positive: left side louder)"
                     : ""));
         }
         if (!gainsRequested)

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -2196,7 +2196,8 @@ public partial class VirtualCrossoverPanel : UserControl
         dialog.Init(
             stereo: false,
             project.StereoSceneOffsetMs,
-            (_, adjustGains) => RunSingleSideProposalAsync(
+            project.StereoLevelDifferenceDb,
+            (_, adjustGains, _) => RunSingleSideProposalAsync(
                 participants, minHz, maxHz, adjustGains));
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
             dialog.Result is not { } result ||
@@ -2253,7 +2254,8 @@ public partial class VirtualCrossoverPanel : UserControl
     // Computes the single-side proposal on a background thread: the alignment
     // cascade, then (when asked) the cut-only gain balance from the run's
     // final snapshots. Board levelling only — a single side has no L/R
-    // relation, so the scene offset plays no part here.
+    // relation, so neither the scene offset nor the level difference plays a
+    // part here.
     private async Task<AutoDelayRunResult> RunSingleSideProposalAsync(
         List<VirtualCrossoverChannel> participants,
         double windowMinHz,
@@ -2290,7 +2292,7 @@ public partial class VirtualCrossoverPanel : UserControl
                         channel.Pair.Mono,
                         RightSide: false,
                         (IAlignmentChannel?)null)),
-                    reprocessor, alignment, sceneOffsetMs: 0, log);
+                    reprocessor, alignment, levelDifferenceDb: 0, log);
             }
 
             IReadOnlyList<AlignmentSnapshot> afterSnapshots =
@@ -2310,14 +2312,15 @@ public partial class VirtualCrossoverPanel : UserControl
                 channel.Name)),
             alignment, decisions, gains);
         string report = VirtualCrossoverAutoDelayReport.Format(
-            outcomes, stereo: false, sceneOffsetMs: 0, adjustGains, sumLoss);
+            outcomes, stereo: false, sceneOffsetMs: 0, adjustGains,
+            levelDifferenceDb: 0, sumLoss);
         // The diagnostic trace is written already at the proposal stage, so a
         // discarded (or failed-looking) run can still be shared and analyzed;
         // Apply rewrites it with the results and the outcome metric appended.
         WriteAlignmentLog(log.ToString());
         return new AutoDelayRunResult(
             outcomes, Stereo: false, project.StereoSceneOffsetMs,
-            adjustGains, report, log);
+            adjustGains, project.StereoLevelDifferenceDb, report, log);
     }
 
     // Bridges the run's channels to the dsp GainBalanceEngine: bands from the
@@ -2330,7 +2333,7 @@ public partial class VirtualCrossoverPanel : UserControl
             bool Mono, bool RightSide, IAlignmentChannel? LeftPeer)> channels,
         AlignmentReprocessor reprocessor,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
-        double sceneOffsetMs,
+        double levelDifferenceDb,
         System.Text.StringBuilder log)
     {
         IReadOnlyList<AlignmentSnapshot> snapshots = reprocessor.Reprocess(alignment);
@@ -2354,7 +2357,7 @@ public partial class VirtualCrossoverPanel : UserControl
                     item.LeftPeer);
             })
             .ToList();
-        return GainBalanceEngine.Compute(inputs, sceneOffsetMs, log);
+        return GainBalanceEngine.Compute(inputs, levelDifferenceDb, log);
     }
 
     private static Dictionary<IAlignmentChannel, Complex[]> ToIrMap(
@@ -2481,9 +2484,11 @@ public partial class VirtualCrossoverPanel : UserControl
 
         if (result.Stereo)
         {
-            // The offset the proposal was computed with becomes the persisted
-            // value only now, so a discarded experiment does not overwrite it.
+            // The inputs the proposal was computed with become the persisted
+            // values only now, so a discarded experiment does not overwrite
+            // them.
             project.StereoSceneOffsetMs = result.SceneOffsetMs;
+            project.StereoLevelDifferenceDb = result.LevelDifferenceDb;
         }
 
         ScheduleSave();
@@ -2732,9 +2737,11 @@ public partial class VirtualCrossoverPanel : UserControl
         dialog.Init(
             stereo: true,
             project.StereoSceneOffsetMs,
-            (sceneOffsetMs, adjustGains) => RunStereoProposalAsync(
+            project.StereoLevelDifferenceDb,
+            (sceneOffsetMs, adjustGains, levelDifferenceDb) => RunStereoProposalAsync(
                 leftSide, rightSide, union, bridgeLeft, bridgeRight,
-                bridgeBandLowHz, bridgeBandHighHz, sceneOffsetMs, adjustGains),
+                bridgeBandLowHz, bridgeBandHighHz, sceneOffsetMs, adjustGains,
+                levelDifferenceDb),
             DescribeLeftRightPolarityMismatch(leftSide, rightSide));
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
             dialog.Result is not { } result ||
@@ -2794,8 +2801,8 @@ public partial class VirtualCrossoverPanel : UserControl
 
     // Computes the stereo proposal on a background thread: the alignment
     // cascade, then (when asked) the cut-only gain balance from the run's
-    // final snapshots — right channels judged against their left peers, the
-    // level tilt derived from the same scene offset the delays honor.
+    // final snapshots — right channels judged against their left peers, tilted
+    // by the L-R level difference the tuner entered.
     private async Task<AutoDelayRunResult> RunStereoProposalAsync(
         List<VirtualCrossoverSideAlignmentChannel> leftSide,
         List<VirtualCrossoverSideAlignmentChannel> rightSide,
@@ -2805,7 +2812,8 @@ public partial class VirtualCrossoverPanel : UserControl
         double bridgeBandLowHz,
         double bridgeBandHighHz,
         double sceneOffsetMs,
-        bool adjustGains)
+        bool adjustGains,
+        double levelDifferenceDb)
     {
         var log = new System.Text.StringBuilder();
         log.AppendLine($"Auto delay (stereo) {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
@@ -2846,7 +2854,7 @@ public partial class VirtualCrossoverPanel : UserControl
                             ? leftSide.FirstOrDefault(left =>
                                 left.Runtime == side.Runtime && !left.RightSide)
                             : null))),
-                    reprocessor, engineAlignment, sceneOffsetMs, log);
+                    reprocessor, engineAlignment, levelDifferenceDb, log);
             }
 
             IReadOnlyList<AlignmentSnapshot> afterSnapshots =
@@ -2883,12 +2891,13 @@ public partial class VirtualCrossoverPanel : UserControl
             engineAlignment, decisions, gains);
         string report = VirtualCrossoverAutoDelayReport.Format(
             outcomes, stereo: true, sceneOffsetMs, adjustGains,
-            leftSumLoss, rightSumLoss);
+            levelDifferenceDb, leftSumLoss, rightSumLoss);
         // Written already at the proposal stage, so a discarded run can still
         // be shared and analyzed; Apply rewrites it with the outcome metric.
         WriteAlignmentLog(log.ToString());
         return new AutoDelayRunResult(
-            outcomes, Stereo: true, sceneOffsetMs, adjustGains, report, log);
+            outcomes, Stereo: true, sceneOffsetMs, adjustGains,
+            levelDifferenceDb, report, log);
     }
 
     // Bridges the pair/side model to the stereo engine on a background thread,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -313,6 +313,13 @@ public sealed class VirtualCrossoverProjectFile
     // left-seated driver; right-seated drivers use a negative value.
     public double StereoSceneOffsetMs { get; set; } = 0.25;
 
+    // The intentional level difference (dB) the Auto delay gain balance aims
+    // for, read as LEFT minus RIGHT: the default asks for the left side 1 dB
+    // BELOW the right, the same image direction as the scene offset traded as
+    // level instead of time. The tuner's own figure, not a value derived from
+    // the offset. Additive: older files lack it and open on this default.
+    public double StereoLevelDifferenceDb { get; set; } = -1.0;
+
     // Which side the tool currently displays and edits (view state).
     public bool ActiveSideRight { get; set; }
 
@@ -656,6 +663,13 @@ public sealed class VirtualCrossoverProjectFile
             Math.Abs(StereoSceneOffsetMs) > MaximumSceneOffsetMs)
         {
             throw new InvalidDataException("The stereo scene offset is invalid.");
+        }
+        if (!double.IsFinite(StereoLevelDifferenceDb) ||
+            Math.Abs(StereoLevelDifferenceDb) >
+                GainBalanceEngine.MaxLevelDifferenceDb)
+        {
+            throw new InvalidDataException(
+                "The stereo L/R level difference is invalid.");
         }
         if (!OverlaySmoothing.IsValid(SmoothingInverseOctaves))
         {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAutoDelayReportTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAutoDelayReportTests.cs
@@ -59,12 +59,15 @@ public sealed class VirtualCrossoverAutoDelayReportTests
             stereo: true,
             sceneOffsetMs: 0.27,
             gainsRequested: true,
+            levelDifferenceDb: -1.5,
             leftSumLoss: new AutoDelaySumLossForecast(-2.0, -0.6),
             rightSumLoss: new AutoDelaySumLossForecast(-2.4, -0.8));
 
         Assert.Contains("stereo", report);
         Assert.Contains("Scene offset +0.27 ms", report);
-        Assert.Contains("gain tilt +2.0 dB", report);
+        // The tilt is the entered figure, independent of the scene offset, and
+        // signed LEFT minus RIGHT.
+        Assert.Contains("L-R level -1.5 dB (positive: left side louder)", report);
         // The at-a-glance summary: change counts, the predicted sum-loss
         // improvement per side, and one warning line per LOW-confidence call.
         Assert.Contains("Changes: 3 delays, 1 polarities, 1 gains", report);
@@ -104,6 +107,7 @@ public sealed class VirtualCrossoverAutoDelayReportTests
             stereo: false,
             sceneOffsetMs: 0,
             gainsRequested: false,
+            levelDifferenceDb: 0,
             leftSumLoss: new AutoDelaySumLossForecast(-1.5, -0.3));
 
         Assert.Contains("single side", report);

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -236,6 +236,7 @@ public sealed class VirtualCrossoverProjectFileTests
                 PhaseDetrendMode = PhaseDetrendMode.Manual
             };
             original.StereoSceneOffsetMs = -0.4;
+            original.StereoLevelDifferenceDb = -1.5;
             original.ActiveSideRight = true;
             original.Pairs[0].Mono = true;
             original.Pairs[0].Left = new VirtualCrossoverChannelSettings
@@ -281,6 +282,8 @@ public sealed class VirtualCrossoverProjectFileTests
             Assert.Equal(original.PhaseFdwCycles, loaded.PhaseFdwCycles);
             Assert.Equal(original.PhaseDetrendMode, loaded.PhaseDetrendMode);
             Assert.Equal(original.StereoSceneOffsetMs, loaded.StereoSceneOffsetMs);
+            Assert.Equal(
+                original.StereoLevelDifferenceDb, loaded.StereoLevelDifferenceDb);
             Assert.Equal(original.ActiveSideRight, loaded.ActiveSideRight);
             Assert.Equal(original.Pairs.Count, loaded.Pairs.Count);
             Assert.True(loaded.Pairs[0].Mono);
@@ -485,6 +488,12 @@ public sealed class VirtualCrossoverProjectFileTests
                 VirtualCrossoverProjectFile.MaximumSceneOffsetMs + 1
         };
         Assert.Throws<InvalidDataException>(() => badSceneOffset.Validate());
+
+        var badLevelDifference = new VirtualCrossoverProjectFile
+        {
+            StereoLevelDifferenceDb = GainBalanceEngine.MaxLevelDifferenceDb + 1
+        };
+        Assert.Throws<InvalidDataException>(() => badLevelDifference.Validate());
 
         var badCalibrationMode = new VirtualCrossoverProjectFile
         {

--- a/tests/Resonalyze.Dsp.Tests/GainBalanceEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/GainBalanceEngineTests.cs
@@ -5,11 +5,11 @@ namespace Resonalyze.Dsp.Tests;
 
 /// <summary>
 /// The cut-only gain balance: eligibility (octave rule over the crossover
-/// band), 1/f-weighted band levels, the scene tilt with its clamp, and the
-/// joint cut-only solve (board levelling + L/R tilt as one system, shifted so
-/// the quietest participant lands at 0 dB of cut). Synthetic spectra are
-/// scaled delta impulses (flat by construction), so every expected level is
-/// plain arithmetic.
+/// band), 1/f-weighted band levels, the requested L-R level difference
+/// (LEFT minus RIGHT) with its clamp, and the joint cut-only solve (board
+/// levelling + L/R tilt as one system, shifted so the quietest participant
+/// lands at 0 dB of cut). Synthetic spectra are scaled delta impulses (flat
+/// by construction), so every expected level is plain arithmetic.
 /// </summary>
 public sealed class GainBalanceEngineTests
 {
@@ -45,16 +45,42 @@ public sealed class GainBalanceEngineTests
             rightSide, leftPeer);
 
     [Fact]
-    public void SceneTiltDb_InterpolatesAndClamps()
+    public void LevelDifferenceDb_PassesTheRequestThroughAndClamps()
     {
-        Assert.Equal(0.0, GainBalanceEngine.SceneTiltDb(0), 9);
-        Assert.Equal(2.0, GainBalanceEngine.SceneTiltDb(0.27), 9);
-        Assert.Equal(-2.0, GainBalanceEngine.SceneTiltDb(-0.27), 9);
-        Assert.Equal(1.0, GainBalanceEngine.SceneTiltDb(0.135), 9);
-        // The offset control reaches ±5 ms; the trade must not extrapolate to
-        // ±37 dB of board attenuation.
-        Assert.Equal(6.0, GainBalanceEngine.SceneTiltDb(5.0), 9);
-        Assert.Equal(-6.0, GainBalanceEngine.SceneTiltDb(-5.0), 9);
+        // The tilt is the tuner's own figure now: inside the range it is
+        // taken verbatim, with no derivation from the scene offset.
+        Assert.Equal(0.0, GainBalanceEngine.LevelDifferenceDb(0), 9);
+        Assert.Equal(2.0, GainBalanceEngine.LevelDifferenceDb(2.0), 9);
+        Assert.Equal(-1.5, GainBalanceEngine.LevelDifferenceDb(-1.5), 9);
+        // Past the range a "level difference" is one side switched off.
+        Assert.Equal(6.0, GainBalanceEngine.LevelDifferenceDb(40.0), 9);
+        Assert.Equal(-6.0, GainBalanceEngine.LevelDifferenceDb(-40.0), 9);
+        // A non-finite request must not poison every target with NaN.
+        Assert.Equal(0.0, GainBalanceEngine.LevelDifferenceDb(double.NaN), 9);
+    }
+
+    [Fact]
+    public void Compute_ReadsTheDifferenceAsLeftMinusRight()
+    {
+        // The one sign the whole feature hangs on: the request is L-R, so the
+        // typical left-hand-drive figure (-1 dB) must land on the LEFT board
+        // as the cut — reading it as R-L would attenuate the far side and
+        // push the image the wrong way.
+        var leftMid = Input("mid L", 1.0);
+        GainBalanceInput rightMid = Input(
+            "mid R", 1.0, rightSide: true, leftPeer: leftMid.Channel);
+        var log = new StringBuilder();
+
+        IReadOnlyList<GainBalanceResult> results = GainBalanceEngine.Compute(
+            [leftMid, rightMid], levelDifferenceDb: -1.0, log);
+
+        Assert.Equal(-1.0, results[0].ProposedGainDb, 1);
+        Assert.Equal(0.0, results[1].ProposedGainDb, 1);
+        // The log is written in the current culture (unlike the report, which
+        // is invariant), so the expectation is formatted the same way.
+        Assert.Contains(
+            $"L-R level difference {-1.0:+0.00;-0.00} dB (positive: left side louder)",
+            log.ToString());
     }
 
     [Fact]
@@ -155,7 +181,7 @@ public sealed class GainBalanceEngineTests
                 Input("B", 0.5),     //  -6 dB
                 Input("C", 0.25)     // -12 dB — the cut-only floor
             ],
-            sceneOffsetMs: 0,
+            levelDifferenceDb: 0,
             log);
 
         Assert.All(results, result => Assert.True(result.Adjusted));
@@ -169,7 +195,7 @@ public sealed class GainBalanceEngineTests
     }
 
     [Fact]
-    public void Compute_SceneTiltAttenuatesTheNearSide()
+    public void Compute_LevelDifferenceAttenuatesTheNearSide()
     {
         var leftMid = Input("mid L", 1.0);
         GainBalanceInput rightMid = Input(
@@ -177,10 +203,10 @@ public sealed class GainBalanceEngineTests
         var log = new StringBuilder();
 
         IReadOnlyList<GainBalanceResult> results = GainBalanceEngine.Compute(
-            [leftMid, rightMid], sceneOffsetMs: 0.27, log);
+            [leftMid, rightMid], levelDifferenceDb: -2.0, log);
 
-        // +0.27 ms scene offset = the right side louder by 2 dB; cut-only, so
-        // the LEFT board takes the -2 dB and the right stays at 0.
+        // L-R = -2 dB asks for the left side 2 dB BELOW the right; cut-only,
+        // so the LEFT board takes the -2 dB and the right stays at 0.
         Assert.Equal(-2.0, results[0].ProposedGainDb, 1);
         Assert.Equal(0.0, results[1].ProposedGainDb, 1);
     }
@@ -194,7 +220,7 @@ public sealed class GainBalanceEngineTests
         var log = new StringBuilder();
 
         IReadOnlyList<GainBalanceResult> results = GainBalanceEngine.Compute(
-            [leftMid, rightMid], sceneOffsetMs: -0.27, log);
+            [leftMid, rightMid], levelDifferenceDb: 2.0, log);
 
         Assert.Equal(0.0, results[0].ProposedGainDb, 1);
         Assert.Equal(-2.0, results[1].ProposedGainDb, 1);
@@ -203,7 +229,7 @@ public sealed class GainBalanceEngineTests
     [Fact]
     public void Compute_QuietRightForcesTheLeftDown()
     {
-        // The right mid is physically 3 dB quieter while the scene wants it
+        // The right mid is physically 3 dB quieter while the tuner wants it
         // 2 dB LOUDER than the left: sequential "level left, then match right"
         // would need a +boost. The joint solve cuts the left instead.
         var leftMid = Input("mid L", 1.0);
@@ -213,7 +239,7 @@ public sealed class GainBalanceEngineTests
         var log = new StringBuilder();
 
         IReadOnlyList<GainBalanceResult> results = GainBalanceEngine.Compute(
-            [leftMid, rightMid], sceneOffsetMs: 0.27, log);
+            [leftMid, rightMid], levelDifferenceDb: -2.0, log);
 
         Assert.Equal(-5.0, results[0].ProposedGainDb, 1);
         Assert.Equal(0.0, results[1].ProposedGainDb, 1);
@@ -231,7 +257,7 @@ public sealed class GainBalanceEngineTests
                 Input("A", 1.0),
                 Input("B", 0.5, currentGainDb: -6.02)
             ],
-            sceneOffsetMs: 0,
+            levelDifferenceDb: 0,
             log);
 
         Assert.Equal(0.0, results[0].ProposedGainDb, 1);
@@ -254,7 +280,7 @@ public sealed class GainBalanceEngineTests
         var log = new StringBuilder();
 
         IReadOnlyList<GainBalanceResult> results = GainBalanceEngine.Compute(
-            [leftMid, rightMid, tweeter], sceneOffsetMs: 0.27, log);
+            [leftMid, rightMid, tweeter], levelDifferenceDb: -2.0, log);
 
         Assert.False(results[0].Adjusted);
         Assert.Contains("right side ineligible", results[0].SkipReason);
@@ -278,7 +304,7 @@ public sealed class GainBalanceEngineTests
         var log = new StringBuilder();
 
         IReadOnlyList<GainBalanceResult> results = GainBalanceEngine.Compute(
-            [leftMid, rightMid], sceneOffsetMs: 0, log);
+            [leftMid, rightMid], levelDifferenceDb: 0, log);
 
         Assert.True(results[1].Adjusted);
         Assert.Equal(AlignmentConfidence.Low, results[1].Confidence);
@@ -299,7 +325,7 @@ public sealed class GainBalanceEngineTests
         var log = new StringBuilder();
 
         IReadOnlyList<GainBalanceResult> results = GainBalanceEngine.Compute(
-            [mid, dead], sceneOffsetMs: 0, log);
+            [mid, dead], levelDifferenceDb: 0, log);
 
         Assert.False(results[1].Adjusted);
         Assert.Contains("below the loudest", results[1].SkipReason);
@@ -324,7 +350,7 @@ public sealed class GainBalanceEngineTests
         var log = new StringBuilder();
 
         IReadOnlyList<GainBalanceResult> results = GainBalanceEngine.Compute(
-            [loud, quiet], sceneOffsetMs: 0, log);
+            [loud, quiet], levelDifferenceDb: 0, log);
 
         Assert.All(results, result => Assert.True(
             result.ProposedGainDb >= -GainBalanceEngine.MaxProposedCutDb &&
@@ -348,7 +374,7 @@ public sealed class GainBalanceEngineTests
         var log = new StringBuilder();
 
         IReadOnlyList<GainBalanceResult> results = GainBalanceEngine.Compute(
-            [leftMid, rightMid, tweeter], sceneOffsetMs: 0.27, log);
+            [leftMid, rightMid, tweeter], levelDifferenceDb: -2.0, log);
 
         Assert.False(results[1].Adjusted);
         Assert.Contains("below the loudest", results[1].SkipReason);
@@ -369,7 +395,7 @@ public sealed class GainBalanceEngineTests
                 Input("raw", 1.0, currentGainDb: 1.5, bandLowHz: 20,
                     bandHighHz: 20_000, hasCrossover: false)
             ],
-            sceneOffsetMs: 0,
+            levelDifferenceDb: 0,
             log);
 
         Assert.False(results[1].Adjusted);


### PR DESCRIPTION
## What

`checkBoxGains` still switches the side-levelling on, but the L/R level tilt is no longer computed for the user. A `DarkNumericUpDown` next to the checkbox takes the difference in dB directly.

## Why

The tilt came from a hardcoded time-intensity trade against the scene offset — `0.27 ms ≈ 2 dB`, clamped at ±6 dB. Two problems: the anchor is a literature figure standing in for a decision that belongs to the tuner, and it welded two independent choices (where the image sits in time, how the sides are levelled) onto one control. Wanting a 1 dB tilt with a 0.4 ms offset was simply not expressible.

## Semantics

The field is signed **LEFT minus RIGHT** — positive means the left side plays louder, negative asks for the left side below the right. Default `-1.0` dB (left 1 dB quieter), the usual left-hand-drive direction, matching the scene offset's convention of pulling the image toward the dash center.

`GainBalanceEngine.Compute` takes the figure verbatim and only clamps to ±6 dB as a typo guard (`MaxLevelDifferenceDb`); a non-finite request reads as no tilt. The request is negated exactly once inside the solve, because every target there is expressed relative to the left board — so the joint cut-only solve, the pair rule and the level-credibility gate are untouched. `SceneTiltDb`, `SceneTiltReferenceMs` and `SceneTiltReferenceDb` are gone.

## UI

The field is enabled only while the gains checkbox is on, and only for a stereo run — a single side has no L/R relation to tilt, exactly like the existing scene-offset field. It stays visible-but-disabled so the value the next run would use is readable. Editing it invalidates a pending proposal like every other input, and Run disables it for the duration.

Declared in `.Designer.cs` with the rest of the row, so font autoscaling covers it.

| gains on | gains off |
|---|---|
| `L/R offset, ms: 0,25` · ☑ `Balance channel gains (cut-only)` · `L-R level, dB: -1,0` | same row, label and field greyed |

## Persistence

`VirtualCrossoverProjectFile.StereoLevelDifferenceDb`, additive (older files open on the default, no schema bump), validated against the same dsp constant. Written on Apply only, beside `StereoSceneOffsetMs`, so a discarded experiment does not overwrite it.

The report header now prints what was entered rather than what was derived:

```
Scene offset +0.25 ms (positive: right side leads), L-R level -1.0 dB (positive: left side louder)
```

## Tests

`Compute_ReadsTheDifferenceAsLeftMinusRight` pins the one sign the feature hangs on: `-1.0` must land the cut on the **left** board — reading it as R−L would attenuate the far side and push the image the wrong way. The paired cases flipped sign accordingly, and `SceneTiltDb_InterpolatesAndClamps` became a pass-through/clamp test. Project-file round-trip and validation cover the new field.

Full suite green: 1493 tests. The dialog was also rendered offscreen in both states to confirm the new row lays out without collision (label 411–485, field 500–572, checkbox ends at 395).

🤖 Generated with [Claude Code](https://claude.com/claude-code)