### PR TITLE
Trust the whitened extremum, and judge a co-move by the near side

### DIFF
--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -195,6 +195,23 @@ public static class AutoAlignmentEngine
     // AlignmentSelection tie-breaks resolve what remains.
     private const double LowJunctionReachFraction = 0.97;
 
+    /// <summary>
+    /// How far past the MEASURED distance to the seed's opposite-polarity
+    /// partner a trusted junction's fine window may reach, so the partner's own
+    /// loss optimum lands inside it as an interior point rather than pinned to
+    /// the edge (an edge pin triggers the retry path instead of a comparison).
+    /// </summary>
+    private const double SeedPartnerReachFactor = 1.2;
+
+    /// <summary>
+    /// And the ceiling on that reach, in crossover periods: three quarters sits
+    /// between the polarity partner a half period out — which the window must
+    /// contain — and the same-polarity rival a full period out, which it must
+    /// not. The same bound, for the same reason, as
+    /// <see cref="OnsetLockReachPeriods"/>.
+    /// </summary>
+    private const double SeedPartnerMaxReachPeriods = 0.75;
+
     // The delay ceiling an AUTO DELAY proposal may reach — tighter than the
     // manual UI range (100 ms, since the Virtual DSP may model any hardware).
     // Car processors cap per-channel delay in the tens of milliseconds (~17 m
@@ -850,7 +867,10 @@ public static class AutoAlignmentEngine
         AppendCorrelationAlignmentDiagnostics(log, pairs);
 
         Dictionary<IAlignmentChannel, double> timeline =
-            BuildArrivalTimeline(byBand, pairs, log, out HashSet<AlignmentJunction> untrustedSeeds);
+            BuildArrivalTimeline(
+                byBand, pairs, log,
+                out HashSet<AlignmentJunction> untrustedSeeds,
+                out Dictionary<AlignmentJunction, double> seedPartnerReach);
 
         // The relatively latest channel is the fixed reference; everyone else is
         // delayed toward it, so the coarse deltas are non-negative.
@@ -882,6 +902,7 @@ public static class AutoAlignmentEngine
                 byBand[i].Channel, byBand[i + 1].Channel, pairs[i],
                 timeline, byBand, reprocess, alignment, log,
                 untrustedSeedJunctions: untrustedSeeds,
+                seedPartnerDistanceMs: seedPartnerReach,
                 onsetLocks: onsetLocks,
                 decisions: decisions,
                 monoChannels: monoChannels);
@@ -892,6 +913,7 @@ public static class AutoAlignmentEngine
                 byBand[i].Channel, byBand[i - 1].Channel, pairs[i - 1],
                 timeline, byBand, reprocess, alignment, log,
                 untrustedSeedJunctions: untrustedSeeds,
+                seedPartnerDistanceMs: seedPartnerReach,
                 onsetLocks: onsetLocks,
                 decisions: decisions,
                 monoChannels: monoChannels);
@@ -910,7 +932,8 @@ public static class AutoAlignmentEngine
         IReadOnlyList<AlignmentSnapshot> byBand,
         IReadOnlyList<AlignmentJunction> pairs,
         StringBuilder log,
