### PR TITLE
Divide the sum loss before smoothing it, not after

### DIFF
--- a/dsp/DataHelper.Resampling.cs
+++ b/dsp/DataHelper.Resampling.cs
@@ -649,6 +649,152 @@ namespace Resonalyze.Dsp
                 : Math.Sqrt(Math.Max(0.0, bandPowers[centerIndex]));
         }
 
+        /// <summary>
+        /// Smooths a RATIO curve that already sits on the logarithmic display grid —
+        /// a per-point dB difference between two responses, such as the Virtual DSP
+        /// summation loss — with a plain arithmetic mean of its decibels.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A ratio is not a level, so it must never take the magnitude path
+        /// (<see cref="SmoothBandLevels"/>, <see cref="LogarithmicResample"/>): those
+        /// average POWER and weight peaks with a cubic mean, which on a ratio reads as
+        /// a bias toward whichever side of the window is closer to 0 dB. More
+        /// importantly the smoothing has to happen HERE, on the finished ratio, and not
+        /// on the two operands before they are divided — see
+        /// <see cref="VirtualCrossoverAnalysis.SumLossCurve"/> for what that order costs.
+        /// </para>
+        /// <para>
+        /// The psychoacoustic mode keeps its frequency-dependent WIDTH (and its Gaussian
+        /// kernel), only dropping the magnitude weighting. Non-finite points — gated-out
+        /// gaps — pass through and are excluded from their neighbours' means, so a gap
+        /// neither spreads nor fills. Points must be ascending and logarithmically
+        /// spaced, as the display grid is.
+        /// </para>
+        /// </remarks>
+        public static List<SignalPoint> SmoothRatioLevels(
+            IReadOnlyList<SignalPoint> ratioDb,
+            double smoothingOctaves,
+            bool psychoacoustic)
+        {
+            ArgumentNullException.ThrowIfNull(ratioDb);
+
+            int steps = ratioDb.Count;
+            var result = new List<SignalPoint>(steps);
+            if (steps < 2 || ratioDb[0].X <= 0 || ratioDb[^1].X <= ratioDb[0].X)
+            {
+                result.AddRange(ratioDb);
+                return result;
+            }
+
+            double octavesPerStep = Math.Log2(ratioDb[^1].X / ratioDb[0].X) / (steps - 1);
+            int smoothingHalfSteps = smoothingOctaves > 0.0 && octavesPerStep > 0.0
+                ? (int)Math.Round(smoothingOctaves * 0.5 / octavesPerStep)
+                : 0;
+            // Matches the resampler and SmoothBandLevels, which also leave the curve
+            // alone when the requested width does not reach a whole grid step.
+            if (!psychoacoustic && smoothingHalfSteps <= 0)
+            {
+                result.AddRange(ratioDb);
+                return result;
+            }
+
+            for (int i = 0; i < steps; i++)
+            {
+                if (!double.IsFinite(ratioDb[i].Y))
+                {
+                    result.Add(ratioDb[i]);
+                    continue;
+                }
+
+                result.Add(new SignalPoint(
+                    ratioDb[i].X,
+                    psychoacoustic
+                        ? GaussianDecibelMean(
+                            ratioDb,
+                            i,
+                            SpectrumSmoothing.PsychoacousticOctaves(ratioDb[i].X),
+                            octavesPerStep)
+                        : BoxDecibelMean(ratioDb, i, smoothingHalfSteps)));
+            }
+
+            return result;
+        }
+
+        // The plain-width mean: every measured point within +/- half the requested
+        // width counts once. Gaps are skipped, so the mean is over what was measured.
+        private static double BoxDecibelMean(
+            IReadOnlyList<SignalPoint> curve,
+            int centerIndex,
+            int halfSteps)
+        {
+            int firstIndex = Math.Max(0, centerIndex - halfSteps);
+            int lastIndex = Math.Min(curve.Count - 1, centerIndex + halfSteps);
+            double total = 0.0;
+            int count = 0;
+            for (int index = firstIndex; index <= lastIndex; index++)
+            {
+                if (double.IsFinite(curve[index].Y))
+                {
+                    total += curve[index].Y;
+                    count++;
+                }
+            }
+
+            return count > 0 ? total / count : curve[centerIndex].Y;
+        }
+
+        // The psychoacoustic width's kernel, shaped exactly like the magnitude one
+        // (Gaussian of the given FWHM, tapered to zero at three sigma) but averaging
+        // decibels linearly instead of cubing powers.
+        private static double GaussianDecibelMean(
+            IReadOnlyList<SignalPoint> curve,
+            int centerIndex,
+            double smoothingOctaves,
+            double octavesPerStep)
+        {
+            const double GaussianFwhmToSigma = 1.0 / 2.354820045;
+            const double GaussianRadiusSigma = 3.0;
+            const double GaussianTaperStartSigma = 2.5;
+            double sigmaSteps = smoothingOctaves * GaussianFwhmToSigma / octavesPerStep;
+            if (!(sigmaSteps > 0.0))
+            {
+                return curve[centerIndex].Y;
+            }
+
+            int radius = Math.Max(1, (int)Math.Ceiling(GaussianRadiusSigma * sigmaSteps));
+            int firstIndex = Math.Max(0, centerIndex - radius);
+            int lastIndex = Math.Min(curve.Count - 1, centerIndex + radius);
+            double weightSum = 0.0;
+            double weightedSum = 0.0;
+            for (int index = firstIndex; index <= lastIndex; index++)
+            {
+                if (!double.IsFinite(curve[index].Y))
+                {
+                    continue;
+                }
+
+                double normalized = (index - centerIndex) / sigmaSteps;
+                double absoluteNormalized = Math.Abs(normalized);
+                if (absoluteNormalized >= GaussianRadiusSigma)
+                {
+                    continue;
+                }
+
+                double taper = absoluteNormalized <= GaussianTaperStartSigma
+                    ? 1.0
+                    : 0.5 * (1.0 + Math.Cos(
+                        Math.PI *
+                        (absoluteNormalized - GaussianTaperStartSigma) /
+                        (GaussianRadiusSigma - GaussianTaperStartSigma)));
+                double weight = Math.Exp(-0.5 * normalized * normalized) * taper;
+                weightedSum += curve[index].Y * weight;
+                weightSum += weight;
+            }
+
+            return weightSum > 1e-12 ? weightedSum / weightSum : curve[centerIndex].Y;
+        }
+
         public static List<SignalPoint> SmoothLinear(List<SignalPoint> input, double smoothingOctaves = 1.0 / 6.0)
         {
             if (input.Count < 2)

--- a/dsp/DataHelper.Spectrum.cs
+++ b/dsp/DataHelper.Spectrum.cs
@@ -128,17 +128,52 @@ namespace Resonalyze.Dsp
             double smoothingInverseOctaves)
         {
             Complex[] spectrum = BuildAnalysisSpectrum(measurement, settings, out _);
-            List<SignalPoint> data = LogarithmicResample(
+            return ResampleGatedMagnitude(
                 GatedMagnitudePoints(spectrum, measurement.SampleRate),
-                20,
-                20000,
-                1024,
                 calibration,
-                SpectrumSmoothing.SmoothingOctaves(smoothingInverseOctaves),
-                psychoacoustic: SpectrumSmoothing.IsPsychoacoustic(
-                    smoothingInverseOctaves));
-            return new AnalysisCurve("Frequency Response", data);
+                smoothingInverseOctaves);
         }
