### PR TITLE
EQ Wizard: calibration and smoothing for dB SPL captures

### DIFF
--- a/dsp/DataHelper.Resampling.cs
+++ b/dsp/DataHelper.Resampling.cs
@@ -453,39 +453,142 @@ namespace Resonalyze.Dsp
                 return output;
             }
 
-            var prefix = new double[steps + 1];
+            double[] smoothedAmplitudes = SmoothBandPowersToAmplitudes(
+                bandPowers, frequencies, octavesPerStep, smoothingHalfSteps, psychoacoustic);
             for (int i = 0; i < steps; i++)
             {
-                prefix[i + 1] = prefix[i] + bandPowers[i];
+                output.Add(new SignalPoint(
+                    frequencies[i],
+                    AmplitudeToDecibels(smoothedAmplitudes[i])));
+            }
+
+            return output;
+        }
+
+        /// <summary>
+        /// Re-applies this analyzer's display smoothing to band levels it already produced
+        /// — the finished dB curve of a dB SPL RTA, on the very grid it was drawn on.
+        /// </summary>
+        /// <remarks>
+        /// A consumer that stores such a curve (an overlay slot, and through it the EQ
+        /// Wizard) has no raw spectrum to go back to, but the smoothing is a SECOND PASS
+        /// over the band powers, not part of the integration — so it can be replayed
+        /// exactly. It shares its core with <see cref="LogarithmicPowerBandResample"/>,
+        /// which is the point: a level-preserving mean of linear POWER, not of decibels,
+        /// with the same window and the same psychoacoustic cubic mean, so "1/6 octave"
+        /// means the same thing in both places and cannot drift apart later.
+        /// A non-finite level marks a band the analyzer could not measure: it is passed
+        /// through and excluded from its neighbours' means, so gaps neither spread nor fill.
+        /// Points must be ascending and logarithmically spaced, as that grid is.
+        /// </remarks>
+        public static List<SignalPoint> SmoothBandLevels(
+            IReadOnlyList<SignalPoint> bandLevelsDb,
+            double smoothingOctaves,
+            bool psychoacoustic)
+        {
+            ArgumentNullException.ThrowIfNull(bandLevelsDb);
+
+            int steps = bandLevelsDb.Count;
+            var result = new List<SignalPoint>(steps);
+            if (steps < 2 || bandLevelsDb[0].X <= 0 || bandLevelsDb[^1].X <= bandLevelsDb[0].X)
+            {
+                result.AddRange(bandLevelsDb);
+                return result;
+            }
+
+            double octavesPerStep =
+                Math.Log2(bandLevelsDb[^1].X / bandLevelsDb[0].X) / (steps - 1);
+            int smoothingHalfSteps = smoothingOctaves > 0.0 && octavesPerStep > 0.0
+                ? (int)Math.Round(smoothingOctaves * 0.5 / octavesPerStep)
+                : 0;
+            // Matches the resampler, which also leaves the levels alone when the requested
+            // width does not reach a whole grid step.
+            if (smoothingHalfSteps <= 0)
+            {
+                result.AddRange(bandLevelsDb);
+                return result;
+            }
+
+            var bandPowers = new double[steps];
+            var frequencies = new double[steps];
+            for (int i = 0; i < steps; i++)
+            {
+                frequencies[i] = bandLevelsDb[i].X;
+                // 10^(dB/10) is the power a level of that many decibels stands for; a gap
+                // stays a gap.
+                bandPowers[i] = double.IsFinite(bandLevelsDb[i].Y)
+                    ? Math.Pow(10.0, bandLevelsDb[i].Y / 10.0)
+                    : double.NaN;
+            }
+
+            double[] smoothedAmplitudes = SmoothBandPowersToAmplitudes(
+                bandPowers, frequencies, octavesPerStep, smoothingHalfSteps, psychoacoustic);
+            for (int i = 0; i < steps; i++)
+            {
+                result.Add(new SignalPoint(
+                    frequencies[i],
+                    double.IsFinite(smoothedAmplitudes[i])
+                        ? AmplitudeToDecibels(smoothedAmplitudes[i])
+                        : double.NaN));
+            }
+
+            return result;
+        }
+
+        // The display smoothing itself: a level-preserving mean of band POWERS returned as
+        // amplitudes. Shared so the live resampler and a replay over stored levels are the
+        // same algorithm by construction. Bands with a non-finite power are excluded from
+        // every mean and stay non-finite in the result.
+        private static double[] SmoothBandPowersToAmplitudes(
+            double[] bandPowers,
+            double[] frequencies,
+            double octavesPerStep,
+            int smoothingHalfSteps,
+            bool psychoacoustic)
+        {
+            int steps = bandPowers.Length;
+            var result = new double[steps];
+
+            // Prefix sums carry a COUNT as well as a total, so a gap simply does not
+            // contribute; with no gaps the count is the plain window width and the mean is
+            // identical to a straight prefix-sum average.
+            var powerPrefix = new double[steps + 1];
+            var countPrefix = new int[steps + 1];
+            for (int i = 0; i < steps; i++)
+            {
+                bool measured = double.IsFinite(bandPowers[i]);
+                powerPrefix[i + 1] = powerPrefix[i] + (measured ? bandPowers[i] : 0.0);
+                countPrefix[i + 1] = countPrefix[i] + (measured ? 1 : 0);
             }
 
             for (int i = 0; i < steps; i++)
             {
-                double smoothedAmplitude;
+                if (!double.IsFinite(bandPowers[i]))
+                {
+                    result[i] = double.NaN;
+                    continue;
+                }
+
                 if (psychoacoustic)
                 {
-                    smoothedAmplitude = PsychoacousticPowerCubicMean(
+                    result[i] = PsychoacousticPowerCubicMean(
                         bandPowers,
                         i,
                         SpectrumSmoothing.PsychoacousticOctaves(frequencies[i]),
                         octavesPerStep);
-                }
-                else
-                {
-                    int lowIndex = Math.Max(0, i - smoothingHalfSteps);
-                    int highIndex = Math.Min(steps - 1, i + smoothingHalfSteps);
-                    double mean =
-                        (prefix[highIndex + 1] - prefix[lowIndex]) /
-                        (highIndex - lowIndex + 1);
-                    smoothedAmplitude = Math.Sqrt(mean);
+                    continue;
                 }
 
-                output.Add(new SignalPoint(
-                    frequencies[i],
-                    AmplitudeToDecibels(smoothedAmplitude)));
+                int lowIndex = Math.Max(0, i - smoothingHalfSteps);
+                int highIndex = Math.Min(steps - 1, i + smoothingHalfSteps);
+                int count = countPrefix[highIndex + 1] - countPrefix[lowIndex];
+                double mean = count > 0
+                    ? (powerPrefix[highIndex + 1] - powerPrefix[lowIndex]) / count
+                    : bandPowers[i];
+                result[i] = Math.Sqrt(mean);
             }
 
-            return output;
+            return result;
         }
 
         private static double PsychoacousticPowerCubicMean(
@@ -508,6 +611,13 @@ namespace Resonalyze.Dsp
             double weightedCubeSum = 0.0;
             for (int index = firstIndex; index <= lastIndex; index++)
             {
+                // A band the analyzer could not measure contributes nothing rather than
+                // poisoning the mean; a live resample never has one.
+                if (!double.IsFinite(bandPowers[index]))
+                {
+                    continue;
+                }
+
                 double normalized = (index - centerIndex) / sigmaSteps;
                 double absoluteNormalized = Math.Abs(normalized);
                 if (absoluteNormalized >= GaussianRadiusSigma)

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -19,17 +19,53 @@ namespace Resonalyze;
 /// stores the drawn curve while keeping the metadata, so a consumer outside the
 /// measurement — the EQ Wizard — still knows the rate its filters must be realized at.
 /// </remarks>
+/// <param name="PointsCalibration">
+/// For a capture with NO raw form only: the microphone calibration baked into the drawn
+/// curve. The overlay freezes it per DRAWN point (their frequencies are the only grid such
+/// a capture has), so a consumer can undo it and apply another — exact, because the
+/// correction is applied additively per frequency. Null when the curve has a raw form (the
+/// correction travels with the raw grid instead) or when no calibration was in effect.
+/// </param>
 public readonly record struct RawCurveCapture(
     IReadOnlyList<SignalPoint> Spectrum,
     IReadOnlyList<double> CalibrationCorrectionDb,
     int SmoothingCode,
-    int? SampleRateHz = null);
+    int? SampleRateHz = null,
+    CalibrationFile? PointsCalibration = null);
 
 internal static class RawCurveRenderer
 {
     public const double StartFrequency = 20.0;
     public const double StopFrequency = 20_000.0;
     public const int PointCount = 1024;
+
+    /// <summary>
+    /// Freezes a calibration onto the frequencies of an ALREADY DRAWN curve. A capture with
+    /// no re-smoothable raw form has no other grid, and the correction must line up with
+    /// the very points it was baked into, so it is sampled per point rather than on the
+    /// standard log grid. A null calibration yields zeros — the honest record of "captured
+    /// with no correction", which still lets a consumer apply one later. Always the same
+    /// length as <paramref name="points"/>, so the two cannot drift apart.
+    /// </summary>
+    public static double[] CaptureCalibrationCorrectionAt(
+        CalibrationFile? calibration,
+        IReadOnlyList<DataPoint> points)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+
+        var correction = new double[points.Count];
+        if (calibration == null)
+        {
+            return correction;
+        }
+
+        for (int i = 0; i < correction.Length; i++)
+        {
+            correction[i] = calibration.GetDecibelCorrection(points[i].X);
+        }
+
+        return correction;
+    }
 
     public static double[] CaptureCalibrationCorrection(CalibrationFile? calibration)
     {
@@ -600,6 +636,13 @@ public sealed class Overlay
     // Frozen microphone correction at the 1024 output frequencies. It remains
     // separate because the primary FR smooths first and calibrates afterwards.
     private double[] rawCalibrationCorrectionDb = Array.Empty<double>();
+    // No-raw captures only (dB SPL): the correction baked into sourcePoints, frozen per
+    // point. Empty when the capture has a raw form or never described itself. Only
+    // consumers outside the plot read it — the drawn curve already includes it.
+    private double[] pointsCalibrationCorrectionDb = Array.Empty<double>();
+    // The smoothing baked into sourcePoints (0 = none); null when unknown. Distinct from
+    // smoothingInverseOctaves, this slot's own display smoothing applied on top.
+    private int? capturedSmoothingCode;
     // Sample rate of the captured measurement; null when unknown (imported text,
     // fallback captures, legacy files). Only consumers outside the plot read it.
     private int? capturedSampleRateHz;
@@ -1418,7 +1461,15 @@ public sealed class Overlay
         DataPoint[] points;
         List<SignalPoint>? spectrum;
         double[] calibrationCorrectionDb;
+        double[] pointsCorrectionDb;
         int seedSmoothing;
+        // The smoothing already baked into the captured points, which is NOT the same as
+        // the slot's own display smoothing seeded below: a raw capture renders its points
+        // unsmoothed, a drawn-curve capture inherits whatever its source mode was showing.
+        // Null where the source never described itself (an operation, a legacy mode): the
+        // points may or may not be smoothed, and guessing "none" would invite a consumer
+        // to smooth them twice.
+        int? bakedSmoothing;
         // The rate describes the measurement, not the raw form, so it survives a capture
         // that falls back to the drawn curve (an SPL trace, an operation, a legacy mode).
         int? sampleRateHz = raw?.SampleRateHz;
@@ -1429,7 +1480,10 @@ public sealed class Overlay
             spectrum = rawCapture.Spectrum as List<SignalPoint> ?? rawCapture.Spectrum.ToList();
             calibrationCorrectionDb = rawCapture.CalibrationCorrectionDb.ToArray();
             points = SmoothRawSpectrum(spectrum, calibrationCorrectionDb, 0);
+            // The correction travels on the raw grid; the drawn points need no copy of it.
+            pointsCorrectionDb = Array.Empty<double>();
             seedSmoothing = rawCapture.SmoothingCode;
+            bakedSmoothing = 0;
         }
         else
         {
@@ -1437,7 +1491,19 @@ public sealed class Overlay
             selected.Points.CopyTo(points);
             spectrum = null;
             calibrationCorrectionDb = Array.Empty<double>();
+            // With no raw form the drawn points ARE the reference, so freeze the
+            // correction baked into them per point (zeros when none was applied). Only a
+            // capture that described itself this way gets one; a curve with no raw
+            // capture at all (an operation, a legacy mode) stays unannotated.
+            pointsCorrectionDb = raw is { } describedCapture
+                ? RawCurveRenderer.CaptureCalibrationCorrectionAt(
+                    describedCapture.PointsCalibration, points)
+                : Array.Empty<double>();
+            // The points already carry their source's smoothing, so the slot's own
+            // smoothing starts at Off (applying the source's again would compound it) —
+            // but record what was baked in so a consumer knows whether it may re-smooth.
             seedSmoothing = 0;
+            bakedSmoothing = raw?.SmoothingCode;
         }
 
         string title = $"Overlay {Index}: {selected.Title ?? string.Empty}";
@@ -1449,6 +1515,8 @@ public sealed class Overlay
         sourcePoints = points;
         rawSpectrumPoints = spectrum;
         rawCalibrationCorrectionDb = calibrationCorrectionDb;
+        pointsCalibrationCorrectionDb = pointsCorrectionDb;
+        capturedSmoothingCode = bakedSmoothing;
         capturedSampleRateHz = sampleRateHz;
         // The curve was drawn in the plot's current scale, so it carries that unit.
         capturedMagnitudeScale = collection.CurrentMagnitudeScale;
@@ -1537,9 +1605,12 @@ public sealed class Overlay
         // A file we exported declares what it holds, so a slot → text → slot round trip
         // keeps its identity; a foreign headerless file states nothing and stays unknown.
         capturedCurveKind = imported.Metadata.CurveKind;
-        // Imported points are a display curve, not an oversampled spectrum.
+        // Imported points are a display curve, not an oversampled spectrum, and a text
+        // file states neither the calibration behind it nor the smoothing already in it.
         rawSpectrumPoints = null;
         rawCalibrationCorrectionDb = Array.Empty<double>();
+        pointsCalibrationCorrectionDb = Array.Empty<double>();
+        capturedSmoothingCode = null;
         capturedSampleRateHz = imported.Metadata.SampleRateHz;
         // Believe a declared unit; assume the current view's otherwise.
         capturedMagnitudeScale =
@@ -1626,6 +1697,8 @@ public sealed class Overlay
         capturedCurveKind = null;
         rawSpectrumPoints = null;
         rawCalibrationCorrectionDb = Array.Empty<double>();
+        pointsCalibrationCorrectionDb = Array.Empty<double>();
+        capturedSmoothingCode = null;
     }
 
     private void ExportDeviationToText()
@@ -2181,6 +2254,8 @@ public sealed class Overlay
                 ? file.RawSpectrum.Select(point => new SignalPoint(point.X, point.Y)).ToList()
                 : null;
             rawCalibrationCorrectionDb = file.RawCalibrationCorrectionDb.ToArray();
+            pointsCalibrationCorrectionDb = file.PointsCalibrationCorrectionDb.ToArray();
+            capturedSmoothingCode = file.CapturedSmoothingCode;
             capturedSampleRateHz = file.SampleRateHz;
             capturedYAxisKey = GetCapturedYAxisKey(file);
             UpdateDrawPoints();
@@ -2280,6 +2355,8 @@ public sealed class Overlay
                 ? rawSpectrumPoints.Select(point => new OverlayPoint(point.X, point.Y)).ToArray()
                 : Array.Empty<OverlayPoint>();
             file.RawCalibrationCorrectionDb = rawCalibrationCorrectionDb.ToArray();
+            file.PointsCalibrationCorrectionDb = pointsCalibrationCorrectionDb.ToArray();
+            file.CapturedSmoothingCode = capturedSmoothingCode;
             file.SampleRateHz = capturedSampleRateHz;
             file.CapturedYAxisKey = capturedYAxisKey;
         }
