### PR TITLE
FDW magnitude, gate-driven Virtual DSP magnitude, a psycho-smoothing spike fix, and self-cleaning history

### DIFF
--- a/dsp/DataHelper.Phase.cs
+++ b/dsp/DataHelper.Phase.cs
@@ -664,6 +664,84 @@ namespace Resonalyze.Dsp
                 coherence);
         }
 
+        /// <summary>
+        /// The same phase construction over an ALREADY BUILT gated analysis
+        /// spectrum (<see cref="GetPhaseAnalysisSpectrum"/> or
+        /// <see cref="SumGatedSpectra"/>), referenced to an absolute sample
+        /// position — for callers that combine spectra before reading phase
+        /// (the Virtual DSP Sum).
+        /// </summary>
+        public static List<SignalPoint> GetGatedPhaseData(
+            Complex[] spectrum,
+            int extractionStart,
+            double referenceSamples,
+            int sampleRate,
+            bool unwrap,
+            IReadOnlyList<double>? coherence = null) =>
+            BuildMeasuredPhase(
+                spectrum,
+                extractionStart,
+                referenceSamples,
+                sampleRate,
+                unwrap,
+                coherence);
+
+        /// <summary>
+        /// The complex sum of gated analysis spectra whose extractions started
+        /// at different absolute positions: each is re-referenced to
+        /// <paramref name="targetExtractionStart"/> (a pure per-bin phase
+        /// rotation; the integer shifts keep the conjugate symmetry of a real
+        /// signal's spectrum) and accumulated, so the result reads exactly like
+        /// one spectrum extracted there. This is how a multi-channel Sum stays
+        /// the vector sum of individually gated channels when their windows do
+        /// not share a position (the Virtual DSP Auto gate). The inputs are not
+        /// modified and must share one FFT length.
+        /// </summary>
+        public static Complex[] SumGatedSpectra(
+            IReadOnlyList<(Complex[] Spectrum, int ExtractionStart)> spectra,
+            int targetExtractionStart)
+        {
+            ArgumentNullException.ThrowIfNull(spectra);
+            if (spectra.Count == 0)
+            {
+                throw new ArgumentException(
+                    "At least one spectrum is required.", nameof(spectra));
+            }
+
+            int length = spectra[0].Spectrum.Length;
+            var combined = new Complex[length];
+            foreach ((Complex[] spectrum, int extractionStart) in spectra)
+            {
+                if (spectrum.Length != length)
+                {
+                    throw new ArgumentException(
+                        "All spectra must share one FFT length.", nameof(spectra));
+                }
+
+                double shift = targetExtractionStart - extractionStart;
+                if (shift == 0.0)
+                {
+                    for (int bin = 0; bin < length; bin++)
+                    {
+                        combined[bin] += spectrum[bin];
+                    }
+
+                    continue;
+                }
+
+                // The same re-reference ApplyTimeReference performs, applied on
+                // the fly so the caller's arrays stay untouched.
+                for (int bin = 0; bin < length; bin++)
+                {
+                    combined[bin] += spectrum[bin] * Complex.FromPolarCoordinates(
+                        1.0,
+                        Math.Tau * bin * shift / length);
+                }
+            }
+
+            return combined;
+        }
+
         public static double ResolvePhaseDetrendMilliseconds(
             IImpulseMeasurement measurement,
             PhaseAnalysisSettings settings)

--- a/dsp/DataHelper.Resampling.cs
+++ b/dsp/DataHelper.Resampling.cs
@@ -254,14 +254,21 @@ namespace Resonalyze.Dsp
 
             // Match the ordinary resampler's minimum half-width of two FFT bins.
             // On a log axis equal Hz distances are asymmetric, so use whichever
-            // side requires the larger octave radius. Below two bins only the
-            // upper distance is defined; DC bounds the available lower side.
+            // side requires the larger octave radius. The lower side is bounded
+            // by the input grid itself: the spectrum's first sample sits one bin
+            // above DC, so the kernel is never asked to reach below it. Without
+            // that bound the lower octave distance diverges as the centre
+            // approaches two bins from DC — the Gaussian then covered the whole
+            // spectrum and the cubic mean drew the (loud) midrange level as a
+            // spike at ~2 bins, mid-display on coarse grids (a 192 kHz
+            // measurement with a 2048-sample window spiked +33 dB at 47 Hz).
             double minimumRadiusHz = 2.0 * inputStep;
             double upperRadiusOctaves = Math.Log2(
                 (centerFrequency + minimumRadiusHz) / centerFrequency);
-            double lowerRadiusOctaves = centerFrequency > minimumRadiusHz
-                ? Math.Log2(
-                    centerFrequency / (centerFrequency - minimumRadiusHz))
+            double lowerEdgeHz = Math.Max(
+                centerFrequency - minimumRadiusHz, inputStep);
+            double lowerRadiusOctaves = centerFrequency > lowerEdgeHz
+                ? Math.Log2(centerFrequency / lowerEdgeHz)
                 : upperRadiusOctaves;
             double minimumRadiusOctaves =
                 Math.Max(upperRadiusOctaves, lowerRadiusOctaves);

--- a/dsp/DataHelper.Spectrum.cs
+++ b/dsp/DataHelper.Spectrum.cs
@@ -28,8 +28,9 @@ namespace Resonalyze.Dsp
         }
 
         /// <summary>
-        /// The primary (linear) response spectrum: Tukey-windowed around the peak,
-        /// oversampled, log-resampled with optional calibration and smoothing. Used
+        /// The primary (linear) response spectrum: windowed around the peak (fixed
+        /// Tukey or FDW), oversampled, log-resampled with optional calibration and
+        /// smoothing. Used
         /// by GetSpectrum for its primary curve and directly for derived responses
         /// (e.g. the complex sum of two transfer impulse responses), where the
         /// per-curve visibility gating of GetSpectrum must not apply.
@@ -54,8 +55,9 @@ namespace Resonalyze.Dsp
 
         /// <summary>
         /// The oversampled linear-frequency spectrum that feeds
-        /// <see cref="GetPrimarySpectrum"/>: Tukey-windowed around the peak and
-        /// oversampled, BEFORE the logarithmic resample, calibration and smoothing.
+        /// <see cref="GetPrimarySpectrum"/>: Tukey-windowed around the peak (or
+        /// FDW-windowed, per <see cref="FrequencyResponseOptions.MagnitudeWindowMode"/>)
+        /// and oversampled, BEFORE the logarithmic resample, calibration and smoothing.
         /// Overlays store this so they reproduce the mode's smoothing EXACTLY (the same
         /// <see cref="LogarithmicResample"/>) at any width, and Off = the raw curve.
         /// </summary>
@@ -63,11 +65,98 @@ namespace Resonalyze.Dsp
             IImpulseMeasurement measurement,
             FrequencyResponseOptions frequencyResponseOptions)
         {
+            if (frequencyResponseOptions.MagnitudeWindowMode ==
+                PhaseWindowMode.FrequencyDependent)
+            {
+                return GetFdwPrimarySpectrum(measurement, frequencyResponseOptions);
+            }
+
             double leftTukeyWindow = (double)frequencyResponseOptions.LeftTukeyWindow / frequencyResponseOptions.Window * 2.0;
             double rightTukeyWindow = (double)frequencyResponseOptions.RightTukeyWindow / frequencyResponseOptions.Window * 2.0;
             double[] window = Windowing.TukeyWindow(frequencyResponseOptions.Window, leftTukeyWindow, rightTukeyWindow);
             int h1Start = measurement.PeakIndex - frequencyResponseOptions.LeftTukeyWindow;
             return GetOversampledSpectrumData(measurement, h1Start, window);
+        }
+
+        // REW-style frequency-dependent window for the magnitude curve, built on
+        // the SAME bank the FDW phase analysis uses (BuildAnalysisSpectrum), so
+        // the two views read one analysis and share its per-impulse cache. The
+        // fixed window's geometry maps directly onto the gate: its fade-in ends
+        // at the peak, so the gate offset is the peak time, and the configured
+        // window is the outer gate that FDW never exceeds — below the transition
+        // frequency (where MagnitudeFdwCycles periods outgrow the window) the
+        // curve is the fixed window's, above it the effective window shrinks as
+        // cycles/frequency. Detrend/unwrap/smoothing fields of the settings
+        // record are phase-only and never reach the bank.
+        private static List<SignalPoint> GetFdwPrimarySpectrum(
+            IImpulseMeasurement measurement,
+            FrequencyResponseOptions options)
+        {
+            double toMilliseconds = 1000.0 / measurement.SampleRate;
+            int plateau = Math.Max(
+                0, options.Window - options.LeftTukeyWindow - options.RightTukeyWindow);
+            var settings = new PhaseAnalysisSettings(
+                PhaseWindowMode.FrequencyDependent,
+                options.MagnitudeFdwCycles,
+                PhaseDetrendMode.Off,
+                ManualDetrendMilliseconds: 0.0,
+                GateOffsetMs: measurement.PeakIndex * toMilliseconds,
+                LeftMs: options.LeftTukeyWindow * toMilliseconds,
+                PlateauMs: plateau * toMilliseconds,
+                RightMs: options.RightTukeyWindow * toMilliseconds,
+                Unwrap: false,
+                SmoothingInverseOctaves: 0.0);
+            Complex[] spectrum = BuildAnalysisSpectrum(measurement, settings, out _);
+            return GatedMagnitudePoints(spectrum, measurement.SampleRate);
+        }
+
+        /// <summary>
+        /// The primary magnitude curve computed through the SAME gate
+        /// construction as the phase analyses (<see cref="PhaseAnalysisSettings"/>:
+        /// absolute ms offset and shoulders, Fixed or FDW) — for callers whose
+        /// magnitude must read exactly the time window their phase view shows
+        /// (the Virtual DSP tool). Shares the gated-spectrum bank and its
+        /// per-impulse cache; the settings' detrend/unwrap/smoothing fields are
+        /// phase-only and never affect the magnitude. Smoothing and calibration
+        /// apply on the logarithmic grid exactly as in
+        /// <see cref="GetPrimarySpectrum"/>.
+        /// </summary>
+        public static AnalysisCurve GetGatedPrimarySpectrum(
+            IImpulseMeasurement measurement,
+            PhaseAnalysisSettings settings,
+            CalibrationFile? calibration,
+            double smoothingInverseOctaves)
+        {
+            Complex[] spectrum = BuildAnalysisSpectrum(measurement, settings, out _);
+            List<SignalPoint> data = LogarithmicResample(
+                GatedMagnitudePoints(spectrum, measurement.SampleRate),
+                20,
+                20000,
+                1024,
+                calibration,
+                SpectrumSmoothing.SmoothingOctaves(smoothingInverseOctaves),
+                psychoacoustic: SpectrumSmoothing.IsPsychoacoustic(
+                    smoothingInverseOctaves));
+            return new AnalysisCurve("Frequency Response", data);
+        }
+
+        // The magnitude bins of a gated analysis spectrum as ascending (Hz, dB)
+        // points on its linear grid — the resample-ready form every gated
+        // magnitude path shares.
+        private static List<SignalPoint> GatedMagnitudePoints(
+            Complex[] spectrum,
+            int sampleRate)
+        {
+            var data = new List<SignalPoint>(spectrum.Length / 2);
+            for (int i = 1; i < spectrum.Length / 2; i++)
+            {
+                double frequency = i * (sampleRate / (double)spectrum.Length);
+                data.Add(new SignalPoint(
+                    frequency,
+                    AmplitudeToDecibels(spectrum[i].Magnitude)));
+            }
+
+            return data;
         }
 
         /// <summary>

--- a/dsp/DataHelper.cs
+++ b/dsp/DataHelper.cs
@@ -29,6 +29,18 @@ namespace Resonalyze.Dsp
         public int Window { get; set; } = 4096;
         public int LeftTukeyWindow { get; set; } = 256;
         public int RightTukeyWindow { get; set; } = 256;
+
+        // Windowing mode for the primary magnitude curve. Fixed applies the one
+        // Tukey window above; FrequencyDependent (REW-style FDW) keeps that
+        // window as the outer gate but shortens the analysis window past the
+        // peak to MagnitudeFdwCycles periods of each frequency, so late cabin
+        // reflections drop out of the treble while the bass keeps the full
+        // window. Defaults to Fixed — the steady-state curve is the canonical
+        // magnitude reading (and what in-car SPL targets are stated against);
+        // FDW is the opt-in quasi-anechoic view. Phase below deliberately
+        // defaults the other way: an ungated in-car phase trace is unreadable.
+        public PhaseWindowMode MagnitudeWindowMode { get; set; } = PhaseWindowMode.Fixed;
+        public int MagnitudeFdwCycles { get; set; } = PhaseAnalysisSettings.DefaultFdwCycles;
         public double SmoothingInverseOctaves { get; set; } = 6;
         public int Offset { get; set; }
         public bool Unwrap { get; set; } = true;

--- a/source/History/MeasurementHistoryPersistence.cs
+++ b/source/History/MeasurementHistoryPersistence.cs
@@ -23,12 +23,6 @@ internal sealed class MeasurementHistoryPersistence
     // History operations save immediately, so a transient load/access failure
     // must not turn the empty recovery view into the persisted source of truth.
     private bool preserveExistingFileBeforeSave;
-    // Entries whose measurement file was not reachable at load. They are hidden
-    // from the caller — nothing can be done with a snapshot whose file is gone —
-    // but they are written back out on every Save. Without this an unmounted
-    // external drive at startup silently truncated the history, and the next
-    // ordinary window close persisted the truncation permanently.
-    private List<PersistedEntry> unreachableEntries = [];
 
     public string? LoadWarning { get; private set; }
 
@@ -41,11 +35,6 @@ internal sealed class MeasurementHistoryPersistence
     public IReadOnlyList<MeasurementHistoryEntry> Load()
     {
         LoadWarning = null;
-        // Retention describes the file as it was just read. Clearing it up front
-        // means a second Load on the same instance, or one that throws before
-        // the entries are partitioned, cannot leak the previous read's rows into
-        // the next Save.
-        unreachableEntries = [];
         try
         {
             if (!File.Exists(pathOnDisk))
@@ -54,8 +43,15 @@ internal sealed class MeasurementHistoryPersistence
                 return Array.Empty<MeasurementHistoryEntry>();
             }
 
-            using FileStream stream = File.OpenRead(pathOnDisk);
-            StoreFile? file = JsonSerializer.Deserialize<StoreFile>(stream, SerializerOptions);
+            // A block, not a using declaration: the read stream must be closed
+            // before the removal rewrite below, or the atomic replace fails
+            // against our own open handle.
+            StoreFile? file;
+            using (FileStream stream = File.OpenRead(pathOnDisk))
+            {
+                file = JsonSerializer.Deserialize<StoreFile>(stream, SerializerOptions);
+            }
+
             if (file == null)
             {
                 throw new InvalidDataException("The history file is empty.");
@@ -72,22 +68,24 @@ internal sealed class MeasurementHistoryPersistence
             file.SchemaVersion = CurrentSchemaVersion;
 
             var reachable = new List<MeasurementHistoryEntry>(file.Entries.Count);
-            var unreachable = new List<PersistedEntry>();
+            var retained = new List<PersistedEntry>(file.Entries.Count);
+            int removedCount = 0;
             foreach (PersistedEntry entry in file.Entries)
             {
                 if (string.IsNullOrWhiteSpace(entry.SourceFilePath))
                 {
-                    // No path at all is a broken record, not an absent drive:
-                    // there is nothing to come back for, so it is dropped.
+                    // No path at all is a broken record: dropped like a missing
+                    // file, it just never counted as a measurement.
                     continue;
                 }
 
                 if (!File.Exists(entry.SourceFilePath))
                 {
-                    unreachable.Add(entry);
+                    removedCount++;
                     continue;
                 }
 
+                retained.Add(entry);
                 reachable.Add(new MeasurementHistoryEntry
                 {
                     Id = entry.Id,
@@ -101,14 +99,30 @@ internal sealed class MeasurementHistoryPersistence
                 });
             }
 
-            unreachableEntries = unreachable;
-            if (unreachable.Count > 0)
+            if (removedCount > 0)
             {
+                // A row whose file is gone is dead weight: it can do nothing but
+                // repeat a warning on every launch — which is exactly what the
+                // previous design did by retaining such rows for the
+                // unplugged-drive case. Drop it from the store NOW, not at the
+                // next mutation's Save: a session without history changes never
+                // saves, and the warning would survive it. Best effort — if the
+                // store cannot be rewritten this launch, the in-memory list is
+                // already clean and the next launch repeats the removal.
+                try
+                {
+                    WriteStore(retained);
+                }
+                catch (Exception exception)
+                    when (exception is IOException or UnauthorizedAccessException)
+                {
+                }
+
                 LoadWarning =
-                    $"{unreachable.Count} measurement(s) are not listed because their files " +
-                    "could not be found — a disconnected drive or a moved folder does this.\r\n\r\n" +
-                    "They are kept in the history file and reappear once the files are " +
-                    "reachable again; nothing has been deleted.";
+                    $"{removedCount} measurement(s) were removed from the history " +
+                    "because their files no longer exist (deleted, or a moved " +
+                    "folder).\r\n\r\nOpening a measurement file adds it back to " +
+                    "the history.";
             }
 
             preserveExistingFileBeforeSave = false;
@@ -155,53 +169,21 @@ internal sealed class MeasurementHistoryPersistence
             })
             .ToList();
 