+
+        /// <summary>
+        /// <see cref="GetGatedPrimarySpectrum"/> at two smoothing widths from ONE
+        /// gate and one FFT: the display curve and the unsmoothed curve. A caller
+        /// that both draws a curve and divides it into another one (the Virtual DSP
+        /// summation loss) needs both, and the gated FFT — not the resample — is
+        /// what costs; see <see cref="VirtualCrossoverAnalysis.SumLossCurve"/> for
+        /// why the division must read the unsmoothed pair.
+        /// </summary>
+        public static (AnalysisCurve Display, AnalysisCurve Unsmoothed)
+            GetGatedPrimarySpectrumPair(
+                IImpulseMeasurement measurement,
+                PhaseAnalysisSettings settings,
+                CalibrationFile? calibration,
+                double smoothingInverseOctaves)
+        {
+            Complex[] spectrum = BuildAnalysisSpectrum(measurement, settings, out _);
+            List<SignalPoint> bins = GatedMagnitudePoints(spectrum, measurement.SampleRate);
+            AnalysisCurve unsmoothed = ResampleGatedMagnitude(bins, calibration, 0);
+            return (
+                smoothingInverseOctaves == 0
+                    ? unsmoothed
+                    : ResampleGatedMagnitude(bins, calibration, smoothingInverseOctaves),
+                unsmoothed);
+        }
+
+        private static AnalysisCurve ResampleGatedMagnitude(
+            List<SignalPoint> bins,
+            CalibrationFile? calibration,
+            double smoothingInverseOctaves) =>
+            new(
+                "Frequency Response",
+                LogarithmicResample(
+                    bins,
+                    20,
+                    20000,
+                    1024,
+                    calibration,
+                    SpectrumSmoothing.SmoothingOctaves(smoothingInverseOctaves),
+                    psychoacoustic: SpectrumSmoothing.IsPsychoacoustic(
+                        smoothingInverseOctaves)));
 
         // The magnitude bins of a gated analysis spectrum as ascending (Hz, dB)
         // points on its linear grid — the resample-ready form every gated

--- a/dsp/DataHelper.cs
+++ b/dsp/DataHelper.cs
@@ -90,6 +90,20 @@ namespace Resonalyze.Dsp
         public int PhaseFdwCycles { get; set; } = PhaseAnalysisSettings.DefaultFdwCycles;
         public PhaseDetrendMode PhaseDetrendMode { get; set; } = PhaseDetrendMode.Auto;
 
+        /// <summary>
+        /// A copy of these options reading a different display smoothing — for a
+        /// caller that needs one curve at two widths (the Compare view's summation
+        /// loss, which must divide UNSMOOTHED curves and smooth the result; see
+        /// <see cref="VirtualCrossoverAnalysis.SumLossCurve"/>) without mutating the
+        /// shared, UI-owned instance.
+        /// </summary>
+        public FrequencyResponseOptions WithSmoothing(double smoothingInverseOctaves)
+        {
+            var copy = (FrequencyResponseOptions)MemberwiseClone();
+            copy.SmoothingInverseOctaves = smoothingInverseOctaves;
+            return copy;
+        }
+
         public PhaseAnalysisSettings CreatePhaseAnalysisSettings() => new(
             PhaseWindowMode,
             PhaseFdwCycles,

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -2434,10 +2434,22 @@ public static class VirtualCrossoverAnalysis
     /// drawn "Sum loss" curve, <see cref="AverageSumLossDb"/> and
     /// <see cref="MinimumSumLossDb"/> all read, so the drawn and measured loss
     /// cannot drift apart.
+    /// <para>
+    /// The operands must be UNSMOOTHED, and any display smoothing asked for through
+    /// <paramref name="smoothingInverseOctaves"/> applies HERE, to the finished
+    /// ratio. Smoothing the two curves first does not commute with the division: a
+    /// fractional-octave window straddling a steep crossover skirt pulls that
+    /// channel's level up toward its own passband — several dB on a 36 dB/octave
+    /// slope, and more again under the psychoacoustic mode's peak-weighted cubic
+    /// mean — while the (flat) sum barely moves. Σ|H| then inflates faster than
+    /// |ΣH| and the curve draws a dip at every corner frequency: a measured 70 Hz
+    /// junction losing a true 0.2 dB read as a 1.6 dB dip that way.
+    /// </para>
     /// </summary>
     public static List<SignalPoint> SumLossCurve(
         IReadOnlyList<SignalPoint> sumCurve,
-        IReadOnlyList<IReadOnlyList<SignalPoint>> channelCurves)
+        IReadOnlyList<IReadOnlyList<SignalPoint>> channelCurves,
+        double smoothingInverseOctaves = 0)
     {
         ArgumentNullException.ThrowIfNull(sumCurve);
         ArgumentNullException.ThrowIfNull(channelCurves);
@@ -2475,7 +2487,12 @@ public static class VirtualCrossoverAnalysis
                     : double.NaN));
         }
 
-        return points;
+        return smoothingInverseOctaves != 0
+            ? DataHelper.SmoothRatioLevels(
+                points,
+                SpectrumSmoothing.SmoothingOctaves(smoothingInverseOctaves),
+                SpectrumSmoothing.IsPsychoacoustic(smoothingInverseOctaves))
+            : points;
     }
 
     /// <summary>
@@ -2653,25 +2670,20 @@ public static class VirtualCrossoverAnalysis
 
     /// <summary>
     /// The average summation loss (dB, &lt;= 0) inside the frequency window: how
