### PR TITLE
Big-latency IRs: peak-anchored arrival search + bass-anchored auto-crossover target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1983,9 +1983,10 @@ it defaults to Off because the measurements are loopback-referenced.
   split rather than shallow filters that only look flat by overlapping widely.
   The gains, though, follow a car target curve rather than a flat sum: the
   midrange and tweeter are levelled to each other (the louder attenuated), and
-  the subwoofer anchors the bass at a chosen elevation over that reference —
-  the **Sub level over mid/treble** field defaults to (and is capped at) the
-  measured elevation, so out of the box the sub keeps its own level and you
+  the lowest bass driver — the subwoofer, or the woofer/midbass in a system
+  without one — anchors the bass at a chosen elevation over that reference —
+  the **Bass level over mid/treble** field defaults to (and is capped at) the
+  measured elevation, so out of the box the bass keeps its own level and you
   only trim the field down if you want less bass. The remaining drivers are fit
   onto the resulting slope cut-only (a driver already below the target keeps
   its level — no measured dip is boosted), and every gain is a cut, so the

--- a/dsp/CrossoverAutoSetup.cs
+++ b/dsp/CrossoverAutoSetup.cs
@@ -824,18 +824,35 @@ public static class CrossoverAutoSetup
             reference.Add(tweeter);
         }
 
-        // Only a subwoofer is the elevated bass anchor. A woofer/midbass that
-        // happens to be the lowest driver (a 2-way without a sub) is a normal
-        // driver levelled into the system, not a hot sub to lift.
+        // The bass anchor: the subwoofer when present, else the lowest
+        // woofer/midbass. A sub-less system's bass driver carries the cabin's
+        // low-end elevation just the same, and the elevation control must
+        // reach it — anchoring only a subwoofer left such a system with a
+        // flat target at the mid/tweeter reference, cutting a woofer with
+        // real cabin gain all the way down to the tweeter (field case:
+        // −24 dB) while the control sat dead at zero.
         int bass = Find(DriverType.Subwoofer);
+        bool subAnchor = bass >= 0;
+        if (bass < 0)
+        {
+            bass = Find(DriverType.Woofer);
+        }
+        if (bass < 0)
+        {
+            bass = Find(DriverType.Midbass);
+        }
 
         // The reference (flat-top) level is the quietest driver apart from the
         // sub, so the whole system is cut to it and the sub is lifted on top.
-        // With the sub excluded, a hot woofer never drags the reference up.
+        // Only a SUBWOOFER anchor is excluded: it is a separately amped,
+        // lifted way, and a quiet one must not drag the whole flat-top down.
+        // A woofer/midbass anchor stays a member of the levelled system, so
+        // when it measures QUIETER than the mid/tweeter the system is still
+        // cut down to it (its measured elevation is then simply zero).
         double referenceLevel = double.PositiveInfinity;
         for (int i = 0; i < n; i++)
         {
-            if (i != bass && levels[i] < referenceLevel)
+            if ((i != bass || !subAnchor) && levels[i] < referenceLevel)
             {
                 referenceLevel = levels[i];
             }

--- a/dsp/SignalEnvelope.cs
+++ b/dsp/SignalEnvelope.cs
@@ -103,8 +103,16 @@ public static class SignalEnvelope
             envelope.Count,
             sampleRate,
             options.SearchWindowMilliseconds);
+        // The noise floor is order-invariant (a sorted quantile), so the one
+        // estimate serves both the anchor decision and the first-arrival
+        // threshold below, before and after any rotation.
+        double noiseRms = EstimateEnvelopeNoiseRms(envelope);
         int rotation = FindSearchAnchorRotation(
-            envelope, searchEnd, options.FirstPeakThresholdBelowMaxDb);
+            envelope,
+            searchEnd,
+            options.FirstPeakThresholdBelowMaxDb,
+            options.FirstPeakMinimumSnrDb,
+            noiseRms);
         IReadOnlyList<double> view = rotation == 0
             ? envelope
             : RotateView(envelope, rotation);
@@ -126,7 +134,6 @@ public static class SignalEnvelope
                 rotation);
         }
 
-        double noiseRms = EstimateEnvelopeNoiseRms(view);
         double thresholdFromMax = strongestPeak *
             Math.Pow(10.0, -Math.Abs(options.FirstPeakThresholdBelowMaxDb) / 20.0);
         double thresholdFromNoise = noiseRms *
@@ -174,20 +181,31 @@ public static class SignalEnvelope
     // reach, and the "strongest peak" that window can offer is whatever
     // residue happens to lead the buffer: the analysis then reports a
     // confident zero. When that happens the window re-anchors on the
