### PR TITLE
Virtual DSP: foldable channel blocks

### DIFF
--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
@@ -32,6 +32,7 @@ namespace Resonalyze
             labelChannel = new Label();
             buttonSource = new Button();
             labelGain = new Label();
+            buttonCollapse = new Button();
             numericGain = new DarkNumericUpDown();
             labelDelay = new Label();
             numericDelay = new DarkNumericUpDown();
@@ -109,6 +110,19 @@ namespace Resonalyze
             labelGain.Size = new Size(48, 15);
             labelGain.TabIndex = 2;
             labelGain.Text = "Gain dB";
+            // 
+            // buttonCollapse
+            // 
+            buttonCollapse.FlatStyle = FlatStyle.Popup;
+            buttonCollapse.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            buttonCollapse.ForeColor = Color.White;
+            buttonCollapse.Location = new Point(8, 54);
+            buttonCollapse.Name = "buttonCollapse";
+            buttonCollapse.Size = new Size(48, 20);
+            buttonCollapse.TabIndex = 37;
+            buttonCollapse.Text = "−";
+            buttonCollapse.UseCompatibleTextRendering = true;
+            buttonCollapse.UseVisualStyleBackColor = true;
             // 
             // numericGain
             // 
@@ -520,7 +534,7 @@ namespace Resonalyze
             labelAllpassBand.ForeColor = Color.FromArgb(170, 176, 190);
             labelAllpassBand.Location = new Point(254, 157);
             labelAllpassBand.Name = "labelAllpassBand";
-            labelAllpassBand.Size = new Size(49, 15);
+            labelAllpassBand.Size = new Size(58, 15);
             labelAllpassBand.TabIndex = 36;
             labelAllpassBand.Text = "= 0.00 ms";
             // 
@@ -541,6 +555,7 @@ namespace Resonalyze
             Controls.Add(labelChannel);
             Controls.Add(buttonSource);
             Controls.Add(labelGain);
+            Controls.Add(buttonCollapse);
             Controls.Add(numericGain);
             Controls.Add(labelDelay);
             Controls.Add(numericDelay);
@@ -589,6 +604,7 @@ namespace Resonalyze
         private Label labelChannel;
         private Button buttonSource;
         private Label labelGain;
+        private Button buttonCollapse;
         private DarkNumericUpDown numericGain;
         private Label labelDelay;
         private DarkNumericUpDown numericDelay;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
@@ -119,7 +119,7 @@ namespace Resonalyze
             buttonCollapse.Location = new Point(8, 54);
             buttonCollapse.Name = "buttonCollapse";
             buttonCollapse.Size = new Size(48, 20);
-            buttonCollapse.TabIndex = 37;
+            buttonCollapse.TabIndex = 8;
             buttonCollapse.Text = "−";
             buttonCollapse.UseCompatibleTextRendering = true;
             buttonCollapse.UseVisualStyleBackColor = true;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
@@ -273,11 +273,17 @@ public partial class VirtualCrossoverChannelControl : UserControl
     }
 
     // The block carries its sizes as designer units; the base scales the bounds and
-    // the size pin, but not the expanded height we parked outside them.
+    // the size pin, but not the expanded height we parked outside them. Container
+    // autoscaling reaches a control through several paths, not all of which touch its
+    // height, so the parked value follows only the calls that actually scale one —
+    // otherwise a folded block would unfold to a height nothing else was scaled to.
     protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
     {
         base.ScaleControl(factor, specified);
-        expandedHeight = (int)Math.Round(expandedHeight * factor.Height);
+        if ((specified & BoundsSpecified.Height) != 0)
+        {
+            expandedHeight = (int)Math.Round(expandedHeight * factor.Height);
+        }
     }
 
     /// <summary>

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
@@ -24,11 +24,18 @@ public partial class VirtualCrossoverChannelControl : UserControl
     private string channelName = "A";
     private bool suppressChangeEvents;
     private bool muted;
+    private bool collapsed;
     private double sampleRateHz = DefaultSampleRateHz;