-    /// far the complex sum falls short of the phase-blind magnitude sum. The
-    /// curves must share one frequency grid (index-aligned).
+    /// far the complex sum falls short of the phase-blind magnitude sum, averaged
+    /// over a curve <see cref="SumLossCurve"/> already built — the read-out and the
+    /// drawn curve are then the same numbers by construction, smoothing included.
     /// </summary>
     public static double? AverageSumLossDb(
-        IReadOnlyList<SignalPoint> sumCurve,
-        IReadOnlyList<IReadOnlyList<SignalPoint>> channelCurves,
+        IReadOnlyList<SignalPoint> lossCurve,
         double minFrequencyHz,
         double maxFrequencyHz)
     {
-        ArgumentNullException.ThrowIfNull(sumCurve);
-        ArgumentNullException.ThrowIfNull(channelCurves);
-        if (channelCurves.Count == 0)
-        {
-            return null;
-        }
+        ArgumentNullException.ThrowIfNull(lossCurve);
 
         double total = 0;
         int samples = 0;
-        foreach (SignalPoint point in SumLossCurve(sumCurve, channelCurves))
+        foreach (SignalPoint point in lossCurve)
         {
             if (point.X < minFrequencyHz || point.X > maxFrequencyHz)
             {
@@ -2692,24 +2704,19 @@ public static class VirtualCrossoverAnalysis
     /// The deepest summation-loss point (dB, &lt;= 0) inside the frequency
     /// window — the companion to <see cref="AverageSumLossDb"/> that a narrow
     /// cancellation notch cannot hide from: the average barely moves on a
-    /// sharp dip that is plainly audible. The curves must share one frequency
-    /// grid (index-aligned) and are expected to be display-smoothed already.
+    /// sharp dip that is plainly audible. Reads a curve
+    /// <see cref="SumLossCurve"/> already built, whose display smoothing decides
+    /// how narrow a notch still counts.
     /// </summary>
     public static double? MinimumSumLossDb(
-        IReadOnlyList<SignalPoint> sumCurve,
-        IReadOnlyList<IReadOnlyList<SignalPoint>> channelCurves,
+        IReadOnlyList<SignalPoint> lossCurve,
         double minFrequencyHz,
         double maxFrequencyHz)
     {
-        ArgumentNullException.ThrowIfNull(sumCurve);
-        ArgumentNullException.ThrowIfNull(channelCurves);
-        if (channelCurves.Count == 0)
-        {
-            return null;
-        }
+        ArgumentNullException.ThrowIfNull(lossCurve);
 
         double? minimum = null;
-        foreach (SignalPoint point in SumLossCurve(sumCurve, channelCurves))
+        foreach (SignalPoint point in lossCurve)
         {
             if (point.X < minFrequencyHz || point.X > maxFrequencyHz)
             {

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -2450,7 +2450,8 @@ public sealed class Overlay
     private DataPoint[]? BuildOperationPointsFor(OverlayOperationPreview settings)
     {
         // Complex sum is computed from the Main and Compare transfer IRs by the
-        // measurement pipeline (identical FR window / calibration / smoothing), not
+        // measurement pipeline (identical FR window / calibration / smoothing — the
+        // sum-loss variant divides its operands unsmoothed and smooths the gap), not
         // from operand curves; only the overlay's own smoothing and offset apply here.
         if (settings.Operation is OverlayOperation.ComplexSum or OverlayOperation.ComplexSumLoss)
         {
@@ -2516,7 +2517,12 @@ public sealed class Overlay
             return null;
         }
 
-        OverlayPoint[] smoothed = OverlayMath.SmoothByOctaves(sumPoints, smoothing);
+        // The loss curve is a RATIO of two responses, not a level: the slot's own
+        // smoothing must average its decibels plainly. The psychoacoustic cubic
+        // mean is a magnitude weighting and biases a ratio (see
+        // DataHelper.SmoothRatioLevels).
+        OverlayPoint[] smoothed = OverlayMath.SmoothByOctaves(
+            sumPoints, smoothing, psychoacousticMagnitude: !showLoss);
         double offset = (double)offsetControl.Value;
         return smoothed
             .Select(point => new DataPoint(point.X, point.Y + offset))

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -2450,9 +2450,11 @@ public sealed class Overlay
     private DataPoint[]? BuildOperationPointsFor(OverlayOperationPreview settings)
     {
         // Complex sum is computed from the Main and Compare transfer IRs by the
-        // measurement pipeline (identical FR window / calibration / smoothing — the
-        // sum-loss variant divides its operands unsmoothed and smooths the gap), not
-        // from operand curves; only the overlay's own smoothing and offset apply here.
+        // measurement pipeline (identical FR window / calibration / smoothing), not
+        // from operand curves; only the overlay's own smoothing and offset apply
+        // here. The sum-LOSS variant divides unsmoothed operands and is smoothed
+        // once, down in the pipeline, at this slot's width — a ratio has no business
+        // carrying the plot's smoothing (see BuildComplexSumPoints).
         if (settings.Operation is OverlayOperation.ComplexSum or OverlayOperation.ComplexSumLoss)
         {
             return BuildComplexSumPoints(
@@ -2508,21 +2510,26 @@ public sealed class Overlay
         int smoothing,
         bool showLoss = false)
     {
+        // The loss curve is a RATIO of two responses, not a level: it is divided out
+        // of unsmoothed operands and smoothed once, by the measurement pipeline, at
+        // THIS slot's width (see DataHelper.SmoothRatioLevels). Handing that width
+        // down instead of smoothing the returned curve here keeps the plot's own
+        // smoothing out of the slot and avoids a second pass; it also keeps the
+        // psychoacoustic mode's variable bandwidth, which the overlay smoother —
+        // magnitude-only by construction — would flatten to a fixed 1/6 octave.
         OverlayPoint[]? sumPoints = collection.Form.BuildComplexSumOverlayPoints(
             delayMs,
             invertPolarity,
-            showLoss);
+            showLoss,
+            showLoss ? smoothing : null);
         if (sumPoints == null || sumPoints.Length < 2)
         {
             return null;
         }
 
-        // The loss curve is a RATIO of two responses, not a level: the slot's own
-        // smoothing must average its decibels plainly. The psychoacoustic cubic
-        // mean is a magnitude weighting and biases a ratio (see
-        // DataHelper.SmoothRatioLevels).
-        OverlayPoint[] smoothed = OverlayMath.SmoothByOctaves(
-            sumPoints, smoothing, psychoacousticMagnitude: !showLoss);
+        OverlayPoint[] smoothed = showLoss
+            ? sumPoints
+            : OverlayMath.SmoothByOctaves(sumPoints, smoothing);
         double offset = (double)offsetControl.Value;
         return smoothed
             .Select(point => new DataPoint(point.X, point.Y + offset))

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -1731,9 +1731,14 @@ internal sealed class PlotModelFactory
     // are perfectly in phase, dropping toward deep cancellation). The magnitude sum ignores
     // delay/polarity, so as those are tuned only the complex sum moves and the gap closes
     // toward 0 as the sources come into phase.
+    // smoothingInverseOctaves is the width the finished gap is smoothed at. It
+    // defaults to the plot's own, which is what the Compare curve wants; an
+    // overlay slot passes ITS width instead, so the slot owns its smoothing
+    // outright rather than inheriting the plot's and adding a second pass.
     internal AnalysisCurve? TryBuildComplexSumLossCurve(
         double compareDelayMs = 0,
-        bool invertComparePolarity = false)
+        bool invertComparePolarity = false,
+        double? smoothingInverseOctaves = null)
     {
         // All three curves are built UNSMOOTHED and the display smoothing applies to
         // the finished gap: a fractional-octave window straddling a steep skirt lifts
@@ -1786,7 +1791,8 @@ internal sealed class PlotModelFactory
                 complexCurve.Points[i].Y - magnitudeSumDb));
         }
 
-        double smoothing = frequencyResponseOptions.SmoothingInverseOctaves;
+        double smoothing = smoothingInverseOctaves
+            ?? frequencyResponseOptions.SmoothingInverseOctaves;
         return new AnalysisCurve(
             "Complex Sum Loss",
             smoothing != 0

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -1656,10 +1656,13 @@ internal sealed class PlotModelFactory
     //
     // compareDelayMs and invertComparePolarity mirror the per-channel delay and
     // polarity switch a DSP would apply to the Compare source, so the predicted sum
-    // can be tuned before touching the hardware.
+    // can be tuned before touching the hardware. options overrides the plot's own
+    // FR options for callers that need a different width (the sum-loss curve builds
+    // its operands unsmoothed).
     internal AnalysisCurve? TryBuildComplexSumCurve(
         double compareDelayMs = 0,
-        bool invertComparePolarity = false)
+        bool invertComparePolarity = false,
+        FrequencyResponseOptions? options = null)
     {
         if (expSweepMeasurement.TransferImpulseResponse is not { Length: > 0 } mainIr)
         {
@@ -1711,10 +1714,11 @@ internal sealed class PlotModelFactory
             length - 1);
         int peakIndex = Math.Min(mainPeak, comparePeak);
 
+        FrequencyResponseOptions curveOptions = options ?? frequencyResponseOptions;
         return DataHelper.GetPrimarySpectrum(
             new ImpulseMeasurementView(sum, peakIndex, expSweepMeasurement.SampleRate),
-            frequencyResponseOptions,
-            GetCalibration(frequencyResponseOptions));
+            curveOptions,
+            GetCalibration(curveOptions));
     }
 
     private static Complex SampleAt(Complex[] source, int index) =>
@@ -1731,7 +1735,14 @@ internal sealed class PlotModelFactory
         double compareDelayMs = 0,
         bool invertComparePolarity = false)
     {
-        if (TryBuildComplexSumCurve(compareDelayMs, invertComparePolarity) is not { } complexCurve)
+        // All three curves are built UNSMOOTHED and the display smoothing applies to
+        // the finished gap: a fractional-octave window straddling a steep skirt lifts
+        // the rolling-off source's level several dB while the flat sum barely moves,
+        // so smoothing the operands first draws summation loss that is not there (see
+        // VirtualCrossoverAnalysis.SumLossCurve).
+        FrequencyResponseOptions rawOptions = frequencyResponseOptions.WithSmoothing(0);
+        if (TryBuildComplexSumCurve(compareDelayMs, invertComparePolarity, rawOptions)
+            is not { } complexCurve)
         {
             return null;
         }
@@ -1751,15 +1762,15 @@ internal sealed class PlotModelFactory
                 mainIr,
                 Math.Clamp(expSweepMeasurement.TransferPeakIndex, 0, mainIr.Length - 1),
                 expSweepMeasurement.SampleRate),
-            frequencyResponseOptions,
-            GetCalibration(frequencyResponseOptions));
+            rawOptions,
+            GetCalibration(rawOptions));
         AnalysisCurve compareMagnitude = DataHelper.GetPrimarySpectrum(
             new ImpulseMeasurementView(
                 compareIr,
                 Math.Clamp(compare.TransferPeakIndex, 0, compareIr.Length - 1),
                 compare.SampleRate),
-            frequencyResponseOptions,
-            GetCalibration(frequencyResponseOptions));
+            rawOptions,
+            GetCalibration(rawOptions));
 
         int count = Math.Min(
             complexCurve.Points.Count,
@@ -1775,7 +1786,15 @@ internal sealed class PlotModelFactory
                 complexCurve.Points[i].Y - magnitudeSumDb));
         }
 
-        return new AnalysisCurve("Complex Sum Loss", points);
+        double smoothing = frequencyResponseOptions.SmoothingInverseOctaves;
+        return new AnalysisCurve(
+            "Complex Sum Loss",
+            smoothing != 0
+                ? DataHelper.SmoothRatioLevels(
+                    points,
+                    SpectrumSmoothing.SmoothingOctaves(smoothing),
+                    SpectrumSmoothing.IsPsychoacoustic(smoothing))
+                : points);
     }
 
     // A harmonic order the user asked for can be missing from the plot: its packet

