### PR TITLE
Find the recorded sweep by matching it, not by looking for something loud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1432,18 +1432,28 @@ played from something else (typically the file written by
 with the inverse filter of the sweep the **current settings** describe, and the
 transfer function is estimated against that same sweep standing in for the
 loopback reference — the excitation is known exactly, because it is the signal
-that was played. If the file has more than one channel, the loudest one by RMS is
-measured and Resonalyze reports which one that was.
+that was played. If the file has more than one channel, the one whose content
+actually matches the sweep is measured — not the loudest, because a dead input is
+rarely silent and its hum can easily out-measure a quiet microphone — and
+Resonalyze reports which one that was.
 
 The recording may be far longer than the sweep — starting the recorder, walking
 to the listening position, playing the sweep and walking back is the normal way
-to make one. Resonalyze locates the excitation and analyzes it together with
-0.5 s before and 2 s of decay after, so the silence never reaches the analysis:
-on a 92-second take of a 2.15-second sweep that is 4.65 s of audio instead of the
-whole file, which cuts the work from 3.4 s and 1.9 GB of transient spectra to
-0.18 s and 100 MB, and the transfer IR the measurement then carries (and writes
-into a saved `.json`) from 268 MB to 8 MB. If a take holds the sweep more than
-once, the first one is measured.
+to make one. The excitation is found by matching the sweep against the recording
+rather than by looking for something loud, which answers the question that
+matters ("where is THIS sweep") instead of a proxy that content can defeat: a
+system whose bass is crossed out is quiet for its first octaves, and a door or a
+voice is louder than a careful measurement. Matching also reaches much further
+down — it concentrates the whole excitation into one peak, worth about 46 dB for
+a two-second sweep — so a take that sounds empty still resolves to the sample.
+
+What is then analyzed is the excitation with 0.5 s before it and 2 s of decay
+after, so the silence never reaches the analysis: on a 92-second take of a
+2.15-second sweep that is 4.65 s of audio instead of the whole file, which cuts
+the work from 3.4 s and 1.9 GB of transient spectra to 0.18 s and 100 MB, and the
+transfer IR the measurement then carries (and writes into a saved `.json`) from
+268 MB to 8 MB. If a take holds the sweep more than once, every occurrence is a
+candidate and the best is measured.
 
 Whatever played the file and whatever recorded it run on their own clocks, so the
 sweep comes back slightly stretched or squeezed — and a per-octave time in whole

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -292,6 +292,16 @@ namespace Resonalyze
                 {
                     throw new InvalidOperationException("Measurement is not initialized.");
                 }
+                // An outstanding claim owns this measurement for an operation
+                // that has no task to wait on — a file import spanning its
+                // decode. A run started underneath it would publish over the
+                // import's result, and its own completion would clear the busy
+                // flag the import is still holding.
+                if (claimed)
+                {
+                    throw new InvalidOperationException(
+                        "The measurement is already busy.");
+                }
 
                 cancellationTokenSource?.Dispose();
                 cancellationTokenSource = new CancellationTokenSource();

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -587,12 +587,13 @@ namespace Resonalyze
         /// </para>
         /// </remarks>
         /// <summary>
-        /// The same import over a multi-channel recording, choosing the channel
-        /// that best MATCHES the sweep rather than the loudest one. A recorder
-        /// routinely delivers one live microphone beside a dead input, and a dead
-        /// input is rarely silent — hum, a preamp hiss, a plugged-in cable picking
-        /// up the car — so "loudest" can name the channel with no measurement in
-        /// it. The chosen one is reported through
+        /// The same import over a multi-channel recording, measuring the channel
+        /// that best MATCHES the sweep (see <see cref="RecordedSweepChannels"/>).
+        /// Only for callers with no one to ask: when more than one channel
+        /// plausibly holds the sweep the best match is not the answer — a DAW's
+        /// reference track is a copy of the excitation and beats the microphone
+        /// every time — so the UI ranks the channels itself and imports the one
+        /// the user picks. The chosen one is reported through
         /// <see cref="ImportedChannelIndex"/>.
         /// </summary>
         public void ImportRecordedSweep(
@@ -607,33 +608,36 @@ namespace Resonalyze
                 throw new InvalidOperationException("The recording has no channels.");
             }
 
-            int chosen = 0;
-            if (channels.Length > 1)
-            {
-                using var probe = new ExponentialSineSweep();
-                SweepSignalConfiguration signal = configuration.Signal;
-                probe.FillData(
-                    signal.LowFrequencyHz,
-                    signal.HighFrequencyHz,
-                    signal.RequestedDurationSeconds,
-                    signal.Bits,
-                    signal.SampleRate);
-                double best = -1;
-                for (int channel = 0; channel < channels.Length; channel++)
-                {
-                    double quality = RecordedSweepDetector
-                        .FindSweeps(channels[channel], probe.SweepData, 1)
-                        .FirstOrDefault().Quality;
-                    if (quality > best)
-                    {
-                        best = quality;
-                        chosen = channel;
-                    }
-                }
-            }
+            ImportRecordedSweep(
+                configuration,
+                channels,
+                sampleRate,
+                channels.Length > 1
+                    ? RecordedSweepChannels.Best(
+                        RecordedSweepChannels.Rank(configuration, channels))
+                    : 0);
+        }
 
-            ImportRecordedSweep(configuration, channels[chosen], sampleRate);
-            ImportedChannelIndex = chosen;
+        /// <summary>
+        /// The import over a named channel of a multi-channel recording.
+        /// </summary>
+        public void ImportRecordedSweep(
+            SweepMeasurementConfiguration configuration,
+            float[][] channels,
+            int sampleRate,
+            int channel)
+        {
+            ArgumentNullException.ThrowIfNull(configuration);
+            ArgumentNullException.ThrowIfNull(channels);
+            if (channels.Length == 0)
+            {
+                throw new InvalidOperationException("The recording has no channels.");
+            }
+            ArgumentOutOfRangeException.ThrowIfNegative(channel);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(channel, channels.Length);
+
+            ImportRecordedSweep(configuration, channels[channel], sampleRate);
+            ImportedChannelIndex = channel;
         }
 
         public void ImportRecordedSweep(

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -81,6 +81,13 @@ namespace Resonalyze
         /// </para>
         /// </summary>
         public double? ImportedTimeScalePpm { get; private set; }
+
+        /// <summary>
+        /// Which channel of an imported recording was measured — the one whose
+        /// match against the sweep was strongest. Zero for a mono file and for
+        /// every result that did not come from a multi-channel import.
+        /// </summary>
+        public int ImportedChannelIndex { get; private set; }
         public bool HasImpulseResponse => SweepDeconvolutionImpulseResponse != null;
         public bool InProgress => inProgress;
         public int SampleRate { get; private set; }
@@ -248,6 +255,7 @@ namespace Resonalyze
             MeasurementMode = SweepMeasurementMode.SweepDeconvolution;
             TimingReference = TimingReference.SynchronizedLoopback;
             ImportedTimeScalePpm = null;
+            ImportedChannelIndex = 0;
             AverageRunCount = Math.Clamp(averaging.RunCount, 1, 64);
             AcceptedAverageRunCount = 0;
             ConfirmEachAverageRun = averaging.ConfirmEachRun;
@@ -568,6 +576,56 @@ namespace Resonalyze
         /// <see cref="MeasurementSplCalibration"/> for this result.
         /// </para>
         /// </remarks>
+        /// <summary>
+        /// The same import over a multi-channel recording, choosing the channel
+        /// that best MATCHES the sweep rather than the loudest one. A recorder
+        /// routinely delivers one live microphone beside a dead input, and a dead
+        /// input is rarely silent — hum, a preamp hiss, a plugged-in cable picking
+        /// up the car — so "loudest" can name the channel with no measurement in
+        /// it. The chosen one is reported through
+        /// <see cref="ImportedChannelIndex"/>.
+        /// </summary>
+        public void ImportRecordedSweep(
+            SweepMeasurementConfiguration configuration,
+            float[][] channels,
+            int sampleRate)
+        {
+            ArgumentNullException.ThrowIfNull(configuration);
+            ArgumentNullException.ThrowIfNull(channels);
+            if (channels.Length == 0)
+            {
+                throw new InvalidOperationException("The recording has no channels.");
+            }
+
+            int chosen = 0;
+            if (channels.Length > 1)
+            {
+                using var probe = new ExponentialSineSweep();
+                SweepSignalConfiguration signal = configuration.Signal;
+                probe.FillData(
+                    signal.LowFrequencyHz,
+                    signal.HighFrequencyHz,
+                    signal.RequestedDurationSeconds,
+                    signal.Bits,
+                    signal.SampleRate);
+                double best = -1;
+                for (int channel = 0; channel < channels.Length; channel++)
+                {
+                    double quality = RecordedSweepDetector
+                        .FindSweeps(channels[channel], probe.SweepData, 1)
+                        .FirstOrDefault().Quality;
+                    if (quality > best)
+                    {
+                        best = quality;
+                        chosen = channel;
+                    }
+                }
+            }
+
+            ImportRecordedSweep(configuration, channels[chosen], sampleRate);
+            ImportedChannelIndex = chosen;
+        }
+
         public void ImportRecordedSweep(
             SweepMeasurementConfiguration configuration,
             float[] recordedSamples,
@@ -658,21 +716,17 @@ namespace Resonalyze
             bool measurable = false;
             int longestExcitation = 0;
             IReadOnlyList<string>? captureIssues = null;
-            // The excitation is found by level, and a level crosses the detector's
-            // threshold INSIDE the fade-in rather than at the first sample, so the
-            // real start sits up to a fade-in (plus one detection window) earlier
-            // than the reported one. Without that slack a take holding exactly the
-            // sweep and no tail reads as cut short by the detector's own lateness.
-            int detectionSlack = sweep.Spec.FadeInSamples + sampleRate / 100;
             foreach (RecordedSweepSpan span in RecordedSweepWindow.LocateCandidates(
-                recordedSamples, sampleRate, sweep.SweepSamples))
+                recordedSamples, sweep.SweepData, sampleRate))
             {
                 // Measured from where the EXCITATION begins, not from the start of
                 // the span: the span counts its lead-in silence too, so a take that
                 // holds a pre-roll and then runs out mid-sweep would read as long
                 // enough and be analyzed against an excitation it never finished.
+                // No slack: the sweep is located by matching it, so its start is a
+                // sample rather than the moment a level crossed a threshold.
                 longestExcitation = Math.Max(longestExcitation, span.ExcitationLength);
-                if (span.ExcitationLength + detectionSlack < sweep.SweepSamples)
+                if (span.ExcitationLength < sweep.SweepSamples)
                 {
                     // Found too close to the end to hold the whole sweep; a later
                     // candidate may still fit.
@@ -723,10 +777,16 @@ namespace Resonalyze
                 }
             }
 
