### PR TITLE
Quality-of-life fixes: SPL view-only scales, EQ Wizard sources, target level, Auto Tune preamp

### DIFF
--- a/dsp/EqAutoTuner.cs
+++ b/dsp/EqAutoTuner.cs
@@ -36,7 +36,12 @@ public static class EqAutoTuner
         /// the curve honestly sits below an unreachable target instead.
         /// Unbounded by default: as a pure curve fit the preamp legitimately
         /// carries the level difference between arbitrarily referenced source
-        /// and target; a caller producing a profile for a real DSP passes 0.
+        /// and target; a caller producing a clip-safe cuts-only profile passes 0.
+        /// With boosts allowed, prefer pinning the preamp instead
+        /// (<see cref="PreampMinDb"/> == <see cref="PreampMaxDb"/>): this cap is
+        /// applied AFTER the bands are placed, so under it a fit that boosts is
+        /// realised below the level its bands were placed against — the whole
+        /// curve drops by the peak boost.
         /// </summary>
         public double TotalGainMaxDb { get; init; } = double.PositiveInfinity;
 

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -98,11 +98,20 @@ internal sealed class LiveSpectrumController : IDisposable
     public RawCurveCapture? BuildRawRtaCapture() =>
         plotModelFactory.BuildRawRtaCurve(lastSnapshot?.InputMagnitude);
 
-    // Whether the plot is currently rendering the absolute dB SPL (RTA) view. SPL is
-    // only effective when it is both selected and backed by a matching calibration,
-    // so this reflects what will actually be drawn — never a stale-calibration request.
+    // Whether the plot is in the absolute dB SPL (RTA) view. This follows the
+    // SELECTION: without a matching calibration the view still shows the SPL axis,
+    // but view-only (see SplViewOnly) — live curves are suppressed rather than the
+    // scale silently falling back to relative.
     private bool RenderingSpl =>
         plotModelFactory.EffectiveLiveSpectrumScale == MagnitudeScale.SoundPressureLevel;
+
+    // dB SPL selected with no matching calibration: the axis and the SPL overlays
+    // show, but live curves have no absolute level to be lifted to and are not
+    // drawn. The record button resets the scale to relative before an actual run,
+    // so this covers idle redraws of a stale snapshot (a scale switch after a stop)
+    // and the moment a running analyzer loses its calibration.
+    private bool SplViewOnly =>
+        RenderingSpl && plotModelFactory.LiveSplOffsetDb == null;
 
     // The plot shows only the reference-free RTA (no transfer function or coherence)
     // when the SPL view is active OR the capture has no loopback reference at all.
@@ -547,6 +556,13 @@ internal sealed class LiveSpectrumController : IDisposable
             RemoveLiveSpectrumSeries(attachedModel);
         }
         attachedModel = model;
+
+        // A view-only SPL plot draws no live curves: at raw (un-lifted) dBFS on the
+        // absolute axis they would read as absurd sound-pressure levels.
+        if (SplViewOnly)
+        {
+            return;
+        }
 
         // The plot is the reference-free microphone (RTA) spectrum whenever the SPL
         // view is active (the transfer function has no scalar SPL under noise) or the

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -55,6 +55,9 @@ internal sealed class LiveSpectrumController : IDisposable
     private LineSeries? coherenceSeries;
     private LineSeries? inputMagnitudeSeries;
     private PlotModel? attachedModel;
+    // The "showing dB SPL overlays only" notice, kept as one instance so the live
+    // redraw can add it exactly once and take it down when view-only ends.
+    private OverlayTextAnnotation? splViewOnlyAnnotation;
 
     public LiveSpectrumController(
         Form owner,
@@ -88,6 +91,14 @@ internal sealed class LiveSpectrumController : IDisposable
 
     public bool InProgress => measurement.InProgress;
     public bool TimerEnabled => timer.Enabled;
+
+    /// <summary>
+    /// Whether the live plot currently has a curve to show — a running capture or a
+    /// kept last snapshot — i.e. whether a view-only SPL scale would actually hide
+    /// something. The options panel colours its dB SPL choice amber by this, so the
+    /// warning marks a real conflict and not a freshly started application.
+    /// </summary>
+    public bool HasDisplayableCurve => measurement.InProgress || lastSnapshot != null;
 
     /// <summary>
     /// The raw form of the RTA trace as last drawn, for an overlay capturing it. The
@@ -558,10 +569,27 @@ internal sealed class LiveSpectrumController : IDisposable
         attachedModel = model;
 
         // A view-only SPL plot draws no live curves: at raw (un-lifted) dBFS on the
-        // absolute axis they would read as absurd sound-pressure levels.
+        // absolute axis they would read as absurd sound-pressure levels. Say WHY the
+        // curve is absent instead of leaving a silently empty plot. The notice is
+        // managed here rather than at model creation so it appears only when a curve
+        // really was suppressed (never on a plot that has nothing to show anyway),
+        // and the Contains guard keeps a live tick from stacking duplicates.
         if (SplViewOnly)
         {
+            splViewOnlyAnnotation ??= PlotModelFactory.CreateSplViewOnlyAnnotation(
+                "No SPL calibration for the live input — showing dB SPL overlays only");
+            if (!model.Annotations.Contains(splViewOnlyAnnotation))
+            {
+                model.Annotations.Add(splViewOnlyAnnotation);
+            }
+
             return;
+        }
+
+        // Leaving view-only reuses the same model on live ticks; take the notice down.
+        if (splViewOnlyAnnotation != null)
+        {
+            model.Annotations.Remove(splViewOnlyAnnotation);
         }
 
         // The plot is the reference-free microphone (RTA) spectrum whenever the SPL

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -36,6 +36,7 @@ internal sealed class LiveSpectrumController : IDisposable
     private const string LiveSpectrumCoherenceTag = "live-spectrum:coherence";
     private const string LiveSpectrumPeakHoldTag = "live-spectrum:peak-hold";
     private const string OverloadAnnotationTag = "live-spectrum:overload";
+    private const string SplViewOnlyAnnotationTag = "live-spectrum:spl-view-only";
     private const long PeakHoldSuppressionMs = 1000;
     private bool disposed;
     private bool redrawInProgress;
@@ -55,9 +56,6 @@ internal sealed class LiveSpectrumController : IDisposable
     private LineSeries? coherenceSeries;
     private LineSeries? inputMagnitudeSeries;
     private PlotModel? attachedModel;
-    // The "showing dB SPL overlays only" notice, kept as one instance so the live
-    // redraw can add it exactly once and take it down when view-only ends.
-    private OverlayTextAnnotation? splViewOnlyAnnotation;
 
     public LiveSpectrumController(
         Form owner,
@@ -572,24 +570,20 @@ internal sealed class LiveSpectrumController : IDisposable
         // absolute axis they would read as absurd sound-pressure levels. Say WHY the
         // curve is absent instead of leaving a silently empty plot. The notice is
         // managed here rather than at model creation so it appears only when a curve
-        // really was suppressed (never on a plot that has nothing to show anyway),
-        // and the Contains guard keeps a live tick from stacking duplicates.
+        // really was suppressed (never on a plot that has nothing to show anyway).
+        // Like the overload annotation, the instance is created per model and tracked
+        // by Tag: an OxyPlot element belongs to ONE PlotModel, so a cached instance
+        // would throw the moment a rebuilt model tried to adopt it while the
+        // discarded model still held it. Remove-then-add keeps a live tick from
+        // stacking duplicates and takes the notice down when view-only ends.
+        RemoveSplViewOnlyAnnotation(model);
         if (SplViewOnly)
         {
-            splViewOnlyAnnotation ??= PlotModelFactory.CreateSplViewOnlyAnnotation(
+            OverlayTextAnnotation notice = PlotModelFactory.CreateSplViewOnlyAnnotation(
                 "No SPL calibration for the live input — showing dB SPL overlays only");
-            if (!model.Annotations.Contains(splViewOnlyAnnotation))
-            {
-                model.Annotations.Add(splViewOnlyAnnotation);
-            }
-
+            notice.Tag = SplViewOnlyAnnotationTag;
+            model.Annotations.Add(notice);
             return;
-        }
-
-        // Leaving view-only reuses the same model on live ticks; take the notice down.
-        if (splViewOnlyAnnotation != null)
-        {
-            model.Annotations.Remove(splViewOnlyAnnotation);
         }
 
         // The plot is the reference-free microphone (RTA) spectrum whenever the SPL
@@ -758,6 +752,20 @@ internal sealed class LiveSpectrumController : IDisposable
             TextColor = OxyColor.FromRgb(255, 170, 0),
             TextHorizontalAlignment = OxyPlot.HorizontalAlignment.Center
         });
+    }
+
+    private static void RemoveSplViewOnlyAnnotation(PlotModel model)
+    {
+        for (int index = model.Annotations.Count - 1; index >= 0; index--)
+        {
+            if (model.Annotations[index] is OverlayTextAnnotation
+                {
+                    Tag: SplViewOnlyAnnotationTag
+                })
+            {
+                model.Annotations.RemoveAt(index);
+            }
+        }
     }
 
     private static void RemoveOverloadAnnotation(PlotModel? model)

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -124,7 +124,18 @@ namespace Resonalyze
             return MeasurementInput is { } identity && calibration.MatchesInput(identity);
         }
 
-        private MeasurementInputIdentity CurrentInputIdentity() => new(
+        /// <summary>
+        /// Whether the NEXT run will carry a usable SPL anchor: an SPL calibration is
+        /// configured and was captured on the input this measurement is configured to
+        /// run on. Mirrors exactly what <see cref="RunAsync"/> freezes onto the result
+        /// (the configured calibration plus the current input identity), so the shell
+        /// can predict dB SPL availability before starting a sweep.
+        /// </summary>
+        public bool NextRunHasSplAnchor =>
+            SplCalibration is { } calibration &&
+            calibration.MatchesInput(CurrentInputIdentity());
+
+        internal MeasurementInputIdentity CurrentInputIdentity() => new(
             AudioBackend,
             SampleRate,
             Bits,

--- a/source/Options/FROptions.cs
+++ b/source/Options/FROptions.cs
@@ -162,10 +162,14 @@ namespace Resonalyze.Options
                 available
                     ? "Absolute dB SPL from the microphone SPL calibration."
                     : "Absolute dB SPL from the microphone SPL calibration.\r\n" +
-                      "View-only right now: this measurement has no valid SPL " +
-                      "calibration or captured loopback level, so only overlays " +
-                      "captured in dB SPL are shown. Starting a measurement " +
-                      "switches the display back to dBr/dBc.");
+                      "View-only right now: the measurement on screen carries no SPL " +
+                      "anchor. The anchor is stamped into a measurement WHEN IT RUNS — " +
+                      "from the SPL calibration configured in Measurement Options plus " +
+                      "the run's captured loopback level — so a configured calibration " +
+                      "alone is not enough. Run a measurement (or load one carrying an " +
+                      "anchor) to activate dB SPL; until then only overlays captured " +
+                      "in dB SPL are shown, and starting a run in this state returns " +
+                      "the display to dBr/dBc.");
         }
 
         protected override void RenderIrPreview()