-        // Carry the entries hidden at load back into the file, minus any that the
-        // live list already covers.
-        //
-        // Matching on Id alone is not enough. If the drive comes back mid-session
-        // and the user opens one of its measurements, the service looks the file
-        // up in the LIVE list — which cannot see the hidden entry — and creates a
-        // fresh one with a new Guid. Keeping the stale copy too would then show
-        // the same measurement twice after the next restart. So the path counts
-        // as identity as well, compared exactly as
-        // MeasurementHistoryService.FindBySourceFilePath compares it, so the two
-        // layers cannot disagree about what "the same file" means.
-        List<PersistedEntry> stillUnreachable = [];
-        if (unreachableEntries.Count > 0)
-        {
-            HashSet<Guid> liveIds = persisted.Select(entry => entry.Id).ToHashSet();
-            HashSet<string> livePaths = persisted
-                .Select(entry => entry.SourceFilePath)
-                .Where(path => !string.IsNullOrWhiteSpace(path))
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        WriteStore(persisted);
+    }
 
-            stillUnreachable = unreachableEntries
-                .Where(entry =>
-                    !liveIds.Contains(entry.Id) &&
-                    !livePaths.Contains(entry.SourceFilePath))
-                .ToList();
-
-            persisted.AddRange(stillUnreachable);
-            // Newest first, matching how the service orders the live list.
-            persisted = persisted.OrderByDescending(entry => entry.Timestamp).ToList();
-        }
-
+    private void WriteStore(List<PersistedEntry> entries)
+    {
         StoreFile file = new()
         {
             SchemaVersion = CurrentSchemaVersion,
-            Entries = persisted
+            Entries = entries
         };
 
         // Temp file + move keeps the store intact if the write is interrupted.
         AtomicFile.Write(
             pathOnDisk,
             stream => JsonSerializer.Serialize(stream, file, SerializerOptions));
-
-        // Only now, and only to what was actually written. An entry superseded
-        // by a live one is gone from the file, so it must be gone from retention
-        // too — otherwise deleting the live entry (which saves immediately)
-        // would write the stale copy straight back and resurrect it.
-        unreachableEntries = stillUnreachable;
     }
 
     private BackupResult BackupUnusableFile()

--- a/source/History/MeasurementHistoryPersistence.cs
+++ b/source/History/MeasurementHistoryPersistence.cs
@@ -70,18 +70,23 @@ internal sealed class MeasurementHistoryPersistence
             var reachable = new List<MeasurementHistoryEntry>(file.Entries.Count);
             var retained = new List<PersistedEntry>(file.Entries.Count);
             int removedCount = 0;
+            bool storeChanged = false;
             foreach (PersistedEntry entry in file.Entries)
             {
                 if (string.IsNullOrWhiteSpace(entry.SourceFilePath))
                 {
                     // No path at all is a broken record: dropped like a missing
-                    // file, it just never counted as a measurement.
+                    // file — silently, it never counted as a measurement — but
+                    // it still marks the store dirty, or it would sit in the
+                    // JSON forever without ever tripping the removal message.
+                    storeChanged = true;
                     continue;
                 }
 
                 if (!File.Exists(entry.SourceFilePath))
                 {
                     removedCount++;
+                    storeChanged = true;
                     continue;
                 }
 
@@ -99,7 +104,7 @@ internal sealed class MeasurementHistoryPersistence
                 });
             }
 
-            if (removedCount > 0)
+            if (storeChanged)
             {
                 // A row whose file is gone is dead weight: it can do nothing but
                 // repeat a warning on every launch — which is exactly what the
@@ -117,7 +122,10 @@ internal sealed class MeasurementHistoryPersistence
                     when (exception is IOException or UnauthorizedAccessException)
                 {
                 }
+            }
 
+            if (removedCount > 0)
+            {
                 LoadWarning =
                     $"{removedCount} measurement(s) were removed from the history " +
                     "because their files no longer exist (deleted, or a moved " +

--- a/source/Options/FROptions.Designer.cs
+++ b/source/Options/FROptions.Designer.cs
@@ -28,6 +28,10 @@ namespace Resonalyze.Options
         /// </summary>
         private void InitializeComponent()
         {
+            labelWindowMode = new Label();
+            comboWindowMode = new DarkComboBox();
+            labelFdwCycles = new Label();
+            comboFdwCycles = new DarkComboBox();
             label1 = new Label();
             numericWindow = new DarkNumericUpDown();
             numericRightWindow = new DarkNumericUpDown();
@@ -55,11 +59,55 @@ namespace Resonalyze.Options
             (numericLeftWindow).BeginInit();
             SuspendLayout();
             //
+            // labelWindowMode
+            //
+            labelWindowMode.AutoSize = true;
+            labelWindowMode.ForeColor = SystemColors.ControlLight;
+            labelWindowMode.Location = new Point(12, 14);
+            labelWindowMode.Name = "labelWindowMode";
+            labelWindowMode.Size = new Size(83, 15);
+            labelWindowMode.TabIndex = 58;
+            labelWindowMode.Text = "Window mode";
+            //
+            // comboWindowMode
+            //
+            comboWindowMode.BackColor = Color.FromArgb(55, 60, 72);
+            comboWindowMode.DropDownStyle = ComboBoxStyle.DropDownList;
+            comboWindowMode.ForeColor = Color.White;
+            comboWindowMode.Items.AddRange(new object[] { "Fixed", "FDW" });
+            comboWindowMode.Location = new Point(153, 13);
+            comboWindowMode.MinimumSize = new Size(36, 19);
+            comboWindowMode.Name = "comboWindowMode";
+            comboWindowMode.Size = new Size(100, 23);
+            comboWindowMode.TabIndex = 59;
+            //
+            // labelFdwCycles
+            //
+            labelFdwCycles.AutoSize = true;
+            labelFdwCycles.ForeColor = SystemColors.ControlLight;
+            labelFdwCycles.Location = new Point(12, 39);
+            labelFdwCycles.Name = "labelFdwCycles";
+            labelFdwCycles.Size = new Size(67, 15);
+            labelFdwCycles.TabIndex = 60;
+            labelFdwCycles.Text = "FDW cycles";
+            //
+            // comboFdwCycles
+            //
+            comboFdwCycles.BackColor = Color.FromArgb(55, 60, 72);
+            comboFdwCycles.DropDownStyle = ComboBoxStyle.DropDownList;
+            comboFdwCycles.ForeColor = Color.White;
+            comboFdwCycles.Items.AddRange(new object[] { 4, 6, 8 });
+            comboFdwCycles.Location = new Point(153, 38);
+            comboFdwCycles.MinimumSize = new Size(36, 19);
+            comboFdwCycles.Name = "comboFdwCycles";
+            comboFdwCycles.Size = new Size(100, 23);
+            comboFdwCycles.TabIndex = 61;
+            //
             // label1
             //
             label1.AutoSize = true;
             label1.ForeColor = SystemColors.ControlLight;
-            label1.Location = new Point(12, 14);
+            label1.Location = new Point(12, 64);
             label1.Name = "label1";
             label1.Size = new Size(51, 15);
             label1.TabIndex = 16;
@@ -71,7 +119,7 @@ namespace Resonalyze.Options
             numericWindow.DecimalPlaces = 0;
             numericWindow.ForeColor = Color.White;
             numericWindow.Increment = new decimal(new int[] { 1, 0, 0, 0 });
-            numericWindow.Location = new Point(153, 12);
+            numericWindow.Location = new Point(153, 62);
             numericWindow.Maximum = new decimal(new int[] { 32768, 0, 0, 0 });
             numericWindow.Minimum = new decimal(new int[] { 4, 0, 0, 0 });
             numericWindow.MinimumSize = new Size(36, 19);
@@ -88,7 +136,7 @@ namespace Resonalyze.Options
             numericRightWindow.DecimalPlaces = 0;
             numericRightWindow.ForeColor = Color.White;
             numericRightWindow.Increment = new decimal(new int[] { 1, 0, 0, 0 });
-            numericRightWindow.Location = new Point(153, 61);
+            numericRightWindow.Location = new Point(153, 111);
             numericRightWindow.Maximum = new decimal(new int[] { 16384, 0, 0, 0 });
             numericRightWindow.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
             numericRightWindow.MinimumSize = new Size(36, 19);
@@ -105,7 +153,7 @@ namespace Resonalyze.Options
             numericLeftWindow.DecimalPlaces = 0;
             numericLeftWindow.ForeColor = Color.White;
             numericLeftWindow.Increment = new decimal(new int[] { 1, 0, 0, 0 });
-            numericLeftWindow.Location = new Point(153, 36);
+            numericLeftWindow.Location = new Point(153, 86);
             numericLeftWindow.Maximum = new decimal(new int[] { 16384, 0, 0, 0 });
             numericLeftWindow.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
             numericLeftWindow.MinimumSize = new Size(36, 19);
@@ -120,7 +168,7 @@ namespace Resonalyze.Options
             //
             label5.AutoSize = true;
             label5.ForeColor = SystemColors.ControlLight;
-            label5.Location = new Point(12, 60);
+            label5.Location = new Point(12, 110);
             label5.Name = "label5";
             label5.Size = new Size(117, 15);
             label5.TabIndex = 19;
@@ -130,7 +178,7 @@ namespace Resonalyze.Options
             //
             label4.AutoSize = true;
             label4.ForeColor = SystemColors.ControlLight;
-            label4.Location = new Point(12, 35);
+            label4.Location = new Point(12, 85);
             label4.Name = "label4";
             label4.Size = new Size(109, 15);
             label4.TabIndex = 18;
@@ -140,7 +188,7 @@ namespace Resonalyze.Options
             //
             label9.AutoSize = true;
             label9.ForeColor = SystemColors.ControlLight;
-            label9.Location = new Point(12, 85);
+            label9.Location = new Point(12, 135);
             label9.Name = "label9";
             label9.Size = new Size(117, 15);
             label9.TabIndex = 29;
@@ -150,7 +198,7 @@ namespace Resonalyze.Options
             //
             comboSmoothingInverseOctaves.BackColor = Color.FromArgb(55, 60, 72);
             comboSmoothingInverseOctaves.ForeColor = Color.White;
-            comboSmoothingInverseOctaves.Location = new Point(153, 84);
+            comboSmoothingInverseOctaves.Location = new Point(153, 134);
             comboSmoothingInverseOctaves.Margin = new Padding(0);
             comboSmoothingInverseOctaves.MinimumSize = new Size(36, 19);
             comboSmoothingInverseOctaves.Name = "comboSmoothingInverseOctaves";
@@ -161,7 +209,7 @@ namespace Resonalyze.Options
             //
             comboCalibration.BackColor = Color.FromArgb(55, 60, 72);
             comboCalibration.ForeColor = Color.White;
-            comboCalibration.Location = new Point(153, 108);
+            comboCalibration.Location = new Point(153, 158);
             comboCalibration.Margin = new Padding(0);
             comboCalibration.MinimumSize = new Size(36, 19);
             comboCalibration.Name = "comboCalibration";
@@ -172,7 +220,7 @@ namespace Resonalyze.Options
             //
             label2.AutoSize = true;
             label2.ForeColor = SystemColors.ControlLight;
-            label2.Location = new Point(12, 110);
+            label2.Location = new Point(12, 160);
             label2.Name = "label2";
             label2.Size = new Size(65, 15);
             label2.TabIndex = 46;
@@ -182,7 +230,7 @@ namespace Resonalyze.Options
             //
             labelScale.AutoSize = true;
             labelScale.ForeColor = SystemColors.ControlLight;
-            labelScale.Location = new Point(12, 137);
+            labelScale.Location = new Point(12, 187);
             labelScale.Name = "labelScale";
             labelScale.Size = new Size(35, 15);
             labelScale.TabIndex = 55;
@@ -193,7 +241,7 @@ namespace Resonalyze.Options
             radioMagnitudeRelative.AutoSize = true;
             radioMagnitudeRelative.Checked = true;
             radioMagnitudeRelative.ForeColor = SystemColors.ControlLight;
-            radioMagnitudeRelative.Location = new Point(72, 135);
+            radioMagnitudeRelative.Location = new Point(72, 185);
             radioMagnitudeRelative.Name = "radioMagnitudeRelative";
             radioMagnitudeRelative.Size = new Size(72, 19);
             radioMagnitudeRelative.TabIndex = 56;
@@ -205,7 +253,7 @@ namespace Resonalyze.Options
             //
             radioMagnitudeSpl.AutoSize = true;
             radioMagnitudeSpl.ForeColor = SystemColors.ControlLight;
-            radioMagnitudeSpl.Location = new Point(153, 135);
+            radioMagnitudeSpl.Location = new Point(153, 185);
             radioMagnitudeSpl.Name = "radioMagnitudeSpl";
             radioMagnitudeSpl.Size = new Size(66, 19);
             radioMagnitudeSpl.TabIndex = 57;
@@ -216,7 +264,7 @@ namespace Resonalyze.Options
             //
             labelCurves.AutoSize = true;
             labelCurves.ForeColor = Color.FromArgb(150, 170, 205);
-            labelCurves.Location = new Point(12, 165);
+            labelCurves.Location = new Point(12, 215);
             labelCurves.Name = "labelCurves";
             labelCurves.Size = new Size(46, 15);
             labelCurves.TabIndex = 53;
@@ -226,7 +274,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowPrimary.AutoSize = true;
             checkBoxShowPrimary.ForeColor = SystemColors.ControlLight;
-            checkBoxShowPrimary.Location = new Point(12, 187);
+            checkBoxShowPrimary.Location = new Point(12, 237);
             checkBoxShowPrimary.Name = "checkBoxShowPrimary";
             checkBoxShowPrimary.Size = new Size(161, 19);
             checkBoxShowPrimary.TabIndex = 48;
@@ -237,7 +285,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowCoherence.AutoSize = true;
             checkBoxShowCoherence.ForeColor = SystemColors.ControlLight;
-            checkBoxShowCoherence.Location = new Point(12, 319);
+            checkBoxShowCoherence.Location = new Point(12, 369);
             checkBoxShowCoherence.Name = "checkBoxShowCoherence";
             checkBoxShowCoherence.Size = new Size(134, 19);
             checkBoxShowCoherence.TabIndex = 54;
@@ -248,7 +296,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowHd2.AutoSize = true;
             checkBoxShowHd2.ForeColor = SystemColors.ControlLight;
-            checkBoxShowHd2.Location = new Point(12, 209);
+            checkBoxShowHd2.Location = new Point(12, 259);
             checkBoxShowHd2.Name = "checkBoxShowHd2";
             checkBoxShowHd2.Size = new Size(81, 19);
             checkBoxShowHd2.TabIndex = 49;
@@ -259,7 +307,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowHd3.AutoSize = true;
             checkBoxShowHd3.ForeColor = SystemColors.ControlLight;
-            checkBoxShowHd3.Location = new Point(12, 231);
+            checkBoxShowHd3.Location = new Point(12, 281);
             checkBoxShowHd3.Name = "checkBoxShowHd3";
             checkBoxShowHd3.Size = new Size(81, 19);
             checkBoxShowHd3.TabIndex = 50;
@@ -270,7 +318,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowHd4.AutoSize = true;
             checkBoxShowHd4.ForeColor = SystemColors.ControlLight;
-            checkBoxShowHd4.Location = new Point(12, 253);
+            checkBoxShowHd4.Location = new Point(12, 303);
             checkBoxShowHd4.Name = "checkBoxShowHd4";
             checkBoxShowHd4.Size = new Size(81, 19);
             checkBoxShowHd4.TabIndex = 51;
@@ -281,7 +329,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowThdPlusNoise.AutoSize = true;
             checkBoxShowThdPlusNoise.ForeColor = SystemColors.ControlLight;
-            checkBoxShowThdPlusNoise.Location = new Point(12, 275);
+            checkBoxShowThdPlusNoise.Location = new Point(12, 325);
             checkBoxShowThdPlusNoise.Name = "checkBoxShowThdPlusNoise";
             checkBoxShowThdPlusNoise.Size = new Size(82, 19);
             checkBoxShowThdPlusNoise.TabIndex = 52;
@@ -292,7 +340,7 @@ namespace Resonalyze.Options
             //
             checkBoxShowNoiseFloor.AutoSize = true;
             checkBoxShowNoiseFloor.ForeColor = SystemColors.ControlLight;
-            checkBoxShowNoiseFloor.Location = new Point(12, 297);
+            checkBoxShowNoiseFloor.Location = new Point(12, 347);
             checkBoxShowNoiseFloor.Name = "checkBoxShowNoiseFloor";
             checkBoxShowNoiseFloor.Size = new Size(114, 19);
             checkBoxShowNoiseFloor.TabIndex = 53;
@@ -302,7 +350,7 @@ namespace Resonalyze.Options
             // irPlotView
             //
             irPlotView.BackColor = Color.FromArgb(32, 36, 46);
-            irPlotView.Location = new Point(12, 345);
+            irPlotView.Location = new Point(12, 395);
             irPlotView.Name = "irPlotView";
             irPlotView.PanCursor = Cursors.Hand;
             irPlotView.Size = new Size(241, 300);
@@ -317,7 +365,11 @@ namespace Resonalyze.Options
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(45, 50, 60);
-            ClientSize = new Size(265, 652);
+            ClientSize = new Size(265, 702);
+            Controls.Add(labelWindowMode);
+            Controls.Add(comboWindowMode);
+            Controls.Add(labelFdwCycles);
+            Controls.Add(comboFdwCycles);
             Controls.Add(irPlotView);
             Controls.Add(labelScale);
             Controls.Add(radioMagnitudeRelative);
@@ -355,6 +407,10 @@ namespace Resonalyze.Options
         }
 
         #endregion
+        private Label labelWindowMode;
+        private DarkComboBox comboWindowMode;
+        private Label labelFdwCycles;
+        private DarkComboBox comboFdwCycles;
         private Label label1;
         private DarkNumericUpDown numericWindow;
         private DarkNumericUpDown numericRightWindow;

--- a/source/Options/FROptions.cs
+++ b/source/Options/FROptions.cs
@@ -18,6 +18,8 @@ namespace Resonalyze.Options
         {
             InitializeComponent();
             BindTukeyWindowControls(numericWindow, numericLeftWindow, numericRightWindow);
+            comboWindowMode.SelectedIndexChanged +=
+                (_, _) => UpdateMagnitudeWindowControlState();
             SmoothingPresetOptions.Configure(
                 comboSmoothingInverseOctaves, includePsychoacoustic: true);
             InitializeToolTips();
@@ -33,6 +35,14 @@ namespace Resonalyze.Options
             AttachMeasurement(expSweepMeasurement);
             InitializeControls(() =>
             {
+                comboWindowMode.SelectedIndex =
+                    frequencyResponseOptions.MagnitudeWindowMode == PhaseWindowMode.Fixed
+                        ? 0
+                        : 1;
+                comboFdwCycles.SelectedItem =
+                    frequencyResponseOptions.MagnitudeFdwCycles is 4 or 6 or 8
+                        ? frequencyResponseOptions.MagnitudeFdwCycles
+                        : PhaseAnalysisSettings.DefaultFdwCycles;
                 numericWindow.Value = frequencyResponseOptions.Window;
                 numericLeftWindow.Value = frequencyResponseOptions.LeftTukeyWindow;
                 numericRightWindow.Value = frequencyResponseOptions.RightTukeyWindow;
@@ -61,6 +71,7 @@ namespace Resonalyze.Options
                 radioMagnitudeRelative.Checked = !spl;
                 RefreshTukeyWindowLimits();
             });
+            UpdateMagnitudeWindowControlState();
             UpdateIrPreview();
         }
 
@@ -68,6 +79,13 @@ namespace Resonalyze.Options
             FrequencyResponseOptions frequencyResponseOptions,
             CurveVisibilityOptions visibility)
         {
+            frequencyResponseOptions.MagnitudeWindowMode = comboWindowMode.SelectedIndex == 0
+                ? PhaseWindowMode.Fixed
+                : PhaseWindowMode.FrequencyDependent;
+            frequencyResponseOptions.MagnitudeFdwCycles =
+                comboFdwCycles.SelectedItem is int cycles
+                    ? cycles
+                    : PhaseAnalysisSettings.DefaultFdwCycles;
             frequencyResponseOptions.Window = (int)numericWindow.Value;
             frequencyResponseOptions.LeftTukeyWindow = (int)numericLeftWindow.Value;
             frequencyResponseOptions.RightTukeyWindow = (int)numericRightWindow.Value;
@@ -89,6 +107,12 @@ namespace Resonalyze.Options
                 : MagnitudeScale.Relative;
             UpdateIrPreview();
         }