-        out HashSet<AlignmentJunction> untrustedSeedJunctions)
+        out HashSet<AlignmentJunction> untrustedSeedJunctions,
+        out Dictionary<AlignmentJunction, double> seedPartnerDistanceMs)
     {
         // Junctions whose coarse seed fell back to the arrival envelope because
         // the PHAT peak was untrusted (a low junction with too few in-band
@@ -922,6 +945,11 @@ public static class AutoAlignmentEngine
         // from and never leaks onto a channel's OTHER, phat-trusted junction.
         untrustedSeedJunctions =
             new HashSet<AlignmentJunction>(ReferenceEqualityComparer.Instance);
+        // And, for the TRUSTED ones, how far the seed's opposite-polarity
+        // partner was measured to sit — the reach the fine window owes it.
+        seedPartnerDistanceMs =
+            new Dictionary<AlignmentJunction, double>(
+                ReferenceEqualityComparer.Instance);
         var timeline = new Dictionary<IAlignmentChannel, double>
         {
             [byBand[0].Channel] = 0
@@ -1352,6 +1380,22 @@ public static class AutoAlignmentEngine
             {
                 untrustedSeedJunctions.Add(pair);
             }
+            else if (LobeBoundaryMs(phat) is > 0 and { } halfSpacingMs)
+            {
+                // A trusted seed fixes WHERE the pair of adjacent lobes sits,
+                // not WHICH of them is right: the peak-vs-trough margin is a
+                // statement about the band's width, so the polarity partner a
+                // half period away is still a live candidate and the loss
+                // search is what settles it (see PhatSeedMinRivalDominance).
+                // That only holds if the fine window can reach the partner, and
+                // the fixed ±2.5 ms cap cannot below ~200 Hz: measured across
+                // the archived cabins, 10 of 13 junctions under 400 Hz put
+                // their partner OUTSIDE it (7.57 ms out at 60 Hz, 3.18 at 150
+                // against a 2.5 ms reach). So a trusted junction records how
+                // far its partner actually sits and the fine window grows to
+                // cover it.
+                seedPartnerDistanceMs[pair] = 2.0 * halfSpacingMs;
+            }
 
             // Full-band processed-IR peak times, a detector-independent arrival
             // proxy: a band-limited arrival that sits many ms LATER than its own
@@ -1413,7 +1457,8 @@ public static class AutoAlignmentEngine
         IReadOnlySet<AlignmentJunction>? untrustedSeedJunctions = null,
         Dictionary<AlignmentJunction, OnsetLockState>? onsetLocks = null,
         Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null,
-        IReadOnlyCollection<IAlignmentChannel>? monoChannels = null)
+        IReadOnlyCollection<IAlignmentChannel>? monoChannels = null,
+        IReadOnlyDictionary<AlignmentJunction, double>? seedPartnerDistanceMs = null)
     {
         // Widen the window when the coarse seed ACROSS this junction (or its
         // secondary, for a joint two-neighbour search) was the untrusted arrival
@@ -1580,14 +1625,34 @@ public static class AutoAlignmentEngine
             double WindowLowMs, double WindowHighMs)
             SearchJunction(double? windowOverrideMs = null)
         {
-            // Only where the coarse seed was untrusted (arrival fallback at a
-            // low junction) let the cap grow toward a half period so the window
-            // can reach a half-period-away flip partner the fixed cap would
-            // hide. A trusted seed already sits on the right lobe, and widening
-            // there would only invite the impostor the tight window excludes.
+            // Where the coarse seed was untrusted (arrival fallback at a low
+            // junction) the cap grows toward a half period so the window can
+            // reach a half-period-away flip partner the fixed cap would hide.
+            //
+            // A TRUSTED seed needs the same reach, for a different reason. It
+            // fixes where the pair of adjacent lobes sits but not which of them
+            // is right — the peak-vs-trough margin measures the band's width,
+            // not the polarity (see PhatSeedMinRivalDominance) — so the loss
+            // search is what settles that, and it can only settle what the
+            // window contains. The reach is the MEASURED distance to the
+            // partner rather than half a period: the real correlation's extrema
+            // do not sit where a monochromatic comb says (3.18 ms at the v5
+            // cabin's 150 Hz junction against a nominal 3.33). Without it the
+            // fixed 2.5 ms cap excluded the partner at 10 of the 13 junctions
+            // under 400 Hz across the archived cabins, and a hundredth of PHAT
+            // coefficient would have decided the polarity with no way back:
+            // the wide diagnostic sweep sees the partner, but reaching it there
+            // costs the 1.6 dB promotion margin a near-tie cannot pay.
+            double partnerReachMs =
+                !wideSeed &&
+                seedPartnerDistanceMs?.TryGetValue(pair, out double partnerMs) == true
+                    ? Math.Min(
+                        SeedPartnerReachFactor * partnerMs,
+                        SeedPartnerMaxReachPeriods * 2.0 * halfPeriodMs)
+                    : 0;
             double maxRangeMs = wideSeed
                 ? Math.Max(MaxFineAlignmentRangeMs, LowJunctionReachFraction * halfPeriodMs)
-                : MaxFineAlignmentRangeMs;
+                : Math.Max(MaxFineAlignmentRangeMs, partnerReachMs);
             double rangeMs = windowOverrideMs ?? Math.Clamp(
                 halfPeriodMs, MinFineAlignmentRangeMs, maxRangeMs);
             double windowLowMs = Math.Min(primaryBase, secondaryBase) - rangeMs;
@@ -1649,6 +1714,12 @@ public static class AutoAlignmentEngine
                 (onsetAnchorMs is { } onsetForLog
                     ? $", ONSET-LOCKED {onsetForLog:0.000} \u00b1{onsetCapMs:0.000} ms"
                     : "") +
+                // The window itself, not just its inputs: which lobes the loss
+                // search could even compare is the first thing to check when a
+                // junction settles on a surprising one, and it is not derivable
+                // from the base and the crossover alone (a trusted seed's reach
+                // follows the MEASURED polarity-partner distance).
+                $", window {windowLow:0.000}..{windowHigh:0.000} ms" +
                 ", candidates " +
                 string.Join("; ", candidates.Select(item =>
                     $"{item.DelayMs:0.000} ms" +
@@ -2493,7 +2564,8 @@ public static class AutoAlignmentEngine
         Dictionary<IAlignmentChannel, double> rightTimeline =
             BuildArrivalTimeline(
                 rightByBand, plan.RightPairs, log,
-                out HashSet<AlignmentJunction> rightUntrustedSeeds);
+                out HashSet<AlignmentJunction> rightUntrustedSeeds,
+                out Dictionary<AlignmentJunction, double> rightSeedPartnerReach);
 
         // The delay that Δ-aligns this right channel to its settled left
         // counterpart — landing its arrival exactly the scene offset ahead,
@@ -2945,7 +3017,8 @@ public static class AutoAlignmentEngine
                 channel, neighbor, pair,
                 rightTimeline, allChannels, reprocess, alignment, log,
                 secondary, secondaryPair, crossTarget, sceneLock, inheritedPolarity,
-                rightUntrustedSeeds, onsetLocks, decisions, plan.MonoChannels);
+                rightUntrustedSeeds, onsetLocks, decisions, plan.MonoChannels,
+                rightSeedPartnerReach);
         }
         for (int i = bridgeIndex - 1; i >= 0; i--)
         {

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -254,17 +254,32 @@ public static class AutoAlignmentEngine
     // search and the wide-window promotion below it.
     private const double PhatSeedMinCoefficient = 0.15;
 
-    // The minimum dominance (Confidence: |best extremum| minus |its rival|) the
-    // PHAT correlation must show before its extremum position is trusted as the
-    // seed. A junction whose corners leave a spectral gap (e.g. LP 1300 /
-    // HP 1800) narrows the effective overlap and the whitened correlation
-    // degenerates into a comb of near-equal lobes: the peak coefficient still
-    // looks healthy, but which lobe it sits on is decided by noise — trusting
-    // it can move the seed whole periods off the arrival estimate (a cycle skip
-    // the prior then cements). Peak-vs-trough closeness is exactly that lobe
-    // ambiguity, so a near-tie sends the seed back to the polarity-blind
-    // arrival envelope.
-    private const double PhatSeedMinDominance = 0.1;
+    /// <summary>
+    /// The margin by which the seed extremum must beat the SAME-POLARITY rival
+    /// one period over before its position is trusted. This is the whole-period
+    /// cycle skip — the error the fine window cannot undo, since its reach is
+    /// capped below a period — so it keeps a gate of its own.
+    ///
+    /// The peak-vs-trough margin does NOT. It used to gate the seed by the same
+    /// figure, and measurement killed that: on a PERFECT synthetic junction —
+    /// two filters off one impulse, no room, no noise, perfectly aligned — the
+    /// peak/trough margin is 0.167 at a two-octave band and falls to 0.100 /
+    /// 0.049 / 0.012 at 1.5 / 1.0 / 0.5 octaves, at every fc, family and slope.
+    /// It measures how wide the analysed band is, not whether the extremum can
+    /// be believed, and the old 0.1 therefore demanded 60 % of what a flawless
+    /// junction can even produce: across the archived cabins it refused 34 of
+    /// 40 junctions, including every one whose extremum the owner's hand tune
+    /// then landed on. What it flags — a half-period ambiguity — is also the
+    /// one the fine window spans and the loss search settles by polarity, so
+    /// the peak-vs-trough figure now only informs the log.
+    ///
+    /// The rival margin is a different statistic on the same scale: the perfect
+    /// junction shows 0.534 of it, so 0.05 is a tenth of the ideal rather than
+    /// the old 0.1 = a fifth. Field: the archived cabins' true rivals sit
+    /// 0.09-0.53 apart, and the junctions that fail this gate are the ones with
+    /// no separated structure at all.
+    /// </summary>
+    private const double PhatSeedMinRivalDominance = 0.05;
 
     // The sub-precedence margin: at a junction with the shared mono sub, a
     // near-tie between the comb lobe that leaves the sub TRAILING the stack and
@@ -1277,13 +1292,14 @@ public static class AutoAlignmentEngine
                 {
                     return $"{seedLabel} too weak";
                 }
-                if (phat.Confidence < PhatSeedMinDominance)
-                {
-                    return "peak-trough near-tie";
-                }
+                // There is deliberately NO peak-vs-trough gate here: that margin
+                // measures the analysed band's width, not the extremum's
+                // credibility (see PhatSeedMinRivalDominance), and the half
+                // period it leaves ambiguous is the one the fine window spans
+                // and the loss search settles by polarity.
                 if (sameSignRival is { } rival &&
                     Math.Abs(seed.Coefficient) - Math.Abs(rival.Coefficient) <
-                        PhatSeedMinDominance)
+                        PhatSeedMinRivalDominance)
                 {
                     return "same-polarity rival near-tie";
                 }
@@ -1296,52 +1312,29 @@ public static class AutoAlignmentEngine
                 // distant modal peak found there is exactly the skip candidate
                 // the veto guards.
                 //
-                // Where the pair can be GRADED against its prediction, an extra
-                // restriction applies on top. Only ever a restriction: the
-                // disagreement figure it keys on is not a bound (see there), so
-                // the clamp below lets it narrow the reach and never widen it.
-                //
-                // It narrows toward comb geometry. The neighbouring
-                // opposite-polarity lobe sits a half spacing H away; with the
-                // anchor off by U toward it the true lobe lies U away and the
-                // neighbour H - U, so a reach R admits the true lobe and
-                // excludes the neighbour only while U <= R < H - U — solvable
-                // only for U < H/2. Past that the neighbour can sit CLOSER to
-                // the anchor than the truth does and no window separates them,
-                // so the seed is refused rather than given a wider one.
-                //
-                // H is MEASURED, not assumed. Half a period at fc describes a
-                // monochromatic comb, but this correlation runs over two octaves
-                // of two real responses and its extrema do not sit where that
-                // idealization says — at the v4 cabin's 180 Hz corner the
-                // whitened peak and trough are 2.665 ms apart against a nominal
-                // half period of 2.778 (2.537 for a flat two-octave window).
-                //
-                // ADJACENCY, not strength: the window's strongest peak and
-                // trough can sit several lobes apart, so the spacing is taken to
-                // the extremum NEIGHBOURING the seed. Without one, or with one
-                // pinned to the window edge (its position then an artifact),
-                // there is no spacing to reason from and a gradeable pair
-                // refuses the seed rather than guessing at one.
-                double lobeBoundaryMs = LobeBoundaryMs(phat);
-                //
                 // A pair whose anchor could not place it inside a lobe has
                 // already been convicted and re-anchored above, which clears
