### PR TITLE
Minimum-phase and excess group delay curves in the Group Delay mode

### DIFF
--- a/dsp/AnalysisModels.cs
+++ b/dsp/AnalysisModels.cs
@@ -25,7 +25,13 @@ public enum AnalysisCurveKind
     // no loopback reference behind it. Unlike a transfer function it carries an
     // absolute level, which is what makes a moving-microphone RTA average usable as
     // an equalization source.
-    InputSpectrum
+    InputSpectrum,
+    // The group-delay counterparts of MinimumPhase/ExcessPhase: the delay the
+    // gated magnitude alone implies (Bode relation), and the all-pass remainder
+    // measured − minimum that no minimum-phase equalizer can move. Appended at
+    // the end: the kind is persisted in overlay files.
+    MinimumPhaseGroupDelay,
+    ExcessGroupDelay
 }
 
 /// <summary>
@@ -60,3 +66,16 @@ public sealed record AnalysisCurve(
     string Name,
     IReadOnlyList<SignalPoint> Points,
     AnalysisCurveKind Kind = AnalysisCurveKind.Primary);
+
+/// <summary>
+/// The Group Delay mode's curve family, computed in one pass over one gate
+/// extraction: the measured group delay plus, when requested, the minimum-phase
+/// group delay implied by the gated magnitude alone and the excess
+/// (measured − minimum). The optional curves are null when the caller did not
+/// ask for the minimum-phase work. All present curves share one frequency grid
+/// and one validity gate: a bin is finite in every curve or NaN in every curve.
+/// </summary>
+public sealed record GroupDelayCurveSet(
+    AnalysisCurve Measured,
+    AnalysisCurve? Minimum,
+    AnalysisCurve? Excess);

--- a/dsp/DataHelper.Phase.cs
+++ b/dsp/DataHelper.Phase.cs
@@ -1057,7 +1057,37 @@ namespace Resonalyze.Dsp
             double plateauMs,
             double rightMs,
             double smoothingInverseOctaves,
-            double magnitudeGateDb = -30.0)
+            double magnitudeGateDb = -30.0) =>
+            GetGroupDelayCurves(
+                measurement,
+                gateOffsetMs,
+                leftMs,
+                plateauMs,
+                rightMs,
+                smoothingInverseOctaves,
+                magnitudeGateDb,
+                includeMinimumPhase: false).Measured;
+
+        /// <summary>
+        /// The Group Delay mode's curve family over ONE gate extraction: the
+        /// measured group delay and, when requested, the minimum-phase group
+        /// delay (from the gated magnitude via the Bode relation) plus the
+        /// excess (measured − minimum). All curves run through the same
+        /// energy-weighted τ evaluation and smoothing and share one validity
+        /// gate, so the subtraction is bin-exact. The measured and excess
+        /// curves are absolute (referenced to the IR start); the minimum-phase
+        /// curve carries no bulk delay by construction, so the excess reads as
+        /// the frequency-dependent arrival time of the all-pass part.
+        /// </summary>
+        public static GroupDelayCurveSet GetGroupDelayCurves(
+            IImpulseMeasurement measurement,
+            double gateOffsetMs,
+            double leftMs,
+            double plateauMs,
+            double rightMs,
+            double smoothingInverseOctaves,
+            double magnitudeGateDb = -30.0,
+            bool includeMinimumPhase = false)
         {
             // Same gate as the phase mode: the left shoulder ends at the gate offset.
             // Wrap handles a gate that runs into negative indices and must read the
@@ -1105,6 +1135,13 @@ namespace Resonalyze.Dsp
                 energy[i] = h.Real * h.Real + h.Imaginary * h.Imaginary;
             }
 
+            // The minimum-phase reconstruction preserves |H| exactly, so the measured
+            // energy array doubles as this curve's denominator and one validity gate
+            // covers every curve.
+            double[]? minimumNumerator = includeMinimumPhase
+                ? ComputeMinimumPhaseGroupDelayNumerator(spectrum, invSampleRate)
+                : null;
+
             double decodedOctaves =
                 SpectrumSmoothing.SmoothingOctaves(smoothingInverseOctaves);
             double smoothingOctaves = decodedOctaves > 0.0
@@ -1123,6 +1160,10 @@ namespace Resonalyze.Dsp
                 SmoothBinsHann(numerator, smoothingOctaves, binWidthHz, minHalfWidthHz);
             double[] smoothedEnergy =
                 SmoothBinsHann(energy, smoothingOctaves, binWidthHz, minHalfWidthHz);
+            double[]? smoothedMinimumNumerator = minimumNumerator == null
+                ? null
+                : SmoothBinsHann(
+                    minimumNumerator, smoothingOctaves, binWidthHz, minHalfWidthHz);
 
             double maxEnergy = 0.0;
             for (int i = 1; i < halfLength; i++)
@@ -1132,7 +1173,10 @@ namespace Resonalyze.Dsp
 
             if (maxEnergy <= 0.0)
             {
-                return new AnalysisCurve("Group Delay", new List<SignalPoint>());
+                return BuildGroupDelayCurveSet(
+                    new List<SignalPoint>(),
+                    includeMinimumPhase ? new List<SignalPoint>() : null,
+                    includeMinimumPhase ? new List<SignalPoint>() : null);
             }
 
             // The validity gate reads against a LOCAL octave-smoothed energy
@@ -1149,6 +1193,10 @@ namespace Resonalyze.Dsp
             double localGateRatio = Math.Pow(10.0, magnitudeGateDb / 10.0);
 
             List<SignalPoint> data = new(halfLength);
+            List<SignalPoint>? minimumData =
+                smoothedMinimumNumerator == null ? null : new(halfLength);
+            List<SignalPoint>? excessData =
+                smoothedMinimumNumerator == null ? null : new(halfLength);
 
             // The gate buffer starts at extractionStart; adding it back makes the group
             // delay absolute (referenced to the IR start), so a peak well into the IR
@@ -1168,14 +1216,87 @@ namespace Resonalyze.Dsp
                 if (smoothedEnergy[i] < minEnergy)
                 {
                     data.Add(new SignalPoint(f, double.NaN));
+                    minimumData?.Add(new SignalPoint(f, double.NaN));
+                    excessData?.Add(new SignalPoint(f, double.NaN));
                     continue;
                 }
 
                 double delaySeconds = smoothedNumerator[i] / smoothedEnergy[i];
-                data.Add(new SignalPoint(f, (delaySeconds + absoluteStartTime) * 1000.0));
+                double measuredMilliseconds =
+                    (delaySeconds + absoluteStartTime) * 1000.0;
+                data.Add(new SignalPoint(f, measuredMilliseconds));
+
+                if (smoothedMinimumNumerator != null)
+                {
+                    double minimumMilliseconds =
+                        smoothedMinimumNumerator[i] / smoothedEnergy[i] * 1000.0;
+                    minimumData!.Add(new SignalPoint(f, minimumMilliseconds));
+                    excessData!.Add(new SignalPoint(
+                        f, measuredMilliseconds - minimumMilliseconds));
+                }
             }
 
-            return new AnalysisCurve("Group Delay", data);
+            return BuildGroupDelayCurveSet(data, minimumData, excessData);
+        }
+
+        private static GroupDelayCurveSet BuildGroupDelayCurveSet(
+            List<SignalPoint> measured,
+            List<SignalPoint>? minimum,
+            List<SignalPoint>? excess) =>
+            new(
+                new AnalysisCurve("Group Delay", measured),
+                minimum == null
+                    ? null
+                    : new AnalysisCurve(
+                        "Minimum Phase GD",
+                        minimum,
+                        AnalysisCurveKind.MinimumPhaseGroupDelay),
+                excess == null
+                    ? null
+                    : new AnalysisCurve(
+                        "Excess GD",
+                        excess,
+                        AnalysisCurveKind.ExcessGroupDelay));
+
+        // Per-bin τ numerator Re[T·conj(H_min)] of the minimum-phase counterpart:
+        // reconstruct |H|·e^{jφ_min} from the measured magnitude, return to the
+        // time domain and time-weight it — the same construction the measured
+        // curve uses, so both divide by the same |H|² and inherit identical
+        // smoothing semantics. h_min is real by construction (log|H| is even, so
+        // φ_min is odd and the spectrum stays conjugate-symmetric); the finite
+        // FFT's imaginary residue is dropped rather than folded into the τ.
+        private static double[] ComputeMinimumPhaseGroupDelayNumerator(
+            Complex[] spectrum,
+            double invSampleRate)
+        {
+            int n = spectrum.Length;
+            double[] magnitude = new double[n];
+            for (int i = 0; i < n; i++)
+            {
+                magnitude[i] = spectrum[i].Magnitude;
+            }
+
+            Complex[] minimumSpectrum = MinimumPhase.Reconstruct(magnitude);
+
+            Complex[] buffer = new Complex[n];
+            Array.Copy(minimumSpectrum, buffer, n);
+            Fourier.Inverse(buffer, FourierOptions.Matlab);
+            for (int i = 0; i < n; i++)
+            {
+                buffer[i] = new Complex(buffer[i].Real * (i * invSampleRate), 0.0);
+            }
+            Fourier.Forward(buffer, FourierOptions.Matlab);
+
+            int halfLength = n / 2;
+            double[] numerator = new double[halfLength];
+            for (int i = 1; i < halfLength; i++)
+            {
+                Complex h = minimumSpectrum[i];
+                Complex t = buffer[i];
+                numerator[i] = t.Real * h.Real + t.Imaginary * h.Imaginary;
+            }
+
+            return numerator;
         }
 
         // The SEED grid: how many anchors span one kernel width before refinement. Not

