### PR TITLE
Anchor the automatic phase gates on the arrival

### DIFF
--- a/dsp/DataHelper.Phase.cs
+++ b/dsp/DataHelper.Phase.cs
@@ -45,6 +45,101 @@ namespace Resonalyze.Dsp
         private static int MillisecondsToSamples(double milliseconds, int sampleRate) =>
             (int)Math.Round(Math.Max(0.0, milliseconds) * sampleRate / 1000.0);
 
+        // One gate placement resolved to samples: where the extraction starts
+        // (a left shoulder before the offset), where the plateau begins (the
+        // offset itself) and the Tukey shape over the gate's own length.
+        private readonly record struct GatePlacement(
+            int ExtractionStart,
+            int PlateauStart,
+            double[] Window);
+
+        // The gate's sample geometry. Everything that needs to know where the
+        // window sits goes through here, so a caller judging a placement can
+        // never be looking at a different window than the one that gets used.
+        private static GatePlacement ResolveGatePlacement(
+            double gateOffsetMs,
+            double leftMs,
+            double plateauMs,
+            double rightMs,
+            int sampleRate)
+        {
+            int gateOffset = MillisecondsToSamples(gateOffsetMs, sampleRate);
+            int left = MillisecondsToSamples(leftMs, sampleRate);
+            int plateau = MillisecondsToSamples(plateauMs, sampleRate);
+            int right = MillisecondsToSamples(rightMs, sampleRate);
+
+            int gate = Math.Clamp(left + plateau + right, 1, GatedFftLength);
+            // Keep the fades coherent if the clamp had to trim the gate.
+            left = Math.Min(left, gate);
+            right = Math.Min(right, gate - left);
+
+            double leftNorm = (double)left / gate * 2.0;
+            double rightNorm = (double)right / gate * 2.0;
+            // Left shoulder ends at the gate offset, so extraction starts a shoulder
+            // earlier; the time correction downstream keeps readings absolute.
+            return new GatePlacement(
+                gateOffset - left,
+                gateOffset,
+                Windowing.TukeyWindow(gate, leftNorm, rightNorm));
+        }
+
+        /// <summary>
+        /// How much of a response's own energy a gate placement throws away
+        /// AHEAD of its plateau, against the energy it keeps (dB, so −∞ means
+        /// nothing was lost and 0 dB means as much was discarded as kept).
+        /// <para>
+        /// This is the test for whether a window may be placed per curve. Two
+        /// curves gated at different absolute positions stay comparable only
+        /// while each window opens before its own channel's response does: a
+        /// window is not a time shift, and re-referencing the extraction to a
+        /// common τ rotates a spectrum but cannot put back a leading edge the
+        /// window removed. The figure deliberately looks only AHEAD of the
+        /// plateau — truncating the decay tail behind it is what a gate is
+        /// for, and every placement does it.
+        /// </para>
+        /// </summary>
+        public static double GateLeadingEdgeLossDb(
+            IImpulseMeasurement measurement,
+            double gateOffsetMs,
+            double leftMs,
+            double plateauMs,
+            double rightMs)
+        {
+            ArgumentNullException.ThrowIfNull(measurement);
+            if (measurement.ImpulseResponse is not { Length: > 0 } impulseResponse ||
+                measurement.SampleRate <= 0)
+            {
+                return double.NegativeInfinity;
+            }
+
+            GatePlacement placement = ResolveGatePlacement(
+                gateOffsetMs, leftMs, plateauMs, rightMs, measurement.SampleRate);
+            double[] window = placement.Window;
+            int end = Math.Min(
+                impulseResponse.Length, placement.ExtractionStart + window.Length);
+
+            double lost = 0;
+            double kept = 0;
+            for (int i = 0; i < end; i++)
+            {
+                double sample = impulseResponse[i].Real;
+                double energy = sample * sample;
+                int inWindow = i - placement.ExtractionStart;
+                double weight = inWindow >= 0 && inWindow < window.Length
+                    ? window[inWindow]
+                    : 0.0;
+                kept += weight * weight * energy;
+                if (i < placement.PlateauStart)
+                {
+                    lost += (1.0 - weight * weight) * energy;
+                }
+            }
+
+            return kept > 0
+                ? 10.0 * Math.Log10(Math.Max(double.Epsilon, lost) / kept)
+                : double.NegativeInfinity;
+        }
+
         // Builds a zero-padded, gated windowed impulse (time domain). The Tukey gate
         // spans left + plateau + right samples; the end of its left shoulder (the
         // fade-in/plateau boundary) is placed at gateOffsetMs from the IR start. Wrap
@@ -58,27 +153,13 @@ namespace Resonalyze.Dsp
             bool wrap,
             out int extractionStart)
         {
-            int sampleRate = measurement.SampleRate;
-            int gateOffset = MillisecondsToSamples(gateOffsetMs, sampleRate);
-            int left = MillisecondsToSamples(leftMs, sampleRate);
-            int plateau = MillisecondsToSamples(plateauMs, sampleRate);
-            int right = MillisecondsToSamples(rightMs, sampleRate);
-
-            int gate = Math.Clamp(left + plateau + right, 1, GatedFftLength);
-            // Keep the fades coherent if the clamp had to trim the gate.
-            left = Math.Min(left, gate);
-            right = Math.Min(right, gate - left);
-
-            double leftNorm = (double)left / gate * 2.0;
-            double rightNorm = (double)right / gate * 2.0;
-            double[] tukey = Windowing.TukeyWindow(gate, leftNorm, rightNorm);
+            GatePlacement placement = ResolveGatePlacement(
+                gateOffsetMs, leftMs, plateauMs, rightMs, measurement.SampleRate);
 
             double[] window = new double[GatedFftLength];
-            Array.Copy(tukey, window, gate);
+            Array.Copy(placement.Window, window, placement.Window.Length);
 
-            // Left shoulder ends at the gate offset, so extraction starts a shoulder
-            // earlier; the time correction downstream keeps readings absolute.
-            extractionStart = gateOffset - left;
+            extractionStart = placement.ExtractionStart;
             return ExtractWindow(measurement, extractionStart, GatedFftLength, window, wrap);
         }
 
@@ -694,8 +775,13 @@ namespace Resonalyze.Dsp
         /// signal's spectrum) and accumulated, so the result reads exactly like
         /// one spectrum extracted there. This is how a multi-channel Sum stays
         /// the vector sum of individually gated channels when their windows do
-        /// not share a position (the Virtual DSP Auto gate). The inputs are not
-        /// modified and must share one FFT length.
+        /// not share a position (the Virtual DSP Auto gate, where each channel
+        /// is gated on its own arrival). Note what the re-reference is: it
+        /// moves a spectrum's time ORIGIN and nothing else, so it cannot make
+        /// spectra comparable whose windows kept different stretches of their
+        /// signals — that condition is the caller's to enforce (see
+        /// <see cref="GateLeadingEdgeLossDb"/>). The inputs are not modified
+        /// and must share one FFT length.
         /// </summary>
         public static Complex[] SumGatedSpectra(
             IReadOnlyList<(Complex[] Spectrum, int ExtractionStart)> spectra,

--- a/dsp/DataHelper.Phase.cs
+++ b/dsp/DataHelper.Phase.cs
@@ -86,7 +86,8 @@ namespace Resonalyze.Dsp
         /// <summary>
         /// How much of a response's own energy a gate placement throws away
         /// AHEAD of its plateau, against the energy it keeps (dB, so −∞ means
-        /// nothing was lost and 0 dB means as much was discarded as kept).
+        /// nothing was lost, 0 dB means as much was discarded as kept, and +∞
+        /// means the window holds none of the channel at all).
         /// <para>
         /// This is the test for whether a window may be placed per curve. Two
         /// curves gated at different absolute positions stay comparable only
@@ -156,9 +157,30 @@ namespace Resonalyze.Dsp
                 lost += (1.0 - weight * weight) * Energy(position);
             }
 