+    private int expandedHeight;
 
     public VirtualCrossoverChannelControl()
     {
         InitializeComponent();
+        // The designer pins the block to one size (MinimumSize == MaximumSize) so the
+        // flow list cannot stretch it; collapsing moves that pin, so the expanded
+        // height has to be remembered before the first collapse overwrites it. Read
+        // here in designer units — ScaleControl scales it with the rest of the block.
+        expandedHeight = MaximumSize.Height;
         // The ripple cap is the DSP's single source of truth (above it the Chebyshev
         // pole math is undefined); the designer value is only a default.
         numericHighPassRipple.Maximum = (decimal)CrossoverFilter.MaximumChebyshevRippleDb;
@@ -82,6 +89,13 @@ public partial class VirtualCrossoverChannelControl : UserControl
     /// <summary>Raised when the user clicks Clear next to PEQ.</summary>
     public event EventHandler? PeqClearClicked;
 
+    /// <summary>
+    /// Raised when the user folds or unfolds the block. Separate from
+    /// <see cref="SettingsChanged"/> on purpose: the fold changes nothing the DSP
+    /// chain computes, so the host persists it without recomputing the curves.
+    /// </summary>
+    public event EventHandler? CollapsedChanged;
+
     [DefaultValue("A")]
     public string ChannelName
     {
@@ -112,6 +126,7 @@ public partial class VirtualCrossoverChannelControl : UserControl
     internal DarkNumericUpDown AllPassQInput => numericAllPassQ;
     internal Label MeasuredPolarityLabel => labelMeasuredPolarity;
     internal Button MuteButton => buttonMute;
+    internal Button CollapseButton => buttonCollapse;
     internal Button PeqLoadButton => buttonPeqLoad;
     internal Button PeqClearButton => buttonPeqClear;
     internal Label PeqInfoLabel => labelPeqInfo;
@@ -176,6 +191,96 @@ public partial class VirtualCrossoverChannelControl : UserControl
     }
 
     /// <summary>
+    /// Folded, the block shows only its header rows — source, gain, delay, polarity —
+    /// and everything from the crossover row down is cut off. A tall project is then
+    /// scannable without scrolling past the chains the user is not tuning right now.
+    /// The state is per block and persists with the project.
+    /// </summary>
+    [DefaultValue(false)]
+    public bool Collapsed
+    {
+        get => collapsed;
+        set
+        {
+            if (collapsed == value)
+            {
+                return;
+            }
+
+            collapsed = value;
+            ApplyCollapsedState();
+        }
+    }
+
+    // The fold line: the top of the crossover row, the first row of the filter chain.
+    // Read off the live control rather than hard-coded — the rows are scaled for the
+    // current DPI (AutoScaleMode.Font) and a pixel literal would cut the wrong one.
+    private int FoldLine => comboBoxCrossoverKind.Top;
+
+    private void ApplyCollapsedState()
+    {
+        buttonCollapse.Text = collapsed ? "+" : "−";
+        // The rows below the fold are hidden, not merely clipped: hidden, they also
+        // leave the tab order, so a folded block cannot take focus into a field the
+        // user cannot see.
+        int keptBottom = 0;
+        SuspendLayout();
+        foreach (Control child in Controls)
+        {
+            bool kept = !collapsed || child.Top < FoldLine;
+            child.Visible = kept;
+            if (kept)
+            {
+                keptBottom = Math.Max(keptBottom, child.Bottom);
+            }
+        }
+
+        ResumeLayout(false);
+        // The border sits outside the client area, hence the Height/ClientSize term.
+        int height = collapsed
+            ? keptBottom + (Height - ClientSize.Height)
+            : expandedHeight;
+        // The whole move runs inside one suspended parent layout: each size assignment
+        // below asks the flow list to reflow, and a list laid out against a half-moved
+        // pin stacks the next block over this one.
+        Control? parent = Parent;
+        parent?.SuspendLayout();
+        try
+        {
+            // MinimumSize == MaximumSize pins the block, so the bound in the way has to
+            // move first — the other one would clamp the assignment. Never through zero:
+            // a zero MaximumSize height reads as "no height" to the flow list, which then
+            // places the next block on top of this one.
+            if (height < MinimumSize.Height)
+            {
+                MinimumSize = new Size(MinimumSize.Width, height);
+                MaximumSize = new Size(MaximumSize.Width, height);
+            }
+            else
+            {
+                MaximumSize = new Size(MaximumSize.Width, height);
+                MinimumSize = new Size(MinimumSize.Width, height);
+            }
+
+            Height = height;
+        }
+        finally
+        {
+            parent?.ResumeLayout(performLayout: true);
+        }
+
+        CollapsedChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    // The block carries its sizes as designer units; the base scales the bounds and
+    // the size pin, but not the expanded height we parked outside them.
+    protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
+    {
+        base.ScaleControl(factor, specified);
+        expandedHeight = (int)Math.Round(expandedHeight * factor.Height);
+    }
+
+    /// <summary>
     /// Shows the acoustic polarity read from the channel's measured IR — the
     /// as-measured wiring of the driver, independent of the Invert switch. Green
     /// "Normal" for a positive-going arrival, red "Inverted" for a negative-going
@@ -218,6 +323,12 @@ public partial class VirtualCrossoverChannelControl : UserControl
             "Channel delay (ms) — the value you would dial into\r\n" +
             "this DSP channel.\r\n" +
             "The mm readout is the equivalent distance in air.");
+        toolTip.SetToolTip(
+            buttonCollapse,
+            "Fold the block down to its header — source, gain, delay\r\n" +
+            "and polarity stay visible, the filter chain is hidden.\r\n" +
+            "Nothing is bypassed: a folded channel plays and counts\r\n" +
+            "exactly as before.");
         toolTip.SetToolTip(
             buttonMute,
             "Mute the channel: exclude it from the sum, the loss,\r\n" +
@@ -478,6 +589,7 @@ public partial class VirtualCrossoverChannelControl : UserControl
             Muted = !Muted;
             RaiseSettingsChanged();
         };
+        buttonCollapse.Click += (_, _) => Collapsed = !Collapsed;
         buttonPeqLoad.Click += (_, _) => PeqLoadClicked?.Invoke(this, EventArgs.Empty);
         buttonPeqClear.Click += (_, _) => PeqClearClicked?.Invoke(this, EventArgs.Empty);
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -671,6 +671,7 @@ public partial class VirtualCrossoverPanel : UserControl
         control.SourceClicked += (_, _) => ShowSourceMenu(channel);
         control.PeqLoadClicked += (_, _) => LoadPeq(channel);
         control.PeqClearClicked += (_, _) => ClearPeq(channel);
+        control.CollapsedChanged += (_, _) => OnChannelCollapsedChanged(channel);
         return channel;
     }
 