-            if (longestExcitation + detectionSlack < sweep.SweepSamples)
+            if (longestExcitation < sweep.SweepSamples)
             {
+                // Two readings fit this, and the data does not choose between
+                // them: a normalized match separates a clean take (1.0) from
+                // noise (0.02) easily, but a noisy real take reads 0.06 and a
+                // recording of a DIFFERENT sweep reads 0.21 — they overlap. So
+                // the message names both rather than picking one on a threshold
+                // that would be wrong as often as right.
                 throw new InvalidOperationException(FormattableString.Invariant(
-                    $"The excitation starts {longestExcitation / (double)sampleRate:0.00} s before the end of the recording, which is less than the sweep's own {sweep.ComputedDuration:0.00} s. The take is cut short — record again with the whole sweep inside it."));
+                    $"The excitation was found only {longestExcitation / (double)sampleRate:0.00} s before the end of the recording, less than the sweep's own {sweep.ComputedDuration:0.00} s. Either the take is cut short — record again with the whole sweep inside it — or this is not a recording of this sweep, in which case check the band and the per-octave time in Measurement Options."));
             }
             if (captureIssues is { Count: > 0 })
             {

--- a/source/Measurements/RecordedSweepChannels.cs
+++ b/source/Measurements/RecordedSweepChannels.cs
@@ -1,0 +1,122 @@
+﻿namespace Resonalyze;
+
+/// <summary>
+/// Which channel of a multi-channel recording holds the measurement.
+/// <para>
+/// Ranked by how well each channel MATCHES the configured sweep rather than by
+/// how loud it is: a recorder routinely delivers one live microphone beside a
+/// dead input, and a dead input is rarely silent — hum, preamp hiss, a cable
+/// picking up the car — so "loudest" can name the channel with no measurement in
+/// it.
+/// </para>
+/// <para>
+/// The rank alone cannot finish the job, though, and that is what
+/// <see cref="IsAmbiguous"/> is for. A file written by a DAW often carries the
+/// played sweep on one track beside the microphone on another, and the played
+/// track is a copy of the excitation: it matches perfectly, wins, and then
+/// measures as a flat, credible, completely meaningless response. No number
+/// separates "the reference track" from "the take" — both are recordings of this
+/// sweep — so when more than one channel plausibly holds it, the choice belongs
+/// to whoever made the recording.
+/// </para>
+/// </summary>
+internal static class RecordedSweepChannels
+{
+    /// <summary>
+    /// How close the runner-up has to come to the best match before the choice
+    /// stops being obvious: a quarter of it, i.e. within 12 dB.
+    /// </summary>
+    /// <remarks>
+    /// Measured as the runner-up's share of the best match, over the cases that
+    /// have to fall on either side of it. A channel that really holds a second
+    /// recording of the sweep is not marginally behind: a microphone beside the
+    /// played reference reads 0.77 and 0.85 of it on two synthetics. A channel
+    /// that holds no take at all is an order of magnitude down: 0.031 and 0.032
+    /// on the dead channel of the two field files, 0.004 for hum. In absolute
+    /// terms the same gap — real takes score 1.00, 0.93, 0.42; hum 0.05, hiss
+    /// 0.01, a recording of a DIFFERENT sweep 0.10. The rule sits between two
+    /// clusters a factor of ten apart rather than on a knife edge, which is what
+    /// makes a threshold defensible here and not for the quality itself.
+    /// </remarks>
+    public const double AmbiguousShare = 0.25;
+
+    /// <summary>
+    /// How well each channel matches the sweep the configuration describes, in
+    /// channel order. The score is a normalized correlation, so it judges shape
+    /// rather than level and a quiet channel holding the take outranks a loud one
+    /// holding hum.
+    /// </summary>
+    public static double[] Rank(
+        SweepMeasurementConfiguration configuration,
+        IReadOnlyList<float[]> channels)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(channels);
+
+        using var probe = new ExponentialSineSweep();
+        SweepSignalConfiguration signal = configuration.Signal;
+        probe.FillData(
+            signal.LowFrequencyHz,
+            signal.HighFrequencyHz,
+            signal.RequestedDurationSeconds,
+            signal.Bits,
+            signal.SampleRate);
+
+        var qualities = new double[channels.Count];
+        for (int channel = 0; channel < channels.Count; channel++)
+        {
+            qualities[channel] = RecordedSweepDetector
+                .FindSweeps(channels[channel], probe.SweepData, 1)
+                .FirstOrDefault().Quality;
+        }
+
+        return qualities;
+    }
+
+    /// <summary>The best-matching channel, or 0 when there is nothing to rank.</summary>
+    public static int Best(IReadOnlyList<double> qualities)
+    {
+        ArgumentNullException.ThrowIfNull(qualities);
+
+        int best = 0;
+        for (int channel = 1; channel < qualities.Count; channel++)
+        {
+            if (qualities[channel] > qualities[best])
+            {
+                best = channel;
+            }
+        }
+
+        return best;
+    }
+
+    /// <summary>
+    /// Whether more than one channel plausibly holds the sweep, in which case the
+    /// import must not choose on its own.
+    /// </summary>
+    public static bool IsAmbiguous(IReadOnlyList<double> qualities)
+    {
+        ArgumentNullException.ThrowIfNull(qualities);
+        if (qualities.Count < 2)
+        {
+            return false;
+        }
+
+        int best = Best(qualities);
+        if (qualities[best] <= 0)
+        {
+            return false;
+        }
+
+        for (int channel = 0; channel < qualities.Count; channel++)
+        {
+            if (channel != best &&
+                qualities[channel] >= qualities[best] * AmbiguousShare)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/source/Measurements/RecordedSweepDetector.cs
+++ b/source/Measurements/RecordedSweepDetector.cs
@@ -1,0 +1,239 @@
+﻿using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Where a sweep was found inside a recording, and how well it matched there.
+/// <see cref="Quality"/> is the normalized correlation (0..1): 1 is the recording
+/// holding nothing but the sweep, and a genuine acoustic take reads a few tenths
+/// — the room, the noise and the system's own response all cost coherence.
+/// </summary>
+internal readonly record struct SweepMatch(int Start, double Quality);
+
+/// <summary>
+/// Finds the excitation in a recording by matching the SWEEP against it, rather
+/// than by looking for something loud.
+/// <para>
+/// The difference is what the question is. A level detector asks where the
+/// recording is loud, which is a proxy that content can defeat from either side:
+/// a system that barely reproduces one end of the band reads as a sweep starting
+/// a second late, and a voice or a door louder than a quiet measurement hides it
+/// completely. Correlating against the known excitation asks where THIS sweep is,
+/// and answers with the sample it starts at.
+/// </para>
+/// <para>
+/// It also answers from much further down. Matched filtering concentrates the
+/// whole sweep into one peak, so its gain is the time-bandwidth product — about
+/// 46 dB for two seconds across 20 Hz to 20 kHz, more for longer sweeps. A sweep
+/// well below the noise floor of the recording still produces a peak; a level
+/// rule cannot see below that floor at all.
+/// </para>
+/// </summary>
+internal static class RecordedSweepDetector
+{
+    // How far apart two matches must sit to count as separate takes: half a
+    // sweep. Closer than that and they are the same arrival being reported twice
+    // (the correlation of a chirp with itself is narrow, but a strong reflection
+    // rides beside the direct sound).
+    private const double SeparationShare = 0.5;
+
+    // The search runs on a decimated copy. Correlating a ten-minute recording at
+    // full rate is exact but costs gigabytes of transient spectra — 5.9 GB, more
+    // than the analysis it exists to set up — while the position it finds is then
+    // refined at full rate anyway. Both signals are averaged and thinned the SAME
+    // way, so the correlation stays a matched filter for the pair: the peak keeps
+    // its place, it only gets broader, and some of the 46 dB of processing gain
+    // goes with the bandwidth.
+    private const int SearchSampleCeiling = 1 << 20;
+
+    private const int MaximumDecimation = 32;
+
+    // How far the full-rate refinement looks either side of the decimated answer:
+    // two decimated samples, which is the most the coarse peak can be out by.
+    private const int RefinementSteps = 2;
+
+    /// <summary>
+    /// The best alignments of <paramref name="sweep"/> inside
+    /// <paramref name="samples"/>, strongest first. Empty when there is nothing to
+    /// match — no samples, no sweep, or a recording shorter than the sweep.
+    /// </summary>
+    public static IReadOnlyList<SweepMatch> FindSweeps(
+        float[] samples,
+        float[] sweep,
+        int maximumMatches)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        ArgumentNullException.ThrowIfNull(sweep);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumMatches);
+        if (sweep.Length == 0 || samples.Length < sweep.Length)
+        {
+            return [];
+        }
+
+        int decimation = ChooseDecimation(samples.Length, sweep.Length);
+        float[] coarseSamples = Decimate(samples, decimation);
+        float[] coarseSweep = Decimate(sweep, decimation);
+
+        // Correlation is convolution with the kernel reversed, and the app's
+        // overlap-add convolution already does the long-signal case in bounded
+        // blocks — the whole point of not transforming a whole recording in one
+        // piece.
+        var reversed = new double[coarseSweep.Length];
+        for (int i = 0; i < coarseSweep.Length; i++)
+        {
+            reversed[i] = coarseSweep[coarseSweep.Length - 1 - i];
+        }
+
+        float[] correlation = FastConvolution.Convolve(coarseSamples, reversed);
+        // Cumulative energies, so every placement can be normalized in constant
+        // time. Judging the match on SHAPE rather than on level is what lets a
+        // quiet channel that holds the sweep outrank a loud one full of hum.
+        double[] recordingEnergy = CumulativeEnergy(coarseSamples);
+        double[] excitationEnergy = CumulativeEnergy(coarseSweep);
+
+        // Placements where the sweep runs off the end of the recording are
+        // included, down to half of it overlapping. A take that stopped mid-sweep
+        // has its true start ONLY among those, and leaving them out does not make
+        // the take usable — it makes the detector answer with the best of the
+        // wrong positions, which then reads as a complete take.
+        int lastStart = coarseSamples.Length - coarseSweep.Length / 2;
+        int separation = Math.Max(1, (int)(coarseSweep.Length * SeparationShare));
+        var matches = new List<SweepMatch>();
+        var taken = new List<int>();
+        for (int match = 0; match < maximumMatches; match++)
+        {
+            int best = -1;
+            double bestQuality = 0;
+            for (int start = 0; start <= lastStart; start++)
+            {
+                if (taken.Exists(other => Math.Abs(other - start) < separation))
+                {
+                    continue;
+                }
+
+                int overlap = Math.Min(coarseSweep.Length, coarseSamples.Length - start);
+                double energy =
+                    excitationEnergy[overlap] *
+                    (recordingEnergy[start + overlap] - recordingEnergy[start]);
+                if (energy <= 0)
+                {
+                    continue;
+                }
+
+                // Convolution output index start + kernel - 1 is the sum of the
+                // recording from `start` against the sweep from its own zero.
+                double quality =
+                    Math.Abs(correlation[start + coarseSweep.Length - 1]) / Math.Sqrt(energy);
+                if (quality > bestQuality)
+                {
+                    bestQuality = quality;
+                    best = start;
+                }
+            }
+
+            if (best < 0)
+            {
+                break;
+            }
+
+            taken.Add(best);
+            matches.Add(decimation == 1
+                ? new SweepMatch(best, bestQuality)
+                : Refine(samples, sweep, best * decimation, decimation * RefinementSteps));
+        }
+
+        return matches;
+    }
+
+    // The coarse answer is out by up to a decimated sample, so the neighbourhood
+    // is searched at full rate — directly, since a few dozen placements of one
+    // kernel is nothing next to a transform.
+    private static SweepMatch Refine(float[] samples, float[] sweep, int around, int reach)
+    {
+        int best = Math.Clamp(around, 0, Math.Max(0, samples.Length - sweep.Length / 2));
+        double bestQuality = -1;
+        double[] excitationEnergy = CumulativeEnergy(sweep);
+        for (int start = around - reach; start <= around + reach; start++)
+        {
+            if (start < 0 || start > samples.Length - sweep.Length / 2)
+            {
+                continue;
+            }
+
+            int overlap = Math.Min(sweep.Length, samples.Length - start);
+            double product = 0;
+            double energy = 0;
+            for (int i = 0; i < overlap; i++)
+            {
+                double recorded = samples[start + i];
+                product += recorded * sweep[i];
+                energy += recorded * recorded;
+            }
+
+            double scale = excitationEnergy[overlap];
+            double quality = energy > 0 && scale > 0
+                ? Math.Abs(product) / Math.Sqrt(scale * energy)
+                : 0.0;
+            if (quality > bestQuality)
+            {
+                bestQuality = quality;
+                best = start;
+            }
+        }
+
+        return new SweepMatch(best, Math.Max(bestQuality, 0.0));
+    }
+
+    // A power of two that brings the search under the ceiling, leaving the sweep
+    // itself long enough to still be a chirp after thinning.
+    private static int ChooseDecimation(int sampleCount, int sweepLength)
+    {
+        int decimation = 1;
+        while (decimation < MaximumDecimation &&
+            sampleCount / decimation > SearchSampleCeiling &&
+            sweepLength / (decimation * 2) >= 1024)
+        {
+            decimation *= 2;
+        }
+
+        return decimation;
+    }
+
+    // Averaged, then thinned. The average is the anti-alias filter — crude, but
+    // both signals get the same one, which is all a matched filter needs.
+    private static float[] Decimate(float[] samples, int decimation)
+    {
+        if (decimation <= 1)
+        {
+            return samples;
+        }
+
+        var thinned = new float[samples.Length / decimation];
+        for (int i = 0; i < thinned.Length; i++)
+        {
+            double sum = 0;
+            int offset = i * decimation;
+            for (int k = 0; k < decimation; k++)
+            {
+                sum += samples[offset + k];
+            }
+
+            thinned[i] = (float)(sum / decimation);
+        }
+
+        return thinned;
+    }
+
+    // Energy of samples[0..i), so any stretch costs one subtraction. Accumulated
+    // in double over what can be tens of millions of terms.
+    private static double[] CumulativeEnergy(float[] samples)
+    {
+        var energy = new double[samples.Length + 1];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            energy[i + 1] = energy[i] + (double)samples[i] * samples[i];
+        }
+
+        return energy;
+    }
+}

--- a/source/Measurements/RecordedSweepDetector.cs
+++ b/source/Measurements/RecordedSweepDetector.cs
@@ -37,13 +37,15 @@ internal static class RecordedSweepDetector
     // rides beside the direct sound).
     private const double SeparationShare = 0.5;
 
-    // The search runs on a decimated copy. Correlating a ten-minute recording at
-    // full rate is exact but costs gigabytes of transient spectra — 5.9 GB, more
-    // than the analysis it exists to set up — while the position it finds is then
-    // refined at full rate anyway. Both signals are averaged and thinned the SAME
-    // way, so the correlation stays a matched filter for the pair: the peak keeps
-    // its place, it only gets broader, and some of the 46 dB of processing gain
-    // goes with the bandwidth.
+    // How many coarse samples the search aims to work in. Correlating a
+    // ten-minute recording at full rate is exact but costs far more than the
+    // analysis it exists to set up, while the position it finds is then refined
+    // at full rate anyway. Both signals are averaged and thinned the SAME way, so
+    // the correlation stays a matched filter for the pair: the peak keeps its
+    // place, it only gets broader, and some of the 46 dB of processing gain goes
+    // with the bandwidth. It is an aim rather than a guarantee — thinning stops
+    // while the sweep is still long enough to correlate — which is why the search
+    // is also chunked.
     private const int SearchSampleCeiling = 1 << 20;
 
     private const int MaximumDecimation = 32;
@@ -76,9 +78,9 @@ internal static class RecordedSweepDetector
         }
 
         int decimation = ChooseDecimation(samples.Length, sweep.Length);
-        float[] coarseSamples = Decimate(samples, decimation);
         float[] coarseSweep = Decimate(sweep, decimation);
         int kernel = coarseSweep.Length;
+        int coarseLength = samples.Length / decimation;
 
         // Correlation is convolution with the kernel reversed.
         var reversed = new double[kernel];
@@ -93,23 +95,23 @@ internal static class RecordedSweepDetector
         // has its true start ONLY among those, and leaving them out does not make
         // the take usable — it makes the detector answer with the best of the
         // wrong positions, which then reads as a complete take.
-        int lastStart = coarseSamples.Length - kernel / 2;
+        int lastStart = coarseLength - kernel / 2;
         int separation = Math.Max(1, (int)(kernel * SeparationShare));
 
-        // Searched in chunks, so what the search holds is set by the chunk rather
-        // than by the recording. Decimation alone cannot promise that: a sweep can
-        // be short enough (5 ms per octave is 53 ms of signal) that thinning it
-        // any further would leave nothing to correlate, and then a ten-minute file
-        // would materialize a correlation and a cumulative energy over all of it.
-        int chunk = Math.Min(
-            coarseSamples.Length, Math.Max(kernel * 4, MinimumSearchChunk));
+        // Searched in chunks, and each chunk is thinned straight out of the
+        // recording, so what the search holds is set by the chunk rather than by
+        // the recording. Decimation alone cannot promise that: a sweep can be
+        // short enough (5 ms per octave is 53 ms of signal) that thinning it any
+        // further would leave nothing to correlate, and then a ten-minute file
+        // would hold a correlation, a cumulative energy and a decimated copy of
+        // itself all at once.
+        int chunk = Math.Min(coarseLength, Math.Max(kernel * 4, MinimumSearchChunk));
         int advance = Math.Max(1, chunk - kernel + 1);
         var pooled = new List<SweepMatch>();
         for (int chunkStart = 0; chunkStart <= lastStart; chunkStart += advance)
         {
-            int available = Math.Min(chunk, coarseSamples.Length - chunkStart);
-            var block = new float[available];
-            Array.Copy(coarseSamples, chunkStart, block, 0, available);
+            int available = Math.Min(chunk, coarseLength - chunkStart);
+            float[] block = DecimateRange(samples, decimation, chunkStart, available);
             float[] correlation = FastConvolution.Convolve(block, reversed);
             // Cumulative energy over the chunk, so every placement normalizes in
             // constant time. Judging the match on SHAPE rather than on level is
@@ -118,7 +120,7 @@ internal static class RecordedSweepDetector
             double[] blockEnergy = CumulativeEnergy(block);
             // Interior chunks only own the placements whose window they hold whole;
             // the last one also owns those running past the end of the recording.
-            bool last = chunkStart + available >= coarseSamples.Length;
+            bool last = chunkStart + available >= coarseLength;
             int localLast = last
                 ? lastStart - chunkStart
                 : Math.Min(available - kernel, advance - 1);
@@ -150,6 +152,12 @@ internal static class RecordedSweepDetector
             }
         }
 
+        // Thinned to one match per neighbourhood BEFORE refining, because the pool
+        // and `separation` are both in decimated samples: a refined start is a
+        // full-rate one, and comparing it against a coarse candidate would measure
+        // a distance in two different units and suppress nothing. Offer() cannot
+        // stand in for this pass — replacing a pooled candidate can leave the
+        // replacement within `separation` of another one.
         var matches = new List<SweepMatch>();
         foreach (SweepMatch match in pooled.OrderByDescending(candidate => candidate.Quality))
         {
@@ -162,30 +170,39 @@ internal static class RecordedSweepDetector
                 continue;
             }
 
-            matches.Add(decimation == 1
-                ? match
-                : Refine(samples, sweep, match.Start * decimation, decimation * RefinementSteps));
+            matches.Add(match);
         }
 
-        return matches;
+        return decimation == 1
+            ? matches
+            : matches.ConvertAll(match =>
+                Refine(samples, sweep, match.Start * decimation, decimation * RefinementSteps));
     }
 
     // Keeps the pooled candidates to one entry per neighbourhood: without it a
     // strong arrival contributes thousands of near-identical placements and the
     // pool grows with the recording, which is what the chunking is avoiding.
+    //
+    // Only the most recent entry is examined, because placements arrive in
+    // increasing position — within a chunk and from one chunk to the next.
+    // Scanning the whole pool instead made the search quadratic in a way only a
+    // SHORT sweep shows: separation is half a sweep, so a 36 ms one leaves tens
+    // of thousands of neighbourhoods in a ten-minute recording, and each of the
+    // twenty-six million placements walked all of them. That cost 143 s where
+    // this costs a fraction of a second.
+    //
+    // A replacement can leave the entry within `separation` of the one before it;
+    // the final pass over the pool is what settles that.
     private static void Offer(List<SweepMatch> pooled, SweepMatch candidate, int separation)
     {
-        for (int i = 0; i < pooled.Count; i++)
+        if (pooled.Count > 0 && candidate.Start - pooled[^1].Start < separation)
         {
-            if (Math.Abs(pooled[i].Start - candidate.Start) < separation)
+            if (candidate.Quality > pooled[^1].Quality)
             {
-                if (candidate.Quality > pooled[i].Quality)
-                {
-                    pooled[i] = candidate;
-                }
-
-                return;
+                pooled[^1] = candidate;
             }
+
+            return;
         }
 
         pooled.Add(candidate);
@@ -243,6 +260,39 @@ internal static class RecordedSweepDetector
         }
 
         return decimation;
+    }
+
+    // One chunk's worth of coarse samples, averaged straight out of the recording
+    // so the whole decimated copy is never materialized. On a short sweep the
+    // ceiling cannot thin the recording far — a 53 ms sweep stops it at two — and
+    // a ten-minute file would then carry tens of megabytes of coarse copy for the
+    // whole search, beside the chunk that is the only part being read.
+    private static float[] DecimateRange(
+        float[] samples,
+        int decimation,
+        int coarseStart,
+        int count)
+    {
+        var block = new float[count];
+        if (decimation <= 1)
+        {
+            Array.Copy(samples, coarseStart, block, 0, count);
+            return block;
+        }
+
+        for (int i = 0; i < count; i++)
+        {
+            double sum = 0;
+            int offset = (coarseStart + i) * decimation;
+            for (int k = 0; k < decimation; k++)
+            {
+                sum += samples[offset + k];
+            }
+
+            block[i] = (float)(sum / decimation);
+        }
+
+        return block;
     }
 
     // Averaged, then thinned. The average is the anti-alias filter — crude, but

