### PR TITLE
Add protective high-pass compensation for sweep measurements

### DIFF
--- a/dsp/ProtectiveHighPassCompensation.cs
+++ b/dsp/ProtectiveHighPassCompensation.cs
@@ -1,0 +1,121 @@
+using System.Numerics;
+using MathNet.Numerics.IntegralTransforms;
+
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// Removes a known protective high-pass from a measured transfer impulse
+/// response. This is the frequency-domain equivalent of filtering the clean
+/// loopback reference through the same high-pass before dividing microphone by
+/// reference, while keeping the original full-band loopback available to the H1
+/// estimator and its coherence calculation.
+/// </summary>
+public static class ProtectiveHighPassCompensation
+{
+    private const int PhaseRefreshInterval = 1_024;
+
+    /// <summary>
+    /// Returns a copy of <paramref name="impulseResponse"/> with the magnitude
+    /// and phase of <paramref name="edge"/> divided out. Inverse gain is capped
+    /// at <paramref name="maximumBoostDb"/> because a stop-band bin contains no
+    /// recoverable loudspeaker information once the protection filter has buried
+    /// it in the measurement noise.
+    /// </summary>
+    public static Complex[] RemoveFromImpulseResponse(
+        IReadOnlyList<Complex> impulseResponse,
+        CrossoverEdge edge,
+        double sampleRateHz,
+        double maximumBoostDb)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        if (impulseResponse.Count == 0)
+        {
+            throw new ArgumentException(
+                "The impulse response must not be empty.",
+                nameof(impulseResponse));
+        }
+        if (sampleRateHz <= 0 || !double.IsFinite(sampleRateHz))
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRateHz));
+        }
+        if (maximumBoostDb < 0 || !double.IsFinite(maximumBoostDb))
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumBoostDb));
+        }
+        if (edge.Family is not (
+            CrossoverFilterFamily.Butterworth or
+            CrossoverFilterFamily.LinkwitzRiley))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(edge),
+                "Protective high-pass compensation supports only Butterworth and Linkwitz-Riley filters.");
+        }
+
+        // BuildSections owns the shared validation of the corner and slope. Do
+        // this once before the FFT loop, rather than rediscovering an invalid
+        // setting independently at every bin through CrossoverFilter.Response.
+        IReadOnlyList<BiquadCoefficients> sections =
+            CrossoverFilter.BuildSections(edge, highPass: true, sampleRateHz);
+        double maximumGain = Math.Pow(10.0, maximumBoostDb / 20.0);
+
+        var spectrum = new Complex[impulseResponse.Count];
+        for (int i = 0; i < spectrum.Length; i++)
+        {
+            spectrum[i] = impulseResponse[i];
+        }
+        Fourier.Forward(spectrum, FourierOptions.Matlab);
+
+        Complex binStep = Complex.Exp(
+            new Complex(0.0, -Math.Tau / spectrum.Length));
+        Complex z1 = Complex.One;
+        for (int bin = 0; bin < spectrum.Length; bin++)
+        {
+            if (bin > 0)
+            {
+                // Step around the unit circle instead of evaluating one complex
+                // exponential per section per bin. Periodic exact refreshes keep
+                // the recurrence from drifting over multi-million-sample IRs.
+                z1 = bin % PhaseRefreshInterval == 0
+                    ? Complex.Exp(new Complex(
+                        0.0,
+                        -Math.Tau * bin / spectrum.Length))
+                    : z1 * binStep;
+            }
+
+            Complex response = Response(sections, z1);
+            spectrum[bin] *= CappedInverse(response, maximumGain);
+        }
+
+        Fourier.Inverse(spectrum, FourierOptions.Matlab);
+        return spectrum;
+    }
+
+    private static Complex Response(
+        IReadOnlyList<BiquadCoefficients> sections,
+        Complex z1)
+    {
+        Complex response = Complex.One;
+        Complex z2 = z1 * z1;
+        foreach (BiquadCoefficients section in sections)
+        {
+            response *= BiquadResponse.Evaluate(section, z1, z2);
+        }
+
+        return response;
+    }
+
+    private static Complex CappedInverse(Complex response, double maximumGain)
+    {
+        double magnitude = response.Magnitude;
+        if (!(magnitude > 0) || !double.IsFinite(magnitude))
+        {
+            // A high-pass has an exact zero at DC. There is no phase or signal
+            // there to recover, so keep that bin at zero instead of inventing a
+            // maximum-gain DC component.
+            return Complex.Zero;
+        }
+
+        double inverseMagnitude = Math.Min(1.0 / magnitude, maximumGain);
+        return Complex.FromPolarCoordinates(inverseMagnitude, -response.Phase);
+    }
+}

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -129,6 +129,8 @@ namespace Resonalyze
         public int AverageRunCount { get; private set; } = 1;
         public int AcceptedAverageRunCount { get; private set; } = 1;
         public bool ConfirmEachAverageRun { get; private set; }
+        public ProtectiveHighPassConfiguration ProtectiveHighPass { get; private set; } =
+            ProtectiveHighPassConfiguration.Off;
         // The SPL calibration CONFIGURED for the next run (follows the settings /
         // dialog). It is snapshotted into MeasurementSplCalibration when a run
         // starts, so recalibrating afterwards never rewrites an existing result.
@@ -259,6 +261,8 @@ namespace Resonalyze
             AverageRunCount = Math.Clamp(averaging.RunCount, 1, 64);
             AcceptedAverageRunCount = 0;
             ConfirmEachAverageRun = averaging.ConfirmEachRun;
+            ProtectiveHighPass = ProtectiveHighPassConfiguration.Normalize(
+                configuration.ProtectiveHighPass);
             QualityReport = null;
             LastError = null;
             CurrentLevels = InputLevelMeterSnapshot.Empty;
@@ -513,7 +517,8 @@ namespace Resonalyze
                     WasapiBufferMilliseconds: WasapiBufferMilliseconds),
                 new SweepAveragingConfiguration(
                     AverageRunCount,
-                    ConfirmEachAverageRun)));
+                    ConfirmEachAverageRun),
+                ProtectiveHighPass));
             // Init just set these from the sweep it regenerated; the recorded
             // geometry wins, since that sweep is a reconstruction and this result
             // came from the original one. The length matters as much as the band:
@@ -1648,10 +1653,25 @@ namespace Resonalyze
             sweepDeconvolutionResult = new MeasurementImpulseResponse(
                 result.SweepImpulseResponse,
                 result.SweepPeakIndex);
-            transferResult = result.TransferImpulseResponse != null
+            Complex[]? transferImpulseResponse = result.TransferImpulseResponse;
+            int transferPeakIndex = result.TransferPeakIndex;
+            if (transferImpulseResponse != null && ProtectiveHighPass.Enabled)
+            {
+                transferImpulseResponse =
+                    ProtectiveHighPassCompensation.RemoveFromImpulseResponse(
+                        transferImpulseResponse,
+                        ProtectiveHighPass.ToEdge(),
+                        SampleRate,
+                        ProtectiveHighPassConfiguration.MaximumCompensationBoostDb);
+                // Removing the high-pass removes its group delay too, so its
+                // corrected arrival is allowed to move instead of inheriting the
+                // filtered response's peak index.
+                transferPeakIndex = FindPeakIndex(transferImpulseResponse);
+            }
+            transferResult = transferImpulseResponse != null
                 ? new MeasurementImpulseResponse(
-                    result.TransferImpulseResponse,
-                    result.TransferPeakIndex)
+                    transferImpulseResponse,
+                    transferPeakIndex)
                 : null;
             TransferCoherence = result.TransferCoherence;
             MicrophoneRecordedSamples = result.MicrophoneRecordedSamples;

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -1664,9 +1664,22 @@ namespace Resonalyze
                         SampleRate,
                         ProtectiveHighPassConfiguration.MaximumCompensationBoostDb);
                 // Removing the high-pass removes its group delay too, so its