--- a/source/Shell/Form1.Compare.cs
+++ b/source/Shell/Form1.Compare.cs
@@ -144,14 +144,18 @@ public partial class Form1
     // polarity flip apply to the Compare response, mirroring a DSP channel setup.
     // When showLoss is set, returns the signed dB gap of the complex sum relative to the
     // magnitude sum (<= 0: how much the real phase-aware sum falls short of the phase-blind
-    // addition) instead of the sum itself.
+    // addition) instead of the sum itself, smoothed at lossSmoothingInverseOctaves — the
+    // asking slot's own width, applied to the finished ratio, so the loss overlay neither
+    // inherits the plot's smoothing nor takes a second pass on top of it.
     internal OverlayPoint[]? BuildComplexSumOverlayPoints(
         double compareDelayMs,
         bool invertComparePolarity,
-        bool showLoss = false)
+        bool showLoss = false,
+        double? lossSmoothingInverseOctaves = null)
     {
         Resonalyze.Dsp.AnalysisCurve? curve = showLoss
-            ? plotModelFactory.TryBuildComplexSumLossCurve(compareDelayMs, invertComparePolarity)
+            ? plotModelFactory.TryBuildComplexSumLossCurve(
+                compareDelayMs, invertComparePolarity, lossSmoothingInverseOctaves)
             : plotModelFactory.TryBuildComplexSumCurve(compareDelayMs, invertComparePolarity);
         return curve?.Points
             .Select(point => new OverlayPoint(point.X, point.Y))

--- a/source/Tools/VirtualCrossover/ProcessedChannel.cs
+++ b/source/Tools/VirtualCrossover/ProcessedChannel.cs
@@ -16,6 +16,17 @@ internal sealed record ProcessedChannel(
     OxyColor Color);
 
 /// <summary>
+/// One gated magnitude curve at the two widths the tool needs, from a single gate
+/// and FFT. <see cref="Display"/> carries the chosen smoothing and is what the plot
+/// draws; <see cref="Unsmoothed"/> is what the summation loss is divided out of,
+/// because smoothing the operands before the division inflates a steep crossover
+/// skirt far more than the (flat) sum and invents a dip at every corner — see
+/// <see cref="VirtualCrossoverAnalysis.SumLossCurve"/>. The two are the same
+/// instance when no smoothing is selected.
+/// </summary>
+internal sealed record GatedMagnitude(AnalysisCurve Display, AnalysisCurve Unsmoothed);
+
+/// <summary>
 /// One side of the car summed: the complex sum of its participating channels'
 /// processed responses, the earliest arrival among them (the window anchor every
 /// curve built from this sum must share) and the project rate they were measured

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -15,26 +15,30 @@ namespace Resonalyze;
 internal sealed class VirtualCrossoverMetrics
 {
     private readonly VirtualCrossoverProcessingCoordinator coordinator;
-    private readonly Func<Complex[], int, int, AnalysisCurve> buildMagnitudeCurve;
+    private readonly Func<Complex[], int, int, GatedMagnitude> buildMagnitudeCurve;
 
     public VirtualCrossoverMetrics(
         VirtualCrossoverProcessingCoordinator coordinator,
-        Func<Complex[], int, int, AnalysisCurve> buildMagnitudeCurve)
+        Func<Complex[], int, int, GatedMagnitude> buildMagnitudeCurve)
     {
         this.coordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
         this.buildMagnitudeCurve = buildMagnitudeCurve
             ?? throw new ArgumentNullException(nameof(buildMagnitudeCurve));
     }
 
-    // The magnitude curves and complex sum the metric reads, built the same way
-    // for the on-screen redraw and for a synchronous read (e.g. the Auto delay
-    // log) so the two never disagree. Fewer than two channels yield no metric.
-    public (List<AnalysisCurve>? Magnitudes, AnalysisCurve? Sum) BuildCurves(
-        List<ProcessedChannel> processed)
+    // The magnitude curves, complex sum and summation loss the metric reads,
+    // built the same way for the on-screen redraw and for a synchronous read
+    // (e.g. the Auto delay log) so the two never disagree. The drawn magnitudes
+    // carry the display smoothing; the loss is divided out of the UNSMOOTHED
+    // pair and smoothed afterwards (see VirtualCrossoverAnalysis.SumLossCurve),
+    // which is why the builder hands back both widths.
+    // Fewer than two channels yield no metric.
+    public (List<AnalysisCurve>? Magnitudes, AnalysisCurve? Sum, List<SignalPoint>? Loss)
+        BuildCurves(List<ProcessedChannel> processed, int smoothingInverseOctaves)
     {
         if (processed.Count < 2)
         {
-            return (null, null);
+            return (null, null, null);
         }
 
         // Every curve — the channels AND the sum — shares one window anchor
@@ -49,11 +53,11 @@ internal sealed class VirtualCrossoverMetrics
         // FDW would need per-channel windows here, exactly what the shared
         // window exists to prevent — so FDW shapes the phase view only.)
         int anchor = processed.Min(item => item.PeakIndex);
-        // One gated build + resample per channel; the panel's magnitude builder
-        // reads only its immutable UI-thread snapshots and the calibration, so
-        // the channels' spectra compute across cores. AsOrdered keeps the
-        // result aligned with the channel list.
-        List<AnalysisCurve> magnitudes = processed
+        // One gated build per channel, resampled at both widths; the panel's
+        // magnitude builder reads only its immutable UI-thread snapshots and the
+        // calibration, so the channels' spectra compute across cores. AsOrdered
+        // keeps the result aligned with the channel list.
+        List<GatedMagnitude> magnitudes = processed
             .AsParallel()
             .AsOrdered()
             .Select(item => buildMagnitudeCurve(
@@ -61,28 +65,34 @@ internal sealed class VirtualCrossoverMetrics
             .ToList();
         Complex[] sum = VirtualCrossoverAnalysis.SumImpulseResponses(
             processed.Select(item => item.ImpulseResponse).ToList());
-        AnalysisCurve sumCurve = buildMagnitudeCurve(
+        GatedMagnitude sumCurve = buildMagnitudeCurve(
             sum, anchor, processed[0].Channel.SampleRate);
-        return (magnitudes, sumCurve);
+        List<SignalPoint> loss = VirtualCrossoverAnalysis.SumLossCurve(
+            sumCurve.Unsmoothed.Points,
+            magnitudes
+                .Select(curve => (IReadOnlyList<SignalPoint>)curve.Unsmoothed.Points)
+                .ToList(),
+            smoothingInverseOctaves);
+        return (
+            magnitudes.Select(curve => curve.Display).ToList(),
+            sumCurve.Display,
+            loss);
     }
 
     // Builds the sum-loss read-outs for a processed set without touching any
     // control, so they can feed the label, its tooltip, and the Auto delay log
-    // from one computation. Empty when there is no metric (fewer than two channels).
+    // from one computation. Reads the very curve the plot draws, so the label
+    // and the trace can never quote different numbers. Empty when there is no
+    // metric (fewer than two channels).
     public List<VirtualCrossoverMetric.Entry> BuildEntries(
         List<ProcessedChannel> processed,
-        List<AnalysisCurve>? magnitudes,
-        AnalysisCurve? sumCurve)
+        List<SignalPoint>? lossCurve)
     {
         var entries = new List<VirtualCrossoverMetric.Entry>();
-        if (magnitudes == null || sumCurve == null)
+        if (lossCurve == null)
         {
             return entries;
         }
-
-        List<IReadOnlyList<SignalPoint>> channelPoints = magnitudes
-            .Select(curve => (IReadOnlyList<SignalPoint>)curve.Points)
-            .ToList();
 
         // Per-junction read-outs first, so an improvement at one crossover is
         // not averaged away by the other. Each junction reads the full sum
@@ -92,9 +102,9 @@ internal sealed class VirtualCrossoverMetrics
             ProcessedChannels.OrderByBand(processed)))
         {
             double? pairLoss = VirtualCrossoverAnalysis.AverageSumLossDb(
-                sumCurve.Points, channelPoints, pair.BandLowHz, pair.BandHighHz);
+                lossCurve, pair.BandLowHz, pair.BandHighHz);
             double? pairDip = VirtualCrossoverAnalysis.MinimumSumLossDb(
-                sumCurve.Points, channelPoints, pair.BandLowHz, pair.BandHighHz);
+                lossCurve, pair.BandLowHz, pair.BandHighHz);
             if (pairLoss.HasValue)
             {
                 entries.Add(new VirtualCrossoverMetric.Entry(
@@ -110,9 +120,9 @@ internal sealed class VirtualCrossoverMetrics
 
         (double minHz, double maxHz) = ProcessedChannels.GetCrossoverWindow(processed);
         double? loss = VirtualCrossoverAnalysis.AverageSumLossDb(
-            sumCurve.Points, channelPoints, minHz, maxHz);
+            lossCurve, minHz, maxHz);
         double? dip = VirtualCrossoverAnalysis.MinimumSumLossDb(
-            sumCurve.Points, channelPoints, minHz, maxHz);
+            lossCurve, minHz, maxHz);
         if (loss.HasValue)
         {
             entries.Add(new VirtualCrossoverMetric.Entry(

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -2013,14 +2013,16 @@ public partial class VirtualCrossoverPanel : UserControl
         using var _ = AppProfiler.Zone("VirtualDSP.RedrawMainPlot");
         List<AnalysisCurve>? magnitudes;
         AnalysisCurve? sumCurve;
+        List<SignalPoint>? lossCurve;
         using (AppProfiler.Zone("VirtualDSP.BuildCurves"))
         {
-            (magnitudes, sumCurve) = metrics.BuildCurves(processed);
+            (magnitudes, sumCurve, lossCurve) = metrics.BuildCurves(
+                processed, magnitudeGate.SmoothingInverseOctaves);
         }
 
         using (AppProfiler.Zone("VirtualDSP.UpdateMetric"))
         {
-            UpdateMetric(processed, magnitudes, sumCurve, stereoDeltas);
+            UpdateMetric(processed, lossCurve, stereoDeltas);
         }
 
         using (AppProfiler.Zone("VirtualDSP.UpdateCrossoverWarning"))
@@ -2034,7 +2036,8 @@ public partial class VirtualCrossoverPanel : UserControl
         AcousticRender acousticRender;
         using (AppProfiler.Zone("VirtualDSP.BuildAcousticRender"))
         {
-            acousticRender = BuildAcousticRender(processed, magnitudes, sumCurve, oppositeSum);
+            acousticRender = BuildAcousticRender(
+                processed, magnitudes, sumCurve, lossCurve, oppositeSum);
         }
 
         using (AppProfiler.Zone("VirtualDSP.AcousticPlotDraw"))
@@ -2051,6 +2054,7 @@ public partial class VirtualCrossoverPanel : UserControl
         List<ProcessedChannel> processed,
         List<AnalysisCurve>? magnitudes,
         AnalysisCurve? sumCurve,
+        List<SignalPoint>? lossCurve,
         AnalysisCurve? oppositeSum)
     {
         string hint = loadingProject
@@ -2070,13 +2074,16 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         return new AcousticRender(
-            hint, BuildMagnitudeCurves(processed, magnitudes, sumCurve, oppositeSum), null);
+            hint,
+            BuildMagnitudeCurves(processed, magnitudes, sumCurve, lossCurve, oppositeSum),
+            null);
     }
 
     private List<AcousticCurve> BuildMagnitudeCurves(
         List<ProcessedChannel> processed,
         List<AnalysisCurve>? magnitudes,
         AnalysisCurve? sumCurve,
+        List<SignalPoint>? lossCurve,
         AnalysisCurve? oppositeSumCurve)
     {
         // The processed curves arrive prebuilt from BuildCurves, but a shown RAW
@@ -2105,7 +2112,9 @@ public partial class VirtualCrossoverPanel : UserControl
                 AnalysisCurve curve = magnitudes != null
                     ? magnitudes[i]
                     : BuildMagnitudeCurve(
-                        item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate);
+                        item.ImpulseResponse,
+                        item.PeakIndex,
+                        item.Channel.SampleRate).Display;
                 curves.Add(new AcousticCurve(
                     item.Channel.Name, curve.Points, item.Color, 1.8, LineStyle.Solid));
             }
@@ -2133,17 +2142,16 @@ public partial class VirtualCrossoverPanel : UserControl
             }
         }
 