-            return kept > 0
-                ? 10.0 * Math.Log10(Math.Max(double.Epsilon, lost) / kept)
-                : double.NegativeInfinity;
+            if (kept > 0)
+            {
+                return 10.0 * Math.Log10(Math.Max(double.Epsilon, lost) / kept);
+            }
+
+            // The window kept nothing of the channel — it sits entirely before
+            // the response or entirely after it. That is the worst a placement
+            // can do, and it must read that way round: as a ratio it IS
+            // infinite loss, and reporting the other infinity would make a
+            // window that misses the channel altogether look like the safest
+            // placement on offer, so a caller comparing two placements would
+            // take it over one that actually holds the channel. Note the
+            // leading-edge sum cannot answer this on its own: a window sitting
+            // entirely BEFORE the response has nothing ahead of its plateau
+            // either. Silence is the one case with no response to misplace.
+            foreach (Complex sample in impulseResponse)
+            {
+                if (sample.Real != 0.0)
+                {
+                    return double.PositiveInfinity;
+                }
+            }
+
+            return double.NegativeInfinity;
         }
 
         // Builds a zero-padded, gated windowed impulse (time domain). The Tukey gate

--- a/dsp/DataHelper.Phase.cs
+++ b/dsp/DataHelper.Phase.cs
@@ -97,6 +97,12 @@ namespace Resonalyze.Dsp
         /// plateau — truncating the decay tail behind it is what a gate is
         /// for, and every placement does it.
         /// </para>
+        /// <para>
+        /// Measured on the nominal gate, not on FDW's per-band windows: those
+        /// are shorter by construction and always truncate, so they answer a
+        /// different question. What this one asks is whether the PLACEMENT is
+        /// sane for the channel.
+        /// </para>
         /// </summary>
         public static double GateLeadingEdgeLossDb(
             IImpulseMeasurement measurement,
@@ -115,24 +121,39 @@ namespace Resonalyze.Dsp
             GatePlacement placement = ResolveGatePlacement(
                 gateOffsetMs, leftMs, plateauMs, rightMs, measurement.SampleRate);
             double[] window = placement.Window;
-            int end = Math.Min(
-                impulseResponse.Length, placement.ExtractionStart + window.Length);
+            int length = impulseResponse.Length;
 
-            double lost = 0;
-            double kept = 0;
-            for (int i = 0; i < end; i++)
+            // The extraction's own addressing (ExtractWindow with wrap): a gate
+            // whose shoulder reaches before the record reads the circular
+            // buffer's tail, which is where a transfer IR's negative-time
+            // content lives. Judging that stretch as empty would pass a
+            // placement whose window is full of content the guard never saw.
+            double Energy(int position)
             {
-                double sample = impulseResponse[i].Real;
-                double energy = sample * sample;
-                int inWindow = i - placement.ExtractionStart;
+                int index = position % length;
+                double sample = impulseResponse[index < 0 ? index + length : index].Real;
+                return sample * sample;
+            }
+
+            double kept = 0;
+            for (int i = 0; i < window.Length; i++)
+            {
+                kept += window[i] * window[i] * Energy(placement.ExtractionStart + i);
+            }
+
+            // Everything ahead of the plateau, weighted by what the window
+            // takes away from it: all of it before the gate opens, the
+            // fade-in's own shape once inside.
+            double lost = 0;
+            for (int position = Math.Min(0, placement.ExtractionStart);
+                position < placement.PlateauStart;
+                position++)
+            {
+                int inWindow = position - placement.ExtractionStart;
                 double weight = inWindow >= 0 && inWindow < window.Length
                     ? window[inWindow]
                     : 0.0;
-                kept += weight * weight * energy;
-                if (i < placement.PlateauStart)
-                {
-                    lost += (1.0 - weight * weight) * energy;
-                }
+                lost += (1.0 - weight * weight) * Energy(position);
             }
 
             return kept > 0

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -451,7 +451,10 @@ public static class TransferIrDiagnostics
     /// <summary>
     /// Estimates where the IR's honest acoustic content starts: the rising-front
     /// crossings of the first credible arrival's Hilbert envelope, read inside
-    /// the record's DOMINANT band. The band-pass is what makes the figure robust
+    /// the record's DOMINANT band, taken at
+    /// <see cref="IrStartBandThresholdDb"/> rather than the tighter content
+    /// floor (a band too narrow cannot resolve the time being read — see that
+    /// constant). The band-pass is what makes the figure robust
     /// on real cabin records — a playback-crosstalk click or other broadband head
     /// garbage carries almost no energy inside a band-limited driver's working
     /// band, so the in-band envelope never sees it and no head-cleaning pass is
@@ -497,7 +500,8 @@ public static class TransferIrDiagnostics
             impulseResponse = head;
         }
 
-        DominantBand band = DetectDominantBand(impulseResponse, sampleRate);
+        DominantBand band = DetectDominantBand(
+            impulseResponse, sampleRate, IrStartBandThresholdDb);
         TimeAlignmentAnalysisResult inBand = TimeAlignmentAnalysis.Analyze(
             impulseResponse, sampleRate, new TimeAlignmentAnalysisOptions
             {
@@ -517,6 +521,35 @@ public static class TransferIrDiagnostics
             ? CrossingsOf(fullBand, band, sampleRate, dominantBandLimited: false)
             : null;
     }
+
+    /// <summary>
+    /// How far below the smoothed spectrum's peak the band
+    /// <see cref="EstimateIrStart"/> reads the arrival in extends. Wider than
+    /// <see cref="DominantBandThresholdDb"/> on purpose: that floor answers
+    /// "where does this driver's energy live", which the crosstalk complement
+    /// band needs answered tightly, while a TIME can only be read as finely as
+    /// the analysis band's own resolution (~1/bandwidth) allows. A 15 dB floor
+    /// around a cabin mode can collapse to a single octave — field case, a door
+    /// woofer at the listening position reading 75-155 Hz, its cancellation
+    /// notches on both sides just too wide to bridge — and in that band nothing
+    /// shorter than ~12 ms resolves: the envelope's only maximum is the mode's
+    /// build-up 8.4 ms past the arrival, and the 25 % crossing walked back from
+    /// it lands at 3.00 ms — 2.5 ms before the record leaves its noise floor,
+    /// 3.4 ms before its peak.
+    /// <para>
+    /// Calibrated across the field sets (v2-v5, 23 records) at 15/20/25/30 dB.
+    /// 25 and 30 agree on the collapsed record (5.64 ms, against a 6.42 ms peak
+    /// and a front at ~5.6 ms) while 20 is still transitional (4.46 ms), so 25
+    /// sits at the near edge of the plateau. Every record whose 15 dB band
+    /// already spanned four octaves or more moves by at most 0.5 ms; the rest
+    /// (subwoofers included, and they stay 2.8 octaves even at this floor) move
+    /// 0.3-1.7 ms later — towards their arrival, and on all 23 still short of
+    /// the record's own peak. None falls back onto the head burst the
+    /// band-limiting exists to reject: every v3/v4 read stays in the 5.2-7.5 ms
+    /// front range.
+    /// </para>
+    /// </summary>
+    private const double IrStartBandThresholdDb = 25.0;
 
     // Below this length the spectral analysis behind the estimate is
     // degenerate (no dominant band to speak of, no quantile noise floor).
@@ -591,7 +624,14 @@ public static class TransferIrDiagnostics
 
         double below = envelope[i];
         double above = envelope[i + 1];
-        double fraction = above > below ? (threshold - below) / (above - below) : 0.0;
+        // The walk can stop at index 0 with the envelope still ABOVE the
+        // threshold — a front that runs off the head of the record. The
+        // interpolation would then extrapolate backwards without bound
+        // (field: a subwoofer's 10 % crossing read -1.5 ms), so it is floored
+        // at the record start, which is as early as the crossing can be.
+        double fraction = above > below
+            ? Math.Max(0.0, (threshold - below) / (above - below))
+            : 0.0;
         return (i + fraction) * 1_000.0 / sampleRate;
     }
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3313,28 +3313,30 @@ public partial class VirtualCrossoverPanel : UserControl
         double detrendMs = ResolveCommonDetrendMs(
             processed, referenceOffsetMs, sampleRate);
 