+
+        // The cycles choice only participates in FDW mode; the window fields stay
+        // active either way because in FDW mode they define the outer gate that
+        // the frequency-dependent windows never exceed.
+        private void UpdateMagnitudeWindowControlState() =>
+            comboFdwCycles.Enabled = comboWindowMode.SelectedIndex == 1;
 
         // SPL is offerable exactly when the plot can render it — mirror
         // MeasurementPlotContext.SplOffsetDb: this measurement's own (snapshot)
@@ -144,6 +168,16 @@ namespace Resonalyze.Options
 
         private void InitializeToolTips()
         {
+            toolTip.SetToolTip(
+                comboWindowMode,
+                "Fixed uses one time window for the entire spectrum (the steady-state " +
+                "in-room response). FDW shortens the analysis window as frequency rises " +
+                "to suppress late cabin reflections (a quasi-anechoic response).");
+            toolTip.SetToolTip(
+                comboFdwCycles,
+                "Periods retained by FDW: 4 suppresses reflections most, 6 is " +
+                "recommended, and 8 retains more reflected detail. The Tukey window " +
+                "below remains the outer gate FDW never exceeds.");
             numericWindow.ApplyToolTip(
                 toolTip,
                 "Sets the FFT window length used to calculate the frequency response.");
@@ -195,8 +229,9 @@ namespace Resonalyze.Options
             toolTip.SetToolTip(
                 irPlotView,
                 "Preview of the transfer impulse response and the analysis window used " +
-                "for the primary curve. The harmonic curves window the sweep-deconvolution " +
-                "IR with automatically derived windows.");
+                "for the primary curve. In FDW mode this window is the outer gate; " +
+                "higher frequencies use shorter windows inside it. The harmonic curves " +
+                "window the sweep-deconvolution IR with automatically derived windows.");
         }
     }
 }

--- a/source/Settings/MeasurementSettingsFile.Schema.cs
+++ b/source/Settings/MeasurementSettingsFile.Schema.cs
@@ -197,6 +197,11 @@ internal sealed partial class MeasurementSettingsFile
         public int Window { get; set; } = 4096;
         public int LeftTukeyWindow { get; set; } = 256;
         public int RightTukeyWindow { get; set; } = 256;
+        // Magnitude FDW ships with a Fixed default, so a file without these
+        // fields keeps its meaning without a migration case.
+        public PhaseWindowMode? MagnitudeWindowMode { get; set; } =
+            Resonalyze.Dsp.PhaseWindowMode.Fixed;
+        public int MagnitudeFdwCycles { get; set; } = PhaseAnalysisSettings.DefaultFdwCycles;
         public double SmoothingInverseOctaves { get; set; } = 6;
         public int Offset { get; set; }
         public bool Unwrap { get; set; } = true;
@@ -243,6 +248,8 @@ internal sealed partial class MeasurementSettingsFile
                 Window = options.Window,
                 LeftTukeyWindow = options.LeftTukeyWindow,
                 RightTukeyWindow = options.RightTukeyWindow,
+                MagnitudeWindowMode = options.MagnitudeWindowMode,
+                MagnitudeFdwCycles = options.MagnitudeFdwCycles,
                 SmoothingInverseOctaves = options.SmoothingInverseOctaves,
                 Offset = options.Offset,
                 Unwrap = options.Unwrap,
@@ -284,6 +291,13 @@ internal sealed partial class MeasurementSettingsFile
             options.Window = window;
             (options.LeftTukeyWindow, options.RightTukeyWindow) =
                 ClampTukeyWindows(LeftTukeyWindow, RightTukeyWindow, window);
+            options.MagnitudeWindowMode = MagnitudeWindowMode is { } magnitudeWindowMode &&
+                Enum.IsDefined(magnitudeWindowMode)
+                    ? magnitudeWindowMode
+                    : Resonalyze.Dsp.PhaseWindowMode.Fixed;
+            options.MagnitudeFdwCycles = MagnitudeFdwCycles is 4 or 6 or 8
+                ? MagnitudeFdwCycles
+                : PhaseAnalysisSettings.DefaultFdwCycles;
             options.SmoothingInverseOctaves =
                 SmoothingPresetOptions.Normalize(SmoothingInverseOctaves);
             options.Offset = Clamp(Offset, -32768, 32768);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverGateDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverGateDialog.cs
@@ -5,11 +5,12 @@ using Resonalyze.Options;
 namespace Resonalyze;
 
 /// <summary>
-/// Manual phase-gate settings for the Virtual DSP phase view, mirroring
-/// the Phase mode gate: offset + left/plateau/right Tukey shoulders in
-/// milliseconds, with a live preview of every channel's processed impulse
-/// response and the window shape, so reflections can be gated out visually.
-/// Nothing is committed until Save; the caller reads the properties afterward.
+/// Manual gate settings for the Virtual DSP magnitude, phase and impulse
+/// views, mirroring the Phase mode gate: offset + left/plateau/right Tukey
+/// shoulders in milliseconds, with a live preview of every channel's processed
+/// impulse response and the window shape, so reflections can be gated out
+/// visually. Nothing is committed until Save; the caller reads the properties
+/// afterward.
 /// </summary>
 internal sealed partial class VirtualCrossoverGateDialog : Form
 {
@@ -28,14 +29,17 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
 
     /// <summary>
     /// Live preview: fired with the candidate gate values (offset, left,
-    /// plateau, right, τ — all ms) on every control change, so the host can
-    /// redraw the phase plot immediately. Nothing is committed until Save; the
-    /// caller reverts to its stored values on Cancel.
+    /// plateau, right, τ — all ms; plus whether the offset is unpinned) on
+    /// every control change, so the host can redraw the gated plots
+    /// immediately. The Auto flag must travel with the preview: an unpinned
+    /// gate places each curve's window on its own arrival, and the preview has
+    /// to show exactly what Save will produce. Nothing is committed until
+    /// Save; the caller reverts to its stored values on Cancel.
     /// </summary>
     [System.ComponentModel.Browsable(false)]
     [System.ComponentModel.DesignerSerializationVisibility(
         System.ComponentModel.DesignerSerializationVisibility.Hidden)]
-    public Action<double, double, double, double, PhaseWindowMode, int,
+    public Action<double, bool, double, double, double, PhaseWindowMode, int,
         PhaseDetrendMode, double>? PreviewChanged { get; set; }
 
     public VirtualCrossoverGateDialog()
@@ -56,6 +60,11 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
             {
                 numericGateOffset.Value = numericGateOffset.ClampValue(fitOffsetMs);
             }
+
+            // The snap above only fires ValueChanged when the value actually
+            // moves; the Auto flag itself changes the gating (per-curve vs
+            // pinned), so the preview must always hear about it.
+            OnGateChanged();
         };
         buttonTauSlope.Click += (_, _) => ApplyEstimatedTau(useSlope: true);
         buttonTauPeak.Click += (_, _) => ApplyEstimatedTau(useSlope: false);
@@ -167,8 +176,8 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         UpdatePreview();
         UpdatePhaseControlState();
         PreviewChanged?.Invoke(
-            GateOffsetMs, LeftMs, PlateauMs, RightMs, WindowMode, FdwCycles,
-            DetrendMode, DetrendMs);
+            GateOffsetMs, AutoOffset, LeftMs, PlateauMs, RightMs, WindowMode,
+            FdwCycles, DetrendMode, DetrendMs);
     }
 
     private void UpdatePhaseControlState()
@@ -264,13 +273,17 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         numericGateOffset.ApplyToolTip(
             toolTip,
             "Gate position: time from the IR start to the end\r\n" +
-            "of the left Tukey shoulder.\r\n" +
-            "Auto keeps it on the earliest channel IR start.");
+            "of the left Tukey shoulder. Pinned, it is one absolute\r\n" +
+            "window for every curve; the field shows the earliest\r\n" +
+            "channel's placement while Auto is pressed.");
         toolTip.SetToolTip(
             checkAutoOffset,
-            "Keep the gate offset on the earliest processed channel's\r\n" +
-            "detected IR start, following source and delay changes.\r\n" +
-            "Release to pin the offset manually.");
+            "Auto places the gate automatically, following source and\r\n" +
+            "delay changes: the magnitude uses ONE window at the earliest\r\n" +
+            "arrival (so the Sum stays the exact sum of the drawn curves),\r\n" +
+            "while each phase curve is gated at its own arrival (so FDW\r\n" +
+            "keeps every channel's treble) with one common time reference.\r\n" +
+            "Release to pin one absolute window for everything instead.");
         numericLeft.ApplyToolTip(
             toolTip,
             "Tukey fade-in before the arrival, in milliseconds.\r\n" +
@@ -305,9 +318,12 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
         toolTip.SetToolTip(
             irPlotView,
             "Preview of every channel's processed impulse response\r\n" +
-            "and the gate window used for the phase view.");
+            "and the gate window used for the magnitude and phase views.");
         toolTip.SetToolTip(comboWindowMode,
-            "Fixed uses one gate. FDW shortens the window as frequency rises.");
+            "Fixed uses one gate. FDW shortens the window as frequency\r\n" +
+            "rises — it shapes the PHASE view only; the magnitude always\r\n" +
+            "reads the fixed gate (no single frequency-dependent window\r\n" +
+            "can hold the summed response's spread arrivals).");
         toolTip.SetToolTip(comboFdwCycles,
             "4 cycles suppresses reflections most; 6 is recommended; 8 retains more detail.");
         toolTip.SetToolTip(comboDetrendMode,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -445,28 +445,6 @@ internal sealed class VirtualCrossoverMetrics
     }
 
     /// <summary>
