### PR TITLE
Add the Audiotec-Fischer 30-band bank as an EQ profile format

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,7 +966,10 @@ lenient: comments, blank lines, disabled (`OFF`) filters, non-peaking types, and
 malformed entries are skipped rather than rejected. The one exception is a
 fixed-layout device bank: the Audiotec-Fischer file is the channel's 30-slot
 table, so a truncated or renumbered one is refused outright rather than imported
-as an empty bank over the EQ you have.
+as an empty bank over the EQ you have — and so is one whose enabled slot claims a
+filter that cannot be read, since in a fixed table that band would simply go
+missing from the tune (`None`, the all-pass slots and `Enabled False` rows remain
+ordinary empty slots).
 **Export as tuning sheet** produces a phone-friendly PDF for reading next to the
 car: the banner, a title, the date and fit range, an EQ preview graph with the
 fit window shaded, the tuning statistics, the preamp, and one card per filter.

--- a/README.md
+++ b/README.md
@@ -958,12 +958,15 @@ PEQ profiles move both ways for Equalizer APO, REW filter settings, Generic CSV,
 EasyEffects (JSON), CamillaDSP (YAML) and the Audiotec-Fischer "Full EQ (30
 bands)" bank the HELIX / MATCH / BRAX DSP PC-Tool imports per channel (the same
 tab-separated block REW exports for that equaliser: PK plus the LS_Q / HS_Q
-shelves, always 30 slots — a bank has no place for the preamp, so it is not
-written and the channel gain stays a PC-Tool setting), and export-only for
-miniDSP biquads (RBJ coefficients at 44.1 / 48 / 96 kHz) and GraphicEQ
-(Wavelet / JamesDSP). Import is deliberately lenient: comments, blank lines,
-disabled (`OFF`) filters, non-peaking types, and malformed entries are skipped
-rather than rejected.
+shelves plus REW's `Modal` rows, always 30 slots — a bank has no place for the
+preamp, so it is not written and the wizard tells you which channel gain to enter
+in the PC-Tool instead), and export-only for miniDSP biquads (RBJ coefficients at
+44.1 / 48 / 96 kHz) and GraphicEQ (Wavelet / JamesDSP). Import is deliberately
+lenient: comments, blank lines, disabled (`OFF`) filters, non-peaking types, and
+malformed entries are skipped rather than rejected. The one exception is a
+fixed-layout device bank: the Audiotec-Fischer file is the channel's 30-slot
+table, so a truncated or renumbered one is refused outright rather than imported
+as an empty bank over the EQ you have.
 **Export as tuning sheet** produces a phone-friendly PDF for reading next to the
 car: the banner, a title, the date and fit range, an EQ preview graph with the
 fit window shaded, the tuning statistics, the preamp, and one card per filter.

--- a/README.md
+++ b/README.md
@@ -955,10 +955,15 @@ error** between Source + EQ and Target, **Filters used**, **Peak boost** and
 ### Import, export, and tuning sheet
 
 PEQ profiles move both ways for Equalizer APO, REW filter settings, Generic CSV,
-EasyEffects (JSON) and CamillaDSP (YAML), and export-only for miniDSP biquads
-(RBJ coefficients at 44.1 / 48 / 96 kHz) and GraphicEQ (Wavelet / JamesDSP).
-Import is deliberately lenient: comments, blank lines, disabled (`OFF`) filters,
-non-peaking types, and malformed entries are skipped rather than rejected.
+EasyEffects (JSON), CamillaDSP (YAML) and the Audiotec-Fischer "Full EQ (30
+bands)" bank the HELIX / MATCH / BRAX DSP PC-Tool imports per channel (the same
+tab-separated block REW exports for that equaliser: PK plus the LS_Q / HS_Q
+shelves, always 30 slots — a bank has no place for the preamp, so it is not
+written and the channel gain stays a PC-Tool setting), and export-only for
+miniDSP biquads (RBJ coefficients at 44.1 / 48 / 96 kHz) and GraphicEQ
+(Wavelet / JamesDSP). Import is deliberately lenient: comments, blank lines,
+disabled (`OFF`) filters, non-peaking types, and malformed entries are skipped
+rather than rejected.
 **Export as tuning sheet** produces a phone-friendly PDF for reading next to the
 car: the banner, a title, the date and fit range, an EQ preview graph with the
 fit window shaded, the tuning statistics, the preamp, and one card per filter.

--- a/TODO.md
+++ b/TODO.md
@@ -312,10 +312,12 @@ items below are what a car DSP tune actually needs, roughly in priority order.
   DSPs (Helix / Audison / miniDSP) have a fixed per-channel band budget and a
   separate master gain the profile must respect. Residual after the
   Audiotec-Fischer bank format: that one format enforces its 30-slot budget
-  (export refuses a longer curve) and never writes the preamp
-  (`IEqProfileFormat.CarriesPreamp` is false), but the EQ Wizard does not yet
-  warn about a non-zero preamp left behind the way it warns about a dropped
-  shelf, and the miniDSP / generic paths still have no budget or gain profile.
+  (export refuses a longer curve, and an import that is not a complete 30-slot
+  table is refused rather than read as an empty bank), never writes the preamp
+  (`IEqProfileFormat.CarriesPreamp` is false) and the wizard now warns about the
+  gain left behind, naming the dB to enter on the device — but the miniDSP /
+  generic paths still have no budget or gain profile, and the warning is
+  per-format metadata, not a device profile.
 
 Deliberately out of scope for car DSP tuning (do not add here): FIR/convolution
 export (car DSPs are biquad), a phase / min-phase / all-pass view (the Virtual

--- a/TODO.md
+++ b/TODO.md
@@ -310,7 +310,12 @@ items below are what a car DSP tune actually needs, roughly in priority order.
   a constructor parameter now, but device biquad limits are not checked and the
   preamp burns a biquad slot instead of mapping to the device's gain control. Car
   DSPs (Helix / Audison / miniDSP) have a fixed per-channel band budget and a
-  separate master gain the profile must respect.
+  separate master gain the profile must respect. Residual after the
+  Audiotec-Fischer bank format: that one format enforces its 30-slot budget
+  (export refuses a longer curve) and never writes the preamp
+  (`IEqProfileFormat.CarriesPreamp` is false), but the EQ Wizard does not yet
+  warn about a non-zero preamp left behind the way it warns about a dropped
+  shelf, and the miniDSP / generic paths still have no budget or gain profile.
 
 Deliberately out of scope for car DSP tuning (do not add here): FIR/convolution
 export (car DSPs are biquad), a phase / min-phase / all-pass view (the Virtual

--- a/dsp/AudiotecFischerFormat.cs
+++ b/dsp/AudiotecFischerFormat.cs
@@ -71,6 +71,10 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
     private const string LowShelfType = "LS_Q";
     private const string HighShelfType = "HS_Q";
     private const string EmptyType = "None";
+    // The slots that legitimately hold no magnitude band: the two all-pass types move
+    // phase only, which no PeqBand can state. Anything else claiming to be an active
+    // filter must be readable, or the bank is not this file.
+    private static readonly string[] PhaseOnlyTypes = ["AP1", "AP2"];
 
     public string Name => "Audiotec Fischer 30-band bank";
     public string Extension => "txt";
@@ -151,7 +155,8 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
                 continue;
             }
 
-            if (!TryParseSlot(line, out int slotNumber, out PeqBand? band))
+            SlotKind kind = ReadSlot(line, out int slotNumber, out PeqBand band);
+            if (kind == SlotKind.NotASlot)
             {
                 // Not a slot row at all: this is not the bank's table.
                 tableIntact = false;
@@ -159,13 +164,16 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
             }
 
             slotsSeen++;
+            // A slot that claims to hold a filter but cannot be read is a band the
+            // import would silently drop from a fixed table — refuse the file instead.
+            tableIntact &= kind != SlotKind.Unreadable;
             // The bank is a fixed table: slot n is the nth row. A file that skips,
             // repeats or renumbers rows is not the channel's slot table, whatever
             // its header says.
             tableIntact &= slotNumber == slotsSeen && slotsSeen <= SlotCount;
-            if (band.HasValue)
+            if (kind == SlotKind.Band)
             {
-                bands.Add(band.Value);
+                bands.Add(band);
             }
         }
 
@@ -194,28 +202,50 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
             fields[3].Equals("Type", StringComparison.OrdinalIgnoreCase);
     }
 
