### PR TITLE
EQ Wizard: build the filter bank by hand, with shelves and undo

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,10 @@ the executable, nothing left on the machine — create an empty file named
 - EQ Wizard: equalize any measured frequency response — an impulse response from
   a file or History, a captured overlay slot, or a curve imported from text —
   toward its own target curve, designing an up-to-32-band parametric EQ (with
-  selectable microphone calibration), using a vertical fader bank, Auto Tune, a
+  selectable microphone calibration), using a vertical fader bank you add
+  filters — bells and low/high shelves — to one at a time and reorder or throw
+  away by dragging them, with undo/redo over the whole bank and the bank itself
+  kept between sessions, Auto Tune, a
   live results read-out, cross-tool PEQ import/export, and a printable
   tuning-sheet PDF. The car case it was built for is a **moving-microphone RTA in
   dB SPL**: no coherence, no impulse response, an absolute datum
@@ -340,9 +343,9 @@ the executable, nothing left on the machine — create an empty file named
       <h3>EQ Wizard</h3>
       <img src="assets/images/eq_wizard.png" alt="EQ Wizard mode">
       <p>Load an impulse response and design a parametric EQ toward its own target
-      curve with microphone calibration, Auto Tune, a 32-band fader bank, per-band
-      curves, a live results read-out, cross-tool import/export, and a
-      tuning-sheet PDF.</p>
+      curve with microphone calibration, Auto Tune, a drag-ordered fader bank of
+      up to 32 filters, per-band curves, a live results read-out, cross-tool
+      import/export, and a tuning-sheet PDF.</p>
     </td>
   </tr>
   <tr>

--- a/dsp/CamillaDspYamlFormat.cs
+++ b/dsp/CamillaDspYamlFormat.cs
@@ -4,10 +4,12 @@ using YamlDotNet.Serialization;
 namespace Resonalyze.Dsp;
 
 /// <summary>
-/// CamillaDSP config (YAML). Exports each PEQ band as a Biquad/Peaking filter plus a
-/// Gain filter for the preamp, wired into a two-channel pipeline. Imports Peaking
-/// biquads and the first Gain filter; other filter types are skipped. Peaking filters
-/// sum commutatively, so filter order does not affect the result.
+/// CamillaDSP config (YAML). Exports each PEQ band as a Biquad — Peaking, Lowshelf
+/// or Highshelf, all of which take the same freq/gain/q triple — plus a Gain filter
+/// for the preamp, wired into a two-channel pipeline. Imports those three biquad
+/// types and the first Gain filter; anything else is skipped. The filters are
+/// cascaded, and a cascade of biquads commutes, so filter order does not affect the
+/// result.
 /// </summary>
 public sealed class CamillaDspYamlFormat : IEqProfileFormat
 {
@@ -38,13 +40,15 @@ public sealed class CamillaDspYamlFormat : IEqProfileFormat
         for (int i = 0; i < curve.Bands.Count; i++)
         {
             PeqBand band = curve.Bands[i];
-            string key = $"peaking_{i:000}";
+            // The key names the slot, not the shape: a filter that changed type
+            // between two exports keeps its place in the pipeline list.
+            string key = $"band_{i:000}";
             filters[key] = new Dictionary<string, object?>
             {
                 ["type"] = "Biquad",
                 ["parameters"] = new Dictionary<string, object?>
                 {
-                    ["type"] = "Peaking",
+                    ["type"] = FilterTypeName(band.Type),
                     ["freq"] = EqTextNumbers.Format(band.FrequencyHz, "0.###"),
                     ["q"] = EqTextNumbers.Format(band.Q, "0.0"),
                     ["gain"] = EqTextNumbers.Format(band.GainDb, "0.0")
@@ -127,7 +131,7 @@ public sealed class CamillaDspYamlFormat : IEqProfileFormat
             }
 
             string? subType = GetString(parameters, "type");
-            if (subType != null && !subType.Equals("Peaking", StringComparison.OrdinalIgnoreCase))
+            if (!TryReadFilterType(subType, out PeqBandType bandType))
             {
                 continue;
             }
@@ -140,12 +144,47 @@ public sealed class CamillaDspYamlFormat : IEqProfileFormat
                 double.IsFinite(q) && q > 0 &&
                 double.IsFinite(bandGain))
             {
-                bands.Add(new PeqBand(frequencyHz, q, bandGain));
+                bands.Add(new PeqBand(frequencyHz, q, bandGain, bandType));
             }
         }
 
         curve = new EqualizationCurve(bands, preampDb);
         return true;
+    }
+
+    // CamillaDSP names the shelves Lowshelf/Highshelf and takes the same freq/gain/q
+    // triple for them as for Peaking (it also accepts a "slope" instead of "q";
+    // exports state q, which is what the library holds).
+    private static string FilterTypeName(PeqBandType type) => type switch
+    {
+        PeqBandType.LowShelf => "Lowshelf",
+        PeqBandType.HighShelf => "Highshelf",
+        _ => "Peaking"
+    };
+
+    // A biquad with no stated sub-type is a Peaking one; anything outside the three
+    // the library can hold (LowpassFO, Notch, the FO shelves, ...) is skipped.
+    private static bool TryReadFilterType(string? name, out PeqBandType type)
+    {
+        type = PeqBandType.Peaking;
+        if (name == null || name.Equals("Peaking", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (name.Equals("Lowshelf", StringComparison.OrdinalIgnoreCase))
+        {
+            type = PeqBandType.LowShelf;
+            return true;
+        }
+
+        if (name.Equals("Highshelf", StringComparison.OrdinalIgnoreCase))
+        {
+            type = PeqBandType.HighShelf;
+            return true;
+        }
+
+        return false;
     }
 
     private static IDictionary<object, object>? GetMap(IDictionary<object, object> map, string key) =>

--- a/dsp/DigitalEqualizationResponse.cs
+++ b/dsp/DigitalEqualizationResponse.cs
@@ -36,7 +36,7 @@ public static class DigitalEqualizationResponse
         }
 
         double magnitude = BiquadResponse.Evaluate(
-            PeakingBiquad.Compute(band, sampleRateHz),
+            PeqBiquad.Compute(band, sampleRateHz),
             frequencyHz,
             sampleRateHz).Magnitude;
         return 20.0 * Math.Log10(Math.Max(magnitude, double.Epsilon));

--- a/dsp/DspChannelChain.cs
+++ b/dsp/DspChannelChain.cs
@@ -64,7 +64,7 @@ public sealed record DspChannelChain(
                 }
 
                 response *= BiquadResponse.Evaluate(
-                    PeakingBiquad.Compute(band, sampleRateHz),
+                    PeqBiquad.Compute(band, sampleRateHz),
                     frequencyHz,
                     sampleRateHz);
             }

--- a/dsp/EasyEffectsFormat.cs
+++ b/dsp/EasyEffectsFormat.cs
@@ -7,12 +7,20 @@ namespace Resonalyze.Dsp;
 /// other band types are skipped on import. The overall level maps to the
 /// equalizer's output gain.
 /// </summary>
+/// <remarks>
+/// EasyEffects does have "Low Shelf" / "High Shelf" band types, but its bands are
+/// LSP filters whose steepness is set by a mode and a slope multiplier alongside
+/// q — not the RBJ shelf Q this library holds — so writing our number into one
+/// would produce a differently-shaped shelf on the target. Shelves are therefore
+/// declared unsupported and dropped from an export instead.
+/// </remarks>
 public sealed class EasyEffectsFormat : IEqProfileFormat
 {
     public string Name => "EasyEffects";
     public string Extension => "json";
     public bool CanImport => true;
     public bool CanExport => true;
+    public bool SupportsShelvingFilters => false;
 
     public string Export(EqualizationCurve curve)
     {

--- a/dsp/EqAutoTuner.cs
+++ b/dsp/EqAutoTuner.cs
@@ -7,6 +7,12 @@ namespace Resonalyze.Dsp;
 /// greedily where the residual error is largest and stops once the remaining error
 /// is negligible or the band budget is exhausted.
 /// </summary>
+/// <remarks>
+/// Peaking bands only, by design: the fit places bells where the residual is worst,
+/// and a shelf is a decision about the whole top or bottom of the range that a
+/// tuner makes deliberately. Callers replace the whole bank with the result, so a
+/// shelf dialled in by hand does not survive a re-fit.
+/// </remarks>
 public static class EqAutoTuner
 {
     public sealed record Options

--- a/dsp/EqualizationCurve.cs
+++ b/dsp/EqualizationCurve.cs
@@ -1,12 +1,22 @@
 namespace Resonalyze.Dsp;
 
 /// <summary>
-/// One parametric (peaking / bell) EQ band, described the way a PEQ slot exposes
-/// it: a centre frequency, a quality factor and a gain. The magnitude response is
-/// the analog peaking prototype, which is sample-rate independent and therefore
-/// suitable for plotting an EQ curve across the audible range.
+/// One EQ band, described the way a PEQ slot exposes it: a centre frequency, a
+/// quality factor, a gain and the shape those three describe (bell by default,
+/// or a shelf — see <see cref="PeqBandType"/>). The magnitude response is the
+/// analog prototype, which is sample-rate independent and therefore suitable for
+/// plotting an EQ curve across the audible range.
 /// </summary>
-public readonly record struct PeqBand(double FrequencyHz, double Q, double GainDb)
+/// <remarks>
+/// <see cref="Type"/> is the last parameter and defaults to
+/// <see cref="PeqBandType.Peaking"/>, so a three-argument band is still a bell and
+/// a settings or project file written before shelves existed reads back as one.
+/// </remarks>
+public readonly record struct PeqBand(
+    double FrequencyHz,
+    double Q,
+    double GainDb,
+    PeqBandType Type = PeqBandType.Peaking)
 {
     /// <summary>
     /// True for a band that contributes nothing: zero gain or degenerate frequency/Q
@@ -27,13 +37,23 @@ public readonly record struct PeqBand(double FrequencyHz, double Q, double GainD
             return 0;
         }
 
-        // Analog peaking prototype H(j2pi f); evaluating |H|^2 in normalised
-        // frequency x = f / f0 keeps it independent of any sample rate.
-        //   |H|^2 = ((1 - x^2)^2 + (A x / Q)^2) / ((1 - x^2)^2 + (x / (A Q))^2)
-        // with A = 10^(gain / 40). At x = 1 this evaluates to A^4, i.e. exactly the
-        // band gain in dB; far from f0 it tends to unity (0 dB).
         double a = Math.Pow(10.0, GainDb / 40.0);
         double x = frequencyHz / FrequencyHz;
+        return Type switch
+        {
+            PeqBandType.LowShelf => ShelfMagnitudeDb(a, x, low: true),
+            PeqBandType.HighShelf => ShelfMagnitudeDb(a, x, low: false),
+            _ => PeakingMagnitudeDb(a, x)
+        };
+    }
+
+    // Analog peaking prototype H(j2pi f); evaluating |H|^2 in normalised frequency
+    // x = f / f0 keeps it independent of any sample rate.
+    //   |H|^2 = ((1 - x^2)^2 + (A x / Q)^2) / ((1 - x^2)^2 + (x / (A Q))^2)
+    // with A = 10^(gain / 40). At x = 1 this evaluates to A^4, i.e. exactly the
+    // band gain in dB; far from f0 it tends to unity (0 dB).
+    private double PeakingMagnitudeDb(double a, double x)
+    {
         double oneMinusXSquared = 1.0 - x * x;
         double baseline = oneMinusXSquared * oneMinusXSquared;
 
@@ -43,6 +63,30 @@ public readonly record struct PeqBand(double FrequencyHz, double Q, double GainD
         double denominator = baseline + denominatorImag * denominatorImag;
 
         return 10.0 * Math.Log10(numerator / denominator);
+    }
+
+    // The RBJ shelving prototypes the cookbook's biquads are derived from, with
+    // s = jx normalised to f0:
+    //   low  shelf  H(s) = A (s^2 + (sqrt(A)/Q) s + A) / (A s^2 + (sqrt(A)/Q) s + 1)
+    //   high shelf  H(s) = A (A s^2 + (sqrt(A)/Q) s + 1) / (s^2 + (sqrt(A)/Q) s + A)
+    // The two are mirror images: the low shelf reaches the full gain at DC and unity
+    // far above f0, the high shelf the other way round, and both pass through half
+    // the gain in dB exactly at f0 — which is what makes f0 the middle of a shelf
+    // rather than its corner.
+    private double ShelfMagnitudeDb(double a, double x, bool low)
+    {
+        double xSquared = x * x;
+        double transition = Math.Sqrt(a) * x / Q;
+        double transitionSquared = transition * transition;
+
+        double lifted = a - xSquared;
+        double flat = 1.0 - a * xSquared;
+        double numeratorReal = low ? lifted : flat;
+        double denominatorReal = low ? flat : lifted;
+
+        double numerator = numeratorReal * numeratorReal + transitionSquared;
+        double denominator = denominatorReal * denominatorReal + transitionSquared;
+        return 20.0 * Math.Log10(a) + 10.0 * Math.Log10(numerator / denominator);
     }
 }
 

--- a/dsp/GenericCsvFormat.cs
+++ b/dsp/GenericCsvFormat.cs
@@ -7,12 +7,15 @@ namespace Resonalyze.Dsp;
 /// A simple, self-describing CSV layout:
 /// <code>
 /// Preamp (dB),-6.0
-/// Filter,Frequency (Hz),Gain (dB),Q
-/// 1,600,6.0,4.0
+/// Filter,Frequency (Hz),Gain (dB),Q,Type
+/// 1,600,6.0,4.0,PK
+/// 2,80,3.0,0.7,LS
 /// </code>
 /// Import is tolerant: the header row and comments are skipped, the preamp row is
 /// recognised by its label, and each data row is read as frequency/gain/Q from its
-/// numeric fields (a leading index column is ignored).
+/// numeric fields (a leading index column is ignored). The type column is read from
+/// the row's non-numeric fields, so a file written before shelves existed — which
+/// has no such column — still reads, every row as a bell.
 /// </summary>
 public sealed class GenericCsvFormat : IEqProfileFormat
 {
@@ -27,7 +30,7 @@ public sealed class GenericCsvFormat : IEqProfileFormat
 
         var builder = new StringBuilder();
         builder.Append("Preamp (dB),").AppendLine(EqTextNumbers.Format(curve.PreampDb, "0.0"));
-        builder.AppendLine("Filter,Frequency (Hz),Gain (dB),Q");
+        builder.AppendLine("Filter,Frequency (Hz),Gain (dB),Q,Type");
         for (int i = 0; i < curve.Bands.Count; i++)
         {
             PeqBand band = curve.Bands[i];
@@ -38,7 +41,9 @@ public sealed class GenericCsvFormat : IEqProfileFormat
                 .Append(',')
                 .Append(EqTextNumbers.Format(band.GainDb, "0.0"))
                 .Append(',')
-                .AppendLine(EqTextNumbers.Format(band.Q, "0.0"));
+                .Append(EqTextNumbers.Format(band.Q, "0.0"))
+                .Append(',')
+                .AppendLine(TypeToken(band.Type));
         }
 
         return builder.ToString();
@@ -121,11 +126,40 @@ public sealed class GenericCsvFormat : IEqProfileFormat
                 continue;
             }
 
-            bands.Add(new PeqBand(frequencyHz, q, gainDb));
+            bands.Add(new PeqBand(frequencyHz, q, gainDb, ReadType(fields)));
             recognized = true;
         }
 
         curve = new EqualizationCurve(bands, preampDb);
         return recognized;
+    }
+
+    private static string TypeToken(PeqBandType type) => type switch
+    {
+        PeqBandType.LowShelf => "LS",
+        PeqBandType.HighShelf => "HS",
+        _ => "PK"
+    };
+
+    // The type is looked up by keyword rather than by column index, so it survives
+    // the leading-index column being present or absent — the same tolerance the
+    // numeric fields already get. An unreadable or missing type is a bell.
+    private static PeqBandType ReadType(string[] fields)
+    {
+        foreach (string field in fields)
+        {
+            string token = field.Trim();
+            if (token.Equals("LS", StringComparison.OrdinalIgnoreCase))
+            {
+                return PeqBandType.LowShelf;
+            }
+
+            if (token.Equals("HS", StringComparison.OrdinalIgnoreCase))
+            {
+                return PeqBandType.HighShelf;
+            }
+        }
+
+        return PeqBandType.Peaking;
     }
 }

--- a/dsp/IEqProfileFormat.cs
+++ b/dsp/IEqProfileFormat.cs
@@ -17,6 +17,19 @@ public interface IEqProfileFormat
     bool CanImport { get; }
     bool CanExport { get; }
 
+    /// <summary>
+    /// Whether the format can carry a shelving band (<see cref="PeqBandType"/>) as
+    /// a shelf. False means the layout has no shelf of the same parameterisation,
+    /// so shelves must be dropped from an export rather than written as something
+    /// the target would realize differently — the caller is expected to say so.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to true: the formats that carry coefficients or a sampled curve
+    /// realize any band shape by construction, and the parametric ones that name a
+    /// shelf with a Q realize ours exactly.
+    /// </remarks>
+    bool SupportsShelvingFilters => true;
+
     /// <summary>Serialises the curve. Only valid when <see cref="CanExport"/>.</summary>
     string Export(EqualizationCurve curve);
 

--- a/dsp/MiniDspFormat.cs
+++ b/dsp/MiniDspFormat.cs
@@ -50,7 +50,7 @@ public sealed class MiniDspFormat : IEqProfileFormat
 
         foreach (PeqBand band in curve.Bands)
         {
-            AppendBiquad(builder, index++, PeakingBiquad.Compute(band, sampleRateHz));
+            AppendBiquad(builder, index++, PeqBiquad.Compute(band, sampleRateHz));
         }
 
         return builder.ToString();

--- a/dsp/PeqBandType.cs
+++ b/dsp/PeqBandType.cs
@@ -25,3 +25,20 @@ public enum PeqBandType
     /// <summary>High shelf: everything above the band is lifted or lowered.</summary>
     HighShelf
 }
+
+/// <summary>Shape questions asked of a <see cref="PeqBandType"/>.</summary>
+public static class PeqBandTypes
+{
+    /// <summary>
+    /// True only for the two shelves. Everything else — the bell, and a value no
+    /// member matches — is a bell, which is what the realization, the header and
+    /// every profile writer already fall back to.
+    /// </summary>
+    /// <remarks>
+    /// Asked through this rather than by testing <c>!= Peaking</c>, so a settings
+    /// file carrying an out-of-range number cannot be a bell to the filter and a
+    /// shelf to the tuning sheet at the same time.
+    /// </remarks>
+    public static bool IsShelving(this PeqBandType type) =>
+        type is PeqBandType.LowShelf or PeqBandType.HighShelf;
+}

--- a/dsp/PeqBandType.cs
+++ b/dsp/PeqBandType.cs
@@ -1,0 +1,27 @@
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// The shape of a filter slot: a bell, or one of the two shelves. All three take
+/// the same three numbers — centre frequency, Q and gain — but read two of them
+/// differently, which is the whole reason the type has to travel with the band.
+/// </summary>
+/// <remarks>
+/// For both shelves the RBJ cookbook puts <see cref="PeqBand.FrequencyHz"/> at the
+/// MIDDLE of the transition, where the response has reached half the shelf gain in
+/// dB, and <see cref="PeqBand.Q"/> controls the knee rather than a bandwidth:
+/// 1/sqrt(2) ~ 0.707 is the steepest shelf that stays monotonic, and anything
+/// above it overshoots before settling. A shelf therefore has no "bandwidth", and
+/// the Q conventions of <see cref="PeqQConvention"/> — which restate a bell's
+/// bandwidth — do not apply to one.
+/// </remarks>
+public enum PeqBandType
+{
+    /// <summary>Peaking / bell, the default: a boost or cut centred on the band.</summary>
+    Peaking,
+
+    /// <summary>Low shelf: everything below the band is lifted or lowered.</summary>
+    LowShelf,
+
+    /// <summary>High shelf: everything above the band is lifted or lowered.</summary>
+    HighShelf
+}

--- a/dsp/PeqBiquad.cs
+++ b/dsp/PeqBiquad.cs
@@ -1,0 +1,20 @@
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// The one place a <see cref="PeqBand"/> becomes coefficients, whatever its
+/// <see cref="PeqBandType"/>. Everything that realizes a band — the response
+/// preview, the Virtual DSP chain and the coefficient exports — goes through here,
+/// so a new band shape is added in one place instead of three.
+/// </summary>
+public static class PeqBiquad
+{
+    /// <remarks>
+    /// A band whose type is neither of the shelves is realized as a bell, which
+    /// includes a value no enum member matches: a hand-edited project or settings
+    /// file must degrade to the default shape, not throw out of the audio path.
+    /// </remarks>
+    public static BiquadCoefficients Compute(PeqBand band, double sampleRateHz) =>
+        band.Type is PeqBandType.LowShelf or PeqBandType.HighShelf
+            ? ShelvingBiquad.Compute(band, sampleRateHz)
+            : PeakingBiquad.Compute(band, sampleRateHz);
+}

--- a/dsp/PeqBiquad.cs
+++ b/dsp/PeqBiquad.cs
@@ -14,7 +14,7 @@ public static class PeqBiquad
     /// file must degrade to the default shape, not throw out of the audio path.
     /// </remarks>
     public static BiquadCoefficients Compute(PeqBand band, double sampleRateHz) =>
-        band.Type is PeqBandType.LowShelf or PeqBandType.HighShelf
+        band.Type.IsShelving()
             ? ShelvingBiquad.Compute(band, sampleRateHz)
             : PeakingBiquad.Compute(band, sampleRateHz);
 }