--- a/source/Measurements/RecordedSweepDetector.cs
+++ b/source/Measurements/RecordedSweepDetector.cs
@@ -48,6 +48,11 @@ internal static class RecordedSweepDetector
 
     private const int MaximumDecimation = 32;
 
+    // The least a search chunk may be. Large enough that the transform inside it
+    // is efficient, small enough that what the search holds stays a few megabytes
+    // whatever the recording and the sweep turn out to be.
+    private const int MinimumSearchChunk = 1 << 18;
+
     // How far the full-rate refinement looks either side of the decimated answer:
     // two decimated samples, which is the most the coarse peak can be out by.
     private const int RefinementSteps = 2;
@@ -73,76 +78,117 @@ internal static class RecordedSweepDetector
         int decimation = ChooseDecimation(samples.Length, sweep.Length);
         float[] coarseSamples = Decimate(samples, decimation);
         float[] coarseSweep = Decimate(sweep, decimation);
+        int kernel = coarseSweep.Length;
 
-        // Correlation is convolution with the kernel reversed, and the app's
-        // overlap-add convolution already does the long-signal case in bounded
-        // blocks — the whole point of not transforming a whole recording in one
-        // piece.
-        var reversed = new double[coarseSweep.Length];
-        for (int i = 0; i < coarseSweep.Length; i++)
+        // Correlation is convolution with the kernel reversed.
+        var reversed = new double[kernel];
+        for (int i = 0; i < kernel; i++)
         {
-            reversed[i] = coarseSweep[coarseSweep.Length - 1 - i];
+            reversed[i] = coarseSweep[kernel - 1 - i];
         }
 
-        float[] correlation = FastConvolution.Convolve(coarseSamples, reversed);
-        // Cumulative energies, so every placement can be normalized in constant
-        // time. Judging the match on SHAPE rather than on level is what lets a
-        // quiet channel that holds the sweep outrank a loud one full of hum.
-        double[] recordingEnergy = CumulativeEnergy(coarseSamples);
         double[] excitationEnergy = CumulativeEnergy(coarseSweep);
-
         // Placements where the sweep runs off the end of the recording are
         // included, down to half of it overlapping. A take that stopped mid-sweep
         // has its true start ONLY among those, and leaving them out does not make
         // the take usable — it makes the detector answer with the best of the
         // wrong positions, which then reads as a complete take.
-        int lastStart = coarseSamples.Length - coarseSweep.Length / 2;
-        int separation = Math.Max(1, (int)(coarseSweep.Length * SeparationShare));
-        var matches = new List<SweepMatch>();
-        var taken = new List<int>();
-        for (int match = 0; match < maximumMatches; match++)
-        {
-            int best = -1;
-            double bestQuality = 0;
-            for (int start = 0; start <= lastStart; start++)
-            {
-                if (taken.Exists(other => Math.Abs(other - start) < separation))
-                {
-                    continue;
-                }
+        int lastStart = coarseSamples.Length - kernel / 2;
+        int separation = Math.Max(1, (int)(kernel * SeparationShare));
 
-                int overlap = Math.Min(coarseSweep.Length, coarseSamples.Length - start);
-                double energy =
-                    excitationEnergy[overlap] *
-                    (recordingEnergy[start + overlap] - recordingEnergy[start]);
+        // Searched in chunks, so what the search holds is set by the chunk rather
+        // than by the recording. Decimation alone cannot promise that: a sweep can
+        // be short enough (5 ms per octave is 53 ms of signal) that thinning it
+        // any further would leave nothing to correlate, and then a ten-minute file
+        // would materialize a correlation and a cumulative energy over all of it.
+        int chunk = Math.Min(
+            coarseSamples.Length, Math.Max(kernel * 4, MinimumSearchChunk));
+        int advance = Math.Max(1, chunk - kernel + 1);
+        var pooled = new List<SweepMatch>();
+        for (int chunkStart = 0; chunkStart <= lastStart; chunkStart += advance)
+        {
+            int available = Math.Min(chunk, coarseSamples.Length - chunkStart);
+            var block = new float[available];
+            Array.Copy(coarseSamples, chunkStart, block, 0, available);
+            float[] correlation = FastConvolution.Convolve(block, reversed);
+            // Cumulative energy over the chunk, so every placement normalizes in
+            // constant time. Judging the match on SHAPE rather than on level is
+            // what lets a quiet channel that holds the sweep outrank a loud one
+            // full of hum.
+            double[] blockEnergy = CumulativeEnergy(block);
+            // Interior chunks only own the placements whose window they hold whole;
+            // the last one also owns those running past the end of the recording.
+            bool last = chunkStart + available >= coarseSamples.Length;
+            int localLast = last
+                ? lastStart - chunkStart
+                : Math.Min(available - kernel, advance - 1);
+            for (int local = 0; local <= localLast; local++)
+            {
+                int overlap = Math.Min(kernel, available - local);
+                double energy = excitationEnergy[overlap] *
+                    (blockEnergy[local + overlap] - blockEnergy[local]);
                 if (energy <= 0)
                 {
                     continue;
                 }
 
-                // Convolution output index start + kernel - 1 is the sum of the
-                // recording from `start` against the sweep from its own zero.
+                // Convolution output index local + kernel - 1 is the sum of the
+                // chunk from `local` against the sweep from its own zero.
                 double quality =
-                    Math.Abs(correlation[start + coarseSweep.Length - 1]) / Math.Sqrt(energy);
-                if (quality > bestQuality)
-                {
-                    bestQuality = quality;
-                    best = start;
-                }
+                    Math.Abs(correlation[local + kernel - 1]) / Math.Sqrt(energy);
+                Offer(pooled, new SweepMatch(chunkStart + local, quality), separation);
             }
 
-            if (best < 0)
+            // The last chunk owns every remaining placement, including the ones
+            // that run past the end. Without this the loop keeps stepping toward
+            // lastStart re-transforming the same tail — and when the whole
+            // recording fits one chunk, `advance` is a single sample, so it does
+            // that thousands of times.
+            if (last)
             {
                 break;
             }
+        }
 
-            taken.Add(best);
+        var matches = new List<SweepMatch>();
+        foreach (SweepMatch match in pooled.OrderByDescending(candidate => candidate.Quality))
+        {
+            if (matches.Count == maximumMatches)
+            {
+                break;
+            }
+            if (matches.Exists(other => Math.Abs(other.Start - match.Start) < separation))
+            {
+                continue;
+            }
+
             matches.Add(decimation == 1
-                ? new SweepMatch(best, bestQuality)
-                : Refine(samples, sweep, best * decimation, decimation * RefinementSteps));
+                ? match
+                : Refine(samples, sweep, match.Start * decimation, decimation * RefinementSteps));
         }
 
         return matches;
+    }
+
+    // Keeps the pooled candidates to one entry per neighbourhood: without it a
+    // strong arrival contributes thousands of near-identical placements and the
+    // pool grows with the recording, which is what the chunking is avoiding.
+    private static void Offer(List<SweepMatch> pooled, SweepMatch candidate, int separation)
+    {
+        for (int i = 0; i < pooled.Count; i++)
+        {
+            if (Math.Abs(pooled[i].Start - candidate.Start) < separation)
+            {
+                if (candidate.Quality > pooled[i].Quality)
+                {
+                    pooled[i] = candidate;
+                }
+
+                return;
+            }
+        }
+
+        pooled.Add(candidate);
     }
 
     // The coarse answer is out by up to a decimated sample, so the neighbourhood

--- a/source/Measurements/RecordedSweepFile.cs
+++ b/source/Measurements/RecordedSweepFile.cs
@@ -1,20 +1,10 @@
 namespace Resonalyze;
 
 /// <summary>
-/// The one channel of a recorded sweep file the analysis runs on, together with
-/// the file's shape and the levels that picked it.
-/// </summary>
-internal sealed record RecordedSweepChannel(
-    float[] Samples,
-    int SampleRate,
-    int ChannelIndex,
-    int ChannelCount,
-    double PeakDbFs,
-    double RmsDbFs);
-
-/// <summary>
 /// Reads a sweep recorded outside Resonalyze — a phone, a handheld recorder, a
-/// DAW — down to the single microphone channel the measurement layer analyzes.
+/// DAW — with the bounds one import is allowed to cost. Which channel carries the
+/// measurement is not decided here: that is a question about the sweep, and only
+/// the measurement layer knows what the sweep is.
 /// </summary>
 internal static class RecordedSweepFile
 {
@@ -25,7 +15,7 @@ internal static class RecordedSweepFile
     private const double MaximumRecordingMinutes = 10.0;
     private const long MaximumDecodedBytes = 512L * 1024 * 1024;
 
-    public static RecordedSweepChannel Load(
+    public static AudioFileContent Load(
         string path,
         CancellationToken cancellationToken = default)
     {
@@ -34,48 +24,17 @@ internal static class RecordedSweepFile
             TimeSpan.FromMinutes(MaximumRecordingMinutes),
             maximumStoredBytes: MaximumDecodedBytes,
             cancellationToken: cancellationToken);
-        return SelectLoudestChannel(content);
-    }
-
-    /// <summary>
-    /// Picks the channel carrying the measurement. By RMS, not peak: a
-    /// recording routinely holds one live microphone and one channel of
-    /// near-silence, and a single click or a DC step in the dead channel would
-    /// win a peak comparison while carrying no sweep at all. Ties keep the
-    /// lower channel, so a genuinely dual-mono file behaves predictably.
-    /// </summary>
-    public static RecordedSweepChannel SelectLoudestChannel(AudioFileContent content)
-    {
-        ArgumentNullException.ThrowIfNull(content);
         if (content.ChannelCount == 0 || content.FrameCount == 0)
         {
             throw new InvalidOperationException("The file carries no audio samples.");
         }
 
-        int loudest = 0;
-        double loudestRms = double.NegativeInfinity;
-        AudioChannelLevel[] levels = RecordedLevelMetering.MeasureChannels(content.Channels);
-        for (int channel = 0; channel < levels.Length; channel++)
-        {
-            if (levels[channel].RmsDbFs > loudestRms)
-            {
-                loudestRms = levels[channel].RmsDbFs;
-                loudest = channel;
-            }
-        }
-
-        return new RecordedSweepChannel(
-            content.Channels[loudest],
-            content.SampleRate,
-            loudest,
-            content.ChannelCount,
-            levels[loudest].PeakDbFs,
-            levels[loudest].RmsDbFs);
+        return content;
     }
 
     /// <summary>
-    /// How the picked channel is named to the user: "left"/"right" for the
-    /// stereo case everyone recognizes, a number beyond it.
+    /// How a channel is named to the user: "left"/"right" for the stereo case
+    /// everyone recognizes, a number beyond it.
     /// </summary>
     public static string DescribeChannel(int channelIndex, int channelCount) =>
         channelCount == 2

--- a/source/Measurements/RecordedSweepWindow.cs
+++ b/source/Measurements/RecordedSweepWindow.cs
@@ -47,7 +47,8 @@ internal static class RecordedSweepWindow
     /// loud. More than one is offered because a take can hold more than one
     /// attempt, and because a match is evidence rather than proof — the caller
     /// analyzes them in order and keeps the one that produces a credible impulse
-    /// response.
+    /// response. Each span covers ONE attempt: the others are cut away, or they
+    /// would read as reflections of it.
     /// </summary>
     /// <remarks>
     /// Always returns at least one span. Degenerate cases — a silent file, no
@@ -74,35 +75,41 @@ internal static class RecordedSweepWindow
         int lead = (int)(LeadInSeconds * sampleRate);
         int bound = sweep.Length + lead + (int)(TailSeconds * sampleRate);
         var spans = new List<RecordedSweepSpan>();
-        // A recording that already fits the bound is analyzed whole — there is
-        // nothing to cut away — but it still needs the excitation start, or a take
-        // that holds a pre-roll and then RUNS OUT mid-sweep reads as long enough.
-        // Every match is still offered: a short take can hold a complete sweep and
-        // a louder half of a second attempt, and answering with only the strongest
-        // would refuse the file over the one that was cut short.
-        if (samples.Length <= bound)
+        foreach (SweepMatch match in matches)
         {
-            foreach (SweepMatch match in matches)
+            // Kept clear of the OTHER takes the file holds. A second attempt
+            // inside the analyzed stretch is a second excitation, and the
+            // transfer estimate has no way to read it as anything but an
+            // enormous reflection of the one being measured — which fails the
+            // shape gate and refuses a file that holds a perfectly good take, or
+            // wins the arrival outright. Only takes that finish before this one
+            // starts, or start after it finishes, are cut on: matches sit at
+            // least half a sweep apart, and trimming on a closer one would cut
+            // into the excitation itself.
+            int head = 0;
+            int limit = samples.Length;
+            foreach (SweepMatch other in matches)
             {
-                if (!spans.Exists(span => span.ExcitationStart == match.Start))
+                if (other.Start >= match.Start + sweep.Length)
                 {
-                    spans.Add(new RecordedSweepSpan(0, samples.Length, match.Start));
+                    limit = Math.Min(limit, other.Start);
+                }
+                else if (other.Start + sweep.Length <= match.Start)
+                {
+                    head = Math.Max(head, other.Start + sweep.Length);
                 }
             }
 
-            return spans.Count > 0 ? spans : [new RecordedSweepSpan(0, samples.Length, 0)];
-        }
-
-        foreach (SweepMatch match in matches)
-        {
-            int start = Math.Clamp(match.Start - lead, 0, samples.Length);
-            int length = Math.Min(bound, samples.Length - start);
-            if (!spans.Exists(span => span.Start == start))
+            int start = Math.Clamp(match.Start - lead, head, samples.Length);
+            int length = Math.Min(bound, limit - start);
+            if (length > 0)
             {
                 spans.Add(new RecordedSweepSpan(start, length, match.Start));
             }
         }
 
-        return spans.Count > 0 ? spans : [new RecordedSweepSpan(0, bound, 0)];
+        return spans.Count > 0
+            ? spans
+            : [new RecordedSweepSpan(0, Math.Min(bound, samples.Length), 0)];
     }
 }

--- a/source/Measurements/RecordedSweepWindow.cs
+++ b/source/Measurements/RecordedSweepWindow.cs
@@ -1,4 +1,4 @@
-﻿namespace Resonalyze;
+namespace Resonalyze;
 
 /// <summary>
 /// The stretch of a recorded sweep file that is worth analyzing: the excitation
@@ -15,22 +15,20 @@ internal readonly record struct RecordedSweepSpan(int Start, int Length, int Exc
 }
 
 /// <summary>