--- a/source/Options/CurveVisibilityOptions.cs
+++ b/source/Options/CurveVisibilityOptions.cs
@@ -27,6 +27,8 @@ public sealed class CurveVisibilityOptions
 
     // Group-delay mode.
     public bool ShowGroupDelay { get; set; } = true;
+    public bool ShowMinimumPhaseGroupDelay { get; set; } = true;
+    public bool ShowExcessGroupDelay { get; set; } = true;
 
     // Shared coherence curve, shown in all three modes.
     public bool ShowCoherence { get; set; } = true;

--- a/source/Options/GDOpt.Designer.cs
+++ b/source/Options/GDOpt.Designer.cs
@@ -42,6 +42,8 @@ namespace Resonalyze.Options
             label1 = new Label();
             labelCurves = new Label();
             checkBoxShowGroupDelay = new CheckBox();
+            checkBoxShowMinimumPhaseGroupDelay = new CheckBox();
+            checkBoxShowExcessGroupDelay = new CheckBox();
             checkBoxShowCoherence = new CheckBox();
             irPlotView = new OxyPlot.WindowsForms.PlotView();
             (numericGateOffset).BeginInit();
@@ -225,22 +227,44 @@ namespace Resonalyze.Options
             checkBoxShowGroupDelay.TabIndex = 64;
             checkBoxShowGroupDelay.Text = "Show group delay";
             checkBoxShowGroupDelay.UseVisualStyleBackColor = true;
-            // 
+            //
+            // checkBoxShowMinimumPhaseGroupDelay
+            //
+            checkBoxShowMinimumPhaseGroupDelay.AutoSize = true;
+            checkBoxShowMinimumPhaseGroupDelay.ForeColor = SystemColors.ControlLight;
+            checkBoxShowMinimumPhaseGroupDelay.Location = new Point(12, 205);
+            checkBoxShowMinimumPhaseGroupDelay.Name = "checkBoxShowMinimumPhaseGroupDelay";
+            checkBoxShowMinimumPhaseGroupDelay.Size = new Size(159, 19);
+            checkBoxShowMinimumPhaseGroupDelay.TabIndex = 65;
+            checkBoxShowMinimumPhaseGroupDelay.Text = "Show minimum-phase GD";
+            checkBoxShowMinimumPhaseGroupDelay.UseVisualStyleBackColor = true;
+            //
+            // checkBoxShowExcessGroupDelay
+            //
+            checkBoxShowExcessGroupDelay.AutoSize = true;
+            checkBoxShowExcessGroupDelay.ForeColor = SystemColors.ControlLight;
+            checkBoxShowExcessGroupDelay.Location = new Point(12, 227);
+            checkBoxShowExcessGroupDelay.Name = "checkBoxShowExcessGroupDelay";
+            checkBoxShowExcessGroupDelay.Size = new Size(110, 19);
+            checkBoxShowExcessGroupDelay.TabIndex = 66;
+            checkBoxShowExcessGroupDelay.Text = "Show excess GD";
+            checkBoxShowExcessGroupDelay.UseVisualStyleBackColor = true;
+            //
             // checkBoxShowCoherence
-            // 
+            //
             checkBoxShowCoherence.AutoSize = true;
             checkBoxShowCoherence.ForeColor = SystemColors.ControlLight;
-            checkBoxShowCoherence.Location = new Point(12, 205);
+            checkBoxShowCoherence.Location = new Point(12, 249);
             checkBoxShowCoherence.Name = "checkBoxShowCoherence";
             checkBoxShowCoherence.Size = new Size(134, 19);
-            checkBoxShowCoherence.TabIndex = 65;
+            checkBoxShowCoherence.TabIndex = 67;
             checkBoxShowCoherence.Text = "Show γ² (coherence)";
             checkBoxShowCoherence.UseVisualStyleBackColor = true;
-            // 
+            //
             // irPlotView
-            // 
+            //
             irPlotView.BackColor = Color.FromArgb(32, 36, 46);
-            irPlotView.Location = new Point(12, 231);
+            irPlotView.Location = new Point(12, 275);
             irPlotView.Name = "irPlotView";
             irPlotView.PanCursor = Cursors.Hand;
             irPlotView.Size = new Size(241, 300);
@@ -255,9 +279,11 @@ namespace Resonalyze.Options
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(45, 50, 60);
-            ClientSize = new Size(265, 538);
+            ClientSize = new Size(265, 582);
             Controls.Add(irPlotView);
             Controls.Add(checkBoxShowCoherence);
+            Controls.Add(checkBoxShowExcessGroupDelay);
+            Controls.Add(checkBoxShowMinimumPhaseGroupDelay);
             Controls.Add(checkBoxShowGroupDelay);
             Controls.Add(labelCurves);
             Controls.Add(numericGateOffset);
@@ -303,6 +329,8 @@ namespace Resonalyze.Options
         private Label label1;
         private Label labelCurves;
         private CheckBox checkBoxShowGroupDelay;
+        private CheckBox checkBoxShowMinimumPhaseGroupDelay;
+        private CheckBox checkBoxShowExcessGroupDelay;
         private CheckBox checkBoxShowCoherence;
         private OxyPlot.WindowsForms.PlotView irPlotView;
     }

--- a/source/Options/GDOpt.cs
+++ b/source/Options/GDOpt.cs
@@ -43,6 +43,9 @@ public partial class GDOpt : ImpulsePreviewOptionsForm
                 SmoothingPresetOptions.Normalize(
                     opt.SmoothingInverseOctaves, includePsychoacoustic: false);
             checkBoxShowGroupDelay.Checked = visibility.ShowGroupDelay;
+            checkBoxShowMinimumPhaseGroupDelay.Checked =
+                visibility.ShowMinimumPhaseGroupDelay;
+            checkBoxShowExcessGroupDelay.Checked = visibility.ShowExcessGroupDelay;
             checkBoxShowCoherence.Checked = visibility.ShowCoherence;
         });
 
@@ -63,6 +66,9 @@ public partial class GDOpt : ImpulsePreviewOptionsForm
                 ? inverseOctaves
                 : SmoothingPresetOptions.SupportedInverseOctaves[0];
         visibility.ShowGroupDelay = checkBoxShowGroupDelay.Checked;
+        visibility.ShowMinimumPhaseGroupDelay =
+            checkBoxShowMinimumPhaseGroupDelay.Checked;
+        visibility.ShowExcessGroupDelay = checkBoxShowExcessGroupDelay.Checked;
         visibility.ShowCoherence = checkBoxShowCoherence.Checked;
         UpdateIrPreview();
     }
@@ -91,6 +97,15 @@ public partial class GDOpt : ImpulsePreviewOptionsForm
         toolTip.SetToolTip(
             checkBoxShowGroupDelay,
             "Shows the group-delay curve.");
+        toolTip.SetToolTip(
+            checkBoxShowMinimumPhaseGroupDelay,
+            "Shows the minimum-phase group delay implied by the gated magnitude " +
+            "response alone (Bode relation) — the part a minimum-phase EQ could correct.");
+        toolTip.SetToolTip(
+            checkBoxShowExcessGroupDelay,
+            "Shows measured minus minimum-phase group delay: the all-pass remainder " +
+            "(bulk delay, crossovers, reflections) that magnitude EQ cannot move. " +
+            "A flat excess curve is a pure delay.");
         toolTip.SetToolTip(
             checkBoxShowCoherence,
             "Shows the measurement coherence (\u03B3\u00B2) curve when the IR was captured with 2+ averaged runs.");

