### PR TITLE
Auto delay RHD support, cross-rate session import fix, and loopback capture guards

### DIFF
--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -97,10 +97,13 @@ public sealed record AlignmentJunction(
 /// BOTH by-band lists as the same <see cref="IAlignmentChannel"/> instance and
 /// are tuned once, by the left pass. The bridge is the highest-frequency pair
 /// with sources on both sides; its band is the top channels' own playing band.
-/// <see cref="SceneOffsetMs"/> is positive when the right side should LEAD
+/// Left and Right are ROLES, not cabin sides: Left is the reference (the
+/// driver's side, settled first), Right the far side fitted to it, and
+/// <see cref="SceneOffsetMs"/> is positive when that far side should LEAD
 /// (arrive earlier at the microphone) by that much — the "image toward the
-/// dash center" convention for a left-seated listener; negative for a
-/// right-seated one.
+/// dash center" convention. A left-hand-drive cabin maps its sides onto the
+/// roles directly; a right-hand-drive one hands the plan MIRRORED (its right
+/// side as Left), so the same positive offset makes its left side lead.
 /// </summary>
 public sealed record StereoAlignmentPlan(
     IReadOnlyList<AlignmentSnapshot> LeftChannelsByBand,
@@ -1800,9 +1803,10 @@ public static class AutoAlignmentEngine
         // frequencies is lobe-ambiguous noise (probed on real car
         // measurements: r ~0.3, dominance ~0.01), while the envelope arrival
         // is the quantity the stereo image follows up there. A positive scene
-        // offset makes the right side LEAD (arrive earlier), pulling the image
-        // toward the right — the dash-center convention for a left-seated
-        // driver; a right-seated driver enters a negative offset.
+        // offset makes the plan's right side — the far side — LEAD (arrive
+        // earlier), pulling the image toward the dash center; a right-hand-
+        // drive caller hands the plan mirrored, so the same rule makes its
+        // actual left side lead.
         IReadOnlyList<AlignmentSnapshot> settled = reprocess(alignment);
         AlignmentSnapshot leftBridgeSnapshot =
             settled.First(item => item.Channel == plan.BridgeLeft);
@@ -1916,11 +1920,11 @@ public static class AutoAlignmentEngine
         log.AppendLine(
             $"Bridge {plan.BridgeLeft.Name} -> {plan.BridgeRight.Name}: " +
             $"band {plan.BridgeBandLowHz:0}-{plan.BridgeBandHighHz:0} Hz, " +
-            $"arrivals L {leftArrival:0.000} / R {rightArrival:0.000} ms " +
+            $"arrivals ref {leftArrival:0.000} / far {rightArrival:0.000} ms " +
             $"(SNR {leftBridge.SignalToNoiseDecibels:0.0} / " +
             $"{rightBridge.SignalToNoiseDecibels:0.0} dB), " +
             $"scene offset {plan.SceneOffsetMs:+0.000;-0.000} ms " +
-            $"(positive: right leads) -> right delay {bridgeDelay:0.000} ms");
+            $"(positive: the far side leads) -> far-top delay {bridgeDelay:0.000} ms");
         if (bridgeDelay < 0)
         {
             // The right top must be ADVANCED — typical when the right side is

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1899,7 +1899,7 @@ public static class AutoAlignmentEngine
                             $"{probe.FirstArrivalDelayMilliseconds:0.000} ms in its " +
                             $"{bridgeProbeLowHz:0}-{plan.BridgeBandHighHz:0} Hz half. " +
                             "The arrival is not a clean direct front, so timing the " +
-                            "whole right side from it would be unreliable. Check the " +
+                            "whole far side from it would be unreliable. Check the " +
                             "top pair's measurements for early reflections.");
                     case ArrivalCertificate.Unverified:
                         bridgeVerified = false;
@@ -3522,7 +3522,7 @@ public static class AutoAlignmentEngine
 
         log.AppendLine(
             $"Junction {monoChannel.Name}/{otherChannel.Name} " +
-            $"(mono, timed by the left side): avg {measured.LossDb:0.00} dB, " +
+            $"(mono, timed by the reference side): avg {measured.LossDb:0.00} dB, " +
             $"dip {measured.DipDb:0.0} dB " +
             $"in {pair.BandLowHz:0}-{pair.BandHighHz:0} Hz" +
             (measured.LossDb < -1.0 || measured.DipDb < -6.0

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -43,6 +43,22 @@ public readonly record struct IrStartEstimate(
     bool DominantBandLimited);
 
 /// <summary>
+/// The time-compactness of a transfer IR: how far (dB) the per-sample energy
+/// of a short circular window around the strongest peak sits above the
+/// per-sample energy of everything outside it. A genuine impulse response is
+/// a localized event — the direct sound plus a cabin decay of at most a few
+/// hundred milliseconds — while the "IR" built from an unusable reference
+/// (a loopback that was bleed instead of the wire) is stationary division
+/// noise across the whole capture. <see cref="PeakDelayMs"/> is the peak's
+/// circular delay, signed: a peak past the buffer midpoint reads as negative
+/// (acausal) time — a diagnostic, not a verdict, because a purely electrical
+/// chain measurement legitimately peaks at zero.
+/// </summary>
+public readonly record struct TransferIrCompactness(
+    double InsideOutsideDb,
+    double PeakDelayMs);
+
+/// <summary>
 /// Record-hygiene diagnostics shared by the manual Time Alignment mode and
 /// the auto-delay launcher: where the driver's energy actually lives in
 /// frequency, and whether the record's head carries a playback-crosstalk
@@ -54,6 +70,106 @@ public readonly record struct IrStartEstimate(
 /// </summary>
 public static class TransferIrDiagnostics
 {
+    /// <summary>
+    /// The compactness floor below which a transfer IR is not a credible
+    /// impulse response. Field calibration (14 records, two cabins): genuine
+    /// measurements — including band-limited subwoofer records — read
+    /// 29.5-48.9 dB, while a whole session whose loopback was playback bleed
+    /// instead of the wire read 11.2-15.7 dB (energy smeared over the full
+    /// 5.5 s buffer, peak at sample 2 or wrapped into negative time). 20 dB
+    /// sits 4 dB above the worst garbage and 9 dB below the weakest genuine
+    /// record — deliberately closer to the garbage side, so a noisy but real
+    /// capture is not refused.
+    /// </summary>
+    public const double MinimumCompactnessDb = 20.0;
+
+    // The compactness window around the peak: 10 ms ahead (window pre-ring)
+    // and 500 ms behind (any cabin decay plus processing latency fits well
+    // inside). Both shrink on short records so the outside stays the
+    // majority of the buffer and the ratio keeps its meaning.
+    private const double CompactnessPreSeconds = 0.010;
+    private const double CompactnessPostSeconds = 0.500;
+    private const int CompactnessMinimumSamples = 256;
+
+    /// <summary>
+    /// Measures the time-compactness of a transfer IR (see
+    /// <see cref="TransferIrCompactness"/>). Null when the record is too
+    /// short or silent to judge. The verdict rests on energy geometry only —
+    /// deliberately no peak-position rule, so an electrical chain
+    /// measurement (mic input wired to a processor output, peak at ~0 ms)
+    /// passes on its clean shape.
+    /// </summary>
+    public static TransferIrCompactness? MeasureCompactness(
+        IReadOnlyList<double> impulseResponse,
+        int sampleRate)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        int length = impulseResponse.Count;
+        if (length < CompactnessMinimumSamples || sampleRate <= 0)
+        {
+            return null;
+        }
+
+        double total = 0;
+        double peak = 0;
+        int peakIndex = 0;
+        for (int i = 0; i < length; i++)
+        {
+            double sample = impulseResponse[i];
+            total += sample * sample;
+            if (Math.Abs(sample) > peak)
+            {
+                peak = Math.Abs(sample);
+                peakIndex = i;
+            }
+        }
+        if (total <= 0)
+        {
+            return null;
+        }
+
+        int pre = Math.Min((int)(CompactnessPreSeconds * sampleRate), length / 16);
+        int post = Math.Min((int)(CompactnessPostSeconds * sampleRate), length / 4);
+        double windowed = 0;
+        for (int k = -pre; k <= post; k++)
+        {
+            int index = ((peakIndex + k) % length + length) % length;
+            double sample = impulseResponse[index];
+            windowed += sample * sample;
+        }
+
+        int windowLength = pre + post + 1;
+        int outsideLength = length - windowLength;
+        double insidePerSample = windowed / windowLength;
+        // A perfectly clean record (synthetic delta) has zero energy outside
+        // the window; the floor caps the ratio instead of dividing by zero.
+        double outsidePerSample = Math.Max(
+            insidePerSample * 1e-12, (total - windowed) / outsideLength);
+        double peakDelayMs = peakIndex <= length / 2
+            ? peakIndex * 1000.0 / sampleRate
+            : (peakIndex - length) * 1000.0 / sampleRate;
+        return new TransferIrCompactness(
+            10 * Math.Log10(insidePerSample / outsidePerSample),
+            peakDelayMs);
+    }
+
+    /// <summary>
+    /// The <see cref="Complex"/> twin of the compactness measure, for
+    /// callers holding the transfer IR in its FFT form.
+    /// </summary>
+    public static TransferIrCompactness? MeasureCompactness(
+        IReadOnlyList<Complex> impulseResponse,
+        int sampleRate)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        var samples = new double[impulseResponse.Count];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            samples[i] = impulseResponse[i].Real;
+        }
+        return MeasureCompactness(samples, sampleRate);
+    }
+
     /// <summary>
     /// How far below the smoothed spectrum's peak the dominant band extends.
     /// Field calibration (v3 cabin, 7 records, threshold sweep 10/12/15/20):

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -97,9 +97,10 @@ public static class TransferIrDiagnostics
     /// short or silent to judge. The verdict rests on energy geometry only —
     /// deliberately no peak-position rule, so an electrical chain
     /// measurement (mic input wired to a processor output, peak at ~0 ms)
-    /// passes on its clean shape.
+    /// passes on its clean shape. Internal: the app holds transfer IRs in
+    /// their FFT form and calls the <see cref="Complex"/> overload.
     /// </summary>
-    public static TransferIrCompactness? MeasureCompactness(
+    internal static TransferIrCompactness? MeasureCompactness(
         IReadOnlyList<double> impulseResponse,
         int sampleRate)
     {

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -72,22 +72,28 @@ public static class TransferIrDiagnostics
 {
     /// <summary>
     /// The compactness floor below which a transfer IR is not a credible
-    /// impulse response. Field calibration (14 records, two cabins): genuine
-    /// measurements — including band-limited subwoofer records — read
-    /// 29.5-48.9 dB, while a whole session whose loopback was playback bleed
-    /// instead of the wire read 11.2-15.7 dB (energy smeared over the full
-    /// 5.5 s buffer, peak at sample 2 or wrapped into negative time). 20 dB
-    /// sits 4 dB above the worst garbage and 9 dB below the weakest genuine
-    /// record — deliberately closer to the garbage side, so a noisy but real
-    /// capture is not refused.
+    /// impulse response. Calibration at the 100 ms/500 ms window, field sets
+    /// (14 records, two cabins) plus synthetic transfers pushed through the
+    /// production excitation gate: genuine measurements read 28.8-48.6 dB,
+    /// ideal band-limited transfers (even a 20-50 Hz band sweep) 42.9+ dB,
+    /// while a session whose loopback was playback bleed instead of the wire
+    /// read 11.2-18.7 dB and gated uncorrelated noise ~0 dB. 22 dB sits
+    /// 3.3 dB above the worst field garbage and 6.8 dB below the weakest
+    /// genuine record — deliberately closer to the garbage side, so a noisy
+    /// but real capture is not refused.
     /// </summary>
-    public const double MinimumCompactnessDb = 20.0;
+    public const double MinimumCompactnessDb = 22.0;
 
-    // The compactness window around the peak: 10 ms ahead (window pre-ring)
-    // and 500 ms behind (any cabin decay plus processing latency fits well
-    // inside). Both shrink on short records so the outside stays the
-    // majority of the buffer and the ratio keeps its meaning.
-    private const double CompactnessPreSeconds = 0.010;
+    // The compactness window around the peak, CIRCULAR because the window
+    // must follow the buffer's topology: a zero-phase excitation gate turns
+    // even an ideal H(f)=1 into a symmetric band-limited kernel whose
+    // pre-ringing lives in negative time, i.e. at the buffer's far end. The
+    // pre side is sized for that ringing at the lowest supported band edges
+    // (10 ms cut a 20-50 Hz band sweep's ideal kernel down to 19.9 dB —
+    // a false rejection; 100 ms reads it at 42.9 dB) and the post side for
+    // any cabin decay plus processing latency. Both shrink on short records
+    // so the outside stays the majority of the buffer.
+    private const double CompactnessPreSeconds = 0.100;
     private const double CompactnessPostSeconds = 0.500;
     private const int CompactnessMinimumSamples = 256;
 
@@ -124,7 +130,10 @@ public static class TransferIrDiagnostics
                 peakIndex = i;
             }
         }
-        if (total <= 0)
+        // Null covers "nothing to measure" AND "not a number to measure":
+        // a single NaN/Infinity poisons every energy sum, and the caller
+        // treats an unmeasurable shape as a refusal, never a pass.
+        if (!double.IsFinite(total) || total <= 0)
         {
             return null;
         }

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -768,13 +768,23 @@ namespace Resonalyze
                 finalLevels);
         }
 
+        // A loopback whose peak sits this far down flags the LIKELY CULPRIT
+        // in the shape-gate message (a wired reference is metered near full
+        // scale; the field garbage set peaked at -33..-49 dBFS). Diagnosis
+        // text only, never a rejection of its own: transfer estimation is
+        // scale-invariant, so a cleanly attenuated wire — the readme itself
+        // says to turn the playback level well down — measures fine and must
+        // not be refused on level alone.
+        private const double SuspiciouslyQuietLoopbackDbFs = -30;
+
         // The averaged transfer IR must LOOK like an impulse response before
-        // anything is published: per-run level checks catch the reference
-        // being quiet, but a level-plausible capture can still divide into
-        // stationary noise (field case: a session whose "loopback" was
-        // playback bleed produced IRs with energy smeared over the whole
-        // buffer). The shape gate is the honest refusal for that class —
-        // the user gets the reason instead of a garbage measurement.
+        // anything is published: a genuine measurement is a localized event,
+        // while a capture whose reference was unusable (field case: a
+        // session whose "loopback" was playback bleed instead of the wire)
+        // divides into stationary noise smeared over the whole buffer. The
+        // shape gate is the honest refusal for that class — scale-invariant,
+        // so it cannot punish a legitimately quiet capture — and the user
+        // gets the reason instead of a garbage measurement.
         private void RequireCredibleTransferIr(SweepAverageResult result)
         {
             if (result.TransferImpulseResponse is not { } transfer)
@@ -787,8 +797,15 @@ namespace Resonalyze
             if (compactness is { } measured &&
                 measured.InsideOutsideDb < TransferIrDiagnostics.MinimumCompactnessDb)
             {
+                InputLevelMeterEntry loopback = result.Levels.Loopback;
+                string levelDiagnosis =
+                    loopback.Available &&
+                    loopback.PeakDbFs < SuspiciouslyQuietLoopbackDbFs
+                        ? FormattableString.Invariant(
+                            $" The loopback peaked at {loopback.PeakDbFs:0.0} dBFS while a wired reference sits near full scale — the input likely picked up bleed instead of the wire.")
+                        : "";
                 throw new InvalidOperationException(FormattableString.Invariant(
-                    $"The transfer function did not form a credible impulse response: the energy around its peak is only {measured.InsideOutsideDb:0.0} dB above the rest of the capture (a real measurement reads 30-50 dB; an unusable reference divides into noise at ~11-16 dB). Check the microphone and loopback wiring and levels, then measure again."));
+                    $"The transfer function did not form a credible impulse response: the energy around its peak is only {measured.InsideOutsideDb:0.0} dB above the rest of the capture (a real measurement reads 30-50 dB; an unusable reference divides into noise at ~11-16 dB).{levelDiagnosis} Check the microphone and loopback wiring and levels, then measure again."));
             }
         }
 

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -535,7 +535,9 @@ namespace Resonalyze
                         ". Check the input levels and the loopback wiring, then measure again.");
                 }
 
-                ApplyAverageResult(accumulator.BuildResult());
+                SweepAverageResult averageResult = accumulator.BuildResult();
+                RequireCredibleTransferIr(averageResult);
+                ApplyAverageResult(averageResult);
                 success = true;
             }
             catch (OperationCanceledException)