-/// Finds the excitation inside a recording that may be far longer than it. The
-/// natural way to make one is to start the recorder, walk to the listening
-/// position, play the sweep and walk back, which leaves tens of seconds of
-/// silence on both sides — and every FFT in the analysis is sized by the
-/// recording, not by the sweep. A five-minute file holding a two-second sweep
-/// costs gigabytes of transient spectra and leaves behind a transfer IR of the
-/// same length, which then has to be held in memory and written into any saved
-/// measurement. Cutting the analysis down to the excitation and its decay bounds
-/// all of that by the sweep's own length.
+/// Cuts a recording down to the part worth analyzing. The natural way to make one
+/// is to start the recorder, walk to the listening position, play the sweep and
+/// walk back, which leaves tens of seconds of silence on both sides — and every
+/// FFT in the analysis is sized by the recording, not by the sweep. A five-minute
+/// file holding a two-second sweep costs gigabytes of transient spectra and leaves
+/// behind a transfer IR of the same length, which then has to be held in memory
+/// and written into any saved measurement. Cutting the analysis down to the
+/// excitation and its decay bounds all of that by the sweep's own length.
 /// </summary>
 internal static class RecordedSweepWindow
 {
     /// <summary>
-    /// Kept before the excitation: enough for the detector to be late (its
-    /// threshold is crossed inside the fade-in, not at the first sample), and
-    /// enough that the arrival does not land at index zero.
+    /// Kept before the excitation, so the arrival does not land at index zero and
+    /// the gate's left shoulder has somewhere to sit.
     /// </summary>
     private const double LeadInSeconds = 0.5;
 
@@ -41,239 +39,60 @@ internal static class RecordedSweepWindow
     /// </summary>
     private const double TailSeconds = 2.0;
 
-    // Level above which a window counts as excited, relative to the loudest
-    // level the recording SUSTAINS. An exponential sweep holds a flat envelope
-    // for its whole length, so its body sits within a few dB of that; 20 dB down
-    // finds the fade-in without being tripped by room noise.
-    private const double ExcitationThresholdRatio = 0.01;
-
-    // How long a level has to hold to set the reference above. A door slam or a
-    // tap on the recorder is one window wide, and letting it define the loudest
-    // level would put the whole sweep below the threshold.
-    private const double SustainSeconds = 0.1;
-
-    // How far over the recording's noise floor a window has to sit to count as
-    // something rather than nothing. Twenty decibels is comfortably below any
-    // usable excitation — the field takes stand 40 to 60 dB over their floors —
-    // and comfortably above the floor's own wander, so silence does not fuse into
-    // one stretch spanning the whole file.
-    private const double FloorThresholdRatio = 100.0;
-
-    // The share of windows taken to be the floor rather than content. A tenth is
-    // enough on a take that is mostly excitation and still right on one that is
-    // mostly silence, where nearly every window is floor anyway.
-    private const double FloorPercentile = 0.1;
-
-    // Silence this long ends a stretch. Shorter drops (a pause between spoken
-    // words, a dip in the sweep's fade) keep the stretch together.
-    private const double GapSeconds = 0.2;
-
-    private const double WindowSeconds = 0.01;
-
     /// <summary>
-    /// Spans that may hold the excitation, most likely first — by how much loud
-    /// audio each stretch carries, earliest first among equals. Ranking cannot be
-    /// certain (a passage of speech before the sweep is loud and sustained too),
-    /// so the caller analyzes them in order and keeps the one that produces a
-    /// credible impulse response instead of committing to the first.
-    /// <para>
-    /// A stretch SHORTER than the sweep is the interesting case: the excitation is
-    /// all there, but part of it sits under the detection threshold because the
-    /// system under test barely reproduces that end of the band — a car whose bass
-    /// is crossed out drops its first octaves by 30 dB, which reads as the sweep
-    /// starting a second late, and the analysis would then be built on an
-    /// excitation whose beginning is outside the window. Which end was lost cannot
-    /// be told from levels, so the span covers BOTH readings: early enough for a
-    /// sweep that ENDS where the loud audio ends, late enough for one that BEGINS
-    /// where it begins. That widens the span only when the stretch is shorter than
-    /// the sweep; for a stretch the sweep's own length it changes nothing.
-    /// </para>
+    /// Spans that may hold the excitation, best match first. The sweep is located
+    /// by matching it against the recording (see
+    /// <see cref="RecordedSweepDetector"/>), so the span sits on where the
+    /// excitation actually is rather than on where the recording happens to be
+    /// loud. More than one is offered because a take can hold more than one
+    /// attempt, and because a match is evidence rather than proof — the caller
+    /// analyzes them in order and keeps the one that produces a credible impulse
+    /// response.
     /// </summary>
     /// <remarks>
     /// Always returns at least one span. Degenerate cases — a silent file, no
-    /// loud stretch at all, a recording already shorter than the bound — fall
-    /// back to as much of the recording as the bound allows, starting at its
-    /// beginning; the caller's credibility check is what judges the result
-    /// either way.
+    /// match at all, a recording already shorter than the bound — fall back to as
+    /// much of the recording as the bound allows; the caller's credibility check
+    /// is what judges the result either way.
     /// </remarks>
     public static IReadOnlyList<RecordedSweepSpan> LocateCandidates(
         float[] samples,
+        float[] sweep,
         int sampleRate,
-        int sweepSamples,
         int maximumCandidates = 3)
     {
         ArgumentNullException.ThrowIfNull(samples);
+        ArgumentNullException.ThrowIfNull(sweep);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumCandidates);
-        if (sampleRate <= 0 || sweepSamples <= 0)
+        if (sampleRate <= 0 || sweep.Length == 0)
         {
             return [new RecordedSweepSpan(0, samples.Length, 0)];
         }
 
-        List<(int Start, int End)> stretches = FindLoudStretches(
-            samples, sampleRate, maximumCandidates);
+        IReadOnlyList<SweepMatch> matches =
+            RecordedSweepDetector.FindSweeps(samples, sweep, maximumCandidates);
         int lead = (int)(LeadInSeconds * sampleRate);
-        int tail = (int)(TailSeconds * sampleRate);
-        int bound = sweepSamples + lead + tail;
+        int bound = sweep.Length + lead + (int)(TailSeconds * sampleRate);
         // A recording that already fits the bound is analyzed whole — there is
         // nothing to cut away — but it still needs the excitation start, or a take
         // that holds a pre-roll and then RUNS OUT mid-sweep reads as long enough.
         if (samples.Length <= bound)
         {
             return [new RecordedSweepSpan(
-                0, samples.Length, stretches.Count > 0 ? stretches[0].Start : 0)];
+                0, samples.Length, matches.Count > 0 ? matches[0].Start : 0)];
         }
 
         var spans = new List<RecordedSweepSpan>();
-        foreach ((int stretchStart, int stretchEnd) in stretches)
+        foreach (SweepMatch match in matches)
         {
-            int earliest = Math.Min(stretchStart, stretchEnd - sweepSamples);
-            int latest = Math.Max(stretchEnd, stretchStart + sweepSamples);
-            int start = Math.Clamp(earliest - lead, 0, samples.Length);
-            int end = Math.Clamp(latest + tail, start, samples.Length);
+            int start = Math.Clamp(match.Start - lead, 0, samples.Length);
+            int length = Math.Min(bound, samples.Length - start);
             if (!spans.Exists(span => span.Start == start))
             {
-                // The DETECTED start, not the earliest possible one, is what the
-                // caller measures the take's completeness against: it is where the
-                // excitation was actually heard, so a take that runs out mid-sweep
-                // still reads as short while a quiet first octave does not.
-                spans.Add(new RecordedSweepSpan(start, end - start, stretchStart));
+                spans.Add(new RecordedSweepSpan(start, length, match.Start));
             }
         }
 
         return spans.Count > 0 ? spans : [new RecordedSweepSpan(0, bound, 0)];
-    }
-
-    // The loud stretches, the one carrying the most loud audio first. The sweep is
-    // one uninterrupted stretch; speech, footsteps and handling noise are shorter
-    // ones, so this usually ranks the excitation first — and when it does not, the
-    // caller falls through to the next candidate.
-    private static List<(int Start, int End)> FindLoudStretches(
-        float[] samples,
-        int sampleRate,
-        int maximumCandidates)
-    {
-        int window = Math.Max(1, (int)(WindowSeconds * sampleRate));
-        int windowCount = samples.Length / window;
-        if (windowCount == 0)
-        {
-            return [];
-        }
-
-        var power = new double[windowCount];
-        for (int index = 0; index < windowCount; index++)
-        {
-            double sum = 0;
-            int offset = index * window;
-            for (int i = 0; i < window; i++)
-            {
-                double sample = samples[offset + i];
-                sum += sample * sample;
-            }
-            power[index] = sum / window;
-        }
-
-        double reference = LoudestSustainedPower(
-            power,
-            Math.Max(1, (int)(SustainSeconds * sampleRate) / window));
-        if (reference <= 0)
-        {
-            return [];
-        }
-
-        // Two thresholds, and the LOWER wins — being generous costs candidates
-        // that the caller then verifies, while being strict costs the recording.
-        //
-        // One is relative to the loudest thing in the file. It fails exactly when
-        // something louder than the sweep shares the take: a door, a voice, a
-        // handling knock 30 dB up puts the whole excitation underneath it, and no
-        // amount of retrying helps because the sweep never becomes a candidate.
-        //
-        // The other is relative to the QUIETEST thing — the noise floor the
-        // recorder was sitting on between events — which the excitation stands
-        // over whatever else is in the file.
-        double threshold = Math.Min(
-            reference * ExcitationThresholdRatio,
-            QuietestSustainedPower(power) * FloorThresholdRatio);
-        int gap = Math.Max(1, (int)(GapSeconds * sampleRate) / window);
-        // (first window, last window, loud windows) per stretch, as they occur.
-        var stretches = new List<(int Start, int End, int Loud)>();
-        int stretchStart = -1;
-        int stretchEnd = -1;
-        int loud = 0;
-        int silent = 0;
-        for (int index = 0; index < windowCount; index++)
-        {
-            if (power[index] >= threshold)
-            {
-                if (stretchStart < 0)
-                {
-                    stretchStart = index;
-                    loud = 0;
-                }
-                stretchEnd = index;
-                loud++;
-                silent = 0;
-                continue;
-            }
-
-            if (stretchStart >= 0 && ++silent >= gap)
-            {
-                stretches.Add((stretchStart, stretchEnd, loud));
-                stretchStart = -1;
-            }
-        }
-        if (stretchStart >= 0)
-        {
-            stretches.Add((stretchStart, stretchEnd, loud));
-        }
-
-        // Longest first, earliest among equals — so a take holding the same sweep
-        // twice measures the first one.
-        return stretches
-            .OrderByDescending(stretch => stretch.Loud)
-            .ThenBy(stretch => stretch.Start)
-            .Take(maximumCandidates)
-            .Select(stretch => (stretch.Start * window, (stretch.End + 1) * window))
-            .ToList();
-    }
-
-    // The level the recording sits at when nothing is happening: a low percentile
-    // of the window powers, which is the noise floor on any take that holds some
-    // silence and an underestimate — harmlessly, since it only widens the search —
-    // on one that does not.
-    private static double QuietestSustainedPower(double[] power)
-    {
-        var sorted = new double[power.Length];
-        Array.Copy(power, sorted, power.Length);
-        Array.Sort(sorted);
-        double floor = sorted[Math.Min(
-            sorted.Length - 1, (int)(sorted.Length * FloorPercentile))];
-        // A digitally silent lead-in reads as an exact zero, which would put the
-        // threshold there and make every sample "loud". Fall back to the quietest
-        // level that is actually a level.
-        return floor > 0 ? floor : sorted.FirstOrDefault(value => value > 0);
-    }
-
-    // The loudest level the recording holds for a whole run of windows, which is
-    // what a sustained excitation reaches and a transient cannot.
-    private static double LoudestSustainedPower(double[] power, int run)
-    {
-        if (power.Length < run)
-        {
-            return power.Length > 0 ? power.Max() : 0.0;
-        }
-
-        double loudest = 0;
-        for (int start = 0; start + run <= power.Length; start++)
-        {
-            double quietest = double.MaxValue;
-            for (int i = 0; i < run; i++)
-            {
-                quietest = Math.Min(quietest, power[start + i]);
-            }
-            loudest = Math.Max(loudest, quietest);
-        }
-
-        return loudest;
     }
 }

--- a/source/Measurements/RecordedSweepWindow.cs
+++ b/source/Measurements/RecordedSweepWindow.cs
@@ -73,16 +73,26 @@ internal static class RecordedSweepWindow
             RecordedSweepDetector.FindSweeps(samples, sweep, maximumCandidates);
         int lead = (int)(LeadInSeconds * sampleRate);
         int bound = sweep.Length + lead + (int)(TailSeconds * sampleRate);
+        var spans = new List<RecordedSweepSpan>();
         // A recording that already fits the bound is analyzed whole — there is
         // nothing to cut away — but it still needs the excitation start, or a take
         // that holds a pre-roll and then RUNS OUT mid-sweep reads as long enough.
+        // Every match is still offered: a short take can hold a complete sweep and
+        // a louder half of a second attempt, and answering with only the strongest
+        // would refuse the file over the one that was cut short.
         if (samples.Length <= bound)
         {
-            return [new RecordedSweepSpan(
-                0, samples.Length, matches.Count > 0 ? matches[0].Start : 0)];
+            foreach (SweepMatch match in matches)
+            {
+                if (!spans.Exists(span => span.ExcitationStart == match.Start))
+                {
+                    spans.Add(new RecordedSweepSpan(0, samples.Length, match.Start));
+                }
+            }
+
+            return spans.Count > 0 ? spans : [new RecordedSweepSpan(0, samples.Length, 0)];
         }
 
-        var spans = new List<RecordedSweepSpan>();
         foreach (SweepMatch match in matches)
         {
             int start = Math.Clamp(match.Start - lead, 0, samples.Length);

--- a/source/Options/RecordedSweepChannelDialog.Designer.cs
+++ b/source/Options/RecordedSweepChannelDialog.Designer.cs
@@ -1,0 +1,147 @@
+﻿namespace Resonalyze.Options
+{
+    partial class RecordedSweepChannelDialog
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            labelInstruction = new Label();
+            channelGridView = new DataGridView();
+            ColumnChannel = new DataGridViewTextBoxColumn();
+            ColumnMatch = new DataGridViewTextBoxColumn();
+            ColumnRms = new DataGridViewTextBoxColumn();
+            ColumnPeak = new DataGridViewTextBoxColumn();
+            buttonMeasure = new Button();
+            buttonCancel = new Button();
+            ((System.ComponentModel.ISupportInitialize)channelGridView).BeginInit();
+            SuspendLayout();
+            //
+            // labelInstruction
+            //
+            labelInstruction.ForeColor = SystemColors.ControlLight;
+            labelInstruction.Location = new Point(16, 16);
+            labelInstruction.Name = "labelInstruction";
+            labelInstruction.Size = new Size(430, 72);
+            labelInstruction.TabIndex = 0;
+            labelInstruction.Text = "More than one channel holds this sweep. A track that recorded the sweep itself — a reference or loopback written beside the microphone — matches best of all, and measures as a flat response. Pick the microphone.";
+            //
+            // channelGridView
+            //
+            channelGridView.AllowUserToAddRows = false;
+            channelGridView.AllowUserToDeleteRows = false;
+            channelGridView.AllowUserToResizeColumns = false;
+            channelGridView.AllowUserToResizeRows = false;
+            channelGridView.BackgroundColor = Color.FromArgb(40, 42, 48);
+            channelGridView.BorderStyle = BorderStyle.None;
+            channelGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            channelGridView.Columns.AddRange(new DataGridViewColumn[] { ColumnChannel, ColumnMatch, ColumnRms, ColumnPeak });
+            channelGridView.Location = new Point(16, 96);
+            channelGridView.Margin = new Padding(0);
+            channelGridView.MultiSelect = false;
+            channelGridView.Name = "channelGridView";
+            channelGridView.ReadOnly = true;
+            channelGridView.RowHeadersVisible = false;
+            channelGridView.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
+            channelGridView.Size = new Size(430, 150);
+            channelGridView.TabIndex = 1;
+            channelGridView.CellDoubleClick += channelGridView_CellDoubleClick;
+            //
+            // ColumnChannel
+            //
+            ColumnChannel.HeaderText = "Channel";
+            ColumnChannel.Name = "ColumnChannel";
+            ColumnChannel.ReadOnly = true;
+            ColumnChannel.Width = 160;
+            //
+            // ColumnMatch
+            //
+            ColumnMatch.HeaderText = "Match";
+            ColumnMatch.Name = "ColumnMatch";
+            ColumnMatch.ReadOnly = true;
+            ColumnMatch.Width = 80;
+            //
+            // ColumnRms
+            //
+            ColumnRms.HeaderText = "RMS";
+            ColumnRms.Name = "ColumnRms";
+            ColumnRms.ReadOnly = true;
+            ColumnRms.Width = 92;
+            //
+            // ColumnPeak
+            //
+            ColumnPeak.HeaderText = "Peak";
+            ColumnPeak.Name = "ColumnPeak";
+            ColumnPeak.ReadOnly = true;
+            ColumnPeak.Width = 92;
+            //
+            // buttonMeasure
+            //
+            buttonMeasure.DialogResult = DialogResult.OK;
+            buttonMeasure.FlatStyle = FlatStyle.Popup;
+            buttonMeasure.ForeColor = Color.White;
+            buttonMeasure.Location = new Point(266, 258);
+            buttonMeasure.Name = "buttonMeasure";
+            buttonMeasure.Size = new Size(104, 30);
+            buttonMeasure.TabIndex = 2;
+            buttonMeasure.Text = "Measure";
+            buttonMeasure.UseVisualStyleBackColor = true;
+            //
+            // buttonCancel
+            //
+            buttonCancel.DialogResult = DialogResult.Cancel;
+            buttonCancel.FlatStyle = FlatStyle.Popup;
+            buttonCancel.ForeColor = Color.White;
+            buttonCancel.Location = new Point(376, 258);
+            buttonCancel.Name = "buttonCancel";
+            buttonCancel.Size = new Size(70, 30);
+            buttonCancel.TabIndex = 3;
+            buttonCancel.Text = "Cancel";
+            buttonCancel.UseVisualStyleBackColor = true;
+            //
+            // RecordedSweepChannelDialog
+            //
+            AcceptButton = buttonMeasure;
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            BackColor = Color.FromArgb(45, 50, 60);
+            CancelButton = buttonCancel;
+            ClientSize = new Size(462, 302);
+            Controls.Add(labelInstruction);
+            Controls.Add(channelGridView);
+            Controls.Add(buttonMeasure);
+            Controls.Add(buttonCancel);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "RecordedSweepChannelDialog";
+            ShowInTaskbar = false;
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "Choose the channel to measure";
+            ((System.ComponentModel.ISupportInitialize)channelGridView).EndInit();
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private Label labelInstruction;
+        private DataGridView channelGridView;
+        private DataGridViewTextBoxColumn ColumnChannel;
+        private DataGridViewTextBoxColumn ColumnMatch;
+        private DataGridViewTextBoxColumn ColumnRms;
+        private DataGridViewTextBoxColumn ColumnPeak;
+        private Button buttonMeasure;
+        private Button buttonCancel;
+    }
+}