@@ -800,6 +801,20 @@ public partial class VirtualCrossoverPanel : UserControl
 
         ScheduleSave();
         RedrawAll();
+    }
+
+    // Folding a block only changes how much of it the list shows: the flow layout
+    // reflows the blocks below it on its own, and no curve, sum or metric depends on
+    // it — so this persists the state and stops there, no recompute, no redraw.
+    private void OnChannelCollapsedChanged(VirtualCrossoverChannel channel)
+    {
+        if (suppressProjectEvents)
+        {
+            return;
+        }
+
+        channel.Pair.Collapsed = ControlFor(channel).Collapsed;
+        ScheduleSave();
     }
 
     private void OnChannelSettingsChanged(VirtualCrossoverChannel channel)
@@ -953,6 +968,7 @@ public partial class VirtualCrossoverPanel : UserControl
             control.BypassCheckBox.Checked = settings.Bypass;
             control.MonoCheckBox.Checked = channel.Pair.Mono;
             control.Muted = !settings.Enabled;
+            control.Collapsed = channel.Pair.Collapsed;
         });
 
         UpdateSourceButton(channel);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -238,6 +238,15 @@ public sealed class VirtualCrossoverChannelSettings
 public sealed class VirtualCrossoverChannelPairSettings
 {
     public bool Mono { get; set; }
+
+    /// <summary>
+    /// View state: the block is folded to its header in the tool. Both sides share
+    /// it — the fold belongs to the block on screen, not to a measurement — and it
+    /// changes nothing the chain computes. Absent from older files, which therefore
+    /// open expanded.
+    /// </summary>
+    public bool Collapsed { get; set; }
+
     public VirtualCrossoverChannelSettings Left { get; set; } = new();
     public VirtualCrossoverChannelSettings Right { get; set; } = new();
 

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverChannelControlCollapseTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverChannelControlCollapseTests.cs
@@ -83,6 +83,64 @@ public sealed class VirtualCrossoverChannelControlCollapseTests
     }
 
     [Fact]