@@ -2577,6 +2654,8 @@ public sealed class Overlay
         capturedCurveKind = null;
         rawSpectrumPoints = null;
         rawCalibrationCorrectionDb = Array.Empty<double>();
+        pointsCalibrationCorrectionDb = Array.Empty<double>();
+        capturedSmoothingCode = null;
         capturedSampleRateHz = null;
         operationConfigured = false;
         sourceSlotA = 0;

--- a/source/Overlays/OverlayFile.cs
+++ b/source/Overlays/OverlayFile.cs
@@ -120,6 +120,27 @@ public sealed class OverlayFile
     // Empty means no calibration or a legacy raw capture.
     public double[] RawCalibrationCorrectionDb { get; set; } = Array.Empty<double>();
 
+    // No-raw captures only (a dB SPL RTA or FR, which cannot store a re-smoothable raw
+    // spectrum): the microphone correction that was baked into the DRAWN Points, frozen
+    // per drawn point (so its length matches Points). It lets a consumer that equalizes
+    // the curve (the EQ Wizard) switch calibration exactly — the SPL correction is applied
+    // additively per frequency, so removing this and applying another is lossless — even
+    // though there is no raw spectrum. Its presence also marks the capture as one whose
+    // Points may be re-smoothed when it was taken unsmoothed. Empty for raw captures
+    // (which use RawCalibrationCorrectionDb) and for legacy files. Additive, so no file
+    // version bump.
+    public double[] PointsCalibrationCorrectionDb { get; set; } = Array.Empty<double>();
+
+    // The display smoothing already BAKED INTO Points at capture time, in the shared
+    // SpectrumSmoothing encoding (0 = none, N = 1/N octave, negative = psychoacoustic).
+    // Distinct from SmoothingInverseOctaves, which is this slot's own display setting
+    // applied ON TOP of Points. A raw capture renders its Points unsmoothed, so it stores
+    // 0; a no-raw capture (dB SPL) stores whatever its source mode was showing. A consumer
+    // that re-smooths the stored curve (the EQ Wizard) may only do so when this is 0 —
+    // smoothing an already-smoothed curve compounds it. Null in legacy files: unknown, so
+    // consumers must assume the curve may already be smoothed. Additive, no version bump.
+    public int? CapturedSmoothingCode { get; set; }
+
     // Sample rate of the measurement this slot was captured from. Carried so a
     // consumer that equalizes the stored curve (the EQ Wizard) can realize its
     // biquads at the rate the curve was measured at instead of assuming one.
@@ -427,6 +448,24 @@ public sealed class OverlayFile
         {
             throw new InvalidDataException(
                 "The raw calibration correction contains a non-finite value.");
+        }
+        if (PointsCalibrationCorrectionDb == null)
+        {
+            throw new InvalidDataException("The points calibration correction is invalid.");
+        }
+        // Frozen per drawn point, so it is only meaningful alongside the points it was
+        // measured on; a mismatched length would silently shift the correction in
+        // frequency.
+        if (PointsCalibrationCorrectionDb.Length != 0 &&
+            PointsCalibrationCorrectionDb.Length != Points.Length)
+        {
+            throw new InvalidDataException(
+                "The points calibration correction does not match the overlay points.");
+        }
+        if (PointsCalibrationCorrectionDb.Any(value => !double.IsFinite(value)))
+        {
+            throw new InvalidDataException(
+                "The points calibration correction contains a non-finite value.");
         }
         if (SampleRateHz is <= 0)
         {

--- a/source/Overlays/OverlayMath.cs
+++ b/source/Overlays/OverlayMath.cs
@@ -3,35 +3,6 @@ using Resonalyze.Dsp;
 namespace Resonalyze;
 
 /// <summary>
-/// The domain a plain fractional-octave width averages magnitudes in. Averaging dB values
-/// directly is a GEOMETRIC mean of the underlying signal: it flattens narrow peaks harder
-/// and fills dips more than the analyzers do, so a curve re-smoothed that way no longer
-/// matches what the measuring mode would have drawn at the same width. A consumer that
-/// re-smooths a stored curve therefore states the domain its source used.
-/// </summary>
-public enum MagnitudeAveraging
-{
-    /// <summary>
-    /// Averages the dB values themselves — the overlay display convention, kept as the
-    /// default so existing curves render exactly as before.
-    /// </summary>
-    Decibel,
-
-    /// <summary>
-    /// Averages linear amplitude, matching <see cref="DataHelper.LogarithmicResample"/>
-    /// with its dB unpacking — the swept frequency response and the relative RTA.
-    /// </summary>
-    Amplitude,
-
-    /// <summary>
-    /// Averages linear power, matching
-    /// <see cref="DataHelper.LogarithmicPowerBandResample"/> — the dB SPL RTA, whose band
-    /// levels are power integrals.
-    /// </summary>
-    Power
-}
-
-/// <summary>
 /// Contains plotting-independent calculations used by overlay comparisons.
 /// </summary>
 public static class OverlayMath
@@ -53,8 +24,7 @@ public static class OverlayMath
     public static OverlayPoint[] SmoothByOctaves(
         IReadOnlyList<OverlayPoint> points,
         int inverseOctaves,
-        bool psychoacousticMagnitude = true,
-        MagnitudeAveraging averaging = MagnitudeAveraging.Decibel)
+        bool psychoacousticMagnitude = true)
     {
         ArgumentNullException.ThrowIfNull(points);
         if (points.Count < 2 || inverseOctaves == 0)
@@ -138,36 +108,19 @@ public static class OverlayMath
                 {
                     weight = 0.5 *
                         (1 + Math.Cos(Math.PI * distance / halfWidth));
-                    sampleValue = averaging switch
-                    {
-                        MagnitudeAveraging.Amplitude =>
-                            Math.Pow(10.0, points[sample].Y / 20.0),
-                        MagnitudeAveraging.Power =>
-                            Math.Pow(10.0, points[sample].Y / 10.0),
-                        _ => points[sample].Y
-                    };
+                    sampleValue = points[sample].Y;
                 }
 
                 weightedSum += sampleValue * weight;
                 weightSum += weight;
             }
 
-            bool averaged = weightSum > 1e-12;
-            double value = averaged ? weightedSum / weightSum : centerPoint.Y;
+            double value = weightSum > 1e-12
+                ? weightedSum / weightSum
+                : centerPoint.Y;
             if (psychoacoustic)
             {
                 value = 20.0 * Math.Log10(Math.Cbrt(value));
-            }
-            else if (averaged)
-            {
-                // Only convert back what was converted going in; the fallback above is
-                // already the centre point's dB.
-                value = averaging switch
-                {
-                    MagnitudeAveraging.Amplitude => 20.0 * Math.Log10(value),
-                    MagnitudeAveraging.Power => 10.0 * Math.Log10(value),
-                    _ => value
-                };
             }
 
             result[center] = new OverlayPoint(centerPoint.X, value);