--- a/source/Options/RecordedSweepChannelDialog.cs
+++ b/source/Options/RecordedSweepChannelDialog.cs
@@ -1,0 +1,83 @@
+using Resonalyze.Ui;
+
+namespace Resonalyze.Options;
+
+/// <summary>
+/// Asks which channel of a multi-channel recording holds the measurement.
+/// <para>
+/// Shown only when the answer is not obvious — see
+/// <see cref="RecordedSweepChannels.IsAmbiguous"/>. The case it exists for is a
+/// DAW file carrying the played sweep on one track and the microphone on
+/// another: the played track is a copy of the excitation, so it matches better
+/// than any acoustic take ever will, wins any automatic choice, and then measures
+/// as a flat response that passes every credibility check there is. Nothing in
+/// the numbers says which track the microphone was on — only the person who made
+/// the recording knows.
+/// </para>
+/// </summary>
+internal sealed partial class RecordedSweepChannelDialog : Form
+{
+    public RecordedSweepChannelDialog(
+        IReadOnlyList<float[]> channels,
+        IReadOnlyList<double> qualities)
+    {
+        ArgumentNullException.ThrowIfNull(channels);
+        ArgumentNullException.ThrowIfNull(qualities);
+
+        InitializeComponent();
+        StyleGrid();
+
+        for (int channel = 0; channel < channels.Count; channel++)
+        {
+            AudioChannelLevel level = RecordedLevelMetering.MeasureSamples(channels[channel]);
+            channelGridView.Rows.Add(
+                RecordedSweepFile.DescribeChannel(channel, channels.Count),
+                FormattableString.Invariant($"{qualities[channel]:0.000}"),
+                FormattableString.Invariant($"{level.RmsDbFs:0.0} dBFS"),
+                FormattableString.Invariant($"{level.PeakDbFs:0.0} dBFS"));
+        }
+
+        // Preselected on the best match, which is the right answer whenever the
+        // file holds no reference track — the common case even here.
+        SelectedChannel = RecordedSweepChannels.Best(qualities);
+        channelGridView.Rows[SelectedChannel].Selected = true;
+        channelGridView.SelectionChanged += (_, _) =>
+        {
+            if (channelGridView.CurrentRow is { } row)
+            {
+                SelectedChannel = row.Index;
+            }
+        };
+    }
+
+    /// <summary>The channel to measure, valid once the dialog returns OK.</summary>
+    public int SelectedChannel { get; private set; }
+
+    private void StyleGrid()
+    {
+        channelGridView.EnableHeadersVisualStyles = false;
+        channelGridView.GridColor = UiPalette.DialogBorder;
+        channelGridView.DefaultCellStyle.BackColor = UiPalette.DialogBackground;
+        channelGridView.DefaultCellStyle.ForeColor = UiPalette.TextPrimary;
+        channelGridView.DefaultCellStyle.SelectionBackColor = UiPalette.ButtonPressedBackground;
+        channelGridView.DefaultCellStyle.SelectionForeColor = UiPalette.TextPrimary;
+        channelGridView.ColumnHeadersDefaultCellStyle.BackColor = UiPalette.ControlSurface;
+        channelGridView.ColumnHeadersDefaultCellStyle.ForeColor = UiPalette.TextPrimary;
+        channelGridView.ColumnHeadersDefaultCellStyle.SelectionBackColor = UiPalette.ControlSurface;
+        channelGridView.ColumnHeadersDefaultCellStyle.SelectionForeColor = UiPalette.TextPrimary;
+        for (int column = 1; column < channelGridView.Columns.Count; column++)
+        {
+            channelGridView.Columns[column].DefaultCellStyle.Alignment =
+                DataGridViewContentAlignment.MiddleRight;
+        }
+    }
+
+    private void channelGridView_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
+    {
+        if (e.RowIndex >= 0)
+        {
+            SelectedChannel = e.RowIndex;
+            DialogResult = DialogResult.OK;
+        }
+    }
+}

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -549,18 +549,24 @@ internal sealed class PlotModelFactory
             // left shoulder. The extraction re-references every spectrum to
             // absolute time and both curves share the one τ resolved above,
             // so their relative phase/delay survives the differing windows.
-            // Only when the two share a time reference: measured phase IS a
-            // time statement, and the shared detrend below exists precisely to
-            // preserve the relative delay between the curves.
-            if (compare is { } compareData && CompareSharesATimeReference())
+            // Per curve, because they do not all make the same claim. Measured
+            // phase IS a time statement — the shared detrend above exists
+            // precisely to preserve the relative delay — and the excess is what
+            // is left after removing the minimum-phase part of it, so both need
+            // the two records on one clock. Minimum phase is reconstructed from
+            // the magnitude alone (Bode), which is why the detrend cannot move
+            // it either: it says nothing about when anything arrived and stays
+            // comparable against an imported recording.
+            if (compare is { } compareData)
             {
+                bool sharesTimeReference = CompareSharesATimeReference();
                 PhaseAnalysisSettings comparePhaseSettings =
                     phaseResponseOptions.PhaseGateAutoFit &&
                     TransferIrStartCache.ResolveStartMs(compareData.Measurement)
                         is { } compareStartMs
                         ? phaseSettings with { GateOffsetMs = compareStartMs }
                         : phaseSettings;
-                if (phaseResponseVisibility.ShowMeasuredPhase)
+                if (phaseResponseVisibility.ShowMeasuredPhase && sharesTimeReference)
                 {
                     AnalysisCurve compareCurve = DataHelper.GetPhase(
                         compareData.Measurement,
@@ -589,7 +595,7 @@ internal sealed class PlotModelFactory
                         phaseUnwrapped: true);
                 }
 
-                if (phaseResponseVisibility.ShowExcessPhase)
+                if (phaseResponseVisibility.ShowExcessPhase && sharesTimeReference)
                 {
                     AnalysisCurve compareCurve = DataHelper.GetExcessPhase(
                         compareData.Measurement,
@@ -768,7 +774,14 @@ internal sealed class PlotModelFactory
                 // per-curve (each record's own IR start): group delay reads
                 // absolute from the IR start, so differently placed windows
                 // stay directly comparable while both direct arrivals survive.
-                if (CompareSharesATimeReference() &&
+                // Which of them may be drawn is per-curve: the measured and the
+                // excess read absolute from the IR start, so they only mean
+                // something when both records sit on one clock, while the
+                // minimum-phase curve comes from the gated magnitude and
+                // carries no bulk delay by construction.
+                bool sharesTimeReference = CompareSharesATimeReference();
+                if ((sharesTimeReference ||
+                        groupDelayVisibility.ShowMinimumPhaseGroupDelay) &&
                     TryCreateCompareMeasurement() is { } compare)
                 {
                     double compareGateOffsetMs =
@@ -793,7 +806,7 @@ internal sealed class PlotModelFactory
                     // extremes swing widely; folding them into the range makes the
                     // scale jump on every edit. Off-scale Compare points are simply
                     // clipped, like any overlay.
-                    if (groupDelayVisibility.ShowGroupDelay)
+                    if (groupDelayVisibility.ShowGroupDelay && sharesTimeReference)
                     {
                         AddCompareLineSeries(
                             model,
@@ -813,6 +826,7 @@ internal sealed class PlotModelFactory
                             Mode.GroupDelay);
                     }
                     if (groupDelayVisibility.ShowExcessGroupDelay &&
+                        sharesTimeReference &&
                         compareCurves.Excess is { } compareExcessCurve)
                     {
                         AddCompareLineSeries(

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -205,15 +205,38 @@ public partial class Form1
             recording = await Task.Run(() => RecordedSweepFile.Load(path));
             // The current settings decide the excitation, exactly as they would for
             // the next sweep. They are handed over rather than applied first: a
-            // rejected recording must leave the measurement on screen alone. Every
-            // channel goes over: which one holds the measurement is decided by
-            // matching them against the sweep, which is the measurement's job.
+            // rejected recording must leave the measurement on screen alone.
             SweepMeasurementConfiguration configuration =
                 measurementSettings.Measurement.BuildConfiguration();
+            // Which channel holds the measurement is a question about the sweep,
+            // not about loudness — but matching only answers it when ONE channel
+            // holds the sweep. A recorder that also wrote the played signal to a
+            // reference track put a copy of the excitation in the file, and a copy
+            // matches better than any acoustic take: it would win, measure flat,
+            // and pass every credibility check on the way. Nothing in the numbers
+            // says which track the microphone was on, so that choice is asked for.
+            double[] qualities = recording.ChannelCount > 1
+                ? await Task.Run(() =>
+                    RecordedSweepChannels.Rank(configuration, recording.Channels))
+                : [0.0];
+            int channel = RecordedSweepChannels.Best(qualities);
+            if (RecordedSweepChannels.IsAmbiguous(qualities))
+            {
+                using var dialog = new Options.RecordedSweepChannelDialog(
+                    recording.Channels, qualities);
+                if (dialog.ShowDialog(this) != DialogResult.OK)
+                {
+                    return;
+                }
+
+                channel = dialog.SelectedChannel;
+            }
+
             await Task.Run(() => expSweepMeasurement.ImportRecordedSweep(
                 configuration,
                 recording.Channels,
-                recording.SampleRate));
+                recording.SampleRate,
+                channel));
         }
 
         ApplyLoadedImpulseResponseState(path);
@@ -243,7 +266,7 @@ public partial class Form1
             AudioChannelLevel level = RecordedLevelMetering.MeasureSamples(
                 recording.Channels[chosen]);
             notes.Add(FormattableString.Invariant(
-                $"The recording has {recording.ChannelCount} channels; the one matching the sweep ({RecordedSweepFile.DescribeChannel(chosen, recording.ChannelCount)}) was measured — {level.RmsDbFs:0.0} dBFS RMS, peak {level.PeakDbFs:0.0} dBFS."));
+                $"The recording has {recording.ChannelCount} channels; {RecordedSweepFile.DescribeChannel(chosen, recording.ChannelCount)} was measured — {level.RmsDbFs:0.0} dBFS RMS, peak {level.PeakDbFs:0.0} dBFS."));
         }
         if (expSweepMeasurement.ImportedTimeScalePpm is { } scalePpm)
         {

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -194,7 +194,7 @@ public partial class Form1
     // it enters the history the way a finished sweep does.
     private async Task ImportRecordedSweepAsync(string path)
     {
-        RecordedSweepChannel recording;
+        AudioFileContent recording;
         // Claimed BEFORE the decode, which on a long recording is seconds of its
         // own: the record button gates on the measurement being busy, and without
         // the claim a run started during the decode would finish and then be
@@ -205,12 +205,14 @@ public partial class Form1
             recording = await Task.Run(() => RecordedSweepFile.Load(path));
             // The current settings decide the excitation, exactly as they would for
             // the next sweep. They are handed over rather than applied first: a
-            // rejected recording must leave the measurement on screen alone.
+            // rejected recording must leave the measurement on screen alone. Every
+            // channel goes over: which one holds the measurement is decided by
+            // matching them against the sweep, which is the measurement's job.
             SweepMeasurementConfiguration configuration =
                 measurementSettings.Measurement.BuildConfiguration();
             await Task.Run(() => expSweepMeasurement.ImportRecordedSweep(
                 configuration,
-                recording.Samples,
+                recording.Channels,
                 recording.SampleRate));
         }
 
@@ -227,7 +229,7 @@ public partial class Form1
     // measured, and whether it had to stretch the reference to match the
     // recording. Silent when there was nothing to decide — a mono file that
     // needed no correction says nothing at all.
-    private void NotifyImportDecisions(RecordedSweepChannel recording)
+    private void NotifyImportDecisions(AudioFileContent recording)
     {
         if (closingInProgress)
         {
@@ -237,8 +239,11 @@ public partial class Form1
         var notes = new List<string>();
         if (recording.ChannelCount > 1)
         {
+            int chosen = expSweepMeasurement.ImportedChannelIndex;
+            AudioChannelLevel level = RecordedLevelMetering.MeasureSamples(
+                recording.Channels[chosen]);
             notes.Add(FormattableString.Invariant(
-                $"The recording has {recording.ChannelCount} channels; the loudest one ({RecordedSweepFile.DescribeChannel(recording.ChannelIndex, recording.ChannelCount)}) was measured — {recording.RmsDbFs:0.0} dBFS RMS, peak {recording.PeakDbFs:0.0} dBFS."));
+                $"The recording has {recording.ChannelCount} channels; the one matching the sweep ({RecordedSweepFile.DescribeChannel(chosen, recording.ChannelCount)}) was measured — {level.RmsDbFs:0.0} dBFS RMS, peak {level.PeakDbFs:0.0} dBFS."));
         }
         if (expSweepMeasurement.ImportedTimeScalePpm is { } scalePpm)
         {

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -266,6 +266,80 @@ public sealed class PlotModelFactoryTests
                 tag.Kind == AnalysisCurveKind.ExcessGroupDelay);
     }
 
+    // An imported recording's time origin is its own arrival, so nothing that
+    // reads absolute time may be drawn beside a measurement that was referenced
+    // to a captured loopback. The minimum-phase curve is not such a statement —
+    // it is reconstructed from the gated magnitude and carries no bulk delay by
+    // construction — so it stays comparable, and hiding it would be hiding valid
+    // data rather than avoiding a wrong number.
+    [Theory]
+    [InlineData(TimingReference.SynchronizedLoopback, true)]
+    [InlineData(TimingReference.RecordedSweep, false)]
+    public void GroupDelay_TheTimeReadingCompareCurvesNeedOneClock(
+        TimingReference compareTiming,
+        bool sharesTheClock)
+    {
+        using var measurement = CreateTransferMeasurement();
+        using var noiseMeasurement = new NoiseMeasurement(new FakeAudioSessionFactory());
+        PlotModelFactory factory = CreateFactory(measurement, noiseMeasurement);
+
+        var compareIr = new Complex[2048];
+        compareIr[64] = Complex.One;
+        factory.SetCompareSourceProvider(
+            () => new CompareAnalysisSource(
+                "Reference",
+                44_100,
+                compareIr,
+                64,
+                TimingReference: compareTiming));
+
+        List<AnalysisCurveKind> kinds = factory.CreateGroupDelay(includeCurves: true).Series
+            .OfType<LineSeries>()
+            .Select(series => series.Tag)
+            .OfType<CurveTag>()
+            .Where(tag => tag.Source == CurveSource.Compare)
+            .Select(tag => tag.Kind)
+            .ToList();
+
+        Assert.Contains(AnalysisCurveKind.MinimumPhaseGroupDelay, kinds);
+        Assert.Equal(sharesTheClock, kinds.Contains(AnalysisCurveKind.Primary));
+        Assert.Equal(sharesTheClock, kinds.Contains(AnalysisCurveKind.ExcessGroupDelay));
+    }
+
+    [Theory]
+    [InlineData(TimingReference.SynchronizedLoopback, true)]
+    [InlineData(TimingReference.RecordedSweep, false)]
+    public void PhaseResponse_TheTimeReadingCompareCurvesNeedOneClock(
+        TimingReference compareTiming,
+        bool sharesTheClock)
+    {
+        using var measurement = CreateTransferMeasurement();
+        using var noiseMeasurement = new NoiseMeasurement(new FakeAudioSessionFactory());
+        PlotModelFactory factory = CreateFactory(measurement, noiseMeasurement);
+
+        var compareIr = new Complex[2048];
+        compareIr[64] = Complex.One;
+        factory.SetCompareSourceProvider(
+            () => new CompareAnalysisSource(
+                "Reference",
+                44_100,
+                compareIr,
+                64,
+                TimingReference: compareTiming));
+
+        List<AnalysisCurveKind> kinds = factory.CreatePhaseResponse(includeCurves: true).Series
+            .OfType<LineSeries>()
+            .Select(series => series.Tag)
+            .OfType<CurveTag>()
+            .Where(tag => tag.Source == CurveSource.Compare)
+            .Select(tag => tag.Kind)
+            .ToList();
+
+        Assert.Contains(AnalysisCurveKind.MinimumPhase, kinds);
+        Assert.Equal(sharesTheClock, kinds.Contains(AnalysisCurveKind.Primary));
+        Assert.Equal(sharesTheClock, kinds.Contains(AnalysisCurveKind.ExcessPhase));
+    }
+
     [Fact]
     public void GroupDelay_TagsMainAndCompareCurvesForLinkedOverlays()
     {

--- a/tests/Resonalyze.App.Tests/RecordedSweepDetectorTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepDetectorTests.cs
@@ -1,0 +1,135 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// Matching the sweep against a recording: where it is, how well it matched, and
+/// what happens when it is not there at all.
+/// </summary>
+public sealed class RecordedSweepDetectorTests : IDisposable
+{
+    private const int SampleRate = 48_000;
+
+    private readonly ExponentialSineSweep sweep = new();
+
+    public RecordedSweepDetectorTests() => sweep.FillData(20, 20_000, 1.0, 24, SampleRate);
+
+    public void Dispose() => sweep.Dispose();
+
+    private float[] Excitation => sweep.SweepData;
+
+    private float[] Take(int start, int trailing, float gain = 1.0f, float noise = 0.0f, int seed = 1)
+    {
+        var samples = new float[start + Excitation.Length + trailing];
+        var random = new Random(seed);
+        for (int i = 0; i < samples.Length; i++)
+        {
+            samples[i] = (float)((random.NextDouble() - 0.5) * 2 * noise);
+        }
+        for (int i = 0; i < Excitation.Length; i++)
+        {
+            samples[start + i] += Excitation[i] * gain;
+        }
+
+        return samples;
+    }
+
+    [Fact]
+    public void FindsTheSweepToTheSample()
+    {
+        const int start = 37_123;
+
+        IReadOnlyList<SweepMatch> matches =
+            RecordedSweepDetector.FindSweeps(Take(start, SampleRate), Excitation, 3);
+
+        Assert.NotEmpty(matches);
+        Assert.Equal(start, matches[0].Start);
+        Assert.Equal(1.0, matches[0].Quality, tolerance: 0.001);
+    }
+
+    // Level says nothing here: the sweep is 20 dB under the noise it was recorded
+    // in, which no threshold can reach. Matching concentrates the whole excitation
+    // into one peak — about 43 dB of gain for this one second — so the position is
+    // still exact.
+    [Fact]
+    public void FindsASweepBuriedUnderNoise()
+    {
+        const int start = 12_345;
+        float[] samples = Take(start, SampleRate, gain: 0.003f, noise: 0.03f);
+
+        IReadOnlyList<SweepMatch> matches =
+            RecordedSweepDetector.FindSweeps(samples, Excitation, 1);
+
+        Assert.Equal(start, matches[0].Start);
+    }
+
+    // Two attempts in one take: both are reported, and the better one leads.
+    [Fact]
+    public void ReportsEveryTakeInTheRecording()
+    {
+        int second = Excitation.Length + 3 * SampleRate;
+        float[] samples = Take(SampleRate, second + SampleRate);
+        for (int i = 0; i < Excitation.Length; i++)
+        {
+            samples[SampleRate + second + i] += Excitation[i] * 0.5f;
+        }
+
+        IReadOnlyList<SweepMatch> matches =
+            RecordedSweepDetector.FindSweeps(samples, Excitation, 2);
+
+        Assert.Equal(2, matches.Count);
+        Assert.Equal(SampleRate, matches[0].Start);
+        Assert.Equal(SampleRate + second, matches[1].Start);
+        Assert.True(matches[0].Quality > matches[1].Quality);
+    }
+
+    // A take that stopped mid-sweep: its true start is only among the placements
+    // that run off the end of the file, so those have to be searched. Leaving them
+    // out does not make the take usable — it makes the answer a wrong position
+    // that then reads as a complete recording.
+    [Fact]
+    public void FindsASweepTheRecordingRanOutOn()
+    {
+        const int start = 24_000;
+        float[] full = Take(start, 0);
+        float[] truncated = full[..(start + (int)(Excitation.Length * 0.7))];
+
+        IReadOnlyList<SweepMatch> matches =
+            RecordedSweepDetector.FindSweeps(truncated, Excitation, 1);
+
+        Assert.Equal(start, matches[0].Start);
+        Assert.True(
+            matches[0].Start + Excitation.Length > truncated.Length,
+            "the match has to show the sweep running past the end of the file");
+    }
+
+    // Quality is a correlation, not a level: the loud channel of hum must not
+    // outrank the quiet one that actually holds the sweep.
+    [Fact]
+    public void QualityJudgesTheShapeRatherThanTheLevel()
+    {
+        float[] quietSweep = Take(SampleRate, SampleRate, gain: 0.01f);
+        var loudHum = new float[quietSweep.Length];
+        for (int i = 0; i < loudHum.Length; i++)
+        {
+            loudHum[i] = (float)(0.5 * Math.Sin(2.0 * Math.PI * 50.0 * i / SampleRate));
+        }
+
+        double sweepQuality = RecordedSweepDetector
+            .FindSweeps(quietSweep, Excitation, 1)[0].Quality;
+        double humQuality = RecordedSweepDetector
+            .FindSweeps(loudHum, Excitation, 1)[0].Quality;
+
+        Assert.True(
+            sweepQuality > humQuality * 4,
+            $"sweep {sweepQuality:0.000} against hum {humQuality:0.000}");
+    }
+
+    [Fact]
+    public void ReportsNothingWhenThereIsNothingToMatch()
+    {
+        Assert.Empty(RecordedSweepDetector.FindSweeps([], Excitation, 1));
+        Assert.Empty(RecordedSweepDetector.FindSweeps(new float[1_000], [], 1));
+        // A recording shorter than the sweep cannot hold it.
+        Assert.Empty(RecordedSweepDetector.FindSweeps(
+            new float[Excitation.Length / 2], Excitation, 1));
+    }
+}

--- a/tests/Resonalyze.App.Tests/RecordedSweepDetectorTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepDetectorTests.cs
@@ -149,6 +149,45 @@ public sealed class RecordedSweepDetectorTests : IDisposable
             $"sweep {sweepQuality:0.000} against hum {humQuality:0.000}");
     }
 