-    // envelope's global maximum — centred, so the first-arrival walk keeps
-    // half a window of pre-context — and the search runs on a rotated view
-    // of the circular buffer (indices are mapped back before returning).
-    // The re-anchor is deliberately conservative: it fires only when NOTHING
-    // in the start-anchored window sits within the first-arrival search
-    // depth of the global peak, i.e. when by the tool's own physics the true
-    // arrival cannot be inside that window. Every record whose front IS
-    // within reach — including the field-validated modal cabins, where a
-    // room mode may out-ring the direct front — keeps the start-anchored
-    // geometry bit for bit.
+    // envelope's global maximum and the search runs on a rotated view of
+    // the circular buffer (indices are mapped back before returning). The
+    // peak is placed at the window's far usable index, not its centre: all
+    // but two samples of the window become pre-history, so a direct
+    // arrival up to a full window ahead of a stronger room mode stays
+    // findable — centring would halve that reach for nothing, because the
+    // first-arrival walk only ever looks BEFORE the strongest peak, and the
+    // post-peak data the mirror/sidelobe checks read stays available
+    // through the full rotated view regardless of the window edge.
+    // The re-anchor is deliberately conservative: it fires only when
+    // NOTHING in the start-anchored window sits within the first-arrival
+    // search depth of the global peak AND above the noise gate — i.e. when
+    // by the tool's own physics the true arrival cannot be inside that
+    // window. (Depth alone is not enough: on a near-noise record the
+    // window's noise bumps can sit within the depth of a weak global peak,
+    // and keeping the window would hand the fallback that noise.) Every
+    // record whose front IS within reach — including the field-validated
+    // modal cabins, where a room mode may out-ring the direct front —
+    // keeps the start-anchored geometry bit for bit.
     private static int FindSearchAnchorRotation(
         IReadOnlyList<double> envelope,
         int searchEnd,
-        double firstPeakThresholdBelowMaxDb)
+        double firstPeakThresholdBelowMaxDb,
+        double firstPeakMinimumSnrDb,
+        double noiseRms)
     {
         int globalIndex = 0;
         double windowMax = 0.0;
@@ -210,7 +228,11 @@ public static class SignalEnvelope
 
         double reachFloor = envelope[globalIndex] *
             Math.Pow(10.0, -Math.Abs(firstPeakThresholdBelowMaxDb) / 20.0);
-        return windowMax >= reachFloor ? 0 : globalIndex - searchEnd / 2;
+        double noiseFloor = noiseRms *
+            Math.Pow(10.0, Math.Max(0, firstPeakMinimumSnrDb) / 20.0);
+        return windowMax >= reachFloor && windowMax >= noiseFloor
+            ? 0
+            : globalIndex - (searchEnd - 2);
     }
 
     private static double[] RotateView(IReadOnlyList<double> envelope, int rotation)

--- a/dsp/SignalEnvelope.cs
+++ b/dsp/SignalEnvelope.cs
@@ -99,24 +99,34 @@ public static class SignalEnvelope
             throw new ArgumentOutOfRangeException(nameof(sampleRate));
         }
 
+        int searchEnd = GetSearchEndIndex(
+            envelope.Count,
+            sampleRate,
+            options.SearchWindowMilliseconds);
+        int rotation = FindSearchAnchorRotation(
+            envelope, searchEnd, options.FirstPeakThresholdBelowMaxDb);
+        IReadOnlyList<double> view = rotation == 0
+            ? envelope
+            : RotateView(envelope, rotation);
+        int Original(int viewIndex) => rotation == 0
+            ? viewIndex
+            : (viewIndex + rotation) % envelope.Count;
+
         (int strongestIndex, double strongestPeak) = FindStrongestPeak(
-            envelope,
+            view,
             sampleRate,
             options.SearchWindowMilliseconds);
         if (options.Mode == PeakSearchMode.StrongestPeak)
         {
             return new PeakSearchResult(
-                strongestIndex,
-                strongestIndex,
+                Original(strongestIndex),
+                Original(strongestIndex),
                 strongestPeak,
-                false);
+                false,
+                rotation);
         }
 
-        int searchEnd = GetSearchEndIndex(
-            envelope.Count,
-            sampleRate,
-            options.SearchWindowMilliseconds);
-        double noiseRms = EstimateEnvelopeNoiseRms(envelope);
+        double noiseRms = EstimateEnvelopeNoiseRms(view);
         double thresholdFromMax = strongestPeak *
             Math.Pow(10.0, -Math.Abs(options.FirstPeakThresholdBelowMaxDb) / 20.0);
         double thresholdFromNoise = noiseRms *