+    public void ScalingWhileFolded_UnfoldsToAHeightThatStillHoldsEveryRow()
+    {
+        // The block parks its expanded height outside the scaled bounds, so a scale
+        // that lands while it is folded is the one way the two can drift apart: the
+        // rows are scaled up, the parked height is not, and unfolding then clips the
+        // bottom of the chain. Scaled both ways because the block travels between
+        // monitors, not only up from 100%.
+        using var control = new VirtualCrossoverChannelControl();
+        control.Collapsed = true;
+        int foldedAt100 = control.Height;
+
+        control.Scale(new SizeF(1.5f, 1.5f));
+
+        Assert.True(control.Height > foldedAt100);
+        Assert.Equal(control.Height, control.MaximumSize.Height);
+        Assert.True(control.InvertCheckBox.Bottom <= control.ClientSize.Height);
+
+        control.Collapsed = false;
+
+        Assert.Equal(control.Height, control.MaximumSize.Height);
+        Assert.True(control.BypassCheckBox.Bottom <= control.ClientSize.Height);
+        Assert.True(control.ShowProcessedCheckBox.Bottom <= control.ClientSize.Height);
+
+        control.Collapsed = true;
+        control.Scale(new SizeF(1 / 1.5f, 1 / 1.5f));
+        control.Collapsed = false;
+
+        Assert.True(control.BypassCheckBox.Bottom <= control.ClientSize.Height);
+        Assert.Equal(control.Height, control.MaximumSize.Height);
+    }
+
+    [Fact]
+    public void ScalingWhileUnfolded_LeavesTheFoldOnTheSameRow()
+    {
+        using var control = new VirtualCrossoverChannelControl();
+        control.Scale(new SizeF(1.5f, 1.5f));
+
+        control.Collapsed = true;
+
+        // The fold line is read off the scaled rows, so it still cuts above the
+        // crossover row rather than at a stale pixel offset.
+        Assert.True(control.InvertCheckBox.Bottom <= control.ClientSize.Height);
+        Assert.False(control.CrossoverKindComboBox.Visible);
+        Assert.True(control.CrossoverKindComboBox.Bottom > control.ClientSize.Height);
+    }
+
+    [Fact]
+    public void FoldButton_IsReachedWithThePolarityRowRatherThanAfterTheChain()
+    {
+        // It sits at the top of the block, so keyboard focus must not walk the whole
+        // filter chain before coming back up to it.
+        using var control = new VirtualCrossoverChannelControl();
+
+        Assert.True(control.CollapseButton.TabIndex > control.InvertCheckBox.TabIndex);
+        Assert.True(control.CollapseButton.TabIndex < control.CrossoverKindComboBox.TabIndex);
+    }
+
+    [Fact]
     public void FoldingInsideTheChannelList_NeverStacksOneBlockOverAnother()
     {
         // The field bug: with the size pin moved through an unbounded intermediate

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverChannelControlCollapseTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverChannelControlCollapseTests.cs
@@ -1,0 +1,163 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The foldable channel block of the Virtual DSP tool: folding shrinks the block to
+/// its header rows so the flow list reflows the blocks below it, and unfolding
+/// restores exactly the block the designer laid out.
+/// </summary>
+public sealed class VirtualCrossoverChannelControlCollapseTests
+{
+    [Fact]
+    public void Collapsing_KeepsTheHeaderRowsAndCutsTheChainRows()
+    {
+        using var control = new VirtualCrossoverChannelControl();
+
+        control.Collapsed = true;
+
+        // Everything down to the polarity row — the row the fold button shares —
+        // stays inside the shrunken block; the crossover row and below are gone.
+        Assert.True(control.InvertCheckBox.Bottom <= control.ClientSize.Height);
+        Assert.True(control.CollapseButton.Bottom <= control.ClientSize.Height);
+        Assert.True(control.MuteButton.Bottom <= control.ClientSize.Height);
+        Assert.True(control.CrossoverKindComboBox.Bottom > control.ClientSize.Height);
+        Assert.False(control.CrossoverKindComboBox.Visible);
+        Assert.False(control.BypassCheckBox.Visible);
+        Assert.True(control.InvertCheckBox.Visible);
+    }
+
+    [Fact]
+    public void Expanding_RestoresTheDesignerHeightAndTheHiddenRows()
+    {
+        using var control = new VirtualCrossoverChannelControl();
+        int expandedHeight = control.Height;
+
+        control.Collapsed = true;
+        int collapsedHeight = control.Height;
+        control.Collapsed = false;
+
+        Assert.True(collapsedHeight < expandedHeight);
+        Assert.Equal(expandedHeight, control.Height);
+        Assert.True(control.CrossoverKindComboBox.Visible);
+        Assert.True(control.BypassCheckBox.Visible);
+    }
+
+    [Fact]
+    public void Collapsing_MovesTheSizePinSoTheFlowListCannotStretchTheBlockBack()
+    {
+        // The block is pinned to one size (MinimumSize == MaximumSize) so the flow
+        // list leaves it alone; a fold that only set Height would be undone by the
+        // next layout pass.
+        using var control = new VirtualCrossoverChannelControl();
+
+        control.Collapsed = true;
+
+        Assert.Equal(control.Height, control.MinimumSize.Height);
+        Assert.Equal(control.Height, control.MaximumSize.Height);
+        control.Height = 1000;
+        Assert.Equal(control.MaximumSize.Height, control.Height);
+    }
+
+    [Fact]
+    public void CollapseButton_TogglesTheStateAndItsLabel()
+    {
+        using var control = new VirtualCrossoverChannelControl();
+        int raised = 0;
+        control.CollapsedChanged += (_, _) => raised++;
+        control.SettingsChanged += (_, _) => Assert.Fail(
+            "Folding a block changes no DSP setting and must not force a recompute.");
+
+        control.CollapseButton.PerformClick();
+
+        Assert.True(control.Collapsed);
+        Assert.Equal("+", control.CollapseButton.Text);
+        Assert.Equal(1, raised);
+
+        control.CollapseButton.PerformClick();
+
+        Assert.False(control.Collapsed);
+        Assert.Equal("−", control.CollapseButton.Text);
+        Assert.Equal(2, raised);
+    }
+
+    [Fact]
+    public void FoldingInsideTheChannelList_NeverStacksOneBlockOverAnother()
+    {
+        // The field bug: with the size pin moved through an unbounded intermediate
+        // state, the flow list laid out the FOLLOWING block against a block it read as
+        // zero-height, and drew it 74 px over the one above — two blocks glued into one.
+        // The list is rebuilt here as the tool builds it, and the stacking is checked
+        // after every fold.
+        using var form = new Form();
+        using var list = new FlowLayoutPanel
+        {
+            AutoScroll = true,
+            FlowDirection = FlowDirection.TopDown,
+            WrapContents = false,
+            Size = new Size(347, 684)
+        };
+        form.Controls.Add(list);
+
+        var blocks = new List<VirtualCrossoverChannelControl>();
+        for (int index = 0; index < 4; index++)
+        {
+            var block = new VirtualCrossoverChannelControl
+            {
+                Margin = new Padding(0, 0, 0, 6),
+                ChannelName = ((char)('A' + index)).ToString()
+            };
+            blocks.Add(block);
+            list.Controls.Add(block);
+        }
+
+        try
+        {
+            form.Show();
+
+            AssertStacked(blocks);
+            blocks[0].Collapsed = true;
+            AssertStacked(blocks);
+            blocks[1].Collapsed = true;
+            AssertStacked(blocks);
+            blocks[0].Collapsed = false;
+            AssertStacked(blocks);
+            blocks[3].Collapsed = true;
+            AssertStacked(blocks);
+        }
+        finally
+        {
+            form.Close();
+            foreach (VirtualCrossoverChannelControl block in blocks)
+            {
+                block.Dispose();
+            }
+        }
+    }
+
+    private static void AssertStacked(IReadOnlyList<VirtualCrossoverChannelControl> blocks)
+    {
+        for (int index = 1; index < blocks.Count; index++)
+        {
+            VirtualCrossoverChannelControl above = blocks[index - 1];
+            VirtualCrossoverChannelControl below = blocks[index];
+            Assert.True(
+                below.Top >= above.Bottom,
+                $"block {below.ChannelName} at {below.Bounds} overlaps " +
+                $"{above.ChannelName} at {above.Bounds}");
+        }
+    }
+
+    [Fact]
+    public void SettingTheSameStateAgain_RaisesNothing()
+    {
+        using var control = new VirtualCrossoverChannelControl();
+        int raised = 0;
+        control.CollapsedChanged += (_, _) => raised++;
+
+        control.Collapsed = false;
+
+        Assert.Equal(0, raised);
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -558,6 +558,30 @@ public sealed class VirtualCrossoverProjectFileTests
     }
 
     [Fact]
+    public void SaveToAndLoadFrom_RoundTripTheFoldedBlocksAndOpenOlderFilesExpanded()
+    {
+        string root = CreateTemporaryDirectory();
+        string path = Path.Combine(root, "folded.json");
+        try
+        {
+            var original = new VirtualCrossoverProjectFile();
+            original.Pairs[0].Collapsed = true;
+
+            original.SaveTo(path);
+            VirtualCrossoverProjectFile loaded = VirtualCrossoverProjectFile.LoadFrom(path);
+
+            Assert.True(loaded.Pairs[0].Collapsed);
+            // The flag is additive: a file written before it existed simply has no
+            // such property, and its blocks open the way they always did.
+            Assert.False(loaded.Pairs[1].Collapsed);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void LoadFrom_ThrowsOnABrokenSessionFile()
     {
         string root = CreateTemporaryDirectory();


### PR DESCRIPTION
Six or eight speakers put the channel list past the window, while only one chain
is usually being tuned. A fold button under the gain label shrinks its block to
the header rows — source, gain, delay, polarity — and the flow list closes the
gap. The state is per block and persists with the project (`Collapsed` on the
channel pair; the flag is additive, so older sessions open expanded).

Folding changes nothing the DSP chain computes, so it raises its own event
rather than `SettingsChanged`: no recompute, no redraw, just the layout and a
save.

### Layout notes

- The fold line is read off the live control (the top of the crossover row)
  instead of a pixel literal — the block is font-scaled, and a constant would
  cut the wrong row on a high-DPI display.
- Rows below the fold are hidden rather than merely clipped, so a folded block
  cannot take focus into a field the user cannot see.
- The block is pinned to one size (`MinimumSize == MaximumSize`) so the flow
  list leaves it alone; the fold moves that pin. Moving it through an unbounded
  intermediate state was a live bug: each size assignment asks the flow list to
  reflow, a zero `MaximumSize` height reads there as "no height", and the next
  block landed 74 px over the one being folded — two blocks glued into one on
  screen. The pin now moves in the safe order inside a suspended parent layout.

### Tests

`VirtualCrossoverChannelControlCollapseTests` covers the fold geometry, the
restored designer height, the size pin, the button toggle and the absence of a
`SettingsChanged` storm. `FoldingInsideTheChannelList_NeverStacksOneBlockOverAnother`
rebuilds the list the way the tool builds it and asserts the stacking after
every fold — it fails on the overlap bug above. The project round-trip of the
new flag is in `VirtualCrossoverProjectFileTests`. App suite: 628/628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