--- a/dsp/PeqQConvention.cs
+++ b/dsp/PeqQConvention.cs
@@ -114,7 +114,7 @@ public static class PeqQConventions
     // where the designed one does not, so a shelf's Q goes to the sheet as it is.
     private static double Scale(PeqBand band, PeqQConvention convention)
     {
-        if (band.IsTransparent || band.Type != PeqBandType.Peaking)
+        if (band.IsTransparent || band.Type.IsShelving())
         {
             return 1.0;
         }

--- a/dsp/PeqQConvention.cs
+++ b/dsp/PeqQConvention.cs
@@ -107,9 +107,14 @@ public static class PeqQConventions
     // Transparent bands carry no gain and no meaningful Q, so they are left exactly as
     // they are rather than pushed through a scale that would still round-trip their
     // placeholder Q.
+    //
+    // Shelves are left alone for a stronger reason: the conventions restate a
+    // BANDWIDTH between half-gain points, and a shelf has none — its Q sets the knee
+    // (see PeqBandType). Scaling it by the gain would print a shelf that overshoots
+    // where the designed one does not, so a shelf's Q goes to the sheet as it is.
     private static double Scale(PeqBand band, PeqQConvention convention)
     {
-        if (band.IsTransparent)
+        if (band.IsTransparent || band.Type != PeqBandType.Peaking)
         {
             return 1.0;
         }

--- a/dsp/PeqTextFile.cs
+++ b/dsp/PeqTextFile.cs
@@ -12,10 +12,21 @@ namespace Resonalyze.Dsp;
 /// </code>
 /// The building blocks (preamp line, filter lines, filter-line parsing) are shared
 /// with the REW format. Parsing is defensive: blank lines, comments, disabled
-/// filters (OFF), unsupported types (only peaking "PK") and malformed lines are
-/// skipped; numbers accept '.' or ',' decimals and the band count is capped, so a
-/// hand-edited or foreign file never throws.
+/// filters (OFF), unsupported types and malformed lines are skipped; numbers accept
+/// '.' or ',' decimals and the band count is capped, so a hand-edited or foreign
+/// file never throws.
 /// </summary>
+/// <remarks>
+/// Three of Equalizer APO's types map onto a <see cref="PeqBand"/>: <c>PK</c>, and
+/// the shelves <c>LSC</c>/<c>HSC</c> written with a Q — which is the same
+/// centre-frequency, half-gain-at-Fc shelf the library realizes. Plain <c>LS</c>
+/// and <c>HS</c> carry no Q and are read at the default shelf Q.
+///
+/// The <c>LS 6dB</c> / <c>LS 12dB</c> family (and its high-shelf twin) is NOT read:
+/// those state a CORNER frequency instead of the middle of the transition, so
+/// taking their Fc as ours would move the shelf. They are skipped like any other
+/// unsupported type rather than imported to the wrong place.
+/// </remarks>
 public static class PeqTextFile
 {
     public static string Format(EqualizationCurve curve)
@@ -33,7 +44,7 @@ public static class PeqTextFile
     internal static string FormatPreampLine(double preampDb) =>
         $"Preamp: {EqTextNumbers.Format(preampDb, "0.0")} dB";
 
-    // The block of "Filter N: ON PK Fc ... Gain ... dB Q ..." lines (no preamp).
+    // The block of "Filter N: ON <type> Fc ... Gain ... dB Q ..." lines (no preamp).
     internal static string FormatFilters(EqualizationCurve curve)
     {
         var builder = new StringBuilder();
@@ -43,7 +54,9 @@ public static class PeqTextFile
             builder
                 .Append("Filter ")
                 .Append((i + 1).ToString(System.Globalization.CultureInfo.InvariantCulture))
-                .Append(": ON PK Fc ")
+                .Append(": ON ")
+                .Append(TypeToken(band.Type))
+                .Append(" Fc ")
                 .Append(EqTextNumbers.Format(band.FrequencyHz, "0.###"))
                 .Append(" Hz Gain ")
                 .Append(EqTextNumbers.Format(band.GainDb, "0.0"))
@@ -54,6 +67,15 @@ public static class PeqTextFile
 
         return builder.ToString();
     }
+
+    // The shelves are written as LSC/HSC — the variant that carries a Q — rather
+    // than as plain LS/HS, whose slope the reader would have to assume.
+    private static string TypeToken(PeqBandType type) => type switch
+    {
+        PeqBandType.LowShelf => "LSC",
+        PeqBandType.HighShelf => "HSC",
+        _ => "PK"
+    };
 
     public static EqualizationCurve Parse(string text) =>
         TryParse(text, out EqualizationCurve curve)
@@ -119,22 +141,33 @@ public static class PeqTextFile
         return recognized;
     }
 
-    // Reads a "Filter N: ON PK Fc F Hz Gain G dB Q Q" line. Disabled (OFF) and
-    // non-peaking filters are ignored, as are lines missing any of Fc/Gain/Q.
+    // Reads a "Filter N: ON <type> Fc F Hz Gain G dB Q Q" line. Disabled (OFF) and
+    // unsupported types are ignored, as are lines missing Fc or Gain. Q may be
+    // absent only on a plain LS/HS, which states no slope of its own.
     private static bool TryParseFilter(string[] tokens, out PeqBand band)
     {
         band = default;
 
-        if (HasToken(tokens, "OFF") || !HasToken(tokens, "PK"))
+        if (HasToken(tokens, "OFF") || !TryReadType(tokens, out PeqBandType type))
         {
             return false;
         }
 
         if (!EqTextNumbers.TryParse(TokenAfter(tokens, "Fc"), out double frequencyHz) ||
-            !EqTextNumbers.TryParse(TokenAfter(tokens, "Gain"), out double gainDb) ||
-            !EqTextNumbers.TryParse(TokenAfter(tokens, "Q"), out double q))
+            !EqTextNumbers.TryParse(TokenAfter(tokens, "Gain"), out double gainDb))
         {
             return false;
+        }
+
+        // A bell without a Q is malformed; a shelf without one is the LS/HS spelling.
+        if (!EqTextNumbers.TryParse(TokenAfter(tokens, "Q"), out double q))
+        {
+            if (type == PeqBandType.Peaking)
+            {
+                return false;
+            }
+
+            q = DefaultShelfQ;
         }
 
         if (!double.IsFinite(frequencyHz) || frequencyHz <= 0 ||
@@ -144,9 +177,58 @@ public static class PeqTextFile
             return false;
         }
 
-        band = new PeqBand(frequencyHz, q, gainDb);
+        band = new PeqBand(frequencyHz, q, gainDb, type);
         return true;
     }
+
+    /// <summary>
+    /// The Q a shelf written without one is read at: the steepest knee that still
+    /// rises monotonically, which is what a filter stating no slope means.
+    /// </summary>
+    internal const double DefaultShelfQ = 0.7071067811865476;
+
+    // Recognises the filter type. A shelf keyword followed by a number states its
+    // steepness in another parameterisation — the corner-frequency "LS 6dB" family,
+    // or "LSC 10.8 dB" in dB per octave — where Fc is not the middle of the
+    // transition and the slope is not our Q. Those are skipped rather than read
+    // into a shelf that would sit somewhere else.
+    private static bool TryReadType(string[] tokens, out PeqBandType type)
+    {
+        type = PeqBandType.Peaking;
+        for (int index = 0; index < tokens.Length; index++)
+        {
+            string token = tokens[index];
+            bool low = token.Equals("LS", StringComparison.OrdinalIgnoreCase) ||
+                token.Equals("LSC", StringComparison.OrdinalIgnoreCase);
+            bool high = token.Equals("HS", StringComparison.OrdinalIgnoreCase) ||
+                token.Equals("HSC", StringComparison.OrdinalIgnoreCase);
+            if (token.Equals("PK", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (!low && !high)
+            {
+                continue;
+            }
+
+            if (index + 1 < tokens.Length && StatesItsOwnSlope(tokens[index + 1]))
+            {
+                return false;
+            }
+
+            type = low ? PeqBandType.LowShelf : PeqBandType.HighShelf;
+            return true;
+        }
+
+        return false;
+    }
+
+    // "6dB", "12dB" or a bare number ahead of the "dB" of a dB/octave slope.
+    private static bool StatesItsOwnSlope(string token) =>
+        EqTextNumbers.TryParse(token, out _) ||
+        (token.EndsWith("dB", StringComparison.OrdinalIgnoreCase) &&
+            EqTextNumbers.TryParse(token[..^2], out _));
 
     private static string? TokenAfter(string[] tokens, string keyword)
     {

--- a/dsp/PeqTextFile.cs
+++ b/dsp/PeqTextFile.cs
@@ -68,9 +68,13 @@ public static class PeqTextFile
         return builder.ToString();
     }
 
-    // The shelves are written as LSC/HSC — the variant that carries a Q — rather
-    // than as plain LS/HS, whose slope the reader would have to assume.
-    private static string TypeToken(PeqBandType type) => type switch
+    /// <summary>
+    /// The Equalizer APO keyword for a band shape. The shelves are written as
+    /// LSC/HSC — the variant that carries a Q — rather than as plain LS/HS, whose
+    /// slope the reader would have to assume. Shared with the Virtual DSP text
+    /// sheet, which prints the same filter lines for a human to type in.
+    /// </summary>
+    public static string TypeToken(PeqBandType type) => type switch
     {
         PeqBandType.LowShelf => "LSC",
         PeqBandType.HighShelf => "HSC",

--- a/dsp/PreparedDspResponse.cs
+++ b/dsp/PreparedDspResponse.cs
@@ -65,7 +65,7 @@ public sealed class PreparedDspResponse
                     continue;
                 }
 
-                sections.Add(PeakingBiquad.Compute(band, sampleRate));
+                sections.Add(PeqBiquad.Compute(band, sampleRate));
             }
         }
 

--- a/dsp/RewFilterFormat.cs
+++ b/dsp/RewFilterFormat.cs
@@ -4,8 +4,9 @@ namespace Resonalyze.Dsp;
 
 /// <summary>
 /// REW "Filter Settings" text. The filter lines are identical to Equalizer APO
-/// (Filter N: ON PK Fc ... Gain ... dB Q ...), so parsing is shared; export adds
-/// REW's header and a preamp line so the value round-trips.
+/// (Filter N: ON PK Fc ... Gain ... dB Q ..., and LSC/HSC for the shelves), so
+/// parsing is shared; export adds REW's header and a preamp line so the value
+/// round-trips.
 /// </summary>
 public sealed class RewFilterFormat : IEqProfileFormat
 {

--- a/dsp/ShelvingBiquad.cs
+++ b/dsp/ShelvingBiquad.cs
@@ -1,0 +1,85 @@
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// RBJ cookbook low/high shelving biquads, in the same normalised, feedback-negated
+/// form as <see cref="PeakingBiquad"/> so the two are interchangeable everywhere a
+/// band is realized.
+/// </summary>
+/// <remarks>
+/// Parameterised by Q rather than by the cookbook's shelf slope S — the two are one
+/// substitution (<c>1/Q = sqrt((A + 1/A)(1/S - 1) + 2)</c>), and Q is what the
+/// devices this application exports to read: Equalizer APO's LSC/HSC, REW's shelf
+/// filters and CamillaDSP's Lowshelf/Highshelf all take a shelf Q. Q = 1/sqrt(2)
+/// is the steepest shelf that still rises monotonically; above that the response
+/// overshoots the shelf before settling on it.
+/// </remarks>
+public static class ShelvingBiquad
+{
+    /// <summary>
+    /// Coefficients for a shelving band at the given sample rate. The band's
+    /// <see cref="PeqBand.Type"/> selects the direction; a peaking band is not a
+    /// shelf and is rejected rather than silently shelved.
+    /// </summary>
+    public static BiquadCoefficients Compute(PeqBand band, double sampleRateHz)
+    {
+        if (sampleRateHz <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRateHz));
+        }
+
+        bool low = band.Type switch
+        {
+            PeqBandType.LowShelf => true,
+            PeqBandType.HighShelf => false,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(band),
+                band.Type,
+                "A shelving biquad needs a low- or high-shelf band.")
+        };
+
+        double a = Math.Pow(10.0, band.GainDb / 40.0);
+        double w0 = 2.0 * Math.PI * band.FrequencyHz / sampleRateHz;
+        double cos = Math.Cos(w0);
+        double alpha = Math.Sin(w0) / (2.0 * band.Q);
+
+        double aPlus = a + 1.0;
+        double aMinus = a - 1.0;
+        // The one term that carries the shelf's knee; everything else is symmetric
+        // between the two directions and only the sign of the cosine terms flips.
+        double knee = 2.0 * Math.Sqrt(a) * alpha;
+
+        double b0;
+        double b1;
+        double b2;
+        double a0;
+        double a1;
+        double a2;
+        if (low)
+        {
+            b0 = a * (aPlus - aMinus * cos + knee);
+            b1 = 2.0 * a * (aMinus - aPlus * cos);
+            b2 = a * (aPlus - aMinus * cos - knee);
+            a0 = aPlus + aMinus * cos + knee;
+            a1 = -2.0 * (aMinus + aPlus * cos);
+            a2 = aPlus + aMinus * cos - knee;
+        }
+        else
+        {
+            b0 = a * (aPlus + aMinus * cos + knee);
+            b1 = -2.0 * a * (aMinus + aPlus * cos);
+            b2 = a * (aPlus + aMinus * cos - knee);
+            a0 = aPlus - aMinus * cos + knee;
+            a1 = 2.0 * (aMinus - aPlus * cos);
+            a2 = aPlus - aMinus * cos - knee;
+        }
+
+        // Normalised to a0 = 1, with a1/a2 negated for the additive feedback form
+        // the exports use — the same convention as PeakingBiquad.
+        return new BiquadCoefficients(
+            b0 / a0,
+            b1 / a0,
+            b2 / a0,
+            -(a1 / a0),
+            -(a2 / a0));
+    }
+}

--- a/source/Settings/MeasurementSettingsFile.Schema.cs
+++ b/source/Settings/MeasurementSettingsFile.Schema.cs
@@ -359,10 +359,24 @@ internal sealed partial class MeasurementSettingsFile
             double.IsFinite(value) ? Math.Clamp(value, min, max) : 0.0;
     }
 
+    // One PEQ filter of the persisted bank. Deliberately its own three numbers
+    // rather than a Dsp PeqBand: a settings file is a format with defaults and
+    // tolerance for missing fields, and PeqBand is the analysis type.
+    internal sealed class PeqBandSettings
+    {
+        public double FrequencyHz { get; set; } = 1000;
+        public double Q { get; set; } = 1;
+        public double GainDb { get; set; }
+
+        // Absent in a file written before shelves existed, which read back as the
+        // bells they were.
+        public PeqBandType Type { get; set; } = PeqBandType.Peaking;
+    }
+
     // Self-contained EQ Wizard state (the mode no longer derives anything from
-    // overlays or the current measurement): the isolated target curve, the gain
-    // range and band count of the fader bank, source smoothing and the microphone
-    // calibration applied to the loaded IR. The loaded IR itself is not persisted.
+    // overlays or the current measurement): the isolated target curve, the filter
+    // bank and its gain range, source smoothing and the microphone calibration
+    // applied to the loaded IR. The loaded IR itself is not persisted.
     internal sealed class EqWizardSettings
     {
         public TargetPreset Preset { get; set; } = TargetPreset.Flat;
@@ -385,7 +399,22 @@ internal sealed partial class MeasurementSettingsFile
         public double TargetOffsetDb { get; set; }
         public double GainMinDb { get; set; } = -15;
         public double GainMaxDb { get; set; } = 6;
-        public int BandCount { get; set; } = 1;
+        // The filter bank in slot order. The order is not decoration — it is what
+        // an exported profile numbers its filters by — so it is stored as written
+        // rather than re-derived on load. An empty list is a real state (a bank
+        // the user cleared) and restores as one.
+        //
+        // Null only in a file written before the bank was persisted (schema 9 and
+        // earlier). Such a file carries BandCount alone, and the bank is rebuilt
+        // as that many ISO-spread filters — exactly what those versions showed.
+        public List<PeqBandSettings>? Bands { get; set; }
+
+        // The EQ preamp, part of the bank rather than of the target.
+        public double PreampDb { get; set; }
+
+        // How many filters the bank holds. Kept in step with Bands and read only
+        // when Bands is absent (see above).
+        public int BandCount { get; set; }
         public int SourceSmoothingInverseOctaves { get; set; }
         public MicrophoneCalibrationMode CalibrationMode { get; set; } =
             MicrophoneCalibrationMode.Off;

--- a/source/Settings/MeasurementSettingsFile.cs
+++ b/source/Settings/MeasurementSettingsFile.cs
@@ -7,7 +7,7 @@ namespace Resonalyze;
 
 internal sealed partial class MeasurementSettingsFile
 {
-    private const int CurrentSchemaVersion = 9;
+    private const int CurrentSchemaVersion = 10;
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
         WriteIndented = true,
@@ -85,6 +85,9 @@ internal sealed partial class MeasurementSettingsFile
                     PhaseAnalysisSettings.DefaultFdwCycles;
             }
 
+            // Version 10 persists the EQ Wizard's filter bank; 7..9 files carry
+            // only its filter count and rebuild a default spread from it.
+            //
             // Version 9 added the SPL calibration; 7 and 8 files simply carry none.
             // A structurally broken anchor drops to null rather than failing the
             // whole settings load — the measurement configuration is the value here.

--- a/source/Shell/Form1.ModeSettings.cs
+++ b/source/Shell/Form1.ModeSettings.cs
@@ -94,6 +94,11 @@ public partial class Form1
 
     private void FlushMeasurementSettings()
     {
+        // The EQ Wizard turns band edits into a settings change only once the bank
+        // goes quiet, so it is asked to land anything still in flight BEFORE the
+        // saver runs. Without this, closing the window within that pause writes the
+        // state from before the last edit and the tune silently rolls back.
+        eqWizardPanel.CommitPendingBankEdit();
         measurementSettingsSaver.Flush();
     }
 

--- a/source/Tools/Eq/EqWizardImportExportCoordinator.cs
+++ b/source/Tools/Eq/EqWizardImportExportCoordinator.cs
@@ -153,7 +153,7 @@ internal sealed class EqWizardImportExportCoordinator
 
         return target.SupportsShelvingFilters
             ? 0
-            : curve.Bands.Count(band => band.Type != PeqBandType.Peaking);
+            : curve.Bands.Count(band => band.Type.IsShelving());
     }
 
     internal static EqualizationCurve WithoutShelvingBands(EqualizationCurve curve)
@@ -161,7 +161,7 @@ internal sealed class EqWizardImportExportCoordinator
         ArgumentNullException.ThrowIfNull(curve);
 
         return new EqualizationCurve(
-            curve.Bands.Where(band => band.Type == PeqBandType.Peaking),
+            curve.Bands.Where(band => !band.Type.IsShelving()),
             curve.PreampDb);
     }
 

--- a/source/Tools/Eq/EqWizardImportExportCoordinator.cs
+++ b/source/Tools/Eq/EqWizardImportExportCoordinator.cs
@@ -122,7 +122,14 @@ internal sealed class EqWizardImportExportCoordinator
                 IEqProfileFormat effectiveFormat = format is GraphicEqFormat
                     ? new GraphicEqFormat(request.SampleRate)
                     : format;
-                writeAllText(request.Path, effectiveFormat.Export(request.Curve));
+                // Dropping the shelves here as well as in the UI is deliberate: the
+                // warning is the user's decision, this is the guarantee. A format
+                // that cannot state our shelf must never receive one written as
+                // something its reader would realize differently.
+                EqualizationCurve curve = request.Target.SupportsShelvingFilters
+                    ? request.Curve
+                    : WithoutShelvingBands(request.Curve);
+                writeAllText(request.Path, effectiveFormat.Export(curve));
             }
             return EqWizardFileResult.Succeeded();
         }
@@ -130,6 +137,32 @@ internal sealed class EqWizardImportExportCoordinator
         {
             return EqWizardFileResult.Failed(exception);
         }
+    }
+
+    /// <summary>
+    /// How many shelving filters an export to <paramref name="target"/> would have
+    /// to leave out. Zero when the format carries them, or when there are none —
+    /// the panel asks only when the answer is going to cost the user something.
+    /// </summary>
+    internal static int CountShelvingBandsDroppedBy(
+        EqWizardExportTarget target,
+        EqualizationCurve curve)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(curve);
+
+        return target.SupportsShelvingFilters
+            ? 0
+            : curve.Bands.Count(band => band.Type != PeqBandType.Peaking);
+    }
+
+    internal static EqualizationCurve WithoutShelvingBands(EqualizationCurve curve)
+    {
+        ArgumentNullException.ThrowIfNull(curve);
+
+        return new EqualizationCurve(
+            curve.Bands.Where(band => band.Type == PeqBandType.Peaking),
+            curve.PreampDb);
     }
 
     private static string BuildFilter<TTarget>(IReadOnlyList<TTarget> targets)
@@ -196,6 +229,9 @@ internal sealed class EqWizardExportTarget : IEqWizardFileTarget
     public string Name { get; }
     public string Extension { get; }
     public bool IsTuningSheet => Format == null;
+
+    // The tuning sheet prints shelves in a table of their own, so it carries them.
+    internal bool SupportsShelvingFilters => Format?.SupportsShelvingFilters ?? true;
 
     internal static EqWizardExportTarget TuningSheet() =>
         new(null, "Tuning sheet (PDF)", "pdf");

--- a/source/Tools/Eq/EqWizardPanel.Bank.cs
+++ b/source/Tools/Eq/EqWizardPanel.Bank.cs
@@ -540,6 +540,13 @@ public partial class EqWizardPanel
         RaiseSettingsChanged();
     }
 
+    /// <summary>
+    /// Lands an edit that is still inside the coalescing pause, so a caller about
+    /// to persist the panel's settings reads the bank the user can see rather than
+    /// the one from before their last keystroke.
+    /// </summary>
+    internal void CommitPendingBankEdit() => CommitBankChange();
+
     // Adopts the current bank as the baseline with no history behind it — the
     // starting point after settings are restored, which is not an edit anyone
     // should be able to undo into.
@@ -572,7 +579,12 @@ public partial class EqWizardPanel
     private void ApplyHistoryState(PeqBankState state)
     {
         SetBank(state);
-        committedBankState = state;
+        // What the strips ended up holding, not what was asked for. A gain range
+        // narrowed since the step was recorded clamps the restored values, and
+        // adopting the unclamped state as the baseline would make the very next
+        // commit see a change nobody made — recording a phantom step and throwing
+        // the redo trail away with it.
+        committedBankState = CaptureBankState();
         UpdateUndoRedoButtons();
     }
 