-                // both arrival-relative tests here: measuring the extremum
-                // against an anchor just found incapable of resolving lobes
-                // (or against a discarded one, after the upper-half probe's
-                // conviction) would veto by a number that refers to nothing.
-                //
-                // Only ever TIGHTER than the standing rule: the disagreement
-                // figure above is not a proven bound, so it may restrict the
-                // seed further but never license a reach the conservative rule
-                // would not already have allowed. Otherwise a mis-measured
-                // spacing, or a bias shared by the measurement and the
-                // prediction, would loosen the gate on an agreement that proves
+                // this arrival-relative test: measuring the extremum against an
+                // anchor just found incapable of resolving lobes (or against a
+                // discarded one, after the upper-half probe's or the predicted
+                // front's conviction) would veto by a number that refers to
                 // nothing.
-                double reachMs = pairPredictionGradeable
-                    ? Math.Min(SeedReachMs(pair.CrossoverHz), lobeBoundaryMs)
-                    : SeedReachMs(pair.CrossoverHz);
+                //
+                // A prediction-GRADEABLE pair used to have its reach clamped
+                // further, to the measured half lobe spacing. The arithmetic
+                // retired that clamp. The certificate it rested on resolves
+                // PredictedArrivalAllowanceMs — max(2.5 ms, half a period at the
+                // band centre) — while the boundary it clamped to is half the
+                // peak-trough spacing, a QUARTER period. A quarter period is
+                // never as coarse as either term of that maximum, so the
+                // certificate could not resolve the reach it was certifying: at
+                // the v5 cabin's 1500 Hz junction a ±2.5 ms "verified" read
+                // enforced a 0.167 ms reach and refused an extremum (r 0.587)
+                // that the panel then measured 0.13 dB better on average and
+                // 2.7 dB shallower in the dip than the lobe the arrival chose.
+                // A gate must not be tightened by evidence fifteen times coarser
+                // than the distance it decides.
+                double reachMs = SeedReachMs(pair.CrossoverHz);
                 // At the boundary itself the two lobes are equidistant, so
                 // the extremum is refused rather than admitted.
                 if (!arrivalReanchored && Math.Abs(seedOffsetMs) >= reachMs)
@@ -1511,8 +1504,20 @@ public static class AutoAlignmentEngine
         // scene lock outranks: the image pin already IS the window.
         double? onsetAnchorMs = null;
         double onsetCapMs = 0;
+        // ... and only where the ANCHOR is the arrival envelope, which is what
+        // the lock exists to replace (see the onset-lock constants). A trusted
+        // whitened extremum is the better witness of the two — it times the
+        // two responses against each other in the junction's own band, where a
+        // threshold onset reads each driver's broadband front separately and
+        // differences their rise times: at the v5 cabin's 1500 Hz junction the
+        // mid's front rises over 0.274 ms and the tweeter's over 0.037, so the
+        // onset difference moved 0.237 ms (0.4 period) across the 10/25/50 %
+        // thresholds and its anchor landed on the weakest lobe of the comb.
+        // Pinning a trusted seed to that would overrule the stronger evidence
+        // with the weaker.
         if (secondaryNeighbor == null &&
             sceneLockToleranceMs == null &&
+            wideSeed &&
             pair.CrossoverHz >= OnsetLockMinCrossoverHz)
         {
             BroadbandOnsetEstimate own =
@@ -3307,11 +3312,13 @@ public static class AutoAlignmentEngine
 
     // Moves both sides of one linked pair by the same delta — the pair's L-R
     // timing (the scene) is invariant under a co-move — searching for the
-    // delta that minimizes the MEAN loss of every junction adjacent to the
-    // pair on either side. The left side may get slightly worse: by the scene
-    // mandate the pinned right channel could not chase its own junction
-    // optimum, and this is the only lever that can recover junction quality
-    // without touching the image. Top pair first, so lower pairs re-balance
+    // delta that minimizes the mean loss of the REFERENCE side's junctions
+    // adjacent to the pair, bounded by the junctions of both sides. The far
+    // side is what the scene mandate pinned off its own junction optimum, and
+    // this is the only lever that can recover junction quality without
+    // touching the image — but it may not buy that recovery with the near
+    // side's alignment (see the evaluator loop). Top pair first, so lower
+    // pairs re-balance
     // against the already-settled uppers. The scan is analytic: ONE reprocess
     // fixes the pair's current responses, each junction gets its gated
     // spectra built once, and every probed delta is an e^{-jωΔ} rotation of
@@ -3350,15 +3357,21 @@ public static class AutoAlignmentEngine
             AlignmentOverride leftOverride = alignment.GetValueOrDefault(link.Left);
             AlignmentOverride rightOverride = alignment.GetValueOrDefault(link.Right);
 
-            // Every junction the pair's channels take part in, on either side.
-            List<AlignmentJunction> adjacent = plan.LeftPairs
+            // Every junction the pair's channels take part in, on either side:
+            // BOTH sides bound how far the shared delta may travel (a move that
+            // leaves the far side a lobe off its own neighbour is not a
+            // candidate at all), while only the reference side's junctions
+            // score it — see the evaluator loop below.
+            List<AlignmentJunction> referenceAdjacent = plan.LeftPairs
                 .Where(pair => pair.Lower.Channel == link.Left ||
                     pair.Upper.Channel == link.Left)
+                .ToList();
+            List<AlignmentJunction> adjacent = referenceAdjacent
                 .Concat(plan.RightPairs.Where(pair =>
                     pair.Lower.Channel == link.Right ||
                     pair.Upper.Channel == link.Right))
                 .ToList();
-            if (adjacent.Count == 0)
+            if (referenceAdjacent.Count == 0)
             {
                 continue;
             }
@@ -3386,15 +3399,22 @@ public static class AutoAlignmentEngine
             // the size of change it can make.
             int gateAnchor = SystemGateAnchor(current);
 
-            // One evaluator per junction: the pair member is the rotated
-            // (moving) channel, its junction neighbor stays fixed. A junction
-            // between the pair and its neighbor never has both ends moving —
-            // the pair's two channels sit on different sides.
+            // One evaluator per junction of the REFERENCE side. The move is
+            // shared, so its criterion is a choice, and a mean over both sides
+            // buys the far side's junction with the near one's: the delta that
+            // wins the average can leave the reference side worse than the
+            // cascade left it. The reference side is the one whose drivers sit
+            // closest to the listener, where a timing error is easiest to hear,
+            // so it is the side the shared move must not spend. The far side
+            // still follows the delta (the scene is preserved either way) and
+            // is still BOUNDED by its own junctions below — it just does not
+            // get a vote on where the pair lands.
             var evaluators = new List<VirtualCrossoverAnalysis.SumLossEvaluator>();
-            foreach (AlignmentJunction junction in adjacent)
+            foreach (AlignmentJunction junction in referenceAdjacent)
             {
-                bool lowerMoves = junction.Lower.Channel == link.Left ||
-                    junction.Lower.Channel == link.Right;
+                // These are the reference side's junctions, so the moving end
+                // is always the link's reference-side member.
+                bool lowerMoves = junction.Lower.Channel == link.Left;
                 IAlignmentChannel mover = lowerMoves
                     ? junction.Lower.Channel
                     : junction.Upper.Channel;
@@ -3578,8 +3598,8 @@ public static class AutoAlignmentEngine
                 log.AppendLine(
                     $"Co-move {link.Left.Name}+{link.Right.Name}: " +
                     $"{bestDelta:+0.00;-0.00} ms to both sides " +
-                    $"(mean dip-penalized junction loss {baseline:0.00} -> " +
-                    $"{bestScore:0.00} dB; scene untouched)");
+                    $"(reference-side dip-penalized junction loss " +
+                    $"{baseline:0.00} -> {bestScore:0.00} dB; scene untouched)");
                 // The move is a bounded in-lobe polish (the lobe decision the
                 // recorded confidence describes stands), but the final delays
                 // differ from the walk's — the report must say so.

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
@@ -66,6 +66,7 @@ namespace Resonalyze
             numericAllPassFreq = new DarkNumericUpDown();
             numericAllPassQ = new DarkNumericUpDown();
             labelAllpassBand = new Label();
+            labelTotalGain = new Label();
             (numericGain).BeginInit();
             (numericDelay).BeginInit();
             (numericHighPassHz).BeginInit();
@@ -135,7 +136,7 @@ namespace Resonalyze
             numericGain.Minimum = new decimal(new int[] { 60, 0, 0, int.MinValue });
             numericGain.MinimumSize = new Size(36, 19);
             numericGain.Name = "numericGain";
-            numericGain.Size = new Size(66, 19);
+            numericGain.Size = new Size(55, 19);
             numericGain.TabIndex = 3;
             numericGain.TextAlign = HorizontalAlignment.Right;
             numericGain.ThousandsSeparator = false;
@@ -146,11 +147,11 @@ namespace Resonalyze
             labelDelay.AutoSize = true;
             labelDelay.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             labelDelay.ForeColor = Color.FromArgb(210, 214, 222);
-            labelDelay.Location = new Point(152, 35);
+            labelDelay.Location = new Point(212, 35);
             labelDelay.Name = "labelDelay";
-            labelDelay.Size = new Size(56, 15);
+            labelDelay.Size = new Size(37, 15);
             labelDelay.TabIndex = 4;
-            labelDelay.Text = "Delay ms";
+            labelDelay.Text = "Delay";
             // 
             // numericDelay
             // 
@@ -158,7 +159,7 @@ namespace Resonalyze
             numericDelay.DecimalPlaces = 2;
             numericDelay.ForeColor = Color.White;
             numericDelay.Increment = new decimal(new int[] { 1, 0, 0, 131072 });
-            numericDelay.Location = new Point(220, 33);
+            numericDelay.Location = new Point(252, 33);
             numericDelay.Maximum = new decimal(new int[] { 100, 0, 0, 0 });
             numericDelay.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
             numericDelay.MinimumSize = new Size(36, 19);
@@ -173,7 +174,7 @@ namespace Resonalyze
             // 
             labelDelayMm.AutoSize = true;
             labelDelayMm.ForeColor = Color.FromArgb(170, 176, 190);
-            labelDelayMm.Location = new Point(220, 54);
+            labelDelayMm.Location = new Point(252, 54);
             labelDelayMm.Name = "labelDelayMm";
             labelDelayMm.Size = new Size(49, 15);
             labelDelayMm.TabIndex = 6;
@@ -538,12 +539,23 @@ namespace Resonalyze
             labelAllpassBand.TabIndex = 36;
             labelAllpassBand.Text = "= 0.00 ms";
             // 
+            // labelTotalGain
+            // 
+            labelTotalGain.AutoSize = true;
+            labelTotalGain.ForeColor = Color.FromArgb(170, 176, 190);
+            labelTotalGain.Location = new Point(131, 35);
+            labelTotalGain.Name = "labelTotalGain";
+            labelTotalGain.Size = new Size(56, 15);
+            labelTotalGain.TabIndex = 37;
+            labelTotalGain.Text = "All +0.0";
+            // 
             // VirtualCrossoverChannelControl
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(46, 51, 62);
             BorderStyle = BorderStyle.FixedSingle;
+            Controls.Add(labelTotalGain);
             Controls.Add(labelAllpassBand);
             Controls.Add(numericAllPassQ);
             Controls.Add(numericAllPassFreq);
@@ -638,5 +650,6 @@ namespace Resonalyze
         private DarkNumericUpDown numericAllPassFreq;
         private DarkNumericUpDown numericAllPassQ;
         private Label labelAllpassBand;
+        private Label labelTotalGain;
     }
 }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
