### PR TITLE
Draw the Compare curve in dB SPL, anchored by its own calibration

### DIFF
--- a/source/History/MeasurementHistoryService.cs
+++ b/source/History/MeasurementHistoryService.cs
@@ -244,6 +244,14 @@ internal sealed class MeasurementHistoryService
             TransferImpulseResponse = transfer,
             TransferCoherence = measurement.TransferCoherence?.ToArray(),
             MeterSnapshot = measurement.CurrentLevels,
+            // Same rule as saving to disk: keep the calibration frozen onto THIS
+            // result, and only when it belongs to the input the result ran on — a
+            // leftover anchor from another device would be trusted on restore.
+            SplCalibration =
+                measurement.MeasurementSplCalibration is { } anchor &&
+                measurement.InputMatches(anchor)
+                    ? anchor
+                    : null,
             Preview = preview,
             Session = session
         };
@@ -287,6 +295,8 @@ internal sealed class MeasurementHistoryService
             TransferImpulseResponse = transfer,
             TransferCoherence = file.TransferCoherence?.ToArray(),
             MeterSnapshot = file.GetMeterSnapshot(),
+            // The file's anchor was validated against its own input when written.
+            SplCalibration = file.SplCalibration,
             Preview = preview,
             Session = session
         };

--- a/source/History/MeasurementHistorySnapshot.cs
+++ b/source/History/MeasurementHistorySnapshot.cs
@@ -43,7 +43,26 @@ internal sealed class MeasurementHistorySnapshot
     public Complex[]? TransferImpulseResponse { get; init; }
     public double[]? TransferCoherence { get; init; }
     public required InputLevelMeterSnapshot MeterSnapshot { get; init; }
+    /// <summary>
+    /// The SPL anchor frozen onto the result this snapshot holds, validated against
+    /// its own input when it was captured (see <c>ImpulseResponseFile.FromMeasurement</c>).
+    /// Together with <see cref="MeterSnapshot"/>'s loopback level it is the whole
+    /// recipe for dB SPL, so restoring the entry — or comparing against it — keeps
+    /// the absolute axis the original measurement had. Null when there was none.
+    /// </summary>
+    public SplCalibration? SplCalibration { get; init; }
     public required MeasurementHistoryPreview Preview { get; init; }
+
+    /// <summary>
+    /// The offset K that turns this snapshot's loopback-referenced magnitude (dBr)
+    /// into dB SPL: <c>K = loopbackPeakDbFs + calibrationOffsetDb</c>. Null without
+    /// an anchor or a captured loopback level. The anchor was matched against its
+    /// own input when stored, so it is trusted here as a loaded file's is.
+    /// </summary>
+    public double? SplOffsetDb =>
+        SplCalibration is { } calibration && MeterSnapshot.Loopback is { Available: true } loopback
+            ? loopback.PeakDbFs + calibration.OffsetDb
+            : null;
     // Settable so the live working state (mode + per-mode settings + active
     // overlays) can be written back into a cached snapshot when navigating away.
     public MeasurementSessionSnapshot? Session { get; set; }
@@ -68,6 +87,7 @@ internal sealed class MeasurementHistorySnapshot
             AverageRunCount = AverageRunCount,
             AcceptedAverageRunCount = AcceptedAverageRunCount,
             AudioSession = AudioSession,
+            SplCalibration = SplCalibration,
             SweepDeconvolutionRealSamples = SweepDeconvolutionImpulseResponse.Select(
                 sample => sample.Real).ToArray(),
             SweepDeconvolutionImaginarySamples = HasImaginarySamples(SweepDeconvolutionImpulseResponse)

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -257,8 +257,9 @@ internal sealed class PlotModelFactory
         // dB SPL follows the SELECTION. Converting the curves additionally needs a
         // valid calibration and loopback level for this measurement; without them the
         // axis still goes SPL but view-only — the measurement's own dBr shapes would