-    /// The complex-sum magnitude of the OPPOSITE side (dashed and translucent
-    /// on the plot), so the two sides' tunes compare at a glance without
-    /// flipping back and forth. Mono channels contribute their single response
-    /// to both sides' sums, exactly as they do physically. Null when the
-    /// opposite side has fewer than two participating channels — a "sum" of
-    /// one driver is just that driver. Uses the coordinator cache, so it shares
-    /// processed responses and staleness handling with the main redraw.
-    /// </summary>
-    public async Task<AnalysisCurve?> ComputeOppositeSumCurveAsync(
-        IReadOnlyList<VirtualCrossoverChannel> channels,
-        bool oppositeRight,
-        long revision)
-    {
-        VirtualCrossoverSideSum? side = await ComputeSideSumAsync(
-            channels, oppositeRight, revision, minimumChannels: 2);
-        return side == null
-            ? null
-            : buildMagnitudeCurve(
-                side.ImpulseResponse, side.AnchorIndex, side.SampleRate);
-    }
-
-    /// <summary>
     /// The complex sum of one side's participating channels, processed through
     /// their chains. Mono channels contribute their single response to both
     /// sides, exactly as they do physically. Null when the side has fewer than

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -37,16 +37,22 @@ internal sealed class VirtualCrossoverMetrics
             return (null, null);
         }
 
-        // Every curve — the channels AND the sum — shares one window anchor (the
-        // earliest arrival): with per-channel anchors the gates capture slightly
-        // different room content and the loss can poke above its 0 dB ceiling.
-        // The summed envelope peak can sit between the arrivals or vanish under
-        // cancellation, so the anchor is the earliest arrival, not the sum peak.
+        // Every curve — the channels AND the sum — shares one window anchor
+        // (the earliest arrival): with per-channel anchors the gates capture
+        // slightly different room content, the drawn Sum stops being the
+        // vector sum of the drawn channels, and the loss can poke above its
+        // 0 dB ceiling. The summed envelope peak can sit between the arrivals
+        // or vanish under cancellation, so the anchor is the earliest arrival,
+        // not the sum peak. (With the gate pinned in the dialog the offset is
+        // absolute and shared by construction; the anchor is the
+        // Auto-placement fallback. The magnitude always reads the FIXED gate —
+        // FDW would need per-channel windows here, exactly what the shared
+        // window exists to prevent — so FDW shapes the phase view only.)
         int anchor = processed.Min(item => item.PeakIndex);
-        // One windowed FFT + resample per channel; GetPrimarySpectrum allocates
-        // its own buffers and reads only the (redraw-stable) options and
-        // calibration, so the channels' spectra compute across cores. AsOrdered
-        // keeps the result aligned with the channel list.
+        // One gated build + resample per channel; the panel's magnitude builder
+        // reads only its immutable UI-thread snapshots and the calibration, so
+        // the channels' spectra compute across cores. AsOrdered keeps the
+        // result aligned with the channel list.
         List<AnalysisCurve> magnitudes = processed
             .AsParallel()
             .AsOrdered()

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -59,10 +59,25 @@ public partial class VirtualCrossoverPanel : UserControl
     // offset is a placeholder; each build stamps its own (see
     // BuildMagnitudeCurve). The initial value only bridges construction: every
     // curve is built after the first unsuppressed redraw refreshed it.
-    private sealed record MagnitudeGateSnapshot(
+    // Internal (with the resolver) so the per-side pin choice is pinned by a
+    // unit test without constructing the panel.
+    internal sealed record MagnitudeGateSnapshot(
         PhaseAnalysisSettings Template,
         double? PinnedOffsetMs,
-        int SmoothingInverseOctaves);
+        double? OppositePinnedOffsetMs,
+        int SmoothingInverseOctaves)
+    {
+        // The one place the pinned-vs-anchor choice lives. The two sides'
+        // arrivals sit at different times and the project stores their pinned
+        // offsets separately — the active side's pin must never window the
+        // OPPOSITE side's sum (its own pin, or its own anchor when unpinned).
+        internal double ResolveGateOffsetMs(
+            bool oppositeSide,
+            int anchorPeakIndex,
+            int sampleRate) =>
+            (oppositeSide ? OppositePinnedOffsetMs : PinnedOffsetMs)
+                ?? anchorPeakIndex * 1_000.0 / sampleRate;
+    }
 
     private MagnitudeGateSnapshot magnitudeGate = new(
         new PhaseAnalysisSettings(
@@ -77,6 +92,7 @@ public partial class VirtualCrossoverPanel : UserControl
             Unwrap: false,
             SmoothingInverseOctaves: 0.0),
         PinnedOffsetMs: null,
+        OppositePinnedOffsetMs: null,
         SmoothingInverseOctaves: 12);
 
     private readonly List<VirtualCrossoverChannel> channels = new();
@@ -1805,6 +1821,7 @@ public partial class VirtualCrossoverPanel : UserControl
                 WindowMode = PhaseWindowMode.Fixed
             },
             PinnedGateOffsetMs,
+            project.PhaseGateFor(!project.ActiveSideRight).OffsetMs,
             comboBoxSmoothing.SelectedItem is int smoothing ? smoothing : 12);
 
         // Every settings/source/view change invalidates the captured render
@@ -1966,11 +1983,19 @@ public partial class VirtualCrossoverPanel : UserControl
         // free. Same staleness rule as above.
         List<VirtualCrossoverMetric.StereoDelta> stereoDeltas =
             await metrics.ComputeStereoDeltasAsync(channels, revision);
-        AnalysisCurve? oppositeSum =
-            checkBoxShowSum.Checked && radioViewMagnitude.Checked
-                ? await metrics.ComputeOppositeSumCurveAsync(
-                    channels, !project.ActiveSideRight, revision)
-                : null;
+        // The side sum comes from metrics (shared coordinator cache); the CURVE
+        // is built here so it windows through the OPPOSITE side's gate
+        // placement — the active side's pin must not gate the other side.
+        AnalysisCurve? oppositeSum = null;
+        if (checkBoxShowSum.Checked && radioViewMagnitude.Checked)
+        {
+            VirtualCrossoverSideSum? oppositeSide = await metrics.ComputeSideSumAsync(
+                channels, !project.ActiveSideRight, revision, minimumChannels: 2);
+            if (oppositeSide != null)
+            {
+                oppositeSum = BuildOppositeMagnitudeCurve(oppositeSide);
+            }
+        }
         if (mainPlotView.IsDisposed || !processingCoordinator.IsCurrent(revision))
         {
             return;
@@ -3201,7 +3226,22 @@ public partial class VirtualCrossoverPanel : UserControl
             impulseResponse,
             peakIndex,
             sampleRate,
-            snapshot.PinnedOffsetMs ?? peakIndex * 1_000.0 / sampleRate);
+            snapshot.ResolveGateOffsetMs(oppositeSide: false, peakIndex, sampleRate));
+    }
+
+    // The opposite side's sum window: its OWN pinned offset (or its own
+    // earliest-arrival anchor when unpinned) — never the active side's pin,
+    // whose placement belongs to different arrival times.
+    private AnalysisCurve BuildOppositeMagnitudeCurve(VirtualCrossoverSideSum side)
+    {
+        MagnitudeGateSnapshot snapshot = magnitudeGate;
+        return BuildGatedMagnitudeCurve(
+            snapshot,
+            side.ImpulseResponse,
+            side.AnchorIndex,
+            side.SampleRate,
+            snapshot.ResolveGateOffsetMs(
+                oppositeSide: true, side.AnchorIndex, side.SampleRate));
     }
 
     // A RAW channel curve lives in its own time: its arrival predates the

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3312,23 +3312,49 @@ public partial class VirtualCrossoverPanel : UserControl
                 detrendMs);
         double referenceSamples = detrendMs * sampleRate / 1_000.0;
 
+        bool includeSum = processed.Count >= 2 && checkBoxShowSum.Checked;
+
+        // The gated spectra are built ONCE per redraw and feed both the shown
+        // channels' curves and the Sum — building them twice was possible
+        // before: the per-impulse cache serializes lookup and insert but not
+        // the bank computation itself, so a channel job and the Sum job racing
+        // on a cold cache could each run the same FFTs. The Sum needs every
+        // processed channel (hidden or not, matching the magnitude Sum); with
+        // the Sum off, hidden channels' banks are skipped entirely. Settings
+        // resolve here on the UI thread; only the bank work fans out.
+        List<(ProcessedChannel Item, PhaseAnalysisSettings Settings)> spectrumInputs =
+            processed
+                .Where(item => includeSum || item.Channel.Settings.ShowProcessedCurve)
+                .Select(item => (item, SettingsFor(item.PeakIndex)))
+                .ToList();
+        List<(ProcessedChannel Item, Complex[] Spectrum, int ExtractionStart)> gated =
+            spectrumInputs
+                .AsParallel()
+                .AsOrdered()
+                .Select(input =>
+                {
+                    Complex[] spectrum = DataHelper.GetPhaseAnalysisSpectrum(
+                        new ImpulseMeasurementView(
+                            input.Item.ImpulseResponse, 0, sampleRate),
+                        input.Settings,
+                        out int extractionStart);
+                    return (input.Item, spectrum, extractionStart);
+                })
+                .ToList();
+
         var jobs = new List<(string Title, OxyColor Color, double Thickness,
-            Func<(List<SignalPoint> Points, List<SignalPoint> WrapSegments)> Build)>();
-        foreach (ProcessedChannel item in processed)
+            Complex[] Spectrum, int ExtractionStart)>();
+        foreach ((ProcessedChannel item, Complex[] spectrum, int extractionStart)
+            in gated)
         {
             if (item.Channel.Settings.ShowProcessedCurve)
             {
-                Complex[] impulseResponse = item.ImpulseResponse;
-                PhaseAnalysisSettings settings = SettingsFor(item.PeakIndex);
                 jobs.Add((
-                    item.Channel.Name,
-                    item.Color,
-                    1.8,
-                    () => BuildPhasePoints(impulseResponse, sampleRate, settings)));
+                    item.Channel.Name, item.Color, 1.8, spectrum, extractionStart));
             }
         }
 
-        if (processed.Count >= 2 && checkBoxShowSum.Checked)
+        if (includeSum)
         {
             // The Sum is the vector sum of the individually gated channel
             // SPECTRA, not a gated summed IR: with per-curve Auto windows a
@@ -3336,32 +3362,30 @@ public partial class VirtualCrossoverPanel : UserControl
             // treble that their own traces keep (FDW windows at high
             // frequencies are shorter than the arrival spread), and the drawn
             // Sum would silently stop being the sum of the drawn channels.
-            // Building it from the channels' own gated spectra keeps
-            // superposition exact by construction, reuses the bank cache the
-            // channel curves already fill, and with a pinned gate reduces to
-            // the gated summed IR by linearity. Every processed channel
-            // contributes, hidden or not, matching the magnitude Sum.
-            List<(Complex[] Ir, PhaseAnalysisSettings Settings)> parts = processed
-                .Select(item => (item.ImpulseResponse, SettingsFor(item.PeakIndex)))
-                .ToList();
-            jobs.Add((
-                "Sum",
-                SumColor,
-                2.4,
-                () => BuildSumPhasePoints(parts, referenceSamples, sampleRate)));
+            // Summing the spectra keeps superposition exact by construction,
+            // and with a pinned gate reduces to the gated summed IR by
+            // linearity.
+            int targetExtractionStart = gated.Min(part => part.ExtractionStart);
+            Complex[] combined = DataHelper.SumGatedSpectra(
+                gated.Select(part => (part.Spectrum, part.ExtractionStart)).ToList(),
+                targetExtractionStart);
+            jobs.Add(("Sum", SumColor, 2.4, combined, targetExtractionStart));
         }
 
-        // One gated FFT per curve, and they are independent: GetGatedPhaseData allocates
-        // its own buffers and reads only the settings captured above, so the curves build
-        // across cores. AsOrdered keeps the plot order stable. Same shape as the
-        // magnitude curves in VirtualCrossoverMetrics.BuildCurves.
+        // One phase read per curve over the spectra built above — every curve
+        // against the same absolute τ, across cores, order stable.
         return jobs
             .AsParallel()
             .AsOrdered()
             .SelectMany(job =>
             {
                 (List<SignalPoint> points, List<SignalPoint> wrapSegments) =
-                    job.Build();
+                    SplitWrapSegments(DataHelper.GetGatedPhaseData(
+                        job.Spectrum,
+                        job.ExtractionStart,
+                        referenceSamples,
+                        sampleRate,
+                        unwrap: false));
                 var curves = new List<AcousticCurve>(2);
                 // The ±360° wrap verticals: the channel's color faded and
                 // thinned well below the curve, dashed, drawn first (i.e.
@@ -3511,56 +3535,6 @@ public partial class VirtualCrossoverPanel : UserControl
             gatePreview?.RightMs ?? project.PhaseGateRightMs,
             Unwrap: false,
             SmoothingInverseOctaves: 0.0);
-
-    // Static on purpose: the caller reads the gate and project state once on the UI
-    // thread and hands the settings down, so this runs on a pool thread without the
-    // compiler letting it reach back into a control.
-    private static (List<SignalPoint> Points, List<SignalPoint> WrapSegments)
-        BuildPhasePoints(
-            Complex[] impulseResponse,
-            int sampleRate,
-            PhaseAnalysisSettings settings)
-    {
-        // The gate construction is shared with the Phase mode (DataHelper's
-        // gated extraction): a Tukey window of left + plateau + right whose
-        // left shoulder ends at the gate offset, zero-padded to the fixed FFT
-        // length so the frequency grid is constant. The τ detrend is the
-        // fractional-sample phase reference; every curve built with the same τ
-        // is directly comparable regardless of where its gate sits.
-        var view = new ImpulseMeasurementView(impulseResponse, 0, sampleRate);
-        return SplitWrapSegments(DataHelper.GetGatedPhaseData(view, settings));
-    }
-
-    // The Sum's twin of BuildPhasePoints: each channel's own gated spectrum,
-    // re-referenced to one extraction start and summed in the complex domain,
-    // then read as phase against the same absolute τ as every channel curve.
-    // Static for the same reason as BuildPhasePoints: everything it reads
-    // arrives as arguments captured on the UI thread.
-    private static (List<SignalPoint> Points, List<SignalPoint> WrapSegments)
-        BuildSumPhasePoints(
-            IReadOnlyList<(Complex[] Ir, PhaseAnalysisSettings Settings)> parts,
-            double referenceSamples,
-            int sampleRate)
-    {
-        var spectra = new List<(Complex[] Spectrum, int ExtractionStart)>(parts.Count);
-        foreach ((Complex[] impulseResponse, PhaseAnalysisSettings settings) in parts)
-        {
-            Complex[] spectrum = DataHelper.GetPhaseAnalysisSpectrum(
-                new ImpulseMeasurementView(impulseResponse, 0, sampleRate),
-                settings,
-                out int extractionStart);
-            spectra.Add((spectrum, extractionStart));
-        }
-
-        int targetExtractionStart = spectra.Min(part => part.ExtractionStart);
-        Complex[] combined = DataHelper.SumGatedSpectra(spectra, targetExtractionStart);
-        return SplitWrapSegments(DataHelper.GetGatedPhaseData(
-            combined,
-            targetExtractionStart,
-            referenceSamples,
-            sampleRate,
-            unwrap: false));
-    }
 
     // Wrapped phase jumps from +180° to −180° between adjacent bins. The
     // main curve breaks at the wrap (NaN) so the jump does not read as a

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3270,32 +3270,45 @@ public partial class VirtualCrossoverPanel : UserControl
                 pinnedOffsetMs ?? ownPeak * 1_000.0 / sampleRate,
                 PhaseDetrendMode.Manual,
                 detrendMs);