+    // Long enough that the search decimates, which is where the pool and the
+    // refined answers stop being the same unit. A coarse start compared against
+    // an already-refined one measures a distance in two scales at once, and here
+    // the second take's COARSE index lands on the first take's FULL-RATE index —
+    // so it reads as the same arrival reported twice and disappears.
+    [Fact]
+    public void ReportsEveryTakeOnceTheSearchDecimates()
+    {
+        const int rate = 48_000;
+        const int first = 12_000;
+        using var shortSweep = new ExponentialSineSweep();
+        shortSweep.FillData(20, 20_000, 0.25, 24, rate);
+        float[] excitation = shortSweep.SweepData;
+        // Back to back, so the takes never overlap: 2 x (first / decimation) is
+        // exactly the second take's coarse index.
+        int second = first + excitation.Length;
+        // Past the search ceiling, which is what turns decimation on.
+        var samples = new float[1_200_000];
+        var random = new Random(99);
+        for (int i = 0; i < samples.Length; i++)
+        {
+            samples[i] = (float)((random.NextDouble() - 0.5) * 1e-4);
+        }
+        for (int i = 0; i < excitation.Length; i++)
+        {
+            samples[first + i] += excitation[i];
+            // The second take is the noisier one, so the clean take ranks first
+            // and the comparison happens in the order that loses it.
+            samples[second + i] +=
+                excitation[i] * 0.5f + (float)((random.NextDouble() - 0.5) * 0.05);
+        }
+
+        IReadOnlyList<SweepMatch> matches =
+            RecordedSweepDetector.FindSweeps(samples, excitation, 3);
+
+        Assert.Contains(matches, match => match.Start == first);
+        Assert.Contains(matches, match => match.Start == second);
+    }
+
     [Fact]
     public void ReportsNothingWhenThereIsNothingToMatch()
     {

--- a/tests/Resonalyze.App.Tests/RecordedSweepDetectorTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepDetectorTests.cs
@@ -61,7 +61,9 @@ public sealed class RecordedSweepDetectorTests : IDisposable
         Assert.Equal(start, matches[0].Start);
     }
 
-    // Two attempts in one take: both are reported, and the better one leads.
+    // Two attempts in one take: both are reported. Neither is the worse match for
+    // being quieter — quality is a correlation, so halving a take's level halves
+    // the numerator and the denominator alike.
     [Fact]
     public void ReportsEveryTakeInTheRecording()
     {
@@ -76,9 +78,33 @@ public sealed class RecordedSweepDetectorTests : IDisposable
             RecordedSweepDetector.FindSweeps(samples, Excitation, 2);
 
         Assert.Equal(2, matches.Count);
+        Assert.Contains(matches, match => match.Start == SampleRate);
+        Assert.Contains(matches, match => match.Start == SampleRate + second);
+        Assert.All(matches, match => Assert.Equal(1.0, match.Quality, tolerance: 0.01));
+    }
+
+    // What DOES separate them is how well each one matches. The take buried in
+    // noise is the weaker match and has to rank below the clean one, because the
+    // caller analyzes them in that order.
+    [Fact]
+    public void RanksTheCleanerTakeFirst()
+    {
+        int second = Excitation.Length + 3 * SampleRate;
+        float[] samples = Take(SampleRate, second + SampleRate);
+        var random = new Random(11);
+        for (int i = 0; i < Excitation.Length; i++)
+        {
+            samples[SampleRate + second + i] +=
+                Excitation[i] * 0.5f + (float)((random.NextDouble() - 0.5) * 0.8);
+        }
+
+        IReadOnlyList<SweepMatch> matches =
+            RecordedSweepDetector.FindSweeps(samples, Excitation, 2);
+
         Assert.Equal(SampleRate, matches[0].Start);
-        Assert.Equal(SampleRate + second, matches[1].Start);
-        Assert.True(matches[0].Quality > matches[1].Quality);
+        Assert.True(
+            matches[0].Quality > matches[1].Quality,
+            $"clean {matches[0].Quality:0.000} against noisy {matches[1].Quality:0.000}");
     }
 
     // A take that stopped mid-sweep: its true start is only among the placements

--- a/tests/Resonalyze.App.Tests/RecordedSweepFileTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepFileTests.cs
@@ -34,77 +34,38 @@ public sealed class RecordedSweepFileTests : IDisposable
         return samples;
     }
 
+    // Every channel is read: which one carries the measurement is decided later,
+    // by matching them against the sweep, and that decision needs them all.
     [Fact]
-    public void MonoFileIsUsedAsIs()
-    {
-        float[] mono = Tone(2_048, 0.4);
-
-        RecordedSweepChannel selected = RecordedSweepFile.SelectLoudestChannel(
-            new AudioFileContent([mono], 48_000));
-
-        Assert.Equal(0, selected.ChannelIndex);
-        Assert.Equal(1, selected.ChannelCount);
-        Assert.Equal(48_000, selected.SampleRate);
-        Assert.Same(mono, selected.Samples);
-    }
-
-    [Fact]
-    public void LoudestChannelWins()
-    {
-        float[] quiet = Tone(2_048, 0.02, seed: 2);
-        float[] loud = Tone(2_048, 0.4, seed: 3);
-
-        RecordedSweepChannel selected = RecordedSweepFile.SelectLoudestChannel(
-            new AudioFileContent([quiet, loud], 48_000));
-
-        Assert.Equal(1, selected.ChannelIndex);
-        Assert.Equal(2, selected.ChannelCount);
-        Assert.Same(loud, selected.Samples);
-        Assert.InRange(selected.PeakDbFs, -9.0, -7.0);
-    }
-
-    // Peak alone would pick the dead channel here: a single sample of full-scale
-    // click beats a sweep that never leaves -20 dBFS. RMS is what carries the
-    // measurement, so RMS is what decides.
-    [Fact]
-    public void ASingleClickDoesNotWinOverASweep()
-    {
-        float[] measurement = Tone(2_048, 0.1, seed: 4);
-        var clickOnly = new float[2_048];
-        clickOnly[17] = 1.0f;
-
-        RecordedSweepChannel selected = RecordedSweepFile.SelectLoudestChannel(
-            new AudioFileContent([clickOnly, measurement], 48_000));
-
-        Assert.Equal(1, selected.ChannelIndex);
-    }
-
-    [Fact]
-    public void EmptyContentIsRefused()
-    {
-        Assert.Throws<InvalidOperationException>(() =>
-            RecordedSweepFile.SelectLoudestChannel(new AudioFileContent([], 48_000)));
-    }
-
-    [Fact]
-    public void LoadReadsTheLoudestChannelOfAStereoFile()
+    public void LoadKeepsEveryChannel()
     {
         string path = Path.Combine(directory, "recording.wav");
         float[] quiet = Tone(4_096, 0.01, seed: 5);
         float[] loud = Tone(4_096, 0.5, seed: 6);
         AudioFileCodec.WriteWav(path, new AudioFileContent([quiet, loud], 44_100));
 
-        RecordedSweepChannel selected = RecordedSweepFile.Load(path);
+        AudioFileContent content = RecordedSweepFile.Load(path);
 
-        Assert.Equal(1, selected.ChannelIndex);
-        Assert.Equal(2, selected.ChannelCount);
-        Assert.Equal(44_100, selected.SampleRate);
-        Assert.Equal(4_096, selected.Samples.Length);
-        // 24-bit round trip: the samples come back, not merely the channel choice.
+        Assert.Equal(2, content.ChannelCount);
+        Assert.Equal(44_100, content.SampleRate);
+        Assert.Equal(4_096, content.FrameCount);
+        // 24-bit round trip: the samples come back, not merely the shape.
         for (int i = 0; i < loud.Length; i++)
         {
-            Assert.Equal(loud[i], selected.Samples[i], tolerance: 1e-6f);
+            Assert.Equal(quiet[i], content.Channels[0][i], tolerance: 1e-6f);
+            Assert.Equal(loud[i], content.Channels[1][i], tolerance: 1e-6f);
         }
+    }
+
+    [Fact]
+    public void AnEmptyFileIsRefused()
+    {
+        string path = Path.Combine(directory, "empty.wav");
+        AudioFileCodec.WriteWav(path, new AudioFileContent([new float[1]], 44_100));
+        // A one-sample file decodes, but a recording of nothing is not a take.
+        File.WriteAllBytes(path, File.ReadAllBytes(path)[..44]);
+
+        Assert.ThrowsAny<Exception>(() => RecordedSweepFile.Load(path));
     }
 
     [Theory]

--- a/tests/Resonalyze.App.Tests/RecordedSweepImportTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepImportTests.cs
@@ -203,8 +203,13 @@ public sealed class RecordedSweepImportTests
         using (measurement.Claim())
         {
             Assert.True(measurement.InProgress);
-            // Nothing else may start a measurement while the claim is held.
+            // Nothing else may start a measurement while the claim is held. A run
+            // has to be refused by name: it does not consult InProgress, and its
+            // own completion would hand back the busy flag the import still owns.
             Assert.Throws<InvalidOperationException>(() => measurement.Init(Configuration()));
+            // Thrown synchronously, before there is any task to await.
+            Assert.Throws<InvalidOperationException>(() => { _ = measurement.RunAsync(); });
+            Assert.True(measurement.InProgress);
             // The import is what the claim was taken for, so it proceeds.
             measurement.ImportRecordedSweep(Configuration(), recording, SampleRate);
             Assert.True(measurement.HasImpulseResponse);

--- a/tests/Resonalyze.App.Tests/RecordedSweepImportTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepImportTests.cs
@@ -89,6 +89,28 @@ public sealed class RecordedSweepImportTests
         Assert.Equal(1, measurement.AcceptedAverageRunCount);
     }
 