--- a/source/Overlays/OverlayMath.cs
+++ b/source/Overlays/OverlayMath.cs
@@ -3,6 +3,35 @@ using Resonalyze.Dsp;
 namespace Resonalyze;
 
 /// <summary>
+/// The domain a plain fractional-octave width averages magnitudes in. Averaging dB values
+/// directly is a GEOMETRIC mean of the underlying signal: it flattens narrow peaks harder
+/// and fills dips more than the analyzers do, so a curve re-smoothed that way no longer
+/// matches what the measuring mode would have drawn at the same width. A consumer that
+/// re-smooths a stored curve therefore states the domain its source used.
+/// </summary>
+public enum MagnitudeAveraging
+{
+    /// <summary>
+    /// Averages the dB values themselves — the overlay display convention, kept as the
+    /// default so existing curves render exactly as before.
+    /// </summary>
+    Decibel,
+
+    /// <summary>
+    /// Averages linear amplitude, matching <see cref="DataHelper.LogarithmicResample"/>
+    /// with its dB unpacking — the swept frequency response and the relative RTA.
+    /// </summary>
+    Amplitude,
+
+    /// <summary>
+    /// Averages linear power, matching
+    /// <see cref="DataHelper.LogarithmicPowerBandResample"/> — the dB SPL RTA, whose band
+    /// levels are power integrals.
+    /// </summary>
+    Power
+}
+
+/// <summary>
 /// Contains plotting-independent calculations used by overlay comparisons.
 /// </summary>
 public static class OverlayMath
@@ -24,7 +53,8 @@ public static class OverlayMath
     public static OverlayPoint[] SmoothByOctaves(
         IReadOnlyList<OverlayPoint> points,
         int inverseOctaves,
-        bool psychoacousticMagnitude = true)
+        bool psychoacousticMagnitude = true,
+        MagnitudeAveraging averaging = MagnitudeAveraging.Decibel)
     {
         ArgumentNullException.ThrowIfNull(points);
         if (points.Count < 2 || inverseOctaves == 0)
@@ -108,19 +138,36 @@ public static class OverlayMath
                 {
                     weight = 0.5 *
                         (1 + Math.Cos(Math.PI * distance / halfWidth));
-                    sampleValue = points[sample].Y;
+                    sampleValue = averaging switch
+                    {
+                        MagnitudeAveraging.Amplitude =>
+                            Math.Pow(10.0, points[sample].Y / 20.0),
+                        MagnitudeAveraging.Power =>
+                            Math.Pow(10.0, points[sample].Y / 10.0),
+                        _ => points[sample].Y
+                    };
                 }
 
                 weightedSum += sampleValue * weight;
                 weightSum += weight;
             }
 
-            double value = weightSum > 1e-12
-                ? weightedSum / weightSum
-                : centerPoint.Y;
+            bool averaged = weightSum > 1e-12;
+            double value = averaged ? weightedSum / weightSum : centerPoint.Y;
             if (psychoacoustic)
             {
                 value = 20.0 * Math.Log10(Math.Cbrt(value));
+            }
+            else if (averaged)
+            {
+                // Only convert back what was converted going in; the fallback above is
+                // already the centre point's dB.
+                value = averaging switch
+                {
+                    MagnitudeAveraging.Amplitude => 20.0 * Math.Log10(value),
+                    MagnitudeAveraging.Power => 10.0 * Math.Log10(value),
+                    _ => value
+                };
             }
 
             result[center] = new OverlayPoint(centerPoint.X, value);

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -175,7 +175,10 @@ internal sealed class PlotModelFactory
         {
             return DescribeWithoutRawForm(
                 (int)Math.Round(frequencyResponseOptions.SmoothingInverseOctaves),
-                expSweepMeasurement.SampleRate);
+                expSweepMeasurement.SampleRate,
+                frequencyResponseOptions.UseCalibration
+                    ? GetCalibration(frequencyResponseOptions)
+                    : null);
         }
 
         CalibrationFile? calibration = GetCalibration(frequencyResponseOptions);
@@ -214,7 +217,12 @@ internal sealed class PlotModelFactory
         int smoothingCode = liveSpectrumOptions.SmoothingInverseOctaves;
         if (EffectiveLiveSpectrumScale == MagnitudeScale.SoundPressureLevel)
         {
-            return DescribeWithoutRawForm(smoothingCode, noiseMeasurement.SampleRate);
+            // No raw form, but the SPL trace applies its correction additively per band,
+            // so handing the calibration over lets a consumer swap it exactly later.
+            return DescribeWithoutRawForm(
+                smoothingCode,
+                noiseMeasurement.SampleRate,
+                GetCalibration(liveSpectrumOptions));
         }
 
         List<SignalPoint> spectrum = LiveRtaRawCapture.BuildRelativeRaw(
@@ -223,7 +231,10 @@ internal sealed class PlotModelFactory
             noiseMeasurement.SampleRate);
         if (spectrum.Count < 2)
         {
-            return DescribeWithoutRawForm(smoothingCode, noiseMeasurement.SampleRate);
+            return DescribeWithoutRawForm(
+                smoothingCode,
+                noiseMeasurement.SampleRate,
+                GetCalibration(liveSpectrumOptions));
         }
 
         return new RawCurveCapture(
@@ -234,13 +245,19 @@ internal sealed class PlotModelFactory
             noiseMeasurement.SampleRate > 0 ? noiseMeasurement.SampleRate : null);
     }
 
-    // A capture with no re-smoothable samples: the overlay stores the drawn curve, but
-    // the rate travels with it so a consumer outside the measurement is not left guessing.
-    private static RawCurveCapture DescribeWithoutRawForm(int smoothingCode, int sampleRate) =>
+    // A capture with no re-smoothable samples: the overlay stores the drawn curve, but the
+    // rate, the smoothing baked into it and the calibration behind it travel with it, so a
+    // consumer outside the measurement is not left guessing — and can still undo the
+    // correction, which these modes apply additively per frequency.
+    private static RawCurveCapture DescribeWithoutRawForm(
+        int smoothingCode,
+        int sampleRate,
+        CalibrationFile? calibration) =>
         new(Array.Empty<SignalPoint>(),
             Array.Empty<double>(),
             smoothingCode,
-            sampleRate > 0 ? sampleRate : null);
+            sampleRate > 0 ? sampleRate : null,
+            calibration);
 
     public PlotModel CreateFrequencyResponse(bool includeCurves)
     {

--- a/source/Tools/Eq/EqWizardCurveSource.cs
+++ b/source/Tools/Eq/EqWizardCurveSource.cs
@@ -140,8 +140,17 @@ internal sealed record EqWizardCurveSource
     /// curve captured under smoothing — or one that never said (a text import, a legacy
     /// slot) — is left alone.
     /// </summary>
+    /// <remarks>
+    /// A no-raw curve additionally has to be an RTA. Re-smoothing must reproduce the
+    /// analyzer that drew the curve, not merely look similar, because the result feeds Auto
+    /// Tune; only the RTA's smoothing is a replayable second pass over the band levels it
+    /// stored (see <see cref="DataHelper.SmoothBandLevels"/>). A dB SPL SWEEP smooths
+    /// linear amplitude inside its Lanczos resampling, which cannot be replayed from the
+    /// finished curve — that one needs its raw spectrum kept, so it stays unsmoothable here
+    /// rather than being smoothed by a near-enough algorithm.
+    /// </remarks>
     public bool SupportsSmoothing =>
         Kind == EqWizardSourceKind.ImpulseResponse ||
         RawSpectrum != null ||
-        CapturedSmoothingCode == 0;
+        (CapturedSmoothingCode == 0 && CurveKind == AnalysisCurveKind.InputSpectrum);
 }

--- a/source/Tools/Eq/EqWizardCurveSource.cs
+++ b/source/Tools/Eq/EqWizardCurveSource.cs
@@ -84,6 +84,25 @@ internal sealed record EqWizardCurveSource
     /// </summary>
     public IReadOnlyList<SignalPoint> Points { get; init; } = Array.Empty<SignalPoint>();
 
+    /// <summary>
+    /// For a curve with NO raw form: the microphone correction baked into
+    /// <see cref="Points"/>, one value per point. These modes (a dB SPL RTA or FR) apply
+    /// the correction additively per frequency, so undoing this and applying another is
+    /// exact even without a raw spectrum — which is what lets the calibration selector work
+    /// here. Empty when the curve has a raw form (the correction travels on the raw grid
+    /// instead) or when the source never declared one (a text import, a legacy slot).
+    /// </summary>
+    public IReadOnlyList<double> PointsCalibrationCorrectionDb { get; init; } =
+        Array.Empty<double>();
+
+    /// <summary>
+    /// The display smoothing already baked into <see cref="Points"/>, in the
+    /// <see cref="SpectrumSmoothing"/> encoding; null when the source never declared it.
+    /// Only a curve captured unsmoothed (0) may be smoothed here — re-smoothing an already
+    /// smoothed curve compounds it.
+    /// </summary>
+    public int? CapturedSmoothingCode { get; init; }
+
     /// <summary>The unit the curve is in, which drives the plot's dB axis.</summary>
     public MagnitudeScale Scale { get; init; } = MagnitudeScale.Relative;
 
@@ -98,17 +117,31 @@ internal sealed record EqWizardCurveSource
 
     /// <summary>
     /// Whether the calibration selector applies. An impulse response is calibrated while
-    /// its FR is computed; an imported curve can only be re-calibrated when its
-    /// uncalibrated raw form was stored — otherwise the correction is already baked in
-    /// and applying another would double it.
+    /// its FR is computed; an imported curve can be re-calibrated when its uncalibrated raw
+    /// form was stored, or — for the no-raw modes that correct additively per frequency (a
+    /// dB SPL RTA or FR) — when the correction baked into its points travelled with it.
+    /// Without either, the correction is already fused into the numbers and applying
+    /// another would double it.
     /// </summary>
     public bool SupportsCalibration =>
-        Kind == EqWizardSourceKind.ImpulseResponse || RawSpectrum != null;
+        Kind == EqWizardSourceKind.ImpulseResponse || HasOwnCalibration;
 
     /// <summary>
-    /// Whether the smoothing selector applies. Same rule: smoothing a curve that is
-    /// already smoothed compounds it, so it is offered only where the unsmoothed
-    /// reference exists.
+    /// Whether the curve carries the correction it was captured with, so "own" can
+    /// reproduce it — either on the raw grid or frozen onto its own points.
     /// </summary>
-    public bool SupportsSmoothing => SupportsCalibration;
+    public bool HasOwnCalibration =>
+        RawSpectrum != null || PointsCalibrationCorrectionDb.Count > 0;
+
+    /// <summary>
+    /// Whether the smoothing selector applies: where an unsmoothed reference exists (an
+    /// impulse response, a stored raw spectrum), or where the curve itself was captured
+    /// unsmoothed and so IS one. Smoothing an already smoothed curve compounds it, so a
+    /// curve captured under smoothing — or one that never said (a text import, a legacy
+    /// slot) — is left alone.
+    /// </summary>
+    public bool SupportsSmoothing =>
+        Kind == EqWizardSourceKind.ImpulseResponse ||
+        RawSpectrum != null ||
+        CapturedSmoothingCode == 0;
 }

--- a/source/Tools/Eq/EqWizardImportedCurve.cs
+++ b/source/Tools/Eq/EqWizardImportedCurve.cs
@@ -3,17 +3,23 @@ using Resonalyze.Dsp;
 namespace Resonalyze;
 
 /// <summary>