-                // corrected arrival is allowed to move instead of inheriting the
-                // filtered response's peak index.
-                transferPeakIndex = FindPeakIndex(transferImpulseResponse);
+                // corrected arrival is allowed to move on a synchronized live
+                // measurement. An import is different: its peak was deliberately
+                // placed at its own 10 ms origin before publication, so preserve
+                // that convention by rotating the corrected arrival back there.
+                int correctedPeakIndex = FindPeakIndex(transferImpulseResponse);
+                if (TimingReference == TimingReference.RecordedSweep)
+                {
+                    transferImpulseResponse = RotateTo(
+                        transferImpulseResponse,
+                        correctedPeakIndex,
+                        result.TransferPeakIndex);
+                }
+                else
+                {
+                    transferPeakIndex = correctedPeakIndex;
+                }
             }
             transferResult = transferImpulseResponse != null
                 ? new MeasurementImpulseResponse(

--- a/source/Measurements/SweepMeasurementConfiguration.cs
+++ b/source/Measurements/SweepMeasurementConfiguration.cs
@@ -1,9 +1,95 @@
+using Resonalyze.Dsp;
+
 namespace Resonalyze;
 
 public sealed record SweepMeasurementConfiguration(
     SweepSignalConfiguration Signal,
     SweepAudioConfiguration Audio,
-    SweepAveragingConfiguration Averaging);
+    SweepAveragingConfiguration Averaging,
+    ProtectiveHighPassConfiguration? ProtectiveHighPass = null);
+
+public enum ProtectiveHighPassKind
+{
+    Off,
+    Butterworth,
+    LinkwitzRiley
+}
+
+/// <summary>
+/// The high-pass the user has configured in the external DSP between the sound
+/// card output and the loudspeaker. The synchronized loopback is captured before
+/// that DSP, so this model is divided out of the resulting transfer IR.
+/// </summary>
+public sealed record ProtectiveHighPassConfiguration(
+    ProtectiveHighPassKind Kind = ProtectiveHighPassKind.Off,
+    double FrequencyHz = 2_000.0,
+    int SlopeDbPerOctave = 24)
+{
+    public const double MaximumCompensationBoostDb = 40.0;
+
+    public static ProtectiveHighPassConfiguration Off { get; } = new();
+
+    public bool Enabled => Kind != ProtectiveHighPassKind.Off;
+
+    public static ProtectiveHighPassConfiguration Normalize(
+        ProtectiveHighPassConfiguration? configuration)
+    {
+        if (configuration == null || !Enum.IsDefined(configuration.Kind))
+        {
+            return Off;
+        }
+
+        double frequencyHz = double.IsFinite(configuration.FrequencyHz)
+            ? Math.Clamp(configuration.FrequencyHz, 10.0, 20_000.0)
+            : 2_000.0;
+        if (configuration.Kind == ProtectiveHighPassKind.Off)
+        {
+            return new ProtectiveHighPassConfiguration(
+                ProtectiveHighPassKind.Off,
+                frequencyHz,
+                NormalizeSlope(
+                    ProtectiveHighPassKind.Butterworth,
+                    configuration.SlopeDbPerOctave));
+        }
+
+        return new ProtectiveHighPassConfiguration(
+            configuration.Kind,
+            frequencyHz,
+            NormalizeSlope(configuration.Kind, configuration.SlopeDbPerOctave));
+    }
+
+    public CrossoverEdge ToEdge()
+    {
+        if (!Enabled)
+        {
+            throw new InvalidOperationException(
+                "An off protective high-pass has no crossover edge.");
+        }
+
+        CrossoverFilterFamily family = Kind switch
+        {
+            ProtectiveHighPassKind.Butterworth => CrossoverFilterFamily.Butterworth,
+            ProtectiveHighPassKind.LinkwitzRiley => CrossoverFilterFamily.LinkwitzRiley,
+            _ => throw new InvalidOperationException(
+                "An off protective high-pass has no crossover edge.")
+        };
+        return new CrossoverEdge(family, FrequencyHz, SlopeDbPerOctave);
+    }
+
+    public static IReadOnlyList<int> SupportedSlopes(ProtectiveHighPassKind kind) =>
+        kind switch
+        {
+            ProtectiveHighPassKind.LinkwitzRiley =>
+                CrossoverFilter.SupportedSlopes(CrossoverFilterFamily.LinkwitzRiley),
+            _ => CrossoverFilter.SupportedSlopes(CrossoverFilterFamily.Butterworth)
+        };
+
+    private static int NormalizeSlope(ProtectiveHighPassKind kind, int slope)
+    {
+        IReadOnlyList<int> supported = SupportedSlopes(kind);
+        return supported.Contains(slope) ? slope : 24;
+    }
+}
 
 public sealed record SweepSignalConfiguration(
     double LowFrequencyHz,

--- a/source/Options/MeasurementOptions.Designer.cs
+++ b/source/Options/MeasurementOptions.Designer.cs
@@ -41,6 +41,11 @@
             labelHighFrequency = new Label();
             numericUpDownLowFrequency = new DarkNumericUpDown();
             labelLowFrequency = new Label();
+            labelProtectiveHighPass = new Label();
+            labelProtectiveHighPassParameters = new Label();
+            comboBoxProtectiveHighPassKind = new DarkComboBox();
+            numericUpDownProtectiveHighPassFrequency = new DarkNumericUpDown();
+            comboBoxProtectiveHighPassSlope = new DarkComboBox();
             numericUpDownBits = new DarkNumericUpDown();
             label2 = new Label();
             comboBoxSampleRate = new DarkComboBox();
@@ -69,6 +74,7 @@
             (numericUpDownRequestedDuration).BeginInit();
             (numericUpDownHighFrequency).BeginInit();
             (numericUpDownLowFrequency).BeginInit();
+            (numericUpDownProtectiveHighPassFrequency).BeginInit();
             (numericUpDownBits).BeginInit();
             (numericUpDownAverageRunCount).BeginInit();
             SuspendLayout();
@@ -78,6 +84,11 @@
             sweepPanel.BackColor = Color.FromArgb(50, 55, 66);
             sweepPanel.BorderStyle = BorderStyle.FixedSingle;
             sweepPanel.Controls.Add(buttonSaveSweepFile);
+            sweepPanel.Controls.Add(comboBoxProtectiveHighPassSlope);
+            sweepPanel.Controls.Add(numericUpDownProtectiveHighPassFrequency);
+            sweepPanel.Controls.Add(comboBoxProtectiveHighPassKind);
+            sweepPanel.Controls.Add(labelProtectiveHighPassParameters);
+            sweepPanel.Controls.Add(labelProtectiveHighPass);
             sweepPanel.Controls.Add(labelActualRangeCaption);
             sweepPanel.Controls.Add(numericUpDownRequestedDuration);
             sweepPanel.Controls.Add(label4);
@@ -87,14 +98,14 @@
             sweepPanel.Controls.Add(labelLowFrequency);
             sweepPanel.Location = new Point(8, 6);
             sweepPanel.Name = "sweepPanel";
-            sweepPanel.Size = new Size(322, 134);
+            sweepPanel.Size = new Size(322, 184);
             sweepPanel.TabIndex = 0;
             //
             // buttonSaveSweepFile
             //
             buttonSaveSweepFile.FlatStyle = FlatStyle.Popup;
             buttonSaveSweepFile.ForeColor = Color.White;
-            buttonSaveSweepFile.Location = new Point(8, 103);
+            buttonSaveSweepFile.Location = new Point(8, 153);
             buttonSaveSweepFile.Name = "buttonSaveSweepFile";
             buttonSaveSweepFile.Size = new Size(307, 23);
             buttonSaveSweepFile.TabIndex = 22;
@@ -195,6 +206,65 @@
             labelLowFrequency.Size = new Size(110, 15);
             labelLowFrequency.TabIndex = 15;
             labelLowFrequency.Text = "Low frequency (Hz)";
+            //
+            // labelProtectiveHighPass
+            //
+            labelProtectiveHighPass.AutoSize = true;
+            labelProtectiveHighPass.ForeColor = SystemColors.ControlLight;
+            labelProtectiveHighPass.Location = new Point(8, 108);
+            labelProtectiveHighPass.Name = "labelProtectiveHighPass";
+            labelProtectiveHighPass.Size = new Size(83, 15);
+            labelProtectiveHighPass.TabIndex = 23;
+            labelProtectiveHighPass.Text = "Protective HPF";
+            //
+            // labelProtectiveHighPassParameters
+            //
+            labelProtectiveHighPassParameters.AutoSize = true;
+            labelProtectiveHighPassParameters.ForeColor = SystemColors.ControlLight;
+            labelProtectiveHighPassParameters.Location = new Point(8, 133);
+            labelProtectiveHighPassParameters.Name = "labelProtectiveHighPassParameters";
+            labelProtectiveHighPassParameters.Size = new Size(104, 15);
+            labelProtectiveHighPassParameters.TabIndex = 24;
+            labelProtectiveHighPassParameters.Text = "Corner (Hz) / slope";
+            //
+            // comboBoxProtectiveHighPassKind
+            //
+            comboBoxProtectiveHighPassKind.BackColor = Color.FromArgb(55, 60, 72);
+            comboBoxProtectiveHighPassKind.ForeColor = Color.White;
+            comboBoxProtectiveHighPassKind.Location = new Point(145, 103);
+            comboBoxProtectiveHighPassKind.Margin = new Padding(0);
+            comboBoxProtectiveHighPassKind.MinimumSize = new Size(36, 19);
+            comboBoxProtectiveHighPassKind.Name = "comboBoxProtectiveHighPassKind";
+            comboBoxProtectiveHighPassKind.Size = new Size(170, 23);
+            comboBoxProtectiveHighPassKind.TabIndex = 25;
+            //
+            // numericUpDownProtectiveHighPassFrequency
+            //
+            numericUpDownProtectiveHighPassFrequency.BackColor = Color.FromArgb(55, 60, 72);
+            numericUpDownProtectiveHighPassFrequency.DecimalPlaces = 0;
+            numericUpDownProtectiveHighPassFrequency.ForeColor = Color.White;
+            numericUpDownProtectiveHighPassFrequency.Increment = new decimal(new int[] { 10, 0, 0, 0 });
+            numericUpDownProtectiveHighPassFrequency.Location = new Point(145, 130);
+            numericUpDownProtectiveHighPassFrequency.Maximum = new decimal(new int[] { 20000, 0, 0, 0 });
+            numericUpDownProtectiveHighPassFrequency.Minimum = new decimal(new int[] { 10, 0, 0, 0 });
+            numericUpDownProtectiveHighPassFrequency.MinimumSize = new Size(36, 19);
+            numericUpDownProtectiveHighPassFrequency.Name = "numericUpDownProtectiveHighPassFrequency";
+            numericUpDownProtectiveHighPassFrequency.Size = new Size(70, 19);
+            numericUpDownProtectiveHighPassFrequency.TabIndex = 26;
+            numericUpDownProtectiveHighPassFrequency.TextAlign = HorizontalAlignment.Right;
+            numericUpDownProtectiveHighPassFrequency.ThousandsSeparator = false;
+            numericUpDownProtectiveHighPassFrequency.Value = new decimal(new int[] { 2000, 0, 0, 0 });
+            //
+            // comboBoxProtectiveHighPassSlope
+            //
+            comboBoxProtectiveHighPassSlope.BackColor = Color.FromArgb(55, 60, 72);
+            comboBoxProtectiveHighPassSlope.ForeColor = Color.White;
+            comboBoxProtectiveHighPassSlope.Location = new Point(220, 128);
+            comboBoxProtectiveHighPassSlope.Margin = new Padding(0);
+            comboBoxProtectiveHighPassSlope.MinimumSize = new Size(36, 19);
+            comboBoxProtectiveHighPassSlope.Name = "comboBoxProtectiveHighPassSlope";
+            comboBoxProtectiveHighPassSlope.Size = new Size(95, 23);
+            comboBoxProtectiveHighPassSlope.TabIndex = 27;
             // 
             // numericUpDownBits
             // 
@@ -251,7 +321,7 @@
             // 
             comboBoxChannel.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxChannel.ForeColor = Color.White;
-            comboBoxChannel.Location = new Point(154, 148);
+            comboBoxChannel.Location = new Point(154, 198);
             comboBoxChannel.Margin = new Padding(0);
             comboBoxChannel.MinimumSize = new Size(36, 19);
             comboBoxChannel.Name = "comboBoxChannel";
@@ -263,7 +333,7 @@
             // 
             label3.AutoSize = true;
             label3.ForeColor = SystemColors.ControlLight;
-            label3.Location = new Point(17, 156);
+            label3.Location = new Point(17, 206);
             label3.Name = "label3";
             label3.Size = new Size(51, 15);
             label3.TabIndex = 5;
@@ -282,7 +352,7 @@
             audioBackendPanel.Controls.Add(label2);
             audioBackendPanel.Controls.Add(comboBoxSampleRate);
             audioBackendPanel.Controls.Add(label1);
-            audioBackendPanel.Location = new Point(8, 304);
+            audioBackendPanel.Location = new Point(8, 354);
             audioBackendPanel.Name = "audioBackendPanel";
             audioBackendPanel.Size = new Size(322, 368);
             audioBackendPanel.TabIndex = 39;
@@ -325,7 +395,7 @@
             // 
             labelAverageRunCount.AutoSize = true;
             labelAverageRunCount.ForeColor = SystemColors.ControlLight;
-            labelAverageRunCount.Location = new Point(17, 182);
+            labelAverageRunCount.Location = new Point(17, 232);
             labelAverageRunCount.Name = "labelAverageRunCount";
             labelAverageRunCount.Size = new Size(85, 15);
             labelAverageRunCount.TabIndex = 27;
@@ -337,7 +407,7 @@
             numericUpDownAverageRunCount.DecimalPlaces = 0;
             numericUpDownAverageRunCount.ForeColor = Color.White;
             numericUpDownAverageRunCount.Increment = new decimal(new int[] { 1, 0, 0, 0 });
-            numericUpDownAverageRunCount.Location = new Point(154, 178);
+            numericUpDownAverageRunCount.Location = new Point(154, 228);
             numericUpDownAverageRunCount.Maximum = new decimal(new int[] { 64, 0, 0, 0 });
             numericUpDownAverageRunCount.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
             numericUpDownAverageRunCount.MinimumSize = new Size(36, 19);
@@ -353,7 +423,7 @@
             // 
             checkBoxConfirmEachAverageRun.AutoSize = true;
             checkBoxConfirmEachAverageRun.ForeColor = SystemColors.ControlLight;
-            checkBoxConfirmEachAverageRun.Location = new Point(154, 202);
+            checkBoxConfirmEachAverageRun.Location = new Point(154, 252);
             checkBoxConfirmEachAverageRun.Name = "checkBoxConfirmEachAverageRun";
             checkBoxConfirmEachAverageRun.Size = new Size(119, 19);
             checkBoxConfirmEachAverageRun.TabIndex = 29;
@@ -365,7 +435,7 @@
             // 
             labelCalibration0.AutoSize = true;
             labelCalibration0.ForeColor = SystemColors.ControlLight;
-            labelCalibration0.Location = new Point(17, 232);
+            labelCalibration0.Location = new Point(17, 282);
             labelCalibration0.Name = "labelCalibration0";
             labelCalibration0.Size = new Size(100, 15);
             labelCalibration0.TabIndex = 30;
@@ -375,7 +445,7 @@
             // 
             buttonCalibration0.FlatStyle = FlatStyle.Popup;
             buttonCalibration0.ForeColor = Color.White;
-            buttonCalibration0.Location = new Point(154, 227);
+            buttonCalibration0.Location = new Point(154, 277);
             buttonCalibration0.Name = "buttonCalibration0";
             buttonCalibration0.Size = new Size(143, 23);
             buttonCalibration0.TabIndex = 31;
@@ -387,7 +457,7 @@
             // 
             buttonClearCalibration0.FlatStyle = FlatStyle.Popup;
             buttonClearCalibration0.ForeColor = Color.White;
-            buttonClearCalibration0.Location = new Point(300, 227);
+            buttonClearCalibration0.Location = new Point(300, 277);
             buttonClearCalibration0.Name = "buttonClearCalibration0";
             buttonClearCalibration0.Size = new Size(24, 23);
             buttonClearCalibration0.TabIndex = 34;
@@ -399,7 +469,7 @@
             //
             labelCalibrationExtra.AutoSize = true;
             labelCalibrationExtra.ForeColor = SystemColors.ControlLight;
-            labelCalibrationExtra.Location = new Point(17, 257);
+            labelCalibrationExtra.Location = new Point(17, 307);
             labelCalibrationExtra.Name = "labelCalibrationExtra";
             labelCalibrationExtra.Size = new Size(106, 15);
             labelCalibrationExtra.TabIndex = 32;
@@ -409,7 +479,7 @@
             //
             buttonCalibrationExtra.FlatStyle = FlatStyle.Popup;
             buttonCalibrationExtra.ForeColor = Color.White;
-            buttonCalibrationExtra.Location = new Point(154, 252);
+            buttonCalibrationExtra.Location = new Point(154, 302);
             buttonCalibrationExtra.Name = "buttonCalibrationExtra";
             buttonCalibrationExtra.Size = new Size(170, 23);
             buttonCalibrationExtra.TabIndex = 33;
@@ -421,7 +491,7 @@
             // 
             labelSplCalibration.AutoSize = true;
             labelSplCalibration.ForeColor = SystemColors.ControlLight;
-            labelSplCalibration.Location = new Point(17, 282);
+            labelSplCalibration.Location = new Point(17, 332);
             labelSplCalibration.Name = "labelSplCalibration";
             labelSplCalibration.Size = new Size(85, 15);
             labelSplCalibration.TabIndex = 36;
@@ -431,7 +501,7 @@
             // 
             buttonSplCalibration.FlatStyle = FlatStyle.Popup;
             buttonSplCalibration.ForeColor = Color.White;
-            buttonSplCalibration.Location = new Point(154, 277);
+            buttonSplCalibration.Location = new Point(154, 327);
             buttonSplCalibration.Name = "buttonSplCalibration";
             buttonSplCalibration.Size = new Size(143, 23);
             buttonSplCalibration.TabIndex = 37;
@@ -443,7 +513,7 @@
             // 
             buttonClearSplCalibration.FlatStyle = FlatStyle.Popup;
             buttonClearSplCalibration.ForeColor = Color.White;
-            buttonClearSplCalibration.Location = new Point(300, 277);
+            buttonClearSplCalibration.Location = new Point(300, 327);
             buttonClearSplCalibration.Name = "buttonClearSplCalibration";
             buttonClearSplCalibration.Size = new Size(24, 23);
             buttonClearSplCalibration.TabIndex = 38;
@@ -472,7 +542,7 @@
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(45, 50, 60);
-            ClientSize = new Size(334, 678);
+            ClientSize = new Size(334, 728);
             Controls.Add(audioBackendPanel);
             Controls.Add(buttonClearSplCalibration);
             Controls.Add(buttonSplCalibration);
@@ -501,6 +571,7 @@
             (numericUpDownRequestedDuration).EndInit();
             (numericUpDownHighFrequency).EndInit();
             (numericUpDownLowFrequency).EndInit();
+            (numericUpDownProtectiveHighPassFrequency).EndInit();
             (numericUpDownBits).EndInit();
             (numericUpDownAverageRunCount).EndInit();
             ResumeLayout(false);
@@ -525,6 +596,11 @@
         private Label labelHighFrequency;
         private Label labelActualRangeCaption;
         private Button buttonSaveSweepFile;
+        private Label labelProtectiveHighPass;
+        private Label labelProtectiveHighPassParameters;
+        private DarkComboBox comboBoxProtectiveHighPassKind;
+        private DarkNumericUpDown numericUpDownProtectiveHighPassFrequency;
+        private DarkComboBox comboBoxProtectiveHighPassSlope;
         private Label labelAudioBackend;
         private DarkComboBox comboBoxAudioBackend;
         private Label labelAverageRunCount;

--- a/source/Options/MeasurementOptions.Designer.cs
+++ b/source/Options/MeasurementOptions.Designer.cs
@@ -42,7 +42,6 @@
             numericUpDownLowFrequency = new DarkNumericUpDown();
             labelLowFrequency = new Label();
             labelProtectiveHighPass = new Label();
-            labelProtectiveHighPassParameters = new Label();
             comboBoxProtectiveHighPassKind = new DarkComboBox();
             numericUpDownProtectiveHighPassFrequency = new DarkNumericUpDown();
             comboBoxProtectiveHighPassSlope = new DarkComboBox();
@@ -87,7 +86,6 @@
             sweepPanel.Controls.Add(comboBoxProtectiveHighPassSlope);
             sweepPanel.Controls.Add(numericUpDownProtectiveHighPassFrequency);
             sweepPanel.Controls.Add(comboBoxProtectiveHighPassKind);
-            sweepPanel.Controls.Add(labelProtectiveHighPassParameters);
             sweepPanel.Controls.Add(labelProtectiveHighPass);
             sweepPanel.Controls.Add(labelActualRangeCaption);
             sweepPanel.Controls.Add(numericUpDownRequestedDuration);
@@ -98,14 +96,14 @@
             sweepPanel.Controls.Add(labelLowFrequency);
             sweepPanel.Location = new Point(8, 6);
             sweepPanel.Name = "sweepPanel";
-            sweepPanel.Size = new Size(322, 184);
+            sweepPanel.Size = new Size(322, 159);
             sweepPanel.TabIndex = 0;
             //
             // buttonSaveSweepFile
             //
             buttonSaveSweepFile.FlatStyle = FlatStyle.Popup;
             buttonSaveSweepFile.ForeColor = Color.White;
-            buttonSaveSweepFile.Location = new Point(8, 153);
+            buttonSaveSweepFile.Location = new Point(8, 128);
             buttonSaveSweepFile.Name = "buttonSaveSweepFile";
             buttonSaveSweepFile.Size = new Size(307, 23);
             buttonSaveSweepFile.TabIndex = 22;
@@ -213,29 +211,19 @@
             labelProtectiveHighPass.ForeColor = SystemColors.ControlLight;
             labelProtectiveHighPass.Location = new Point(8, 108);
             labelProtectiveHighPass.Name = "labelProtectiveHighPass";
-            labelProtectiveHighPass.Size = new Size(83, 15);
+            labelProtectiveHighPass.Size = new Size(28, 15);
             labelProtectiveHighPass.TabIndex = 23;
-            labelProtectiveHighPass.Text = "Protective HPF";
-            //
-            // labelProtectiveHighPassParameters
-            //
-            labelProtectiveHighPassParameters.AutoSize = true;
-            labelProtectiveHighPassParameters.ForeColor = SystemColors.ControlLight;
-            labelProtectiveHighPassParameters.Location = new Point(8, 133);
-            labelProtectiveHighPassParameters.Name = "labelProtectiveHighPassParameters";
-            labelProtectiveHighPassParameters.Size = new Size(104, 15);
-            labelProtectiveHighPassParameters.TabIndex = 24;
-            labelProtectiveHighPassParameters.Text = "Corner (Hz) / slope";
+            labelProtectiveHighPass.Text = "HPF";
             //
             // comboBoxProtectiveHighPassKind
             //
             comboBoxProtectiveHighPassKind.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxProtectiveHighPassKind.ForeColor = Color.White;
-            comboBoxProtectiveHighPassKind.Location = new Point(145, 103);
+            comboBoxProtectiveHighPassKind.Location = new Point(38, 103);
             comboBoxProtectiveHighPassKind.Margin = new Padding(0);
             comboBoxProtectiveHighPassKind.MinimumSize = new Size(36, 19);
             comboBoxProtectiveHighPassKind.Name = "comboBoxProtectiveHighPassKind";
-            comboBoxProtectiveHighPassKind.Size = new Size(170, 23);
+            comboBoxProtectiveHighPassKind.Size = new Size(118, 23);
             comboBoxProtectiveHighPassKind.TabIndex = 25;
             //
             // numericUpDownProtectiveHighPassFrequency
@@ -244,12 +232,12 @@
             numericUpDownProtectiveHighPassFrequency.DecimalPlaces = 0;
             numericUpDownProtectiveHighPassFrequency.ForeColor = Color.White;
             numericUpDownProtectiveHighPassFrequency.Increment = new decimal(new int[] { 10, 0, 0, 0 });
-            numericUpDownProtectiveHighPassFrequency.Location = new Point(145, 130);
+            numericUpDownProtectiveHighPassFrequency.Location = new Point(161, 105);
             numericUpDownProtectiveHighPassFrequency.Maximum = new decimal(new int[] { 20000, 0, 0, 0 });
             numericUpDownProtectiveHighPassFrequency.Minimum = new decimal(new int[] { 10, 0, 0, 0 });
             numericUpDownProtectiveHighPassFrequency.MinimumSize = new Size(36, 19);
             numericUpDownProtectiveHighPassFrequency.Name = "numericUpDownProtectiveHighPassFrequency";
-            numericUpDownProtectiveHighPassFrequency.Size = new Size(70, 19);
+            numericUpDownProtectiveHighPassFrequency.Size = new Size(55, 19);
             numericUpDownProtectiveHighPassFrequency.TabIndex = 26;
             numericUpDownProtectiveHighPassFrequency.TextAlign = HorizontalAlignment.Right;
             numericUpDownProtectiveHighPassFrequency.ThousandsSeparator = false;
@@ -259,11 +247,11 @@
             //
             comboBoxProtectiveHighPassSlope.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxProtectiveHighPassSlope.ForeColor = Color.White;
-            comboBoxProtectiveHighPassSlope.Location = new Point(220, 128);
+            comboBoxProtectiveHighPassSlope.Location = new Point(221, 103);
             comboBoxProtectiveHighPassSlope.Margin = new Padding(0);
             comboBoxProtectiveHighPassSlope.MinimumSize = new Size(36, 19);
             comboBoxProtectiveHighPassSlope.Name = "comboBoxProtectiveHighPassSlope";
-            comboBoxProtectiveHighPassSlope.Size = new Size(95, 23);
+            comboBoxProtectiveHighPassSlope.Size = new Size(94, 23);
             comboBoxProtectiveHighPassSlope.TabIndex = 27;
             // 
             // numericUpDownBits
@@ -321,7 +309,7 @@
             // 
             comboBoxChannel.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxChannel.ForeColor = Color.White;
-            comboBoxChannel.Location = new Point(154, 198);
+            comboBoxChannel.Location = new Point(154, 173);
             comboBoxChannel.Margin = new Padding(0);
             comboBoxChannel.MinimumSize = new Size(36, 19);
             comboBoxChannel.Name = "comboBoxChannel";
@@ -333,7 +321,7 @@
             // 
             label3.AutoSize = true;
             label3.ForeColor = SystemColors.ControlLight;
-            label3.Location = new Point(17, 206);
+            label3.Location = new Point(17, 181);
             label3.Name = "label3";
             label3.Size = new Size(51, 15);
             label3.TabIndex = 5;
@@ -352,9 +340,9 @@
             audioBackendPanel.Controls.Add(label2);
             audioBackendPanel.Controls.Add(comboBoxSampleRate);
             audioBackendPanel.Controls.Add(label1);
-            audioBackendPanel.Location = new Point(8, 354);
+            audioBackendPanel.Location = new Point(8, 329);
             audioBackendPanel.Name = "audioBackendPanel";
-            audioBackendPanel.Size = new Size(322, 368);
+            audioBackendPanel.Size = new Size(322, 343);
             audioBackendPanel.TabIndex = 39;
             //
             // button1
@@ -362,7 +350,7 @@
             button1.DialogResult = DialogResult.OK;
             button1.FlatStyle = FlatStyle.Popup;
             button1.ForeColor = Color.White;
-            button1.Location = new Point(8, 339);
+            button1.Location = new Point(8, 314);
             button1.Name = "button1";
             button1.Size = new Size(307, 23);
             button1.TabIndex = 12;
@@ -395,7 +383,7 @@
             // 
             labelAverageRunCount.AutoSize = true;
             labelAverageRunCount.ForeColor = SystemColors.ControlLight;
-            labelAverageRunCount.Location = new Point(17, 232);
+            labelAverageRunCount.Location = new Point(17, 207);
             labelAverageRunCount.Name = "labelAverageRunCount";
             labelAverageRunCount.Size = new Size(85, 15);
             labelAverageRunCount.TabIndex = 27;
@@ -407,7 +395,7 @@
             numericUpDownAverageRunCount.DecimalPlaces = 0;
             numericUpDownAverageRunCount.ForeColor = Color.White;
             numericUpDownAverageRunCount.Increment = new decimal(new int[] { 1, 0, 0, 0 });
-            numericUpDownAverageRunCount.Location = new Point(154, 228);
+            numericUpDownAverageRunCount.Location = new Point(154, 203);
             numericUpDownAverageRunCount.Maximum = new decimal(new int[] { 64, 0, 0, 0 });
             numericUpDownAverageRunCount.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
             numericUpDownAverageRunCount.MinimumSize = new Size(36, 19);
@@ -423,7 +411,7 @@
             // 
             checkBoxConfirmEachAverageRun.AutoSize = true;
             checkBoxConfirmEachAverageRun.ForeColor = SystemColors.ControlLight;
-            checkBoxConfirmEachAverageRun.Location = new Point(154, 252);
+            checkBoxConfirmEachAverageRun.Location = new Point(154, 227);
             checkBoxConfirmEachAverageRun.Name = "checkBoxConfirmEachAverageRun";
             checkBoxConfirmEachAverageRun.Size = new Size(119, 19);
             checkBoxConfirmEachAverageRun.TabIndex = 29;
@@ -435,7 +423,7 @@
             // 
             labelCalibration0.AutoSize = true;
             labelCalibration0.ForeColor = SystemColors.ControlLight;
-            labelCalibration0.Location = new Point(17, 282);
+            labelCalibration0.Location = new Point(17, 257);
             labelCalibration0.Name = "labelCalibration0";
             labelCalibration0.Size = new Size(100, 15);
             labelCalibration0.TabIndex = 30;
@@ -445,7 +433,7 @@
             // 
             buttonCalibration0.FlatStyle = FlatStyle.Popup;
             buttonCalibration0.ForeColor = Color.White;
-            buttonCalibration0.Location = new Point(154, 277);
+            buttonCalibration0.Location = new Point(154, 252);
             buttonCalibration0.Name = "buttonCalibration0";
             buttonCalibration0.Size = new Size(143, 23);
             buttonCalibration0.TabIndex = 31;
@@ -457,7 +445,7 @@
             // 
             buttonClearCalibration0.FlatStyle = FlatStyle.Popup;
             buttonClearCalibration0.ForeColor = Color.White;
-            buttonClearCalibration0.Location = new Point(300, 277);
+            buttonClearCalibration0.Location = new Point(300, 252);
             buttonClearCalibration0.Name = "buttonClearCalibration0";
             buttonClearCalibration0.Size = new Size(24, 23);
             buttonClearCalibration0.TabIndex = 34;
@@ -469,7 +457,7 @@
             //
             labelCalibrationExtra.AutoSize = true;
             labelCalibrationExtra.ForeColor = SystemColors.ControlLight;
-            labelCalibrationExtra.Location = new Point(17, 307);
+            labelCalibrationExtra.Location = new Point(17, 282);
             labelCalibrationExtra.Name = "labelCalibrationExtra";
             labelCalibrationExtra.Size = new Size(106, 15);
             labelCalibrationExtra.TabIndex = 32;
@@ -479,7 +467,7 @@
             //
             buttonCalibrationExtra.FlatStyle = FlatStyle.Popup;
             buttonCalibrationExtra.ForeColor = Color.White;
-            buttonCalibrationExtra.Location = new Point(154, 302);
+            buttonCalibrationExtra.Location = new Point(154, 277);
             buttonCalibrationExtra.Name = "buttonCalibrationExtra";
             buttonCalibrationExtra.Size = new Size(170, 23);
             buttonCalibrationExtra.TabIndex = 33;
@@ -491,7 +479,7 @@
             // 
             labelSplCalibration.AutoSize = true;
             labelSplCalibration.ForeColor = SystemColors.ControlLight;
-            labelSplCalibration.Location = new Point(17, 332);
+            labelSplCalibration.Location = new Point(17, 307);
             labelSplCalibration.Name = "labelSplCalibration";
             labelSplCalibration.Size = new Size(85, 15);
             labelSplCalibration.TabIndex = 36;
@@ -501,7 +489,7 @@
             // 
             buttonSplCalibration.FlatStyle = FlatStyle.Popup;
             buttonSplCalibration.ForeColor = Color.White;
-            buttonSplCalibration.Location = new Point(154, 327);
+            buttonSplCalibration.Location = new Point(154, 302);
             buttonSplCalibration.Name = "buttonSplCalibration";
             buttonSplCalibration.Size = new Size(143, 23);
             buttonSplCalibration.TabIndex = 37;
@@ -513,7 +501,7 @@
             // 
             buttonClearSplCalibration.FlatStyle = FlatStyle.Popup;
             buttonClearSplCalibration.ForeColor = Color.White;
-            buttonClearSplCalibration.Location = new Point(300, 327);
+            buttonClearSplCalibration.Location = new Point(300, 302);
             buttonClearSplCalibration.Name = "buttonClearSplCalibration";
             buttonClearSplCalibration.Size = new Size(24, 23);
             buttonClearSplCalibration.TabIndex = 38;
@@ -542,7 +530,7 @@
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(45, 50, 60);
-            ClientSize = new Size(334, 728);
+            ClientSize = new Size(334, 678);
             Controls.Add(audioBackendPanel);
             Controls.Add(buttonClearSplCalibration);
             Controls.Add(buttonSplCalibration);
@@ -597,7 +585,6 @@
         private Label labelActualRangeCaption;
         private Button buttonSaveSweepFile;
         private Label labelProtectiveHighPass;
-        private Label labelProtectiveHighPassParameters;
         private DarkComboBox comboBoxProtectiveHighPassKind;
         private DarkNumericUpDown numericUpDownProtectiveHighPassFrequency;
         private DarkComboBox comboBoxProtectiveHighPassSlope;

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -118,6 +118,7 @@ namespace Resonalyze.Options
         public MeasurementOptions()
         {
             InitializeComponent();
+            InitializeProtectiveHighPassControls();
             WireAudioBackendPanelEvents();
             TryStartEndpointMonitoring();
             Disposed += (_, _) => DisposeEndpointMonitoring();
@@ -212,7 +213,102 @@ namespace Resonalyze.Options
                 "measurement would play it: same band, pace, sample rate and " +
                 "playback channel, and the same 6 dB of headroom (-6 dBFS peak), " +
                 "with a second of silence before and after it.");
+            deviceToolTip.SetToolTip(
+                comboBoxProtectiveHighPassKind,
+                "Protective high-pass configured in the external DSP between the " +
+                "sound-card output and the loudspeaker. Resonalyze removes its " +
+                "magnitude and phase from the loopback-referenced transfer IR.");
+            numericUpDownProtectiveHighPassFrequency.ApplyToolTip(
+                deviceToolTip,
+                "Protective high-pass corner frequency (Hz). The loopback must be " +
+                "captured before the external DSP, directly from the sound-card output.");
+            deviceToolTip.SetToolTip(
+                comboBoxProtectiveHighPassSlope,
+                "Protective high-pass slope. Compensation is limited to 40 dB; " +
+                "deeper in the stop band the measurement cannot recover signal " +
+                "that the protection filter buried in noise.");
         }