@@ -26,6 +26,7 @@ public partial class VirtualCrossoverChannelControl : UserControl
     private bool muted;
     private bool collapsed;
     private double sampleRateHz = DefaultSampleRateHz;
+    private double peqPreampDb;
     private int expandedHeight;
 
     public VirtualCrossoverChannelControl()
@@ -50,6 +51,7 @@ public partial class VirtualCrossoverChannelControl : UserControl
         UpdateAllPassAvailability();
         UpdateAllPassGroupDelay();
         UpdateDelayDistance();
+        UpdateTotalGain();
     }
 
     /// <summary>
@@ -74,6 +76,28 @@ public partial class VirtualCrossoverChannelControl : UserControl
 
             sampleRateHz = value;
             UpdateAllPassGroupDelay();
+        }
+    }
+
+    /// <summary>
+    /// The preamp of the PEQ loaded into this channel (dB), pushed by the host — the
+    /// bands themselves stay with the project, but their broadband offset is part of
+    /// the level the user has to dial in, so the block folds it into the gain readout.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public double PeqPreampDb
+    {
+        get => peqPreampDb;
+        set
+        {
+            if (peqPreampDb == value)
+            {
+                return;
+            }
+
+            peqPreampDb = value;
+            UpdateTotalGain();
         }
     }
 
@@ -127,6 +151,7 @@ public partial class VirtualCrossoverChannelControl : UserControl
     internal Button MuteButton => buttonMute;
     internal Button CollapseButton => buttonCollapse;
     internal Label PeqInfoLabel => labelPeqInfo;
+    internal Label TotalGainLabel => labelTotalGain;
     internal CheckBox ShowRawCheckBox => checkBoxShowRaw;
     internal CheckBox ShowProcessedCheckBox => checkBoxShowProcessed;
     internal CheckBox BypassCheckBox => checkBoxBypass;
@@ -317,6 +342,13 @@ public partial class VirtualCrossoverChannelControl : UserControl
             "were captured through the same playback chain;\r\n" +
             "compensate any difference here.");
         toolTip.SetToolTip(
+            labelTotalGain,
+            "Channel gain with the loaded PEQ's preamp folded in —\r\n" +
+            "the single level to dial in on a DSP whose equalizer\r\n" +
+            "has no preamp of its own.\r\n" +
+            "Shown only when the PEQ carries a preamp; the bands\r\n" +
+            "themselves are frequency-dependent and not part of it.");
+        toolTip.SetToolTip(
             checkBoxInvert,
             "Invert the channel polarity — the DSP polarity switch.\r\n" +
             "Also the null test: with polarity flipped, the deepest\r\n" +
@@ -472,6 +504,7 @@ public partial class VirtualCrossoverChannelControl : UserControl
         UpdateAllPassAvailability();
         UpdateAllPassGroupDelay();
         UpdateDelayDistance();
+        UpdateTotalGain();
     }
 
     private void PopulateCrossoverCombos()
@@ -596,7 +629,11 @@ public partial class VirtualCrossoverChannelControl : UserControl
         buttonPeqLoad.Click += (_, _) => PeqLoadClicked?.Invoke(this, EventArgs.Empty);
         buttonPeqClear.Click += (_, _) => PeqClearClicked?.Invoke(this, EventArgs.Empty);
 
-        numericGain.ValueChanged += (_, _) => RaiseSettingsChanged();
+        numericGain.ValueChanged += (_, _) =>
+        {
+            UpdateTotalGain();
+            RaiseSettingsChanged();
+        };
         numericDelay.ValueChanged += (_, _) =>
         {
             UpdateDelayDistance();
@@ -725,6 +762,22 @@ public partial class VirtualCrossoverChannelControl : UserControl
         labelAllpassBand.Text = milliseconds >= 100
             ? $"= {milliseconds:0} ms"
             : $"= {milliseconds:0.00} ms";
+    }
+
+    // The one level to dial in: many DSPs have no separate preamp for their equalizer,
+    // so the PEQ's preamp has to be folded into the channel gain when the tune is typed
+    // in — the same sum the tuning sheets print. Blank without a preamp, where it would
+    // only repeat the Gain field it sits next to.
+    private void UpdateTotalGain()
+    {
+        if (peqPreampDb == 0)
+        {
+            labelTotalGain.Text = string.Empty;
+            return;
+        }
+
+        double totalDb = (double)numericGain.Value + peqPreampDb;
+        labelTotalGain.Text = $"All {totalDb:+0.0;-0.0;0.0}";
     }
 
     // The ruler-check readout: the delay expressed as a distance in air.

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
@@ -45,22 +45,26 @@ internal static class VirtualCrossoverMetric
     /// <summary>
     /// Compact per-junction column for the narrow host read-out panel: a
     /// monospace "name  avg / dip" line each, no frequency ranges (those are