+        double referenceSamples = detrendMs * sampleRate / 1_000.0;
 
-        var jobs = new List<(string Title, Complex[] Ir, OxyColor Color,
-            double Thickness, PhaseAnalysisSettings Settings)>();
+        var jobs = new List<(string Title, OxyColor Color, double Thickness,
+            Func<(List<SignalPoint> Points, List<SignalPoint> WrapSegments)> Build)>();
         foreach (ProcessedChannel item in processed)
         {
             if (item.Channel.Settings.ShowProcessedCurve)
             {
+                Complex[] impulseResponse = item.ImpulseResponse;
+                PhaseAnalysisSettings settings = SettingsFor(item.PeakIndex);
                 jobs.Add((
                     item.Channel.Name,
-                    item.ImpulseResponse,
                     item.Color,
                     1.8,
-                    SettingsFor(item.PeakIndex)));
+                    () => BuildPhasePoints(impulseResponse, sampleRate, settings)));
             }
         }
 
         if (processed.Count >= 2 && checkBoxShowSum.Checked)
         {
-            Complex[] sum = VirtualCrossoverAnalysis.SumImpulseResponses(
-                processed.Select(item => item.ImpulseResponse).ToList());
+            // The Sum is the vector sum of the individually gated channel
+            // SPECTRA, not a gated summed IR: with per-curve Auto windows a
+            // single window over the summed IR would exclude late channels'
+            // treble that their own traces keep (FDW windows at high
+            // frequencies are shorter than the arrival spread), and the drawn
+            // Sum would silently stop being the sum of the drawn channels.
+            // Building it from the channels' own gated spectra keeps
+            // superposition exact by construction, reuses the bank cache the
+            // channel curves already fill, and with a pinned gate reduces to
+            // the gated summed IR by linearity. Every processed channel
+            // contributes, hidden or not, matching the magnitude Sum.
+            List<(Complex[] Ir, PhaseAnalysisSettings Settings)> parts = processed
+                .Select(item => (item.ImpulseResponse, SettingsFor(item.PeakIndex)))
+                .ToList();
             jobs.Add((
                 "Sum",
-                sum,
                 SumColor,
                 2.4,
-                SettingsFor(processed.Min(item => item.PeakIndex))));
+                () => BuildSumPhasePoints(parts, referenceSamples, sampleRate)));
         }
 
         // One gated FFT per curve, and they are independent: GetGatedPhaseData allocates
@@ -3308,7 +3321,7 @@ public partial class VirtualCrossoverPanel : UserControl
             .SelectMany(job =>
             {
                 (List<SignalPoint> points, List<SignalPoint> wrapSegments) =
-                    BuildPhasePoints(job.Ir, sampleRate, job.Settings);
+                    job.Build();
                 var curves = new List<AcousticCurve>(2);
                 // The ±360° wrap verticals: the channel's color faded and
                 // thinned well below the curve, dashed, drawn first (i.e.
@@ -3475,13 +3488,48 @@ public partial class VirtualCrossoverPanel : UserControl
         // fractional-sample phase reference; every curve built with the same τ
         // is directly comparable regardless of where its gate sits.
         var view = new ImpulseMeasurementView(impulseResponse, 0, sampleRate);
-        List<SignalPoint> phase = DataHelper.GetGatedPhaseData(view, settings);
+        return SplitWrapSegments(DataHelper.GetGatedPhaseData(view, settings));
+    }
 
-        // Wrapped phase jumps from +180° to −180° between adjacent bins. The
-        // main curve breaks at the wrap (NaN) so the jump does not read as a
-        // real phase transition drawn at full stroke; the jump itself goes
-        // into WrapSegments — NaN-separated two-point verticals the caller
-        // draws as a thinner dashed twin, keeping the wrap visible.
+    // The Sum's twin of BuildPhasePoints: each channel's own gated spectrum,
+    // re-referenced to one extraction start and summed in the complex domain,
+    // then read as phase against the same absolute τ as every channel curve.
+    // Static for the same reason as BuildPhasePoints: everything it reads
+    // arrives as arguments captured on the UI thread.
+    private static (List<SignalPoint> Points, List<SignalPoint> WrapSegments)
+        BuildSumPhasePoints(
+            IReadOnlyList<(Complex[] Ir, PhaseAnalysisSettings Settings)> parts,
+            double referenceSamples,
+            int sampleRate)
+    {
+        var spectra = new List<(Complex[] Spectrum, int ExtractionStart)>(parts.Count);
+        foreach ((Complex[] impulseResponse, PhaseAnalysisSettings settings) in parts)
+        {
+            Complex[] spectrum = DataHelper.GetPhaseAnalysisSpectrum(
+                new ImpulseMeasurementView(impulseResponse, 0, sampleRate),
+                settings,
+                out int extractionStart);
+            spectra.Add((spectrum, extractionStart));
+        }
+
+        int targetExtractionStart = spectra.Min(part => part.ExtractionStart);
+        Complex[] combined = DataHelper.SumGatedSpectra(spectra, targetExtractionStart);
+        return SplitWrapSegments(DataHelper.GetGatedPhaseData(
+            combined,
+            targetExtractionStart,
+            referenceSamples,
+            sampleRate,
+            unwrap: false));
+    }
+
+    // Wrapped phase jumps from +180° to −180° between adjacent bins. The
+    // main curve breaks at the wrap (NaN) so the jump does not read as a
+    // real phase transition drawn at full stroke; the jump itself goes
+    // into WrapSegments — NaN-separated two-point verticals the caller
+    // draws as a thinner dashed twin, keeping the wrap visible.
+    private static (List<SignalPoint> Points, List<SignalPoint> WrapSegments)
+        SplitWrapSegments(List<SignalPoint> phase)
+    {
         var points = new List<SignalPoint>(phase.Count);
         var wrapSegments = new List<SignalPoint>();
         SignalPoint? previous = null;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -50,10 +50,34 @@ public partial class VirtualCrossoverPanel : UserControl
         Interval = SaveDebounceMilliseconds
     };
 
-    // The tool renders through the standard FR pipeline (window around the peak,
-    // log grid, smoothing) with its own options instance, so the FR mode's
-    // settings stay untouched.
-    private readonly FrequencyResponseOptions frequencyResponseOptions = new();
+    // The magnitude view reads through the SAME gate as the phase and impulse
+    // views (the gate dialog's offset, shoulders and Fixed/FDW mode), so the
+    // three views describe one time window. One immutable record, refreshed on
+    // the UI thread by RequestRedraw and read by reference from the PLINQ
+    // magnitude builds on worker threads — a single atomic reference, never
+    // the live controls, the project or the gate-preview tuple. The template's
+    // offset is a placeholder; each build stamps its own (see
+    // BuildMagnitudeCurve). The initial value only bridges construction: every
+    // curve is built after the first unsuppressed redraw refreshed it.
+    private sealed record MagnitudeGateSnapshot(
+        PhaseAnalysisSettings Template,
+        double? PinnedOffsetMs,
+        int SmoothingInverseOctaves);
+
+    private MagnitudeGateSnapshot magnitudeGate = new(
+        new PhaseAnalysisSettings(
+            PhaseWindowMode.Fixed,
+            PhaseAnalysisSettings.DefaultFdwCycles,
+            PhaseDetrendMode.Off,
+            ManualDetrendMilliseconds: 0.0,
+            GateOffsetMs: 0.0,
+            LeftMs: FrequencyResponseOptions.DefaultPhaseLeftMs,
+            PlateauMs: FrequencyResponseOptions.DefaultPhasePlateauMs,
+            RightMs: FrequencyResponseOptions.DefaultPhaseRightMs,
+            Unwrap: false,
+            SmoothingInverseOctaves: 0.0),
+        PinnedOffsetMs: null,
+        SmoothingInverseOctaves: 12);
 
     private readonly List<VirtualCrossoverChannel> channels = new();
 
@@ -75,12 +99,15 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private VirtualCrossoverProjectFile project = new();
 
-    // Candidate gate values while the gate dialog is open, so the phase plot
-    // tracks the dialog live; null once it closes (Save committed them to the
-    // project, Cancel reverts by simply dropping them).
-    private (double OffsetMs, double LeftMs, double PlateauMs, double RightMs,
-        PhaseWindowMode WindowMode, int FdwCycles, PhaseDetrendMode DetrendMode,
-        double DetrendMs)? gatePreview;
+    // Candidate gate values while the gate dialog is open, so the gated plots
+    // track the dialog live; null once it closes (Save committed them to the
+    // project, Cancel reverts by simply dropping them). AutoOffset mirrors the
+    // dialog's Auto button: the preview must gate per-curve exactly as Save
+    // will, while OffsetMs still shows where the dialog's window sits (the
+    // impulse overlays draw it).
+    private (double OffsetMs, bool AutoOffset, double LeftMs, double PlateauMs,
+        double RightMs, PhaseWindowMode WindowMode, int FdwCycles,
+        PhaseDetrendMode DetrendMode, double DetrendMs)? gatePreview;
     private VirtualCrossoverAcousticPlot acousticPlot = null!;
     private VirtualCrossoverDspChainPlot dspChainPlot = null!;
     private bool initialized;
@@ -331,7 +358,6 @@ public partial class VirtualCrossoverPanel : UserControl
             radioSideRight.Checked = project.ActiveSideRight;
             radioSideLeft.Checked = !project.ActiveSideRight;
             acousticPlot.ConfigureForView(CurrentAcousticView());
-            UpdateGateButtonAvailability();
             comboBoxSmoothing.SelectedItem =
                 OverlaySmoothing.IsValid(project.SmoothingCode)
                     ? project.SmoothingCode
@@ -971,17 +997,11 @@ public partial class VirtualCrossoverPanel : UserControl
     private void OnViewModeChanged()
     {
         acousticPlot.ConfigureForView(CurrentAcousticView());
-        UpdateGateButtonAvailability();
         // Fractional-octave smoothing shapes only the frequency-domain curves;
         // grey it out in the impulse view where it has no effect.
         comboBoxSmoothing.Enabled = !radioViewImpulse.Checked;
         OnViewChanged();
     }
-
-    // The gate shapes the phase and impulse views; grey the button out on the
-    // magnitude view so it does not suggest an effect on those curves.
-    private void UpdateGateButtonAvailability() =>
-        buttonPhaseGate.Enabled = !radioViewMagnitude.Checked;
 
     private void OnViewChanged()
     {
@@ -1712,8 +1732,8 @@ public partial class VirtualCrossoverPanel : UserControl
             "Run Auto delay afterward to phase-align the result.");
         toolTip.SetToolTip(
             buttonPhaseGate,
-            "Configure the gate for the phase and impulse views:\r\n" +
-            "offset and Tukey fades, with an IR preview — cut the\r\n" +
+            "Configure the gate for the magnitude, phase and impulse\r\n" +
+            "views: offset and Tukey fades, with an IR preview — cut the\r\n" +
             "window before the first reflection for clean traces.\r\n" +
             "Where the gate SITS — its offset and the detrend τ — belongs\r\n" +
             "to the side you are viewing (L or R): their drivers arrive at\r\n" +
@@ -1758,9 +1778,6 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
-        frequencyResponseOptions.SmoothingInverseOctaves =
-            comboBoxSmoothing.SelectedItem is int smoothing ? smoothing : 12;
-
         RequestRedraw();
     }
 
@@ -1769,6 +1786,27 @@ public partial class VirtualCrossoverPanel : UserControl
     // the UI thread, so the flag and the task handle need no synchronization.
     private void RequestRedraw()
     {
+        // Every redraw path funnels through here on the UI thread, so this is
+        // the one place the magnitude-gate snapshot can be refreshed without
+        // the worker-thread builds ever touching live state.
+        magnitudeGate = new MagnitudeGateSnapshot(
+            CreateVirtualPhaseSettings(
+                gateOffsetMs: 0.0,
+                PhaseDetrendMode.Off,
+                manualDetrendMilliseconds: 0.0) with
+            {
+                // The magnitude always reads the FIXED gate. FDW cannot hold
+                // the summed response: its high-frequency windows are shorter
+                // than the channels' arrival spread, so no single window keeps
+                // every channel's treble inside the one summed IR, and the
+                // drawn Sum and the loss read-out collapse. The dialog's
+                // Window mode and FDW cycles therefore shape the PHASE view
+                // only.
+                WindowMode = PhaseWindowMode.Fixed
+            },
+            PinnedGateOffsetMs,
+            comboBoxSmoothing.SelectedItem is int smoothing ? smoothing : 12);
+
         // Every settings/source/view change invalidates the captured render
         // snapshot, not only side switches. A running FFT may finish, but the
         // coordinator will neither cache nor publish its stale result.
@@ -2022,7 +2060,7 @@ public partial class VirtualCrossoverPanel : UserControl
             ProcessedChannel item = processed[i];
             if (item.Channel.Settings.ShowRawCurve)
             {
-                AnalysisCurve raw = BuildMagnitudeCurve(
+                AnalysisCurve raw = BuildRawMagnitudeCurve(
                     item.Channel.TransferImpulseResponse!,
                     item.Channel.TransferPeakIndex,
                     item.Channel.SampleRate);
@@ -3142,15 +3180,63 @@ public partial class VirtualCrossoverPanel : UserControl
         }
     }
 
+    // The gate-driven magnitude shared by the processed channels, the sums and
+    // the metrics — always through the FIXED gate (see the snapshot refresh:
+    // FDW is phase-only, it cannot hold a multi-arrival sum). A pinned (or
+    // pinned-previewed) offset is one absolute window for every curve;
+    // unpinned (Auto), the window anchors at the peak the CALLER passes — the
+    // shared earliest arrival for channels and sums (one window is what keeps
+    // the drawn Sum the exact vector sum of the drawn channels and the
+    // sum-loss under its 0 dB ceiling; see VirtualCrossoverMetrics.BuildCurves)
+    // and the raw curve's own peak. Runs on PLINQ worker threads: reads only
+    // the immutable snapshot RequestRedraw refreshed.
     private AnalysisCurve BuildMagnitudeCurve(
         Complex[] impulseResponse,
         int peakIndex,
         int sampleRate)
     {
-        return DataHelper.GetPrimarySpectrum(
+        MagnitudeGateSnapshot snapshot = magnitudeGate;
+        return BuildGatedMagnitudeCurve(
+            snapshot,
+            impulseResponse,
+            peakIndex,
+            sampleRate,
+            snapshot.PinnedOffsetMs ?? peakIndex * 1_000.0 / sampleRate);
+    }
+
+    // A RAW channel curve lives in its own time: its arrival predates the
+    // processed gate by the channel's delay, so even a pinned processed-view
+    // offset would clip it into the left fade. Same gate durations and window
+    // mode, always anchored on the raw response's own peak.
+    private AnalysisCurve BuildRawMagnitudeCurve(
+        Complex[] impulseResponse,
+        int peakIndex,
+        int sampleRate)
+    {
+        return BuildGatedMagnitudeCurve(
+            magnitudeGate,
+            impulseResponse,
+            peakIndex,
+            sampleRate,
+            peakIndex * 1_000.0 / sampleRate);
+    }
+
+    private AnalysisCurve BuildGatedMagnitudeCurve(
+        MagnitudeGateSnapshot snapshot,
+        Complex[] impulseResponse,
+        int peakIndex,
+        int sampleRate,
+        double gateOffsetMs)
+    {
+        PhaseAnalysisSettings gate = snapshot.Template with
+        {
+            GateOffsetMs = gateOffsetMs
+        };
+        return DataHelper.GetGatedPrimarySpectrum(
             new ImpulseMeasurementView(impulseResponse, peakIndex, sampleRate),
-            frequencyResponseOptions,
-            Calibration);
+            gate,
+            Calibration,
+            snapshot.SmoothingInverseOctaves);
     }
 
     private List<AcousticCurve> BuildPhaseCurves(List<ProcessedChannel> processed)
@@ -3158,39 +3244,58 @@ public partial class VirtualCrossoverPanel : UserControl
         // The gate's own path: every shown channel is gated and FFT'd here, one
         // after another, plus one more for the sum.
         using var _ = AppProfiler.Zone("VirtualDSP.BuildPhaseCurves");
-        // One shared absolute reference (the earliest arrival) keeps the curves'
-        // relative phase intact — that relative alignment through the crossover
-        // region is exactly what this view is for.
+        // One shared absolute τ reference (the earliest arrival) keeps the
+        // curves' relative phase intact — that relative alignment through the
+        // crossover region is exactly what this view is for. The WINDOWS need
+        // not share a position for that: BuildMeasuredPhase re-references every
+        // extraction to the common absolute τ.
         int sampleRate = processed[0].Channel.SampleRate;
-        double gateOffsetMs = gatePreview?.OffsetMs
+        double referenceOffsetMs = gatePreview?.OffsetMs
             ?? ResolveGateOffsetMs(processed, sampleRate);
-        double detrendMs = ResolveCommonDetrendMs(processed, gateOffsetMs, sampleRate);
+        double detrendMs = ResolveCommonDetrendMs(
+            processed, referenceOffsetMs, sampleRate);
 
-        // Read the gate and project state ONCE, here on the UI thread: every curve gets
-        // the identical settings anyway, and the workers below must not reach back into
+        // Read the gate and project state ONCE, here on the UI thread —
+        // including each curve's own gate placement: pinned, every curve
+        // shares one absolute window; unpinned (Auto), each IR gates at its
+        // own arrival PEAK, so FDW's short high-frequency windows keep a late
+        // channel's treble instead of silently excluding it. The peak, not the
+        // estimated IR start: the start estimator is unvalidated on virtually
+        // crossovered responses and can place the window off the energy (see
+        // BuildMagnitudeCurve). The workers below must not reach back into
         // gatePreview or project.
-        PhaseAnalysisSettings settings = CreateVirtualPhaseSettings(
-            gateOffsetMs,
-            PhaseDetrendMode.Manual,
-            detrendMs);
+        double? pinnedOffsetMs = PinnedGateOffsetMs;
+        PhaseAnalysisSettings SettingsFor(int ownPeak) =>
+            CreateVirtualPhaseSettings(
+                pinnedOffsetMs ?? ownPeak * 1_000.0 / sampleRate,
+                PhaseDetrendMode.Manual,
+                detrendMs);
 
-        var jobs = new List<(string Title, Complex[] Ir, OxyColor Color, double Thickness)>();
+        var jobs = new List<(string Title, Complex[] Ir, OxyColor Color,
+            double Thickness, PhaseAnalysisSettings Settings)>();
         foreach (ProcessedChannel item in processed)
         {
             if (item.Channel.Settings.ShowProcessedCurve)
             {
-                jobs.Add((item.Channel.Name, item.ImpulseResponse, item.Color, 1.8));
+                jobs.Add((
+                    item.Channel.Name,
+                    item.ImpulseResponse,
+                    item.Color,
+                    1.8,
+                    SettingsFor(item.PeakIndex)));
             }
         }
 
         if (processed.Count >= 2 && checkBoxShowSum.Checked)
         {
+            Complex[] sum = VirtualCrossoverAnalysis.SumImpulseResponses(
+                processed.Select(item => item.ImpulseResponse).ToList());
             jobs.Add((
                 "Sum",
-                VirtualCrossoverAnalysis.SumImpulseResponses(
-                    processed.Select(item => item.ImpulseResponse).ToList()),
+                sum,
                 SumColor,
-                2.4));
+                2.4,
+                SettingsFor(processed.Min(item => item.PeakIndex))));
         }
 
         // One gated FFT per curve, and they are independent: GetGatedPhaseData allocates