-        // be lies on an absolute axis and are omitted, while overlays captured in
-        // dB SPL (gated by EffectiveFrequencyResponseScale) remain visible. Starting
+        // be lies on an absolute axis and are omitted, while what carries its own
+        // absolute reference stays visible: overlays captured in dB SPL (gated by
+        // EffectiveFrequencyResponseScale) and a Compare with an anchor. Starting
         // a run in that state drops the display back to dBr/dBc (Form1), so a fresh
         // measurement is never born hidden.
         bool splRequested =
@@ -268,64 +269,52 @@ internal sealed class PlotModelFactory
         bool splViewOnly = splRequested && !renderSpl;
 
         // Magnitude is derived from the loopback transfer IR, which is required.
-        if (splViewOnly &&
-            measurementContext.CanIncludeCurves(includeCurves) &&
+        if (measurementContext.CanIncludeCurves(includeCurves) &&
             measurementContext.HasTransferImpulseResponse)
         {
-            // This measurement cannot supply SPL (no calibration, no loopback level,
-            // or a calibration from another input): say why its curves are absent.
-            AddSplViewOnlyAnnotation(model);
-        }
-        else if (measurementContext.CanIncludeCurves(includeCurves) &&
-            measurementContext.HasTransferImpulseResponse)
-        {
-            IReadOnlyList<AnalysisCurve> curves = measurementContext.CreateFrequencyResponseCurves(
-                frequencyResponseOptions,
-                GetCalibration(frequencyResponseOptions),
-                frequencyResponseVisibility.ToSpectrumCurves());
-            if (renderSpl)
+            IReadOnlyList<AnalysisCurve> curves = Array.Empty<AnalysisCurve>();
+            if (splViewOnly)
             {
-                curves = SplConversion.ToSoundPressureLevel(curves, splOffset!.Value);
+                // This measurement cannot supply SPL (no calibration, no loopback
+                // level, or a calibration from another input): say why its curves are
+                // absent. The Compare curve below is judged on its own anchor, so a
+                // calibrated comparison stays visible next to the notice, exactly as
+                // an SPL-captured overlay does.
+                AddSplViewOnlyAnnotation(model);
             }
-
-            foreach (AnalysisCurve curve in curves)
+            else
             {
-                AddLineSeries(
-                    model,
-                    curve,
-                    renderSpl ? SplTrackerFormat : DistortionTrackerFormat(curve.Kind),
-                    Mode.FrequencyResponse,
-                    DecibelAxisKey);
-            }
-
-            // Overlay the Compare magnitude (primary only; harmonics stay Main-only to
-            // keep the plot readable), computed with the identical options/calibration.
-            // The Compare source carries no loopback level or calibration, so it has no
-            // absolute reference; it is omitted in SPL mode rather than drawn as dBr.
-            if (!renderSpl && TryCreateCompareMeasurement() is { } compare)
-            {
-                IReadOnlyList<AnalysisCurve> compareCurves = DataHelper.GetSpectrum(
-                    compare.Measurement,
+                curves = measurementContext.CreateFrequencyResponseCurves(
                     frequencyResponseOptions,
                     GetCalibration(frequencyResponseOptions),
-                    frequencyResponseVisibility.ToSpectrumCurves() & SpectrumCurves.Primary);
-                foreach (AnalysisCurve curve in compareCurves)
+                    frequencyResponseVisibility.ToSpectrumCurves());
+                if (renderSpl)
                 {
-                    AddCompareLineSeries(
+                    curves = SplConversion.ToSoundPressureLevel(curves, splOffset!.Value);
+                }
+
+                foreach (AnalysisCurve curve in curves)
+                {
+                    AddLineSeries(
                         model,
                         curve,
-                        DistortionTrackerFormat(curve.Kind),
-                        compare.DisplayName,
-                        Mode.FrequencyResponse);
+                        renderSpl ? SplTrackerFormat : DistortionTrackerFormat(curve.Kind),
+                        Mode.FrequencyResponse,
+                        DecibelAxisKey);
                 }
             }
 
-            AddMeasurementCoherenceIfAvailable(
-                model,
-                frequencyResponseOptions,
-                frequencyResponseVisibility.ShowCoherence);
+            AddCompareFrequencyResponse(model, splRequested, splViewOnly);
 
-            AddHiddenHarmonicAnnotation(model, curves);
+            if (!splViewOnly)
+            {
+                AddMeasurementCoherenceIfAvailable(
+                    model,
+                    frequencyResponseOptions,
+                    frequencyResponseVisibility.ShowCoherence);
+
+                AddHiddenHarmonicAnnotation(model, curves);
+            }
         }
         else if (measurementContext.CanIncludeCurves(includeCurves) &&
                  !measurementContext.HasTransferImpulseResponse)
@@ -337,7 +326,8 @@ internal sealed class PlotModelFactory
         // In SPL mode the whole plot is absolute dB SPL, which needs a different
         // default window and clamps (curves sit near 40–110 dB, far above the dBr
         // ceiling). The axis follows the SELECTION — a view-only SPL plot keeps the
-        // SPL axis for its overlays. Otherwise the primary is the loopback-referenced
+        // SPL axis for whatever can still be drawn on it (overlays, a calibrated
+        // Compare). Otherwise the primary is the loopback-referenced
         // transfer magnitude (dBr) and the harmonic / THD / noise curves are ratios
         // to the fundamental (dBc); the axis names both.
         if (splRequested)
@@ -372,6 +362,75 @@ internal sealed class PlotModelFactory
         kind == AnalysisCurveKind.Primary
             ? "{0}\n{2:0.0} Hz\n{4:0.00} dBr (vs reference)"
             : "{0}\n{2:0.0} Hz\n{4:0.00} dBc (vs fundamental)";
+
+    /// <summary>
+    /// Overlays the Compare magnitude on the Frequency Response plot (primary only;
+    /// harmonics stay Main-only to keep the plot readable), computed with the
+    /// identical options/calibration.
+    /// <para>
+    /// On the absolute axis the Compare curve is converted with <em>its own</em> K:
+    /// the two measurements carry their own loopback levels, so borrowing the main
+    /// measurement's offset would misplace it (they agree only when both were
+    /// captured in one session). A Compare without an anchor has no absolute
+    /// reference at all — it is omitted rather than drawn as dBr on a dB SPL scale,
+    /// and the plot says which measurement is missing instead of leaving the curve
+    /// silently absent.
+    /// </para>
+    /// </summary>
+    private void AddCompareFrequencyResponse(
+        PlotModel model,
+        bool splRequested,
+        bool splViewOnly)
+    {
+        if (TryCreateCompareMeasurement() is not { } compare)
+        {
+            return;
+        }
+
+        double? compareOffset = splRequested ? compare.SplOffsetDb : null;
+        if (splRequested && compareOffset is null)
+        {
+            model.Annotations.Add(CreateCompareWithoutSplAnnotation(
+                compare.DisplayName, splViewOnly));
+            return;
+        }
+
+        IReadOnlyList<AnalysisCurve> compareCurves = DataHelper.GetSpectrum(
+            compare.Measurement,
+            frequencyResponseOptions,
+            GetCalibration(frequencyResponseOptions),
+            frequencyResponseVisibility.ToSpectrumCurves() & SpectrumCurves.Primary);
+        if (compareOffset is { } offsetDb)
+        {
+            compareCurves = SplConversion.ToSoundPressureLevel(compareCurves, offsetDb);
+        }
+
+        foreach (AnalysisCurve curve in compareCurves)
+        {
+            AddCompareLineSeries(
+                model,
+                curve,
+                compareOffset.HasValue ? SplTrackerFormat : DistortionTrackerFormat(curve.Kind),
+                compare.DisplayName,
+                Mode.FrequencyResponse);
+        }
+    }
+
+    // Sits a line below the main measurement's view-only notice when both are
+    // shown, so the two explanations do not overprint each other.
+    private static OverlayTextAnnotation CreateCompareWithoutSplAnnotation(
+        string compareName,
+        bool splViewOnly)
+    {
+        OverlayTextAnnotation note = CreateSplViewOnlyAnnotation(
+            $"No SPL calibration for {compareName} — the compared curve is hidden in dB SPL");
+        if (splViewOnly)
+        {
+            note.TextPosition = new DataPoint(note.TextPosition.X, note.TextPosition.Y + 1);
+        }
+
+        return note;
+    }
 
     public PlotModel CreatePhaseResponse(bool includeCurves)
     {
@@ -1511,7 +1570,10 @@ internal sealed class PlotModelFactory
     // built from the transfer IR — loopback is mandatory for every measurement).
     // Requires a matching sample rate, otherwise the gate (in ms) and the
     // frequency axis would not align with the main measurement.
-    private (IImpulseMeasurement Measurement, string DisplayName, double[]? Coherence)?
+    private (IImpulseMeasurement Measurement,
+        string DisplayName,
+        double[]? Coherence,
+        double? SplOffsetDb)?
         TryCreateCompareMeasurement()
     {
         if (getCompareSource?.Invoke() is not { } compare)
@@ -1529,7 +1591,8 @@ internal sealed class PlotModelFactory
         return (
             new ImpulseMeasurementView(transferIr, peakIndex, compare.SampleRate),
             compare.DisplayName,
-            compare.TransferCoherence);
+            compare.TransferCoherence,
+            compare.SplOffsetDb);
     }
 
     // The complex (vector) sum of the Main and Compare transfer responses, i.e.

--- a/source/Shell/CompareSelection.cs
+++ b/source/Shell/CompareSelection.cs
@@ -51,7 +51,10 @@ internal sealed class CompareSelection
             selection.Snapshot.SampleRate,
             transferIr,
             selection.Snapshot.TransferPeakIndex ?? 0,
-            selection.Snapshot.TransferCoherence);
+            selection.Snapshot.TransferCoherence,
+            // Its OWN K, not the main measurement's: the two were captured at
+            // different loopback levels unless they share a session.
+            selection.Snapshot.SplOffsetDb);
     }
 
     public TimeAlignmentCompareMeasurement? GetTimeAlignmentMeasurement() =>
