### PR TITLE
Anchor junction measurements on the system, not the pair

### DIFF
--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -354,11 +354,22 @@ public static class AutoAlignmentEngine
 
     /// <summary>
     /// The sample every junction measurement of a run anchors its direct-sound
-    /// gate on: the earliest peak across ALL the run's channels — the whole
-    /// system's first arrival, the same anchor the metric read-out uses. Taken
-    /// over a snapshot set rendered in one frame, so every junction of a run is
-    /// judged through the same window and the search cannot rank alignments
-    /// differently from the panel that displays them.
+    /// gate on: the earliest peak across ALL the run's channels, rendered in
+    /// one frame. Two properties matter and neither is the pair's own peak.
+    ///
+    /// It is EARLY — no channel's own rise can fall inside the window's
+    /// fade-in, which is what made a pair-anchored window misjudge a slow
+    /// channel's phase (see the gate remarks in VirtualCrossoverAnalysis).
+    ///
+    /// It is SHARED — one window for every junction, side and probe of a run,
+    /// so candidates, co-move cells and cross-side comparisons are all
+    /// measured through the same one. This is the same PLACEMENT RULE the
+    /// metric read-out follows (VirtualCrossoverMetrics.BuildCurves anchors on
+    /// its channel set's earliest peak), not the same sample: the read-out
+    /// runs on the applied delays and on the displayed side alone, so its
+    /// anchor lands wherever those put it. Matching it exactly is not the
+    /// goal and is not achievable mid-cascade — being early enough for every
+    /// channel, and the same for every comparison, is.
     /// </summary>
     private static int SystemGateAnchor(IEnumerable<AlignmentSnapshot> scope) =>
         scope.Min(item => item.PeakIndex);
@@ -1208,29 +1219,35 @@ public static class AutoAlignmentEngine
                     : 0;
             }
 
-            // Only where the anchor is still the RAW read and the disagreement
-            // is real. A pair the prediction already convicted upstream carries
-            // its replacement anchor and a stand-in disagreement figure (twice
-            // the allowance, not a measurement), and a disagreement inside the
-            // predictor's own accuracy floor is estimator noise — convicting on
-            // either would lift the seed-reach veto at junctions that never
-            // asked for it, on numbers that say nothing.
+            // Only on MEASURED lobe geometry, only where the anchor is still
+            // the RAW read, and only on a disagreement the predictor can call
+            // real:
+            //  - no separated opposite-sign structure in the window (or an
+            //    edge-pinned one) means the spacing this conviction reasons
+            //    from was never measured, and absence of evidence may not
+            //    license re-anchoring plus the lifting of the seed-reach veto.
+            //    Those junctions keep the conservative path: the reach rule
+            //    below already refuses an extremum there, since a zero
+            //    boundary floors its reach at zero;
+            //  - a pair the prediction already convicted upstream carries its
+            //    replacement anchor and a stand-in disagreement figure (twice
+            //    the allowance, not a measurement);
+            //  - a disagreement inside the predictor's own accuracy floor is
+            //    estimator noise.
             if (!arrivalReanchored && pairPredictionGradeable &&
                 !lowerLatchedByPrediction && !upperLatchedByPrediction &&
                 predictionDisagreementMs >= PredictedArrivalAccuracyMs)
             {
                 double boundaryMs = LobeBoundaryMs(phat);
-                if (!(boundaryMs > 0) || predictionDisagreementMs >= boundaryMs)
+                if (boundaryMs > 0 && predictionDisagreementMs >= boundaryMs)
                 {
                     log.AppendLine(
                         $"  {pair.Lower.Channel.Name}/{pair.Upper.Channel.Name}: " +
                         $"the arrival anchor disagrees with the predicted fronts " +
                         $"by {predictionDisagreementMs:0.000} ms against a " +
-                        (boundaryMs > 0
-                            ? $"{boundaryMs:0.000} ms lobe boundary"
-                            : "lobe boundary the correlation does not show") +
-                        $" — it cannot place the junction inside a lobe, so both " +
-                        $"sides re-anchor on their predicted fronts " +
+                        $"{boundaryMs:0.000} ms lobe boundary — it cannot place " +
+                        $"the junction inside a lobe, so both sides re-anchor on " +
+                        $"their predicted fronts " +
                         $"({lowerArrival:0.000}/{upperArrival:0.000} -> " +
                         $"{lowerPrediction:0.000}/{upperPrediction:0.000} ms)");
                     lowerArrival = lowerPrediction;
@@ -3361,6 +3378,13 @@ public static class AutoAlignmentEngine
             IReadOnlyList<AlignmentSnapshot> current = reprocess(alignment);
             Complex[] IrOf(IAlignmentChannel channel) =>
                 current.First(item => item.Channel == channel).ImpulseResponse;
+            // The same window the searches were decided through. Without it
+            // this pass would re-judge settled pairs on a pair-anchored
+            // surface — the very measurement the cascade stopped using — and
+            // it moves channels for as little as the co-move threshold, so a
+            // fraction-of-a-dB difference between the two windows is exactly
+            // the size of change it can make.
+            int gateAnchor = SystemGateAnchor(current);
 
             // One evaluator per junction: the pair member is the rotated
             // (moving) channel, its junction neighbor stays fixed. A junction
@@ -3385,7 +3409,8 @@ public static class AutoAlignmentEngine
                         junction.BandLowHz,
                         junction.BandHighHz,
                         levelMatch: true,
-                        requireDelayEvidence: true);
+                        requireDelayEvidence: true,
+                        gateAnchor);
                 if (evaluator != null)
                 {
                     evaluators.Add(evaluator);

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -353,6 +353,17 @@ public static class AutoAlignmentEngine
     private const double OnsetLockMaxSpreadPeriods = 0.5;
 
     /// <summary>
+    /// The sample every junction measurement of a run anchors its direct-sound
+    /// gate on: the earliest peak across ALL the run's channels — the whole
+    /// system's first arrival, the same anchor the metric read-out uses. Taken
+    /// over a snapshot set rendered in one frame, so every junction of a run is
+    /// judged through the same window and the search cannot rank alignments
+    /// differently from the panel that displays them.
+    /// </summary>
+    private static int SystemGateAnchor(IEnumerable<AlignmentSnapshot> scope) =>
+        scope.Min(item => item.PeakIndex);
+
+    /// <summary>
     /// The minimum envelope peak-to-noise grade (dB) both channels' onset
     /// estimates must carry before the lock trusts them. The spread gate alone
     /// cannot refuse a noise-only record: random crossings can look stable
@@ -1157,7 +1168,7 @@ public static class AutoAlignmentEngine
             // the delay to add to the upper channel, i.e. that quantity negated.
             double passOctaves = Math.Log2(pair.BandHighHz / pair.BandLowHz);
             double centerLagMs = lowerArrival - upperArrival;
-            CorrelationAlignmentResult phat =
+            CorrelationAlignmentResult Correlate(double centerMs) =>
                 VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
                     pair.Lower.ImpulseResponse,
                     pair.Upper.ImpulseResponse,
@@ -1165,8 +1176,75 @@ public static class AutoAlignmentEngine
                     pair.CrossoverHz,
                     passOctaves,
                     SeedCorrelationRangeMs(pair.CrossoverHz),
-                    centerLagMs,
+                    centerMs,
                     phaseTransform: true);