@@ -126,16 +136,16 @@ public static class SignalEnvelope
         var candidates = new List<int>();
         for (int i = 1; i < searchEnd - 1; i++)
         {
-            if (envelope[i] >= threshold &&
-                envelope[i] >= envelope[i - 1] &&
-                envelope[i] >= envelope[i + 1])
+            if (view[i] >= threshold &&
+                view[i] >= view[i - 1] &&
+                view[i] >= view[i + 1])
             {
                 candidates.Add(i);
             }
         }
 
         int firstArrivalIndex = EliminatePreRingingSidelobes(
-            envelope,
+            view,
             candidates,
             options.AnalysisKernelEnvelope,
             threshold,
@@ -143,17 +153,75 @@ public static class SignalEnvelope
         if (firstArrivalIndex >= 0)
         {
             return new PeakSearchResult(
-                firstArrivalIndex,
-                strongestIndex,
+                Original(firstArrivalIndex),
+                Original(strongestIndex),
                 strongestPeak,
-                false);
+                false,
+                rotation);
         }
 
         return new PeakSearchResult(
-            strongestIndex,
-            strongestIndex,
+            Original(strongestIndex),
+            Original(strongestIndex),
             strongestPeak,
-            true);
+            true,
+            rotation);
+    }
+
+    // A measurement chain with real processing latency (a DSP or amplifier
+    // buffering the playback longer than the search window — field case: a
+    // ~163 ms chain) parks the whole IR beyond the start-anchored window's
+    // reach, and the "strongest peak" that window can offer is whatever
+    // residue happens to lead the buffer: the analysis then reports a
+    // confident zero. When that happens the window re-anchors on the
+    // envelope's global maximum — centred, so the first-arrival walk keeps
+    // half a window of pre-context — and the search runs on a rotated view
+    // of the circular buffer (indices are mapped back before returning).
+    // The re-anchor is deliberately conservative: it fires only when NOTHING
+    // in the start-anchored window sits within the first-arrival search
+    // depth of the global peak, i.e. when by the tool's own physics the true
+    // arrival cannot be inside that window. Every record whose front IS
+    // within reach — including the field-validated modal cabins, where a
+    // room mode may out-ring the direct front — keeps the start-anchored
+    // geometry bit for bit.
+    private static int FindSearchAnchorRotation(
+        IReadOnlyList<double> envelope,
+        int searchEnd,
+        double firstPeakThresholdBelowMaxDb)
+    {
+        int globalIndex = 0;
+        double windowMax = 0.0;
+        for (int i = 0; i < envelope.Count; i++)
+        {
+            if (envelope[i] > envelope[globalIndex])
+            {
+                globalIndex = i;
+            }
+            if (i < searchEnd && envelope[i] > windowMax)
+            {
+                windowMax = envelope[i];
+            }
+        }
+
+        if (globalIndex < searchEnd)
+        {
+            return 0;
+        }
+
+        double reachFloor = envelope[globalIndex] *
+            Math.Pow(10.0, -Math.Abs(firstPeakThresholdBelowMaxDb) / 20.0);
+        return windowMax >= reachFloor ? 0 : globalIndex - searchEnd / 2;
+    }
+
+    private static double[] RotateView(IReadOnlyList<double> envelope, int rotation)
+    {
+        var view = new double[envelope.Count];
+        for (int i = 0; i < view.Length; i++)
+        {
+            view[i] = envelope[(i + rotation) % envelope.Count];
+        }
+
+        return view;
     }
 
     // For stationary Gaussian noise the Hilbert envelope is Rayleigh-
@@ -425,8 +493,18 @@ public sealed class PeakSearchOptions
     public IReadOnlyList<double>? AnalysisKernelEnvelope { get; init; }
 }
 
+/// <summary>
+/// Indices are in the envelope's own coordinates. <see cref="SearchRotation"/>
+/// is non-zero when the search window re-anchored on the envelope's global
+/// maximum (a chain latency beyond the window's reach): the window then covered
+/// [SearchRotation, SearchRotation + window) circularly, and a consumer
+/// measuring distances between the returned indices must measure them in that
+/// window's frame — <c>(index - SearchRotation) mod length</c> — or a pair
+/// straddling the buffer seam reads as a buffer-length separation.
+/// </summary>
 public readonly record struct PeakSearchResult(
     int SelectedIndex,
     int StrongestIndex,
     double StrongestPeak,
-    bool FallbackUsed);
+    bool FallbackUsed,
+    int SearchRotation = 0);

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -165,10 +165,19 @@ public static class TimeAlignmentAnalysis
         // events — unless the valley between them is deep enough to prove the
         // events resolved anyway (destructive interference can resolve faster
         // than the nominal 1/BW).
+        // Distances are measured in the SEARCH WINDOW's frame: when the window
+        // re-anchored on a far peak (chain latency beyond its reach), the two
+        // indices may straddle the circular buffer's seam, and their raw
+        // difference would read as a buffer-length gap.
+        int searchRotation = peakSearchResult.SearchRotation;
+        int relativeFirst = RelativeToSearchWindow(
+            envelopePeakIndex, searchRotation, envelope.Length);
+        int relativeStrongest = RelativeToSearchWindow(
+            strongestPeakIndex, searchRotation, envelope.Length);
         double separationMilliseconds =