@@ -764,6 +766,30 @@ namespace Resonalyze
                 captured.MicrophoneChannel,
                 captured.LoopbackChannel,
                 finalLevels);
+        }
+
+        // The averaged transfer IR must LOOK like an impulse response before
+        // anything is published: per-run level checks catch the reference
+        // being quiet, but a level-plausible capture can still divide into
+        // stationary noise (field case: a session whose "loopback" was
+        // playback bleed produced IRs with energy smeared over the whole
+        // buffer). The shape gate is the honest refusal for that class —
+        // the user gets the reason instead of a garbage measurement.
+        private void RequireCredibleTransferIr(SweepAverageResult result)
+        {
+            if (result.TransferImpulseResponse is not { } transfer)
+            {
+                return;
+            }
+
+            TransferIrCompactness? compactness =
+                TransferIrDiagnostics.MeasureCompactness(transfer, SampleRate);
+            if (compactness is { } measured &&
+                measured.InsideOutsideDb < TransferIrDiagnostics.MinimumCompactnessDb)
+            {
+                throw new InvalidOperationException(FormattableString.Invariant(
+                    $"The transfer function did not form a credible impulse response: the energy around its peak is only {measured.InsideOutsideDb:0.0} dB above the rest of the capture (a real measurement reads 30-50 dB; an unusable reference divides into noise at ~11-16 dB). Check the microphone and loopback wiring and levels, then measure again."));
+            }
         }
 
         private void ApplyAverageResult(SweepAverageResult result)

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -792,21 +792,33 @@ namespace Resonalyze
                 return;
             }
 
+            // FAIL-CLOSED: a shape that cannot be measured at all (null —
+            // degenerate or non-finite content) is a refusal, not a pass. A
+            // NaN anywhere in the capture would otherwise sail through every
+            // comparison and publish an unusable measurement.
             TransferIrCompactness? compactness =
                 TransferIrDiagnostics.MeasureCompactness(transfer, SampleRate);
             if (compactness is { } measured &&
-                measured.InsideOutsideDb < TransferIrDiagnostics.MinimumCompactnessDb)
+                double.IsFinite(measured.InsideOutsideDb) &&
+                measured.InsideOutsideDb >= TransferIrDiagnostics.MinimumCompactnessDb)
             {
-                InputLevelMeterEntry loopback = result.Levels.Loopback;
-                string levelDiagnosis =
-                    loopback.Available &&
-                    loopback.PeakDbFs < SuspiciouslyQuietLoopbackDbFs
-                        ? FormattableString.Invariant(
-                            $" The loopback peaked at {loopback.PeakDbFs:0.0} dBFS while a wired reference sits near full scale — the input likely picked up bleed instead of the wire.")
-                        : "";
-                throw new InvalidOperationException(FormattableString.Invariant(
-                    $"The transfer function did not form a credible impulse response: the energy around its peak is only {measured.InsideOutsideDb:0.0} dB above the rest of the capture (a real measurement reads 30-50 dB; an unusable reference divides into noise at ~11-16 dB).{levelDiagnosis} Check the microphone and loopback wiring and levels, then measure again."));
+                return;
             }
+
+            InputLevelMeterEntry loopback = result.Levels.Loopback;
+            string levelDiagnosis =
+                loopback.Available &&
+                loopback.PeakDbFs < SuspiciouslyQuietLoopbackDbFs
+                    ? FormattableString.Invariant(
+                        $" The loopback peaked at {loopback.PeakDbFs:0.0} dBFS while a wired reference sits near full scale — the input likely picked up bleed instead of the wire.")
+                    : "";
+            string shapeDiagnosis =
+                compactness is { } value && double.IsFinite(value.InsideOutsideDb)
+                    ? FormattableString.Invariant(
+                        $"the energy around its peak is only {value.InsideOutsideDb:0.0} dB above the rest of the capture (a real measurement reads 29-49 dB; an unusable reference divides into noise well below {TransferIrDiagnostics.MinimumCompactnessDb:0} dB)")
+                    : "its shape could not be measured at all (the capture is degenerate or carries non-finite samples)";
+            throw new InvalidOperationException(
+                $"The transfer function did not form a credible impulse response: {shapeDiagnosis}.{levelDiagnosis} Check the microphone and loopback wiring and levels, then measure again.");
         }
 
         private void ApplyAverageResult(SweepAverageResult result)

--- a/source/Measurements/SweepRunQuality.cs
+++ b/source/Measurements/SweepRunQuality.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Resonalyze.Dsp;
 
 namespace Resonalyze;
 
@@ -6,8 +7,8 @@ namespace Resonalyze;
 /// Acceptance checks for one captured sweep run, evaluated BEFORE the run is
 /// added to the average, so one bad capture can no longer contaminate it
 /// irreversibly. Deliberately limited to unambiguous failures (clipping, a
-/// dead signal, an undersized capture): statistical outlier checks
-/// (peak-delay vs median, IR correlation against a reference run) need
+/// dead or far-too-quiet signal, an undersized capture): statistical outlier
+/// checks (peak-delay vs median, IR correlation against a reference run) need
 /// thresholds calibrated on real multi-run captures and are a later phase.
 /// </summary>
 internal static class SweepRunQualityCheck
@@ -19,6 +20,20 @@ internal static class SweepRunQualityCheck
     /// never rejected.
     /// </summary>
     public const double SilentPeakThreshold = 1e-4;
+
+    /// <summary>
+    /// Loopback peak below which the reference is rejected as too quiet
+    /// (~-30 dBFS). A wired loopback is an electrical reference and sits
+    /// near full scale on any sane gain staging; a "reference" tens of dB
+    /// down is in practice not the wire but playback bleed into an open or
+    /// mis-routed input, and the transfer function would divide the
+    /// microphone response by that noise. Field case: a whole session
+    /// captured with loopback peaks at -33..-49 dBFS passed the silence
+    /// check and produced garbage transfer IRs on every channel. Sits far
+    /// above <see cref="SilentPeakThreshold"/> and far below any real wired
+    /// reference, so neither neighbor is ever misclassified.
+    /// </summary>
+    public const double QuietLoopbackPeakThreshold = 0.0316;
 
     /// <summary>
     /// Issues found in the captured run; empty means the run is accepted.
@@ -54,9 +69,19 @@ internal static class SweepRunQualityCheck
             issues.Add("the microphone signal is silent");
         }
 
-        if (loopback != null && Peak(loopback) < SilentPeakThreshold)
+        if (loopback != null)
         {
-            issues.Add("the loopback reference signal is silent");
+            double loopbackPeak = Peak(loopback);
+            if (loopbackPeak < SilentPeakThreshold)
+            {
+                issues.Add("the loopback reference signal is silent");
+            }
+            else if (loopbackPeak < QuietLoopbackPeakThreshold)
+            {
+                double loopbackPeakDb = DataHelper.AmplitudeToDecibels(loopbackPeak);
+                issues.Add(FormattableString.Invariant(
+                    $"the loopback reference is too quiet to trust (peak {loopbackPeakDb:0.0} dBFS; a wired loopback sits near full scale)"));
+            }
         }
 
         return issues;

--- a/source/Measurements/SweepRunQuality.cs
+++ b/source/Measurements/SweepRunQuality.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Resonalyze.Dsp;
 
 namespace Resonalyze;
 
@@ -7,9 +6,14 @@ namespace Resonalyze;
 /// Acceptance checks for one captured sweep run, evaluated BEFORE the run is
 /// added to the average, so one bad capture can no longer contaminate it
 /// irreversibly. Deliberately limited to unambiguous failures (clipping, a
-/// dead or far-too-quiet signal, an undersized capture): statistical outlier
-/// checks (peak-delay vs median, IR correlation against a reference run) need
+/// dead signal, an undersized capture): statistical outlier checks
+/// (peak-delay vs median, IR correlation against a reference run) need
 /// thresholds calibrated on real multi-run captures and are a later phase.
+/// A quiet-but-present loopback is deliberately NOT a failure here: transfer
+/// estimation is scale-invariant, so a cleanly attenuated wire (the readme
+/// itself says to turn the playback level well down) measures fine — whether
+/// a reference was usable is judged by the transfer IR's SHAPE after the
+/// runs (see ExpSweepMeasurement.RequireCredibleTransferIr).
 /// </summary>
 internal static class SweepRunQualityCheck
 {
@@ -20,20 +24,6 @@ internal static class SweepRunQualityCheck
     /// never rejected.
     /// </summary>
     public const double SilentPeakThreshold = 1e-4;
-
-    /// <summary>
-    /// Loopback peak below which the reference is rejected as too quiet
-    /// (~-30 dBFS). A wired loopback is an electrical reference and sits
-    /// near full scale on any sane gain staging; a "reference" tens of dB
-    /// down is in practice not the wire but playback bleed into an open or
-    /// mis-routed input, and the transfer function would divide the
-    /// microphone response by that noise. Field case: a whole session
-    /// captured with loopback peaks at -33..-49 dBFS passed the silence
-    /// check and produced garbage transfer IRs on every channel. Sits far
-    /// above <see cref="SilentPeakThreshold"/> and far below any real wired
-    /// reference, so neither neighbor is ever misclassified.
-    /// </summary>
-    public const double QuietLoopbackPeakThreshold = 0.0316;
 
     /// <summary>
     /// Issues found in the captured run; empty means the run is accepted.
@@ -69,19 +59,9 @@ internal static class SweepRunQualityCheck
             issues.Add("the microphone signal is silent");
         }
 
-        if (loopback != null)
+        if (loopback != null && Peak(loopback) < SilentPeakThreshold)
         {
-            double loopbackPeak = Peak(loopback);
-            if (loopbackPeak < SilentPeakThreshold)
-            {
-                issues.Add("the loopback reference signal is silent");
-            }
-            else if (loopbackPeak < QuietLoopbackPeakThreshold)
-            {
-                double loopbackPeakDb = DataHelper.AmplitudeToDecibels(loopbackPeak);
-                issues.Add(FormattableString.Invariant(
-                    $"the loopback reference is too quiet to trust (peak {loopbackPeakDb:0.0} dBFS; a wired loopback sits near full scale)"));
-            }
+            issues.Add("the loopback reference signal is silent");
         }
 
         return issues;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