-        if (checkBoxShowLoss.Checked)
+        if (checkBoxShowLoss.Checked && lossCurve != null)
         {
             // The signed dB gap between the complex sum and the phase-blind
             // magnitude sum of the processed channels (<= 0 by the triangle
-            // inequality); shares the one SumLossCurve definition with the metric,
-            // so the drawn curve and the measured loss cannot drift apart.
-            List<SignalPoint> points = VirtualCrossoverAnalysis.SumLossCurve(
-                sumCurve.Points,
-                magnitudes.Select(curve => curve.Points).ToList());
+            // inequality), built once in BuildCurves out of the UNSMOOTHED
+            // magnitudes and smoothed as a ratio afterwards — the very list the
+            // read-out averages, so the drawn curve and the measured loss cannot
+            // drift apart.
             curves.Add(new AcousticCurve(
-                "Sum loss", points, LossColor, 1.8, LineStyle.Dash));
+                "Sum loss", lossCurve, LossColor, 1.8, LineStyle.Dash));
         }
 
         return curves;
@@ -2153,8 +2161,7 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private void UpdateMetric(
         List<ProcessedChannel> processed,
-        List<AnalysisCurve>? magnitudes,
-        AnalysisCurve? sumCurve,
+        List<SignalPoint>? lossCurve,
         IReadOnlyList<VirtualCrossoverMetric.StereoDelta>? stereoDeltas = null)
     {
         // The read-out lives in the host's right-side panel (where overlays sit in
@@ -2166,7 +2173,7 @@ public partial class VirtualCrossoverPanel : UserControl
         List<VirtualCrossoverMetric.Entry> entries;
         using (AppProfiler.Zone("VirtualDSP.BuildEntries"))
         {
-            entries = metrics.BuildEntries(processed, magnitudes, sumCurve);
+            entries = metrics.BuildEntries(processed, lossCurve);
         }
 
         // The junction phase block is informative only: it renders alongside
@@ -2666,12 +2673,12 @@ public partial class VirtualCrossoverPanel : UserControl
         bool metricSideRight = project.ActiveSideRight;
         ProcessedRender? render = await ProcessChannelsAsync();
         List<ProcessedChannel> outcomeChannels = render?.Channels ?? [];
-        (List<AnalysisCurve>? outcomeMagnitudes, AnalysisCurve? outcomeSum) =
-            metrics.BuildCurves(outcomeChannels);
+        (_, _, List<SignalPoint>? outcomeLoss) =
+            metrics.BuildCurves(outcomeChannels, magnitudeGate.SmoothingInverseOctaves);
         result.Log.AppendLine(
             $"Metric ({(metricSideRight ? "R" : "L")} side):");
         result.Log.AppendLine(VirtualCrossoverMetric.FormatDetail(
-            metrics.BuildEntries(outcomeChannels, outcomeMagnitudes, outcomeSum)));
+            metrics.BuildEntries(outcomeChannels, outcomeLoss)));
         WriteAlignmentLog(result.Log.ToString());
     }
 
@@ -3218,7 +3225,7 @@ public partial class VirtualCrossoverPanel : UserControl
     // sum-loss under its 0 dB ceiling; see VirtualCrossoverMetrics.BuildCurves)
     // and the raw curve's own peak. Runs on PLINQ worker threads: reads only
     // the immutable snapshot RequestRedraw refreshed.
-    private AnalysisCurve BuildMagnitudeCurve(
+    private GatedMagnitude BuildMagnitudeCurve(
         Complex[] impulseResponse,
         int peakIndex,
         int sampleRate)
@@ -3244,7 +3251,7 @@ public partial class VirtualCrossoverPanel : UserControl
             side.AnchorIndex,
             side.SampleRate,
             snapshot.ResolveGateOffsetMs(
-                oppositeSide: true, side.AnchorIndex, side.SampleRate));
+                oppositeSide: true, side.AnchorIndex, side.SampleRate)).Display;
     }
 
     // A RAW channel curve lives in its own time: its arrival predates the
@@ -3261,10 +3268,13 @@ public partial class VirtualCrossoverPanel : UserControl
             impulseResponse,
             peakIndex,
             sampleRate,
-            peakIndex * 1_000.0 / sampleRate);
+            peakIndex * 1_000.0 / sampleRate).Display;
     }
 