-            (strongestPeakIndex - envelopePeakIndex) * 1000.0 / sampleRate;
+            (relativeStrongest - relativeFirst) * 1000.0 / sampleRate;
         double valleyDepthDb = ValleyDepthDb(
-            envelope, envelopePeakIndex, strongestPeakIndex);
+            envelope, relativeFirst, relativeStrongest, searchRotation);
         double blurMilliseconds = SeparateArrivalThresholdMilliseconds;
         if (options.UseBandpassWindow)
         {
@@ -300,22 +309,34 @@ public static class TimeAlignmentAnalysis
     // destructive interference nulls faster than the envelope's rise time.
     private const double SeparateArrivalResolvedValleyDb = 20.0;
 
+    // A peak position expressed in the search window's frame: its offset from
+    // the window's start, which for a re-anchored (rotated) window is where
+    // the contiguous around-the-peak geometry lives. With no rotation this is
+    // the index itself.
+    private static int RelativeToSearchWindow(int index, int rotation, int length) =>
+        ((index - rotation) % length + length) % length;
+
     // The envelope dip between the two peaks, in dB below the LOWER of them
-    // (>= 0; 0 when the envelope never dips).
+    // (>= 0; 0 when the envelope never dips). Peak positions arrive in the
+    // search window's frame; envelope reads map back through the rotation, so
+    // the walk follows the window's contiguous geometry across the buffer seam.
     private static double ValleyDepthDb(
         IReadOnlyList<double> envelope,
-        int firstIndex,
-        int secondIndex)
+        int relativeFirstIndex,
+        int relativeSecondIndex,
+        int rotation)
     {
-        int from = Math.Min(firstIndex, secondIndex);
-        int to = Math.Max(firstIndex, secondIndex);
+        int from = Math.Min(relativeFirstIndex, relativeSecondIndex);
+        int to = Math.Max(relativeFirstIndex, relativeSecondIndex);
         double valley = double.MaxValue;
         for (int i = from; i <= to; i++)
         {
-            valley = Math.Min(valley, envelope[i]);
+            valley = Math.Min(valley, envelope[(i + rotation) % envelope.Count]);
         }
 
-        double reference = Math.Min(envelope[firstIndex], envelope[secondIndex]);
+        double reference = Math.Min(
+            envelope[(relativeFirstIndex + rotation) % envelope.Count],
+            envelope[(relativeSecondIndex + rotation) % envelope.Count]);
         if (reference <= 0.0 || valley <= 0.0)
         {
             return valley <= 0.0 && reference > 0.0 ? double.PositiveInfinity : 0.0;

--- a/source/Options/GDOpt.Designer.cs
+++ b/source/Options/GDOpt.Designer.cs
@@ -69,9 +69,9 @@ namespace Resonalyze.Options
             checkAutoFit.FlatAppearance.CheckedBackColor = Color.FromArgb(80, 100, 140);
             checkAutoFit.FlatStyle = FlatStyle.Flat;
             checkAutoFit.ForeColor = Color.White;
-            checkAutoFit.Location = new Point(110, 11);
+            checkAutoFit.Location = new Point(104, 11);
             checkAutoFit.Name = "checkAutoFit";
-            checkAutoFit.Size = new Size(40, 21);
+            checkAutoFit.Size = new Size(46, 21);
             checkAutoFit.TabIndex = 61;
             checkAutoFit.Text = "Auto";
             checkAutoFit.TextAlign = ContentAlignment.MiddleCenter;

--- a/source/Options/PROpt.Designer.cs
+++ b/source/Options/PROpt.Designer.cs
@@ -82,9 +82,9 @@ namespace Resonalyze.Options
             checkAutoFit.FlatAppearance.CheckedBackColor = Color.FromArgb(80, 100, 140);
             checkAutoFit.FlatStyle = FlatStyle.Flat;
             checkAutoFit.ForeColor = Color.White;
-            checkAutoFit.Location = new Point(110, 103);
+            checkAutoFit.Location = new Point(104, 103);
             checkAutoFit.Name = "checkAutoFit";
-            checkAutoFit.Size = new Size(40, 21);
+            checkAutoFit.Size = new Size(46, 21);
             checkAutoFit.TabIndex = 61;
             checkAutoFit.Text = "Auto";
             checkAutoFit.TextAlign = ContentAlignment.MiddleCenter;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoSetupDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoSetupDialog.Designer.cs
@@ -198,7 +198,7 @@ namespace Resonalyze
             labelSubElevation.Name = "labelSubElevation";
             labelSubElevation.Size = new Size(160, 15);
             labelSubElevation.TabIndex = 20;
-            labelSubElevation.Text = "Sub level over mid/treble:";
+            labelSubElevation.Text = "Bass level over mid/treble:";
             //
             // subElevation
             //

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoSetupDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoSetupDialog.cs
@@ -242,9 +242,10 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
             "slopes — the textbook crossover.");
         toolTip.SetToolTip(
             subElevation,
-            "How far the lowest driver sits above the levelled midrange/tweeter.\r\n" +
-            "Starts at (and is capped by) the measured elevation — the sub at its\r\n" +
-            "own level; lower it to flatten the bottom. The midrange/tweeter are\r\n" +
+            "How far the lowest driver (the sub, or the woofer/midbass when no\r\n" +
+            "sub is present) sits above the levelled midrange/tweeter. Starts at\r\n" +
+            "(and is capped by) the measured elevation — the bass at its own\r\n" +
+            "level; lower it to flatten the bottom. The midrange/tweeter are\r\n" +
             "levelled to each other and the remaining drivers are only cut, never\r\n" +
             "boosted, onto the resulting target.");
     }
@@ -366,7 +367,7 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
             .ToList();
         double span = window.Count > 0 ? window.Max() - window.Min() : 0;
         string elevation = subElevationInitialized
-            ? $"  ·  sub +{(double)subElevation.Value:0.0} dB over mid/treble"
+            ? $"  ·  bass +{(double)subElevation.Value:0.0} dB over mid/treble"
             : string.Empty;
         return $"Predicted sum spans {span:0.0} dB over " +
             $"{FormatHz(low.LowHz)}–{FormatHz(high.HighHz)}{elevation}";