-        // Read the gate and project state ONCE, here on the UI thread; the
-        // workers below must not reach back into gatePreview or project.
-        List<double> offsets = ResolvePhaseGateOffsets(
-            processed, referenceOffsetMs, sampleRate);
-        double referenceSamples = detrendMs * sampleRate / 1_000.0;
-
-        bool includeSum = processed.Count >= 2 && checkBoxShowSum.Checked;
-
         // The gated spectra are built ONCE per redraw and feed both the shown
         // channels' curves and the Sum — building them twice was possible
         // before: the per-impulse cache serializes lookup and insert but not
         // the bank computation itself, so a channel job and the Sum job racing
         // on a cold cache could each run the same FFTs. The Sum needs every
         // processed channel (hidden or not, matching the magnitude Sum); with
-        // the Sum off, hidden channels' banks are skipped entirely. Settings
-        // resolve here on the UI thread; only the bank work fans out.
+        // the Sum off, hidden channels' banks are skipped entirely.
+        bool includeSum = processed.Count >= 2 && checkBoxShowSum.Checked;
+        List<ProcessedChannel> gatedChannels = processed
+            .Where(item => includeSum || item.Channel.Settings.ShowProcessedCurve)
+            .ToList();
+
+        // Read the gate and project state ONCE, here on the UI thread; the
+        // workers below must not reach back into gatePreview or project. The
+        // placements are resolved over the gated set only, so hiding a curve
+        // cannot move the window of the ones still drawn.
+        List<double> offsets = ResolvePhaseGateOffsets(
+            gatedChannels, referenceOffsetMs, sampleRate);
+        double referenceSamples = detrendMs * sampleRate / 1_000.0;
+
         List<(ProcessedChannel Item, Complex[] Spectrum, int ExtractionStart)> gated =
-            processed
+            gatedChannels
                 .Select((item, index) => (item, Settings: CreateVirtualPhaseSettings(
                     offsets[index], PhaseDetrendMode.Manual, detrendMs)))