@@ -3203,7 +3308,7 @@ public partial class VirtualCrossoverPanel : UserControl
             .SelectMany(job =>
             {
                 (List<SignalPoint> points, List<SignalPoint> wrapSegments) =
-                    BuildPhasePoints(job.Ir, sampleRate, settings);
+                    BuildPhasePoints(job.Ir, sampleRate, job.Settings);
                 var curves = new List<AcousticCurve>(2);
                 // The ±360° wrap verticals: the channel's color faded and
                 // thinned well below the curve, dashed, drawn first (i.e.
@@ -3273,6 +3378,20 @@ public partial class VirtualCrossoverPanel : UserControl
     // fitting the gate on one no longer throws the other off.
     private VirtualCrossoverPhaseGateSettings ActiveGate =>
         project.PhaseGateFor(project.ActiveSideRight);
+
+    // The one pinned absolute gate offset, or null when the gate is unpinned
+    // (Auto) — in the dialog preview and in the committed state alike. Null
+    // means automatic placement, which differs by view: the magnitude anchors
+    // ONE shared window at the earliest processed arrival (keeping the drawn
+    // Sum the exact vector sum of the drawn channels), while each PHASE curve
+    // gates at its own arrival peak — FDW's high-frequency windows are
+    // shorter than the channels' arrival spread, and a shared window silently
+    // excluded late channels' treble. The phase stays comparable because its
+    // τ reference is common and absolute regardless of where each extraction
+    // started.
+    private double? PinnedGateOffsetMs => gatePreview is { } preview
+        ? preview.AutoOffset ? null : preview.OffsetMs
+        : ActiveGate.OffsetMs;
 
     // A stored gate offset is used as-is; an unconfigured side (Auto) follows
     // the earliest ESTIMATED IR START of the processed channels — the
@@ -3439,11 +3558,11 @@ public partial class VirtualCrossoverPanel : UserControl
         // The callback is wired after Init so seeding the controls does not
         // trigger a redundant redraw; from here every dialog change repaints the
         // phase plot immediately.
-        dialog.PreviewChanged = (offsetMs, leftMs, plateauMs, rightMs, windowMode,
-            fdwCycles, detrendMode, detrendMs) =>
+        dialog.PreviewChanged = (offsetMs, autoOffset, leftMs, plateauMs, rightMs,
+            windowMode, fdwCycles, detrendMode, detrendMs) =>
         {
-            gatePreview = (offsetMs, leftMs, plateauMs, rightMs, windowMode,
-                fdwCycles, detrendMode, detrendMs);
+            gatePreview = (offsetMs, autoOffset, leftMs, plateauMs, rightMs,
+                windowMode, fdwCycles, detrendMode, detrendMs);
             RequestRedraw();
         };
 

--- a/tests/Resonalyze.App.Tests/FROptionsTests.cs
+++ b/tests/Resonalyze.App.Tests/FROptionsTests.cs
@@ -1,0 +1,56 @@
+using Resonalyze.Dsp;
+using Resonalyze.Options;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class FROptionsTests
+{
+    [Fact]
+    public void MagnitudeWindowModeRoundTripsThroughThePanel()
+    {
+        using var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        var options = new FrequencyResponseOptions
+        {
+            MagnitudeWindowMode = PhaseWindowMode.FrequencyDependent,
+            MagnitudeFdwCycles = 8
+        };
+        using var panel = new FROptions();
+        panel.Init(
+            measurement,
+            options,
+            new CurveVisibilityOptions(),
+            hasZeroDegreeCalibration: false,
+            hasNinetyDegreeCalibration: false);
+
+        var written = new FrequencyResponseOptions();
+        panel.SetOptions(written, new CurveVisibilityOptions());
+
+        Assert.Equal(PhaseWindowMode.FrequencyDependent, written.MagnitudeWindowMode);
+        Assert.Equal(8, written.MagnitudeFdwCycles);
+    }
+
+    [Fact]
+    public void InvalidStoredCyclesFallBackToTheDefaultChoice()
+    {
+        using var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        var options = new FrequencyResponseOptions
+        {
+            MagnitudeWindowMode = PhaseWindowMode.Fixed,
+            MagnitudeFdwCycles = 123
+        };
+        using var panel = new FROptions();
+        panel.Init(
+            measurement,
+            options,
+            new CurveVisibilityOptions(),
+            hasZeroDegreeCalibration: false,
+            hasNinetyDegreeCalibration: false);
+
+        var written = new FrequencyResponseOptions();
+        panel.SetOptions(written, new CurveVisibilityOptions());
+
+        Assert.Equal(PhaseWindowMode.Fixed, written.MagnitudeWindowMode);
+        Assert.Equal(
+            PhaseAnalysisSettings.DefaultFdwCycles, written.MagnitudeFdwCycles);
+    }
+}

--- a/tests/Resonalyze.App.Tests/MeasurementHistoryPersistenceTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementHistoryPersistenceTests.cs
@@ -72,7 +72,7 @@ public sealed class MeasurementHistoryPersistenceTests : IDisposable
     }
 
     [Fact]
-    public void Load_HidesEntriesWhoseSourceFileIsMissing_AndSaysSo()
+    public void Load_RemovesEntriesWhoseSourceFileIsMissing_AndSaysSo()
     {
         string sourcePath = Path.Combine(directory, "deleted.json");
         File.WriteAllText(sourcePath, "{}");
@@ -81,119 +81,41 @@ public sealed class MeasurementHistoryPersistenceTests : IDisposable
         File.Delete(sourcePath);
 
         Assert.Empty(persistence.Load());
-        Assert.NotNull(persistence.LoadWarning);
+        Assert.Contains("removed", persistence.LoadWarning);
     }
 
     /// <summary>
-    /// The field case this guards: an external drive is not mounted at startup,
-    /// so the measurements on it vanish from the list — and then any ordinary
-    /// window close writes the truncated list back, deleting them for good.
+    /// The owner's policy: a history row whose measurement file is gone is dead
+    /// weight and is dropped AT LOAD, with the store rewritten immediately — a
+    /// session without history mutations never saves, and the removal (and its
+    /// one-time message) must not depend on one. The previous design retained
+    /// such rows for the unplugged-drive case, which greeted every launch with
+    /// the same warning.
     /// </summary>
     [Fact]
-    public void Save_AfterAnUnreachableFileWasHidden_DoesNotDropItFromTheStore()
+    public void Load_RemovesUnreachableEntriesFromTheStoreImmediately()
     {
         string reachablePath = Path.Combine(directory, "reachable.json");
-        string unreachablePath = Path.Combine(directory, "on-external-drive.json");
+        string unreachablePath = Path.Combine(directory, "deleted.json");
         File.WriteAllText(reachablePath, "{}");
         File.WriteAllText(unreachablePath, "{}");
-
         MeasurementHistoryEntry reachable = CreateEntry(reachablePath);
-        MeasurementHistoryEntry unreachable = CreateEntry(unreachablePath);
         var first = new MeasurementHistoryPersistence(storePath);
-        first.Save(new[] { reachable, unreachable });
+        first.Save(new[] { reachable, CreateEntry(unreachablePath) });
 
-        // The drive goes away, the app restarts, and the user does anything at
-        // all that saves — here, the still-visible entry alone is written back.
+        // The file disappears; the next launch removes its row at load, with
+        // no Save in between.
         File.Delete(unreachablePath);
         var second = new MeasurementHistoryPersistence(storePath);
-        IReadOnlyList<MeasurementHistoryEntry> visible = second.Load();
-        Assert.Equal(reachable.Id, Assert.Single(visible).Id);
-        second.Save(visible);
+        Assert.Equal(reachable.Id, Assert.Single(second.Load()).Id);
+        Assert.NotNull(second.LoadWarning);
 
-        // The drive comes back.
+        // Even with the file back, the row is gone for good and the following
+        // launch is quiet.
         File.WriteAllText(unreachablePath, "{}");
         var third = new MeasurementHistoryPersistence(storePath);
-        IReadOnlyList<Guid> restored = third.Load().Select(entry => entry.Id).ToList();
-
-        Assert.Equal(2, restored.Count);
-        Assert.Contains(unreachable.Id, restored);
-        Assert.Contains(reachable.Id, restored);
+        Assert.Equal(reachable.Id, Assert.Single(third.Load()).Id);
         Assert.Null(third.LoadWarning);
-    }
-
-    /// <summary>
-    /// The drive comes back mid-session and the user opens one of its files. The
-    /// service looks the path up in the LIVE list, cannot see the hidden entry,
-    /// and creates a fresh one with a new id — so the retained copy must be
-    /// matched by path too, or the measurement shows up twice after a restart.
-    /// </summary>
-    [Fact]
-    public void Save_WhenAHiddenFileIsReopenedUnderANewId_DoesNotDuplicateIt()
-    {
-        string sourcePath = Path.Combine(directory, "on-external-drive.json");
-        File.WriteAllText(sourcePath, "{}");
-        var first = new MeasurementHistoryPersistence(storePath);
-        first.Save(new[] { CreateEntry(sourcePath) });
-
-        File.Delete(sourcePath);
-        var second = new MeasurementHistoryPersistence(storePath);
-        Assert.Empty(second.Load());
-
-        // Drive back; the service re-adds the same file as a brand new entry.
-        File.WriteAllText(sourcePath, "{}");
-        MeasurementHistoryEntry reopened = CreateEntry(sourcePath);
-        second.Save(new[] { reopened });
-
-        var third = new MeasurementHistoryPersistence(storePath);
-        MeasurementHistoryEntry only = Assert.Single(third.Load());
-        Assert.Equal(reopened.Id, only.Id);
-    }
-
-    [Fact]
-    public void Save_WhenAHiddenFileIsReopened_MatchesThePathCaseInsensitively()
-    {
-        string sourcePath = Path.Combine(directory, "Mixed Case.json");
-        File.WriteAllText(sourcePath, "{}");
-        var first = new MeasurementHistoryPersistence(storePath);
-        first.Save(new[] { CreateEntry(sourcePath) });
-
-        File.Delete(sourcePath);
-        var second = new MeasurementHistoryPersistence(storePath);
-        second.Load();
-
-        File.WriteAllText(sourcePath, "{}");
-        second.Save(new[] { CreateEntry(sourcePath.ToUpperInvariant()) });
-
-        var third = new MeasurementHistoryPersistence(storePath);
-        Assert.Single(third.Load());
-    }
-
-    /// <summary>
-    /// Continues from the reopen case: once the retained copy has been super-
-    /// seded by a live entry, deleting that live entry must not bring the old
-    /// one back. Deleting saves immediately, so the retained set has to be
-    /// updated by the save that dropped it, not left holding a stale row.
-    /// </summary>
-    [Fact]
-    public void Save_AfterAHiddenEntryWasSuperseded_DoesNotResurrectItOnDelete()
-    {
-        string sourcePath = Path.Combine(directory, "on-external-drive.json");
-        File.WriteAllText(sourcePath, "{}");
-        var first = new MeasurementHistoryPersistence(storePath);
-        first.Save(new[] { CreateEntry(sourcePath) });
-
-        // Drive gone: the entry is hidden and retained.
-        File.Delete(sourcePath);
-        var second = new MeasurementHistoryPersistence(storePath);
-        Assert.Empty(second.Load());
-
-        // Drive back, file reopened as a new entry, then deleted by the user.
-        File.WriteAllText(sourcePath, "{}");
-        second.Save(new[] { CreateEntry(sourcePath) });
-        second.Save(Array.Empty<MeasurementHistoryEntry>());
-
-        var third = new MeasurementHistoryPersistence(storePath);
-        Assert.Empty(third.Load());
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/MeasurementHistoryPersistenceTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementHistoryPersistenceTests.cs
@@ -84,6 +84,26 @@ public sealed class MeasurementHistoryPersistenceTests : IDisposable
         Assert.Contains("removed", persistence.LoadWarning);
     }
 
+    [Fact]
+    public void Load_CleansPathlessRowsOutOfTheStore_Silently()
+    {
+        // A broken row with no path never counted as a measurement: no warning
+        // for it — but the store must still be rewritten, or the row would sit
+        // in the JSON forever without ever tripping the missing-file removal.
+        File.WriteAllText(
+            storePath,
+            """
+            {"schemaVersion":1,"entries":[{"id":"00000000-0000-0000-0000-000000000001",
+            "displayName":"broken","timestamp":"2026-07-30T00:00:00+00:00",
+            "sourceFilePath":"   "}]}
+            """);
+        var persistence = new MeasurementHistoryPersistence(storePath);
+
+        Assert.Empty(persistence.Load());
+        Assert.Null(persistence.LoadWarning);
+        Assert.DoesNotContain("sourceFilePath", File.ReadAllText(storePath));
+    }
+
     /// <summary>
     /// The owner's policy: a history row whose measurement file is gone is dead
     /// weight and is dropped AT LOAD, with the store rewritten immediately — a

--- a/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
@@ -209,6 +209,54 @@ public sealed class MeasurementSettingsMigrationTests
         Assert.True(options.GroupDelayGateAutoFit);
     }
 