-    /// on hover).
+    /// on hover). Two decimals, like the arrival and junction-phase blocks
+    /// below it: genuine lobe alternatives differ by hundredths here (the v5
+    /// cabin's 150 Hz junction separates its two candidates by 0.08 dB), and
+    /// at one decimal the read-out cannot show which of two settings is
+    /// better — the very comparison this column exists for.
     /// </summary>
     public static string FormatCompact(IReadOnlyList<Entry> entries)
     {
+        const string Header = "Sum loss (dB)\r\n         avg /   dip\r\n\r\n";
         if (entries.Count == 0)
         {
-            return "Sum loss (dB)\r\n  avg / dip\r\n\r\n—";
+            return Header + "—";
         }
 
-        var builder = new System.Text.StringBuilder(
-            "Sum loss (dB)\r\n  avg / dip\r\n\r\n");
+        var builder = new System.Text.StringBuilder(Header);
         foreach (Entry entry in entries)
         {
             string name = (entry.IsTotal ? "Total" : entry.Junction).PadRight(6);
-            string dip = entry.DipDb.HasValue ? $"{entry.DipDb.Value,5:0.0}" : "    —";
-            builder.AppendLine($"{name}{entry.AverageDb,5:0.0} /{dip}");
+            string dip = entry.DipDb.HasValue ? $"{entry.DipDb.Value,6:0.00}" : "     —";
+            builder.AppendLine($"{name}{entry.AverageDb,6:0.00} /{dip}");
         }
 
         return builder.ToString().TrimEnd();
@@ -342,7 +346,8 @@ internal static class VirtualCrossoverMetric
 
     /// <summary>
     /// Full multi-line breakdown for the tooltip and the Auto delay log, one
-    /// read-out per line, including the band each was measured over.
+    /// read-out per line, including the band each was measured over. Two
+    /// decimals, like the column it explains (see <see cref="FormatCompact"/>).
     /// </summary>
     public static string FormatDetail(IReadOnlyList<Entry> entries)
     {
@@ -354,8 +359,8 @@ internal static class VirtualCrossoverMetric
         return "Sum loss avg\r\n" + string.Join("\r\n", entries.Select(entry =>
         {
             string name = entry.IsTotal ? "Total" : entry.Junction;
-            string dip = entry.DipDb.HasValue ? $", dip {entry.DipDb.Value:0.0} dB" : "";
-            return $"{name}: {entry.AverageDb:0.0} dB avg{dip} " +
+            string dip = entry.DipDb.HasValue ? $", dip {entry.DipDb.Value:0.00} dB" : "";
+            return $"{name}: {entry.AverageDb:0.00} dB avg{dip} " +
                 $"({FrequencyText.Format(entry.LowHz)} – {FrequencyText.Format(entry.HighHz)})";
         }));
     }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -1076,7 +1076,7 @@ public partial class VirtualCrossoverPanel : UserControl
         });
 
         UpdateSourceButton(channel);
-        UpdatePeqLabel(channel);
+        UpdatePeqReadouts(channel);
     }
 
     private void ReadControlIntoSettings(VirtualCrossoverChannel channel)
@@ -1542,7 +1542,7 @@ public partial class VirtualCrossoverPanel : UserControl
             .ToList();
         channel.Settings.PeqPreampDb = curve.PreampDb;
         channel.Settings.PeqSourceName = Path.GetFileName(dialog.FileName);
-        UpdatePeqLabel(channel);
+        UpdatePeqReadouts(channel);
         ScheduleSave();
         RedrawAll();
     }
@@ -1552,12 +1552,12 @@ public partial class VirtualCrossoverPanel : UserControl
         channel.Settings.PeqBands = new List<PeqBand>();
         channel.Settings.PeqPreampDb = 0;
         channel.Settings.PeqSourceName = null;
-        UpdatePeqLabel(channel);
+        UpdatePeqReadouts(channel);
         ScheduleSave();
         RedrawAll();
     }
 
-    private void UpdatePeqLabel(VirtualCrossoverChannel channel)
+    private void UpdatePeqReadouts(VirtualCrossoverChannel channel)
     {
         VirtualCrossoverChannelSettings settings = channel.Settings;
         bool noPeq = settings.PeqBands.Count == 0 && settings.PeqPreampDb == 0;
@@ -1565,7 +1565,12 @@ public partial class VirtualCrossoverPanel : UserControl
             ? "No PEQ"
             : $"{settings.PeqSourceName ?? "PEQ"}: {settings.PeqBands.Count} bands, " +
               $"preamp {settings.PeqPreampDb:0.0} dB";
-        Label peqInfoLabel = ControlFor(channel).PeqInfoLabel;
+        // The preamp also lands in the block's gain row, which reads out the level the
+        // two stages come to together; the block keeps that readout in step with its
+        // own gain field, so the preamp is all it needs from here.
+        VirtualCrossoverChannelControl control = ControlFor(channel);
+        control.PeqPreampDb = settings.PeqPreampDb;
+        Label peqInfoLabel = control.PeqInfoLabel;
         peqInfoLabel.Text = text;
         // The label is narrow and clips the file name; the full text lives in the
         // tooltip. Nothing worth hovering when there is no PEQ.

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverChannelControlTotalGainTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverChannelControlTotalGainTests.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The channel block's all-in gain readout: the level the two broadband stages of
+/// the chain — the channel gain and the loaded PEQ's preamp — come to together,
+/// which is what gets typed into a DSP whose equalizer has no preamp of its own.
+/// </summary>
+public sealed class VirtualCrossoverChannelControlTotalGainTests
+{
+    [Fact]
+    public void WithoutAPeqPreamp_TheReadoutStaysBlank()
+    {
+        using var control = new VirtualCrossoverChannelControl();
+
+        control.GainInput.Value = -6.0m;
+
+        // Nothing to add to the gain: the readout would only repeat the field
+        // standing next to it.
+        Assert.Equal(string.Empty, control.TotalGainLabel.Text);
+    }
+
+    [Fact]
+    public void WithAPeqPreamp_TheReadoutSumsItWithTheGain()
+    {
+        using var control = new VirtualCrossoverChannelControl();
+
+        control.GainInput.Value = -3.5m;
+        control.PeqPreampDb = -4.5;
+
+        Assert.Equal(Expected(-8.0), control.TotalGainLabel.Text);
+    }
+
+    [Fact]
+    public void ChangingTheGain_RefreshesTheReadout()
+    {
+        using var control = new VirtualCrossoverChannelControl();
+        control.PeqPreampDb = -4.5;
+
+        control.GainInput.Value = 2.0m;
+
+        Assert.Equal(Expected(-2.5), control.TotalGainLabel.Text);
+    }
+
+    [Fact]
+    public void ClearingThePeq_BlanksTheReadoutAgain()
+    {
+        using var control = new VirtualCrossoverChannelControl();
+        control.GainInput.Value = -3.5m;
+        control.PeqPreampDb = -4.5;
+
+        control.PeqPreampDb = 0;
+
+        Assert.Equal(string.Empty, control.TotalGainLabel.Text);
+    }
+
+    [Fact]
+    public void ABatchUpdate_LeavesTheReadoutMatchingTheAppliedGain()
+    {
+        // The host applies stored settings with the change events suppressed, so the
+        // readout has to be refreshed by the batch itself rather than by the
+        // SettingsChanged the suppressed field never raises.
+        using var control = new VirtualCrossoverChannelControl();
+        control.PeqPreampDb = -4.5;
+        control.SettingsChanged += (_, _) => Assert.Fail(
+            "Applying stored settings must not look like a user edit.");
+
+        control.RunBatchUpdate(() => control.GainInput.Value = -1.5m);
+
+        Assert.Equal(Expected(-6.0), control.TotalGainLabel.Text);
+    }
+
+    // The block sits next to a numeric field that formats in the user's culture, so
+    // the readout follows it rather than pinning an invariant separator.
+    private static string Expected(double totalDb) =>
+        "All " + totalDb.ToString("+0.0;-0.0;0.0", CultureInfo.CurrentCulture);
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -38,9 +38,11 @@ public sealed class VirtualCrossoverMetricTests
         {
             string text = VirtualCrossoverMetric.FormatCompact([Junction, Total]);
 
-            Assert.StartsWith("Sum loss (dB)\r\n  avg / dip\r\n\r\n", text);
-            Assert.Contains("A/B    -1.2 / -6.5", text);
-            Assert.Contains("Total  -0.8 /    —", text);
+            // Two decimals: lobe alternatives differ by hundredths of a dB,
+            // and the columns line up under the header at that width.
+            Assert.StartsWith("Sum loss (dB)\r\n         avg /   dip\r\n\r\n", text);
+            Assert.Contains("A/B    -1.23 / -6.50", text);
+            Assert.Contains("Total  -0.80 /     —", text);
         });
     }
 