@@ -769,7 +781,15 @@ public partial class EqWizardPanel
         IEnumerable<PeqBand> bands = settings.Bands != null
             ? settings.Bands
                 .Take(MaxPeqSlotCount)
-                .Select(band => new PeqBand(band.FrequencyHz, band.Q, band.GainDb, band.Type))
+                .Select(band => new PeqBand(
+                    band.FrequencyHz,
+                    band.Q,
+                    band.GainDb,
+                    // The enum converter accepts a number no member matches, and a
+                    // shape nothing recognises must become a bell HERE — the one
+                    // place it enters the app — rather than at each of the places
+                    // that later ask what it is.
+                    Enum.IsDefined(band.Type) ? band.Type : PeqBandType.Peaking))
             : Enumerable
                 .Range(0, Math.Clamp(settings.BandCount, 0, MaxPeqSlotCount))
                 .Select(index => new PeqBand(DefaultBandFrequencyHz(index), DefaultBandQ, 0));

--- a/source/Tools/Eq/EqWizardPanel.Bank.cs
+++ b/source/Tools/Eq/EqWizardPanel.Bank.cs
@@ -1,0 +1,795 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+// The filter-bank half of the EQ Wizard: the PEQ strips, the grid they live in,
+// the drag-and-drop that reorders and removes them, and the undo history over
+// the whole bank.
+//
+// The bank starts empty and grows by the "+" tile. A strip's index in
+// `peqSlots` IS its filter number, its cell in the grid and its position in an
+// exported profile, so every structural change ends in LayoutSlots(), and the
+// order is part of the undo state rather than a display detail.
+public partial class EqWizardPanel
+{
+    // A bell added by the "+" tile: mid-band and narrow. A new filter starts as
+    // a deliberate, tight correction the user then drags into place, not as a
+    // wide bell that colours half the spectrum on the first nudge.
+    private const double AddedBandFrequencyHz = 1000;
+    private const double AddedBandQ = 5;
+
+    // A new shelf starts at the corner the target curve's own shelves default to,
+    // with the steepest knee that stays monotonic — the neutral shelf, before the
+    // user decides it should overshoot.
+    private const double AddedLowShelfFrequencyHz = 100;
+    private const double AddedHighShelfFrequencyHz = 5000;
+    private const double AddedShelfQ = 0.7;
+
+    // How long the bank must sit still before a burst of field or fader edits is
+    // recorded as one undo step. The timer restarts on every change, so a whole
+    // fader drag — however long — collapses into a single step.
+    private const int BankEditIdleMilliseconds = 600;
+
+    private readonly List<PeqSlotControl> peqSlots = new();
+    private readonly PeqBankHistory bankHistory = new();
+    private readonly System.Windows.Forms.Timer bankEditTimer = new()
+    {
+        Interval = BankEditIdleMilliseconds
+    };
+
+    private TableLayoutPanel peqSlotTable = null!;
+    private PeqAddSlotControl addSlotTile = null!;
+    // Rebuilt on every open (the checkmarks follow the strip it was opened on), so
+    // the last one is not owned by the designer container — see Dispose.
+    private ContextMenuStrip? bandTypeMenu;
+    private PeqBankState committedBankState = PeqBankState.Empty;
+    private PeqSlotControl? selectedSlot;
+    private PeqSlotControl? draggedSlot;
+    private int draggedSlotOrigin;
+    private bool draggedSlotDropped;
+    private bool draggedSlotCancelled;
+    private bool restoringBank;
+    private bool suppressBandCountSync;
+
+    // ISO 266 preferred 1/3-octave centre frequencies, the ones a 31/32-band
+    // graphic EQ is built on. 32 values (16 Hz .. 20 kHz) match the maximum bank
+    // exactly: the standard 31-band 20 Hz..20 kHz set plus 16 Hz below it. They
+    // are the starting spread when a whole bank is created at once; a single
+    // band added by hand starts at AddedBandFrequencyHz instead.
+    private static readonly double[] IsoThirdOctaveCentersHz =
+    {
+        16, 20, 25, 31.5, 40, 50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500,
+        630, 800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
+        10000, 12500, 16000, 20000
+    };
+
+    // The neutral Q a whole-bank spread starts on.
+    private const double DefaultBandQ = 1.0;
+
+    private static double DefaultBandFrequencyHz(int index) =>
+        IsoThirdOctaveCentersHz[
+            Math.Clamp(index, 0, IsoThirdOctaveCentersHz.Length - 1)];
+
+    private void InitializePeqSlotTable()
+    {
+        peqSlotTable = new DoubleBufferedTableLayoutPanel
+        {
+            BackColor = panelPEQ.BackColor,
+            ColumnCount = PeqColumnCount,
+            Dock = DockStyle.Fill,
+            Margin = Padding.Empty,
+            Padding = new Padding(2),
+            RowCount = PeqRowCount
+        };
+
+        for (int column = 0; column < PeqColumnCount; column++)
+        {
+            peqSlotTable.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f / PeqColumnCount));
+        }
+        for (int row = 0; row < PeqRowCount; row++)
+        {
+            peqSlotTable.RowStyles.Add(new RowStyle(SizeType.Percent, 100f / PeqRowCount));
+        }
+
+        peqSlotTable.Click += (_, _) => DeselectBand();
+        peqSlotTable.AllowDrop = true;
+        peqSlotTable.DragEnter += SlotDragOver;
+        peqSlotTable.DragOver += SlotDragOver;
+        peqSlotTable.DragDrop += SlotDragDrop;
+
+        addSlotTile = new PeqAddSlotControl
+        {
+            Dock = DockStyle.Fill,
+            Margin = new Padding(1),
+            AllowDrop = true
+        };
+        addSlotTile.AddRequested += (_, args) => AddBand(args.Type);
+        addSlotTile.DragEnter += SlotDragOver;
+        addSlotTile.DragOver += SlotDragOver;
+        addSlotTile.DragDrop += SlotDragDrop;
+        SetTip(addSlotTile,
+            "Add a filter: PK a peaking bell, HS a high shelf, LS a low shelf. Drag " +
+            "a filter by its number to reorder it, or out of the bank to remove it; " +
+            "right-click the number to change its type. Ctrl+Z undoes any of it.");
+
+        panelPEQ.Controls.Add(peqSlotTable);
+        bankEditTimer.Tick += (_, _) => CommitBankChange();
+        LayoutSlots();
+    }
+
+    // The EQ Filters selector creates or trims a whole bank at once: picking N
+    // brings the bank to N filters, appending them spread over the ISO centres
+    // or dropping the trailing ones. It stays in step with what the "+" tile and
+    // drag-removal do, so it always reads as the current filter count.
+    private void InitializeBandsComboBox()
+    {
+        darkComboBoxBands.Items.Clear();
+        for (int count = 0; count <= MaxPeqSlotCount; count++)
+        {
+            darkComboBoxBands.Items.Add(count);
+        }
+
+        darkComboBoxBands.SelectedIndexChanged += DarkComboBoxBandsSelectedIndexChanged;
+        SyncBandCountCombo();
+    }
+
+    private void DarkComboBoxBandsSelectedIndexChanged(object? sender, EventArgs e)
+    {
+        if (suppressBandCountSync)
+        {
+            return;
+        }
+
+        SetBandCount(darkComboBoxBands.SelectedItem is int count ? count : 0);
+    }
+
+    private void SyncBandCountCombo()
+    {
+        suppressBandCountSync = true;
+        try
+        {
+            // Items are 0..MaxPeqSlotCount in order, so the index IS the count.
+            darkComboBoxBands.SelectedIndex = peqSlots.Count;
+        }
+        finally
+        {
+            suppressBandCountSync = false;
+        }
+    }
+
+    // Brings the bank to a given number of filters, keeping the ones already
+    // there. Appended filters take the ISO centre of the position they land on.
+    private void SetBandCount(int count)
+    {
+        count = Math.Clamp(count, 0, MaxPeqSlotCount);
+        if (count == peqSlots.Count)
+        {
+            return;
+        }
+
+        CommitBankChange();
+        suppressRedraw = true;
+        try
+        {
+            while (peqSlots.Count > count)
+            {
+                RemoveSlot(peqSlots[^1]);
+            }
+
+            while (peqSlots.Count < count)
+            {
+                InsertSlot(
+                    peqSlots.Count,
+                    new PeqBand(DefaultBandFrequencyHz(peqSlots.Count), DefaultBandQ, 0));
+            }
+
+            LayoutSlots();
+        }
+        finally
+        {
+            suppressRedraw = false;
+        }
+
+        SyncBandCountCombo();
+        RaiseSettingsChanged();
+        DrawSelectedCurves();
+        CommitBankChange();
+    }
+
+    // The three shapes as the right-click menu offers them. The add tile names them
+    // with its own short tokens (PK/HS/LS); a menu has room for the full words.
+    private static readonly (PeqBandType Type, string Label)[] BandTypeChoices =
+    {
+        (PeqBandType.Peaking, "Peaking (bell)"),
+        (PeqBandType.HighShelf, "High shelf"),
+        (PeqBandType.LowShelf, "Low shelf")
+    };
+
+    // Changing an existing filter's shape keeps its frequency, Q and gain: the
+    // alternative is deleting the strip and dialling it in again, and a bell and a
+    // shelf at the same corner are exactly what a tuner compares.
+    private void ShowBandTypeMenu(PeqSlotControl slot, Point screenPoint)
+    {
+        if (!peqSlots.Contains(slot))
+        {
+            return;
+        }
+
+        bandTypeMenu?.Dispose();
+        bandTypeMenu = new ContextMenuStrip();
+        foreach ((PeqBandType type, string label) in BandTypeChoices)
+        {
+            PeqBandType chosen = type;
+            var item = new ToolStripMenuItem(label, null, (_, _) => SetBandType(slot, chosen))
+            {
+                Checked = slot.BandType == type
+            };
+            bandTypeMenu.Items.Add(item);
+        }
+
+        DropDownFocusGuard.Attach(bandTypeMenu);
+        bandTypeMenu.Show(screenPoint);
+    }
+
+    private void SetBandType(PeqSlotControl slot, PeqBandType type)
+    {
+        if (!peqSlots.Contains(slot) || slot.BandType == type)
+        {
+            return;
+        }
+
+        CommitBankChange();
+        slot.BandType = type;
+        SelectSlot(slot);
+        RaiseSettingsChanged();
+        DrawSelectedCurves();
+        CommitBankChange();
+    }
+
+    // The band a freshly added slot starts on, per shape.
+    private static PeqBand NewBand(PeqBandType type) => type switch
+    {
+        PeqBandType.LowShelf =>
+            new PeqBand(AddedLowShelfFrequencyHz, AddedShelfQ, 0, type),
+        PeqBandType.HighShelf =>
+            new PeqBand(AddedHighShelfFrequencyHz, AddedShelfQ, 0, type),
+        _ => new PeqBand(AddedBandFrequencyHz, AddedBandQ, 0, type)
+    };
+
+    // Adds one filter at the end of the bank and selects it, so its curve is
+    // highlighted straight away and the next fader move is obviously its own.
+    private void AddBand(PeqBandType type)
+    {
+        if (peqSlots.Count >= MaxPeqSlotCount)
+        {
+            return;
+        }
+
+        CommitBankChange();
+        PeqSlotControl slot = InsertSlot(peqSlots.Count, NewBand(type));
+        LayoutSlots();
+        SyncBandCountCombo();
+        SelectSlot(slot);
+        RaiseSettingsChanged();
+        DrawSelectedCurves();
+        CommitBankChange();
+    }
+
+    // Builds a strip for a band and puts it in the list. The caller lays the grid
+    // out afterwards, so a batch of inserts costs one layout pass.
+    private PeqSlotControl InsertSlot(int index, PeqBand band)
+    {
+        var slot = new PeqSlotControl
+        {
+            Dock = DockStyle.Fill,
+            Margin = new Padding(1)
+        };
+        slot.SetGainRange(numericGainMin.Value, numericGainMax.Value);
+        // Values first, handlers second: a fresh strip is not an edit of the
+        // bank and must not arm the undo timer or redraw the plot three times.
+        WriteBand(slot, band);
+        slot.FrequencyInput.ValueChanged += BankValueChanged;
+        slot.QInput.ValueChanged += BankValueChanged;
+        slot.GainInput.ValueChanged += BankValueChanged;
+        SetTip(slot.FrequencyInput, FrequencyTip);
+        SetTip(slot.QInput, QTip);
+        SetTip(slot.GainInput, GainTip);
+        SetTip(slot.SlotLabel,
+            "Filter number and type, and the drag handle: drag it to reorder the " +
+            "filter or out of the bank to remove it, right-click to switch between " +
+            "a bell and a shelf.");
+        slot.Activated += (sender, _) => SelectSlot((PeqSlotControl)sender!);
+        slot.TypeMenuRequested += (sender, args) =>
+            ShowBandTypeMenu((PeqSlotControl)sender!, args.ScreenPoint);
+        slot.DragStartRequested += (sender, _) => BeginSlotDrag((PeqSlotControl)sender!);
+        slot.EnableDropTarget(SlotDragOver, SlotDragDrop);
+
+        peqSlots.Insert(index, slot);
+        peqSlotTable.Controls.Add(slot);
+        return slot;
+    }
+
+    private void RemoveSlot(PeqSlotControl slot)
+    {
+        if (!peqSlots.Remove(slot))
+        {
+            return;
+        }
+
+        if (selectedSlot == slot)
+        {
+            selectedSlot = null;
+        }
+
+        peqSlotTable.Controls.Remove(slot);
+        slot.Dispose();
+    }
+
+    private static void WriteBand(PeqSlotControl slot, PeqBand band)
+    {
+        slot.BandType = band.Type;
+        slot.FrequencyInput.Value = slot.FrequencyInput.ClampValue(band.FrequencyHz);
+        slot.QInput.Value = slot.QInput.ClampValue(band.Q);
+        slot.GainInput.Value = slot.GainInput.ClampValue(band.GainDb);
+    }
+
+    private static PeqBand ReadBand(PeqSlotControl slot) => new(
+        (double)slot.FrequencyInput.Value,
+        (double)slot.QInput.Value,
+        (double)slot.GainInput.Value,
+        slot.BandType);
+
+    // Moves a strip to another position in the bank, shifting the ones in
+    // between. Called repeatedly while dragging, so it does nothing when the
+    // target is where the strip already is.
+    private void MoveSlot(PeqSlotControl slot, int index)
+    {
+        int current = peqSlots.IndexOf(slot);
+        if (current < 0 || current == index)
+        {
+            return;
+        }
+
+        peqSlots.RemoveAt(current);
+        peqSlots.Insert(Math.Clamp(index, 0, peqSlots.Count), slot);
+        LayoutSlots();
+    }
+
+    // Re-seats every strip in its cell and renumbers it, then parks the "+" tile
+    // after the last one. Cell assignments are made with layout suspended, so
+    // the two-controls-in-one-cell states in the middle of the loop are never
+    // laid out — the table only ever sees the finished, collision-free set.
+    private void LayoutSlots()
+    {
+        peqSlotTable.SuspendLayout();
+        try
+        {
+            for (int index = 0; index < peqSlots.Count; index++)
+            {
+                peqSlots[index].SlotNumber = index + 1;
+                SetCell(peqSlots[index], index);
+            }
+
+            if (peqSlots.Count < MaxPeqSlotCount)
+            {
+                if (!peqSlotTable.Controls.Contains(addSlotTile))
+                {
+                    peqSlotTable.Controls.Add(addSlotTile);
+                }
+
+                SetCell(addSlotTile, peqSlots.Count);
+            }
+            else if (peqSlotTable.Controls.Contains(addSlotTile))
+            {
+                // Hiding it is not enough: an invisible control still holds its
+                // cell, and the 32nd strip would be pushed out of the grid.
+                peqSlotTable.Controls.Remove(addSlotTile);
+            }
+        }
+        finally
+        {
+            peqSlotTable.ResumeLayout();
+        }
+    }
+
+    private void SetCell(Control control, int index)
+    {
+        (int column, int row) = PeqSlotGrid.CellOf(index, PeqColumnCount);
+        peqSlotTable.SetCellPosition(
+            control,
+            new TableLayoutPanelCellPosition(column, row));
+    }
+
+    // Selects a band so its individual contribution is highlighted on the plot.
+    // Selecting another band replaces the previous highlight.
+    private void SelectSlot(PeqSlotControl slot)
+    {
+        if (slot == selectedSlot || !peqSlots.Contains(slot))
+        {
+            return;
+        }
+
+        selectedSlot = slot;
+        foreach (PeqSlotControl other in peqSlots)
+        {
+            other.SetSelected(other == slot);
+        }
+
+        DrawSelectedCurves();
+    }
+
+    // Clears the single-band highlight and removes its curve from the plot.
+    private void DeselectBand()
+    {
+        if (selectedSlot == null)
+        {
+            return;
+        }
+
+        selectedSlot = null;
+        foreach (PeqSlotControl slot in peqSlots)
+        {
+            slot.SetSelected(false);
+        }
+
+        DrawSelectedCurves();
+    }
+
+    // A band or preamp edit is a step in the undo history, but only once the user
+    // stops: the timer restarts here and records the whole burst as one step.
+    private void BankValueChanged(object? sender, EventArgs e)
+    {
+        ArmBankEditTimer();
+        DrawSelectedCurves();
+    }
+
+    private void ArmBankEditTimer()
+    {
+        if (restoringBank)
+        {
+            return;
+        }
+
+        bankEditTimer.Stop();
+        bankEditTimer.Start();
+    }
+
+    private PeqBankState CaptureBankState() =>
+        new(peqSlots.Select(ReadBand), (double)NumericGain.Value);
+
+    // Rebuilds the strips to match a bank state, reusing the ones already there.
+    // Pure UI: what this means for the undo history is the caller's call.
+    private void SetBank(PeqBankState state)
+    {
+        int selectedIndex = selectedSlot == null ? -1 : peqSlots.IndexOf(selectedSlot);
+
+        restoringBank = true;
+        suppressRedraw = true;
+        try
+        {
+            while (peqSlots.Count > state.Bands.Count)
+            {
+                RemoveSlot(peqSlots[^1]);
+            }
+
+            for (int index = 0; index < state.Bands.Count; index++)
+            {
+                if (index < peqSlots.Count)
+                {
+                    WriteBand(peqSlots[index], state.Bands[index]);
+                }
+                else
+                {
+                    InsertSlot(index, state.Bands[index]);
+                }
+            }
+
+            NumericGain.Value = NumericGain.ClampValue(state.PreampDb);
+            LayoutSlots();
+        }
+        finally
+        {
+            suppressRedraw = false;
+            restoringBank = false;
+        }
+
+        bankEditTimer.Stop();
+        SyncBandCountCombo();
+        RestoreSelection(selectedIndex);
+        RaiseSettingsChanged();
+        DrawSelectedCurves();
+    }
+
+    // Keeps the highlight on the same position in the bank across a rebuild, and
+    // drops it when that position no longer exists.
+    private void RestoreSelection(int index)
+    {
+        if (index < 0 || index >= peqSlots.Count)
+        {
+            DeselectBand();
+            return;
+        }
+
+        selectedSlot = null;
+        SelectSlot(peqSlots[index]);
+    }
+
+    // Records everything edited since the last step as one undo step. Called
+    // when the bank goes quiet, and up front by every structural change so a
+    // half-typed field never rides along with the add/remove/reorder that
+    // follows it.
+    private void CommitBankChange()
+    {
+        bankEditTimer.Stop();
+        if (restoringBank)
+        {
+            return;
+        }
+
+        PeqBankState current = CaptureBankState();
+        if (current.Equals(committedBankState))
+        {
+            return;
+        }
+
+        bankHistory.Push(committedBankState);
+        committedBankState = current;
+        UpdateUndoRedoButtons();
+        // The bank is persisted, and a step is exactly the granularity worth
+        // saving at: a whole fader gesture becomes one write, not one per frame.
+        RaiseSettingsChanged();
+    }
+
+    // Adopts the current bank as the baseline with no history behind it — the
+    // starting point after settings are restored, which is not an edit anyone
+    // should be able to undo into.
+    private void ResetBankHistory()
+    {
+        bankEditTimer.Stop();
+        bankHistory.Clear();
+        committedBankState = CaptureBankState();
+        UpdateUndoRedoButtons();
+    }
+
+    private void UndoBankChange()
+    {
+        CommitBankChange();
+        if (bankHistory.TryUndo(committedBankState, out PeqBankState previous))
+        {
+            ApplyHistoryState(previous);
+        }
+    }
+
+    private void RedoBankChange()
+    {
+        CommitBankChange();
+        if (bankHistory.TryRedo(committedBankState, out PeqBankState next))
+        {
+            ApplyHistoryState(next);
+        }
+    }
+
+    private void ApplyHistoryState(PeqBankState state)
+    {
+        SetBank(state);
+        committedBankState = state;
+        UpdateUndoRedoButtons();
+    }
+
+    private void UpdateUndoRedoButtons()
+    {
+        buttonUndo.Enabled = bankHistory.CanUndo;
+        buttonRedo.Enabled = bankHistory.CanRedo;
+    }
+
+    // Undo/redo are bound at the panel rather than the focused field: the fields
+    // are where the editing happens, and a text box's own Ctrl+Z would otherwise
+    // swallow the shortcut and undo a keystroke instead of a filter. Losing
+    // in-field text undo is the deliberate trade — a field commits its value on
+    // Enter or focus loss, and that value is what the history holds.
+    protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+    {
+        switch (keyData)
+        {
+            case Keys.Control | Keys.Z:
+                UndoBankChange();
+                return true;
+            case Keys.Control | Keys.Y:
+            case Keys.Control | Keys.Shift | Keys.Z:
+                RedoBankChange();
+                return true;
+            default:
+                return base.ProcessCmdKey(ref msg, keyData);
+        }
+    }
+
+    // Runs the drag of one strip. The bank re-orders live under the pointer, so
+    // by the time the drop lands there is nothing left to apply; what remains is
+    // deciding what a drag that did NOT land on the bank meant.
+    private void BeginSlotDrag(PeqSlotControl slot)
+    {
+        if (draggedSlot != null || !peqSlots.Contains(slot))
+        {
+            return;
+        }
+
+        CommitBankChange();
+        draggedSlot = slot;
+        draggedSlotOrigin = peqSlots.IndexOf(slot);
+        draggedSlotDropped = false;
+        draggedSlotCancelled = false;
+        slot.SetDragging(true);
+        try
+        {
+            DoDragDrop(slot, DragDropEffects.Move);
+        }
+        finally
+        {
+            draggedSlot = null;
+            slot.SetDragging(false);
+        }
+
+        if (draggedSlotCancelled)
+        {
+            // Escape puts the strip back where it was picked up from.
+            MoveSlot(slot, draggedSlotOrigin);
+        }
+        else if (!draggedSlotDropped)
+        {
+            // Dropped away from the bank: the strip is thrown away. Moving it
+            // through the grid on the way out left the others in their original
+            // relative order, so removing it now is the whole of the change.
+            RemoveSlot(slot);
+            LayoutSlots();
+            SyncBandCountCombo();
+        }
+
+        RaiseSettingsChanged();
+        DrawSelectedCurves();
+        CommitBankChange();
+    }
+
+    private void SlotDragOver(object? sender, DragEventArgs e)
+    {
+        if (draggedSlot == null)
+        {
+            e.Effect = DragDropEffects.None;
+            return;
+        }
+
+        e.Effect = DragDropEffects.Move;
+        MoveSlot(draggedSlot, TargetIndexAt(new Point(e.X, e.Y)));
+    }
+
+    private void SlotDragDrop(object? sender, DragEventArgs e)
+    {
+        if (draggedSlot == null)
+        {
+            return;
+        }
+
+        e.Effect = DragDropEffects.Move;
+        draggedSlotDropped = true;
+    }
+
+    // The slot index a screen point falls on, clamped to the filters that exist:
+    // the empty cells past the end (and the "+" tile) all mean "last".
+    private int TargetIndexAt(Point screenPoint)
+    {
+        if (peqSlots.Count == 0)
+        {
+            return 0;
+        }
+
+        Point client = peqSlotTable.PointToClient(screenPoint);
+        Padding padding = peqSlotTable.Padding;
+        int index = PeqSlotGrid.IndexAt(
+            peqSlotTable.GetColumnWidths(),
+            peqSlotTable.GetRowHeights(),
+            new Point(client.X - padding.Left, client.Y - padding.Top));
+        return Math.Clamp(index, 0, peqSlots.Count - 1);
+    }
+
+    // The pointer feedback IS the removal warning: inside the bank the strip is
+    // being moved, outside it is being thrown away.
+    protected override void OnGiveFeedback(GiveFeedbackEventArgs e)
+    {
+        base.OnGiveFeedback(e);
+        if (draggedSlot == null)
+        {
+            return;
+        }
+
+        e.UseDefaultCursors = false;
+        Cursor.Current = IsOverBank(Cursor.Position)
+            ? Cursors.SizeAll
+            : TrashCursor.Instance;
+    }
+
+    protected override void OnQueryContinueDrag(QueryContinueDragEventArgs e)
+    {
+        base.OnQueryContinueDrag(e);
+        if (e.EscapePressed)
+        {
+            draggedSlotCancelled = true;
+        }
+    }
+
+    private bool IsOverBank(Point screenPoint) =>
+        peqSlotTable.RectangleToScreen(peqSlotTable.ClientRectangle).Contains(screenPoint);
+
+    // Clears the filter bank outright: no filters and no preamp. The source, the
+    // target and the Auto Tune settings are deliberately untouched — this clears
+    // the tune, not the setup it was made against.
+    private void ResetBands()
+    {
+        if (peqSlots.Count == 0 && NumericGain.Value == 0)
+        {
+            return;
+        }
+
+        // A tune can represent a lot of manual work, so the one button that
+        // throws all of it away at once asks first — Ctrl+Z or not.
+        if (MessageBox.Show(
+                FindForm(),
+                "Reset the whole filter bank?" +
+                Environment.NewLine + Environment.NewLine +
+                "Every filter is removed and the preamp returns to 0 dB. The source " +
+                "curve, the target and the Auto Tune settings are kept, and Ctrl+Z " +
+                "brings the filters back.",
+                "EQ Wizard",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning) != DialogResult.Yes)
+        {
+            return;
+        }
+
+        CommitBankChange();
+        SetBank(PeqBankState.Empty);
+        CommitBankChange();
+    }
+
+    // Replaces the bank with a computed or imported one (Auto Tune, Import) as a
+    // single undo step, however many filters it holds.
+    private void ApplyEqualizationCurve(EqualizationCurve curve)
+    {
+        CommitBankChange();
+        SetBank(new PeqBankState(
+            curve.Bands.Take(MaxPeqSlotCount),
+            curve.PreampDb));
+        CommitBankChange();
+    }
+
+    // Restores the bank saved with the settings, and makes it the baseline the
+    // history starts from — reopening the app is not an edit anyone should be
+    // able to undo past. A file from before the bank was persisted carries only
+    // a filter count, and rebuilds the ISO-centred spread those versions showed.
+    private void ApplyPersistedBank(MeasurementSettingsFile.EqWizardSettings settings)
+    {
+        IEnumerable<PeqBand> bands = settings.Bands != null
+            ? settings.Bands
+                .Take(MaxPeqSlotCount)
+                .Select(band => new PeqBand(band.FrequencyHz, band.Q, band.GainDb, band.Type))
+            : Enumerable
+                .Range(0, Math.Clamp(settings.BandCount, 0, MaxPeqSlotCount))
+                .Select(index => new PeqBand(DefaultBandFrequencyHz(index), DefaultBandQ, 0));
+
+        // Out-of-range or corrupt numbers are clamped by the strips themselves
+        // (see WriteBand), so a hand-edited file loses the odd value, not the bank.
+        SetBank(new PeqBankState(bands, settings.PreampDb));
+        ResetBankHistory();
+    }
+
+    // The bank as the settings file stores it, in slot order.
+    private List<MeasurementSettingsFile.PeqBandSettings> CaptureBands() =>
+        peqSlots
+            .Select(ReadBand)
+            .Select(band => new MeasurementSettingsFile.PeqBandSettings
+            {
+                FrequencyHz = band.FrequencyHz,
+                Q = band.Q,
+                GainDb = band.GainDb,
+                Type = band.Type
+            })
+            .ToList();
+}