--- a/source/Options/FROptions.cs
+++ b/source/Options/FROptions.cs
@@ -14,9 +14,14 @@ namespace Resonalyze.Options
 {
     public partial class FROptions : ImpulsePreviewOptionsForm
     {
+        // The designer's normal dB SPL text colour, restored when the choice leaves
+        // the amber view-only state.
+        private readonly Color splChoiceReadyForeColor;
+
         public FROptions()
         {
             InitializeComponent();
+            splChoiceReadyForeColor = radioMagnitudeSpl.ForeColor;
             BindTukeyWindowControls(numericWindow, numericLeftWindow, numericRightWindow);
             comboWindowMode.SelectedIndexChanged +=
                 (_, _) => UpdateMagnitudeWindowControlState();
@@ -60,13 +65,12 @@ namespace Resonalyze.Options
                 checkBoxShowHd4.Checked = visibility.ShowHd4;
                 checkBoxShowThdPlusNoise.Checked = visibility.ShowThdPlusNoise;
                 checkBoxShowNoiseFloor.Checked = visibility.ShowNoiseFloor;
-                // Keep the radio Enabled and mute it instead, so a disabled SPL choice
-                // renders in the theme's muted colour rather than the near-black system
-                // grey that WinForms would paint on the dark background.
-                bool splAvailable = IsSplAvailable();
-                UiStyle.SetTextEnabledLook(radioMagnitudeSpl, splAvailable, interactive: true);
-                bool spl = frequencyResponseOptions.MagnitudeScale == MagnitudeScale.SoundPressureLevel
-                    && splAvailable;
+                // The selection follows the options verbatim: dB SPL is choosable even
+                // without a valid calibration (view-only, amber), so it must not be
+                // silently rewritten to relative here.
+                UpdateSplChoiceLook();
+                bool spl = frequencyResponseOptions.MagnitudeScale ==
+                    MagnitudeScale.SoundPressureLevel;
                 radioMagnitudeSpl.Checked = spl;
                 radioMagnitudeRelative.Checked = !spl;
                 RefreshTukeyWindowLimits();
@@ -127,25 +131,41 @@ namespace Resonalyze.Options
             measurement.InputMatches(calibration);
 
         /// <summary>
-        /// Re-evaluates whether dB SPL can be offered, without disturbing the current
-        /// selection. The panel can open before a measurement runs (no captured
-        /// loopback level yet), so the choice starts disabled; the host calls this once
-        /// a measurement or a loaded file provides the level, so the user can switch to
-        /// SPL without reopening the panel.
+        /// Re-evaluates whether this measurement can supply dB SPL and recolours the
+        /// choice accordingly, in both directions, without disturbing the selection:
+        /// the scale stays selectable either way and is merely view-only (overlays,
+        /// no measurement curves) until a valid calibration and loopback level exist.
+        /// The host calls this after every run completion and file load.
         /// </summary>
-        public void RefreshSplAvailability()
+        public void RefreshSplAvailability() => UpdateSplChoiceLook();
+
+        /// <summary>
+        /// Drops the scale selection back to dBr/dBc. The host calls this when a run
+        /// starts while the display is view-only SPL, so the fresh measurement is not
+        /// born hidden; switching back to SPL afterwards stays available.
+        /// </summary>
+        public void ForceRelativeScale() => radioMagnitudeRelative.Checked = true;
+
+        // The scale choice is never locked: without a valid SPL calibration the dB SPL
+        // axis is still useful for VIEWING overlays captured in SPL, so the choice
+        // stays clickable and turns amber to say the measurement's own curves will be
+        // hidden. (It used to be muted and non-interactive, which made SPL unreachable
+        // before the first run.)
+        private void UpdateSplChoiceLook()
         {
             bool available = IsSplAvailable();
-            UiStyle.SetTextEnabledLook(radioMagnitudeSpl, available, interactive: true);
-
-            // If SPL was the chosen scale but is no longer available (a run failed, or a
-            // file without a usable anchor was loaded), the plot already fell back to
-            // relative — move the selection with it so the checked radio does not
-            // contradict the axis.
-            if (!available && radioMagnitudeSpl.Checked)
-            {
-                radioMagnitudeRelative.Checked = true;
-            }
+            radioMagnitudeSpl.ForeColor = available
+                ? splChoiceReadyForeColor
+                : UiPalette.WarningAmber;
+            toolTip.SetToolTip(
+                radioMagnitudeSpl,
+                available
+                    ? "Absolute dB SPL from the microphone SPL calibration."
+                    : "Absolute dB SPL from the microphone SPL calibration.\r\n" +
+                      "View-only right now: this measurement has no valid SPL " +
+                      "calibration or captured loopback level, so only overlays " +
+                      "captured in dB SPL are shown. Starting a measurement " +
+                      "switches the display back to dBr/dBc.");
         }
 
         protected override void RenderIrPreview()
@@ -200,10 +220,8 @@ namespace Resonalyze.Options
                 radioMagnitudeRelative,
                 "Native scale: the response in dBr (relative to the loopback reference), " +
                 "distortion and noise in dBc (relative to the fundamental).");
-            toolTip.SetToolTip(
-                radioMagnitudeSpl,
-                "Absolute dB SPL from the microphone SPL calibration. Available only when this " +
-                "measurement has a valid calibration and a captured loopback level.");
+            // radioMagnitudeSpl's tooltip is owned by UpdateSplChoiceLook: it names
+            // the current availability state, which a static line here cannot.
             toolTip.SetToolTip(
                 checkBoxShowPrimary,
                 "Shows the primary frequency-response curve.");

--- a/source/Options/FROptions.cs
+++ b/source/Options/FROptions.cs
@@ -148,28 +148,46 @@ namespace Resonalyze.Options
 
         // The scale choice is never locked: without a valid SPL calibration the dB SPL
         // axis is still useful for VIEWING overlays captured in SPL, so the choice
-        // stays clickable and turns amber to say the measurement's own curves will be
-        // hidden. (It used to be muted and non-interactive, which made SPL unreachable
-        // before the first run.)
+        // stays clickable. Amber flags a REAL conflict only — a measurement is on
+        // screen whose curves cannot be rendered in SPL, so choosing SPL hides them.
+        // Before any measurement there is nothing to hide and nothing to warn about:
+        // the choice keeps its normal colour, and with an SPL calibration configured
+        // the first run simply comes up in dB SPL.
         private void UpdateSplChoiceLook()
         {
             bool available = IsSplAvailable();
-            radioMagnitudeSpl.ForeColor = available
-                ? splChoiceReadyForeColor
-                : UiPalette.WarningAmber;
-            toolTip.SetToolTip(
-                radioMagnitudeSpl,
-                available
-                    ? "Absolute dB SPL from the microphone SPL calibration."
-                    : "Absolute dB SPL from the microphone SPL calibration.\r\n" +
-                      "View-only right now: the measurement on screen carries no SPL " +
-                      "anchor. The anchor is stamped into a measurement WHEN IT RUNS — " +
-                      "from the SPL calibration configured in Measurement Options plus " +
-                      "the run's captured loopback level — so a configured calibration " +
-                      "alone is not enough. Run a measurement (or load one carrying an " +
-                      "anchor) to activate dB SPL; until then only overlays captured " +
-                      "in dB SPL are shown, and starting a run in this state returns " +
-                      "the display to dBr/dBc.");
+            bool measurementOnScreen = Measurement is { HasImpulseResponse: true };
+            bool viewOnlyConflict = !available && measurementOnScreen;
+            radioMagnitudeSpl.ForeColor = viewOnlyConflict
+                ? UiPalette.WarningAmber
+                : splChoiceReadyForeColor;
+            toolTip.SetToolTip(radioMagnitudeSpl, DescribeSplChoice(available, viewOnlyConflict));
+        }
+
+        private static string DescribeSplChoice(bool available, bool viewOnlyConflict)
+        {
+            const string Base = "Absolute dB SPL from the microphone SPL calibration.";
+            if (available)
+            {
+                return Base;
+            }
+
+            if (viewOnlyConflict)
+            {
+                return Base + "\r\n" +
+                    "View-only: the measurement on screen carries no SPL anchor (it " +
+                    "is stamped at run time from the configured calibration plus the " +
+                    "run's loopback level), so its curves cannot be shown in dB SPL — " +
+                    "only overlays captured in dB SPL are. A new measurement with an " +
+                    "SPL calibration configured comes up in dB SPL; starting one " +
+                    "without returns the display to dBr/dBc.";
+            }
+
+            return Base + "\r\n" +
+                "No measurement yet. With an SPL calibration configured in " +
+                "Measurement Options, the first run comes up in dB SPL; without one, " +
+                "starting a run switches the display back to dBr/dBc. Overlays " +
+                "captured in dB SPL are shown either way.";
         }
 
         protected override void RenderIrPreview()

--- a/source/Options/LiveSpectrumOpt.cs
+++ b/source/Options/LiveSpectrumOpt.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using Resonalyze.Dsp;
 using Resonalyze.Ui;
 
@@ -29,6 +30,10 @@ namespace Resonalyze.Options
         // SPL-only; the plain Pink/Brown/White excitations are shared.
         private NoiseColor userSignalType = NoiseColor.PinkPeriodic;
 
+        // The designer's normal dB SPL text colour, restored when the choice leaves
+        // the amber view-only state.
+        private readonly Color splChoiceReadyForeColor;
+
         /// <summary>
         /// Raised when the user clicks Reset Average. Handled live (without an
         /// Apply / restart) so the Infinite averaging preset can be cleared.
@@ -38,6 +43,7 @@ namespace Resonalyze.Options
         public LiveSpectrumOpt()
         {
             InitializeComponent();
+            splChoiceReadyForeColor = radioMagnitudeSpl.ForeColor;
             SmoothingPresetOptions.Configure(
                 comboSmoothingInverseOctaves, includePsychoacoustic: true);
             buttonResetAverage.Click += (_, _) => ResetAverageRequested?.Invoke();
@@ -117,13 +123,11 @@ namespace Resonalyze.Options
             checkPeakHold.Checked = options.PeakHold;
             checkCoherence.Checked = options.ShowCoherence;
 
-            // SPL shows the microphone (RTA) spectrum in absolute dB SPL; it is
-            // offerable only when a matching SPL calibration is configured for the
-            // live input. A stale/absent calibration mutes the choice (kept Enabled so
-            // the dark theme's muted colour is used, not the near-black system grey).
-            UiStyle.SetTextEnabledLook(radioMagnitudeSpl, isSplAvailable, interactive: true);
-            bool spl = options.MagnitudeScale == MagnitudeScale.SoundPressureLevel
-                && isSplAvailable;
+            // The selection follows the options verbatim: dB SPL is choosable even
+            // without a matching calibration (view-only, amber), so it must not be
+            // silently rewritten to relative here.
+            RefreshSplAvailability(isSplAvailable);
+            bool spl = options.MagnitudeScale == MagnitudeScale.SoundPressureLevel;
             radioMagnitudeSpl.Checked = spl;
             radioMagnitudeRelative.Checked = !spl;
             UpdateScaleDependentControls();
@@ -134,6 +138,43 @@ namespace Resonalyze.Options
                 hasZeroDegreeCalibration,
                 hasNinetyDegreeCalibration);
         }
+
+        /// <summary>
+        /// Recolours the dB SPL choice for the given availability, in both directions,
+        /// without disturbing the selection: the scale stays selectable either way and
+        /// is merely view-only (overlays, no live curves) until a matching SPL
+        /// calibration exists for the live input. The host calls this when the
+        /// configured calibration changes while the panel is open.
+        /// </summary>
+        public void RefreshSplAvailability(bool isSplAvailable)
+        {
+            // The choice is never locked: without a calibration the dB SPL axis is
+            // still useful for VIEWING overlays captured in SPL, so it stays clickable
+            // and turns amber to say live curves will not be drawn. (It used to be
+            // muted and non-interactive, which made SPL unreachable until calibrated.)
+            radioMagnitudeSpl.ForeColor = isSplAvailable
+                ? splChoiceReadyForeColor
+                : UiPalette.WarningAmber;
+            toolTip.SetToolTip(
+                radioMagnitudeSpl,
+                isSplAvailable
+                    ? "Absolute dB SPL. Shows the microphone (RTA) spectrum from the "
+                      + "SPL calibration; the transfer function is a dimensionless "
+                      + "ratio with no scalar SPL under noise, so it is hidden."
+                    : "Absolute dB SPL. View-only right now: no SPL calibration is "
+                      + "configured for the live input (or it was captured on a "
+                      + "different input), so only overlays captured in dB SPL are "
+                      + "shown. Configure it in Measurement Options — Calibration; "
+                      + "starting the analyzer in this state switches the display "
+                      + "back to relative.");
+        }
+
+        /// <summary>
+        /// Drops the scale selection back to relative. The host calls this when the
+        /// analyzer starts (or loses its calibration mid-run) while the display is
+        /// view-only SPL; switching back to SPL afterwards stays available.
+        /// </summary>
+        public void ForceRelativeScale() => radioMagnitudeRelative.Checked = true;
 
         public void SetOptions(LiveSpectrumOptions options)
         {
@@ -496,12 +537,8 @@ namespace Resonalyze.Options
             toolTip.SetToolTip(
                 radioMagnitudeRelative,
                 "Native scale: the transfer function and RTA in relative dB.");
-            toolTip.SetToolTip(
-                radioMagnitudeSpl,
-                "Absolute dB SPL. Shows the microphone (RTA) spectrum from the SPL "
-                + "calibration; the transfer function is a dimensionless ratio with no "
-                + "scalar SPL under noise, so it is hidden. Available only when a matching "
-                + "SPL calibration is configured for the live input.");
+            // radioMagnitudeSpl's tooltip is owned by RefreshSplAvailability: it
+            // names the current availability state, which a static line here cannot.
         }
     }
 }