-/// Re-renders an imported curve that has NO raw form — a dB SPL RTA or frequency response,
-/// whose band levels cannot be re-gridded back to a raw spectrum without inventing data.
+/// Re-renders an imported curve that has NO raw form — a dB SPL capture, whose band levels
+/// cannot be re-gridded back to a raw spectrum without inventing data.
 /// </summary>
 /// <remarks>
 /// Such a curve is not a dead end: these modes apply the microphone correction ADDITIVELY
 /// per frequency, so the correction frozen at capture can be subtracted back out exactly
 /// and another applied in its place. The order mirrors the primary frequency-response path
-/// — uncalibrate, smooth, then calibrate — so a curve re-smoothed here matches what the
-/// measuring mode would have drawn at that width. Everything happens on the curve's OWN
+/// — uncalibrate, smooth, then calibrate. Everything happens on the curve's OWN
 /// frequencies: no resampling, so the display range is never extrapolated beyond the bands
 /// the analyzer actually resolved.
+/// <para>
+/// Smoothing is delegated to <see cref="DataHelper.SmoothBandLevels"/>, which shares its
+/// core with the RTA's own resampler. Re-smoothing with a merely similar window would not
+/// do: this curve goes into Auto Tune, and a mean taken in the wrong domain or over the
+/// wrong window suppresses narrow peaks differently from the analyzer, so the fit would
+/// chase a shape the measurement never had at that width.
+/// </para>
 /// </remarks>
 internal static class EqWizardImportedCurve
 {
@@ -29,8 +35,7 @@ internal static class EqWizardImportedCurve
         IReadOnlyList<SignalPoint> points,
         IReadOnlyList<double> capturedCorrectionDb,
         IReadOnlyList<double> targetCorrectionDb,
-        int smoothingCode,
-        MagnitudeAveraging averaging = MagnitudeAveraging.Power)
+        int smoothingCode)
     {
         ArgumentNullException.ThrowIfNull(points);
         ArgumentNullException.ThrowIfNull(capturedCorrectionDb);
@@ -47,7 +52,7 @@ internal static class EqWizardImportedCurve
         // Back to the uncalibrated level the analyzer measured. A NaN (a band below the
         // measurement threshold) stays NaN through every step, so gaps are neither filled
         // nor spread.
-        var working = new OverlayPoint[points.Count];
+        var working = new SignalPoint[points.Count];
         for (int i = 0; i < working.Length; i++)
         {
             double value = points[i].Y;
@@ -56,32 +61,28 @@ internal static class EqWizardImportedCurve
                 value += capturedCorrectionDb[i];
             }
 
-            working[i] = new OverlayPoint(points[i].X, value);
+            working[i] = new SignalPoint(points[i].X, value);
         }
 
-        if (smooths)
-        {
-            // The overlay smoother works in place on these very frequencies, so the curve
-            // keeps its own band grid. Magnitude semantics: this path only ever carries a
-            // magnitude response, which is what the psychoacoustic width is defined for.
-            // The averaging domain is the source analyzer's, not the overlay display's —
-            // averaging dB directly is a geometric mean and would suppress narrow peaks
-            // harder than the mode that drew the curve, feeding Auto Tune a shape the
-            // measurement never had.
-            working = OverlayMath.SmoothByOctaves(
-                working, smoothingCode, psychoacousticMagnitude: true, averaging);
-        }
+        IReadOnlyList<SignalPoint> smoothed = smooths
+            // The analyzer's own second pass, replayed over its own band levels on their
+            // own grid — same window, same power-domain mean, same psychoacoustic form.
+            ? DataHelper.SmoothBandLevels(
+                working,
+                SpectrumSmoothing.SmoothingOctaves(smoothingCode),
+                SpectrumSmoothing.IsPsychoacoustic(smoothingCode))
+            : working;
 
         var result = new SignalPoint[points.Count];
         for (int i = 0; i < result.Length; i++)
         {
-            double value = working[i].Y;
+            double value = smoothed[i].Y;
             if (hasTarget)
             {
                 value -= targetCorrectionDb[i];
             }
 
-            result[i] = new SignalPoint(working[i].X, value);
+            result[i] = new SignalPoint(smoothed[i].X, value);
         }
 
         return result;

--- a/source/Tools/Eq/EqWizardImportedCurve.cs
+++ b/source/Tools/Eq/EqWizardImportedCurve.cs
@@ -29,7 +29,8 @@ internal static class EqWizardImportedCurve
         IReadOnlyList<SignalPoint> points,
         IReadOnlyList<double> capturedCorrectionDb,
         IReadOnlyList<double> targetCorrectionDb,
-        int smoothingCode)
+        int smoothingCode,
+        MagnitudeAveraging averaging = MagnitudeAveraging.Power)
     {
         ArgumentNullException.ThrowIfNull(points);
         ArgumentNullException.ThrowIfNull(capturedCorrectionDb);
@@ -63,8 +64,12 @@ internal static class EqWizardImportedCurve
             // The overlay smoother works in place on these very frequencies, so the curve
             // keeps its own band grid. Magnitude semantics: this path only ever carries a
             // magnitude response, which is what the psychoacoustic width is defined for.
+            // The averaging domain is the source analyzer's, not the overlay display's —
+            // averaging dB directly is a geometric mean and would suppress narrow peaks
+            // harder than the mode that drew the curve, feeding Auto Tune a shape the
+            // measurement never had.
             working = OverlayMath.SmoothByOctaves(
-                working, smoothingCode, psychoacousticMagnitude: true);
+                working, smoothingCode, psychoacousticMagnitude: true, averaging);
         }
 
         var result = new SignalPoint[points.Count];

--- a/source/Tools/Eq/EqWizardImportedCurve.cs
+++ b/source/Tools/Eq/EqWizardImportedCurve.cs
@@ -1,0 +1,108 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Re-renders an imported curve that has NO raw form — a dB SPL RTA or frequency response,
+/// whose band levels cannot be re-gridded back to a raw spectrum without inventing data.
+/// </summary>
+/// <remarks>
+/// Such a curve is not a dead end: these modes apply the microphone correction ADDITIVELY
+/// per frequency, so the correction frozen at capture can be subtracted back out exactly
+/// and another applied in its place. The order mirrors the primary frequency-response path
+/// — uncalibrate, smooth, then calibrate — so a curve re-smoothed here matches what the
+/// measuring mode would have drawn at that width. Everything happens on the curve's OWN
+/// frequencies: no resampling, so the display range is never extrapolated beyond the bands
+/// the analyzer actually resolved.
+/// </remarks>
+internal static class EqWizardImportedCurve
+{
+    /// <summary>
+    /// Renders <paramref name="points"/> with <paramref name="capturedCorrectionDb"/>
+    /// removed, <paramref name="smoothingCode"/> applied, and
+    /// <paramref name="targetCorrectionDb"/> applied in its place. Both corrections are
+    /// per-point and are ignored unless they line up with the points — a mismatched length
+    /// is not aligned to these frequencies at all. An empty correction means none, so
+    /// passing empty for both and a smoothing code of 0 returns the input untouched.
+    /// </summary>
+    public static IReadOnlyList<SignalPoint> Render(
+        IReadOnlyList<SignalPoint> points,
+        IReadOnlyList<double> capturedCorrectionDb,
+        IReadOnlyList<double> targetCorrectionDb,
+        int smoothingCode)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+        ArgumentNullException.ThrowIfNull(capturedCorrectionDb);
+        ArgumentNullException.ThrowIfNull(targetCorrectionDb);
+
+        bool hasCaptured = capturedCorrectionDb.Count == points.Count && points.Count > 0;
+        bool hasTarget = targetCorrectionDb.Count == points.Count && points.Count > 0;
+        bool smooths = smoothingCode != 0 && points.Count >= 2;
+        if (!hasCaptured && !hasTarget && !smooths)
+        {
+            return points;
+        }
+
+        // Back to the uncalibrated level the analyzer measured. A NaN (a band below the
+        // measurement threshold) stays NaN through every step, so gaps are neither filled
+        // nor spread.
+        var working = new OverlayPoint[points.Count];
+        for (int i = 0; i < working.Length; i++)
+        {
+            double value = points[i].Y;
+            if (hasCaptured)
+            {
+                value += capturedCorrectionDb[i];
+            }
+
+            working[i] = new OverlayPoint(points[i].X, value);
+        }
+
+        if (smooths)
+        {
+            // The overlay smoother works in place on these very frequencies, so the curve
+            // keeps its own band grid. Magnitude semantics: this path only ever carries a
+            // magnitude response, which is what the psychoacoustic width is defined for.
+            working = OverlayMath.SmoothByOctaves(
+                working, smoothingCode, psychoacousticMagnitude: true);
+        }
+
+        var result = new SignalPoint[points.Count];
+        for (int i = 0; i < result.Length; i++)
+        {
+            double value = working[i].Y;
+            if (hasTarget)
+            {
+                value -= targetCorrectionDb[i];
+            }
+
+            result[i] = new SignalPoint(working[i].X, value);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Samples a calibration profile at each of <paramref name="points"/>' frequencies,
+    /// giving the per-point correction <see cref="Render"/> takes. A null profile yields
+    /// an empty correction — "none", which is exactly what the Off mode needs.
+    /// </summary>
+    public static IReadOnlyList<double> SampleCorrection(
+        CalibrationFile? calibration,
+        IReadOnlyList<SignalPoint> points)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+        if (calibration == null)
+        {
+            return Array.Empty<double>();
+        }
+
+        var correction = new double[points.Count];
+        for (int i = 0; i < correction.Length; i++)
+        {
+            correction[i] = calibration.GetDecibelCorrection(points[i].X);
+        }
+
+        return correction;
+    }
+}

--- a/source/Tools/Eq/EqWizardPanel.Designer.cs
+++ b/source/Tools/Eq/EqWizardPanel.Designer.cs
@@ -65,6 +65,7 @@
             labelSampleRate = new Label();
             buttonImport = new Button();
             buttonExport = new Button();
+            buttonResetBands = new Button();
             (NumericTargetOffset).BeginInit();
             (NumericGain).BeginInit();
             (numericToHz).BeginInit();
@@ -493,14 +494,26 @@
             buttonExport.TabIndex = 58;
             buttonExport.Text = "Export";
             buttonExport.UseVisualStyleBackColor = true;
-            // 
+            //
+            // buttonResetBands
+            //
+            buttonResetBands.FlatStyle = FlatStyle.Popup;
+            buttonResetBands.ForeColor = Color.White;
+            buttonResetBands.Location = new Point(2, 275);
+            buttonResetBands.Name = "buttonResetBands";
+            buttonResetBands.Size = new Size(186, 24);
+            buttonResetBands.TabIndex = 59;
+            buttonResetBands.Text = "Reset filters";
+            buttonResetBands.UseVisualStyleBackColor = true;
+            //
             // EqWizardPanel
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             AutoScroll = true;
             BackColor = Color.FromArgb(40, 44, 54);
             BorderStyle = BorderStyle.FixedSingle;
+            Controls.Add(buttonResetBands);
             Controls.Add(buttonExport);
             Controls.Add(buttonImport);
             Controls.Add(labelCalibration);
@@ -571,5 +584,6 @@
         private Label labelSmooth;
         private Button buttonImport;
         private Button buttonExport;
+        private Button buttonResetBands;
     }
 }

--- a/source/Tools/Eq/EqWizardPanel.Designer.cs
+++ b/source/Tools/Eq/EqWizardPanel.Designer.cs
@@ -102,7 +102,7 @@
             labelBands.AutoSize = true;
             labelBands.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             labelBands.ForeColor = Color.FromArgb(210, 214, 222);