@@ -52,7 +54,7 @@ public sealed class VirtualCrossoverMetricTests
             string text = VirtualCrossoverMetric.FormatDetail([Junction]);
 
             Assert.Equal(
-                "Sum loss avg\r\nA/B: -1.2 dB avg, dip -6.5 dB " +
+                "Sum loss avg\r\nA/B: -1.23 dB avg, dip -6.50 dB " +
                 "(900 Hz – 3.6 kHz)",
                 text);
         });

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -181,14 +181,15 @@ public sealed class AutoAlignmentEngineTests
         Assert.Equal(AlignmentDecisionKind.Reference, decisions[woofer].Kind);
         Assert.Null(decisions[woofer].Confidence);
         Assert.Contains("reference", decisions[woofer].Detail);
-        // The clean synthetic junction has razor-sharp fronts, so the onset
-        // lock pins the tweeter: the decision reports the Locked kind (the
-        // constraint chose, not the acoustics) with no confidence, naming the
-        // junction and the constraint in the detail.
-        Assert.Equal(AlignmentDecisionKind.Locked, decisions[tweeter].Kind);
-        Assert.Null(decisions[tweeter].Confidence);
+        // The clean synthetic junction's whitened extremum is unambiguous, so
+        // the seed is trusted and the onset lock stands down (it exists to
+        // replace an arrival-envelope anchor, not a measured one): the tweeter
+        // reports a free Search, naming its junction and carrying the rival
+        // margin as confidence.
+        Assert.Equal(AlignmentDecisionKind.Search, decisions[tweeter].Kind);
+        Assert.NotNull(decisions[tweeter].Confidence);
         Assert.Contains("vs W", decisions[tweeter].Detail);
-        Assert.Contains("onset-locked", decisions[tweeter].Detail);
+        Assert.DoesNotContain("onset-locked", decisions[tweeter].Detail);
     }
 
     [Fact]
@@ -342,19 +343,25 @@ public sealed class AutoAlignmentEngineTests
     [Fact]
     public void Compute_SeedErrorAtASharpJunction_OnsetLockRecoversDirectly()
     {
-        // A 2 kHz junction: the stage-1 seed says 1.0 ms but the search-time
-        // optimum is +0.4 ms — 1.2 periods off, beyond the fine window around
-        // the seed. Above the lock's frequency gate the broadband onsets of
+        // A 2 kHz junction whose seed is NOT trusted — the tweeter carries a
+        // near-equal copy a full period out, so the whitened correlation's
+        // same-polarity rival ties and the coarse offset falls back to the
+        // arrival envelope. That envelope says 1.0 ms while the search-time
+        // optimum is +0.4 ms, 1.2 periods off and beyond the fine window
+        // around it. Above the lock's frequency gate the broadband onsets of
         // the search-time IRs re-anchor the window on the true front, so the
         // optimum is found directly: no edge retry, no promotion, and the
-        // chosen delay lands on the front-aligned lobe.
+        // chosen delay lands on the front-aligned lobe. (With a TRUSTED seed
+        // the lock stands down — it replaces an arrival anchor, and a measured
+        // extremum is the better witness; see Compute_ReportsPerChannelDecisions.)
         var woofer = new TestChannel("W", DelayedImpulse(1.0));
         var tweeter = new TestChannel(
-            "T", DelayedImpulse(0.0), reprocessIr: DelayedImpulse(0.6));
+            "T", ImpulseWithEcho(0.0, 0.995, 0.5, 1.0),
+            reprocessIr: DelayedImpulse(0.6));
         var log = new StringBuilder();
 
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
-            Run([woofer, tweeter], [2_000], log);
+            Run([woofer, tweeter], [2_000], log, bands: [(700, 5_600)]);
 
         Assert.InRange(alignment[tweeter].DelayMs, 0.35, 0.45);
         Assert.Contains("ONSET-LOCKED", log.ToString());
@@ -611,7 +618,7 @@ public sealed class AutoAlignmentEngineTests
         // the ones refusing this seed; the rival rule must.
         var midbass = new TestChannel("B", DelayedImpulse(15.0));
         var mid = new TestChannel(
-            "C", ImpulseWithEcho(0.0, 0.97, 11.76, 1.0));
+            "C", ImpulseWithEcho(0.0, 0.995, 11.76, 1.0));
         var log = new StringBuilder();
 
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
@@ -636,7 +643,7 @@ public sealed class AutoAlignmentEngineTests
         // near-tie must send the seed back to the arrival envelope.
         var midbass = new TestChannel("B", DelayedImpulse(15.0));
         var mid = new TestChannel(
-            "C", ImpulseWithEcho(0.0, -0.97, 11.76, -1.0));
+            "C", ImpulseWithEcho(0.0, -0.995, 11.76, -1.0));
         var log = new StringBuilder();
 
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
@@ -1070,6 +1077,129 @@ public sealed class AutoAlignmentEngineTests
         var ir = new Complex[length];
         ir[position] = Complex.One;
         return ir;