@@ -30,122 +30,146 @@ namespace Resonalyze
         /// </summary>
         private void InitializeComponent()
         {
+            radioLeftHandDrive = new RadioButton();
+            radioRightHandDrive = new RadioButton();
             labelSceneOffset = new Label();
             numericSceneOffset = new DarkNumericUpDown();
             checkBoxGains = new CheckBox();
-            labelLevelDifference = new Label();
-            numericLevelDifference = new DarkNumericUpDown();
-            labelLevelDifferenceHint = new Label();
+            labelNearSideCut = new Label();
+            numericNearSideCut = new DarkNumericUpDown();
+            labelNearSideCutHint = new Label();
             buttonRun = new Button();
             labelStatus = new Label();
             textBoxReport = new TextBox();
             buttonApply = new Button();
             buttonCancel = new Button();
             (numericSceneOffset).BeginInit();
-            (numericLevelDifference).BeginInit();
+            (numericNearSideCut).BeginInit();
             SuspendLayout();
-            // 
+            //
+            // radioLeftHandDrive
+            //
+            radioLeftHandDrive.AutoSize = true;
+            radioLeftHandDrive.Checked = true;
+            radioLeftHandDrive.ForeColor = Color.White;
+            radioLeftHandDrive.Location = new Point(12, 13);
+            radioLeftHandDrive.Name = "radioLeftHandDrive";
+            radioLeftHandDrive.Size = new Size(48, 19);
+            radioLeftHandDrive.TabIndex = 0;
+            radioLeftHandDrive.TabStop = true;
+            radioLeftHandDrive.Text = "LHD";
+            //
+            // radioRightHandDrive
+            //
+            radioRightHandDrive.AutoSize = true;
+            radioRightHandDrive.ForeColor = Color.White;
+            radioRightHandDrive.Location = new Point(64, 13);
+            radioRightHandDrive.Name = "radioRightHandDrive";
+            radioRightHandDrive.Size = new Size(50, 19);
+            radioRightHandDrive.TabIndex = 1;
+            radioRightHandDrive.Text = "RHD";
+            //
             // labelSceneOffset
-            // 
+            //
             labelSceneOffset.AutoSize = true;
             labelSceneOffset.ForeColor = Color.FromArgb(185, 190, 200);
-            labelSceneOffset.Location = new Point(12, 16);
+            labelSceneOffset.Location = new Point(124, 16);
             labelSceneOffset.Name = "labelSceneOffset";
-            labelSceneOffset.Size = new Size(61, 15);
-            labelSceneOffset.TabIndex = 0;
-            labelSceneOffset.Text = "L/R offset:";
-            // 
+            labelSceneOffset.Size = new Size(42, 15);
+            labelSceneOffset.TabIndex = 2;
+            labelSceneOffset.Text = "Offset:";
+            //
             // numericSceneOffset
-            // 
+            //
             numericSceneOffset.BackColor = Color.FromArgb(55, 60, 72);
             numericSceneOffset.DecimalPlaces = 2;
             numericSceneOffset.ForeColor = Color.White;
             numericSceneOffset.Increment = new decimal(new int[] { 5, 0, 0, 131072 });
-            numericSceneOffset.Location = new Point(84, 12);
+            numericSceneOffset.Location = new Point(172, 12);
             numericSceneOffset.Maximum = new decimal(new int[] { 5, 0, 0, 0 });
-            numericSceneOffset.Minimum = new decimal(new int[] { 5, 0, 0, int.MinValue });
+            numericSceneOffset.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
             numericSceneOffset.MinimumSize = new Size(36, 19);
             numericSceneOffset.Name = "numericSceneOffset";
-            numericSceneOffset.Size = new Size(92, 21);
-            numericSceneOffset.TabIndex = 1;
+            numericSceneOffset.Size = new Size(80, 21);
+            numericSceneOffset.TabIndex = 3;
             numericSceneOffset.TextAlign = HorizontalAlignment.Right;
             numericSceneOffset.ThousandsSeparator = false;
             numericSceneOffset.Value = new decimal(new int[] { 27, 0, 0, 131072 });
             numericSceneOffset.ValueSuffix = "ms";
-            // 
+            //
             // checkBoxGains
-            // 
+            //
             checkBoxGains.AutoSize = true;
             checkBoxGains.Checked = true;
             checkBoxGains.CheckState = CheckState.Checked;
             checkBoxGains.ForeColor = Color.White;
-            checkBoxGains.Location = new Point(196, 14);
+            checkBoxGains.Location = new Point(268, 14);
             checkBoxGains.Name = "checkBoxGains";
             checkBoxGains.Size = new Size(199, 19);
-            checkBoxGains.TabIndex = 2;
+            checkBoxGains.TabIndex = 4;
             checkBoxGains.Text = "Balance channel gains (cut-only)";
-            // 
-            // labelLevelDifference
-            // 
-            labelLevelDifference.AutoSize = true;
-            labelLevelDifference.ForeColor = Color.FromArgb(185, 190, 200);
-            labelLevelDifference.Location = new Point(403, 16);
-            labelLevelDifference.Name = "labelLevelDifference";
-            labelLevelDifference.Size = new Size(55, 15);
-            labelLevelDifference.TabIndex = 3;
-            labelLevelDifference.Text = "L-R level:";
-            // 
-            // numericLevelDifference
-            // 
-            numericLevelDifference.BackColor = Color.FromArgb(55, 60, 72);
-            numericLevelDifference.DecimalPlaces = 1;
-            numericLevelDifference.ForeColor = Color.White;
-            numericLevelDifference.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
-            numericLevelDifference.Location = new Point(463, 12);
-            numericLevelDifference.Maximum = new decimal(new int[] { 6, 0, 0, 0 });
-            numericLevelDifference.Minimum = new decimal(new int[] { 6, 0, 0, int.MinValue });
-            numericLevelDifference.MinimumSize = new Size(36, 19);
-            numericLevelDifference.Name = "numericLevelDifference";
-            numericLevelDifference.Size = new Size(72, 21);
-            numericLevelDifference.TabIndex = 4;
-            numericLevelDifference.TextAlign = HorizontalAlignment.Right;
-            numericLevelDifference.ThousandsSeparator = false;
-            numericLevelDifference.Value = new decimal(new int[] { 1, 0, 0, int.MinValue });
-            numericLevelDifference.ValueSuffix = "dB";
-            // 
-            // labelLevelDifferenceHint
-            // 
-            labelLevelDifferenceHint.AutoSize = true;
-            labelLevelDifferenceHint.ForeColor = Color.FromArgb(120, 125, 135);
-            labelLevelDifferenceHint.Location = new Point(543, 16);
-            labelLevelDifferenceHint.Name = "labelLevelDifferenceHint";
-            labelLevelDifferenceHint.Size = new Size(137, 15);
-            labelLevelDifferenceHint.TabIndex = 5;
-            labelLevelDifferenceHint.Text = "LHD -1…-2 ; RHD +1…+2";
-            // 
+            //
+            // labelNearSideCut
+            //
+            labelNearSideCut.AutoSize = true;
+            labelNearSideCut.ForeColor = Color.FromArgb(185, 190, 200);
+            labelNearSideCut.Location = new Point(475, 16);
+            labelNearSideCut.Name = "labelNearSideCut";
+            labelNearSideCut.Size = new Size(84, 15);
+            labelNearSideCut.TabIndex = 5;
+            labelNearSideCut.Text = "Near side cut:";
+            //
+            // numericNearSideCut
+            //
+            numericNearSideCut.BackColor = Color.FromArgb(55, 60, 72);
+            numericNearSideCut.DecimalPlaces = 1;
+            numericNearSideCut.ForeColor = Color.White;
+            numericNearSideCut.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
+            numericNearSideCut.Location = new Point(565, 12);
+            numericNearSideCut.Maximum = new decimal(new int[] { 6, 0, 0, 0 });
+            numericNearSideCut.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
+            numericNearSideCut.MinimumSize = new Size(36, 19);
+            numericNearSideCut.Name = "numericNearSideCut";
+            numericNearSideCut.Size = new Size(72, 21);
+            numericNearSideCut.TabIndex = 6;
+            numericNearSideCut.TextAlign = HorizontalAlignment.Right;
+            numericNearSideCut.ThousandsSeparator = false;
+            numericNearSideCut.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            numericNearSideCut.ValueSuffix = "dB";
+            //
+            // labelNearSideCutHint
+            //
+            labelNearSideCutHint.AutoSize = true;
+            labelNearSideCutHint.ForeColor = Color.FromArgb(120, 125, 135);
+            labelNearSideCutHint.Location = new Point(645, 16);
+            labelNearSideCutHint.Name = "labelNearSideCutHint";
+            labelNearSideCutHint.Size = new Size(70, 15);
+            labelNearSideCutHint.TabIndex = 7;
+            labelNearSideCutHint.Text = "typical 1…2";
+            //
             // buttonRun
-            // 
+            //
             buttonRun.BackColor = Color.FromArgb(46, 51, 67);
             buttonRun.FlatStyle = FlatStyle.Popup;
             buttonRun.ForeColor = Color.White;
             buttonRun.Location = new Point(12, 44);
             buttonRun.Name = "buttonRun";
             buttonRun.Size = new Size(120, 26);
-            buttonRun.TabIndex = 6;
+            buttonRun.TabIndex = 8;
             buttonRun.Text = "Run";
             buttonRun.UseVisualStyleBackColor = false;
-            // 
+            //
             // labelStatus
-            // 
+            //
             labelStatus.AutoSize = true;
             labelStatus.ForeColor = Color.FromArgb(185, 190, 200);
             labelStatus.Location = new Point(144, 50);
             labelStatus.Name = "labelStatus";
             labelStatus.Size = new Size(0, 15);
-            labelStatus.TabIndex = 7;
-            // 
+            labelStatus.TabIndex = 9;
+            //
             // textBoxReport
-            // 
+            //
             textBoxReport.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             textBoxReport.BackColor = Color.FromArgb(33, 36, 45);
             textBoxReport.BorderStyle = BorderStyle.FixedSingle;
@@ -156,48 +180,50 @@ namespace Resonalyze
             textBoxReport.Name = "textBoxReport";
             textBoxReport.ReadOnly = true;
             textBoxReport.ScrollBars = ScrollBars.Vertical;
-            textBoxReport.Size = new Size(700, 553);
-            textBoxReport.TabIndex = 8;
-            // 
+            textBoxReport.Size = new Size(752, 553);
+            textBoxReport.TabIndex = 10;
+            //
             // buttonApply
-            // 
+            //
             buttonApply.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
             buttonApply.BackColor = Color.FromArgb(46, 51, 67);
             buttonApply.DialogResult = DialogResult.OK;
             buttonApply.FlatStyle = FlatStyle.Popup;
             buttonApply.ForeColor = Color.White;
-            buttonApply.Location = new Point(538, 643);
+            buttonApply.Location = new Point(590, 643);
             buttonApply.Name = "buttonApply";
             buttonApply.Size = new Size(84, 26);
-            buttonApply.TabIndex = 9;
+            buttonApply.TabIndex = 11;
             buttonApply.Text = "Apply";
             buttonApply.UseVisualStyleBackColor = false;
-            // 
+            //
             // buttonCancel
-            // 
+            //
             buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
             buttonCancel.DialogResult = DialogResult.Cancel;
             buttonCancel.FlatStyle = FlatStyle.Popup;
             buttonCancel.ForeColor = Color.White;
-            buttonCancel.Location = new Point(628, 643);
+            buttonCancel.Location = new Point(680, 643);
             buttonCancel.Name = "buttonCancel";
             buttonCancel.Size = new Size(84, 26);
-            buttonCancel.TabIndex = 10;
+            buttonCancel.TabIndex = 12;
             buttonCancel.Text = "Discard";
             buttonCancel.UseVisualStyleBackColor = true;
-            // 
+            //
             // VirtualCrossoverAutoDelayDialog
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(40, 44, 54);
-            ClientSize = new Size(724, 681);
+            ClientSize = new Size(776, 681);
+            Controls.Add(radioLeftHandDrive);
+            Controls.Add(radioRightHandDrive);
             Controls.Add(labelSceneOffset);
             Controls.Add(numericSceneOffset);
             Controls.Add(checkBoxGains);
-            Controls.Add(labelLevelDifference);
-            Controls.Add(numericLevelDifference);
-            Controls.Add(labelLevelDifferenceHint);
+            Controls.Add(labelNearSideCut);
+            Controls.Add(numericNearSideCut);
+            Controls.Add(labelNearSideCutHint);
             Controls.Add(buttonRun);
             Controls.Add(labelStatus);
             Controls.Add(textBoxReport);
@@ -206,25 +232,27 @@ namespace Resonalyze
             Font = new Font("Segoe UI", 9F);
             ForeColor = Color.White;
             MinimizeBox = false;
-            MinimumSize = new Size(740, 360);
+            MinimumSize = new Size(792, 360);
             Name = "VirtualCrossoverAutoDelayDialog";
             ShowInTaskbar = false;
             StartPosition = FormStartPosition.CenterParent;
             Text = "Auto delay";
             (numericSceneOffset).EndInit();
-            (numericLevelDifference).EndInit();
+            (numericNearSideCut).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
 
         #endregion
 
+        private RadioButton radioLeftHandDrive;
+        private RadioButton radioRightHandDrive;
         private Label labelSceneOffset;
         private DarkNumericUpDown numericSceneOffset;
         private CheckBox checkBoxGains;
-        private Label labelLevelDifference;
-        private DarkNumericUpDown numericLevelDifference;
-        private Label labelLevelDifferenceHint;
+        private Label labelNearSideCut;
+        private DarkNumericUpDown numericNearSideCut;
+        private Label labelNearSideCutHint;
         private Button buttonRun;
         private Label labelStatus;
         private TextBox textBoxReport;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
@@ -1,7 +1,8 @@
 namespace Resonalyze;
 
 /// <summary>
-/// The Auto delay dialog: the stereo scene offset and the gain-balance
+/// The Auto delay dialog: the steering layout (LHD/RHD), the stereo scene
+/// offset and the gain-balance
 /// opt-in, a Run command that computes a PROPOSAL (delays, polarities and
 /// optionally gains) without touching the channels, the before/after report
 /// with per-channel confidence, and Apply/Discard. Nothing is written until
@@ -25,7 +26,7 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
     private static readonly Color StatusWarning = Color.FromArgb(230, 184, 0);
     private static readonly Color StatusError = Color.FromArgb(240, 100, 110);
 
-    private Func<double, bool, double, Task<AutoDelayRunResult>>? runner;
+    private Func<AutoDelayRunRequest, Task<AutoDelayRunResult>>? runner;
     private bool stereo;
     private bool running;
 
@@ -35,20 +36,32 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
         CancelButton = buttonCancel;
         buttonApply.Enabled = false;
         buttonRun.Click += async (_, _) => await RunAsync();
+        // One handler covers both radios: any LHD<->RHD toggle flips RHD's
+        // own Checked, so LHD needs no listener of its own.
+        radioRightHandDrive.CheckedChanged += (_, _) => InvalidateResult();
         numericSceneOffset.ValueChanged += (_, _) => InvalidateResult();
-        numericLevelDifference.ValueChanged += (_, _) => InvalidateResult();
+        numericNearSideCut.ValueChanged += (_, _) => InvalidateResult();
         checkBoxGains.CheckedChanged += (_, _) =>
         {
-            UpdateLevelDifferenceEnabled();
+            UpdateNearSideCutEnabled();
             InvalidateResult();
         };
+        string layoutTip =
+            "The steering position. The driver's side is the timing\r\n" +
+            "reference: it aligns first and the far side is fitted to it,\r\n" +
+            "leading by the scene offset.\r\n" +
+            "LHD: the left side is the reference, the right side leads.\r\n" +
+            "RHD: the right side is the reference, the left side leads\r\n" +
+            "(the right lags by the offset).";
+        toolTip.SetToolTip(radioLeftHandDrive, layoutTip);
+        toolTip.SetToolTip(radioRightHandDrive, layoutTip);
         toolTip.SetToolTip(
             numericSceneOffset,
             "Stereo scene offset (ms).\r\n" +
-            "Positive: the RIGHT side arrives earlier by this much,\r\n" +
-            "pulling the image from the driver's axis toward the\r\n" +
-            "dash center on a left-hand-drive car. Typical: 0.2–0.3 ms.\r\n" +
-            "Right-hand drive: enter a negative value.\r\n" +
+            "The far side arrives earlier by this much, pulling the image\r\n" +
+            "from the driver's axis toward the dash center: on LHD the\r\n" +
+            "right side leads, on RHD the left side does.\r\n" +
+            "Typical: 0.2–0.3 ms.\r\n" +
             "0 = image centered on the measurement position.");
         toolTip.SetToolTip(
             checkBoxGains,
@@ -58,17 +71,14 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
             "right offset by the L-R level below. Subwoofers, mono channels\r\n" +
             "and channels without a crossover keep their gain. This is a\r\n" +
             "starting balance, not a final tonal decision.");
-        numericLevelDifference.ApplyToolTip(
+        numericNearSideCut.ApplyToolTip(
             toolTip,
-            "The intentional level difference (dB) the balance aims for,\r\n" +
-            "read as LEFT minus RIGHT.\r\n" +
-            "Negative: the left side plays quieter by this much, pulling\r\n" +
-            "the image away from the driver's axis toward the dash center\r\n" +
-            "on a left-hand-drive car — the same placement as the offset\r\n" +
-            "above, traded as level instead of time. Typical: -1 to -2 dB.\r\n" +
-            "Right-hand drive: a positive value.\r\n" +
+            "How much quieter the NEAR (driver's) side plays than the far\r\n" +
+            "side (dB) — the level twin of the scene offset, pulling the\r\n" +
+            "image from the driver's axis toward the dash center. Which\r\n" +
+            "side is near comes from the LHD/RHD switch. Typical: 1–2 dB.\r\n" +
             "0 = both sides levelled to the same target.\r\n" +
-            "Cut-only: the tilt is produced by attenuating the near side.");
+            "Cut-only: produced by attenuating the near side's channels.");
         // The designer's Dispose releases the tooltip; no Disposed handler.
     }
 
@@ -77,39 +87,45 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
 
     /// <summary>
     /// Seeds the dialog: the run mode (a single-side run has no L/R relation