+
+        private void InitializeProtectiveHighPassControls()
+        {
+            comboBoxProtectiveHighPassKind.Items.AddRange(
+            [
+                ProtectiveHighPassKind.Off,
+                ProtectiveHighPassKind.Butterworth,
+                ProtectiveHighPassKind.LinkwitzRiley
+            ]);
+            comboBoxProtectiveHighPassKind.Format += (_, args) =>
+            {
+                if (args.ListItem is ProtectiveHighPassKind kind)
+                {
+                    args.Value = kind switch
+                    {
+                        ProtectiveHighPassKind.LinkwitzRiley => "Linkwitz-Riley",
+                        _ => kind.ToString()
+                    };
+                }
+            };
+            comboBoxProtectiveHighPassSlope.Format += (_, args) =>
+            {
+                if (args.ListItem is int slope)
+                {
+                    args.Value = $"{slope} dB/oct";
+                }
+            };
+            comboBoxProtectiveHighPassKind.SelectedIndexChanged += (_, _) =>
+            {
+                PopulateProtectiveHighPassSlopes();
+                UpdateProtectiveHighPassAvailability();
+                RaiseSweepSettingsChanged();
+            };
+            numericUpDownProtectiveHighPassFrequency.ValueChanged += (_, _) =>
+                RaiseSweepSettingsChanged();
+            comboBoxProtectiveHighPassSlope.SelectedIndexChanged += (_, _) =>
+                RaiseSweepSettingsChanged();
+
+            comboBoxProtectiveHighPassKind.SelectedItem = ProtectiveHighPassKind.Off;
+            PopulateProtectiveHighPassSlopes(preferredSlope: 24);
+            UpdateProtectiveHighPassAvailability();
+        }
+
+        private ProtectiveHighPassKind SelectedProtectiveHighPassKind =>
+            comboBoxProtectiveHighPassKind.SelectedItem is ProtectiveHighPassKind kind
+                ? kind
+                : ProtectiveHighPassKind.Off;
+
+        private void PopulateProtectiveHighPassSlopes(int? preferredSlope = null)
+        {
+            int? previousSlope = preferredSlope ??
+                (comboBoxProtectiveHighPassSlope.SelectedItem is int slope ? slope : null);
+            comboBoxProtectiveHighPassSlope.Items.Clear();
+            foreach (int supportedSlope in ProtectiveHighPassConfiguration.SupportedSlopes(
+                SelectedProtectiveHighPassKind))
+            {
+                comboBoxProtectiveHighPassSlope.Items.Add(supportedSlope);
+            }
+
+            int index = previousSlope.HasValue
+                ? comboBoxProtectiveHighPassSlope.Items.IndexOf(previousSlope.Value)
+                : -1;
+            comboBoxProtectiveHighPassSlope.SelectedIndex = index >= 0
+                ? index
+                : comboBoxProtectiveHighPassSlope.Items.IndexOf(24);
+        }
+
+        private void UpdateProtectiveHighPassAvailability()
+        {
+            bool enabled = SelectedProtectiveHighPassKind != ProtectiveHighPassKind.Off;
+            UiStyle.SetTextEnabledLook(labelProtectiveHighPassParameters, enabled);
+            numericUpDownProtectiveHighPassFrequency.Enabled = enabled;
+            comboBoxProtectiveHighPassSlope.Enabled = enabled;
+        }
+
+        private ProtectiveHighPassConfiguration ReadProtectiveHighPass() =>
+            ProtectiveHighPassConfiguration.Normalize(
+                new ProtectiveHighPassConfiguration(
+                    SelectedProtectiveHighPassKind,
+                    (double)numericUpDownProtectiveHighPassFrequency.Value,
+                    comboBoxProtectiveHighPassSlope.SelectedItem is int slope ? slope : 24));
 
         internal void Init(
             ExpSweepMeasurement expSweepMeasurement,
@@ -312,6 +408,18 @@ namespace Resonalyze.Options
                 settings.SampleRate) * 1000.0;
             numericUpDownRequestedDuration.Value = numericUpDownRequestedDuration.ClampValue(
                 perOctaveMs > 0 ? Math.Round(perOctaveMs) : 100.0);