--- a/source/Options/LiveSpectrumOpt.cs
+++ b/source/Options/LiveSpectrumOpt.cs
@@ -64,7 +64,8 @@ namespace Resonalyze.Options
             LiveSpectrumOptions options,
             bool hasZeroDegreeCalibration,
             bool hasNinetyDegreeCalibration,
-            bool isSplAvailable)
+            bool isSplAvailable,
+            bool hasLiveCurve)
         {
             // The signal list is populated per scale in UpdateScaleDependentControls
             // below; remember the stored signal so it survives a scale round-trip.
@@ -124,9 +125,9 @@ namespace Resonalyze.Options
             checkCoherence.Checked = options.ShowCoherence;
 
             // The selection follows the options verbatim: dB SPL is choosable even
-            // without a matching calibration (view-only, amber), so it must not be
+            // without a matching calibration (view-only), so it must not be
             // silently rewritten to relative here.
-            RefreshSplAvailability(isSplAvailable);
+            RefreshSplAvailability(isSplAvailable, hasLiveCurve);
             bool spl = options.MagnitudeScale == MagnitudeScale.SoundPressureLevel;
             radioMagnitudeSpl.Checked = spl;
             radioMagnitudeRelative.Checked = !spl;
@@ -140,33 +141,56 @@ namespace Resonalyze.Options
         }
 
         /// <summary>
-        /// Recolours the dB SPL choice for the given availability, in both directions,
-        /// without disturbing the selection: the scale stays selectable either way and
-        /// is merely view-only (overlays, no live curves) until a matching SPL
-        /// calibration exists for the live input. The host calls this when the
-        /// configured calibration changes while the panel is open.
+        /// Recolours the dB SPL choice, in both directions, without disturbing the
+        /// selection: the scale stays selectable either way and is merely view-only
+        /// (overlays, no live curves) until a matching SPL calibration exists for the
+        /// live input. The host calls this when the configured calibration changes
+        /// while the panel is open.
         /// </summary>
-        public void RefreshSplAvailability(bool isSplAvailable)
+        public void RefreshSplAvailability(bool isSplAvailable, bool hasLiveCurve)
         {
             // The choice is never locked: without a calibration the dB SPL axis is
-            // still useful for VIEWING overlays captured in SPL, so it stays clickable
-            // and turns amber to say live curves will not be drawn. (It used to be
-            // muted and non-interactive, which made SPL unreachable until calibrated.)
-            radioMagnitudeSpl.ForeColor = isSplAvailable
-                ? splChoiceReadyForeColor
-                : UiPalette.WarningAmber;
+            // still useful for VIEWING overlays captured in SPL, so it stays
+            // clickable. Amber flags a REAL conflict only — a live curve exists that
+            // the view-only state would hide. On a freshly started application there
+            // is nothing to hide and nothing to warn about, so the choice keeps its
+            // normal colour and the tooltip does the explaining.
+            bool viewOnlyConflict = !isSplAvailable && hasLiveCurve;
+            radioMagnitudeSpl.ForeColor = viewOnlyConflict
+                ? UiPalette.WarningAmber
+                : splChoiceReadyForeColor;
             toolTip.SetToolTip(
                 radioMagnitudeSpl,
-                isSplAvailable
-                    ? "Absolute dB SPL. Shows the microphone (RTA) spectrum from the "
-                      + "SPL calibration; the transfer function is a dimensionless "
-                      + "ratio with no scalar SPL under noise, so it is hidden."
-                    : "Absolute dB SPL. View-only right now: no SPL calibration is "
-                      + "configured for the live input (or it was captured on a "
-                      + "different input), so only overlays captured in dB SPL are "
-                      + "shown. Configure it in Measurement Options — Calibration; "
-                      + "starting the analyzer in this state switches the display "
-                      + "back to relative.");
+                DescribeSplChoice(isSplAvailable, viewOnlyConflict));
+        }
+
+        private static string DescribeSplChoice(bool isSplAvailable, bool viewOnlyConflict)
+        {
+            const string Base =
+                "Absolute dB SPL. Shows the microphone (RTA) spectrum from the SPL " +
+                "calibration; the transfer function is a dimensionless ratio with no " +
+                "scalar SPL under noise, so it is hidden.";
+            if (isSplAvailable)
+            {
+                return Base;
+            }
+
+            if (viewOnlyConflict)
+            {
+                return Base + "\r\n" +
+                    "View-only right now: no SPL calibration is configured for the " +
+                    "live input (or it was captured on a different input), so the " +
+                    "live curve is hidden — only overlays captured in dB SPL are " +
+                    "shown. Configure it in Measurement Options — Calibration; " +
+                    "starting the analyzer in this state switches the display back " +
+                    "to relative.";
+            }
+
+            return Base + "\r\n" +
+                "No SPL calibration is configured for the live input (Measurement " +
+                "Options — Calibration). Starting the analyzer without one switches " +
+                "the display back to relative; overlays captured in dB SPL are " +
+                "shown either way.";
         }
 
         /// <summary>

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -1302,13 +1302,15 @@ public sealed class Overlay
             return;
         }
 
-        // A debounced offset save still in flight would re-create the file right
-        // after the delete below; the slot is going away, so the write is moot.
-        offsetSaveTimer.Stop();
-
         try
         {
             OverlayFile.Delete(mode, Index);
+            // A debounced offset save still in flight is moot for a slot that is
+            // going away — but only once the delete succeeded: stopping it earlier
+            // would silently drop the user's offset when the delete fails and the
+            // slot lives on. (A tick landing after the reset below is a no-op:
+            // TrySaveCurrentState declines an empty slot.)
+            offsetSaveTimer.Stop();
         }
         catch (Exception exception)
         {
@@ -1319,6 +1321,11 @@ public sealed class Overlay
         Hide();
         ResetState();
         collection.NotifyCapturedOverlayChanged();
+        // Hide() already refreshed the shell, but that ran BEFORE the reset, with
+        // the slot still counting as occupied. Re-notify with the cleared state, or
+        // the bulk Show/Hide All buttons and the labels panel stay stale after the
+        // last slot is cleared.
+        collection.NotifyPlotChanged();
     }
 
     internal void CloseCaptureMenu()

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -597,6 +597,7 @@ public sealed class Overlay
     private readonly ToolStripItem exportDeviationMenuItem;
     private readonly ToolStripItem targetMenuItem;
     private readonly ToolStripItem settingsMenuItem;
+    private readonly ToolStripItem clearSlotMenuItem;
     private readonly System.Windows.Forms.Timer longPressTimer;
     private readonly System.Windows.Forms.Timer offsetSaveTimer;
     private bool longPressTriggered;
@@ -707,7 +708,8 @@ public sealed class Overlay
             out captureCurveMenuItem,
             out exportDeviationMenuItem,
             out targetMenuItem,
-            out settingsMenuItem);
+            out settingsMenuItem,
+            out clearSlotMenuItem);
         DropDownFocusGuard.Attach(captureMenu);
 
         // Holding the button for over half a second jumps straight to the slot's