-            labelBands.Location = new Point(9, 147);
+            labelBands.Location = new Point(9, 172);
             labelBands.Margin = new Padding(3);
             labelBands.Name = "labelBands";
             labelBands.Size = new Size(56, 15);
@@ -124,7 +124,7 @@
             // 
             darkComboBoxBands.BackColor = Color.FromArgb(55, 60, 72);
             darkComboBoxBands.ForeColor = Color.White;
-            darkComboBoxBands.Location = new Point(108, 145);
+            darkComboBoxBands.Location = new Point(108, 170);
             darkComboBoxBands.MinimumSize = new Size(36, 19);
             darkComboBoxBands.Name = "darkComboBoxBands";
             darkComboBoxBands.Size = new Size(80, 19);
@@ -166,7 +166,7 @@
             NumericGain.DecimalPlaces = 1;
             NumericGain.ForeColor = Color.White;
             NumericGain.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
-            NumericGain.Location = new Point(108, 170);
+            NumericGain.Location = new Point(108, 195);
             NumericGain.Maximum = new decimal(new int[] { 80, 0, 0, 0 });
             NumericGain.Minimum = new decimal(new int[] { 80, 0, 0, int.MinValue });
             NumericGain.MinimumSize = new Size(36, 19);
@@ -183,7 +183,7 @@
             labelGain.AutoSize = true;
             labelGain.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             labelGain.ForeColor = Color.FromArgb(210, 214, 222);
-            labelGain.Location = new Point(9, 172);
+            labelGain.Location = new Point(9, 197);
             labelGain.Margin = new Padding(3);
             labelGain.Name = "labelGain";
             labelGain.Size = new Size(48, 15);
@@ -353,7 +353,7 @@
             checkBoxBypass.AutoSize = true;
             checkBoxBypass.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             checkBoxBypass.ForeColor = Color.FromArgb(210, 214, 222);
-            checkBoxBypass.Location = new Point(13, 195);
+            checkBoxBypass.Location = new Point(13, 220);
             checkBoxBypass.Name = "checkBoxBypass";
             checkBoxBypass.Size = new Size(62, 19);
             checkBoxBypass.TabIndex = 53;
@@ -476,7 +476,7 @@
             //
             buttonImport.FlatStyle = FlatStyle.Popup;
             buttonImport.ForeColor = Color.White;
-            buttonImport.Location = new Point(2, 221);
+            buttonImport.Location = new Point(2, 246);
             buttonImport.Name = "buttonImport";
             buttonImport.Size = new Size(87, 24);
             buttonImport.TabIndex = 57;
@@ -487,7 +487,7 @@
             // 
             buttonExport.FlatStyle = FlatStyle.Popup;
             buttonExport.ForeColor = Color.White;
-            buttonExport.Location = new Point(101, 221);
+            buttonExport.Location = new Point(101, 246);
             buttonExport.Name = "buttonExport";
             buttonExport.Size = new Size(87, 24);
             buttonExport.TabIndex = 58;

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -351,7 +351,7 @@ public partial class EqWizardPanel
     //  - a curve with no uncalibrated reference cannot be re-calibrated at all (Off).
     private EqWizardCalibrationMode ChooseCalibrationMode(EqWizardCurveSource source)
     {
-        if (source.RawSpectrum != null)
+        if (source.HasOwnCalibration)
         {
             return EqWizardCalibrationMode.Own;
         }
@@ -421,13 +421,19 @@ public partial class EqWizardPanel
     // An imported curve is already a finished response. When its uncalibrated reference
     // was stored it is re-rendered exactly the way the mode it came from would — same
     // resampler, so the mode's smoothing reproduces the on-screen reference. Without that
-    // reference (a dB SPL RTA, a text curve) the stored display points are the only
-    // truth and are used as-is.
+    // reference (a dB SPL capture) the curve's own points are the reference: the
+    // correction frozen onto them comes back out, the width applies on their own grid, and
+    // the chosen correction goes on instead. A curve that declared neither (a text import,
+    // a legacy slot) has nothing to undo and is drawn as stored.
     private IReadOnlyList<SignalPoint> ComputeImportedCurve(EqWizardCurveSource source)
     {
         if (source.RawSpectrum is not { Count: >= 2 } raw)
         {
-            return source.Points;
+            return EqWizardImportedCurve.Render(
+                source.Points,
+                source.PointsCalibrationCorrectionDb,
+                ResolvePointsCalibrationCorrection(source),
+                source.SupportsSmoothing ? SourceSmoothingInverseOctaves : 0);
         }
 
         return RawCurveRenderer.Render(
@@ -435,6 +441,20 @@ public partial class EqWizardPanel
             ResolveCurveCalibrationCorrection(source),
             SourceSmoothingInverseOctaves);
     }
+
+    // The same choice as ResolveCurveCalibrationCorrection, but frozen on the curve's own
+    // points instead of the raw output grid — the only frequencies a no-raw capture has.
+    private IReadOnlyList<double> ResolvePointsCalibrationCorrection(
+        EqWizardCurveSource source) => calibrationMode switch
+        {
+            EqWizardCalibrationMode.Own => source.PointsCalibrationCorrectionDb,
+            EqWizardCalibrationMode.Degrees0 or EqWizardCalibrationMode.Degrees90 =>
+                EqWizardImportedCurve.SampleCorrection(
+                    calibrationResolver?.Invoke(
+                        EqWizardCalibration.ToMicrophoneMode(calibrationMode)),
+                    source.Points),
+            _ => Array.Empty<double>()
+        };
 
     // The correction subtracted after smoothing: none, the one frozen at capture, or a
     // configured profile re-frozen on the same output grid.
@@ -750,7 +770,7 @@ public partial class EqWizardPanel
             new(EqWizardCalibrationMode.Off, "Off")
         };
 
-        if (loadedSource is { RawSpectrum: not null })
+        if (loadedSource is { HasOwnCalibration: true })
         {
             options.Add(new EqWizardCalibrationOption(
                 EqWizardCalibrationMode.Own, "Own (as captured)"));

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -433,8 +433,7 @@ public partial class EqWizardPanel
                 source.Points,
                 source.PointsCalibrationCorrectionDb,
                 ResolvePointsCalibrationCorrection(source),
-                source.SupportsSmoothing ? SourceSmoothingInverseOctaves : 0,
-                SourceAveragingDomain(source));
+                source.SupportsSmoothing ? SourceSmoothingInverseOctaves : 0);
         }
 
         return RawCurveRenderer.Render(
@@ -442,15 +441,6 @@ public partial class EqWizardPanel
             ResolveCurveCalibrationCorrection(source),
             SourceSmoothingInverseOctaves);
     }
-
-    // The domain the mode that DREW this curve averages magnitudes in, so re-smoothing it
-    // here reproduces that mode's shape rather than the overlay display's. An RTA band
-    // level is a power integral; a swept response is smoothed as linear amplitude. An
-    // undeclared curve (a text import) is never re-smoothed, so its value is moot.
-    private static MagnitudeAveraging SourceAveragingDomain(EqWizardCurveSource source) =>
-        source.CurveKind == AnalysisCurveKind.InputSpectrum
-            ? MagnitudeAveraging.Power
-            : MagnitudeAveraging.Amplitude;
 
     // The same choice as ResolveCurveCalibrationCorrection, but frozen on the curve's own
     // points instead of the raw output grid — the only frequencies a no-raw capture has.

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -433,7 +433,8 @@ public partial class EqWizardPanel
                 source.Points,
                 source.PointsCalibrationCorrectionDb,
                 ResolvePointsCalibrationCorrection(source),
-                source.SupportsSmoothing ? SourceSmoothingInverseOctaves : 0);
+                source.SupportsSmoothing ? SourceSmoothingInverseOctaves : 0,
+                SourceAveragingDomain(source));
         }
 
         return RawCurveRenderer.Render(
@@ -441,6 +442,15 @@ public partial class EqWizardPanel
             ResolveCurveCalibrationCorrection(source),
             SourceSmoothingInverseOctaves);
     }
+
+    // The domain the mode that DREW this curve averages magnitudes in, so re-smoothing it
+    // here reproduces that mode's shape rather than the overlay display's. An RTA band
+    // level is a power integral; a swept response is smoothed as linear amplitude. An
+    // undeclared curve (a text import) is never re-smoothed, so its value is moot.
+    private static MagnitudeAveraging SourceAveragingDomain(EqWizardCurveSource source) =>
+        source.CurveKind == AnalysisCurveKind.InputSpectrum
+            ? MagnitudeAveraging.Power
+            : MagnitudeAveraging.Amplitude;
 
     // The same choice as ResolveCurveCalibrationCorrection, but frozen on the curve's own
     // points instead of the raw output grid — the only frequencies a no-raw capture has.

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -108,6 +108,7 @@ public partial class EqWizardPanel : UserControl
         buttonOverlaySettings.Click += (_, _) => OpenTargetSettings();
         buttonImport.Click += (_, _) => ImportPeq();
         buttonExport.Click += (_, _) => ExportPeq();
+        buttonResetBands.Click += (_, _) => ResetBands();
         numericFromHz.ValueChanged += (_, _) => FrequencyBoundChanged(fromChanged: true);
         numericToHz.ValueChanged += (_, _) => FrequencyBoundChanged(fromChanged: false);
         numericGainMin.ValueChanged += (_, _) => GainBoundChanged(minChanged: true);
@@ -252,6 +253,10 @@ public partial class EqWizardPanel : UserControl
             "EQ preamp (dB) applied on top of all bands. Usually negative to leave " +
             "headroom for boosts.");
         SetTip(labelBands, darkComboBoxBands, "Number of PEQ bands shown.");
+        SetTip(buttonResetBands,
+            "Clear the whole filter bank: every band back to its default frequency " +
+            "at Q 1 and 0 dB, preamp 0 dB, one active filter. The source, the target " +
+            "and the Auto Tune settings are kept.");
         SetTip(labelSmooth, comboBoxSmooth,
             "Smoothing of the source curve (1/N octave), used for display and Auto " +
             "Tune. Unavailable for an imported curve that was already smoothed when it " +
@@ -372,6 +377,10 @@ public partial class EqWizardPanel : UserControl
     private static double DefaultBandFrequencyHz(int index) =>
         IsoThirdOctaveCentersHz[
             Math.Clamp(index, 0, IsoThirdOctaveCentersHz.Length - 1)];
+
+    // The neutral Q a strip starts on, matching the designer's initial value for the
+    // field. Reset filters restores it, so the two must agree.
+    private const double DefaultBandQ = 1.0;
 
     // The Bands control sets how many strips are active; the remaining strips stay
     // visible but disabled and are excluded from the EQ curve and the stats.
@@ -845,6 +854,55 @@ public partial class EqWizardPanel : UserControl
         }
 
         return options;