+    // A pre-FDW-magnitude file has no MagnitudeWindowMode/MagnitudeFdwCycles
+    // fields; its magnitude must keep reading through the fixed window. Real
+    // JSON again, for the same missing-property reason as the gate tests above.
+    [Fact]
+    public void PreFdwMagnitudeFileStaysFixed()
+    {
+        MeasurementSettingsFile.FrequencyResponseSettings settings =
+            DeserializeFrequencyResponse("""{"Window": 2048}""");
+        var options = new FrequencyResponseOptions
+        {
+            MagnitudeWindowMode = PhaseWindowMode.FrequencyDependent,
+            MagnitudeFdwCycles = 8
+        };
+
+        settings.ApplyTo(options, new CurveVisibilityOptions());
+
+        Assert.Equal(PhaseWindowMode.Fixed, options.MagnitudeWindowMode);
+        Assert.Equal(
+            PhaseAnalysisSettings.DefaultFdwCycles, options.MagnitudeFdwCycles);
+    }
+
+    [Fact]
+    public void MagnitudeFdwRoundTripsAndValidatesCycles()
+    {
+        var stored = new FrequencyResponseOptions
+        {
+            MagnitudeWindowMode = PhaseWindowMode.FrequencyDependent,
+            MagnitudeFdwCycles = 8
+        };
+        var restored = new FrequencyResponseOptions();
+
+        MeasurementSettingsFile.FrequencyResponseSettings.Capture(
+                stored, new CurveVisibilityOptions())
+            .ApplyTo(restored, new CurveVisibilityOptions());
+
+        Assert.Equal(PhaseWindowMode.FrequencyDependent, restored.MagnitudeWindowMode);
+        Assert.Equal(8, restored.MagnitudeFdwCycles);
+
+        MeasurementSettingsFile.FrequencyResponseSettings settings =
+            DeserializeFrequencyResponse("""{"MagnitudeFdwCycles": 123}""");
+        var options = new FrequencyResponseOptions();
+
+        settings.ApplyTo(options, new CurveVisibilityOptions());
+
+        Assert.Equal(
+            PhaseAnalysisSettings.DefaultFdwCycles, options.MagnitudeFdwCycles);
+    }
+
     private static MeasurementSettingsFile.FrequencyResponseSettings
         DeserializeFrequencyResponse(string json) =>
         System.Text.Json.JsonSerializer

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMagnitudeGateTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMagnitudeGateTests.cs
@@ -1,0 +1,55 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// Pins the per-side gate placement of the Virtual DSP magnitude snapshot: the
+/// two sides' arrivals sit at different times and the project stores their
+/// pinned offsets separately, so the active side's pin must never window the
+/// opposite side's sum (the field case: L pinned at 10 ms, R pinned at 14 ms,
+/// viewing L — the dashed Sum R must be gated at 14 ms).
+/// </summary>
+public sealed class VirtualCrossoverMagnitudeGateTests
+{
+    private static VirtualCrossoverPanel.MagnitudeGateSnapshot Snapshot(
+        double? pinnedOffsetMs,
+        double? oppositePinnedOffsetMs) => new(
+            new PhaseAnalysisSettings(
+                PhaseWindowMode.Fixed,
+                PhaseAnalysisSettings.DefaultFdwCycles,
+                PhaseDetrendMode.Off,
+                ManualDetrendMilliseconds: 0.0,
+                GateOffsetMs: 0.0,
+                LeftMs: 0.5,
+                PlateauMs: 4.0,
+                RightMs: 1.5,
+                Unwrap: false,
+                SmoothingInverseOctaves: 0.0),
+            pinnedOffsetMs,
+            oppositePinnedOffsetMs,
+            SmoothingInverseOctaves: 12);
+
+    [Fact]
+    public void EachSideUsesItsOwnPinnedOffset()
+    {
+        VirtualCrossoverPanel.MagnitudeGateSnapshot snapshot = Snapshot(
+            pinnedOffsetMs: 10.0, oppositePinnedOffsetMs: 14.0);
+
+        Assert.Equal(10.0, snapshot.ResolveGateOffsetMs(
+            oppositeSide: false, anchorPeakIndex: 960, sampleRate: 48_000));
+        Assert.Equal(14.0, snapshot.ResolveGateOffsetMs(
+            oppositeSide: true, anchorPeakIndex: 960, sampleRate: 48_000));
+    }
+
+    [Fact]
+    public void AnUnpinnedSideAnchorsAtTheGivenPeak_EvenWhenTheOtherIsPinned()
+    {
+        VirtualCrossoverPanel.MagnitudeGateSnapshot snapshot = Snapshot(
+            pinnedOffsetMs: 10.0, oppositePinnedOffsetMs: null);
+
+        Assert.Equal(10.0, snapshot.ResolveGateOffsetMs(
+            oppositeSide: false, anchorPeakIndex: 960, sampleRate: 48_000));
+        Assert.Equal(20.0, snapshot.ResolveGateOffsetMs(
+            oppositeSide: true, anchorPeakIndex: 960, sampleRate: 48_000));
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -163,41 +163,21 @@ public sealed class VirtualCrossoverMetricsTests
     }
 
     [Fact]
-    public async Task ComputeOppositeSumCurveAsync_ReturnsNull_WithFewerThanTwoParticipatingChannels()
+    public async Task ComputeSideSumAsync_SumsTheParticipatingSides()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
         var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
         long revision = coordinator.Invalidate();
 
-        AnalysisCurve? result = await metrics.ComputeOppositeSumCurveAsync(
-            [ResolvedChannel("A", 48_000)], oppositeRight: false, revision);
-
-        Assert.Null(result);
-    }
-
-    [Fact]
-    public async Task ComputeOppositeSumCurveAsync_SumsTheParticipatingSides()
-    {
-        using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        Complex[]? summed = null;
-        var metrics = new VirtualCrossoverMetrics(
-            coordinator,
-            (ir, _, _) =>
-            {
-                summed = ir;
-                return EmptyCurve;
-            });
-        long revision = coordinator.Invalidate();
-
-        AnalysisCurve? result = await metrics.ComputeOppositeSumCurveAsync(
+        VirtualCrossoverSideSum? side = await metrics.ComputeSideSumAsync(
             [ResolvedChannel("A", 48_000), ResolvedChannel("B", 48_000)],
-            oppositeRight: false,
-            revision);
+            rightSide: false,
+            revision,
+            minimumChannels: 2);
 
-        // Two participating sides → a sum curve is built from a non-empty response.
-        Assert.Same(EmptyCurve, result);
-        Assert.NotNull(summed);
-        Assert.NotEmpty(summed);
+        Assert.NotNull(side);
+        Assert.Equal(2, side.ChannelCount);
+        Assert.NotEmpty(side.ImpulseResponse);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -76,7 +76,9 @@ public sealed class VirtualCrossoverMetricsTests
         Assert.NotNull(magnitudes);
         Assert.Equal(2, magnitudes.Count);
         Assert.NotNull(sum);
-        // Two channel spectra + one sum spectrum, all anchored to the earliest peak.
+        // Two channel spectra + one sum spectrum, all anchored to the earliest
+        // peak: one shared window is what keeps the drawn Sum the vector sum
+        // of the drawn channels and the loss under its 0 dB ceiling.
         Assert.Equal(3, captured.Count);
         Assert.All(captured, entry => Assert.Equal(2, entry.Peak));
         // One of the calls built the complex sum of the two responses.

--- a/tests/Resonalyze.Dsp.Tests/DataHelperResampleTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/DataHelperResampleTests.cs
@@ -247,6 +247,37 @@ public sealed class DataHelperResampleTests
         Assert.InRange(output[0].Y, 1.0, 19.0);
     }
 