@@ -70,9 +73,15 @@ internal sealed record CompareMeasurementSelection(
 // The Compare measurement's transfer IR used by the mode plots (Frequency Response
 // magnitude, Phase / Group Delay and the gated IR preview). Matching sample rate is
 // validated by the consumers.
+//
+// SplOffsetDb is this measurement's own K (loopback level + calibration offset), so
+// the Compare magnitude can be drawn on the absolute axis beside the main curve;
+// null when the compared measurement carries no SPL anchor, and then Frequency
+// Response omits it in dB SPL rather than drawing dBr on an absolute scale.
 public readonly record struct CompareAnalysisSource(
     string DisplayName,
     int SampleRate,
     Complex[] TransferImpulseResponse,
     int TransferPeakIndex,
-    double[]? TransferCoherence = null);
+    double[]? TransferCoherence = null,
+    double? SplOffsetDb = null);

--- a/source/Shell/Form1.History.cs
+++ b/source/Shell/Form1.History.cs
@@ -233,6 +233,13 @@ public partial class Form1
             achievedLowHz,
             achievedHighHz);
         expSweepMeasurement.RestoreLevelSnapshot(snapshot.MeterSnapshot);
+        // Restore the anchor with the levels, exactly as opening the file would
+        // (Form1.FileOperations): both halves of K travel with the entry, so a
+        // restored measurement keeps the dB SPL axis it was measured on. The stored
+        // anchor was matched against its own input, so its capture identity stands
+        // in for the result's.
+        expSweepMeasurement.MeasurementSplCalibration = snapshot.SplCalibration;
+        expSweepMeasurement.MeasurementInput = snapshot.SplCalibration?.CaptureIdentity;
 
         if (snapshot.Session != null)
         {
@@ -243,6 +250,11 @@ public partial class Form1
         SetImpulseResponseSourceFile(sourceFilePath);
         sessionTracker.SetImpulseResponseAvailable(true);
         UpdatePeakInfo();
+        // The restored entry brings its own anchor, so whether dB SPL is fully
+        // available just changed — keep an open panel's warning in step, as loading
+        // a file does.
+        dockedModeSettingsHost.InvokeIfOpen<Options.FROptions>(
+            panel => panel.RefreshSplAvailability());
 
         if (snapshot.Session != null)
         {

--- a/tests/Resonalyze.App.Tests/CompareSelectionTests.cs
+++ b/tests/Resonalyze.App.Tests/CompareSelectionTests.cs
@@ -61,6 +61,50 @@ public sealed class CompareSelectionTests
         Assert.Same(coherence, source.Value.TransferCoherence);
     }
 
+    // The Compare curve is drawn on the absolute axis with its OWN K, so the
+    // selection has to carry it: loopback peak (-6 dBFS) + anchor offset
+    // (94 - -20 = 114) = 108 dB SPL at 0 dBr.
+    [Fact]
+    public void GetAnalysisSource_CarriesTheComparedMeasurementsSplOffset()
+    {
+        var selection = new CompareSelection();
+        selection.Set("a.json", null, CreateSnapshot(
+            transferIr: [new(0.25, 0)],
+            calibration: new SplCalibration
+            {
+                ReferenceLevelDbSpl = 94,
+                MeasuredLevelDbFs = -20
+            },
+            meterSnapshot: new InputLevelMeterSnapshot(
+                new InputLevelMeterEntry(true, -3, -6, false, false),
+                new InputLevelMeterEntry(true, -6, -9, false, false))));
+
+        CompareAnalysisSource? source = selection.GetAnalysisSource();
+
+        Assert.Equal(108.0, source!.Value.SplOffsetDb!.Value, tolerance: 1e-9);
+    }
+
+    // Half a recipe is no recipe: an anchor without the measurement's loopback
+    // level cannot place the curve absolutely, and neither can a level alone.
+    [Fact]
+    public void GetAnalysisSource_HasNoSplOffsetWithoutBothHalves()
+    {
+        var anchor = new SplCalibration { ReferenceLevelDbSpl = 94, MeasuredLevelDbFs = -20 };
+        var levels = new InputLevelMeterSnapshot(
+            new InputLevelMeterEntry(true, -3, -6, false, false),
+            new InputLevelMeterEntry(true, -6, -9, false, false));
+
+        var withoutLevels = new CompareSelection();
+        withoutLevels.Set("a.json", null, CreateSnapshot(
+            transferIr: [new(0.25, 0)], calibration: anchor));
+        Assert.Null(withoutLevels.GetAnalysisSource()!.Value.SplOffsetDb);
+
+        var withoutAnchor = new CompareSelection();
+        withoutAnchor.Set("a.json", null, CreateSnapshot(
+            transferIr: [new(0.25, 0)], meterSnapshot: levels));
+        Assert.Null(withoutAnchor.GetAnalysisSource()!.Value.SplOffsetDb);
+    }
+
     [Fact]
     public void GetAnalysisSource_ReturnsNullWithoutATransferIr()
     {
@@ -75,7 +119,9 @@ public sealed class CompareSelectionTests
         Complex[]? sweepIr = null,
         Complex[]? transferIr = null,
         int? transferPeakIndex = null,
-        double[]? coherence = null) =>
+        double[]? coherence = null,
+        SplCalibration? calibration = null,
+        InputLevelMeterSnapshot? meterSnapshot = null) =>
         new()
         {
             SampleRate = 48_000,
@@ -84,7 +130,8 @@ public sealed class CompareSelectionTests
             TransferImpulseResponse = transferIr,
             TransferPeakIndex = transferPeakIndex,
             TransferCoherence = coherence,
-            MeterSnapshot = InputLevelMeterSnapshot.Empty,
+            MeterSnapshot = meterSnapshot ?? InputLevelMeterSnapshot.Empty,
+            SplCalibration = calibration,
             Preview = new MeasurementHistoryPreview()
         };
 }