+            ProtectiveHighPassConfiguration protectiveHighPass =
+                ProtectiveHighPassConfiguration.Normalize(
+                    new ProtectiveHighPassConfiguration(
+                        settings.ProtectiveHighPassKind,
+                        settings.ProtectiveHighPassFrequencyHz,
+                        settings.ProtectiveHighPassSlopeDbPerOctave));
+            comboBoxProtectiveHighPassKind.SelectedItem = protectiveHighPass.Kind;
+            numericUpDownProtectiveHighPassFrequency.Value =
+                numericUpDownProtectiveHighPassFrequency.ClampValue(
+                    protectiveHighPass.FrequencyHz);
+            PopulateProtectiveHighPassSlopes(protectiveHighPass.SlopeDbPerOctave);
+            UpdateProtectiveHighPassAvailability();
             // Total duration and the achieved-range line are filled by the shared
             // preview at the end of Init, once the sample-rate control is settled.
             numericUpDownAverageRunCount.Value = Math.Clamp(settings.AverageRunCount, 1, 64);
@@ -490,7 +598,8 @@ namespace Resonalyze.Options
                     WasapiBufferMilliseconds: settings.WasapiBufferMilliseconds),
                 new SweepAveragingConfiguration(
                     averageRunCount,
-                    confirmEachAverageRun)));
+                    confirmEachAverageRun),
+                ReadProtectiveHighPass()));
 
             settings.LowFrequencyHz = lowFrequencyHz;
             settings.HighFrequencyHz = highFrequencyHz;