-    // Reads one slot row: whether the line IS a slot of this bank (its number), and
-    // the band it holds, if any. Empty (None), all-pass, disabled, unknown-type and
-    // malformed rows are slots holding no band — a bank is a fixed table, so most
-    // rows of a real file are expected to be empty. Telling "no band here" from
-    // "not this bank's table" is what lets an incomplete file be refused.
-    private static bool TryParseSlot(string line, out int slotNumber, out PeqBand? band)
+    /// <summary>What one line of a bank turns out to be.</summary>
+    private enum SlotKind
     {
-        band = null;
-        slotNumber = 0;
+        /// <summary>Not a row of this table at all.</summary>
+        NotASlot,
+
+        /// <summary>A slot that legitimately holds no band: None, all-pass, or OFF.</summary>
+        Empty,
+
+        /// <summary>A slot holding a band this profile can state.</summary>
+        Band,
+
+        /// <summary>A slot claiming a filter whose type or numbers cannot be read.</summary>
+        Unreadable
+    }
+
+    // Reads one slot row: whether the line IS a slot of this bank (its number), what
+    // kind of slot, and the band it holds. Telling "no band here" from "not this
+    // bank's table" is what lets an incomplete file be refused; telling both from
+    // "a filter I cannot read" is what stops a band going missing unnoticed.
+    private static SlotKind ReadSlot(string line, out int slotNumber, out PeqBand band)
+    {
+        band = default;
 
         string[] fields = SplitRow(line);
         if (fields.Length < 4 ||
             !int.TryParse(fields[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out slotNumber) ||
             fields[3].Length == 0)
         {
-            return false;
+            slotNumber = 0;
+            return SlotKind.NotASlot;
         }
 
-        if (fields.Length < 6 ||
-            fields[1].Equals("False", StringComparison.OrdinalIgnoreCase))
+        // An OFF filter occupies its slot and contributes nothing, whatever it says
+        // afterwards — as elsewhere in these formats.
+        if (fields[1].Equals("False", StringComparison.OrdinalIgnoreCase))
         {
-            return true;
+            return SlotKind.Empty;
+        }
+
+        if (fields[3].Equals(EmptyType, StringComparison.OrdinalIgnoreCase) ||
+            PhaseOnlyTypes.Contains(fields[3], StringComparer.OrdinalIgnoreCase))
+        {
+            return SlotKind.Empty;
         }
 
         PeqBandType type;
@@ -234,14 +264,17 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
         }
         else
         {
-            // None, AP1, AP2 or anything else this layout may grow: a slot, no band.
-            return true;
+            // An enabled slot of a type this reader does not know. It may well be a
+            // filter that shapes magnitude, so passing it off as an empty slot would
+            // quietly change the tune.
+            return SlotKind.Unreadable;
         }
 
-        if (!EqTextNumbers.TryParse(fields[4], out double frequencyHz) ||
+        if (fields.Length < 6 ||
+            !EqTextNumbers.TryParse(fields[4], out double frequencyHz) ||
             !EqTextNumbers.TryParse(fields[5], out double gainDb))
         {
-            return true;
+            return SlotKind.Unreadable;
         }
 
         // The Q cell may be blank on a hand-edited row: a bell can still be read
@@ -253,7 +286,7 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
                 if (!EqTextNumbers.TryParse(FieldAt(fields, 7), out double bandwidthHz) ||
                     bandwidthHz <= 0)
                 {
-                    return true;
+                    return SlotKind.Unreadable;
                 }
 
                 q = frequencyHz / bandwidthHz;
@@ -268,11 +301,11 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
             !double.IsFinite(q) || q <= 0 ||
             !double.IsFinite(gainDb))
         {
-            return true;
+            return SlotKind.Unreadable;
         }
 
         band = new PeqBand(frequencyHz, q, gainDb, type);
-        return true;
+        return SlotKind.Band;
     }
 
     // Tab-separated as exported; a copy pasted through something that turned the

