### PR TITLE
Virtual DSP sheet: spell out the sides, keep a channel on one page

### DIFF
--- a/source/Tools/Sheets/PdfSheet.cs
+++ b/source/Tools/Sheets/PdfSheet.cs
@@ -77,7 +77,15 @@ internal sealed class PdfSheet : IDisposable
         image.LockAspectRatio = true;
     }
 
-    public void AddFilterCards(IReadOnlyList<PeqBand> bands)
+    /// <summary>
+    /// Lays the bands out as a grid of filter cards. An optional
+    /// <paramref name="caption"/> is added as the table's HEADING row rather than as a
+    /// paragraph above it: a full bank is 32 filters — eight rows — so the grid really can
+    /// break across pages, and only a heading row is repeated on each of them. A caption
+    /// left outside the table would name the first page and leave the rest anonymous,
+    /// which on a sheet holding several channels reads as the wrong channel's filters.
+    /// </summary>
+    public void AddFilterCards(IReadOnlyList<PeqBand> bands, string? caption = null)
     {
         if (bands.Count == 0)
         {
@@ -90,6 +98,20 @@ internal sealed class PdfSheet : IDisposable
             Column cardColumn = table.AddColumn(Unit.FromCentimeter(4.3));
             cardColumn.LeftPadding = Unit.FromMillimeter(2.5);
             cardColumn.RightPadding = Unit.FromMillimeter(2.5);
+        }
+
+        if (!string.IsNullOrWhiteSpace(caption))
+        {
+            Row captionRow = table.AddRow();
+            captionRow.HeadingFormat = true;
+            // Never leave the caption alone at the foot of a page.
+            captionRow.KeepWith = 1;
+            captionRow.TopPadding = Unit.FromMillimeter(2);
+            captionRow.Cells[0].MergeRight = FilterCardColumns - 1;
+
+            Paragraph captionParagraph = captionRow.Cells[0].AddParagraph(caption);
+            captionParagraph.Format.Font.Bold = true;
+            captionParagraph.Format.Font.Size = 12;
         }
 
         Row? row = null;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverSheet.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverSheet.cs
@@ -77,18 +77,26 @@ internal static class VirtualCrossoverSheet
     /// "(mono)" section, a stereo pair prints its left and right sides
     /// separately.
     /// </summary>
+    // The side suffixes a section heading carries. Spelled out rather than "L"/"R":
+    // a printed sheet is read in a car, often upside down on a phone. Named constants
+    // because consumers switch on the suffix, and a literal would silently stop matching
+    // the moment the wording changed.
+    internal const string LeftSuffix = " Left";
+    internal const string RightSuffix = " Right";
+    internal const string MonoSuffix = " (mono)";
+
     internal static IEnumerable<(VirtualCrossoverChannelSettings Settings, string SideSuffix)>
         SideSections(VirtualCrossoverChannelPairSettings pair)
     {
         ArgumentNullException.ThrowIfNull(pair);
         if (pair.Mono)
         {
-            yield return (pair.Left, " (mono)");
+            yield return (pair.Left, MonoSuffix);
             yield break;
         }
 
-        yield return (pair.Left, " L");
-        yield return (pair.Right, " R");
+        yield return (pair.Left, LeftSuffix);
+        yield return (pair.Right, RightSuffix);
     }
 
     /// <summary>

--- a/source/Tools/VirtualCrossover/VirtualCrossoverSheetPdf.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverSheetPdf.cs
@@ -75,7 +75,8 @@ internal static class VirtualCrossoverSheetPdf
                 if (channel.HasSource)
                 {
                     participating.Add(
-                        (i, sideSuffix, sideSuffix == " R", channel));
+                        (i, sideSuffix,
+                         sideSuffix == VirtualCrossoverSheet.RightSuffix, channel));
                 }
             }
         }
@@ -131,8 +132,8 @@ internal static class VirtualCrossoverSheetPdf
         }
 
         Row header = table.AddRow();