-    private AnalysisCurve BuildGatedMagnitudeCurve(
+    // Both widths of one gated build: the smoothed curve the plot draws and the
+    // unsmoothed one the summation loss divides (see GatedMagnitude). One gate,
+    // one FFT, two resamples — the second resample is the cheap half.
+    private GatedMagnitude BuildGatedMagnitudeCurve(
         MagnitudeGateSnapshot snapshot,
         Complex[] impulseResponse,
         int peakIndex,
@@ -3275,11 +3285,13 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             GateOffsetMs = gateOffsetMs
         };
-        return DataHelper.GetGatedPrimarySpectrum(
-            new ImpulseMeasurementView(impulseResponse, peakIndex, sampleRate),
-            gate,
-            Calibration,
-            snapshot.SmoothingInverseOctaves);
+        (AnalysisCurve display, AnalysisCurve unsmoothed) =
+            DataHelper.GetGatedPrimarySpectrumPair(
+                new ImpulseMeasurementView(impulseResponse, peakIndex, sampleRate),
+                gate,
+                Calibration,
+                snapshot.SmoothingInverseOctaves);
+        return new GatedMagnitude(display, unsmoothed);
     }
 
     private List<AcousticCurve> BuildPhaseCurves(List<ProcessedChannel> processed)
@@ -3926,7 +3938,7 @@ public partial class VirtualCrossoverPanel : UserControl
         AnalysisCurve sumCurve = BuildMagnitudeCurve(
             sum,
             processed.Min(item => item.PeakIndex),
-            processed[0].Channel.SampleRate);
+            processed[0].Channel.SampleRate).Display;
 
         string title = "vDSP Sum " + string.Join(
             "+",
@@ -3979,10 +3991,10 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
         List<ProcessedChannel> metricChannels = render.Channels;
-        (List<AnalysisCurve>? metricMagnitudes, AnalysisCurve? metricSum) =
-            metrics.BuildCurves(metricChannels);
+        (_, _, List<SignalPoint>? metricLoss) =
+            metrics.BuildCurves(metricChannels, magnitudeGate.SmoothingInverseOctaves);
         string metricLine = VirtualCrossoverMetric.FormatLabel(
-            metrics.BuildEntries(metricChannels, metricMagnitudes, metricSum));
+            metrics.BuildEntries(metricChannels, metricLoss));
         // The sheet prints BOTH sides, so the rate comes from any physically
         // resolved side — reading only the active side through the delegating
         // properties would fall back to 48 kHz when, say, the shown left side

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -805,6 +805,51 @@ public sealed class PlotModelFactoryTests
         Assert.All(loss.Points, point => Assert.True(point.Y < -40.0));
     }
 
+    [Fact]
+    public void ComplexSumLoss_WithAnExplicitWidth_IgnoresThePlotsOwnSmoothing()
+    {
+        // An overlay slot asks for the loss at ITS width. The plot's smoothing must
+        // not reach the curve at all: it neither bakes into the operands (they are
+        // divided unsmoothed) nor smooths the ratio, so switching the plot from
+        // psychoacoustic to 1/6 octave leaves the slot's curve bit-identical — and
+        // a slot set to Off gets a genuinely unsmoothed ratio.
+        using var measurement = CreateTransferMeasurement();
+        using var noiseMeasurement = new NoiseMeasurement(new FakeAudioSessionFactory());
+        var options = new FrequencyResponseOptions
+        {
+            SmoothingInverseOctaves = SpectrumSmoothing.PsychoacousticCode
+        };
+        PlotModelFactory factory = CreateFactory(
+            measurement, noiseMeasurement, frequencyResponseOptions: options);
+        var compareIr = new Complex[2048];
+        compareIr[70] = Complex.One;
+        factory.SetCompareSourceProvider(
+            () => new CompareAnalysisSource("Reference", 44_100, compareIr, 70));
+
+        AnalysisCurve? underPsychoacoustic =
+            factory.TryBuildComplexSumLossCurve(smoothingInverseOctaves: 0);
+        options.SmoothingInverseOctaves = 6;
+        AnalysisCurve? underSixth =
+            factory.TryBuildComplexSumLossCurve(smoothingInverseOctaves: 0);
+
+        Assert.NotNull(underPsychoacoustic);
+        Assert.NotNull(underSixth);
+        Assert.Equal(underPsychoacoustic.Points.Count, underSixth.Points.Count);
+        for (int i = 0; i < underSixth.Points.Count; i++)
+        {
+            Assert.Equal(underPsychoacoustic.Points[i].Y, underSixth.Points[i].Y, 12);
+        }
+
+        // And the width that IS asked for still acts: the same curve smoothed
+        // psychoacoustically differs from the unsmoothed one.
+        AnalysisCurve? smoothed = factory.TryBuildComplexSumLossCurve(
+            smoothingInverseOctaves: SpectrumSmoothing.PsychoacousticCode);
+        Assert.NotNull(smoothed);
+        Assert.Contains(
+            smoothed.Points.Zip(underSixth.Points),
+            pair => Math.Abs(pair.First.Y - pair.Second.Y) > 0.01);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -15,6 +15,7 @@ namespace Resonalyze.App.Tests;
 public sealed class VirtualCrossoverMetricsTests
 {
     private static readonly AnalysisCurve EmptyCurve = new("x", []);
+    private static readonly GatedMagnitude EmptyMagnitude = new(EmptyCurve, EmptyCurve);
 
     private static Complex[] Impulse(int peak = 10)
     {
@@ -43,13 +44,14 @@ public sealed class VirtualCrossoverMetricsTests
     public void BuildCurves_ReturnsNoMetric_ForFewerThanTwoChannels()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
 
-        (List<AnalysisCurve>? magnitudes, AnalysisCurve? sum) =
-            metrics.BuildCurves([Processed("A", Impulse(), 5, 48_000)]);
+        (List<AnalysisCurve>? magnitudes, AnalysisCurve? sum, List<SignalPoint>? loss) =
+            metrics.BuildCurves([Processed("A", Impulse(), 5, 48_000)], 0);
 
         Assert.Null(magnitudes);
         Assert.Null(sum);
+        Assert.Null(loss);
     }
 
     [Fact]
@@ -62,16 +64,17 @@ public sealed class VirtualCrossoverMetricsTests
             (ir, peak, rate) =>
             {
                 captured.Add((ir, peak, rate));
-                return EmptyCurve;
+                return EmptyMagnitude;
             });
         Complex[] a = Impulse(12);
         Complex[] b = Impulse(20);
 
-        (List<AnalysisCurve>? magnitudes, AnalysisCurve? sum) = metrics.BuildCurves(
+        (List<AnalysisCurve>? magnitudes, AnalysisCurve? sum, _) = metrics.BuildCurves(
         [
             Processed("A", a, peak: 5, rate: 48_000),
             Processed("B", b, peak: 2, rate: 48_000)
-        ]);
+        ],
+        0);
 
         Assert.NotNull(magnitudes);
         Assert.Equal(2, magnitudes.Count);
@@ -90,10 +93,10 @@ public sealed class VirtualCrossoverMetricsTests
     public void BuildEntries_IsEmptyWhenThereIsNoMetric()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
 
         Assert.Empty(metrics.BuildEntries(
-            [Processed("A", Impulse(), 5, 48_000)], magnitudes: null, sumCurve: null));
+            [Processed("A", Impulse(), 5, 48_000)], lossCurve: null));
     }
 
     // A channel processed through a real crossover chain, for the junction
@@ -131,7 +134,7 @@ public sealed class VirtualCrossoverMetricsTests
     public void BuildPhaseEntries_IsEmptyForFewerThanTwoChannels()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
 
         Assert.Empty(metrics.BuildPhaseEntries(
             [ProcessedThroughChain("A", CrossoverKind.LowPass, 200)]));
@@ -141,7 +144,7 @@ public sealed class VirtualCrossoverMetricsTests
     public void BuildPhaseEntries_ReadsTheJunctionAndRecoversAMisalignment()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
 
         // Passed upper-first on purpose: the entries must order by band, not by
         // argument order. The upper channel runs 2 ms late, so the read-out