--- a/source/Plotting/CurveTag.cs
+++ b/source/Plotting/CurveTag.cs
@@ -43,6 +43,8 @@ public sealed record CurveTag(
         AnalysisCurveKind.NoiseFloor => "Noise floor",
         AnalysisCurveKind.MinimumPhase => "Minimum phase",
         AnalysisCurveKind.ExcessPhase => "Excess phase",
+        AnalysisCurveKind.MinimumPhaseGroupDelay => "Minimum-phase group delay",
+        AnalysisCurveKind.ExcessGroupDelay => "Excess group delay",
         AnalysisCurveKind.InputSpectrum => "Input Spectrum (RTA)",
         _ => mode switch
         {

--- a/source/Plotting/OxyPlotAdapter.cs
+++ b/source/Plotting/OxyPlotAdapter.cs
@@ -51,6 +51,10 @@ internal static class OxyPlotAdapter
             AnalysisCurveKind.NoiseFloor => OxyColor.FromRgb(128, 128, 128),
             AnalysisCurveKind.MinimumPhase => OxyColor.FromRgb(0, 200, 255),
             AnalysisCurveKind.ExcessPhase => OxyColor.FromRgb(130, 220, 90),
+            // The GD counterparts reuse the phase pair's hues so "minimum = cyan,
+            // excess = green" reads the same across modes.
+            AnalysisCurveKind.MinimumPhaseGroupDelay => OxyColor.FromRgb(0, 200, 255),
+            AnalysisCurveKind.ExcessGroupDelay => OxyColor.FromRgb(130, 220, 90),
             _ => OxyColor.FromRgb(255, 127, 0)
         };
     }

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -635,6 +635,15 @@ internal sealed class PlotModelFactory
                     UpdateGroupDelayRange(
                         curves.Measured, ref minimum, ref maximum, ref hasValidData);
                 }
+                // The Y auto-fit reads the MEASURED curve only. Near the sweep-band
+                // edges the magnitude rolls off steeply, the cepstral reconstruction
+                // legitimately turns that slope into tens of ms of minimum-phase
+                // group delay (~1/f at the low edge), and the excess mirrors it with
+                // the opposite sign — the validity gate keeps those bins because the
+                // rolloff tracks its own local envelope down to the −60 dB backstop.
+                // Folding them into the fit would flatten a useful 2–5 ms measured
+                // curve onto a ±30 ms scale; off-scale minimum/excess points simply
+                // clip, like any overlay.
                 if (groupDelayVisibility.ShowMinimumPhaseGroupDelay &&
                     curves.Minimum is { } minimumCurve)
                 {
@@ -644,8 +653,6 @@ internal sealed class PlotModelFactory
                         groupDelayTrackerFormat,
                         Mode.GroupDelay,
                         GroupDelayAxisKey);
-                    UpdateGroupDelayRange(
-                        minimumCurve, ref minimum, ref maximum, ref hasValidData);
                 }
                 if (groupDelayVisibility.ShowExcessGroupDelay &&
                     curves.Excess is { } excessCurve)
@@ -656,8 +663,6 @@ internal sealed class PlotModelFactory
                         groupDelayTrackerFormat,
                         Mode.GroupDelay,
                         GroupDelayAxisKey);
-                    UpdateGroupDelayRange(
-                        excessCurve, ref minimum, ref maximum, ref hasValidData);
                 }
 
                 // Overlay the Compare measurement with the identical gate
@@ -683,10 +688,12 @@ internal sealed class PlotModelFactory
                         GroupDelayMagnitudeGateDb,
                         includeMinimumPhase);
                     // Draw the Compare curves as overlays but keep the Y-axis auto-fit
-                    // driven by the main measurement only. The Compare group delay is
-                    // gated at the same offset, so as the gate moves its extremes swing
-                    // widely; folding them into the range makes the scale jump on every
-                    // edit. Off-scale Compare points are simply clipped, like any overlay.
+                    // driven by the main measured curve only. The Compare group delay
+                    // shares the gate LENGTH and smoothing (its placement is per-curve
+                    // under Auto, resolved above), so as the gate settings move its
+                    // extremes swing widely; folding them into the range makes the
+                    // scale jump on every edit. Off-scale Compare points are simply
+                    // clipped, like any overlay.
                     if (groupDelayVisibility.ShowGroupDelay)
                     {
                         AddCompareLineSeries(

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -632,18 +632,28 @@ internal sealed class PlotModelFactory
                         groupDelayTrackerFormat,
                         Mode.GroupDelay,
                         GroupDelayAxisKey);
+                }
+                // The Y auto-fit never reads the minimum/excess POINT VALUES. Near
+                // the sweep-band edges the magnitude rolls off steeply, the cepstral
+                // reconstruction legitimately turns that slope into tens of ms of
+                // minimum-phase group delay (~1/f at the low edge), and the excess
+                // mirrors it with the opposite sign — the validity gate keeps those
+                // bins because the rolloff tracks its own local envelope down to the
+                // −60 dB backstop. Folding them in would flatten a useful 2–5 ms
+                // measured curve onto a ±30 ms scale; off-scale points simply clip.
+                //
+                // The measured extremes still drive the fit when only the excess is
+                // shown: in band the excess tracks the measured absolute level
+                // (their difference is the minimum curve, ≈ 0 away from the
+                // rolloffs), so the measured range is the spike-free proxy for
+                // where the excess lives. The minimum curve lives around zero
+                // instead — showing it extends the fitted range to include zero.
+                if (groupDelayVisibility.ShowGroupDelay ||
+                    groupDelayVisibility.ShowExcessGroupDelay)
+                {
                     UpdateGroupDelayRange(
                         curves.Measured, ref minimum, ref maximum, ref hasValidData);
                 }
-                // The Y auto-fit reads the MEASURED curve only. Near the sweep-band
-                // edges the magnitude rolls off steeply, the cepstral reconstruction
-                // legitimately turns that slope into tens of ms of minimum-phase
-                // group delay (~1/f at the low edge), and the excess mirrors it with
-                // the opposite sign — the validity gate keeps those bins because the
-                // rolloff tracks its own local envelope down to the −60 dB backstop.
-                // Folding them into the fit would flatten a useful 2–5 ms measured
-                // curve onto a ±30 ms scale; off-scale minimum/excess points simply
-                // clip, like any overlay.
                 if (groupDelayVisibility.ShowMinimumPhaseGroupDelay &&
                     curves.Minimum is { } minimumCurve)
                 {
@@ -653,6 +663,11 @@ internal sealed class PlotModelFactory
                         groupDelayTrackerFormat,
                         Mode.GroupDelay,
                         GroupDelayAxisKey);
+                    if (hasValidData)
+                    {
+                        minimum = Math.Min(minimum, 0.0);
+                        maximum = Math.Max(maximum, 0.0);
+                    }
                 }
                 if (groupDelayVisibility.ShowExcessGroupDelay &&
                     curves.Excess is { } excessCurve)

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -588,10 +588,19 @@ internal sealed class PlotModelFactory
         double minimum = +1000;
         double maximum = -1000;
         bool hasValidData = false;