--- a/source/Tools/Eq/EqWizardPanel.Bank.cs
+++ b/source/Tools/Eq/EqWizardPanel.Bank.cs
@@ -541,11 +541,28 @@ public partial class EqWizardPanel
     }
 
     /// <summary>
-    /// Lands an edit that is still inside the coalescing pause, so a caller about
-    /// to persist the panel's settings reads the bank the user can see rather than
-    /// the one from before their last keystroke.
+    /// Lands an edit that is still in flight, so a caller about to persist the
+    /// panel's settings reads the bank the user can see rather than the one from
+    /// before their last keystroke.
     /// </summary>
-    internal void CommitPendingBankEdit() => CommitBankChange();
+    /// <remarks>
+    /// Two things can be pending, and the text is the earlier of them: a field
+    /// carries typed text until it loses focus or takes Enter, and only then does
+    /// the value change that starts the coalescing pause. An ordinary close
+    /// disables the form first, which takes the focus out of the field and commits
+    /// the text on the way; an OS shutdown flushes immediately, with the caret
+    /// still in the box. So the editors are landed first and the bank second.
+    /// </remarks>
+    internal void CommitPendingBankEdit()
+    {
+        NumericGain.CommitText();
+        foreach (PeqSlotControl slot in peqSlots)
+        {
+            slot.CommitPendingText();
+        }
+
+        CommitBankChange();
+    }
 
     // Adopts the current bank as the baseline with no history behind it — the
     // starting point after settings are restored, which is not an edit anyone

--- a/source/Tools/Eq/EqWizardPanel.Designer.cs
+++ b/source/Tools/Eq/EqWizardPanel.Designer.cs
@@ -20,6 +20,11 @@
                 // owned by the designer container and would otherwise leak its handle.
                 sourceMenu?.Dispose();
                 sourceMenu = null;
+                bandTypeMenu?.Dispose();
+                bandTypeMenu = null;
+                // Created in code (see EqWizardPanel.Bank.cs), so it is not in the
+                // designer container either.
+                bankEditTimer.Dispose();
             }
 
             base.Dispose(disposing);
@@ -66,6 +71,8 @@
             buttonImport = new Button();
             buttonExport = new Button();
             buttonResetBands = new Button();
+            buttonUndo = new Button();
+            buttonRedo = new Button();
             comboBoxQConvention = new DarkComboBox();
             labelQConvention = new Label();
             (NumericTargetOffset).BeginInit();
@@ -508,6 +515,30 @@
             buttonResetBands.Text = "Reset filters";
             buttonResetBands.UseVisualStyleBackColor = true;
             //
+            // buttonUndo
+            //
+            buttonUndo.Enabled = false;
+            buttonUndo.FlatStyle = FlatStyle.Popup;
+            buttonUndo.ForeColor = Color.White;
+            buttonUndo.Location = new Point(2, 335);
+            buttonUndo.Name = "buttonUndo";
+            buttonUndo.Size = new Size(87, 24);
+            buttonUndo.TabIndex = 62;
+            buttonUndo.Text = "Undo";
+            buttonUndo.UseVisualStyleBackColor = true;
+            //
+            // buttonRedo
+            //
+            buttonRedo.Enabled = false;
+            buttonRedo.FlatStyle = FlatStyle.Popup;
+            buttonRedo.ForeColor = Color.White;
+            buttonRedo.Location = new Point(101, 335);
+            buttonRedo.Name = "buttonRedo";
+            buttonRedo.Size = new Size(87, 24);
+            buttonRedo.TabIndex = 63;
+            buttonRedo.Text = "Redo";
+            buttonRedo.UseVisualStyleBackColor = true;
+            //
             // comboBoxQConvention
             //
             comboBoxQConvention.BackColor = Color.FromArgb(55, 60, 72);
@@ -539,6 +570,8 @@
             BorderStyle = BorderStyle.FixedSingle;
             Controls.Add(labelQConvention);
             Controls.Add(comboBoxQConvention);
+            Controls.Add(buttonUndo);
+            Controls.Add(buttonRedo);
             Controls.Add(buttonResetBands);
             Controls.Add(buttonExport);
             Controls.Add(buttonImport);
@@ -611,6 +644,8 @@
         private Button buttonImport;
         private Button buttonExport;
         private Button buttonResetBands;
+        private Button buttonUndo;
+        private Button buttonRedo;
         private DarkComboBox comboBoxQConvention;
         private Label labelQConvention;
     }

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -1044,8 +1044,7 @@ public partial class EqWizardPanel
             numericGainMax.Value = numericGainMax.ClampValue(settings.GainMaxDb);
             checkBoxCutsOnly.Checked = settings.CutsOnly;
             SetSourceSmoothing(settings.SourceSmoothingInverseOctaves);
-            darkComboBoxBands.SelectedIndex =
-                Math.Clamp(settings.BandCount, 1, MaxPeqSlotCount) - 1;
+            ApplyPersistedBank(settings);
 
             InvalidateSourceCurve();
             ApplyGainRange();
@@ -1081,7 +1080,9 @@ public partial class EqWizardPanel
         TargetOffsetDb = (double)NumericTargetOffset.Value,
         GainMinDb = (double)numericGainMin.Value,
         GainMaxDb = (double)numericGainMax.Value,
-        BandCount = Math.Clamp(activeBandCount, 1, MaxPeqSlotCount),
+        Bands = CaptureBands(),
+        PreampDb = (double)NumericGain.Value,
+        BandCount = peqSlots.Count,
         SourceSmoothingInverseOctaves = SourceSmoothingInverseOctaves,
         CalibrationMode = preferredIrCalibrationMode,
         ManualSampleRateHz = manualSampleRateHz,

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -38,9 +38,17 @@ public partial class EqWizardPanel : UserControl
     // shared left axis tens of dB away from 0, where the filter shape would be clipped).
     private const string EqGainAxisKey = "eq-wizard:gain";
 
-    private const string FrequencyTip = "Band center frequency (Hz).";
-    private const string QTip = "Band quality factor (Q) — higher Q is a narrower band.";
-    private const string GainTip = "Band gain (dB). Positive boosts, negative cuts.";
+    private const string FrequencyTip =
+        "Band center frequency (Hz). On a shelf this is the middle of the " +
+        "transition, where the response has reached half the shelf's gain — not " +
+        "the corner where it flattens out.";
+    private const string QTip =
+        "Band quality factor (Q). On a bell, higher Q is a narrower band. On a " +
+        "shelf it is the knee instead: 0.7 is the steepest shelf that still rises " +
+        "evenly, and above that the response overshoots before settling.";
+    private const string GainTip =
+        "Band gain (dB). Positive boosts, negative cuts. A shelf reaches this gain " +
+        "beyond its transition and half of it at the center frequency.";
 
     private readonly WrappingToolTip toolTip = new()
     {
@@ -50,17 +58,13 @@ public partial class EqWizardPanel : UserControl
         ShowAlways = true
     };
 
-    private readonly List<PeqSlotControl> peqSlots = new();
     private readonly EqWizardAutoTuneOrchestrator autoTuneOrchestrator = new();
     private readonly EqWizardImportExportCoordinator importExportCoordinator = new();
-    private TableLayoutPanel peqSlotTable = null!;
     private PlotLabelsPanelController plotLabels = null!;
     private PlotWatermarkAnnotation hintAnnotation = null!;
     private LineAnnotation fromMarker = null!;
     private LineAnnotation toMarker = null!;
     private RectangleAnnotation rangeFill = null!;
-    private int selectedBandIndex = -1;
-    private int activeBandCount;
     private EqTuneStats? lastStats;
     private bool suppressRedraw;
     private bool suppressWindowClamp;
@@ -96,7 +100,9 @@ public partial class EqWizardPanel : UserControl
         buttonSource.Click += (_, _) => buttonSource.BeginInvoke(ShowSourceMenu);
         comboBoxCalibration.SelectedIndexChanged += (_, _) => OnCalibrationChanged();
         NumericTargetOffset.ValueChanged += (_, _) => OnTargetOffsetChanged();
-        NumericGain.ValueChanged += (_, _) => DrawSelectedCurves();
+        // The preamp is part of the filter bank's undo state, so it goes through
+        // the same coalescing path as a band field.
+        NumericGain.ValueChanged += BankValueChanged;
         checkBoxBypass.CheckedChanged += (_, _) => DrawSelectedCurves();
         checkBoxCutsOnly.CheckedChanged += (_, _) =>
         {
@@ -110,6 +116,8 @@ public partial class EqWizardPanel : UserControl
         buttonImport.Click += (_, _) => ImportPeq();
         buttonExport.Click += (_, _) => ExportPeq();
         buttonResetBands.Click += (_, _) => ResetBands();
+        buttonUndo.Click += (_, _) => UndoBankChange();
+        buttonRedo.Click += (_, _) => RedoBankChange();
         numericFromHz.ValueChanged += (_, _) => FrequencyBoundChanged(fromChanged: true);
         numericToHz.ValueChanged += (_, _) => FrequencyBoundChanged(fromChanged: false);
         numericGainMin.ValueChanged += (_, _) => GainBoundChanged(minChanged: true);
@@ -253,11 +261,18 @@ public partial class EqWizardPanel : UserControl
         SetTip(labelGain, NumericGain,
             "EQ preamp (dB) applied on top of all bands. Usually negative to leave " +
             "headroom for boosts.");
-        SetTip(labelBands, darkComboBoxBands, "Number of PEQ bands shown.");
+        SetTip(labelBands, darkComboBoxBands,
+            "How many PEQ filters the bank holds. Picking a number creates or trims " +
+            "the whole bank at once, spreading new filters over the ISO third-octave " +
+            "centres; the + tile adds them one at a time instead.");
         SetTip(buttonResetBands,
-            "Clear the whole filter bank: every band back to its default frequency " +
-            "at Q 1 and 0 dB, preamp 0 dB, one active filter. The source, the target " +
-            "and the Auto Tune settings are kept.");
+            "Clear the whole filter bank: no filters, preamp 0 dB. The source, the " +
+            "target and the Auto Tune settings are kept.");
+        SetTip(buttonUndo,
+            "Undo the last change to the filter bank — a band edit, an added or " +
+            "removed filter, a reorder, an import or an Auto Tune (Ctrl+Z). The " +
+            "source, the target and the Auto Tune settings are not part of it.");
+        SetTip(buttonRedo, "Redo the last undone change to the filter bank (Ctrl+Y).");
         SetTip(labelSmooth, comboBoxSmooth,
             "Smoothing of the source curve (1/N octave), used for display and Auto " +
             "Tune. Unavailable for an imported curve that was already smoothed when it " +
@@ -332,129 +347,6 @@ public partial class EqWizardPanel : UserControl
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     internal Action<EqTuneStats?>? ResultsChanged { get; set; }
-
-    // Builds all 32 band strips once. Hiding unused strips would waste the fader
-    // bank, so the whole 16x2 grid is always shown; the Bands control only chooses
-    // how many are active (SetActiveBandCount), the rest stay visible but greyed.
-    private void CreatePeqSlots()
-    {
-        peqSlotTable.SuspendLayout();
-        suppressRedraw = true;
-        try
-        {
-            for (int index = 0; index < MaxPeqSlotCount; index++)
-            {
-                var slot = new PeqSlotControl
-                {
-                    Dock = DockStyle.Fill,
-                    Margin = new Padding(1),
-                    SlotNumber = index + 1
-                };
-                // Row-major: bands 1..16 fill the top row left to right, 17..32
-                // the bottom row, matching how the fader bank reads.
-                int row = index / PeqColumnCount;
-                int column = index % PeqColumnCount;
-                slot.FrequencyInput.Value =
-                    slot.FrequencyInput.ClampValue(DefaultBandFrequencyHz(index));
-                slot.FrequencyInput.ValueChanged += PeqBandValueChanged;
-                slot.QInput.ValueChanged += PeqBandValueChanged;
-                slot.GainInput.ValueChanged += PeqBandValueChanged;
-                SetTip(slot.FrequencyInput, FrequencyTip);
-                SetTip(slot.QInput, QTip);
-                SetTip(slot.GainInput, GainTip);
-                slot.Activated += (sender, _) => SelectBand((PeqSlotControl)sender!);
-                peqSlots.Add(slot);
-                peqSlotTable.Controls.Add(slot, column, row);
-            }
-        }
-        finally
-        {
-            suppressRedraw = false;
-            peqSlotTable.ResumeLayout();
-        }
-    }
-
-    // ISO 266 preferred 1/3-octave centre frequencies, the ones a 31/32-band
-    // graphic EQ is built on. 32 values (16 Hz .. 20 kHz) match the 32 strips
-    // exactly: the standard 31-band 20 Hz..20 kHz set plus 16 Hz below it.
-    private static readonly double[] IsoThirdOctaveCentersHz =
-    {
-        16, 20, 25, 31.5, 40, 50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500,
-        630, 800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
-        10000, 12500, 16000, 20000
-    };
-
-    // Default band centre for a strip: its ISO 1/3-octave frequency (audiophile
-    // graphic-EQ default) instead of every band starting at 1 kHz.
-    private static double DefaultBandFrequencyHz(int index) =>
-        IsoThirdOctaveCentersHz[
-            Math.Clamp(index, 0, IsoThirdOctaveCentersHz.Length - 1)];
-
-    // The neutral Q a strip starts on, matching the designer's initial value for the
-    // field. Reset filters restores it, so the two must agree.
-    private const double DefaultBandQ = 1.0;
-
-    // The Bands control sets how many strips are active; the remaining strips stay
-    // visible but disabled and are excluded from the EQ curve and the stats.
-    private void SetActiveBandCount(int count)
-    {
-        activeBandCount = Math.Clamp(count, 1, MaxPeqSlotCount);
-        for (int index = 0; index < peqSlots.Count; index++)
-        {
-            peqSlots[index].Enabled = index < activeBandCount;
-        }
-
-        // A band that just became inactive must not stay selected/highlighted.
-        if (selectedBandIndex >= activeBandCount)
-        {
-            DeselectBand();
-        }
-
-        // Changing the active count changes the EQ curve, so redraw.
-        RaiseSettingsChanged();
-        DrawSelectedCurves();
-    }
-
-    // The active band strips (the leading prefix of the always-present 32).
-    private IEnumerable<PeqSlotControl> ActiveSlots => peqSlots.Take(activeBandCount);
-
-    private void PeqBandValueChanged(object? sender, EventArgs e) => DrawSelectedCurves();
-
-    // Selects a band so its individual contribution is highlighted on the plot.
-    // Selecting another band replaces the previous highlight.
-    private void SelectBand(PeqSlotControl slot)
-    {
-        int index = peqSlots.IndexOf(slot);
-        if (index < 0 || index == selectedBandIndex)
-        {
-            return;
-        }
-
-        selectedBandIndex = index;
-        for (int i = 0; i < peqSlots.Count; i++)
-        {
-            peqSlots[i].SetSelected(i == index);
-        }
-
-        DrawSelectedCurves();
-    }
-
-    // Clears the single-band highlight and removes its curve from the plot.
-    private void DeselectBand()
-    {
-        if (selectedBandIndex < 0)
-        {
-            return;
-        }
-
-        selectedBandIndex = -1;
-        foreach (PeqSlotControl slot in peqSlots)
-        {
-            slot.SetSelected(false);
-        }
-
-        DrawSelectedCurves();
-    }
 
     private void InitializePlotWizard()
     {
@@ -702,16 +594,10 @@ public partial class EqWizardPanel : UserControl
         model.InvalidatePlot(true);
     }
 
-    // Reads the active PEQ slots and the preamp control into a logical EQ curve.
-    // Inactive strips (beyond the chosen band count) are excluded.
-    private EqualizationCurve BuildEqualizationCurve()
-    {
-        IEnumerable<PeqBand> bands = ActiveSlots.Select(slot => new PeqBand(
-            (double)slot.FrequencyInput.Value,
-            (double)slot.QInput.Value,
-            (double)slot.GainInput.Value));
-        return new EqualizationCurve(bands, (double)NumericGain.Value);
-    }
+    // Reads the PEQ strips and the preamp control into a logical EQ curve. Every
+    // strip in the bank is a filter — an unwanted one is removed, not parked.
+    private EqualizationCurve BuildEqualizationCurve() =>
+        new(peqSlots.Select(ReadBand), (double)NumericGain.Value);
 
     // Computes the tuning read-out for the results panel: how well Source + EQ
     // matches the target, plus the EQ's own boost/cut extents and headroom.
@@ -752,7 +638,7 @@ public partial class EqWizardPanel : UserControl
         }
 
         double rms = valid > 0 ? Math.Sqrt(sumSquares / valid) : 0;