+    }
+
+    // A midbass whose own front is followed by a strong late in-cabin build-up
+    // INSIDE a 150 Hz junction's band: the channel's steep low-pass leaves the
+    // band's energy sitting on the build-up, so the PROCESSED envelope fronts
+    // on it while the driver's un-crossovered front stays where it was. That
+    // is the predicted-arrival probe's conviction shape one junction up from
+    // LowFrontUnderCabinBuildUp, whose sub-corner modes fall outside this band.
+    private static Complex[] FrontUnderInBandBuildUp(
+        int length, double buildUpMs, double amplitude)
+    {
+        Complex[] ir = VirtualCrossoverAnalysis.ApplyChain(
+            SingleImpulse(length, BasePosition),
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.BandPass,
+                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 400, 24),
+                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 40, 24))),
+            SampleRate);
+        int start = BasePosition + (int)Math.Round(buildUpMs / 1000.0 * SampleRate);
+        const double AttackSeconds = 0.004;
+        const double DecaySeconds = 0.05;
+        foreach (double modeHz in new[] { 85.0, 95.0, 108.0 })
+        {
+            for (int i = start; i < ir.Length; i++)
+            {
+                double t = (i - start) / (double)SampleRate;
+                ir[i] += amplitude *
+                    (1 - Math.Exp(-t / AttackSeconds)) *
+                    Math.Exp(-t / DecaySeconds) *
+                    Math.Sin(2 * Math.PI * modeHz * t);
+            }
+        }
+
+        return ir;
+    }
+
+    [Fact]
+    public void Compute_NearTiedPeakAndTrough_StillSeedFromTheExtremum()
+    {
+        // The v5 cabin's 150 Hz junction, where the peak-vs-trough gate used to
+        // refuse the seed. Steep corners leave a narrow effective overlap, so
+        // the whitened correlation's envelope barely decays over a half period
+        // and its peak and trough come within a few hundredths — which says how
+        // wide the band is, not whether the extremum can be believed (a PERFECT
+        // synthetic junction only reaches 0.167 there). The extremum must seed
+        // the search anyway: the half period it leaves ambiguous is the one the
+        // fine window spans and the loss search settles by polarity. The field
+        // cost of the old refusal: the mid parked a lobe off, at -0.22 dB
+        // average junction loss where the extremum's lobe read -0.14 dB and
+        // matched the owner's hand tune to 0.02 ms.
+        const int Length = 32_768;
+        var midbassChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.BandPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 130, 36),
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 60, 36)));
+        var midChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.BandPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 1700, 48),
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 170, 36)));
+        Complex[] midbassBypassed = FrontUnderInBandBuildUp(Length, 9.0, 0.25);
+        Complex[] midBypassed = SingleImpulse(
+            Length, BasePosition + 4 * SampleRate / 1000);
+
+        AlignmentSnapshot Snapshot(
+            string name, Complex[] bypassed, DspChannelChain chain)
+        {
+            Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(
+                bypassed, chain, SampleRate, out ValidSampleRange range);
+            return new AlignmentSnapshot(
+                new TestChannel(name, processed), processed,
+                VirtualCrossoverAnalysis.FindPeakIndex(processed), range,
+                chain, bypassed);
+        }
+
+        AlignmentSnapshot midbass = Snapshot("B", midbassBypassed, midbassChain);
+        AlignmentSnapshot mid = Snapshot("C", midBypassed, midChain);
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides)
+        {
+            AlignmentSnapshot One(
+                AlignmentSnapshot side, Complex[] bypassed, DspChannelChain chain)
+            {
+                AlignmentOverride over = overrides.GetValueOrDefault(side.Channel);
+                Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(
+                    bypassed,
+                    chain with
+                    {
+                        DelayMs = over.DelayMs,
+                        InvertPolarity = over.InvertPolarity
+                    },
+                    SampleRate,
+                    out ValidSampleRange range);
+                return side with
+                {
+                    ImpulseResponse = processed,
+                    PeakIndex = VirtualCrossoverAnalysis.FindPeakIndex(processed),
+                    ValidRange = range
+                };
+            }
+
+            return
+            [
+                One(midbass, midbassBypassed, midbassChain),
+                One(mid, midBypassed, midChain)
+            ];
+        }
+
+        var log = new StringBuilder();
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        AutoAlignmentEngine.Compute(
+            [midbass, mid],
+            [new AlignmentJunction(midbass, mid, 150, 75, 300)],
+            Reprocess,
+            alignment,
+            log);
+
+        string pairLine = TestLog.Line(log.ToString(), "Pair B/C");
+        // The fixture must actually reach the state under test: a near-tied
+        // extremum (and, as in the field, a pair anchor the prediction had to
+        // replace — the case where believing the arrival instead cost most).
+        Assert.Contains("modal latch behind the crossover", log.ToString());
+        Assert.Matches(@"dom 0,0\d\d", pairLine.Replace('.', ','));
+        Assert.Contains("seed phat", pairLine);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Numerics;
+﻿using System.Globalization;
+using System.Numerics;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Resonalyze.Dsp.Tests;
 
@@ -402,6 +404,49 @@ public sealed class AutoAlignmentEngineTests
         Assert.Contains("phat trough", pairLine);
         Assert.Contains("-> seed phat", pairLine);
         Assert.DoesNotContain("WIDE SEED", TestLog.Line(text, "Channel C:"));
+    }
+
+    [Fact]
+    public void Compute_TrustedSeedAtALowJunction_KeepsBothPolaritiesInTheWindow()
+    {
+        // An 85 Hz junction: the polarity partner sits a half period — 5.9 ms —
+        // from the seed, well past the fixed 2.5 ms cap a trusted seed's fine
+        // window used to carry. A trusted seed fixes WHERE the adjacent lobes
+        // sit, not WHICH one is right (the peak-vs-trough margin measures the
+        // band's width), so the loss search settles the polarity — and it can
+        // only settle what its window contains. The window therefore reaches
+        // the MEASURED partner distance, and both polarities must appear as
+        // candidates. Without it a hundredth of PHAT coefficient would decide
+        // the junction outright: the diagnostic sweep sees the partner, but
+        // reaching it there costs a 1.6 dB promotion margin no near-tie pays.
+        var midbass = new TestChannel("B", DelayedImpulse(15.2));
+        var mid = new TestChannel("C", DelayedImpulse(0.0, invert: true));
+        var log = new StringBuilder();
+
+        Run([midbass, mid], [85], log);
+
+        string channelLine = TestLog.Line(log.ToString(), "Channel C:");
+        // The premise: a trusted seed, so the wide-seed machinery is not what
+        // opened the window.
+        Assert.DoesNotContain("WIDE SEED", channelLine);
+        Match window = Regex.Match(
+            channelLine.Replace(',', '.'),
+            @"window (-?\d+\.\d+)\.\.(-?\d+\.\d+) ms");
+        Assert.True(window.Success, channelLine);
+        double low = double.Parse(
+            window.Groups[1].Value, CultureInfo.InvariantCulture);
+        double high = double.Parse(
+            window.Groups[2].Value, CultureInfo.InvariantCulture);
+        // The pick sits at 15.2 ms; its polarity partners are a half period
+        // (5.88 ms) to each side, and at least one of them must be reachable —
+        // the fixed 2.5 ms cap reached neither.
+        Assert.True(
+            high - 15.2 >= 5.0 || 15.2 - low >= 5.0,
+            $"the polarity partner is out of the search window:\r\n{channelLine}");
+        // ...and never as far as the same-polarity rival a full period out.
+        Assert.True(
+            high - low < 2.0 * 1000.0 / 85.0,
+            $"the window must stay inside one period:\r\n{channelLine}");
     }
 
     [Fact]
@@ -1193,13 +1238,23 @@ public sealed class AutoAlignmentEngineTests
             alignment,
             log);
 
-        string pairLine = TestLog.Line(log.ToString(), "Pair B/C");
+        string text = log.ToString();
+        string pairLine = TestLog.Line(text, "Pair B/C");
         // The fixture must actually reach the state under test: a near-tied
         // extremum (and, as in the field, a pair anchor the prediction had to
         // replace — the case where believing the arrival instead cost most).
-        Assert.Contains("modal latch behind the crossover", log.ToString());
+        Assert.Contains("modal latch behind the crossover", text);
         Assert.Matches(@"dom 0,0\d\d", pairLine.Replace('.', ','));
         Assert.Contains("seed phat", pairLine);
+
+        // The half period the near-tie leaves open reaches the loss search:
+        // both polarities are candidates, which is the whole reason a near-tied
+        // extremum is allowed to seed. (Here the partner sits inside the fixed
+        // cap; Compute_TrustedSeedAtALowJunction_KeepsBothPolaritiesInTheWindow
+        // covers the low junctions where it does not.)
+        string channelLine = TestLog.Line(text, "Channel C:");
+        Assert.Contains(" inv (", channelLine);
+        Assert.Contains("; ", channelLine);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -629,6 +629,50 @@ public sealed class StereoAlignmentTests
     }
 
     [Fact]