+            CorrelationAlignmentResult phat = Correlate(centerLagMs);
+
+            // The lobe-boundary conviction. Where the pair anchor disagrees
+            // with its own predicted fronts by more than the measured half
+            // lobe spacing, it cannot say WHICH lobe the junction sits on —
+            // and an anchor that cannot resolve lobes must not be the thing
+            // that resolves this one. It used to only VETO the extremum here
+            // and then seed the timeline from that same anchor, prior and
+            // all: the field case that exposed the asymmetry (a 55 Hz sub
+            // junction whose envelope read sat 8.7 ms past its predicted
+            // front, 0.96 of an allowance — under every conviction bar,
+            // because the allowance IS half a period at fc and therefore
+            // cannot be tighter than the lobe spacing it would have to
+            // resolve) parked the whole stack a half period late while a
+            // whitened extremum at r 0.99 stood refused. So convict the
+            // anchor instead: move both sides to their predicted fronts, like
+            // the upper-half probe's conviction does, re-center the
+            // correlation on the corrected lag, and let the extremum be
+            // judged on its own quality below.
+            double LobeBoundaryMs(CorrelationAlignmentResult result)
+            {
+                CorrelationDelayCandidate best = result.BestByMagnitude;
+                CorrelationDelayCandidate? adjacent = best.InvertPolarity
+                    ? result.NegativeOppositeNeighbor
+                    : result.PositiveOppositeNeighbor;
+                return adjacent is { EdgePinned: false } neighbour
+                    ? Math.Abs(neighbour.DelayMs - best.DelayMs) / 2.0
+                    : 0;
+            }
+
+            // Only where the anchor is still the RAW read and the disagreement
+            // is real. A pair the prediction already convicted upstream carries
+            // its replacement anchor and a stand-in disagreement figure (twice
+            // the allowance, not a measurement), and a disagreement inside the
+            // predictor's own accuracy floor is estimator noise — convicting on
+            // either would lift the seed-reach veto at junctions that never
+            // asked for it, on numbers that say nothing.
+            if (!arrivalReanchored && pairPredictionGradeable &&
+                !lowerLatchedByPrediction && !upperLatchedByPrediction &&
+                predictionDisagreementMs >= PredictedArrivalAccuracyMs)
+            {
+                double boundaryMs = LobeBoundaryMs(phat);
+                if (!(boundaryMs > 0) || predictionDisagreementMs >= boundaryMs)
+                {
+                    log.AppendLine(
+                        $"  {pair.Lower.Channel.Name}/{pair.Upper.Channel.Name}: " +
+                        $"the arrival anchor disagrees with the predicted fronts " +
+                        $"by {predictionDisagreementMs:0.000} ms against a " +
+                        (boundaryMs > 0
+                            ? $"{boundaryMs:0.000} ms lobe boundary"
+                            : "lobe boundary the correlation does not show") +
+                        $" — it cannot place the junction inside a lobe, so both " +
+                        $"sides re-anchor on their predicted fronts " +
+                        $"({lowerArrival:0.000}/{upperArrival:0.000} -> " +
+                        $"{lowerPrediction:0.000}/{upperPrediction:0.000} ms)");
+                    lowerArrival = lowerPrediction;
+                    upperArrival = upperPrediction;
+                    arrivalReanchored = true;
+                    centerLagMs = lowerArrival - upperArrival;
+                    // Re-centered ONCE, never iterated: the window is period-wide
+                    // and the corrected lag is where the extremum should be read
+                    // from, but a second conviction pass off the new reading would
+                    // be a loop with no fixed point.
+                    phat = Correlate(centerLagMs);
+                }
+            }
+
             CorrelationDelayCandidate seed = phat.BestByMagnitude;
             CorrelationDelayCandidate? sameSignRival =
                 seed.InvertPolarity ? phat.NegativeRival : phat.PositiveRival;
@@ -1228,25 +1306,15 @@ public static class AutoAlignmentEngine
                 // pinned to the window edge (its position then an artifact),
                 // there is no spacing to reason from and a gradeable pair
                 // refuses the seed rather than guessing at one.