-        header.Cells[1].AddParagraph("L").Format.Font.Bold = true;
-        header.Cells[2].AddParagraph("R").Format.Font.Bold = true;
+        header.Cells[1].AddParagraph("Left").Format.Font.Bold = true;
+        header.Cells[2].AddParagraph("Right").Format.Font.Bold = true;
 
         AddPairRow(table, "Source", left.DisplayName, right.DisplayName);
         AddPairRow(table, "Gain",
@@ -143,15 +144,20 @@ internal static class VirtualCrossoverSheetPdf
         AddPairRow(table, "Crossover",
             VirtualCrossoverSheet.DescribeCrossover(left),
             VirtualCrossoverSheet.DescribeCrossover(right));
+        if (HasAllPass(left) || HasAllPass(right))
+        {
+            AddPairRow(table, "All-pass", AllPassText(left), AllPassText(right));
+        }
         if (HasPeq(left) || HasPeq(right))
         {
             AddPairRow(table, "PEQ", PeqSummary(left), PeqSummary(right));
         }
 
-        AddPeqCards(
-            sheet, $"PEQ {VirtualCrossoverSheet.ChannelName(index)} L", left);
-        AddPeqCards(
-            sheet, $"PEQ {VirtualCrossoverSheet.ChannelName(index)} R", right);
+        KeepTogether(table);
+
+        string channelName = VirtualCrossoverSheet.ChannelName(index);
+        AddPeqCards(sheet, $"Channel {channelName} Left — PEQ", left);
+        AddPeqCards(sheet, $"Channel {channelName} Right — PEQ", right);
     }
 
     // The value strings shared by the pair table and the single-channel
@@ -163,14 +169,32 @@ internal static class VirtualCrossoverSheetPdf
     private static string PolarityText(VirtualCrossoverChannelSettings channel) =>
         channel.InvertPolarity ? "Inverted" : "Normal";
 
+    private static bool HasAllPass(VirtualCrossoverChannelSettings channel) =>
+        channel.AllPassType != AllPassType.Off;
+
+    private static string AllPassText(VirtualCrossoverChannelSettings channel) =>
+        HasAllPass(channel)
+            ? VirtualCrossoverSheet.DescribeAllPass(channel)
+            : "—";
+
     private static bool HasPeq(VirtualCrossoverChannelSettings channel) =>
         channel.PeqBands.Count > 0 || channel.PeqPreampDb != 0;
 
-    private static string PeqSummary(VirtualCrossoverChannelSettings channel) =>
-        HasPeq(channel)
-            ? $"{channel.PeqSourceName ?? "custom"}, " +
-              $"preamp {Signed(channel.PeqPreampDb)} dB"
-            : "—";
+    // Names the profile, how many filters it holds and its preamp — the three things
+    // needed to check a channel against the DSP being typed into, without counting cards.
+    private static string PeqSummary(VirtualCrossoverChannelSettings channel)
+    {
+        if (!HasPeq(channel))
+        {
+            return "—";
+        }
+
+        string filters = channel.PeqBands.Count == 1
+            ? "1 filter"
+            : $"{channel.PeqBands.Count} filters";
+        return $"{channel.PeqSourceName ?? "custom"} · {filters} · " +
+            $"preamp {Signed(channel.PeqPreampDb)} dB";
+    }
 
     // The pair table names each side's PEQ in one summary row; the band cards
     // print below it per side, captioned, so the two sides cannot be mixed up.
@@ -188,7 +212,20 @@ internal static class VirtualCrossoverSheetPdf
         paragraph.Format.Font.Bold = true;
         paragraph.Format.Font.Size = 12;
         paragraph.Format.SpaceBefore = Unit.FromMillimeter(2);
+        // A caption stranded at the foot of a page would leave its cards looking like
+        // they belong to the channel above.
+        paragraph.Format.KeepWithNext = true;
         sheet.AddFilterCards(channel.PeqBands);
+    }
+
+    // Binds a value table into one block so a page break cannot strand the crossover and
+    // PEQ rows on the next page, away from the channel heading that names them.
+    private static void KeepTogether(Table table)
+    {
+        if (table.Rows.Count > 1)
+        {
+            table.Rows[0].KeepWith = table.Rows.Count - 1;
+        }
     }
 
     private static void AddPairRow(
@@ -224,12 +261,21 @@ internal static class VirtualCrossoverSheetPdf
         AddRow(table, "Delay", DelayText(channel));
         AddRow(table, "Polarity", PolarityText(channel));
         AddRow(table, "Crossover", VirtualCrossoverSheet.DescribeCrossover(channel));
+        if (HasAllPass(channel))
+        {
+            AddRow(table, "All-pass", AllPassText(channel));
+        }
         if (HasPeq(channel))
         {
             AddRow(table, "PEQ", PeqSummary(channel));
         }
 
-        sheet.AddFilterCards(channel.PeqBands);
+        KeepTogether(table);
+        // Captioned like the pair layout, so a page of cards always says whose they are.
+        AddPeqCards(
+            sheet,
+            $"Channel {VirtualCrossoverSheet.ChannelName(index)}{sideSuffix} — PEQ",
+            channel);
     }
 
     // The section heading and the label-column value table shared by the pair