-        int filtersUsed = ActiveSlots.Count(
+        int filtersUsed = peqSlots.Count(
             slot => Math.Abs((double)slot.GainInput.Value) >= 0.05);
 
         double peakBoost = double.NegativeInfinity;
@@ -852,7 +738,7 @@ public partial class EqWizardPanel : UserControl
         bool cutsOnly = checkBoxCutsOnly.Checked;
         double pinnedPreampDb = (double)NumericGain.Value;
 
-        var options = new EqAutoTuner.Options
+        return new EqAutoTuner.Options
         {
             MaxBands = Math.Clamp(bandLimit, 1, MaxPeqSlotCount),
             MinFrequencyHz = minHz,
@@ -868,105 +754,13 @@ public partial class EqWizardPanel : UserControl
             // Cuts-only is the safe default for a car tune: never boost an
             // interference null. Unchecking it allows boosts, still gated to
             // reliable regions (high coherence, not inside a narrow deep null).
-            CutsOnlyMode = cutsOnly
+            CutsOnlyMode = cutsOnly,
+            // Q has no panel-level range control; the strips' own limits are the
+            // range, and reading them from the control class rather than from a
+            // strip keeps them available when the bank is empty.
+            QMin = PeqSlotControl.MinimumQ,
+            QMax = PeqSlotControl.MaximumQ
         };
-
-        // Q has no panel-level range control, so take its bounds from a band field.
-        if (peqSlots.Count > 0)
-        {
-            PeqSlotControl slot = peqSlots[0];
-            options = options with
-            {
-                QMin = (double)slot.QInput.Minimum,
-                QMax = (double)slot.QInput.Maximum
-            };
-        }
-
-        return options;
-    }
-
-    // Puts the whole filter bank back to the state the panel starts in: every strip at
-    // its ISO third-octave home frequency, Q 1, gain 0, no preamp, one active band. The
-    // source, the target and the Auto Tune settings are deliberately untouched — this
-    // clears the tune, not the setup it was made against.
-    private void ResetBands()
-    {
-        // A tune can represent a lot of manual work and there is no undo here, so the
-        // one destructive button in the panel asks first.
-        if (MessageBox.Show(
-                FindForm(),
-                "Reset all EQ filters to their defaults?" +
-                Environment.NewLine + Environment.NewLine +
-                "Every band returns to its default frequency with Q 1 and 0 dB gain, " +
-                "the preamp returns to 0 dB, and the filter count returns to 1. The " +
-                "source curve, the target and the Auto Tune settings are kept.",
-                "EQ Wizard",
-                MessageBoxButtons.YesNo,
-                MessageBoxIcon.Warning) != DialogResult.Yes)
-        {
-            return;
-        }
-
-        suppressRedraw = true;
-        try
-        {
-            for (int index = 0; index < peqSlots.Count; index++)
-            {
-                PeqSlotControl slot = peqSlots[index];
-                slot.FrequencyInput.Value =
-                    slot.FrequencyInput.ClampValue(DefaultBandFrequencyHz(index));
-                slot.QInput.Value = slot.QInput.ClampValue(DefaultBandQ);
-                slot.GainInput.Value = slot.GainInput.ClampValue(0);
-            }
-
-            NumericGain.Value = NumericGain.ClampValue(0);
-            // Setting the selection fires SetActiveBandCount, which also drops a
-            // highlighted band that no longer exists.
-            darkComboBoxBands.SelectedIndex = 0;
-        }
-        finally
-        {
-            suppressRedraw = false;
-        }
-
-        DeselectBand();
-        RaiseSettingsChanged();
-        DrawSelectedCurves();
-    }
-
-    private void ApplyEqualizationCurve(EqualizationCurve curve)
-    {
-        suppressRedraw = true;
-        try
-        {
-            int bandCount = Math.Clamp(curve.Bands.Count, 1, MaxPeqSlotCount);
-            darkComboBoxBands.SelectedIndex = bandCount - 1;
-
-            for (int i = 0; i < peqSlots.Count; i++)
-            {
-                PeqSlotControl slot = peqSlots[i];
-                if (i < curve.Bands.Count)
-                {
-                    PeqBand band = curve.Bands[i];
-                    slot.FrequencyInput.Value = slot.FrequencyInput.ClampValue(band.FrequencyHz);
-                    slot.QInput.Value = slot.QInput.ClampValue(band.Q);
-                    slot.GainInput.Value = slot.GainInput.ClampValue(band.GainDb);
-                }
-                else
-                {
-                    // No band for this slot: leave it transparent.
-                    slot.GainInput.Value = slot.GainInput.ClampValue(0);
-                }
-            }
-
-            NumericGain.Value = NumericGain.ClampValue(curve.PreampDb);
-        }
-        finally
-        {
-            suppressRedraw = false;
-        }
-
-        DrawSelectedCurves();
     }
 
     // The user-defined Auto Tune frequency window (From/To). Bounds are ordered and
@@ -1004,11 +798,18 @@ public partial class EqWizardPanel : UserControl
         }
 
         EqualizationCurve curve = BuildEqualizationCurve();
+        EqWizardExportTarget target =
+            importExportCoordinator.ResolveExportTarget(dialog.FilterIndex);
+        if (!ConfirmShelvingBandsDropped(target, curve))
+        {
+            return;
+        }
+
         (double minHz, double maxHz) = GetFrequencyWindow();
         EqWizardFileResult result = importExportCoordinator.Export(
             new EqWizardExportRequest(
                 dialog.FileName,
-                importExportCoordinator.ResolveExportTarget(dialog.FilterIndex),
+                target,
                 curve,
                 EqSampleRate,
                 System.IO.Path.GetFileNameWithoutExtension(dialog.FileName),
@@ -1020,6 +821,33 @@ public partial class EqWizardPanel : UserControl
         {
             ShowFileError("PEQ could not be exported.", result.Exception!);
         }
+    }
+
+    // A format that cannot state our shelves would otherwise export a file that is
+    // quietly not the tune on screen. The user is told exactly what would be left
+    // out and decides; the coordinator drops them either way.
+    private bool ConfirmShelvingBandsDropped(
+        EqWizardExportTarget target,
+        EqualizationCurve curve)
+    {
+        int dropped = EqWizardImportExportCoordinator.CountShelvingBandsDroppedBy(
+            target, curve);
+        if (dropped == 0)
+        {
+            return true;
+        }
+
+        string filters = dropped == 1 ? "shelving filter" : $"{dropped} shelving filters";
+        return MessageBox.Show(
+            FindForm(),
+            $"{target.Name} cannot carry a shelving filter the way this EQ defines " +
+            $"one, so the {filters} would be left out." +
+            Environment.NewLine + Environment.NewLine +
+            "The exported profile will hold the peaking filters and the preamp only, " +
+            "and will not match the curve on screen. Export anyway?",
+            "EQ Wizard",
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Warning) == DialogResult.Yes;
     }
 
     // Loads a PEQ using the format chosen in the dialog and applies it. Parsing
@@ -1144,19 +972,18 @@ public partial class EqWizardPanel : UserControl
     // stand out against where the response should land.
     private void AddSelectedBandCurve(PlotModel model, EqWizardCurve? baseline)
     {
-        if (selectedBandIndex < 0 ||
-            selectedBandIndex >= peqSlots.Count ||
-            baseline is not { Points.Count: >= 2 })
+        if (selectedSlot == null || baseline is not { Points.Count: >= 2 })
         {
             return;
         }
 
-        PeqSlotControl slot = peqSlots[selectedBandIndex];
-        var band = new PeqBand(
-            (double)slot.FrequencyInput.Value,
-            (double)slot.QInput.Value,
-            (double)slot.GainInput.Value);
+        int slotNumber = peqSlots.IndexOf(selectedSlot) + 1;
+        if (slotNumber < 1)
+        {
+            return;
+        }
 
+        PeqBand band = ReadBand(selectedSlot);
         var points = baseline.Points
             .Select(point => new DataPoint(
                 point.X,
@@ -1166,7 +993,7 @@ public partial class EqWizardPanel : UserControl
         AddWizardSeries(
             model,
             new EqWizardCurve(
-                $"Band {selectedBandIndex + 1}",
+                $"Band {slotNumber}",
                 BandCurveColor,
                 2,
                 LineStyle.Dash,
@@ -1265,44 +1092,6 @@ public partial class EqWizardPanel : UserControl
         return x0 + f * (x1 - x0);
     }
 
-    private void InitializePeqSlotTable()
-    {
-        peqSlotTable = new TableLayoutPanel
-        {
-            BackColor = panelPEQ.BackColor,
-            ColumnCount = PeqColumnCount,
-            Dock = DockStyle.Fill,
-            Margin = Padding.Empty,
-            Padding = new Padding(2),
-            RowCount = PeqRowCount
-        };
-
-        for (int column = 0; column < PeqColumnCount; column++)
-        {
-            peqSlotTable.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f / PeqColumnCount));
-        }
-        for (int row = 0; row < PeqRowCount; row++)
-        {
-            peqSlotTable.RowStyles.Add(new RowStyle(SizeType.Percent, 100f / PeqRowCount));
-        }
-
-        peqSlotTable.Click += (_, _) => DeselectBand();
-        panelPEQ.Controls.Add(peqSlotTable);
-        CreatePeqSlots();
-    }
-
-    private void InitializeBandsComboBox()
-    {
-        darkComboBoxBands.Items.Clear();
-        for (int count = 1; count <= MaxPeqSlotCount; count++)
-        {
-            darkComboBoxBands.Items.Add(count);
-        }
-
-        darkComboBoxBands.SelectedIndexChanged += DarkComboBoxBandsSelectedIndexChanged;
-        darkComboBoxBands.SelectedIndex = 0;
-    }
-
     // The band limit caps how many bands Auto Tune may create (4..32, default 4).
     private void InitializeBandsLimitComboBox()
     {
@@ -1338,13 +1127,5 @@ public partial class EqWizardPanel : UserControl
             DrawSelectedCurves();
         };
         comboBoxSmooth.SelectedIndex = 0;
-    }
-
-    private void DarkComboBoxBandsSelectedIndexChanged(object? sender, EventArgs e)
-    {
-        int slotCount = darkComboBoxBands.SelectedItem is int selectedCount
-            ? selectedCount
-            : 1;
-        SetActiveBandCount(slotCount);
     }
 }

--- a/source/Tools/Eq/PeqAddSlotControl.cs
+++ b/source/Tools/Eq/PeqAddSlotControl.cs
@@ -1,0 +1,198 @@
+using System.Drawing.Drawing2D;
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>Which band shape an add zone stands for.</summary>
+internal sealed class PeqAddBandEventArgs : EventArgs
+{
+    public PeqAddBandEventArgs(PeqBandType type)
+    {
+        Type = type;
+    }
+
+    public PeqBandType Type { get; }
+}
+
+/// <summary>
+/// The "add a filter" tile that trails the PEQ strips: an empty slot outline split
+/// into one zone per band shape, each with its own frame, plus and label. It always
+/// sits in the cell after the last strip and disappears once the bank is full, so
+/// the grid reads as a list the user extends rather than a fixed bank of 32 with
+/// most of it greyed out.
+/// </summary>
+/// <remarks>
+/// Three zones rather than one tile opening a menu: adding a filter is the most
+/// repeated action in the panel, and a menu costs a second click and a jump away
+/// from the strip. The zones keep the shapes visible — the tile says what the bank
+/// can hold — and each one lands directly on the shape it names.
+/// </remarks>
+internal sealed class PeqAddSlotControl : Control
+{
+    private static readonly Color OutlineColor = Color.FromArgb(70, 78, 94);
+    private static readonly Color OutlineHoverColor = UiPalette.AccentBlueSoft;
+    private static readonly Color GlyphColor = Color.FromArgb(120, 130, 148);
+    private static readonly Color GlyphHoverColor = UiPalette.TextPrimarySoft;
+
+    // Top to bottom: the bell first as the one used most, then the shelves in the
+    // order they sit on a frequency axis drawn upwards — high above low.
+    private static readonly (PeqBandType Type, string Label)[] Zones =
+    {
+        (PeqBandType.Peaking, "PK"),
+        (PeqBandType.HighShelf, "HS"),
+        (PeqBandType.LowShelf, "LS")
+    };
+
+    private int hoveredZone = -1;
+
+    public PeqAddSlotControl()
+    {
+        SetStyle(
+            ControlStyles.UserPaint |
+            ControlStyles.AllPaintingInWmPaint |
+            ControlStyles.OptimizedDoubleBuffer |
+            ControlStyles.ResizeRedraw,
+            true);
+
+        BackColor = Color.FromArgb(20, 22, 30);
+        Cursor = Cursors.Hand;
+        TabStop = false;
+    }
+
+    /// <summary>Raised with the shape of the zone that was clicked.</summary>
+    public event EventHandler<PeqAddBandEventArgs>? AddRequested;
+
+    protected override void OnMouseMove(MouseEventArgs e)
+    {
+        base.OnMouseMove(e);
+        SetHoveredZone(ZoneAt(e.Y));
+    }
+
+    protected override void OnMouseLeave(EventArgs e)
+    {
+        base.OnMouseLeave(e);
+        SetHoveredZone(-1);
+    }
+
+    protected override void OnMouseClick(MouseEventArgs e)
+    {
+        base.OnMouseClick(e);
+        if (e.Button != MouseButtons.Left)
+        {
+            return;
+        }
+
+        int zone = ZoneAt(e.Y);
+        if (zone >= 0)
+        {
+            AddRequested?.Invoke(this, new PeqAddBandEventArgs(Zones[zone].Type));
+        }
+    }
+
+    private void SetHoveredZone(int zone)
+    {
+        if (hoveredZone == zone)
+        {
+            return;
+        }
+
+        hoveredZone = zone;
+        Invalidate();
+    }
+
+    private int ZoneAt(int y)
+    {
+        if (Height <= 0)
+        {
+            return -1;
+        }
+
+        // Bounded rather than trusted: the last zone carries the rounding remainder,
+        // so a click on the final pixel row must not index past the array.
+        return Math.Clamp(y * Zones.Length / Height, 0, Zones.Length - 1);
+    }
+
+    // The zones split the tile evenly, the last one taking whatever the division
+    // left over, so together they cover it exactly with no seam at the bottom.
+    private Rectangle ZoneBounds(int zone)
+    {
+        int top = Height * zone / Zones.Length;
+        int bottom = Height * (zone + 1) / Zones.Length;
+        return Rectangle.FromLTRB(0, top, Width, bottom);
+    }
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        base.OnPaint(e);
+
+        Graphics graphics = e.Graphics;
+        graphics.Clear(BackColor);
+        graphics.SmoothingMode = SmoothingMode.AntiAlias;
+
+        for (int zone = 0; zone < Zones.Length; zone++)
+        {
+            DrawZone(graphics, zone);
+        }
+    }
+
+    private void DrawZone(Graphics graphics, int zone)
+    {
+        Rectangle bounds = ZoneBounds(zone);
+        bounds.Inflate(-2, -2);
+        if (bounds.Width <= 0 || bounds.Height <= 0)
+        {
+            return;
+        }
+
+        bool hovered = hoveredZone == zone;
+
+        // A wash of the colour the filter itself will wear, so the zone and the
+        // strip it creates are recognisably the same thing.
+        using (var wash = new SolidBrush(PeqBandPalette.TileZone(Zones[zone].Type)))
+        {
+            graphics.FillRectangle(wash, bounds);
+        }
+
+        using var outline = new Pen(hovered ? OutlineHoverColor : OutlineColor)
+        {
+            DashStyle = DashStyle.Dash
+        };
+        graphics.DrawRectangle(outline, bounds);
+
+        Color glyphColor = hovered ? GlyphHoverColor : GlyphColor;
+
+        // The plus sits above the label, both sized off the zone so they stay
+        // proportional at any DPI and at any panel width.
+        int arm = Math.Max(3, Math.Min(bounds.Width, bounds.Height) / 7);
+        int plusY = bounds.Top + bounds.Height * 2 / 5;
+        int centerX = bounds.Left + bounds.Width / 2;
+        using (var glyph = new Pen(glyphColor, 2f))
+        {
+            graphics.DrawLine(glyph, centerX - arm, plusY, centerX + arm, plusY);
+            graphics.DrawLine(glyph, centerX, plusY - arm, centerX, plusY + arm);
+        }
+
+        // The label names the shape with the same token the strip header shows once
+        // the filter exists, so the tile and the bank speak one vocabulary.
+        var labelArea = Rectangle.FromLTRB(
+            bounds.Left,
+            plusY + arm,
+            bounds.Right,
+            bounds.Bottom);
+        if (labelArea.Height <= 0)
+        {
+            return;
+        }
+
+        TextRenderer.DrawText(
+            graphics,
+            Zones[zone].Label,
+            Font,
+            labelArea,
+            glyphColor,
+            TextFormatFlags.HorizontalCenter |
+            TextFormatFlags.VerticalCenter |
+            TextFormatFlags.SingleLine |
+            TextFormatFlags.NoPadding);
+    }
+}

--- a/source/Tools/Eq/PeqBandPalette.cs
+++ b/source/Tools/Eq/PeqBandPalette.cs
@@ -1,0 +1,46 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// The tint that tells the three band shapes apart at a glance in a bank of up to
+/// 32 strips. Shared by the strips and by the add tile's zones, so the colour that
+/// offers a shape is the colour the filter then carries.
+/// </summary>
+/// <remarks>
+/// The shift is in hue, not in brightness: all three sit at the same weight against
+/// the panel, so a bank does not read as some filters being more important than
+/// others. The direction follows how the two shelves are heard — the low shelf
+/// warm, the high shelf cool — which is also the way round they are stacked on the
+/// add tile.
+/// </remarks>
+internal static class PeqBandPalette
+{
+    /// <summary>The strip's own background.</summary>
+    public static Color Strip(PeqBandType type) => type switch
+    {
+        PeqBandType.LowShelf => Color.FromArgb(58, 50, 45),
+        PeqBandType.HighShelf => Color.FromArgb(40, 56, 62),
+        _ => Color.FromArgb(44, 50, 60)
+    };
+
+    /// <summary>The same strip while it is the highlighted band.</summary>
+    public static Color SelectedStrip(PeqBandType type) => type switch
+    {
+        PeqBandType.LowShelf => Color.FromArgb(78, 66, 58),
+        PeqBandType.HighShelf => Color.FromArgb(52, 76, 86),
+        _ => Color.FromArgb(58, 66, 86)
+    };
+
+    /// <summary>
+    /// The wash behind an add-tile zone: the strip colour, dimmed most of the way
+    /// to the panel behind it. The zone is an empty slot, not a filter, so it only
+    /// hints at the colour the filter would have.
+    /// </summary>
+    public static Color TileZone(PeqBandType type) => type switch
+    {
+        PeqBandType.LowShelf => Color.FromArgb(32, 27, 24),
+        PeqBandType.HighShelf => Color.FromArgb(22, 31, 35),
+        _ => Color.FromArgb(25, 28, 34)
+    };
+}

--- a/source/Tools/Eq/PeqBankHistory.cs
+++ b/source/Tools/Eq/PeqBankHistory.cs
@@ -1,0 +1,82 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Undo/redo over whole <see cref="PeqBankState"/> snapshots. A snapshot is a
+/// handful of numbers, so keeping the last <see cref="Capacity"/> of them costs
+/// less than the bookkeeping an undoable-command model would need — and it is
+/// correct for every operation by construction, including Auto Tune and import,
+/// which replace the entire bank rather than editing one band.
+/// </summary>
+internal sealed class PeqBankHistory
+{
+    /// <summary>How many steps back the bank remembers; the oldest is dropped.</summary>
+    public const int Capacity = 100;
+
+    private readonly List<PeqBankState> undo = new();
+    private readonly List<PeqBankState> redo = new();
+
+    public bool CanUndo => undo.Count > 0;
+
+    public bool CanRedo => redo.Count > 0;
+
+    public void Clear()
+    {
+        undo.Clear();
+        redo.Clear();
+    }
+
+    /// <summary>
+    /// Records the state a change moved away from. Recording is what makes a
+    /// change a step, so it also drops the redo trail: the future that was
+    /// undone is no longer reachable from the branch the user just took.
+    /// </summary>
+    public void Push(PeqBankState previous)
+    {
+        ArgumentNullException.ThrowIfNull(previous);
+
+        undo.Add(previous);
+        if (undo.Count > Capacity)
+        {
+            undo.RemoveAt(0);
+        }
+
+        redo.Clear();
+    }
+
+    /// <summary>
+    /// Steps back one state, handing <paramref name="current"/> to the redo
+    /// stack. False (and an untouched history) when there is nothing to undo.
+    /// </summary>
+    public bool TryUndo(PeqBankState current, out PeqBankState previous)
+    {
+        ArgumentNullException.ThrowIfNull(current);
+
+        if (undo.Count == 0)
+        {
+            previous = current;
+            return false;
+        }
+
+        previous = undo[^1];
+        undo.RemoveAt(undo.Count - 1);
+        redo.Add(current);
+        return true;
+    }
+
+    /// <summary>Steps forward again, handing <paramref name="current"/> back to undo.</summary>
+    public bool TryRedo(PeqBankState current, out PeqBankState next)
+    {
+        ArgumentNullException.ThrowIfNull(current);
+
+        if (redo.Count == 0)
+        {
+            next = current;
+            return false;
+        }
+
+        next = redo[^1];
+        redo.RemoveAt(redo.Count - 1);
+        undo.Add(current);
+        return true;
+    }
+}