-                CorrelationDelayCandidate? neighbor = seed.InvertPolarity
-                    ? phat.NegativeOppositeNeighbor
-                    : phat.PositiveOppositeNeighbor;
-                double lobeBoundaryMs = neighbor is { EdgePinned: false } adjacent
-                    ? Math.Abs(adjacent.DelayMs - seed.DelayMs) / 2.0
-                    : 0;
+                double lobeBoundaryMs = LobeBoundaryMs(phat);
                 //
-                // Gated on !arrivalReanchored like the offset test below it:
-                // once the upper-half probe has thrown the full-band arrivals
-                // away, the uncertainty measured against the DISCARDED anchor
-                // describes nothing, and vetoing on it would veto by a number
-                // that refers to nothing.
-                if (!arrivalReanchored && pairPredictionGradeable &&
-                    (!(lobeBoundaryMs > 0) ||
-                        predictionDisagreementMs >= lobeBoundaryMs))
-                {
-                    return "arrival uncertain past the lobe boundary";
-                }
-
+                // A pair whose anchor could not place it inside a lobe has
+                // already been convicted and re-anchored above, which clears
+                // both arrival-relative tests here: measuring the extremum
+                // against an anchor just found incapable of resolving lobes
+                // (or against a discarded one, after the upper-half probe's
+                // conviction) would veto by a number that refers to nothing.
+                //
                 // Only ever TIGHTER than the standing rule: the disagreement
                 // figure above is not a proven bound, so it may restrict the
                 // seed further but never license a reach the conservative rule
@@ -1382,6 +1450,13 @@ public static class AutoAlignmentEngine
         AlignmentSnapshot primaryNeighborSnapshot =
             current.First(item => item.Channel == neighborChannel);
         Complex[] variableIr = variableSnapshot.ImpulseResponse;
+        // The gate anchor of every loss measurement below: the whole system's
+        // first arrival, NOT this pair's (see the gate remarks in
+        // VirtualCrossoverAnalysis). The metric read-out the user tunes by
+        // anchors there, and a pair-anchored window at a sub/woofer junction
+        // starts inside the sub's own rise and ranks the pair's alignments
+        // differently from what the panel then shows.
+        int gateAnchor = SystemGateAnchor(current);
         var neighborIrs = new List<Complex[]>
         {
             primaryNeighborSnapshot.ImpulseResponse
@@ -1527,7 +1602,8 @@ public static class AutoAlignmentEngine
                     // Search-side level match: the lobe choice must not depend
                     // on the channels' playback gains (see BuildAlignmentBins).
                     levelMatch: true,
-                    out IReadOnlyList<AlignmentCandidate> allOptima);
+                    out IReadOnlyList<AlignmentCandidate> allOptima,
+                    gateAnchorSample: gateAnchor);
             return (candidates, allOptima, windowLowMs, windowHighMs);
         }
 
@@ -3640,7 +3716,12 @@ public static class AutoAlignmentEngine
                         lowHz,
                         highHz,
                         levelMatch: true,
-                        requireDelayEvidence);
+                        requireDelayEvidence,
+                        // One system-anchored window, like the searches above:
+                        // the co-move compares cells of a grid, and a window
+                        // that moved with each cell's own pair would compare
+                        // them through different measurements.
+                        SystemGateAnchor(current));
                 return loss is { } value
                     ? value.LossDb +
                         VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
@@ -3913,7 +3994,8 @@ public static class AutoAlignmentEngine
             new List<Complex[]> { other },
             monoChannel.SampleRate,
             pair.BandLowHz,
-            pair.BandHighHz);
+            pair.BandHighHz,
+            gateAnchorSample: SystemGateAnchor(current));
         if (loss is not { } measured)
         {
             log.AppendLine(

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1494,9 +1494,10 @@ public static class VirtualCrossoverAnalysis
     // WHICH channels set that anchor is a decision the caller owns
     // (gateAnchorSample). Measuring one junction of a multiway system with an
     // anchor taken from the PAIR alone places the window tens of milliseconds
-    // later than the read-out's — the metric anchors on the whole system's
-    // first arrival (VirtualCrossoverMetrics.BuildCurves) — and at a
-    // sub/woofer junction the two then rank the same alignments differently:
+    // later than a window anchored on the whole system's first arrival — the
+    // placement the metric read-out uses (VirtualCrossoverMetrics.BuildCurves)
+    // — and at a sub/woofer junction the two then rank the same alignments
+    // differently:
     // on a field cabin (LP/HP 55 Hz, 36 dB/oct) the pair-anchored window read
     // the tuned alignment at -0.44 dB and preferred one 2 ms later, while the
     // system-anchored window read it at -0.02 dB, the sharpest optimum of the
@@ -2388,7 +2389,8 @@ public static class VirtualCrossoverAnalysis
             double minFrequencyHz,
             double maxFrequencyHz,
             bool levelMatch = false,
-            bool requireDelayEvidence = false)
+            bool requireDelayEvidence = false,
+            int? gateAnchorSample = null)
         {
             List<AlignmentBin> bins = BuildAlignmentBins(
                 variableImpulseResponse,
@@ -2398,7 +2400,8 @@ public static class VirtualCrossoverAnalysis
                 maxFrequencyHz,
                 minDelayMs: -1,
                 maxDelayMs: 1,
-                levelMatch);
+                levelMatch,
+                gateAnchorSample);
             if (bins.Count == 0 ||
                 (requireDelayEvidence && !HoldsDelayEvidence(bins)))
             {

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -375,6 +375,15 @@ public static class VirtualCrossoverAnalysis
     /// exposing both lets the caller disambiguate with evidence this search
     /// cannot see — typically the channel's other crossover junction.
     /// </summary>
+    /// <param name="gateAnchorSample">
+    /// The sample the shared direct-sound gate anchors on. Null takes the
+    /// earliest peak of the responses passed in — right for a standalone
+    /// two-response question, WRONG for one junction of a multiway system,
+    /// where the pair's own peak places the window later than the read-out's
+    /// and can rank the junction's alignments differently (see the gate
+    /// constants' remarks). A caller aligning a system passes the whole
+    /// system's first arrival, the same anchor the metric read-out uses.
+    /// </param>
     public static IReadOnlyList<AlignmentCandidate> FindAlignmentCandidates(
         Complex[] variableImpulseResponse,
         IReadOnlyList<Complex[]> fixedImpulseResponses,
@@ -386,11 +395,13 @@ public static class VirtualCrossoverAnalysis
         double? priorDelayMs = null,
         double priorSigmaMs = 0,
         bool? forcedPolarity = null,
-        bool levelMatch = false) =>
+        bool levelMatch = false,
+        int? gateAnchorSample = null) =>
         FindAlignmentCandidates(
             variableImpulseResponse, fixedImpulseResponses, sampleRate,
             minFrequencyHz, maxFrequencyHz, minDelayMs, maxDelayMs,
-            priorDelayMs, priorSigmaMs, forcedPolarity, levelMatch, out _);
+            priorDelayMs, priorSigmaMs, forcedPolarity, levelMatch, out _,
+            gateAnchorSample);
 
     /// <summary>
     /// The overload that also reports EVERY refined local optimum (best