+    }
+
+    // Puts the whole filter bank back to the state the panel starts in: every strip at
+    // its ISO third-octave home frequency, Q 1, gain 0, no preamp, one active band. The
+    // source, the target and the Auto Tune settings are deliberately untouched — this
+    // clears the tune, not the setup it was made against.
+    private void ResetBands()
+    {
+        // A tune can represent a lot of manual work and there is no undo here, so the
+        // one destructive button in the panel asks first.
+        if (MessageBox.Show(
+                FindForm(),
+                "Reset all EQ filters to their defaults?" +
+                Environment.NewLine + Environment.NewLine +
+                "Every band returns to its default frequency with Q 1 and 0 dB gain, " +
+                "the preamp returns to 0 dB, and the filter count returns to 1. The " +
+                "source curve, the target and the Auto Tune settings are kept.",
+                "EQ Wizard",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning) != DialogResult.Yes)
+        {
+            return;
+        }
+
+        suppressRedraw = true;
+        try
+        {
+            for (int index = 0; index < peqSlots.Count; index++)
+            {
+                PeqSlotControl slot = peqSlots[index];
+                slot.FrequencyInput.Value =
+                    slot.FrequencyInput.ClampValue(DefaultBandFrequencyHz(index));
+                slot.QInput.Value = slot.QInput.ClampValue(DefaultBandQ);
+                slot.GainInput.Value = slot.GainInput.ClampValue(0);
+            }
+
+            NumericGain.Value = NumericGain.ClampValue(0);
+            // Setting the selection fires SetActiveBandCount, which also drops a
+            // highlighted band that no longer exists.
+            darkComboBoxBands.SelectedIndex = 0;
+        }
+        finally
+        {
+            suppressRedraw = false;
+        }
+
+        DeselectBand();
+        RaiseSettingsChanged();
+        DrawSelectedCurves();
     }
 
     private void ApplyEqualizationCurve(EqualizationCurve curve)

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -241,7 +241,8 @@ public partial class EqWizardPanel : UserControl
         SetTip(labelCalibration, comboBoxCalibration,
             "Microphone calibration applied to the source curve. \"Own\" re-uses the " +
             "correction stored with an imported curve; unavailable when the curve " +
-            "carries no uncalibrated reference (its calibration is already baked in).");
+            "arrived without one (a text import), where its calibration is already " +
+            "baked in and cannot be undone.");
         SetTip(labelSampleRate, comboBoxSampleRate,
             "Sample rate the fitted filters are realized at, and the rate written into " +
             "an exported profile. Locked to the source's own rate when it states one.");
@@ -253,8 +254,8 @@ public partial class EqWizardPanel : UserControl
         SetTip(labelBands, darkComboBoxBands, "Number of PEQ bands shown.");
         SetTip(labelSmooth, comboBoxSmooth,
             "Smoothing of the source curve (1/N octave), used for display and Auto " +
-            "Tune. Unavailable for an imported curve that carries no unsmoothed " +
-            "reference, where it would compound the smoothing already applied.");
+            "Tune. Unavailable for an imported curve that was already smoothed when it " +
+            "was captured, or that never said — smoothing it again would compound it.");
         SetTip(checkBoxBypass,
             "Show the curves without the EQ applied (Source + EQ equals Source).");
         SetTip(labelGainMin, numericGainMin,

--- a/source/Tools/Eq/EqWizardSourceResolver.cs
+++ b/source/Tools/Eq/EqWizardSourceResolver.cs
@@ -130,8 +130,11 @@ internal sealed class EqWizardSourceResolver
     {
         // The slot's own offset is a display device for pulling curves apart on the plot;
         // equalization needs the level as measured, so it is deliberately not applied.
-        IReadOnlyList<SignalPoint> points = NormalizePoints(
-            file.Points.Select(point => new SignalPoint(point.X, point.Y)));
+        // The points-aligned correction rides along through normalization so it keeps
+        // pointing at the frequencies it was frozen on.
+        (IReadOnlyList<SignalPoint> points, double[] pointsCorrection) = NormalizePoints(
+            file.Points.Select(point => new SignalPoint(point.X, point.Y)),
+            file.PointsCalibrationCorrectionDb);
         IReadOnlyList<SignalPoint>? raw = file.RawSpectrum.Length >= 2
             ? file.RawSpectrum.Select(point => new SignalPoint(point.X, point.Y)).ToArray()
             : null;
@@ -144,6 +147,8 @@ internal sealed class EqWizardSourceResolver
             RawSpectrum = raw,
             OwnCalibrationCorrectionDb = file.RawCalibrationCorrectionDb.ToArray(),
             Points = points,
+            PointsCalibrationCorrectionDb = pointsCorrection,
+            CapturedSmoothingCode = file.CapturedSmoothingCode,
             Scale = file.CapturedMagnitudeScale,
             SampleRateHz = file.SampleRateHz,
             CurveKind = file.CapturedCurveKind
@@ -274,12 +279,33 @@ internal sealed class EqWizardSourceResolver
         IEnumerable<SignalPoint> points)
     {
         ArgumentNullException.ThrowIfNull(points);
+        return NormalizePoints(points, companion: null).Points;
+    }
 
-        var result = new List<SignalPoint>();
-        foreach (SignalPoint point in points
-            .Where(point => double.IsFinite(point.X) && point.X > 0 &&
-                !double.IsInfinity(point.Y))
-            .OrderBy(point => point.X))
+    /// <summary>
+    /// Normalizes the points together with a per-point companion array (the calibration
+    /// correction frozen on those very points), so reordering or dropping a point carries
+    /// its companion value along. Normalizing the two separately would let them shift
+    /// against each other and silently apply a correction at the wrong frequency. A
+    /// companion of a different length is not aligned to these points at all and is
+    /// discarded rather than guessed at.
+    /// </summary>
+    internal static (IReadOnlyList<SignalPoint> Points, double[] Companion) NormalizePoints(
+        IEnumerable<SignalPoint> points,
+        IReadOnlyList<double>? companion)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+
+        List<SignalPoint> source = points as List<SignalPoint> ?? points.ToList();
+        bool hasCompanion = companion is { Count: > 0 } && companion.Count == source.Count;
+
+        var result = new List<SignalPoint>(source.Count);
+        var companionResult = new List<double>(hasCompanion ? source.Count : 0);
+        foreach ((SignalPoint point, int index) in source
+            .Select((point, index) => (point, index))
+            .Where(entry => double.IsFinite(entry.point.X) && entry.point.X > 0 &&
+                !double.IsInfinity(entry.point.Y))
+            .OrderBy(entry => entry.point.X))
         {
             if (result.Count > 0 && result[^1].X == point.X)
             {
@@ -287,9 +313,13 @@ internal sealed class EqWizardSourceResolver
             }
 
             result.Add(point);
+            if (hasCompanion)
+            {
+                companionResult.Add(companion![index]);
+            }
         }
 
-        return result;
+        return (result, companionResult.ToArray());
     }
 
     private static string DescribeSlot(OverlayFile file) =>

--- a/tests/Resonalyze.App.Tests/EqWizardImportedCurveTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardImportedCurveTests.cs
@@ -87,11 +87,52 @@ public sealed class EqWizardImportedCurveTests
             points, Array.Empty<double>(), Array.Empty<double>(), 6);
 
         Assert.Equal(points.Select(point => point.X), result.Select(point => point.X));
-        double worst = result
-            .Skip(20)
-            .Take(160)
-            .Max(point => Math.Abs(point.Y - 80));
-        Assert.True(worst < 2.0, $"Ripple only fell to {worst:0.0} dB.");
+
+        // The jagged ±5 dB collapses to a nearly flat line...
+        double[] band = result.Skip(20).Take(160).Select(point => point.Y).ToArray();
+        double swing = band.Max() - band.Min();
+        Assert.True(swing < 1.0, $"Ripple only fell to a {swing:0.0} dB swing.");
+        // ...which settles ABOVE the arithmetic dB midpoint, because the average is taken
+        // over linear power like the analyzer's: the loud half of the ripple carries far
+        // more energy than the quiet half. A dB mean would land on 80.
+        Assert.All(band, value => Assert.InRange(value, 80.0, 85.0));
+        Assert.True(
+            band.Average() > 81.0,
+            $"Levelled at {band.Average():0.0} dB — that is a decibel mean, not a power one.");
+    }
+
+    [Fact]
+    public void Render_SmoothsInTheSourceAnalyzersDomainNotInDecibels()
+    {
+        // Averaging dB values is a GEOMETRIC mean: it pulls a narrow peak down much harder
+        // than the analyzers, which average linear power (the SPL RTA's band integrals) or
+        // linear amplitude (a swept response). A curve smoothed the wrong way feeds Auto
+        // Tune a peak the measurement never had at that width.
+        //
+        // One 20 dB spike on an otherwise flat 80 dB curve, smoothed a full octave: the
+        // energy-preserving means keep noticeably more of it than a dB mean would.
+        var points = new List<SignalPoint>();
+        for (int i = 0; i < 121; i++)
+        {
+            double f = 100 * Math.Pow(2, i / 20.0); // 100 Hz .. 6.4 kHz, 1/20 oct steps
+            points.Add(new SignalPoint(f, i == 60 ? 100 : 80));
+        }
+
+        double PeakOf(MagnitudeAveraging averaging) =>
+            EqWizardImportedCurve.Render(
+                points, Array.Empty<double>(), Array.Empty<double>(), 1, averaging)[60].Y;
+
+        double power = PeakOf(MagnitudeAveraging.Power);
+        double amplitude = PeakOf(MagnitudeAveraging.Amplitude);
+        double decibel = PeakOf(MagnitudeAveraging.Decibel);
+
+        // The linear-domain means retain the spike; the dB mean nearly erases it.
+        Assert.True(
+            power > decibel + 3,
+            $"Power mean {power:0.0} dB is not meaningfully above the dB mean {decibel:0.0} dB.");
+        Assert.True(amplitude > decibel + 1);
+        // Power weights the peak at least as heavily as amplitude does.
+        Assert.True(power >= amplitude);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/EqWizardImportedCurveTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardImportedCurveTests.cs
@@ -83,12 +83,14 @@ public sealed class EqWizardImportedCurveTests
             points.Add(new SignalPoint(f, 80 + (i % 2 == 0 ? 5 : -5)));
         }
 
+        // A third of an octave spans plenty of these steps, so the alternation averages
+        // out rather than leaving a residue that depends on the window landing odd or even.
         IReadOnlyList<SignalPoint> result = EqWizardImportedCurve.Render(
-            points, Array.Empty<double>(), Array.Empty<double>(), 6);
+            points, Array.Empty<double>(), Array.Empty<double>(), 3);
 
         Assert.Equal(points.Select(point => point.X), result.Select(point => point.X));
 
-        // The jagged ±5 dB collapses to a nearly flat line...
+        // The jagged 10 dB peak-to-peak collapses to a nearly flat line...
         double[] band = result.Skip(20).Take(160).Select(point => point.Y).ToArray();
         double swing = band.Max() - band.Min();
         Assert.True(swing < 1.0, $"Ripple only fell to a {swing:0.0} dB swing.");
@@ -102,15 +104,14 @@ public sealed class EqWizardImportedCurveTests
     }
 
     [Fact]