--- a/source/Tools/Eq/PeqBankState.cs
+++ b/source/Tools/Eq/PeqBankState.cs
@@ -1,0 +1,48 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// A snapshot of the EQ Wizard filter bank: the bands in slot order plus the
+/// preamp. The order is part of the state, not a display detail — an exported
+/// profile numbers its filters by it — so the same bands in a different order
+/// are a different state, and re-ordering is undoable like any other edit.
+/// </summary>
+internal sealed class PeqBankState : IEquatable<PeqBankState>
+{
+    /// <summary>An empty bank with a neutral preamp: what "Reset filters" leaves.</summary>
+    public static readonly PeqBankState Empty = new(Array.Empty<PeqBand>(), 0);
+
+    private readonly PeqBand[] bands;
+
+    public PeqBankState(IEnumerable<PeqBand> bands, double preampDb)
+    {
+        ArgumentNullException.ThrowIfNull(bands);
+
+        this.bands = bands.ToArray();
+        PreampDb = preampDb;
+    }
+
+    public IReadOnlyList<PeqBand> Bands => bands;
+
+    public double PreampDb { get; }
+
+    public bool Equals(PeqBankState? other) =>
+        other != null &&
+        PreampDb.Equals(other.PreampDb) &&
+        bands.AsSpan().SequenceEqual(other.bands.AsSpan());
+
+    public override bool Equals(object? obj) => Equals(obj as PeqBankState);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(PreampDb);
+        foreach (PeqBand band in bands)
+        {
+            hash.Add(band);
+        }
+
+        return hash.ToHashCode();
+    }
+}

--- a/source/Tools/Eq/PeqSlotControl.cs
+++ b/source/Tools/Eq/PeqSlotControl.cs
@@ -1,37 +1,172 @@
 using System.ComponentModel;
+using Resonalyze.Dsp;
 
 namespace Resonalyze;
 
+/// <summary>Where a strip's context menu was asked for, in screen coordinates.</summary>
+internal sealed class PeqSlotMenuEventArgs : EventArgs
+{
+    public PeqSlotMenuEventArgs(Point screenPoint)
+    {
+        ScreenPoint = screenPoint;
+    }
+
+    public Point ScreenPoint { get; }
+}
+
 public partial class PeqSlotControl : UserControl
 {
-    private static readonly Color NormalBackColor = Color.FromArgb(44, 50, 60);
-    private static readonly Color SelectedBackColor = Color.FromArgb(58, 66, 86);
+    /// <summary>
+    /// The Q range every strip accepts. Held here rather than only in the
+    /// designer because the panel needs it to bound Auto Tune even when the bank
+    /// holds no strip to read it from.
+    /// </summary>
+    internal const double MinimumQ = 0.1;
+
+    /// <inheritdoc cref="MinimumQ"/>
+    internal const double MaximumQ = 20;
+
+    // The strip being carried is dimmed, so the gap it will leave and the cell it
+    // currently sits in read differently from the strips it is passing over. One
+    // colour for all three shapes: a strip in flight is a strip in flight, and its
+    // type is still named in the header.
+    private static readonly Color DraggingBackColor = Color.FromArgb(32, 36, 45);
 
     private int slotNumber = 1;
+    private PeqBandType bandType = PeqBandType.Peaking;
     private bool suppressGainSync;
+    private bool selected;
+    private bool dragging;
+    private bool dragArmed;
+    private Point dragOrigin;
 
     public PeqSlotControl()
     {
         InitializeComponent();
+        qInput.Minimum = (decimal)MinimumQ;
+        qInput.Maximum = (decimal)MaximumQ;
         WireGainFader();
         HookActivation(this);
+        // The number strip is the drag handle. It has to be: the fader owns the
+        // mouse for gain and the three fields own it for editing, and WinForms
+        // mouse events do not bubble to the parent, so there is nowhere else on
+        // the strip a drag could start without stealing a working gesture.
+        HookDragHandle(slotLabel);
+        slotLabel.Cursor = Cursors.SizeAll;
+        // The designer's colours are a starting point for the design surface; the
+        // palette is what the strip actually wears.
+        ApplyStripColor();
     }
 
     // Raised when the user clicks the slot or focuses any of its fields, so the
     // host can show this band's individual contribution.
     public event EventHandler? Activated;
 
-    public void SetSelected(bool selected)
+    // Raised once the pointer has left the system drag threshold with the number
+    // strip held down. The host runs the drag-and-drop loop, because only it
+    // knows the bank the strip is being moved within.
+    public event EventHandler? DragStartRequested;
+
+    // Raised on a right-click of the number strip: the host offers the band shapes,
+    // since it owns the bank the change is an undo step of.
+    internal event EventHandler<PeqSlotMenuEventArgs>? TypeMenuRequested;
+
+    public void SetSelected(bool isSelected)
     {
-        Color color = selected ? SelectedBackColor : NormalBackColor;
+        selected = isSelected;
+        ApplyStripColor();
+    }
+
+    // Marks the strip as the one currently being carried by the pointer.
+    internal void SetDragging(bool isDragging)
+    {
+        dragging = isDragging;
+        ApplyStripColor();
+    }
+
+    private void ApplyStripColor()
+    {
+        Color color = dragging
+            ? DraggingBackColor
+            : selected
+                ? PeqBandPalette.SelectedStrip(bandType)
+                : PeqBandPalette.Strip(bandType);
         BackColor = color;
         slotLayout.BackColor = color;
         // The fader paints its background from the strip colour, so it must be
-        // told to repaint when the selection tint changes. It also gates its
-        // click-to-drag on whether this band is the selected one.
+        // told to repaint when the tint changes. It also gates its click-to-drag
+        // on whether this band is the selected one.
         fader.StripActive = selected;
         fader.BackColor = color;
         fader.Invalidate();
+    }
+
+    // Registers the whole strip — fields and fader included — as a drop target,
+    // so a drag passing over any part of it reaches the host's handlers instead
+    // of dying on a child window that never registered one.
+    internal void EnableDropTarget(DragEventHandler dragOver, DragEventHandler drop)
+    {
+        foreach (Control control in SelfAndDescendants(this))
+        {
+            control.AllowDrop = true;
+            control.DragEnter += dragOver;
+            control.DragOver += dragOver;
+            control.DragDrop += drop;
+        }
+    }
+
+    private static IEnumerable<Control> SelfAndDescendants(Control root)
+    {
+        yield return root;
+        foreach (Control child in root.Controls)
+        {
+            foreach (Control descendant in SelfAndDescendants(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    private void HookDragHandle(Control handle)
+    {
+        handle.MouseDown += (sender, args) =>
+        {
+            if (args.Button != MouseButtons.Left)
+            {
+                return;
+            }
+
+            dragArmed = true;
+            dragOrigin = ((Control)sender!).PointToScreen(args.Location);
+        };
+        handle.MouseMove += (sender, args) =>
+        {
+            if (!dragArmed || args.Button != MouseButtons.Left)
+            {
+                return;
+            }
+
+            Point current = ((Control)sender!).PointToScreen(args.Location);
+            Size threshold = SystemInformation.DragSize;
+            if (Math.Abs(current.X - dragOrigin.X) < threshold.Width &&
+                Math.Abs(current.Y - dragOrigin.Y) < threshold.Height)
+            {
+                return;
+            }
+
+            dragArmed = false;
+            DragStartRequested?.Invoke(this, EventArgs.Empty);
+        };
+        handle.MouseUp += (sender, args) =>
+        {
+            dragArmed = false;
+            if (args.Button == MouseButtons.Right)
+            {
+                TypeMenuRequested?.Invoke(
+                    this,
+                    new PeqSlotMenuEventArgs(((Control)sender!).PointToScreen(args.Location)));
+            }
+        };
     }
 
     // Keeps the vertical fader and the gain field in lock-step: the numeric field
@@ -99,9 +234,38 @@ public partial class PeqSlotControl : UserControl
         set
         {
             slotNumber = Math.Max(1, value);
-            slotLabel.Text = slotNumber.ToString();
+            UpdateSlotLabel();
         }
     }
+
+    /// <summary>
+    /// The filter shape this strip holds. The three fields stay the same, but a
+    /// shelf reads two of them differently (see <see cref="PeqBandType"/>), so the
+    /// header names the type rather than leaving it to be guessed from the curve.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    internal PeqBandType BandType
+    {
+        get => bandType;
+        set
+        {
+            bandType = value;
+            UpdateSlotLabel();
+            ApplyStripColor();
+        }
+    }
+
+    /// <summary>Short header token for a band shape: "PK", "LS" or "HS".</summary>
+    internal static string DescribeType(PeqBandType type) => type switch
+    {
+        PeqBandType.LowShelf => "LS",
+        PeqBandType.HighShelf => "HS",
+        _ => "PK"
+    };
+
+    private void UpdateSlotLabel() =>
+        slotLabel.Text = $"{slotNumber} {DescribeType(bandType)}";
 
     // Applies a new gain range to both the numeric field and the fader so they
     // keep sharing one scale. The min is <= 0 <= max, so ordering never inverts;
@@ -114,6 +278,9 @@ public partial class PeqSlotControl : UserControl
         fader.Maximum = (double)maximum;
         fader.Value = (double)gainInput.Value;
     }
+
+    // The number strip, which doubles as the drag handle: the host tips it.
+    internal Control SlotLabel => slotLabel;
 
     internal DarkNumericUpDown FrequencyInput => frequencyInput;
 

--- a/source/Tools/Eq/PeqSlotControl.cs
+++ b/source/Tools/Eq/PeqSlotControl.cs
@@ -279,6 +279,19 @@ public partial class PeqSlotControl : UserControl
         fader.Value = (double)gainInput.Value;
     }
 
+    /// <summary>
+    /// Lands text typed into any of the three fields without waiting for the focus
+    /// to leave it. A field commits on Leave or Enter, which is enough while the
+    /// application is running but not when it is being torn down with the caret
+    /// still in the box.
+    /// </summary>
+    internal void CommitPendingText()
+    {
+        frequencyInput.CommitText();
+        qInput.CommitText();
+        gainInput.CommitText();
+    }
+
     // The number strip, which doubles as the drag handle: the host tips it.
     internal Control SlotLabel => slotLabel;
 

--- a/source/Tools/Eq/PeqSlotGrid.cs
+++ b/source/Tools/Eq/PeqSlotGrid.cs
@@ -1,0 +1,54 @@
+namespace Resonalyze;
+
+/// <summary>
+/// The row-major geometry of the PEQ strip grid: which cell a slot index lives
+/// in, and which slot index a point falls on while a strip is being dragged.
+/// Kept apart from the panel (and from WinForms layout) because the hit test is
+/// where an off-by-one silently drops a strip in the wrong place.
+/// </summary>
+internal static class PeqSlotGrid
+{
+    /// <summary>The (column, row) of a slot index, filling each row left to right.</summary>
+    public static (int Column, int Row) CellOf(int index, int columnCount) =>
+        (index % columnCount, index / columnCount);
+
+    /// <summary>
+    /// The slot index under a point given in the grid's content coordinates (the
+    /// panel's padding already subtracted). Points outside the grid clamp to the
+    /// nearest cell, so a drag that strays past an edge still has a target.
+    /// </summary>
+    public static int IndexAt(
+        IReadOnlyList<int> columnWidths,
+        IReadOnlyList<int> rowHeights,
+        Point point)
+    {
+        ArgumentNullException.ThrowIfNull(columnWidths);
+        ArgumentNullException.ThrowIfNull(rowHeights);
+
+        if (columnWidths.Count == 0 || rowHeights.Count == 0)
+        {
+            return 0;
+        }
+
+        int column = TrackIndexAt(columnWidths, point.X);
+        int row = TrackIndexAt(rowHeights, point.Y);
+        return row * columnWidths.Count + column;
+    }
+
+    // The index of the band containing an offset along one axis, clamped to the
+    // first/last band for offsets before or past the track.
+    private static int TrackIndexAt(IReadOnlyList<int> sizes, int offset)
+    {
+        int start = 0;
+        for (int index = 0; index < sizes.Count; index++)
+        {
+            start += sizes[index];
+            if (offset < start)
+            {
+                return Math.Max(index, 0);
+            }
+        }
+
+        return sizes.Count - 1;
+    }
+}

--- a/source/Tools/Sheets/PdfSheet.cs
+++ b/source/Tools/Sheets/PdfSheet.cs
@@ -106,7 +106,48 @@ internal sealed class PdfSheet : IDisposable
     /// the wrong channel's filters. Continuation blocks carry it too, marked as such,
     /// since a long bank can put them on a page of their own.
     /// </remarks>
+    /// <remarks>
+    /// Shelves are printed in a table of their own, after the bells. They are not
+    /// the same filter with a different number: their frequency is the middle of a
+    /// transition rather than a centre, their Q is a knee rather than a bandwidth
+    /// (so the DSP's Q convention does not restate it), and they need a row saying
+    /// which direction they shelve. Mixing them into the bell table would put four
+    /// meanings under three row labels. Both tables keep the filter's number in the
+    /// bank, so the sheet, the panel and an exported profile agree on what
+    /// "filter 5" is.
+    /// </remarks>
     public void AddFilterTable(IReadOnlyList<PeqBand> bands, string? caption = null)
+    {
+        ArgumentNullException.ThrowIfNull(bands);
+
+        (IReadOnlyList<NumberedBand> peaking, IReadOnlyList<NumberedBand> shelving) =
+            SplitByShape(bands);
+        AddBandTable(peaking, caption, shelving: false);
+        AddBandTable(shelving, ShelfCaption(caption), shelving: true);
+    }
+
+    /// <summary>
+    /// Splits a bank into the bells and the shelves, each entry keeping its number
+    /// in the bank rather than in its own table — the number is what the panel
+    /// shows and what an exported profile calls the filter.
+    /// </summary>
+    internal static (IReadOnlyList<NumberedBand> Peaking, IReadOnlyList<NumberedBand> Shelving)
+        SplitByShape(IReadOnlyList<PeqBand> bands)
+    {
+        ArgumentNullException.ThrowIfNull(bands);
+
+        List<NumberedBand> numbered = bands
+            .Select((band, index) => new NumberedBand(index + 1, band))
+            .ToList();
+        return (
+            numbered.Where(entry => entry.Band.Type == PeqBandType.Peaking).ToList(),
+            numbered.Where(entry => entry.Band.Type != PeqBandType.Peaking).ToList());
+    }
+
+    private void AddBandTable(
+        IReadOnlyList<NumberedBand> bands,
+        string? caption,
+        bool shelving)
     {
         for (int start = 0; start < bands.Count; start += FiltersPerTableBlock)
         {
@@ -119,7 +160,7 @@ internal sealed class PdfSheet : IDisposable
                 gap.Format.SpaceAfter = 0;
             }
 
-            AddFilterTableBlock(bands, start, BlockCaption(caption, start));
+            AddFilterTableBlock(bands, start, BlockCaption(caption, start), shelving);
         }
     }
 
@@ -128,7 +169,21 @@ internal sealed class PdfSheet : IDisposable
             ? caption
             : $"{caption} (cont.)";
 
-    private void AddFilterTableBlock(IReadOnlyList<PeqBand> bands, int start, string? caption)
+    // The shelf table always names itself, even where the bell table above it needs
+    // no caption: an unlabelled second table of filters reads as a continuation.
+    private static string ShelfCaption(string? caption) =>
+        string.IsNullOrWhiteSpace(caption)
+            ? "Shelving filters"
+            : $"{caption} — shelving filters";
+
+    /// <summary>A band together with its position in the bank it came from.</summary>
+    internal readonly record struct NumberedBand(int Number, PeqBand Band);
+
+    private void AddFilterTableBlock(
+        IReadOnlyList<NumberedBand> bands,
+        int start,
+        string? caption,
+        bool shelving)
     {
         var table = Section.AddTable();
         table.Borders.Width = 0.5;
@@ -161,32 +216,42 @@ internal sealed class PdfSheet : IDisposable
 
         int count = Math.Min(FiltersPerTableBlock, bands.Count - start);
 
-        // "PK" labels the numbers as peaking-filter slots — the type to select in the DSP
-        // alongside them. The three value rows are bound to this row so a block cannot be
-        // split from its own column headings.
+        // The corner cell labels what kind of filter the numbers below are — the type to
+        // select in the DSP alongside them. The value rows are bound to this row so a
+        // block cannot be split from its own column headings.
         Row header = table.AddRow();
         header.HeadingFormat = true;
-        header.KeepWith = 3;
-        WriteLabel(header.Cells[0], "PK", bold: true);
+        header.KeepWith = shelving ? 4 : 3;
+        WriteLabel(header.Cells[0], shelving ? "Shelf" : "PK", bold: true);
         for (int i = 0; i < count; i++)
         {
             Paragraph number = header.Cells[i + 1].AddParagraph(
-                (start + i + 1).ToString(System.Globalization.CultureInfo.InvariantCulture));
+                bands[start + i].Number.ToString(System.Globalization.CultureInfo.InvariantCulture));
             number.Format.Font.Bold = true;
             number.Format.Font.Size = 10;
+        }
+
+        if (shelving)
+        {
+            // Which way the shelf runs is the first thing to dial in, and the one thing
+            // a bell table never has to say.
+            AddFilterValueRow(table, "Type", bands, start, count, bold: true,
+                value: band => band.Type == PeqBandType.LowShelf ? "LS" : "HS");
         }
 
         // Gain first: it is the value most often changed by ear once the sheet is in hand.
         // Q is restated in the target DSP's convention and says so on its own row, because
         // frequency and gain mean the same thing everywhere but Q does not — and a bank
         // running to several blocks must not rely on a note printed once in the subtitle.
+        // A shelf's Q is not a bandwidth and no convention restates it, so its row is
+        // labelled plainly rather than with a convention it does not follow.
         AddFilterValueRow(table, "Gain, dB", bands, start, count, bold: true,
             value: band => SheetFormat.Signed(band.GainDb));
         AddFilterValueRow(table, "F, Hz", bands, start, count, bold: false,
             value: band => SheetFormat.Number(band.FrequencyHz, "0"));
         AddFilterValueRow(
             table,
-            $"Q · {PeqQConventions.DescribeShort(qConvention)}",
+            shelving ? "Q" : $"Q · {PeqQConventions.DescribeShort(qConvention)}",
             bands, start, count, bold: false,
             value: band => SheetFormat.Number(band.Q, "0.0#"));
     }