@@ -413,7 +424,8 @@ public static class VirtualCrossoverAnalysis
         double priorSigmaMs,
         bool? forcedPolarity,
         bool levelMatch,
-        out IReadOnlyList<AlignmentCandidate> allOptima)
+        out IReadOnlyList<AlignmentCandidate> allOptima,
+        int? gateAnchorSample = null)
     {
         List<AlignmentBin> bins = BuildAlignmentBins(
             variableImpulseResponse,
@@ -423,7 +435,8 @@ public static class VirtualCrossoverAnalysis
             maxFrequencyHz,
             minDelayMs,
             maxDelayMs,
-            levelMatch);
+            levelMatch,
+            gateAnchorSample);
         if (bins.Count == 0 || !HoldsDelayEvidence(bins))
         {
             allOptima = Array.Empty<AlignmentCandidate>();
@@ -1145,7 +1158,8 @@ public static class VirtualCrossoverAnalysis
         double startDelayMs,
         double endDelayMs,
         double stepMs,
-        bool invertVariable)
+        bool invertVariable,
+        int? gateAnchorSample = null)
     {
         ArgumentNullException.ThrowIfNull(variableImpulseResponse);
         ArgumentNullException.ThrowIfNull(fixedImpulseResponse);
@@ -1204,7 +1218,12 @@ public static class VirtualCrossoverAnalysis
                 new List<Complex[]> { fixedFrame },
                 sampleRate,
                 bandLowHz,
-                bandHighHz);
+                bandHighHz,
+                // The frame shifted both responses by the guard, so a caller's
+                // anchor (stated in the responses' own coordinates) shifts with
+                // them; without the guard offset the window would sit that far
+                // early and fade over content it must not touch.
+                gateAnchorSample: gateAnchorSample + guardSamples);
             if (loss is { } value)
             {
                 points.Add(new JunctionSweepPoint(
@@ -1472,6 +1491,20 @@ public static class VirtualCrossoverAnalysis
     // displays the gated direct sound. One gate shared by all channels, like
     // the metric's shared anchor, so the loss keeps its 0 dB ceiling.
     //
+    // WHICH channels set that anchor is a decision the caller owns
+    // (gateAnchorSample). Measuring one junction of a multiway system with an
+    // anchor taken from the PAIR alone places the window tens of milliseconds
+    // later than the read-out's — the metric anchors on the whole system's
+    // first arrival (VirtualCrossoverMetrics.BuildCurves) — and at a
+    // sub/woofer junction the two then rank the same alignments differently:
+    // on a field cabin (LP/HP 55 Hz, 36 dB/oct) the pair-anchored window read
+    // the tuned alignment at -0.44 dB and preferred one 2 ms later, while the
+    // system-anchored window read it at -0.02 dB, the sharpest optimum of the
+    // sweep, agreeing with the panel and with the whitened correlation
+    // (r 0.99). A window whose fade-in cuts into the slow channel's own rise
+    // shifts that channel's apparent phase, and the junction search must not
+    // decide a lobe on an artifact of where the window happened to start.
+    //
     // The window is sized in TIME, not samples. A fixed 4096 samples is ~85 ms
     // at 48 kHz but only 43 ms at 96 kHz and 21 ms at 192 kHz — the higher the
     // rate, the shorter the physical window — and the delay estimate is flat for
@@ -1556,7 +1589,8 @@ public static class VirtualCrossoverAnalysis
         double maxFrequencyHz,
         double minDelayMs,
         double maxDelayMs,
-        bool levelMatch = false)
+        bool levelMatch = false,
+        int? gateAnchorSample = null)
     {
         ArgumentNullException.ThrowIfNull(variableImpulseResponse);
         ArgumentNullException.ThrowIfNull(fixedImpulseResponses);
@@ -1574,10 +1608,18 @@ public static class VirtualCrossoverAnalysis
             throw new ArgumentException("The search window is invalid.");
         }
 
-        int anchor = FindPeakIndex(variableImpulseResponse);
-        foreach (Complex[] ir in fixedImpulseResponses)
+        int anchor;
+        if (gateAnchorSample is { } shared)
         {
-            anchor = Math.Min(anchor, FindPeakIndex(ir));
+            anchor = Math.Clamp(shared, 0, variableImpulseResponse.Length - 1);
+        }
+        else
+        {
+            anchor = FindPeakIndex(variableImpulseResponse);
+            foreach (Complex[] ir in fixedImpulseResponses)
+            {
+                anchor = Math.Min(anchor, FindPeakIndex(ir));
+            }
         }
 
         // The earliest arrival must land on the window's plateau, never inside
@@ -2199,7 +2241,8 @@ public static class VirtualCrossoverAnalysis
         double minFrequencyHz,
         double maxFrequencyHz,
         bool levelMatch = false,
-        bool requireDelayEvidence = false)
+        bool requireDelayEvidence = false,
+        int? gateAnchorSample = null)
     {
         // The delay window only gates parameter validation here — the
         // measurement itself evaluates the responses exactly as given.
@@ -2211,7 +2254,8 @@ public static class VirtualCrossoverAnalysis
             maxFrequencyHz,
             minDelayMs: -1,
             maxDelayMs: 1,
-            levelMatch);
+            levelMatch,
+            gateAnchorSample);
         // A caller COMPARING alignments across this band (rather than
         // reporting what a sum happens to measure) must not read a verdict
         // off a band where the delay is not observable: with one side only a

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3816,7 +3816,10 @@ public partial class VirtualCrossoverPanel : UserControl
         JunctionCorrelationView? data = null;
         try
         {
-            data = await Task.Run(() => BuildCorrelationView(pair));
+            List<ProcessedChannel> scope = lastProcessedRender is { } render
+                ? render.Channels.ToList()
+                : [pair.Lower, pair.Upper];
+            data = await Task.Run(() => BuildCorrelationView(pair, scope));
         }
         catch (Exception exception)
         {
@@ -3842,24 +3845,29 @@ public partial class VirtualCrossoverPanel : UserControl
     // The off-thread compute of one junction's correlation view. Both
     // channels enter PROCESSED (delays, polarity, filters applied), so lag 0
     // is the current alignment and every reading is a correction to the
-    // UPPER channel. The pair is cropped to the alignment engine's own
-    // direct-sound window first: the correlation and the honest loss sweep
-    // then read the same basis Auto delay searches, and the sweep's per-point
+    // UPPER channel. The WHOLE side is cropped and anchored, not just the
+    // pair: crop and gate follow the alignment engine's own basis, so the
+    // drawn score is the surface Auto delay searches and the read-out
+    // reports — a pair-anchored window would draw a different one (see the
+    // gate remarks in VirtualCrossoverAnalysis). The sweep's per-point
     // inverse FFTs shrink from the capture length to the crop.
-    private static JunctionCorrelationView BuildCorrelationView(AdjacentPair pair)
+    private static JunctionCorrelationView BuildCorrelationView(
+        AdjacentPair pair, IReadOnlyList<ProcessedChannel> scope)
     {
         using var _ = AppProfiler.Zone("VirtualDSP.BuildCorrelationView");
         int sampleRate = pair.Lower.Channel.SampleRate;
+        List<ProcessedChannel> all = scope.Contains(pair.Lower)
+            ? scope.ToList()
+            : [pair.Lower, pair.Upper];
         Complex[][] cropped = VirtualCrossoverAnalysis.CropSharedDirectSoundWindow(
-            new List<Complex[]>
-            {
-                pair.Lower.ImpulseResponse,
-                pair.Upper.ImpulseResponse
-            },
+            all.Select(item => item.ImpulseResponse).ToList(),
             AutoDelaySearchCropLength,
             AutoDelaySearchCropPrePeakSamples);
-        Complex[] lower = cropped[0];
-        Complex[] upper = cropped[1];
+        Complex[] lower = cropped[all.IndexOf(pair.Lower)];
+        Complex[] upper = cropped[all.IndexOf(pair.Upper)];
+        // The system's first arrival, the anchor the metric read-out and the
+        // alignment search share.
+        int gateAnchor = cropped.Min(VirtualCrossoverAnalysis.FindPeakIndex);
 
         // The window spans 1.5 crossover periods to each side (floored at the
         // fixed diagnostic span), so the neighboring comb lobes both ways are
@@ -3888,7 +3896,7 @@ public partial class VirtualCrossoverPanel : UserControl
             VirtualCrossoverAnalysis.JunctionLossSweep(
                 upper, lower, sampleRate,
                 pair.BandLowHz, pair.BandHighHz,
-                -windowMs, windowMs, stepMs, invert)
+                -windowMs, windowMs, stepMs, invert, gateAnchor)
             .Select(point => new SignalPoint(
                 point.DelayMs,
                 point.LossDb +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3865,8 +3865,10 @@ public partial class VirtualCrossoverPanel : UserControl
             AutoDelaySearchCropPrePeakSamples);
         Complex[] lower = cropped[all.IndexOf(pair.Lower)];
         Complex[] upper = cropped[all.IndexOf(pair.Upper)];
-        // The system's first arrival, the anchor the metric read-out and the
-        // alignment search share.
+        // The displayed side's first arrival — the same placement rule the
+        // read-out beside this plot uses, over the same channel set and the
+        // same applied delays, so the drawn score and the read-out's numbers
+        // come from one window.
         int gateAnchor = cropped.Min(VirtualCrossoverAnalysis.FindPeakIndex);
 
         // The window spans 1.5 crossover periods to each side (floored at the

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -1031,6 +1031,126 @@ public sealed class AutoAlignmentEngineTests
                 latched, latchedMs, 100, 400, out _));
     }
 