@@ -166,7 +169,7 @@ public sealed class VirtualCrossoverMetricsTests
     public async Task ComputeSideSumAsync_SumsTheParticipatingSides()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
         long revision = coordinator.Invalidate();
 
         VirtualCrossoverSideSum? side = await metrics.ComputeSideSumAsync(
@@ -184,7 +187,7 @@ public sealed class VirtualCrossoverMetricsTests
     public async Task ComputeSideSumAsync_HonorsTheMinimumChannelCount()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
         long revision = coordinator.Invalidate();
 
         // One resolved channel: enough for the audition (minimum 1), not for
@@ -206,7 +209,7 @@ public sealed class VirtualCrossoverMetricsTests
     public async Task ComputeSideSumAsync_MonoChannelContributesToBothSidesAtFullLevel()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
         // A mono channel (a sub) resolved on its single slot: program material
         // routes it into BOTH ears at full level, so both side sums must carry
         // its response unattenuated.
@@ -232,7 +235,7 @@ public sealed class VirtualCrossoverMetricsTests
     public async Task ComputeSideSumAsync_ReturnsNullForAStaleRevision()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
         long revision = coordinator.Invalidate();
         coordinator.Invalidate();
 
@@ -247,7 +250,7 @@ public sealed class VirtualCrossoverMetricsTests
     public async Task ComputeStereoDeltasAsync_SkipsAStereoPairWithOnlyOneSideResolved()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
         long revision = coordinator.Invalidate();
 
         // A stereo pair (not mono) with only the left side resolved is not eligible
@@ -278,7 +281,7 @@ public sealed class VirtualCrossoverMetricsTests
     public async Task ComputeStereoDeltasAsync_ReportsOneDeltaForAResolvedStereoPair()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
         long revision = coordinator.Invalidate();
         var channel = new VirtualCrossoverChannel("A");
         Resolve(channel, rightSide: false);
@@ -323,7 +326,7 @@ public sealed class VirtualCrossoverMetricsTests
         // wavelet — the disagreement IS the latch. The right side has a
         // clean dominant direct and must stay unflagged.
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
         long revision = coordinator.Invalidate();
 
         var latched = new Complex[8_192];
@@ -360,7 +363,7 @@ public sealed class VirtualCrossoverMetricsTests
     public async Task ComputeStereoDeltasAsync_MonoChannelReportsNoRightSide()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
-        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyCurve);
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _) => EmptyMagnitude);
         long revision = coordinator.Invalidate();
         var channel = new VirtualCrossoverChannel("Sub") { Pair = { Mono = true } };
         Resolve(channel, rightSide: false);

--- a/tests/Resonalyze.Dsp.Tests/LogarithmicPowerBandResampleTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/LogarithmicPowerBandResampleTests.cs
@@ -502,6 +502,57 @@ public sealed class LogarithmicPowerBandResampleTests
         Assert.Equal(-6, smoothed[301].Y, 6);
     }
 
+    [Fact]
+    public void SmoothRatioLevels_KeepsThePsychoacousticBandwidth()
+    {
+        // Dropping the cubic weighting must not drop the WIDTH schedule with it: the
+        // psychoacoustic mode is 1/3 octave below 100 Hz, narrowing to its 1/6-octave
+        // base by 1 kHz. A one-point notch therefore smooths away harder than a plain
+        // 1/6 octave does in the bass, and no harder than it in the treble — which is
+        // exactly what a caller that flattened the mode to a fixed 1/6 would lose.
+        List<SignalPoint> WithNotchAt(double frequency)
+        {
+            var curve = new List<SignalPoint>();
+            for (int i = 0; i < 600; i++)
+            {
+                double f = 20 * Math.Pow(2, i / 60.0);
+                curve.Add(new SignalPoint(
+                    f, Math.Abs(Math.Log2(f / frequency)) < 1.0 / 120 ? -12 : 0));
+            }
+
+            return curve;
+        }
+
+        static double DepthAt(List<SignalPoint> curve, double frequency, bool psychoacoustic)
+        {
+            List<SignalPoint> smoothed = DataHelper.SmoothRatioLevels(
+                curve,
+                psychoacoustic
+                    ? SpectrumSmoothing.SmoothingOctaves(SpectrumSmoothing.PsychoacousticCode)
+                    : 1.0 / 6.0,
+                psychoacoustic);
+            return smoothed
+                .Where(point => Math.Abs(Math.Log2(point.X / frequency)) < 1.0 / 120)
+                .Min(point => point.Y);
+        }
+
+        List<SignalPoint> bassNotch = WithNotchAt(50);
+        List<SignalPoint> trebleNotch = WithNotchAt(4_000);
+
+        // 50 Hz: the psychoacoustic window is twice as wide, so the notch is spread
+        // thinner and reads shallower than under a fixed 1/6 octave.
+        Assert.True(
+            DepthAt(bassNotch, 50, psychoacoustic: true) >
+            DepthAt(bassNotch, 50, psychoacoustic: false) + 0.3,
+            "the psychoacoustic mode must smooth wider than 1/6 octave in the bass");
+
+        // 4 kHz: both are 1/6 octave wide, so the two agree within the kernel shape.
+        Assert.Equal(
+            DepthAt(trebleNotch, 4_000, psychoacoustic: false),
+            DepthAt(trebleNotch, 4_000, psychoacoustic: true),
+            1);
+    }
+
     private static float[] CreateSine(int length, int bin)
     {
         var samples = new float[length];

--- a/tests/Resonalyze.Dsp.Tests/LogarithmicPowerBandResampleTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/LogarithmicPowerBandResampleTests.cs
@@ -474,6 +474,34 @@ public sealed class LogarithmicPowerBandResampleTests
         Assert.Equal(80, smoothed[101].Y, 6);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SmoothRatioLevels_AveragesDecibelsWithoutTheMagnitudeBias(bool psychoacoustic)
+    {
+        // A ratio curve is not a level: across a -6 dB step it must read the mean of
+        // DECIBELS, near the -3 dB middle. A power mean of the same window — the
+        // magnitude path — would read about -2.0 dB there, and the cubic peak
+        // weighting higher still. Gaps stay gaps and are excluded from their
+        // neighbours' means.
+        var ratio = new List<SignalPoint>();
+        for (int i = 0; i < 400; i++)
+        {
+            double f = 100 * Math.Pow(2, i / 40.0);
+            ratio.Add(new SignalPoint(f, i == 300 ? double.NaN : i < 200 ? 0 : -6));
+        }
+
+        List<SignalPoint> smoothed =
+            DataHelper.SmoothRatioLevels(ratio, 1.0 / 3.0, psychoacoustic);
+
+        Assert.InRange(smoothed[199].Y, -3.2, -2.4);
+        Assert.Equal(0, smoothed[100].Y, 6);
+        Assert.Equal(-6, smoothed[380].Y, 6);
+        Assert.True(double.IsNaN(smoothed[300].Y));
+        Assert.Equal(-6, smoothed[299].Y, 6);
+        Assert.Equal(-6, smoothed[301].Y, 6);
+    }
+
     private static float[] CreateSine(int length, int bin)
     {
         var samples = new float[length];

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -571,9 +571,13 @@ public sealed class VirtualCrossoverAnalysisTests
         };
 
         double? zeroLoss = VirtualCrossoverAnalysis.AverageSumLossDb(
-            coherentSum, [channel, channel], 100, 10_000);
+            VirtualCrossoverAnalysis.SumLossCurve(coherentSum, [channel, channel]),
+            100,
+            10_000);
         double? loss = VirtualCrossoverAnalysis.AverageSumLossDb(
-            degradedSum, [channel, channel], 100, 10_000);
+            VirtualCrossoverAnalysis.SumLossCurve(degradedSum, [channel, channel]),
+            100,
+            10_000);
 
         Assert.NotNull(zeroLoss);
         Assert.Equal(0.0, zeroLoss.Value, 3);
@@ -596,7 +600,9 @@ public sealed class VirtualCrossoverAnalysisTests
         };
 
         double? dip = VirtualCrossoverAnalysis.MinimumSumLossDb(
-            sum, [channel, channel], 100, 10_000);
+            VirtualCrossoverAnalysis.SumLossCurve(sum, [channel, channel]),
+            100,
+            10_000);
 
         Assert.NotNull(dip);
         Assert.Equal(-12.0, dip.Value, 3);
@@ -609,7 +615,9 @@ public sealed class VirtualCrossoverAnalysisTests
         var sum = new List<SignalPoint> { new(100, -20.0), new(1_000, 6.0206) };
 
         double? loss = VirtualCrossoverAnalysis.AverageSumLossDb(
-            sum, [channel, channel], 500, 2_000);
+            VirtualCrossoverAnalysis.SumLossCurve(sum, [channel, channel]),
+            500,
+            2_000);
 
         Assert.NotNull(loss);
         Assert.Equal(0.0, loss.Value, 3);