-    public void Render_SmoothsInTheSourceAnalyzersDomainNotInDecibels()
+    public void Render_SmoothingIsTheAnalyzersOwnAndNotADecibelMean()
     {
         // Averaging dB values is a GEOMETRIC mean: it pulls a narrow peak down much harder
-        // than the analyzers, which average linear power (the SPL RTA's band integrals) or
-        // linear amplitude (a swept response). A curve smoothed the wrong way feeds Auto
-        // Tune a peak the measurement never had at that width.
+        // than the analyzer, which averages linear band POWER. A curve smoothed that way
+        // feeds Auto Tune a peak the measurement never had at this width.
         //
-        // One 20 dB spike on an otherwise flat 80 dB curve, smoothed a full octave: the
-        // energy-preserving means keep noticeably more of it than a dB mean would.
+        // One 20 dB spike on an otherwise flat 80 dB curve. The power mean must keep
+        // clearly more of it than the dB mean of the same window would.
         var points = new List<SignalPoint>();
         for (int i = 0; i < 121; i++)
         {
@@ -118,21 +119,15 @@ public sealed class EqWizardImportedCurveTests
             points.Add(new SignalPoint(f, i == 60 ? 100 : 80));
         }
 
-        double PeakOf(MagnitudeAveraging averaging) =>
-            EqWizardImportedCurve.Render(
-                points, Array.Empty<double>(), Array.Empty<double>(), 1, averaging)[60].Y;
+        double peak = EqWizardImportedCurve.Render(
+            points, Array.Empty<double>(), Array.Empty<double>(), 1)[60].Y;
 
-        double power = PeakOf(MagnitudeAveraging.Power);
-        double amplitude = PeakOf(MagnitudeAveraging.Amplitude);
-        double decibel = PeakOf(MagnitudeAveraging.Decibel);
-
-        // The linear-domain means retain the spike; the dB mean nearly erases it.
+        // A one-octave window here spans 21 points, so a dB mean would read
+        // (20 * 80 + 100) / 21 ≈ 81.0 dB, while the power mean keeps ~10*log10((20 + 100)/21)
+        // above the floor ≈ 87.6 dB.
         Assert.True(
-            power > decibel + 3,
-            $"Power mean {power:0.0} dB is not meaningfully above the dB mean {decibel:0.0} dB.");
-        Assert.True(amplitude > decibel + 1);
-        // Power weights the peak at least as heavily as amplitude does.
-        Assert.True(power >= amplitude);
+            peak > 86.0,
+            $"Peak read {peak:0.0} dB — that is a decibel mean, not the analyzer's power one.");
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/EqWizardImportedCurveTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardImportedCurveTests.cs
@@ -1,0 +1,132 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class EqWizardImportedCurveTests
+{
+    private static SignalPoint[] Curve(params (double X, double Y)[] values) =>
+        values.Select(value => new SignalPoint(value.X, value.Y)).ToArray();
+
+    [Fact]
+    public void Render_WithNothingToDo_ReturnsTheInputUntouched()
+    {
+        SignalPoint[] points = Curve((100, 80), (1_000, 78), (10_000, 74));
+
+        IReadOnlyList<SignalPoint> result = EqWizardImportedCurve.Render(
+            points, Array.Empty<double>(), Array.Empty<double>(), 0);
+
+        Assert.Same(points, result);
+    }
+
+    [Fact]
+    public void Render_SwappingCalibration_ReplacesTheCapturedCorrectionExactly()
+    {
+        // The capture was taken through a profile that read +2/-1/+3 dB at these
+        // frequencies; the user picks a different profile. The stored level is
+        // (measured - captured), so the result must be (measured - chosen) — the first
+        // profile fully undone, not stacked with the second.
+        double[] captured = { 2, -1, 3 };
+        double[] chosen = { -0.5, 4, 1 };
+        SignalPoint[] points = Curve((100, 80), (1_000, 78), (10_000, 74));
+
+        IReadOnlyList<SignalPoint> result =
+            EqWizardImportedCurve.Render(points, captured, chosen, 0);
+
+        for (int i = 0; i < points.Length; i++)
+        {
+            double measured = points[i].Y + captured[i];
+            Assert.Equal(measured - chosen[i], result[i].Y, 9);
+            Assert.Equal(points[i].X, result[i].X);
+        }
+    }
+
+    [Fact]
+    public void Render_OwnCalibration_IsALosslessRoundTrip()
+    {
+        // Reproducing the captured calibration must return the stored curve bit for bit:
+        // the correction is removed and the very same one applied again.
+        double[] captured = { 2, -1, 3 };
+        SignalPoint[] points = Curve((100, 80), (1_000, 78), (10_000, 74));
+
+        IReadOnlyList<SignalPoint> result =
+            EqWizardImportedCurve.Render(points, captured, captured, 0);
+
+        Assert.All(
+            result.Select((point, i) => (point, i)),
+            entry => Assert.Equal(points[entry.i].Y, entry.point.Y, 12));
+    }
+
+    [Fact]
+    public void Render_CalibrationOff_LeavesTheUncalibratedLevel()
+    {
+        double[] captured = { 2, -1, 3 };
+        SignalPoint[] points = Curve((100, 80), (1_000, 78), (10_000, 74));
+
+        IReadOnlyList<SignalPoint> result =
+            EqWizardImportedCurve.Render(points, captured, Array.Empty<double>(), 0);
+
+        Assert.Equal(82, result[0].Y, 9);
+        Assert.Equal(77, result[1].Y, 9);
+        Assert.Equal(77, result[2].Y, 9);
+    }
+
+    [Fact]
+    public void Render_Smoothing_FlattensRippleOnTheCurvesOwnFrequencies()
+    {
+        // A jagged curve on a log grid: smoothing must reduce the swing while keeping the
+        // exact same frequencies — a no-raw curve must never be resampled onto the display
+        // range, which would invent bands the analyzer never resolved.
+        var points = new List<SignalPoint>();
+        for (int i = 0; i < 200; i++)
+        {
+            double f = 100 * Math.Pow(100, i / 199.0); // 100 Hz .. 10 kHz
+            points.Add(new SignalPoint(f, 80 + (i % 2 == 0 ? 5 : -5)));
+        }
+
+        IReadOnlyList<SignalPoint> result = EqWizardImportedCurve.Render(
+            points, Array.Empty<double>(), Array.Empty<double>(), 6);
+
+        Assert.Equal(points.Select(point => point.X), result.Select(point => point.X));
+        double worst = result
+            .Skip(20)
+            .Take(160)
+            .Max(point => Math.Abs(point.Y - 80));
+        Assert.True(worst < 2.0, $"Ripple only fell to {worst:0.0} dB.");
+    }
+
+    [Fact]
+    public void Render_KeepsUnmeasuredBandsAsGaps()
+    {
+        // A NaN marks a band the analyzer could not measure. It must survive every step:
+        // filling it would invent data for the fitter to correct.
+        SignalPoint[] points = Curve((100, 80), (1_000, double.NaN), (10_000, 74));
+        double[] captured = { 1, 1, 1 };
+
+        IReadOnlyList<SignalPoint> result =
+            EqWizardImportedCurve.Render(points, captured, Array.Empty<double>(), 6);
+
+        Assert.True(double.IsNaN(result[1].Y));
+        Assert.True(double.IsFinite(result[0].Y));
+        Assert.True(double.IsFinite(result[2].Y));
+    }
+
+    [Fact]
+    public void Render_IgnoresACorrectionThatDoesNotLineUpWithThePoints()
+    {
+        // A correction of a different length is not aligned to these frequencies, so
+        // applying it would shift the curve against its own calibration.
+        SignalPoint[] points = Curve((100, 80), (1_000, 78), (10_000, 74));
+
+        IReadOnlyList<SignalPoint> result = EqWizardImportedCurve.Render(
+            points, new double[] { 5, 5 }, Array.Empty<double>(), 0);
+
+        Assert.Same(points, result);
+    }
+
+    [Fact]
+    public void SampleCorrection_WithoutAProfile_MeansNoCorrection()
+    {
+        Assert.Empty(EqWizardImportedCurve.SampleCorrection(
+            null, Curve((100, 80), (1_000, 78))));
+    }
+}

--- a/tests/Resonalyze.App.Tests/EqWizardSourceResolverTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardSourceResolverTests.cs
@@ -333,9 +333,32 @@ public sealed class EqWizardSourceResolverTests
     {
         // Its points already carry 1/6-octave smoothing; smoothing them again compounds it.
         OverlayFile file = CreateCapturedSlot(1);
+        file.CapturedCurveKind = AnalysisCurveKind.InputSpectrum;
         file.Points = [new OverlayPoint(100, 80), new OverlayPoint(1_000, 78)];
         file.PointsCalibrationCorrectionDb = [0, 0];
         file.CapturedSmoothingCode = 6;
+
+        EqWizardCurveSource source = EqWizardSourceResolver.CreateFromOverlayFile(file);
+
+        Assert.True(source.SupportsCalibration);
+        Assert.False(source.SupportsSmoothing);
+    }
+
+    [Fact]
+    public void CreateFromOverlayFile_UnsmoothedSplSweep_OffersCalibrationButNotSmoothing()
+    {
+        // A dB SPL SWEEP has no raw form here either, and its calibration can still be
+        // swapped. But its smoothing happens inside a Lanczos resample of linear
+        // amplitude, which cannot be replayed from the finished curve — so it is left
+        // unsmoothable rather than smoothed by a near-enough algorithm, which would feed
+        // Auto Tune a shape the measurement never had. Only the RTA's smoothing is a
+        // replayable second pass over stored band levels.
+        OverlayFile file = CreateCapturedSlot(1);
+        file.CapturedCurveKind = AnalysisCurveKind.Primary;
+        file.CapturedMagnitudeScale = MagnitudeScale.SoundPressureLevel;
+        file.Points = [new OverlayPoint(100, 80), new OverlayPoint(1_000, 78)];
+        file.PointsCalibrationCorrectionDb = [1.0, -1.0];
+        file.CapturedSmoothingCode = 0;
 
         EqWizardCurveSource source = EqWizardSourceResolver.CreateFromOverlayFile(file);
 

--- a/tests/Resonalyze.App.Tests/EqWizardSourceResolverTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardSourceResolverTests.cs
@@ -304,6 +304,96 @@ public sealed class EqWizardSourceResolverTests
             () => EqWizardSourceResolver.CreateFromTextCurve(curve, "target.txt"));
     }
 
