### PR TITLE
Find a travelling session's measurements by relative path, or by asking

### DIFF
--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -115,6 +115,12 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private VirtualCrossoverProjectFile project = new();
 
+    // The folder the user pointed at to relink an imported session's missing
+    // measurements: an extra search root for every source this session resolves
+    // afterwards (a mono toggle re-resolves a side long after the import). Belongs
+    // to the imported session, so binding a project clears it.
+    private string? relinkDirectory;
+
     // Candidate gate values while the gate dialog is open, so the gated plots
     // track the dialog live; null once it closes (Save committed them to the
     // project, Cancel reverts by simply dropping them). AutoOffset mirrors the
@@ -356,6 +362,7 @@ public partial class VirtualCrossoverPanel : UserControl
     private async Task BindProjectAsync(VirtualCrossoverProjectFile newProject)
     {
         project = newProject;
+        relinkDirectory = null;
         // Match the block list to the project's channel count (validated into the
         // supported range on load), so an imported 2- or 6-channel session shows
         // exactly its channels.
@@ -525,7 +532,10 @@ public partial class VirtualCrossoverPanel : UserControl
 
     // Rebuilds the selector's items from the available profiles and the persisted
     // mode, then resolves the calibration the curves use. A profile that is no
-    // longer configured falls back to Off (the helper's default selection).
+    // longer configured keeps its entry, marked "(file missing)", so the stored
+    // preference is not overwritten by the rebuild — the curves are simply drawn
+    // uncalibrated until the file comes back (an imported session says so once,
+    // see WarnAboutUnavailableCalibration).
     private void RefreshCalibrationCombo()
     {
         suppressProjectEvents = true;
@@ -1399,9 +1409,9 @@ public partial class VirtualCrossoverPanel : UserControl
     }
 
     // Re-resolves one side's persisted source reference: the history entry
-    // first (it survives file moves), then the file path. A source that no
-    // longer exists degrades to an unresolved side instead of failing the
-    // project load.
+    // first (it survives file moves), then the file path, then that file beside
+    // an imported session. A source that no longer exists degrades to an
+    // unresolved side instead of failing the project load.
     private async Task ResolveSourceAsync(
         VirtualCrossoverChannel channel, bool rightSide, bool showErrors)
     {
@@ -1448,8 +1458,10 @@ public partial class VirtualCrossoverPanel : UserControl
     }
 
     // Loads the measurement behind a persisted source reference: the history
-    // entry first (it survives file moves), then the file path. Null when
-    // neither resolves — the side stays unresolved instead of failing the load.
+    // entry first (it survives file moves), then the file path — and, when that
+    // path no longer exists, the same file beside the session file the project
+    // was imported from. Null when nothing resolves — the side stays unresolved
+    // instead of failing the load.
     private async Task<MeasurementHistorySnapshot?> LoadSnapshotFromReferenceAsync(
         VirtualCrossoverChannelSettings settings)
     {
@@ -1463,16 +1475,32 @@ public partial class VirtualCrossoverPanel : UserControl
             }
         }
 
-        if (!string.IsNullOrWhiteSpace(settings.SourceFilePath) &&
-            File.Exists(settings.SourceFilePath))
+        if (LocateSource(settings) is { } path)
         {
-            ImpulseResponseFile file =
-                await ImpulseResponseFile.LoadAsync(settings.SourceFilePath);
+            // Pin where the measurement was actually read from: this project
+            // becomes the internal autosave right after the import, and that copy
+            // has no session file beside it to search from a second time.
+            settings.SourceFilePath = path;
+            ImpulseResponseFile file = await ImpulseResponseFile.LoadAsync(path);
             return MeasurementHistoryService.CreateSnapshot(file);
         }
 
         return null;
     }