@@ -241,6 +287,8 @@ internal static class VirtualCrossoverSheetPdf
         heading.Format.Font.Size = 15;
         heading.Format.SpaceBefore = Unit.FromMillimeter(5);
         heading.Format.SpaceAfter = Unit.FromMillimeter(1);
+        // Never break between a channel heading and the values it introduces.
+        heading.Format.KeepWithNext = true;
     }
 
     private static Table AddValueTable(Section section)

--- a/source/Tools/VirtualCrossover/VirtualCrossoverSheetPdf.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverSheetPdf.cs
@@ -208,14 +208,10 @@ internal static class VirtualCrossoverSheetPdf
             return;
         }
 
-        Paragraph paragraph = sheet.Section.AddParagraph(caption);
-        paragraph.Format.Font.Bold = true;
-        paragraph.Format.Font.Size = 12;
-        paragraph.Format.SpaceBefore = Unit.FromMillimeter(2);
-        // A caption stranded at the foot of a page would leave its cards looking like
-        // they belong to the channel above.
-        paragraph.Format.KeepWithNext = true;
-        sheet.AddFilterCards(channel.PeqBands);
+        // The caption goes INSIDE the card table as its heading row, so it repeats when a
+        // long bank breaks across pages; a paragraph above the table would name only the
+        // first page and leave the rest looking like the previous channel's filters.
+        sheet.AddFilterCards(channel.PeqBands, caption);
     }
 
     // Binds a value table into one block so a page break cannot strand the crossover and

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
@@ -96,6 +96,49 @@ public sealed class VirtualCrossoverSheetPdfTests
     }
 
     [Fact]