+    // The sub/woofer field shape at a low junction: the sub's own front plus a
+    // late in-cabin build-up BELOW the corner. Its steep low-pass concentrates
+    // the junction band's energy exactly there, so the PROCESSED envelope
+    // fronts on the build-up while the driver's own (un-crossovered) front is
+    // still where it was — the read then sits several ms past what the chain
+    // can explain, without reaching the modal-latch conviction bar.
+    private static Complex[] LowFrontUnderCabinBuildUp(
+        int length, double buildUpMs, double amplitude)
+    {
+        Complex[] ir = VirtualCrossoverAnalysis.ApplyChain(
+            SingleImpulse(length, BasePosition),
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.BandPass,
+                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 300, 24),
+                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 25, 24))),
+            SampleRate);
+        int start = BasePosition + (int)Math.Round(buildUpMs / 1000.0 * SampleRate);
+        const double AttackSeconds = 0.002;
+        const double DecaySeconds = 0.06;
+        foreach (double modeHz in new[] { 33.0, 38.0, 44.0 })
+        {
+            for (int i = start; i < ir.Length; i++)
+            {
+                double t = (i - start) / (double)SampleRate;
+                ir[i] += amplitude *
+                    (1 - Math.Exp(-t / AttackSeconds)) *
+                    Math.Exp(-t / DecaySeconds) *
+                    Math.Sin(2 * Math.PI * modeHz * t);
+            }
+        }
+
+        return ir;
+    }
+
+    private static Complex[] SingleImpulse(int length, int position)
+    {
+        var ir = new Complex[length];
+        ir[position] = Complex.One;
+        return ir;
+    }
+
+    [Fact]
+    public void Compute_ConvictsAnAnchorThatCannotPlaceTheJunctionInsideALobe()
+    {
+        // 55 Hz junction, 36 dB/oct both sides: the lobes sit ~9 ms apart, and
+        // the arrival allowance (half a period at the band centre) is exactly
+        // that — so a read dragged a lobe late by an in-cabin build-up passes
+        // every conviction bar the predictor has. What still catches it is the
+        // pair's own geometry: the read disagrees with the predicted fronts by
+        // more than the measured half lobe spacing, i.e. it cannot say WHICH
+        // lobe the junction is on, and an anchor that cannot resolve lobes must
+        // not be the thing that resolves this one.
+        const int Length = 32_768;
+        var subChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.LowPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
+        var wooferChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.BandPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 180, 36),
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
+        Complex[] subBypassed = LowFrontUnderCabinBuildUp(Length, 2.0, 0.02);
+        Complex[] wooferBypassed = SingleImpulse(Length, BasePosition);
+
+        AlignmentSnapshot Snapshot(string name, Complex[] bypassed, DspChannelChain chain)
+        {
+            Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(
+                bypassed, chain, SampleRate, out ValidSampleRange range);
+            return new AlignmentSnapshot(
+                new TestChannel(name, processed), processed,
+                VirtualCrossoverAnalysis.FindPeakIndex(processed), range,
+                chain, bypassed);
+        }
+
+        AlignmentSnapshot sub = Snapshot("SUB", subBypassed, subChain);
+        AlignmentSnapshot woofer = Snapshot("W", wooferBypassed, wooferChain);
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides)
+        {
+            AlignmentSnapshot One(AlignmentSnapshot side, Complex[] bypassed, DspChannelChain chain)
+            {
+                AlignmentOverride over = overrides.GetValueOrDefault(side.Channel);
+                Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(
+                    bypassed,
+                    chain with { DelayMs = over.DelayMs, InvertPolarity = over.InvertPolarity },
+                    SampleRate,
+                    out ValidSampleRange range);
+                return side with
+                {
+                    ImpulseResponse = processed,
+                    PeakIndex = VirtualCrossoverAnalysis.FindPeakIndex(processed),
+                    ValidRange = range
+                };
+            }
+
+            return [One(sub, subBypassed, subChain), One(woofer, wooferBypassed, wooferChain)];
+        }
+
+        var log = new StringBuilder();
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        AutoAlignmentEngine.Compute(
+            [sub, woofer],
+            [new AlignmentJunction(sub, woofer, 55, 27.5, 110)],
+            Reprocess,
+            alignment,
+            log);
+
+        // What this pins is the RULE: the pair is convicted and re-anchored on
+        // its predicted fronts instead of the seed being vetoed by the very
+        // anchor that cannot resolve lobes (which is what the trace said
+        // before — "seed arrival (arrival uncertain past the lobe boundary)").
+        // The fixture cannot also pin the resulting delay: one side carries a
+        // synthetic build-up, so its honest alignment is not arithmetic. That
+        // half is validated on the field cabin the fix came from, where the
+        // corrected anchor lands the junction on the hand-tuned delay
+        // (5.29 ms against 5.23 by hand) at 0.0 dB average summation loss.
+        string trace = log.ToString();
+        Assert.Contains("cannot place the junction inside a lobe", trace);
+        Assert.DoesNotContain("arrival uncertain past the lobe boundary", trace);
+    }
+
     [Fact]
     public void PredictedArrival_GradesEveryState()
     {

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -1073,16 +1073,14 @@ public sealed class AutoAlignmentEngineTests
     }
 
     [Fact]