--- a/dsp/AudiotecFischerFormat.cs
+++ b/dsp/AudiotecFischerFormat.cs
@@ -1,0 +1,253 @@
+using System.Globalization;
+using System.Text;
+
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// The Audiotec-Fischer "Full EQ (30 bands)" bank: the tab-separated block REW
+/// exports with its Audiotec Fischer equaliser selected, and the file the HELIX /
+/// MATCH / BRAX DSP PC-Tool imports into one channel's EQ:
+/// <code>
+/// Audiotec_Fischer_Full_EQ_(30_bands)
+/// Number	Enabled	Control	Type	Frequency(Hz)	Gain(dB)	Q	Bandwidth(Hz)	TargetT60(ms)
+/// 1	True	Auto	PK	80.0	-2.0	4.00	20
+/// 2	True	Auto	LS_Q	50.0	-1.0	0.70
+/// 3	True	Auto	None
+/// </code>
+/// The bank is the channel's slot table, so it always holds exactly
+/// <see cref="SlotCount"/> rows and an unused slot is a row of type <c>None</c>.
+/// <c>PK</c> is a bell; <c>LS_Q</c> / <c>HS_Q</c> are the shelves stated with a
+/// centre frequency and a Q — the shelf REW's "LS Q" / "HS Q" types describe and
+/// this library realizes, so they travel unchanged. <c>Bandwidth(Hz)</c> is REW's
+/// companion figure for a bell, <c>Fc / Q</c> — the RBJ relation, consistent with
+/// the processors' place in the <see cref="PeqQConvention"/> crib — and
+/// <c>TargetT60(ms)</c> is REW housekeeping; import ignores both (Q wins, and a
+/// row carrying a bandwidth but no Q reads Q = Fc / BW).
+/// </summary>
+/// <remarks>
+/// The bank holds equalization only. Crossovers, delay, polarity and the phase
+/// stage live in other PC-Tool fields, and so does the channel gain: the file has
+/// no slot for a preamp, so <see cref="CarriesPreamp"/> is false — an export leaves
+/// the preamp out and an import reads 0, and the caller is expected to say so, as
+/// it does for a dropped shelf. <c>AP1</c> / <c>AP2</c> rows — the PC-Tool's first-
+/// and second-order all-pass slots — move phase only, which a magnitude profile has
+/// no band shape for; they are skipped on import and never written. A row whose
+/// <c>Enabled</c> reads <c>False</c> is skipped like an OFF filter elsewhere.
+///
+/// The row shapes follow REW's export byte for byte — a bell row ends in the empty
+/// TargetT60 cell, a shelf row ends at its Q, an unused row at its <c>None</c> —
+/// because that is the layout the PC-Tool is known to accept. Parsing is
+/// defensive: a UTF-8 BOM, CR/LF, ragged rows, trailing tabs and spaces in place
+/// of tabs are all tolerated (numbers read as in the other text formats), and the
+/// file is recognised by its bank header even when every slot is <c>None</c> (a
+/// valid empty bank).
+/// </remarks>
+public sealed class AudiotecFischerFormat : IEqProfileFormat
+{
+    /// <summary>
+    /// The slots a bank holds — the per-channel band budget of these processors,
+    /// two short of <see cref="EqualizationCurve.MaxBandCount"/>. A curve with more
+    /// bands cannot be written honestly, so <see cref="Export"/> refuses it rather
+    /// than dropping bands.
+    /// </summary>
+    public const int SlotCount = 30;
+
+    private const string BankHeader = "Audiotec_Fischer_Full_EQ_(30_bands)";
+    private const string ColumnHeader =
+        "Number\tEnabled\tControl\tType\tFrequency(Hz)\tGain(dB)\tQ\tBandwidth(Hz)\tTargetT60(ms)\t";
+
+    private const string BellType = "PK";
+    private const string LowShelfType = "LS_Q";
+    private const string HighShelfType = "HS_Q";
+    private const string EmptyType = "None";
+
+    public string Name => "Audiotec Fischer 30-band bank";
+    public string Extension => "txt";
+    public bool CanImport => true;
+    public bool CanExport => true;
+    public bool CarriesPreamp => false;
+
+    public string Export(EqualizationCurve curve)
+    {
+        ArgumentNullException.ThrowIfNull(curve);
+        if (curve.Bands.Count > SlotCount)
+        {
+            throw new ArgumentException(
+                $"An Audiotec-Fischer bank holds {SlotCount} slots; this curve has " +
+                $"{curve.Bands.Count} bands.",
+                nameof(curve));
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine(BankHeader);
+        builder.AppendLine(ColumnHeader);
+        for (int slot = 1; slot <= SlotCount; slot++)
+        {
+            builder
+                .Append(slot.ToString(CultureInfo.InvariantCulture))
+                .Append("\tTrue\tAuto\t");
+            if (slot > curve.Bands.Count)
+            {
+                builder.Append(EmptyType).AppendLine("\t");
+                continue;
+            }
+
+            PeqBand band = curve.Bands[slot - 1];
+            builder
+                .Append(TypeToken(band.Type))
+                .Append('\t')
+                .Append(EqTextNumbers.Format(band.FrequencyHz, "0.0##"))
+                .Append('\t')
+                .Append(EqTextNumbers.Format(band.GainDb, "0.0#"))
+                .Append('\t')
+                .Append(EqTextNumbers.Format(band.Q, "0.00##"));
+            if (band.Type.IsShelving())
+            {
+                builder.AppendLine();
+                continue;
+            }
+
+            builder
+                .Append('\t')
+                .Append(EqTextNumbers.Format(band.FrequencyHz / band.Q, "0.##"))
+                .AppendLine("\t");
+        }
+
+        return builder.ToString();
+    }
+
+    public bool TryImport(string text, out EqualizationCurve curve)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        bool recognized = false;
+        var bands = new List<PeqBand>();
+
+        foreach (string rawLine in text.TrimStart('\uFEFF').Split('\n'))
+        {
+            if (bands.Count >= EqualizationCurve.MaxBandCount)
+            {
+                break;
+            }
+
+            string line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (line.Contains(BankHeader, StringComparison.OrdinalIgnoreCase) ||
+                IsColumnHeader(line))
+            {
+                recognized = true;
+                continue;
+            }
+
+            if (TryParseRow(line, out PeqBand band))
+            {
+                bands.Add(band);
+                recognized = true;
+            }
+        }
+
+        curve = new EqualizationCurve(bands);
+        return recognized;
+    }
+
+    private static string TypeToken(PeqBandType type) => type switch
+    {
+        PeqBandType.LowShelf => LowShelfType,
+        PeqBandType.HighShelf => HighShelfType,
+        _ => BellType
+    };
+
+    // "Number<tab>Enabled<tab>Control<tab>Type ..." — the second line of every export.
+    private static bool IsColumnHeader(string line)
+    {
+        string[] fields = SplitRow(line);
+        return fields.Length >= 4 &&
+            fields[0].Equals("Number", StringComparison.OrdinalIgnoreCase) &&
+            fields[1].Equals("Enabled", StringComparison.OrdinalIgnoreCase) &&
+            fields[3].Equals("Type", StringComparison.OrdinalIgnoreCase);
+    }
+
+    // Reads one slot row. Empty (None), all-pass, disabled, unknown-type and
+    // malformed rows all read as "no band" — a bank is a fixed table, so most rows
+    // of a real file are expected to be empty.
+    private static bool TryParseRow(string line, out PeqBand band)
+    {
+        band = default;
+
+        string[] fields = SplitRow(line);
+        if (fields.Length < 6 ||
+            !int.TryParse(fields[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out _) ||
+            fields[1].Equals("False", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        PeqBandType type;
+        if (fields[3].Equals(BellType, StringComparison.OrdinalIgnoreCase))
+        {
+            type = PeqBandType.Peaking;
+        }
+        else if (fields[3].Equals(LowShelfType, StringComparison.OrdinalIgnoreCase))
+        {
+            type = PeqBandType.LowShelf;
+        }
+        else if (fields[3].Equals(HighShelfType, StringComparison.OrdinalIgnoreCase))
+        {
+            type = PeqBandType.HighShelf;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (!EqTextNumbers.TryParse(fields[4], out double frequencyHz) ||
+            !EqTextNumbers.TryParse(fields[5], out double gainDb))
+        {
+            return false;
+        }
+
+        // The Q cell may be blank on a hand-edited row: a bell can still be read
+        // from REW's bandwidth column, a shelf comes in at the default knee.
+        if (!EqTextNumbers.TryParse(FieldAt(fields, 6), out double q) || q <= 0)
+        {
+            if (type == PeqBandType.Peaking)
+            {
+                if (!EqTextNumbers.TryParse(FieldAt(fields, 7), out double bandwidthHz) ||
+                    bandwidthHz <= 0)
+                {
+                    return false;
+                }
+
+                q = frequencyHz / bandwidthHz;
+            }
+            else
+            {
+                q = PeqTextFile.DefaultShelfQ;
+            }
+        }
+
+        if (!double.IsFinite(frequencyHz) || frequencyHz <= 0 ||
+            !double.IsFinite(q) || q <= 0 ||
+            !double.IsFinite(gainDb))
+        {
+            return false;
+        }
+
+        band = new PeqBand(frequencyHz, q, gainDb, type);
+        return true;
+    }
+
+    // Tab-separated as exported; a copy pasted through something that turned the
+    // tabs into spaces still splits, since no cell of this layout contains a space.
+    private static string[] SplitRow(string line) =>
+        line.Contains('\t')
+            ? line.Split('\t').Select(field => field.Trim()).ToArray()
+            : line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+
+    private static string? FieldAt(string[] fields, int index) =>
+        index < fields.Length ? fields[index] : null;
+}

--- a/dsp/AudiotecFischerFormat.cs
+++ b/dsp/AudiotecFischerFormat.cs
@@ -135,7 +135,7 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
     {
         ArgumentNullException.ThrowIfNull(text);
 
-        bool headerSeen = false;
+        bool bankHeaderSeen = false;
         int slotsSeen = 0;
         bool tableIntact = true;
         var bands = new List<PeqBand>();
@@ -148,10 +148,17 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
                 continue;
             }
 
-            if (line.Contains(BankHeader, StringComparison.OrdinalIgnoreCase) ||
-                IsColumnHeader(line))
+            if (line.Contains(BankHeader, StringComparison.OrdinalIgnoreCase))
             {
-                headerSeen = true;
+                bankHeaderSeen = true;
+                continue;
+            }
+
+            if (IsColumnHeader(line))
+            {
+                // REW writes the same column line above every equaliser's table, so
+                // it names nothing on its own; it is skipped when present and never
+                // required. Only the bank header says whose thirty slots follow.
                 continue;
             }
 
@@ -179,8 +186,10 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
 
         // Recognition is the caller's only defence: a "successful" import replaces
         // the EQ on screen, so an incomplete or over-long bank must fail here
-        // rather than arrive as an empty (or unexportable) curve.
-        bool recognized = headerSeen && tableIntact && slotsSeen == SlotCount;
+        // rather than arrive as an empty (or unexportable) curve. Thirty rows under
+        // a column header are not enough to claim the file: without the bank header
+        // there is nothing saying these slots are this processor's.
+        bool recognized = bankHeaderSeen && tableIntact && slotsSeen == SlotCount;
         curve = new EqualizationCurve(recognized ? bands : Array.Empty<PeqBand>());
         return recognized;
     }

--- a/dsp/AudiotecFischerFormat.cs
+++ b/dsp/AudiotecFischerFormat.cs
@@ -21,8 +21,13 @@ namespace Resonalyze.Dsp;
 /// this library realizes, so they travel unchanged. <c>Bandwidth(Hz)</c> is REW's
 /// companion figure for a bell, <c>Fc / Q</c> — the RBJ relation, consistent with
 /// the processors' place in the <see cref="PeqQConvention"/> crib — and
-/// <c>TargetT60(ms)</c> is REW housekeeping; import ignores both (Q wins, and a
-/// row carrying a bandwidth but no Q reads Q = Fc / BW).
+/// <c>TargetT60(ms)</c> carries REW's modal-filter target; import ignores both
+/// (Q wins, and a row carrying a bandwidth but no Q reads Q = Fc / BW).
+/// <c>Modal</c> is REW's room-mode filter: a bell whose width REW derives from that
+/// T60, written into this bank with the Fc / Gain / Q of the filter it realizes, so
+/// it is read as a <see cref="PeqBandType.Peaking"/> band like any other bell —
+/// dropping it would quietly widen a hole in the tune. The T60 itself is REW's
+/// optimizer metadata, has no slot in the processor, and is not kept.
 /// </summary>
 /// <remarks>
 /// The bank holds equalization only. Crossovers, delay, polarity and the phase
@@ -39,8 +44,12 @@ namespace Resonalyze.Dsp;
 /// because that is the layout the PC-Tool is known to accept. Parsing is
 /// defensive: a UTF-8 BOM, CR/LF, ragged rows, trailing tabs and spaces in place
 /// of tabs are all tolerated (numbers read as in the other text formats), and the
-/// file is recognised by its bank header even when every slot is <c>None</c> (a
-/// valid empty bank).
+/// file is recognised by its bank header together with a COMPLETE slot table —
+/// exactly <see cref="SlotCount"/> rows numbered 1..30, in order. An empty bank
+/// (thirty <c>None</c> rows) is valid and neutral; a truncated or renumbered one is
+/// NOT recognised, because importing it as "no bands" would silently replace the
+/// user's EQ with nothing, and a bank with more rows than the channel has slots
+/// would import what this format then refuses to export.
 /// </remarks>
 public sealed class AudiotecFischerFormat : IEqProfileFormat
 {
@@ -57,6 +66,8 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
         "Number\tEnabled\tControl\tType\tFrequency(Hz)\tGain(dB)\tQ\tBandwidth(Hz)\tTargetT60(ms)\t";
 
     private const string BellType = "PK";
+    // REW's room-mode filter: a bell in this bank, its T60 only optimizer metadata.
+    private const string ModalType = "Modal";
     private const string LowShelfType = "LS_Q";
     private const string HighShelfType = "HS_Q";
     private const string EmptyType = "None";
@@ -120,16 +131,13 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
     {
         ArgumentNullException.ThrowIfNull(text);
 
-        bool recognized = false;
+        bool headerSeen = false;
+        int slotsSeen = 0;
+        bool tableIntact = true;
         var bands = new List<PeqBand>();
 
         foreach (string rawLine in text.TrimStart('\uFEFF').Split('\n'))
         {
-            if (bands.Count >= EqualizationCurve.MaxBandCount)
-            {
-                break;
-            }
-
             string line = rawLine.Trim();
             if (line.Length == 0 || line.StartsWith('#'))
             {
@@ -139,18 +147,33 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
             if (line.Contains(BankHeader, StringComparison.OrdinalIgnoreCase) ||
                 IsColumnHeader(line))
             {
-                recognized = true;
+                headerSeen = true;
                 continue;
             }
 
-            if (TryParseRow(line, out PeqBand band))
+            if (!TryParseSlot(line, out int slotNumber, out PeqBand? band))
             {
-                bands.Add(band);
-                recognized = true;
+                // Not a slot row at all: this is not the bank's table.
+                tableIntact = false;
+                continue;
+            }
+
+            slotsSeen++;
+            // The bank is a fixed table: slot n is the nth row. A file that skips,
+            // repeats or renumbers rows is not the channel's slot table, whatever
+            // its header says.
+            tableIntact &= slotNumber == slotsSeen && slotsSeen <= SlotCount;
+            if (band.HasValue)
+            {
+                bands.Add(band.Value);
             }
         }
 
-        curve = new EqualizationCurve(bands);
+        // Recognition is the caller's only defence: a "successful" import replaces
+        // the EQ on screen, so an incomplete or over-long bank must fail here
+        // rather than arrive as an empty (or unexportable) curve.
+        bool recognized = headerSeen && tableIntact && slotsSeen == SlotCount;
+        curve = new EqualizationCurve(recognized ? bands : Array.Empty<PeqBand>());
         return recognized;
     }
 
@@ -171,23 +194,33 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
             fields[3].Equals("Type", StringComparison.OrdinalIgnoreCase);
     }
 
-    // Reads one slot row. Empty (None), all-pass, disabled, unknown-type and
-    // malformed rows all read as "no band" — a bank is a fixed table, so most rows
-    // of a real file are expected to be empty.
-    private static bool TryParseRow(string line, out PeqBand band)
+    // Reads one slot row: whether the line IS a slot of this bank (its number), and
+    // the band it holds, if any. Empty (None), all-pass, disabled, unknown-type and
+    // malformed rows are slots holding no band — a bank is a fixed table, so most
+    // rows of a real file are expected to be empty. Telling "no band here" from
+    // "not this bank's table" is what lets an incomplete file be refused.
+    private static bool TryParseSlot(string line, out int slotNumber, out PeqBand? band)
     {
-        band = default;
+        band = null;
+        slotNumber = 0;
 
         string[] fields = SplitRow(line);
-        if (fields.Length < 6 ||
-            !int.TryParse(fields[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out _) ||
-            fields[1].Equals("False", StringComparison.OrdinalIgnoreCase))
+        if (fields.Length < 4 ||
+            !int.TryParse(fields[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out slotNumber) ||
+            fields[3].Length == 0)
         {
             return false;
         }
 
+        if (fields.Length < 6 ||
+            fields[1].Equals("False", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
         PeqBandType type;
-        if (fields[3].Equals(BellType, StringComparison.OrdinalIgnoreCase))
+        if (fields[3].Equals(BellType, StringComparison.OrdinalIgnoreCase) ||
+            fields[3].Equals(ModalType, StringComparison.OrdinalIgnoreCase))
         {
             type = PeqBandType.Peaking;
         }
@@ -201,13 +234,14 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
         }
         else
         {
-            return false;
+            // None, AP1, AP2 or anything else this layout may grow: a slot, no band.
+            return true;
         }
 
         if (!EqTextNumbers.TryParse(fields[4], out double frequencyHz) ||
             !EqTextNumbers.TryParse(fields[5], out double gainDb))
         {
-            return false;
+            return true;
         }
 
         // The Q cell may be blank on a hand-edited row: a bell can still be read
@@ -219,7 +253,7 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
                 if (!EqTextNumbers.TryParse(FieldAt(fields, 7), out double bandwidthHz) ||
                     bandwidthHz <= 0)
                 {
-                    return false;
+                    return true;
                 }
 
                 q = frequencyHz / bandwidthHz;
@@ -234,7 +268,7 @@ public sealed class AudiotecFischerFormat : IEqProfileFormat
             !double.IsFinite(q) || q <= 0 ||
             !double.IsFinite(gainDb))
         {
-            return false;
+            return true;
         }
 
         band = new PeqBand(frequencyHz, q, gainDb, type);

--- a/dsp/EqProfileFormats.cs
+++ b/dsp/EqProfileFormats.cs
@@ -14,6 +14,7 @@ public static class EqProfileFormats
         new GenericCsvFormat(),
         new EasyEffectsFormat(),
         new CamillaDspYamlFormat(),
+        new AudiotecFischerFormat(),
         // Biquad coefficients are rate-specific, and biquad-consuming devices
         // process at different internal rates (car DSPs commonly at 44.1 kHz,
         // miniDSP 2x4 at 48 kHz, HD/DDRC-class at 96 kHz) — one dialog entry

--- a/dsp/IEqProfileFormat.cs
+++ b/dsp/IEqProfileFormat.cs
@@ -30,6 +30,19 @@ public interface IEqProfileFormat
     /// </remarks>
     bool SupportsShelvingFilters => true;
 
+    /// <summary>
+    /// Whether the layout has a place for the whole-profile gain
+    /// (<see cref="EqualizationCurve.PreampDb"/>). False means the target keeps that
+    /// gain in a control the file never reaches — a car DSP's channel gain — so an
+    /// export leaves the preamp out and an import reads it as 0; the caller is
+    /// expected to say so, as it does for a dropped shelf.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to true: the formats that carry a preamp line, an output-gain field
+    /// or a gain biquad realize it by construction.
+    /// </remarks>
+    bool CarriesPreamp => true;
+
     /// <summary>Serialises the curve. Only valid when <see cref="CanExport"/>.</summary>
     string Export(EqualizationCurve curve);
 

--- a/source/Tools/Eq/EqWizardImportExportCoordinator.cs
+++ b/source/Tools/Eq/EqWizardImportExportCoordinator.cs
@@ -156,6 +156,30 @@ internal sealed class EqWizardImportExportCoordinator
             : curve.Bands.Count(band => band.Type.IsShelving());
     }
 
+    /// <summary>
+    /// The preamp an export to <paramref name="target"/> would leave behind, in dB.
+    /// Zero when the format carries it, and zero when there is none to lose — the
+    /// panel asks only when the answer is going to cost the user something.
+    /// </summary>
+    /// <remarks>
+    /// A format without a preamp slot (a car DSP's per-channel bank: the gain is a
+    /// separate control on the device) writes the bands only. The whole curve is
+    /// then quietly that many dB off the tune on screen, which is worse than a
+    /// dropped band: nothing in the exported file hints at it, so the user has to
+    /// be told which gain to enter by hand.
+    /// </remarks>
+    internal static double PreampDroppedBy(
+        EqWizardExportTarget target,
+        EqualizationCurve curve)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(curve);
+
+        return target.CarriesPreamp || curve.PreampDb == 0
+            ? 0
+            : curve.PreampDb;
+    }
+
     internal static EqualizationCurve WithoutShelvingBands(EqualizationCurve curve)
     {
         ArgumentNullException.ThrowIfNull(curve);
@@ -232,6 +256,9 @@ internal sealed class EqWizardExportTarget : IEqWizardFileTarget
 
     // The tuning sheet prints shelves in a table of their own, so it carries them.
     internal bool SupportsShelvingFilters => Format?.SupportsShelvingFilters ?? true;
+
+    // ... and prints the preamp with them, so it carries that too.
+    internal bool CarriesPreamp => Format?.CarriesPreamp ?? true;
 
     internal static EqWizardExportTarget TuningSheet() =>
         new(null, "Tuning sheet (PDF)", "pdf");

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -867,11 +867,14 @@ public partial class EqWizardPanel : UserControl
         }
 
         string gain = FormattableString.Invariant($"{preampDb:+0.0;-0.0} dB");
+        // The preamp is signed: leaving out a cut makes the export louder than the
+        // curve on screen, leaving out a boost makes it quieter. Say which.
+        string direction = preampDb < 0 ? "louder" : "quieter";
         return MessageBox.Show(
             FindForm(),
             $"{target.Name} has no place for the preamp, so the {gain} would be left " +
-            "out and the exported bands alone are that much louder than the tune on " +
-            "screen." +
+            $"out and the exported bands alone are that much {direction} than the tune " +
+            "on screen." +
             Environment.NewLine + Environment.NewLine +
             $"Enter {gain} in the channel's own gain control on the device after " +
             "importing the bands. Export anyway?",

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -801,7 +801,8 @@ public partial class EqWizardPanel : UserControl
         EqualizationCurve curve = BuildEqualizationCurve();
         EqWizardExportTarget target =
             importExportCoordinator.ResolveExportTarget(dialog.FilterIndex);
-        if (!ConfirmShelvingBandsDropped(target, curve))
+        if (!ConfirmShelvingBandsDropped(target, curve) ||
+            !ConfirmPreampDropped(target, curve))
         {
             return;
         }
@@ -846,6 +847,34 @@ public partial class EqWizardPanel : UserControl
             Environment.NewLine + Environment.NewLine +
             "The exported profile will hold the peaking filters and the preamp only, " +
             "and will not match the curve on screen. Export anyway?",
+            "EQ Wizard",
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Warning) == DialogResult.Yes;
+    }
+
+    // A format whose layout has no preamp slot exports the bands only, so the whole
+    // curve lands on the device that many dB off the tune on screen — and, unlike a
+    // dropped band, nothing in the file says so. Tell the user the number to enter
+    // in the device's own gain control; they decide.
+    private bool ConfirmPreampDropped(
+        EqWizardExportTarget target,
+        EqualizationCurve curve)
+    {
+        double preampDb = EqWizardImportExportCoordinator.PreampDroppedBy(target, curve);
+        if (preampDb == 0)
+        {
+            return true;
+        }
+
+        string gain = FormattableString.Invariant($"{preampDb:+0.0;-0.0} dB");
+        return MessageBox.Show(
+            FindForm(),
+            $"{target.Name} has no place for the preamp, so the {gain} would be left " +
+            "out and the exported bands alone are that much louder than the tune on " +
+            "screen." +
+            Environment.NewLine + Environment.NewLine +
+            $"Enter {gain} in the channel's own gain control on the device after " +
+            "importing the bands. Export anyway?",
             "EQ Wizard",
             MessageBoxButtons.YesNo,
             MessageBoxIcon.Warning) == DialogResult.Yes;

--- a/tests/Resonalyze.App.Tests/EqWizardPreampExportTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardPreampExportTests.cs
@@ -1,0 +1,88 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+// The other thing a device format can quietly fail to carry: the preamp. A car
+// DSP's per-channel bank keeps the gain in a control of its own, so an export
+// leaves the whole curve that many dB off the tune on screen — with nothing in the
+// file to hint at it. The panel must be able to say exactly what is being left.
+public sealed class EqWizardPreampExportTests
+{
+    private static EqualizationCurve Mixed() => new(
+        new[]
+        {
+            new PeqBand(1_000, 4.0, -6.0),
+            new PeqBand(80, 0.7, 4.5, PeqBandType.LowShelf),
+            new PeqBand(6_300, 1.1, -3.5, PeqBandType.HighShelf)
+        },
+        -6.5);
+
+    private static EqWizardExportTarget TargetFor(IEqProfileFormat format) => new(format);
+
+    [Fact]
+    public void TheWarningReportsExactlyTheGainThatWouldBeLost()
+    {
+        Assert.Equal(
+            -6.5,
+            EqWizardImportExportCoordinator.PreampDroppedBy(
+                TargetFor(new AudiotecFischerFormat()), Mixed()),
+            9);
+
+        // Nothing to warn about when the format carries it...
+        Assert.Equal(
+            0,
+            EqWizardImportExportCoordinator.PreampDroppedBy(
+                TargetFor(new EqualizerApoFormat()), Mixed()),
+            9);
+
+        // ...nor when the curve has no preamp to lose.
+        Assert.Equal(
+            0,
+            EqWizardImportExportCoordinator.PreampDroppedBy(
+                TargetFor(new AudiotecFischerFormat()),
+                new EqualizationCurve(new[] { new PeqBand(1_000, 1, 3) })),
+            9);
+    }
+
+    [Fact]
+    public void TheTuningSheetCarriesThePreampAndTheShelves()
+    {
+        // It prints them in tables of its own, so neither warning fires for it.
+        EqWizardExportTarget sheet = EqWizardExportTarget.TuningSheet();
+
+        Assert.Equal(0, EqWizardImportExportCoordinator.PreampDroppedBy(sheet, Mixed()), 9);
+        Assert.Equal(
+            0,
+            EqWizardImportExportCoordinator.CountShelvingBandsDroppedBy(sheet, Mixed()));
+    }
+
+    [Fact]
+    public void ThePreampIsAbsentFromTheExportedBankItself()
+    {
+        string? written = null;
+        var coordinator = new EqWizardImportExportCoordinator(
+            EqProfileFormats.Importable,
+            EqProfileFormats.Exportable,
+            _ => string.Empty,
+            (_, text) => written = text,
+            _ => { });
+
+        EqWizardFileResult result = coordinator.Export(new EqWizardExportRequest(
+            "bank.txt",
+            TargetFor(new AudiotecFischerFormat()),
+            Mixed(),
+            96_000,
+            "title",
+            20,
+            20_000,
+            null));
+
+        Assert.True(result.Success);
+        Assert.NotNull(written);
+        Assert.DoesNotContain("-6.5", written);
+        // The bands themselves are all there — the loss is the gain, and only that.
+        Assert.Contains("1000.0", written);
+        Assert.Contains("80.0", written);
+        Assert.Contains("6300.0", written);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/AudiotecFischerFormatTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AudiotecFischerFormatTests.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Resonalyze.Dsp.Tests;
 
 // The Audiotec-Fischer bank both ways: what a real REW export reads as, what a
@@ -61,6 +63,22 @@ public sealed class AudiotecFischerFormatTests
             .Select(line => line.TrimEnd('\r'))
             .ToArray();
 
+    // A complete bank around the rows a test cares about: the layout is a fixed
+    // table, so anything short of thirty slots is not this format (see
+    // Import_RefusesATruncatedOrRenumberedBank) and every fixture must fill it.
+    private static string Bank(params string[] rows)
+    {
+        var text = new StringBuilder("Audiotec_Fischer_Full_EQ_(30_bands)\n");
+        for (int slot = 1; slot <= AudiotecFischerFormat.SlotCount; slot++)
+        {
+            text.AppendLine(slot <= rows.Length
+                ? $"{slot}\t{rows[slot - 1]}"
+                : $"{slot}\tTrue\tAuto\tNone\t");
+        }
+
+        return text.ToString();
+    }
+
     [Fact]
     public void IsRegisteredForImportAndExport()
     {
@@ -89,11 +107,7 @@ public sealed class AudiotecFischerFormatTests
     {
         // REW writes both; Q is what the slot means. A bandwidth that disagrees
         // (here 500 Hz against Q 4 at 1 kHz, i.e. Q 2) must not move the band.
-        string text =
-            "Audiotec_Fischer_Full_EQ_(30_bands)\n" +
-            "1\tTrue\tAuto\tPK\t1000\t-3\t4.00\t500\t\n";
-
-        EqualizationCurve curve = Format.Import(text);
+        EqualizationCurve curve = Format.Import(Bank("True\tAuto\tPK\t1000\t-3\t4.00\t500\t"));
 
         Assert.Equal(4.0, Assert.Single(curve.Bands).Q, 6);
     }
@@ -101,11 +115,7 @@ public sealed class AudiotecFischerFormatTests
     [Fact]
     public void Import_ReadsQFromTheBandwidthWhenTheQCellIsBlank()
     {
-        string text =
-            "Audiotec_Fischer_Full_EQ_(30_bands)\n" +
-            "1\tTrue\tAuto\tPK\t1000\t-3\t\t250\t\n";
-
-        EqualizationCurve curve = Format.Import(text);
+        EqualizationCurve curve = Format.Import(Bank("True\tAuto\tPK\t1000\t-3\t\t250\t"));
 
         Assert.Equal(4.0, Assert.Single(curve.Bands).Q, 6);
     }
@@ -113,11 +123,7 @@ public sealed class AudiotecFischerFormatTests
     [Fact]
     public void Import_ReadsAShelfWithoutAQAtTheDefaultKnee()
     {
-        string text =
-            "Audiotec_Fischer_Full_EQ_(30_bands)\n" +
-            "1\tTrue\tAuto\tHS_Q\t8000\t-2\n";
-
-        PeqBand band = Assert.Single(Format.Import(text).Bands);
+        PeqBand band = Assert.Single(Format.Import(Bank("True\tAuto\tHS_Q\t8000\t-2")).Bands);
 
         Assert.Equal(PeqBandType.HighShelf, band.Type);
         Assert.Equal(PeqTextFile.DefaultShelfQ, band.Q, 9);
@@ -129,18 +135,15 @@ public sealed class AudiotecFischerFormatTests
         // The two all-pass slots move phase only, which no PeqBand can state; a
         // disabled row is an OFF filter; a None row is an empty slot; a bell with
         // neither Q nor bandwidth says nothing about its width.
-        string text =
-            "Audiotec_Fischer_Full_EQ_(30_bands)\n" +
-            "1\tTrue\tAuto\tPK\t100\t-2\t2.00\t50\t\n" +
-            "2\tFalse\tAuto\tPK\t200\t-2\t2.00\t100\t\n" +
-            "3\tTrue\tAuto\tAP1\t300\n" +
-            "4\tTrue\tAuto\tAP2\t400\t\t1.50\n" +
-            "5\tTrue\tAuto\tNone\t\n" +
-            "6\tTrue\tAuto\tPK\t600\t-2\t\t\t\n" +
-            "7\tTrue\tAuto\tPK\tnot-a-number\t-2\t2.00\n" +
-            "8\tTrue\tAuto\tPK\t800\t-1\t1.00\t800\t\n";
-
-        EqualizationCurve curve = Format.Import(text);
+        EqualizationCurve curve = Format.Import(Bank(
+            "True\tAuto\tPK\t100\t-2\t2.00\t50\t",
+            "False\tAuto\tPK\t200\t-2\t2.00\t100\t",
+            "True\tAuto\tAP1\t300",
+            "True\tAuto\tAP2\t400\t\t1.50",
+            "True\tAuto\tNone\t",
+            "True\tAuto\tPK\t600\t-2\t\t\t",
+            "True\tAuto\tPK\tnot-a-number\t-2\t2.00",
+            "True\tAuto\tPK\t800\t-1\t1.00\t800\t"));
 
         Assert.Equal(2, curve.Bands.Count);
         Assert.Equal(100, curve.Bands[0].FrequencyHz);
@@ -157,7 +160,9 @@ public sealed class AudiotecFischerFormatTests
             "\uFEFFAudiotec_Fischer_Full_EQ_(30_bands)\r\n" +
             "Number Enabled Control Type Frequency(Hz) Gain(dB) Q Bandwidth(Hz) TargetT60(ms)\r\n" +
             "1 True Auto PK 2504.0 -12.2 1.27 1972\r\n" +
-            "2 True Manual LS_Q 44.3 -11.0 0.7\r\n";
+            "2 True Manual LS_Q 44.3 -11.0 0.7\r\n" +
+            string.Concat(Enumerable.Range(3, AudiotecFischerFormat.SlotCount - 2)
+                .Select(slot => $"{slot} True Auto None\r\n"));
 
         Assert.True(Format.TryImport(text, out EqualizationCurve curve));
 
@@ -180,6 +185,71 @@ public sealed class AudiotecFischerFormatTests
         Assert.False(Format.TryImport("Preamp: -6.0 dB\nFilter 1: ON PK Fc 600 Hz Gain 6.0 dB Q 4.0\n", out _));
         Assert.False(Format.TryImport("Preamp (dB),-6.0\nFilter,Frequency (Hz),Gain (dB),Q,Type\n1,600,6.0,4.0,PK\n", out _));
         Assert.False(Format.TryImport(string.Empty, out _));
+    }
+
+    [Fact]
+    public void Import_ReadsARewModalRowAsABell()
+    {
+        // REW's room-mode filter occupies a slot like any other and realizes a bell:
+        // the row carries Fc, gain and the Q of that bell, with the T60 the optimizer
+        // aimed at in the last cell. (The row below is a modal filter set in REW 5.40
+        // to 120 Hz / -6 dB / T60 300 ms; its realized Q, fitted from REW's own EQ
+        // response, is 11.6 — not any textbook T60 identity, which is exactly why the
+        // Q column is the only thing to read.) Dropping the row, as this format did
+        // before, silently left a room mode uncorrected.
+        EqualizationCurve curve = Format.Import(Bank(
+            "True\tAuto\tModal\t120.0\t-6.0\t11.59\t10.35\t300.0\t",
+            "True\tAuto\tPK\t200.0\t-2.0\t4.00\t50.00\t"));
+
+        Assert.Equal(2, curve.Bands.Count);
+        Assert.Equal(new PeqBand(120, 11.59, -6.0), curve.Bands[0]);
+        Assert.Equal(PeqBandType.Peaking, curve.Bands[0].Type);
+        Assert.Equal(new PeqBand(200, 4.0, -2.0), curve.Bands[1]);
+
+        // Written back it is a plain bell: the processor has no modal slot, and the
+        // T60 was REW's optimizer metadata, not part of the filter the device runs.
+        Assert.Equal(
+            "1\tTrue\tAuto\tPK\t120.0\t-6.0\t11.59\t10.35\t",
+            Lines(Format.Export(curve))[2]);
+    }
+
+    [Fact]
+    public void Import_RefusesATruncatedOrRenumberedBank()
+    {
+        // The bank is a fixed 30-slot table and a successful import REPLACES the
+        // EQ on screen, so anything that is not that table must fail recognition
+        // rather than arrive as an empty curve and wipe the user's tune.
+        string full = Bank("True\tAuto\tPK\t1000\t-3\t4.00\t250\t");
+        Assert.True(Format.TryImport(full, out EqualizationCurve intact));
+        Assert.Single(intact.Bands);
+
+        string[] rows = full.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // a bank cut short (a partial copy/paste, a truncated download)
+        Assert.False(Format.TryImport(string.Join("\n", rows.Take(rows.Length - 1)), out _));
+        // the header alone — the case that used to import as "no bands"
+        Assert.False(Format.TryImport("Audiotec_Fischer_Full_EQ_(30_bands)\n", out _));
+        // more rows than the channel has slots: this format would refuse to export it
+        Assert.False(Format.TryImport(
+            full + $"{AudiotecFischerFormat.SlotCount + 1}\tTrue\tAuto\tPK\t900\t-1\t2.00\t450\t\n",
+            out _));
+        // renumbered/repeated rows are not the slot table either
+        Assert.False(Format.TryImport(full.Replace("\n2\tTrue", "\n1\tTrue"), out _));
+    }
+
+    [Fact]
+    public void Import_KeepsAFullBankOfBandsWithinTheSlotBudget()
+    {
+        // Thirty bells fill the table; the curve type allows 32, the channel does
+        // not, and what imports must be what this format can write back.
+        string full = Bank(Enumerable.Range(1, AudiotecFischerFormat.SlotCount)
+            .Select(slot => $"True\tAuto\tPK\t{100 * slot}\t-1.0\t2.00\t{50 * slot}\t")
+            .ToArray());
+
+        Assert.True(Format.TryImport(full, out EqualizationCurve curve));
+
+        Assert.Equal(AudiotecFischerFormat.SlotCount, curve.Bands.Count);
+        Assert.Equal(AudiotecFischerFormat.SlotCount, Format.Import(Format.Export(curve)).Bands.Count);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/AudiotecFischerFormatTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AudiotecFischerFormatTests.cs
@@ -192,21 +192,25 @@ public sealed class AudiotecFischerFormatTests
     {
         // REW's room-mode filter occupies a slot like any other and realizes a bell:
         // the row carries Fc, gain and the Q of that bell, with the T60 the optimizer
-        // aimed at in the last cell. (The row below is a modal filter set in REW 5.40
-        // to 120 Hz / -6 dB / T60 300 ms; its realized Q, fitted from REW's own EQ
-        // response, is 11.6 — not any textbook T60 identity, which is exactly why the
-        // Q column is the only thing to read.) Dropping the row, as this format did
-        // before, silently left a room mode uncorrected.
+        // aimed at in the last cell. The three rows below are a byte-exact bank from
+        // REW 5.40 Beta 132 with this equaliser selected (two modal filters and a
+        // plain bell); note that a modal Q is not any textbook T60 identity — 120 Hz
+        // at -6 dB and T60 300 ms realizes Q 11.59, not the 16.4 that
+        // pi*f0*T60/ln(1000) would give — so the Q column is the only thing to read.
+        // Dropping these rows, as this format did before, silently left a room mode
+        // uncorrected.
         EqualizationCurve curve = Format.Import(Bank(
-            "True\tAuto\tModal\t120.0\t-6.0\t11.59\t10.35\t300.0\t",
+            "True\tAuto\tModal\t120.0\t-6.0\t11.59\t10.35\t300\t",
+            "True\tAuto\tModal\t45.0\t-4.5\t9.48\t4.75\t600\t",
             "True\tAuto\tPK\t200.0\t-2.0\t4.00\t50.00\t"));
 
-        Assert.Equal(2, curve.Bands.Count);
+        Assert.Equal(3, curve.Bands.Count);
         Assert.Equal(new PeqBand(120, 11.59, -6.0), curve.Bands[0]);
-        Assert.Equal(PeqBandType.Peaking, curve.Bands[0].Type);
-        Assert.Equal(new PeqBand(200, 4.0, -2.0), curve.Bands[1]);
+        Assert.Equal(new PeqBand(45, 9.48, -4.5), curve.Bands[1]);
+        Assert.All(curve.Bands, band => Assert.Equal(PeqBandType.Peaking, band.Type));
+        Assert.Equal(new PeqBand(200, 4.0, -2.0), curve.Bands[2]);
 
-        // Written back it is a plain bell: the processor has no modal slot, and the
+        // Written back they are plain bells: the processor has no modal slot, and the
         // T60 was REW's optimizer metadata, not part of the filter the device runs.
         Assert.Equal(
             "1\tTrue\tAuto\tPK\t120.0\t-6.0\t11.59\t10.35\t",

--- a/tests/Resonalyze.Dsp.Tests/AudiotecFischerFormatTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AudiotecFischerFormatTests.cs
@@ -267,6 +267,31 @@ public sealed class AudiotecFischerFormatTests
     }
 
     [Fact]
+    public void Import_RequiresTheBankHeaderNotTheColumnLine()
+    {
+        // REW prints the same "Number / Enabled / Control / Type ..." line above
+        // every equaliser's table, so thirty well-numbered rows under it may be
+        // another processor's bank entirely; only the bank header says whose slots
+        // these are. Recognising the columns alone would let a foreign table import
+        // and replace the EQ on screen.
+        string columnsOnly =
+            "Number\tEnabled\tControl\tType\tFrequency(Hz)\tGain(dB)\tQ\tBandwidth(Hz)\tTargetT60(ms)\t\r\n" +
+            string.Concat(Enumerable
+                .Range(1, AudiotecFischerFormat.SlotCount)
+                .Select(slot => $"{slot}\tTrue\tAuto\tNone\t\r\n"));
+        Assert.False(Format.TryImport(columnsOnly, out _));
+
+        // The column line is auxiliary the other way round: the bank header and its
+        // table are enough on their own, which is what a copy taken without the
+        // column row looks like.
+        Assert.True(Format.TryImport(Bank("True\tAuto\tPK\t1000\t-3\t4.00\t250\t"), out EqualizationCurve curve));
+        Assert.Single(curve.Bands);
+
+        // A real export carries both and still reads.
+        Assert.True(Format.TryImport(RewExport, out _));
+    }
+
+    [Fact]
     public void Import_KeepsAFullBankOfBandsWithinTheSlotBudget()
     {
         // Thirty bells fill the table; the curve type allows 32, the channel does

--- a/tests/Resonalyze.Dsp.Tests/AudiotecFischerFormatTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AudiotecFischerFormatTests.cs
@@ -130,24 +130,49 @@ public sealed class AudiotecFischerFormatTests
     }
 
     [Fact]
-    public void Import_SkipsDisabledAllPassEmptyAndMalformedRows()
+    public void Import_SkipsTheSlotsThatHoldNoBand()
     {
         // The two all-pass slots move phase only, which no PeqBand can state; a
-        // disabled row is an OFF filter; a None row is an empty slot; a bell with
-        // neither Q nor bandwidth says nothing about its width.
+        // disabled row is an OFF filter (whatever it says after that); a None row is
+        // an empty slot. All three are slots the bank legitimately spends on nothing.
         EqualizationCurve curve = Format.Import(Bank(
             "True\tAuto\tPK\t100\t-2\t2.00\t50\t",
             "False\tAuto\tPK\t200\t-2\t2.00\t100\t",
+            "False\tAuto\tPK\tnot-a-number\t-2\t2.00",
             "True\tAuto\tAP1\t300",
             "True\tAuto\tAP2\t400\t\t1.50",
             "True\tAuto\tNone\t",
-            "True\tAuto\tPK\t600\t-2\t\t\t",
-            "True\tAuto\tPK\tnot-a-number\t-2\t2.00",
             "True\tAuto\tPK\t800\t-1\t1.00\t800\t"));
 
         Assert.Equal(2, curve.Bands.Count);
         Assert.Equal(100, curve.Bands[0].FrequencyHz);
         Assert.Equal(800, curve.Bands[1].FrequencyHz);
+    }
+
+    [Fact]
+    public void Import_RefusesASlotThatClaimsAFilterItCannotRead()
+    {
+        // An enabled band row whose numbers do not read, and an enabled row of a type
+        // this reader does not know, are both bands that would go missing from a fixed
+        // table without a word. In a device bank that is a changed tune, so the file is
+        // refused instead — the same protection as a truncated bank.
+        foreach (string row in new[]
+        {
+            "True\tAuto\tPK\tnot-a-number\t-2\t2.00\t50\t",   // unreadable centre
+            "True\tAuto\tPK\t600\t-2\t\t\t",                  // neither Q nor bandwidth
+            "True\tAuto\tPK\t600\t-2\t0\t0\t",                // a width of zero
+            "True\tAuto\tHS_Q\t8000\tnot-a-number\t0.7",        // unreadable gain
+            "True\tAuto\tNotch\t1000\t-6\t4.00\t250\t",       // a magnitude filter we do not model
+        })
+        {
+            Assert.False(Format.TryImport(Bank(row), out EqualizationCurve refused), row);
+            Assert.Empty(refused.Bands);
+        }
+
+        // ...while the same rows turned OFF are ordinary empty slots.
+        Assert.True(Format.TryImport(
+            Bank("False\tAuto\tNotch\t1000\t-6\t4.00\t250\t"), out EqualizationCurve disabled));
+        Assert.Empty(disabled.Bands);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/AudiotecFischerFormatTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AudiotecFischerFormatTests.cs
@@ -1,0 +1,271 @@
+namespace Resonalyze.Dsp.Tests;
+
+// The Audiotec-Fischer bank both ways: what a real REW export reads as, what a
+// curve writes as (the row shapes the PC-Tool is known to accept), and what the
+// layout cannot carry — the preamp, more than 30 bands, the all-pass slots.
+public sealed class AudiotecFischerFormatTests
+{
+    // A real REW export ("Equaliser: Audiotec Fischer", Full EQ 30 bands) of a
+    // 20-band channel: 18 bells and both shelves, then ten unused slots. Kept
+    // byte for byte — trailing tabs, ragged shelf rows, four-significant-digit
+    // bandwidths — because that is the shape the PC-Tool imported.
+    private const string RewExport =
+        "Audiotec_Fischer_Full_EQ_(30_bands)\r\n" +
+        "Number\tEnabled\tControl\tType\tFrequency(Hz)\tGain(dB)\tQ\tBandwidth(Hz)\tTargetT60(ms)\t\r\n" +
+        "1\tTrue\tAuto\tPK\t30.0\t-2.0\t3.00\t10.00\t\r\n" +
+        "2\tTrue\tAuto\tPK\t45.0\t1.5\t3.00\t15.00\t\r\n" +
+        "3\tTrue\tManual\tLS_Q\t50.0\t-1.0\t0.7\r\n" +
+        "4\tTrue\tAuto\tPK\t80.0\t-2.0\t4.00\t20.00\t\r\n" +
+        "5\tTrue\tAuto\tPK\t120.0\t2.0\t3.00\t40.00\t\r\n" +
+        "6\tTrue\tAuto\tPK\t200.0\t-3.0\t2.00\t100.0\t\r\n" +
+        "7\tTrue\tAuto\tPK\t315.0\t2.0\t3.00\t105.0\t\r\n" +
+        "8\tTrue\tAuto\tPK\t500.0\t-2.0\t4.00\t125.0\t\r\n" +
+        "9\tTrue\tAuto\tPK\t630.0\t1.5\t5.00\t126.0\t\r\n" +
+        "10\tTrue\tAuto\tPK\t800.0\t-2.5\t5.00\t160.0\t\r\n" +
+        "11\tTrue\tAuto\tPK\t1000.0\t2.0\t2.00\t500.0\t\r\n" +
+        "12\tTrue\tAuto\tPK\t1250.0\t-2.0\t5.00\t250.0\t\r\n" +
+        "13\tTrue\tAuto\tPK\t1600.0\t1.5\t4.00\t400.0\t\r\n" +
+        "14\tTrue\tAuto\tPK\t2000.0\t-3.0\t5.00\t400.0\t\r\n" +
+        "15\tTrue\tAuto\tPK\t2500.0\t2.0\t3.00\t833.0\t\r\n" +
+        "16\tTrue\tAuto\tPK\t3150.0\t-2.0\t4.00\t787.0\t\r\n" +
+        "17\tTrue\tManual\tPK\t5000.0\t1.0\t3.00\t1666\t\r\n" +
+        "18\tTrue\tManual\tPK\t8000.0\t-2.0\t2.00\t4000\t\r\n" +
+        "19\tTrue\tAuto\tPK\t12500.0\t-1.5\t2.00\t6250\t\r\n" +
+        "20\tTrue\tManual\tHS_Q\t10000.0\t-1.0\t0.7\r\n" +
+        "21\tTrue\tAuto\tNone\t\r\n" +
+        "22\tTrue\tAuto\tNone\t\r\n" +
+        "23\tTrue\tAuto\tNone\t\r\n" +
+        "24\tTrue\tAuto\tNone\t\r\n" +
+        "25\tTrue\tAuto\tNone\t\r\n" +
+        "26\tTrue\tAuto\tNone\t\r\n" +
+        "27\tTrue\tAuto\tNone\t\r\n" +
+        "28\tTrue\tAuto\tNone\t\r\n" +
+        "29\tTrue\tAuto\tNone\t\r\n" +
+        "30\tTrue\tAuto\tNone\t\r\n";
+
+    // Typed as the interface: Import() is a default interface member and is not
+    // reachable through the class itself.
+    private static readonly IEqProfileFormat Format = new AudiotecFischerFormat();
+
+    private static EqualizationCurve Mixed() => new(
+        new[]
+        {
+            new PeqBand(80, 0.7, 4.5, PeqBandType.LowShelf),
+            new PeqBand(1_000, 4.0, -6.0),
+            new PeqBand(6_300, 1.1, -3.5, PeqBandType.HighShelf)
+        },
+        -6.5);
+
+    private static string[] Lines(string text) =>
+        text.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.TrimEnd('\r'))
+            .ToArray();
+
+    [Fact]
+    public void IsRegisteredForImportAndExport()
+    {
+        Assert.Contains(EqProfileFormats.Importable, format => format is AudiotecFischerFormat);
+        Assert.Contains(EqProfileFormats.Exportable, format => format is AudiotecFischerFormat);
+    }
+
+    [Fact]
+    public void Import_ReadsARealRewExport()
+    {
+        Assert.True(Format.TryImport(RewExport, out EqualizationCurve curve));
+
+        // Twenty bands, in slot order; the ten None rows are not bands.
+        Assert.Equal(20, curve.Bands.Count);
+        Assert.Equal(0, curve.PreampDb);
+
+        Assert.Equal(new PeqBand(30, 3.0, -2.0), curve.Bands[0]);
+        Assert.Equal(new PeqBand(50, 0.7, -1.0, PeqBandType.LowShelf), curve.Bands[2]);
+        Assert.Equal(new PeqBand(5_000, 3.0, 1.0), curve.Bands[16]);
+        Assert.Equal(new PeqBand(10_000, 0.7, -1.0, PeqBandType.HighShelf), curve.Bands[19]);
+        Assert.Equal(18, curve.Bands.Count(band => band.Type == PeqBandType.Peaking));
+    }
+
+    [Fact]
+    public void Import_QWinsOverTheBandwidthColumn()
+    {
+        // REW writes both; Q is what the slot means. A bandwidth that disagrees
+        // (here 500 Hz against Q 4 at 1 kHz, i.e. Q 2) must not move the band.
+        string text =
+            "Audiotec_Fischer_Full_EQ_(30_bands)\n" +
+            "1\tTrue\tAuto\tPK\t1000\t-3\t4.00\t500\t\n";
+
+        EqualizationCurve curve = Format.Import(text);
+
+        Assert.Equal(4.0, Assert.Single(curve.Bands).Q, 6);
+    }
+
+    [Fact]
+    public void Import_ReadsQFromTheBandwidthWhenTheQCellIsBlank()
+    {
+        string text =
+            "Audiotec_Fischer_Full_EQ_(30_bands)\n" +
+            "1\tTrue\tAuto\tPK\t1000\t-3\t\t250\t\n";
+
+        EqualizationCurve curve = Format.Import(text);
+
+        Assert.Equal(4.0, Assert.Single(curve.Bands).Q, 6);
+    }
+
+    [Fact]
+    public void Import_ReadsAShelfWithoutAQAtTheDefaultKnee()
+    {
+        string text =
+            "Audiotec_Fischer_Full_EQ_(30_bands)\n" +
+            "1\tTrue\tAuto\tHS_Q\t8000\t-2\n";
+
+        PeqBand band = Assert.Single(Format.Import(text).Bands);
+
+        Assert.Equal(PeqBandType.HighShelf, band.Type);
+        Assert.Equal(PeqTextFile.DefaultShelfQ, band.Q, 9);
+    }
+
+    [Fact]
+    public void Import_SkipsDisabledAllPassEmptyAndMalformedRows()
+    {
+        // The two all-pass slots move phase only, which no PeqBand can state; a
+        // disabled row is an OFF filter; a None row is an empty slot; a bell with
+        // neither Q nor bandwidth says nothing about its width.
+        string text =
+            "Audiotec_Fischer_Full_EQ_(30_bands)\n" +
+            "1\tTrue\tAuto\tPK\t100\t-2\t2.00\t50\t\n" +
+            "2\tFalse\tAuto\tPK\t200\t-2\t2.00\t100\t\n" +
+            "3\tTrue\tAuto\tAP1\t300\n" +
+            "4\tTrue\tAuto\tAP2\t400\t\t1.50\n" +
+            "5\tTrue\tAuto\tNone\t\n" +
+            "6\tTrue\tAuto\tPK\t600\t-2\t\t\t\n" +
+            "7\tTrue\tAuto\tPK\tnot-a-number\t-2\t2.00\n" +
+            "8\tTrue\tAuto\tPK\t800\t-1\t1.00\t800\t\n";
+
+        EqualizationCurve curve = Format.Import(text);
+
+        Assert.Equal(2, curve.Bands.Count);
+        Assert.Equal(100, curve.Bands[0].FrequencyHz);
+        Assert.Equal(800, curve.Bands[1].FrequencyHz);
+    }
+
+    [Fact]
+    public void Import_ToleratesABomCrLfAndSpacesForTabs()
+    {
+        // A copy that went through an editor or a chat window: BOM in front, CR/LF,
+        // tabs flattened to spaces. No cell of the layout contains a space, so the
+        // columns still separate.
+        string text =
+            "\uFEFFAudiotec_Fischer_Full_EQ_(30_bands)\r\n" +
+            "Number Enabled Control Type Frequency(Hz) Gain(dB) Q Bandwidth(Hz) TargetT60(ms)\r\n" +
+            "1 True Auto PK 2504.0 -12.2 1.27 1972\r\n" +
+            "2 True Manual LS_Q 44.3 -11.0 0.7\r\n";
+
+        Assert.True(Format.TryImport(text, out EqualizationCurve curve));
+
+        Assert.Equal(2, curve.Bands.Count);
+        Assert.Equal(new PeqBand(2504, 1.27, -12.2), curve.Bands[0]);
+        Assert.Equal(new PeqBand(44.3, 0.7, -11.0, PeqBandType.LowShelf), curve.Bands[1]);
+    }
+
+    [Fact]
+    public void Import_RecognisesAnEmptyBankAndNotForeignText()
+    {
+        // Thirty None rows are a valid (neutral) bank, so the header alone
+        // recognises the file; an Equalizer APO profile or a CSV is not this
+        // format however many numbers it holds.
+        string empty = "Audiotec_Fischer_Full_EQ_(30_bands)\n" +
+            string.Concat(Enumerable.Range(1, 30).Select(slot => $"{slot}\tTrue\tAuto\tNone\t\n"));
+        Assert.True(Format.TryImport(empty, out EqualizationCurve curve));
+        Assert.Empty(curve.Bands);
+
+        Assert.False(Format.TryImport("Preamp: -6.0 dB\nFilter 1: ON PK Fc 600 Hz Gain 6.0 dB Q 4.0\n", out _));
+        Assert.False(Format.TryImport("Preamp (dB),-6.0\nFilter,Frequency (Hz),Gain (dB),Q,Type\n1,600,6.0,4.0,PK\n", out _));
+        Assert.False(Format.TryImport(string.Empty, out _));
+    }
+
+    [Fact]
+    public void Export_WritesTheBankHeaderAndExactlyThirtySlots()
+    {
+        string[] lines = Lines(Format.Export(Mixed()));
+
+        Assert.Equal(2 + AudiotecFischerFormat.SlotCount, lines.Length);
+        Assert.Equal("Audiotec_Fischer_Full_EQ_(30_bands)", lines[0]);
+        Assert.Equal(
+            "Number\tEnabled\tControl\tType\tFrequency(Hz)\tGain(dB)\tQ\tBandwidth(Hz)\tTargetT60(ms)\t",
+            lines[1]);
+        for (int slot = 4; slot <= AudiotecFischerFormat.SlotCount; slot++)
+        {
+            Assert.Equal($"{slot}\tTrue\tAuto\tNone\t", lines[slot + 1]);
+        }
+    }
+
+    [Fact]
+    public void Export_WritesBellsAndShelvesInRewsRowShapes()
+    {
+        // A bell row carries REW's Fc / Q bandwidth and ends in the empty TargetT60
+        // cell; a shelf row ends at its Q — the exact shapes of the real export.
+        string[] lines = Lines(Format.Export(Mixed()));
+
+        Assert.Equal("1\tTrue\tAuto\tLS_Q\t80.0\t4.5\t0.70", lines[2]);
+        Assert.Equal("2\tTrue\tAuto\tPK\t1000.0\t-6.0\t4.00\t250\t", lines[3]);
+        Assert.Equal("3\tTrue\tAuto\tHS_Q\t6300.0\t-3.5\t1.10", lines[4]);
+    }
+
+    [Fact]
+    public void Export_LeavesThePreampOutAndSaysSo()
+    {
+        Assert.False(Format.CarriesPreamp);
+        Assert.True(((IEqProfileFormat)new EqualizerApoFormat()).CarriesPreamp);
+        Assert.DoesNotContain("-6.5", Format.Export(Mixed()));
+        Assert.Equal(0, Format.Import(Format.Export(Mixed())).PreampDb);
+    }
+
+    [Fact]
+    public void Export_RefusesMoreBandsThanTheBankHasSlots()
+    {
+        // The library allows 32; the processor has 30. Dropping two silently is
+        // exactly the kind of quiet loss the caller cannot see, so refuse.
+        var overfull = new EqualizationCurve(
+            Enumerable.Range(1, AudiotecFischerFormat.SlotCount + 1)
+                .Select(index => new PeqBand(100 * index, 2.0, -1.0)));
+
+        ArgumentException error = Assert.Throws<ArgumentException>(
+            () => Format.Export(overfull));
+        Assert.Contains("30", error.Message);
+
+        var full = new EqualizationCurve(
+            Enumerable.Range(1, AudiotecFischerFormat.SlotCount)
+                .Select(index => new PeqBand(100 * index, 2.0, -1.0)));
+        Assert.Equal(AudiotecFischerFormat.SlotCount, Format.Import(
+            Format.Export(full)).Bands.Count);
+    }
+
+    [Fact]
+    public void RoundTrip_KeepsShapeOrderAndValues()
+    {
+        EqualizationCurve original = Mixed();
+
+        Assert.True(Format.TryImport(Format.Export(original), out EqualizationCurve read));
+
+        Assert.Equal(original.Bands.Count, read.Bands.Count);
+        for (int index = 0; index < original.Bands.Count; index++)
+        {
+            Assert.Equal(original.Bands[index].Type, read.Bands[index].Type);
+            Assert.Equal(original.Bands[index].FrequencyHz, read.Bands[index].FrequencyHz, 3);
+            Assert.Equal(original.Bands[index].Q, read.Bands[index].Q, 3);
+            Assert.Equal(original.Bands[index].GainDb, read.Bands[index].GainDb, 3);
+        }
+    }
+
+    [Fact]
+    public void RoundTrip_SurvivesARealExportUnchanged()
+    {
+        // Import the REW file, write it back, import again: the same 20 bands. The
+        // bytes differ (our bandwidth is not truncated to four digits) but no band
+        // moves, which is what the PC-Tool would care about.
+        EqualizationCurve first = Format.Import(RewExport);
+
+        EqualizationCurve second = Format.Import(Format.Export(first));
+
+        Assert.Equal(first.Bands, second.Bands);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/EqProfileFormatsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EqProfileFormatsTests.cs
@@ -19,7 +19,9 @@ public sealed class EqProfileFormatsTests
 
         EqualizationCurve parsed = format.Import(format.Export(original));
 
-        Assert.Equal(original.PreampDb, parsed.PreampDb, 4);
+        // A format whose layout has no place for the preamp (a car DSP bank, where
+        // the gain is a separate control) reads it back as 0 by declaration.
+        Assert.Equal(format.CarriesPreamp ? original.PreampDb : 0, parsed.PreampDb, 4);
         Assert.Equal(original.Bands.Count, parsed.Bands.Count);
         for (int i = 0; i < original.Bands.Count; i++)
         {

--- a/tests/Resonalyze.Dsp.Tests/EqProfileShelfFormatsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EqProfileShelfFormatsTests.cs
@@ -33,6 +33,7 @@ public sealed class EqProfileShelfFormatsTests
     [InlineData(typeof(RewFilterFormat))]
     [InlineData(typeof(GenericCsvFormat))]
     [InlineData(typeof(CamillaDspYamlFormat))]
+    [InlineData(typeof(AudiotecFischerFormat))]
     public void RoundTrip_KeepsEachBandsShapeAndOrder(Type formatType)
     {
         var format = (IEqProfileFormat)Activator.CreateInstance(formatType)!;


### PR DESCRIPTION
Item 1 of #86, opened at your request there.

The HELIX / MATCH / BRAX DSP PC-Tool imports one channel's EQ from a tab-separated "Full EQ (30 bands)" bank — the same block REW exports with its Audiotec Fischer equaliser selected. Until now a wizard profile could only reach those processors through REW. This adds `AudiotecFischerFormat` to `EqProfileFormats.All`, both directions:

- **Export** writes PK bells and the LS_Q / HS_Q shelves (a centre frequency and a Q — the shelf this library realizes, so they travel unchanged), always exactly 30 slots with unused ones as `None`, and REW's row shapes byte for byte: a bell row ends in the empty TargetT60 cell, a shelf row at its Q, an unused row at its `None` — because that is the layout the PC-Tool is known to accept. REW's Bandwidth column is written as Fc / Q (the RBJ relation, consistent with the `PeqQConvention` crib).
- **Import** reads the same; Q wins over the bandwidth column unless the Q cell is blank (then Q = Fc / BW); a shelf without a Q comes in at `PeqTextFile.DefaultShelfQ`. AP1 / AP2 rows move phase only, which no `PeqBand` can state, so they are skipped and never written; `Enabled False` rows are skipped like OFF filters; a BOM, CR/LF, ragged rows, trailing tabs and spaces in place of tabs are tolerated; an all-`None` bank is recognised as a valid empty profile.
- **What the layout cannot carry, said rather than hidden.** The bank has no place for the preamp — the channel gain is a separate PC-Tool control — so this adds `IEqProfileFormat.CarriesPreamp` (default `true`, the same shape as `SupportsShelvingFilters`): the format declares `false`, writes no preamp, reads it back as 0, and the shared round-trip test asserts that by declaration. More than 30 bands is refused on export with an `ArgumentException` (which `EqWizardImportExportCoordinator` already surfaces) rather than truncated; `AudiotecFischerFormat.SlotCount` is public for a later device profile.

Tests: `AudiotecFischerFormatTests` pins import against a real REW export of a 20-band channel (18 bells + both shelves + ten empty slots), the row shapes on export, the preamp/slot-budget/all-pass rules, tolerance, recognition vs. foreign text, and round trips; `EqProfileShelfFormatsTests.RoundTrip_KeepsEachBandsShapeAndOrder` now runs over this format too.

README's import/export paragraph lists the format. `TODO.md`'s "device export needs a target-device profile" item keeps the residual: the EQ Wizard does not yet warn about a non-zero preamp left behind the way it warns about a dropped shelf, and the miniDSP / generic paths still have no budget or gain profile. I can follow up on the warning; it is app-side, and I cannot run `Resonalyze.App.Tests` here.

Verified on macOS arm64: `Resonalyze.Dsp.Tests` 1104 / 1104 (was 1089), and `source/Resonalyze.sln` compiles with `-p:EnableWindowsTargeting=true` — the App and Audio suites need your Windows CI. No warnings, no suppressions.

Background: the fixture and the format knowledge come from [autosound-tuning-skill](https://github.com/ayukhno/autosound-tuning-skill), where the same bank is parsed and generated in Python (`rew_tool/atf_eq.py`) for Helix tunes driven from REW; the C# here is written fresh against this repo's conventions and is offered under the repository's MIT licence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