@@ -540,6 +649,11 @@ namespace Resonalyze.Options
             settings.PlaybackChannel = GetSelectedPlaybackChannel();
             settings.AverageRunCount = (int)numericUpDownAverageRunCount.Value;
             settings.ConfirmEachAverageRun = checkBoxConfirmEachAverageRun.Checked;
+            ProtectiveHighPassConfiguration protectiveHighPass = ReadProtectiveHighPass();
+            settings.ProtectiveHighPassKind = protectiveHighPass.Kind;
+            settings.ProtectiveHighPassFrequencyHz = protectiveHighPass.FrequencyHz;
+            settings.ProtectiveHighPassSlopeDbPerOctave =
+                protectiveHighPass.SlopeDbPerOctave;
         }
 
         // The duration field holds a per-octave pace; expand it to the total sweep

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -218,6 +218,9 @@ namespace Resonalyze.Options
                 "Protective high-pass configured in the external DSP between the " +
                 "sound-card output and the loudspeaker. Resonalyze removes its " +
                 "magnitude and phase from the loopback-referenced transfer IR.");
+            deviceToolTip.SetToolTip(
+                labelProtectiveHighPass,
+                "Optional protective high-pass configured in the external DSP.");
             numericUpDownProtectiveHighPassFrequency.ApplyToolTip(
                 deviceToolTip,
                 "Protective high-pass corner frequency (Hz). The loopback must be " +
@@ -298,7 +301,6 @@ namespace Resonalyze.Options
         private void UpdateProtectiveHighPassAvailability()
         {
             bool enabled = SelectedProtectiveHighPassKind != ProtectiveHighPassKind.Off;
-            UiStyle.SetTextEnabledLook(labelProtectiveHighPassParameters, enabled);
             numericUpDownProtectiveHighPassFrequency.Enabled = enabled;
             comboBoxProtectiveHighPassSlope.Enabled = enabled;
         }

--- a/source/Settings/MeasurementSettingsFile.Schema.cs
+++ b/source/Settings/MeasurementSettingsFile.Schema.cs
@@ -53,6 +53,9 @@ internal sealed partial class MeasurementSettingsFile
         // (its minimum is 2), and a lone sweep gives nothing to average away.
         public int AverageRunCount { get; set; } = 2;
         public bool ConfirmEachAverageRun { get; set; }
+        public ProtectiveHighPassKind ProtectiveHighPassKind { get; set; }
+        public double ProtectiveHighPassFrequencyHz { get; set; } = 2_000.0;
+        public int ProtectiveHighPassSlopeDbPerOctave { get; set; } = 24;
         public string? MicrophoneCalibration0DegreesPath { get; set; }
         // Legacy field (schema <= 10, when 90° was a second fixed slot), kept
         // ONLY so old files deserialize into the migration, which turns the file
@@ -146,6 +149,10 @@ internal sealed partial class MeasurementSettingsFile
                 AsioOutputChannelOffset = measurement.AsioOutputChannelOffset,
                 AverageRunCount = measurement.AverageRunCount,
                 ConfirmEachAverageRun = measurement.ConfirmEachAverageRun,
+                ProtectiveHighPassKind = measurement.ProtectiveHighPass.Kind,
+                ProtectiveHighPassFrequencyHz = measurement.ProtectiveHighPass.FrequencyHz,
+                ProtectiveHighPassSlopeDbPerOctave =
+                    measurement.ProtectiveHighPass.SlopeDbPerOctave,
                 SplCalibration = measurement.SplCalibration
             };
 