+    // Which channel holds the measurement is a question about the sweep, not
+    // about loudness: a dead input is rarely silent, and hum or hiss on it can
+    // easily out-measure a quiet microphone that actually recorded the take.
+    [Fact]
+    public void ImportMeasuresTheChannelThatMatchesRatherThanTheLoudest()
+    {
+        using ExpSweepMeasurement measurement = CreateMeasurement();
+        float[] sweepChannel = RecordSweep(measurement, 1_500, gain: 0.02f);
+        var humChannel = new float[sweepChannel.Length];
+        for (int i = 0; i < humChannel.Length; i++)
+        {
+            humChannel[i] = (float)(0.5 * Math.Sin(2.0 * Math.PI * 50.0 * i / SampleRate));
+        }
+
+        measurement.ImportRecordedSweep(
+            Configuration(), [humChannel, sweepChannel], SampleRate);
+
+        Assert.Equal(1, measurement.ImportedChannelIndex);
+        Assert.True(measurement.HasImpulseResponse);
+        Assert.Equal(Arrival, measurement.Transfer!.PeakIndex);
+    }
+
     // The point of the transfer estimate: what comes back is the PATH the sweep
     // travelled, not just where it started. A recording of the sweep through a
     // direct arrival plus one reflection must come back as those two arrivals,

--- a/tests/Resonalyze.App.Tests/RecordedSweepImportTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepImportTests.cs
@@ -146,6 +146,58 @@ public sealed class RecordedSweepImportTests
         Assert.Equal(reflectionGain, reflectionLevel / directLevel, tolerance: 0.02);
     }
 
+    // Two attempts in one file, the second one louder and cut off by the end of
+    // the recording. The complete take is the usable one, and it has to be
+    // measured on its own: a second excitation inside the analyzed stretch is
+    // indistinguishable from an enormous reflection of the first, which either
+    // fails the shape gate — refusing a file that holds a perfectly good take —
+    // or wins the arrival outright. Each take carries its own reflection, so the
+    // result says which one was measured.
+    [Fact]
+    public void ASecondLouderAttemptDoesNotCostTheCompleteTake()
+    {
+        const int lead = 2_000;
+        const int firstReflection = 300;
+        const int secondReflection = 700;
+        const float reflectionGain = 0.5f;
+        using ExpSweepMeasurement measurement = CreateMeasurement();
+        float[] sweep = measurement.Sweep!.SweepData;
+        int second = lead + sweep.Length + (SampleRate / 4);
+        var recording = new float[second + (int)(sweep.Length * 0.85)];
+
+        // The complete take, 17 dB below the second one.
+        for (int i = 0; i < sweep.Length; i++)
+        {
+            recording[lead + i] += sweep[i] * 0.14f;
+            recording[lead + firstReflection + i] += sweep[i] * 0.14f * reflectionGain;
+        }
+        // The second attempt: louder, and the file stops partway through it.
+        for (int i = 0; i < sweep.Length && second + i < recording.Length; i++)
+        {
+            recording[second + i] += sweep[i];
+        }
+        for (int i = 0; i < sweep.Length && second + secondReflection + i < recording.Length; i++)
+        {
+            recording[second + secondReflection + i] += sweep[i] * reflectionGain;
+        }
+
+        measurement.ImportRecordedSweep(Configuration(), recording, SampleRate);
+
+        Complex[] transfer = measurement.TransferImpulseResponse!;
+        int peak = measurement.Transfer!.PeakIndex;
+        Assert.Equal(Arrival, peak);
+        // The complete take's own reflection, at its own spacing and strength —
+        // and nothing at the second take's spacing.
+        double direct = Math.Abs(transfer[peak].Real);
+        Assert.Equal(
+            reflectionGain,
+            Math.Abs(transfer[peak + firstReflection].Real) / direct,
+            tolerance: 0.05);
+        Assert.True(
+            Math.Abs(transfer[peak + secondReflection].Real) / direct < 0.1,
+            $"the second take's reflection came through at {Math.Abs(transfer[peak + secondReflection].Real) / direct:0.000}");
+    }
+
     // A take made the way people actually make them: recorder started, walk to the
     // seat, play the sweep, walk back, stop. The minutes of silence must not reach
     // the FFTs — they would size every spectrum and the stored transfer IR with

--- a/tests/Resonalyze.App.Tests/RecordedSweepImportTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepImportTests.cs
@@ -5,9 +5,9 @@ using Resonalyze.Dsp;
 namespace Resonalyze.App.Tests;
 
 /// <summary>
-/// Importing a sweep recorded outside Resonalyze: the file's loudest channel is
-/// what gets measured, and the analysis runs against the configured sweep
-/// standing in for the loopback reference.
+/// Importing a sweep recorded outside Resonalyze: the channel that matches the
+/// configured sweep is what gets measured, and the analysis runs against that
+/// sweep standing in for the loopback reference.
 /// </summary>
 public sealed class RecordedSweepImportTests
 {
@@ -108,6 +108,73 @@ public sealed class RecordedSweepImportTests
 
         Assert.Equal(1, measurement.ImportedChannelIndex);
         Assert.True(measurement.HasImpulseResponse);
+        Assert.Equal(Arrival, measurement.Transfer!.PeakIndex);
+    }
+
+    // A dead input is no competition, whatever it is doing: the choice is not
+    // ambiguous and the import makes it on its own, as it did before there was
+    // anything to ask about.
+    [Fact]
+    public void ADeadInputIsNoCompetitionForTheChannelHoldingTheTake()
+    {
+        using ExpSweepMeasurement measurement = CreateMeasurement();
+        float[] sweepChannel = RecordSweep(measurement, 1_500, gain: 0.02f);
+        var humChannel = new float[sweepChannel.Length];
+        for (int i = 0; i < humChannel.Length; i++)
+        {
+            humChannel[i] = (float)(0.5 * Math.Sin(2.0 * Math.PI * 50.0 * i / SampleRate));
+        }
+
+        double[] qualities =
+            RecordedSweepChannels.Rank(Configuration(), [humChannel, sweepChannel]);
+
+        Assert.Equal(1, RecordedSweepChannels.Best(qualities));
+        Assert.False(
+            RecordedSweepChannels.IsAmbiguous(qualities),
+            $"hum {qualities[0]:0.000} against the take {qualities[1]:0.000}");
+    }
+
+    // The case no ranking can settle: a DAW wrote the played sweep to a reference
+    // track beside the microphone. The reference is a COPY of the excitation, so
+    // it matches better than any acoustic take ever will — it would win, measure
+    // as a flat response and pass every credibility check on the way out. The
+    // import has to notice that it cannot choose.
+    [Fact]
+    public void AReferenceTrackBesideTheMicrophoneIsNotTheImportsChoiceToMake()
+    {
+        using ExpSweepMeasurement measurement = CreateMeasurement();
+        // The reference track: the played sweep, nothing else on it.
+        float[] reference = RecordSweep(measurement, 1_500, gain: 0.5f);
+        // The microphone: direct sound a few ms later, two reflections, some room.
+        float[] sweep = measurement.Sweep!.SweepData;
+        var microphone = new float[reference.Length];
+        var random = new Random(77);
+        for (int i = 0; i < microphone.Length; i++)
+        {
+            microphone[i] = (float)((random.NextDouble() - 0.5) * 1e-3);
+        }
+        int[] taps = [1_500 + 144, 1_500 + 346, 1_500 + 677];
+        float[] gains = [0.35f, -0.18f, 0.11f];
+        for (int tap = 0; tap < taps.Length; tap++)
+        {
+            for (int i = 0; i < sweep.Length && taps[tap] + i < microphone.Length; i++)
+            {
+                microphone[taps[tap] + i] += sweep[i] * gains[tap];
+            }
+        }
+
+        double[] qualities =
+            RecordedSweepChannels.Rank(Configuration(), [reference, microphone]);
+
+        // The copy does win — that is the whole problem.
+        Assert.Equal(0, RecordedSweepChannels.Best(qualities));
+        Assert.True(
+            RecordedSweepChannels.IsAmbiguous(qualities),
+            $"reference {qualities[0]:0.000} against the microphone {qualities[1]:0.000}");
+        // And the caller can then measure the channel it was told to.
+        measurement.ImportRecordedSweep(
+            Configuration(), [reference, microphone], SampleRate, channel: 1);
+        Assert.Equal(1, measurement.ImportedChannelIndex);
         Assert.Equal(Arrival, measurement.Transfer!.PeakIndex);
     }
 

--- a/tests/Resonalyze.App.Tests/RecordedSweepWindowTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepWindowTests.cs
@@ -67,6 +67,33 @@ public sealed class RecordedSweepWindowTests : IDisposable
         Assert.True(span.ExcitationLength < SweepSamples);
     }
 