+    public void Build_PeqCaption_IsARepeatingHeadingRowOfTheCardTable()
+    {
+        // A full bank is 32 filters — eight card rows — so the grid can break across
+        // pages. A caption in a paragraph above the table would name only the first page
+        // and leave the rest looking like the previous channel's filters. Only a heading
+        // row is repeated by MigraDoc on every page a table spans, so the caption must
+        // live INSIDE the card table as one.
+        var project = new VirtualCrossoverProjectFile();
+        project.Pairs[0].Mono = true;
+        project.Pairs[0].Left.SourceFilePath = "sub.json";
+        project.Pairs[0].Left.DisplayName = "Sub";
+        for (int i = 0; i < EqualizationCurve.MaxBandCount; i++)
+        {
+            project.Pairs[0].Left.PeqBands.Add(new PeqBand(100 + (i * 100), 2.0, -1.0));
+        }
+
+        using PdfSheet sheet = VirtualCrossoverSheetPdf.Build(project, null, 48_000);
+
+        Table cardTable = CardTables(sheet.Document).Single();
+        Row caption = cardTable.Rows[0];
+        Assert.Contains("Channel A (mono) — PEQ", CellText(caption.Cells[0]));
+        Assert.True(caption.HeadingFormat, "The caption row does not repeat across pages.");
+        // Spans the whole grid, and cannot be left stranded above its first cards.
+        Assert.Equal(cardTable.Columns.Count - 1, caption.Cells[0].MergeRight);
+        Assert.True(caption.KeepWith >= 1);
+        // The bank really is long enough to break: eight card rows plus the caption.
+        Assert.Equal(9, cardTable.Rows.Count);
+    }
+
+    // The filter-card grid is the four-column table; the value tables are one or three.
+    private static IEnumerable<Table> CardTables(Document document)
+    {
+        DocumentElements elements = document.LastSection.Elements;
+        for (int i = 0; i < elements.Count; i++)
+        {
+            if (elements[i] is Table { Columns.Count: 4 } table)
+            {
+                yield return table;
+            }
+        }
+    }
+
+    [Fact]
     public void Build_SingleChannelSection_CaptionsItsPeqCards()
     {
         // The one-sided layout used to drop the filter cards straight after the table

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
@@ -24,10 +24,11 @@ public sealed class VirtualCrossoverSheetPdfTests
         using PdfSheet sheet = VirtualCrossoverSheetPdf.Build(project, null, 48_000);
         Table pairTable = PairTables(sheet.Document).Single();
 
-        // A pair table is three columns (label + L + R) with an L/R header row.
+        // A pair table is three columns (label + left + right) with a spelled-out
+        // header row: a bare "L"/"R" is easy to misread on a printed sheet.
         Assert.Equal(3, pairTable.Columns.Count);
-        Assert.Equal("L", CellText(pairTable.Rows[0].Cells[1]));
-        Assert.Equal("R", CellText(pairTable.Rows[0].Cells[2]));
+        Assert.Equal("Left", CellText(pairTable.Rows[0].Cells[1]));
+        Assert.Equal("Right", CellText(pairTable.Rows[0].Cells[2]));
 
         // Both sides' values sit side by side in one row each.
         Assert.Equal("L woof", RowValue(pairTable, "Source", left: true));
@@ -55,6 +56,90 @@ public sealed class VirtualCrossoverSheetPdfTests
 
         // No three-column pair table — every section is a single-channel table.
         Assert.Empty(PairTables(sheet.Document));
+    }
+
+    [Fact]
+    public void Build_PairSection_PrintsAllPassAndNamesEachSidesPeqInFull()
+    {
+        var project = new VirtualCrossoverProjectFile();
+        project.Pairs[1].Left.SourceFilePath = "l.json";
+        project.Pairs[1].Left.DisplayName = "L mid";
+        project.Pairs[1].Left.AllPassType = AllPassType.SecondOrder;
+        project.Pairs[1].Left.AllPassFrequencyHz = 250;
+        project.Pairs[1].Left.AllPassQ = 0.7;
+        project.Pairs[1].Left.PeqPreampDb = -5;
+        project.Pairs[1].Left.PeqSourceName = "L_MID_eq.txt";
+        project.Pairs[1].Left.PeqBands.Add(new PeqBand(1000, 2.0, -3.0));
+        project.Pairs[1].Left.PeqBands.Add(new PeqBand(250, 4.0, -2.0));
+        project.Pairs[1].Right.SourceFilePath = "r.json";
+        project.Pairs[1].Right.DisplayName = "R mid";
+
+        using PdfSheet sheet = VirtualCrossoverSheetPdf.Build(project, null, 48_000);
+        Table pairTable = PairTables(sheet.Document).Single();
+
+        // The all-pass is a dialled-in stage; the text sheet always printed it and the
+        // PDF must not quietly drop it.
+        Assert.Contains("250", RowValue(pairTable, "All-pass", left: true));
+        Assert.Equal("—", RowValue(pairTable, "All-pass", left: false));
+
+        // The summary names the profile, its filter count and its preamp, so a channel
+        // can be checked against the DSP without counting cards.
+        string peq = RowValue(pairTable, "PEQ", left: true);
+        Assert.Contains("L_MID_eq.txt", peq);
+        Assert.Contains("2 filters", peq);
+        Assert.Contains("-5", peq);
+
+        // The cards below are captioned with the channel AND the spelled-out side.
+        string document = AllText(sheet.Document);
+        Assert.Contains("Channel B Left — PEQ", document);
+        Assert.DoesNotContain("PEQ B L", document);
+    }
+
+    [Fact]
+    public void Build_SingleChannelSection_CaptionsItsPeqCards()
+    {
+        // The one-sided layout used to drop the filter cards straight after the table
+        // with no caption, so a page of cards did not say whose they were.
+        var project = new VirtualCrossoverProjectFile();
+        project.Pairs[0].Mono = true;
+        project.Pairs[0].Left.SourceFilePath = "sub.json";
+        project.Pairs[0].Left.DisplayName = "Sub";
+        project.Pairs[0].Left.PeqBands.Add(new PeqBand(45, 3.0, -4.0));
+
+        using PdfSheet sheet = VirtualCrossoverSheetPdf.Build(project, null, 48_000);
+
+        Assert.Contains("Channel A (mono) — PEQ", AllText(sheet.Document));
+    }
+
+    // Every caption and cell in the sheet, flattened, so a test can assert that a piece
+    // of wording appears (or no longer appears) anywhere in the document.
+    private static string AllText(Document document)
+    {
+        var builder = new StringBuilder();
+        DocumentElements elements = document.LastSection.Elements;
+        for (int i = 0; i < elements.Count; i++)
+        {
+            switch (elements[i])
+            {
+                case Paragraph paragraph:
+                    AppendParagraphText(paragraph, builder);
+                    builder.Append('\n');
+                    break;
+                case Table table:
+                    for (int r = 0; r < table.Rows.Count; r++)
+                    {
+                        for (int c = 0; c < table.Columns.Count; c++)
+                        {
+                            builder.Append(CellText(table.Rows[r].Cells[c])).Append(' ');
+                        }
+                    }
+
+                    builder.Append('\n');
+                    break;
+            }
+        }
+
+        return builder.ToString();
     }
 
     private static IEnumerable<Table> PairTables(Document document)