@@ -227,7 +234,12 @@ internal sealed partial class MeasurementSettingsFile
                     WasapiBufferMilliseconds: Clamp(WasapiBufferMilliseconds, 10, 100)),
                 new SweepAveragingConfiguration(
                     Clamp(AverageRunCount, 1, 64),
-                    ConfirmEachAverageRun));
+                    ConfirmEachAverageRun),
+                ProtectiveHighPassConfiguration.Normalize(
+                    new ProtectiveHighPassConfiguration(
+                        ProtectiveHighPassKind,
+                        ProtectiveHighPassFrequencyHz,
+                        ProtectiveHighPassSlopeDbPerOctave)));
         }
     }
 

--- a/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
+++ b/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
@@ -1,5 +1,7 @@
 using Resonalyze.Audio;
 using Resonalyze.Dsp;
+using MathNet.Numerics.IntegralTransforms;
+using System.Numerics;
 
 namespace Resonalyze.App.Tests;
 
@@ -41,6 +43,65 @@ public sealed class AbstractedMeasurementTests
         Assert.True(success, measurement.LastError?.ToString());
         Assert.True(measurement.HasImpulseResponse);
         Assert.Equal(1, factory.DuplexOpenCount);
+    }
+
+    [Fact]
+    public async Task ProtectiveHighPass_IsRemovedFromThePublishedTransferIrOnly()
+    {
+        var edge = new CrossoverEdge(
+            CrossoverFilterFamily.LinkwitzRiley,
+            2_000,
+            24);
+        var factory = new FakeAudioSessionFactory(
+            duplexFactory: (_, signal) => new RecordingDuplexSession(
+                signal,
+                (_, s, tail, _) => Task.FromResult(
+                    SyntheticCapture.ProtectedLoudspeaker(s, tail, edge, 44_100))));
+        using ExpSweepMeasurement measurement = CreateSweep(factory);
+        measurement.Init(new SweepMeasurementConfiguration(
+            new SweepSignalConfiguration(
+                20,
+                20_000,
+                44_100,
+                24,
+                0.05,
+                PlaybackChannel.Mono),
+            new SweepAudioConfiguration(
+                WaveInputChannelOffset: 0,
+                WaveLoopbackInputChannelOffset: 1),
+            new SweepAveragingConfiguration(),
+            new ProtectiveHighPassConfiguration(
+                ProtectiveHighPassKind.LinkwitzRiley,
+                2_000,
+                24)));
+
+        bool success = await measurement.RunAsync();
+
+        Assert.True(success, measurement.LastError?.ToString());
+        Assert.NotNull(measurement.TransferImpulseResponse);
+        Assert.NotNull(measurement.SweepDeconvolutionImpulseResponse);
+
+        using ExpSweepMeasurement uncompensated = CreateSweep(factory);
+        bool uncompensatedSuccess = await uncompensated.RunAsync();
+        Assert.True(uncompensatedSuccess, uncompensated.LastError?.ToString());
+
+        Complex[] transfer = measurement.TransferImpulseResponse!.ToArray();
+        Complex[] rawTransfer = uncompensated.TransferImpulseResponse!.ToArray();
+        Fourier.Forward(transfer, FourierOptions.Matlab);
+        Fourier.Forward(rawTransfer, FourierOptions.Matlab);
+        int cornerBin = (int)Math.Round(2_000.0 * transfer.Length / measurement.SampleRate);
+        int passBandBin = (int)Math.Round(8_000.0 * transfer.Length / measurement.SampleRate);
+        double transferCornerRelativeDb = 20.0 * Math.Log10(
+            transfer[cornerBin].Magnitude / transfer[passBandBin].Magnitude);
+        double rawCornerRelativeDb = 20.0 * Math.Log10(
+            rawTransfer[cornerBin].Magnitude / rawTransfer[passBandBin].Magnitude);
+
+        Assert.InRange(transferCornerRelativeDb, -0.2, 0.2);
+        Assert.InRange(rawCornerRelativeDb, -6.3, -5.7);
+        Assert.InRange(Math.Abs(transfer[cornerBin].Phase), 0.0, 0.05);
+        Assert.Equal(
+            uncompensated.SweepDeconvolutionImpulseResponse,
+            measurement.SweepDeconvolutionImpulseResponse);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/Fakes/RecordingSessions.cs
+++ b/tests/Resonalyze.App.Tests/Fakes/RecordingSessions.cs
@@ -1,4 +1,5 @@
 using Resonalyze.Audio;
+using Resonalyze.Dsp;
 
 namespace Resonalyze.App.Tests;
 
@@ -34,6 +35,28 @@ internal static class SyntheticCapture
     public static AudioCaptureResult QuietCleanLoopback(AudioPlaybackSignal signal, int tailSamples)
     {
         (float[] mic, float[] loop) = BuildChannels(signal, tailSamples, 0.5f, 0.0089f);
+        return new AudioCaptureResult(
+            [mic, loop], 0, 1, StereoSeparationExpected: true,
+            AudioCaptureAnomalies.None, Diagnostics: null);
+    }
+
+    // The physical arrangement behind protective-HPF compensation: loopback is
+    // captured directly from the sound-card output, while only the microphone
+    // path passes through the external DSP's high-pass.
+    public static AudioCaptureResult ProtectedLoudspeaker(
+        AudioPlaybackSignal signal,
+        int tailSamples,
+        CrossoverEdge edge,
+        double sampleRateHz)
+    {
+        (float[] mic, float[] loop) = BuildChannels(signal, tailSamples, 0.5f, 0.25f);
+        IReadOnlyList<BiquadCoefficients> sections =
+            CrossoverFilter.BuildSections(edge, highPass: true, sampleRateHz);
+        foreach (BiquadCoefficients section in sections)
+        {
+            ApplySection(mic, section);
+        }
+
         return new AudioCaptureResult(
             [mic, loop], 0, 1, StereoSeparationExpected: true,
             AudioCaptureAnomalies.None, Diagnostics: null);
@@ -235,6 +258,25 @@ internal static class SyntheticCapture
             loop[i] = signal.MonoSamples[i] * loopScale;
         }
         return (mic, loop);
+    }
+
+    private static void ApplySection(float[] samples, BiquadCoefficients section)
+    {
+        double x1 = 0;
+        double x2 = 0;
+        double y1 = 0;
+        double y2 = 0;
+        for (int i = 0; i < samples.Length; i++)
+        {
+            double x = samples[i];
+            double y = section.B0 * x + section.B1 * x1 + section.B2 * x2 +
+                section.A1 * y1 + section.A2 * y2;
+            samples[i] = (float)y;
+            x2 = x1;
+            x1 = x;
+            y2 = y1;
+            y1 = y;
+        }
     }
 }
 