--- a/tests/Resonalyze.Dsp.Tests/BroadbandOnsetTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/BroadbandOnsetTests.cs
@@ -39,6 +39,25 @@ public sealed class BroadbandOnsetTests
     }
 
     [Fact]
+    public void EstimateBroadbandOnset_FindsAFrontParkedBeyondTheSearchWindowByChainLatency()
+    {
+        // Field case (3RC): a DSP/amplifier chain buffers the playback for
+        // ~160 ms, beyond the 80 ms peak-search window — the onset must land
+        // on the real front there, not on the buffer-seam residue at zero.
+        Complex[] impulseResponse = Silence(131_072);
+        const int DeltaIndex = 7_680; // 160 ms at 48 kHz
+        impulseResponse[DeltaIndex] = Complex.One;
+
+        BroadbandOnsetEstimate estimate =
+            VirtualCrossoverAnalysis.EstimateBroadbandOnset(impulseResponse, Rate);
+
+        double deltaMs = DeltaIndex * 1_000.0 / Rate;
+        double sampleMs = 1_000.0 / Rate;
+        Assert.True(estimate.IsValid);
+        Assert.InRange(estimate.OnsetMs, deltaMs - 4 * sampleMs, deltaMs + sampleMs);
+    }
+
+    [Fact]
     public void EstimateBroadbandOnset_CrossingsAreMonotonicInTheThreshold()
     {
         // A slow Hann-windowed tone burst: the envelope rises over many samples,

--- a/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CrossoverRankedProposalTests.cs
@@ -516,6 +516,68 @@ public sealed class CrossoverRankedProposalTests
         Assert.All(over, p => Assert.True(p.GainDb <= 0.0 + 1e-9));
     }
 
+    // The field case behind the woofer anchor: a 3-way with no subwoofer,
+    // whose woofer carries real cabin gain. The woofer must anchor the bass
+    // exactly as a sub would — kept at its raw level by default, trimmable
+    // through the elevation control — instead of being cut all the way down
+    // to the mid/tweeter reference (−24 dB on the field system).
+    [Fact]
+    public void ApplyTargetCurveGains_WithoutASubTheWooferAnchorsTheBass()
+    {
+        List<SignalPoint> Shelf(double lowHz, double highHz, double levelDb) =>
+            BandCurve(lowHz, highHz).Select(p => new SignalPoint(p.X, p.Y + levelDb)).ToList();
+        var sources = new List<AutoSetupSource>
+        {
+            new(Shelf(30, 260, 12), DriverType.Woofer),
+            new(Shelf(200, 5_000, 0), DriverType.Midrange),
+            new(Shelf(2_000, 20_000, 2), DriverType.Tweeter),
+        };
+        IReadOnlyList<CrossoverProposal> proposals =
+            CrossoverAutoSetup.Propose(sources, Options());
+
+        // The hot woofer keeps its raw level by default (the measured
+        // elevation), the louder tweeter is levelled to the midrange, and
+        // every gain stays a cut.
+        double measured = CrossoverAutoSetup.MeasuredSubElevationDb(
+            sources, proposals, SampleRate);
+        Assert.True(measured > 8, $"measured elevation {measured} unexpectedly small");
+        Assert.True(Math.Abs(proposals[0].GainDb) < 1.0, $"woofer moved {proposals[0].GainDb} dB");
+        Assert.Equal(0.0, proposals[1].GainDb, precision: 6);
+        Assert.True(proposals[2].GainDb < -0.5, $"tweeter {proposals[2].GainDb} not attenuated");
+        Assert.All(proposals, p => Assert.True(p.GainDb <= 1e-9));
+
+        // Trimming the elevation to zero flattens the bottom: only then is the
+        // woofer cut down toward the reference.
+        IReadOnlyList<CrossoverProposal> flat = CrossoverAutoSetup.ApplyTargetCurveGains(
+            sources, proposals, SampleRate, subElevationDb: 0);
+        Assert.True(flat[0].GainDb < -8, $"flat woofer {flat[0].GainDb} not cut");
+        Assert.Equal(proposals[1].GainDb, flat[1].GainDb, precision: 6);
+    }
+
+    // The conservative side of the woofer anchor: a bass driver QUIETER than
+    // the mid/treble has no elevation to preserve (cut-only gains cannot lift
+    // it), so the system still levels down to it — the pre-anchor behavior.
+    [Fact]
+    public void ApplyTargetCurveGains_AQuietWooferWithoutASubStaysLevelMatched()
+    {
+        List<SignalPoint> Shelf(double lowHz, double highHz, double levelDb) =>
+            BandCurve(lowHz, highHz).Select(p => new SignalPoint(p.X, p.Y + levelDb)).ToList();
+        var sources = new List<AutoSetupSource>
+        {
+            new(Shelf(40, 2_000, -6), DriverType.Woofer),
+            new(Shelf(1_000, 20_000, 0), DriverType.Tweeter),
+        };
+        IReadOnlyList<CrossoverProposal> proposals =
+            CrossoverAutoSetup.Propose(sources, Options());
+
+        double measured = CrossoverAutoSetup.MeasuredSubElevationDb(
+            sources, proposals, SampleRate);
+        Assert.Equal(0.0, measured, precision: 6);
+        // The quiet woofer stays put; the louder tweeter is cut down to it.
+        Assert.True(Math.Abs(proposals[0].GainDb) < 0.5, $"woofer moved {proposals[0].GainDb} dB");
+        Assert.True(proposals[1].GainDb < proposals[0].GainDb, "tweeter not cut to the woofer");
+    }
+
     // With ideal impulse drivers a matched LR24 handover is losslessly
     // alignable, so the post-check must hand the win to the conventional
     // candidate with a near-zero penalty.