@@ -1253,7 +1255,8 @@ public sealed class Overlay
         out ToolStripMenuItem captureCurveItem,
         out ToolStripItem exportDeviationItem,
         out ToolStripItem targetItem,
-        out ToolStripItem settingsItem)
+        out ToolStripItem settingsItem,
+        out ToolStripItem clearSlotItem)
     {
         var menu = new ContextMenuStrip();
         captureCurveItem = new ToolStripMenuItem("Capture curve…");
@@ -1280,7 +1283,42 @@ public sealed class Overlay
             "\u2699  Settings\u2026", // \u2699 gear
             null,
             (_, _) => OpenSettings());
+        clearSlotItem = menu.Items.Add(
+            "\u2715  Clear slot", // \u2715 multiplication x
+            null,
+            (_, _) => ClearSlot());
         return menu;
+    }
+
+    // Empties the slot: the saved file goes, the row returns to its virgin state,
+    // and everything reading captured slots (calculated overlays, target sources,
+    // the EQ Wizard's slot menu) sees it gone. A curve saved into the cleared slot
+    // later gets the automatic name again, exactly like a never-used slot.
+    private void ClearSlot()
+    {
+        Mode mode = CurrentOverlayMode;
+        if (mode == Mode.None)
+        {
+            return;
+        }
+
+        // A debounced offset save still in flight would re-create the file right
+        // after the delete below; the slot is going away, so the write is moot.
+        offsetSaveTimer.Stop();
+
+        try
+        {
+            OverlayFile.Delete(mode, Index);
+        }
+        catch (Exception exception)
+        {
+            ShowStorageError("Overlay slot could not be cleared.", exception);
+            return;
+        }
+
+        Hide();
+        ResetState();
+        collection.NotifyCapturedOverlayChanged();
     }
 
     internal void CloseCaptureMenu()
@@ -1375,6 +1413,9 @@ public sealed class Overlay
         targetMenuItem.Visible = OverlayTargets.SupportsMode(CurrentOverlayMode);
         settingsMenuItem.Enabled =
             SeriesMode == CurrentOverlayMode && HasConfiguredContent();
+        // Clearing only applies to a slot that holds content, under the same
+        // mode-ownership rule as Settings.
+        clearSlotMenuItem.Enabled = settingsMenuItem.Enabled;
         captureMenu.Show(captureButton, new Point(0, captureButton.Height));
     }
 
@@ -1506,7 +1547,12 @@ public sealed class Overlay
             bakedSmoothing = raw?.SmoothingCode;
         }
 
-        string title = $"Overlay {Index}: {selected.Title ?? string.Empty}";
+        // An occupied slot keeps its name across a re-capture — the user may have
+        // renamed it, and a re-measure updates the curve, not the label. Only an
+        // empty (never used or cleared) slot gets the automatic name. Evaluated
+        // before the state below is overwritten.
+        string title = OverlaySlotName.ForSave(
+            HasConfiguredContent(), Title, Index, selected.Title ?? string.Empty);
         Mode mode = CurrentOverlayMode;
 
         Hide();
@@ -1596,6 +1642,14 @@ public sealed class Overlay
             return;
         }
 
+        // Same rule as a capture: an occupied slot keeps its name, only an empty one
+        // is named after the file. Evaluated before the state below is overwritten.
+        string importedTitle = OverlaySlotName.ForSave(
+            HasConfiguredContent(),
+            Title,
+            Index,
+            System.IO.Path.GetFileNameWithoutExtension(dialog.FileName));
+
         Hide();
         kind = OverlayKind.Captured;
         operationConfigured = false;
@@ -1620,8 +1674,7 @@ public sealed class Overlay
             .Select(point => new DataPoint(point.X, point.Y))
             .ToArray();
         SeriesMode = mode;
-        Title = $"Overlay {Index}: " +
-            System.IO.Path.GetFileNameWithoutExtension(dialog.FileName);
+        Title = importedTitle;
         UpdateKindGlyph();
         UpdateDrawPoints();
 

--- a/source/Overlays/OverlaySlotName.cs
+++ b/source/Overlays/OverlaySlotName.cs
@@ -13,6 +13,19 @@ namespace Resonalyze;
 /// </remarks>
 internal static class OverlaySlotName
 {
+    /// <summary>
+    /// The name a slot takes when a curve is saved into it. An occupied slot keeps
+    /// its current name — the user may have renamed it, and a re-capture updates the
+    /// curve, not the label — while an empty (never used or cleared) slot gets the
+    /// automatic "Overlay {slot}: {source}" form.
+    /// </summary>
+    public static string ForSave(
+        bool slotOccupied,
+        string currentTitle,
+        int slot,
+        string sourceName) =>
+        slotOccupied ? currentTitle : $"Overlay {slot}: {sourceName}";
+
     public static string Shorten(string title, int slot)
     {
         ArgumentNullException.ThrowIfNull(title);

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -85,14 +85,6 @@ internal sealed class PlotModelFactory
         frequencyResponseOptions.MagnitudeScale;
 
     /// <summary>
-    /// The sweep measurement's SPL anchor (see
-    /// <see cref="MeasurementPlotContext.SplOffsetDb"/>); null when dB SPL can only
-    /// be viewed, not rendered from this measurement. The shell reads this to drop a
-    /// view-only SPL display back to dBr/dBc when a run starts.
-    /// </summary>
-    public double? FrequencyResponseSplOffsetDb => measurementContext.SplOffsetDb;
-
-    /// <summary>
     /// The offset that turns the reference-free live RTA magnitude (raw microphone
     /// dBFS) into dB SPL: <c>SPL = mic + calibration.OffsetDb</c>. Unlike the swept
     /// frequency response there is NO loopback term — the RTA is already the plain

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -123,16 +123,15 @@ internal sealed class PlotModelFactory
     }
 
     /// <summary>
-    /// The scale the Live Spectrum plot actually renders in — SPL only when it is
-    /// both selected and available. The live controller and overlays gate on this,
-    /// not on the requested scale, so a missing/mismatched calibration falls back to
-    /// the native dB view instead of an empty SPL plot.
+    /// The scale the Live Spectrum plot renders in — simply the selected one, like
+    /// the Frequency Response scale. Without a matching SPL calibration the plot no
+    /// longer falls back to the native dB view: it keeps the dB SPL axis in a
+    /// view-only state — overlays captured in dB SPL show, live curves are not drawn
+    /// (see LiveSpectrumController) — and the record button drops the display back
+    /// to relative before an actual run starts.
     /// </summary>
     public MagnitudeScale EffectiveLiveSpectrumScale =>
-        liveSpectrumOptions.MagnitudeScale == MagnitudeScale.SoundPressureLevel &&
-        LiveSplOffsetDb.HasValue
-            ? MagnitudeScale.SoundPressureLevel
-            : MagnitudeScale.Relative;
+        liveSpectrumOptions.MagnitudeScale;
 
     // The dB offset applied to the live RTA / peak-hold curves when the plot is in
     // SPL mode; zero in the native (relative) view. The transfer function is never

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -1725,14 +1725,22 @@ internal sealed class PlotModelFactory
 
     private static void AddSplViewOnlyAnnotation(PlotModel model)
     {
-        model.Annotations.Add(new OverlayTextAnnotation
-        {
-            Text = "No SPL calibration for this measurement — showing dB SPL overlays only",
-            TextPosition = new DataPoint(0.5, 3),
-            TextFlowDirection = TextFlowDirection.TopDown,
-            FontSize = 12,
-            TextColor = OxyColor.FromRgb(255, 170, 0),
-            TextHorizontalAlignment = OxyPlot.HorizontalAlignment.Center
-        });
+        model.Annotations.Add(CreateSplViewOnlyAnnotation(
+            "No SPL calibration for this measurement — showing dB SPL overlays only"));
     }
+
+    /// <summary>
+    /// The "showing dB SPL overlays only" notice, shared by the Frequency Response
+    /// model above and the live controller (which manages its instance itself: a live
+    /// model persists across ticks, so the notice must be addable and removable).
+    /// </summary>
+    internal static OverlayTextAnnotation CreateSplViewOnlyAnnotation(string text) => new()
+    {
+        Text = text,
+        TextPosition = new DataPoint(0.5, 3),
+        TextFlowDirection = TextFlowDirection.TopDown,
+        FontSize = 12,
+        TextColor = OxyColor.FromRgb(255, 170, 0),
+        TextHorizontalAlignment = OxyPlot.HorizontalAlignment.Center
+    };
 }

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -75,17 +75,22 @@ internal sealed class PlotModelFactory
         getCompareSource = provider;
 
     /// <summary>
-    /// The scale the Frequency Response plot actually renders in — SPL only when it
-    /// is both selected and available, matching <c>renderSpl</c> in
-    /// <see cref="CreateFrequencyResponse"/>. Overlays gate on this, not on the
-    /// requested scale, so a stale-calibration fallback to dBr does not mis-tag or
-    /// mis-show overlays.
+    /// The scale the Frequency Response plot renders in — simply the selected one.
+    /// Without a valid SPL anchor the plot no longer falls back to dBr: it keeps the
+    /// dB SPL axis in a view-only state (overlays shown, measurement curves omitted,
+    /// see <see cref="CreateFrequencyResponse"/>), so overlays gate on the selection
+    /// and follow the axis exactly.
     /// </summary>
     public MagnitudeScale EffectiveFrequencyResponseScale =>
-        frequencyResponseOptions.MagnitudeScale == MagnitudeScale.SoundPressureLevel &&
-        measurementContext.SplOffsetDb.HasValue
-            ? MagnitudeScale.SoundPressureLevel
-            : MagnitudeScale.Relative;
+        frequencyResponseOptions.MagnitudeScale;
+
+    /// <summary>
+    /// The sweep measurement's SPL anchor (see
+    /// <see cref="MeasurementPlotContext.SplOffsetDb"/>); null when dB SPL can only
+    /// be viewed, not rendered from this measurement. The shell reads this to drop a
+    /// view-only SPL display back to dBr/dBc when a run starts.
+    /// </summary>
+    public double? FrequencyResponseSplOffsetDb => measurementContext.SplOffsetDb;
 
     /// <summary>
     /// The offset that turns the reference-free live RTA magnitude (raw microphone
@@ -258,15 +263,29 @@ internal sealed class PlotModelFactory
         PlotModel model = PlotModelStyle.CreateTitledModel(
             measurementContext.CreateTitle("Frequency Response"));
 
