### PR TITLE
UI: overlay slot names, wrapped tooltips, Enter that stays in the field

### DIFF
--- a/source/History/MeasurementHistorySnapshotMetadata.cs
+++ b/source/History/MeasurementHistorySnapshotMetadata.cs
@@ -78,6 +78,8 @@ internal sealed class MeasurementHistorySnapshotMetadata
                 $"Loopback: peak {MeterSnapshot.Loopback.PeakDbFs:0.0} dBFS, RMS {MeterSnapshot.Loopback.RmsDbFs:0.0} dBFS");
         }
 
-        return string.Join(Environment.NewLine, lines);
+        // These land on ToolStrip items and grid cells, which do not go through the
+        // app's wrapping tooltip, so the wrap happens here instead.
+        return ToolTipTextWrapper.Wrap(string.Join(Environment.NewLine, lines));
     }
 }

--- a/source/Options/ACOpt.cs
+++ b/source/Options/ACOpt.cs
@@ -5,7 +5,7 @@ namespace Resonalyze.Options
 {
     public partial class ACOpt : Form
     {
-        private readonly ToolTip toolTip = new();
+        private readonly WrappingToolTip toolTip = new();
 
         public ACOpt()
         {

--- a/source/Options/IROpt.cs
+++ b/source/Options/IROpt.cs
@@ -13,7 +13,7 @@ namespace Resonalyze.Options
 {
     public partial class IROpt : Form
     {
-        private readonly ToolTip toolTip = new();
+        private readonly WrappingToolTip toolTip = new();
 
         public IROpt()
         {

--- a/source/Options/ImpulsePreviewOptionsForm.cs
+++ b/source/Options/ImpulsePreviewOptionsForm.cs
@@ -14,7 +14,7 @@ namespace Resonalyze.Options;
 /// </summary>
 public class ImpulsePreviewOptionsForm : Form
 {
-    protected readonly ToolTip toolTip = new();
+    protected readonly WrappingToolTip toolTip = new();
     private bool initializingControls;
 
     public ImpulsePreviewOptionsForm()

--- a/source/Options/LiveSpectrumOpt.cs
+++ b/source/Options/LiveSpectrumOpt.cs
@@ -9,7 +9,7 @@ namespace Resonalyze.Options
             { 256, 512, 1024, 2048, 4096, 8192, 16384 };
         private static readonly int[] OverlapPercents = { 0, 50, 75 };
         private static readonly int[] CoherenceLimits = { 0, 10, 20, 25, 30, 40, 50 };
-        private readonly ToolTip toolTip = new();
+        private readonly WrappingToolTip toolTip = new();
 
         // The user's chosen analysis window and overlap, tracked independently of the
         // combos so they survive the periodic-pink override that forces the window to

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -15,7 +15,7 @@ namespace Resonalyze.Options
 {
     public partial class MeasurementOptions : Form
     {
-        private readonly ToolTip deviceToolTip = new();
+        private readonly WrappingToolTip deviceToolTip = new();
         // Raised the moment any calibration (microphone 0°/90° file or the SPL
         // anchor) is selected, captured, or cleared, so the host can apply and
         // persist it immediately instead of only when the panel is applied.

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -4,7 +4,6 @@ using OxyPlot.Series;
 using Resonalyze.Dsp;
 using Button = System.Windows.Forms.Button;
 using CheckBox = System.Windows.Forms.CheckBox;
-using ToolTip = System.Windows.Forms.ToolTip;
 
 namespace Resonalyze;
 
@@ -102,7 +101,7 @@ public sealed class OverlayCollection
         Form1 form,
         Panel container,
         OxyPlot.WindowsForms.PlotView plotView,
-        ToolTip toolTip,
+        WrappingToolTip toolTip,
         Action notifyPlotChanged)
     {
         Form = form;
@@ -134,12 +133,18 @@ public sealed class OverlayCollection
             .FirstOrDefault()
             ?? throw new InvalidOperationException(
                 "Overlay template checkbox is missing.");
+        Label templateNameLabel = templatePanel.Controls
+            .OfType<Label>()
+            .FirstOrDefault()
+            ?? throw new InvalidOperationException(
+                "Overlay template name label is missing.");
 
         overlays.Add(new Overlay(
             templatePanel,
             templateCaptureButton,
             templateOffset,
             templateCheckBox,
+            templateNameLabel,
             1,
             toolTip,
             this));
@@ -154,16 +159,19 @@ public sealed class OverlayCollection
             CheckBox checkBox = CreateCheckBox(templateCheckBox, index);
             DarkNumericUpDown offset = CreateOffset(templateOffset, index);
             Button captureButton = CreateCaptureButton(templateCaptureButton, index);
+            Label nameLabel = CreateNameLabel(templateNameLabel, index);
 
             panel.Controls.Add(checkBox);
             panel.Controls.Add(offset);
             panel.Controls.Add(captureButton);
+            panel.Controls.Add(nameLabel);
 
             overlays.Add(new Overlay(
                 panel,
                 captureButton,
                 offset,
                 checkBox,
+                nameLabel,
                 index,
                 toolTip,
                 this));
@@ -495,6 +503,25 @@ public sealed class OverlayCollection
         };
     }
 
+    // Cloned from the designer template so the label inherits the font and the
+    // coordinates the designer already scaled for the current DPI.
+    private static Label CreateNameLabel(Label template, int index)
+    {
+        return new Label
+        {
+            AutoEllipsis = template.AutoEllipsis,
+            AutoSize = template.AutoSize,
+            BackColor = template.BackColor,
+            Font = template.Font,
+            ForeColor = template.ForeColor,
+            Location = template.Location,
+            Name = $"labelOverlay{index}",
+            Size = template.Size,
+            TextAlign = template.TextAlign,
+            UseCompatibleTextRendering = template.UseCompatibleTextRendering
+        };
+    }
+
     private static Button CreateCaptureButton(Button template, int index)
     {
         return new Button
@@ -525,6 +552,8 @@ public sealed class Overlay
     private readonly Button captureButton;
     private readonly DarkNumericUpDown offsetControl;
     private readonly CheckBox checkBox;
+    private readonly Label nameLabel;
+    private readonly WrappingToolTip toolTip;
     private readonly Color defaultColor;
     private readonly decimal defaultOffset;
     private readonly ContextMenuStrip captureMenu;
@@ -535,6 +564,7 @@ public sealed class Overlay
     private readonly System.Windows.Forms.Timer longPressTimer;
     private readonly System.Windows.Forms.Timer offsetSaveTimer;
     private bool longPressTriggered;
+    private string title = "";
 
     private OverlayKind kind = OverlayKind.Captured;
     private bool updatingControls;
@@ -614,14 +644,17 @@ public sealed class Overlay
         Button captureButton,
         DarkNumericUpDown offsetControl,
         CheckBox checkBox,
+        Label nameLabel,
         int index,
-        ToolTip toolTip,
+        WrappingToolTip toolTip,
         OverlayCollection collection)
     {
         this.panel = panel;
         this.captureButton = captureButton;
         this.offsetControl = offsetControl;
         this.checkBox = checkBox;
+        this.nameLabel = nameLabel;
+        this.toolTip = toolTip;
         this.collection = collection;
         defaultColor = panel.BackColor;
         defaultOffset = offsetControl.Value;
@@ -661,7 +694,25 @@ public sealed class Overlay
     }
 
     public int Index { get; }
-    public string Title { get; private set; } = "";
+
+    /// <summary>
+    /// The slot's display name. Assigning it also refreshes the panel's name label,
+    /// so every path that names a slot — capture, import, settings, load, reset —
+    /// keeps the label in step.
+    /// </summary>
+    public string Title
+    {
+        get => title;
+        private set
+        {
+            title = value;
+            nameLabel.Text = ShortenSlotName(value);
+            toolTip.SetToolTip(
+                nameLabel,
+                value.Length > 0 ? value : "Empty overlay slot");
+        }
+    }
+
     public Mode SeriesMode { get; private set; }
     public bool Checked => checkBox.Checked;
     public OverlayKind Kind => kind;
@@ -1800,7 +1851,7 @@ public sealed class Overlay
         targetToleranceDb = dialog.ToleranceDb;
         targetDeviationMode = dialog.DeviationMode;
         UpdateKindGlyph();
-        panel.BackColor = dialog.SelectedColor;
+        SetPanelColor(dialog.SelectedColor);
         strokeThickness = dialog.StrokeThickness;
         lineStyle = dialog.LineStyle;
         opacityPercent = dialog.OpacityPercent;
@@ -1855,7 +1906,7 @@ public sealed class Overlay
         bool wasChecked = Checked;
         Hide();
         Title = dialog.OverlayName;
-        panel.BackColor = dialog.SelectedColor;
+        SetPanelColor(dialog.SelectedColor);
         strokeThickness = dialog.StrokeThickness;
         lineStyle = dialog.LineStyle;
         opacityPercent = dialog.OpacityPercent;
@@ -1940,7 +1991,7 @@ public sealed class Overlay
         useAmplitudeSpace = dialog.UseAmplitudeSpace;
         compareDelayMs = dialog.CompareDelayMs;
         compareInvertPolarity = dialog.CompareInvertPolarity;
-        panel.BackColor = dialog.SelectedColor;
+        SetPanelColor(dialog.SelectedColor);
         strokeThickness = dialog.StrokeThickness;
         lineStyle = dialog.LineStyle;
         opacityPercent = dialog.OpacityPercent;
@@ -2078,7 +2129,7 @@ public sealed class Overlay
                 file.Offset,
                 (double)offsetControl.Minimum,
                 (double)offsetControl.Maximum);
-            panel.BackColor = Color.FromArgb(file.ColorArgb);
+            SetPanelColor(Color.FromArgb(file.ColorArgb));
         }
         finally
         {
@@ -2564,7 +2615,7 @@ public sealed class Overlay
         try
         {
             SetChecked(false);
-            panel.BackColor = defaultColor;
+            SetPanelColor(defaultColor);
             offsetControl.Value = defaultOffset;
         }
         finally
@@ -2575,6 +2626,51 @@ public sealed class Overlay
         SetAvailability(false);
         captureButton.Enabled = true;
         UpdateKindGlyph();
+    }
+
+    // A captured or imported slot is titled "Overlay {Index}: …", and the panel
+    // already shows the slot number on its capture button, so both the "Overlay"
+    // lead-in and a leading number repeating this slot are dead weight in a label
+    // this narrow. A number that belongs to the name survives: only a whole leading
+    // token equal to this slot's own number is dropped, so slot 4 shortens
+    // "Overlay 4: Input Spectrum" to "Input Spectrum" but keeps "40 Hz notch".
+    private string ShortenSlotName(string title)
+    {
+        const string prefix = "Overlay";
+        string name = title.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? title[prefix.Length..].TrimStart()
+            : title;
+
+        string number = Index.ToString();
+        if (!name.StartsWith(number, StringComparison.Ordinal))
+        {
+            return name;
+        }
+
+        string rest = name[number.Length..];
+        if (rest.Length == 0 || (rest[0] != ':' && !char.IsWhiteSpace(rest[0])))
+        {
+            return name;
+        }
+
+        rest = rest.TrimStart();
+        if (rest.StartsWith(':'))
+        {
+            rest = rest[1..].TrimStart();
+        }
+
+        // A title that is nothing but the slot number keeps it: an empty label
+        // would read as an empty slot.
+        return rest.Length > 0 ? rest : name;
+    }
+
+    // The slot colour is the curve colour — random per panel and user-editable — so
+    // the name is drawn in whichever of black / white stays legible on top of it.
+    private void SetPanelColor(Color color)
+    {
+        panel.BackColor = color;
+        double luminance = (0.299 * color.R + 0.587 * color.G + 0.114 * color.B) / 255.0;
+        nameLabel.ForeColor = luminance > 0.55 ? Color.Black : Color.White;
     }
 
     // Shows the slot number plus a compact kind glyph: plain number for a

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -706,7 +706,7 @@ public sealed class Overlay
         private set
         {
             title = value;
-            nameLabel.Text = ShortenSlotName(value);
+            nameLabel.Text = OverlaySlotName.Shorten(value, Index);
             toolTip.SetToolTip(
                 nameLabel,
                 value.Length > 0 ? value : "Empty overlay slot");
@@ -2626,42 +2626,6 @@ public sealed class Overlay
         SetAvailability(false);
         captureButton.Enabled = true;
         UpdateKindGlyph();
-    }
-
-    // A captured or imported slot is titled "Overlay {Index}: …", and the panel
-    // already shows the slot number on its capture button, so both the "Overlay"
-    // lead-in and a leading number repeating this slot are dead weight in a label
-    // this narrow. A number that belongs to the name survives: only a whole leading
-    // token equal to this slot's own number is dropped, so slot 4 shortens
-    // "Overlay 4: Input Spectrum" to "Input Spectrum" but keeps "40 Hz notch".
-    private string ShortenSlotName(string title)
-    {
-        const string prefix = "Overlay";
-        string name = title.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-            ? title[prefix.Length..].TrimStart()
-            : title;
-
-        string number = Index.ToString();
-        if (!name.StartsWith(number, StringComparison.Ordinal))
-        {
-            return name;
-        }
-
-        string rest = name[number.Length..];
-        if (rest.Length == 0 || (rest[0] != ':' && !char.IsWhiteSpace(rest[0])))
-        {
-            return name;
-        }
-
-        rest = rest.TrimStart();
-        if (rest.StartsWith(':'))
-        {
-            rest = rest[1..].TrimStart();
-        }
-
-        // A title that is nothing but the slot number keeps it: an empty label
-        // would read as an empty slot.
-        return rest.Length > 0 ? rest : name;
     }
 
     // The slot colour is the curve colour — random per panel and user-editable — so

--- a/source/Overlays/OverlayOperationSettingsDialog.Designer.cs
+++ b/source/Overlays/OverlayOperationSettingsDialog.Designer.cs
@@ -44,7 +44,7 @@ namespace Resonalyze
             opacityValueLabel = new Label();
             cancelButton = new Button();
             saveButton = new Button();
-            toolTip = new ToolTip(components);
+            toolTip = new WrappingToolTip(components);
             numericTimeOffset = new DarkNumericUpDown();
             labelTimeOffset = new Label();
             checkBoxInvPhase = new CheckBox();
@@ -479,7 +479,7 @@ namespace Resonalyze
         private Label opacityValueLabel;
         private Button cancelButton;
         private Button saveButton;
-        private ToolTip toolTip;
+        private WrappingToolTip toolTip;
         private DarkNumericUpDown numericTimeOffset;
         private Label labelTimeOffset;
         private CheckBox checkBoxInvPhase;

--- a/source/Overlays/OverlaySettingsDialog.Designer.cs
+++ b/source/Overlays/OverlaySettingsDialog.Designer.cs
@@ -35,7 +35,7 @@ namespace Resonalyze
             clearButton = new Button();
             cancelButton = new Button();
             saveButton = new Button();
-            toolTip = new ToolTip(components);
+            toolTip = new WrappingToolTip(components);
             (thicknessInput).BeginInit();
             (opacityTrackBar).BeginInit();
             SuspendLayout();
@@ -273,6 +273,6 @@ namespace Resonalyze
         private Button clearButton;
         private Button cancelButton;
         private Button saveButton;
-        private ToolTip toolTip;
+        private WrappingToolTip toolTip;
     }
 }

--- a/source/Overlays/OverlaySlotName.cs
+++ b/source/Overlays/OverlaySlotName.cs
@@ -1,0 +1,36 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Shortens a slot title for the narrow name label in the overlay panel.
+/// </summary>
+/// <remarks>
+/// A captured or imported slot is titled "Overlay {slot}: …", and the capture button
+/// right beside the label already shows the number, so that prefix is pure repetition in
+/// a label this narrow. Only that exact generated form is removed (plus the bare
+/// "{slot}: " an older file may carry): a title the user typed is shown as it is, so
+/// "Overlayed response", "Overlay correction", "4 Ω response" and "2 way" survive intact.
+/// A prefix naming a different slot also survives — there it is information, not noise.
+/// </remarks>
+internal static class OverlaySlotName
+{
+    public static string Shorten(string title, int slot)
+    {
+        ArgumentNullException.ThrowIfNull(title);
+
+        string number = slot.ToString();
+        foreach (string prefix in (string[])[$"Overlay {number}:", $"{number}:"])
+        {
+            if (!title.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            string rest = title[prefix.Length..].TrimStart();
+            // A title that is nothing but the prefix keeps it: an empty label would
+            // read as an empty slot.
+            return rest.Length > 0 ? rest : title;
+        }
+
+        return title;
+    }
+}

--- a/source/Overlays/OverlayTargetSettingsDialog.Designer.cs
+++ b/source/Overlays/OverlayTargetSettingsDialog.Designer.cs
@@ -60,7 +60,7 @@ namespace Resonalyze
             previewPlot = new OxyPlot.WindowsForms.PlotView();
             cancelButton = new Button();
             saveButton = new Button();
-            toolTip = new ToolTip(components);
+            toolTip = new WrappingToolTip(components);
             (toleranceInput).BeginInit();
             (tiltInput).BeginInit();
             (bassGainInput).BeginInit();
@@ -718,6 +718,6 @@ namespace Resonalyze
         private OxyPlot.WindowsForms.PlotView previewPlot;
         private Button cancelButton;
         private Button saveButton;
-        private ToolTip toolTip;
+        private WrappingToolTip toolTip;
     }
 }

--- a/source/Shell/Form1.Designer.cs
+++ b/source/Shell/Form1.Designer.cs
@@ -36,12 +36,13 @@ namespace Resonalyze
             overlays = new Panel();
             overlayPanel1 = new Panel();
             buttonSaveOverlay = new Button();
+            labelOverlay1 = new Label();
             numericUpDown1 = new DarkNumericUpDown();
             checkBox1 = new CheckBox();
             buttonRecordOpt = new Button();
             buttonSave = new Button();
             buttonLoad = new Button();
-            toolTip1 = new ToolTip(components);
+            toolTip1 = new WrappingToolTip(components);
             buttonOverlayShowAll = new Button();
             buttonOverlayHideAll = new Button();
             buttonCurrentModeSettings = new Button();
@@ -107,6 +108,7 @@ namespace Resonalyze
             // 
             overlayPanel1.BackColor = Color.OrangeRed;
             overlayPanel1.Controls.Add(buttonSaveOverlay);
+            overlayPanel1.Controls.Add(labelOverlay1);
             overlayPanel1.Controls.Add(numericUpDown1);
             overlayPanel1.Controls.Add(checkBox1);
             overlayPanel1.Location = new Point(3, 3);
@@ -126,7 +128,21 @@ namespace Resonalyze
             buttonSaveOverlay.Text = "1";
             buttonSaveOverlay.UseCompatibleTextRendering = true;
             buttonSaveOverlay.UseVisualStyleBackColor = false;
-            // 
+            //
+            // labelOverlay1
+            //
+            labelOverlay1.AutoEllipsis = true;
+            labelOverlay1.AutoSize = false;
+            labelOverlay1.BackColor = Color.Transparent;
+            labelOverlay1.Font = new Font("Segoe UI", 7.5F);
+            labelOverlay1.ForeColor = Color.Black;
+            labelOverlay1.Location = new Point(64, 5);
+            labelOverlay1.Name = "labelOverlay1";
+            labelOverlay1.Size = new Size(78, 15);
+            labelOverlay1.TabIndex = 3;
+            labelOverlay1.TextAlign = ContentAlignment.MiddleLeft;
+            labelOverlay1.UseCompatibleTextRendering = true;
+            //
             // numericUpDown1
             // 
             numericUpDown1.BackColor = Color.FromArgb(50, 55, 80);
@@ -448,12 +464,13 @@ namespace Resonalyze
         private OxyPlot.WindowsForms.PlotView plotView1;
         private Panel overlays;
         private Button buttonSaveOverlay;
+        private Label labelOverlay1;
         private CheckBox checkBox1;
         private Panel overlayPanel1;
         private Button buttonRecordOpt;
         private Button buttonSave;
         private Button buttonLoad;
-        private ToolTip toolTip1;
+        private WrappingToolTip toolTip1;
         private Button buttonOverlayShowAll;
         private Button buttonCurrentModeSettings;
         private Button buttonOverlayHideAll;

--- a/source/Tools/Eq/EqResultsPanel.cs
+++ b/source/Tools/Eq/EqResultsPanel.cs
@@ -19,7 +19,7 @@ public sealed partial class EqResultsPanel : UserControl
     private static readonly Color BadColor = Color.FromArgb(232, 86, 76);
     private static readonly Color InfoColor = Color.FromArgb(0, 209, 255);
 
-    private readonly ToolTip toolTip = new()
+    private readonly WrappingToolTip toolTip = new()
     {
         InitialDelay = 500,
         ReshowDelay = 150,

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -163,7 +163,9 @@ public partial class EqWizardPanel
         {
             var item = new ToolStripMenuItem(MenuText.Trim($"{slot.Slot}: {slot.Title}"))
             {
-                ToolTipText = slot.Description
+                // A menu item's tooltip is drawn by the ToolStrip, not by the app's
+                // wrapping tooltip, and a slot description can carry a full file path.
+                ToolTipText = ToolTipTextWrapper.Wrap(slot.Description)
             };
             item.Click += (_, _) => LoadCurveFromSlot(slot.Slot);
             slotItem.DropDownItems.Add(item);

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using OxyPlot;
 using OxyPlot.Annotations;
 using OxyPlot.Axes;
@@ -42,7 +42,7 @@ public partial class EqWizardPanel : UserControl
     private const string QTip = "Band quality factor (Q) — higher Q is a narrower band.";
     private const string GainTip = "Band gain (dB). Positive boosts, negative cuts.";
 
-    private readonly ToolTip toolTip = new()
+    private readonly WrappingToolTip toolTip = new()
     {
         InitialDelay = 500,
         ReshowDelay = 150,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
@@ -10,7 +10,7 @@ namespace Resonalyze;
 /// </summary>
 internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
 {
-    private readonly ToolTip toolTip = new()
+    private readonly WrappingToolTip toolTip = new()
     {
         InitialDelay = 500,
         ReshowDelay = 150,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoSetupDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoSetupDialog.cs
@@ -23,7 +23,7 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
         Label BandLabel,
         DarkComboBox TypeComboBox);
 
-    private readonly ToolTip toolTip = new()
+    private readonly WrappingToolTip toolTip = new()
     {
         InitialDelay = 500,
         ReshowDelay = 150,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
@@ -308,7 +308,7 @@ public partial class VirtualCrossoverChannelControl : UserControl
     /// block owns the descriptions of its own sub-controls, so the host no longer
     /// reaches through into each input to set them.
     /// </summary>
-    public void ApplyTooltips(ToolTip toolTip)
+    public void ApplyTooltips(WrappingToolTip toolTip)
     {
         ArgumentNullException.ThrowIfNull(toolTip);
         // The numeric fields register on their inner editor too (via ApplyToolTip) so

--- a/source/Tools/VirtualCrossover/VirtualCrossoverGateDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverGateDialog.cs
@@ -13,7 +13,7 @@ namespace Resonalyze;
 /// </summary>
 internal sealed partial class VirtualCrossoverGateDialog : Form
 {
-    private readonly ToolTip toolTip = new()
+    private readonly WrappingToolTip toolTip = new()
     {
         InitialDelay = 500,
         ReshowDelay = 150,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -65,7 +65,7 @@ public partial class VirtualCrossoverPanel : UserControl
         channelControls = new();
     private readonly VirtualCrossoverProcessingCoordinator processingCoordinator = new();
     private readonly VirtualCrossoverMetrics metrics;
-    private readonly ToolTip toolTip = new()
+    private readonly WrappingToolTip toolTip = new()
     {
         InitialDelay = 500,
         ReshowDelay = 150,

--- a/source/Ui/Controls/DarkNumericUpDown.cs
+++ b/source/Ui/Controls/DarkNumericUpDown.cs
@@ -705,7 +705,19 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
             // A dialog's AcceptButton consumes Enter before the editor's KeyDown
             // ever fires; commit here so the accept handler reads the typed text
             // rather than the last committed value.
+            bool hadPendingEdit = HasPendingEditorText;
             CommitEditorText();
+
+            // The Enter that lands a typed number stops here. Letting it through as
+            // well would fire the dialog's default button in the same keystroke —
+            // in the Virtual DSP auto-setup that means running the whole crossover
+            // proposal and closing the window while the user was still filling in a
+            // field. A second Enter, with nothing pending, reaches the accept button
+            // as usual, so the keyboard route to OK survives.
+            if (hadPendingEdit)
+            {
+                return true;
+            }
         }
 
         return base.ProcessCmdKey(ref msg, keyData);
@@ -780,6 +792,14 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
             UpdateEditorText();
         }
     }
+
+    // True while the editor holds text that is not the committed value's own rendering:
+    // a half-typed number, an edited one, or something unparseable. Comparing against
+    // FormatValue is what UpdateEditorText writes, so an untouched field reads false.
+    private bool HasPendingEditorText =>
+        !suppressEditorSync &&
+        editor != null &&
+        !string.Equals(editor.Text, FormatValue(value), StringComparison.Ordinal);
 
     private bool TryParseEditorText(out decimal parsed) =>
         NumericTextParser.TryParse(editor.Text, CultureInfo.CurrentCulture, out parsed);
@@ -995,7 +1015,7 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
     /// Assigns a tooltip to the control and its inner text editor so it shows
     /// regardless of whether the cursor is over the number or the spin buttons.
     /// </summary>
-    public void ApplyToolTip(ToolTip toolTip, string text)
+    public void ApplyToolTip(WrappingToolTip toolTip, string text)
     {
         ArgumentNullException.ThrowIfNull(toolTip);
         toolTip.SetToolTip(this, text);

--- a/source/Ui/Controls/WrappingToolTip.cs
+++ b/source/Ui/Controls/WrappingToolTip.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+
+namespace Resonalyze;
+
+/// <summary>
+/// The tooltip every window in the app uses: identical to <see cref="ToolTip"/> except
+/// that assigned text is word-wrapped by <see cref="ToolTipTextWrapper"/> instead of
+/// being drawn as one endless line.
+/// </summary>
+/// <remarks>
+/// <see cref="ToolTip.SetToolTip"/> is neither virtual nor routed through an overridable
+/// hook, so wrapping has to intercept the call itself — hence the hiding method below.
+/// A reference typed as the base <see cref="ToolTip"/> would slip past it, so everything
+/// that takes a tooltip to fill in (for example <see cref="DarkNumericUpDown.ApplyToolTip"/>)
+/// declares this type rather than the base one, which lets the compiler keep that promise.
+/// </remarks>
+public sealed class WrappingToolTip : ToolTip
+{
+    public WrappingToolTip()
+    {
+    }
+
+    public WrappingToolTip(IContainer container)
+        : base(container)
+    {
+    }
+
+    public new void SetToolTip(Control control, string? caption) =>
+        base.SetToolTip(control, ToolTipTextWrapper.Wrap(caption));
+}

--- a/source/Ui/Dialogs/MeasurementHistoryWindow.cs
+++ b/source/Ui/Dialogs/MeasurementHistoryWindow.cs
@@ -10,7 +10,7 @@ internal partial class MeasurementHistoryWindow : Form
 {
     private readonly List<Guid> rowEntryIds = [];
     private readonly Font activeEntryFont;
-    private readonly ToolTip historyToolTip = new() { ShowAlways = true };
+    private readonly WrappingToolTip historyToolTip = new() { ShowAlways = true };
     private Guid? activeEntryId;
     private bool suppressSelectionEvents;
 

--- a/source/Ui/ToolTipTextWrapper.cs
+++ b/source/Ui/ToolTipTextWrapper.cs
@@ -1,0 +1,125 @@
+using System.Text;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Word-wraps tooltip text. A WinForms tooltip never wraps by itself: one long sentence
+/// is drawn as a single line that can span — and run off — the whole screen, so the prose
+/// tooltips this app leans on have to arrive pre-broken.
+/// </summary>
+/// <remarks>
+/// The author's own newlines are kept as they are (they separate bullets and caveats) and
+/// each such paragraph is wrapped within them. Continuation lines of a bulleted paragraph
+/// are indented under the item's text so the list stays scannable. Wrapping is idempotent:
+/// text that already fits comes back unchanged, so re-wrapping is harmless.
+/// </remarks>
+internal static class ToolTipTextWrapper
+{
+    /// <summary>
+    /// Longest line the wrapper aims for, in characters. At the tooltip's default font
+    /// that is roughly 450 px — wide enough for a technical sentence, narrow enough to
+    /// stay next to the control it explains.
+    /// </summary>
+    public const int DefaultLineLength = 64;
+
+    private static readonly string[] LineBreaks = ["\r\n", "\n", "\r"];
+
+    // Markers that open a list item; a wrapped continuation is indented past them.
+    private static readonly string[] BulletMarkers = ["• ", "- ", "– ", "* "];
+
+    public static string Wrap(string? text, int maxLineLength = DefaultLineLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxLineLength, 8);
+        if (string.IsNullOrEmpty(text))
+        {
+            return text ?? string.Empty;
+        }
+
+        string[] paragraphs = text.Split(LineBreaks, StringSplitOptions.None);
+        var lines = new List<string>(paragraphs.Length);
+        foreach (string paragraph in paragraphs)
+        {
+            WrapParagraph(paragraph, maxLineLength, lines);
+        }
+
+        // Windows tooltips take CRLF; normalize to it even when the input used \n.
+        return string.Join("\r\n", lines);
+    }
+
+    private static void WrapParagraph(
+        string paragraph,
+        int maxLineLength,
+        List<string> output)
+    {
+        if (paragraph.Length <= maxLineLength)
+        {
+            output.Add(paragraph);
+            return;
+        }
+
+        string leading = paragraph[..(paragraph.Length - paragraph.TrimStart().Length)];
+        string indent = leading + new string(' ', BulletWidth(paragraph));
+        // A deeply indented paragraph must not squeeze the text down to nothing: give up
+        // on the alignment rather than on the wrapping.
+        if (indent.Length > maxLineLength - 8)
+        {
+            indent = string.Empty;
+        }
+
+        var line = new StringBuilder();
+        int emitted = 0;
+        foreach (string word in paragraph.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (line.Length == 0)
+            {
+                line.Append(emitted == 0 ? leading : indent);
+            }
+            else if (line.Length + 1 + word.Length > maxLineLength)
+            {
+                output.Add(line.ToString());
+                emitted++;
+                line.Clear();
+                line.Append(indent);
+            }
+            else
+            {
+                line.Append(' ');
+            }
+
+            line.Append(word);
+
+            // A single unbreakable token — a path, a URL — can outgrow the whole line
+            // budget on its own. Hard-split the overflow: one break inside a path beats
+            // a tooltip wider than the screen.
+            while (line.Length > maxLineLength)
+            {
+                output.Add(line.ToString(0, maxLineLength));
+                emitted++;
+                string remainder = line.ToString(
+                    maxLineLength,
+                    line.Length - maxLineLength);
+                line.Clear();
+                line.Append(indent).Append(remainder);
+            }
+        }
+
+        if (line.Length > 0)
+        {
+            output.Add(line.ToString());
+        }
+    }
+
+    private static int BulletWidth(string paragraph)
+    {
+        string trimmed = paragraph.TrimStart();
+        foreach (string marker in BulletMarkers)
+        {
+            if (trimmed.StartsWith(marker, StringComparison.Ordinal))
+            {
+                return marker.Length;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/tests/Resonalyze.App.Tests/DarkNumericUpDownEnterKeyTests.cs
+++ b/tests/Resonalyze.App.Tests/DarkNumericUpDownEnterKeyTests.cs
@@ -1,0 +1,95 @@
+using System.Globalization;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// Enter inside one of these fields used to reach the host dialog's AcceptButton in the
+/// same keystroke: in the Virtual DSP auto-setup that ran the whole crossover proposal
+/// and closed the window while a value was still being typed. The control now keeps the
+/// Enter that lands an edit and passes on the one that has nothing to commit.
+/// </summary>
+public sealed class DarkNumericUpDownEnterKeyTests
+{
+    [Fact]
+    public void Enter_CommitsTypedTextAndIsNotPassedOnToTheAcceptButton()
+    {
+        using var control = NewControl();
+        Editor(control).Text = FormatLocal(12.5m);
+
+        bool handled = PressEnter(control);
+
+        Assert.True(handled);
+        Assert.Equal(12.5m, control.Value);
+    }
+
+    [Fact]
+    public void Enter_WithNothingPending_ReachesTheAcceptButton()
+    {
+        using var control = NewControl();
+        control.Value = 12.5m;
+
+        bool handled = PressEnter(control);
+
+        Assert.False(handled);
+        Assert.Equal(12.5m, control.Value);
+    }
+
+    [Fact]
+    public void Enter_AfterCommittingAnEdit_ReachesTheAcceptButtonOnTheSecondPress()
+    {
+        using var control = NewControl();
+        Editor(control).Text = FormatLocal(30m);
+
+        Assert.True(PressEnter(control));
+        Assert.False(PressEnter(control));
+        Assert.Equal(30m, control.Value);
+    }
+
+    [Fact]
+    public void Enter_OnUnparseableText_RestoresTheValueAndStaysInTheField()
+    {
+        using var control = NewControl();
+        control.Value = 6m;
+        Editor(control).Text = "not a number";
+
+        bool handled = PressEnter(control);
+
+        Assert.True(handled);
+        Assert.Equal(6m, control.Value);
+        Assert.Equal(FormatLocal(6m), Editor(control).Text);
+    }
+
+    private static DarkNumericUpDown NewControl() => new()
+    {
+        DecimalPlaces = 1,
+        Minimum = 0,
+        Maximum = 60,
+        Increment = 1,
+        Value = 0
+    };
+
+    private static TextBox Editor(DarkNumericUpDown control) =>
+        control.Controls.OfType<TextBox>().Single();
+
+    private static string FormatLocal(decimal value) =>
+        value.ToString("F1", CultureInfo.CurrentCulture);
+
+    // ProcessCmdKey is where a dialog key is offered to the control before the form's
+    // default button sees it; true means the control kept the key.
+    private static bool PressEnter(DarkNumericUpDown control)
+    {
+        MethodInfo method = typeof(DarkNumericUpDown).GetMethod(
+            "ProcessCmdKey",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("ProcessCmdKey is missing.");
+        var message = new Message
+        {
+            Msg = 0x0100, // WM_KEYDOWN
+            WParam = (IntPtr)Keys.Enter
+        };
+        object[] arguments = [message, Keys.Enter];
+        return (bool)method.Invoke(control, arguments)!;
+    }
+}

--- a/tests/Resonalyze.App.Tests/OverlaySlotNameTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlaySlotNameTests.cs
@@ -1,0 +1,77 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The overlay panel's name label is narrow and its capture button already shows the
+/// slot number, so the generated "Overlay {slot}: " prefix is dropped. Everything else
+/// is the user's own wording — including the numbers and units an audio name carries —
+/// and has to survive untouched.
+/// </summary>
+public sealed class OverlaySlotNameTests
+{
+    [Theory]
+    [InlineData("Overlay 4: Input Spectrum (RTA)", 4, "Input Spectrum (RTA)")]
+    [InlineData("Overlay 12: Input Spectrum (RTA)", 12, "Input Spectrum (RTA)")]
+    [InlineData("overlay 4: main", 4, "main")]
+    public void Shorten_DropsTheGeneratedPrefix(string title, int slot, string expected)
+    {
+        Assert.Equal(expected, OverlaySlotName.Shorten(title, slot));
+    }
+
+    // A file written before the label existed can carry the bare numbered form.
+    [Theory]
+    [InlineData("4: Main", 4, "Main")]
+    [InlineData("12:Main", 12, "Main")]
+    public void Shorten_DropsTheBareNumberedPrefix(string title, int slot, string expected)
+    {
+        Assert.Equal(expected, OverlaySlotName.Shorten(title, slot));
+    }
+
+    [Theory]
+    [InlineData("Overlayed response", 4)]
+    [InlineData("Overlay correction", 4)]
+    [InlineData("Overlays of the left door", 4)]
+    public void Shorten_KeepsANameThatMerelyStartsWithTheWordOverlay(string title, int slot)
+    {
+        Assert.Equal(title, OverlaySlotName.Shorten(title, slot));
+    }
+
+    [Theory]
+    [InlineData("4 Ω response", 4)]
+    [InlineData("4 inch midrange", 4)]
+    [InlineData("2 way", 2)]
+    [InlineData("40 Hz notch", 4)]
+    [InlineData("4kHz shelf", 4)]
+    public void Shorten_KeepsALeadingNumberThatBelongsToTheName(string title, int slot)
+    {
+        Assert.Equal(title, OverlaySlotName.Shorten(title, slot));
+    }
+
+    // The prefix is only noise when it repeats this slot; naming another one is
+    // information worth showing.
+    [Theory]
+    [InlineData("Overlay 5: Input Spectrum", 4)]
+    [InlineData("5: Main", 4)]
+    public void Shorten_KeepsAPrefixNamingADifferentSlot(string title, int slot)
+    {
+        Assert.Equal(title, OverlaySlotName.Shorten(title, slot));
+    }
+
+    [Theory]
+    [InlineData("Overlay 4:", 4)]
+    [InlineData("4:", 4)]
+    [InlineData("4: ", 4)]
+    public void Shorten_KeepsATitleThatIsNothingButThePrefix(string title, int slot)
+    {
+        // An empty label would read as an empty slot.
+        Assert.Equal(title, OverlaySlotName.Shorten(title, slot));
+    }
+
+    [Theory]
+    [InlineData("r sub", 6)]
+    [InlineData("110 SPL", 1)]
+    [InlineData("", 3)]
+    public void Shorten_LeavesAPlainNameAlone(string title, int slot)
+    {
+        Assert.Equal(title, OverlaySlotName.Shorten(title, slot));
+    }
+}

--- a/tests/Resonalyze.App.Tests/ToolTipTextWrapperTests.cs
+++ b/tests/Resonalyze.App.Tests/ToolTipTextWrapperTests.cs
@@ -1,0 +1,151 @@
+using System.Windows.Forms;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class ToolTipTextWrapperTests
+{
+    [Fact]
+    public void Wrap_LeavesShortTextAlone()
+    {
+        const string text = "Overlay vertical offset (dB)";
+
+        Assert.Equal(text, ToolTipTextWrapper.Wrap(text));
+    }
+
+    [Fact]
+    public void Wrap_BreaksALongSentenceIntoLinesWithinTheBudget()
+    {
+        string wrapped = ToolTipTextWrapper.Wrap(
+            "Overlaps successive analysis frames by sliding the FFT window a " +
+            "fraction of its size. Higher overlap gives faster, smoother " +
+            "averaging at the cost of more CPU.");
+
+        string[] lines = Lines(wrapped);
+        Assert.True(lines.Length > 1);
+        Assert.All(lines, line => Assert.True(
+            line.Length <= ToolTipTextWrapper.DefaultLineLength,
+            $"line too long ({line.Length}): {line}"));
+    }
+
+    [Fact]
+    public void Wrap_KeepsEveryWordAndTheirOrder()
+    {
+        const string text =
+            "Applies the selected microphone calibration file so the displayed " +
+            "curve reads in absolute terms rather than relative decibels.";
+
+        string wrapped = ToolTipTextWrapper.Wrap(text);
+
+        Assert.Equal(
+            text.Split(' '),
+            wrapped.Split(["\r\n", " "], StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    [Fact]
+    public void Wrap_PreservesTheAuthorsOwnBreaks()
+    {
+        string wrapped = ToolTipTextWrapper.Wrap(
+            "Channel gain (dB).\r\nCompensate any difference here.");
+
+        Assert.Equal(
+            ["Channel gain (dB).", "Compensate any difference here."],
+            Lines(wrapped));
+    }
+
+    [Fact]
+    public void Wrap_NormalizesLoneLineFeedsToCrLf()
+    {
+        string wrapped = ToolTipTextWrapper.Wrap("First line.\nSecond line.");
+
+        Assert.Equal("First line.\r\nSecond line.", wrapped);
+    }
+
+    [Fact]
+    public void Wrap_IndentsTheContinuationOfABulletUnderItsText()
+    {
+        string wrapped = ToolTipTextWrapper.Wrap(
+            "Excitation noise played during the measurement.\r\n" +
+            "• Pink noise (periodic): one FFT-length period of exactly pink " +
+            "noise, looped. Deterministic and leakage-free.\r\n" +
+            "• White noise: equal energy per hertz.");
+
+        string[] lines = Lines(wrapped);
+        Assert.Equal("Excitation noise played during the measurement.", lines[0]);
+        Assert.StartsWith("• Pink noise", lines[1], StringComparison.Ordinal);
+        // The bullet's own wrapped remainder lines up with its text, and the next
+        // bullet still starts at the left edge.
+        Assert.StartsWith("  ", lines[2]);
+        Assert.DoesNotContain(
+            "•",
+            lines[2][..2]);
+        Assert.Equal("• White noise: equal energy per hertz.", lines[^1]);
+    }
+
+    [Fact]
+    public void Wrap_IsIdempotent()
+    {
+        const string text =
+            "Frequencies whose coherence falls below this limit are drawn dimmed " +
+            "and dashed to flag where the transfer function is unreliable. Off " +
+            "disables the marking.";
+
+        string once = ToolTipTextWrapper.Wrap(text);
+
+        Assert.Equal(once, ToolTipTextWrapper.Wrap(once));
+    }
+
+    [Fact]
+    public void Wrap_HardSplitsATokenThatCannotFitOnALine()
+    {
+        string path = @"D:\hobby\" + new string('x', 120) + @"\measurement.wav";
+
+        string[] lines = Lines(ToolTipTextWrapper.Wrap("Source: " + path));
+
+        Assert.True(lines.Length > 2);
+        Assert.All(lines, line => Assert.True(
+            line.Length <= ToolTipTextWrapper.DefaultLineLength,
+            $"line too long ({line.Length}): {line}"));
+        // A break replaces the space it lands on, so compare with whitespace removed:
+        // nothing inside the path may be dropped.
+        Assert.Equal(
+            ("Source: " + path).Replace(" ", string.Empty),
+            string.Concat(lines).Replace(" ", string.Empty));
+    }
+
+    [Fact]
+    public void Wrap_HandlesEmptyInput()
+    {
+        Assert.Equal(string.Empty, ToolTipTextWrapper.Wrap(null));
+        Assert.Equal(string.Empty, ToolTipTextWrapper.Wrap(string.Empty));
+    }
+
+    [Fact]
+    public void Wrap_RejectsALineBudgetTooSmallForWords()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ToolTipTextWrapper.Wrap("text", maxLineLength: 4));
+    }
+
+    // The app assigns tooltips through WrappingToolTip, including from designer code;
+    // this is the interception every one of those assignments relies on.
+    [Fact]
+    public void WrappingToolTip_StoresTheWrappedTextForTheControl()
+    {
+        using var toolTip = new WrappingToolTip();
+        using var control = new Label();
+
+        toolTip.SetToolTip(
+            control,
+            "Sets the FFT block size. Longer sequences give finer frequency " +
+            "resolution but slower visual updates.");
+
+        string stored = toolTip.GetToolTip(control);
+        Assert.Contains("\r\n", stored);
+        Assert.All(Lines(stored), line => Assert.True(
+            line.Length <= ToolTipTextWrapper.DefaultLineLength,
+            $"line too long ({line.Length}): {line}"));
+    }
+
+    private static string[] Lines(string text) =>
+        text.Split("\r\n", StringSplitOptions.None);
+}


### PR DESCRIPTION
Three UI fixes from one session, all in the WinForms shell.

## Overlay slot names

The overlay panel left a wide dead gap between the capture button and the offset spinner, and the only clue to what a slot held was its colour. The name goes there now.

* `Title` became a property whose setter refreshes the label, so capture, import, the settings dialogs, the on-disk load and the mode-switch reset all keep it in step through one path.
* A stored title reads `Overlay {Index}: ...` and the button right beside the label already shows the number, so exactly that generated prefix is dropped (plus the bare `{Index}: ` an older file may carry): slot 4 shows `Input Spectrum (RTA)`. Nothing else is touched, so hand-typed names survive whole — `Overlayed response`, `Overlay correction`, `4 Ω response`, `2 way` — as does a prefix naming a *different* slot, where the number is information rather than repetition. The rule lives in `OverlaySlotName` so it can be tested without standing up a panel.
* The label ellipsizes, so the full name stays in its tooltip; the text is drawn black or white by the luminance of the slot colour it sits on.
* The label is declared in the designer and cloned per slot the same way the button, checkbox and spinner already are, so it inherits the DPI-scaled font and coordinates.

Verified in the running app against the existing saved overlays: all 12 slots read correctly, no slot colour makes the text unreadable, the spinner is never overlapped.

## Tooltips wrap

A WinForms tooltip never wraps by itself. A scan of all 197 tooltip assignments found 104 with a line longer than 64 characters, 26 longer than 120, the worst a single 274-character line drawn straight across the screen.

* `ToolTipTextWrapper` wraps to a 64-character budget: the author's own newlines are kept (they separate bullets and caveats), each paragraph is wrapped inside them, a bullet's continuation is indented under the item's text, and an unbreakable token such as a file path is hard-split. It is idempotent.
* `WrappingToolTip` is what every window now declares, so all 169 `SetToolTip` and 59 `ApplyToolTip` call sites — designer code included — wrap with no edits to a single tooltip string. `ToolTip.SetToolTip` is not virtual, so the interception is a hiding method; every declaration and every parameter that takes a tooltip names the wrapping type, which lets the compiler rule out a base-typed reference slipping past it.
* Tooltips drawn by ToolStrip items and grid cells never go through that class, so the two that carry variable text (history metadata, EQ Wizard slot descriptions with a full path) call the wrapper themselves.

## Enter no longer runs the auto crossover

Reported against the Virtual DSP auto-setup dialog: pressing Enter inside a numeric field applied the whole crossover proposal and closed the window.

The cause was shared, not local to that dialog. `DarkNumericUpDown.ProcessCmdKey` committed the typed text on Enter and deliberately passed the key on so the accept handler would read the fresh value — which made "finish typing a number" and "run the setup" the same keystroke.

Now the Enter that lands an edit is kept, and an Enter with nothing pending still reaches the dialog's default button, so the keyboard route to OK survives. This covers every numeric field in the app, not only the one that surfaced it.

## Tests

36 new tests across three classes:

* `OverlaySlotNameTests` — the generated prefixes, hand-typed names beginning with `Overlay`, leading numbers that belong to the name (`4 Ω response`, `40 Hz notch`), a prefix naming another slot, and a title that is nothing but the prefix.
* `ToolTipTextWrapperTests` — line budget, word preservation, authored breaks, bullet indentation, idempotence, path splitting, and the interception through `WrappingToolTip.SetToolTip`/`GetToolTip` that designer code relies on.
* `DarkNumericUpDownEnterKeyTests` — Enter in both directions, including unparseable text.

Full suite: 1651 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