+    // ------------------------------------- no-raw captures (dB SPL calibration/smoothing)
+
+    [Fact]
+    public void CreateFromOverlayFile_NoRawCapture_CarriesItsPointsCalibrationAndSmoothing()
+    {
+        // A dB SPL RTA has no raw spectrum, but the correction frozen onto its points and
+        // the smoothing it was taken under travel with it — which is what lets the wizard
+        // offer the calibration selector, and the smoothing one for an unsmoothed capture.
+        OverlayFile file = CreateCapturedSlot(1);
+        file.CapturedCurveKind = AnalysisCurveKind.InputSpectrum;
+        file.CapturedMagnitudeScale = MagnitudeScale.SoundPressureLevel;
+        file.Points = [new OverlayPoint(100, 80), new OverlayPoint(1_000, 78)];
+        file.PointsCalibrationCorrectionDb = [1.5, -2.0];
+        file.CapturedSmoothingCode = 0;
+
+        EqWizardCurveSource source = EqWizardSourceResolver.CreateFromOverlayFile(file);
+
+        Assert.Null(source.RawSpectrum);
+        Assert.Equal([1.5, -2.0], source.PointsCalibrationCorrectionDb);
+        Assert.True(source.HasOwnCalibration);
+        Assert.True(source.SupportsCalibration);
+        Assert.True(source.SupportsSmoothing);
+    }
+
+    [Fact]
+    public void CreateFromOverlayFile_NoRawCaptureTakenSmoothed_DoesNotOfferSmoothing()
+    {
+        // Its points already carry 1/6-octave smoothing; smoothing them again compounds it.
+        OverlayFile file = CreateCapturedSlot(1);
+        file.Points = [new OverlayPoint(100, 80), new OverlayPoint(1_000, 78)];
+        file.PointsCalibrationCorrectionDb = [0, 0];
+        file.CapturedSmoothingCode = 6;
+
+        EqWizardCurveSource source = EqWizardSourceResolver.CreateFromOverlayFile(file);
+
+        Assert.True(source.SupportsCalibration);
+        Assert.False(source.SupportsSmoothing);
+    }
+
+    [Fact]
+    public void CreateFromOverlayFile_LegacyCaptureWithoutAnnotations_OffersNeither()
+    {
+        // A slot from before these fields existed says nothing: its calibration cannot be
+        // undone and its points may already be smoothed, so both selectors stay closed.
+        OverlayFile file = CreateCapturedSlot(1);
+        file.Points = [new OverlayPoint(100, 80), new OverlayPoint(1_000, 78)];
+
+        EqWizardCurveSource source = EqWizardSourceResolver.CreateFromOverlayFile(file);
+
+        Assert.False(source.HasOwnCalibration);
+        Assert.False(source.SupportsCalibration);
+        Assert.False(source.SupportsSmoothing);
+    }
+
+    [Fact]
+    public void CreateFromOverlayFile_DroppedPointsTakeTheirCorrectionWithThem()
+    {
+        // Normalization reorders and drops points (a duplicate frequency here). If the
+        // correction were normalized separately it would shift by one and be applied at
+        // the wrong frequencies — a silent mis-calibration.
+        OverlayFile file = CreateCapturedSlot(1);
+        file.Points =
+        [
+            new OverlayPoint(1_000, 78),
+            new OverlayPoint(100, 80),
+            new OverlayPoint(100, 99)   // duplicate frequency: dropped
+        ];
+        file.PointsCalibrationCorrectionDb = [3.0, 1.0, 9.0];
+
+        EqWizardCurveSource source = EqWizardSourceResolver.CreateFromOverlayFile(file);
+
+        Assert.Equal([100, 1_000], source.Points.Select(point => point.X));
+        // 100 Hz keeps ITS correction (1.0) and 1 kHz keeps its own (3.0).
+        Assert.Equal([1.0, 3.0], source.PointsCalibrationCorrectionDb);
+    }
+
+    [Fact]
+    public void CreateFromOverlayFile_MismatchedCorrectionIsDiscarded()
+    {
+        // Not aligned to these points, so it cannot be trusted to name their frequencies.
+        OverlayFile file = CreateCapturedSlot(1);
+        file.Points = [new OverlayPoint(100, 80), new OverlayPoint(1_000, 78)];
+        file.PointsCalibrationCorrectionDb = [1.0];
+
+        EqWizardCurveSource source = EqWizardSourceResolver.CreateFromOverlayFile(file);
+
+        Assert.Empty(source.PointsCalibrationCorrectionDb);
+        Assert.False(source.SupportsCalibration);
+    }
+
     // ------------------------------------------------------------- point hygiene
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/OverlayFileTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlayFileTests.cs
@@ -114,6 +114,71 @@ public sealed class OverlayFileTests
     }
 
     [Fact]
+    public void SaveThenLoad_RoundTripsANoRawCaptureAnnotation()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var original = new OverlayFile
+            {
+                SavedAtUtc = DateTimeOffset.UtcNow,
+                Mode = Mode.LiveSpectrum,
+                Slot = 3,
+                Title = "SPL RTA",
+                ColorArgb = Color.Green.ToArgb(),
+                CapturedMagnitudeScale = MagnitudeScale.SoundPressureLevel,
+                Points = [new OverlayPoint(100, 80), new OverlayPoint(1_000, 78)],
+                // No raw spectrum: a dB SPL capture stores the drawn curve, plus the
+                // correction frozen onto those very points and the width behind them.
+                PointsCalibrationCorrectionDb = [1.5, -2.0],
+                CapturedSmoothingCode = 0
+            };
+
+            original.Save(root);
+            OverlayFile? loaded = OverlayFile.Load(Mode.LiveSpectrum, 3, root);
+
+            Assert.NotNull(loaded);
+            Assert.Empty(loaded!.RawSpectrum);
+            Assert.Equal([1.5, -2.0], loaded.PointsCalibrationCorrectionDb);
+            Assert.Equal(0, loaded.CapturedSmoothingCode);
+            // Files written before the fields existed say nothing at all.
+            Assert.Empty(new OverlayFile().PointsCalibrationCorrectionDb);
+            Assert.Null(new OverlayFile().CapturedSmoothingCode);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Save_RejectsAPointsCalibrationThatDoesNotMatchThePoints()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var file = new OverlayFile
+            {
+                SavedAtUtc = DateTimeOffset.UtcNow,
+                Mode = Mode.LiveSpectrum,
+                Slot = 2,
+                Title = "Mismatched",
+                ColorArgb = Color.Green.ToArgb(),
+                Points = [new OverlayPoint(100, 80), new OverlayPoint(1_000, 78)],
+                // Frozen per drawn point, so a different length would silently shift the
+                // correction in frequency.
+                PointsCalibrationCorrectionDb = [1.5]
+            };
+
+            Assert.Throws<InvalidDataException>(() => file.Save(root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void SaveAndLoad_RoundTripsPsychoacousticSmoothingAsAPlainWidthPlusFlag()
     {
         // Same additive-field pattern as CapturedMagnitudeScale: the file keeps

--- a/tests/Resonalyze.Dsp.Tests/LogarithmicPowerBandResampleTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/LogarithmicPowerBandResampleTests.cs
@@ -396,6 +396,84 @@ public sealed class LogarithmicPowerBandResampleTests
         return accumulated;
     }
 
+    [Theory]
+    [InlineData(1.0 / 6.0, false)]
+    [InlineData(1.0 / 3.0, false)]
+    [InlineData(1.0, false)]
+    [InlineData(SpectrumSmoothing.PsychoacousticBaseInverseOctaves / 6.0, true)]
+    public void SmoothBandLevels_ReplaysExactlyWhatTheResamplerWouldHaveDrawn(
+        double smoothingOctaves,
+        bool psychoacoustic)
+    {
+        // A consumer that stored the FINISHED band levels (a captured dB SPL RTA overlay,
+        // and through it the EQ Wizard) has no raw spectrum left, but smoothing is a second
+        // pass over the band powers rather than part of the integration. Replaying it over
+        // the stored levels must therefore land on exactly the curve the analyzer would
+        // have drawn at that width — not merely something similar, because that curve is
+        // what the EQ is fitted against. This is the guard against the two drifting apart.
+        const int sampleRate = 48_000;
+        const int fftLength = 4_096;
+        var rng = new Random(11);
+        var amplitude = new double[fftLength / 2];
+        for (int i = 0; i < amplitude.Length; i++)
+        {
+            // Scatter plus a couple of narrow peaks, where smoothing differences show up.
+            amplitude[i] = 0.01 + (rng.NextDouble() * 0.02);
+            if (i is 300 or 301 or 900)
+            {
+                amplitude[i] = 0.5;
+            }
+        }
+
+        List<SignalPoint> Resample(double octaves, bool psycho) =>
+            DataHelper.LogarithmicPowerBandResample(
+                amplitude,
+                fftLength,
+                sampleRate,
+                windowEnbwBins: 1.5,
+                windowMainLobeBins: 3.0,
+                start: 20,
+                stop: 20_000,
+                steps: 1024,
+                smoothingOctaves: octaves,
+                psychoacoustic: psycho);
+
+        // What the analyzer draws at this width, versus the unsmoothed levels a capture
+        // stores, re-smoothed afterwards to the same width.
+        List<SignalPoint> drawn = Resample(smoothingOctaves, psychoacoustic);
+        List<SignalPoint> replayed = DataHelper.SmoothBandLevels(
+            Resample(0.0, false), smoothingOctaves, psychoacoustic);
+
+        Assert.Equal(drawn.Count, replayed.Count);
+        double worst = 0;
+        for (int i = 0; i < drawn.Count; i++)
+        {
+            Assert.Equal(drawn[i].X, replayed[i].X, 9);
+            worst = Math.Max(worst, Math.Abs(drawn[i].Y - replayed[i].Y));
+        }
+
+        Assert.True(worst < 1e-9, $"Replayed smoothing differs by up to {worst:0.#####} dB.");
+    }
+
+    [Fact]
+    public void SmoothBandLevels_KeepsUnmeasuredBandsAsGapsAndDoesNotSpreadThem()
+    {
+        var levels = new List<SignalPoint>();
+        for (int i = 0; i < 200; i++)
+        {
+            double f = 100 * Math.Pow(2, i / 40.0);
+            levels.Add(new SignalPoint(f, i == 100 ? double.NaN : 80));
+        }
+
+        List<SignalPoint> smoothed = DataHelper.SmoothBandLevels(levels, 1.0 / 3.0, false);
+
+        Assert.True(double.IsNaN(smoothed[100].Y));
+        // The gap contributes nothing, so its neighbours keep the surrounding level
+        // instead of being dragged toward a floor.
+        Assert.Equal(80, smoothed[99].Y, 6);
+        Assert.Equal(80, smoothed[101].Y, 6);
+    }
+
     private static float[] CreateSine(int length, int bin)
     {
         var samples = new float[length];


### PR DESCRIPTION
A dB SPL capture — the Live Spectrum RTA the moving-microphone workflow produces —
stores its drawn curve rather than a raw spectrum, because its band levels cannot be
re-gridded to the display range without inventing bands the analyzer never resolved.
That left the calibration **and** the smoothing selector greyed out in the EQ Wizard for
exactly those curves.

Neither has to be a dead end.

## Calibration

These modes apply the microphone correction **additively per frequency** (the SPL RTA
subtracts it per band, then adds a constant SPL offset that comes from a *separate* SPL
calibration and does not depend on the 0°/90° choice). So the correction frozen at
capture can be taken back out exactly and another applied in its place — no raw spectrum
needed. `Own` reproduces the capture losslessly.

## Smoothing

A curve captured with smoothing Off **is** an unsmoothed reference, so it may be smoothed
here. One captured under smoothing — or one that never said (a text import, a legacy
slot) — is left alone, because smoothing an already smoothed curve compounds it.

## How

Two additive overlay fields, no file version bump:

- `PointsCalibrationCorrectionDb` — frozen per **drawn point**, since those frequencies
  are the only grid such a capture has; validated against the point count.
- `CapturedSmoothingCode` — null in legacy files, meaning "unknown", so nothing is assumed.

`EqWizardImportedCurve` renders the curve the way the measuring mode would: uncalibrate →
smooth **on its own frequencies** → calibrate with the chosen profile. No resampling, so
the display range is never extrapolated; NaN gaps survive every step.

One trap worth naming: the correction is aligned by index, and point normalization sorts
and drops duplicates. Normalizing the two separately would silently shift the calibration
in frequency, so they are normalized together.

## Also in here

- **Restores the EQ Filters selector**, which the sample-rate row added in #55 had placed
  at identical coordinates and covered in the z-order. The control was never removed —
  just hidden underneath.
- **A Reset filters button**: every band back to its default frequency at Q 1 and 0 dB,
  preamp 0, one active filter. The source, target and Auto Tune settings are kept — it
  clears the tune, not the setup. There is no undo here, so it asks first.

## Notes

Existing overlay files predate the annotations and stay as they are; re-capture a slot to
get the selectors.

## Testing

`EqWizardImportedCurveTests` (exact profile swap, lossless `Own` round trip, smoothing on
the curve's own grid, NaN gaps, mismatched correction ignored), resolver gating and paired
normalization, overlay round trip and validation. Panel layout re-checked for control
overlaps. DSP 875, App 682 green; builds with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