--- a/tests/Resonalyze.App.Tests/MeasurementHistoryServiceTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementHistoryServiceTests.cs
@@ -75,6 +75,36 @@ public sealed class MeasurementHistoryServiceTests : IDisposable
         Assert.NotEmpty(snapshot.SweepDeconvolutionImpulseResponse);
     }
 
+    // Both halves of K used to be split up by the history: the loopback level rode
+    // along in the meter snapshot while the anchor was dropped, so a restored entry
+    // — or a Compare picked from history — could not be shown in dB SPL, and saving
+    // the entry back to disk wrote a file with no calibration at all.
+    [Fact]
+    public void Snapshot_CarriesTheSplAnchorFromTheFileAndBackToIt()
+    {
+        ImpulseResponseFile file = ImpulseResponseFileAtomicSaveTests.CreateFile(
+            sampleValue: 1.0);
+        file.SplCalibration = new SplCalibration
+        {
+            ReferenceLevelDbSpl = 94,
+            MeasuredLevelDbFs = -20,
+            Backend = Resonalyze.Audio.AudioBackend.Wave,
+            SampleRate = 48_000,
+            Bits = 24
+        };
+        file.LoopbackLevels = new ImpulseResponseFile.LevelSnapshotFileEntry
+        {
+            PeakDbFs = -6,
+            RmsDbFs = -9
+        };
+
+        MeasurementHistorySnapshot snapshot = MeasurementHistoryService.CreateSnapshot(file);
+
+        Assert.Same(file.SplCalibration, snapshot.SplCalibration);
+        Assert.Equal(108.0, snapshot.SplOffsetDb!.Value, tolerance: 1e-9);
+        Assert.Same(file.SplCalibration, snapshot.ToImpulseResponseFile().SplCalibration);
+    }
+
     private MeasurementHistoryService CreateService() =>
         new(new MeasurementHistoryPersistence(
             Path.Combine(directory, "measurement-history.json")));

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -886,6 +886,129 @@ public sealed class PlotModelFactoryTests
         Assert.Contains("overlays only", note.Text, StringComparison.OrdinalIgnoreCase);
     }
 