-    /// to honor), the persisted scene offset and L-R level difference, and the
-    /// panel's compute delegate (scene offset ms, balance gains, L-R level
-    /// difference dB) -> proposal.
+    /// to honor), the persisted steering layout, scene offset and near-side
+    /// cut, and the panel's compute delegate (run inputs) -> proposal.
     /// <paramref name="polarityWarning"/> is a non-empty red heads-up shown at
     /// launch when a driver's left and right measured polarities disagree.
     /// </summary>
     public void Init(
         bool stereo,
         double sceneOffsetMs,
-        double levelDifferenceDb,
-        Func<double, bool, double, Task<AutoDelayRunResult>> runner,
+        bool rightHandDrive,
+        double nearSideCutDb,
+        Func<AutoDelayRunRequest, Task<AutoDelayRunResult>> runner,
         string? polarityWarning = null)
     {
         this.stereo = stereo;
         this.runner = runner;
+        radioLeftHandDrive.Checked = !rightHandDrive;
+        radioRightHandDrive.Checked = rightHandDrive;
         numericSceneOffset.Value = Math.Clamp(
             (decimal)sceneOffsetMs,
             numericSceneOffset.Minimum,
             numericSceneOffset.Maximum);
-        numericLevelDifference.Value = Math.Clamp(
-            (decimal)levelDifferenceDb,
-            numericLevelDifference.Minimum,
-            numericLevelDifference.Maximum);
-        UpdateLevelDifferenceEnabled();
+        numericNearSideCut.Value = Math.Clamp(
+            (decimal)nearSideCutDb,
+            numericNearSideCut.Minimum,
+            numericNearSideCut.Maximum);
+        UpdateNearSideCutEnabled();
         if (!stereo)
         {
+            string singleSideTip =
+                "Only one side is measured, so this run aligns a single\r\n" +
+                "side and the L/R scene offset does not apply.";
+            radioLeftHandDrive.Enabled = false;
+            radioRightHandDrive.Enabled = false;
             labelSceneOffset.Enabled = false;
             numericSceneOffset.Enabled = false;
-            toolTip.SetToolTip(
-                numericSceneOffset,
-                "Only one side is measured, so this run aligns a single\r\n" +
-                "side and the L/R scene offset does not apply.");
-            numericLevelDifference.ApplyToolTip(
+            toolTip.SetToolTip(radioLeftHandDrive, singleSideTip);
+            toolTip.SetToolTip(radioRightHandDrive, singleSideTip);
+            toolTip.SetToolTip(numericSceneOffset, singleSideTip);
+            numericNearSideCut.ApplyToolTip(
                 toolTip,
                 "Only one side is measured, so there is no L/R relation to\r\n" +
                 "tilt: the gain balance levels this side's board alone.");
@@ -117,9 +133,9 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
 
         textBoxReport.Text =
             (stereo
-                ? "Stereo run: the left side aligns first, the right top is " +
-                  "timed to the left one honoring the scene offset, and the " +
-                  "right side descends from it."
+                ? "Stereo run: the driver's side aligns first, the far top " +
+                  "is timed to it honoring the scene offset, and the far " +
+                  "side descends from it."
                 : "Single-side run: the displayed side's channels align " +
                   "against each other.") +
             Environment.NewLine + Environment.NewLine +
@@ -131,16 +147,16 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
         }
     }
 
-    // The L-R level difference is an input to the gain balance only: with the
+    // The near-side cut is an input to the gain balance only: with the
     // checkbox off no gain is written at all, and a single-side run has no L/R
     // relation to tilt. Kept visible-but-disabled either way, so the value the
     // next stereo run would use stays readable.
-    private void UpdateLevelDifferenceEnabled()
+    private void UpdateNearSideCutEnabled()
     {
         bool enabled = stereo && checkBoxGains.Checked;
-        labelLevelDifference.Enabled = enabled;
-        numericLevelDifference.Enabled = enabled;
-        labelLevelDifferenceHint.Enabled = enabled;
+        labelNearSideCut.Enabled = enabled;
+        numericNearSideCut.Enabled = enabled;
+        labelNearSideCutHint.Enabled = enabled;
     }
 
     // Once a proposal exists, any input change makes it stale: Apply must
@@ -190,19 +206,22 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
         buttonRun.Enabled = false;
         buttonApply.Enabled = false;
         buttonCancel.Enabled = false;
+        radioLeftHandDrive.Enabled = false;
+        radioRightHandDrive.Enabled = false;
         numericSceneOffset.Enabled = false;
         checkBoxGains.Enabled = false;
-        labelLevelDifference.Enabled = false;
-        numericLevelDifference.Enabled = false;
-        labelLevelDifferenceHint.Enabled = false;
+        labelNearSideCut.Enabled = false;
+        numericNearSideCut.Enabled = false;
+        labelNearSideCutHint.Enabled = false;
         SetStatus("Aligning…", StatusNeutral);
         UseWaitCursor = true;
         try
         {
-            AutoDelayRunResult result = await runner(
+            AutoDelayRunResult result = await runner(new AutoDelayRunRequest(
                 (double)numericSceneOffset.Value,
+                radioRightHandDrive.Checked,
                 checkBoxGains.Checked,
-                (double)numericLevelDifference.Value);
+                (double)numericNearSideCut.Value));
             if (IsDisposed)
             {
                 return;
@@ -235,9 +254,11 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
                 running = false;
                 buttonRun.Enabled = true;
                 buttonCancel.Enabled = true;
+                radioLeftHandDrive.Enabled = stereo;
+                radioRightHandDrive.Enabled = stereo;
                 numericSceneOffset.Enabled = stereo;
                 checkBoxGains.Enabled = true;
-                UpdateLevelDifferenceEnabled();
+                UpdateNearSideCutEnabled();
                 UseWaitCursor = false;
             }
         }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayReport.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayReport.cs
@@ -36,6 +36,31 @@ internal sealed record AutoDelayChannelOutcome(
 internal sealed record AutoDelaySumLossForecast(double BeforeDb, double AfterDb);
 
 /// <summary>
+/// The inputs of one Auto delay run as the dialog collected them: the scene
+/// offset magnitude (ms, non-negative — the far side leads by this much),
+/// the steering layout that decides which side is the far one (LHD: the
+/// right side leads; RHD: the left side leads, the right lags), the gain
+/// balance opt-in, and the near-side cut it aims for (dB, non-negative —
+/// how much quieter the driver's side plays than the far one). Both
+/// magnitudes are layout-neutral: the layout toggle, not the user, owns
+/// every sign.
+/// </summary>
+internal sealed record AutoDelayRunRequest(
+    double SceneOffsetMs,
+    bool RightHandDrive,
+    bool AdjustGains,
+    double NearSideCutDb)
+{
+    /// <summary>
+    /// The tilt in the gain engine's LEFT-minus-RIGHT convention: the near
+    /// side is the left one on LHD (left quieter, negative) and the right
+    /// one on RHD (left louder, positive).
+    /// </summary>
+    public double LevelDifferenceDb =>
+        RightHandDrive ? NearSideCutDb : -NearSideCutDb;
+}
+
+/// <summary>
 /// A completed (not yet applied) Auto delay run: the per-channel outcomes,
 /// the run mode and inputs, the formatted report the dialog shows, and the
 /// diagnostic log the Apply step closes with the resulting metric.
@@ -43,9 +68,7 @@ internal sealed record AutoDelaySumLossForecast(double BeforeDb, double AfterDb)
 internal sealed record AutoDelayRunResult(
     IReadOnlyList<AutoDelayChannelOutcome> Outcomes,
     bool Stereo,
-    double SceneOffsetMs,
-    bool GainsRequested,
-    double LevelDifferenceDb,
+    AutoDelayRunRequest Request,
     string ReportText,
     StringBuilder Log);
 
@@ -59,9 +82,7 @@ internal static class VirtualCrossoverAutoDelayReport
     public static string Format(
         IReadOnlyList<AutoDelayChannelOutcome> outcomes,
         bool stereo,
-        double sceneOffsetMs,
-        bool gainsRequested,
-        double levelDifferenceDb,
+        AutoDelayRunRequest request,
         AutoDelaySumLossForecast? leftSumLoss = null,
         AutoDelaySumLossForecast? rightSumLoss = null)
     {
@@ -74,15 +95,16 @@ internal static class VirtualCrossoverAutoDelayReport
         if (stereo)
         {
             text.AppendLine(FormattableString.Invariant(
-                $"Scene offset {sceneOffsetMs:+0.00;-0.00;0.00} ms ") +
-                "(positive: right side leads)" +
-                (gainsRequested
+                $"Scene offset {request.SceneOffsetMs:0.00} ms ") +
+                (request.RightHandDrive
+                    ? "(RHD: left side leads)"
+                    : "(LHD: right side leads)") +
+                (request.AdjustGains
                     ? FormattableString.Invariant(
-                        $", L-R level {GainBalanceEngine.LevelDifferenceDb(levelDifferenceDb):+0.0;-0.0;0.0} dB") +
-                      " (positive: left side louder)"
+                        $", near-side cut {Math.Abs(GainBalanceEngine.LevelDifferenceDb(request.LevelDifferenceDb)):0.0} dB")
                     : ""));
         }
-        if (!gainsRequested)
+        if (!request.AdjustGains)
         {
             text.AppendLine("Gains not adjusted (checkbox off).");
         }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
@@ -304,7 +304,7 @@ namespace Resonalyze
             buttonAutoDelay.Name = "buttonAutoDelay";
             buttonAutoDelay.Size = new Size(125, 24);
             buttonAutoDelay.TabIndex = 12;
-            buttonAutoDelay.Text = "Auto delay";
+            buttonAutoDelay.Text = "Auto delay...";
             buttonAutoDelay.UseVisualStyleBackColor = false;
             // 
             // buttonAutoSetup

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -348,16 +348,26 @@ public partial class VirtualCrossoverPanel : UserControl
 
         RefreshCalibrationCombo();
 
+        // BOTH physical slots of EVERY channel are wiped before anything
+        // resolves. Per slot, because through the effective accessor a mono
+        // pair's real right slot is unreachable, and a stale measurement from
+        // the previous project would otherwise resurface the moment the pair
+        // stops being mono. Across ALL channels up front, because the rate
+        // guard in TryAssignSource scans every still-resolved side: cleared
+        // one channel at a time, an imported session at a different sample
+        // rate would lose that vote against the previous project's channels
+        // — each source silently refused against the not-yet-replaced rest,
+        // leaving only the last channel resolved.
         foreach (VirtualCrossoverChannel channel in channels)
         {
-            // BOTH physical slots are wiped first — through the effective
-            // accessor a mono pair's real right slot is unreachable, and a
-            // stale measurement from the previous project would otherwise
-            // resurface the moment the pair stops being mono. Then both sides
-            // resolve up front (the stereo Auto delay needs them together); a
-            // mono pair resolves its single slot once.
             channel.PhysicalSideState(false).Clear();
             channel.PhysicalSideState(true).Clear();
+        }
+
+        foreach (VirtualCrossoverChannel channel in channels)
+        {
+            // Both sides resolve up front (the stereo Auto delay needs them
+            // together); a mono pair resolves its single slot once.
             foreach (bool rightSide in new[] { false, true })
             {
                 if (channel.Pair.Mono && rightSide)
@@ -2217,9 +2227,10 @@ public partial class VirtualCrossoverPanel : UserControl
         dialog.Init(
             stereo: false,
             project.StereoSceneOffsetMs,
-            project.StereoLevelDifferenceDb,
-            (_, adjustGains, _) => RunSingleSideProposalAsync(
-                participants, minHz, maxHz, adjustGains));
+            project.StereoRightHandDrive,
+            Math.Abs(project.StereoLevelDifferenceDb),
+            request => RunSingleSideProposalAsync(
+                participants, minHz, maxHz, request));
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
             dialog.Result is not { } result ||
             IsDisposed)
@@ -2281,8 +2292,9 @@ public partial class VirtualCrossoverPanel : UserControl
         List<VirtualCrossoverChannel> participants,
         double windowMinHz,
         double windowMaxHz,
-        bool adjustGains)
+        AutoDelayRunRequest request)
     {
+        bool adjustGains = request.AdjustGains;
         var log = new System.Text.StringBuilder();
         log.AppendLine($"Auto delay {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
         log.AppendLine($"Crossover window: {windowMinHz:0} - {windowMaxHz:0} Hz");
@@ -2333,15 +2345,12 @@ public partial class VirtualCrossoverPanel : UserControl
                 channel.Name)),
             alignment, decisions, gains);
         string report = VirtualCrossoverAutoDelayReport.Format(
-            outcomes, stereo: false, sceneOffsetMs: 0, adjustGains,
-            levelDifferenceDb: 0, sumLoss);
+            outcomes, stereo: false, request, sumLoss);
         // The diagnostic trace is written already at the proposal stage, so a
         // discarded (or failed-looking) run can still be shared and analyzed;
         // Apply rewrites it with the results and the outcome metric appended.
         WriteAlignmentLog(log.ToString());
-        return new AutoDelayRunResult(
-            outcomes, Stereo: false, project.StereoSceneOffsetMs,
-            adjustGains, project.StereoLevelDifferenceDb, report, log);
+        return new AutoDelayRunResult(outcomes, Stereo: false, request, report, log);
     }
 
     // Bridges the run's channels to the dsp GainBalanceEngine: bands from the
@@ -2507,9 +2516,12 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             // The inputs the proposal was computed with become the persisted
             // values only now, so a discarded experiment does not overwrite
-            // them.
-            project.StereoSceneOffsetMs = result.SceneOffsetMs;
-            project.StereoLevelDifferenceDb = result.LevelDifferenceDb;
+            // them. The tilt is stored in the signed L-R convention
+            // (LevelDifferenceDb restates the near-side cut per the layout),
+            // keeping the file readable by older builds.
+            project.StereoSceneOffsetMs = result.Request.SceneOffsetMs;
+            project.StereoRightHandDrive = result.Request.RightHandDrive;
+            project.StereoLevelDifferenceDb = result.Request.LevelDifferenceDb;
         }
 
         ScheduleSave();
@@ -2674,10 +2686,11 @@ public partial class VirtualCrossoverPanel : UserControl
         return (left, right);
     }
 
-    // The stereo Auto delay: left side first, then the L/R bridge at the top
-    // pair honoring the scene offset, then the right-side descent — the
-    // cascade itself lives in AutoAlignmentEngine.ComputeStereo (dsp,
-    // unit-tested on synthetic systems and real car measurements).
+    // The stereo Auto delay: the driver's side first (left on LHD, right on
+    // RHD), then the L/R bridge at the top pair honoring the scene offset,
+    // then the far side's descent — the cascade itself lives in
+    // AutoAlignmentEngine.ComputeStereo (dsp, unit-tested on synthetic
+    // systems and real car measurements), fed a mirrored plan for RHD.
     private async Task AutoAlignStereoAsync(
         List<VirtualCrossoverSideAlignmentChannel> leftSide,
         List<VirtualCrossoverSideAlignmentChannel> rightSide,
@@ -2755,14 +2768,18 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         using var dialog = new VirtualCrossoverAutoDelayDialog();
+        // The dialog edits the tilt as a layout-neutral NEAR-SIDE CUT; the
+        // project stores it in the gain engine's signed L-R convention (so
+        // older builds read the same file), hence the magnitude here and the
+        // layout-signed write-back in CommitAutoDelayResult.
         dialog.Init(
             stereo: true,
             project.StereoSceneOffsetMs,
-            project.StereoLevelDifferenceDb,
-            (sceneOffsetMs, adjustGains, levelDifferenceDb) => RunStereoProposalAsync(
+            project.StereoRightHandDrive,
+            Math.Abs(project.StereoLevelDifferenceDb),
+            request => RunStereoProposalAsync(
                 leftSide, rightSide, union, bridgeLeft, bridgeRight,
-                bridgeBandLowHz, bridgeBandHighHz, sceneOffsetMs, adjustGains,
-                levelDifferenceDb),
+                bridgeBandLowHz, bridgeBandHighHz, request),
             DescribeLeftRightPolarityMismatch(leftSide, rightSide));
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
             dialog.Result is not { } result ||
@@ -2832,16 +2849,23 @@ public partial class VirtualCrossoverPanel : UserControl
         VirtualCrossoverSideAlignmentChannel bridgeRight,
         double bridgeBandLowHz,
         double bridgeBandHighHz,
-        double sceneOffsetMs,
-        bool adjustGains,
-        double levelDifferenceDb)
+        AutoDelayRunRequest request)
     {
         var log = new System.Text.StringBuilder();
         log.AppendLine($"Auto delay (stereo) {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
         log.AppendLine(
-            $"Scene offset {sceneOffsetMs:+0.00;-0.00} ms (positive: right side leads); " +
-            $"bridge {bridgeLeft.Name} -> {bridgeRight.Name} " +
+            $"Layout {(request.RightHandDrive ? "RHD" : "LHD")}: scene offset " +
+            $"{request.SceneOffsetMs:0.00} ms, the " +
+            $"{(request.RightHandDrive ? "left" : "right")} side leads; " +
+            $"bridge {(request.RightHandDrive ? bridgeRight : bridgeLeft).Name} -> " +
+            $"{(request.RightHandDrive ? bridgeLeft : bridgeRight).Name} " +
             $"in {bridgeBandLowHz:0}-{bridgeBandHighHz:0} Hz");
+        if (request.RightHandDrive)
+        {
+            log.AppendLine(
+                "RHD run: the engine trace below reads in mirrored " +
+                "coordinates (ref = the right side, far = the left).");
+        }
         log.AppendLine("Previous delay / polarity settings ignored for this run.");
 
         var engineAlignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
@@ -2853,8 +2877,8 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             AlignmentReprocessor reprocessor = ComputeStereoAlignment(
                 leftSide, rightSide, union, bridgeLeft, bridgeRight,
-                bridgeBandLowHz, bridgeBandHighHz, sceneOffsetMs,
-                engineAlignment, decisions, log);
+                bridgeBandLowHz, bridgeBandHighHz, request.SceneOffsetMs,
+                request.RightHandDrive, engineAlignment, decisions, log);
             // The "before" snapshots carry the CURRENT delays and polarities —
             // the alignment itself deliberately ignores them, so they exist
             // only for the report's before/after sum-loss forecast.
@@ -2863,8 +2887,10 @@ public partial class VirtualCrossoverPanel : UserControl
                     side => (IAlignmentChannel)side,
                     side => new AlignmentOverride(
                         side.Settings.DelayMs, side.Settings.InvertPolarity)));
-            if (adjustGains)
+            if (request.AdjustGains)
             {
+                // request.LevelDifferenceDb: the near-side cut restated in
+                // the gain engine's signed L-R convention per the layout.
                 gains = ComputeGainBalance(
                     union.Select(side => (
                         (IAlignmentChannel)side,
@@ -2875,7 +2901,7 @@ public partial class VirtualCrossoverPanel : UserControl
                             ? leftSide.FirstOrDefault(left =>
                                 left.Runtime == side.Runtime && !left.RightSide)
                             : null))),
-                    reprocessor, engineAlignment, levelDifferenceDb, log);
+                    reprocessor, engineAlignment, request.LevelDifferenceDb, log);
             }
 
             IReadOnlyList<AlignmentSnapshot> afterSnapshots =
@@ -2911,14 +2937,11 @@ public partial class VirtualCrossoverPanel : UserControl
                     side.Name)),
             engineAlignment, decisions, gains);
         string report = VirtualCrossoverAutoDelayReport.Format(
-            outcomes, stereo: true, sceneOffsetMs, adjustGains,
-            levelDifferenceDb, leftSumLoss, rightSumLoss);
+            outcomes, stereo: true, request, leftSumLoss, rightSumLoss);
         // Written already at the proposal stage, so a discarded run can still
         // be shared and analyzed; Apply rewrites it with the outcome metric.
         WriteAlignmentLog(log.ToString());
-        return new AutoDelayRunResult(
-            outcomes, Stereo: true, sceneOffsetMs, adjustGains,
-            levelDifferenceDb, report, log);
+        return new AutoDelayRunResult(outcomes, Stereo: true, request, report, log);
     }
 
     // Bridges the pair/side model to the stereo engine on a background thread,
@@ -2933,6 +2956,7 @@ public partial class VirtualCrossoverPanel : UserControl
         double bridgeBandLowHz,
         double bridgeBandHighHz,
         double sceneOffsetMs,
+        bool rightHandDrive,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         Dictionary<IAlignmentChannel, AlignmentDecision> decisions,
         System.Text.StringBuilder log)
@@ -2979,9 +3003,17 @@ public partial class VirtualCrossoverPanel : UserControl
             return pairs;
         }
 
+        // The engine's plan is written in reference/far ROLES: plan-left is
+        // the driver's side the cascade settles first, plan-right the far
+        // side fitted to it, and a positive scene offset makes the far side
+        // lead. LHD maps the cabin sides onto the roles directly. RHD hands
+        // the plan MIRRORED — the right side anchors, the left one is fitted
+        // — so the same non-negative offset makes the left side lead (the
+        // right lags by it), the dash-center image for a right-seated driver.
         // The L/R pair links (the shared playing band of each stereo pair)
         // aim the descent's gentle prior at the cross-side-consistent delay —