@@ -637,6 +645,82 @@ public sealed class VirtualCrossoverAnalysisTests
         Assert.Equal(-6.0206, loss[1].Y, 3);
         Assert.Equal(0.0, loss[2].Y, 3);
     }
+
+    [Fact]
+    public void SumLossCurve_SmoothsTheRatio_NotTheOperands()
+    {
+        // An ideal complementary crossover at 70 Hz: the two amplitudes are in
+        // phase and add to exactly 1 at every frequency, each rolling off at
+        // 48 dB/octave past the corner. The sum is therefore flat 0 dB and the
+        // honest loss is 0 dB everywhere — flat sum, steep operands, which is the
+        // geometry of every real crossover corner. 70 Hz is also where the
+        // psychoacoustic window is at its widest. Any dip here is invented.
+        static double Complementary(double frequency)
+        {
+            double ratio = Math.Pow(frequency / 70.0, 8);
+            return 1.0 / (1.0 + ratio);
+        }
+
+        List<SignalPoint> lowPass = LinearBins(frequency => Math.Max(
+            -120.0, DataHelper.AmplitudeToDecibels(Complementary(frequency))));
+        List<SignalPoint> highPass = LinearBins(frequency => Math.Max(
+            -120.0, DataHelper.AmplitudeToDecibels(1.0 - Complementary(frequency))));
+        List<SignalPoint> together = LinearBins(_ => 0.0);
+
+        double psycho = SpectrumSmoothing.PsychoacousticCode;
+        List<SignalPoint> honest = VirtualCrossoverAnalysis.SumLossCurve(
+            Resample(together, 0),
+            [Resample(lowPass, 0), Resample(highPass, 0)],
+            psycho);
+
+        // Smoothing the finished ratio cannot move a curve that is flat at 0 dB.
+        Assert.All(
+            honest.Where(point => point.X is >= 50 and <= 15_000),
+            point => Assert.Equal(0.0, point.Y, 2));
+
+        // The order the panel used to run — smooth the operands, then divide.
+        // The wide low-frequency window pulls the skirt up toward its own
+        // passband while the flat sum barely moves, and the difference draws a
+        // dip at the corner that no measurement contains.
+        List<SignalPoint> fromSmoothedOperands = VirtualCrossoverAnalysis.SumLossCurve(
+            Resample(together, psycho),
+            [Resample(lowPass, psycho), Resample(highPass, psycho)]);
+
+        double invented = fromSmoothedOperands
+            .Where(point => point.X is >= 50 and <= 100)
+            .Min(point => point.Y);
+        Assert.True(
+            invented < -0.5,
+            $"the operand-first order should invent a dip at the corner: {invented}");
+    }
+
+    // A 2 Hz linear grid standing in for the FFT bins the display resamples.
+    private static List<SignalPoint> LinearBins(Func<double, double> decibelsAt)
+    {
+        var bins = new List<SignalPoint>(10_000);
+        for (int i = 1; i <= 10_000; i++)
+        {
+            double frequency = i * 2.0;
+            bins.Add(new SignalPoint(frequency, decibelsAt(frequency)));
+        }
+
+        return bins;
+    }
+
+    private static double At(List<SignalPoint> bins, double frequency) =>
+        bins[Math.Clamp((int)Math.Round(frequency / 2.0) - 1, 0, bins.Count - 1)].Y;
+
+    private static List<SignalPoint> Resample(
+        List<SignalPoint> bins,
+        double smoothingInverseOctaves) =>
+        DataHelper.LogarithmicResample(
+            bins,
+            20,
+            20_000,
+            1024,
+            null,
+            SpectrumSmoothing.SmoothingOctaves(smoothingInverseOctaves),
+            psychoacoustic: SpectrumSmoothing.IsPsychoacoustic(smoothingInverseOctaves));
 
     [Fact]
     public void SumLossCurve_TruncatesToTheShortestGrid()
@@ -676,8 +760,7 @@ public sealed class VirtualCrossoverAnalysisTests
         // 6 kHz is quiet in absolute terms, but no louder neighbor sits within an
         // octave (nearest is 1.5 kHz, further down and quieter), so it is kept.
         Assert.Equal(0.0, loss[3].Y, 3);
-        double? dip = VirtualCrossoverAnalysis.MinimumSumLossDb(
-            sum, [channel], 20, 8_000);
+        double? dip = VirtualCrossoverAnalysis.MinimumSumLossDb(loss, 20, 8_000);
         Assert.NotNull(dip);
         Assert.Equal(0.0, dip.Value, 3);
     }


### PR DESCRIPTION
The Virtual DSP "Sum loss" curve drew dips at 75 Hz and 170 Hz in the
psychoacoustic mode that the unsmoothed curve does not contain. Both sat on
crossover corners (70 Hz sub/bass, 180 Hz bass/mid), and the 75 Hz one is
entirely manufactured: the same session measures −0.19 dB of true loss there.

## Why

The loss is `20log10(|ΣH|) − 20log10(Σ|H|)`, and both operands were display-
smoothed before the subtraction. That does not commute. A fractional-octave
window straddling a steep skirt pulls the rolling-off channel up toward its own
passband — several dB on a 36 dB/octave slope, and more again under the
psychoacoustic mode's peak-weighted cubic mean — while the flat sum barely
moves. Measured on the same session, at the 70 Hz corner the bass channel reads
−21.6 dB unsmoothed and −16.4 dB smoothed (+5.2 dB) against +1.1 dB for the sum,
so `Σ|H|` inflates faster than `|ΣH|` and the difference is drawn as a dip.

The plain 1/N modes hide it in the bass only because their window clamps to the
two-bin minimum down there and effectively does nothing; the psychoacoustic mode
is 1/3 octave below 100 Hz, which is where the artifact appears.

## What changed

- `SumLossCurve` takes the smoothing width and applies it to the finished ratio;
  its operands must now be unsmoothed, and the doc says why.
- New `DataHelper.SmoothRatioLevels`: a plain arithmetic mean of decibels on the
  display grid (box for a fixed width, Gaussian for the psychoacoustic one). The
  psychoacoustic mode keeps its frequency-dependent WIDTH and loses only the
  cubic magnitude weighting, which biases a ratio. Non-finite points stay gaps
  and are excluded from their neighbours' means.
- `AverageSumLossDb` / `MinimumSumLossDb` read a curve that was already built
  instead of deriving their own, so the read-out and the drawn trace are the
  same numbers by construction, smoothing included.
- `GetGatedPrimarySpectrumPair` returns the display and unsmoothed curves from
  one gate and one FFT (the same instance when smoothing is off), so the honest
  order costs one extra resample per curve, not a second gated FFT.
- Same defect, same fix in the Compare view's `Complex Sum Loss` and in the
  overlay slot that stores it.

## Effect on the reported session (psychoacoustic mode)

| f, Hz | before | after | unsmoothed |
|---|---|---|---|
| 75 | −1.63 | **−0.22** | −0.19 |
| 170 | −2.16 | **−0.73** | −1.25 |
| 180 | −1.60 | −0.74 | −0.27 |
| 1500 | −1.51 | −0.80 | −0.01 |

Per-junction read-outs: sub/bass avg −0.70 → −0.24, dip −1.63 → −0.67;
bass/mid avg −0.83 → −0.46, dip −2.19 → −0.74. The real 170 Hz cancellation
survives, widened and shallowed by the smoothing as a narrow notch should be;
the invented corner dips are gone. The smoothing selector no longer moves the
measured loss by half a dB, so it can no longer disagree with Auto delay's own
prediction, which is computed on a fixed internal grid.

## Tests

- `SumLossCurve_SmoothsTheRatio_NotTheOperands` — an ideal complementary 70 Hz /
  48 dB/octave crossover, in phase, whose sum is flat 0 dB: the honest answer is
  0 dB at every frequency. The shipped order returns it; the operand-first order
  invents a −0.87 dB dip at the corner, so the test fails on the old code.
- `SmoothRatioLevels_AveragesDecibelsWithoutTheMagnitudeBias` — a −6 dB step
  smooths toward the arithmetic middle (a power mean would read ≈ −2.0 dB), and
  gaps neither spread nor fill.
- Full solution suite green (2079 tests).

Verified end to end against the reporting session's own measurements through a
scratchpad harness that replays the panel's pipeline (chain application, shared
anchor, 5/50/20 ms fixed gate) on the four left-side channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