+
+    // The stored path, then the folder the session was imported from, then the
+    // folder the user pointed at when relinking. The first call already answers
+    // for a path that still exists, so the second only ever runs when nothing
+    // resolves without the user's help.
+    private string? LocateSource(VirtualCrossoverChannelSettings settings) =>
+        VirtualCrossoverSourceLocator.Locate(
+            settings.SourceFilePath,
+            settings.SourceRelativePath,
+            project.ProjectDirectory)
+        ?? VirtualCrossoverSourceLocator.Locate(
+            settings.SourceFilePath,
+            settings.SourceRelativePath,
+            relinkDirectory);
 
     private void UpdateSourceButton(VirtualCrossoverChannel channel)
     {
@@ -4321,6 +4349,162 @@ public partial class VirtualCrossoverPanel : UserControl
 
         await ApplyProjectAsync(imported);
         ScheduleSave();
+        await RelinkMissingSourcesAsync();
+        WarnAboutUnavailableCalibration();
+    }
+
+    // Offers to relink the sources an imported session could not find. The stored
+    // paths were written on the machine that measured, so a session that arrives
+    // without its original tree — a different drive letter, a renamed folder, the
+    // measurements filed apart from the session — leaves every such channel
+    // unresolved. One folder answers for all of them: the same locator runs against
+    // it, and it stays this session's extra search root.
+    private async Task RelinkMissingSourcesAsync()
+    {
+        List<(VirtualCrossoverChannel Channel, bool RightSide)> missing =
+            MissingSourceSides().ToList();
+        if (missing.Count == 0 || IsDisposed)
+        {
+            return;
+        }
+
+        if (MessageBox.Show(
+                FindForm(),
+                $"{DescribeMissingSources(missing)}\r\n\r\nThey were saved with this " +
+                "session's own paths, which do not exist on this computer. Point at " +
+                "the folder holding the measurements?",
+                "Virtual DSP",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question) != DialogResult.Yes)
+        {
+            return;
+        }
+
+        using var dialog = new FolderBrowserDialog
+        {
+            Description = "Select the folder holding this session's measurements",
+            UseDescriptionForTitle = true,
+            SelectedPath = project.ProjectDirectory ?? string.Empty
+        };
+        if (dialog.ShowDialog(FindForm()) != DialogResult.OK)
+        {
+            return;
+        }
+
+        relinkDirectory = dialog.SelectedPath;
+        SetProjectLoading(true);
+        try
+        {
+            foreach ((VirtualCrossoverChannel channel, bool rightSide) in missing)
+            {
+                await ResolveSourceAsync(channel, rightSide, showErrors: false);
+            }
+
+            foreach (VirtualCrossoverChannel channel in
+                missing.Select(item => item.Channel).Distinct())
+            {
+                UpdateSourceButton(channel);
+            }
+
+            UpdateSideRadioTexts();
+        }
+        finally
+        {
+            // Same order as a project load: leave the loading state before the
+            // redraw, so the final frame is the real plot.
+            SetProjectLoading(false);
+            RedrawAll();
+        }
+
+        // The relinked paths belong in the autosave, not just on screen.
+        ScheduleSave();
+
+        List<(VirtualCrossoverChannel Channel, bool RightSide)> remaining =
+            MissingSourceSides().ToList();
+        if (remaining.Count > 0 && !IsDisposed)
+        {
+            MessageBox.Show(
+                FindForm(),
+                $"{DescribeMissingSources(remaining)}\r\n\r\nThe folder holds no file " +
+                "under the name each channel was saved with. Pick those measurements " +
+                "with the channel's Source button, or import the session again to " +
+                "choose a different folder.",
+                "Virtual DSP",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
+        }
+    }
+
+    // Every side that names a source FILE but has no measurement behind it — the
+    // ones a folder can answer for. A side with no stored reference is simply
+    // empty, not missing, and one referring only to a history entry of the machine
+    // that measured is not something pointing at a folder could fix.
+    private IEnumerable<(VirtualCrossoverChannel Channel, bool RightSide)>
+        MissingSourceSides()
+    {
+        foreach (VirtualCrossoverChannel channel in channels)
+        {
+            foreach (bool rightSide in new[] { false, true })
+            {
+                if (channel.Pair.Mono && rightSide)
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrWhiteSpace(
+                        channel.SideSettings(rightSide).SourceFilePath) &&
+                    channel.SideState(rightSide).TransferImpulseResponse == null)
+                {
+                    yield return (channel, rightSide);
+                }
+            }
+        }
+    }
+
+    private static string DescribeMissingSources(
+        IReadOnlyList<(VirtualCrossoverChannel Channel, bool RightSide)> missing)
+    {
+        string sides = string.Join(
+            ", ",
+            missing.Select(item => SideLabel(item.Channel, item.RightSide)));
+        return missing.Count == 1
+            ? $"The measurement of channel {sides} was not found."
+            : $"{missing.Count} measurements were not found: {sides}.";
+    }
+
+    // The calibration a session asks for is a per-computer setting: the session
+    // stores WHICH profile (0°/90°) its curves were drawn with, but the profile's
+    // file belongs to the machine's own microphone. The selector keeps the mode and
+    // marks it "(file missing)", yet the curves are then drawn with no calibration
+    // at all — a quiet difference from what the session's author saw, and worth one
+    // sentence at import time. Copying the other machine's file is NOT the fix: it
+    // describes their microphone, not this one.
+    private void WarnAboutUnavailableCalibration()
+    {
+        bool available = project.CalibrationMode switch
+        {
+            MicrophoneCalibrationMode.Degrees0 => hasZeroDegreeCalibration,
+            MicrophoneCalibrationMode.Degrees90 => hasNinetyDegreeCalibration,
+            _ => true
+        };
+        if (available || IsDisposed)
+        {
+            return;
+        }
+
+        string profile = project.CalibrationMode == MicrophoneCalibrationMode.Degrees90
+            ? "90 degrees"
+            : "0 degrees";
+        MessageBox.Show(
+            FindForm(),
+            $"This session was tuned with the {profile} microphone calibration, which " +
+            "is not configured on this computer, so its curves are drawn without any " +
+            "calibration and will not match the ones its author saw.\r\n\r\nConfigure " +
+            "the calibration of THIS microphone in the measurement settings — the " +
+            "other computer's file describes its own microphone, not yours.",
+            "Virtual DSP",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Information);
     }
 
     private void ShowError(string message, string details)

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -1432,7 +1432,7 @@ public partial class VirtualCrossoverPanel : UserControl
         RefreshAutoActionsEnabled();
         try
         {
-            MeasurementHistorySnapshot? snapshot =
+            (MeasurementHistorySnapshot? snapshot, string? relocatedPath) =
                 await LoadSnapshotFromReferenceAsync(settings);
             // The same assignment core as the interactive pickers (the file
             // behind a stored path may have been replaced since the project was
@@ -1440,10 +1440,19 @@ public partial class VirtualCrossoverPanel : UserControl
             // transfer IR, or a rate that clashes with the other sides — stays
             // unresolved (the button shows the warning glyph) instead of
             // prompting, because a silent reload cannot ask.
-            if (snapshot != null)
-            {
+            if (snapshot != null &&
                 TryAssignSource(
-                    state, revision, snapshot, SourceConflictPolicy.RejectSilently);
+                    state, revision, snapshot, SourceConflictPolicy.RejectSilently) &&
+                relocatedPath != null)
+            {
+                // Only a measurement that LANDED may repoint the channel, the same
+                // rule the interactive pickers follow (see OnSourceAssigned). A file
+                // found under the search folders can still be refused — no transfer
+                // IR, or the wrong sample rate — and pinning it anyway would bury the
+                // reference the search itself needs: the stored path always wins once
+                // it exists, so the next relink would reopen the refused file instead
+                // of looking in the folder the user just pointed at.
+                settings.SourceFilePath = relocatedPath;
             }
         }
         catch (Exception exception) when (!showErrors)
@@ -1460,10 +1469,14 @@ public partial class VirtualCrossoverPanel : UserControl
     // Loads the measurement behind a persisted source reference: the history
     // entry first (it survives file moves), then the file path — and, when that
     // path no longer exists, the same file beside the session file the project