-        // the same Δ the metric panel verifies afterwards.
+        // the same Δ the metric panel verifies afterwards; their first member
+        // is the settled reference-side channel, mirrored alike.
         var pairLinks = new List<StereoPairLink>();
         foreach (VirtualCrossoverSideAlignmentChannel right in rightSide.Where(side => side.RightSide))
         {
@@ -3003,23 +3035,27 @@ public partial class VirtualCrossoverPanel : UserControl
             // too-narrow intersection, so such a link could never measure.
             if (highHz >= lowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
             {
-                pairLinks.Add(new StereoPairLink(left, right, lowHz, highHz));
+                pairLinks.Add(rightHandDrive
+                    ? new StereoPairLink(right, left, lowHz, highHz)
+                    : new StereoPairLink(left, right, lowHz, highHz));
             }
         }
 
-        List<AlignmentSnapshot> leftByBand = ByBand(leftSide);
-        List<AlignmentSnapshot> rightByBand = ByBand(rightSide);
+        List<AlignmentSnapshot> referenceByBand =
+            ByBand(rightHandDrive ? rightSide : leftSide);
+        List<AlignmentSnapshot> farByBand =
+            ByBand(rightHandDrive ? leftSide : rightSide);
         AutoAlignmentEngine.ComputeStereo(
             new StereoAlignmentPlan(
-                leftByBand,
-                Pairs(leftByBand),
-                rightByBand,
-                Pairs(rightByBand),
+                referenceByBand,
+                Pairs(referenceByBand),
+                farByBand,
+                Pairs(farByBand),
                 union.Where(side => side.Runtime.Pair.Mono)
                     .Cast<IAlignmentChannel>()
                     .ToList(),
-                bridgeLeft,
-                bridgeRight,
+                rightHandDrive ? bridgeRight : bridgeLeft,
+                rightHandDrive ? bridgeLeft : bridgeRight,
                 bridgeBandLowHz,
                 bridgeBandHighHz,
                 sceneOffsetMs,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -348,42 +348,63 @@ public partial class VirtualCrossoverPanel : UserControl
 
         RefreshCalibrationCombo();
 
-        // BOTH physical slots of EVERY channel are wiped before anything
-        // resolves. Per slot, because through the effective accessor a mono
-        // pair's real right slot is unreachable, and a stale measurement from
-        // the previous project would otherwise resurface the moment the pair
-        // stops being mono. Across ALL channels up front, because the rate
-        // guard in TryAssignSource scans every still-resolved side: cleared
-        // one channel at a time, an imported session at a different sample
-        // rate would lose that vote against the previous project's channels
-        // — each source silently refused against the not-yet-replaced rest,
-        // leaving only the last channel resolved.
-        foreach (VirtualCrossoverChannel channel in channels)
-        {
-            channel.PhysicalSideState(false).Clear();
-            channel.PhysicalSideState(true).Clear();
-        }
-
-        foreach (VirtualCrossoverChannel channel in channels)
-        {
-            // Both sides resolve up front (the stereo Auto delay needs them
-            // together); a mono pair resolves its single slot once.
-            foreach (bool rightSide in new[] { false, true })
+        await RestoreProjectSourcesAsync(
+            channels,
+            channel => channel.Pair.Mono,
+            channel =>
             {
-                if (channel.Pair.Mono && rightSide)
-                {
-                    continue;
-                }
-
-                await ResolveSourceAsync(channel, rightSide, showErrors: false);
-            }
-
-            UpdateSourceButton(channel);
-        }
+                channel.PhysicalSideState(false).Clear();
+                channel.PhysicalSideState(true).Clear();
+            },
+            (channel, rightSide) =>
+                ResolveSourceAsync(channel, rightSide, showErrors: false),
+            UpdateSourceButton);
 
         UpdateSideRadioTexts();
         // The final redraw is issued by ApplyProjectAsync after the loading
         // state clears, so it draws the real plot instead of the loading note.
+    }
+
+    // The restore ORDER is the cross-rate import contract: BOTH physical
+    // slots of EVERY channel are wiped before the first source resolves.
+    // Per slot, because through the effective accessor a mono pair's real
+    // right slot is unreachable, and a stale measurement from the previous
+    // project would otherwise resurface the moment the pair stops being
+    // mono. Across ALL channels up front, because the rate guard in
+    // TryAssignSource scans every still-resolved side: cleared one channel
+    // at a time, an imported session at a different sample rate would lose
+    // that vote against the previous project's channels — each source
+    // silently refused against the not-yet-replaced rest, leaving only the
+    // last channel resolved (field bug). Then both sides of each channel
+    // resolve up front (the stereo Auto delay needs them together); a mono
+    // pair resolves its single slot once. Static and delegate-fed so the
+    // order itself is unit-testable.
+    internal static async Task RestoreProjectSourcesAsync<TChannel>(
+        IReadOnlyList<TChannel> channels,
+        Func<TChannel, bool> isMono,
+        Action<TChannel> clearBothSlots,
+        Func<TChannel, bool, Task> resolveSide,
+        Action<TChannel> channelRestored)
+    {
+        foreach (TChannel channel in channels)
+        {
+            clearBothSlots(channel);
+        }
+
+        foreach (TChannel channel in channels)
+        {
+            foreach (bool rightSide in new[] { false, true })
+            {
+                if (isMono(channel) && rightSide)
+                {
+                    continue;
+                }
+
+                await resolveSide(channel, rightSide);
+            }
+
+            channelRestored(channel);
+        }
     }
 
     private void ScheduleSave()
@@ -2226,7 +2247,7 @@ public partial class VirtualCrossoverPanel : UserControl
         using var dialog = new VirtualCrossoverAutoDelayDialog();
         dialog.Init(
             stereo: false,
-            project.StereoSceneOffsetMs,
+            project.StereoSceneOffsetMagnitudeMs,
             project.StereoRightHandDrive,
             Math.Abs(project.StereoLevelDifferenceDb),
             request => RunSingleSideProposalAsync(
@@ -2516,11 +2537,12 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             // The inputs the proposal was computed with become the persisted
             // values only now, so a discarded experiment does not overwrite
-            // them. The tilt is stored in the signed L-R convention
-            // (LevelDifferenceDb restates the near-side cut per the layout),
-            // keeping the file readable by older builds.
-            project.StereoSceneOffsetMs = result.Request.SceneOffsetMs;
-            project.StereoRightHandDrive = result.Request.RightHandDrive;
+            // them. Both figures are stored with the layout in their signs
+            // (the scene offset via SetStereoScene, the tilt via the L-R
+            // convention LevelDifferenceDb restates), keeping the file
+            // readable — and safely resavable — by older builds.
+            project.SetStereoScene(
+                result.Request.SceneOffsetMs, result.Request.RightHandDrive);
             project.StereoLevelDifferenceDb = result.Request.LevelDifferenceDb;
         }
 
@@ -2768,13 +2790,14 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         using var dialog = new VirtualCrossoverAutoDelayDialog();
-        // The dialog edits the tilt as a layout-neutral NEAR-SIDE CUT; the
-        // project stores it in the gain engine's signed L-R convention (so
-        // older builds read the same file), hence the magnitude here and the
+        // The dialog edits both tuning figures as layout-neutral magnitudes;
+        // the project stores each with the layout in its sign (the scene
+        // offset's wire format, the gain engine's L-R convention), so older
+        // builds read the same file — hence the magnitudes here and the
         // layout-signed write-back in CommitAutoDelayResult.
         dialog.Init(
             stereo: true,
-            project.StereoSceneOffsetMs,
+            project.StereoSceneOffsetMagnitudeMs,
             project.StereoRightHandDrive,
             Math.Abs(project.StereoLevelDifferenceDb),
             request => RunStereoProposalAsync(

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -317,19 +317,43 @@ public sealed class VirtualCrossoverProjectFile
         new VirtualCrossoverChannelPairSettings()
     ];
 
-    // The stereo Auto delay scene offset (ms), a non-negative magnitude: the
-    // far side leads (arrives earlier) by this much, pulling the image toward
-    // the dash center. Which side is "far" comes from StereoRightHandDrive.
-    // Legacy files carried the layout in this value's sign (negative meant a
-    // right-seated driver); Migrate normalizes them.
+    // The stereo Auto delay scene offset (ms) ON THE WIRE: the magnitude
+    // with the steering layout in its SIGN (negative = right-hand drive) —
+    // deliberately the exact pre-flag format. A build from before
+    // StereoRightHandDrive existed reads an RHD session correctly and even
+    // RESAVES it without silently flipping it to LHD: the unknown flag would
+    // not survive such a resave, the sign does. In-app code reads the
+    // magnitude via StereoSceneOffsetMagnitudeMs and the layout via the
+    // flag, and writes both through SetStereoScene so they never disagree.
     public double StereoSceneOffsetMs { get; set; } = 0.25;
 
     // The steering position the stereo Auto delay aligns for: false = LHD
     // (the left side is the timing reference and the right side leads by the
     // scene offset), true = RHD (mirrored — the right side is the reference
-    // and lags the left by the offset). Additive: older files lack it and
-    // open as LHD unless a negative legacy offset says otherwise (Migrate).
+    // and lags the left by the offset). Kept explicit despite the sign
+    // above carrying the same fact, so a zero offset still remembers the
+    // layout; Migrate re-aligns the pair when a legacy or foreign file has
+    // only one of them. Additive: older files lack it and open as LHD
+    // unless a negative offset says otherwise.
     public bool StereoRightHandDrive { get; set; }
+
+    /// <summary>The scene offset as the UI edits it: a layout-neutral,
+    /// non-negative magnitude (the sign on the wire belongs to the layout,
+    /// see <see cref="StereoSceneOffsetMs"/>).</summary>
+    [JsonIgnore]
+    public double StereoSceneOffsetMagnitudeMs => Math.Abs(StereoSceneOffsetMs);
+
+    /// <summary>
+    /// The one writer of the stereo scene: keeps the wire sign and the
+    /// layout flag consistent (see <see cref="StereoSceneOffsetMs"/>).
+    /// </summary>
+    public void SetStereoScene(double offsetMagnitudeMs, bool rightHandDrive)
+    {
+        StereoRightHandDrive = rightHandDrive;
+        StereoSceneOffsetMs = rightHandDrive
+            ? -Math.Abs(offsetMagnitudeMs)
+            : Math.Abs(offsetMagnitudeMs);
+    }
 
     // The intentional level difference (dB) the Auto delay gain balance aims
     // for, stored as LEFT minus RIGHT: the default asks for the left side
@@ -594,15 +618,19 @@ public sealed class VirtualCrossoverProjectFile
             file.Version = 5;
         }
 
-        // The steering layout used to live in the scene offset's SIGN
-        // (negative = right-hand drive). It is its own flag now and the
-        // offset a magnitude, so a legacy negative value converts here. No
-        // version bump: this build never writes a negative offset, and an
-        // older build opening a new RHD file falls back to LHD semantics the
-        // same way it ignores any other additive flag.
+        // The scene offset's wire SIGN and the layout flag state one fact
+        // (see the properties): re-align them here for files that carry only
+        // one — a pre-flag file (sign only, possibly resaved by an older
+        // build that dropped the flag) or a hand-edited one. The sign is the
+        // wider channel (every build honors it), so it wins over a missing
+        // flag; a set flag over a positive offset wins the other way, so a
+        // zero-or-positive RHD file keeps its layout.
         if (file.StereoSceneOffsetMs < 0)
         {
             file.StereoRightHandDrive = true;
+        }
+        else if (file.StereoRightHandDrive)
+        {
             file.StereoSceneOffsetMs = -file.StereoSceneOffsetMs;
         }
     }
@@ -693,10 +721,10 @@ public sealed class VirtualCrossoverProjectFile
             throw new InvalidDataException(
                 "The virtual crossover channel count is invalid.");
         }
-        // Non-negative by construction: the UI only produces magnitudes and
-        // Migrate normalizes legacy sign-carrying files before validation.
+        // Signed on the wire (the sign is the layout); only the magnitude is
+        // bounded.
         if (!double.IsFinite(StereoSceneOffsetMs) ||
-            StereoSceneOffsetMs is < 0 or > MaximumSceneOffsetMs)
+            Math.Abs(StereoSceneOffsetMs) > MaximumSceneOffsetMs)
         {
             throw new InvalidDataException("The stereo scene offset is invalid.");
         }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -317,16 +317,29 @@ public sealed class VirtualCrossoverProjectFile
         new VirtualCrossoverChannelPairSettings()
     ];
 
-    // The stereo Auto delay scene offset (ms): positive makes the right side
-    // LEAD (arrive earlier), pulling the image toward the dash center for a
-    // left-seated driver; right-seated drivers use a negative value.
+    // The stereo Auto delay scene offset (ms), a non-negative magnitude: the
+    // far side leads (arrives earlier) by this much, pulling the image toward
+    // the dash center. Which side is "far" comes from StereoRightHandDrive.
+    // Legacy files carried the layout in this value's sign (negative meant a
+    // right-seated driver); Migrate normalizes them.
     public double StereoSceneOffsetMs { get; set; } = 0.25;
 
+    // The steering position the stereo Auto delay aligns for: false = LHD
+    // (the left side is the timing reference and the right side leads by the
+    // scene offset), true = RHD (mirrored — the right side is the reference
+    // and lags the left by the offset). Additive: older files lack it and
+    // open as LHD unless a negative legacy offset says otherwise (Migrate).
+    public bool StereoRightHandDrive { get; set; }
+
     // The intentional level difference (dB) the Auto delay gain balance aims
-    // for, read as LEFT minus RIGHT: the default asks for the left side 1 dB
-    // BELOW the right, the same image direction as the scene offset traded as
-    // level instead of time. The tuner's own figure, not a value derived from
-    // the offset. Additive: older files lack it and open on this default.
+    // for, stored as LEFT minus RIGHT: the default asks for the left side
+    // 1 dB BELOW the right, the same image direction as the scene offset
+    // traded as level instead of time. The tuner's own figure, not a value
+    // derived from the offset. The UI edits it as a layout-neutral,
+    // non-negative NEAR-SIDE CUT; the sign written here follows
+    // StereoRightHandDrive (LHD: negative, RHD: positive), so older builds
+    // read the same file unchanged. Additive: older files lack it and open
+    // on this default.
     public double StereoLevelDifferenceDb { get; set; } = -1.0;
 
     // Which side the tool currently displays and edits (view state).
@@ -580,6 +593,18 @@ public sealed class VirtualCrossoverProjectFile
             file.LegacyPhaseDetrendMs = null;
             file.Version = 5;
         }
+
+        // The steering layout used to live in the scene offset's SIGN
+        // (negative = right-hand drive). It is its own flag now and the
+        // offset a magnitude, so a legacy negative value converts here. No
+        // version bump: this build never writes a negative offset, and an
+        // older build opening a new RHD file falls back to LHD semantics the
+        // same way it ignores any other additive flag.
+        if (file.StereoSceneOffsetMs < 0)
+        {
+            file.StereoRightHandDrive = true;
+            file.StereoSceneOffsetMs = -file.StereoSceneOffsetMs;
+        }
     }
 
     /// <summary>
@@ -668,8 +693,10 @@ public sealed class VirtualCrossoverProjectFile
             throw new InvalidDataException(
                 "The virtual crossover channel count is invalid.");
         }
+        // Non-negative by construction: the UI only produces magnitudes and
+        // Migrate normalizes legacy sign-carrying files before validation.
         if (!double.IsFinite(StereoSceneOffsetMs) ||
-            Math.Abs(StereoSceneOffsetMs) > MaximumSceneOffsetMs)
+            StereoSceneOffsetMs is < 0 or > MaximumSceneOffsetMs)
         {
             throw new InvalidDataException("The stereo scene offset is invalid.");
         }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -337,11 +337,26 @@ public sealed class VirtualCrossoverProjectFile
     // unless a negative offset says otherwise.
     public bool StereoRightHandDrive { get; set; }
 