+    public void ComputeStereo_ReferenceSideProposal_IsIndependentOfTheFarSide()
+    {
+        // The reference side is settled first and only the pair co-move can
+        // move it afterwards — and that co-move is judged on the REFERENCE
+        // side's junctions alone, so the near side's relations cannot depend
+        // on the far side's acoustics at all. Derange the far mid (a strong
+        // second lobe 0.7 ms behind its arrival) and every relation on the
+        // reference side must come out identical. The far side still BOUNDS
+        // the shared delta — it can veto one that would leave it a lobe out —
+        // it just cannot ask for one. (This pins the invariant, not the
+        // criterion: the two criteria happen to agree on this fixture. The
+        // criterion's evidence is the archived-cabin battery, where judging
+        // by the mean cost the reference side up to 0.03 dB of junction loss
+        // it had already won.)
+        (_, TestChannel[] left, _,
+            Dictionary<IAlignmentChannel, AlignmentOverride> plain, _) = RunStereo(
+                sceneOffsetMs: 0.25, linkBands: UserLinkBands);
+        (_, TestChannel[] derangedLeft, _,
+            Dictionary<IAlignmentChannel, AlignmentOverride> deranged,
+            StringBuilder derangedLog) = RunStereo(
+                sceneOffsetMs: 0.25, linkBands: UserLinkBands, rightMidEchoMs: 0.7);
+
+        // The premise: a co-move actually ran on the deranged pair, so the
+        // criterion had something to decide.
+        Assert.Contains("Co-move L mid+R mid: ", derangedLog.ToString());
+
+        // Compared RELATIVE to the reference side's own bottom channel: the
+        // mono co-move and the final normalization both shift every channel
+        // uniformly, which changes no relation and is not what this pins.
+        for (int i = 1; i < left.Length; i++)
+        {
+            Assert.Equal(
+                plain.GetValueOrDefault(left[i]).DelayMs -
+                    plain.GetValueOrDefault(left[0]).DelayMs,
+                deranged.GetValueOrDefault(derangedLeft[i]).DelayMs -
+                    deranged.GetValueOrDefault(derangedLeft[0]).DelayMs,
+                2);
+            Assert.Equal(
+                plain.GetValueOrDefault(left[i]).InvertPolarity,
+                deranged.GetValueOrDefault(derangedLeft[i]).InvertPolarity);
+        }
+    }
+
+    [Fact]
     public void ComputeStereo_NearTheDelayCeilingTheSceneSurvives()
     {
         // The left side is 46 ms late, parking the whole right side just
@@ -703,14 +747,21 @@ public sealed class StereoAlignmentTests
         //  - woof's trusted junction stays narrow even though woof is the untrusted
         //    UPPER of sub/woof — the channel-keyed version would have leaked the wide
         //    window onto this unrelated, trusted junction.
-        var sub = new TestChannel("sub", ImpulseWithEcho(1.0, 0.9, 5.0, 0.85));
+        // The sub's echo sits a full 80 Hz period out and all but matches the
+        // direct copy, so its whitened correlation carries two same-polarity
+        // lobes a period apart that the RIVAL gate cannot separate — the
+        // whole-period ambiguity the fine window cannot undo, and the one
+        // remaining reason to fall back to the arrival. Its junction band is
+        // widened like the sibling rival tests', so the kernel's own trough
+        // stays shallow and the rival rule is what refuses the seed.
+        var sub = new TestChannel("sub", ImpulseWithEcho(1.0, 0.995, 12.5, 1.0));
         var woof = new TestChannel("woof", ImpulseAtMs(3.0));
         var mid = new TestChannel("mid", ImpulseAtMs(6.0));
         TestChannel[] all = [sub, woof, mid];
         List<AlignmentSnapshot> snapshots = all.Select(c => Snapshot(c, default)).ToList();
         var pairs = new List<AlignmentJunction>
         {
-            Junction(snapshots[0], snapshots[1], 80),
+            new(snapshots[0], snapshots[1], 80, 30, 340),
             Junction(snapshots[1], snapshots[2], 120)
         };
         var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();


### PR DESCRIPTION
The owner reported that Auto delay's junctions kept landing a lobe away
from what he tunes by hand, and that his hand tunes land on the peak of
`abs(PHAT)` every time. They do — and three gates were refusing that
extremum.

## The measurement that started it

A **perfect** synthetic junction — two filters off one impulse, no room,
no noise, perfectly aligned — produces a peak-vs-trough margin of
**0.167** at a two-octave band, identically at every fc, family and
slope, falling to 0.100 / 0.049 / 0.012 at 1.5 / 1.0 / 0.5 octaves. The
figure measures the analysed band's width, not whether the extremum can
be believed. The gate stood at 0.1 — 60 % of what a flawless junction can
even produce — and across the archived cabins it refused **34 of 40
junctions**.

## What changed

- **Peak-vs-trough gate: removed.** The half period it flags is the one
  the fine window spans and the loss search settles by polarity.
- **Same-polarity rival gate: kept**, under its own constant
  (`PhatSeedMinRivalDominance` = 0.05, a tenth of that statistic's own
  0.534 ideal). That whole-period skip is the error the window cannot
  undo.
- **Seed-reach clamp: removed.** It rested on a certificate resolving
  `max(2.5 ms, half a period)` yet tightened the reach to a quarter
  period — fifteen times finer than the evidence can see.
- **Onset lock stands down for a trusted seed.** It exists to replace an
  arrival-envelope anchor. At the v5 cabin's 1500 Hz junction the mid's
  front rises over 0.274 ms against the tweeter's 0.037, so the onset
  difference moved 0.4 period across its 10/25/50 % thresholds and
  anchored on the weakest lobe of the comb.
- **Pair co-move judged on the reference side alone.** A shared delta's
  criterion decides whose junction pays; a mean over both sides buys the
  far side's with the near one's, and the near side holds the drivers
  closest to the listener. Both sides still bound how far the delta may
  travel.
- **Sum-loss read-out in hundredths.** Lobe alternatives differ by
  hundredths of a dB; at one decimal the column could not show which of
  two settings is better.

## Battery

Seven saved sessions across v2 / v3 / v3-validated / v4 / v5 /
v5-manual / 3RC — 40 junctions — each re-run through the engine on the
session's own chains and scored on the **panel read-out**, beside the
settings saved in that session:

**19 junctions better, 10 worse, 11 unchanged. Mean summation loss
+0.006 dB, mean dip +0.275 dB.**

The ten regressions run 0.02–0.08 dB of average loss (v3's low junctions,
two far-side top junctions); the proposal still beats every one of those
sessions' saved settings by a wide margin. Old reference figures were
explicitly cleared for breaking — the panel metric is the judge.

On the owner's hand-tuned v5 session the proposal now reproduces his
relations at all three left junctions, including the polarity flip at
C/D that it used to miss:

| junction | auto | hand |
|---|---|---|
| A/B | −0.03 / −0.11 | −0.03 / −0.11 |
| B/C | −0.13 / −0.69 | −0.13 / −0.69 |
| C/D | −0.28 / −3.51 | −0.29 / −2.40 |

## Tests

`Resonalyze.Dsp.Tests` 1040, `Resonalyze.App.Tests` 920,
`Resonalyze.Audio.Tests` 142 — all green. Six tests updated or added; each
still pins a live contract:

- the two same-polarity rival fixtures are tightened (0.97 → 0.995) so
  their margins fall below the new constant;
- the wide-seed window test now earns its untrusted seed from the rival
  gate (a full-period echo, widened band) rather than the removed one;
- a clean synthetic junction now reports a free `Search`, not an
  onset-`Locked` pick;
- the onset-lock recovery test's fixture now produces an untrusted seed —
  the case the lock still owns;
- `Compute_NearTiedPeakAndTrough_StillSeedFromTheExtremum` pins the
  removal on the field junction that motivated it;
- `ComputeStereo_ReferenceSideProposal_IsIndependentOfTheFarSide` pins the
  co-move invariant (the criterion's own evidence is the battery — the
  two criteria agree on that fixture).

The first commit carries in-progress work from the working tree (each
channel's total gain beside its PEQ read-out) that was not part of this
investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