-        // dB SPL is available only with a valid calibration and loopback level for
-        // this measurement; otherwise the plot stays in native loopback-referenced dB.
+        // dB SPL follows the SELECTION. Converting the curves additionally needs a
+        // valid calibration and loopback level for this measurement; without them the
+        // axis still goes SPL but view-only — the measurement's own dBr shapes would
+        // be lies on an absolute axis and are omitted, while overlays captured in
+        // dB SPL (gated by EffectiveFrequencyResponseScale) remain visible. Starting
+        // a run in that state drops the display back to dBr/dBc (Form1), so a fresh
+        // measurement is never born hidden.
         bool splRequested =
             frequencyResponseOptions.MagnitudeScale == MagnitudeScale.SoundPressureLevel;
         double? splOffset = splRequested ? measurementContext.SplOffsetDb : null;
         bool renderSpl = splOffset.HasValue;
+        bool splViewOnly = splRequested && !renderSpl;
 
         // Magnitude is derived from the loopback transfer IR, which is required.
-        if (measurementContext.CanIncludeCurves(includeCurves) &&
+        if (splViewOnly &&
+            measurementContext.CanIncludeCurves(includeCurves) &&
+            measurementContext.HasTransferImpulseResponse)
+        {
+            // This measurement cannot supply SPL (no calibration, no loopback level,
+            // or a calibration from another input): say why its curves are absent.
+            AddSplViewOnlyAnnotation(model);
+        }
+        else if (measurementContext.CanIncludeCurves(includeCurves) &&
             measurementContext.HasTransferImpulseResponse)
         {
             IReadOnlyList<AnalysisCurve> curves = measurementContext.CreateFrequencyResponseCurves(
@@ -316,13 +335,6 @@ internal sealed class PlotModelFactory
                 frequencyResponseVisibility.ShowCoherence);
 
             AddHiddenHarmonicAnnotation(model, curves);
-
-            // The user asked for SPL but this measurement cannot supply it (no
-            // calibration, no loopback level, or a calibration from another input).
-            if (splRequested && !renderSpl)
-            {
-                AddSplUnavailableAnnotation(model);
-            }
         }
         else if (measurementContext.CanIncludeCurves(includeCurves) &&
                  !measurementContext.HasTransferImpulseResponse)
@@ -333,10 +345,11 @@ internal sealed class PlotModelFactory
         PlotModelStyle.AddFrequencyAxis(model);
         // In SPL mode the whole plot is absolute dB SPL, which needs a different
         // default window and clamps (curves sit near 40–110 dB, far above the dBr
-        // ceiling). Otherwise the primary is the loopback-referenced transfer
-        // magnitude (dBr) and the harmonic / THD / noise curves are ratios to the
-        // fundamental (dBc); the axis names both.
-        if (renderSpl)
+        // ceiling). The axis follows the SELECTION — a view-only SPL plot keeps the
+        // SPL axis for its overlays. Otherwise the primary is the loopback-referenced
+        // transfer magnitude (dBr) and the harmonic / THD / noise curves are ratios
+        // to the fundamental (dBc); the axis names both.
+        if (splRequested)
         {
             PlotModelStyle.AddDecibelAxis(
                 model,
@@ -1719,11 +1732,11 @@ internal sealed class PlotModelFactory
         });
     }
 
-    private static void AddSplUnavailableAnnotation(PlotModel model)
+    private static void AddSplViewOnlyAnnotation(PlotModel model)
     {
         model.Annotations.Add(new OverlayTextAnnotation
         {
-            Text = "No SPL calibration for this measurement — showing dBr/dBc",
+            Text = "No SPL calibration for this measurement — showing dB SPL overlays only",
             TextPosition = new DataPoint(0.5, 3),
             TextFlowDirection = TextFlowDirection.TopDown,
             FontSize = 12,

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -142,7 +142,8 @@ public partial class Form1
                 ApplyLoadedImpulseResponseState(dialog.FileName);
                 sessionTracker.MarkLoadedFile(dialog.FileName, file);
                 // A loaded file carries its own SPL calibration and loopback level, so
-                // an open Frequency Response panel can now offer dB SPL for it.
+                // an open Frequency Response panel can now show dB SPL as fully
+                // available (not just view-only) for it.
                 dockedModeSettingsHost.InvokeIfOpen<Options.FROptions>(
                     panel => panel.RefreshSplAvailability());
             }

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -228,7 +228,8 @@ public partial class Form1
             // The Frequency Response panel evaluates dB SPL availability only when it
             // opens; a run changes it in both directions (a good run captures the
             // loopback level SPL needs; a failed/aborted run clears the level snapshot),
-            // so re-offer or withdraw SPL after EVERY completion, not just success.
+            // so recolour the SPL choice — full or view-only — after EVERY completion,
+            // not just success.
             dockedModeSettingsHost.InvokeIfOpen<Options.FROptions>(
                 panel => panel.RefreshSplAvailability());
 

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -160,10 +160,32 @@ public partial class Form1
                 return;
             }
 
+            ResetSplViewOnlyDisplayForRun();
             PrepareSweepMeasurementForRun();
             EnterMeasurementRunningState();
             _ = expSweepMeasurement.RunAsync();
         }
+    }
+
+    // A sweep started while Frequency Response displays dB SPL WITHOUT a valid
+    // calibration (the view-only state that shows overlays only) would come up with
+    // its fresh curves hidden. Drop the DISPLAY back to dBr/dBc at start — nothing
+    // else: switching to SPL again stays available at any time.
+    private void ResetSplViewOnlyDisplayForRun()
+    {
+        if (frequencyResponseOptions.MagnitudeScale !=
+                Dsp.MagnitudeScale.SoundPressureLevel ||
+            plotModelFactory.FrequencyResponseSplOffsetDb.HasValue)
+        {
+            return;
+        }
+
+        frequencyResponseOptions.MagnitudeScale = Dsp.MagnitudeScale.Relative;
+        SaveMeasurementSettings();
+        // An open panel must follow the reset, or its next apply-on-change would
+        // write SPL right back into the options.
+        dockedModeSettingsHost.InvokeIfOpen<Options.FROptions>(
+            panel => panel.ForceRelativeScale());
     }
 
     // One-time notice after loading a settings file written by a version that

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -112,6 +112,7 @@ public partial class Form1
         {
             if (!liveSpectrumController.InProgress)
             {
+                ResetLiveSplViewOnlyDisplayForRun();
                 await startupAudioWarmup.WaitAsync();
             }
 
@@ -165,6 +166,27 @@ public partial class Form1
             EnterMeasurementRunningState();
             _ = expSweepMeasurement.RunAsync();
         }
+    }
+
+    // The Live Spectrum mirror of ResetSplViewOnlyDisplayForRun below: an analyzer
+    // started while the display is view-only SPL would draw no curves at all, so
+    // drop the display to relative first (StartAsync then normalizes a Silent
+    // signal into a real excitation for the relative scale). Also called when a
+    // RUNNING analyzer loses its calibration, where staying in SPL would blank it.
+    private void ResetLiveSplViewOnlyDisplayForRun()
+    {
+        if (liveSpectrumOptions.MagnitudeScale != Dsp.MagnitudeScale.SoundPressureLevel ||
+            plotModelFactory.LiveSplOffsetDb.HasValue)
+        {
+            return;
+        }
+
+        liveSpectrumOptions.MagnitudeScale = Dsp.MagnitudeScale.Relative;
+        SaveMeasurementSettings();
+        // An open panel must follow the reset, or its next apply-on-change would
+        // write SPL right back into the options.
+        dockedModeSettingsHost.InvokeIfOpen<Options.LiveSpectrumOpt>(
+            panel => panel.ForceRelativeScale());
     }
 
     // A sweep started while Frequency Response displays dB SPL WITHOUT a valid
@@ -233,6 +255,19 @@ public partial class Form1
         measurementSettings.Measurement.SplCalibration = selection.SplCalibration;
         expSweepMeasurement.SplCalibration = selection.SplCalibration;
         RefreshCalibrationConsumers();
+        // Losing the SPL anchor while the analyzer RUNS in dB SPL would leave it
+        // drawing nothing (view-only suppresses live curves), so drop the display to
+        // relative first — the calibration refresh below then restarts the capture on
+        // a scale its signal fits. An IDLE view-only SPL display is legitimate (it
+        // shows overlays) and is left alone. The open live panel's amber state
+        // follows the new calibration either way.
+        if (liveSpectrumController.InProgress)
+        {
+            ResetLiveSplViewOnlyDisplayForRun();
+        }
+        dockedModeSettingsHost.InvokeIfOpen<Options.LiveSpectrumOpt>(
+            panel => panel.RefreshSplAvailability(
+                plotModelFactory.LiveSplOffsetDb.HasValue));
         // Persist the calibration itself up front so it survives even if the redraw
         // below fails; the normalized live options are re-saved afterwards.
         ScheduleMeasurementSettingsSave();

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -271,7 +271,8 @@ public partial class Form1
         }
         dockedModeSettingsHost.InvokeIfOpen<Options.LiveSpectrumOpt>(
             panel => panel.RefreshSplAvailability(
-                plotModelFactory.LiveSplOffsetDb.HasValue));
+                plotModelFactory.LiveSplOffsetDb.HasValue,
+                liveSpectrumController.HasDisplayableCurve));
         // Persist the calibration itself up front so it survives even if the redraw
         // below fails; the normalized live options are re-saved afterwards.
         ScheduleMeasurementSettingsSave();

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -161,8 +161,10 @@ public partial class Form1
                 return;
             }
 
-            ResetSplViewOnlyDisplayForRun();
             PrepareSweepMeasurementForRun();
+            // After Prepare, so the anchor prediction reads the input configuration
+            // this run will actually use.
+            ResetSplViewOnlyDisplayForRun();
             EnterMeasurementRunningState();
             _ = expSweepMeasurement.RunAsync();
         }
@@ -189,15 +191,17 @@ public partial class Form1
             panel => panel.ForceRelativeScale());
     }
 
-    // A sweep started while Frequency Response displays dB SPL WITHOUT a valid
-    // calibration (the view-only state that shows overlays only) would come up with
-    // its fresh curves hidden. Drop the DISPLAY back to dBr/dBc at start — nothing
-    // else: switching to SPL again stays available at any time.
+    // A sweep started in dB SPL only stays there when the RUN AHEAD can supply SPL —
+    // i.e. an SPL calibration is configured for the input it will use, so the fresh
+    // measurement comes up in dB SPL directly. Without one the new curves would be
+    // born hidden (view-only shows overlays only), so the display drops to dBr/dBc.
+    // Deliberately NOT gated on the previous measurement's anchor: that one is
+    // irrelevant the moment a new run starts.
     private void ResetSplViewOnlyDisplayForRun()
     {
         if (frequencyResponseOptions.MagnitudeScale !=
                 Dsp.MagnitudeScale.SoundPressureLevel ||
-            plotModelFactory.FrequencyResponseSplOffsetDb.HasValue)
+            expSweepMeasurement.NextRunHasSplAnchor)
         {
             return;
         }