+    // RHD with a ZERO offset still needs its layout on the wire — the sign
+    // IS the layout for pre-flag builds, IEEE -0.0 neither compares below
+    // zero nor survives a decimal round-trip, and the explicit flag does not
+    // survive an old build's resave. So a zero RHD magnitude serializes as
+    // this tiny negative marker instead: a tenth of the UI's 0.01 ms grid
+    // and a twentieth of a sample at 48 kHz, i.e. exactly zero to every
+    // consumer (old builds apply it as an inaudible scene offset and
+    // preserve it on resave), and the magnitude accessor reads it back as
+    // zero. The UI cannot produce a genuine 0.001 ms offset, so the marker
+    // is unambiguous.
+    private const double RhdZeroOffsetMarkerMs = 0.001;
+
     /// <summary>The scene offset as the UI edits it: a layout-neutral,
-    /// non-negative magnitude (the sign on the wire belongs to the layout,
-    /// see <see cref="StereoSceneOffsetMs"/>).</summary>
+    /// non-negative magnitude (the sign on the wire belongs to the layout —
+    /// see <see cref="StereoSceneOffsetMs"/> and the zero-marker note).</summary>
     [JsonIgnore]
-    public double StereoSceneOffsetMagnitudeMs => Math.Abs(StereoSceneOffsetMs);
+    public double StereoSceneOffsetMagnitudeMs =>
+        Math.Abs(StereoSceneOffsetMs) <= RhdZeroOffsetMarkerMs
+            ? 0
+            : Math.Abs(StereoSceneOffsetMs);
 
     /// <summary>
     /// The one writer of the stereo scene: keeps the wire sign and the
@@ -351,7 +366,7 @@ public sealed class VirtualCrossoverProjectFile
     {
         StereoRightHandDrive = rightHandDrive;
         StereoSceneOffsetMs = rightHandDrive
-            ? -Math.Abs(offsetMagnitudeMs)
+            ? -Math.Max(Math.Abs(offsetMagnitudeMs), RhdZeroOffsetMarkerMs)
             : Math.Abs(offsetMagnitudeMs);
     }
 

--- a/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
+++ b/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
@@ -102,6 +102,53 @@ public sealed class AbstractedMeasurementTests
         Assert.NotNull(measurement.QualityReport);
     }
 
+    // The field case behind the reference-level check: the "loopback" is
+    // playback bleed into a mis-routed input (~-41 dBFS), so every run and
+    // its retry fail, and the MEASUREMENT must fail naming the reason —
+    // not complete into a garbage transfer function.
+    [Fact]
+    public async Task QuietLoopbackFailsTheMeasurementWithTheReason()
+    {
+        var factory = new FakeAudioSessionFactory(
+            duplexFactory: (_, signal) => new RecordingDuplexSession(
+                signal, (_, s, tail, _) => Task.FromResult(
+                    SyntheticCapture.QuietLoopback(s, tail))));
+        using ExpSweepMeasurement measurement = CreateSweep(factory);
+
+        bool success = await measurement.RunAsync();
+
+        Assert.False(success);
+        Assert.Equal(0, measurement.AcceptedAverageRunCount);
+        Assert.NotNull(measurement.LastError);
+        Assert.Contains("Every sweep run failed", measurement.LastError!.Message);
+        Assert.Contains(
+            "the loopback reference is too quiet", measurement.LastError.Message);
+    }
+
+    // The second garbage class: every level check passes (mic and loopback
+    // both carry plausible signal), but the microphone recorded noise
+    // uncorrelated with the sweep, so the transfer function divides into
+    // stationary noise. The shape gate must fail the measurement with the
+    // reason instead of publishing a garbage transfer IR.
+    [Fact]
+    public async Task NoiseTransferFailsTheMeasurementWithTheReason()
+    {
+        var factory = new FakeAudioSessionFactory(
+            duplexFactory: (_, signal) => new RecordingDuplexSession(
+                signal, (_, s, tail, _) => Task.FromResult(
+                    SyntheticCapture.NoiseMicrophone(s, tail))));
+        using ExpSweepMeasurement measurement = CreateSweep(factory);
+
+        bool success = await measurement.RunAsync();
+
+        Assert.False(success);
+        Assert.False(measurement.HasImpulseResponse);
+        Assert.NotNull(measurement.LastError);
+        Assert.Contains(
+            "transfer function did not form a credible impulse response",
+            measurement.LastError!.Message);
+    }
+
     [Fact]
     public async Task CancellationDisposesTheSession()
     {

--- a/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
+++ b/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
@@ -102,27 +102,48 @@ public sealed class AbstractedMeasurementTests
         Assert.NotNull(measurement.QualityReport);
     }
 
-    // The field case behind the reference-level check: the "loopback" is
-    // playback bleed into a mis-routed input (~-41 dBFS), so every run and
-    // its retry fail, and the MEASUREMENT must fail naming the reason —
-    // not complete into a garbage transfer function.
+    // A cleanly attenuated wire at ~-41 dBFS must MEASURE: transfer
+    // estimation is scale-invariant, and the readme itself tells the user to
+    // turn the playback level well down. Level alone is no verdict — the
+    // shape gate below owns the usable/garbage distinction.
     [Fact]
-    public async Task QuietLoopbackFailsTheMeasurementWithTheReason()
+    public async Task QuietCleanLoopbackStillMeasures()
     {
         var factory = new FakeAudioSessionFactory(
             duplexFactory: (_, signal) => new RecordingDuplexSession(
                 signal, (_, s, tail, _) => Task.FromResult(
-                    SyntheticCapture.QuietLoopback(s, tail))));
+                    SyntheticCapture.QuietCleanLoopback(s, tail))));
+        using ExpSweepMeasurement measurement = CreateSweep(factory);
+
+        bool success = await measurement.RunAsync();
+
+        Assert.True(success, measurement.LastError?.ToString());
+        Assert.True(measurement.HasImpulseResponse);
+    }
+
+    // The field failure behind the shape gate: the "loopback" input picked
+    // up bleed (~-41 dBFS of content uncorrelated with the sweep), every
+    // per-run check passes, and the measurement must fail naming both the
+    // non-compact shape and the suspicious reference level.
+    [Fact]
+    public async Task BleedLoopbackFailsNamingTheLevel()
+    {
+        var factory = new FakeAudioSessionFactory(
+            duplexFactory: (_, signal) => new RecordingDuplexSession(
+                signal, (_, s, tail, _) => Task.FromResult(
+                    SyntheticCapture.BleedLoopback(s, tail))));
         using ExpSweepMeasurement measurement = CreateSweep(factory);
 
         bool success = await measurement.RunAsync();
 
         Assert.False(success);
-        Assert.Equal(0, measurement.AcceptedAverageRunCount);
+        Assert.False(measurement.HasImpulseResponse);
         Assert.NotNull(measurement.LastError);
-        Assert.Contains("Every sweep run failed", measurement.LastError!.Message);
         Assert.Contains(
-            "the loopback reference is too quiet", measurement.LastError.Message);
+            "transfer function did not form a credible impulse response",
+            measurement.LastError!.Message);
+        Assert.Contains("bleed instead of the wire", measurement.LastError.Message);
+        Assert.Contains("dBFS", measurement.LastError.Message);
     }
 
     // The second garbage class: every level check passes (mic and loopback

--- a/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
+++ b/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
@@ -146,6 +146,29 @@ public sealed class AbstractedMeasurementTests
         Assert.Contains("dBFS", measurement.LastError.Message);
     }
 
+    // The fail-closed side of the shape gate: one NaN in the capture slips
+    // every level comparison and poisons the transfer IR into NaN, where
+    // "compactness < threshold" would be false. An UNMEASURABLE shape must
+    // refuse the measurement, not publish it.
+    [Fact]
+    public async Task NaNCaptureFailsClosed()
+    {
+        var factory = new FakeAudioSessionFactory(
+            duplexFactory: (_, signal) => new RecordingDuplexSession(
+                signal, (_, s, tail, _) => Task.FromResult(
+                    SyntheticCapture.NaNMicrophone(s, tail))));
+        using ExpSweepMeasurement measurement = CreateSweep(factory);
+
+        bool success = await measurement.RunAsync();
+
+        Assert.False(success);
+        Assert.False(measurement.HasImpulseResponse);
+        Assert.NotNull(measurement.LastError);
+        Assert.Contains(
+            "its shape could not be measured at all",
+            measurement.LastError!.Message);
+    }
+
     // The second garbage class: every level check passes (mic and loopback
     // both carry plausible signal), but the microphone recorded noise
     // uncorrelated with the sweep, so the transfer function divides into

--- a/tests/Resonalyze.App.Tests/Fakes/RecordingSessions.cs
+++ b/tests/Resonalyze.App.Tests/Fakes/RecordingSessions.cs
@@ -57,6 +57,18 @@ internal static class SyntheticCapture
             AudioCaptureAnomalies.None, Diagnostics: null);
     }
 
+    // A capture poisoned by one non-finite sample: NaN slips every level
+    // comparison, the transfer IR comes out NaN, and only the fail-closed
+    // shape gate stands between it and a published measurement.
+    public static AudioCaptureResult NaNMicrophone(AudioPlaybackSignal signal, int tailSamples)
+    {
+        (float[] mic, float[] loop) = BuildChannels(signal, tailSamples, 0.5f, 0.25f);
+        mic[100] = float.NaN;
+        return new AudioCaptureResult(
+            [mic, loop], 0, 1, StereoSeparationExpected: true,
+            AudioCaptureAnomalies.None, Diagnostics: null);
+    }
+
     // A level-plausible capture whose microphone recorded only noise
     // uncorrelated with the sweep (deterministic LCG): every per-run level
     // check passes, but the transfer function divides into stationary noise

--- a/tests/Resonalyze.App.Tests/Fakes/RecordingSessions.cs
+++ b/tests/Resonalyze.App.Tests/Fakes/RecordingSessions.cs
@@ -27,6 +27,35 @@ internal static class SyntheticCapture
             AudioCaptureAnomalies.None, Diagnostics: null);
     }
 
+    // A loopback that carries signal but sits ~-41 dBFS (the field-observed
+    // bleed-instead-of-wire level): the quality check rejects the run as an
+    // untrustworthy reference.
+    public static AudioCaptureResult QuietLoopback(AudioPlaybackSignal signal, int tailSamples)
+    {
+        (float[] mic, float[] loop) = BuildChannels(signal, tailSamples, 0.5f, 0.0089f);
+        return new AudioCaptureResult(
+            [mic, loop], 0, 1, StereoSeparationExpected: true,
+            AudioCaptureAnomalies.None, Diagnostics: null);
+    }
+
+    // A level-plausible capture whose microphone recorded only noise
+    // uncorrelated with the sweep (deterministic LCG): every per-run level
+    // check passes, but the transfer function divides into stationary noise
+    // — the shape gate's case.
+    public static AudioCaptureResult NoiseMicrophone(AudioPlaybackSignal signal, int tailSamples)
+    {
+        (float[] mic, float[] loop) = BuildChannels(signal, tailSamples, 0.0f, 0.25f);
+        uint state = 987_654_321u;
+        for (int i = 0; i < mic.Length; i++)
+        {
+            state = state * 1_664_525u + 1_013_904_223u;
+            mic[i] = (float)(state / 4_294_967_296.0 - 0.5) * 0.5f;
+        }
+        return new AudioCaptureResult(
+            [mic, loop], 0, 1, StereoSeparationExpected: true,
+            AudioCaptureAnomalies.None, Diagnostics: null);
+    }
+
     private static (float[] Microphone, float[] Loopback) BuildChannels(
         AudioPlaybackSignal signal, int tailSamples, float micScale, float loopScale)
     {

--- a/tests/Resonalyze.App.Tests/Fakes/RecordingSessions.cs
+++ b/tests/Resonalyze.App.Tests/Fakes/RecordingSessions.cs
@@ -27,12 +27,31 @@ internal static class SyntheticCapture
             AudioCaptureAnomalies.None, Diagnostics: null);
     }
 
-    // A loopback that carries signal but sits ~-41 dBFS (the field-observed
-    // bleed-instead-of-wire level): the quality check rejects the run as an
-    // untrustworthy reference.
-    public static AudioCaptureResult QuietLoopback(AudioPlaybackSignal signal, int tailSamples)
+    // A CLEANLY attenuated loopback wire at ~-41 dBFS (the readme's
+    // "playback level well down" workflow taken far): still an exact copy of
+    // the sweep, so the scale-invariant transfer estimate is perfectly
+    // usable and the measurement must succeed.
+    public static AudioCaptureResult QuietCleanLoopback(AudioPlaybackSignal signal, int tailSamples)
     {
         (float[] mic, float[] loop) = BuildChannels(signal, tailSamples, 0.5f, 0.0089f);
+        return new AudioCaptureResult(
+            [mic, loop], 0, 1, StereoSeparationExpected: true,
+            AudioCaptureAnomalies.None, Diagnostics: null);
+    }
+
+    // The field failure: the "loopback" input picked up bleed, not the wire
+    // — uncorrelated content at ~-41 dBFS (deterministic LCG noise). Every
+    // per-run check passes, but the transfer function divides the microphone
+    // by garbage and the shape gate must refuse it, naming the level.
+    public static AudioCaptureResult BleedLoopback(AudioPlaybackSignal signal, int tailSamples)
+    {
+        (float[] mic, float[] loop) = BuildChannels(signal, tailSamples, 0.5f, 0.0f);
+        uint state = 555_555_555u;
+        for (int i = 0; i < loop.Length; i++)
+        {
+            state = state * 1_664_525u + 1_013_904_223u;
+            loop[i] = (float)((state / 4_294_967_296.0 - 0.5) * 2 * 0.0089);
+        }
         return new AudioCaptureResult(
             [mic, loop], 0, 1, StereoSeparationExpected: true,
             AudioCaptureAnomalies.None, Diagnostics: null);

--- a/tests/Resonalyze.App.Tests/SweepRunQualityCheckTests.cs
+++ b/tests/Resonalyze.App.Tests/SweepRunQualityCheckTests.cs
@@ -62,6 +62,36 @@ public sealed class SweepRunQualityCheckTests
         Assert.Contains("the loopback reference signal is silent", issues);
     }
 
+    // The field case behind the check: a whole session captured with the
+    // loopback peaking tens of dB below full scale (bleed into a mis-routed
+    // input, not the wire) passed the silence check and produced garbage
+    // transfer IRs on every channel. -41 dBFS is one of those captures.
+    [Fact]
+    public void Assess_QuietLoopbackIsRejectedWithItsLevel()
+    {
+        IReadOnlyList<string> issues = SweepRunQualityCheck.Assess(
+            Tone(SweepSamples, 0.5f),
+            Tone(SweepSamples, 0.0089f),
+            SweepSamples);
+
+        string issue = Assert.Single(issues);
+        Assert.StartsWith("the loopback reference is too quiet", issue);
+        Assert.Contains("-41.0 dBFS", issue);
+    }
+
+    // Quiet-but-plausible stays accepted: the threshold separates "not a
+    // wired reference at all" from merely conservative gain staging.
+    [Fact]
+    public void Assess_ModeratelyLowLoopbackIsAccepted()
+    {
+        IReadOnlyList<string> issues = SweepRunQualityCheck.Assess(
+            Tone(SweepSamples, 0.5f),
+            Tone(SweepSamples, 0.1f),
+            SweepSamples);
+
+        Assert.Empty(issues);
+    }
+
     [Fact]
     public void Assess_MissingLoopbackSkipsTheLoopbackCheck()
     {

--- a/tests/Resonalyze.App.Tests/SweepRunQualityCheckTests.cs
+++ b/tests/Resonalyze.App.Tests/SweepRunQualityCheckTests.cs
@@ -62,31 +62,17 @@ public sealed class SweepRunQualityCheckTests
         Assert.Contains("the loopback reference signal is silent", issues);
     }
 
-    // The field case behind the check: a whole session captured with the
-    // loopback peaking tens of dB below full scale (bleed into a mis-routed
-    // input, not the wire) passed the silence check and produced garbage
-    // transfer IRs on every channel. -41 dBFS is one of those captures.
+    // Quiet-but-present is ACCEPTED per run, however far down it sits:
+    // transfer estimation is scale-invariant, so a cleanly attenuated wire
+    // (the readme itself says to turn the playback level well down) measures
+    // fine. Whether the reference was USABLE is judged by the transfer IR's
+    // shape after the runs — a bleed-fed capture cannot pass that gate.
     [Fact]