--- a/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
@@ -107,6 +107,63 @@ public sealed class SignalEnvelopeTests
     }
 
     [Fact]
+    public void FindPeak_ReAnchorsOnAGlobalPeakBeyondAnEmptyWindow()
+    {
+        // A chain latency parks the whole IR beyond the search window: the
+        // start-anchored window holds only residue far below the first-arrival
+        // search depth, so the search re-anchors on the global envelope
+        // maximum and reports it in the envelope's own coordinates.
+        var envelope = new double[48_000];
+        Array.Fill(envelope, 1e-6);
+        envelope[19_999] = 0.6;
+        envelope[20_000] = 1.0; // ~417 ms, far beyond the 80 ms window
+        envelope[20_001] = 0.6;
+
+        PeakSearchResult result = SignalEnvelope.FindPeak(
+            envelope,
+            sampleRate: 48_000,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                SearchWindowMilliseconds = 80
+            });
+
+        Assert.Equal(20_000, result.StrongestIndex);
+        Assert.Equal(20_000, result.SelectedIndex);
+        Assert.NotEqual(0, result.SearchRotation);
+    }
+
+    [Fact]
+    public void FindPeak_KeepsTheStartAnchoredWindowWhenItHoldsReachableContent()
+    {
+        // The re-anchor gate is conservative: content inside the start-anchored
+        // window within the first-arrival search depth of the global peak means
+        // the true front may live there (the modal-cabin geometry, where a room
+        // mode out-rings the direct front), so the legacy window must stay.
+        var envelope = new double[48_000];
+        Array.Fill(envelope, 1e-6);
+        envelope[499] = 0.12;
+        envelope[500] = 0.2; // in-window, -14 dB re the far global peak
+        envelope[501] = 0.12;
+        envelope[19_999] = 0.6;
+        envelope[20_000] = 1.0; // global maximum beyond the window
+        envelope[20_001] = 0.6;
+
+        PeakSearchResult result = SignalEnvelope.FindPeak(
+            envelope,
+            sampleRate: 48_000,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                SearchWindowMilliseconds = 80
+            });
+
+        Assert.Equal(500, result.StrongestIndex);
+        Assert.Equal(500, result.SelectedIndex);
+        Assert.Equal(0, result.SearchRotation);
+    }
+
+    [Fact]
     public void FindFractionalPeakOffset_ClampsToHalfSample()
     {
         double offset = SignalEnvelope.FindFractionalPeakOffset(

--- a/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
@@ -134,6 +134,37 @@ public sealed class SignalEnvelopeTests
     }
 
     [Fact]
+    public void FindPeak_ReAnchorsPastALoudSeamResidue()
+    {
+        // The 3RC head shape: the acausal residue wrapped across the buffer
+        // seam decays from sample 0, sitting tens of dB above the noise
+        // floor yet more than the search depth below the real peak — loud
+        // residue is still residue, and the window re-anchors past it.
+        var envelope = new double[48_000];
+        Array.Fill(envelope, 1e-6);
+        for (int i = 0; i < 200; i++)
+        {
+            envelope[i] = Math.Max(1e-6, 0.02 * Math.Exp(-i / 12.0));
+        }
+        envelope[19_999] = 0.6;
+        envelope[20_000] = 1.0;
+        envelope[20_001] = 0.6;
+
+        PeakSearchResult result = SignalEnvelope.FindPeak(
+            envelope,
+            sampleRate: 48_000,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                SearchWindowMilliseconds = 80
+            });
+
+        Assert.Equal(20_000, result.StrongestIndex);
+        Assert.Equal(20_000, result.SelectedIndex);
+        Assert.NotEqual(0, result.SearchRotation);
+    }
+
+    [Fact]
     public void FindPeak_KeepsTheStartAnchoredWindowWhenItHoldsReachableContent()
     {
         // The re-anchor gate is conservative: content inside the start-anchored

--- a/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
@@ -165,6 +165,35 @@ public sealed class SignalEnvelopeTests
     }
 
     [Fact]