@@ -96,24 +181,29 @@ public sealed class VirtualCrossoverSheetPdfTests
         {
             if (elements[i] is Paragraph paragraph)
             {
-                for (int j = 0; j < paragraph.Elements.Count; j++)
-                {
-                    switch (paragraph.Elements[j])
+                AppendParagraphText(paragraph, builder);
+            }
+        }
+    }
+
+    private static void AppendParagraphText(Paragraph paragraph, StringBuilder builder)
+    {
+        for (int j = 0; j < paragraph.Elements.Count; j++)
+        {
+            switch (paragraph.Elements[j])
+            {
+                case Text text:
+                    builder.Append(text.Content);
+                    break;
+                case FormattedText formatted:
+                    for (int k = 0; k < formatted.Elements.Count; k++)
                     {
-                        case Text text:
-                            builder.Append(text.Content);
-                            break;
-                        case FormattedText formatted:
-                            for (int k = 0; k < formatted.Elements.Count; k++)
-                            {
-                                if (formatted.Elements[k] is Text inner)
-                                {
-                                    builder.Append(inner.Content);
-                                }
-                            }
-                            break;
+                        if (formatted.Elements[k] is Text inner)
+                        {
+                            builder.Append(inner.Content);
+                        }
                     }
-                }
+                    break;
             }
         }
     }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetTests.cs
@@ -56,8 +56,16 @@ public sealed class VirtualCrossoverSheetTests
         Assert.Contains("woofer-peq.txt, preamp -1.5 dB", text);
         Assert.Contains("Filter 1: ON PK Fc 120 Hz Gain -4.0 dB Q 2.0", text);
 
-        Assert.Contains("Channel B L — tweeter.json", text);
-        Assert.Contains("Channel B R — tweeter R.json", text);
+        Assert.Contains("Channel B Left — tweeter.json", text);
+        Assert.Contains("Channel B Right — tweeter R.json", text);
+        // The suffixes are constants because the PDF matches on them to decide which
+        // graph traces are dashed; a literal would stop matching if the wording changed.
+        Assert.Equal(
+            VirtualCrossoverSheet.RightSuffix,
+            VirtualCrossoverSheet
+                .SideSections(new VirtualCrossoverChannelPairSettings())
+                .Last()
+                .SideSuffix);
         Assert.Contains("0.68 ms", text);
         Assert.Contains("High-pass Butterworth 18 dB/oct @ 2000 Hz", text);
         Assert.Contains("Normal", text);


### PR DESCRIPTION
The tuning sheet is read in a car, off paper or a phone, and a report of a channel split
across a page boundary prompted a pass over its readability.

## Sides spelled out

`Left` and `Right` instead of `L` and `R` — the pair table header, the section headings of
both the PDF and the text sheet, and the PEQ captions (`Channel C Left — PEQ` rather than
`PEQ C L`).

The suffixes become named constants. They are not only wording: the PDF matches on the
right-hand suffix to decide which graph traces are dashed, so a literal would have
silently stopped matching the moment the wording changed — a regression this PR would
otherwise have shipped. Covered by a test.

## Page breaks

From the reported case: the channel heading and the first rows on one page, the crossover
and PEQ rows orphaned on the next.

- A channel heading keeps with the table it introduces.
- A value table binds its rows into one block.
- A PEQ caption keeps with its cards, so a page of filters always says whose they are.

## Content gaps closed

- **The PDF prints the all-pass stage.** Only the text sheet had it, though it is a
  dialled-in value someone has to type into the DSP.
- **The single-channel layout captions its filter cards** like the pair layout does;
  previously the cards followed the table unlabelled.
- **The PEQ summary names the filter count** (`L_MID_eq.txt · 10 filters · preamp 0.0 dB`),
  so a channel can be checked against the DSP being typed into without counting cards.

## Notes

Filter order is deliberately unchanged (by descending gain, as fitted) so the numbering in
the sheet still matches the DSP export file. Sorting by frequency would read better for
manual entry but would break that correspondence.

## Testing

Two new tests (all-pass printed and each side's PEQ named in full; the single-channel
layout captions its cards), plus the suffix-constant guard. Rendered against a real
project to check the wording end to end. App suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
