### PR TITLE
Put the X-curve back on the ISO line, and stop the room preset claiming Harman

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,13 +839,16 @@ frame by frame.
 
 The shape is built from four editable terms — an overall **tilt** around a 1 kHz
 pivot, a **bass shelf**, a **treble shelf**, and a **presence** bump/dip — with
-editable presets: `Flat`, `Room (gentle)`, `Harman room`, `Warm`, `Car`,
+editable presets: `Flat`, `Room (gentle)`, `Room (Harman-style)`, `Warm`, `Car`,
 `Car (mild)`, `Car (bass)`, `House / bass boost`, `X-curve (cinema)`, `Smiley`,
 `BBC dip`, `Custom`. The three car presets share one in-car shape — a bass shelf
 over a flat 400 Hz…5 kHz band, then a gentle rolloff reaching ≈3 dB by 20 kHz —
-and differ only in how much bass they lift (+6, +9 or +12 dB). The deviation curve
-is **Deviation** (`measurement − target`), **EQ correction** (`target −
-measurement`, the gain to dial into an equalizer), or **None**. Target overlays are available in Frequency Response and Live Spectrum.
+and differ only in how much bass they lift (+6, +9 or +12 dB); a new target
+overlay opens on `Car`. `X-curve (cinema)` follows ISO 2969 / SMPTE ST 202 —
+flat to 2 kHz, then ≈-3 dB/oct. The deviation curve is **Deviation**
+(`measurement − target`), **EQ correction** (`target − measurement`, the gain to
+dial into an equalizer), or **None**. Target overlays are available in Frequency
+Response and Live Spectrum.
 
 ![Target overlay settings](assets/images/target_overlay.jpg)
 

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -669,7 +669,7 @@ public sealed class Overlay
     private bool targetConfigured;
     private readonly TargetOverlayCurveBuilder targetCurveBuilder = new();
     private int targetSourceSlot;
-    private TargetPreset targetPreset = TargetPreset.HarmanRoom;
+    private TargetPreset targetPreset = OverlayTargets.DefaultPreset;
     private double targetTiltDbPerOctave;
     private double targetBassShelfGainDb;
     private double targetBassShelfFrequencyHz = 100;
@@ -2743,7 +2743,7 @@ public sealed class Overlay
         compareInvertPolarity = false;
         targetConfigured = false;
         targetSourceSlot = 0;
-        targetPreset = TargetPreset.HarmanRoom;
+        targetPreset = OverlayTargets.DefaultPreset;
         targetTiltDbPerOctave = 0;
         targetBassShelfGainDb = 0;
         targetBassShelfFrequencyHz = 100;

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -1920,7 +1920,7 @@ public sealed class Overlay
             collection.GetCaptureSourceOptions();
         TargetCurveSpec spec = targetConfigured
             ? CurrentTargetSpec()
-            : TargetCurveSpec.FromPreset(TargetPreset.HarmanRoom);
+            : TargetCurveSpec.FromPreset(OverlayTargets.DefaultPreset);
 
         // Live preview while the dialog is open: the target shape, tolerance band,
         // and deviation curve redraw on the main plot as the parameters change, so
@@ -1932,7 +1932,7 @@ public sealed class Overlay
             SeriesMode,
             targetConfigured ? Title : $"Target {Index}",
             targetConfigured ? targetSourceSlot : 0,
-            targetConfigured ? targetPreset : TargetPreset.HarmanRoom,
+            targetConfigured ? targetPreset : OverlayTargets.DefaultPreset,
             spec,
             targetConfigured ? targetToleranceDb : 3,
             targetConfigured ? targetDeviationMode : TargetDeviationMode.Deviation,