+        bool showAnyGroupDelayCurve =
+            groupDelayVisibility.ShowGroupDelay ||
+            groupDelayVisibility.ShowMinimumPhaseGroupDelay ||
+            groupDelayVisibility.ShowExcessGroupDelay;
+        // The minimum-phase reconstruction is computed only when a curve
+        // built on it is actually shown.
+        bool includeMinimumPhase =
+            groupDelayVisibility.ShowMinimumPhaseGroupDelay ||
+            groupDelayVisibility.ShowExcessGroupDelay;
         // Group delay is only meaningful with a transfer IR (loopback timing).
         if (measurementContext.CanIncludeCurves(includeCurves) &&
             measurementContext.HasTransferImpulseResponse &&
-            (groupDelayVisibility.ShowGroupDelay || groupDelayVisibility.ShowCoherence))
+            (showAnyGroupDelayCurve || groupDelayVisibility.ShowCoherence))
         {
             const string groupDelayTrackerFormat = "{0}\n{2:0.0} Hz\n{4:0.000} ms";
             // Auto gate: same contract as the phase plot — re-snap the offset
@@ -601,21 +610,55 @@ internal sealed class PlotModelFactory
             {
                 groupDelayOptions.GroupDelayGateOffsetMs = gdStartMs;
             }
-            if (groupDelayVisibility.ShowGroupDelay)
+            if (showAnyGroupDelayCurve)
             {
                 // The gate is positioned by its Gate offset (left-shoulder-end) within the
                 // transfer IR; the group delay reads absolute, referenced to the IR start.
                 IImpulseMeasurement measurement = measurementContext.CreatePrimaryMeasurement();
-                AnalysisCurve curve = DataHelper.GetGroupDelay(
+                GroupDelayCurveSet curves = DataHelper.GetGroupDelayCurves(
                     measurement,
                     groupDelayOptions.GroupDelayGateOffsetMs,
                     groupDelayOptions.GroupDelayLeftMs,
                     groupDelayOptions.GroupDelayPlateauMs,
                     groupDelayOptions.GroupDelayRightMs,
                     groupDelayOptions.SmoothingInverseOctaves,
-                    GroupDelayMagnitudeGateDb);
-                AddLineSeries(model, curve, groupDelayTrackerFormat, Mode.GroupDelay, GroupDelayAxisKey);
-                UpdateGroupDelayRange(curve, ref minimum, ref maximum, ref hasValidData);
+                    GroupDelayMagnitudeGateDb,
+                    includeMinimumPhase);
+                if (groupDelayVisibility.ShowGroupDelay)
+                {
+                    AddLineSeries(
+                        model,
+                        curves.Measured,
+                        groupDelayTrackerFormat,
+                        Mode.GroupDelay,
+                        GroupDelayAxisKey);
+                    UpdateGroupDelayRange(
+                        curves.Measured, ref minimum, ref maximum, ref hasValidData);
+                }
+                if (groupDelayVisibility.ShowMinimumPhaseGroupDelay &&
+                    curves.Minimum is { } minimumCurve)
+                {
+                    AddLineSeries(
+                        model,
+                        minimumCurve,
+                        groupDelayTrackerFormat,
+                        Mode.GroupDelay,
+                        GroupDelayAxisKey);
+                    UpdateGroupDelayRange(
+                        minimumCurve, ref minimum, ref maximum, ref hasValidData);
+                }
+                if (groupDelayVisibility.ShowExcessGroupDelay &&
+                    curves.Excess is { } excessCurve)
+                {
+                    AddLineSeries(
+                        model,
+                        excessCurve,
+                        groupDelayTrackerFormat,
+                        Mode.GroupDelay,
+                        GroupDelayAxisKey);
+                    UpdateGroupDelayRange(
+                        excessCurve, ref minimum, ref maximum, ref hasValidData);
+                }
 
                 // Overlay the Compare measurement with the identical gate
                 // length / smoothing. Under Auto the gate PLACEMENT is
@@ -630,25 +673,49 @@ internal sealed class PlotModelFactory
                             is { } compareStartMs
                             ? compareStartMs
                             : groupDelayOptions.GroupDelayGateOffsetMs;
-                    AnalysisCurve compareCurve = DataHelper.GetGroupDelay(
+                    GroupDelayCurveSet compareCurves = DataHelper.GetGroupDelayCurves(
                         compare.Measurement,
                         compareGateOffsetMs,
                         groupDelayOptions.GroupDelayLeftMs,
                         groupDelayOptions.GroupDelayPlateauMs,
                         groupDelayOptions.GroupDelayRightMs,
                         groupDelayOptions.SmoothingInverseOctaves,
-                        GroupDelayMagnitudeGateDb);
-                    // Draw the Compare curve as an overlay but keep the Y-axis auto-fit
+                        GroupDelayMagnitudeGateDb,
+                        includeMinimumPhase);
+                    // Draw the Compare curves as overlays but keep the Y-axis auto-fit
                     // driven by the main measurement only. The Compare group delay is
                     // gated at the same offset, so as the gate moves its extremes swing
                     // widely; folding them into the range makes the scale jump on every
                     // edit. Off-scale Compare points are simply clipped, like any overlay.
-                    AddCompareLineSeries(
-                        model,
-                        compareCurve,
-                        groupDelayTrackerFormat,
-                        compare.DisplayName,
-                        Mode.GroupDelay);
+                    if (groupDelayVisibility.ShowGroupDelay)
+                    {
+                        AddCompareLineSeries(
+                            model,
+                            compareCurves.Measured,
+                            groupDelayTrackerFormat,
+                            compare.DisplayName,
+                            Mode.GroupDelay);
+                    }
+                    if (groupDelayVisibility.ShowMinimumPhaseGroupDelay &&
+                        compareCurves.Minimum is { } compareMinimumCurve)
+                    {
+                        AddCompareLineSeries(
+                            model,
+                            compareMinimumCurve,
+                            groupDelayTrackerFormat,
+                            compare.DisplayName,
+                            Mode.GroupDelay);
+                    }
+                    if (groupDelayVisibility.ShowExcessGroupDelay &&
+                        compareCurves.Excess is { } compareExcessCurve)
+                    {
+                        AddCompareLineSeries(
+                            model,
+                            compareExcessCurve,
+                            groupDelayTrackerFormat,
+                            compare.DisplayName,
+                            Mode.GroupDelay);
+                    }
                 }
             }
 
@@ -659,7 +726,7 @@ internal sealed class PlotModelFactory
         }
         else if (measurementContext.CanIncludeCurves(includeCurves) &&
                  !measurementContext.HasTransferImpulseResponse &&
-                 groupDelayVisibility.ShowGroupDelay)
+                 showAnyGroupDelayCurve)
         {
             AddRequiresTransferIrAnnotation(model);
         }

--- a/source/Settings/MeasurementSettingsFile.Schema.cs
+++ b/source/Settings/MeasurementSettingsFile.Schema.cs
@@ -219,6 +219,8 @@ internal sealed partial class MeasurementSettingsFile
         public bool ShowThdPlusNoise { get; set; } = true;
         public bool ShowNoiseFloor { get; set; } = true;
         public bool ShowGroupDelay { get; set; } = true;
+        public bool ShowMinimumPhaseGroupDelay { get; set; } = true;
+        public bool ShowExcessGroupDelay { get; set; } = true;
         // Nullable and deliberately WITHOUT an initializer: System.Text.Json
         // never assigns a missing property, so an initializer value would
         // survive deserialization and a pre-Auto file (v <= 9, field absent)
@@ -267,6 +269,8 @@ internal sealed partial class MeasurementSettingsFile
                 ShowThdPlusNoise = visibility.ShowThdPlusNoise,
                 ShowNoiseFloor = visibility.ShowNoiseFloor,
                 ShowGroupDelay = visibility.ShowGroupDelay,
+                ShowMinimumPhaseGroupDelay = visibility.ShowMinimumPhaseGroupDelay,
+                ShowExcessGroupDelay = visibility.ShowExcessGroupDelay,
                 PhaseGateAutoFit = options.PhaseGateAutoFit,
                 PhaseGateOffsetMs = options.PhaseGateOffsetMs,
                 PhaseLeftMs = options.PhaseLeftMs,
@@ -317,6 +321,8 @@ internal sealed partial class MeasurementSettingsFile
             visibility.ShowThdPlusNoise = ShowThdPlusNoise;
             visibility.ShowNoiseFloor = ShowNoiseFloor;
             visibility.ShowGroupDelay = ShowGroupDelay;
+            visibility.ShowMinimumPhaseGroupDelay = ShowMinimumPhaseGroupDelay;
+            visibility.ShowExcessGroupDelay = ShowExcessGroupDelay;
             // Absent in a pre-Auto file: enable Auto only when the stored
             // offset is the untouched default. A deliberately fitted/typed
             // gate must stay manual — the Auto re-snap would silently

--- a/tests/Resonalyze.App.Tests/CurveTagTests.cs
+++ b/tests/Resonalyze.App.Tests/CurveTagTests.cs
@@ -29,6 +29,11 @@ public sealed class CurveTagTests
     [InlineData(Mode.PhaseResponse, AnalysisCurveKind.Primary, "Measured phase")]
     [InlineData(Mode.PhaseResponse, AnalysisCurveKind.MinimumPhase, "Minimum phase")]
     [InlineData(Mode.GroupDelay, AnalysisCurveKind.Primary, "Group delay")]