-    public void Assess_QuietLoopbackIsRejectedWithItsLevel()
+    public void Assess_QuietButPresentLoopbackIsAccepted()
     {
         IReadOnlyList<string> issues = SweepRunQualityCheck.Assess(
             Tone(SweepSamples, 0.5f),
             Tone(SweepSamples, 0.0089f),
-            SweepSamples);
-
-        string issue = Assert.Single(issues);
-        Assert.StartsWith("the loopback reference is too quiet", issue);
-        Assert.Contains("-41.0 dBFS", issue);
-    }
-
-    // Quiet-but-plausible stays accepted: the threshold separates "not a
-    // wired reference at all" from merely conservative gain staging.
-    [Fact]
-    public void Assess_ModeratelyLowLoopbackIsAccepted()
-    {
-        IReadOnlyList<string> issues = SweepRunQualityCheck.Assess(
-            Tone(SweepSamples, 0.5f),
-            Tone(SweepSamples, 0.1f),
             SweepSamples);
 
         Assert.Empty(issues);

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAutoDelayReportTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAutoDelayReportTests.cs
@@ -57,17 +57,19 @@ public sealed class VirtualCrossoverAutoDelayReportTests
                     delayKind: AlignmentDecisionKind.Locked)
             ],
             stereo: true,
-            sceneOffsetMs: 0.27,
-            gainsRequested: true,
-            levelDifferenceDb: -1.5,
+            new AutoDelayRunRequest(
+                SceneOffsetMs: 0.27,
+                RightHandDrive: false,
+                AdjustGains: true,
+                NearSideCutDb: 1.5),
             leftSumLoss: new AutoDelaySumLossForecast(-2.0, -0.6),
             rightSumLoss: new AutoDelaySumLossForecast(-2.4, -0.8));
 
         Assert.Contains("stereo", report);
-        Assert.Contains("Scene offset +0.27 ms", report);
-        // The tilt is the entered figure, independent of the scene offset, and
-        // signed LEFT minus RIGHT.
-        Assert.Contains("L-R level -1.5 dB (positive: left side louder)", report);
+        // Both figures are layout-neutral magnitudes; the layout names the
+        // sides they act on.
+        Assert.Contains("Scene offset 0.27 ms (LHD: right side leads)", report);
+        Assert.Contains("near-side cut 1.5 dB", report);
         // The at-a-glance summary: change counts, the predicted sum-loss
         // improvement per side, and one warning line per LOW-confidence call.
         Assert.Contains("Changes: 3 delays, 1 polarities, 1 gains", report);
@@ -97,6 +99,40 @@ public sealed class VirtualCrossoverAutoDelayReportTests
     }
 
     [Fact]
+    public void Format_RightHandDriveNamesTheLeftSideAsLeading()
+    {
+        string report = VirtualCrossoverAutoDelayReport.Format(
+            [Outcome("A L", 0.0, 1.25)],
+            stereo: true,
+            new AutoDelayRunRequest(
+                SceneOffsetMs: 0.25,
+                RightHandDrive: true,
+                AdjustGains: false,
+                NearSideCutDb: 0));
+
+        // RHD mirrors the reference: the right side is fitted to lag, so the
+        // LEFT side is the one the offset makes lead.
+        Assert.Contains("Scene offset 0.25 ms (RHD: left side leads)", report);
+    }
+
+    // The user enters the tilt as a layout-neutral near-side cut; the sign
+    // of the gain engine's L-R figure comes from the layout alone (near =
+    // left on LHD, right on RHD) — switching LHD/RHD must never require
+    // re-entering a sign, exactly like the scene offset.
+    [Fact]
+    public void RunRequest_SignsTheNearSideCutByTheLayout()
+    {
+        Assert.Equal(
+            -1.5,
+            new AutoDelayRunRequest(0.25, RightHandDrive: false, true, 1.5)
+                .LevelDifferenceDb);
+        Assert.Equal(
+            1.5,
+            new AutoDelayRunRequest(0.25, RightHandDrive: true, true, 1.5)
+                .LevelDifferenceDb);
+    }
+
+    [Fact]
     public void Format_SingleSideWithoutGains()
     {
         string report = VirtualCrossoverAutoDelayReport.Format(
@@ -105,9 +141,11 @@ public sealed class VirtualCrossoverAutoDelayReportTests
                 delayKind: AlignmentDecisionKind.Reference,
                 delayDetail: "reference (others align to it)")],
             stereo: false,
-            sceneOffsetMs: 0,
-            gainsRequested: false,
-            levelDifferenceDb: 0,
+            new AutoDelayRunRequest(
+                SceneOffsetMs: 0,
+                RightHandDrive: false,
+                AdjustGains: false,
+                NearSideCutDb: 0),
             leftSumLoss: new AutoDelaySumLossForecast(-1.5, -0.3));
 
         Assert.Contains("single side", report);

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -138,6 +138,35 @@ public sealed class VirtualCrossoverProjectFileTests
     }
 
     [Fact]
+    public void LoadOrDefault_LegacyNegativeSceneOffset_BecomesRightHandDrive()
+    {
+        // The steering layout used to live in the scene offset's SIGN
+        // (negative = right-seated driver). Such a payload must open as an
+        // RHD project carrying the equivalent magnitude — not trip the
+        // non-negative validation and cost the user their session.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            new VirtualCrossoverProjectFile().Save(root);
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            JsonObject file = JsonNode.Parse(File.ReadAllText(path))!.AsObject();
+            file["stereoSceneOffsetMs"] = -0.4;
+            file.Remove("stereoRightHandDrive");
+            File.WriteAllText(path, file.ToJsonString());
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.True(loaded.StereoRightHandDrive);
+            Assert.Equal(0.4, loaded.StereoSceneOffsetMs);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void AllPass_RoundTripsThroughTheProjectFile()
     {
         string root = CreateTemporaryDirectory();
@@ -235,7 +264,8 @@ public sealed class VirtualCrossoverProjectFileTests
                 PhaseFdwCycles = 8,
                 PhaseDetrendMode = PhaseDetrendMode.Manual
             };
-            original.StereoSceneOffsetMs = -0.4;
+            original.StereoSceneOffsetMs = 0.4;
+            original.StereoRightHandDrive = true;
             original.StereoLevelDifferenceDb = -1.5;
             original.ActiveSideRight = true;
             original.Pairs[0].Mono = true;
@@ -282,6 +312,8 @@ public sealed class VirtualCrossoverProjectFileTests
             Assert.Equal(original.PhaseFdwCycles, loaded.PhaseFdwCycles);
             Assert.Equal(original.PhaseDetrendMode, loaded.PhaseDetrendMode);
             Assert.Equal(original.StereoSceneOffsetMs, loaded.StereoSceneOffsetMs);
+            Assert.Equal(
+                original.StereoRightHandDrive, loaded.StereoRightHandDrive);
             Assert.Equal(
                 original.StereoLevelDifferenceDb, loaded.StereoLevelDifferenceDb);
             Assert.Equal(original.ActiveSideRight, loaded.ActiveSideRight);
@@ -488,6 +520,15 @@ public sealed class VirtualCrossoverProjectFileTests
                 VirtualCrossoverProjectFile.MaximumSceneOffsetMs + 1
         };
         Assert.Throws<InvalidDataException>(() => badSceneOffset.Validate());