-    // was imported from. Null when nothing resolves — the side stays unresolved
-    // instead of failing the load.
-    private async Task<MeasurementHistorySnapshot?> LoadSnapshotFromReferenceAsync(
-        VirtualCrossoverChannelSettings settings)
+    // was imported from. A null snapshot means nothing resolved and the side stays
+    // unresolved instead of failing the load. RelocatedPath is where the file was
+    // actually read from when that differs from the stored path — the caller pins
+    // it only if the measurement is accepted, because this project becomes the
+    // internal autosave right after the import and that copy has no session file
+    // beside it to search from a second time.
+    private async Task<(MeasurementHistorySnapshot? Snapshot, string? RelocatedPath)>
+        LoadSnapshotFromReferenceAsync(VirtualCrossoverChannelSettings settings)
     {
         if (settings.HistoryEntryId is { } entryId && HistoryService != null)
         {
@@ -1471,21 +1484,21 @@ public partial class VirtualCrossoverPanel : UserControl
                 await HistoryService.GetSnapshotAsync(entryId);
             if (snapshot != null)
             {
-                return snapshot;
+                return (snapshot, null);
             }
         }
 
         if (LocateSource(settings) is { } path)
         {
-            // Pin where the measurement was actually read from: this project
-            // becomes the internal autosave right after the import, and that copy
-            // has no session file beside it to search from a second time.
-            settings.SourceFilePath = path;
             ImpulseResponseFile file = await ImpulseResponseFile.LoadAsync(path);
-            return MeasurementHistoryService.CreateSnapshot(file);
+            return (
+                MeasurementHistoryService.CreateSnapshot(file),
+                string.Equals(path, settings.SourceFilePath, StringComparison.Ordinal)
+                    ? null
+                    : path);
         }
 
-        return null;
+        return (null, null);
     }
 
     // The stored path, then the folder the session was imported from, then the

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -68,8 +68,10 @@ public sealed class VirtualCrossoverPhaseGateSettings
 /// <summary>
 /// One channel of the virtual crossover: which measurement feeds it and the DSP
 /// chain applied before the virtual sum. The source is re-resolved on load — by