+    public void FindPeak_ReAnchorsWhenTheWindowHoldsOnlySubNoiseContent()
+    {
+        // A near-noise record with a weak but real event beyond the window:
+        // the window's noise sits within the 25 dB search depth of that weak
+        // global peak, but below the noise gate — depth alone would keep the
+        // start-anchored window, whose content then fails the first-arrival
+        // threshold and the fallback returns a noise sample. Sub-noise
+        // content must not block the re-anchor.
+        var envelope = new double[48_000];
+        Array.Fill(envelope, 0.01);
+        envelope[19_999] = 0.06;
+        envelope[20_000] = 0.1; // the only real event, beyond the window
+        envelope[20_001] = 0.06;
+
+        PeakSearchResult result = SignalEnvelope.FindPeak(
+            envelope,
+            sampleRate: 48_000,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                SearchWindowMilliseconds = 80
+            });
+
+        Assert.Equal(20_000, result.StrongestIndex);
+        Assert.Equal(20_000, result.SelectedIndex);
+        Assert.NotEqual(0, result.SearchRotation);
+    }
+
+    [Fact]
     public void FindPeak_KeepsTheStartAnchoredWindowWhenItHoldsReachableContent()
     {
         // The re-anchor gate is conservative: content inside the start-anchored

--- a/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
@@ -117,6 +117,28 @@ public sealed class TimeAlignmentAnalysisTests
     }
 
     [Fact]
+    public void Analyze_FindsADirectArrivalAFullWindowAheadOfTheStrongestPeak()
+    {
+        // The review counter-example for the re-anchored window's placement:
+        // a weak direct arrival 55 ms ahead of a stronger room mode, with
+        // the start-anchored window empty (chain latency). Centring the
+        // window on the mode would leave only 40 ms of pre-history and lose
+        // the direct sound; anchored at the window's far edge, almost the
+        // full 80 ms ahead of the mode stays searchable.
+        var impulseResponse = new double[131_072];
+        impulseResponse[7_680] = 0.3;  // direct arrival, 160 ms at 48 kHz
+        impulseResponse[10_320] = 1.0; // stronger room mode, 215 ms
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, new TimeAlignmentAnalysisOptions());
+
+        Assert.InRange(result.FirstArrivalDelayMilliseconds, 159.5, 160.5);
+        Assert.InRange(result.StrongestDelayMilliseconds, 214.5, 215.5);
+        Assert.True(result.StrongestPeakIsSeparateArrival);
+        Assert.InRange(result.StrongestPeakSeparationMilliseconds, 54.5, 55.5);
+    }
+
+    [Fact]
     public void Analyze_KeepsTheTwoPeakTrapGeometryUnderChainLatency()
     {
         // The weak-direct/strong-mode pair of the classic trap, shifted whole

--- a/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
@@ -78,6 +78,65 @@ public sealed class TimeAlignmentAnalysisTests
     }
 
     [Fact]