--- a/source/Overlays/OverlayFile.cs
+++ b/source/Overlays/OverlayFile.cs
@@ -598,6 +598,13 @@ public enum TargetDeviationMode
 public enum TargetPreset
 {
     Flat,
+
+    /// <summary>
+    /// Shown as "Room (Harman-style)": a room slope with a bass lift in the
+    /// spirit of the Harman work, not a reproduction of a published curve. The
+    /// member keeps its original name because presets persist by name, in both
+    /// overlay files and the measurement settings.
+    /// </summary>
     HarmanRoom,
     RoomGentle,
     Warm,
@@ -652,7 +659,12 @@ public sealed record TargetCurveSpec(
         TargetPreset.CarMild => new(0, 6, 100, 0.9, -3, 10_000, 0.7, 0, 3_000, 1.0),
         TargetPreset.CarBass => new(0, 12, 100, 0.9, -3, 10_000, 0.7, 0, 3_000, 1.0),
         TargetPreset.House => new(0, 6, 120, 1.0, 0, 5_000, 1.5, 0, 3_000, 1.0),
-        TargetPreset.XCurve => new(0, 0, 100, 1.5, -10, 2_500, 2.0, 0, 3_000, 1.0),
+        // ISO 2969 / SMPTE ST 202: flat to 2 kHz, then -3 dB/octave. The shelf
+        // used to sit at 2.5 kHz / 2.0 octaves, whose tail reached down into the
+        // midrange and put the curve 2.1 dB low at 1 kHz and 4.2 dB low at 2 kHz,
+        // where the standard is still flat. A higher, narrower shelf tracks the
+        // straight line to within 0.6 dB (see OverlayTargetTests.XCurveTable).
+        TargetPreset.XCurve => new(0, 0, 100, 1.5, -10, 6_300, 1.2, 0, 3_000, 1.0),
         TargetPreset.Smiley => new(0, 6, 100, 1.0, 5, 4_000, 1.5, 0, 3_000, 1.0),
         TargetPreset.BbcDip => new(-0.5, 0, 100, 1.5, 0, 5_000, 1.5, -3, 2_800, 1.0),
         _ => new TargetCurveSpec(-0.5, 0, 100, 1.5, 0, 5_000, 1.5, 0, 3_000, 1.0)
@@ -710,6 +722,12 @@ public sealed record TargetCurveResult(
 
 public static class OverlayTargets
 {
+    /// <summary>
+    /// Preset a Target overlay opens with before it has been configured. This is
+    /// a car analyzer, so the in-car shape is the sane starting point.
+    /// </summary>
+    public const TargetPreset DefaultPreset = TargetPreset.Car;
+
     /// <summary>
     /// Modes a Target overlay can be defined in. A target is a magnitude shape in
     /// dB — a tilt with shelves — so it only means something on a dB-over-frequency

--- a/source/Overlays/OverlayFile.cs
+++ b/source/Overlays/OverlayFile.cs
@@ -729,6 +729,24 @@ public static class OverlayTargets
     public const TargetPreset DefaultPreset = TargetPreset.Car;
 
     /// <summary>
+    /// The preset a stored target should present itself as. A target persists
+    /// its shape as parameters, not as a reference to the preset table, so one
+    /// saved before a preset's numbers changed still names that preset while
+    /// drawing the old shape. Report such a target as <see cref="TargetPreset.
+    /// Custom"/>: the stored curve is left exactly as the user had it, and the
+    /// name stops promising a shape it no longer has.
+    /// </summary>
+    public static TargetPreset ResolvePreset(TargetPreset preset, TargetCurveSpec spec)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+
+        return preset == TargetPreset.Custom ||
+               spec == TargetCurveSpec.FromPreset(preset)
+            ? preset
+            : TargetPreset.Custom;
+    }
+
+    /// <summary>
     /// Modes a Target overlay can be defined in. A target is a magnitude shape in
     /// dB — a tilt with shelves — so it only means something on a dB-over-frequency
     /// axis. On the phase (degrees), group delay (ms), impulse and autocorrelation

--- a/source/Overlays/OverlayTargetSettingsDialog.cs
+++ b/source/Overlays/OverlayTargetSettingsDialog.cs
@@ -49,7 +49,7 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
         suppressEvents = true;
         nameTextBox.Text = name;
         SelectSource(sourceSlot);
-        presetComboBox.SelectedItem = preset;
+        presetComboBox.SelectedItem = OverlayTargets.ResolvePreset(preset, spec);
         ApplySpec(spec);
         toleranceInput.Value = ClampToRange(toleranceInput, toleranceDb);
         deviationModeComboBox.SelectedItem = deviationMode;

--- a/source/Overlays/OverlayTargetSettingsDialog.cs
+++ b/source/Overlays/OverlayTargetSettingsDialog.cs
@@ -508,7 +508,7 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
         TargetPreset.Flat =>
             "Flat reference — no tilt or shelving (studio / anechoic target).",
         TargetPreset.HarmanRoom =>
-            "Harman room — gentle ≈-0.8 dB/oct downslope with a bass lift; a common preference for home listening rooms.",
+            "Room (Harman-style) — gentle ≈-0.8 dB/oct downslope with a bass lift, in the spirit of the Harman work; a common preference for home listening rooms.",
         TargetPreset.RoomGentle =>
             "Gentle room slope — slight downward tilt and a small bass lift.",
         TargetPreset.Warm =>
@@ -522,7 +522,7 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
         TargetPreset.House =>
             "House / bass boost — flat overall with an elevated low end.",
         TargetPreset.XCurve =>
-            "X-curve — high-frequency rolloff above ≈2.5 kHz for cinema-sized rooms.",
+            "X-curve (cinema) — ISO 2969 / SMPTE ST 202: flat to 2 kHz, then ≈-3 dB/oct, for cinema-sized rooms.",
         TargetPreset.Smiley =>
             "Smiley — boosted bass and treble (consumer 'loudness' shape).",
         TargetPreset.BbcDip =>
@@ -541,7 +541,7 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
     private static string GetPresetLabel(TargetPreset preset) => preset switch
     {
         TargetPreset.Flat => "Flat",
-        TargetPreset.HarmanRoom => "Harman room",
+        TargetPreset.HarmanRoom => "Room (Harman-style)",
         TargetPreset.RoomGentle => "Room (gentle)",
         TargetPreset.Warm => "Warm",
         TargetPreset.Car => "Car",

--- a/tests/Resonalyze.App.Tests/OverlayTargetTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlayTargetTests.cs
@@ -182,6 +182,50 @@ public sealed class OverlayTargetTests
     }
 
     [Fact]
+    public void ResolvePreset_KeepsAPresetWhoseParametersStillMatch()
+    {
+        foreach (TargetPreset preset in Enum.GetValues<TargetPreset>())
+        {
+            Assert.Equal(
+                preset,
+                OverlayTargets.ResolvePreset(preset, TargetCurveSpec.FromPreset(preset)));
+        }
+    }
+
+    [Theory]
+    // The shapes these two presets had before they were refitted. A target saved
+    // back then persisted these numbers plus the preset name, so on load the name
+    // would advertise the new shape over the old curve.
+    [InlineData(TargetPreset.XCurve, 0, 0, 100, 1.5, -10, 2_500, 2.0)]
+    [InlineData(TargetPreset.Car, -1.0, 8, 80, 1.5, 0, 5_000, 1.5)]
+    public void ResolvePreset_FallsBackToCustomWhenTheStoredShapeMovedOn(
+        TargetPreset preset,
+        double tilt,
+        double bassGain, double bassFreq, double bassWidth,
+        double trebleGain, double trebleFreq, double trebleWidth)
+    {
+        var stored = new TargetCurveSpec(
+            tilt,
+            bassGain, bassFreq, bassWidth,
+            trebleGain, trebleFreq, trebleWidth,
+            0, 3_000, 1.0);
+
+        Assert.Equal(TargetPreset.Custom, OverlayTargets.ResolvePreset(preset, stored));
+    }
+
+    [Fact]
+    public void ResolvePreset_LeavesCustomAlone()
+    {
+        // Custom has no canonical shape to compare against, so any parameters
+        // are its parameters.
+        TargetCurveSpec spec = Spec(tilt: -3, bassGain: 11, presenceGain: 2);
+
+        Assert.Equal(
+            TargetPreset.Custom,
+            OverlayTargets.ResolvePreset(TargetPreset.Custom, spec));
+    }
+
+    [Fact]
     public void BuildTarget_DeviationIsMeasurementMinusShiftedTarget()
     {
         OverlayPoint[] source =

--- a/tests/Resonalyze.App.Tests/OverlayTargetTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlayTargetTests.cs
@@ -134,6 +134,53 @@ public sealed class OverlayTargetTests
         Assert.Equal(car.Evaluate(20_000), bass.Evaluate(20_000), tolerance: 1e-6);
     }
 
+    /// <summary>
+    /// The X-curve of ISO 2969 / SMPTE ST 202: flat to 2 kHz, then -3 dB per
+    /// octave. A tanh shelf cannot make a hard knee followed by a straight line,
+    /// so the tolerance below is the fit error of the closest shelf; what it
+    /// really guards is that the rolloff starts at the knee and not an octave
+    /// early, which is how this preset was wrong before (-2.1 dB at 1 kHz).
+    /// </summary>
+    public static TheoryData<double, double> XCurveTable => new()
+    {
+        { 200, 0.0 }, { 500, 0.0 }, { 1_000, 0.0 }, { 2_000, 0.0 },
+        { 2_500, -0.97 }, { 3_150, -1.97 }, { 4_000, -3.0 }, { 5_000, -3.97 },
+        { 6_300, -4.97 }, { 8_000, -6.0 }, { 10_000, -6.97 }, { 12_500, -7.93 },
+        { 16_000, -9.0 }, { 20_000, -9.97 }
+    };
+
+    [Theory]
+    [MemberData(nameof(XCurveTable))]
+    public void Evaluate_XCurveFollowsTheIsoLine(double frequencyHz, double expectedDb)
+    {
+        TargetCurveSpec spec = TargetCurveSpec.FromPreset(TargetPreset.XCurve);
+
+        Assert.Equal(expectedDb, spec.Evaluate(frequencyHz), tolerance: 0.7);
+    }
+
+    [Fact]
+    public void Evaluate_XCurveStaysFlatBelowTheKnee()
+    {
+        TargetCurveSpec spec = TargetCurveSpec.FromPreset(TargetPreset.XCurve);
+
+        // The standard is flat all the way to the 2 kHz knee, so the shelf tail
+        // must not reach the midrange — the old preset was 2.1 dB down at 1 kHz.
+        Assert.Equal(0.0, spec.Evaluate(1_000), tolerance: 0.2);
+        Assert.Equal(0.0, spec.Evaluate(500), tolerance: 0.1);
+        Assert.Equal(0.0, spec.Evaluate(100), tolerance: 0.1);
+    }
+
+    [Fact]
+    public void DefaultPreset_IsTheInCarShape()
+    {
+        // A new target overlay opens on this preset; this is a car analyzer, so
+        // it must not open on a room curve.
+        TargetCurveSpec spec = TargetCurveSpec.FromPreset(OverlayTargets.DefaultPreset);
+
+        Assert.Equal(TargetPreset.Car, OverlayTargets.DefaultPreset);
+        Assert.Equal(0.0, spec.TiltDbPerOctave, precision: 9);
+    }
+
     [Fact]
     public void BuildTarget_DeviationIsMeasurementMinusShiftedTarget()
     {


### PR DESCRIPTION
Follow-up to #80. If the car presets were room curves wearing a car label, the obvious question was whether the rest were valid — so I audited all nine against one rule: **a preset named after an external document has to reproduce that document; a preset that is just a voicing can only be judged against its own description.**

Only two name a document. Both were off, and one was off the same way the car presets were.

## `X-curve` — the same defect class

ISO 2969 / SMPTE ST 202 is flat to 2 kHz, then −3 dB/octave. The preset put its shelf at 2.5 kHz over 2.0 octaves, and that tail reached deep into the band the standard leaves alone:

| | 500 Hz | 1 kHz | 2 kHz | 4 kHz | 10 kHz |
|---|---|---|---|---|---|
| ISO | 0 | 0 | 0 | −3.00 | −6.97 |
| before | −0.89 | −2.10 | −4.20 | −6.63 | −8.81 |
| after | −0.02 | −0.12 | −0.58 | −2.47 | −7.53 |

Same gain, higher and narrower shelf — **−10 dB / 6300 Hz / 1.2 octaves**. Max deviation from the standard's line drops from **4.2 dB to 0.60 dB** across 200 Hz…20 kHz. The parametrization was never the problem; a tanh shelf cannot make a hard knee, but it gets within 0.6 dB of one. The parameters are chosen on the grid the dialog can actually display (one decimal on gain and width), so a preset does not silently round when the user touches the control.

The dialog description promised "rolloff above ≈2.5 kHz" while the curve was already 0.9 dB down at 500 Hz; it now names the standard.

## `Harman room` → `Room (Harman-style)`

Its +4 dB @ 105 Hz over −0.8 dB/oct is a reasonable room voicing in that spirit, but it is not a reproduction of any published curve, and the widely quoted Harman figures (+6.6 dB below 105 Hz, −2.4 dB above 2.5 kHz) come from the *headphone*-target lineage measured on a head simulator, which does not transfer 1:1 to a room measurement. Rather than move the numbers toward a source I cannot cleanly cite, the name stops promising a document.

**The enum member keeps the name `HarmanRoom`** — presets persist by name in both overlay files and the measurement settings (`JsonStringEnumConverter`), so renaming the member would fail to parse every stored target. A doc comment on the member records why the display name differs.

## New target overlays open on `Car`

The default was `HarmanRoom`, duplicated across two call sites in `Overlay.cs`. This is a car analyzer; the default is now `OverlayTargets.DefaultPreset` = `Car`, which also de-duplicates the value.

## The other six are clean

`Flat`, `Room (gentle)`, `Warm`, `House / bass boost`, `Smiley` and `BBC dip` name no external document and each matches its own description. Two cosmetic notes left alone: `Smiley`'s minimum sits near 500–700 Hz rather than 1 kHz, and `BBC dip` carries a −0.5 dB/oct tilt on top of the dip, so it reads −1.0 dB at 1 kHz.

## Tests

`XCurveTable` pins fourteen points to the standard's line (tolerance 0.7 dB = the shelf fit error), `Evaluate_XCurveStaysFlatBelowTheKnee` guards specifically against the tail creeping back under the knee, and `DefaultPreset_IsTheInCarShape` pins the new-overlay default.

`dotnet test tests/Resonalyze.App.Tests -c Release --filter "Category!=Hardware"` → 969 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