+    [InlineData(
+        Mode.GroupDelay,
+        AnalysisCurveKind.MinimumPhaseGroupDelay,
+        "Minimum-phase group delay")]
+    [InlineData(Mode.GroupDelay, AnalysisCurveKind.ExcessGroupDelay, "Excess group delay")]
     [InlineData(Mode.ImpulseResponse, AnalysisCurveKind.Primary, "Impulse")]
     public void Label_DescribesMainCurve(Mode mode, AnalysisCurveKind kind, string expected)
     {

--- a/tests/Resonalyze.App.Tests/CurveVisibilityOptionsTests.cs
+++ b/tests/Resonalyze.App.Tests/CurveVisibilityOptionsTests.cs
@@ -47,6 +47,8 @@ public sealed class CurveVisibilityOptionsTests
         visibility.ShowMinimumPhase = true;
         visibility.ShowExcessPhase = true;
         visibility.ShowGroupDelay = true;
+        visibility.ShowMinimumPhaseGroupDelay = true;
+        visibility.ShowExcessGroupDelay = true;
         visibility.ShowCoherence = true;
 
         Assert.Equal(SpectrumCurves.None, visibility.ToSpectrumCurves());
@@ -64,6 +66,8 @@ public sealed class CurveVisibilityOptionsTests
         ShowMinimumPhase = false,
         ShowExcessPhase = false,
         ShowGroupDelay = false,
+        ShowMinimumPhaseGroupDelay = false,
+        ShowExcessGroupDelay = false,
         ShowCoherence = false
     };
 

--- a/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
@@ -257,6 +257,38 @@ public sealed class MeasurementSettingsMigrationTests
             PhaseAnalysisSettings.DefaultFdwCycles, options.MagnitudeFdwCycles);
     }
 
+    // A pre-excess-GD file has no ShowMinimumPhaseGroupDelay /
+    // ShowExcessGroupDelay fields; the new curves default ON (real JSON for
+    // the same missing-property reason as the gate tests above). A stored
+    // false must survive the roundtrip, or the checkboxes would re-arm on
+    // every restart.
+    [Fact]
+    public void GroupDelayCurveFlags_DefaultOnForOldFilesAndRoundTripWhenOff()
+    {
+        MeasurementSettingsFile.FrequencyResponseSettings legacy =
+            DeserializeFrequencyResponse("""{"ShowGroupDelay": false}""");
+        var visibility = new CurveVisibilityOptions();
+
+        legacy.ApplyTo(new FrequencyResponseOptions(), visibility);
+
+        Assert.False(visibility.ShowGroupDelay);
+        Assert.True(visibility.ShowMinimumPhaseGroupDelay);
+        Assert.True(visibility.ShowExcessGroupDelay);
+
+        var stored = new CurveVisibilityOptions
+        {
+            ShowMinimumPhaseGroupDelay = false,
+            ShowExcessGroupDelay = false
+        };
+        var restored = new CurveVisibilityOptions();
+        MeasurementSettingsFile.FrequencyResponseSettings.Capture(
+                new FrequencyResponseOptions(), stored)
+            .ApplyTo(new FrequencyResponseOptions(), restored);
+
+        Assert.False(restored.ShowMinimumPhaseGroupDelay);
+        Assert.False(restored.ShowExcessGroupDelay);
+    }
+
     private static MeasurementSettingsFile.FrequencyResponseSettings
         DeserializeFrequencyResponse(string json) =>
         System.Text.Json.JsonSerializer

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -172,6 +172,37 @@ public sealed class PlotModelFactoryTests
     }
 
     [Fact]