+    public void Analyze_FindsAnArrivalParkedBeyondTheSearchWindowByChainLatency()
+    {
+        // Field case (3RC): a DSP/amplifier chain buffers the playback for
+        // ~160 ms, so the whole transfer IR sits beyond the 80 ms peak-search
+        // window and the start-anchored search used to report a confident
+        // zero (the strongest thing it could reach was the buffer-seam
+        // residue at sample 0).
+        var impulseResponse = new double[131_072];
+        impulseResponse[7_680] = 1.0; // 160 ms at 48 kHz
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate,
+            new TimeAlignmentAnalysisOptions { WrapPeakPositions = true });
+
+        Assert.Equal(7_680, result.StrongestEnvelopePeakIndex);
+        Assert.InRange(result.StrongestDelayMilliseconds, 159.9, 160.1);
+        Assert.InRange(result.FirstArrivalDelayMilliseconds, 159.9, 160.1);
+        Assert.False(result.StrongestPeakIsSeparateArrival);
+    }
+
+    [Fact]
+    public void Analyze_ReportsALeadingArrivalBeyondTheWindowAsANegativeDelay()
+    {
+        // An IR whose energy leads the reference wraps to the buffer's far
+        // end — unreachable for the start-anchored window; the re-anchored
+        // search finds it there and the wrap maps it to the negative delay
+        // it is.
+        var impulseResponse = new double[131_072];
+        impulseResponse[131_072 - 480] = 1.0; // -10 ms at 48 kHz
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate,
+            new TimeAlignmentAnalysisOptions { WrapPeakPositions = true });
+
+        Assert.InRange(result.StrongestDelayMilliseconds, -10.1, -9.9);
+        Assert.InRange(result.FirstArrivalDelayMilliseconds, -10.1, -9.9);
+    }
+
+    [Fact]
+    public void Analyze_KeepsTheTwoPeakTrapGeometryUnderChainLatency()
+    {
+        // The weak-direct/strong-mode pair of the classic trap, shifted whole
+        // by a 160 ms chain latency: the separation and the separate-arrival
+        // flag must read exactly as they do at the buffer start, measured in
+        // the re-anchored window's frame.
+        var impulseResponse = new double[131_072];
+        impulseResponse[7_680] = 0.3; // weak direct arrival
+        impulseResponse[8_080] = 1.0; // strong late arrival (room mode)
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            impulseResponse, SampleRate, new TimeAlignmentAnalysisOptions());
+
+        Assert.Equal(8_080, result.StrongestEnvelopePeakIndex);
+        Assert.InRange(result.FirstArrivalPeakSample, 7_670.0, 7_690.0);
+        Assert.True(result.StrongestPeakIsSeparateArrival);
+        Assert.InRange(result.StrongestPeakSeparationMilliseconds, 8.0, 8.7);
+    }
+
+    [Fact]
     public void Analyze_WrapPeakPositionsLeavesASubHalfArrivalUnchanged()
     {
         // The peak search is capped at length/2, so a real arrival always lands in

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -1130,6 +1130,24 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void AnalyzeBandLimitedArrival_FindsAnArrivalParkedBeyondTheSearchWindowByChainLatency()
+    {
+        // Field case (3RC): a DSP/amplifier chain buffers the playback for
+        // ~160 ms — far beyond the 80 ms peak-search window. The Virtual DSP
+        // arrival reads (delay suggestions, gate placement) must find the
+        // real front there instead of the buffer-seam residue at zero.
+        Complex[] ir = UnitImpulse(131_072, 7_680); // 160 ms at 48 kHz
+
+        TimeAlignmentAnalysisResult result =
+            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                ir, SampleRate, 500, 2_000);
+
+        Assert.True(result.IsValid);
+        Assert.InRange(result.FirstArrivalDelayMilliseconds, 159.0, 161.0);
+        Assert.InRange(result.StrongestDelayMilliseconds, 159.0, 161.0);
+    }
+
+    [Fact]
     public void AnalyzeBandLimitedArrival_AcceptsExactlyAThirdOctave()
     {
         Complex[] ir = UnitImpulse(8_192, 480);


### PR DESCRIPTION
Two fixes for measurement chains with real processing latency (field case, the 3RC session: a DSP and amplifier buffering the playback for ~163 ms), plus review-driven hardening. They share the field data but are independent changes; commits are separated per concern.

## 1. Peak-anchored arrival search (`dsp/SignalEnvelope.cs`, `dsp/TimeAlignmentAnalysis.cs`)

**Problem.** The peak search window (80 ms) always started at the buffer's sample zero. A chain latency beyond that parks the whole transfer IR out of reach; the strongest thing the window could offer was the acausal residue wrapped around the buffer seam, so full-band Time Alignment reported a confident **0.000 ms** with an excellent-looking SNR, and every Auto gate-offset control (Phase, Group Delay, Virtual DSP gate) failed through the shared `EstimateIrStart` path.

**Fix.** `SignalEnvelope.FindPeak` re-anchors the search window on the envelope's global maximum, running the search on a rotated view of the circular buffer and mapping indices back:

- The global peak lands at the window's **far usable index** (review finding): the first-arrival walk only looks before the strongest peak, and post-peak data stays reachable through the full rotated view, so all but two samples of the window serve as pre-history — a direct arrival up to a full window ahead of a stronger room mode stays findable.
- The re-anchor is conservative: it fires only when nothing in the start-anchored window sits within the first-arrival search depth (25 dB) of the global peak **and** above the noise gate (review finding: sub-noise window content must not block the re-anchor and then resurface through the fallback). Records whose front is reachable — including the field-validated modal cabins — keep the legacy geometry bit for bit.
- `PeakSearchResult` carries the window rotation; separation/valley between first arrival and strongest peak are measured in the window's frame, so a pair straddling the buffer seam does not read as a buffer-length gap. Leading (negative-delay) arrivals wrapped at the buffer's far end are now findable and report as negative delays.

On the finer re-anchor discriminators proposed in review (noise-only emptiness, rise-from-floor, edge-pinned maximum): all were prototyped and measurably fail — the field seam residue sits ~50 dB above the noise floor, and oscillating Hilbert/bandpass skirt nulls fake both a rise and an interior peak. The depth-plus-noise gate is the rule that survives; a dedicated test pins the loud-seam-residue shape.

## 2. Auto-crossover: bass anchor without a subwoofer (`dsp/CrossoverAutoSetup.cs`)

**Problem.** The target-curve gain fit anchored the bass only on a Subwoofer-typed channel. A system without one got a flat target at the mid/tweeter reference: a woofer carrying real cabin gain was cut all the way down to it (field: **−24.3 dB**) while the sub-elevation control sat dead at zero.

**Fix.** The bass anchor is the subwoofer when present, else the lowest woofer/midbass: its measured elevation over the levelled mid/tweeter is kept by default and trimmed through the control (relabelled "Bass level over mid/treble"). Only a subwoofer anchor is excluded from the flat-top reference; a woofer/midbass anchor stays a member of the levelled system, so a bass driver measuring quieter than the mid/treble still levels the system down to itself — the pre-anchor behavior. Crossover frequency/family/slope selection is untouched. Includes a 6 px layout tweak of the Phase/GD Auto gate buttons.

## Verification

- Behavioral tests fail on the pre-fix code (verified by stashing the dsp changes); review counter-examples (direct arrival 55 ms ahead of a stronger mode; sub-noise window blocking) pinned as synthetics.
- Full solution suite green: 963 dsp + 781 app + 138 audio.
- Field battery (six-record 3RC session, stock 80 ms window): L 163.1/162.9/162.8 ms, R 162.0/161.5/161.6 ms — bit-identical to a wide-window reference and unchanged across the review-driven geometry changes. Auto-crossover field check: bands, crossovers and mid/tweeter gains identical to the pre-fix wizard; the woofer keeps its 24.3 dB measured elevation instead of the −24.3 dB cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