+    [Theory]
+    [InlineData(23.4375)] // 192 kHz / 8192: two bins ≈ 47 Hz, mid-display
+    [InlineData(46.875)] // 192 kHz / 4096: two bins ≈ 94 Hz
+    public void LogarithmicResample_PsychoacousticStaysLocalNearTwoBinsOnACoarseGrid(
+        double stepHz)
+    {
+        // A quiet low end against a loud midrange, on a grid coarse enough that
+        // the two-bin resolution floor lands INSIDE the display range. The
+        // lower octave radius of the Gaussian floor used to diverge just above
+        // two bins from DC: the kernel swallowed the whole spectrum and the
+        // cubic mean drew the midrange level as a spike on the low-frequency
+        // floor (field case: a 192 kHz measurement with a 2048-sample window
+        // spiked +33 dB at 47 Hz). Every point in the formerly diverging zone
+        // must stay at the local floor.
+        var input = new List<SignalPoint>();
+        for (double f = stepHz; f <= 24_000; f += stepHz)
+        {
+            input.Add(new SignalPoint(f, f < 500 ? -50.0 : -15.0));
+        }
+
+        List<SignalPoint> psycho = DataHelper.LogarithmicResample(
+            input, 20, 20_000, 1024,
+            smoothingOctaves: 1.0 / 6.0,
+            psychoacoustic: true);
+
+        Assert.All(
+            psycho.Where(point => point.X > 2.0 * stepHz && point.X < 3.5 * stepHz),
+            point => Assert.True(point.Y < -45.0,
+                $"{point.Y:0.##} dB at {point.X:0.##} Hz on a -50 dB floor."));
+    }
+
     [Fact]
     public void LogarithmicPowerBandResample_PsychoacousticDoesNotClipANarrowDip()
     {

--- a/tests/Resonalyze.Dsp.Tests/FrequencyDependentMagnitudeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FrequencyDependentMagnitudeTests.cs
@@ -1,0 +1,179 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class FrequencyDependentMagnitudeTests
+{
+    private const int SampleRate = 48_000;
+
+    [Fact]
+    public void Fdw_KeepsTheFixedResponseWhileTheWindowStillSpansTheReflection()
+    {
+        // Below the frequency where the FDW window still contains the whole
+        // reflection inside its plateau (~800 Hz here, asserted with margin for
+        // the bank interpolation), the magnitude must read exactly like the
+        // fixed window: FDW only removes what the shrinking window excludes.
+        IReadOnlyList<SignalPoint> fixedCurve = Spectrum(Options(PhaseWindowMode.Fixed));
+        IReadOnlyList<SignalPoint> fdwCurve = Spectrum(
+            Options(PhaseWindowMode.FrequencyDependent));
+
+        Assert.Equal(fixedCurve.Count, fdwCurve.Count);
+        foreach ((SignalPoint expected, SignalPoint actual) in fixedCurve.Zip(fdwCurve)
+                     .Where(pair => pair.First.X is >= 100 and <= 500))
+        {
+            Assert.Equal(expected.X, actual.X, precision: 9);
+            Assert.True(Math.Abs(actual.Y - expected.Y) < 0.1,
+                $"FDW moved the clamped band by {actual.Y - expected.Y:0.###} dB " +
+                $"at {expected.X:0.#} Hz.");
+        }
+    }
+
+    [Fact]
+    public void Fdw_SuppressesTheLateReflectionRippleAtHighFrequency()
+    {
+        // The point of the feature: a 2 ms reflection combs the fixed-window
+        // treble with ~7 dB peak-to-peak ripple; a 6-cycle window at 8+ kHz is
+        // under 1 ms long, so the reflection falls outside it and the ripple
+        // collapses.
+        double fixedRipple = PeakToPeakDb(
+            Spectrum(Options(PhaseWindowMode.Fixed)), 8_000, 16_000);
+        double fdwRipple = PeakToPeakDb(
+            Spectrum(Options(PhaseWindowMode.FrequencyDependent)), 8_000, 16_000);
+
+        Assert.True(fixedRipple > 5.0,
+            $"Fixture lost its comb: fixed ripple is only {fixedRipple:0.##} dB.");
+        Assert.True(fdwRipple < fixedRipple * 0.25,
+            $"FDW ripple {fdwRipple:0.##} dB vs fixed {fixedRipple:0.##} dB.");
+    }
+
+    [Fact]
+    public void Fdw_FewerCyclesSuppressTheReflectionMore()
+    {
+        // In the transition band (a 2 ms reflection against 8-cycle windows of
+        // 1.3-2.7 ms) the longer window still sees part of the reflection while
+        // the 4-cycle window has already dropped it.
+        double fourCycles = PeakToPeakDb(
+            Spectrum(Options(PhaseWindowMode.FrequencyDependent, cycles: 4)),
+            3_000,
+            6_000);
+        double eightCycles = PeakToPeakDb(
+            Spectrum(Options(PhaseWindowMode.FrequencyDependent, cycles: 8)),
+            3_000,
+            6_000);
+
+        Assert.True(eightCycles > 0.5,
+            $"Fixture lost its transition band: 8-cycle ripple is {eightCycles:0.##} dB.");
+        Assert.True(fourCycles < eightCycles,
+            $"4 cycles ({fourCycles:0.##} dB) did not suppress more than 8 " +
+            $"({eightCycles:0.##} dB).");
+    }
+
+    [Fact]
+    public void Fdw_InvalidCyclesFallsBackToSix()
+    {
+        IReadOnlyList<SignalPoint> invalid = Spectrum(
+            Options(PhaseWindowMode.FrequencyDependent, cycles: 123));
+        IReadOnlyList<SignalPoint> six = Spectrum(
+            Options(PhaseWindowMode.FrequencyDependent, cycles: 6));
+
+        Assert.Equal(six, invalid);
+    }
+
+    [Fact]
+    public void GatedSpectrum_MatchesTheFrequencyResponseFdwCurveOnTheSameGate()
+    {
+        // The gate-driven magnitude (the Virtual DSP view) and the Frequency
+        // Response mode's FDW curve must be ONE analysis when their gates
+        // coincide — the FR window maps onto a peak-anchored gate. Bit-equal,
+        // not approximate: both paths must run through the same bank and the
+        // same resample, or the two views drift apart.
+        SyntheticMeasurement measurement = ReflectedImpulse();
+        FrequencyResponseOptions options =
+            Options(PhaseWindowMode.FrequencyDependent);
+        double toMilliseconds = 1_000.0 / SampleRate;
+        var settings = new PhaseAnalysisSettings(
+            PhaseWindowMode.FrequencyDependent,
+            FdwCycles: 6,
+            PhaseDetrendMode.Off,
+            ManualDetrendMilliseconds: 0.0,
+            GateOffsetMs: 480 * toMilliseconds,
+            LeftMs: 256 * toMilliseconds,
+            PlateauMs: (4_096 - 512) * toMilliseconds,
+            RightMs: 256 * toMilliseconds,
+            Unwrap: false,
+            SmoothingInverseOctaves: 0.0);
+
+        AnalysisCurve frequencyResponse = DataHelper.GetPrimarySpectrum(
+            measurement, options, calibration: null);
+        AnalysisCurve gated = DataHelper.GetGatedPrimarySpectrum(
+            ReflectedImpulse(), settings, calibration: null,
+            smoothingInverseOctaves: 0.0);
+
+        Assert.Equal(frequencyResponse.Points, gated.Points);
+    }
+
+    [Fact]
+    public void GatedSpectrum_FixedGateOnADelayedDeltaIsFlat()
+    {
+        var impulse = new Complex[8_192];
+        impulse[960] = Complex.One; // 20 ms
+        var measurement = new SyntheticMeasurement(impulse, SampleRate, 960);
+        var settings = new PhaseAnalysisSettings(
+            PhaseWindowMode.Fixed,
+            FdwCycles: 6,
+            PhaseDetrendMode.Off,
+            ManualDetrendMilliseconds: 0.0,
+            GateOffsetMs: 20.0,
+            LeftMs: 1.0,
+            PlateauMs: 5.0,
+            RightMs: 3.0,
+            Unwrap: false,
+            SmoothingInverseOctaves: 0.0);
+
+        AnalysisCurve gated = DataHelper.GetGatedPrimarySpectrum(
+            measurement, settings, calibration: null, smoothingInverseOctaves: 0.0);
+
+        Assert.All(gated.Points, point => Assert.True(Math.Abs(point.Y) < 0.1,
+            $"{point.Y:0.###} dB at {point.X:0.#} Hz for a unit delta."));
+    }
+
+    // Direct arrival plus a 0.4 reflection 2 ms later — the fixture FDW exists
+    // for. The IR is long enough that neither extraction path runs off its end.
+    private static SyntheticMeasurement ReflectedImpulse()
+    {
+        var impulse = new Complex[8_192];
+        impulse[480] = Complex.One;
+        impulse[576] = new Complex(0.4, 0.0);
+        return new SyntheticMeasurement(impulse, SampleRate, 480);
+    }
+
+    private static FrequencyResponseOptions Options(
+        PhaseWindowMode mode,
+        int cycles = 6) => new()
+    {
+        Window = 4_096,
+        LeftTukeyWindow = 256,
+        RightTukeyWindow = 256,
+        SmoothingInverseOctaves = 0,
+        UseCalibration = false,
+        MagnitudeWindowMode = mode,
+        MagnitudeFdwCycles = cycles
+    };
+
+    private static IReadOnlyList<SignalPoint> Spectrum(
+        FrequencyResponseOptions options) =>
+        DataHelper.GetPrimarySpectrum(ReflectedImpulse(), options, calibration: null)
+            .Points;
+
+    private static double PeakToPeakDb(
+        IReadOnlyList<SignalPoint> curve,
+        double low,
+        double high)
+    {
+        List<double> band = curve
+            .Where(point => point.X >= low && point.X <= high)
+            .Select(point => point.Y)
+            .ToList();
+        return band.Max() - band.Min();
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
@@ -135,6 +135,44 @@ public sealed class FrequencyDependentPhaseTests
     }
 
     [Fact]
+    public void PerCurveGates_WithACommonReference_PreserveRelativePhase()
+    {
+        // The Virtual DSP Auto gate places each channel's WINDOW on its own
+        // arrival (so FDW keeps a late channel's treble) while every curve
+        // shares one absolute τ. The relative phase must survive exactly as
+        // with a shared window: BuildMeasuredPhase re-references each
+        // extraction to the absolute τ, so where the window sits must not
+        // matter — only what it contains.
+        SyntheticMeasurement first = DelayedImpulse(480); // 10 ms
+        SyntheticMeasurement second = DelayedImpulse(576); // 12 ms
+        PhaseAnalysisSettings sharedReference = Settings(
+            PhaseWindowMode.FrequencyDependent,
+            6,
+            PhaseDetrendMode.Manual,
+            manualMs: 10.0,
+            gateOffsetMs: 10.0);
+        PhaseAnalysisSettings ownWindow = sharedReference with
+        {
+            GateOffsetMs = 12.0
+        };
+
+        List<SignalPoint> firstPhase = DataHelper.GetGatedPhaseData(
+            first, sharedReference);
+        List<SignalPoint> secondPhase = DataHelper.GetGatedPhaseData(
+            second, ownWindow);
+
+        foreach ((SignalPoint a, SignalPoint b) in firstPhase.Zip(secondPhase)
+                     .Where(pair => pair.First.X is >= 200 and <= 10_000))
+        {
+            double expected = -Math.Tau * a.X * 96 / SampleRate;
+            double actual = Math.IEEERemainder(b.Y - a.Y, Math.Tau);
+            double error = Math.IEEERemainder(actual - expected, Math.Tau);
+            Assert.True(Math.Abs(error) < 1e-5,
+                $"Relative-phase error {error:e} at {a.X:0.#} Hz with per-curve gates.");
+        }
+    }
+
+    [Fact]
     public void CommonAutoDetrend_DoesNotIndependentlyFlattenOtherChannels()
     {
         SyntheticMeasurement anchor = DelayedImpulse(480);

--- a/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
@@ -173,6 +173,61 @@ public sealed class FrequencyDependentPhaseTests
     }
 
     [Fact]
+    public void SumGatedSpectra_ReReferencesEachPartBeforeAdding()
+    {
+        // One delta seen through two window POSITIONS (both plateaus contain
+        // it): the windowed content is identical up to the extraction shift,
+        // so re-referenced to one start the two spectra must coincide and
+        // their sum must equal exactly twice the directly extracted one —
+        // pinning the rotation's sign and scale, which the Virtual DSP Sum
+        // (the vector sum of individually gated channels) rests on.
+        SyntheticMeasurement measurement = DelayedImpulse(960); // 20 ms
+        PhaseAnalysisSettings at20 = Settings(
+            PhaseWindowMode.Fixed, 6, PhaseDetrendMode.Manual, gateOffsetMs: 20.0);
+        PhaseAnalysisSettings at18 = at20 with { GateOffsetMs = 18.0 };
+
+        Complex[] a = DataHelper.GetPhaseAnalysisSpectrum(
+            measurement, at20, out int startA);
+        Complex[] b = DataHelper.GetPhaseAnalysisSpectrum(
+            measurement, at18, out int startB);
+        Assert.NotEqual(startA, startB);
+
+        Complex[] combined = DataHelper.SumGatedSpectra(
+            [(a, startA), (b, startB)], startA);
+
+        for (int bin = 1; bin < combined.Length / 2; bin++)
+        {
+            Complex expected = 2.0 * a[bin];
+            double error = (combined[bin] - expected).Magnitude;
+            Assert.True(error <= 1e-9 * (1.0 + expected.Magnitude),
+                $"Re-reference broken by {error:e} at bin {bin} " +
+                $"({bin * (double)SampleRate / combined.Length:0.#} Hz).");
+        }
+    }
+
+    [Fact]
+    public void GatedPhaseData_FromSpectrum_MatchesTheMeasurementPath()
+    {
+        SyntheticMeasurement measurement = ReflectedImpulse();
+        PhaseAnalysisSettings settings = Settings(
+            PhaseWindowMode.FrequencyDependent, 6, PhaseDetrendMode.Manual,
+            manualMs: 10.0);
+
+        List<SignalPoint> viaMeasurement = DataHelper.GetGatedPhaseData(
+            measurement, settings);
+        Complex[] spectrum = DataHelper.GetPhaseAnalysisSpectrum(
+            measurement, settings, out int extractionStart);
+        List<SignalPoint> viaSpectrum = DataHelper.GetGatedPhaseData(
+            spectrum,
+            extractionStart,
+            referenceSamples: 10.0 * SampleRate / 1_000.0,
+            SampleRate,
+            unwrap: false);
+
+        Assert.Equal(viaMeasurement, viaSpectrum);
+    }
+
+    [Fact]
     public void CommonAutoDetrend_DoesNotIndependentlyFlattenOtherChannels()
     {
         SyntheticMeasurement anchor = DelayedImpulse(480);

--- a/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
@@ -206,6 +206,61 @@ public sealed class FrequencyDependentPhaseTests
     }
 
     [Fact]
+    public void SumOfOwnGatedSpectra_KeepsTheLateChannelsTreble()
+    {
+        // The property the Virtual DSP Sum rests on, end to end: two unit
+        // arrivals 3 ms apart, each FDW-gated at its OWN arrival, summed as
+        // spectra. At high frequencies each window keeps its arrival, so the
+        // band-averaged summed POWER reads both (~2; the interference cross
+        // term averages out across the band). The old construction — one
+        // summed IR through a single window anchored at the earliest arrival —
+        // reads only the early channel (~1): the FDW window there is far
+        // shorter than the 3 ms spread.
+        var early = new Complex[8_192];
+        early[480] = Complex.One; // 10 ms
+        var late = new Complex[8_192];
+        late[624] = Complex.One; // 13 ms
+        PhaseAnalysisSettings atEarly = Settings(
+            PhaseWindowMode.FrequencyDependent, 6, PhaseDetrendMode.Manual,
+            gateOffsetMs: 10.0);
+        PhaseAnalysisSettings atLate = atEarly with { GateOffsetMs = 13.0 };
+
+        Complex[] a = DataHelper.GetPhaseAnalysisSpectrum(
+            new SyntheticMeasurement(early, SampleRate, 480), atEarly, out int startA);
+        Complex[] b = DataHelper.GetPhaseAnalysisSpectrum(
+            new SyntheticMeasurement(late, SampleRate, 624), atLate, out int startB);
+        Complex[] combined = DataHelper.SumGatedSpectra(
+            [(a, startA), (b, startB)], Math.Min(startA, startB));
+
+        var summedIr = new Complex[8_192];
+        for (int i = 0; i < summedIr.Length; i++)
+        {
+            summedIr[i] = early[i] + late[i];
+        }
+        Complex[] gatedSummedIr = DataHelper.GetPhaseAnalysisSpectrum(
+            new SyntheticMeasurement(summedIr, SampleRate, 480), atEarly, out _);
+
+        double combinedPower = BandPower(combined, 8_000, 15_000);
+        double gatedSumPower = BandPower(gatedSummedIr, 8_000, 15_000);
+        Assert.InRange(combinedPower, 1.7, 2.3);
+        Assert.InRange(gatedSumPower, 0.7, 1.3);
+
+        static double BandPower(Complex[] spectrum, double lowHz, double highHz)
+        {
+            double binWidth = (double)SampleRate / spectrum.Length;
+            int lowBin = (int)(lowHz / binWidth);
+            int highBin = (int)(highHz / binWidth);
+            double sum = 0.0;
+            for (int bin = lowBin; bin <= highBin; bin++)
+            {
+                sum += spectrum[bin].Magnitude * spectrum[bin].Magnitude;
+            }
+
+            return sum / (highBin - lowBin + 1);
+        }
+    }
+
+    [Fact]
     public void GatedPhaseData_FromSpectrum_MatchesTheMeasurementPath()
     {
         SyntheticMeasurement measurement = ReflectedImpulse();


### PR DESCRIPTION
Four changes from one working session, each with its own commit.

## 1. FDW for the frequency-response magnitude

The FR mode gains a REW-style frequency-dependent window (`Window mode: Fixed/FDW` + `FDW cycles: 4/6/8` in the FR options), reusing the phase analysis' FDW bank — same 3-centers/octave gates, complex-linear interpolation, shared per-impulse cache. The fixed Tukey window maps onto the gate (fade-in ends at the peak; the configured window is the outer gate FDW never exceeds), so below the transition frequency the FDW curve equals the fixed one exactly — pinned by test. Off by default: existing curves do not move; pre-FDW settings files read as Fixed (pinned on real JSON without the fields). Overlays store the FDW'd raw spectrum, so Compare and the EQ wizard inherit it; harmonics keep their own windows.

## 2. Psychoacoustic smoothing: the two-bin spike

Field find (192 kHz measurement, 2048-sample window): a +33 dB spike at 47 Hz manufactured by the display pipeline. The Gaussian sigma floor's lower octave radius `log2(f/(f−2Δ))` diverges as a display point approaches two bins from DC — the kernel swallowed the whole spectrum and the cubic mean drew the midrange level onto the LF floor. At 48 kHz the diverging zone sits below 20 Hz, which is why it was never seen. Fix: clamp the kernel's lower edge to the first input bin — bit-identical behaviour outside the formerly diverging zone, red-then-green synthetic on two grid widths. Verified against the reporting measurement: the 47 Hz point returns to the stored preview's value.

## 3. Virtual DSP: magnitude through the gate; FDW stays phase-only

The vDSP magnitude (channels, sums, overlay capture, sum-loss metrics) now reads the gate dialog's window (offset + ms shoulders) instead of a private fixed 4096-sample window, and the Gate button is available from the magnitude view. Two design points, both learned the hard way during the session:

- **The magnitude always reads the FIXED gate.** No single frequency-dependent window can hold the summed response's spread arrivals — FDW's HF windows are shorter than the inter-channel delay spread, which either fakes late channels' treble (shared window) or breaks Sum/Loss (per-channel windows). FDW therefore shapes the phase view only; the dialog says so.
- **Auto placement differs by view**: magnitude anchors one shared window at the earliest arrival (the drawn Sum stays the exact vector sum of the drawn channels; sum-loss stays ≤ 0 dB), while each phase curve gates at its own arrival **peak** — not the start estimator, which is unvalidated on virtually crossovered IRs and placed windows off the energy — under one common absolute τ. Relative phase across per-curve windows is pinned by a new dsp test. The dialog preview carries the Auto flag so it renders exactly what Save produces; raw curves always self-anchor.

Worker-thread builds read one immutable UI-thread snapshot (record reference) refreshed in the single redraw funnel.

## 4. History: drop entries whose files are gone

Rows whose measurement files no longer exist were retained for the unplugged-drive case and greeted every launch with the same "History recovery" warning. They are now removed at load and the store is rewritten immediately (a session without history mutations never saves, so the removal cannot wait for one); the one-time message says what actually happened. The retention merge in Save goes with the mechanism it served. Caught by the new test: the read stream must close before the rewrite, or the atomic replace fails against our own handle.

## Verification

- 1817 tests green (930 dsp / 749 app / 138 audio), zero warnings.
- Field checks still open: FDW magnitude vs REW on a cabin measurement; vDSP magnitude/Loss sanity on the v3 set after the final per-view Auto split; `Fixed↔FDW` toggle should now change the phase view only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)