@@ -194,7 +259,7 @@ internal sealed class PdfSheet : IDisposable
     private void AddFilterValueRow(
         Table table,
         string label,
-        IReadOnlyList<PeqBand> bands,
+        IReadOnlyList<NumberedBand> bands,
         int start,
         int count,
         bool bold,
@@ -207,7 +272,7 @@ internal sealed class PdfSheet : IDisposable
 
         for (int i = 0; i < count; i++)
         {
-            PeqBand band = PeqQConventions.ToConvention(bands[start + i], qConvention);
+            PeqBand band = PeqQConventions.ToConvention(bands[start + i].Band, qConvention);
             Paragraph paragraph = row.Cells[i + 1].AddParagraph(value(band));
             paragraph.Format.Font.Size = 10;
             paragraph.Format.Font.Bold = bold;

--- a/source/Tools/Sheets/PdfSheet.cs
+++ b/source/Tools/Sheets/PdfSheet.cs
@@ -140,8 +140,8 @@ internal sealed class PdfSheet : IDisposable
             .Select((band, index) => new NumberedBand(index + 1, band))
             .ToList();
         return (
-            numbered.Where(entry => entry.Band.Type == PeqBandType.Peaking).ToList(),
-            numbered.Where(entry => entry.Band.Type != PeqBandType.Peaking).ToList());
+            numbered.Where(entry => !entry.Band.Type.IsShelving()).ToList(),
+            numbered.Where(entry => entry.Band.Type.IsShelving()).ToList());
     }
 
     private void AddBandTable(

--- a/source/Tools/Sheets/VirtualCrossoverSheet.cs
+++ b/source/Tools/Sheets/VirtualCrossoverSheet.cs
@@ -76,8 +76,12 @@ internal static class VirtualCrossoverSheet
                     {
                         PeqBand peq = PeqQConventions.ToConvention(
                             channel.PeqBands[band], qConvention);
+                        // The keyword comes from the profile writer rather than being
+                        // spelled here: a shelf printed as PK is an instruction to
+                        // dial in the wrong filter.
                         builder.AppendLine(
-                            $"    Filter {band + 1}: ON PK Fc {Number(peq.FrequencyHz, "0.###")} Hz " +
+                            $"    Filter {band + 1}: ON {PeqTextFile.TypeToken(peq.Type)} " +
+                            $"Fc {Number(peq.FrequencyHz, "0.###")} Hz " +
                             $"Gain {Signed(peq.GainDb)} dB Q {Number(peq.Q, "0.0#")}");
                     }
                 }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -173,7 +173,8 @@ public sealed class VirtualCrossoverChannelSettings
         {
             if (!double.IsFinite(band.FrequencyHz) || band.FrequencyHz <= 0 ||
                 !double.IsFinite(band.Q) || band.Q <= 0 ||
-                !double.IsFinite(band.GainDb))
+                !double.IsFinite(band.GainDb) ||
+                !Enum.IsDefined(band.Type))
             {
                 throw new InvalidDataException("A PEQ band is invalid.");
             }

--- a/source/Ui/Controls/DoubleBufferedTableLayoutPanel.cs
+++ b/source/Ui/Controls/DoubleBufferedTableLayoutPanel.cs
@@ -1,0 +1,15 @@
+namespace Resonalyze;
+
+/// <summary>
+/// A <see cref="TableLayoutPanel"/> that paints double-buffered. The stock panel
+/// does not, and <see cref="Control.DoubleBuffered"/> is protected, so a grid
+/// whose cells are re-assigned live (the PEQ strips during a drag) flickers
+/// without this subclass.
+/// </summary>
+internal sealed class DoubleBufferedTableLayoutPanel : TableLayoutPanel
+{
+    public DoubleBufferedTableLayoutPanel()
+    {
+        DoubleBuffered = true;
+    }
+}

--- a/source/Ui/TrashCursor.cs
+++ b/source/Ui/TrashCursor.cs
@@ -1,0 +1,148 @@
+using System.ComponentModel;
+using System.Drawing.Drawing2D;
+using System.Runtime.InteropServices;
+
+namespace Resonalyze.Ui;
+
+/// <summary>
+/// The "drop it here and it is gone" cursor shown while a PEQ strip is dragged
+/// outside its bank. Drawn rather than shipped as a <c>.cur</c> asset so it
+/// follows the application palette, and built through
+/// <c>CreateIconIndirect</c> because that is the only way to place the hotspot:
+/// a cursor made from an <c>HICON</c> alone lands its hotspot wherever the icon
+/// says, which is not the middle of the bin.
+/// </summary>
+internal static class TrashCursor
+{
+    private const int Size = 32;
+
+    private static Cursor? cursor;
+
+    /// <summary>
+    /// The shared cursor, created on first use. Never disposed: it lives for the
+    /// process, and a <see cref="Cursor"/> built from a handle does not own it.
+    /// </summary>
+    public static Cursor Instance => cursor ??= Create();
+
+    private static Cursor Create()
+    {
+        using var bitmap = new Bitmap(Size, Size);
+        using (Graphics graphics = Graphics.FromImage(bitmap))
+        {
+            graphics.SmoothingMode = SmoothingMode.AntiAlias;
+            Draw(graphics);
+        }
+
+        // The hotspot sits in the middle of the bin, so what the pointer covers
+        // is what is about to be thrown away.
+        return FromBitmap(bitmap, new Point(Size / 2, Size / 2));
+    }
+
+    // Flat line art in the application's own idiom — thin strokes with rounded
+    // joins, no fill — rather than a solid pictogram, which reads as borrowed
+    // from another program's icon set. A single dark contour sits under the
+    // strokes: the app is dark throughout, but a strip can be dragged past the
+    // window onto whatever the desktop is showing.
+    private static void Draw(Graphics graphics)
+    {
+        using var body = new GraphicsPath();
+        body.AddLine(9f, 12f, 10.5f, 26f);
+        body.AddArc(10.5f, 24f, 11f, 5f, 180f, -180f);
+        body.AddLine(23f, 12f, 9f, 12f);
+
+        using var lid = new GraphicsPath();
+        lid.AddLine(6f, 9.5f, 26f, 9.5f);
+
+        using var handle = new GraphicsPath();
+        handle.AddLine(13f, 6f, 13f, 9.5f);
+        handle.AddLine(13f, 6f, 19f, 6f);
+        handle.AddLine(19f, 6f, 19f, 9.5f);
+
+        using (var contour = RoundedPen(Color.FromArgb(170, 8, 10, 14), 3.4f))
+        {
+            graphics.DrawPath(contour, body);
+            graphics.DrawPath(contour, lid);
+            graphics.DrawPath(contour, handle);
+        }
+
+        using (var stroke = RoundedPen(UiPalette.ErrorSoft, 1.9f))
+        {
+            graphics.DrawPath(stroke, body);
+            graphics.DrawPath(stroke, lid);
+            graphics.DrawPath(stroke, handle);
+        }
+
+        // The two ribs stay inside the body outline, so they need no contour.
+        using var ribs = RoundedPen(Color.FromArgb(190, UiPalette.ErrorSoft), 1.4f);
+        graphics.DrawLine(ribs, 13.5f, 15f, 13.5f, 23f);
+        graphics.DrawLine(ribs, 18.5f, 15f, 18.5f, 23f);
+    }
+
+    private static Pen RoundedPen(Color color, float width) => new(color, width)
+    {
+        LineJoin = LineJoin.Round,
+        StartCap = LineCap.Round,
+        EndCap = LineCap.Round
+    };
+
+    private static Cursor FromBitmap(Bitmap bitmap, Point hotspot)
+    {
+        IntPtr icon = bitmap.GetHicon();
+        try
+        {
+            if (!GetIconInfo(icon, out IconInfo info))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            try
+            {
+                info.IsIcon = false;
+                info.HotspotX = hotspot.X;
+                info.HotspotY = hotspot.Y;
+                IntPtr handle = CreateIconIndirect(ref info);
+                if (handle == IntPtr.Zero)
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                return new Cursor(handle);
+            }
+            finally
+            {
+                // GetIconInfo hands out copies of both bitmaps; they are ours to free.
+                DeleteObject(info.MaskBitmap);
+                DeleteObject(info.ColorBitmap);
+            }
+        }
+        finally
+        {
+            DestroyIcon(icon);
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IconInfo
+    {
+        public bool IsIcon;
+        public int HotspotX;
+        public int HotspotY;
+        public IntPtr MaskBitmap;
+        public IntPtr ColorBitmap;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetIconInfo(IntPtr icon, out IconInfo info);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr CreateIconIndirect(ref IconInfo info);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DestroyIcon(IntPtr icon);
+
+    [DllImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeleteObject(IntPtr handle);
+}

--- a/tests/Resonalyze.App.Tests/EqWizardBankPersistenceTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardBankPersistenceTests.cs
@@ -1,3 +1,6 @@
+using Resonalyze.Dsp;
+using PeqBandSettings = Resonalyze.MeasurementSettingsFile.PeqBandSettings;
+
 namespace Resonalyze.App.Tests;
 
 // The EQ Wizard's filter bank is user-curated — the filters, and the order they
@@ -54,6 +57,27 @@ public sealed class EqWizardBankPersistenceTests : IDisposable
 
         Assert.NotNull(reloaded.EqWizard.Bands);
         Assert.Empty(reloaded.EqWizard.Bands!);
+    }
+
+    [Fact]
+    public void AShapeNoMemberMatchesIsAcceptedByTheFileAndNormalisedOnLoad()
+    {
+        // The enum converter takes a number outside the enum, so the settings file
+        // can hold one. The panel normalises it to a bell when it rebuilds the bank
+        // (ApplyPersistedBank); this pins the half the file layer owns — that such a
+        // file loads at all instead of failing the whole settings read.
+        string path = NewSettingsPath();
+        File.WriteAllText(
+            path,
+            "{ \"SchemaVersion\": 10, \"EqWizard\": { \"Bands\": [ " +
+            "{ \"FrequencyHz\": 1000, \"Q\": 2, \"GainDb\": 3, \"Type\": 99 } ] } }");
+
+        MeasurementSettingsFile settings = MeasurementSettingsFile.LoadOrDefault(path);
+
+        Assert.Null(settings.LoadWarning);
+        PeqBandSettings band = Assert.Single(settings.EqWizard.Bands!);
+        Assert.False(Enum.IsDefined(band.Type));
+        Assert.False(band.Type.IsShelving());
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/EqWizardBankPersistenceTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardBankPersistenceTests.cs
@@ -1,0 +1,89 @@
+namespace Resonalyze.App.Tests;
+
+// The EQ Wizard's filter bank is user-curated — the filters, and the order they
+// are numbered in — so it is stored in the settings file rather than rebuilt
+// from a count. These pin the file layer: what is written comes back, and a file
+// from before the bank was persisted still opens.
+public sealed class EqWizardBankPersistenceTests : IDisposable
+{
+    private readonly string directory = Path.Combine(
+        Path.GetTempPath(),
+        $"resonalyze-eq-bank-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void SavedBankComesBackInTheSameOrder()
+    {
+        string path = NewSettingsPath();
+        MeasurementSettingsFile settings = MeasurementSettingsFile.LoadOrDefault(path);
+        settings.EqWizard.Bands = new List<MeasurementSettingsFile.PeqBandSettings>
+        {
+            new() { FrequencyHz = 4000, Q = 8.5, GainDb = -4.5 },
+            new() { FrequencyHz = 63, Q = 1.2, GainDb = 3 },
+            new() { FrequencyHz = 1000, Q = 5, GainDb = 0 }
+        };
+        settings.EqWizard.BandCount = 3;
+        settings.EqWizard.PreampDb = -6.5;
+        settings.Save();
+
+        MeasurementSettingsFile reloaded = MeasurementSettingsFile.LoadOrDefault(path);
+
+        Assert.Null(reloaded.LoadWarning);
+        List<MeasurementSettingsFile.PeqBandSettings> bands = reloaded.EqWizard.Bands!;
+        Assert.Equal(3, bands.Count);
+        // Order is what an exported profile numbers its filters by: the 4 kHz cut
+        // must still be filter 1, not sorted back into frequency order.
+        Assert.Equal(4000, bands[0].FrequencyHz);
+        Assert.Equal(8.5, bands[0].Q);
+        Assert.Equal(-4.5, bands[0].GainDb);
+        Assert.Equal(63, bands[1].FrequencyHz);
+        Assert.Equal(1000, bands[2].FrequencyHz);
+        Assert.Equal(-6.5, reloaded.EqWizard.PreampDb);
+    }
+
+    [Fact]
+    public void AnEmptyBankIsAStateOfItsOwn()
+    {
+        // A cleared bank must reopen cleared. It is only the absence of the whole
+        // list — an older file — that means "rebuild from the count".
+        string path = NewSettingsPath();
+        MeasurementSettingsFile settings = MeasurementSettingsFile.LoadOrDefault(path);
+        settings.EqWizard.Bands = new List<MeasurementSettingsFile.PeqBandSettings>();
+        settings.Save();
+
+        MeasurementSettingsFile reloaded = MeasurementSettingsFile.LoadOrDefault(path);
+
+        Assert.NotNull(reloaded.EqWizard.Bands);
+        Assert.Empty(reloaded.EqWizard.Bands!);
+    }
+
+    [Fact]
+    public void AFileFromBeforeTheBankWasPersistedKeepsItsFilterCount()
+    {
+        string path = NewSettingsPath();
+        File.WriteAllText(
+            path,
+            "{ \"SchemaVersion\": 9, \"EqWizard\": { \"BandCount\": 6 } }");
+
+        MeasurementSettingsFile settings = MeasurementSettingsFile.LoadOrDefault(path);
+
+        Assert.Null(settings.LoadWarning);
+        // No bank in the file: the panel rebuilds the ISO spread that version showed.
+        Assert.Null(settings.EqWizard.Bands);
+        Assert.Equal(6, settings.EqWizard.BandCount);
+        Assert.Equal(0, settings.EqWizard.PreampDb);
+    }
+
+    private string NewSettingsPath()
+    {
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, "measurement-settings.json");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/Resonalyze.App.Tests/EqWizardShelfExportTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardShelfExportTests.cs
@@ -1,0 +1,123 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+// Two promises about shelves leaving the EQ Wizard: a format that cannot state
+// one never receives it, and the tuning sheet prints them apart from the bells
+// without renumbering either.
+public sealed class EqWizardShelfExportTests
+{
+    private static EqualizationCurve Mixed() => new(
+        new[]
+        {
+            new PeqBand(1_000, 4.0, -6.0),
+            new PeqBand(80, 0.7, 4.5, PeqBandType.LowShelf),
+            new PeqBand(2_500, 3.0, -2.0),
+            new PeqBand(6_300, 1.1, -3.5, PeqBandType.HighShelf)
+        },
+        -6.5);
+
+    private static EqWizardExportTarget TargetFor(IEqProfileFormat format) => new(format);
+
+    [Fact]
+    public void AFormatThatCannotStateAShelfNeverReceivesOne()
+    {
+        string? written = null;
+        var coordinator = new EqWizardImportExportCoordinator(
+            EqProfileFormats.Importable,
+            EqProfileFormats.Exportable,
+            _ => string.Empty,
+            (_, text) => written = text,
+            _ => { });
+
+        EqWizardFileResult result = coordinator.Export(new EqWizardExportRequest(
+            "profile.json",
+            TargetFor(new EasyEffectsFormat()),
+            Mixed(),
+            48_000,
+            "title",
+            20,
+            20_000,
+            null));
+
+        Assert.True(result.Success);
+        Assert.NotNull(written);
+        // Both bells survive; neither shelf is written as something the reader
+        // would realize with a different shape.
+        Assert.Contains("1000", written);
+        Assert.Contains("2500", written);
+        Assert.DoesNotContain("80.0", written);
+        Assert.DoesNotContain("6300", written);
+    }
+
+    [Fact]
+    public void TheWarningCountsExactlyWhatWouldBeLost()
+    {
+        Assert.Equal(
+            2,
+            EqWizardImportExportCoordinator.CountShelvingBandsDroppedBy(
+                TargetFor(new EasyEffectsFormat()), Mixed()));
+
+        // Nothing to warn about when the format carries them...
+        Assert.Equal(
+            0,
+            EqWizardImportExportCoordinator.CountShelvingBandsDroppedBy(
+                TargetFor(new EqualizerApoFormat()), Mixed()));
+
+        // ...nor when the bank holds no shelf at all.
+        Assert.Equal(
+            0,
+            EqWizardImportExportCoordinator.CountShelvingBandsDroppedBy(
+                TargetFor(new EasyEffectsFormat()),
+                new EqualizationCurve(new[] { new PeqBand(1_000, 1, 3) })));
+    }
+
+    [Fact]
+    public void WithoutShelvingBands_KeepsTheBellsInOrderAndThePreamp()
+    {
+        EqualizationCurve stripped =
+            EqWizardImportExportCoordinator.WithoutShelvingBands(Mixed());
+
+        Assert.Equal(2, stripped.Bands.Count);
+        Assert.Equal(1_000, stripped.Bands[0].FrequencyHz);
+        Assert.Equal(2_500, stripped.Bands[1].FrequencyHz);
+        Assert.Equal(-6.5, stripped.PreampDb);
+    }
+
+    [Fact]
+    public void TheSheetSplitsTheTablesButKeepsTheBankNumbering()
+    {
+        (IReadOnlyList<PdfSheet.NumberedBand> peaking,
+            IReadOnlyList<PdfSheet.NumberedBand> shelving) =
+            PdfSheet.SplitByShape(Mixed().Bands);
+
+        // Filter 2 is a shelf and filter 3 a bell; each keeps the number the panel
+        // shows and an exported profile writes, rather than being renumbered 1..n
+        // inside its own table.
+        Assert.Equal(new[] { 1, 3 }, peaking.Select(entry => entry.Number));
+        Assert.Equal(new[] { 2, 4 }, shelving.Select(entry => entry.Number));
+        Assert.Equal(PeqBandType.LowShelf, shelving[0].Band.Type);
+        Assert.Equal(PeqBandType.HighShelf, shelving[1].Band.Type);
+    }
+
+    [Fact]
+    public void ASheetWithBothKindsOfFilterStillWrites()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"shelf_{Guid.NewGuid():N}.pdf");
+        try
+        {
+            TuningSheetPdf.Export(path, "LEFT MID", Mixed(), 20, 20_000, 48_000, null);
+
+            byte[] bytes = File.ReadAllBytes(path);
+            Assert.True(bytes.Length > 0);
+            Assert.Equal("%PDF", System.Text.Encoding.ASCII.GetString(bytes, 0, 4));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/tests/Resonalyze.App.Tests/EqWizardShelfExportTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardShelfExportTests.cs
@@ -100,6 +100,34 @@ public sealed class EqWizardShelfExportTests
         Assert.Equal(PeqBandType.HighShelf, shelving[1].Band.Type);
     }
 
+    // A settings or project file can carry a number no enum member matches. Whatever
+    // the app decides it is, it has to decide the SAME thing everywhere: the filter
+    // that gets realized, the profile that gets exported and the table it is printed
+    // in must not disagree about whether it is a shelf.
+    [Fact]
+    public void AnUnknownShapeIsABellToEveryConsumerAlike()
+    {
+        var unknown = new PeqBand(1_000, 2, 3, (PeqBandType)99);
+        var curve = new EqualizationCurve(new[] { unknown });
+
+        Assert.False(unknown.Type.IsShelving());
+        // Realized as a bell rather than throwing out of the audio path...
+        Assert.Equal(
+            PeakingBiquad.Compute(unknown, 48_000),
+            PeqBiquad.Compute(unknown, 48_000));
+        // ...kept by an export that drops shelves...
+        Assert.Equal(
+            0,
+            EqWizardImportExportCoordinator.CountShelvingBandsDroppedBy(
+                TargetFor(new EasyEffectsFormat()), curve));
+        Assert.Single(EqWizardImportExportCoordinator.WithoutShelvingBands(curve).Bands);
+        // ...and printed in the bell table, not labelled as a shelf.
+        (IReadOnlyList<PdfSheet.NumberedBand> peaking,
+            IReadOnlyList<PdfSheet.NumberedBand> shelving) = PdfSheet.SplitByShape(curve.Bands);
+        Assert.Single(peaking);
+        Assert.Empty(shelving);
+    }
+
     [Fact]
     public void ASheetWithBothKindsOfFilterStillWrites()
     {

--- a/tests/Resonalyze.App.Tests/PeqBankHistoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PeqBankHistoryTests.cs
@@ -1,0 +1,99 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class PeqBankHistoryTests
+{
+    private static PeqBankState Bank(params double[] frequenciesHz) =>
+        new(frequenciesHz.Select(hz => new PeqBand(hz, 5, -3)), 0);
+
+    [Fact]
+    public void UndoAndRedo_WalkTheRecordedStatesBothWays()
+    {
+        var history = new PeqBankHistory();
+        PeqBankState first = Bank(100);
+        PeqBankState second = Bank(100, 200);
+        PeqBankState third = Bank(100, 200, 400);
+
+        history.Push(first);
+        history.Push(second);
+
+        Assert.True(history.TryUndo(third, out PeqBankState back));
+        Assert.Equal(second, back);
+        Assert.True(history.TryUndo(back, out back));
+        Assert.Equal(first, back);
+        Assert.False(history.CanUndo);
+
+        Assert.True(history.TryRedo(back, out PeqBankState forward));
+        Assert.Equal(second, forward);
+        Assert.True(history.TryRedo(forward, out forward));
+        Assert.Equal(third, forward);
+        Assert.False(history.CanRedo);
+    }
+
+    [Fact]
+    public void TryUndo_OnAnEmptyHistoryLeavesTheStateAlone()
+    {
+        var history = new PeqBankHistory();
+        PeqBankState current = Bank(1000);
+
+        Assert.False(history.TryUndo(current, out PeqBankState result));
+        Assert.Equal(current, result);
+        Assert.False(history.CanRedo);
+    }
+
+    [Fact]
+    public void Push_DropsTheRedoTrail()
+    {
+        // Undoing and then editing again takes a new branch: the future that was
+        // undone is no longer reachable, so redo must not resurrect it.
+        var history = new PeqBankHistory();
+        history.Push(Bank(100));
+        Assert.True(history.TryUndo(Bank(100, 200), out PeqBankState _));
+        Assert.True(history.CanRedo);
+
+        history.Push(Bank(100));
+
+        Assert.False(history.CanRedo);
+    }
+
+    [Fact]
+    public void Push_KeepsOnlyTheMostRecentStatesOnceFull()
+    {
+        var history = new PeqBankHistory();
+        for (int index = 0; index <= PeqBankHistory.Capacity; index++)
+        {
+            history.Push(Bank(100 + index));
+        }
+
+        // Capacity + 1 states were pushed, so the oldest is gone; walking all the
+        // way back must land on the second one, never on the dropped first.
+        PeqBankState state = Bank(9000);
+        int steps = 0;
+        while (history.TryUndo(state, out state))
+        {
+            steps++;
+        }
+
+        Assert.Equal(PeqBankHistory.Capacity, steps);
+        Assert.Equal(Bank(101), state);
+    }
+
+    [Fact]
+    public void States_WithTheSameBandsInADifferentOrderAreNotEqual()
+    {
+        // Order is what an exported profile numbers its filters by, so a reorder
+        // is a real change and has to be recordable as one.
+        Assert.NotEqual(Bank(100, 200), Bank(200, 100));
+        Assert.Equal(Bank(100, 200), Bank(100, 200));
+    }
+
+    [Fact]
+    public void States_DifferOnPreampAlone()
+    {
+        var quiet = new PeqBankState(new[] { new PeqBand(100, 5, -3) }, -6);
+        var loud = new PeqBankState(new[] { new PeqBand(100, 5, -3) }, 0);
+
+        Assert.NotEqual(quiet, loud);
+    }
+}

--- a/tests/Resonalyze.App.Tests/PeqSlotControlCommitTests.cs
+++ b/tests/Resonalyze.App.Tests/PeqSlotControlCommitTests.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// A strip's fields commit typed text when they lose focus or take Enter, which is
+/// enough while the application is running. It is not enough while it is being torn
+/// down: an OS shutdown persists the settings with the caret still in the box, and
+/// the value read there would be the one from before the number was typed.
+/// </summary>
+public sealed class PeqSlotControlCommitTests
+{
+    [Fact]
+    public void CommitPendingText_LandsTypedTextInEveryFieldWithoutLeavingIt()
+    {
+        using var slot = new PeqSlotControl();
+        Editor(slot.FrequencyInput).Text = Local(315m);
+        Editor(slot.QInput).Text = Local(2.5m);
+        Editor(slot.GainInput).Text = Local(-4.5m);
+
+        // Nothing has left the fields, so nothing has committed yet.
+        Assert.NotEqual(315m, slot.FrequencyInput.Value);
+
+        slot.CommitPendingText();
+
+        Assert.Equal(315m, slot.FrequencyInput.Value);
+        Assert.Equal(2.5m, slot.QInput.Value);
+        Assert.Equal(-4.5m, slot.GainInput.Value);
+    }
+
+    [Fact]
+    public void CommitPendingText_LeavesAnUntouchedStripAlone()
+    {
+        using var slot = new PeqSlotControl();
+        slot.FrequencyInput.Value = 1_000m;
+        slot.QInput.Value = 5m;
+        slot.GainInput.Value = 0m;
+
+        slot.CommitPendingText();
+
+        Assert.Equal(1_000m, slot.FrequencyInput.Value);
+        Assert.Equal(5m, slot.QInput.Value);
+        Assert.Equal(0m, slot.GainInput.Value);
+    }
+
+    [Fact]
+    public void CommitPendingText_OnUnparseableTextKeepsTheCommittedValue()
+    {
+        using var slot = new PeqSlotControl();
+        slot.GainInput.Value = -3m;
+        Editor(slot.GainInput).Text = "not a number";
+
+        slot.CommitPendingText();
+
+        Assert.Equal(-3m, slot.GainInput.Value);
+    }
+
+    // The editor is the control's own inner TextBox; the tests reach it the same way
+    // DarkNumericUpDownEnterKeyTests does, since typing is what they simulate.
+    private static TextBox Editor(DarkNumericUpDown control) =>
+        (TextBox)typeof(DarkNumericUpDown)
+            .GetField("editor", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(control)!;
+
+    private static string Local(decimal value) =>
+        value.ToString(CultureInfo.CurrentCulture);
+}

--- a/tests/Resonalyze.App.Tests/PeqSlotGridTests.cs
+++ b/tests/Resonalyze.App.Tests/PeqSlotGridTests.cs
@@ -1,0 +1,39 @@
+using System.Drawing;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class PeqSlotGridTests
+{
+    // A 4-column grid of 20 px cells over two 30 px rows, standing in for the
+    // panel's 16x2 strip grid.
+    private static readonly int[] Columns = { 20, 20, 20, 20 };
+    private static readonly int[] Rows = { 30, 30 };
+
+    [Theory]
+    [InlineData(0, 0, 0)]
+    [InlineData(19, 29, 0)]
+    [InlineData(20, 0, 1)]
+    [InlineData(79, 29, 3)]
+    [InlineData(0, 30, 4)]
+    [InlineData(45, 59, 6)]
+    public void IndexAt_ReadsTheGridRowMajor(int x, int y, int expected) =>
+        Assert.Equal(expected, PeqSlotGrid.IndexAt(Columns, Rows, new Point(x, y)));
+
+    [Fact]
+    public void IndexAt_ClampsAPointDraggedPastTheEdges()
+    {
+        // A drag that strays outside the grid still has to name a target cell,
+        // otherwise the strip would jump to slot 1 on every overshoot.
+        Assert.Equal(0, PeqSlotGrid.IndexAt(Columns, Rows, new Point(-40, -10)));
+        Assert.Equal(7, PeqSlotGrid.IndexAt(Columns, Rows, new Point(400, 200)));
+    }
+
+    [Fact]
+    public void CellOf_FillsEachRowLeftToRight()
+    {
+        Assert.Equal((0, 0), PeqSlotGrid.CellOf(0, 16));
+        Assert.Equal((15, 0), PeqSlotGrid.CellOf(15, 16));
+        Assert.Equal((0, 1), PeqSlotGrid.CellOf(16, 16));
+        Assert.Equal((15, 1), PeqSlotGrid.CellOf(31, 16));
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetTests.cs
@@ -58,6 +58,48 @@ public sealed class VirtualCrossoverSheetTests
         Assert.Contains($"Fc 120 Hz Gain -4.0 dB {expectedQ}", text);
     }
 
+    // The text sheet is an instruction to type filters into a DSP, so it has to name
+    // the shape as well as the numbers. A shelf printed as PK sends the tuner to the
+    // wrong filter type with the right frequency — the shape reads plausible and the
+    // curve is wrong. LSC/HSC are the Equalizer APO keywords that carry a Q, which is
+    // what the sheet prints beside them.
+    [Fact]
+    public void FormatText_NamesTheFilterShapeOfEveryBand()
+    {
+        VirtualCrossoverProjectFile project = CreateProject();
+        project.Pairs[0].Left!.PeqBands =
+        [
+            new PeqBand(120, 2.0, -4.0),
+            new PeqBand(80, 0.7, 4.5, PeqBandType.LowShelf),
+            new PeqBand(6_300, 1.1, -3.5, PeqBandType.HighShelf)
+        ];
+
+        string text = VirtualCrossoverSheet.FormatText(project, null);
+
+        Assert.Contains("Filter 1: ON PK Fc 120 Hz Gain -4.0 dB Q 2", text);
+        Assert.Contains("Filter 2: ON LSC Fc 80 Hz Gain +4.5 dB Q 0.7", text);
+        Assert.Contains("Filter 3: ON HSC Fc 6300 Hz Gain -3.5 dB Q 1.1", text);
+    }
+
+    // A shelf's Q is a knee, not a bandwidth, so no convention restates it — while the
+    // bell beside it is restated as usual.
+    [Fact]
+    public void FormatText_LeavesAShelfQAloneUnderAProportionalConvention()
+    {
+        VirtualCrossoverProjectFile project = CreateProject();
+        project.Pairs[0].Left!.PeqBands =
+        [
+            new PeqBand(120, 2.0, -4.0),
+            new PeqBand(80, 0.7, 12.0, PeqBandType.LowShelf)
+        ];
+
+        string text = VirtualCrossoverSheet.FormatText(
+            project, null, PeqQConvention.Symmetric);
+
+        Assert.Contains("Fc 120 Hz Gain -4.0 dB Q 2.52", text);
+        Assert.Contains("Fc 80 Hz Gain +12.0 dB Q 0.7", text);
+    }
+
     // Named on every sheet, including the default one — a sheet that does not say which
     // convention its Q belongs to is unreadable a month later.
     [Theory]

--- a/tests/Resonalyze.Dsp.Tests/EqProfileShelfFormatsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EqProfileShelfFormatsTests.cs
@@ -1,0 +1,126 @@
+namespace Resonalyze.Dsp.Tests;
+
+// What the shelves survive on the way out to another program and back. The
+// formats that state a shelf with a centre frequency and a Q hold ours exactly;
+// the ones that cannot say so are declared unsupported and drop them, which the
+// EQ Wizard turns into a warning before the file is written.
+public sealed class EqProfileShelfFormatsTests
+{
+    private static EqualizationCurve Mixed() => new(
+        new[]
+        {
+            new PeqBand(80, 0.7, 4.5, PeqBandType.LowShelf),
+            new PeqBand(1_000, 4.0, -6.0),
+            new PeqBand(6_300, 1.1, -3.5, PeqBandType.HighShelf)
+        },
+        -6.5);
+
+    [Fact]
+    public void EqualizerApo_WritesTheShelvesAsLscAndHsc()
+    {
+        string text = new EqualizerApoFormat().Export(Mixed());
+
+        // LSC/HSC are the variants that carry a Q, and their Fc is the middle of the
+        // transition — the same shelf this library realizes. Plain LS/HS would leave
+        // the reader to assume a slope.
+        Assert.Contains("ON LSC Fc 80 Hz Gain 4.5 dB Q 0.7", text);
+        Assert.Contains("ON PK Fc 1000 Hz Gain -6.0 dB Q 4.0", text);
+        Assert.Contains("ON HSC Fc 6300 Hz Gain -3.5 dB Q 1.1", text);
+    }
+
+    [Theory]
+    [InlineData(typeof(EqualizerApoFormat))]
+    [InlineData(typeof(RewFilterFormat))]
+    [InlineData(typeof(GenericCsvFormat))]
+    [InlineData(typeof(CamillaDspYamlFormat))]
+    public void RoundTrip_KeepsEachBandsShapeAndOrder(Type formatType)
+    {
+        var format = (IEqProfileFormat)Activator.CreateInstance(formatType)!;
+        EqualizationCurve original = Mixed();
+
+        Assert.True(format.TryImport(format.Export(original), out EqualizationCurve read));
+
+        Assert.Equal(original.Bands.Count, read.Bands.Count);
+        for (int index = 0; index < original.Bands.Count; index++)
+        {
+            PeqBand expected = original.Bands[index];
+            PeqBand actual = read.Bands[index];
+            Assert.Equal(expected.Type, actual.Type);
+            Assert.Equal(expected.FrequencyHz, actual.FrequencyHz, 3);
+            Assert.Equal(expected.Q, actual.Q, 3);
+            Assert.Equal(expected.GainDb, actual.GainDb, 3);
+        }
+    }
+
+    [Fact]
+    public void EqualizerApo_ReadsAShelfWrittenWithoutAQ()
+    {
+        // Plain LS/HS state no slope of their own, so they come in at the steepest
+        // knee that stays monotonic rather than being dropped.
+        Assert.True(new EqualizerApoFormat().TryImport(
+            "Filter 1: ON LS Fc 100 Hz Gain 5.0 dB",
+            out EqualizationCurve curve));
+
+        PeqBand band = Assert.Single(curve.Bands);
+        Assert.Equal(PeqBandType.LowShelf, band.Type);
+        Assert.Equal(100, band.FrequencyHz);
+        Assert.Equal(5.0, band.GainDb);
+        Assert.Equal(0.7071, band.Q, 3);
+    }
+
+    [Theory]
+    // The corner-frequency family: Fc is the corner, not the middle of the
+    // transition, so reading it as ours would move the shelf.
+    [InlineData("Filter 1: ON LS 6dB Fc 50 Hz Gain 7.2 dB")]
+    [InlineData("Filter 1: ON HS 12dB Fc 500 Hz Gain 5.0 dB")]
+    // The dB-per-octave spelling of LSC: the number is a slope, not our Q.
+    [InlineData("Filter 1: ON LSC 10.8 dB Fc 300 Hz Gain 5.0 dB")]
+    public void EqualizerApo_SkipsShelvesStatedInAnotherParameterisation(string line)
+    {
+        new EqualizerApoFormat().TryImport(line, out EqualizationCurve curve);
+
+        Assert.Empty(curve.Bands);
+    }
+
+    [Fact]
+    public void GenericCsv_ReadsAFileWrittenBeforeTheTypeColumnExisted()
+    {
+        string legacy = string.Join(
+            Environment.NewLine,
+            "Preamp (dB),-3.0",
+            "Filter,Frequency (Hz),Gain (dB),Q",
+            "1,600,6.0,4.0");
+
+        Assert.True(new GenericCsvFormat().TryImport(legacy, out EqualizationCurve curve));
+
+        PeqBand band = Assert.Single(curve.Bands);
+        Assert.Equal(PeqBandType.Peaking, band.Type);
+        Assert.Equal(600, band.FrequencyHz);
+    }
+
+    [Fact]
+    public void MiniDsp_RealizesAShelfAsItsOwnCoefficients()
+    {
+        // Coefficients carry any shape by construction; the check is that the
+        // exporter went through the dispatcher and not through the peaking formula.
+        var shelf = new PeqBand(120, 0.7, 6, PeqBandType.LowShelf);
+        string text = new MiniDspFormat(48_000).Export(new EqualizationCurve(new[] { shelf }));
+        BiquadCoefficients expected = ShelvingBiquad.Compute(shelf, 48_000);
+
+        Assert.Contains($"b0={EqTextNumbers.Format(expected.B0, "0.00000000")}", text);
+        Assert.Contains($"a2={EqTextNumbers.Format(expected.A2, "0.00000000")}", text);
+    }
+
+    [Fact]
+    public void EasyEffects_DeclaresItCannotCarryAShelf()
+    {
+        // Its shelving bands are LSP filters whose steepness comes from a mode and a
+        // slope multiplier, not from an RBJ shelf Q, so ours cannot be written into
+        // one. Declaring that is what makes the EQ Wizard warn instead of lie.
+        // Read through the interface: the capability is a default interface member,
+        // which is exactly how every caller sees it.
+        Assert.False(((IEqProfileFormat)new EasyEffectsFormat()).SupportsShelvingFilters);
+        Assert.True(((IEqProfileFormat)new EqualizerApoFormat()).SupportsShelvingFilters);
+        Assert.True(((IEqProfileFormat)new MiniDspFormat(48_000)).SupportsShelvingFilters);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/ShelvingBiquadTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/ShelvingBiquadTests.cs
@@ -1,0 +1,139 @@
+namespace Resonalyze.Dsp.Tests;
+
+// The defining properties of an RBJ shelf, pinned against the realized biquad
+// rather than against a second copy of the same formula: full gain on its own
+// side, unity on the other, and exactly half the gain at the stated frequency —
+// which is what makes that frequency the middle of the transition.
+public sealed class ShelvingBiquadTests
+{
+    private const double SampleRate = 48_000;
+
+    private static double MagnitudeDb(PeqBand band, double frequencyHz) =>
+        DigitalEqualizationResponse.MagnitudeDbAt(band, frequencyHz, SampleRate);
+
+    [Theory]
+    [InlineData(6.0)]
+    [InlineData(-9.0)]
+    public void LowShelf_LiftsBelowAndLeavesAboveAlone(double gainDb)
+    {
+        var band = new PeqBand(200, 0.7, gainDb, PeqBandType.LowShelf);
+
+        Assert.Equal(gainDb, MagnitudeDb(band, 5), 1);
+        Assert.Equal(gainDb / 2, MagnitudeDb(band, 200), 2);
+        Assert.Equal(0, MagnitudeDb(band, 10_000), 1);
+    }
+
+    [Theory]
+    [InlineData(6.0)]
+    [InlineData(-9.0)]
+    public void HighShelf_IsTheMirrorImage(double gainDb)
+    {
+        var band = new PeqBand(4_000, 0.7, gainDb, PeqBandType.HighShelf);
+
+        Assert.Equal(0, MagnitudeDb(band, 40), 1);
+        Assert.Equal(gainDb / 2, MagnitudeDb(band, 4_000), 2);
+        // Not Nyquist itself: the bilinear transform pins the response there, and a
+        // shelf is judged where music lives.
+        Assert.Equal(gainDb, MagnitudeDb(band, 18_000), 1);
+    }
+
+    [Fact]
+    public void ShelfQ_BelowTheMonotonicLimitDoesNotOvershoot()
+    {
+        var band = new PeqBand(500, 0.7071, 8, PeqBandType.LowShelf);
+
+        double previous = MagnitudeDb(band, 20_000);
+        foreach (double frequency in EqualizationCurve.LogFrequencyGrid(20, 20_000, 400).Reverse())
+        {
+            double current = MagnitudeDb(band, frequency);
+            Assert.True(
+                current >= previous - 1e-9,
+                $"the shelf dips at {frequency:0} Hz: {current:0.000} after {previous:0.000} dB");
+            previous = current;
+        }
+
+        Assert.True(previous <= 8 + 1e-6, "the shelf overshot its own gain.");
+    }
+
+    [Fact]
+    public void ShelfQ_AboveTheMonotonicLimitOvershoots()
+    {
+        // The reason a shelf's Q is a knee and not a bandwidth: past 1/sqrt(2) the
+        // response rises past the shelf before settling on it. A user typing a
+        // bell's Q into a shelf has to be able to see that in the curve.
+        var band = new PeqBand(500, 3.0, 8, PeqBandType.LowShelf);
+
+        double peak = EqualizationCurve.LogFrequencyGrid(20, 20_000, 400)
+            .Max(frequency => MagnitudeDb(band, frequency));
+
+        Assert.True(peak > 9.0, $"a Q of 3 should overshoot 8 dB; it peaked at {peak:0.0}.");
+    }
+
+    [Fact]
+    public void AnalogPrototypeAgreesWithTheRealizedBiquad()
+    {
+        // The prototype is what plots and synthetic sources use; it has to be the
+        // same filter as the biquad, not merely a similar shape. They part company
+        // as the bilinear transform warps toward Nyquist, so this holds where a
+        // shelf is judged, not at the very top.
+        var shelves = new[]
+        {
+            new PeqBand(120, 0.7, 6, PeqBandType.LowShelf),
+            new PeqBand(3_000, 1.2, -8, PeqBandType.HighShelf)
+        };
+
+        foreach (PeqBand band in shelves)
+        {
+            foreach (double frequency in EqualizationCurve.LogFrequencyGrid(20, 8_000, 60))
+            {
+                double analog = band.MagnitudeDbAt(frequency);
+                double digital = MagnitudeDb(band, frequency);
+                // An absolute tolerance rather than a rounded comparison: the two
+                // differ by hundredths of a dB, which a decimal-place assert can
+                // still fail on either side of a rounding boundary.
+                Assert.True(
+                    Math.Abs(analog - digital) < 0.15,
+                    $"{band.Type} at {frequency:0} Hz: prototype {analog:0.000} dB, " +
+                    $"biquad {digital:0.000} dB");
+            }
+        }
+    }
+
+    [Fact]
+    public void ATransparentShelfIsFlat()
+    {
+        var band = new PeqBand(1_000, 0.7, 0, PeqBandType.LowShelf);
+
+        Assert.True(band.IsTransparent);
+        Assert.Equal(0, MagnitudeDb(band, 100), 6);
+        Assert.Equal(0, MagnitudeDb(band, 10_000), 6);
+    }
+
+    [Fact]
+    public void ComputeRejectsAPeakingBand()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ShelvingBiquad.Compute(new PeqBand(1_000, 1, 6), SampleRate));
+    }
+
+    [Fact]
+    public void QConventions_LeaveAShelfAlone()
+    {
+        // The conventions restate a bandwidth between half-gain points. A shelf has
+        // none, so rescaling its Q by the gain would print a shelf that overshoots
+        // where the designed one does not.
+        var shelf = new PeqBand(100, 0.7, 12, PeqBandType.LowShelf);
+
+        Assert.Equal(
+            shelf.Q,
+            PeqQConventions.ToConvention(shelf, PeqQConvention.Symmetric).Q,
+            10);
+        Assert.Equal(
+            shelf.Q,
+            PeqQConventions.ToConvention(shelf, PeqQConvention.Classic).Q,
+            10);
+        // A bell of the same depth is restated, so the test is really testing the type.
+        var bell = new PeqBand(100, 0.7, 12);
+        Assert.True(PeqQConventions.ToConvention(bell, PeqQConvention.Symmetric).Q > 1.3);
+    }
+}


### PR DESCRIPTION
The PEQ bank stops being a fixed rack of 32 mostly-greyed strips and becomes a
list the user builds: filters are added one at a time, reordered and thrown away
by dragging, undone with Ctrl+Z, kept between sessions, and can now be shelves as
well as bells.

## The bank

* Opens empty. Filters are added from a tile split into one zone per shape — PK,
  HS, LS — each with its own dashed frame, plus and label. The tile trails the
  last strip and disappears at 32.
* A strip is dragged by its **number** to reorder it (the bank re-orders live
  under the pointer) and dragged **out of the bank** to remove it, with the
  cursor turning into a bin outside and Escape putting the strip back.
* Right-clicking the number switches a filter between a bell and a shelf in
  place, keeping its frequency, Q and gain.
* A strip's index IS its filter number, its cell and the number an exported
  profile writes — so order is state, not decoration.

## Undo

Snapshots of the whole bank (filters, order, preamp), 100 deep. Field and fader
edits coalesce into one step once the bank goes quiet; an add, a removal, a
reorder, an import and a whole Auto Tune result are each a single step. The
source, the target and the Auto Tune settings are deliberately **not** part of
it, and the shortcut is bound at the panel — which costs a numeric field its own
in-place Ctrl+Z, a deliberate trade.

## Persistence

`EqWizardSettings` now carries the bank itself (frequency, Q, gain and shape per
filter, in slot order) plus the preamp, written once per undo step. Schema goes
9 → 10; a 7..9 file carries only the filter count and still opens, rebuilding the
ISO-centred spread those versions showed. An empty bank round-trips as empty —
only a missing list means "rebuild from the count".

## Shelving filters

`PeqBand` gains a `Type` as a defaulted fourth positional parameter, so no
existing call site changed and old files read back as bells. All realization goes
through one new dispatcher, `PeqBiquad`, which the response preview, the Virtual
DSP chain and the coefficient exports now share.

Shelves are parameterised by an **RBJ shelf Q** — the parameter the export
targets actually read:

| Format | Shelves |
| --- | --- |
| Equalizer APO, REW | `LSC` / `HSC` with a Q (verified against the APO configuration reference) |
| CamillaDSP | `Lowshelf` / `Highshelf`, same freq/gain/q triple |
| Generic CSV | new `Type` column; files without it still read |
| miniDSP, GraphicEQ | free — coefficients and a sampled curve carry any shape |
| EasyEffects | **cannot state ours** — declared unable, warned about, dropped |

EasyEffects' shelving bands are LSP filters whose steepness comes from a mode and
a slope multiplier rather than an RBJ Q, so writing our number into one would
produce a differently-shaped shelf on the target. The panel says exactly how many
filters would be left out and asks; the coordinator strips them either way, so a
file can never contain a shelf the reader would realize differently.

Import gains shelves as a side effect — a REW file's shelves used to be dropped
silently. The `LS 6dB` / `HS 12dB` and `LSC 10.8 dB` spellings state a corner
frequency or a dB-per-octave slope, so they are still skipped rather than read
into a shelf that would sit somewhere else.

Two consequences that would otherwise be silent bugs:

* **The Q conventions no longer restate a shelf.** They translate a bandwidth
  between half-gain points; a shelf has none (its Q is a knee), so scaling it by
  the gain would have printed a shelf that overshoots where the designed one does
  not.
* **The tuning sheets print shelves in their own table**, after the bells and
  keeping the bank numbering, because frequency, Q and direction do not mean what
  the three bell rows say.

Auto Tune is unchanged by design: bells only, and it still replaces the whole
bank, so a hand-dialled shelf does not survive a re-fit. That is now stated where
it is decided.

## Verification

1967 tests, zero warnings. New coverage: shelf math against the realized biquad
(full gain on its own side, unity on the other, exactly half at Fc, monotonic at
Q 0.707, overshoot at Q 3, analog prototype vs biquad), profile round-trips
keeping shape and order, the rejected parameterisations, export exclusion and
count, the sheet's table split with bank numbering, undo/redo semantics, the drag
hit test and settings round-trips.

Beyond the suites, the bank was driven end-to-end on a live panel in a scratchpad
harness (53 checks): grid cells and renumbering after every reorder, the add tile
appearing and disappearing at 32, the drag hit test against real strip geometry,
undo of a reorder/removal/type change, a curated bank surviving capture into a
fresh panel, and the actual curve — a +6 dB low shelf measuring **+5.94 dB at
30 Hz and 0.00 dB at 15 kHz**.

**Not machine-verified:** the mouse gestures themselves (the OLE drag loop, the
zone clicks, the bin cursor appearing) were exercised by hand, not by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