--- a/source/Shell/Form1.ModeSettings.cs
+++ b/source/Shell/Form1.ModeSettings.cs
@@ -140,7 +140,8 @@ public partial class Form1
                     liveSpectrumOptions,
                     microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees0),
                     microphoneCalibration.Has(MicrophoneCalibrationMode.Degrees90),
-                    plotModelFactory.LiveSplOffsetDb.HasValue);
+                    plotModelFactory.LiveSplOffsetDb.HasValue,
+                    liveSpectrumController.HasDisplayableCurve);
                 opt.ResetAverageRequested += liveSpectrumController.ResetAverage;
             },
             ApplyLiveSpectrumOptionsAsync,

--- a/source/Shell/Form1.Plotting.cs
+++ b/source/Shell/Form1.Plotting.cs
@@ -222,6 +222,14 @@ public partial class Form1
         }
 
         buttonRecord.Text = liveSpectrumController.InProgress ? "Stop" : "Start";
+        // The controller calls this on every start/stop/completion — exactly when a
+        // live curve appears or settles, i.e. when an uncalibrated dB SPL choice
+        // becomes (or stops being) a real conflict. Follow it on the open panel, so
+        // the amber state is not frozen at whatever was true when the panel opened.
+        dockedModeSettingsHost.InvokeIfOpen<Options.LiveSpectrumOpt>(
+            panel => panel.RefreshSplAvailability(
+                plotModelFactory.LiveSplOffsetDb.HasValue,
+                liveSpectrumController.HasDisplayableCurve));
     }
 
     private void UpdatePlotLabelsPanel()

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -120,13 +120,14 @@ namespace Resonalyze
             overlayCollection = dependencies.OverlayCollection;
             plotLabelsPanelController = dependencies.PlotLabelsPanelController;
             plotModelFactory = dependencies.PlotModelFactory;
-            // Overlays are tagged with, and gated by, the magnitude scale the plot is
-            // ACTUALLY rendered in — SPL only when the plot is showing SPL (selected and
-            // available). Live Spectrum shares Frequency Response's overlay slots, so it
-            // must report its OWN effective scale here; otherwise a Live SPL plot would
-            // gate overlays as Relative and show dBr overlays on the dB SPL axis. Every
-            // other mode, and any dBr fallback, is Relative. Wired after plotModelFactory
-            // is assigned (the lambda reads it).
+            // Overlays are tagged with, and gated by, the magnitude scale of the axis
+            // the plot shows — which now simply follows the SELECTION: without a valid
+            // calibration the plot keeps the SPL axis in a view-only state instead of
+            // falling back to dBr, so overlays track the axis exactly. Live Spectrum
+            // shares Frequency Response's overlay slots, so it must report its OWN
+            // scale here; otherwise a Live SPL plot would gate overlays as Relative
+            // and show dBr overlays on the dB SPL axis. Every other mode is Relative.
+            // Wired after plotModelFactory is assigned (the lambda reads it).
             overlayCollection.SetMagnitudeScaleProvider(
                 () => CurrentMode switch
                 {

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -332,7 +332,7 @@ public partial class EqWizardPanel
             InvalidateSourceCurve();
 
             ApplyAxisForSource();
-            SuggestTargetOffset();
+            SuggestTargetOffsetUnlessTargetVisible();
         }
         finally
         {
@@ -582,11 +582,7 @@ public partial class EqWizardPanel
             Measurement: null,
             Scale: MagnitudeScale.SoundPressureLevel
         };
-        EqWizardAxisRange range = loadedSource is { Measurement: null }
-            ? EqWizardPlotFit.ForCurve(
-                GetSourceCurve()?.Points.Select(point => new SignalPoint(point.X, point.Y))
-                    ?? Enumerable.Empty<SignalPoint>())
-            : EqWizardPlotFit.ImpulseResponseRange;
+        EqWizardAxisRange range = ComputeAxisRangeForSource();
 
         // Widen the absolute bounds before the view, so setting the view can never be
         // clipped by limits left over from the previous source.
@@ -600,10 +596,49 @@ public partial class EqWizardPanel
         axis.Reset();
     }
 
-    // Lands the target on the freshly loaded source's own level. Most important for an
-    // absolute (SPL) curve, which starts tens of dB from a relative target — but every
-    // source needs it: it also clears the previous source's offset, so switching from an
-    // 80 dB SPL curve back to a near-0 dB impulse response cannot strand the target high.
+    // The default view the plot gets for the current source — and the yardstick for
+    // whether the target is still visible after a source switch.
+    private EqWizardAxisRange ComputeAxisRangeForSource() =>
+        loadedSource is { Measurement: null }
+            ? EqWizardPlotFit.ForCurve(
+                GetSourceCurve()?.Points.Select(point => new SignalPoint(point.X, point.Y))
+                    ?? Enumerable.Empty<SignalPoint>())
+            : EqWizardPlotFit.ImpulseResponseRange;
+
+    // Landing the target on a fresh source is a RESCUE, not a policy: when the target
+    // at its current offset is still at least partially inside the new source's
+    // default view, the user's placement survives the switch — two sources at similar
+    // levels must not reset a deliberately moved target. Only a target entirely
+    // off-screen (typically a relative ↔ SPL datum change of tens of dB, in either
+    // direction) is landed on the new source, which also un-strands an offset left
+    // over from the previous one.
+    private void SuggestTargetOffsetUnlessTargetVisible()
+    {
+        if (EqWizardPlotFit.IsCurveVisible(
+                CurrentTargetPoints(), ComputeAxisRangeForSource()))
+        {
+            return;
+        }
+
+        SuggestTargetOffset();
+    }
+
+    // The target as it would be drawn right now: the current spec and offset on the
+    // grid the plot uses — the source's frequencies, or the default 20 Hz .. 20 kHz
+    // grid when the source has no usable curve.
+    private IEnumerable<SignalPoint> CurrentTargetPoints()
+    {
+        double offset = (double)NumericTargetOffset.Value;
+        IEnumerable<double> frequencies = GetSourceCurve() is { Points.Count: >= 2 } source
+            ? source.Points.Select(point => point.X)
+            : DefaultTargetGrid;
+        return frequencies.Select(
+            frequency => new SignalPoint(frequency, targetSpec.Evaluate(frequency) + offset));
+    }
+
+    // Lands the target on the freshly loaded source's own level: the gap between their
+    // mean levels inside the tuning window, most important for an absolute (SPL) curve,
+    // which starts tens of dB from a relative target.
     private void SuggestTargetOffset()
     {
         if (GetSourceCurve() is not { Points.Count: >= 2 } source)

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -837,26 +837,38 @@ public partial class EqWizardPanel : UserControl
 
         (double minHz, double maxHz) = GetFrequencyWindow();
 
+        // The preamp policy differs by mode. Cuts-only: the auto preamp may move
+        // within the control's range — it aligns to the least-excess point and can
+        // only lower the curve — and the 0 dB total-gain ceiling keeps the profile
+        // clip-free. Boosts allowed: the preamp belongs to the user. Auto-centring
+        // it would put broadband gain where the Target Level datum belongs, and the
+        // ceiling would then "compensate" fitted boosts by dropping the preamp
+        // AFTER the fit — bands placed against one level but realised far lower, so
+        // the whole curve fell by the peak boost instead of the window rising to
+        // the target. Pinning min = max = the current value collapses every preamp
+        // decision in the tuner to a no-op: bands carry the full correction within
+        // Max Gain, and any positive total gain is the user's explicit choice,
+        // reported by the headroom read-out.
+        bool cutsOnly = checkBoxCutsOnly.Checked;
+        double pinnedPreampDb = (double)NumericGain.Value;
+
         var options = new EqAutoTuner.Options
         {
             MaxBands = Math.Clamp(bandLimit, 1, MaxPeqSlotCount),
             MinFrequencyHz = minHz,
             MaxFrequencyHz = maxHz,
-            PreampMinDb = (double)NumericGain.Minimum,
-            PreampMaxDb = (double)NumericGain.Maximum,
+            PreampMinDb = cutsOnly ? (double)NumericGain.Minimum : pinnedPreampDb,
+            PreampMaxDb = cutsOnly ? (double)NumericGain.Maximum : pinnedPreampDb,
             // Per-band gain is bounded by the Min/Max Gain fields, exactly like the
             // manual faders, so Auto Tune never proposes a gain the strips reject.
             BandGainMinDb = (double)numericGainMin.Value,
             BandGainMaxDb = (double)numericGainMax.Value,
-            // The wizard's output is a profile for a real DSP: the total gain
-            // (preamp + bands) must not exceed 0 dB anywhere, or the profile
-            // clips before the user ever sees the headroom read-out.
-            TotalGainMaxDb = 0,
+            TotalGainMaxDb = cutsOnly ? 0 : double.PositiveInfinity,
             SampleRateHz = EqSampleRate,
             // Cuts-only is the safe default for a car tune: never boost an
             // interference null. Unchecking it allows boosts, still gated to
             // reliable regions (high coherence, not inside a narrow deep null).
-            CutsOnlyMode = checkBoxCutsOnly.Checked
+            CutsOnlyMode = cutsOnly
         };
 
         // Q has no panel-level range control, so take its bounds from a band field.

--- a/source/Tools/Eq/EqWizardPlotFit.cs
+++ b/source/Tools/Eq/EqWizardPlotFit.cs
@@ -73,6 +73,33 @@ internal static class EqWizardPlotFit
             maximum + PanMarginDb);
     }
 
