### PR TITLE
Guard protective HPF compensation reliability

### DIFF
--- a/dsp/DspMath.cs
+++ b/dsp/DspMath.cs
@@ -48,4 +48,22 @@ public static class DspMath
 
         return result;
     }
+
+    /// <summary>
+    /// Raised-cosine soft gate: zero at and below <paramref name="low"/>, one at
+    /// and above <paramref name="high"/>, and a smooth transition between them.
+    /// </summary>
+    internal static double RaisedCosineGate(double value, double low, double high)
+    {
+        if (value <= low)
+        {
+            return 0.0;
+        }
+        if (value >= high)
+        {
+            return 1.0;
+        }
+
+        return 0.5 - 0.5 * Math.Cos(Math.PI * (value - low) / (high - low));
+    }
 }

--- a/dsp/ProtectiveHighPassCompensation.cs
+++ b/dsp/ProtectiveHighPassCompensation.cs
@@ -3,6 +3,38 @@ using MathNet.Numerics.IntegralTransforms;
 
 namespace Resonalyze.Dsp;
 
+public sealed record ProtectiveHighPassCompensationResult(
+    Complex[] ImpulseResponse,
+    double[] Reliability)
+{
+    /// <summary>
+    /// Applies the compensation-validity mask to an existing coherence estimate.
+    /// The transfer estimator already folds its excitation validity into coherence;
+    /// this adds the corresponding target-side validity after the known high-pass.
+    /// </summary>
+    public double[]? MaskCoherence(IReadOnlyList<double>? coherence)
+    {
+        if (coherence == null)
+        {
+            return null;
+        }
+        if (coherence.Count != Reliability.Length)
+        {
+            throw new ArgumentException(
+                "Coherence and compensation reliability must use the same frequency grid.",
+                nameof(coherence));
+        }
+
+        var masked = new double[coherence.Count];
+        for (int i = 0; i < masked.Length; i++)
+        {
+            masked[i] = coherence[i] * Reliability[i];
+        }
+
+        return masked;
+    }
+}
+
 /// <summary>
 /// Removes a known protective high-pass from a measured transfer impulse
 /// response. This is the frequency-domain equivalent of filtering the clean
@@ -13,15 +45,18 @@ namespace Resonalyze.Dsp;
 public static class ProtectiveHighPassCompensation
 {
     private const int PhaseRefreshInterval = 1_024;
+    private const double ReliabilityFadeWidthDb = 6.0;
 
     /// <summary>
     /// Returns a copy of <paramref name="impulseResponse"/> with the magnitude
-    /// and phase of <paramref name="edge"/> divided out. Inverse gain is capped
-    /// at <paramref name="maximumBoostDb"/> because a stop-band bin contains no
-    /// recoverable loudspeaker information once the protection filter has buried
-    /// it in the measurement noise.
+    /// and phase of <paramref name="edge"/> divided out, plus the per-bin
+    /// reliability of that inversion. Full trust ends 6 dB before
+    /// <paramref name="maximumBoostDb"/>; a raised-cosine fade reaches zero at
+    /// the limit. Unrecoverable bins are suppressed by a smooth frequency mask
+    /// derived only from that known-filter reliability; measured coherence is
+    /// deliberately not punched into the IR bin by bin.
     /// </summary>
-    public static Complex[] RemoveFromImpulseResponse(
+    public static ProtectiveHighPassCompensationResult RemoveFromImpulseResponse(
         IReadOnlyList<Complex> impulseResponse,
         CrossoverEdge edge,
         double sampleRateHz,
@@ -65,6 +100,7 @@ public static class ProtectiveHighPassCompensation
         }
         Fourier.Forward(spectrum, FourierOptions.Matlab);
 
+        var reliability = new double[spectrum.Length / 2 + 1];
         Complex binStep = Complex.Exp(
             new Complex(0.0, -Math.Tau / spectrum.Length));
         Complex z1 = Complex.One;
@@ -83,11 +119,25 @@ public static class ProtectiveHighPassCompensation
             }
 
             Complex response = Response(sections, z1);
-            spectrum[bin] *= CappedInverse(response, maximumGain);
+            int foldedBin = Math.Min(bin, spectrum.Length - bin);
+            double reliabilityWeight;
+            if (bin <= spectrum.Length / 2)
+            {
+                reliabilityWeight = ReliabilityWeight(
+                    response.Magnitude,
+                    maximumBoostDb);
+                reliability[foldedBin] = reliabilityWeight;
+            }
+            else
+            {
+                reliabilityWeight = reliability[foldedBin];
+            }
+
+            spectrum[bin] *= reliabilityWeight * CappedInverse(response, maximumGain);
         }
 
         Fourier.Inverse(spectrum, FourierOptions.Matlab);
