### PR TITLE
Make the input meter's peak behave like a peak

### DIFF
--- a/source/Measurements/InputLevelMeterSnapshot.cs
+++ b/source/Measurements/InputLevelMeterSnapshot.cs
@@ -13,6 +13,25 @@ internal readonly record struct InputLevelMeterEntry(
         double.NegativeInfinity,
         false,
         false);
+
+    /// <summary>
+    /// Folds this entry into <paramref name="newer"/>, which supersedes it.
+    /// Peak and the full-scale flags are maxima over the window they describe,
+    /// so they have to survive being coalesced away — a peak that existed only
+    /// in a dropped window is exactly what the meter is for. RMS is an average:
+    /// only the newest one means anything. An availability change resets the
+    /// fold, because levels from a channel that has since gone away say nothing
+    /// about the one that replaced it.
+    /// </summary>
+    public InputLevelMeterEntry Merge(InputLevelMeterEntry newer) =>
+        Available && newer.Available
+            ? new InputLevelMeterEntry(
+                true,
+                Math.Max(PeakDbFs, newer.PeakDbFs),
+                newer.RmsDbFs,
+                Clipped || newer.Clipped,
+                FullScaleReference || newer.FullScaleReference)
+            : newer;
 }
 
 internal readonly record struct InputLevelMeterSnapshot(
@@ -22,4 +41,9 @@ internal readonly record struct InputLevelMeterSnapshot(
     public static InputLevelMeterSnapshot Empty => new(
         InputLevelMeterEntry.Unavailable,
         InputLevelMeterEntry.Unavailable);
+
+    /// <summary>Folds this snapshot into the one that supersedes it.</summary>
+    public InputLevelMeterSnapshot Merge(InputLevelMeterSnapshot newer) => new(
+        Microphone.Merge(newer.Microphone),
+        Loopback.Merge(newer.Loopback));
 }

--- a/source/Ui/CoalescingDispatcher.cs
+++ b/source/Ui/CoalescingDispatcher.cs
@@ -7,11 +7,17 @@ namespace Resonalyze;
 /// per second at small buffer sizes; posting every snapshot to the UI message
 /// queue would flood the pump with stale updates.
 /// </summary>
+/// <remarks>
+/// Latest-wins assumes a superseded value carries nothing the newest one does
+/// not. When it does — a peak that only ever existed in the window that got
+/// dropped — pass <paramref name="merge"/> to fold it in instead.
+/// </remarks>
 internal sealed class CoalescingDispatcher<T>
 {
     private readonly object sync = new();
     private readonly Func<Action, bool> tryPost;
     private readonly Action<T> apply;
+    private readonly Func<T, T, T>? merge;
     private T pendingValue = default!;
     private bool dispatchQueued;
 
@@ -21,17 +27,29 @@ internal sealed class CoalescingDispatcher<T>
     /// flag is released and a later offer can try again.
     /// </param>
     /// <param name="apply">Receives the newest value on the consumer thread.</param>
-    public CoalescingDispatcher(Func<Action, bool> tryPost, Action<T> apply)
+    /// <param name="merge">
+    /// Folds a still-undelivered value (first argument) into the one that
+    /// supersedes it (second). Omit for plain latest-wins.
+    /// </param>
+    public CoalescingDispatcher(
+        Func<Action, bool> tryPost,
+        Action<T> apply,
+        Func<T, T, T>? merge = null)
     {
         this.tryPost = tryPost;
         this.apply = apply;
+        this.merge = merge;
     }
 
     public void Offer(T value)
     {
         lock (sync)
         {
-            pendingValue = value;
+            // Only a queued value is still pending delivery; once drained, the
+            // field holds an already-applied value that must not be folded in.
+            pendingValue = dispatchQueued && merge != null
+                ? merge(pendingValue, value)
+                : value;
             if (dispatchQueued)
             {
                 return;

--- a/source/Ui/Controls/InputLevelMeterBallistics.cs
+++ b/source/Ui/Controls/InputLevelMeterBallistics.cs
@@ -1,0 +1,204 @@
+namespace Resonalyze;
+
+/// <summary>
+/// What one meter row draws. There is a single peak here — the held one —
+/// because with an instant attack a separately smoothed "current" peak could
+/// only ever read lower than the hold it is derived from.
+/// </summary>
+internal readonly record struct InputLevelMeterState(
+    bool Available,
+    double DisplayedRmsDbFs,
+    double HoldPeakDbFs,
+    long HoldTimestampMs,
+    bool HoldClipped,
+    bool HoldFullScaleReference,
+    double TextPeakDbFs,
+    double TextRmsDbFs,
+    long LastTextUpdateMs)
+{
+    public static InputLevelMeterState CreateUnavailable() => new(
+        false,
+        InputLevelMeterBallistics.MinimumDecibels,
+        InputLevelMeterBallistics.MinimumDecibels,
+        0,
+        false,
+        false,
+        InputLevelMeterBallistics.MinimumDecibels,
+        InputLevelMeterBallistics.MinimumDecibels,
+        0);
+
+    public static InputLevelMeterState CreateActive(
+        InputLevelMeterEntry target,
+        long nowMs) => new(
+        true,
+        target.RmsDbFs,
+        target.PeakDbFs,
+        nowMs,
+        target.Clipped,
+        target.FullScaleReference,
+        target.PeakDbFs,
+        target.RmsDbFs,
+        nowMs);
+
+    /// <summary>
+    /// Whether the held peak is the kind of hot the user has to act on. A
+    /// reference channel sitting at full scale is the expected condition, not a
+    /// fault, so it alarms on nothing but the microphone's own clipping.
+    /// </summary>
+    public bool IsAlarming =>
+        HoldClipped ||
+        (HoldPeakDbFs >= InputLevelMeterBallistics.WarningDecibels && !HoldFullScaleReference);
+}
+
+/// <summary>
+/// The two entries one row's animation reads: the newest snapshot as the
+/// current level, and that level folded with the peaks and full-scale flags no
+/// frame has latched yet.
+/// </summary>
+/// <remarks>
+/// The two have to stay apart. Several dispatcher drains can land between two
+/// animation frames — they arrive as posted callbacks, which outrank the
+/// low-priority WM_TIMER the animation runs on — so a frame must see the
+/// loudest window among them, not just the last. But the hold's decay floor
+/// wants the current level: on a frame with no snapshot behind it, flooring on
+/// a consumed fold would let the hold sag and re-latch on the next one.
+/// </remarks>
+internal readonly record struct InputLevelMeterTarget(
+    InputLevelMeterEntry Level,
+    InputLevelMeterEntry Pending)
+{
+    public static InputLevelMeterTarget Unavailable => new(
+        InputLevelMeterEntry.Unavailable,
+        InputLevelMeterEntry.Unavailable);
+
+    /// <summary>Takes a newly arrived snapshot, folding it into the pending events.</summary>
+    public InputLevelMeterTarget Fold(InputLevelMeterEntry entry) =>
+        new(entry, Pending.Merge(entry));
+
+    /// <summary>
+    /// Drops what a frame has latched. A peak left in the fold would latch
+    /// again on some later frame, once the hold had decayed past it, and report
+    /// an event that is seconds old.
+    /// </summary>
+    public InputLevelMeterTarget Consume() => new(Level, Level);
+}
+
+/// <summary>
+/// The meter's ballistics: how one row's displayed state advances from the
+/// levels the audio layer publishes. Peak and RMS are treated as different
+/// kinds of quantity — the peak is an event to latch and then let decay, the
+/// RMS a level to ease towards — which is the whole reason this reads the way
+/// it does.
+/// </summary>
+internal static class InputLevelMeterBallistics
+{
+    /// <summary>Bottom of the meter's scale, and where an idle row rests.</summary>
+    public const double MinimumDecibels = -60;
+    public const double MaximumDecibels = 0;
+    /// <summary>At or above this, a held peak is worth alarming about.</summary>
+    public const double WarningDecibels = -3;
+    public const long PeakHoldDurationMs = 1050;
+    public const long TextUpdateIntervalMs = 500;
+    public const double PeakHoldFallDbPerSecond = 24;
+    // The hold's fall is a display rate, not a physical one, so it alone is
+    // rate-limited: after a stalled message pump, settling seconds of decay in
+    // a single frame would teleport the marker across the track. Everything
+    // else advances on true elapsed time — RMS is a level, and the level the
+    // input is at now is the honest thing to show once the pump recovers.
+    public const double MaximumHoldFallSeconds = 0.25;
+    // RMS ballistics as time constants rather than per-tick fractions: a fixed
+    // fraction makes the meter's speed depend on how often the timer actually
+    // fires, and WM_TIMER coalesces whenever the UI thread is busy — which it
+    // is during a measurement. These match the factors this replaced at a
+    // nominal 33 ms tick (0.42 attack, 0.12 release).
+    private const double RmsAttackSeconds = 0.060;
+    private const double RmsReleaseSeconds = 0.260;
+
+    public static InputLevelMeterState Advance(
+        InputLevelMeterState state,
+        InputLevelMeterEntry target,
+        long nowMs,
+        double dt)
+    {
+        if (!target.Available)
+        {
+            // Keep the existing unavailable state so idle frames compare equal.
+            return state.Available ? InputLevelMeterState.CreateUnavailable() : state;
+        }
+
+        if (!state.Available)
+        {
+            return InputLevelMeterState.CreateActive(target, nowMs);
+        }
+
+        double displayedRms = SmoothRms(state.DisplayedRmsDbFs, target.RmsDbFs, dt);
+
+        // The peak latches instantly. target.PeakDbFs is already the true
+        // maximum of one 30 Hz meter window, so easing towards it would report a
+        // transient tens of dB below the sample that caused it — a single loud
+        // window would never be shown at all.
+        double holdPeak = state.HoldPeakDbFs;
+        long holdTimestamp = state.HoldTimestampMs;
+        // The full-scale flags describe the peak being held, not the newest
+        // window: re-reading them every frame turns a reference channel red the
+        // moment it steps off full scale, while its own peak is still on screen.
+        bool holdClipped = state.HoldClipped || target.Clipped;
+        bool holdFullScale = state.HoldFullScaleReference || target.FullScaleReference;
+        // Strictly greater: at equality — digital silence pinned to the dB
+        // floor, or a loopback pinned to full scale — re-stamping the hold would
+        // make every frame "change" the state and defeat the caller's idle
+        // repaint skip.
+        if (target.PeakDbFs > holdPeak)
+        {
+            holdPeak = target.PeakDbFs;
+            holdTimestamp = nowMs;
+        }
+        else if (nowMs - holdTimestamp > PeakHoldDurationMs)
+        {
+            holdPeak = Math.Max(
+                target.PeakDbFs,
+                holdPeak - PeakHoldFallDbPerSecond * Math.Min(dt, MaximumHoldFallSeconds));
+        }
+
+        if (holdPeak < WarningDecibels)
+        {
+            // The peak that earned the flags has decayed out of the warning
+            // zone; they expire with it.
+            holdClipped = false;
+            holdFullScale = false;
+        }
+
+        double textPeak = state.TextPeakDbFs;
+        double textRms = state.TextRmsDbFs;
+        long textTimestamp = state.LastTextUpdateMs;
+        // The readout quotes the hold, not the live window: the hold outlives
+        // the text interval by design (1050 > 500 ms), so every latched peak is
+        // still standing when the next update samples it. Re-stamping only on a
+        // real change keeps a settled meter comparing equal.
+        if (nowMs - textTimestamp >= TextUpdateIntervalMs &&
+            (holdPeak != textPeak || displayedRms != textRms))
+        {
+            textPeak = holdPeak;
+            textRms = displayedRms;
+            textTimestamp = nowMs;
+        }
+
+        return new InputLevelMeterState(
+            true,
+            displayedRms,
+            holdPeak,
+            holdTimestamp,
+            holdClipped,
+            holdFullScale,
+            textPeak,
+            textRms,
+            textTimestamp);
+    }
+
+    private static double SmoothRms(double current, double target, double dt)
+    {
+        double seconds = target > current ? RmsAttackSeconds : RmsReleaseSeconds;
+        double alpha = 1.0 - Math.Exp(-dt / seconds);
+        return current + (target - current) * alpha;
+    }
+}

--- a/source/Ui/Controls/InputLevelMeterController.cs
+++ b/source/Ui/Controls/InputLevelMeterController.cs
@@ -6,9 +6,11 @@ internal sealed class InputLevelMeterController : IDisposable
     private readonly InputLevelMeterPanel panel;
     private readonly ExpSweepMeasurement sweepMeasurement;
     private readonly NoiseMeasurement noiseMeasurement;
-    // Levels arrive on audio worker threads on every buffer, which outpaces the
-    // message pump at small ASIO buffer sizes; coalesce to a single queued UI
-    // update carrying the newest snapshot.
+    // Levels arrive on audio worker threads, already throttled to 30 Hz by
+    // AudioLevelAccumulator; a busy message pump still falls behind that, so
+    // coalesce to a single queued UI update. Fold rather than drop: each
+    // snapshot is the peak of its own window, and the loudest one is usually
+    // the one the pump was too busy to take.
     private readonly CoalescingDispatcher<InputLevelMeterSnapshot> dispatcher;
     private bool disposed;
 
@@ -24,7 +26,8 @@ internal sealed class InputLevelMeterController : IDisposable
         this.noiseMeasurement = noiseMeasurement;
         dispatcher = new CoalescingDispatcher<InputLevelMeterSnapshot>(
             TryPostToOwner,
-            ApplyOnUiThread);
+            ApplyOnUiThread,
+            static (superseded, newest) => superseded.Merge(newest));
 
         sweepMeasurement.LevelsAvailable += HandleLevels;
         noiseMeasurement.LevelsAvailable += HandleLevels;

--- a/source/Ui/Controls/InputLevelMeterPanel.cs
+++ b/source/Ui/Controls/InputLevelMeterPanel.cs
@@ -1,4 +1,4 @@
-using System.Drawing.Drawing2D;
+﻿using System.Drawing.Drawing2D;
 
 namespace Resonalyze;
 
@@ -15,39 +15,16 @@ internal sealed class InputLevelMeterPanel : Control
     private static readonly Color TextColor = UiPalette.MeterText;
     private static readonly Color MutedTextColor = UiPalette.MeterMutedText;
     private static readonly Color PeakHoldColor = UiPalette.MeterPeakHold;
-    private const long PeakHoldDurationMs = 1050;
-    private const long TextUpdateIntervalMs = 500;
-    private const double MinimumDecibels = -60;
-    private const double MaximumDecibels = 0;
+    private const double MinimumDecibels = InputLevelMeterBallistics.MinimumDecibels;
+    private const double MaximumDecibels = InputLevelMeterBallistics.MaximumDecibels;
     // Fill colour steps, read off the held peak.
-    private const double WarningDecibels = -3;
     private const double HotDecibels = -12;
     private const double LoudDecibels = -24;
-    // RMS ballistics as time constants rather than per-tick fractions: a fixed
-    // fraction makes the meter's speed depend on how often the timer actually
-    // fires, and WM_TIMER coalesces whenever the UI thread is busy — which it is
-    // during a measurement. These match the previous factors at a nominal
-    // 33 ms tick (0.42 attack, 0.12 release), so the meter still looks the same.
-    private const double RmsAttackSeconds = 0.060;
-    private const double RmsReleaseSeconds = 0.260;
-    private const double PeakHoldFallDbPerSecond = 24;
-    // The hold's fall is a display rate, not a physical one, so it alone is
-    // rate-limited: after a stalled message pump, settling seconds of decay in
-    // a single frame would teleport the marker across the track. Everything
-    // else advances on true elapsed time — RMS is a level, and the level the
-    // input is at now is the honest thing to show once the pump recovers.
-    private const double MaximumHoldFallSeconds = 0.25;
     private readonly System.Windows.Forms.Timer animationTimer;
-    // The newest snapshot as received: the current level, which stands until the
-    // next one replaces it.
-    private InputLevelMeterEntry microphoneLevel = InputLevelMeterEntry.Unavailable;
-    private InputLevelMeterEntry loopbackLevel = InputLevelMeterEntry.Unavailable;
-    // The same, folded with the peaks and full-scale flags no frame has latched
-    // yet. Animate reads these, then drops them back to the level above.
-    private InputLevelMeterEntry microphoneTarget = InputLevelMeterEntry.Unavailable;
-    private InputLevelMeterEntry loopbackTarget = InputLevelMeterEntry.Unavailable;
-    private MeterVisualState microphoneState = MeterVisualState.CreateUnavailable();
-    private MeterVisualState loopbackState = MeterVisualState.CreateUnavailable();
+    private InputLevelMeterTarget microphoneTarget = InputLevelMeterTarget.Unavailable;
+    private InputLevelMeterTarget loopbackTarget = InputLevelMeterTarget.Unavailable;
+    private InputLevelMeterState microphoneState = InputLevelMeterState.CreateUnavailable();
+    private InputLevelMeterState loopbackState = InputLevelMeterState.CreateUnavailable();
     // Monotonic clock: a wall-clock (NTP/DST) step must not distort the
     // animation delta or the peak-hold timing.
     private long lastAnimationTickMs = Environment.TickCount64;
@@ -74,25 +51,16 @@ internal sealed class InputLevelMeterPanel : Control
 
     public void SetLevels(InputLevelMeterSnapshot levels)
     {
-        // Fold rather than overwrite. Several dispatcher drains can land between
-        // two animation ticks — they arrive as posted callbacks, which outrank
-        // the low-priority WM_TIMER the animation runs on — and the peak of a
-        // window the timer never got to look at is exactly the one worth
-        // keeping. Animate consumes the fold once it has latched it.
-        microphoneLevel = levels.Microphone;
-        loopbackLevel = levels.Loopback;
-        microphoneTarget = microphoneTarget.Merge(levels.Microphone);
-        loopbackTarget = loopbackTarget.Merge(levels.Loopback);
+        microphoneTarget = microphoneTarget.Fold(levels.Microphone);
+        loopbackTarget = loopbackTarget.Fold(levels.Loopback);
     }
 
     public void ClearLevels()
     {
-        microphoneLevel = InputLevelMeterEntry.Unavailable;
-        loopbackLevel = InputLevelMeterEntry.Unavailable;
-        microphoneTarget = InputLevelMeterEntry.Unavailable;
-        loopbackTarget = InputLevelMeterEntry.Unavailable;
-        microphoneState = MeterVisualState.CreateUnavailable();
-        loopbackState = MeterVisualState.CreateUnavailable();
+        microphoneTarget = InputLevelMeterTarget.Unavailable;
+        loopbackTarget = InputLevelMeterTarget.Unavailable;
+        microphoneState = InputLevelMeterState.CreateUnavailable();
+        loopbackState = InputLevelMeterState.CreateUnavailable();
         Invalidate();
     }
 
@@ -134,7 +102,7 @@ internal sealed class InputLevelMeterPanel : Control
     private void DrawRow(
         Graphics graphics,
         string label,
-        MeterVisualState state,
+        InputLevelMeterState state,
         Rectangle rowRectangle)
     {
         int padding = ScaleValue(2);
@@ -220,7 +188,7 @@ internal sealed class InputLevelMeterPanel : Control
     private static void DrawRmsFill(
         Graphics graphics,
         Rectangle rectangle,
-        MeterVisualState state)
+        InputLevelMeterState state)
     {
         Rectangle innerRectangle = Rectangle.Inflate(rectangle, -1, -1);
         int width = GetTrackX(innerRectangle, state.DisplayedRmsDbFs) - innerRectangle.Left;
@@ -241,7 +209,7 @@ internal sealed class InputLevelMeterPanel : Control
     private static void DrawPeakMarker(
         Graphics graphics,
         Rectangle rectangle,
-        MeterVisualState state)
+        InputLevelMeterState state)
     {
         Rectangle innerRectangle = Rectangle.Inflate(rectangle, -1, -1);
         int x = GetTrackX(innerRectangle, state.HoldPeakDbFs);
@@ -249,18 +217,9 @@ internal sealed class InputLevelMeterPanel : Control
         graphics.DrawLine(markerPen, x, rectangle.Top - 1, x, rectangle.Bottom + 1);
     }
 
-    /// <summary>
-    /// Whether the held peak is the kind of hot the user has to act on. A
-    /// reference channel sitting at full scale is the expected condition, not a
-    /// fault, so it alarms on nothing but the microphone's own clipping.
-    /// </summary>
-    private static bool IsAlarming(MeterVisualState state) =>
-        state.HoldClipped ||
-        (state.HoldPeakDbFs >= WarningDecibels && !state.HoldFullScaleReference);
-
-    private static Color GetRmsColor(MeterVisualState state)
+    private static Color GetRmsColor(InputLevelMeterState state)
     {
-        if (IsAlarming(state))
+        if (state.IsAlarming)
         {
             return UiPalette.WarningRed;
         }
@@ -274,8 +233,8 @@ internal sealed class InputLevelMeterPanel : Control
             : UiPalette.MeterLowAccent;
     }
 
-    private static Color GetPeakMarkerColor(MeterVisualState state) =>
-        IsAlarming(state)
+    private static Color GetPeakMarkerColor(InputLevelMeterState state) =>
+        state.IsAlarming
             ? UiPalette.ErrorSoftTint
             : PeakHoldColor;
 
@@ -299,16 +258,14 @@ internal sealed class InputLevelMeterPanel : Control
         double dt = Math.Max((now - lastAnimationTickMs) / 1000.0, 0.001);
         lastAnimationTickMs = now;
 
-        MeterVisualState newMicrophoneState =
-            AdvanceState(microphoneState, microphoneTarget, now, dt);
-        MeterVisualState newLoopbackState =
-            AdvanceState(loopbackState, loopbackTarget, now, dt);
-        // Drop back to the plain level, unconditionally — including on the idle
-        // path below. A peak left in the fold would latch again on some later
-        // tick, once the hold had decayed past it, and report an event that is
-        // seconds old.
-        microphoneTarget = microphoneLevel;
-        loopbackTarget = loopbackLevel;
+        InputLevelMeterState newMicrophoneState = InputLevelMeterBallistics.Advance(
+            microphoneState, microphoneTarget.Pending, now, dt);
+        InputLevelMeterState newLoopbackState = InputLevelMeterBallistics.Advance(
+            loopbackState, loopbackTarget.Pending, now, dt);
+        // Unconditionally, including on the idle path below: this frame has
+        // latched whatever the fold was carrying.
+        microphoneTarget = microphoneTarget.Consume();
+        loopbackTarget = loopbackTarget.Consume();
         if (newMicrophoneState == microphoneState &&
             newLoopbackState == loopbackState)
         {
@@ -319,94 +276,6 @@ internal sealed class InputLevelMeterPanel : Control
         microphoneState = newMicrophoneState;
         loopbackState = newLoopbackState;
         Invalidate();
-    }
-
-    private static MeterVisualState AdvanceState(
-        MeterVisualState state,
-        InputLevelMeterEntry target,
-        long nowMs,
-        double dt)
-    {
-        if (!target.Available)
-        {
-            // Keep the existing unavailable state so idle ticks compare equal.
-            return state.Available ? MeterVisualState.CreateUnavailable() : state;
-        }
-
-        if (!state.Available)
-        {
-            return MeterVisualState.CreateActive(target, nowMs);
-        }
-
-        double displayedRms = SmoothRms(state.DisplayedRmsDbFs, target.RmsDbFs, dt);
-
-        // The peak latches instantly. target.PeakDbFs is already the true
-        // maximum of one 30 Hz meter window, so easing towards it would report a
-        // transient tens of dB below the sample that caused it — a single loud
-        // window would never be shown at all.
-        double holdPeak = state.HoldPeakDbFs;
-        long holdTimestamp = state.HoldTimestampMs;
-        // The full-scale flags describe the peak being held, not the newest
-        // window: re-reading them every tick turns a reference channel red the
-        // moment it steps off full scale, while its own peak is still on screen.
-        bool holdClipped = state.HoldClipped || target.Clipped;
-        bool holdFullScale = state.HoldFullScaleReference || target.FullScaleReference;
-        // Strictly greater: at equality — digital silence pinned to the dB
-        // floor, or a loopback pinned to full scale — re-stamping the hold would
-        // make every tick "change" the state and defeat the idle repaint skip in
-        // Animate.
-        if (target.PeakDbFs > holdPeak)
-        {
-            holdPeak = target.PeakDbFs;
-            holdTimestamp = nowMs;
-        }
-        else if (nowMs - holdTimestamp > PeakHoldDurationMs)
-        {
-            holdPeak = Math.Max(
-                target.PeakDbFs,
-                holdPeak - PeakHoldFallDbPerSecond * Math.Min(dt, MaximumHoldFallSeconds));
-        }
-
-        if (holdPeak < WarningDecibels)
-        {
-            // The peak that earned the flags has decayed out of the warning
-            // zone; they expire with it.
-            holdClipped = false;
-            holdFullScale = false;
-        }
-
-        double textPeak = state.TextPeakDbFs;
-        double textRms = state.TextRmsDbFs;
-        long textTimestamp = state.LastTextUpdateMs;
-        // The readout quotes the hold, not the live window: the hold outlives
-        // the text interval by design (1050 > 500 ms), so every latched peak is
-        // still standing when the next update samples it. Re-stamping only on a
-        // real change keeps a settled meter comparing equal — see Animate.
-        if (nowMs - textTimestamp >= TextUpdateIntervalMs &&
-            (holdPeak != textPeak || displayedRms != textRms))
-        {
-            textPeak = holdPeak;
-            textRms = displayedRms;
-            textTimestamp = nowMs;
-        }
-
-        return new MeterVisualState(
-            true,
-            displayedRms,
-            holdPeak,
-            holdTimestamp,
-            holdClipped,
-            holdFullScale,
-            textPeak,
-            textRms,
-            textTimestamp);
-    }
-
-    private static double SmoothRms(double current, double target, double dt)
-    {
-        double seconds = target > current ? RmsAttackSeconds : RmsReleaseSeconds;
-        double alpha = 1.0 - Math.Exp(-dt / seconds);
-        return current + (target - current) * alpha;
     }
 
     private (Rectangle Mic, Rectangle Loop) GetRowRectangles()
@@ -429,7 +298,7 @@ internal sealed class InputLevelMeterPanel : Control
         return (mic, loop);
     }
 
-    private string FormatValueText(MeterVisualState state, int availableWidth)
+    private string FormatValueText(InputLevelMeterState state, int availableWidth)
     {
         if (!state.Available)
         {
@@ -448,45 +317,4 @@ internal sealed class InputLevelMeterPanel : Control
 
     private int ScaleValue(int value) =>
         (int)Math.Round(value * DeviceDpi / 96.0);
-
-    /// <summary>
-    /// What one row draws. There is a single peak here — the held one — because
-    /// with an instant attack a separately smoothed "current" peak would only
-    /// ever read lower than the hold it is derived from.
-    /// </summary>
-    private readonly record struct MeterVisualState(
-        bool Available,
-        double DisplayedRmsDbFs,
-        double HoldPeakDbFs,
-        long HoldTimestampMs,
-        bool HoldClipped,
-        bool HoldFullScaleReference,
-        double TextPeakDbFs,
-        double TextRmsDbFs,
-        long LastTextUpdateMs)
-    {
-        public static MeterVisualState CreateUnavailable() => new(
-            false,
-            MinimumDecibels,
-            MinimumDecibels,
-            0,
-            false,
-            false,
-            MinimumDecibels,
-            MinimumDecibels,
-            0);
-
-        public static MeterVisualState CreateActive(
-            InputLevelMeterEntry target,
-            long nowMs) => new(
-            true,
-            target.RmsDbFs,
-            target.PeakDbFs,
-            nowMs,
-            target.Clipped,
-            target.FullScaleReference,
-            target.PeakDbFs,
-            target.RmsDbFs,
-            nowMs);
-    }
 }

--- a/source/Ui/Controls/InputLevelMeterPanel.cs
+++ b/source/Ui/Controls/InputLevelMeterPanel.cs
@@ -35,6 +35,12 @@ internal sealed class InputLevelMeterPanel : Control
     // single tick drop the peak hold by tens of dB.
     private const double MaximumStepSeconds = 0.25;
     private readonly System.Windows.Forms.Timer animationTimer;
+    // The newest snapshot as received: the current level, which stands until the
+    // next one replaces it.
+    private InputLevelMeterEntry microphoneLevel = InputLevelMeterEntry.Unavailable;
+    private InputLevelMeterEntry loopbackLevel = InputLevelMeterEntry.Unavailable;
+    // The same, folded with the peaks and full-scale flags no frame has latched
+    // yet. Animate reads these, then drops them back to the level above.
     private InputLevelMeterEntry microphoneTarget = InputLevelMeterEntry.Unavailable;
     private InputLevelMeterEntry loopbackTarget = InputLevelMeterEntry.Unavailable;
     private MeterVisualState microphoneState = MeterVisualState.CreateUnavailable();
@@ -65,12 +71,21 @@ internal sealed class InputLevelMeterPanel : Control
 
     public void SetLevels(InputLevelMeterSnapshot levels)
     {
-        microphoneTarget = levels.Microphone;
-        loopbackTarget = levels.Loopback;
+        // Fold rather than overwrite. Several dispatcher drains can land between
+        // two animation ticks — they arrive as posted callbacks, which outrank
+        // the low-priority WM_TIMER the animation runs on — and the peak of a
+        // window the timer never got to look at is exactly the one worth
+        // keeping. Animate consumes the fold once it has latched it.
+        microphoneLevel = levels.Microphone;
+        loopbackLevel = levels.Loopback;
+        microphoneTarget = microphoneTarget.Merge(levels.Microphone);
+        loopbackTarget = loopbackTarget.Merge(levels.Loopback);
     }
 
     public void ClearLevels()
     {
+        microphoneLevel = InputLevelMeterEntry.Unavailable;
+        loopbackLevel = InputLevelMeterEntry.Unavailable;
         microphoneTarget = InputLevelMeterEntry.Unavailable;
         loopbackTarget = InputLevelMeterEntry.Unavailable;
         microphoneState = MeterVisualState.CreateUnavailable();
@@ -288,6 +303,12 @@ internal sealed class InputLevelMeterPanel : Control
             AdvanceState(microphoneState, microphoneTarget, now, dt);
         MeterVisualState newLoopbackState =
             AdvanceState(loopbackState, loopbackTarget, now, dt);
+        // Drop back to the plain level, unconditionally — including on the idle
+        // path below. A peak left in the fold would latch again on some later
+        // tick, once the hold had decayed past it, and report an event that is
+        // seconds old.
+        microphoneTarget = microphoneLevel;
+        loopbackTarget = loopbackLevel;
         if (newMicrophoneState == microphoneState &&
             newLoopbackState == loopbackState)
         {

--- a/source/Ui/Controls/InputLevelMeterPanel.cs
+++ b/source/Ui/Controls/InputLevelMeterPanel.cs
@@ -31,9 +31,12 @@ internal sealed class InputLevelMeterPanel : Control
     private const double RmsAttackSeconds = 0.060;
     private const double RmsReleaseSeconds = 0.260;
     private const double PeakHoldFallDbPerSecond = 24;
-    // Upper bound on one animation step: a stalled message pump must not let a
-    // single tick drop the peak hold by tens of dB.
-    private const double MaximumStepSeconds = 0.25;
+    // The hold's fall is a display rate, not a physical one, so it alone is
+    // rate-limited: after a stalled message pump, settling seconds of decay in
+    // a single frame would teleport the marker across the track. Everything
+    // else advances on true elapsed time — RMS is a level, and the level the
+    // input is at now is the honest thing to show once the pump recovers.
+    private const double MaximumHoldFallSeconds = 0.25;
     private readonly System.Windows.Forms.Timer animationTimer;
     // The newest snapshot as received: the current level, which stands until the
     // next one replaces it.
@@ -293,10 +296,7 @@ internal sealed class InputLevelMeterPanel : Control
     private void Animate()
     {
         long now = Environment.TickCount64;
-        double dt = Math.Clamp(
-            (now - lastAnimationTickMs) / 1000.0,
-            0.001,
-            MaximumStepSeconds);
+        double dt = Math.Max((now - lastAnimationTickMs) / 1000.0, 0.001);
         lastAnimationTickMs = now;
 
         MeterVisualState newMicrophoneState =
@@ -364,7 +364,7 @@ internal sealed class InputLevelMeterPanel : Control
         {
             holdPeak = Math.Max(
                 target.PeakDbFs,
-                holdPeak - PeakHoldFallDbPerSecond * dt);
+                holdPeak - PeakHoldFallDbPerSecond * Math.Min(dt, MaximumHoldFallSeconds));
         }
 
         if (holdPeak < WarningDecibels)

--- a/source/Ui/Controls/InputLevelMeterPanel.cs
+++ b/source/Ui/Controls/InputLevelMeterPanel.cs
@@ -15,15 +15,25 @@ internal sealed class InputLevelMeterPanel : Control
     private static readonly Color TextColor = UiPalette.MeterText;
     private static readonly Color MutedTextColor = UiPalette.MeterMutedText;
     private static readonly Color PeakHoldColor = UiPalette.MeterPeakHold;
-    private static readonly Color FullScaleColor = UiPalette.MeterFullScale;
-    private static readonly Color DimFillColor = UiPalette.MeterDimFill;
-    private const long PeakHoldDurationMs = 700;
+    private const long PeakHoldDurationMs = 1050;
     private const long TextUpdateIntervalMs = 500;
     private const double MinimumDecibels = -60;
     private const double MaximumDecibels = 0;
-    private const double AttackFactor = 0.42;
-    private const double ReleaseFactor = 0.12;
+    // Fill colour steps, read off the held peak.
+    private const double WarningDecibels = -3;
+    private const double HotDecibels = -12;
+    private const double LoudDecibels = -24;
+    // RMS ballistics as time constants rather than per-tick fractions: a fixed
+    // fraction makes the meter's speed depend on how often the timer actually
+    // fires, and WM_TIMER coalesces whenever the UI thread is busy — which it is
+    // during a measurement. These match the previous factors at a nominal
+    // 33 ms tick (0.42 attack, 0.12 release), so the meter still looks the same.
+    private const double RmsAttackSeconds = 0.060;
+    private const double RmsReleaseSeconds = 0.260;
     private const double PeakHoldFallDbPerSecond = 24;
+    // Upper bound on one animation step: a stalled message pump must not let a
+    // single tick drop the peak hold by tens of dB.
+    private const double MaximumStepSeconds = 0.25;
     private readonly System.Windows.Forms.Timer animationTimer;
     private InputLevelMeterEntry microphoneTarget = InputLevelMeterEntry.Unavailable;
     private InputLevelMeterEntry loopbackTarget = InputLevelMeterEntry.Unavailable;
@@ -44,7 +54,6 @@ internal sealed class InputLevelMeterPanel : Control
 
         BackColor = SurfaceColor;
         ForeColor = TextColor;
-        Font = new Font("Segoe UI", 8.75f, FontStyle.Bold, GraphicsUnit.Point);
 
         animationTimer = new System.Windows.Forms.Timer
         {
@@ -177,23 +186,36 @@ internal sealed class InputLevelMeterPanel : Control
 
         for (int db = (int)MinimumDecibels + 5; db < MaximumDecibels; db += 5)
         {
-            int x = innerRectangle.Left + (int)Math.Round((innerRectangle.Width - 1) * Normalize(db));
+            int x = GetTrackX(innerRectangle, db);
             graphics.DrawLine(tickPen, x, innerRectangle.Top, x, innerRectangle.Bottom);
         }
     }
+
+    /// <summary>
+    /// The one dB→pixel mapping of the track. Fill, ticks and the peak marker
+    /// all read the same scale, so the edge of the fill lines up with the tick
+    /// it has just reached.
+    /// </summary>
+    private static int GetTrackX(Rectangle innerRectangle, double valueDbFs) =>
+        innerRectangle.Left + (int)Math.Round((innerRectangle.Width - 1) * Normalize(valueDbFs));
 
     private static void DrawRmsFill(
         Graphics graphics,
         Rectangle rectangle,
         MeterVisualState state)
     {
-        int width = (int)Math.Round(rectangle.Width * Normalize(state.DisplayedRmsDbFs));
+        Rectangle innerRectangle = Rectangle.Inflate(rectangle, -1, -1);
+        int width = GetTrackX(innerRectangle, state.DisplayedRmsDbFs) - innerRectangle.Left;
         if (width <= 0)
         {
             return;
         }
 
-        Rectangle fillRectangle = new(rectangle.X + 1, rectangle.Y + 1, Math.Min(width, rectangle.Width - 2), rectangle.Height - 2);
+        Rectangle fillRectangle = new(
+            innerRectangle.Left,
+            innerRectangle.Top,
+            width,
+            innerRectangle.Height);
         using var brush = new SolidBrush(GetRmsColor(state));
         graphics.FillRectangle(brush, fillRectangle);
     }
@@ -204,42 +226,40 @@ internal sealed class InputLevelMeterPanel : Control
         MeterVisualState state)
     {
         Rectangle innerRectangle = Rectangle.Inflate(rectangle, -1, -1);
-        int x = innerRectangle.Left + (int)Math.Round((innerRectangle.Width - 1) * Normalize(state.HoldPeakDbFs));
+        int x = GetTrackX(innerRectangle, state.HoldPeakDbFs);
         using var markerPen = new Pen(GetPeakMarkerColor(state), 2);
         graphics.DrawLine(markerPen, x, rectangle.Top - 1, x, rectangle.Bottom + 1);
     }
 
+    /// <summary>
+    /// Whether the held peak is the kind of hot the user has to act on. A
+    /// reference channel sitting at full scale is the expected condition, not a
+    /// fault, so it alarms on nothing but the microphone's own clipping.
+    /// </summary>
+    private static bool IsAlarming(MeterVisualState state) =>
+        state.HoldClipped ||
+        (state.HoldPeakDbFs >= WarningDecibels && !state.HoldFullScaleReference);
+
     private static Color GetRmsColor(MeterVisualState state)
     {
-        if (state.Clipped || state.DisplayedPeakDbFs >= -3)
+        if (IsAlarming(state))
         {
             return UiPalette.WarningRed;
         }
-        if (state.DisplayedPeakDbFs >= -12)
+        if (state.HoldPeakDbFs >= HotDecibels)
         {
             return UiPalette.WarningOrange;
         }
-        if (state.DisplayedPeakDbFs >= -24)
-        {
-            return UiPalette.SuccessGreenAlt;
-        }
 
-        return state.Available
-            ? UiPalette.MeterLowAccent
-            : DimFillColor;
+        return state.HoldPeakDbFs >= LoudDecibels
+            ? UiPalette.SuccessGreenAlt
+            : UiPalette.MeterLowAccent;
     }
 
-    private static Color GetPeakMarkerColor(MeterVisualState state)
-    {
-        if (state.FullScaleReference)
-        {
-            return PeakHoldColor;
-        }
-
-        return state.Clipped || state.HoldPeakDbFs >= -3
+    private static Color GetPeakMarkerColor(MeterVisualState state) =>
+        IsAlarming(state)
             ? UiPalette.ErrorSoftTint
             : PeakHoldColor;
-    }
 
     private static double Normalize(double valueDbFs)
     {
@@ -258,7 +278,10 @@ internal sealed class InputLevelMeterPanel : Control
     private void Animate()
     {
         long now = Environment.TickCount64;
-        double dt = Math.Max((now - lastAnimationTickMs) / 1000.0, 0.001);
+        double dt = Math.Clamp(
+            (now - lastAnimationTickMs) / 1000.0,
+            0.001,
+            MaximumStepSeconds);
         lastAnimationTickMs = now;
 
         MeterVisualState newMicrophoneState =
@@ -294,53 +317,75 @@ internal sealed class InputLevelMeterPanel : Control
             return MeterVisualState.CreateActive(target, nowMs);
         }
 
-        double displayedPeak = Smooth(state.DisplayedPeakDbFs, target.PeakDbFs);
-        double displayedRms = Smooth(state.DisplayedRmsDbFs, target.RmsDbFs);
+        double displayedRms = SmoothRms(state.DisplayedRmsDbFs, target.RmsDbFs, dt);
 
+        // The peak latches instantly. target.PeakDbFs is already the true
+        // maximum of one 30 Hz meter window, so easing towards it would report a
+        // transient tens of dB below the sample that caused it — a single loud
+        // window would never be shown at all.
         double holdPeak = state.HoldPeakDbFs;
         long holdTimestamp = state.HoldTimestampMs;
-        // Strictly greater: at equality (a fully converged meter) re-stamping
-        // the hold would make every tick "change" the state and defeat the
-        // idle repaint skip in Animate.
-        if (displayedPeak > holdPeak)
+        // The full-scale flags describe the peak being held, not the newest
+        // window: re-reading them every tick turns a reference channel red the
+        // moment it steps off full scale, while its own peak is still on screen.
+        bool holdClipped = state.HoldClipped || target.Clipped;
+        bool holdFullScale = state.HoldFullScaleReference || target.FullScaleReference;
+        // Strictly greater: at equality — digital silence pinned to the dB
+        // floor, or a loopback pinned to full scale — re-stamping the hold would
+        // make every tick "change" the state and defeat the idle repaint skip in
+        // Animate.
+        if (target.PeakDbFs > holdPeak)
         {
-            holdPeak = displayedPeak;
+            holdPeak = target.PeakDbFs;
             holdTimestamp = nowMs;
         }
         else if (nowMs - holdTimestamp > PeakHoldDurationMs)
         {
             holdPeak = Math.Max(
-                displayedPeak,
+                target.PeakDbFs,
                 holdPeak - PeakHoldFallDbPerSecond * dt);
+        }
+
+        if (holdPeak < WarningDecibels)
+        {
+            // The peak that earned the flags has decayed out of the warning
+            // zone; they expire with it.
+            holdClipped = false;
+            holdFullScale = false;
         }
 
         double textPeak = state.TextPeakDbFs;
         double textRms = state.TextRmsDbFs;
         long textTimestamp = state.LastTextUpdateMs;
-        if (nowMs - state.LastTextUpdateMs >= TextUpdateIntervalMs)
+        // The readout quotes the hold, not the live window: the hold outlives
+        // the text interval by design (1050 > 500 ms), so every latched peak is
+        // still standing when the next update samples it. Re-stamping only on a
+        // real change keeps a settled meter comparing equal — see Animate.
+        if (nowMs - textTimestamp >= TextUpdateIntervalMs &&
+            (holdPeak != textPeak || displayedRms != textRms))
         {
-            textPeak = displayedPeak;
+            textPeak = holdPeak;
             textRms = displayedRms;
             textTimestamp = nowMs;
         }
 
         return new MeterVisualState(
             true,
-            displayedPeak,
             displayedRms,
             holdPeak,
             holdTimestamp,
+            holdClipped,
+            holdFullScale,
             textPeak,
             textRms,
-            textTimestamp,
-            target.Clipped,
-            target.FullScaleReference);
+            textTimestamp);
     }
 
-    private static double Smooth(double current, double target)
+    private static double SmoothRms(double current, double target, double dt)
     {
-        double factor = target > current ? AttackFactor : ReleaseFactor;
-        return current + (target - current) * factor;
+        double seconds = target > current ? RmsAttackSeconds : RmsReleaseSeconds;
+        double alpha = 1.0 - Math.Exp(-dt / seconds);
+        return current + (target - current) * alpha;
     }
 
     private (Rectangle Mic, Rectangle Loop) GetRowRectangles()
@@ -383,42 +428,44 @@ internal sealed class InputLevelMeterPanel : Control
     private int ScaleValue(int value) =>
         (int)Math.Round(value * DeviceDpi / 96.0);
 
+    /// <summary>
+    /// What one row draws. There is a single peak here — the held one — because
+    /// with an instant attack a separately smoothed "current" peak would only
+    /// ever read lower than the hold it is derived from.
+    /// </summary>
     private readonly record struct MeterVisualState(
         bool Available,
-        double DisplayedPeakDbFs,
         double DisplayedRmsDbFs,
         double HoldPeakDbFs,
         long HoldTimestampMs,
+        bool HoldClipped,
+        bool HoldFullScaleReference,
         double TextPeakDbFs,
         double TextRmsDbFs,
-        long LastTextUpdateMs,
-        bool Clipped,
-        bool FullScaleReference)
+        long LastTextUpdateMs)
     {
         public static MeterVisualState CreateUnavailable() => new(
             false,
             MinimumDecibels,
             MinimumDecibels,
-            MinimumDecibels,
-            0,
-            MinimumDecibels,
-            MinimumDecibels,
             0,
             false,
-            false);
+            false,
+            MinimumDecibels,
+            MinimumDecibels,
+            0);
 
         public static MeterVisualState CreateActive(
             InputLevelMeterEntry target,
             long nowMs) => new(
             true,
-            target.PeakDbFs,
             target.RmsDbFs,
             target.PeakDbFs,
-            nowMs,
-            target.PeakDbFs,
-            target.RmsDbFs,
             nowMs,
             target.Clipped,
-            target.FullScaleReference);
+            target.FullScaleReference,
+            target.PeakDbFs,
+            target.RmsDbFs,
+            nowMs);
     }
 }