+    /// <summary>
+    /// Whether a drawn curve is at least partially visible in the given default view:
+    /// some finite level falls inside [Minimum, Maximum]. Loading a new source keeps
+    /// the user's target level when the target passes this test — re-suggesting would
+    /// discard a deliberately placed target that can still be seen; only a target
+    /// entirely off-screen (typically a relative ↔ SPL datum change of tens of dB)
+    /// gets landed on the new source.
+    /// </summary>
+    public static bool IsCurveVisible(
+        IEnumerable<SignalPoint> points,
+        EqWizardAxisRange range)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+
+        foreach (SignalPoint point in points)
+        {
+            if (double.IsFinite(point.Y) &&
+                point.Y >= range.Minimum &&
+                point.Y <= range.Maximum)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>The major-step the right EQ-gain axis snaps its bounds to.</summary>
     private const double EqGainAxisStepDb = 6;
 

--- a/source/Tools/Eq/EqWizardSourceResolver.cs
+++ b/source/Tools/Eq/EqWizardSourceResolver.cs
@@ -76,8 +76,12 @@ internal sealed class EqWizardSourceResolver
     /// </summary>
     internal static bool IsEligible(OverlayFile file)
     {
+        // The plot's own dB axis shows up in a capture in two spellings: no key at all
+        // (a Live Spectrum series carries none) or the named dB axis key — sweep modes
+        // attach every curve to their dB axis BY KEY. Both are the level axis; only a
+        // genuinely different axis (coherence) disqualifies.
         return file.Kind == OverlayKind.Captured &&
-            file.CapturedYAxisKey == null &&
+            file.CapturedYAxisKey is null or PlotModelFactory.DecibelAxisKey &&
             file.CapturedCurveKind is not null &&
             IsEqualizableResponse(role: null, file.CapturedCurveKind) &&
             file.Points.Length >= 2;

--- a/tests/Resonalyze.App.Tests/EqWizardPlotFitTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardPlotFitTests.cs
@@ -112,6 +112,38 @@ public sealed class EqWizardPlotFitTests
     }
 
     [Fact]
+    public void IsCurveVisible_TrueWhenAnyPointFallsInsideTheView()
+    {
+        var range = new EqWizardAxisRange(-30, 0, -70, 40);
+
+        // Mostly above the view, but the tail dips into it: still (partially) visible,
+        // so a source switch must keep the user's target level rather than re-land it.
+        Assert.True(EqWizardPlotFit.IsCurveVisible(
+        [
+            new SignalPoint(100, 25),
+            new SignalPoint(1_000, 12),
+            new SignalPoint(10_000, -4)
+        ], range));
+    }
+
+    [Fact]
+    public void IsCurveVisible_FalseWhenTheCurveIsEntirelyOffScreen()
+    {
+        var range = new EqWizardAxisRange(-30, 0, -70, 40);
+
+        // An SPL-level target over a relative source's view: nothing of it can be
+        // seen, which is the one case where the wizard re-lands the target.
+        Assert.False(EqWizardPlotFit.IsCurveVisible(
+        [
+            new SignalPoint(100, 75),
+            new SignalPoint(10_000, 68)
+        ], range));
+        // An unmeasured band is not a visible point.
+        Assert.False(EqWizardPlotFit.IsCurveVisible(
+            [new SignalPoint(100, double.NaN)], range));
+    }
+
+    [Fact]
     public void SuggestTargetOffsetDb_LandsAFlatTargetOnTheSourceMean()
     {
         SignalPoint[] points =

--- a/tests/Resonalyze.App.Tests/EqWizardSourceResolverTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardSourceResolverTests.cs
@@ -42,6 +42,19 @@ public sealed class EqWizardSourceResolverTests
         Assert.False(EqWizardSourceResolver.IsEligible(file));
     }
 
+    [Fact]
+    public void IsEligible_AcceptsASweepCaptureOnTheNamedDecibelAxis()
+    {
+        OverlayFile file = CreateCapturedSlot(1);
+        // Sweep modes attach every curve to the dB axis BY KEY, so a Frequency Response
+        // capture records that key rather than null. It is still the plot's own level
+        // axis — reading it as "a secondary axis" hid every sweep capture from the
+        // wizard while the RTA (whose series carries no key) sailed through.
+        file.CapturedYAxisKey = PlotModelFactory.DecibelAxisKey;
+
+        Assert.True(EqWizardSourceResolver.IsEligible(file));
+    }
+
     [Theory]
     [InlineData(OverlayKind.Operation)]
     [InlineData(OverlayKind.Target)]
@@ -59,7 +72,11 @@ public sealed class EqWizardSourceResolverTests
         string root = CreateTemporaryDirectory();
         try
         {
-            Save(CreateCapturedSlot(3), root);
+            OverlayFile sweep = CreateCapturedSlot(3);
+            // A sweep FR capture stores the named dB axis key; the file round trip must
+            // still surface it — this is the path the live slot menu takes.
+            sweep.CapturedYAxisKey = PlotModelFactory.DecibelAxisKey;
+            Save(sweep, root);
             Save(CreateCapturedSlot(1), root);
 
             OverlayFile ineligible = CreateCapturedSlot(2);

--- a/tests/Resonalyze.App.Tests/LiveSpectrumControllerTests.cs
+++ b/tests/Resonalyze.App.Tests/LiveSpectrumControllerTests.cs
@@ -149,6 +149,14 @@ public sealed class LiveSpectrumControllerTests
         // stack up into duplicates.
         AddLiveSpectrumSeries(controller, model, snapshot);
         Assert.Single(model.Annotations.OfType<OverlayTextAnnotation>());
+
+        // RebuildModel (a smoothing change, leaving and re-entering the mode)
+        // creates a NEW model while the old one still holds its notice. An OxyPlot
+        // element belongs to one PlotModel, so the notice must be created per model
+        // — reusing the first instance threw InvalidOperationException here.
+        var rebuilt = new OxyPlot.PlotModel();
+        AddLiveSpectrumSeries(controller, rebuilt, snapshot);
+        Assert.Single(rebuilt.Annotations.OfType<OverlayTextAnnotation>());
     }
 
     private static void SetField(object target, string name, object value) =>

--- a/tests/Resonalyze.App.Tests/LiveSpectrumControllerTests.cs
+++ b/tests/Resonalyze.App.Tests/LiveSpectrumControllerTests.cs
@@ -102,4 +102,67 @@ public sealed class LiveSpectrumControllerTests
 
         Assert.Null(peakHoldField.GetValue(controller));
     }
+
+    [Fact]
+    public void ViewOnlySpl_ExplainsTheSuppressedCurveInsteadOfAnEmptyPlot()
+    {
+        // dB SPL selected with no calibration configured: the snapshot's curves are
+        // suppressed (raw dBFS on an absolute axis would be garbage), and the model
+        // must say why instead of silently showing an empty plot. The notice is added
+        // by the series path, so it appears only when a curve really was suppressed.
+        using var sweep = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+        var controller = (LiveSpectrumController)RuntimeHelpers.GetUninitializedObject(
+            typeof(LiveSpectrumController));
+        SetField(controller, "measurement", noise);
+        SetField(controller, "liveSpectrumOptions", new LiveSpectrumOptions());
+        SetField(controller, "plotModelFactory", new PlotModelFactory(
+            sweep,
+            noise,
+            _ => null,
+            new PlotPresentationOptions(
+                FrequencyResponse: new FrequencyResponseOptions(),
+                PhaseResponse: new FrequencyResponseOptions(),
+                GroupDelay: new FrequencyResponseOptions(),
+                FrequencyResponseVisibility: new CurveVisibilityOptions(),
+                PhaseResponseVisibility: new CurveVisibilityOptions(),
+                GroupDelayVisibility: new CurveVisibilityOptions(),
+                ImpulseResponse: new ImpulseResponseOptions(),
+                LiveSpectrum: new LiveSpectrumOptions
+                {
+                    MagnitudeScale = MagnitudeScale.SoundPressureLevel
+                },
+                Waterfall: new WaterfallGenerateOptions(),
+                BurstDecay: new WaterfallGenerateOptions())));
+
+        var model = new OxyPlot.PlotModel();
+        var snapshot = new LiveSpectrumSnapshot(
+            [-30.0, -32.0], Coherence: null, InputMagnitude: [-30.0, -32.0]);
+        AddLiveSpectrumSeries(controller, model, snapshot);
+
+        Assert.Empty(model.Series);
+        OverlayTextAnnotation note =
+            Assert.Single(model.Annotations.OfType<OverlayTextAnnotation>());
+        Assert.Contains("overlays only", note.Text, StringComparison.OrdinalIgnoreCase);
+
+        // A live tick re-adds the series into the SAME model: the notice must not
+        // stack up into duplicates.
+        AddLiveSpectrumSeries(controller, model, snapshot);
+        Assert.Single(model.Annotations.OfType<OverlayTextAnnotation>());
+    }
+
+    private static void SetField(object target, string name, object value) =>
+        typeof(LiveSpectrumController)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(target, value);
+
+    private static void AddLiveSpectrumSeries(
+        LiveSpectrumController controller,
+        OxyPlot.PlotModel model,
+        LiveSpectrumSnapshot snapshot) =>
+        typeof(LiveSpectrumController)
+            .GetMethod(
+                "AddLiveSpectrumSeries",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(controller, [model, snapshot]);
 }

--- a/tests/Resonalyze.App.Tests/OverlaySlotNameTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlaySlotNameTests.cs
@@ -74,4 +74,32 @@ public sealed class OverlaySlotNameTests
     {
         Assert.Equal(title, OverlaySlotName.Shorten(title, slot));
     }
+
+    [Fact]
+    public void ForSave_AnOccupiedSlotKeepsItsName()
+    {
+        // Re-capturing into a named slot updates the curve, not the label: the name
+        // may be the user's own ("Left tweeter") and must survive a re-measure.
+        Assert.Equal(
+            "Left tweeter",
+            OverlaySlotName.ForSave(
+                slotOccupied: true,
+                "Left tweeter",
+                slot: 4,
+                "Frequency Response"));
+    }
+
+    [Fact]
+    public void ForSave_AnEmptySlotGetsTheAutomaticName()
+    {
+        // A never-used or cleared slot is named after what was captured, exactly as
+        // before the keep-the-name rule existed.
+        Assert.Equal(
+            "Overlay 4: Frequency Response",
+            OverlaySlotName.ForSave(
+                slotOccupied: false,
+                "",
+                slot: 4,
+                "Frequency Response"));
+    }
 }

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -1138,20 +1138,25 @@ public sealed class PlotModelFactoryTests
         PlotModelFactory factory =
             CreateFactory(measurement, noise, liveSpectrumOptions: options);
 
-        // No configured calibration: SPL requested but unavailable, stay on native dB.
+        // No configured calibration: the offset is unavailable, but the scale (and so
+        // the axis and the overlay gate) follows the SELECTION — the view-only state
+        // that lets overlays captured in dB SPL be seen. The controller suppresses
+        // live curves there, and the record button resets the scale before a run.
         Assert.Null(factory.LiveSplOffsetDb);
-        Assert.Equal(MagnitudeScale.Relative, factory.EffectiveLiveSpectrumScale);
+        Assert.Equal(
+            MagnitudeScale.SoundPressureLevel, factory.EffectiveLiveSpectrumScale);
         var dbAxis = (OxyPlot.Axes.LinearAxis)factory.CreateLiveSpectrum().Axes.First(
             axis => axis.Key == PlotModelFactory.DecibelAxisKey);
-        Assert.Equal("dB", dbAxis.Title);
+        Assert.Equal("dB SPL", dbAxis.Title);
 
         // A calibration captured on a different digital input (sample rate) does not