-        return spectrum;
+        return new ProtectiveHighPassCompensationResult(spectrum, reliability);
     }
 
     private static Complex Response(
@@ -117,5 +167,31 @@ public static class ProtectiveHighPassCompensation
 
         double inverseMagnitude = Math.Min(1.0 / magnitude, maximumGain);
         return Complex.FromPolarCoordinates(inverseMagnitude, -response.Phase);
+    }
+
+    private static double ReliabilityWeight(double magnitude, double maximumBoostDb)
+    {
+        if (!(magnitude > 0.0) || !double.IsFinite(magnitude))
+        {
+            return 0.0;
+        }
+
+        double requiredBoostDb = Math.Max(0.0, -20.0 * Math.Log10(magnitude));
+        double fullTrustBoostDb = Math.Max(
+            0.0,
+            maximumBoostDb - ReliabilityFadeWidthDb);
+        if (requiredBoostDb <= fullTrustBoostDb)
+        {
+            return 1.0;
+        }
+        if (requiredBoostDb >= maximumBoostDb)
+        {
+            return 0.0;
+        }
+
+        return 1.0 - DspMath.RaisedCosineGate(
+            requiredBoostDb,
+            fullTrustBoostDb,
+            maximumBoostDb);
     }
 }

--- a/dsp/TransferFunction.cs
+++ b/dsp/TransferFunction.cs
@@ -282,12 +282,13 @@ public static class TransferFunction
         var weights = new double[fftLength];
         for (int bin = 0; bin < fftLength; bin++)
         {
-            double weight = SoftGate(referencePowerSpectrum[bin], gateLow, gateHigh);
+            double weight = DspMath.RaisedCosineGate(
+                referencePowerSpectrum[bin], gateLow, gateHigh);
             if (weight > 0 && hasLowEdge)
             {
                 // Zero below the achieved low edge (nothing was excited there),
                 // rising to unity where the fade-in completes.
-                weight *= SoftGate(
+                weight *= DspMath.RaisedCosineGate(
                     NyquistFraction(bin),
                     gate.LowZeroNyquistFraction,
                     gate.LowFullNyquistFraction);
@@ -296,7 +297,7 @@ public static class TransferFunction
             {
                 // Mirror: unity where the fade-out starts, zero above the
                 // achieved high edge.
-                weight *= 1.0 - SoftGate(
+                weight *= 1.0 - DspMath.RaisedCosineGate(
                     NyquistFraction(bin),
                     gate.HighFullNyquistFraction,
                     gate.HighZeroNyquistFraction);
@@ -428,7 +429,8 @@ public static class TransferFunction
         double weightSum = 0;
         for (int bin = 0; bin < fftLength; bin++)
         {
-            double bandWeight = SoftGate(gateReference[bin], gateLow, gateHigh);
+            double bandWeight = DspMath.RaisedCosineGate(
+                gateReference[bin], gateLow, gateHigh);
             if (bandWeight <= 0)
             {
                 continue;
@@ -487,22 +489,6 @@ public static class TransferFunction
         // normalizes the coefficient to [0, 1].
         double normalizer = weightSum / fftLength;
         return new PhaseTransformCorrelation(correlation, normalizer);
-    }
-
-    // Raised-cosine soft gate: 0 below low, 1 above high, a smooth cosine ramp
-    // between. Keeps the passband at unity while fading the excitation edges.
-    private static double SoftGate(double value, double low, double high)
-    {
-        if (value <= low)
-        {
-            return 0.0;
-        }
-        if (value >= high)
-        {
-            return 1.0;
-        }
-
-        return 0.5 - 0.5 * Math.Cos(Math.PI * (value - low) / (high - low));
     }
 
     // Sub-sample peak location by a fine windowed-sinc (Lanczos) upsampling around

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -321,7 +321,8 @@ public static class TransferIrDiagnostics
     public static DominantBand DetectDominantBand(
         IReadOnlyList<double> impulseResponse,
         int sampleRate,
-        double thresholdDb = DominantBandThresholdDb)
+        double thresholdDb = DominantBandThresholdDb,
+        IReadOnlyList<double>? coherence = null)
     {
         ArgumentNullException.ThrowIfNull(impulseResponse);
         if (impulseResponse.Count == 0)
@@ -345,6 +346,29 @@ public static class TransferIrDiagnostics
         int half = length / 2;
         double topHz = Math.Min(20_000, sampleRate * 0.45);
 
+        double CoherenceAt(double hz)
+        {
+            if (coherence == null || coherence.Count < 2)
+            {
+                return 1.0;
+            }
+
+            double position = hz * 2.0 * (coherence.Count - 1) / sampleRate;
+            if (position <= 0.0)
+            {
+                return coherence[0];
+            }
+            if (position >= coherence.Count - 1)
+            {
+                return coherence[^1];
+            }
+
+            int lower = (int)position;
+            double fraction = position - lower;
+            return coherence[lower] * (1.0 - fraction) +
+                coherence[lower + 1] * fraction;
+        }
+
         double SmoothedDb(double hz)
         {
             double lo = hz / Math.Pow(2.0, 1.0 / 12);
@@ -356,11 +380,26 @@ public static class TransferIrDiagnostics
                 i2 = i1;
             }
             double sum = 0;
+            int trustedCount = 0;
+            int binCount = i2 - i1 + 1;
             for (int i = i1; i <= i2; i++)
             {
+                double binCoherence = CoherenceAt((double)i * sampleRate / length);
+                if (!double.IsFinite(binCoherence) || binCoherence < 0.5)
+                {
+                    continue;
+                }
+
                 sum += spectrum[i].Magnitude * spectrum[i].Magnitude;
+                trustedCount++;
             }
-            return 10 * Math.Log10(Math.Max(1e-24, sum / (i2 - i1 + 1)));
+            // A lone coherent bin must not represent a whole 1/6-octave
+            // window. Require at least half of the window to be trustworthy;
+            // this also makes the detected band edge stable when γ² jitters
+            // around the threshold in a few adjacent bins.
+            return trustedCount * 2 >= binCount
+                ? 10 * Math.Log10(Math.Max(1e-24, sum / trustedCount))
+                : double.NegativeInfinity;
         }
 
         // 1/24-octave log grid over the audible range.
@@ -370,6 +409,12 @@ public static class TransferIrDiagnostics
         {
             gridHz.Add(hz);
             gridDb.Add(SmoothedDb(hz));
+        }
+
+        if (coherence != null && gridDb.All(double.IsNegativeInfinity))
+        {
+            throw new InvalidOperationException(
+                "No reliable signal remains above the coherence threshold.");
         }
 
         int peakIndex = 0;

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -1655,14 +1655,17 @@ namespace Resonalyze
                 result.SweepPeakIndex);
             Complex[]? transferImpulseResponse = result.TransferImpulseResponse;
             int transferPeakIndex = result.TransferPeakIndex;
+            double[]? transferCoherence = result.TransferCoherence;
             if (transferImpulseResponse != null && ProtectiveHighPass.Enabled)
             {
-                transferImpulseResponse =
+                ProtectiveHighPassCompensationResult compensation =
                     ProtectiveHighPassCompensation.RemoveFromImpulseResponse(
                         transferImpulseResponse,
                         ProtectiveHighPass.ToEdge(),
                         SampleRate,
                         ProtectiveHighPassConfiguration.MaximumCompensationBoostDb);
+                transferImpulseResponse = compensation.ImpulseResponse;
+                transferCoherence = compensation.MaskCoherence(transferCoherence);
                 // Removing the high-pass removes its group delay too, so its
                 // corrected arrival is allowed to move on a synchronized live
                 // measurement. An import is different: its peak was deliberately
@@ -1686,7 +1689,7 @@ namespace Resonalyze
                     transferImpulseResponse,
                     transferPeakIndex)
                 : null;
-            TransferCoherence = result.TransferCoherence;
+            TransferCoherence = transferCoherence;
             MicrophoneRecordedSamples = result.MicrophoneRecordedSamples;
             LoopbackRecordedSamples = result.LoopbackRecordedSamples;
             MeasurementMode = result.TransferImpulseResponse != null

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -360,7 +360,9 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         if (options.BandMode == TimeAlignmentBandMode.AutoBand)
         {
             DominantBand band = TransferIrDiagnostics.DetectDominantBand(
-                source.TransferImpulseResponse, source.SampleRate);
+                source.TransferImpulseResponse,
+                source.SampleRate,
+                coherence: source.TransferCoherence);
             lastAutoBand = band;
             centerHz = Math.Sqrt(band.LowHz * band.HighHz);
             passOctaves = Math.Log2(band.HighHz / band.LowHz);

--- a/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
+++ b/tests/Resonalyze.App.Tests/AbstractedMeasurementTests.cs
@@ -45,8 +45,11 @@ public sealed class AbstractedMeasurementTests
         Assert.Equal(1, factory.DuplexOpenCount);
     }
 
-    [Fact]
-    public async Task ProtectiveHighPass_IsRemovedFromThePublishedTransferIrOnly()
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task ProtectiveHighPass_IsRemovedFromThePublishedTransferIrOnly(
+        int runCount)
     {
         var edge = new CrossoverEdge(
             CrossoverFilterFamily.LinkwitzRiley,
@@ -69,7 +72,7 @@ public sealed class AbstractedMeasurementTests
             new SweepAudioConfiguration(
                 WaveInputChannelOffset: 0,
                 WaveLoopbackInputChannelOffset: 1),
-            new SweepAveragingConfiguration(),
+            new SweepAveragingConfiguration(runCount),
             new ProtectiveHighPassConfiguration(
                 ProtectiveHighPassKind.LinkwitzRiley,
                 2_000,
@@ -80,6 +83,7 @@ public sealed class AbstractedMeasurementTests
         Assert.True(success, measurement.LastError?.ToString());
         Assert.NotNull(measurement.TransferImpulseResponse);
         Assert.NotNull(measurement.SweepDeconvolutionImpulseResponse);
+        Assert.Equal(runCount > 1, measurement.TransferCoherence != null);
 
         using ExpSweepMeasurement uncompensated = CreateSweep(factory);
         bool uncompensatedSuccess = await uncompensated.RunAsync();
@@ -91,6 +95,7 @@ public sealed class AbstractedMeasurementTests
         Fourier.Forward(rawTransfer, FourierOptions.Matlab);
         int cornerBin = (int)Math.Round(2_000.0 * transfer.Length / measurement.SampleRate);
         int passBandBin = (int)Math.Round(8_000.0 * transfer.Length / measurement.SampleRate);
+        int stopBandBin = (int)Math.Round(250.0 * transfer.Length / measurement.SampleRate);
         double transferCornerRelativeDb = 20.0 * Math.Log10(
             transfer[cornerBin].Magnitude / transfer[passBandBin].Magnitude);
         double rawCornerRelativeDb = 20.0 * Math.Log10(
@@ -99,6 +104,25 @@ public sealed class AbstractedMeasurementTests
         Assert.InRange(transferCornerRelativeDb, -0.2, 0.2);
         Assert.InRange(rawCornerRelativeDb, -6.3, -5.7);
         Assert.InRange(Math.Abs(transfer[cornerBin].Phase), 0.0, 0.05);
+        double gatedStopBandRelativeDb = 20.0 * Math.Log10(
+            transfer[stopBandBin].Magnitude / transfer[passBandBin].Magnitude);
+        Assert.True(
+            gatedStopBandRelativeDb < -140.0,
+            $"unreliable stopband remained at {gatedStopBandRelativeDb:0.0} dB");
+
+        if (measurement.TransferCoherence is { } coherence)
+        {
+            int coherenceFftLength = (coherence.Length - 1) * 2;
+            int coherenceStopBin = (int)Math.Round(
+                250.0 * coherenceFftLength / measurement.SampleRate);
+            int coherenceCornerBin = (int)Math.Round(
+                2_000.0 * coherenceFftLength / measurement.SampleRate);
+            // The two synthetic runs are identical, so raw MSC is one everywhere.
+            // The protective-filter validity must still reject the unrecoverable
+            // stopband while leaving the correction's trusted band untouched.
+            Assert.Equal(0.0, coherence[coherenceStopBin], 12);
+            Assert.InRange(coherence[coherenceCornerBin], 0.99, 1.0);
+        }
         Assert.Equal(
             uncompensated.SweepDeconvolutionImpulseResponse,
             measurement.SweepDeconvolutionImpulseResponse);

--- a/tests/Resonalyze.Dsp.Tests/ProtectiveHighPassCompensationTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/ProtectiveHighPassCompensationTests.cs
@@ -12,18 +12,20 @@ public sealed class ProtectiveHighPassCompensationTests
     [InlineData(CrossoverFilterFamily.Butterworth, 24)]
     [InlineData(CrossoverFilterFamily.LinkwitzRiley, 24)]
     [InlineData(CrossoverFilterFamily.LinkwitzRiley, 48)]
-    public void RemoveFromImpulseResponse_RecoversMagnitudeAndPhaseAboveTheBoostLimit(
+    public void RemoveFromImpulseResponse_RecoversMagnitudeAndPhaseInTheTrustedBand(
         CrossoverFilterFamily family,
         int slope)
     {
         var edge = new CrossoverEdge(family, 2_000, slope);
         Complex[] filtered = FilteredImpulse(edge);
 
-        Complex[] corrected = ProtectiveHighPassCompensation.RemoveFromImpulseResponse(
-            filtered,
-            edge,
-            SampleRate,
-            maximumBoostDb: 40.0);
+        ProtectiveHighPassCompensationResult result =
+            ProtectiveHighPassCompensation.RemoveFromImpulseResponse(
+                filtered,
+                edge,
+                SampleRate,
+                maximumBoostDb: 40.0);
+        Complex[] corrected = result.ImpulseResponse;
         Fourier.Forward(corrected, FourierOptions.Matlab);
 
         foreach (double frequencyHz in new[] { 2_000.0, 4_000.0, 10_000.0 })
@@ -35,7 +37,7 @@ public sealed class ProtectiveHighPassCompensationTests
     }
 
     [Fact]
-    public void RemoveFromImpulseResponse_CapsStopBandRecoveryAtFortyDecibels()
+    public void RemoveFromImpulseResponse_SuppressesStopBandAndMarksItUnreliable()
     {
         var edge = new CrossoverEdge(
             CrossoverFilterFamily.LinkwitzRiley,
@@ -43,23 +45,102 @@ public sealed class ProtectiveHighPassCompensationTests
             48);
         Complex[] filtered = FilteredImpulse(edge);
 
-        Complex[] corrected = ProtectiveHighPassCompensation.RemoveFromImpulseResponse(
-            filtered,
-            edge,
-            SampleRate,
-            maximumBoostDb: 40.0);
+        ProtectiveHighPassCompensationResult result =
+            ProtectiveHighPassCompensation.RemoveFromImpulseResponse(
+                filtered,
+                edge,
+                SampleRate,
+                maximumBoostDb: 40.0);
+        Complex[] corrected = result.ImpulseResponse;
         Fourier.Forward(corrected, FourierOptions.Matlab);
 
         int stopBandBin = (int)Math.Round(250.0 * Length / SampleRate);
-        Complex originalResponse = CrossoverFilter.Response(
-            new CrossoverSpec(CrossoverKind.HighPass, HighPassEdge: edge),
-            stopBandBin * SampleRate / Length,
-            SampleRate);
-        double expectedMagnitude = originalResponse.Magnitude * 100.0;
-
-        Assert.Equal(expectedMagnitude, corrected[stopBandBin].Magnitude, 8);
-        Assert.True(corrected[stopBandBin].Magnitude < 0.01);
+        Assert.Equal(0.0, result.Reliability[stopBandBin], 12);
+        Assert.True(corrected[stopBandBin].Magnitude < 1e-12);
         Assert.Equal(0.0, corrected[0].Magnitude, 12);
+    }
+
+    [Fact]
+    public void RemoveFromImpulseResponse_FadesReliabilityBeforeTheBoostLimit()
+    {
+        var edge = new CrossoverEdge(
+            CrossoverFilterFamily.Butterworth,
+            3_800,
+            12);
+        Complex[] filtered = FilteredImpulse(edge);
+
+        ProtectiveHighPassCompensationResult result =
+            ProtectiveHighPassCompensation.RemoveFromImpulseResponse(
+                filtered,
+                edge,
+                SampleRate,
+                maximumBoostDb: 40.0);
+
+        int stopBin = (int)Math.Round(300.0 * Length / SampleRate);
+        int fadeBin = (int)Math.Round(450.0 * Length / SampleRate);
+        int trustedBin = (int)Math.Round(700.0 * Length / SampleRate);
+        Assert.Equal(0.0, result.Reliability[stopBin], 12);
+        Assert.InRange(result.Reliability[fadeBin], 0.25, 0.75);
+        Assert.Equal(1.0, result.Reliability[trustedBin], 12);
+
+        Complex[] corrected = result.ImpulseResponse.ToArray();
+        Fourier.Forward(corrected, FourierOptions.Matlab);
+        // The IR uses the complete six-decibel reliability fade itself. A
+        // second confidence-domain threshold here would collapse that smooth
+        // transition back into a near-brick-wall frequency edge.
+        Assert.Equal(result.Reliability[fadeBin], corrected[fadeBin].Magnitude, 8);
+
+        double[] coherence = new double[result.Reliability.Length];
+        Array.Fill(coherence, 1.0);
+        double[] masked = Assert.IsType<double[]>(result.MaskCoherence(coherence));
+        Assert.Equal(result.Reliability, masked);
+    }
+
+    [Theory]
+    [InlineData(CrossoverFilterFamily.Butterworth, 12, 30.0)]
+    [InlineData(CrossoverFilterFamily.LinkwitzRiley, 24, 30.0)]
+    [InlineData(CrossoverFilterFamily.LinkwitzRiley, 48, 30.0)]
+    [InlineData(CrossoverFilterFamily.Butterworth, 12, 3_800.0)]
+    [InlineData(CrossoverFilterFamily.LinkwitzRiley, 48, 3_800.0)]
+    public void RemoveFromImpulseResponse_ReliabilityFadePreservesArrival(
+        CrossoverFilterFamily family,
+        int slope,
+        double frequencyHz)
+    {
+        const int longLength = 131_072;
+        var edge = new CrossoverEdge(family, frequencyHz, slope);
+        ProtectiveHighPassCompensationResult compensation =
+            ProtectiveHighPassCompensation.RemoveFromImpulseResponse(
+                FilteredImpulse(edge, longLength),
+                edge,
+                SampleRate,
+                maximumBoostDb: 40.0);
+        double[] corrected = Array.ConvertAll(
+            compensation.ImpulseResponse,
+            sample => sample.Real);
+
+        TimeAlignmentAnalysisResult arrival = TimeAlignmentAnalysis.Analyze(
+            corrected,
+            (int)SampleRate,
+            new TimeAlignmentAnalysisOptions
+            {
+                WrapPeakPositions = true
+            });
+
+        Assert.True(arrival.IsValid);
+        Assert.InRange(Math.Abs(arrival.FirstArrivalDelayMilliseconds), 0.0, 0.05);
+
+        // A dangerous zero-phase mask would leave a sidelobe above the normal
+        // first-arrival threshold far from the circular impulse. Keep the
+        // central ±500 ms region below that -25 dB decision level.
+        int farGuard = (int)Math.Round(0.5 * SampleRate);
+        double farPeak = arrival.EnvelopeSamples
+            .Skip(farGuard)
+            .Take(arrival.EnvelopeSamples.Length - 2 * farGuard)
+            .Max();
+        Assert.True(
+            farPeak < arrival.StrongestEnvelopePeak * Math.Pow(10.0, -25.0 / 20.0),
+            $"far ringing is {20.0 * Math.Log10(farPeak / arrival.StrongestEnvelopePeak):0.0} dB");
     }
 
     [Fact]
@@ -75,9 +156,12 @@ public sealed class ProtectiveHighPassCompensationTests
                 maximumBoostDb: 40.0));
     }
 
-    private static Complex[] FilteredImpulse(CrossoverEdge edge)
+    private static Complex[] FilteredImpulse(CrossoverEdge edge) =>
+        FilteredImpulse(edge, Length);
+
+    private static Complex[] FilteredImpulse(CrossoverEdge edge, int length)
     {
-        var spectrum = new Complex[Length];
+        var spectrum = new Complex[length];
         CrossoverSpec spec = new(CrossoverKind.HighPass, HighPassEdge: edge);
         for (int bin = 0; bin < spectrum.Length; bin++)
         {

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -106,6 +106,78 @@ public sealed class TransferIrDiagnosticsTests
     }
 
     [Fact]
+    public void DetectDominantBand_IgnoresAFalsePeakBelowTheCoherenceFloor()
+    {
+        var impulseResponse = new double[65_536];
+        AddToneBurst(
+            impulseResponse,
+            startMs: 20.0,
+            frequencyHz: 160,
+            periods: 40,
+            amplitude: 10.0);
+        AddToneBurst(
+            impulseResponse,
+            startMs: 20.0,
+            frequencyHz: 3_000,
+            periods: 40,
+            amplitude: 1.0);
+        var coherence = new double[impulseResponse.Length / 2 + 1];
+        int firstTrustedBin = (int)Math.Ceiling(
+            500.0 * impulseResponse.Length / SampleRate);
+        Array.Fill(coherence, 1.0, firstTrustedBin, coherence.Length - firstTrustedBin);
+
+        DominantBand rawBand = TransferIrDiagnostics.DetectDominantBand(
+            impulseResponse, SampleRate);
+        DominantBand trustedBand = TransferIrDiagnostics.DetectDominantBand(
+            impulseResponse,
+            SampleRate,
+            coherence: coherence);
+
+        Assert.InRange(rawBand.PeakHz, 120, 220);
+        Assert.InRange(trustedBand.PeakHz, 2_500, 3_500);
+        Assert.True(trustedBand.LowHz >= 500);
+    }
+
+    [Fact]
+    public void DetectDominantBand_DoesNotPromoteOneTrustedBinToAWholeBand()
+    {
+        var impulseResponse = new double[65_536];
+        AddToneBurst(
+            impulseResponse,
+            startMs: 20.0,
+            frequencyHz: 2_000,
+            periods: 80,
+            amplitude: 1.0);
+        AddToneBurst(
+            impulseResponse,
+            startMs: 20.0,
+            frequencyHz: 5_000,
+            periods: 80,
+            amplitude: 20.0);
+        var coherence = new double[impulseResponse.Length / 2 + 1];
+        int trustedLowBin = (int)Math.Floor(
+            1_700.0 * impulseResponse.Length / SampleRate);
+        int trustedHighBin = (int)Math.Ceiling(
+            2_300.0 * impulseResponse.Length / SampleRate);
+        Array.Fill(
+            coherence,
+            1.0,
+            trustedLowBin,
+            trustedHighBin - trustedLowBin + 1);
+        int isolatedBin = (int)Math.Round(
+            5_000.0 * impulseResponse.Length / SampleRate);
+        coherence[isolatedBin] = 1.0;
+
+        DominantBand band = TransferIrDiagnostics.DetectDominantBand(
+            impulseResponse,
+            SampleRate,
+            coherence: coherence);
+
+        Assert.InRange(band.PeakHz, 1_700, 2_300);
+        Assert.True(band.HighHz < 3_000);
+    }
+
+    [Fact]
     public void DetectCrosstalkHead_FindsTheEarlyBroadbandClick()
     {
         // -21 dB re the record's max — the field click's level, inside the


### PR DESCRIPTION
## Summary

- derive a smooth reliability mask from the inverse boost required to remove the configured protective HPF
- suppress only the unrecoverable stopband of the compensated IR and apply the same reliability to transfer coherence
- make Time Alignment Auto Band ignore frequency windows without enough coherent bins
- share the raised-cosine gate implementation and add regressions for single-run, sparse-coherence, exact Butterworth 12 dB/oct, and time-domain arrival paths

## Root cause

Protective-filter inversion was capped at 40 dB, but the capped stopband could still amplify deterministic residuals into apparently strong low-frequency IR content. With identical averages, raw coherence could remain close to one there. Time Alignment then detected its automatic band from IR magnitude alone, selected the false low-frequency peak, and could wrap a distant circular arrival into a seconds-long delay.

For newly processed measurements, the compensated IR is now band-limited with the complete six-decibel reliability fade derived only from the known filter response. Measured coherence remains confidence metadata rather than punching noisy bin-by-bin holes into the IR. Auto Band additionally requires at least half of each 1/6-octave window to meet the coherence threshold.

## Impact

Users get corrected magnitude and phase wherever the protective HPF can be inverted reliably. Unrecoverable stopband content from new measurements is no longer presented as acoustic data or allowed to steer Time Alignment.

Legacy saved measurements do not contain the protective-HPF configuration or reliability mask, so this PR cannot guarantee reconstruction of their stopband. A legacy file benefits from the coherence-aware Auto Band only when its stored coherence already identifies the false band; otherwise it must be measured again.

## Validation

- `dotnet test source/Resonalyze.sln -c Release --filter "Category!=Hardware"`
- 2252 tests passed
- BW12, LR24, and LR48 arrival/ringing regressions at 30 Hz; BW12 and LR48 at 3.8 kHz
- reproduced the reported field measurement: Auto Band changed from 104–240 Hz with an approximately 1.5 s false delay to 659–19,331 Hz and a 0.480 ms delay (specific to that file's stored coherence)