+    // The Compare curve used to vanish the moment the plot went to dB SPL. It has
+    // its own K (own loopback level, own anchor), so it belongs on the absolute
+    // axis — placed by that K, not by the main measurement's.
+    [Fact]
+    public void CreateFrequencyResponse_InSplMode_DrawsCompareWithItsOwnOffset()
+    {
+        const int peakSample = 64;
+        ExpSweepMeasurement measurement = CreateSplTransferMeasurement(
+            peakSample, loopbackPeakDbFs: -6, referenceLevelDbSpl: 94, measuredLevelDbFs: -20);
+        // K_main = -6 + (94 - -20) = 108 dB at 0 dBr.
+        using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+
+        PlotModelFactory factory = CreateFactory(
+            measurement,
+            noise,
+            frequencyResponseOptions: new FrequencyResponseOptions
+            {
+                MagnitudeScale = MagnitudeScale.SoundPressureLevel
+            });
+        // The same impulse on the Compare side, so the two dBr shapes are identical
+        // and the only thing separating the curves on screen is K_compare - K_main.
+        var compareImpulse = new Complex[2048];
+        compareImpulse[peakSample] = Complex.One;
+        factory.SetCompareSourceProvider(() => new CompareAnalysisSource(
+            "quieter.json", 44_100, compareImpulse, peakSample, SplOffsetDb: 96.0));
+
+        List<LineSeries> series = factory.CreateFrequencyResponse(includeCurves: true)
+            .Series.OfType<LineSeries>().ToList();
+        LineSeries main = series.Single(item => item.Tag is CurveTag
+        {
+            Kind: AnalysisCurveKind.Primary,
+            Source: CurveSource.Main
+        });
+        LineSeries compare = series.Single(item => item.Tag is CurveTag
+        {
+            Kind: AnalysisCurveKind.Primary,
+            Source: CurveSource.Compare
+        });
+
+        Assert.Contains("quieter.json", compare.Title);
+        Assert.Contains("dB SPL", compare.TrackerFormatString);
+        Assert.Equal(main.Points.Count, compare.Points.Count);
+        for (int i = 0; i < main.Points.Count; i++)
+        {
+            Assert.Equal(main.Points[i].X, compare.Points[i].X, tolerance: 1e-9);
+            Assert.Equal(main.Points[i].Y - 12.0, compare.Points[i].Y, tolerance: 1e-9);
+        }
+    }
+
+    // Without an anchor of its own the compared measurement has no absolute level;
+    // drawing its dBr shape on a dB SPL axis would be a lie, so it stays out — but
+    // the plot has to name it, or the curve just silently disappears (which is how
+    // this was reported).
+    [Fact]
+    public void CreateFrequencyResponse_InSplMode_OmitsAnUncalibratedCompareAndSaysSo()
+    {
+        ExpSweepMeasurement measurement = CreateSplTransferMeasurement(
+            peakSample: 64, loopbackPeakDbFs: -6, referenceLevelDbSpl: 94,
+            measuredLevelDbFs: -20);
+        using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+
+        PlotModelFactory factory = CreateFactory(
+            measurement,
+            noise,
+            frequencyResponseOptions: new FrequencyResponseOptions
+            {
+                MagnitudeScale = MagnitudeScale.SoundPressureLevel
+            });
+        var compareImpulse = new Complex[2048];
+        compareImpulse[64] = Complex.One;
+        factory.SetCompareSourceProvider(() => new CompareAnalysisSource(
+            "uncalibrated.json", 44_100, compareImpulse, 64));
+
+        OxyPlot.PlotModel model = factory.CreateFrequencyResponse(includeCurves: true);
+
+        Assert.DoesNotContain(
+            model.Series.OfType<LineSeries>(),
+            item => item.Tag is CurveTag { Source: CurveSource.Compare });
+        OverlayTextAnnotation note =
+            Assert.Single(model.Annotations.OfType<OverlayTextAnnotation>());
+        Assert.Contains("uncalibrated.json", note.Text);
+    }
+
+    // Mirrors the overlay rule: an SPL-capable source stays visible even when the
+    // measurement itself cannot supply SPL, so the view-only plot is not empty when
+    // there is something honest to show.
+    [Fact]
+    public void CreateFrequencyResponse_SplViewOnly_StillDrawsACalibratedCompare()
+    {
+        ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+
+        PlotModelFactory factory = CreateFactory(
+            measurement,
+            noise,
+            frequencyResponseOptions: new FrequencyResponseOptions
+            {
+                MagnitudeScale = MagnitudeScale.SoundPressureLevel
+            });
+        var compareImpulse = new Complex[2048];
+        compareImpulse[64] = Complex.One;
+        factory.SetCompareSourceProvider(() => new CompareAnalysisSource(
+            "calibrated.json", 44_100, compareImpulse, 64, SplOffsetDb: 100.0));
+
+        OxyPlot.PlotModel model = factory.CreateFrequencyResponse(includeCurves: true);
+
+        // The measurement's own curves stay out, with the notice explaining why...
+        Assert.DoesNotContain(
+            model.Series.OfType<LineSeries>(),
+            item => item.Tag is CurveTag { Source: CurveSource.Main });
+        OverlayTextAnnotation note =
+            Assert.Single(model.Annotations.OfType<OverlayTextAnnotation>());
+        Assert.Contains("overlays only", note.Text, StringComparison.OrdinalIgnoreCase);
+        // ...while the compared measurement, which does carry an anchor, is drawn.
+        LineSeries compare = Assert.Single(
+            model.Series.OfType<LineSeries>(),
+            item => item.Tag is CurveTag { Source: CurveSource.Compare });
+        // A unit impulse is 0 dBr at every frequency, so the trace sits at K.
+        Assert.All(
+            compare.Points,
+            point => Assert.Equal(100.0, point.Y, tolerance: 1e-6));
+    }
+
     [Fact]
     public void CreateFrequencyResponse_InRelativeMode_LeavesRoomForAPaddedLoopback()
     {
@@ -1001,6 +1124,35 @@ public sealed class PlotModelFactoryTests
             measurementMode: SweepMeasurementMode.LoopbackTransfer,
             transferImpulseResponse: transferImpulse,
             transferPeakIndex: peakSample);