+
+        // The offset is a magnitude now — the layout lives in its own flag,
+        // and a negative value can only be a legacy payload, which Migrate
+        // normalizes before validation ever sees it.
+        var negativeSceneOffset = new VirtualCrossoverProjectFile
+        {
+            StereoSceneOffsetMs = -0.25
+        };
+        Assert.Throws<InvalidDataException>(() => negativeSceneOffset.Validate());
 
         var badLevelDifference = new VirtualCrossoverProjectFile
         {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -140,10 +140,9 @@ public sealed class VirtualCrossoverProjectFileTests
     [Fact]
     public void LoadOrDefault_LegacyNegativeSceneOffset_BecomesRightHandDrive()
     {
-        // The steering layout used to live in the scene offset's SIGN
-        // (negative = right-seated driver). Such a payload must open as an
-        // RHD project carrying the equivalent magnitude — not trip the
-        // non-negative validation and cost the user their session.
+        // The wire format carries the steering layout in the offset's SIGN
+        // (negative = right-seated driver). A pre-flag payload must open as
+        // an RHD project with the equivalent magnitude.
         string root = CreateTemporaryDirectory();
         try
         {
@@ -158,7 +157,39 @@ public sealed class VirtualCrossoverProjectFileTests
                 VirtualCrossoverProjectFile.LoadOrDefault(root);
 
             Assert.True(loaded.StereoRightHandDrive);
-            Assert.Equal(0.4, loaded.StereoSceneOffsetMs);
+            Assert.Equal(0.4, loaded.StereoSceneOffsetMagnitudeMs);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadOrDefault_RhdSurvivesAnOldBuildResaveThatDropsTheFlag()
+    {
+        // An older build knows nothing of stereoRightHandDrive: it reads the
+        // layout from the offset's sign (the wire keeps the pre-flag
+        // format exactly for this) and a resave DROPS the unknown flag. The
+        // sign must carry the layout back in — without it the resave would
+        // silently and permanently flip an RHD session to LHD.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var saved = new VirtualCrossoverProjectFile();
+            saved.SetStereoScene(0.25, rightHandDrive: true);
+            saved.Save(root);
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            JsonObject file = JsonNode.Parse(File.ReadAllText(path))!.AsObject();
+            Assert.Equal(-0.25, (double)file["stereoSceneOffsetMs"]!);
+            file.Remove("stereoRightHandDrive");
+            File.WriteAllText(path, file.ToJsonString());
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.True(loaded.StereoRightHandDrive);
+            Assert.Equal(0.25, loaded.StereoSceneOffsetMagnitudeMs);
         }
         finally
         {
@@ -264,8 +295,7 @@ public sealed class VirtualCrossoverProjectFileTests
                 PhaseFdwCycles = 8,
                 PhaseDetrendMode = PhaseDetrendMode.Manual
             };
-            original.StereoSceneOffsetMs = 0.4;
-            original.StereoRightHandDrive = true;
+            original.SetStereoScene(0.4, rightHandDrive: true);
             original.StereoLevelDifferenceDb = -1.5;
             original.ActiveSideRight = true;
             original.Pairs[0].Mono = true;
@@ -520,15 +550,6 @@ public sealed class VirtualCrossoverProjectFileTests
                 VirtualCrossoverProjectFile.MaximumSceneOffsetMs + 1
         };
         Assert.Throws<InvalidDataException>(() => badSceneOffset.Validate());
-
-        // The offset is a magnitude now — the layout lives in its own flag,
-        // and a negative value can only be a legacy payload, which Migrate
-        // normalizes before validation ever sees it.
-        var negativeSceneOffset = new VirtualCrossoverProjectFile
-        {
-            StereoSceneOffsetMs = -0.25
-        };
-        Assert.Throws<InvalidDataException>(() => negativeSceneOffset.Validate());
 
         var badLevelDifference = new VirtualCrossoverProjectFile
         {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -198,6 +198,39 @@ public sealed class VirtualCrossoverProjectFileTests
     }
 
     [Fact]
+    public void LoadOrDefault_RhdWithZeroOffsetSurvivesAnOldBuildResave()
+    {
+        // The edge of the signed wire format: a zero magnitude has no sign
+        // to carry the layout (IEEE -0.0 neither compares below zero nor
+        // survives a decimal round-trip), so RHD+0 serializes as a tiny
+        // negative marker the runtime reads back as zero. Without it, an
+        // old build's resave — which drops the unknown flag — would
+        // silently flip the session to LHD.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var saved = new VirtualCrossoverProjectFile();
+            saved.SetStereoScene(0, rightHandDrive: true);
+            saved.Save(root);
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            JsonObject file = JsonNode.Parse(File.ReadAllText(path))!.AsObject();
+            Assert.True((double)file["stereoSceneOffsetMs"]! < 0);
+            file.Remove("stereoRightHandDrive");
+            File.WriteAllText(path, file.ToJsonString());
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.True(loaded.StereoRightHandDrive);
+            Assert.Equal(0, loaded.StereoSceneOffsetMagnitudeMs);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void AllPass_RoundTripsThroughTheProjectFile()
     {
         string root = CreateTemporaryDirectory();

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSourceRestoreTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSourceRestoreTests.cs
@@ -1,0 +1,41 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The project-bind source restore sequence (see
+/// <see cref="VirtualCrossoverPanel.RestoreProjectSourcesAsync{TChannel}"/>):
+/// its ORDER is the cross-rate import contract.
+/// </summary>
+public sealed class VirtualCrossoverSourceRestoreTests
+{
+    // The field bug this pins: importing a session at a different sample
+    // rate lost every channel but the last, because each new source was
+    // rate-checked against the previous project's not-yet-replaced
+    // channels. Every wipe must precede the FIRST resolve.
+    [Fact]
+    public async Task RestoreProjectSourcesAsync_WipesEveryChannelBeforeResolvingAny()
+    {
+        var log = new List<string>();
+        string[] channels = ["A", "B", "C"];
+
+        await VirtualCrossoverPanel.RestoreProjectSourcesAsync(
+            channels,
+            isMono: channel => channel == "B",
+            clearBothSlots: channel => log.Add($"clear {channel}"),
+            resolveSide: (channel, rightSide) =>
+            {
+                log.Add($"resolve {channel} {(rightSide ? "R" : "L")}");
+                return Task.CompletedTask;
+            },
+            channelRestored: channel => log.Add($"done {channel}"));
+
+        Assert.Equal(
+            [
+                "clear A", "clear B", "clear C",
+                "resolve A L", "resolve A R", "done A",
+                // The mono pair resolves its single slot once.
+                "resolve B L", "done B",
+                "resolve C L", "resolve C R", "done C"
+            ],
+            log);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -6,11 +6,13 @@ using System.Text.RegularExpressions;
 namespace Resonalyze.Dsp.Tests;
 
 /// <summary>
-/// The stereo alignment cascade: left side first, then the top-pair arrival
-/// bridge with the scene offset (positive = the right side leads), then the
-/// right-side descent that must not touch mono channels. The synthetic
-/// systems place impulses at known positions, so every stage's contribution
-/// is verifiable arithmetic.
+/// The stereo alignment cascade: the plan's reference (left-role) side
+/// first, then the top-pair arrival bridge with the scene offset (positive
+/// = the plan's right-role side, the far one, leads), then the far-side
+/// descent that must not touch mono channels. A right-hand-drive caller
+/// hands the plan mirrored — the mirrored-plan test pins that shape. The
+/// synthetic systems place impulses at known positions, so every stage's
+/// contribution is verifiable arithmetic.
 /// </summary>
 public sealed class StereoAlignmentTests
 {
@@ -87,7 +89,8 @@ public sealed class StereoAlignmentTests
             double leftLateMs = 0,
             double rightMidAmplitude = 1.0,
             int[]? reprocessCount = null,
-            double globalLateMs = 0)
+            double globalLateMs = 0,
+            bool mirrorPlan = false)
     {
         var sub = new TestChannel(
             "sub", ImpulseAtMs(2.0 + leftLateMs + globalLateMs));
@@ -127,9 +130,15 @@ public sealed class StereoAlignmentTests
             {
                 if (linkBands[i] is { } band)
                 {
-                    pairLinks.Add(new StereoPairLink(
-                        linkChannels[i].Left, linkChannels[i].Right,
-                        band.LowHz, band.HighHz));
+                    // The link's first member is the settled reference-side
+                    // channel, so a mirrored plan swaps the pair too.
+                    pairLinks.Add(mirrorPlan
+                        ? new StereoPairLink(
+                            linkChannels[i].Right, linkChannels[i].Left,
+                            band.LowHz, band.HighHz)
+                        : new StereoPairLink(
+                            linkChannels[i].Left, linkChannels[i].Right,
+                            band.LowHz, band.HighHz));
                 }
             }
         }
@@ -168,13 +177,13 @@ public sealed class StereoAlignmentTests
         var log = new StringBuilder();
         AutoAlignmentEngine.ComputeStereo(
             new StereoAlignmentPlan(
-                leftSnapshots,
-                leftPairs,
-                rightSnapshots,
-                rightPairs,
+                mirrorPlan ? rightSnapshots : leftSnapshots,
+                mirrorPlan ? rightPairs : leftPairs,
+                mirrorPlan ? leftSnapshots : rightSnapshots,
+                mirrorPlan ? leftPairs : rightPairs,
                 new HashSet<IAlignmentChannel> { sub },
-                leftTwr,
-                rightTwr,
+                mirrorPlan ? rightTwr : leftTwr,
+                mirrorPlan ? leftTwr : rightTwr,
                 BridgeBandLowHz: 2_500,
                 BridgeBandHighHz: 12_000,
                 SceneOffsetMs: sceneOffsetMs,
@@ -220,6 +229,46 @@ public sealed class StereoAlignmentTests
         double leftTop = FinalArrivalMs(left[2], 0.0, alignment);
         double rightTop = FinalArrivalMs(right[2], 1.5, alignment);
         Assert.InRange(leftTop - rightTop, -0.30, -0.20);
+    }
+
+    [Fact]
+    public void ComputeStereo_MirroredPlanMakesTheLeftSideLead()
+    {
+        // The right-hand-drive shape: the caller mirrors the plan (the right
+        // side is the reference the cascade settles first, the left one is
+        // fitted to it), and the same POSITIVE offset now makes the left
+        // side lead — the right top's final arrival is 0.25 ms LATER.
+        (TestChannel sub, TestChannel[] left, TestChannel[] right,
+            Dictionary<IAlignmentChannel, AlignmentOverride> alignment, _) =
+            RunStereo(sceneOffsetMs: 0.25, mirrorPlan: true);
+
+        double leftTop = FinalArrivalMs(left[2], 0.0, alignment);
+        double rightTop = FinalArrivalMs(right[2], 1.5, alignment);
+        Assert.InRange(rightTop - leftTop, 0.20, 0.30);
+
+        // Both sides must still cohere internally: the reference walk now
+        // runs on the right side (tuning the shared sub along the way) and
+        // the descent on the left, whose woofer sits between TWO settled
+        // references (the mono sub and its mid) — hence the wider tolerance
+        // mirroring the LHD test's fitted side.
+        double[] naturals = [1.0, 0.4, 0.0];
+        for (int i = 0; i < 2; i++)
+        {
+            Assert.InRange(
+                Math.Abs(
+                    FinalArrivalMs(right[i], naturals[i] + 1.5, alignment) -
+                    FinalArrivalMs(right[i + 1], naturals[i + 1] + 1.5, alignment)),
+                0, 0.1);
+            Assert.InRange(
+                Math.Abs(
+                    FinalArrivalMs(left[i], naturals[i], alignment) -
+                    FinalArrivalMs(left[i + 1], naturals[i + 1], alignment)),
+                0, 0.2);
+        }
+
+        double minimum = new[] { sub, left[0], left[1], left[2], right[0], right[1], right[2] }
+            .Min(channel => alignment.GetValueOrDefault(channel).DelayMs);
+        Assert.InRange(minimum, 0, 0.011);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -351,8 +351,10 @@ public sealed class StereoAlignmentTests
             - monoAlignment.GetValueOrDefault(woof).DelayMs;
         Assert.InRange(Math.Abs(stereoRelative - monoRelative), 0, 0.011);
 
-        // The right pass reports the pinned junction instead of tuning it.
-        Assert.Contains("mono, timed by the left side", log.ToString());
+        // The far pass reports the pinned junction instead of tuning it
+        // (role-based wording: on a mirrored RHD plan the reference side is
+        // physically the right one).
+        Assert.Contains("mono, timed by the reference side", log.ToString());
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -289,6 +289,135 @@ public sealed class TransferIrDiagnosticsTests
             impulseResponse, SampleRate));
     }
 
+    // Deterministic LCG noise, the same generator the noise-only estimate
+    // test uses — the compactness tests must never flake either.
+    private static double[] StationaryNoise(int length, uint seed)
+    {
+        var samples = new double[length];
+        uint state = seed;
+        for (int i = 0; i < samples.Length; i++)
+        {
+            state = state * 1_664_525u + 1_013_904_223u;
+            samples[i] = state / 4_294_967_296.0 - 0.5;
+        }
+        return samples;
+    }
+
+    [Fact]
+    public void MeasureCompactness_GenuineDecayReadsHigh()
+    {
+        // A CAUSAL arrival — fast attack, exponential decay — over a
+        // realistic noise floor, in a buffer many times the compactness
+        // window: the good-measurement shape (field records read
+        // 29.5-48.9 dB). Deliberately not the symmetric Hann burst of the
+        // crosstalk tests: half of that burst's energy precedes its peak,
+        // which no real transfer IR does, and the 10 ms pre-window would
+        // rightly count it as spread.
+        double[] impulseResponse = StationaryNoise(131_072, seed: 7);
+        for (int i = 0; i < impulseResponse.Length; i++)
+        {
+            impulseResponse[i] *= 0.001;
+        }
+        int start = (int)(0.010 * SampleRate);
+        double decaySamples = 0.050 * SampleRate;
+        for (int i = 0; i < (int)(0.500 * SampleRate); i++)
+        {
+            impulseResponse[start + i] +=
+                Math.Exp(-i / decaySamples) *
+                Math.Sin(Math.Tau * 300 * i / SampleRate);
+        }
+
+        TransferIrCompactness? compactness =
+            TransferIrDiagnostics.MeasureCompactness(impulseResponse, SampleRate);
+
+        Assert.NotNull(compactness);
+        Assert.True(
+            compactness.Value.InsideOutsideDb >=
+                TransferIrDiagnostics.MinimumCompactnessDb + 10,
+            $"genuine shape read {compactness.Value.InsideOutsideDb:0.0} dB");
+        // The envelope peaks at the first sine crest right after the onset.
+        Assert.InRange(compactness.Value.PeakDelayMs, 5, 30);
+    }
+
+    // The field shape of a transfer built from an unusable reference (a
+    // loopback that was playback bleed): stationary division noise across
+    // the whole buffer with giant spikes at the circular wrap point — peak
+    // at sample ~2 or wrapped into negative time, energy everywhere. The
+    // real set read 11.2-15.7 dB.
+    [Fact]
+    public void MeasureCompactness_StationaryNoiseWithWrapSpikesReadsLow()
+    {
+        double[] impulseResponse = StationaryNoise(262_144, seed: 42);
+        impulseResponse[1] = 300;
+        impulseResponse[^2] = -240;
+
+        TransferIrCompactness? compactness =
+            TransferIrDiagnostics.MeasureCompactness(impulseResponse, SampleRate);
+
+        Assert.NotNull(compactness);
+        Assert.True(
+            compactness.Value.InsideOutsideDb <
+                TransferIrDiagnostics.MinimumCompactnessDb,
+            $"garbage shape read {compactness.Value.InsideOutsideDb:0.0} dB");
+    }
+
+    [Fact]
+    public void MeasureCompactness_PureNoiseReadsNearZero()
+    {
+        TransferIrCompactness? compactness = TransferIrDiagnostics.MeasureCompactness(
+            StationaryNoise(262_144, seed: 9), SampleRate);
+
+        Assert.NotNull(compactness);
+        Assert.InRange(compactness.Value.InsideOutsideDb, -3, 3);
+    }
+
+    // No peak-position rule, by design: an electrical chain measurement
+    // (mic input wired straight to a processor output) legitimately peaks
+    // at zero delay and must pass on its clean shape alone.
+    [Fact]
+    public void MeasureCompactness_ElectricalDeltaAtZeroPasses()
+    {
+        var impulseResponse = new double[65_536];
+        impulseResponse[0] = 1.0;
+
+        TransferIrCompactness? compactness =
+            TransferIrDiagnostics.MeasureCompactness(impulseResponse, SampleRate);
+
+        Assert.NotNull(compactness);
+        Assert.True(
+            compactness.Value.InsideOutsideDb >=
+                TransferIrDiagnostics.MinimumCompactnessDb);
+        Assert.Equal(0, compactness.Value.PeakDelayMs);
+    }
+
+    [Fact]
+    public void MeasureCompactness_RefusesDegenerateInput()
+    {
+        // Too short to carve a meaningful window, or nothing to measure.
+        Assert.Null(TransferIrDiagnostics.MeasureCompactness(
+            new double[100], SampleRate));
+        Assert.Null(TransferIrDiagnostics.MeasureCompactness(
+            new double[65_536], SampleRate));
+        Assert.Null(TransferIrDiagnostics.MeasureCompactness(
+            StationaryNoise(65_536, seed: 3), sampleRate: 0));
+    }
+
+    [Fact]
+    public void MeasureCompactness_ComplexTwinMatchesTheRealPath()
+    {
+        double[] impulseResponse = StationaryNoise(65_536, seed: 11);
+        AddToneBurst(impulseResponse, startMs: 15.0, frequencyHz: 500, periods: 20, amplitude: 3.0);
+        var complexIr = new System.Numerics.Complex[impulseResponse.Length];
+        for (int i = 0; i < impulseResponse.Length; i++)
+        {
+            complexIr[i] = impulseResponse[i];
+        }
+
+        Assert.Equal(
+            TransferIrDiagnostics.MeasureCompactness(impulseResponse, SampleRate),
+            TransferIrDiagnostics.MeasureCompactness(complexIr, SampleRate));
+    }
+
     [Fact]
     public void CleanCrosstalkHead_ZerosTheHeadAndKeepsTheRest()
     {

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -309,10 +309,10 @@ public sealed class TransferIrDiagnosticsTests
         // A CAUSAL arrival — fast attack, exponential decay — over a
         // realistic noise floor, in a buffer many times the compactness
         // window: the good-measurement shape (field records read
-        // 29.5-48.9 dB). Deliberately not the symmetric Hann burst of the
-        // crosstalk tests: half of that burst's energy precedes its peak,
-        // which no real transfer IR does, and the 10 ms pre-window would
-        // rightly count it as spread.
+        // 28.8-48.6 dB). Deliberately not the symmetric Hann burst of the
+        // crosstalk tests: a real acoustic IR is front-loaded, and the
+        // symmetric case (a zero-phase gate kernel) is covered by the
+        // gated-transfer band tests below.
         double[] impulseResponse = StationaryNoise(131_072, seed: 7);
         for (int i = 0; i < impulseResponse.Length; i++)
         {
@@ -400,6 +400,74 @@ public sealed class TransferIrDiagnosticsTests
             new double[65_536], SampleRate));
         Assert.Null(TransferIrDiagnostics.MeasureCompactness(
             StationaryNoise(65_536, seed: 3), sampleRate: 0));
+
+        // Non-finite content refuses too — the caller treats null as a
+        // failed measurement, so a NaN capture can never pass by silently
+        // poisoning every comparison.
+        double[] poisonedByNaN = StationaryNoise(65_536, seed: 4);
+        poisonedByNaN[123] = double.NaN;
+        Assert.Null(TransferIrDiagnostics.MeasureCompactness(
+            poisonedByNaN, SampleRate));
+        double[] poisonedByInfinity = StationaryNoise(65_536, seed: 5);
+        poisonedByInfinity[321] = double.PositiveInfinity;
+        Assert.Null(TransferIrDiagnostics.MeasureCompactness(
+            poisonedByInfinity, SampleRate));
+    }
+
+    // Band sweeps are a supported workflow, and the zero-phase excitation
+    // gate turns even an ideal H(f)=1 into a symmetric band-limited kernel
+    // whose pre-ringing lives in negative (wrapped) time — the compactness
+    // window must accommodate it at every allowed band. Each case runs the
+    // PRODUCTION estimator with the production gate shape (full band plus
+    // fade guard bands): the ideal transfer must clear the floor with
+    // margin, gated uncorrelated noise must stay far below it. A 10 ms
+    // pre-window failed the 20-50 Hz case at 19.9 dB — the review find
+    // behind this test.
+    [Theory]
+    [InlineData(20.0, 50.0)]
+    [InlineData(20.0, 80.0)]
+    [InlineData(50.0, 100.0)]
+    [InlineData(100.0, 200.0)]
+    [InlineData(0.0, 0.0)] // full range
+    public void MeasureCompactness_JudgesGatedTransfersAtEveryBand(
+        double lowFullHz, double highFullHz)
+    {
+        const int FrameLength = 262_144;
+        double nyquist = SampleRate / 2.0;
+        ExcitationBandGate gate = lowFullHz > 0
+            ? new ExcitationBandGate(
+                lowFullHz / 1.44 / nyquist,
+                lowFullHz / nyquist,
+                highFullHz / nyquist,
+                Math.Min(1.0, highFullHz * 1.386 / nyquist))
+            : ExcitationBandGate.FullBand;
+        double[] reference = StationaryNoise(FrameLength, seed: 7);
+        double[] uncorrelated = StationaryNoise(FrameLength, seed: 1234);
+
+        double[] ideal = TransferFunction.ComputeAveragedRelativeIr(
+            [new TransferFunctionFrame(reference, reference)],
+            gate).ImpulseResponse;
+        double[] garbage = TransferFunction.ComputeAveragedRelativeIr(
+            [new TransferFunctionFrame(reference, uncorrelated)],
+            gate).ImpulseResponse;
+
+        TransferIrCompactness? idealCompactness =
+            TransferIrDiagnostics.MeasureCompactness(ideal, SampleRate);
+        TransferIrCompactness? garbageCompactness =
+            TransferIrDiagnostics.MeasureCompactness(garbage, SampleRate);
+
+        Assert.NotNull(idealCompactness);
+        Assert.True(
+            idealCompactness.Value.InsideOutsideDb >=
+                TransferIrDiagnostics.MinimumCompactnessDb + 10,
+            $"ideal {lowFullHz}-{highFullHz} Hz read " +
+            $"{idealCompactness.Value.InsideOutsideDb:0.0} dB");
+        Assert.NotNull(garbageCompactness);
+        Assert.True(
+            garbageCompactness.Value.InsideOutsideDb <
+                TransferIrDiagnostics.MinimumCompactnessDb - 10,
+            $"garbage {lowFullHz}-{highFullHz} Hz read " +
+            $"{garbageCompactness.Value.InsideOutsideDb:0.0} dB");
     }
 
     [Fact]


### PR DESCRIPTION
## Auto delay: LHD/RHD steering layouts

The stereo alignment plan is now written in **reference/far roles**: plan-left is the driver''s side the cascade settles first, plan-right the far side fitted to it, a positive scene offset makes the far side lead. LHD maps the cabin directly; **RHD hands the plan mirrored** — the right side anchors (tuning the shared mono sub in its walk), the left top bridges to it, and the right side lags by the offset. The engine is functionally unchanged (docs, bridge log and the bridge-certification message speak in role terms); the mirrored-plan shape is pinned by a synthetic test.

UI: an LHD/RHD toggle in the Auto delay dialog; both tuning figures are **layout-neutral magnitudes** — the scene offset is non-negative, and the level tilt is entered as a **near-side cut** (how much quieter the driver''s side plays), restated into the gain engine''s signed L−R convention by the layout. Switching LHD/RHD never requires re-entering a sign.

Persistence: the wire keeps the **pre-flag signed format** (negative offset = RHD), plus an explicit additive `StereoRightHandDrive` flag; both are written consistently through `SetStereoScene`. An older build therefore reads an RHD session correctly and even **resaves it without silently flipping the layout** (the sign survives the flag being dropped); RHD with a zero offset serializes as a −0.001 ms marker (zero to every consumer) so its layout survives too. Both resave paths are pinned by tests. No version bump needed.

## Session import fix

Importing a session recorded at a different sample rate lost every channel but the last: sources re-resolved one channel at a time, and the rate guard (which scans every still-resolved side) silently refused each new source against the not-yet-replaced old ones. All channels are wiped up front now; the restore sequence is a delegate-fed static whose wipe-all-before-resolving order is unit-tested.

## Capture-quality gate (field case: a session whose loopback was playback bleed, peaks −33…−49 dBFS, garbage transfer IRs on every channel)

One scale-invariant verdict: the averaged transfer IR must be **time-compact** — per-sample energy in a circular peak−100 ms…peak+500 ms window at least **22 dB** above the rest of the capture. Calibration: ideal transfers through the production excitation gate read 42.9+ dB on every band down to a 20–50 Hz band sweep (the 100 ms pre-window covers the zero-phase gate kernel''s wrapped pre-ringing), genuine field records 28.8–48.6 dB, the field garbage set 11.2–18.7 dB, gated uncorrelated noise ~0 dB. The gate is **fail-closed**: an unmeasurable shape (degenerate or non-finite — one NaN slips every level comparison) refuses the measurement.

Deliberately **no per-run level rejection**: transfer estimation is scale-invariant and the README''s own workflow attenuates playback, so a cleanly attenuated wire at −41 dBFS measures fine. A suspiciously quiet loopback (< −30 dBFS) is only named inside the shape gate''s failure message as the likely culprit. No peak-position rule either: an electrical chain measurement legitimately peaks at zero delay.

## Tests

1782 green (Dsp 921, App 723, Audio 138): mirrored-plan cascade, layout-signed tilt, report wording, wire-format round-trips incl. both old-build resave simulations, the import restore order, compactness across five bands through the production gate plus NaN/Infinity/degenerate refusals, and four end-to-end fake-session paths (quiet clean wire succeeds; bleed, noise-mic and NaN captures fail with their reasons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)