--- a/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementSettingsMigrationTests.cs
@@ -89,6 +89,53 @@ public sealed class MeasurementSettingsMigrationTests
     }
 
     [Fact]
+    public void ProtectiveHighPass_RoundTripsThroughCapturedSettings()
+    {
+        using var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        measurement.Init(new SweepMeasurementConfiguration(
+            new SweepSignalConfiguration(
+                20,
+                20_000,
+                48_000,
+                24,
+                1.0,
+                PlaybackChannel.Mono),
+            new SweepAudioConfiguration(),
+            new SweepAveragingConfiguration(),
+            new ProtectiveHighPassConfiguration(
+                ProtectiveHighPassKind.Butterworth,
+                3_150,
+                36)));
+
+        MeasurementSettingsFile.SweepMeasurementSettings captured =
+            MeasurementSettingsFile.SweepMeasurementSettings.Capture(measurement);
+        SweepMeasurementConfiguration rebuilt = captured.BuildConfiguration();
+
+        Assert.Equal(ProtectiveHighPassKind.Butterworth, captured.ProtectiveHighPassKind);
+        Assert.Equal(3_150, captured.ProtectiveHighPassFrequencyHz);
+        Assert.Equal(36, captured.ProtectiveHighPassSlopeDbPerOctave);
+        Assert.Equal(measurement.ProtectiveHighPass, rebuilt.ProtectiveHighPass);
+    }
+
+    [Fact]
+    public void ProtectiveHighPass_InvalidLinkwitzRileySlopeFallsBackToTwentyFour()
+    {
+        var settings = new MeasurementSettingsFile.SweepMeasurementSettings
+        {
+            ProtectiveHighPassKind = ProtectiveHighPassKind.LinkwitzRiley,
+            ProtectiveHighPassFrequencyHz = 2_500,
+            ProtectiveHighPassSlopeDbPerOctave = 18
+        };
+
+        ProtectiveHighPassConfiguration protectiveHighPass =
+            settings.BuildConfiguration().ProtectiveHighPass!;
+
+        Assert.Equal(ProtectiveHighPassKind.LinkwitzRiley, protectiveHighPass.Kind);
+        Assert.Equal(2_500, protectiveHighPass.FrequencyHz);
+        Assert.Equal(24, protectiveHighPass.SlopeDbPerOctave);
+    }
+
+    [Fact]
     public void RestoreImpulseResponse_PreservesCurrentWasapiConfiguration()
     {
         using var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
@@ -127,6 +174,39 @@ public sealed class MeasurementSettingsMigrationTests
         Assert.Equal(40, measurement.WasapiBufferMilliseconds);
         Assert.Equal("USB Input", measurement.WasapiCaptureEndpointName);
         Assert.Equal("USB Output", measurement.WasapiRenderEndpointName);
+    }
+
+    [Fact]
+    public void RestoreImpulseResponse_PreservesCurrentProtectiveHighPassConfiguration()
+    {
+        using var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        var protectiveHighPass = new ProtectiveHighPassConfiguration(
+            ProtectiveHighPassKind.LinkwitzRiley,
+            2_000,
+            48);
+        measurement.Init(new SweepMeasurementConfiguration(
+            new SweepSignalConfiguration(
+                20,
+                20_000,
+                48_000,
+                24,
+                1.0,
+                PlaybackChannel.Mono),
+            new SweepAudioConfiguration(),
+            new SweepAveragingConfiguration(),
+            protectiveHighPass));
+
+        measurement.RestoreImpulseResponse(
+            20,
+            20_000,
+            48_000,
+            24,
+            1.0,
+            PlaybackChannel.Mono,
+            [System.Numerics.Complex.Zero, System.Numerics.Complex.One],
+            1);
+
+        Assert.Equal(protectiveHighPass, measurement.ProtectiveHighPass);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/RecordedSweepImportTests.cs
+++ b/tests/Resonalyze.App.Tests/RecordedSweepImportTests.cs
@@ -89,6 +89,34 @@ public sealed class RecordedSweepImportTests
         Assert.Equal(1, measurement.AcceptedAverageRunCount);
     }
 