+        return measurement;
+    }
+
+    // A transfer measurement carrying the whole SPL recipe: an anchor frozen onto
+    // the result and pinned to the input it ran on, plus a captured loopback level.
+    // K = loopbackPeakDbFs + (referenceLevelDbSpl - measuredLevelDbFs).
+    private static ExpSweepMeasurement CreateSplTransferMeasurement(
+        int peakSample,
+        double loopbackPeakDbFs,
+        double referenceLevelDbSpl,
+        double measuredLevelDbFs)
+    {
+        ExpSweepMeasurement measurement = CreateTransferMeasurement(peakSample);
+        var anchor = new SplCalibration
+        {
+            ReferenceLevelDbSpl = referenceLevelDbSpl,
+            MeasuredLevelDbFs = measuredLevelDbFs,
+            Backend = Resonalyze.Audio.AudioBackend.Wave,
+            SampleRate = 44_100,
+            Bits = 24,
+            MicrophoneChannelOffset = 0,
+            InputDeviceNumber = -1
+        };
+        measurement.MeasurementSplCalibration = anchor;
+        measurement.MeasurementInput = anchor.CaptureIdentity;
+        measurement.RestoreLevelSnapshot(new InputLevelMeterSnapshot(
+            new InputLevelMeterEntry(true, -3, -6, false, false),
+            new InputLevelMeterEntry(
+                true, loopbackPeakDbFs, loopbackPeakDbFs - 3, false, false)));
         return measurement;
     }
 