-                .Where(input =>
-                    includeSum || input.item.Channel.Settings.ShowProcessedCurve)
                 .AsParallel()
                 .AsOrdered()
                 .Select(input =>
@@ -3478,22 +3480,45 @@ public partial class VirtualCrossoverPanel : UserControl
     /// The ceiling on <see cref="DataHelper.GateLeadingEdgeLossDb"/> for a
     /// per-curve phase window: above it the window is cutting into its own
     /// channel's leading edge and the curve stops being comparable with its
-    /// neighbours, so the whole set falls back to one shared window.
+    /// neighbours.
     /// <para>
     /// Measured on the v5 field session (four processed channels, gate
     /// 5/50/20 ms): windows placed on each channel's own arrival START read
     /// -28.4 to -72.2 dB, while the arrival-PEAK placement that drew a
     /// summing pair as antiphase read -3.5 to -10.8 dB — it discards a fifth
     /// to nearly half of a steeply low-passed channel's own energy. -20 dB
-    /// sits in the middle of that 17.6 dB gap; a placement that lands there is
-    /// refused in favour of the shared window, which needs no such condition.
+    /// sits in the middle of that 17.6 dB gap.
     /// </para>
     /// </summary>
     private const double MaxPhaseGateLeadingEdgeLossDb = -20.0;
 
     /// <summary>
+    /// Whether a per-curve window may be used for a channel, from what it
+    /// discards ahead of its plateau against what the shared window would.
+    /// <para>
+    /// The ceiling alone is not the question, because a gate can be too short
+    /// to hold a channel's leading edge WHEREVER it is placed: the project
+    /// default (0.5/4/1.5 ms) cannot contain one period of a 55 Hz subwoofer,
+    /// and on the field session it read -19.4 dB at the channel's own arrival
+    /// and -19.4 dB at the shared one — identical. Refusing there buys no
+    /// accuracy and costs the per-curve placement that keeps a late channel
+    /// inside FDW's short windows, so the shared window has to be the better
+    /// placement for this channel before it is worth taking. The arrival-PEAK
+    /// placements this guard exists to catch are 25.7 to 61.4 dB worse than
+    /// the shared window, so both conditions hold there with room to spare.
+    /// </para>
+    /// </summary>
+    internal static bool AllowsPerCurvePhaseGate(
+        double perCurveLossDb,
+        double sharedLossDb) =>
+        perCurveLossDb <= MaxPhaseGateLeadingEdgeLossDb ||
+        perCurveLossDb <= sharedLossDb;
+
+    /// <summary>
     /// Where each phase curve's window sits, aligned with
-    /// <paramref name="processed"/>.
+    /// <paramref name="gatedChannels"/> — the channels that are actually
+    /// gated, so a hidden curve can never move the placement of the drawn
+    /// ones.
     /// <para>
     /// A pinned gate is one absolute window for every curve. Auto gives each
     /// channel its OWN estimated arrival, which is what lets FDW's short
@@ -3501,17 +3526,17 @@ public partial class VirtualCrossoverPanel : UserControl
     /// of on whichever channel happened to arrive first — the whole point of
     /// reading phase through FDW. Per-curve placement is only comparable while
     /// every window opens before its channel's response does, so each one is
-    /// measured against <see cref="MaxPhaseGateLeadingEdgeLossDb"/> and the
-    /// whole set drops back to the shared window if any fails: mixing the two
-    /// placements would be worse than either.
+    /// put to <see cref="AllowsPerCurvePhaseGate"/> and the whole set drops
+    /// back to the shared window if any fails: mixing the two placements would
+    /// be worse than either.
     /// </para>
     /// </summary>
     private List<double> ResolvePhaseGateOffsets(
-        List<ProcessedChannel> processed,
+        IReadOnlyList<ProcessedChannel> gatedChannels,
         double sharedOffsetMs,
         int sampleRate)
     {
-        List<double> Shared() => processed.Select(_ => sharedOffsetMs).ToList();
+        List<double> Shared() => gatedChannels.Select(_ => sharedOffsetMs).ToList();
         if (PinnedGateOffsetMs is not null)
         {
             return Shared();
@@ -3520,18 +3545,17 @@ public partial class VirtualCrossoverPanel : UserControl
         double leftMs = gatePreview?.LeftMs ?? project.PhaseGateLeftMs;
         double plateauMs = gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs;
         double rightMs = gatePreview?.RightMs ?? project.PhaseGateRightMs;
-        var perCurve = new List<double>(processed.Count);
-        foreach (ProcessedChannel item in processed)
+        var perCurve = new List<double>(gatedChannels.Count);
+        foreach (ProcessedChannel item in gatedChannels)
         {
+            var view = new ImpulseMeasurementView(item.ImpulseResponse, 0, sampleRate);
             double startMs = TransferIrStartCache.ResolveStartMs(
                 item.ImpulseResponse, sampleRate, item.PeakIndex);
-            double lossDb = DataHelper.GateLeadingEdgeLossDb(
-                new ImpulseMeasurementView(item.ImpulseResponse, 0, sampleRate),
-                startMs,
-                leftMs,
-                plateauMs,
-                rightMs);
-            if (lossDb > MaxPhaseGateLeadingEdgeLossDb)
+            if (!AllowsPerCurvePhaseGate(
+                    DataHelper.GateLeadingEdgeLossDb(
+                        view, startMs, leftMs, plateauMs, rightMs),
+                    DataHelper.GateLeadingEdgeLossDb(
+                        view, sharedOffsetMs, leftMs, plateauMs, rightMs)))
             {
                 return Shared();
             }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3301,30 +3301,22 @@ public partial class VirtualCrossoverPanel : UserControl
         using var _ = AppProfiler.Zone("VirtualDSP.BuildPhaseCurves");
         // One shared absolute τ reference (the earliest arrival) keeps the
         // curves' relative phase intact — that relative alignment through the
-        // crossover region is exactly what this view is for. The WINDOWS need
-        // not share a position for that: BuildMeasuredPhase re-references every
-        // extraction to the common absolute τ.
+        // crossover region is exactly what this view is for. The WINDOWS may
+        // still follow each channel's own arrival: BuildMeasuredPhase
+        // re-references every extraction to the common absolute τ, which is
+        // exact as long as no window cuts into its own channel — the condition
+        // ResolvePhaseGateOffsets enforces before it hands out per-curve
+        // placements.
         int sampleRate = processed[0].Channel.SampleRate;
         double referenceOffsetMs = gatePreview?.OffsetMs
             ?? ResolveGateOffsetMs(processed, sampleRate);
         double detrendMs = ResolveCommonDetrendMs(
             processed, referenceOffsetMs, sampleRate);
 
-        // Read the gate and project state ONCE, here on the UI thread —
-        // including each curve's own gate placement: pinned, every curve
-        // shares one absolute window; unpinned (Auto), each IR gates at its
-        // own arrival PEAK, so FDW's short high-frequency windows keep a late
-        // channel's treble instead of silently excluding it. The peak, not the
-        // estimated IR start: the start estimator is unvalidated on virtually
-        // crossovered responses and can place the window off the energy (see
-        // BuildMagnitudeCurve). The workers below must not reach back into
-        // gatePreview or project.
-        double? pinnedOffsetMs = PinnedGateOffsetMs;
-        PhaseAnalysisSettings SettingsFor(int ownPeak) =>
-            CreateVirtualPhaseSettings(
-                pinnedOffsetMs ?? ownPeak * 1_000.0 / sampleRate,
-                PhaseDetrendMode.Manual,
-                detrendMs);
+        // Read the gate and project state ONCE, here on the UI thread; the
+        // workers below must not reach back into gatePreview or project.
+        List<double> offsets = ResolvePhaseGateOffsets(
+            processed, referenceOffsetMs, sampleRate);
         double referenceSamples = detrendMs * sampleRate / 1_000.0;
 
         bool includeSum = processed.Count >= 2 && checkBoxShowSum.Checked;
@@ -3337,23 +3329,22 @@ public partial class VirtualCrossoverPanel : UserControl
         // processed channel (hidden or not, matching the magnitude Sum); with
         // the Sum off, hidden channels' banks are skipped entirely. Settings
         // resolve here on the UI thread; only the bank work fans out.
-        List<(ProcessedChannel Item, PhaseAnalysisSettings Settings)> spectrumInputs =
-            processed
-                .Where(item => includeSum || item.Channel.Settings.ShowProcessedCurve)
-                .Select(item => (item, SettingsFor(item.PeakIndex)))
-                .ToList();
         List<(ProcessedChannel Item, Complex[] Spectrum, int ExtractionStart)> gated =
-            spectrumInputs
+            processed
+                .Select((item, index) => (item, Settings: CreateVirtualPhaseSettings(
+                    offsets[index], PhaseDetrendMode.Manual, detrendMs)))
+                .Where(input =>
+                    includeSum || input.item.Channel.Settings.ShowProcessedCurve)
                 .AsParallel()
                 .AsOrdered()
                 .Select(input =>
                 {
                     Complex[] spectrum = DataHelper.GetPhaseAnalysisSpectrum(
                         new ImpulseMeasurementView(
-                            input.Item.ImpulseResponse, 0, sampleRate),
+                            input.item.ImpulseResponse, 0, sampleRate),
                         input.Settings,
                         out int extractionStart);
-                    return (input.Item, spectrum, extractionStart);
+                    return (input.item, spectrum, extractionStart);
                 })
                 .ToList();
 
@@ -3372,13 +3363,12 @@ public partial class VirtualCrossoverPanel : UserControl
         if (includeSum)
         {
             // The Sum is the vector sum of the individually gated channel
-            // SPECTRA, not a gated summed IR: with per-curve Auto windows a
-            // single window over the summed IR would exclude late channels'
-            // treble that their own traces keep (FDW windows at high
-            // frequencies are shorter than the arrival spread), and the drawn
-            // Sum would silently stop being the sum of the drawn channels.
+            // SPECTRA, not a gate over the summed IR: under Auto the windows
+            // follow each channel's own arrival, and no single window over one
+            // summed IR could hold every channel's treble at once (FDW's
+            // high-frequency windows are shorter than the arrival spread).
             // Summing the spectra keeps superposition exact by construction,
-            // and with a pinned gate reduces to the gated summed IR by
+            // and with one shared window reduces to the gated summed IR by
             // linearity.
             int targetExtractionStart = gated.Min(part => part.ExtractionStart);
             Complex[] combined = DataHelper.SumGatedSpectra(
@@ -3474,16 +3464,83 @@ public partial class VirtualCrossoverPanel : UserControl
     // The one pinned absolute gate offset, or null when the gate is unpinned
     // (Auto) — in the dialog preview and in the committed state alike. Null
     // means automatic placement, which differs by view: the magnitude anchors
-    // ONE shared window at the earliest processed arrival (keeping the drawn
-    // Sum the exact vector sum of the drawn channels), while each PHASE curve
-    // gates at its own arrival peak — FDW's high-frequency windows are
-    // shorter than the channels' arrival spread, and a shared window silently
-    // excluded late channels' treble. The phase stays comparable because its
-    // τ reference is common and absolute regardless of where each extraction
-    // started.
+    // ONE shared window at the earliest processed PEAK (keeping the drawn Sum
+    // the exact vector sum of the drawn channels), while the PHASE curves each
+    // follow their own estimated arrival START so FDW's short high-frequency
+    // windows land on the right channel's first cycles — see
+    // ResolvePhaseGateOffsets for the condition that keeps those curves
+    // comparable, and what happens when it does not hold.
     private double? PinnedGateOffsetMs => gatePreview is { } preview
         ? preview.AutoOffset ? null : preview.OffsetMs
         : ActiveGate.OffsetMs;
+
+    /// <summary>
+    /// The ceiling on <see cref="DataHelper.GateLeadingEdgeLossDb"/> for a
+    /// per-curve phase window: above it the window is cutting into its own
+    /// channel's leading edge and the curve stops being comparable with its
+    /// neighbours, so the whole set falls back to one shared window.
+    /// <para>
+    /// Measured on the v5 field session (four processed channels, gate
+    /// 5/50/20 ms): windows placed on each channel's own arrival START read
+    /// -28.4 to -72.2 dB, while the arrival-PEAK placement that drew a
+    /// summing pair as antiphase read -3.5 to -10.8 dB — it discards a fifth
+    /// to nearly half of a steeply low-passed channel's own energy. -20 dB
+    /// sits in the middle of that 17.6 dB gap; a placement that lands there is
+    /// refused in favour of the shared window, which needs no such condition.
+    /// </para>
+    /// </summary>
+    private const double MaxPhaseGateLeadingEdgeLossDb = -20.0;
+
+    /// <summary>
+    /// Where each phase curve's window sits, aligned with
+    /// <paramref name="processed"/>.
+    /// <para>
+    /// A pinned gate is one absolute window for every curve. Auto gives each
+    /// channel its OWN estimated arrival, which is what lets FDW's short
+    /// high-frequency windows sit on that channel's own first cycles instead
+    /// of on whichever channel happened to arrive first — the whole point of
+    /// reading phase through FDW. Per-curve placement is only comparable while
+    /// every window opens before its channel's response does, so each one is
+    /// measured against <see cref="MaxPhaseGateLeadingEdgeLossDb"/> and the
+    /// whole set drops back to the shared window if any fails: mixing the two
+    /// placements would be worse than either.
+    /// </para>
+    /// </summary>
+    private List<double> ResolvePhaseGateOffsets(
+        List<ProcessedChannel> processed,
+        double sharedOffsetMs,
+        int sampleRate)
+    {
+        List<double> Shared() => processed.Select(_ => sharedOffsetMs).ToList();
+        if (PinnedGateOffsetMs is not null)
+        {
+            return Shared();
+        }
+
+        double leftMs = gatePreview?.LeftMs ?? project.PhaseGateLeftMs;
+        double plateauMs = gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs;
+        double rightMs = gatePreview?.RightMs ?? project.PhaseGateRightMs;
+        var perCurve = new List<double>(processed.Count);
+        foreach (ProcessedChannel item in processed)
+        {
+            double startMs = TransferIrStartCache.ResolveStartMs(
+                item.ImpulseResponse, sampleRate, item.PeakIndex);
+            double lossDb = DataHelper.GateLeadingEdgeLossDb(
+                new ImpulseMeasurementView(item.ImpulseResponse, 0, sampleRate),
+                startMs,
+                leftMs,
+                plateauMs,
+                rightMs);
+            if (lossDb > MaxPhaseGateLeadingEdgeLossDb)
+            {
+                return Shared();
+            }
+
+            perCurve.Add(startMs);
+        }
+
+        return perCurve;
+    }
 
     // A stored gate offset is used as-is; an unconfigured side (Auto) follows
     // the earliest ESTIMATED IR START of the processed channels — the

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverPhaseGatePlacementTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverPhaseGatePlacementTests.cs
@@ -46,4 +46,21 @@ public sealed class VirtualCrossoverPhaseGatePlacementTests
         // Equally bad is allowed; measurably worse is not.
         Assert.False(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(-12.7, -12.8));
     }
+
+    [Fact]
+    public void ASharedWindowHoldingNoneOfTheChannelNeverTakesItsPlacement()
+    {
+        // The case that would put the late-channel omission back: channels at
+        // 0 ms and 20 ms with the default 6 ms gate, the shared window on the
+        // early one. The late channel is nowhere inside that window, so
+        // falling back to it would delete the channel from the phase view and
+        // from Sum - the exact defect per-curve placement exists to prevent.
+        // GateLeadingEdgeLossDb reports such a window as infinite loss, so
+        // however poorly the channel's own placement scores, it is still the
+        // better of the two and is kept.
+        Assert.True(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(
+            -10.0, double.PositiveInfinity));
+        Assert.True(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(
+            0.0, double.PositiveInfinity));
+    }
 }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverPhaseGatePlacementTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverPhaseGatePlacementTests.cs
@@ -1,0 +1,49 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// Pins when the Virtual DSP phase view may gate each curve on its own arrival
+/// rather than on one shared window. Per-curve placement is what keeps FDW's
+/// short high-frequency windows on the right channel's first cycles; it is only
+/// comparable while each window opens before its own channel's response, which
+/// is what the leading-edge loss measures.
+/// </summary>
+public sealed class VirtualCrossoverPhaseGatePlacementTests
+{
+    [Fact]
+    public void APlacementThatKeepsItsLeadingEdgeIsAllowed()
+    {
+        // The field session's own-arrival placements, against the shared
+        // window: both well under the ceiling.
+        Assert.True(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(-28.4, -31.5));
+        Assert.True(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(-44.9, -44.9));
+        Assert.True(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(-65.5, -72.2));
+    }
+
+    [Fact]
+    public void APlacementOnTheArrivalPeakIsRefused()
+    {
+        // What this guard exists for: the peak placement that drew a summing
+        // subwoofer/bass pair as antiphase. Over the ceiling AND far worse
+        // than the shared window would be.
+        Assert.False(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(-3.5, -44.9));
+        Assert.False(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(-5.8, -31.5));
+        Assert.False(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(-10.8, -72.2));
+    }
+
+    [Fact]
+    public void AGateTooShortForTheChannelDoesNotCostItThePerCurveWindow()
+    {
+        // The project default gate (0.5/4/1.5 ms) cannot hold one period of a
+        // 55 Hz subwoofer wherever it is placed: on the field session it read
+        // -19.4 dB at the channel's own arrival and -19.4 dB at the shared
+        // one. Refusing there would buy no accuracy and would drop the whole
+        // set onto a 6 ms window that a channel arriving 20 ms later falls
+        // straight out of — the omission per-curve placement exists to
+        // prevent. Over the ceiling is not enough; the shared window has to be
+        // the better placement.
+        Assert.True(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(-19.4, -19.4));
+        Assert.True(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(-12.8, -12.7));
+        // Equally bad is allowed; measurably worse is not.
+        Assert.False(VirtualCrossoverPanel.AllowsPerCurvePhaseGate(-12.7, -12.8));
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
@@ -135,14 +135,17 @@ public sealed class FrequencyDependentPhaseTests
     }
 
     [Fact]
-    public void PerCurveGates_WithACommonReference_PreserveRelativePhase()
+    public void DifferentGatePositions_ThatBothContainTheWholeResponse_AgreeOnRelativePhase()
     {
-        // The Virtual DSP Auto gate places each channel's WINDOW on its own
-        // arrival (so FDW keeps a late channel's treble) while every curve
-        // shares one absolute τ. The relative phase must survive exactly as
-        // with a shared window: BuildMeasuredPhase re-references each
-        // extraction to the absolute τ, so where the window sits must not
-        // matter — only what it contains.
+        // The re-reference contract, stated on the case where it holds: two
+        // window POSITIONS whose plateaus both contain the whole (here
+        // one-sample) response. BuildMeasuredPhase moves each extraction to the
+        // absolute τ, so the placement cancels and only the content counts.
+        // This is what lets the Virtual DSP phase view gate each curve on its
+        // own arrival — but ONLY while the condition holds, which is why the
+        // placement is measured first (GateLeadingEdgeLossDb). The two tests
+        // below are its other half: what a window that cuts into its channel
+        // does, and that the guard sees the difference.
         SyntheticMeasurement first = DelayedImpulse(480); // 10 ms
         SyntheticMeasurement second = DelayedImpulse(576); // 12 ms
         PhaseAnalysisSettings sharedReference = Settings(
@@ -170,6 +173,160 @@ public sealed class FrequencyDependentPhaseTests
             Assert.True(Math.Abs(error) < 1e-5,
                 $"Relative-phase error {error:e} at {a.X:0.#} Hz with per-curve gates.");
         }
+    }
+
+    [Fact]
+    public void AGatePlacedOnTheArrivalPeak_TruncatesALowPassedChannelAndMovesItsPhase()
+    {
+        // Why the Virtual DSP phase view cannot gate each curve at its own
+        // arrival PEAK. A steeply low-passed channel peaks long after it
+        // starts, so a window whose plateau begins at the peak keeps only a
+        // short shoulder of the rise; the response the FFT sees is no longer
+        // the channel's, and the common τ cannot restore it. The same IR read
+        // through a window that contains it and through one placed on its peak
+        // must therefore DISAGREE: this shape reads 177° apart, the field pair
+        // 176°.
+        SyntheticMeasurement channel = LowPassedArrival(startSample: 480);
+        // The field session's gate: long enough that, placed on the arrival, it
+        // holds the whole channel — so only the PLACEMENT differs below.
+        PhaseAnalysisSettings containing = Settings(
+            PhaseWindowMode.FrequencyDependent,
+            6,
+            PhaseDetrendMode.Manual,
+            manualMs: 10.0,
+            gateOffsetMs: 10.0) with
+        {
+            LeftMs = 5.0,
+            PlateauMs = 50.0,
+            RightMs = 20.0
+        };
+        PhaseAnalysisSettings onThePeak = containing with
+        {
+            GateOffsetMs = FindPeakMs(channel)
+        };
+
+        List<SignalPoint> whole = DataHelper.GetGatedPhaseData(channel, containing);
+        List<SignalPoint> truncated = DataHelper.GetGatedPhaseData(channel, onThePeak);
+
+        double worstDegrees = 0;
+        foreach ((SignalPoint a, SignalPoint b) in whole.Zip(truncated)
+                     .Where(pair => pair.First.X is >= 40 and <= 120))
+        {
+            worstDegrees = Math.Max(
+                worstDegrees,
+                Math.Abs(Math.IEEERemainder(b.Y - a.Y, Math.Tau)) / Math.PI * 180.0);
+        }
+
+        Assert.True(
+            worstDegrees > 45.0,
+            $"the peak-placed window changed the read by only {worstDegrees:0.0}°; " +
+            "if placement no longer matters here, the guard can be revisited");
+    }
+
+    [Fact]
+    public void GateLeadingEdgeLoss_SeparatesAContainingPlacementFromATruncatingOne()
+    {
+        // The guard the per-curve placement rests on. It must read the same
+        // channel as safe when the window opens before its response and unsafe
+        // when the plateau starts on its peak — the two placements the test
+        // above showed 177° apart. Field figures at the same gate: own-arrival
+        // placements -28.4 to -72.2 dB, peak placements -3.5 to -10.8 dB.
+        SyntheticMeasurement channel = LowPassedArrival(startSample: 480);
+
+        double containing = DataHelper.GateLeadingEdgeLossDb(
+            channel, gateOffsetMs: 10.0, leftMs: 5.0, plateauMs: 50.0, rightMs: 20.0);
+        double onThePeak = DataHelper.GateLeadingEdgeLossDb(
+            channel, FindPeakMs(channel), leftMs: 5.0, plateauMs: 50.0, rightMs: 20.0);
+
+        Assert.True(
+            containing < -20.0,
+            $"a window opening on the arrival lost {containing:0.0} dB ahead of its plateau");
+        Assert.True(
+            onThePeak > -20.0,
+            $"a window opening on the peak lost only {onThePeak:0.0} dB ahead of its plateau");
+        // And the two verdicts must not sit next to each other: the whole point
+        // is a gap wide enough to put a ceiling in.
+        Assert.True(
+            onThePeak - containing > 15.0,
+            $"the guard separated the placements by only {onThePeak - containing:0.0} dB");
+    }
+
+    [Fact]
+    public void AGuardedPerCurvePlacement_ReadsTheSamePhaseAsAContainingSharedOne()
+    {
+        // What the guard buys: once a placement passes it, moving the window
+        // from a shared position to the channel's own arrival must not move the
+        // curve where the channel actually plays. That is the invariant the
+        // Virtual DSP phase view relies on to give each channel its own FDW
+        // window without making the curves incomparable.
+        SyntheticMeasurement channel = LowPassedArrival(startSample: 480);
+        PhaseAnalysisSettings shared = Settings(
+            PhaseWindowMode.FrequencyDependent,
+            6,
+            PhaseDetrendMode.Manual,
+            manualMs: 10.0,
+            gateOffsetMs: 8.0) with
+        {
+            LeftMs = 5.0,
+            PlateauMs = 50.0,
+            RightMs = 20.0
+        };
+        PhaseAnalysisSettings ownArrival = shared with { GateOffsetMs = 10.0 };
+        Assert.True(
+            DataHelper.GateLeadingEdgeLossDb(channel, 8.0, 5.0, 50.0, 20.0) < -20.0);
+        Assert.True(
+            DataHelper.GateLeadingEdgeLossDb(channel, 10.0, 5.0, 50.0, 20.0) < -20.0);
+
+        List<SignalPoint> sharedPhase = DataHelper.GetGatedPhaseData(channel, shared);
+        List<SignalPoint> ownPhase = DataHelper.GetGatedPhaseData(channel, ownArrival);
+
+        // Judged where this channel plays — a 55 Hz ring decaying over 25 ms
+        // carries its energy within roughly ±15 Hz of that, and a phase
+        // difference read where there is no output is noise, not a defect.
+        // (Field corroboration on the real channels, each inside its own
+        // passband: 0.2-1.5° between the shared and the own-arrival placement.)
+        foreach ((SignalPoint a, SignalPoint b) in sharedPhase.Zip(ownPhase)
+                     .Where(pair => pair.First.X is >= 45 and <= 70))
+        {
+            double degrees =
+                Math.Abs(Math.IEEERemainder(b.Y - a.Y, Math.Tau)) / Math.PI * 180.0;
+            Assert.True(
+                degrees < 5.0,
+                $"a guarded placement moved the read {degrees:0.0}° at {a.X:0.#} Hz");
+        }
+    }
+
+    // A band-limited arrival that keeps rising for some 15 ms after it starts —
+    // the shape a steep low-pass gives a subwoofer channel, where the peak the
+    // Auto gate used to anchor on sits nowhere near the arrival. Field figures
+    // for scale: start 15.6 ms, peak 36.7 ms.
+    private static SyntheticMeasurement LowPassedArrival(int startSample)
+    {
+        const double CyclesHz = 55.0;
+        double rise = 15.0 * SampleRate / 1000.0;
+        double decay = 25.0 * SampleRate / 1000.0;
+        var samples = new Complex[4_096];
+        for (int i = 0; startSample + i < samples.Length; i++)
+        {
+            double envelope = (1.0 - Math.Exp(-i / rise)) * Math.Exp(-i / decay);
+            samples[startSample + i] =
+                envelope * Math.Sin(Math.Tau * CyclesHz * i / SampleRate);
+        }
+        return new SyntheticMeasurement(samples, SampleRate, startSample);
+    }
+
+    private static double FindPeakMs(SyntheticMeasurement measurement)
+    {
+        Complex[] samples = measurement.ImpulseResponse!;
+        int peak = 0;
+        for (int i = 0; i < samples.Length; i++)
+        {
+            if (Math.Abs(samples[i].Real) > Math.Abs(samples[peak].Real))
+            {
+                peak = i;
+            }
+        }
+        return peak * 1_000.0 / measurement.SampleRate;
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
@@ -279,6 +279,33 @@ public sealed class FrequencyDependentPhaseTests
     }
 
     [Fact]
+    public void GateLeadingEdgeLoss_AWindowHoldingNoneOfTheChannelReadsAsUnsafe()
+    {
+        // The degenerate placement: a 6 ms window at 0 ms against a channel
+        // that arrives at 20 ms. Everything the channel has is ahead of the
+        // plateau and nothing is kept, which is the WORST a placement can do —
+        // so it has to read that way. Reading it as "nothing lost" would make
+        // a window that contains none of the channel look like the safest
+        // placement on offer, and a caller comparing two placements would then
+        // pick it over one that actually holds the channel.
+        var samples = new Complex[4_096];
+        samples[SampleRate * 20 / 1_000] = Complex.One;
+        var channel = new SyntheticMeasurement(
+            samples, SampleRate, SampleRate * 20 / 1_000);
+
+        double missed = DataHelper.GateLeadingEdgeLossDb(
+            channel, gateOffsetMs: 0.0, leftMs: 0.5, plateauMs: 4.0, rightMs: 1.5);
+        double onTheArrival = DataHelper.GateLeadingEdgeLossDb(
+            channel, gateOffsetMs: 20.0, leftMs: 0.5, plateauMs: 4.0, rightMs: 1.5);
+
+        Assert.True(
+            missed > onTheArrival,
+            $"a window holding none of the channel read {missed:0.0} dB against " +
+            $"{onTheArrival:0.0} dB for one placed on its arrival");
+        Assert.False(double.IsNegativeInfinity(missed));
+    }
+
+    [Fact]
     public void AGuardedPerCurvePlacement_ReadsTheSamePhaseAsAContainingSharedOne()
     {
         // What the guard buys: once a placement passes it, moving the window

--- a/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FrequencyDependentPhaseTests.cs
@@ -252,6 +252,33 @@ public sealed class FrequencyDependentPhaseTests
     }
 
     [Fact]
+    public void GateLeadingEdgeLoss_SeesTheWrappedContentAGateReachingBeforeZeroReads()
+    {
+        // A gate offset smaller than its left shoulder — legal, and reachable
+        // now that the crossing walk is floored at the record start. The phase
+        // path extracts with wrap, so that shoulder reads the circular
+        // buffer's tail; the guard has to read the same samples or it would
+        // judge a window it never saw. Here the tail carries a full-scale
+        // sample inside the fade-in: treating the stretch before zero as empty
+        // would report nothing lost at all.
+        var samples = new Complex[4_096];
+        samples[0] = Complex.One;      // the arrival, at the plateau
+        samples[^12] = Complex.One;    // negative time, inside the fade-in
+        var channel = new SyntheticMeasurement(samples, SampleRate, 0);
+
+        double loss = DataHelper.GateLeadingEdgeLossDb(
+            channel, gateOffsetMs: 0.0, leftMs: 0.5, plateauMs: 4.0, rightMs: 1.5);
+
+        Assert.True(
+            double.IsFinite(loss),
+            "the wrapped shoulder read as empty, so nothing counted as lost");
+        // And it is enough content to refuse the placement, not a rounding
+        // artefact: this reads -2.2 dB against the guard's -20 dB ceiling,
+        // where ignoring the wrap reports -3233 dB, i.e. nothing lost at all.
+        Assert.True(loss > -20.0, $"the wrapped content only read {loss:0.0} dB");
+    }
+
+    [Fact]
     public void AGuardedPerCurvePlacement_ReadsTheSamePhaseAsAContainingSharedOne()
     {
         // What the guard buys: once a placement passes it, moving the window

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -215,6 +215,55 @@ public sealed class TransferIrDiagnosticsTests
     }
 
     [Fact]
+    public void EstimateIrStart_ACabinModeDoesNotDragTheReadOffTheArrival()
+    {
+        // The field failure behind the arrival band's wider floor: a door
+        // woofer at the listening position, where one cabin mode towers ~20 dB
+        // over the driver's own working band. Read at the 15 dB CONTENT floor
+        // the band collapses around that mode — and a band that narrow cannot
+        // resolve anything shorter than its own ~8 ms, so the crossing walked
+        // back from its smeared envelope read 15.9 ms for an arrival at 20 ms,
+        // milliseconds before the record leaves its noise floor. The arrival
+        // band has to reach past the mode into the content the driver has.
+        var impulseResponse = new double[65_536];
+        int arrival = SampleRate * 20 / 1000;
+        double decay = 30.0 * SampleRate / 1000.0;
+        for (int i = 0; arrival + i < impulseResponse.Length && i < 12 * decay; i++)
+        {
+            impulseResponse[arrival + i] += Math.Exp(-i / decay) *
+                Math.Sin(Math.Tau * 123.0 * i / SampleRate);
+        }
+        // The driver's own front: wideband and brief, so it stands 20 dB below
+        // the mode across the spectrum however tall its samples are.
+        int front = (int)Math.Round(0.4 * SampleRate / 1000.0);
+        for (int i = 0; i < front; i++)
+        {
+            impulseResponse[arrival + i] +=
+                10.0 * (0.5 - 0.5 * Math.Cos(Math.Tau * i / front));
+        }
+
+        // The premise: at the content floor this record's band IS the mode.
+        DominantBand contentBand = TransferIrDiagnostics.DetectDominantBand(
+            impulseResponse, SampleRate);
+        Assert.True(
+            contentBand.HighHz < 300,
+            $"content band {contentBand.LowHz:0}-{contentBand.HighHz:0} Hz no longer collapses");
+
+        IrStartEstimate? start = TransferIrDiagnostics.EstimateIrStart(
+            impulseResponse, SampleRate);
+
+        Assert.NotNull(start);
+        Assert.True(start.Value.DominantBandLimited);
+        Assert.True(
+            start.Value.BandHighHz > 1_000,
+            $"the arrival band stopped at {start.Value.BandHighHz:0} Hz, inside the mode");
+        Assert.InRange(start.Value.StartMs, 19.0, 20.05);
+        Assert.True(
+            start.Value.EarlyMs >= 18.5,
+            $"even the 10 % crossing must hug the arrival; it read {start.Value.EarlyMs:0.00} ms");
+    }
+
+    [Fact]
     public void EstimateIrStart_ReadsASharpBroadbandFrontTightly()
     {
         var impulseResponse = new double[32_768];
@@ -231,6 +280,32 @@ public sealed class TransferIrDiagnosticsTests
         Assert.InRange(start.Value.StartMs, 19.5, 20.05);
         Assert.InRange(
             start.Value.LateMs - start.Value.EarlyMs, 0.0, 0.5);
+    }
+
+    [Fact]
+    public void EstimateIrStart_AFrontRunningOffTheRecordHeadStaysAtZero()
+    {
+        // A narrowband arrival that begins before the record does: the
+        // envelope is already well above the low crossings at sample 0, so
+        // the backward walk runs out of record. The crossings must stop at
+        // the record start rather than extrapolate into negative time.
+        var impulseResponse = new double[65_536];
+        double decay = 40.0 * SampleRate / 1000.0;
+        for (int i = 0; i < impulseResponse.Length; i++)
+        {
+            impulseResponse[i] =
+                Math.Exp(-i / decay) * Math.Sin(Math.Tau * 45.0 * i / SampleRate);
+        }
+
+        IrStartEstimate? start = TransferIrDiagnostics.EstimateIrStart(
+            impulseResponse, SampleRate);
+
+        Assert.NotNull(start);
+        Assert.True(
+            start.Value.EarlyMs >= 0.0,
+            $"the 10 % crossing read {start.Value.EarlyMs:0.00} ms");
+        Assert.True(start.Value.StartMs >= 0.0);
+        Assert.True(start.Value.LateMs >= 0.0);
     }
 
     [Fact]


### PR DESCRIPTION
Two Auto gate anchors were landing where there was no sound yet, found on the v5 field session.

## 1. The arrival was read in a band too narrow to time it

`Fit` on Phase / Group Delay resolved **3.00 ms** for `l bass.json`, while the record sits at its noise floor until ~5.6 ms and peaks at 6.42 ms. (The value is in `measurement-settings.json` as `GroupDelayGateOffsetMs = 3.0042051107682832`.)

`EstimateIrStart` reads the arrival inside the dominant band taken at the **content** floor, 15 dB. On this record a 123 Hz cabin mode towers over the door woofer's own band, and the cancellation notches either side are one to two grid steps too wide to bridge — so the band collapsed to **75-155 Hz, one octave**, where nothing shorter than ~12 ms resolves. The in-band envelope's only maximum is then the mode's build-up at 14.8 ms, and the 25 % crossing walked back from it lands before any sound. The right channel of the same driver got 5.46 octaves — the detector was on a knife edge.

The estimate had been saying so all along: its Early/Late spread read **5.5 ms** here against fractions of a millisecond on healthy records. Nothing looked.

A time can only be read as finely as the analysis band allows, so the arrival now gets its own floor (25 dB), leaving the content floor — which the crosstalk complement band needs answered tightly — untouched. `l bass` now reads **5.64 ms**, spread 1.2 ms.

Calibrated across v2-v5, 23 records, at 15/20/25/30 dB. 25 and 30 agree on the collapsed record while 20 is still transitional; records already four octaves wide move ≤ 0.5 ms; the narrow ones move 0.3-1.7 ms *later*, towards their arrival and still short of their own peak; every v3/v4 read stays in the 5.2-7.5 ms front range, i.e. none falls back onto the head burst the band-limiting exists to reject.

Widening the band also exposed a latent edge: the crossing walk could extrapolate past the head of the record into negative time (-1.5 ms on a subwoofer) where its own comment promised 0.0. Floored.

## 2. Virtual DSP gated each phase curve on its peak

With the gate on Auto, a subwoofer/bass pair that sums to within 9° across its 55 Hz junction was drawn **117-176° apart** — the phase view called antiphase what the sum-loss read-out beside it called near-perfect. Both sides, every pair.

Auto anchored each curve's window on that channel's own processed **peak**. A window is not a time shift: it multiplies each IR by a different stretch of itself, and re-referencing the extraction to the common τ rotates a spectrum but cannot put back what the window removed. A steeply low-passed channel peaks long after it starts — field: start 15.6 ms, **peak 36.7 ms** — so its own leading edge fell outside its window while its neighbour's stayed intact.

The invariant this rested on had been pinned on **deltas**, where any containing window is equivalent, then generalised in a comment to band-limited channels, where it is false.

Per-curve placement is kept — it is what lets FDW's short high-frequency windows sit on the right channel's first cycles — but anchored on each channel's own estimated arrival **start**, and measured first. `DataHelper.GateLeadingEdgeLossDb` reports how much of a channel's energy a placement discards *ahead of* its plateau (truncating the tail behind it is what a gate is for); if any channel fails, the whole set falls back to one shared window, since mixing placements is worse than either.

| placement (v5 session, gate 5/50/20) | leading-edge loss |
|---|---|
| own arrival start | -28.4 … -72.2 dB — pass |
| own peak (what caused this) | -3.5 … -10.8 dB — refused |

Ceiling -20 dB, in the middle of a 17.6 dB gap. Sub vs bass at the junction now reads 0.0-12.6°, matching the pinned gate.

The gate geometry also resolves in one place now, so a placement can never be judged against a different window than the one that gets used.

## Notes

- At high frequencies the FDW window is short by design and *always* truncating, so placement genuinely selects which cycles are read. Anchoring on each channel's own arrival is the intended semantics there ("this driver's first 6 cycles"), not a defect — but it means the mid/tweeter junction reads differently from a shared window by tens of degrees. Sum loss remains the independent check.
- Phase and magnitude resolve their Auto anchors from different figures (earliest processed **peak** vs earliest estimated **start**); left as is, so the sum-loss numbers do not move.

## Testing

`dotnet test source/Resonalyze.sln -c Release` — **1036 / 911 / 142** passing (dsp / app / audio), nothing skipped in dsp.

Five new tests, each verified to fail without its fix:

- a cabin mode must not drag the arrival read off the front (fails with the content floor: "the arrival band stopped at 143 Hz, inside the mode");
- a front running off the head of the record stays at zero (fails at -5.96 ms);
- a window placed on a slow-rising channel's peak moves the read by **177°** (field pair: 176°);
- the guard separates a containing placement from a truncating one, by more than 15 dB;
- a placement that passes the guard does not move the read inside the channel's own band.

The delta test that had been over-generalised is renamed to what it actually proves and now points at its own boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