+    [Fact]
+    public void ProtectiveHighPassCompensationKeepsTheImportedArrivalAtItsOwnReference()
+    {
+        var protectiveHighPass = new ProtectiveHighPassConfiguration(
+            ProtectiveHighPassKind.LinkwitzRiley,
+            250,
+            48);
+        SweepMeasurementConfiguration configuration = Configuration() with
+        {
+            ProtectiveHighPass = protectiveHighPass
+        };
+        using var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        measurement.Init(configuration);
+        float[] recording = RecordSweep(measurement, startOffset: 2_400);
+        ApplyHighPass(recording, protectiveHighPass.ToEdge());
+
+        measurement.ImportRecordedSweep(configuration, recording, SampleRate);
+
+        Assert.Equal(TimingReference.RecordedSweep, measurement.TimingReference);
+        Assert.Equal(Arrival, measurement.Transfer!.PeakIndex);
+        Assert.Equal(
+            Arrival,
+            Array.IndexOf(
+                measurement.TransferImpulseResponse!,
+                measurement.TransferImpulseResponse!
+                    .MaxBy(sample => sample.Magnitude)));
+    }
+
     // Which channel holds the measurement is a question about the sweep, not
     // about loudness: a dead input is rarely silent, and hum or hiss on it can
     // easily out-measure a quiet microphone that actually recorded the take.
@@ -468,6 +496,31 @@ public sealed class RecordedSweepImportTests
         }
 
         return result;
+    }
+
+    private static void ApplyHighPass(float[] samples, CrossoverEdge edge)
+    {
+        foreach (BiquadCoefficients section in CrossoverFilter.BuildSections(
+            edge,
+            highPass: true,
+            SampleRate))
+        {
+            double x1 = 0;
+            double x2 = 0;
+            double y1 = 0;
+            double y2 = 0;
+            for (int i = 0; i < samples.Length; i++)
+            {
+                double x = samples[i];
+                double y = section.B0 * x + section.B1 * x1 + section.B2 * x2 +
+                    section.A1 * y1 + section.A2 * y2;
+                samples[i] = (float)y;
+                x2 = x1;
+                x1 = x;
+                y2 = y1;
+                y1 = y;
+            }
+        }
     }
 
     // And it does not invent one: a recording of the very sweep the settings

--- a/tests/Resonalyze.Dsp.Tests/ProtectiveHighPassCompensationTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/ProtectiveHighPassCompensationTests.cs
@@ -1,0 +1,92 @@
+using System.Numerics;
+using MathNet.Numerics.IntegralTransforms;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class ProtectiveHighPassCompensationTests
+{
+    private const double SampleRate = 48_000;
+    private const int Length = 16_384;
+
+    [Theory]
+    [InlineData(CrossoverFilterFamily.Butterworth, 24)]
+    [InlineData(CrossoverFilterFamily.LinkwitzRiley, 24)]
+    [InlineData(CrossoverFilterFamily.LinkwitzRiley, 48)]
+    public void RemoveFromImpulseResponse_RecoversMagnitudeAndPhaseAboveTheBoostLimit(
+        CrossoverFilterFamily family,
+        int slope)
+    {
+        var edge = new CrossoverEdge(family, 2_000, slope);
+        Complex[] filtered = FilteredImpulse(edge);
+
+        Complex[] corrected = ProtectiveHighPassCompensation.RemoveFromImpulseResponse(
+            filtered,
+            edge,
+            SampleRate,
+            maximumBoostDb: 40.0);
+        Fourier.Forward(corrected, FourierOptions.Matlab);
+
+        foreach (double frequencyHz in new[] { 2_000.0, 4_000.0, 10_000.0 })
+        {
+            int bin = (int)Math.Round(frequencyHz * Length / SampleRate);
+            Assert.Equal(1.0, corrected[bin].Magnitude, 8);
+            Assert.Equal(0.0, corrected[bin].Phase, 8);
+        }
+    }
+
+    [Fact]
+    public void RemoveFromImpulseResponse_CapsStopBandRecoveryAtFortyDecibels()
+    {
+        var edge = new CrossoverEdge(
+            CrossoverFilterFamily.LinkwitzRiley,
+            2_000,
+            48);
+        Complex[] filtered = FilteredImpulse(edge);
+
+        Complex[] corrected = ProtectiveHighPassCompensation.RemoveFromImpulseResponse(
+            filtered,
+            edge,
+            SampleRate,
+            maximumBoostDb: 40.0);
+        Fourier.Forward(corrected, FourierOptions.Matlab);
+
+        int stopBandBin = (int)Math.Round(250.0 * Length / SampleRate);
+        Complex originalResponse = CrossoverFilter.Response(
+            new CrossoverSpec(CrossoverKind.HighPass, HighPassEdge: edge),
+            stopBandBin * SampleRate / Length,
+            SampleRate);
+        double expectedMagnitude = originalResponse.Magnitude * 100.0;
+
+        Assert.Equal(expectedMagnitude, corrected[stopBandBin].Magnitude, 8);
+        Assert.True(corrected[stopBandBin].Magnitude < 0.01);
+        Assert.Equal(0.0, corrected[0].Magnitude, 12);
+    }
+
+    [Fact]
+    public void RemoveFromImpulseResponse_RejectsAnUnsupportedFamily()
+    {
+        var edge = new CrossoverEdge(CrossoverFilterFamily.Bessel, 2_000, 24);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ProtectiveHighPassCompensation.RemoveFromImpulseResponse(
+                [Complex.One],
+                edge,
+                SampleRate,
+                maximumBoostDb: 40.0));
+    }
+
+    private static Complex[] FilteredImpulse(CrossoverEdge edge)
+    {
+        var spectrum = new Complex[Length];
+        CrossoverSpec spec = new(CrossoverKind.HighPass, HighPassEdge: edge);
+        for (int bin = 0; bin < spectrum.Length; bin++)
+        {
+            int signedBin = bin <= spectrum.Length / 2 ? bin : bin - spectrum.Length;
+            double frequencyHz = signedBin * SampleRate / spectrum.Length;
+            spectrum[bin] = CrossoverFilter.Response(spec, frequencyHz, SampleRate);
+        }
+
+        Fourier.Inverse(spectrum, FourierOptions.Matlab);
+        return spectrum;
+    }
+}


### PR DESCRIPTION
## What changed

- Added an optional protective HPF row to Measurement Options with Off, Butterworth, and Linkwitz–Riley families, configurable corner frequency, and supported slopes.
- Persisted the protective-filter configuration and carried it through sweep measurement setup.
- Removed the modeled HPF magnitude and phase from the published loopback-referenced transfer IR.
- Limited inverse compensation to 40 dB so deeply attenuated stop-band noise is not presented as recovered signal.
- Kept the raw sweep-deconvolution IR unchanged for harmonic diagnostics.
- Added DSP unit tests, measurement A/B coverage, and settings round-trip/normalization tests.

## Why

A tweeter can be protected by a high-pass configured in an external DSP while running a full sweep. Because the loopback reference is captured directly from the sound-card output before that DSP, the measured transfer IR otherwise includes the protective filter. Modeling and dividing out the same HPF yields a substantially honest loudspeaker IR without sacrificing hardware protection.

## User impact

Users can enter the same HPF family, corner, and slope used in their external DSP. Resonalyze compensates its amplitude and phase automatically in frequency response, phase, group-delay, time-alignment, and other analyses derived from the transfer IR.

## Validation

- `dotnet test source/Resonalyze.sln -c Release --filter "Category!=Hardware"`
- 2,242 tests passed (1,081 DSP, 1,019 app, 142 audio)
- Release build completed with 0 warnings and 0 errors