### PR DESCRIPTION
## The report

With a second measurement loaded through **Compare**, its curve disappeared from Frequency Response as soon as the plot was switched to dB SPL.

## Root cause

`CreateFrequencyResponse` gated the Compare overlay behind `!renderSpl`, with the comment *"The Compare source carries no loopback level or calibration, so it has no absolute reference"*.

That was only true because the anchor was lost on the way in. Every Compare source is built from a `MeasurementHistorySnapshot`, and the snapshot never carried `SplCalibration` — it was dropped in three independent places (`CreateSnapshot(measurement, …)`, `CreateSnapshot(file, …)`, `ToImpulseResponseFile()`). Half the recipe for K survived (the loopback level, in `MeterSnapshot`); the other half did not.

## The change

- **The snapshot carries the anchor.** `MeasurementHistorySnapshot.SplCalibration` plus a derived `SplOffsetDb` (`K = loopbackPeakDbFs + calibrationOffsetDb`). It is populated from a loaded file and from a live measurement under the same rule the disk format already applies — only when the anchor belongs to the input the result ran on — and written back out by `ToImpulseResponseFile()`, so saving from history no longer strips the calibration.
- **Compare carries its own K.** `CompareAnalysisSource.SplOffsetDb`; the Compare magnitude is converted with *its own* offset, not the main measurement's. The two agree only when both were captured in one session — borrowing the main offset would misplace the curve.
- **An uncalibrated Compare is still omitted**, because its dBr shape on an absolute axis would be a lie — but the plot now names the measurement it hid instead of the curve silently vanishing, which is how this was reported in the first place.
- **View-only SPL** (the main measurement has no anchor) now still draws a *calibrated* Compare, mirroring the existing rule for overlays captured in dB SPL.
- **Restoring a history entry keeps its anchor**, so a restored measurement no longer falls back to dBr; the open Frequency Response panel refreshes its SPL availability the same way a file load does.

## Verification

A throwaway harness (not committed — no real-data tests in the repo) ran the owner's own pair, `l1.json` as Main and `r1.json` as Compare, both from one session:

| | |
|---|---|
| K, main / compare | 101.48 / 101.48 dB (same session: loopback −6.02 dBFS, anchor 104 dB @ −3.50 dBFS) |
| 1 kHz | 71.3 vs 72.3 dB SPL |
| Both primaries drawn | yes, on the dB SPL axis |

New pinned behavior: the Compare curve is placed by its own K (main − 12 dB when K differs by 12), an anchorless Compare is omitted *and named*, a calibrated Compare survives view-only SPL, and the anchor round-trips file → snapshot → file.

Full suite green: 787 app + 998 dsp + 138 audio, build with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)