+    public void GroupDelay_AxisAutoFit_ReadsTheMeasuredCurveOnly()
+    {
+        // Near the sweep-band edges the minimum/excess pair legitimately swings
+        // by tens of ms (the cepstral reconstruction of the magnitude rolloff),
+        // and folding that into the auto-fit would flatten a 2–5 ms measured
+        // curve onto a huge scale. The axis range must be identical whether the
+        // pair is shown or not; off-scale pair points just clip.
+        using var measurement = CreateTransferMeasurement();
+        using var noiseMeasurement = new NoiseMeasurement(new FakeAudioSessionFactory());
+
+        OxyPlot.Axes.Axis AxisOf(bool showPair)
+        {
+            var visibility = new CurveVisibilityOptions
+            {
+                ShowGroupDelay = true,
+                ShowMinimumPhaseGroupDelay = showPair,
+                ShowExcessGroupDelay = showPair
+            };
+            PlotModelFactory factory = CreateFactory(
+                measurement, noiseMeasurement, groupDelayVisibility: visibility);
+            return factory.CreateGroupDelay(includeCurves: true).Axes
+                .First(axis => axis.Key == PlotModelFactory.GroupDelayAxisKey);
+        }
+
+        OxyPlot.Axes.Axis withPair = AxisOf(showPair: true);
+        OxyPlot.Axes.Axis measuredOnly = AxisOf(showPair: false);
+        Assert.Equal(measuredOnly.Minimum, withPair.Minimum, precision: 9);
+        Assert.Equal(measuredOnly.Maximum, withPair.Maximum, precision: 9);
+    }
+
+    [Fact]
     public void GroupDelay_CompareSource_GetsMinimumAndExcessCurvesToo()
     {
         using var measurement = CreateTransferMeasurement();

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -116,7 +116,12 @@ public sealed class PlotModelFactoryTests
     {
         using var measurement = CreateTransferMeasurement();
         using var noiseMeasurement = new NoiseMeasurement(new FakeAudioSessionFactory());
-        var groupDelayVisibility = new CurveVisibilityOptions { ShowGroupDelay = false };
+        var groupDelayVisibility = new CurveVisibilityOptions
+        {
+            ShowGroupDelay = false,
+            ShowMinimumPhaseGroupDelay = false,
+            ShowExcessGroupDelay = false
+        };
         PlotModelFactory factory =
             CreateFactory(measurement, noiseMeasurement, groupDelayVisibility: groupDelayVisibility);
 
@@ -124,6 +129,77 @@ public sealed class PlotModelFactoryTests
 
         groupDelayVisibility.ShowGroupDelay = true;
         Assert.NotEmpty(factory.CreateGroupDelay(includeCurves: true).Series);
+    }
+
+    [Fact]
+    public void GroupDelay_MinimumAndExcessCurves_FollowTheirFlags()
+    {
+        using var measurement = CreateTransferMeasurement();
+        using var noiseMeasurement = new NoiseMeasurement(new FakeAudioSessionFactory());
+        var groupDelayVisibility = new CurveVisibilityOptions
+        {
+            ShowGroupDelay = true,
+            ShowMinimumPhaseGroupDelay = true,
+            ShowExcessGroupDelay = true
+        };
+        PlotModelFactory factory =
+            CreateFactory(measurement, noiseMeasurement, groupDelayVisibility: groupDelayVisibility);
+
+        List<CurveTag> tags = factory.CreateGroupDelay(includeCurves: true).Series
+            .OfType<LineSeries>()
+            .Select(series => series.Tag)
+            .OfType<CurveTag>()
+            .ToList();
+        Assert.Contains(tags, tag => tag.Kind == AnalysisCurveKind.Primary);
+        Assert.Contains(
+            tags, tag => tag.Kind == AnalysisCurveKind.MinimumPhaseGroupDelay);
+        Assert.Contains(tags, tag => tag.Kind == AnalysisCurveKind.ExcessGroupDelay);
+
+        // Each curve follows its own flag: hiding the measured curve must not
+        // take the minimum/excess pair down with it, and vice versa.
+        groupDelayVisibility.ShowGroupDelay = false;
+        groupDelayVisibility.ShowExcessGroupDelay = false;
+        tags = factory.CreateGroupDelay(includeCurves: true).Series
+            .OfType<LineSeries>()
+            .Select(series => series.Tag)
+            .OfType<CurveTag>()
+            .ToList();
+        Assert.DoesNotContain(tags, tag => tag.Kind == AnalysisCurveKind.Primary);
+        Assert.Contains(
+            tags, tag => tag.Kind == AnalysisCurveKind.MinimumPhaseGroupDelay);
+        Assert.DoesNotContain(
+            tags, tag => tag.Kind == AnalysisCurveKind.ExcessGroupDelay);
+    }
+
+    [Fact]
+    public void GroupDelay_CompareSource_GetsMinimumAndExcessCurvesToo()
+    {
+        using var measurement = CreateTransferMeasurement();
+        using var noiseMeasurement = new NoiseMeasurement(new FakeAudioSessionFactory());
+        PlotModelFactory factory = CreateFactory(measurement, noiseMeasurement);
+
+        var compareIr = new Complex[2048];
+        compareIr[64] = Complex.One;
+        factory.SetCompareSourceProvider(
+            () => new CompareAnalysisSource(
+                "Reference",
+                44_100,
+                compareIr,
+                64));
+
+        List<CurveTag> tags = factory.CreateGroupDelay(includeCurves: true).Series
+            .OfType<LineSeries>()
+            .Select(series => series.Tag)
+            .OfType<CurveTag>()
+            .ToList();
+        Assert.Contains(
+            tags,
+            tag => tag.Source == CurveSource.Compare &&
+                tag.Kind == AnalysisCurveKind.MinimumPhaseGroupDelay);
+        Assert.Contains(
+            tags,
+            tag => tag.Source == CurveSource.Compare &&
+                tag.Kind == AnalysisCurveKind.ExcessGroupDelay);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -172,23 +172,24 @@ public sealed class PlotModelFactoryTests
     }
 
     [Fact]
-    public void GroupDelay_AxisAutoFit_ReadsTheMeasuredCurveOnly()
+    public void GroupDelay_AxisAutoFit_FollowsMeasuredAndPinsZeroForMinimum()
     {
-        // Near the sweep-band edges the minimum/excess pair legitimately swings
-        // by tens of ms (the cepstral reconstruction of the magnitude rolloff),
-        // and folding that into the auto-fit would flatten a 2–5 ms measured
-        // curve onto a huge scale. The axis range must be identical whether the
-        // pair is shown or not; off-scale pair points just clip.
-        using var measurement = CreateTransferMeasurement();
+        // A ~5.4 ms arrival — the typical car-audio scale, where the measured
+        // range (±2 ms pad) no longer straddles zero on its own. The fit must
+        // follow the measured absolute level even when only the excess is shown
+        // (in band the excess tracks it), must extend to zero when the minimum
+        // curve is shown (it lives at ≈ 0), and must never read the pair's own
+        // point values (their band-edge cepstral swings would wreck the scale).
+        using var measurement = CreateTransferMeasurement(peakSample: 240);
         using var noiseMeasurement = new NoiseMeasurement(new FakeAudioSessionFactory());
 
-        OxyPlot.Axes.Axis AxisOf(bool showPair)
+        OxyPlot.Axes.Axis AxisOf(bool showMeasured, bool showMinimum, bool showExcess)
         {
             var visibility = new CurveVisibilityOptions
             {
-                ShowGroupDelay = true,
-                ShowMinimumPhaseGroupDelay = showPair,
-                ShowExcessGroupDelay = showPair
+                ShowGroupDelay = showMeasured,
+                ShowMinimumPhaseGroupDelay = showMinimum,
+                ShowExcessGroupDelay = showExcess
             };
             PlotModelFactory factory = CreateFactory(
                 measurement, noiseMeasurement, groupDelayVisibility: visibility);
@@ -196,10 +197,42 @@ public sealed class PlotModelFactoryTests
                 .First(axis => axis.Key == PlotModelFactory.GroupDelayAxisKey);
         }
 
-        OxyPlot.Axes.Axis withPair = AxisOf(showPair: true);
-        OxyPlot.Axes.Axis measuredOnly = AxisOf(showPair: false);
-        Assert.Equal(measuredOnly.Minimum, withPair.Minimum, precision: 9);
-        Assert.Equal(measuredOnly.Maximum, withPair.Maximum, precision: 9);
+        // All three curves: the ~5.4 ms measured level AND the ≈ 0 minimum
+        // curve must both land inside the fitted range.
+        OxyPlot.Axes.Axis allThree = AxisOf(
+            showMeasured: true, showMinimum: true, showExcess: true);
+        Assert.True(
+            allThree.Minimum < 0.2,
+            $"the minimum curve is clipped out (axis starts at {allThree.Minimum:0.00} ms)");
+        Assert.True(
+            allThree.Maximum > 5.0,
+            $"the measured level is clipped out (axis ends at {allThree.Maximum:0.00} ms)");
+
+        // Excess only (measured hidden): the axis still follows the measured
+        // absolute level, where the in-band excess actually lives — not the
+        // −5…+5 default that would push an 8–10 ms system off screen.
+        OxyPlot.Axes.Axis excessOnly = AxisOf(
+            showMeasured: false, showMinimum: false, showExcess: true);
+        Assert.True(
+            excessOnly.Maximum > 5.0,
+            $"the excess curve is clipped out (axis ends at {excessOnly.Maximum:0.00} ms)");
+        Assert.True(
+            excessOnly.Minimum < 5.0,
+            $"the excess curve is clipped out (axis starts at {excessOnly.Minimum:0.00} ms)");
+
+        // Measured + excess without the minimum curve: no zero extension — the
+        // range stays tight around the arrival.
+        OxyPlot.Axes.Axis withoutMinimum = AxisOf(
+            showMeasured: true, showMinimum: false, showExcess: true);
+        Assert.True(
+            withoutMinimum.Minimum > 2.0,
+            $"zero was pinned with no minimum curve shown ({withoutMinimum.Minimum:0.00} ms)");
+
+        // Minimum alone: the default −5…+5 window already contains the curve.
+        OxyPlot.Axes.Axis minimumOnly = AxisOf(
+            showMeasured: false, showMinimum: true, showExcess: false);
+        Assert.Equal(-5.0, minimumOnly.Minimum);
+        Assert.Equal(5.0, minimumOnly.Maximum);
     }
 
     [Fact]
@@ -924,10 +957,10 @@ public sealed class PlotModelFactoryTests
         return measurement;
     }
 
-    private static ExpSweepMeasurement CreateTransferMeasurement()
+    private static ExpSweepMeasurement CreateTransferMeasurement(int peakSample = 64)
     {
         var transferImpulse = new Complex[2048];
-        transferImpulse[64] = Complex.One;
+        transferImpulse[peakSample] = Complex.One;
 
         var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
         measurement.RestoreImpulseResponse(
@@ -938,10 +971,10 @@ public sealed class PlotModelFactoryTests
             sweepDurationSeconds: 1.0,
             playChannel: PlaybackChannel.Mono,
             sweepDeconvolutionImpulseResponse: transferImpulse,
-            sweepDeconvolutionPeakIndex: 64,
+            sweepDeconvolutionPeakIndex: peakSample,
             measurementMode: SweepMeasurementMode.LoopbackTransfer,
             transferImpulseResponse: transferImpulse,
-            transferPeakIndex: 64);
+            transferPeakIndex: peakSample);
         return measurement;
     }
 