-    public void Compute_ConvictsAnAnchorThatCannotPlaceTheJunctionInsideALobe()
+    public void Compute_KeepsTheConservativePathWhenTheLobeGeometryIsUnmeasured()
     {
         // 55 Hz junction, 36 dB/oct both sides: the lobes sit ~9 ms apart, and
         // the arrival allowance (half a period at the band centre) is exactly
         // that — so a read dragged a lobe late by an in-cabin build-up passes
-        // every conviction bar the predictor has. What still catches it is the
-        // pair's own geometry: the read disagrees with the predicted fronts by
-        // more than the measured half lobe spacing, i.e. it cannot say WHICH
-        // lobe the junction is on, and an anchor that cannot resolve lobes must
-        // not be the thing that resolves this one.
+        // every conviction bar the predictor has. The lobe-boundary conviction
+        // catches that class, but only where the boundary is MEASURED; this
+        // fixture is the other case, and the assertions below say which.
         const int Length = 32_768;
         var subChain = new DspChannelChain(Crossover: new CrossoverSpec(
             CrossoverKind.LowPass,
@@ -1092,7 +1090,13 @@ public sealed class AutoAlignmentEngineTests
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 180, 36),
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
         Complex[] subBypassed = LowFrontUnderCabinBuildUp(Length, 2.0, 0.02);
-        Complex[] wooferBypassed = SingleImpulse(Length, BasePosition);
+        // The woofer fires 23 ms after the sub's front, which only re-centres
+        // the correlation window (a pure delay moves a channel's read and its
+        // prediction together, so the pair's disagreement is untouched) — far
+        // enough from the window edge that the seed's neighbouring lobe is
+        // measured rather than edge-pinned.
+        Complex[] wooferBypassed = SingleImpulse(
+            Length, BasePosition + 23 * SampleRate / 1000);
 
         AlignmentSnapshot Snapshot(string name, Complex[] bypassed, DspChannelChain chain)
         {
@@ -1137,18 +1141,27 @@ public sealed class AutoAlignmentEngineTests
             alignment,
             log);
 
-        // What this pins is the RULE: the pair is convicted and re-anchored on
-        // its predicted fronts instead of the seed being vetoed by the very
-        // anchor that cannot resolve lobes (which is what the trace said
-        // before — "seed arrival (arrival uncertain past the lobe boundary)").
-        // The fixture cannot also pin the resulting delay: one side carries a
-        // synthetic build-up, so its honest alignment is not arithmetic. That
-        // half is validated on the field cabin the fix came from, where the
-        // corrected anchor lands the junction on the hand-tuned delay
-        // (5.29 ms against 5.23 by hand) at 0.0 dB average summation loss.
+        // This pair's whitened correlation shows no INTERIOR lobe beside its
+        // seed — the nearest opposite extremum is pinned to the window edge,
+        // so its position is an artifact and the lobe spacing the conviction
+        // reasons from was never measured. Absence of that evidence may not
+        // license re-anchoring (and with it the lifting of the seed-reach
+        // veto): the pair keeps the conservative path instead, which is the
+        // reach rule refusing the extremum on a zero-floored reach.
+        //
+        // The conviction's other half — an anchor convicted where the geometry
+        // IS measured — is validated on the field cabin the fix came from
+        // (55 Hz junction, a 6.82 ms disagreement against a measured 4.13 ms
+        // lobe boundary), where the corrected anchor lands the junction on the
+        // hand-tuned delay, 5.29 ms against 5.23 by hand, at 0.0 dB average
+        // summation loss. A synthetic pair rich enough to show interior lobes
+        // AND carry a lobe-sized arrival error has no arithmetically known
+        // answer to assert against, so it is not faked here.
         string trace = log.ToString();
-        Assert.Contains("cannot place the junction inside a lobe", trace);
-        Assert.DoesNotContain("arrival uncertain past the lobe boundary", trace);
+        Assert.DoesNotContain("cannot place the junction inside a lobe", trace);
+        Assert.True(
+            trace.Contains("beyond the arrival's reach"),
+            $"the seed should have been refused conservatively:\r\n{trace}");
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
@@ -175,6 +175,85 @@ public sealed class JunctionCorrelationCurveTests
         return ir;
     }
 
+    private static Complex[] Filtered(CrossoverSpec crossover) =>
+        VirtualCrossoverAnalysis.ApplyChain(
+            ImpulseAtMs(0), new DspChannelChain(Crossover: crossover), SampleRate);
+
+    [Fact]
+    public void AlignmentCandidates_JudgeTheJunctionThroughTheGivenSystemAnchor()
+    {
+        // A subwoofer and its woofer partner fired from the SAME impulse
+        // through the field cabin's edges (55 Hz, 36 dB/oct Butterworth; the
+        // woofer's own 180 Hz low-pass is what puts the optimum a couple of
+        // milliseconds early). Two filtered copies of one impulse in a silent
+        // record CAN sum flat: at the right delay and polarity the junction is
+        // arithmetic, with no room to blame. The system-anchored window finds
+        // exactly that; the pair-anchored one — its fade-in cutting into both
+        // drivers' rise — cannot see a flat sum anywhere.
+        Complex[] sub = Filtered(new CrossoverSpec(
+            CrossoverKind.LowPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
+        Complex[] woofer = Filtered(new CrossoverSpec(
+            CrossoverKind.BandPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 180, 36),
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
+
+        AlignmentCandidate Best(int? anchor) => VirtualCrossoverAnalysis
+            .FindAlignmentCandidates(
+                woofer, [sub], SampleRate, 27.5, 110, -9, 9,
+                priorDelayMs: null, priorSigmaMs: 0, forcedPolarity: null,
+                levelMatch: true, out _, gateAnchorSample: anchor)[0];
+
+        AlignmentCandidate systemAnchored = Best(BasePosition);
+        Assert.True(
+            systemAnchored.InvertPolarity,
+            "36 dB/oct edges at one corner hand over inverted");
+        Assert.InRange(systemAnchored.DelayMs, -4.5, -2.5);
+        Assert.InRange(systemAnchored.LossDb, -0.02, 0.0);
+        Assert.InRange(systemAnchored.DipDb, -0.05, 0.0);
+
+        AlignmentCandidate pairAnchored = Best(null);
+        Assert.True(
+            pairAnchored.LossDb < -0.10 && pairAnchored.DipDb < -0.3,
+            $"the pair-anchored window cannot read the flat sum: " +
+            $"avg {pairAnchored.LossDb:0.00}, dip {pairAnchored.DipDb:0.00} dB");
+    }
+
+    [Fact]
+    public void AlignmentCandidates_PairAnchoredWindowMisreadsTheSameJunction()
+    {
+        // The same junction with the anchor left to the pair: the window then
+        // starts inside the drivers' own rise and the surface it measures is
+        // not the one the read-out shows — this is what let a field sub/woofer
+        // junction (55 Hz, 36 dB/oct) be settled a half period out. Pinned so
+        // the two anchors cannot silently converge and hide the distinction.
+        Complex[] sub = Filtered(new CrossoverSpec(
+            CrossoverKind.LowPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
+        Complex[] woofer = Filtered(new CrossoverSpec(
+            CrossoverKind.BandPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 180, 36),
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
+
+        // The true alignment itself — zero delay, the woofer inverted — read
+        // through each window.
+        Complex[] inverted = woofer.Select(value => -value).ToArray();
+        (double LossDb, double DipDb)? pairAnchored =
+            VirtualCrossoverAnalysis.MeasureSumLoss(
+                inverted, [sub], SampleRate, 27.5, 110, levelMatch: true);
+        (double LossDb, double DipDb)? systemAnchored =
+            VirtualCrossoverAnalysis.MeasureSumLoss(
+                inverted, [sub], SampleRate, 27.5, 110, levelMatch: true,
+                gateAnchorSample: BasePosition);
+
+        Assert.NotNull(pairAnchored);
+        Assert.NotNull(systemAnchored);
+        Assert.True(
+            systemAnchored.Value.LossDb > pairAnchored.Value.LossDb + 0.05,
+            $"the system-anchored window must read the truth more honestly: " +
+            $"{systemAnchored.Value.LossDb:0.00} vs {pairAnchored.Value.LossDb:0.00} dB");
+    }
+
     [Fact]
     public void JunctionLossSweep_InvertedPolarityShiftsTheCombByHalfAPeriod()
     {


### PR DESCRIPTION
Auto delay could settle a sub/woofer junction a half period out, and lowering a crossover corner moved the whole stack with it. Two defects, both found by replaying the engine on a field cabin's own measurements.

## The pair-anchored window

`BuildAlignmentBins` anchored the direct-sound gate on the earliest peak of the **pair**; the metric read-out (`VirtualCrossoverMetrics.BuildCurves`) anchors on the whole system's first arrival. At a sub/woofer junction those two windows sit ~15 ms apart, and the search then ranks alignments differently from the panel that displays them. Same two responses, same band, same metric — only the anchor differs:

| delay | polarity | pair-anchored | system-anchored |
|---|---|---|---|
| 5.23 ms | inv | −0.44 / −1.56 | **−0.02 / −0.07** |
| 7.00 ms | inv | **−0.25 / −0.84** | −0.23 / −0.58 |
| 17.03 ms | norm | −0.65 / −3.51 | −1.08 / −4.06 |

The anchor is now the caller's decision (`gateAnchorSample`), and every junction measurement of a run — the candidate search, the co-move grid, the fixed mono junction, and the drawn correlation view — shares the system anchor.

## The anchor that vetoed the evidence and then decided

A pair whose arrival disagrees with its own predicted fronts by more than the measured half lobe spacing had that fact used only to **veto** the whitened extremum; the same arrival then seeded the timeline and carried the quadratic prior. An anchor declared unable to resolve lobes went on to resolve one.

The predictor could not catch this on its own: `PredictedArrivalAllowanceMs` is half a period at fc, which *is* the lobe spacing, so a lobe-sized arrival error reads as "verified" by construction (the field case sat at 0.96 of an allowance).

It now convicts the anchor instead — both sides re-anchor on their predicted fronts, the correlation re-centers on the corrected lag, and the extremum is judged on its own quality. Bounded so it cannot fire on noise: only where the anchor is still the raw read (a pair the predictor already convicted keeps its own replacement) and the disagreement clears the predictor's accuracy floor.

## Field result

Reproduced bit-for-bit against the cabin's saved alignment log, then re-run with the fix:

| | B L | C L | D L | B R | C R | D R |
|---|---|---|---|---|---|---|
| 70 Hz before | 9.63 | 15.08 | 15.30 | 8.00 | 13.38 | 13.58 |
| 70 Hz after | **5.05** | 10.51 | 10.73 | 3.32 | 8.81 | 9.01 |
| 55 Hz before | 18.00 | 23.38 | 23.60 | 15.70 | 21.68 | 21.88 |
| 55 Hz after | **5.29** | 10.67 | 10.89 | 3.45 | 8.97 | 9.17 |

The 55 Hz proposal is now the delay the cabin's owner had reached by hand (5.23 ms with the sub inverted), at 0.0 dB average summation loss and on the whitened correlation's own extremum (r 0.99). Moving the corner from 70 to 55 Hz shifts the stack by 0.2 ms instead of 8.4 — what the two chains' group delays actually predict. The whole side's read-out improves against the hand tune as well (total −0.21 / −4.25 dB against −0.24 / −6.01).

## Tests

`Resonalyze.Dsp.Tests` 1031 passed, `Resonalyze.App.Tests` 911 passed / 6 skipped (hardware).

Three new: two pin the gate anchor (a synthetic crossover pair sums flat, 0.00 / 0.00 dB, only when the window is anchored on the system — the pair-anchored window cannot read a flat sum anywhere), one pins the conviction rule replacing the veto. The conviction's *physics* is validated on the field cabin rather than synthetically: a fixture carrying a synthetic build-up has no arithmetically known true delay, and the test says so instead of pretending otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