--- a/source/Ui/UiPalette.cs
+++ b/source/Ui/UiPalette.cs
@@ -42,7 +42,6 @@ internal static class UiPalette
     public static Color MeterText => Color.FromArgb(225, 230, 240);
     public static Color MeterMutedText => Color.FromArgb(128, 135, 150);
     public static Color MeterPeakHold => Color.FromArgb(248, 248, 252);
-    public static Color MeterFullScale => Color.FromArgb(95, 200, 255);
     public static Color MeterLowAccent => Color.FromArgb(88, 182, 255);
     public static Color MeterDimFill => Color.FromArgb(80, 86, 100);
     public static Color MeterTrackInactive => Color.FromArgb(30, 34, 42);

--- a/tests/Resonalyze.App.Tests/CoalescingDispatcherTests.cs
+++ b/tests/Resonalyze.App.Tests/CoalescingDispatcherTests.cs
@@ -114,6 +114,54 @@ public sealed class CoalescingDispatcherTests
     }
 
     [Fact]
+    public void Offer_FoldsSupersededValuesWhenGivenAMerge()
+    {
+        var posted = new List<Action>();
+        var applied = new List<int>();
+        var dispatcher = new CoalescingDispatcher<int>(
+            drain =>
+            {
+                posted.Add(drain);
+                return true;
+            },
+            applied.Add,
+            (superseded, newest) => superseded + newest);
+
+        dispatcher.Offer(1);
+        dispatcher.Offer(2);
+        dispatcher.Offer(3);
+        posted[0]();
+
+        // Still one dispatch, but nothing the dropped offers carried is lost.
+        Assert.Single(posted);
+        Assert.Equal(new[] { 6 }, applied);
+    }
+
+    [Fact]
+    public void Offer_DoesNotFoldAnAlreadyDeliveredValue()
+    {
+        var posted = new List<Action>();
+        var applied = new List<int>();
+        var dispatcher = new CoalescingDispatcher<int>(
+            drain =>
+            {
+                posted.Add(drain);
+                return true;
+            },
+            applied.Add,
+            (superseded, newest) => superseded + newest);
+
+        dispatcher.Offer(1);
+        posted[0]();
+        dispatcher.Offer(2);
+        posted[1]();
+
+        // The drained value stays in the field; folding it into the next offer
+        // would report a level twice.
+        Assert.Equal(new[] { 1, 2 }, applied);
+    }
+
+    [Fact]
     public void Offer_IsSafeUnderConcurrentProducers()
     {
         var applied = new List<int>();

--- a/tests/Resonalyze.App.Tests/InputLevelMeterBallisticsTests.cs
+++ b/tests/Resonalyze.App.Tests/InputLevelMeterBallisticsTests.cs
@@ -1,0 +1,258 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The input meter's ballistics. The peak is an event — latched whole, held,
+/// then decayed — and most of what is pinned here is some way of losing one.
+/// </summary>
+public sealed class InputLevelMeterBallisticsTests
+{
+    private const double Tick = 0.033;
+    private const long TickMs = 33;
+
+    private static InputLevelMeterEntry Entry(
+        double peakDbFs,
+        double rmsDbFs,
+        bool clipped = false,
+        bool fullScaleReference = false) =>
+        new(true, peakDbFs, rmsDbFs, clipped, fullScaleReference);
+
+    [Fact]
+    public void Advance_LatchesAPeakOnTheVeryNextFrame()
+    {
+        long now = 1000;
+        InputLevelMeterState state = InputLevelMeterState.CreateActive(Entry(-60, -60), now);
+
+        state = InputLevelMeterBallistics.Advance(state, Entry(-6, -30), now + TickMs, Tick);
+
+        // Smoothing the way up would show about -37 dBFS here, and would need
+        // some 300 ms to arrive.
+        Assert.Equal(-6, state.HoldPeakDbFs);
+    }
+
+    [Fact]
+    public void Advance_CapturesATransientThatLivedInOneWindow()
+    {
+        long now = 1000;
+        InputLevelMeterState state = InputLevelMeterState.CreateActive(Entry(-40, -46), now);
+
+        now += TickMs;
+        state = InputLevelMeterBallistics.Advance(state, Entry(-1, -44), now, Tick);
+        Assert.Equal(-1, state.HoldPeakDbFs);
+
+        // The window it lived in is long gone; the marker still reports it.
+        for (int i = 0; i < 20; i++)
+        {
+            now += TickMs;
+            state = InputLevelMeterBallistics.Advance(state, Entry(-40, -46), now, Tick);
+            Assert.Equal(-1, state.HoldPeakDbFs);
+        }
+    }
+
+    [Fact]
+    public void Advance_HoldsForTheFullDurationThenFallsAtTheStatedRate()
+    {
+        long now = 1000;
+        InputLevelMeterState state = InputLevelMeterState.CreateActive(Entry(-40, -46), now);
+        now += TickMs;
+        state = InputLevelMeterBallistics.Advance(state, Entry(-6, -30), now, Tick);
+        long peakAt = now;
+
+        // Every frame this loop runs falls inside the plateau.
+        while (now + TickMs - peakAt <= InputLevelMeterBallistics.PeakHoldDurationMs)
+        {
+            now += TickMs;
+            state = InputLevelMeterBallistics.Advance(state, Entry(-40, -46), now, Tick);
+        }
+
+        double atHoldEnd = state.HoldPeakDbFs;
+        Assert.Equal(-6, atHoldEnd);
+
+        long fallStart = now;
+        while (now - fallStart < 330)
+        {
+            now += TickMs;
+            state = InputLevelMeterBallistics.Advance(state, Entry(-40, -46), now, Tick);
+        }
+
+        double fallen = atHoldEnd - state.HoldPeakDbFs;
+        double expected = InputLevelMeterBallistics.PeakHoldFallDbPerSecond * ((now - fallStart) / 1000.0);
+        Assert.Equal(expected, fallen, 1);
+    }
+
+    [Fact]
+    public void Advance_NeverFallsBelowTheCurrentLevel()
+    {
+        long now = 1000;
+        InputLevelMeterState state = InputLevelMeterState.CreateActive(Entry(-6, -12), now);
+
+        for (int i = 0; i < 200; i++)
+        {
+            now += TickMs;
+            state = InputLevelMeterBallistics.Advance(state, Entry(-20, -26), now, Tick);
+        }
+
+        Assert.Equal(-20, state.HoldPeakDbFs);
+    }
+
+    [Theory]
+    // A settled meter, digital silence pinned to the dB floor, and a loopback
+    // pinned to full scale: each holds a peak exactly equal to the incoming
+    // one, which a non-strict hold comparison would re-stamp every frame.
+    [InlineData(-20, -26, false)]
+    [InlineData(-160, -160, false)]
+    [InlineData(0, -8, true)]
+    public void Advance_LeavesASettledStateUntouched(
+        double peakDbFs,
+        double rmsDbFs,
+        bool fullScaleReference)
+    {
+        long now = 1000;
+        InputLevelMeterEntry target = Entry(peakDbFs, rmsDbFs, fullScaleReference: fullScaleReference);
+        InputLevelMeterState state = InputLevelMeterState.CreateActive(target, now);
+        for (int i = 0; i < 120; i++)
+        {
+            now += TickMs;
+            state = InputLevelMeterBallistics.Advance(state, target, now, Tick);
+        }
+
+        // Equality is what lets the panel skip repainting an idle meter.
+        InputLevelMeterState next = InputLevelMeterBallistics.Advance(state, target, now + TickMs, Tick);
+
+        Assert.Equal(state, next);
+    }
+
+    [Fact]
+    public void Advance_RateLimitsTheHoldButNotTheLevelAfterAStall()
+    {
+        long now = 1000;
+        InputLevelMeterState state = InputLevelMeterState.CreateActive(Entry(-3, -20), now);
+
+        // Two seconds of stalled message pump, then one frame.
+        state = InputLevelMeterBallistics.Advance(state, Entry(-45, -50), now + 2000, 2.0);
+
+        double maximumFall =
+            InputLevelMeterBallistics.PeakHoldFallDbPerSecond *
+            InputLevelMeterBallistics.MaximumHoldFallSeconds;
+        Assert.Equal(-3 - maximumFall, state.HoldPeakDbFs, 3);
+        // The level, unlike the hold, is not a display rate: it lands on what
+        // the input is actually doing now.
+        Assert.Equal(-50, state.DisplayedRmsDbFs, 1);
+    }
+
+    [Fact]
+    public void Advance_PutsTheHeldPeakInTheReadout()
+    {
+        long now = 1000;
+        InputLevelMeterState state = InputLevelMeterState.CreateActive(Entry(-40, -46), now);
+        now += TickMs;
+        state = InputLevelMeterBallistics.Advance(state, Entry(-2, -44), now, Tick);
+
+        // The hold outlives the text interval, so the next update cannot miss it.
+        long lastUpdate = state.LastTextUpdateMs;
+        while (state.LastTextUpdateMs == lastUpdate)
+        {
+            now += TickMs;
+            state = InputLevelMeterBallistics.Advance(state, Entry(-40, -46), now, Tick);
+        }
+
+        Assert.True(
+            now - lastUpdate < InputLevelMeterBallistics.PeakHoldDurationMs,
+            "the readout must refresh while the peak is still held");
+        Assert.Equal(-2, state.TextPeakDbFs);
+    }
+
+    [Fact]
+    public void IsAlarming_SeparatesAMicrophoneClipFromAReferenceAtFullScale()
+    {
+        long now = 1000;
+
+        Assert.True(InputLevelMeterState
+            .CreateActive(Entry(0, -8, clipped: true), now)
+            .IsAlarming);
+        Assert.False(InputLevelMeterState
+            .CreateActive(Entry(0, -8, fullScaleReference: true), now)
+            .IsAlarming);
+    }
+
+    [Fact]
+    public void Advance_KeepsTheFullScaleFlagsUntilTheirPeakHasDecayed()
+    {
+        long now = 1000;
+        InputLevelMeterState state = InputLevelMeterState.CreateActive(Entry(-30, -36), now);
+        now += TickMs;
+        state = InputLevelMeterBallistics.Advance(
+            state, Entry(0, -8, fullScaleReference: true), now, Tick);
+
+        // The reference has stepped off full scale, but its peak is still up:
+        // re-reading the flag from this window would turn that peak red.
+        now += TickMs;
+        state = InputLevelMeterBallistics.Advance(state, Entry(-32, -38), now, Tick);
+        Assert.True(state.HoldFullScaleReference);
+        Assert.False(state.IsAlarming);
+
+        for (int i = 0; i < 100; i++)
+        {
+            now += TickMs;
+            state = InputLevelMeterBallistics.Advance(state, Entry(-32, -38), now, Tick);
+        }
+
+        Assert.False(state.HoldFullScaleReference);
+    }
+
+    [Fact]
+    public void Advance_HoldsAnUnavailableStateSteady()
+    {
+        InputLevelMeterState state = InputLevelMeterState.CreateUnavailable();
+
+        InputLevelMeterState next = InputLevelMeterBallistics.Advance(
+            state, InputLevelMeterEntry.Unavailable, 1000, Tick);
+
+        Assert.Equal(state, next);
+        Assert.False(next.Available);
+    }
+
+    [Fact]
+    public void Target_KeepsTheLoudestOfSeveralDrainsInOneFrame()
+    {
+        InputLevelMeterTarget target = InputLevelMeterTarget.Unavailable
+            .Fold(Entry(-40, -46));
+
+        // Posted callbacks outrank WM_TIMER, so both of these can be applied
+        // before the animation gets a frame.
+        target = target.Fold(Entry(-2, -44));
+        target = target.Fold(Entry(-38, -45));
+
+        Assert.Equal(-2, target.Pending.PeakDbFs);
+        // The level, which floors the hold's decay, is the newest one.
+        Assert.Equal(-38, target.Level.PeakDbFs);
+    }
+
+    [Fact]
+    public void Target_DropsAPeakTheFrameHasAlreadyLatched()
+    {
+        InputLevelMeterTarget target = InputLevelMeterTarget.Unavailable
+            .Fold(Entry(-40, -46))
+            .Fold(Entry(-2, -44))
+            .Fold(Entry(-38, -45))
+            .Consume();
+
+        // Left in the fold, that -2 dBFS would latch again once the hold had
+        // decayed past it and report an event seconds old. What remains is the
+        // newest window, which is a level, not an event.
+        Assert.Equal(-38, target.Pending.PeakDbFs);
+        Assert.Equal(target.Level, target.Pending);
+    }
+
+    [Fact]
+    public void Target_SurvivesAFrameWithNoSnapshotBehindIt()
+    {
+        InputLevelMeterTarget target = InputLevelMeterTarget.Unavailable
+            .Fold(Entry(-20, -26))
+            .Consume()
+            .Consume();
+
+        // Consuming must not erase the level: it is what stops the hold sagging
+        // below the signal on a frame that received nothing.
+        Assert.Equal(-20, target.Pending.PeakDbFs);
+    }
+}

--- a/tests/Resonalyze.App.Tests/InputLevelMeterSnapshotTests.cs
+++ b/tests/Resonalyze.App.Tests/InputLevelMeterSnapshotTests.cs
@@ -1,0 +1,74 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class InputLevelMeterSnapshotTests
+{
+    [Fact]
+    public void Merge_KeepsTheLoudestPeakAndTheNewestRms()
+    {
+        var superseded = new InputLevelMeterEntry(true, -2, -30, false, false);
+        var newest = new InputLevelMeterEntry(true, -24, -26, false, false);
+
+        InputLevelMeterEntry merged = superseded.Merge(newest);
+
+        // The -2 dBFS window never reached the UI on its own; losing it is what
+        // makes a peak meter under-read a transient.
+        Assert.Equal(-2, merged.PeakDbFs);
+        Assert.Equal(-26, merged.RmsDbFs);
+    }
+
+    [Fact]
+    public void Merge_CarriesFullScaleFlagsForward()
+    {
+        var superseded = new InputLevelMeterEntry(true, 0, -12, true, false);
+        var newest = new InputLevelMeterEntry(true, -18, -24, false, true);
+
+        InputLevelMeterEntry merged = superseded.Merge(newest);
+
+        Assert.True(merged.Clipped);
+        Assert.True(merged.FullScaleReference);
+    }
+
+    [Fact]
+    public void Merge_TakesTheNewestWhenAvailabilityChanges()
+    {
+        var loud = new InputLevelMeterEntry(true, -1, -9, true, false);
+
+        // A channel that has gone away, then one that has just appeared: in
+        // neither direction does the older reading describe the newer channel.
+        Assert.Equal(
+            InputLevelMeterEntry.Unavailable,
+            loud.Merge(InputLevelMeterEntry.Unavailable));
+        Assert.Equal(loud, InputLevelMeterEntry.Unavailable.Merge(loud));
+    }
+
+    [Fact]
+    public void Merge_FoldsBothRowsOfASnapshot()
+    {
+        var superseded = new InputLevelMeterSnapshot(
+            new InputLevelMeterEntry(true, -4, -30, false, false),
+            new InputLevelMeterEntry(true, -20, -28, false, false));
+        var newest = new InputLevelMeterSnapshot(
+            new InputLevelMeterEntry(true, -30, -34, false, false),
+            new InputLevelMeterEntry(true, 0, -6, false, true));
+
+        InputLevelMeterSnapshot merged = superseded.Merge(newest);
+
+        Assert.Equal(-4, merged.Microphone.PeakDbFs);
+        Assert.Equal(0, merged.Loopback.PeakDbFs);
+        Assert.True(merged.Loopback.FullScaleReference);
+    }
+
+    [Fact]
+    public void Merge_IsAssociativeOverAChainOfDroppedWindows()
+    {
+        var first = new InputLevelMeterEntry(true, -3, -20, false, false);
+        var second = new InputLevelMeterEntry(true, -40, -44, false, false);
+        var third = new InputLevelMeterEntry(true, -38, -42, false, false);
+
+        // How the dispatcher folds: each superseded value into the next.
+        InputLevelMeterEntry merged = first.Merge(second).Merge(third);
+
+        Assert.Equal(-3, merged.PeakDbFs);
+        Assert.Equal(-42, merged.RmsDbFs);
+    }
+}


### PR DESCRIPTION
The peak-hold marker was fed the **smoothed** peak instead of the raw one, so it eased towards a level over ~300 ms and never reached a transient that lived in a single 30 Hz window at all.

Simulating the old ballistics: a background of −40 dBFS with one window at −1 dBFS latched the marker at **−23.6 dBFS — a 22.6 dB under-read** on the very event a peak meter exists to catch. `AudioLevelAccumulator` already hands the panel the true maximum of each window, so easing towards it only threw that maximum away.

## The fix

- **Instant attack, latched from `target.PeakDbFs`.** The separately smoothed "current" peak is gone: under an instant attack it could only ever read lower than the hold derived from it, so the fill colour and the readout now come off the hold. Hold duration is **1050 ms**.
- **Full-scale flags live and die with the peak they describe.** They used to be re-read from the newest window every tick, so a reference channel turned its own held peak red the moment it stepped off full scale.
- **One `IsAlarming` predicate for fill and marker.** The marker exempted the full-scale reference and the fill did not, which left the loopback bar permanently red at its normal operating level.
- **RMS uses time constants (60/260 ms), not per-tick fractions.** `WM_TIMER` coalesces whenever the UI thread is busy — which it is during a measurement — so a fixed fraction made the ballistics depend on load. The values match the old factors at a nominal 33 ms tick.
- **The animation step is clamped to 250 ms**, so a stalled pump cannot drop the hold by tens of dB in one tick.
- **The text timestamp is re-stamped only on a real change**, so the idle repaint skip works as its comment already claimed (it was repainting at 2 Hz on a static signal).
- **Fill, ticks and marker share one dB→pixel mapping.** They used two, so the edge of the fill missed the tick it had reached.
- Dead weight: the unused `FullScaleColor`/`UiPalette.MeterFullScale`, the unreachable `DimFillColor` branch, and the constructor `Font` that `Form1.Designer.cs` overwrites (leaking the one it created).

## Losing peaks before the panel ever saw them

`CoalescingDispatcher` is latest-wins, and its comment justified that with "a thousand callbacks per second at small ASIO buffer sizes". That is no longer how levels arrive: both publishers (`AsioFullDuplexSession`, `PcmCaptureSession`) go through `AudioLevelAccumulator`, hard-throttled to 30 Hz. A busy pump still falls behind that, and every dropped snapshot took its window's peak with it.

The dispatcher now takes an optional merge, and the meter passes one that keeps the maximum peak, ORs the full-scale flags, takes the newest RMS, and resets the fold when availability changes. Clipping verdicts were never at risk — `SweepRunQualityCheck` scans the whole recorded buffer independently — but the live indicator was.

## Verification

`dotnet test` is green (2061 tests) with 7 new ones covering the merge and the dispatcher.

The ballistics live in a private nested type inside a `Control`, so they are pinned by a scratchpad harness driving the real `AdvanceState` through reflection — 10 scenarios, all passing: instant attack (−60 → −6 in one tick), a single-window −1 dBFS transient captured in full and held, plateau then an 8.7 dB fall over the next 330 ms, state equality on digital silence and on a full-scale loopback (the case a non-strict hold comparison would re-stamp every tick), the clamped step, and the readout quoting the transient.

The panel rendered through `DrawToBitmap` at three levels confirms the drawing changes — notably a clipped microphone red while a loopback at the same 0 dBFS stays amber.

**Not covered:** how the 1050 ms / 24 dB/s feel on real hardware, and whether the fill staying red for ~1 s after a transient reads well. Both want a field pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Follow-up: the same hole one layer down (Codex review)

`Drain` clears the queued flag *before* applying, so each further offer posts a fresh callback — and posted callbacks outrank the low-priority `WM_TIMER` the animation runs on. Two drains could therefore be applied between two ticks, and `SetLevels` overwrote its target, so the second one buried the first one's peak before any frame looked at it. The dispatcher merge did not cover that window.

The panel now keeps the newest snapshot as the current **level** and folds peaks and full-scale flags into a separate target that a frame consumes. The two have to stay separate: on a tick with no snapshot behind it the decay floor must still be held up by the current level, otherwise the hold sags a dB and re-latches on the next tick — a visible blip on a steady signal.

Harness scenario 11 covers it: two `SetLevels` calls between two `Animate` calls on a real panel instance, asserting the −2 dBFS transient survives the −38 dBFS snapshot that followed it, and that the fold does not outlive the frame that consumed it.


### Follow-up: the hold's fall is rate-limited, the clock is not

Clamping the whole animation step made every ballistic lag real time after a stall longer than 250 ms — RMS included, which is wrong: RMS is a level, and once the pump recovers the honest thing to show is what the input is doing now, not a value catching up through frames nobody saw. Only the hold's decay is bounded now, because that one is a display rate: settling seconds of it in a single frame would teleport the marker across the track.


### Follow-up: the ballistics are no longer trapped in a Control

The state machine deciding what a peak does was a private nested type inside `InputLevelMeterPanel`, so the most delicate part of this change could only be exercised by a reflection harness living outside the repo. It now sits in `InputLevelMeterBallistics` + `InputLevelMeterState` — no GDI, no `Control` — and the eleven scenarios that harness covered are tests: instant latch, a transient that lived in one 30 Hz window, plateau then the stated fall rate, the decay floor, state equality on a settled meter / digital silence / a full-scale loopback (the case a non-strict hold comparison would re-stamp every frame), the rate-limited hold against a wall-clock RMS after a stall, the readout quoting the hold, and the full-scale flags outliving the window that raised them.

`InputLevelMeterTarget` now carries the level/pending split the panel was keeping in four loose fields, which makes the fold-and-consume rule — the thing that keeps a transient alive across several dispatcher drains — testable as a value instead of as a sequence of private field writes.

Worth noting: three of the ported assertions failed on their first run. Two loops stepped one frame past the boundary they meant to sit on, and one expected a consumed fold to still hold a peak that was by then the newest window's own level. The behaviour was right in each case and the tests were wrong — but that is the difference between a harness someone ran once and a check that runs on every build.