--- a/tests/Resonalyze.Dsp.Tests/GroupDelayCurvesTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/GroupDelayCurvesTests.cs
@@ -1,0 +1,262 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class GroupDelayCurvesTests
+{
+    private const int SampleRate = 48_000;
+    private const int TransformLength = 4096;
+
+    [Fact]
+    public void PureDelay_MinimumIsFlatZeroAndExcessCarriesTheDelay()
+    {
+        // A delayed delta has a flat magnitude, so the whole measured delay is
+        // all-pass: the minimum-phase curve must sit at 0 and the excess must
+        // read the full arrival time.
+        const int delaySamples = 24;
+        var response = new Complex[TransformLength];
+        response[delaySamples] = Complex.One;
+        var measurement = new SyntheticMeasurement(
+            response,
+            SampleRate,
+            maxMagnitudeIndex: 0);
+
+        GroupDelayCurveSet curves = DataHelper.GetGroupDelayCurves(
+            measurement,
+            gateOffsetMs: 0,
+            leftMs: 0,
+            plateauMs: TransformLength * 1000.0 / SampleRate,
+            rightMs: 0,
+            smoothingInverseOctaves: 96,
+            includeMinimumPhase: true);
+
+        Assert.NotNull(curves.Minimum);
+        Assert.NotNull(curves.Excess);
+        AnalysisCurve minimum = curves.Minimum!;
+        AnalysisCurve excess = curves.Excess!;
+        Assert.Equal(
+            curves.Measured.Points.Select(point => point.X),
+            minimum.Points.Select(point => point.X));
+        Assert.Equal(
+            curves.Measured.Points.Select(point => point.X),
+            excess.Points.Select(point => point.X));
+
+        double delayMilliseconds = delaySamples * 1000.0 / SampleRate;
+        List<int> band = AnalysisBandIndices(curves.Measured, 1_000, 18_000);
+        Assert.NotEmpty(band);
+        Assert.All(band, i => Assert.InRange(
+            curves.Measured.Points[i].Y,
+            delayMilliseconds - 1e-9,
+            delayMilliseconds + 1e-9));
+        Assert.All(band, i => Assert.InRange(
+            minimum.Points[i].Y, -1e-6, 1e-6));
+        Assert.All(band, i => Assert.InRange(
+            excess.Points[i].Y,
+            delayMilliseconds - 1e-6,
+            delayMilliseconds + 1e-6));
+    }
+
+    [Fact]
+    public void MinimumPhaseSystem_HasNearZeroExcess()
+    {
+        // h[n] = 0.9ⁿ is a one-pole system, minimum-phase by construction (the
+        // pole sits inside the unit circle; the truncation zeros sit at radius
+        // 0.9 too). Its measured group delay is fully explained by the
+        // magnitude, so the excess must read ≈ 0 across the band — this is the
+        // curve pair agreeing about a system an EQ could actually correct.
+        var response = new Complex[TransformLength];
+        for (int i = 0; i < 1_000; i++)
+        {
+            response[i] = new Complex(Math.Pow(0.9, i), 0);
+        }
+        var measurement = new SyntheticMeasurement(
+            response,
+            SampleRate,
+            maxMagnitudeIndex: 0);
+
+        GroupDelayCurveSet curves = DataHelper.GetGroupDelayCurves(
+            measurement,
+            gateOffsetMs: 0,
+            leftMs: 0,
+            plateauMs: TransformLength * 1000.0 / SampleRate,
+            rightMs: 0,
+            smoothingInverseOctaves: 96,
+            includeMinimumPhase: true);
+
+        List<int> band = AnalysisBandIndices(curves.Measured, 100, 18_000);
+        Assert.NotEmpty(band);
+        // The system's own delay reaches ~0.19 ms at the low end; the excess
+        // must be an order of magnitude under that everywhere.
+        Assert.All(band, i => Assert.InRange(
+            curves.Excess!.Points[i].Y, -0.01, 0.01));
+    }
+
+    [Fact]
+    public void AllPass_DispersionLandsInExcessNotMinimum()
+    {
+        // A second-order all-pass at 1 kHz (Q = 2): |H| = 1 everywhere, so the
+        // minimum-phase curve must stay flat ≈ 0 while the group-delay pile-up
+        // at the corner (τ ≈ 4Q/ω₀ ≈ 1.27 ms) lands entirely in the excess.
+        IReadOnlyList<BiquadCoefficients> sections = AllPassFilter.BuildSections(
+            new AllPassSpec(AllPassType.SecondOrder, 1_000.0, Q: 2.0),
+            SampleRate);
+        Assert.NotEmpty(sections);
+
+        double[] impulse = new double[TransformLength];
+        impulse[0] = 1.0;
+        foreach (BiquadCoefficients biquad in sections)
+        {
+            impulse = FilterAdditiveFeedback(biquad, impulse);
+        }
+        var response = new Complex[TransformLength];
+        for (int i = 0; i < TransformLength; i++)
+        {
+            response[i] = new Complex(impulse[i], 0);
+        }
+        var measurement = new SyntheticMeasurement(
+            response,
+            SampleRate,
+            maxMagnitudeIndex: 0);
+
+        GroupDelayCurveSet curves = DataHelper.GetGroupDelayCurves(
+            measurement,
+            gateOffsetMs: 0,
+            leftMs: 0,
+            plateauMs: TransformLength * 1000.0 / SampleRate,
+            rightMs: 0,
+            smoothingInverseOctaves: 96,
+            includeMinimumPhase: true);
+
+        List<int> band = AnalysisBandIndices(curves.Measured, 100, 18_000);
+        Assert.NotEmpty(band);
+        Assert.All(band, i => Assert.InRange(
+            curves.Minimum!.Points[i].Y, -0.05, 0.05));
+
+        double excessAtCorner = InterpolateY(curves.Excess!, 1_000.0);
+        double excessFarAbove = InterpolateY(curves.Excess!, 10_000.0);
+        Assert.True(
+            excessAtCorner - excessFarAbove > 0.8,
+            $"the all-pass dispersion never reached the excess curve " +
+            $"({excessAtCorner:0.000} ms at 1 kHz vs {excessFarAbove:0.000} ms at 10 kHz)");
+    }
+
+    [Fact]
+    public void ValidityGate_BlanksTheSameBinsInEveryCurve()
+    {
+        // A differencer's low end falls below the −60 dB global backstop, so
+        // some bins gate to NaN. The three curves must agree bin-exactly: a
+        // reader overlaying them must never see an excess value whose measured
+        // or minimum operand was blanked.
+        var response = new Complex[TransformLength];
+        response[0] = Complex.One;
+        response[1] = -Complex.One;
+        var measurement = new SyntheticMeasurement(
+            response,
+            SampleRate,
+            maxMagnitudeIndex: 0);
+
+        GroupDelayCurveSet curves = DataHelper.GetGroupDelayCurves(
+            measurement,
+            gateOffsetMs: 0,
+            leftMs: 0,
+            plateauMs: TransformLength * 1000.0 / SampleRate,
+            rightMs: 0,
+            smoothingInverseOctaves: 0,
+            includeMinimumPhase: true);
+
+        Assert.Equal(curves.Measured.Points.Count, curves.Minimum!.Points.Count);
+        Assert.Equal(curves.Measured.Points.Count, curves.Excess!.Points.Count);
+        for (int i = 0; i < curves.Measured.Points.Count; i++)
+        {
+            bool measuredIsNaN = double.IsNaN(curves.Measured.Points[i].Y);
+            Assert.Equal(measuredIsNaN, double.IsNaN(curves.Minimum.Points[i].Y));
+            Assert.Equal(measuredIsNaN, double.IsNaN(curves.Excess.Points[i].Y));
+        }
+        Assert.Contains(curves.Measured.Points, point => double.IsNaN(point.Y));
+        Assert.Contains(curves.Measured.Points, point => double.IsFinite(point.Y));
+    }
+
+    [Fact]
+    public void GetGroupDelay_IsTheMeasuredCurveOfTheSet()
+    {
+        const int delaySamples = 24;
+        var response = new Complex[TransformLength];
+        response[delaySamples] = Complex.One;
+        var measurement = new SyntheticMeasurement(
+            response,
+            SampleRate,
+            maxMagnitudeIndex: 0);
+        double plateauMs = TransformLength * 1000.0 / SampleRate;
+
+        AnalysisCurve wrapper = DataHelper.GetGroupDelay(
+            measurement,
+            gateOffsetMs: 0,
+            leftMs: 0,
+            plateauMs: plateauMs,
+            rightMs: 0,
+            smoothingInverseOctaves: 96);
+        GroupDelayCurveSet set = DataHelper.GetGroupDelayCurves(
+            measurement,
+            gateOffsetMs: 0,
+            leftMs: 0,
+            plateauMs: plateauMs,
+            rightMs: 0,
+            smoothingInverseOctaves: 96);
+
+        // The default set carries no minimum-phase work at all — the wrapper
+        // must not silently pay for curves nobody asked for.
+        Assert.Null(set.Minimum);
+        Assert.Null(set.Excess);
+        Assert.Equal(wrapper.Points, set.Measured.Points);
+    }
+
+    private static List<int> AnalysisBandIndices(
+        AnalysisCurve curve,
+        double lowHz,
+        double highHz)
+    {
+        var indices = new List<int>();
+        for (int i = 0; i < curve.Points.Count; i++)
+        {
+            if (curve.Points[i].X >= lowHz && curve.Points[i].X <= highHz)
+            {
+                indices.Add(i);
+            }
+        }
+
+        return indices;
+    }
+
+    // Reads the curve at the frequency nearest to the target (the grids are
+    // dense — 32768-point FFT — so nearest is as good as interpolation here).
+    private static double InterpolateY(AnalysisCurve curve, double frequencyHz)
+    {
+        SignalPoint nearest = curve.Points
+            .Where(point => double.IsFinite(point.Y))
+            .MinBy(point => Math.Abs(point.X - frequencyHz));
+        return nearest.Y;
+    }
+
+    // y[n] = b0·x[n] + b1·x[n−1] + b2·x[n−2] + a1·y[n−1] + a2·y[n−2] — the
+    // additive-feedback convention BiquadCoefficients documents.
+    private static double[] FilterAdditiveFeedback(
+        BiquadCoefficients biquad,
+        double[] input)
+    {
+        double[] output = new double[input.Length];
+        double x1 = 0.0, x2 = 0.0, y1 = 0.0, y2 = 0.0;
+        for (int i = 0; i < input.Length; i++)
+        {
+            double x = input[i];
+            double y = biquad.B0 * x + biquad.B1 * x1 + biquad.B2 * x2 +
+                biquad.A1 * y1 + biquad.A2 * y2;
+            output[i] = y;
+            x2 = x1;
+            x1 = x;
+            y2 = y1;
+            y1 = y;
+        }
+
+        return output;
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/GroupDelayCurvesTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/GroupDelayCurvesTests.cs
@@ -141,6 +141,94 @@ public sealed class GroupDelayCurvesTests
     }
 
     [Fact]
+    public void BulkDelayedMinimumPhaseSystem_SplitsDelayFromDispersion()
+    {
+        // The app's typical geometry: a propagation delay in front of a
+        // minimum-phase driver response, the auto gate offset landing on the
+        // arrival, and a non-zero left Tukey shoulder (so extractionStart ≠ 0).
+        // The split must be clean: the minimum curve reads the one-pole's own
+        // dispersion with NO bulk delay in it, and the excess reads the full
+        // 5 ms bulk delay, flat across the band.
+        const int delaySamples = 240; // 5 ms at 48 kHz.
+        var response = new Complex[TransformLength];
+        for (int i = 0; i < 600; i++)
+        {
+            response[delaySamples + i] = new Complex(Math.Pow(0.9, i), 0);
+        }
+        var measurement = new SyntheticMeasurement(
+            response,
+            SampleRate,
+            maxMagnitudeIndex: delaySamples);
+
+        GroupDelayCurveSet curves = DataHelper.GetGroupDelayCurves(
+            measurement,
+            gateOffsetMs: delaySamples * 1000.0 / SampleRate,
+            leftMs: 2.0,
+            plateauMs: 20.0,
+            rightMs: 5.0,
+            smoothingInverseOctaves: 96,
+            includeMinimumPhase: true);
+
+        double bulkDelayMilliseconds = delaySamples * 1000.0 / SampleRate;
+        List<int> band = AnalysisBandIndices(curves.Measured, 100, 18_000);
+        Assert.NotEmpty(band);
+        Assert.All(band, i => Assert.InRange(
+            curves.Excess!.Points[i].Y,
+            bulkDelayMilliseconds - 0.02,
+            bulkDelayMilliseconds + 0.02));
+
+        // The dispersion stays in the minimum curve: the one-pole's group delay
+        // reaches ~0.19 ms toward DC and near-zero at the top of the band.
+        double minimumLow = InterpolateY(curves.Minimum!, 100.0);
+        double minimumHigh = InterpolateY(curves.Minimum!, 10_000.0);
+        Assert.True(
+            minimumLow - minimumHigh > 0.1,
+            $"the one-pole dispersion never reached the minimum curve " +
+            $"({minimumLow:0.000} ms at 100 Hz vs {minimumHigh:0.000} ms at 10 kHz)");
+    }
+
+    [Fact]
+    public void WrapGate_LeftShoulderBeforeIrStart_KeepsTheSplit()
+    {
+        // A peak near the IR start with a left shoulder longer than the offset:
+        // extractionStart goes negative and the gate reads the cyclic tail (the
+        // same wrap path GroupDelay_WrapsWhenLeftShoulderPrecedesIrStart pins for
+        // the measured curve). The time re-reference must not leak into the
+        // minimum curve: measured and excess read the true absolute arrival,
+        // minimum stays at zero.
+        const int peakSample = 5;
+        var response = new Complex[TransformLength];
+        response[peakSample] = Complex.One;
+        var measurement = new SyntheticMeasurement(
+            response,
+            SampleRate,
+            maxMagnitudeIndex: peakSample);
+
+        GroupDelayCurveSet curves = DataHelper.GetGroupDelayCurves(
+            measurement,
+            gateOffsetMs: peakSample * 1000.0 / SampleRate,
+            leftMs: 48 * 1000.0 / SampleRate, // 48 samples > peak → wrap.
+            plateauMs: 256 * 1000.0 / SampleRate,
+            rightMs: 64 * 1000.0 / SampleRate,
+            smoothingInverseOctaves: 96,
+            includeMinimumPhase: true);
+
+        double arrivalMilliseconds = peakSample * 1000.0 / SampleRate;
+        List<int> band = AnalysisBandIndices(curves.Measured, 1_000, 18_000);
+        Assert.NotEmpty(band);
+        Assert.All(band, i => Assert.InRange(
+            curves.Measured.Points[i].Y,
+            arrivalMilliseconds - 1e-6,
+            arrivalMilliseconds + 1e-6));
+        Assert.All(band, i => Assert.InRange(
+            curves.Minimum!.Points[i].Y, -1e-6, 1e-6));
+        Assert.All(band, i => Assert.InRange(
+            curves.Excess!.Points[i].Y,
+            arrivalMilliseconds - 1e-6,
+            arrivalMilliseconds + 1e-6));
+    }
+
+    [Fact]
     public void ValidityGate_BlanksTheSameBinsInEveryCurve()
     {
         // A differencer's low end falls below the −60 dB global backstop, so


### PR DESCRIPTION
## Summary

The Group Delay mode now renders the pair REW calls **minimum-phase group delay** and **excess group delay**, closing the curve half of the long-standing excess-delay follow-up.

- **Minimum Phase GD** (cyan, like the phase mode's Minimum Phase) is reconstructed from the gated magnitude alone — cepstral Bode relation via the existing `MinimumPhase.Reconstruct` — then pushed back through the **same** energy-weighted τ machinery (`τ = Re[T·conj(H)] / |H|²`), the same smoothing and the same validity gate as the measured curve. The reconstruction preserves |H| exactly, so both curves share one |H|² denominator and one gate: a bin is finite in every curve or NaN in every curve.
- **Excess GD** (green, like Excess Phase) is the pointwise measured − minimum. It stays **absolute** (referenced to the IR start), so it reads as the frequency-dependent arrival time of the all-pass part: a flat excess curve is a pure delay; deviations are crossovers/reflections that magnitude EQ cannot move.
- `GetGroupDelay` became a thin wrapper over the new `GetGroupDelayCurves`; the measured path is unchanged line-for-line and a pin test asserts the wrapper returns the set's Measured curve with no minimum-phase work paid for.
- Compare sources get all three curves (dashed/dimmed, same as the phase mode); the minimum/excess pair joins the Y-axis auto-fit for the main measurement only.
- Two new GDOpt checkboxes with explanatory tooltips; visibility persists through settings. A pre-feature settings file (fields absent) defaults the new curves **on**; a stored `false` survives the roundtrip.
- New `AnalysisCurveKind.MinimumPhaseGroupDelay` / `ExcessGroupDelay` are appended at the enum tail (the kind is persisted in overlay files); overlay capture/linking works via the stable keys `GroupDelay:MinimumPhaseGroupDelay:Main` / `GroupDelay:ExcessGroupDelay:Main`. GD mode is outside the overlays' amplitude space, so no psychoacoustic averaging applies to the new curves.

## Test plan

- `GroupDelayCurvesTests` (new, dsp): four synthetic discriminators + a wrapper pin —
  - pure delay δ(24 samples): minimum ≈ 0 (±1e-6 ms), excess = the delay;
  - one-pole 0.9ⁿ (minimum-phase by construction): excess ≈ 0 (±0.01 ms) while the system's own τ reaches ~0.19 ms;
  - second-order all-pass 1 kHz Q=2: the ~1.27 ms corner dispersion lands in excess, minimum stays flat (±0.05 ms);
  - differencer: NaN masks agree bin-exactly across all three curves;
  - `GetGroupDelay` ≡ `GetGroupDelayCurves(...).Measured`, with no minimum/excess computed by default.
- App tests: per-flag series presence/absence with independent toggles, Compare tagged min/excess curves, CurveTag labels, settings migration (default-on for legacy JSON, off-state roundtrip).
- Full suite green: 948 dsp + 772 app + 138 audio, 0 warnings (warnings-as-errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)