+    // A short take can hold a complete sweep and the louder beginning of a second
+    // attempt that the file then cut off. Answering with only the strongest match
+    // would refuse the file over the one that was cut short, so every match is
+    // offered and the caller can fall through to the complete one.
+    [Fact]
+    public void AShortRecordingOffersEveryTakeItHolds()
+    {
+        // The second attempt starts a quarter of a second after the first ends and
+        // keeps most of the sweep — enough of it to be a candidate at all — and it
+        // is the louder of the two.
+        int second = SweepSamples + SampleRate / 4;
+        float[] samples = Recording(0, 2 * SampleRate, sweepGain: 0.2f, noise: 0.0005f);
+        for (int i = 0; i < samples.Length - second; i++)
+        {
+            samples[second + i] += Sweep[i];
+        }
+
+        IReadOnlyList<RecordedSweepSpan> spans = Locate(samples);
+
+        Assert.All(spans, span => Assert.Equal(0, span.Start));
+        Assert.Contains(spans, span => span.ExcitationStart == 0);
+        Assert.Contains(spans, span => span.ExcitationStart == second);
+        // And the complete one is the usable candidate.
+        Assert.True(spans.First(span => span.ExcitationStart == 0).ExcitationLength >= SweepSamples);
+        Assert.True(spans.First(span => span.ExcitationStart == second).ExcitationLength < SweepSamples);
+    }
+
     [Fact]
     public void ShortRecordingsAreAnalyzedWhole()
     {

--- a/tests/Resonalyze.App.Tests/RecordedSweepWindowTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepWindowTests.cs
@@ -70,7 +70,9 @@ public sealed class RecordedSweepWindowTests : IDisposable
     // A short take can hold a complete sweep and the louder beginning of a second
     // attempt that the file then cut off. Answering with only the strongest match
     // would refuse the file over the one that was cut short, so every match is
-    // offered and the caller can fall through to the complete one.
+    // offered and the caller can fall through to the complete one — each on a
+    // span that holds its own attempt and not the other, which would otherwise
+    // read as an enormous reflection of it.
     [Fact]
     public void AShortRecordingOffersEveryTakeItHolds()
     {
@@ -86,12 +88,18 @@ public sealed class RecordedSweepWindowTests : IDisposable
 
         IReadOnlyList<RecordedSweepSpan> spans = Locate(samples);
 
-        Assert.All(spans, span => Assert.Equal(0, span.Start));
         Assert.Contains(spans, span => span.ExcitationStart == 0);
         Assert.Contains(spans, span => span.ExcitationStart == second);
-        // And the complete one is the usable candidate.
-        Assert.True(spans.First(span => span.ExcitationStart == 0).ExcitationLength >= SweepSamples);
-        Assert.True(spans.First(span => span.ExcitationStart == second).ExcitationLength < SweepSamples);
+        // The complete one is the usable candidate, and its span stops where the
+        // second attempt begins.
+        RecordedSweepSpan complete = spans.First(span => span.ExcitationStart == 0);
+        Assert.True(complete.ExcitationLength >= SweepSamples);
+        Assert.Equal(0, complete.Start);
+        Assert.Equal(second, complete.Start + complete.Length);
+        // And the cut-short one starts after the first attempt has finished.
+        RecordedSweepSpan truncated = spans.First(span => span.ExcitationStart == second);
+        Assert.True(truncated.ExcitationLength < SweepSamples);
+        Assert.Equal(SweepSamples, truncated.Start);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/RecordedSweepWindowTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepWindowTests.cs
@@ -1,37 +1,53 @@
-﻿namespace Resonalyze.App.Tests;
+﻿using Resonalyze.Audio;
+
+namespace Resonalyze.App.Tests;
 
 /// <summary>
-/// Locating the excitation inside a recording that is mostly silence — the shape
-/// of every file made by starting a recorder, walking to the seat, playing the
-/// sweep and walking back.
+/// Locating the excitation inside a recording that is mostly something else — the
+/// shape of every file made by starting a recorder, walking to the seat, playing
+/// the sweep and walking back. The sweep is found by matching it, so these build
+/// recordings out of the real excitation rather than a stand-in tone.
 /// </summary>
-public sealed class RecordedSweepWindowTests
+public sealed class RecordedSweepWindowTests : IDisposable
 {
     private const int SampleRate = 48_000;
-    private const int SweepSamples = 96_000;
+
+    private readonly ExponentialSineSweep sweep = new();
+
+    public RecordedSweepWindowTests() => sweep.FillData(20, 20_000, 2.0, 24, SampleRate);
+
+    public void Dispose() => sweep.Dispose();
+
+    private float[] Sweep => sweep.SweepData;
+
+    private int SweepSamples => sweep.SweepSamples;
 
     // The window is the sweep plus 0.5 s of lead-in and 2 s of tail.
-    private const int Bound = SweepSamples + (int)(2.5 * SampleRate);
+    private int Bound => SweepSamples + (int)(2.5 * SampleRate);
 
-    private static float[] Recording(
+    private float[] Recording(
         int leadSilence,
-        int excitation,
         int trailingSilence,
-        float noise = 0.0f)
+        float sweepGain = 1.0f,
+        float noise = 0.0f,
+        int seed = 4242)
     {
-        var samples = new float[leadSilence + excitation + trailingSilence];
-        var random = new Random(4242);
+        var samples = new float[leadSilence + SweepSamples + trailingSilence];
+        var random = new Random(seed);
         for (int i = 0; i < samples.Length; i++)
         {
             samples[i] = (float)((random.NextDouble() - 0.5) * 2 * noise);
         }
-        for (int i = 0; i < excitation; i++)
+        for (int i = 0; i < SweepSamples; i++)
         {
-            samples[leadSilence + i] += (float)(Math.Sin(i * 0.02) * 0.4);
+            samples[leadSilence + i] += Sweep[i] * sweepGain;
         }
 
         return samples;
     }
+
+    private IReadOnlyList<RecordedSweepSpan> Locate(float[] samples) =>
+        RecordedSweepWindow.LocateCandidates(samples, Sweep, SampleRate);
 
     // A pre-roll followed by a sweep the file cuts short: the span is the whole
     // (short) recording, but what is left of the excitation inside it is what
@@ -40,23 +56,23 @@ public sealed class RecordedSweepWindowTests
     public void AShortRecordingStillReportsWhereTheExcitationBegins()
     {
         int preRoll = SampleRate / 2;
-        float[] samples = Recording(preRoll, (int)(SweepSamples * 0.85), 0, noise: 0.0005f);
+        float[] full = Recording(preRoll, 0, noise: 0.0005f);
+        float[] samples = full[..(preRoll + (int)(SweepSamples * 0.85))];
 
-        RecordedSweepSpan span =
-            RecordedSweepWindow.LocateCandidates(samples, SampleRate, SweepSamples)[0];
+        RecordedSweepSpan span = Locate(samples)[0];
 
         Assert.Equal(0, span.Start);
         Assert.Equal(samples.Length, span.Length);
-        Assert.InRange(span.ExcitationStart, preRoll - 480, preRoll + 480);
+        Assert.InRange(span.ExcitationStart, preRoll - 8, preRoll + 8);
         Assert.True(span.ExcitationLength < SweepSamples);
     }
 
     [Fact]
     public void ShortRecordingsAreAnalyzedWhole()
     {
-        float[] samples = Recording(4_800, SweepSamples, 4_800);
+        float[] samples = Recording(4_800, 4_800);
 
-        RecordedSweepSpan span = RecordedSweepWindow.LocateCandidates(samples, SampleRate, SweepSamples)[0];
+        RecordedSweepSpan span = Locate(samples)[0];
 
         Assert.Equal(0, span.Start);
         Assert.Equal(samples.Length, span.Length);
@@ -68,69 +84,80 @@ public sealed class RecordedSweepWindowTests
     public void LongSilenceAroundTheSweepIsCutAway()
     {
         const int lead = 60 * SampleRate;
-        float[] samples = Recording(lead, SweepSamples, 60 * SampleRate, noise: 0.001f);
+        float[] samples = Recording(lead, 60 * SampleRate, noise: 0.001f);
 
-        RecordedSweepSpan span = RecordedSweepWindow.LocateCandidates(samples, SampleRate, SweepSamples)[0];
+        RecordedSweepSpan span = Locate(samples)[0];
 
-        // Half a second of lead-in is kept before the excitation.
-        Assert.InRange(span.Start, lead - SampleRate / 2 - 480, lead - SampleRate / 2 + 480);
+        // Matched to the sample, so the lead-in is exactly what was asked for.
+        Assert.Equal(lead - SampleRate / 2, span.Start);
+        Assert.Equal(lead, span.ExcitationStart);
         Assert.Equal(Bound, span.Length);
-        Assert.True(span.Start + span.Length <= samples.Length);
-        // The whole excitation is inside the window.
-        Assert.True(span.Start + span.Length >= lead + SweepSamples);
     }
 
-    // A door slam or a knock on the recorder is one window wide; the onset has to
-    // be the sustained rise, or the analysis would start before the real sweep
-    // and cut its end off.
+    // What the level detector could never do: find a sweep that is QUIETER than
+    // the noise it was recorded in. Matching concentrates the whole excitation
+    // into one peak, which is worth about 46 dB over two seconds — so a take a
+    // listener would call empty still resolves to the sample.
+    [Theory]
+    [InlineData(0.3f)]
+    [InlineData(0.03f)]
+    [InlineData(0.003f)]
+    public void ASweepUnderTheNoiseFloorIsStillFound(float sweepGain)
+    {
+        const int lead = 20 * SampleRate;
+        float[] samples = Recording(lead, 20 * SampleRate, sweepGain, noise: 0.03f);
+
+        RecordedSweepSpan span = Locate(samples)[0];
+
+        Assert.Equal(lead, span.ExcitationStart);
+        Assert.Equal(Bound, span.Length);
+    }
+
+    // A door slam, a knock on the recorder: loud, and nothing like the sweep.
     [Fact]
-    public void AnIsolatedClickBeforeTheSweepIsNotTheOnset()
+    public void AnIsolatedClickIsNotMistakenForTheSweep()
     {
         const int lead = 30 * SampleRate;
-        float[] samples = Recording(lead, SweepSamples, 30 * SampleRate, noise: 0.001f);
+        float[] samples = Recording(lead, 30 * SampleRate, noise: 0.001f);
         samples[SampleRate] = 1.0f;
         samples[SampleRate + 1] = -1.0f;
 
-        RecordedSweepSpan span = RecordedSweepWindow.LocateCandidates(samples, SampleRate, SweepSamples)[0];
-
-        Assert.InRange(span.Start, lead - SampleRate, lead);
+        Assert.Equal(lead, Locate(samples)[0].ExcitationStart);
     }
 
-    // Speech or handling noise before the sweep is loud AND sustained, so no
-    // level rule can rank it away with certainty — but the sweep must at least be
-    // among the candidates the caller then tries.
-    [Fact]
-    public void SustainedNoiseBeforeTheSweepStillOffersTheSweep()
+    // Speech or handling noise before the sweep is loud and sustained, and here it
+    // is far louder than the sweep — the case a threshold hung off the loudest
+    // thing in the file cannot survive at all. Matching does not care how loud the
+    // interference is, only that it is not this sweep.
+    [Theory]
+    [InlineData(10.0)]
+    [InlineData(30.0)]
+    public void InterferenceLouderThanTheSweepIsNotTheMatch(double interferenceOverSweepDb)
     {
         const int lead = 60 * SampleRate;
-        float[] samples = Recording(lead, SweepSamples, 10 * SampleRate, noise: 0.001f);
-        // Four seconds of interference — longer than the sweep itself — starting
-        // one second in, at a level the sweep only just exceeds.
-        var random = new Random(99);
+        float[] samples = Recording(lead, 10 * SampleRate, sweepGain: 0.4f, noise: 0.0002f);
+        double interference = 0.4 * Math.Pow(10.0, interferenceOverSweepDb / 20.0);
+        var random = new Random(5150);
         for (int i = 0; i < 4 * SampleRate; i++)
         {
-            samples[SampleRate + i] += (float)((random.NextDouble() - 0.5) * 0.6);
+            samples[2 * SampleRate + i] +=
+                (float)((random.NextDouble() - 0.5) * 2 * interference);
         }
 
-        IReadOnlyList<RecordedSweepSpan> candidates =
-            RecordedSweepWindow.LocateCandidates(samples, SampleRate, SweepSamples);
-
-        Assert.Contains(candidates, span =>
-            span.Start <= lead && span.Start + span.Length >= lead + SweepSamples);
+        Assert.Equal(lead, Locate(samples)[0].ExcitationStart);
     }
 
     // The system under test barely reproduces one end of the band — a car whose
-    // bass is crossed out drops its first octaves by 30 dB — so the excitation is
-    // only heard from part-way in. The window must still hold ALL of it: analyzing
-    // from where the level rose would build the result on an excitation whose
-    // beginning is outside the window, and nothing downstream would notice.
+    // bass is crossed out drops its first octaves by 30 dB, which a level rule
+    // read as the sweep starting a second late. The match is made against the
+    // whole waveform, so the quiet end costs coherence, not position.
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void AQuietEndOfTheBandDoesNotPushTheExcitationOutOfTheWindow(bool quietHead)
+    public void AQuietEndOfTheBandDoesNotMoveTheWindow(bool quietHead)
     {
         const int lead = 30 * SampleRate;
-        float[] samples = Recording(lead, SweepSamples, 30 * SampleRate, noise: 0.0005f);
+        float[] samples = Recording(lead, 30 * SampleRate, noise: 0.0005f);
         int quiet = (int)(SweepSamples * 0.4);
         for (int i = 0; i < quiet; i++)
         {
@@ -138,42 +165,12 @@ public sealed class RecordedSweepWindowTests
             samples[at] *= 0.0316f;
         }
 
-        RecordedSweepSpan span =
-            RecordedSweepWindow.LocateCandidates(samples, SampleRate, SweepSamples)[0];
+        RecordedSweepSpan span = Locate(samples)[0];
 
-        Assert.True(span.Start <= lead, $"the window starts at {span.Start}, after the excitation at {lead}");
-        Assert.True(
-            span.Start + span.Length >= lead + SweepSamples,
-            $"the window ends at {span.Start + span.Length}, before the excitation ends at {lead + SweepSamples}");
-        // Widened, but still bounded by the sweep's own length.
-        Assert.True(span.Length <= 2 * SweepSamples + (int)(2.5 * SampleRate));
-    }
-
-    // The case a threshold hung off the loudest thing in the file cannot survive:
-    // a door, a voice or a knock on the recorder 30 dB ABOVE a quiet measurement
-    // sweep. Twenty decibels under that interference is still well over the sweep,
-    // so the excitation never becomes a candidate at all and no amount of retrying
-    // reaches it. Measured against the noise floor instead, both are candidates.
-    [Theory]
-    [InlineData(10.0)]
-    [InlineData(30.0)]
-    public void InterferenceLouderThanTheSweepDoesNotHideIt(double interferenceOverSweepDb)
-    {
-        const int lead = 60 * SampleRate;
-        float[] samples = Recording(lead, SweepSamples, 10 * SampleRate, noise: 0.0002f);
-        double interference = 0.4 * Math.Pow(10.0, interferenceOverSweepDb / 20.0);
-        var random = new Random(5150);
-        for (int i = 0; i < SampleRate; i++)
-        {
-            samples[2 * SampleRate + i] +=
-                (float)((random.NextDouble() - 0.5) * 2 * interference);
-        }
-
-        IReadOnlyList<RecordedSweepSpan> candidates =
-            RecordedSweepWindow.LocateCandidates(samples, SampleRate, SweepSamples);
-
-        Assert.Contains(candidates, span =>
-            span.Start <= lead && span.Start + span.Length >= lead + SweepSamples);
+        Assert.Equal(lead, span.ExcitationStart);
+        // And no widening to cover which end went quiet: the span is the ordinary
+        // bound, where the level detector had to grow it by a quarter.
+        Assert.Equal(Bound, span.Length);
     }
 
     [Fact]
@@ -181,20 +178,19 @@ public sealed class RecordedSweepWindowTests
     {
         var samples = new float[10 * 60 * SampleRate];
 
-        RecordedSweepSpan span = RecordedSweepWindow.LocateCandidates(samples, SampleRate, SweepSamples)[0];
+        RecordedSweepSpan span = Locate(samples)[0];
 
         Assert.Equal(0, span.Start);
         Assert.Equal(Bound, span.Length);
     }
 
-    [Theory]
-    [InlineData(0)]
-    [InlineData(-1)]
-    public void ADegenerateSweepLengthLeavesTheRecordingAlone(int sweepSamples)
+    [Fact]
+    public void ADegenerateSweepLeavesTheRecordingAlone()
     {
-        float[] samples = Recording(0, 1_024, 0);
+        float[] samples = Recording(0, 0);
 
-        RecordedSweepSpan span = RecordedSweepWindow.LocateCandidates(samples, SampleRate, sweepSamples)[0];
+        RecordedSweepSpan span =
+            RecordedSweepWindow.LocateCandidates(samples, [], SampleRate)[0];
 
         Assert.Equal(0, span.Start);
         Assert.Equal(samples.Length, span.Length);


### PR DESCRIPTION
The recorded-sweep import found its excitation by looking for something loud. That is a proxy, and every failure it had came from the gap between the proxy and the question — each one fixed on its own terms as it turned up:

- a system whose bass is crossed out is quiet for its first octaves, so the window started up to 1.1 s late and the analysis was built on an excitation whose beginning was outside it;
- a voice or a door louder than a careful measurement hid the sweep from the threshold entirely;
- a stretch shorter than the sweep could not say which end it had lost, so the span had to widen to cover both readings.

Correlating the recording against the sweep removes the class rather than the instances: it answers where **this** sweep is, with the sample it starts at.

## What it buys

**Range.** Matching concentrates the whole excitation into one peak — the time-bandwidth product, about 46 dB for a two-second sweep. A sweep 20 dB *under* the noise it was recorded in is located exactly; a level rule cannot see below that floor at all. Tested at three levels, plus interference 30 dB above the sweep, an isolated click, and a quiet end of the band at either edge.

**Three things that stop needing fixes.** The window no longer widens to cover an unknown end (that cost a quarter of the analysis on a rolled-off system). The cut-short check needs no slack for a late detector, because a match is a sample rather than the moment a level crossed a threshold. And a dead input can no longer out-measure a quiet microphone that holds the take.

**Simplification.** The level machinery is gone: two reference levels, a sustain rule, a noise-floor percentile, a gap rule, stretch merging and the both-ends widening — replaced by a correlation and a peak.

## Where matching stops, and the import has to ask

A match says which channel holds the sweep. It cannot say which channel is the **microphone**, and those are different questions the moment a recorder also writes the played signal to a reference track: that track is a *copy* of the excitation, so it matches better than any acoustic take ever will. Measured on a two-channel synthetic, the reference reads 1.000 against the microphone's 0.771, wins any automatic choice, and then measures 22.3 dB of arrival sharpness and 73.5 dB of compactness — a flat response that passes every credibility check there is. Not an error; a wrong measurement, silently, from exactly the DAW workflow this feature invites.

So when more than one channel plausibly holds the sweep, the import stops choosing:

```
More than one channel holds this sweep. A track that recorded the sweep
itself — a reference or loopback written beside the microphone — matches
best of all, and measures as a flat response. Pick the microphone.

  Channel        Match        RMS         Peak
  left           1.000   -9.0 dBFS   -6.0 dBFS
  right          0.771  -24.8 dBFS  -20.0 dBFS

                              [ Measure ]  [ Cancel ]
```

Whether the question exists at all *can* be decided, and that gap is wide. As a share of the best match, a channel that really holds a second recording reads 0.77 and 0.85 on two synthetics; a channel holding no take reads 0.031 and 0.032 on the dead channel of the two field files, and 0.004 for hum. The rule sits between two clusters a factor of ten apart. A stereo file with one dead input — the common case, and the one matching was introduced for — still imports without a word.

## Each take gets its own window

A file holding two attempts was refused outright. Offering both matches only decided which one was allowed to be called complete; the window still ran to the end of the recording either way, so the second attempt sat inside the analysis of the first, where a transfer estimate can read it as nothing but an enormous reflection. A complete take at −17 dB followed by a louder one the file cut off failed the shape gate, and the whole recording was lost.

Each span is now cut clear of the other takes — it starts after the previous one has finished and stops where the next one begins. Only takes a whole sweep away are cut on: matches sit half a sweep apart, and trimming on a closer one would cut into the excitation itself. An end-to-end test pins it by giving the two takes different reflections and asking which one came back.

## Cost

The search runs decimated, in chunks thinned straight out of the recording, and the winning position is refined at full rate. Both signals are averaged and thinned the same way, so the correlation stays a matched filter for the pair: the peak keeps its place and only gets broader.

| recording | search | allocated |
|---|---|---|
| 10 s | 100 ms | 42.6 MB |
| 92 s | 174 ms | 40.7 MB |
| 300 s | 72 ms | 20.5 MB |
| 600 s | 87 ms | 19.1 MB |

Position exact at every length (2.15 s sweep, 44.1 kHz). The short recordings allocate *more* because they are under the ceiling and never decimated — which is the ceiling doing its job. For scale, the cheapest naive form of the same question, one whole-recording correlation at full rate with no cumulative energy beside it, costs 1601 ms and 223 MB at 600 s.

The ceiling is an aim rather than a guarantee: thinning stops while the sweep is still long enough to correlate, so the shortest sweep the panel allows — 5 ms per octave, 36 ms of signal — cannot be thinned at all. That case is what the chunking is for, and it is now 1.6 s and 542 MB of churn across ~100 chunks for a ten-minute recording, with the position still exact. It was 143 s before the pool stopped scanning itself: separation is half a sweep, so a short sweep leaves tens of thousands of neighbourhoods, and each of twenty-six million placements walked all of them. Placements arrive in increasing position, so only the most recent entry can be near — which also took the ordinary ten-minute search from 163 ms to 87 ms.

One import of the 4.3-second field sweep goes from 1.7 s to 1.9 s overall, the difference being one correlation per channel.

## Details worth review

Placements where the sweep runs off the end of the file are searched too, down to half of it overlapping — a take that stopped mid-sweep has its true start **only** among those. Leaving them out did not make such a take usable; it made the detector answer with the best of the wrong positions, which then read as a complete recording.

The final pass over the candidate pool compared two different units: the pool and the separation are in decimated samples, but the entries already accepted had been refined, and a refined start is a full-rate one. A second take whose coarse index happened to land near the first take's full-rate index read as the same arrival twice and was dropped. Nothing caught it because decimation is off until a recording passes the ceiling; the pass now runs in coarse samples throughout and refines what survives.

One refusal changed its wording rather than gaining a threshold. When the excitation is found too close to the end, two readings fit and the data does not separate them: a normalized match tells a clean take (1.0) from noise (0.02) easily, but a noisy real take reads 0.06 while a recording of a *different* sweep reads 0.21. The message now names both possibilities instead of choosing on a threshold that would be wrong as often as right.

Finally, two things the import touches outside the detector. The Compare timing check is made per curve rather than around the whole block: measured phase, group delay and the excess read absolute from the IR start and need both records on one clock, but the minimum-phase curves are reconstructed from the gated magnitude and carry no bulk delay by construction — hiding those against an imported recording was hiding valid data. And `RunAsync` refuses to start under an outstanding claim: it consulted only whether a measurement task was running, so a run begun during an import would have published over its result and handed back the busy flag the import still held.

## Verification

Field takes unchanged through the new path: same channels chosen (now by match), arrival 10 ms, group delay 10.0 and 10.2 ms, arrival sharpness 20.2 and 14.2 dB, scale correction +100 ppm and none.

Full suite green: 142 + 888 + 1024. No compiler warnings — the build treats them as errors; the two `NETSDK1187` notices come from a package and predate this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