-        // apply to this live input.
+        // apply to this live input either: still no offset, still view-only.
         SplCalibration mismatched = LiveAnchorMatching(noise, 94, -16);
         mismatched.SampleRate = 48_000;
         measurement.SplCalibration = mismatched;
         Assert.Null(factory.LiveSplOffsetDb);
-        Assert.Equal(MagnitudeScale.Relative, factory.EffectiveLiveSpectrumScale);
+        Assert.Equal(
+            MagnitudeScale.SoundPressureLevel, factory.EffectiveLiveSpectrumScale);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -855,7 +855,7 @@ public sealed class PlotModelFactoryTests
     }
 
     [Fact]
-    public void CreateFrequencyResponse_WithoutCalibration_StaysOnTheRelativeAxis()
+    public void CreateFrequencyResponse_SplWithoutCalibration_IsViewOnly()
     {
         ExpSweepMeasurement measurement = CreateTransferMeasurement();
         using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
@@ -864,11 +864,37 @@ public sealed class PlotModelFactoryTests
             MagnitudeScale = MagnitudeScale.SoundPressureLevel
         };
 
-        OxyPlot.PlotModel model = CreateFactory(
-                measurement, noise, frequencyResponseOptions: splOptions)
+        PlotModelFactory factory = CreateFactory(
+            measurement, noise, frequencyResponseOptions: splOptions);
+        OxyPlot.PlotModel model = factory.CreateFrequencyResponse(includeCurves: true);
+
+        // SPL was requested without a calibration. The axis used to fall back to
+        // dBr/dBc, which made SPL unreachable before the first calibrated run; now
+        // it stays SPL so overlays captured in dB SPL can at least be viewed...
+        var dbAxis = (OxyPlot.Axes.LinearAxis)model.Axes.First(
+            axis => axis.Key == PlotModelFactory.DecibelAxisKey);
+        Assert.Equal("dB SPL", dbAxis.Title);
+        Assert.Equal(PlotModelStyle.SplDecibelMaximum, dbAxis.Maximum);
+        // ...and the overlay gate follows the axis, or those overlays stay hidden...
+        Assert.Equal(
+            MagnitudeScale.SoundPressureLevel,
+            factory.EffectiveFrequencyResponseScale);
+        // ...while the measurement's own curves are omitted — their dBr shapes would
+        // read as absolute levels — replaced by the explanatory annotation.
+        Assert.Empty(model.Series);
+        var note = Assert.Single(model.Annotations.OfType<OverlayTextAnnotation>());
+        Assert.Contains("overlays only", note.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateFrequencyResponse_InRelativeMode_LeavesRoomForAPaddedLoopback()
+    {
+        ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+
+        OxyPlot.PlotModel model = CreateFactory(measurement, noise)
             .CreateFrequencyResponse(includeCurves: true);
 
-        // SPL was requested but no calibration is available: fall back to dBr/dBc.
         var dbAxis = (OxyPlot.Axes.LinearAxis)model.Axes.First(
             axis => axis.Key == PlotModelFactory.DecibelAxisKey);
         Assert.Equal("dBr/dBc", dbAxis.Title);

--- a/tests/Resonalyze.App.Tests/SplCalibrationTests.cs
+++ b/tests/Resonalyze.App.Tests/SplCalibrationTests.cs
@@ -66,6 +66,36 @@ public sealed class SplCalibrationTests
     }
 
     [Fact]
+    public void NextRunHasSplAnchor_PredictsFromTheConfiguredCalibrationAndInput()
+    {
+        // The record button decides BEFORE a sweep whether the display may stay in
+        // dB SPL: only when the run ahead will carry an anchor. The previous
+        // measurement's anchor is irrelevant — it dies the moment the run starts.
+        using var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        Assert.False(measurement.NextRunHasSplAnchor);
+
+        MeasurementInputIdentity identity = measurement.CurrentInputIdentity();
+        var anchor = new SplCalibration
+        {
+            ReferenceLevelDbSpl = 94,
+            MeasuredLevelDbFs = -20,
+            Backend = identity.Backend,
+            SampleRate = identity.SampleRate,
+            Bits = identity.Bits,
+            MicrophoneChannelOffset = identity.MicrophoneChannelOffset,
+            InputDeviceNumber = identity.InputDeviceNumber,
+            WasapiCaptureEndpointId = identity.WasapiCaptureEndpointId,
+            AsioDriverName = identity.AsioDriverName
+        };
+        measurement.SplCalibration = anchor;
+        Assert.True(measurement.NextRunHasSplAnchor);
+
+        // A calibration from a different digital input does not light SPL up.
+        anchor.SampleRate = identity.SampleRate + 1;
+        Assert.False(measurement.NextRunHasSplAnchor);
+    }
+
+    [Fact]
     public async Task ImpulseResponseFile_RoundTripsTheAnchor()
     {
         string path = Path.Combine(Path.GetTempPath(), $"resonalyze-ir-{Guid.NewGuid():N}.json");

--- a/tests/Resonalyze.Dsp.Tests/EqAutoTunerTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EqAutoTunerTests.cs
@@ -53,6 +53,44 @@ public sealed class EqAutoTunerTests
     }
 
     [Fact]
+    public void Tune_PinnedPreamp_RaisesAWindowBelowTargetInsteadOfLoweringTheCurve()
+    {
+        // The wizard's boost mode pins the preamp to the user's value (min = max)
+        // and applies no total-gain ceiling. The source sits 5 dB below the target
+        // inside the fit window: the correction must come from boost bands, with
+        // the preamp untouched. The old wizard options (a free preamp plus a 0 dB
+        // ceiling) mean-centred the preamp UP, fitted the bands against that level,
+        // then the ceiling slammed the preamp to -(peak boost) AFTER the fit — the
+        // realised curve dropped by the peak boost instead of the window rising.
+        IReadOnlyList<SignalPoint> source = Grid(_ => -5.0);
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+
+        EqualizationCurve curve = EqAutoTuner.Tune(
+            source,
+            target,
+            new EqAutoTuner.Options
+            {
+                MinFrequencyHz = 20,
+                MaxFrequencyHz = 300,
+                PreampMinDb = 0,
+                PreampMaxDb = 0,
+                BandGainMaxDb = 6
+            });
+
+        Assert.Equal(0, curve.PreampDb, 9);
+        Assert.NotEmpty(curve.Bands);
+        // The window is lifted towards the target...
+        Assert.True(
+            curve.MagnitudeDbAt(100) > 3.0,
+            $"the window got {curve.MagnitudeDbAt(100):0.0} dB of the needed +5.");
+        // ...and nothing anywhere is pulled down — the failure mode being pinned.
+        double minGain = EqualizationCurve
+            .LogFrequencyGrid(20, 20_000, 400)
+            .Min(curve.MagnitudeDbAt);
+        Assert.True(minGain >= -0.5, $"the curve was lowered by {minGain:0.0} dB.");
+    }
+
+    [Fact]
     public void Tune_ConstantLevelDifference_UsesPreampAndNoBands()
     {
         IReadOnlyList<SignalPoint> source = Grid(_ => -40);


### PR DESCRIPTION
User-facing quality-of-life fixes collected on one branch, plus review follow-ups and an overlay-slot workflow improvement.

## EQ Wizard

- **Sweep FR overlay slots were never accepted as sources.** `IsEligible` read a null `CapturedYAxisKey` as "the plot's own dB axis", but since ce8d68b the Frequency Response plot attaches every curve to its dB axis by key (`"decibel"`), so every sweep capture was rejected as legacy — only Live Spectrum RTA captures ever passed. The named dB axis key is now accepted alongside null; coherence stays excluded by its own key.
- **Target Level survives a source switch while the target is still visible.** Loading a source re-landed the target on the source's mean level unconditionally. The suggestion is now a rescue: it fires only when the target at its current offset would be entirely outside the new source's default view (a relative ↔ SPL datum change); a visible target keeps the user's placement.
- **Auto Tune with boosts no longer drops the whole curve.** With the source below the target, the fit mean-centred the preamp up, placed bands against that level, then the wizard's 0 dB total-gain ceiling capped the preamp to −(peak boost) after the fit — a −6 dB preamp surprise that lowered everything instead of raising the window. Boost mode now pins the preamp to the user's value (min = max) with no total-gain ceiling: bands carry the correction within Max Gain, positive total gain is the user's explicit choice, and the headroom read-out reports it. Cuts-only keeps its field-validated auto preamp and clip-free ceiling.

## dB SPL scale (Frequency Response + Live Spectrum)

- **dBr/dBc → dB SPL is switchable at any time**, so overlays captured in dB SPL can be viewed before a calibrated run. Without a valid anchor the plot keeps the SPL axis in a view-only state: overlays follow the axis (the effective scale now equals the selection), measurement/live curves are omitted behind an explanatory annotation instead of being drawn as false absolute levels. The live notice is created per model and tracked by Tag — an OxyPlot element belongs to one PlotModel — and appears only when a curve really was suppressed.
- **Starting a run in view-only drops the display back to the native scale** — but only when the run ahead cannot supply SPL. The sweep gate is the new `ExpSweepMeasurement.NextRunHasSplAnchor` (configured calibration matched against the input the run will use — exactly what `RunAsync` freezes), so the first calibrated measurement starts and comes up in dB SPL. The live analyzer's gate (`LiveSplOffsetDb`) already predicted correctly; losing the calibration while running live in SPL resets the same way.
- **The amber marking flags a real conflict only**: a measurement on screen (FR) or a live curve — running capture or kept snapshot (`HasDisplayableCurve`) — that view-only would hide. Before that the choice keeps its normal colour, tooltips explain each state, and the open live panel's amber follows calibration changes and analyzer start/stop/completion.

## Overlay slots

- **Saving into an occupied slot keeps the slot's name** (`OverlaySlotName.ForSave`): a re-capture or text import updates the curve, not the label, so a renamed slot survives a re-measure. An empty slot still gets the automatic "Overlay {slot}: {source}" name.
- **New Clear slot action** in the overlay menu (enabled under the same mode-ownership rule as Settings): deletes the slot file, resets the row, refreshes the shell (bulk buttons, labels panel) and notifies captured-overlay consumers; a pending debounced offset save survives a failed delete. A curve saved into the cleared slot gets the automatic name again.

## Tests

Every behavior is pinned UI-free: slot eligibility with the named axis key (round-trip through the file), view-only plot models for both modes (including the per-model live notice, whose regression test fails with the exact OxyPlot exception on the cached-instance code), the relative-axis padded-loopback headroom, `NextRunHasSplAnchor`, target visibility, slot naming, and `Tune_PinnedPreamp_RaisesAWindowBelowTargetInsteadOfLoweringTheCurve` (fails under the old wizard options). Suites: Dsp 951/951, App 781/781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)