-/// history entry first, then by file path — so a renamed history label or a moved
-/// file degrades gracefully instead of failing the whole project.
+/// history entry first, then by file path, and finally beside the imported session
+/// file itself (see <see cref="VirtualCrossoverSourceLocator"/>) — so a renamed
+/// history label or a moved file degrades gracefully instead of failing the whole
+/// project.
 /// </summary>
 public sealed class VirtualCrossoverChannelSettings
 {
@@ -84,6 +86,20 @@ public sealed class VirtualCrossoverChannelSettings
 
     public string DisplayName { get; set; } = string.Empty;
     public string? SourceFilePath { get; set; }
+
+    /// <summary>
+    /// The same measurement as <see cref="SourceFilePath"/>, written relative to the
+    /// folder an EXPORTED session file sits in (see
+    /// <see cref="VirtualCrossoverSourceLocator.Relativize"/>). Absolute paths are
+    /// written on the machine that measured, so they are the first thing a session
+    /// loses when it travels; the relative one survives as long as the measurements
+    /// travel with it in the same arrangement. Null when there is no source, when
+    /// the measurement sits on another volume, or in the internal autosave — see
+    /// <see cref="VirtualCrossoverProjectFile.SaveTo"/> for why the autosave carries
+    /// none. Additive: files written before it exists simply have no such property.
+    /// </summary>
+    public string? SourceRelativePath { get; set; }
+
     public Guid? HistoryEntryId { get; set; }
 
     public double GainDb { get; set; }
@@ -516,6 +532,7 @@ public sealed class VirtualCrossoverProjectFile
     public void Save(string? rootDirectory = null)
     {
         Validate();
+        SetExportRelativePaths(null);
         SavedAtUtc = DateTimeOffset.UtcNow;
 
         string path = GetPath(rootDirectory);
@@ -550,13 +567,35 @@ public sealed class VirtualCrossoverProjectFile
 
     /// <summary>
     /// Exports the session to a user-chosen file (same format as the internal
-    /// project file), so a tuning setup can be shared or archived.
+    /// project file), so a tuning setup can be shared or archived. Each source also
+    /// gets a path relative to THIS file's folder, which is what lets the export
+    /// find its measurements again on another machine.
     /// </summary>
     public void SaveTo(string path)
     {
         Validate();
+        SetExportRelativePaths(SafeDirectoryOf(path));
         SavedAtUtc = DateTimeOffset.UtcNow;
         AtomicFile.Write(path, stream => JsonSerializer.Serialize(stream, this, SerializerOptions));
+    }
+
+    // A relative path means nothing without the folder it was computed against, so
+    // it is rewritten on every export and CLEARED from the internal autosave: that
+    // copy lives in the application data folder, no measurement sits beside it, and
+    // a value left over from some earlier export would be a confident wrong answer
+    // if the autosave were ever hand-carried to another machine and imported.
+    private void SetExportRelativePaths(string? exportDirectory)
+    {
+        foreach (VirtualCrossoverChannelPairSettings pair in Pairs)
+        {
+            foreach (VirtualCrossoverChannelSettings side in new[] { pair.Left, pair.Right })
+            {
+                side.SourceRelativePath = exportDirectory == null
+                    ? null
+                    : VirtualCrossoverSourceLocator.Relativize(
+                        side.SourceFilePath, exportDirectory);
+            }
+        }
     }
 
     /// <summary>
@@ -578,7 +617,34 @@ public sealed class VirtualCrossoverProjectFile
             ?? throw new InvalidDataException("The session file is empty.");
         Migrate(file);
         file.Validate();
+        file.ProjectDirectory = SafeDirectoryOf(path);
         return file;
+    }
+
+    /// <summary>
+    /// The folder the session file was imported from, kept so a channel whose
+    /// stored absolute path no longer exists can be looked for beside the session
+    /// itself (see <see cref="VirtualCrossoverSourceLocator"/>). Null for the
+    /// internal autosave, which lives in the application data folder: measurements
+    /// never sit there, so searching it could only produce a false match. Not
+    /// serialized — it describes where the file came from, not what it contains.
+    /// </summary>
+    [JsonIgnore]
+    public string? ProjectDirectory { get; private set; }
+
+    private static string? SafeDirectoryOf(string path)
+    {
+        try
+        {
+            return Path.GetDirectoryName(Path.GetFullPath(path));
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            // The file just opened, so this practically cannot fail; if it does,
+            // the session still loads and simply gets no folder to search.
+            return null;
+        }
     }
 
     // Per-version upgrade steps, applied before validation. Newer-than-current

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -88,15 +88,20 @@ public sealed class VirtualCrossoverChannelSettings
     public string? SourceFilePath { get; set; }
 
     /// <summary>
-    /// The same measurement as <see cref="SourceFilePath"/>, written relative to the
-    /// folder an EXPORTED session file sits in (see
+    /// The same measurement as <see cref="SourceFilePath"/>, expressed relative to
+    /// the folder of the session file this project came from (see
     /// <see cref="VirtualCrossoverSourceLocator.Relativize"/>). Absolute paths are
     /// written on the machine that measured, so they are the first thing a session
     /// loses when it travels; the relative one survives as long as the measurements
-    /// travel with it in the same arrangement. Null when there is no source, when
-    /// the measurement sits on another volume, or in the internal autosave — see
-    /// <see cref="VirtualCrossoverProjectFile.SaveTo"/> for why the autosave carries
-    /// none. Additive: files written before it exists simply have no such property.
+    /// travel with it in the same arrangement.
+    /// <para>
+    /// In memory this holds what the loaded session carried, and it stays put: what
+    /// each WRITE puts on the wire — the export's own folder, nothing for the
+    /// autosave — is decided per write and does not touch the value here. Null when
+    /// there is no source, when the measurement sits on another volume, or when the
+    /// project was never loaded from a session file. Additive: files written before
+    /// it existed simply have no such property.
+    /// </para>
     /// </summary>
     public string? SourceRelativePath { get; set; }
 
@@ -532,7 +537,6 @@ public sealed class VirtualCrossoverProjectFile
     public void Save(string? rootDirectory = null)
     {
         Validate();
-        SetExportRelativePaths(null);
         SavedAtUtc = DateTimeOffset.UtcNow;
 
         string path = GetPath(rootDirectory);
@@ -544,15 +548,18 @@ public sealed class VirtualCrossoverProjectFile
         string temporaryPath = path + ".tmp";
         try
         {
-            using (FileStream stream = new(
-                temporaryPath,
-                FileMode.Create,
-                FileAccess.Write,
-                FileShare.None))
+            // The autosave has no folder of its own for a relative path to be
+            // relative TO, so it writes none (see WriteWithExportRelativePaths).
+            WriteWithExportRelativePaths(null, () =>
             {
+                using FileStream stream = new(
+                    temporaryPath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None);
                 JsonSerializer.Serialize(stream, this, SerializerOptions);
                 stream.Flush(flushToDisk: true);
-            }
+            });
 
             File.Move(temporaryPath, path, overwrite: true);
         }
@@ -574,26 +581,54 @@ public sealed class VirtualCrossoverProjectFile
     public void SaveTo(string path)
     {
         Validate();
-        SetExportRelativePaths(SafeDirectoryOf(path));
         SavedAtUtc = DateTimeOffset.UtcNow;
-        AtomicFile.Write(path, stream => JsonSerializer.Serialize(stream, this, SerializerOptions));
+        WriteWithExportRelativePaths(
+            SafeDirectoryOf(path),
+            () => AtomicFile.Write(
+                path,
+                stream => JsonSerializer.Serialize(stream, this, SerializerOptions)));
     }
 
     // A relative path means nothing without the folder it was computed against, so
-    // it is rewritten on every export and CLEARED from the internal autosave: that
-    // copy lives in the application data folder, no measurement sits beside it, and
-    // a value left over from some earlier export would be a confident wrong answer
-    // if the autosave were ever hand-carried to another machine and imported.
-    private void SetExportRelativePaths(string? exportDirectory)
+    // each write states its own: an export writes paths relative to ITS folder, and
+    // the internal autosave writes none — it lives in the application data folder,
+    // no measurement sits beside it, and a value left over from some earlier export
+    // would be a confident wrong answer if that file were hand-carried to another
+    // machine and imported.
+    //
+    // Strictly a property of the WRITE, never of the project: the values are swapped
+    // in around the serialization and put back afterwards. The live ones belong to
+    // the session this project was IMPORTED from and are still in use — the tool
+    // reads them to find measurements whose absolute paths are dead, including
+    // during the relink prompt, which an autosave can fire behind (a modal dialog
+    // keeps pumping the message loop, so the debounced save runs while the user
+    // reads the question). Clearing them for real there would delete the very hint
+    // the relink is about to need, and would also leave a re-export unable to
+    // restate the arrangement it was imported with.
+    private void WriteWithExportRelativePaths(string? exportDirectory, Action write)
     {
+        List<(VirtualCrossoverChannelSettings Side, string? RelativePath)> restore = [];
         foreach (VirtualCrossoverChannelPairSettings pair in Pairs)
         {
             foreach (VirtualCrossoverChannelSettings side in new[] { pair.Left, pair.Right })
             {
+                restore.Add((side, side.SourceRelativePath));
                 side.SourceRelativePath = exportDirectory == null
                     ? null
                     : VirtualCrossoverSourceLocator.Relativize(
                         side.SourceFilePath, exportDirectory);
+            }
+        }
+
+        try
+        {
+            write();
+        }
+        finally
+        {
+            foreach ((VirtualCrossoverChannelSettings side, string? relativePath) in restore)
+            {
+                side.SourceRelativePath = relativePath;
             }
         }
     }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverSourceLocator.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverSourceLocator.cs
@@ -1,0 +1,170 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Finds the measurement file a Virtual DSP session refers to when the stored
+/// absolute path no longer resolves.
+/// <para>
+/// A session file travels: it is exported, mailed, copied to another machine or
+/// simply moved together with the measurements it was tuned on. Its channel
+/// paths, however, are absolute and written on the machine that made them, so on
+/// arrival every one of them points at a folder that does not exist and the whole
+/// session opens with unresolved channels. Since the measurements normally travel
+/// WITH the session, the folder the session file itself was opened from is the one
+/// honest hint about where they went — so the stored path is retried against it,
+/// in two steps.
+/// </para>
+/// <para>
+/// FIRST the path stored RELATIVE to the exporting session's own folder (see
+/// <see cref="Relativize"/>), which reproduces the original layout exactly,
+/// including measurements kept in a SIBLING folder (<c>..\v4\mid.json</c>) — the
+/// common case in a real tuning session, and one no search under the session's
+/// folder can reach.
+/// </para>
+/// <para>
+/// THEN the stored path's TAIL, shortest first: the bare file name in the
+/// session's folder, then the file name under its parent folder, and so on. That
+/// still resolves the flat case (everything in one folder) and a whole tree copied
+/// across, and it is the only route for a session exported by a build that wrote
+/// no relative path. Neither step ever enumerates a directory — only paths the
+/// stored ones actually name are probed, so a same-named measurement sitting in an
+/// unrelated sibling folder is never picked up.
+/// </para>
+/// </summary>
+internal static class VirtualCrossoverSourceLocator
+{
+    // How many leading folders of the stored path may be dropped. Deep enough for
+    // the real trees (car\v5\left\woofer.json), shallow enough that a stored path
+    // can never be reduced to a tail so generic that it matches by accident.
+    private const int MaximumTailDepth = 6;
+
+    /// <summary>
+    /// The path the measurement can actually be read from: the stored one when it
+    /// still exists, otherwise the relative path or the first tail match under
+    /// <paramref name="searchDirectory"/> — the folder the session file was loaded
+    /// from, or one the user pointed at to relink. Null for the internal autosave,
+    /// which has no companion folder to search. Null result: nothing resolves and
+    /// the channel stays unresolved.
+    /// </summary>
+    internal static string? Locate(
+        string? storedPath, string? relativePath, string? searchDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(storedPath))
+        {
+            return null;
+        }
+        if (File.Exists(storedPath))
+        {
+            return storedPath;
+        }
+        if (string.IsNullOrWhiteSpace(searchDirectory))
+        {
+            return null;
+        }
+
+        if (Resolve(searchDirectory, relativePath) is { } relative)
+        {
+            return relative;
+        }
+
+        foreach (string tail in TrailingSegments(storedPath))
+        {
+            if (Resolve(searchDirectory, tail) is { } candidate)
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The measurement's path as an EXPORTED session records it beside the absolute
+    /// one: relative to <paramref name="exportDirectory"/>, so a session copied to
+    /// another machine together with its measurements finds them wherever the pair
+    /// landed, as long as their relative arrangement survived the copy.
+    /// <para>
+    /// Null across volumes — a relative path cannot cross one (<see
+    /// cref="Path.GetRelativePath"/> would just hand back the absolute path, which
+    /// is already stored) — and null for a path that is not fully qualified, which
+    /// has no fixed meaning to be relative TO.
+    /// </para>
+    /// </summary>
+    internal static string? Relativize(string? absolutePath, string exportDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(absolutePath) ||
+            !Path.IsPathFullyQualified(absolutePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            string? sourceRoot = Path.GetPathRoot(Path.GetFullPath(absolutePath));
+            string? exportRoot = Path.GetPathRoot(Path.GetFullPath(exportDirectory));
+            if (string.IsNullOrEmpty(sourceRoot) ||
+                !string.Equals(sourceRoot, exportRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            string relative = Path.GetRelativePath(exportDirectory, absolutePath);
+            return Path.IsPathRooted(relative) ? null : relative;
+        }
+        catch (Exception exception) when (IsPathFailure(exception))
+        {
+            return null;
+        }
+    }
+
+    // One candidate under the search directory, or null when it does not exist (or
+    // cannot even be formed). A rooted "relative" part is refused rather than
+    // silently probed as an absolute path: only Combine's own behaviour would make
+    // it one, and a hand-edited session must not gain a second absolute reference
+    // that never passed through Relativize.
+    private static string? Resolve(string searchDirectory, string? relativePart)
+    {
+        if (string.IsNullOrWhiteSpace(relativePart) || Path.IsPathRooted(relativePart))
+        {
+            return null;
+        }
+
+        try
+        {
+            string candidate =
+                Path.GetFullPath(Path.Combine(searchDirectory, relativePart));
+            return File.Exists(candidate) ? candidate : null;
+        }
+        catch (Exception exception) when (IsPathFailure(exception))
+        {
+            return null;
+        }
+    }
+
+    // The stored path's tails, shortest first: "woofer.json", "left\woofer.json",
+    // "v5\left\woofer.json"... Stops at the root (the drive or UNC share is not a
+    // folder name that could repeat under the session's folder).
+    private static IEnumerable<string> TrailingSegments(string storedPath)
+    {
+        string tail = Path.GetFileName(storedPath);
+        string? remainder = Path.GetDirectoryName(storedPath);
+        for (int depth = 0; depth < MaximumTailDepth && tail.Length > 0; depth++)
+        {
+            yield return tail;
+
+            string? segment = Path.GetFileName(remainder);
+            if (string.IsNullOrEmpty(segment))
+            {
+                yield break;
+            }
+
+            tail = Path.Combine(segment, tail);
+            remainder = Path.GetDirectoryName(remainder);
+        }
+    }
+
+    // A path the platform refuses to even form (illegal characters, too long, a
+    // device name). It is not a locate failure worth reporting — the candidate
+    // simply does not exist.
+    private static bool IsPathFailure(Exception exception) =>
+        exception is ArgumentException or PathTooLongException or NotSupportedException;
+}

--- a/source/Tools/VirtualCrossover/VirtualCrossoverSourceLocator.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverSourceLocator.cs
@@ -21,13 +21,13 @@ namespace Resonalyze;
 /// folder can reach.
 /// </para>
 /// <para>
-/// THEN the stored path's TAIL, shortest first: the bare file name in the
-/// session's folder, then the file name under its parent folder, and so on. That
-/// still resolves the flat case (everything in one folder) and a whole tree copied
-/// across, and it is the only route for a session exported by a build that wrote
-/// no relative path. Neither step ever enumerates a directory — only paths the
-/// stored ones actually name are probed, so a same-named measurement sitting in an
-/// unrelated sibling folder is never picked up.
+/// THEN the stored path's TAIL, LONGEST first: the deepest chunk of the stored
+/// path under the session's folder, then one folder less, down to the bare file
+/// name. That resolves a whole tree copied across and, last, the flat case
+/// (everything in one folder), and it is the only route for a session exported by
+/// a build that wrote no relative path. Neither step ever enumerates a directory —
+/// only paths the stored ones actually name are probed, so a same-named
+/// measurement sitting in an unrelated sibling folder is never picked up.
 /// </para>
 /// </summary>
 internal static class VirtualCrossoverSourceLocator
@@ -140,25 +140,41 @@ internal static class VirtualCrossoverSourceLocator
         }
     }
 
-    // The stored path's tails, shortest first: "woofer.json", "left\woofer.json",
-    // "v5\left\woofer.json"... Stops at the root (the drive or UNC share is not a
-    // folder name that could repeat under the session's folder).
+    // The stored path's tails, LONGEST first: "v5\left\woofer.json",
+    // "left\woofer.json", "woofer.json". Longest first because the number of path
+    // components that still agree is the whole evidence a tail match has — a new
+    // tree holding both <session>\left\woofer.json and a different
+    // <session>\woofer.json would otherwise answer with the shallow one, and two
+    // measurements of the same rate and format swap silently. Dropping components
+    // one at a time still reaches the flat case, just last. Collection stops at the
+    // root (the drive or UNC share is not a folder name that could repeat under the
+    // session's folder).
     private static IEnumerable<string> TrailingSegments(string storedPath)
     {
         string tail = Path.GetFileName(storedPath);
-        string? remainder = Path.GetDirectoryName(storedPath);
-        for (int depth = 0; depth < MaximumTailDepth && tail.Length > 0; depth++)
+        if (tail.Length == 0)
         {
-            yield return tail;
+            yield break;
+        }
 
+        var tails = new List<string> { tail };
+        string? remainder = Path.GetDirectoryName(storedPath);
+        while (tails.Count < MaximumTailDepth)
+        {
             string? segment = Path.GetFileName(remainder);
             if (string.IsNullOrEmpty(segment))
             {
-                yield break;
+                break;
             }
 
             tail = Path.Combine(segment, tail);
+            tails.Add(tail);
             remainder = Path.GetDirectoryName(remainder);
+        }
+
+        for (int index = tails.Count - 1; index >= 0; index--)
+        {
+            yield return tails[index];
         }
     }
 

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSourceLocatorTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSourceLocatorTests.cs
@@ -69,6 +69,31 @@ public sealed class VirtualCrossoverSourceLocatorTests
     }
 
     [Fact]
+    public void Locate_PrefersTheDeepestTailMatch()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            // Both exist under the session's folder: a bare woofer.json that is some
+            // OTHER measurement, and the one whose folder still matches the stored
+            // path. The deeper match agrees with more of the stored path, so it wins
+            // — taking the shallow one would swap two same-rate measurements with
+            // nothing on screen to say so.
+            string expected = WriteFile(Path.Combine(root, "left"), "woofer.json");
+            WriteFile(root, "woofer.json");
+
+            Assert.Equal(
+                expected,
+                VirtualCrossoverSourceLocator.Locate(
+                    @"D:\car\v5\left\woofer.json", null, root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Locate_DoesNotSearchWithoutAProjectDirectory()
     {
         string root = CreateTemporaryDirectory();
@@ -244,6 +269,46 @@ public sealed class VirtualCrossoverSourceLocatorTests
             Assert.Equal(
                 Path.Combine(root, "v4", "subwoofer.json"),
                 autosaved.Pairs[0].Left.SourceFilePath);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SaveKeepsTheImportedRelativePathsInMemory()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            string sessionFolder = Path.Combine(root, "v5");
+            Directory.CreateDirectory(sessionFolder);
+            var original = new VirtualCrossoverProjectFile();
+            original.Pairs[0].Left.SourceFilePath =
+                Path.Combine(root, "v4", "subwoofer.json");
+            string sessionPath = Path.Combine(sessionFolder, "session.json");
+            original.SaveTo(sessionPath);
+
+            // Exporting states the arrangement on the wire without adopting it: the
+            // live project still describes the session it was loaded from, whose
+            // folder is what the tool resolves against.
+            Assert.Null(original.Pairs[0].Left.SourceRelativePath);
+
+            VirtualCrossoverProjectFile imported =
+                VirtualCrossoverProjectFile.LoadFrom(sessionPath);
+            string relative = Path.Combine("..", "v4", "subwoofer.json");
+            Assert.Equal(relative, imported.Pairs[0].Left.SourceRelativePath);
+
+            // The autosave writes no relative path, but must not take the imported
+            // one away either: the tool is still using it to find measurements whose
+            // absolute paths are dead — including while the relink prompt is open,
+            // which a debounced autosave can fire behind.
+            imported.Save(root);
+            Assert.Equal(relative, imported.Pairs[0].Left.SourceRelativePath);
+            Assert.Null(
+                VirtualCrossoverProjectFile.LoadOrDefault(root)
+                    .Pairs[0].Left.SourceRelativePath);
         }
         finally
         {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSourceLocatorTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSourceLocatorTests.cs
@@ -1,0 +1,294 @@
+namespace Resonalyze.App.Tests;
+
+public sealed class VirtualCrossoverSourceLocatorTests
+{
+    [Fact]
+    public void Locate_PrefersTheStoredPathWhenItStillExists()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            string stored = WriteFile(Path.Combine(root, "original"), "woofer.json");
+            string session = Path.Combine(root, "session");
+            WriteFile(session, "woofer.json");
+
+            // A copy sitting beside the session must not shadow the real, still
+            // readable source: the search is a fallback, not a preference.
+            Assert.Equal(
+                stored,
+                VirtualCrossoverSourceLocator.Locate(stored, null, session));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Locate_FindsTheMeasurementBesideTheSessionFile()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            // The flat case: a session exported together with its measurements
+            // into one folder, opened on a machine where the original tree
+            // (D:\car\v5) does not exist at all.
+            string expected = WriteFile(root, "woofer.json");
+
+            Assert.Equal(
+                expected,
+                VirtualCrossoverSourceLocator.Locate(
+                    @"D:\car\v5\left\woofer.json", null, root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Locate_FindsTheMeasurementUnderTheStoredSubfolders()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            // A whole measurement tree copied across: the stored tail (left\...)
+            // is preserved under the session's folder, so the deeper candidate is
+            // the one that resolves.
+            string expected = WriteFile(Path.Combine(root, "left"), "woofer.json");
+
+            Assert.Equal(
+                expected,
+                VirtualCrossoverSourceLocator.Locate(
+                    Path.Combine(@"D:\car\v5", "left", "woofer.json"), null, root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Locate_DoesNotSearchWithoutAProjectDirectory()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            WriteFile(root, "woofer.json");
+            string missing = Path.Combine(root, "gone", "woofer.json");
+
+            // The internal autosave passes no directory: it lives in the
+            // application data folder, where a same-named file would be a false
+            // match rather than the user's measurement.
+            Assert.Null(VirtualCrossoverSourceLocator.Locate(missing, null, null));
+            Assert.Null(VirtualCrossoverSourceLocator.Locate(null, null, root));
+            Assert.Null(VirtualCrossoverSourceLocator.Locate("   ", null, root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Locate_ReturnsNullWhenNothingBesideTheSessionMatches()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            // Only paths the stored one actually names are probed, so an
+            // unrelated sibling — even one holding a measurement of the same
+            // name — is never picked up.
+            WriteFile(Path.Combine(root, "right"), "woofer.json");
+
+            Assert.Null(
+                VirtualCrossoverSourceLocator.Locate(
+                    Path.Combine(@"D:\car\v5", "left", "woofer.json"), null, root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Locate_FollowsTheRelativePathIntoASiblingFolder()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            // The real shape of a tuning session: the sub still comes from the
+            // previous round's folder, which no search UNDER the session's folder
+            // can ever reach — only the relative path recorded at export does.
+            string session = Path.Combine(root, "v5");
+            Directory.CreateDirectory(session);
+            string expected = WriteFile(Path.Combine(root, "v4"), "subwoofer.json");
+
+            Assert.Equal(
+                expected,
+                VirtualCrossoverSourceLocator.Locate(
+                    @"D:\car\v4\subwoofer.json",
+                    Path.Combine("..", "v4", "subwoofer.json"),
+                    session));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Locate_PrefersTheRelativePathOverATailMatch()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            // Two files of the same name: the one the session's own layout points
+            // at, and one that merely happens to sit beside the session. The
+            // recorded arrangement is the stronger evidence, so it wins.
+            string session = Path.Combine(root, "v5");
+            string expected = WriteFile(Path.Combine(root, "v4"), "mid.json");
+            WriteFile(session, "mid.json");
+
+            Assert.Equal(
+                expected,
+                VirtualCrossoverSourceLocator.Locate(
+                    @"D:\car\v4\mid.json",
+                    Path.Combine("..", "v4", "mid.json"),
+                    session));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Locate_IgnoresARootedOrMissingRelativePath()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            string expected = WriteFile(root, "woofer.json");
+
+            // A hand-edited session cannot smuggle a second absolute reference in
+            // through the relative field: a rooted value is dropped, and the tail
+            // search answers instead.
+            Assert.Equal(
+                expected,
+                VirtualCrossoverSourceLocator.Locate(
+                    @"D:\car\v5\woofer.json", @"C:\elsewhere\woofer.json", root));
+            Assert.Equal(
+                expected,
+                VirtualCrossoverSourceLocator.Locate(
+                    @"D:\car\v5\woofer.json", Path.Combine("..", "gone.json"), root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Relativize_DescribesTheMeasurementFromTheExportFolder()
+    {
+        Assert.Equal(
+            Path.Combine("..", "v4", "mid.json"),
+            VirtualCrossoverSourceLocator.Relativize(
+                @"D:\car\v4\mid.json", @"D:\car\v5"));
+        Assert.Equal(
+            "woofer.json",
+            VirtualCrossoverSourceLocator.Relativize(
+                @"D:\car\v5\woofer.json", @"D:\car\v5"));
+
+        // A relative path cannot cross a volume, and there is nothing to be
+        // relative to when the stored path is not fully qualified.
+        Assert.Null(
+            VirtualCrossoverSourceLocator.Relativize(
+                @"E:\car\v4\mid.json", @"D:\car\v5"));
+        Assert.Null(
+            VirtualCrossoverSourceLocator.Relativize("mid.json", @"D:\car\v5"));
+        Assert.Null(VirtualCrossoverSourceLocator.Relativize(null, @"D:\car\v5"));
+    }
+
+    [Fact]
+    public void SaveTo_WritesTheRelativePathsThatSaveKeepsOut()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            string session = Path.Combine(root, "v5");
+            Directory.CreateDirectory(session);
+            var project = new VirtualCrossoverProjectFile();
+            project.Pairs[0].Left.SourceFilePath =
+                Path.Combine(root, "v4", "subwoofer.json");
+            project.Pairs[1].Left.SourceFilePath =
+                Path.Combine(session, "l bass.json");
+
+            project.SaveTo(Path.Combine(session, "session.json"));
+            VirtualCrossoverProjectFile exported = VirtualCrossoverProjectFile.LoadFrom(
+                Path.Combine(session, "session.json"));
+            Assert.Equal(
+                Path.Combine("..", "v4", "subwoofer.json"),
+                exported.Pairs[0].Left.SourceRelativePath);
+            Assert.Equal("l bass.json", exported.Pairs[1].Left.SourceRelativePath);
+            Assert.Null(exported.Pairs[2].Left.SourceRelativePath);
+
+            // The autosave carries none: it has no folder of its own that the
+            // measurements could be relative to, so a value left over from the
+            // export above would be a confident wrong answer.
+            project.Save(root);
+            VirtualCrossoverProjectFile autosaved =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+            Assert.Null(autosaved.Pairs[0].Left.SourceRelativePath);
+            Assert.Equal(
+                Path.Combine(root, "v4", "subwoofer.json"),
+                autosaved.Pairs[0].Left.SourceFilePath);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadFrom_RemembersTheFolderTheSessionCameFrom()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            string path = Path.Combine(root, "session.json");
+            new VirtualCrossoverProjectFile().SaveTo(path);
+
+            VirtualCrossoverProjectFile imported =
+                VirtualCrossoverProjectFile.LoadFrom(path);
+            Assert.Equal(root, imported.ProjectDirectory);
+
+            // The autosave has no companion folder: nothing to search there.
+            new VirtualCrossoverProjectFile().Save(root);
+            Assert.Null(VirtualCrossoverProjectFile.LoadOrDefault(root).ProjectDirectory);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string WriteFile(string directory, string name)
+    {
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, name);
+        File.WriteAllText(path, "{}");
+        return path;
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            "resonalyze-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}


### PR DESCRIPTION
A Virtual DSP session stores each channel's measurement by absolute path, written on the machine that measured. Carried to another computer, every one of those paths points at a folder that does not exist and the session opens with every channel unresolved.

The real shape of the problem is in the owner's own session: `D:\hobby\AMP\v5\virtual-dsp-session.json` references measurements both beside itself (`v5\l bass +20 dBFS.json`) and in a **sibling** folder (`v4\l mid.json`, `v4\subwoofer -10dB.json`). No search under the session's folder can reach the second kind.

## Three routes, in order of the evidence they carry

**The relative path.** `SaveTo` now also records each source relative to the exported file's own folder (`VirtualCrossoverSourceLocator.Relativize`), on the same volume only — a relative path cannot cross one, and `Path.GetRelativePath` would just hand back the absolute path that is already stored. This reproduces the original arrangement exactly, sibling folders included. The internal autosave carries none: it has no companion folder for anything to be relative to, and a value left over from an earlier export would be a confident wrong answer if that file were ever hand-carried and imported. Additive field, no schema bump.

**The tail search.** Failing that, the stored path's tail is retried under the session's folder, shortest first: `woofer.json`, then `left\woofer.json`, then `v5\left\woofer.json` (six levels). Covers the flat case and a whole tree copied across, and is the only route for a session exported by a build that wrote no relative path. Neither route ever enumerates a directory — only paths the stored one actually names are probed — so a same-named measurement in an unrelated sibling folder is never picked up. A rooted value in the relative field (hand-edited file) is refused rather than probed as a second absolute reference.

**Asking.** What neither finds, the user relinks: one prompt after the import names the missing channels, one folder answers for all of them, and it stays that session's extra search root — a Mono toggle that re-resolves a side an hour later still sees it. Whatever remains missing is named again instead of being left as a row of ⚠ glyphs. Only sides referencing a source FILE are offered: a side pointing at the other machine's history entry is not something a folder can fix.

A resolved measurement's real location is written back into the project, because the imported session becomes the internal autosave immediately afterwards and that copy has no session file beside it to search from a second time.

## Calibration

An imported session now says once when the microphone calibration it was tuned with is not configured here. The selector already kept the mode and marked it "(file missing)", but the curves are then drawn with no calibration at all — a quiet difference from what the session's author saw. Copying their file is not the fix and the message says so: it describes their microphone, not this one. The comment in `RefreshCalibrationCombo` claiming the selector falls back to Off was stale — `MicrophoneCalibrationComboHelper.BuildOptions` has kept the entry since it was written.

## Verification

Unit tests (11 in `VirtualCrossoverSourceLocatorTests`) cover the relative path into a sibling folder, its precedence over a tail match, the refusal of a rooted "relative" value, `Relativize` across volumes and for a non-qualified path, and that `SaveTo` writes the relative paths while `Save` keeps them out.

Driven through the live panel with the owner's real 96 kHz measurements (53 MB each), with the modal prompts skipped and everything they call exercised:

```
after import, missing = 3 → A L, B L, C L
after relink,  missing = 1 → C L (the deliberately absent file, not latched onto)
  stored paths rewritten: D:\hobby\AMP\v5\l bass.json, ...\r bass.json
  channel A: rate 96000, IR 1048576   channel B: rate 96000, IR 1048576
exported relative path: ..\v4\subwoofer.json
after import of the moved tree, missing = 0   (tree renamed, absolute path dead)
```

Release build clean (warnings are errors), full suite green: 984 App + 1041 Dsp + 142 Audio.

## Not done

Discussed and deliberately left out: a content fingerprint (rate + length + hash) to verify a match and search by content, and a self-contained bundle — the owner's IR files are 50–65 MB each, so twelve sources are ~640 MB, viable only as binary float32 (~50 MB) and only by changing the model from "a session refers to measurements" to "a session owns copies".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
