### PR TITLE
Refuse a Virtual DSP gate that opens after the drivers arrive

### DIFF
--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -135,6 +135,13 @@ public partial class VirtualCrossoverPanel : UserControl
     // state on purpose: the answer describes the sheet being printed, not the panel
     // or the project (see AskSheetQConvention).
     private PeqQConvention? sheetQConvention;
+    // The verdict on the window the side on screen is gated at, from the last
+    // redraw (null before the first one, or with no processed channels). The
+    // Auto commands read this instead of judging the placement themselves:
+    // both are disabled until the redraw that fills it has settled, which is
+    // the same condition that puts their curves on screen — see
+    // RefreshAutoActionsEnabled.
+    private GatePlacementVerdict? gatePlacement;
     private VirtualCrossoverAcousticPlot acousticPlot = null!;
     private VirtualCrossoverDspChainPlot dspChainPlot = null!;
     private bool initialized;
@@ -2067,9 +2074,9 @@ public partial class VirtualCrossoverPanel : UserControl
             UpdateMetric(processed, lossCurve, stereoDeltas);
         }
 
-        using (AppProfiler.Zone("VirtualDSP.UpdateCrossoverWarning"))
+        using (AppProfiler.Zone("VirtualDSP.UpdateWarnings"))
         {
-            UpdateCrossoverWarning(processed);
+            UpdateWarnings(processed);
         }
 
         // Split from the draw on purpose: building the curves (the phase view's
@@ -2246,6 +2253,45 @@ public partial class VirtualCrossoverPanel : UserControl
         MetricChanged?.Invoke(compact, detail);
     }
 
+    // One warning line under the plot, and only one: the gate placement comes
+    // first because it decides whether the curves describe the channels at all
+    // — a window that opens after the drivers arrive turns every one of them
+    // into its own reverberant tail, and the crossover spread below is read off
+    // the applied delays, which stay true meanwhile.
+    private void UpdateWarnings(List<ProcessedChannel> processed)
+    {
+        gatePlacement = JudgeGatePlacement(processed);
+        if (gatePlacement is { CutsChannels: true } verdict)
+        {
+            ShowWarning(
+                FormatGateCutWarning(verdict),
+                FormatGateCutDetail(verdict),
+                GateWarningColor);
+            return;
+        }
+
+        UpdateCrossoverWarning(processed);
+    }
+
+    private void ShowWarning(string text, string detail, Color color)
+    {
+        labelCrossoverWarning.ForeColor = color;
+        labelCrossoverWarning.Text = text;
+        toolTip.SetToolTip(labelCrossoverWarning, detail);
+        labelCrossoverWarning.Visible = true;
+    }
+
+    private void HideWarning()
+    {
+        labelCrossoverWarning.Visible = false;
+        toolTip.SetToolTip(labelCrossoverWarning, string.Empty);
+    }
+
+    // Amber for the gate: it says the view cannot be read yet, not that the
+    // tuning is wrong. The crossover spread keeps the red it always had.
+    private static readonly Color GateWarningColor = Color.FromArgb(230, 184, 0);
+    private static readonly Color CrossoverWarningColor = Color.FromArgb(235, 110, 95);
+
     // The spread of alignment delays, above which the setup is flagged. A driver
     // whose crossover has pathological group delay (a narrow or steep low-
     // frequency band-pass) arrives so late that Auto delay must push every other
@@ -2266,7 +2312,7 @@ public partial class VirtualCrossoverPanel : UserControl
             .ToList();
         if (active.Count < 2)
         {
-            labelCrossoverWarning.Visible = false;
+            HideWarning();
             return;
         }
 
@@ -2277,21 +2323,18 @@ public partial class VirtualCrossoverPanel : UserControl
         double spread = earliestDelay - latest.Channel.Settings.DelayMs;
         if (spread <= CrossoverGroupDelayWarningMs)
         {
-            labelCrossoverWarning.Visible = false;
-            toolTip.SetToolTip(labelCrossoverWarning, string.Empty);
+            HideWarning();
             return;
         }
 
         string name = latest.Channel.Name;
-        labelCrossoverWarning.Text =
-            $"⚠ {name} lags the others by ~{spread:0} ms — check its crossover.";
-        toolTip.SetToolTip(
-            labelCrossoverWarning,
+        ShowWarning(
+            $"⚠ {name} lags the others by ~{spread:0} ms — check its crossover.",
             $"{name} arrives ~{spread:0} ms after the other drivers, so Auto delay pushes " +
             "them out by that much to match it.\r\n\r\n" +
             "This is usually excessive crossover group delay — a narrow or steep low-frequency " +
-            "band-pass. Reduce its slope or widen its band to bring the alignment delays down.");
-        labelCrossoverWarning.Visible = true;
+            "band-pass. Reduce its slope or widen its band to bring the alignment delays down.",
+            CrossoverWarningColor);
     }
 
     // The two alignment stages, their tuning constants and the selection
@@ -2363,6 +2406,11 @@ public partial class VirtualCrossoverPanel : UserControl
                 string.Join(", ", bypassed.Select(channel => channel.Name)) +
                 ".\r\n\r\nDisable Bypass on every participating channel " +
                 "(or mute the channel to exclude it) and run Auto delay again.");
+            return;
+        }
+
+        if (RefuseOnMisplacedGate("Auto delay"))
+        {
             return;
         }
 
@@ -2888,6 +2936,14 @@ public partial class VirtualCrossoverPanel : UserControl
                 string.Join(", ", bypassed.Select(item => item.Name)) +
                 ".\r\n\r\nDisable Bypass on every participating channel " +
                 "(or mute the channel to exclude it) and run Auto delay again.");
+            return;
+        }
+
+        // The verdict describes the side on screen; the detail text says so and
+        // asks for the other one to be checked after switching, because only
+        // the shown side's channels have been processed to judge it against.
+        if (RefuseOnMisplacedGate("Auto delay"))
+        {
             return;
         }
 
@@ -3519,10 +3575,13 @@ public partial class VirtualCrossoverPanel : UserControl
         : ActiveGate.OffsetMs;
 
     /// <summary>
-    /// The ceiling on <see cref="DataHelper.GateLeadingEdgeLossDb"/> for a
-    /// per-curve phase window: above it the window is cutting into its own
-    /// channel's leading edge and the curve stops being comparable with its
-    /// neighbours.
+    /// The ceiling on <see cref="DataHelper.GateLeadingEdgeLossDb"/>: above it
+    /// a window is cutting into its channel's leading edge, and the curve stops
+    /// describing that channel — it starts describing what came after it.
+    /// Two placements are put to this figure: whether a phase curve may take
+    /// its own window (<see cref="AllowsPerCurvePhaseGate"/>) and whether the
+    /// window in use holds the channels at all
+    /// (<see cref="JudgeGatePlacement"/>).
     /// <para>
     /// Measured on the v5 field session (four processed channels, gate
     /// 5/50/20 ms): windows placed on each channel's own arrival START read
@@ -3531,8 +3590,15 @@ public partial class VirtualCrossoverPanel : UserControl
     /// to nearly half of a steeply low-passed channel's own energy. -20 dB
     /// sits in the middle of that 17.6 dB gap.
     /// </para>
+    /// <para>
+    /// The Passat session put the other end on the scale: a 15.06 ms gate
+    /// inherited from another car's project, against processed arrivals at
+    /// 4.10 to 5.97 ms, read +1.0 to +15.2 dB — at the top of that range the
+    /// window discards thirty times the energy it keeps — while the same
+    /// channels gated on their own arrivals read -42.9 to -55.0 dB.
+    /// </para>
     /// </summary>
-    private const double MaxPhaseGateLeadingEdgeLossDb = -20.0;
+    private const double MaxGateLeadingEdgeLossDb = -20.0;
 
     /// <summary>
     /// Whether a per-curve window may be used for a channel, from what it
@@ -3553,7 +3619,7 @@ public partial class VirtualCrossoverPanel : UserControl
     internal static bool AllowsPerCurvePhaseGate(
         double perCurveLossDb,
         double sharedLossDb) =>
-        perCurveLossDb <= MaxPhaseGateLeadingEdgeLossDb ||
+        perCurveLossDb <= MaxGateLeadingEdgeLossDb ||
         perCurveLossDb <= sharedLossDb;
 
     /// <summary>
@@ -3625,6 +3691,189 @@ public partial class VirtualCrossoverPanel : UserControl
         int sampleRate) =>
         processed.Min(item => TransferIrStartCache.ResolveStartMs(
             item.ImpulseResponse, sampleRate, item.PeakIndex));
+
+    /// <summary>
+    /// One channel the gate placement cuts into: its label, where its response
+    /// starts (ms) and what the window throws away ahead of its plateau
+    /// (<see cref="DataHelper.GateLeadingEdgeLossDb"/>, dB).
+    /// </summary>
+    internal readonly record struct GateCutChannel(
+        string Name,
+        double StartMs,
+        double LeadingEdgeLossDb);
+
+    /// <summary>
+    /// The window the side on screen is actually gated at, judged against the
+    /// channels it windows: where its plateau starts, whether that placement is
+    /// pinned or Auto, where Auto would put it, and the channels it cuts into.
+    /// </summary>
+    internal sealed record GatePlacementVerdict(
+        double OffsetMs,
+        bool Pinned,
+        bool RightSide,
+        double AutoOffsetMs,
+        IReadOnlyList<GateCutChannel> Cut)
+    {
+        public bool CutsChannels => Cut.Count > 0;
+
+        public string SideLabel => RightSide ? "R" : "L";
+    }
+
+    /// <summary>
+    /// Judges the magnitude view's window against every processed channel: the
+    /// gate is an ABSOLUTE time, so a placement that belonged to one set of
+    /// measurements windows the reverberant tail of the next set instead of
+    /// their response — and nothing about a channel's curve says so, because a
+    /// tail has a magnitude too. The magnitude placement is the one judged
+    /// (mirroring <see cref="VirtualCrossoverMetrics.BuildCurves"/>'s shared
+    /// anchor): it is what the drawn curves, the Sum and the sum-loss read-out
+    /// are built from, and it is never the earlier of the two — it anchors on
+    /// the earliest processed PEAK where the phase view's shared placement
+    /// anchors on the earliest estimated START — so a magnitude window that
+    /// opens in time answers for that one as well. The phase view's per-curve
+    /// placements keep their own guard in
+    /// <see cref="ResolvePhaseGateOffsets"/>.
+    /// </summary>
+    private GatePlacementVerdict? JudgeGatePlacement(
+        IReadOnlyList<ProcessedChannel> processed)
+    {
+        if (processed.Count == 0)
+        {
+            return null;
+        }
+
+        MagnitudeGateSnapshot snapshot = magnitudeGate;
+        int sampleRate = processed[0].Channel.SampleRate;
+        double offsetMs = snapshot.ResolveGateOffsetMs(
+            oppositeSide: false, processed.Min(item => item.PeakIndex), sampleRate);
+        var cut = new List<GateCutChannel>();
+        foreach (ProcessedChannel item in processed)
+        {
+            double startMs = TransferIrStartCache.ResolveStartMs(
+                item.ImpulseResponse, sampleRate, item.PeakIndex);
+            var view = new ImpulseMeasurementView(item.ImpulseResponse, 0, sampleRate);
+            double lossDb = Loss(offsetMs);
+            if (GateCutsChannel(startMs, offsetMs, lossDb, Loss(startMs)))
+            {
+                cut.Add(new GateCutChannel(item.Channel.Name, startMs, lossDb));
+            }
+
+            double Loss(double placementMs) => DataHelper.GateLeadingEdgeLossDb(
+                view,
+                placementMs,
+                snapshot.Template.LeftMs,
+                snapshot.Template.PlateauMs,
+                snapshot.Template.RightMs);
+        }
+
+        return new GatePlacementVerdict(
+            offsetMs,
+            snapshot.PinnedOffsetMs is not null,
+            project.ActiveSideRight,
+            EarliestStartMs(processed, sampleRate),
+            cut);
+    }
+
+    /// <summary>
+    /// Whether the window in use cuts a channel: its front lies outside the
+    /// plateau — the claim the warning makes, so it is a condition — and the
+    /// PLACEMENT is what costs it, which is the same relation
+    /// <see cref="AllowsPerCurvePhaseGate"/> makes, read the other way round:
+    /// over the ceiling, and measurably worse than the same gate on the
+    /// channel's own arrival.
+    /// <para>
+    /// That second half is what keeps a short gate from reading as a
+    /// misplacement. The project default (0.5/4/1.5 ms) cannot hold one period
+    /// of a 55 Hz subwoofer wherever it is placed — the field session read
+    /// -19.4 dB at the channel's own arrival and -19.4 dB at the shared one —
+    /// and a gate the user cannot fix by moving is not something to stop them
+    /// with. The misplacements this catches are 44 to 70 dB apart on that
+    /// comparison.
+    /// </para>
+    /// </summary>
+    internal static bool GateCutsChannel(
+        double startMs,
+        double gateOffsetMs,
+        double placementLossDb,
+        double ownArrivalLossDb) =>
+        startMs < gateOffsetMs &&
+        !AllowsPerCurvePhaseGate(placementLossDb, ownArrivalLossDb);
+
+    // The plot's one-line form of the verdict; the detail below carries the
+    // per-channel figures and what to do about them.
+    internal static string FormatGateCutWarning(GatePlacementVerdict verdict)
+    {
+        string names = string.Join(", ", verdict.Cut.Select(item => item.Name));
+        double earliest = verdict.Cut.Min(item => item.StartMs);
+        double latest = verdict.Cut.Max(item => item.StartMs);
+        string arrivals = verdict.Cut.Count == 1 || Math.Abs(latest - earliest) < 0.005
+            ? $"{earliest:0.00} ms"
+            : $"{earliest:0.00}–{latest:0.00} ms";
+        return $"⚠ {verdict.SideLabel} gate at {verdict.OffsetMs:0.00} ms opens after " +
+            $"{names} arrive ({arrivals}) — those curves read the reverberant tail.";
+    }
+
+    // The tooltip, and the body of the refusal the automatic commands show:
+    // the same explanation either way, so the plot and the dialogs cannot
+    // describe the same placement differently.
+    internal static string FormatGateCutDetail(GatePlacementVerdict verdict)
+    {
+        var text = new System.Text.StringBuilder();
+        text.Append($"The gate's plateau starts at {verdict.OffsetMs:0.00} ms, but these ")
+            .Append("channels arrive before it, so their curves — and the sum-loss ")
+            .Append("read-out built from them — are made of the reverberant tail ")
+            .AppendLine("instead of the response:")
+            .AppendLine();
+        foreach (GateCutChannel item in verdict.Cut)
+        {
+            text.AppendLine(
+                $"    {item.Name} — arrives {item.StartMs:0.00} ms, leading-edge loss " +
+                FormatLeadingEdgeLossDb(item.LeadingEdgeLossDb));
+        }
+
+        text.AppendLine()
+            .Append("(Leading-edge loss is what the window throws away ahead of its ")
+            .Append("plateau against what it keeps, so ")
+            .Append($"{MaxGateLeadingEdgeLossDb:0} dB is already the ceiling.)")
+            .AppendLine()
+            .AppendLine();
+        text.Append(verdict.Pinned
+            ? "Open Gate… and press Auto: the window then follows this side's " +
+                $"earliest arrival, {verdict.AutoOffsetMs:0.00} ms."
+            : "The gate is on Auto and still lands there, which means a shoulder too " +
+                "short for these arrivals: widen the left fade in Gate…, or check what " +
+                "those channels' sources hold ahead of their front.");
+        text.Append(" Each side keeps its own gate placement, so the one fitted on ")
+            .Append(verdict.SideLabel)
+            .Append(" says nothing about ")
+            .Append(verdict.RightSide ? "L" : "R")
+            .Append(" — switch sides and check it too.");
+        return text.ToString();
+    }
+
+    // A window that holds none of the channel at all reads as infinite loss;
+    // printing "∞ dB" beats a number nobody can place.
+    private static string FormatLeadingEdgeLossDb(double lossDb) =>
+        double.IsFinite(lossDb) ? $"{lossDb:+0.0;-0.0} dB" : "∞ (the window holds none of it)";
+
+    // Refuses an automatic command while the side on screen is gated on a
+    // window that opens after its own channels arrive. Neither search reads the
+    // gate itself, but both are judged on what it produces — the curves, the
+    // sum-loss read-out and (for Auto delay) the outcome metric written into
+    // the alignment log — so a run started here can only be verified against a
+    // view of the reverberant tail.
+    private bool RefuseOnMisplacedGate(string command)
+    {
+        if (gatePlacement is not { CutsChannels: true } verdict)
+        {
+            return false;
+        }
+
+        ShowError(
+            $"{command} cannot run while the {verdict.SideLabel} side's gate is misplaced.",
+            FormatGateCutDetail(verdict));
+        return true;
+    }
 
     // The τ detrend follows the same pattern: unconfigured projects reference
     // the earliest arrival. One τ serves every curve, so their relative phase —
@@ -4201,6 +4450,15 @@ public partial class VirtualCrossoverPanel : UserControl
         if (participating.Count < 2)
         {
             System.Media.SystemSounds.Beep.Play();
+            return;
+        }
+
+        // The band read below is gate-independent (it windows each raw response
+        // on its own peak), but the proposal it writes is checked on the plot
+        // and in the sum-loss read-out, both of which the gate builds — so a
+        // misplaced window still has to be dealt with before the wizard runs.
+        if (RefuseOnMisplacedGate("Auto crossover"))
+        {
             return;
         }
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3777,9 +3777,8 @@ public partial class VirtualCrossoverPanel : UserControl
     /// <summary>
     /// Whether the window in use cuts a channel: its front lies outside the
     /// plateau — the claim the warning makes, so it is a condition — and the
-    /// PLACEMENT is what costs it, which is the same relation
-    /// <see cref="AllowsPerCurvePhaseGate"/> makes, read the other way round:
-    /// over the ceiling, and measurably worse than the same gate on the
+    /// PLACEMENT is what costs it — over the ceiling, and worse by
+    /// <see cref="GateMisplacementMarginDb"/> than the same gate on the
     /// channel's own arrival.
     /// <para>
     /// That second half is what keeps a short gate from reading as a
@@ -3787,8 +3786,11 @@ public partial class VirtualCrossoverPanel : UserControl
     /// of a 55 Hz subwoofer wherever it is placed — the field session read
     /// -19.4 dB at the channel's own arrival and -19.4 dB at the shared one —
     /// and a gate the user cannot fix by moving is not something to stop them
-    /// with. The misplacements this catches are 44 to 70 dB apart on that
-    /// comparison.
+    /// with. <see cref="AllowsPerCurvePhaseGate"/> makes the same comparison
+    /// with no margin at all, which is right THERE: its penalty for reading a
+    /// hair's difference as significant is one curve falling back to the shared
+    /// window. Here the penalty is an amber line and two refused commands, so
+    /// the difference has to be one the user can act on.
     /// </para>
     /// </summary>
     internal static bool GateCutsChannel(
@@ -3797,7 +3799,19 @@ public partial class VirtualCrossoverPanel : UserControl
         double placementLossDb,
         double ownArrivalLossDb) =>
         startMs < gateOffsetMs &&
-        !AllowsPerCurvePhaseGate(placementLossDb, ownArrivalLossDb);
+        placementLossDb > MaxGateLeadingEdgeLossDb &&
+        placementLossDb > ownArrivalLossDb + GateMisplacementMarginDb;
+
+    /// <summary>
+    /// How much worse than the channel's own arrival a placement has to read
+    /// before it counts as misplaced: 3 dB, the window discarding twice the
+    /// energy that moving it would. Nothing separates a short gate from a
+    /// misplaced one by a hair — the field misplacements are 44 to 70 dB apart
+    /// on this comparison and the short-gate case is 0.0 dB apart, so the
+    /// margin only has to be clear of arithmetic noise between two nearby
+    /// offsets.
+    /// </summary>
+    private const double GateMisplacementMarginDb = 3.0;
 
     // The plot's one-line form of the verdict; the detail below carries the
     // per-channel figures and what to do about them.

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3692,31 +3692,54 @@ public partial class VirtualCrossoverPanel : UserControl
         processed.Min(item => TransferIrStartCache.ResolveStartMs(
             item.ImpulseResponse, sampleRate, item.PeakIndex));
 
+    /// <summary>Which way the window fails a channel.</summary>
+    internal enum GateCutKind
+    {
+        /// <summary>
+        /// It opens after the channel's front, so the curve is built from
+        /// whatever came after the response.
+        /// </summary>
+        OpensAfterArrival,
+
+        /// <summary>
+        /// It is over before the channel arrives, so the curve holds none of
+        /// the channel at all.
+        /// </summary>
+        ClosesBeforeArrival
+    }
+
     /// <summary>
-    /// One channel the gate placement cuts into: its label, where its response
-    /// starts (ms) and what the window throws away ahead of its plateau
-    /// (<see cref="DataHelper.GateLeadingEdgeLossDb"/>, dB).
+    /// One channel the gate placement fails: its label, where its response
+    /// starts (ms), which way the window misses it and what the window throws
+    /// away ahead of its plateau
+    /// (<see cref="DataHelper.GateLeadingEdgeLossDb"/>, dB — meaningful for
+    /// <see cref="GateCutKind.OpensAfterArrival"/> only).
     /// </summary>
     internal readonly record struct GateCutChannel(
         string Name,
         double StartMs,
+        GateCutKind Kind,
         double LeadingEdgeLossDb);
 
     /// <summary>
     /// The window the side on screen is actually gated at, judged against the
-    /// channels it windows: where its plateau starts, whether that placement is
-    /// pinned or Auto, where Auto would put it, and the channels it cuts into.
+    /// channels it windows: where its plateau starts and ends, whether the
+    /// placement is pinned or Auto, and the channels it fails.
     /// </summary>
     internal sealed record GatePlacementVerdict(
         double OffsetMs,
+        double PlateauMs,
         bool Pinned,
         bool RightSide,
-        double AutoOffsetMs,
         IReadOnlyList<GateCutChannel> Cut)
     {
         public bool CutsChannels => Cut.Count > 0;
 
         public string SideLabel => RightSide ? "R" : "L";
+
+        public double PlateauEndMs => OffsetMs + PlateauMs;
+
+        public bool Any(GateCutKind kind) => Cut.Any(item => item.Kind == kind);
     }
 
     /// <summary>
@@ -3753,9 +3776,14 @@ public partial class VirtualCrossoverPanel : UserControl
                 item.ImpulseResponse, sampleRate, item.PeakIndex);
             var view = new ImpulseMeasurementView(item.ImpulseResponse, 0, sampleRate);
             double lossDb = Loss(offsetMs);
-            if (GateCutsChannel(startMs, offsetMs, lossDb, Loss(startMs)))
+            if (JudgeGateCut(
+                    startMs,
+                    offsetMs,
+                    snapshot.Template.PlateauMs,
+                    lossDb,
+                    Loss(startMs)) is { } kind)
             {
-                cut.Add(new GateCutChannel(item.Channel.Name, startMs, lossDb));
+                cut.Add(new GateCutChannel(item.Channel.Name, startMs, kind, lossDb));
             }
 
             double Loss(double placementMs) => DataHelper.GateLeadingEdgeLossDb(
@@ -3768,39 +3796,62 @@ public partial class VirtualCrossoverPanel : UserControl
 
         return new GatePlacementVerdict(
             offsetMs,
+            snapshot.Template.PlateauMs,
             snapshot.PinnedOffsetMs is not null,
             project.ActiveSideRight,
-            EarliestStartMs(processed, sampleRate),
             cut);
     }
 
     /// <summary>
-    /// Whether the window in use cuts a channel: its front lies outside the
-    /// plateau — the claim the warning makes, so it is a condition — and the
-    /// PLACEMENT is what costs it — over the ceiling, and worse by
-    /// <see cref="GateMisplacementMarginDb"/> than the same gate on the
-    /// channel's own arrival.
+    /// How the window in use fails a channel, or null when it holds it.
+    /// A window has two ways to miss: it can open after the channel's front,
+    /// or be over before the channel arrives at all.
     /// <para>
-    /// That second half is what keeps a short gate from reading as a
-    /// misplacement. The project default (0.5/4/1.5 ms) cannot hold one period
-    /// of a 55 Hz subwoofer wherever it is placed — the field session read
+    /// The two are judged differently BECAUSE the leading-edge figure only
+    /// answers the first. It is a ratio of what the window discards ahead of
+    /// its plateau to what it keeps, and a channel that lands past the window
+    /// has nothing ahead of that plateau either — so it reads not as bad but
+    /// as EXCELLENT. Measured: a tweeter delayed 20 ms out of a 4 ms plateau
+    /// reads -282 dB there, the best figure of any channel in that session,
+    /// with its curve holding none of the channel. (The +∞ that
+    /// <see cref="DataHelper.GateLeadingEdgeLossDb"/> reserves for "the window
+    /// kept nothing" needs a bit-for-bit silent window, which a measured record
+    /// does not give.) So the far side is decided on the window's geometry
+    /// instead: the channel's front has to be inside the plateau.
+    /// </para>
+    /// <para>
+    /// The near side is the placement question: over the ceiling, and worse by
+    /// <see cref="GateMisplacementMarginDb"/> than the same gate on the
+    /// channel's own arrival. That comparison is what keeps a short gate from
+    /// reading as a misplacement — the project default cannot hold one period
+    /// of a 55 Hz subwoofer wherever it is placed, and the field session read
     /// -19.4 dB at the channel's own arrival and -19.4 dB at the shared one —
-    /// and a gate the user cannot fix by moving is not something to stop them
-    /// with. <see cref="AllowsPerCurvePhaseGate"/> makes the same comparison
-    /// with no margin at all, which is right THERE: its penalty for reading a
-    /// hair's difference as significant is one curve falling back to the shared
-    /// window. Here the penalty is an amber line and two refused commands, so
-    /// the difference has to be one the user can act on.
+    /// because a gate the user cannot fix by moving is not something to stop
+    /// them with. <see cref="AllowsPerCurvePhaseGate"/> makes the same
+    /// comparison with no margin at all, which is right THERE: its penalty for
+    /// reading a hair's difference as significant is one curve falling back to
+    /// the shared window. Here the penalty is an amber line and two refused
+    /// commands, so the difference has to be one the user can act on.
     /// </para>
     /// </summary>
-    internal static bool GateCutsChannel(
+    internal static GateCutKind? JudgeGateCut(
         double startMs,
         double gateOffsetMs,
+        double plateauMs,
         double placementLossDb,
-        double ownArrivalLossDb) =>
-        startMs < gateOffsetMs &&
-        placementLossDb > MaxGateLeadingEdgeLossDb &&
-        placementLossDb > ownArrivalLossDb + GateMisplacementMarginDb;
+        double ownArrivalLossDb)
+    {
+        if (startMs > gateOffsetMs + plateauMs)
+        {
+            return GateCutKind.ClosesBeforeArrival;
+        }
+
+        return startMs < gateOffsetMs &&
+            placementLossDb > MaxGateLeadingEdgeLossDb &&
+            placementLossDb > ownArrivalLossDb + GateMisplacementMarginDb
+                ? GateCutKind.OpensAfterArrival
+                : null;
+    }
 
     /// <summary>
     /// How much worse than the channel's own arrival a placement has to read
@@ -3814,17 +3865,37 @@ public partial class VirtualCrossoverPanel : UserControl
     private const double GateMisplacementMarginDb = 3.0;
 
     // The plot's one-line form of the verdict; the detail below carries the
-    // per-channel figures and what to do about them.
+    // per-channel figures and what to do about them. The two ways a window
+    // misses produce different curves — the tail of the response, or none of
+    // it — so the line says which one the reader is looking at.
     internal static string FormatGateCutWarning(GatePlacementVerdict verdict)
     {
         string names = string.Join(", ", verdict.Cut.Select(item => item.Name));
         double earliest = verdict.Cut.Min(item => item.StartMs);
         double latest = verdict.Cut.Max(item => item.StartMs);
-        string arrivals = verdict.Cut.Count == 1 || Math.Abs(latest - earliest) < 0.005
+        bool one = verdict.Cut.Count == 1;
+        string arrivals = one || Math.Abs(latest - earliest) < 0.005
             ? $"{earliest:0.00} ms"
             : $"{earliest:0.00}–{latest:0.00} ms";
-        return $"⚠ {verdict.SideLabel} gate at {verdict.OffsetMs:0.00} ms opens after " +
-            $"{names} arrive ({arrivals}) — those curves read the reverberant tail.";
+        string curves = one ? "that curve reads" : "those curves read";
+        string opening = $"⚠ {verdict.SideLabel} gate at {verdict.OffsetMs:0.00} ms ";
+        if (!verdict.Any(GateCutKind.ClosesBeforeArrival))
+        {
+            return opening +
+                $"opens after {names} {(one ? "arrives" : "arrive")} ({arrivals}) — " +
+                $"{curves} the reverberant tail.";
+        }
+
+        if (!verdict.Any(GateCutKind.OpensAfterArrival))
+        {
+            return opening +
+                $"is over before {names} {(one ? "arrives" : "arrive")} ({arrivals}) — " +
+                $"{(one ? "that curve holds" : "those curves hold")} none of " +
+                $"{(one ? "it" : "them")}.";
+        }
+
+        return opening + $"misses {names} (arriving {arrivals}) — " +
+            $"{(one ? "that curve is" : "those curves are")} not the response.";
     }
 
     // The tooltip, and the body of the refusal the automatic commands show:
@@ -3832,32 +3903,57 @@ public partial class VirtualCrossoverPanel : UserControl
     // describe the same placement differently.
     internal static string FormatGateCutDetail(GatePlacementVerdict verdict)
     {
+        bool opensLate = verdict.Any(GateCutKind.OpensAfterArrival);
+        bool closesEarly = verdict.Any(GateCutKind.ClosesBeforeArrival);
         var text = new System.Text.StringBuilder();
-        text.Append($"The gate's plateau starts at {verdict.OffsetMs:0.00} ms, but these ")
-            .Append("channels arrive before it, so their curves — and the sum-loss ")
-            .Append("read-out built from them — are made of the reverberant tail ")
-            .AppendLine("instead of the response:")
+        text.Append($"The gate's plateau runs from {verdict.OffsetMs:0.00} to ")
+            .Append($"{verdict.PlateauEndMs:0.00} ms, and these channels fall outside it, ")
+            .Append("so their curves — and the sum-loss read-out built from them — do ")
+            .AppendLine("not describe the drivers:")
             .AppendLine();
         foreach (GateCutChannel item in verdict.Cut)
         {
-            text.AppendLine(
-                $"    {item.Name} — arrives {item.StartMs:0.00} ms, leading-edge loss " +
-                FormatLeadingEdgeLossDb(item.LeadingEdgeLossDb));
+            text.AppendLine(item.Kind == GateCutKind.OpensAfterArrival
+                ? $"    {item.Name} — arrives {item.StartMs:0.00} ms, ahead of the plateau; " +
+                    "the curve is the reverberant tail, leading-edge loss " +
+                    FormatLeadingEdgeLossDb(item.LeadingEdgeLossDb)
+                : $"    {item.Name} — arrives {item.StartMs:0.00} ms, after the plateau " +
+                    "ends; the window is over before it starts and its curve holds " +
+                    "none of it");
         }
 
-        text.AppendLine()
-            .Append("(Leading-edge loss is what the window throws away ahead of its ")
-            .Append("plateau against what it keeps, so ")
-            .Append($"{MaxGateLeadingEdgeLossDb:0} dB is already the ceiling.)")
-            .AppendLine()
-            .AppendLine();
-        text.Append(verdict.Pinned
-            ? "Open Gate… and press Auto: the window then follows this side's " +
-                $"earliest arrival, {verdict.AutoOffsetMs:0.00} ms."
-            : "The gate is on Auto and still lands there, which means a shoulder too " +
-                "short for these arrivals: widen the left fade in Gate…, or check what " +
-                "those channels' sources hold ahead of their front.");
-        text.Append(" Each side keeps its own gate placement, so the one fitted on ")
+        if (opensLate)
+        {
+            text.AppendLine()
+                .Append("(Leading-edge loss is what the window throws away ahead of its ")
+                .Append("plateau against what it keeps, so ")
+                .Append($"{MaxGateLeadingEdgeLossDb:0} dB is already the ceiling.)")
+                .AppendLine();
+        }
+
+        text.AppendLine();
+        if (opensLate)
+        {
+            text.Append(verdict.Pinned
+                ? "Open Gate… and press Auto: the window then follows this side's own " +
+                    "earliest arrival instead of a time fixed to other measurements. "
+                : "The gate is on Auto and still opens late, which means a shoulder too " +
+                    "short for these arrivals: widen the left fade in Gate…, or check " +
+                    "what those channels' sources hold ahead of their front. ");
+        }
+
+        if (closesEarly)
+        {
+            double latest = verdict.Cut
+                .Where(item => item.Kind == GateCutKind.ClosesBeforeArrival)
+                .Max(item => item.StartMs);
+            text.Append(opensLate ? "The window also has to be " : "The window has to be ")
+                .Append("long enough to reach them: raise the ")
+                .Append($"plateau in Gate… until it covers {latest:0.00} ms, or take the ")
+                .Append("delay that pushes them out of it back. ");
+        }
+
+        text.Append("Each side keeps its own gate placement, so the one fitted on ")
             .Append(verdict.SideLabel)
             .Append(" says nothing about ")
             .Append(verdict.RightSide ? "L" : "R")

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3729,6 +3729,7 @@ public partial class VirtualCrossoverPanel : UserControl
     internal sealed record GatePlacementVerdict(
         double OffsetMs,
         double PlateauMs,
+        double RightMs,
         bool Pinned,
         bool RightSide,
         IReadOnlyList<GateCutChannel> Cut)
@@ -3738,6 +3739,13 @@ public partial class VirtualCrossoverPanel : UserControl
         public string SideLabel => RightSide ? "R" : "L";
 
         public double PlateauEndMs => OffsetMs + PlateauMs;
+
+        /// <summary>
+        /// Where the Tukey window reaches zero: the plateau plus the fade-out
+        /// behind it. Content between <see cref="PlateauEndMs"/> and here is
+        /// attenuated, not absent.
+        /// </summary>
+        public double WindowEndMs => PlateauEndMs + RightMs;
 
         public bool Any(GateCutKind kind) => Cut.Any(item => item.Kind == kind);
     }
@@ -3780,6 +3788,7 @@ public partial class VirtualCrossoverPanel : UserControl
                     startMs,
                     offsetMs,
                     snapshot.Template.PlateauMs,
+                    snapshot.Template.RightMs,
                     lossDb,
                     Loss(startMs)) is { } kind)
             {
@@ -3797,6 +3806,7 @@ public partial class VirtualCrossoverPanel : UserControl
         return new GatePlacementVerdict(
             offsetMs,
             snapshot.Template.PlateauMs,
+            snapshot.Template.RightMs,
             snapshot.PinnedOffsetMs is not null,
             project.ActiveSideRight,
             cut);
@@ -3817,7 +3827,13 @@ public partial class VirtualCrossoverPanel : UserControl
     /// <see cref="DataHelper.GateLeadingEdgeLossDb"/> reserves for "the window
     /// kept nothing" needs a bit-for-bit silent window, which a measured record
     /// does not give.) So the far side is decided on the window's geometry
-    /// instead: the channel's front has to be inside the plateau.
+    /// instead: the channel's front has to be inside the window — the plateau
+    /// AND the fade-out behind it, because the fade starts at unity and a
+    /// front just past the plateau is attenuated, not missing. How far into a
+    /// fade a front may land before the curve stops describing the channel is
+    /// a continuum this deliberately does not judge: nothing measured says
+    /// where in it to draw a line, and the end of the window is the one place
+    /// the answer is not a matter of degree.
     /// </para>
     /// <para>
     /// The near side is the placement question: over the ceiling, and worse by
@@ -3838,10 +3854,11 @@ public partial class VirtualCrossoverPanel : UserControl
         double startMs,
         double gateOffsetMs,
         double plateauMs,
+        double rightMs,
         double placementLossDb,
         double ownArrivalLossDb)
     {
-        if (startMs > gateOffsetMs + plateauMs)
+        if (startMs >= gateOffsetMs + plateauMs + rightMs)
         {
             return GateCutKind.ClosesBeforeArrival;
         }
@@ -3905,11 +3922,21 @@ public partial class VirtualCrossoverPanel : UserControl
     {
         bool opensLate = verdict.Any(GateCutKind.OpensAfterArrival);
         bool closesEarly = verdict.Any(GateCutKind.ClosesBeforeArrival);
+        bool one = verdict.Cut.Count == 1;
         var text = new System.Text.StringBuilder();
         text.Append($"The gate's plateau runs from {verdict.OffsetMs:0.00} to ")
-            .Append($"{verdict.PlateauEndMs:0.00} ms, and these channels fall outside it, ")
-            .Append("so their curves — and the sum-loss read-out built from them — do ")
-            .AppendLine("not describe the drivers:")
+            .Append($"{verdict.PlateauEndMs:0.00} ms")
+            // The fade-out only matters to the reader when a channel fell off
+            // the far end: that is the edge it was measured against.
+            .Append(closesEarly
+                ? $", with its fade-out over at {verdict.WindowEndMs:0.00} ms, "
+                : ", ")
+            .Append(one
+                ? "and this channel falls outside it, so its curve — and the sum-loss " +
+                    "read-out built from it — does not describe the driver:"
+                : "and these channels fall outside it, so their curves — and the " +
+                    "sum-loss read-out built from them — do not describe the drivers:")
+            .AppendLine()
             .AppendLine();
         foreach (GateCutChannel item in verdict.Cut)
         {
@@ -3917,9 +3944,9 @@ public partial class VirtualCrossoverPanel : UserControl
                 ? $"    {item.Name} — arrives {item.StartMs:0.00} ms, ahead of the plateau; " +
                     "the curve is the reverberant tail, leading-edge loss " +
                     FormatLeadingEdgeLossDb(item.LeadingEdgeLossDb)
-                : $"    {item.Name} — arrives {item.StartMs:0.00} ms, after the plateau " +
-                    "ends; the window is over before it starts and its curve holds " +
-                    "none of it");
+                : $"    {item.Name} — arrives {item.StartMs:0.00} ms, after the window " +
+                    $"closes at {verdict.WindowEndMs:0.00} ms; it is over before the " +
+                    "channel starts and the curve holds none of it");
         }
 
         if (opensLate)
@@ -3948,9 +3975,12 @@ public partial class VirtualCrossoverPanel : UserControl
                 .Where(item => item.Kind == GateCutKind.ClosesBeforeArrival)
                 .Max(item => item.StartMs);
             text.Append(opensLate ? "The window also has to be " : "The window has to be ")
-                .Append("long enough to reach them: raise the ")
-                .Append($"plateau in Gate… until it covers {latest:0.00} ms, or take the ")
-                .Append("delay that pushes them out of it back. ");
+                .Append("long enough to reach ")
+                .Append(one ? "it" : "them")
+                .Append(": raise the plateau in Gate… past ")
+                .Append($"{latest:0.00} ms, or take back the delay that pushes ")
+                .Append(one ? "it" : "them")
+                .Append(" out of the window. ");
         }
 
         text.Append("Each side keeps its own gate placement, so the one fitted on ")

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverGatePlacementWarningTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverGatePlacementWarningTests.cs
@@ -6,14 +6,15 @@ namespace Resonalyze.App.Tests;
 
 /// <summary>
 /// Pins when Virtual DSP reports the window it gates the shown side at as
-/// misplaced, and what it says about it. A gate offset is an ABSOLUTE time, so
-/// it outlives the measurements it was fitted on: the Passat session inherited
-/// 15.06 ms from another car's project and drew every driver's reverberant tail
-/// as its response — at full plausibility, because a tail has a magnitude too,
-/// which is why this has to be reported rather than looked at.
+/// failing its channels, and what it says about it. A gate offset is an
+/// ABSOLUTE time, so it outlives the measurements it was fitted on: the Passat
+/// session inherited 15.06 ms from another car's project and drew every
+/// driver's reverberant tail as its response — at full plausibility, because a
+/// tail has a magnitude too, which is why this has to be reported rather than
+/// looked at.
 /// <para>
 /// Every figure below is what the panel itself computes on that session: the
-/// estimated start of each PROCESSED channel, and
+/// estimated start of each PROCESSED channel and
 /// <see cref="Resonalyze.Dsp.DataHelper.GateLeadingEdgeLossDb"/> at the
 /// placement in use against the same gate on that channel's own arrival
 /// (5/50/20 ms, the gate the session was saved with).
@@ -22,22 +23,32 @@ namespace Resonalyze.App.Tests;
 public sealed class VirtualCrossoverGatePlacementWarningTests
 {
     [Fact]
-    public void AGateInheritedFromAnotherSessionReadsAsCutting()
+    public void AGateInheritedFromAnotherSessionReadsAsOpeningLate()
     {
-        // The right side, pinned at 15.06 ms: midbass, midrange and tweeter all
-        // arrive between 4.1 and 6.0 ms, and the window is 43 to 70 dB worse
+        // The right side, pinned at 15.06 ms: the midbass, midrange and tweeter
+        // all arrive between 4.1 and 6.0 ms, and the window is 43 to 70 dB worse
         // there than on their own arrivals.
-        Assert.True(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 5.967, gateOffsetMs: 15.06, placementLossDb: 1.0, ownArrivalLossDb: -42.9));
-        Assert.True(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 4.101, gateOffsetMs: 15.06, placementLossDb: 9.9, ownArrivalLossDb: -53.7));
-        Assert.True(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 4.119, gateOffsetMs: 15.06, placementLossDb: 15.2, ownArrivalLossDb: -55.0));
+        Assert.Equal(
+            VirtualCrossoverPanel.GateCutKind.OpensAfterArrival,
+            VirtualCrossoverPanel.JudgeGateCut(
+                startMs: 5.967, gateOffsetMs: 15.06, plateauMs: 50.0,
+                placementLossDb: 1.0, ownArrivalLossDb: -42.9));
+        Assert.Equal(
+            VirtualCrossoverPanel.GateCutKind.OpensAfterArrival,
+            VirtualCrossoverPanel.JudgeGateCut(
+                startMs: 4.101, gateOffsetMs: 15.06, plateauMs: 50.0,
+                placementLossDb: 9.9, ownArrivalLossDb: -53.7));
+        Assert.Equal(
+            VirtualCrossoverPanel.GateCutKind.OpensAfterArrival,
+            VirtualCrossoverPanel.JudgeGateCut(
+                startMs: 4.119, gateOffsetMs: 15.06, plateauMs: 50.0,
+                placementLossDb: 15.2, ownArrivalLossDb: -55.0));
         // Not the subwoofer of that same side: its own 65 Hz low-pass delays it
         // to 10.4 ms and smears its front, so the same window discards only
         // -21.3 dB of it. Over the ceiling is the test, not "arrives earlier".
-        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 10.388, gateOffsetMs: 15.06, placementLossDb: -21.3, ownArrivalLossDb: -34.9));
+        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
+            startMs: 10.388, gateOffsetMs: 15.06, plateauMs: 50.0,
+            placementLossDb: -21.3, ownArrivalLossDb: -34.9));
     }
 
     [Fact]
@@ -48,45 +59,82 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
         // start before it — the anchor is a PEAK and their fronts precede it —
         // and one of them is measurably worse there than on its own arrival,
         // which is exactly why the ceiling is the other half of the test.
-        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 2.907, gateOffsetMs: 2.969, placementLossDb: -67.4, ownArrivalLossDb: -68.4));
-        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 2.924, gateOffsetMs: 2.969, placementLossDb: -50.8, ownArrivalLossDb: -63.3));
-        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 4.739, gateOffsetMs: 2.969, placementLossDb: -65.7, ownArrivalLossDb: -50.7));
+        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
+            startMs: 2.907, gateOffsetMs: 2.969, plateauMs: 50.0,
+            placementLossDb: -67.4, ownArrivalLossDb: -68.4));
+        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
+            startMs: 2.924, gateOffsetMs: 2.969, plateauMs: 50.0,
+            placementLossDb: -50.8, ownArrivalLossDb: -63.3));
+        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
+            startMs: 4.739, gateOffsetMs: 2.969, plateauMs: 50.0,
+            placementLossDb: -65.7, ownArrivalLossDb: -50.7));
     }
 
     [Fact]
-    public void AChannelDelayedPastTheGateIsNotFlagged()
+    public void AChannelInsideThePlateauIsNotFlaggedForArrivingLate()
     {
-        // Alignment delays move a driver AFTER the window opens. Nothing of it
-        // lies ahead of the plateau then, which is the placement working, not
-        // failing — flagging it would fire on every aligned setup.
-        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 20.0, gateOffsetMs: 4.125, placementLossDb: -60.0, ownArrivalLossDb: -30.0));
+        // Alignment delays move a driver AFTER the window opens. As long as the
+        // plateau still covers it, nothing of it lies ahead of the window and
+        // nothing is missing behind it — that is the placement working.
+        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
+            startMs: 20.0, gateOffsetMs: 4.125, plateauMs: 50.0,
+            placementLossDb: -60.0, ownArrivalLossDb: -30.0));
+    }
+
+    [Fact]
+    public void AChannelBeyondThePlateauReadsAsAWindowThatClosedTooEarly()
+    {
+        // The same session with the DEFAULT gate (0.5/4/1.5 ms) and its tweeter
+        // delayed 20 ms: the Auto window's plateau is over at 11.11 ms and the
+        // driver lands at 24.12 ms, so its curve holds none of it. The
+        // leading-edge figure not only fails to say so — it reads -282.0 dB
+        // there, the BEST placement figure in that session, because a channel
+        // past the window has nothing ahead of the plateau to lose either. That
+        // is why this side is decided on the window's geometry.
+        Assert.Equal(
+            VirtualCrossoverPanel.GateCutKind.ClosesBeforeArrival,
+            VirtualCrossoverPanel.JudgeGateCut(
+                startMs: 24.119, gateOffsetMs: 7.115, plateauMs: 4.0,
+                placementLossDb: -282.0, ownArrivalLossDb: -55.0));
+        Assert.Equal(
+            VirtualCrossoverPanel.GateCutKind.ClosesBeforeArrival,
+            VirtualCrossoverPanel.JudgeGateCut(
+                startMs: 20.0, gateOffsetMs: 4.125, plateauMs: 4.0,
+                placementLossDb: -60.0, ownArrivalLossDb: -30.0));
+        // The boundary belongs to the plateau: a front on its last sample is
+        // still inside the window.
+        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
+            startMs: 8.125, gateOffsetMs: 4.125, plateauMs: 4.0,
+            placementLossDb: -60.0, ownArrivalLossDb: -30.0));
     }
 
     [Fact]
     public void AGateTooShortForTheChannelIsNotReportedAsAMisplacement()
     {
-        // The v5 session's default gate (0.5/4/1.5 ms) cannot hold one period
-        // of a 55 Hz subwoofer wherever it sits: -19.4 dB at the shared window
-        // and -19.4 dB at the channel's own arrival. Over the ceiling, but no
+        // The v5 session's default gate cannot hold one period of a 55 Hz
+        // subwoofer wherever it sits: -19.4 dB at the shared window and
+        // -19.4 dB at the channel's own arrival. Over the ceiling, but no
         // placement fixes it — reporting it would stop the automatic commands
         // on something moving the gate cannot cure.
-        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 3.0, gateOffsetMs: 4.0, placementLossDb: -19.4, ownArrivalLossDb: -19.4));
+        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
+            startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0,
+            placementLossDb: -19.4, ownArrivalLossDb: -19.4));
         // And two nearby offsets never read bit-identically on a real response,
         // so the margin — not a bare comparison — is what keeps that case out:
         // a hair's difference, and a difference no user can act on, both stay
         // below it.
-        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 3.0, gateOffsetMs: 4.0, placementLossDb: -19.399, ownArrivalLossDb: -19.4));
-        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 3.0, gateOffsetMs: 4.0, placementLossDb: -17.0, ownArrivalLossDb: -19.4));
+        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
+            startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0,
+            placementLossDb: -19.399, ownArrivalLossDb: -19.4));
+        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
+            startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0,
+            placementLossDb: -17.0, ownArrivalLossDb: -19.4));
         // Worse by the margin is a placement problem again.
-        Assert.True(VirtualCrossoverPanel.GateCutsChannel(
-            startMs: 3.0, gateOffsetMs: 4.0, placementLossDb: -12.7, ownArrivalLossDb: -19.4));
+        Assert.Equal(
+            VirtualCrossoverPanel.GateCutKind.OpensAfterArrival,
+            VirtualCrossoverPanel.JudgeGateCut(
+                startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0,
+                placementLossDb: -12.7, ownArrivalLossDb: -19.4));
     }
 
     [Fact]
@@ -101,6 +149,38 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
             // The arrivals as a range, so the line stays one line however many
             // channels the side holds.
             Assert.Contains("4.10–5.97 ms", warning);
+            Assert.Contains("reverberant tail", warning);
+        });
+    }
+
+    [Fact]
+    public void AWindowThatClosedTooEarlySaysThatInsteadOfBlamingTheTail()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            var verdict = new VirtualCrossoverPanel.GatePlacementVerdict(
+                OffsetMs: 4.125,
+                PlateauMs: 4.0,
+                Pinned: false,
+                RightSide: false,
+                Cut: new List<VirtualCrossoverPanel.GateCutChannel>
+                {
+                    new("D", 19.108, VirtualCrossoverPanel.GateCutKind.ClosesBeforeArrival, -2.2)
+                });
+
+            string warning = VirtualCrossoverPanel.FormatGateCutWarning(verdict);
+            // Singular, and the right failure: the curve holds none of the
+            // channel rather than holding the wrong part of it.
+            Assert.Contains("is over before D arrives (19.11 ms)", warning);
+            Assert.Contains("that curve holds none of it", warning);
+
+            string detail = VirtualCrossoverPanel.FormatGateCutDetail(verdict);
+            Assert.Contains("plateau runs from 4.13 to 8.13 ms", detail);
+            Assert.Contains("the window is over before it starts", detail);
+            // A longer window is the fix here; the leading-edge figure has
+            // nothing to say about this one, so it is not quoted.
+            Assert.Contains("until it covers 19.11 ms", detail);
+            Assert.DoesNotContain("leading-edge loss", detail);
         });
     }
 
@@ -111,13 +191,12 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
         {
             string detail = VirtualCrossoverPanel.FormatGateCutDetail(PassatVerdict(pinned: true));
 
-            Assert.Contains("plateau starts at 15.06 ms", detail);
+            Assert.Contains("plateau runs from 15.06 to 65.06 ms", detail);
             Assert.Contains("press Auto", detail);
-            // Where Auto would put it: the figure the user is being asked to accept.
-            Assert.Contains("4.10 ms", detail);
             // Every channel it cuts, with what the window costs that channel.
-            Assert.Contains("C — arrives 4.10 ms, leading-edge loss +9.9 dB", detail);
-            Assert.Contains("D — arrives 4.12 ms, leading-edge loss +15.2 dB", detail);
+            Assert.Contains("C — arrives 4.10 ms, ahead of the plateau", detail);
+            Assert.Contains("leading-edge loss +9.9 dB", detail);
+            Assert.Contains("leading-edge loss +15.2 dB", detail);
             // The other side keeps its own placement, and only the shown side
             // was judged, so the reader is sent to check it.
             Assert.Contains("says nothing about L", detail);
@@ -125,7 +204,7 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
     }
 
     [Fact]
-    public void AnAutoGateThatStillCutsIsToldToWidenTheShoulderInstead()
+    public void AnAutoGateThatStillOpensLateIsToldToWidenTheShoulderInstead()
     {
         RunWithInvariantCulture(() =>
         {
@@ -143,12 +222,13 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
         {
             var verdict = new VirtualCrossoverPanel.GatePlacementVerdict(
                 OffsetMs: 15.06,
+                PlateauMs: 50.0,
                 Pinned: true,
                 RightSide: true,
-                AutoOffsetMs: 4.101,
                 Cut: new List<VirtualCrossoverPanel.GateCutChannel>
                 {
-                    new("D", 4.119, double.PositiveInfinity)
+                    new("D", 4.119, VirtualCrossoverPanel.GateCutKind.OpensAfterArrival,
+                        double.PositiveInfinity)
                 });
 
             Assert.Contains(
@@ -175,13 +255,13 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
     private static VirtualCrossoverPanel.GatePlacementVerdict PassatVerdict(bool pinned) =>
         new(
             OffsetMs: 15.06,
+            PlateauMs: 50.0,
             Pinned: pinned,
             RightSide: true,
-            AutoOffsetMs: 4.101,
             Cut: new List<VirtualCrossoverPanel.GateCutChannel>
             {
-                new("B", 5.967, 1.0),
-                new("C", 4.101, 9.9),
-                new("D", 4.119, 15.2)
+                new("B", 5.967, VirtualCrossoverPanel.GateCutKind.OpensAfterArrival, 1.0),
+                new("C", 4.101, VirtualCrossoverPanel.GateCutKind.OpensAfterArrival, 9.9),
+                new("D", 4.119, VirtualCrossoverPanel.GateCutKind.OpensAfterArrival, 15.2)
             });
 }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverGatePlacementWarningTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverGatePlacementWarningTests.cs
@@ -31,23 +31,23 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
         Assert.Equal(
             VirtualCrossoverPanel.GateCutKind.OpensAfterArrival,
             VirtualCrossoverPanel.JudgeGateCut(
-                startMs: 5.967, gateOffsetMs: 15.06, plateauMs: 50.0,
+                startMs: 5.967, gateOffsetMs: 15.06, plateauMs: 50.0, rightMs: 20.0,
                 placementLossDb: 1.0, ownArrivalLossDb: -42.9));
         Assert.Equal(
             VirtualCrossoverPanel.GateCutKind.OpensAfterArrival,
             VirtualCrossoverPanel.JudgeGateCut(
-                startMs: 4.101, gateOffsetMs: 15.06, plateauMs: 50.0,
+                startMs: 4.101, gateOffsetMs: 15.06, plateauMs: 50.0, rightMs: 20.0,
                 placementLossDb: 9.9, ownArrivalLossDb: -53.7));
         Assert.Equal(
             VirtualCrossoverPanel.GateCutKind.OpensAfterArrival,
             VirtualCrossoverPanel.JudgeGateCut(
-                startMs: 4.119, gateOffsetMs: 15.06, plateauMs: 50.0,
+                startMs: 4.119, gateOffsetMs: 15.06, plateauMs: 50.0, rightMs: 20.0,
                 placementLossDb: 15.2, ownArrivalLossDb: -55.0));
         // Not the subwoofer of that same side: its own 65 Hz low-pass delays it
         // to 10.4 ms and smears its front, so the same window discards only
         // -21.3 dB of it. Over the ceiling is the test, not "arrives earlier".
         Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
-            startMs: 10.388, gateOffsetMs: 15.06, plateauMs: 50.0,
+            startMs: 10.388, gateOffsetMs: 15.06, plateauMs: 50.0, rightMs: 20.0,
             placementLossDb: -21.3, ownArrivalLossDb: -34.9));
     }
 
@@ -60,13 +60,13 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
         // and one of them is measurably worse there than on its own arrival,
         // which is exactly why the ceiling is the other half of the test.
         Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
-            startMs: 2.907, gateOffsetMs: 2.969, plateauMs: 50.0,
+            startMs: 2.907, gateOffsetMs: 2.969, plateauMs: 50.0, rightMs: 20.0,
             placementLossDb: -67.4, ownArrivalLossDb: -68.4));
         Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
-            startMs: 2.924, gateOffsetMs: 2.969, plateauMs: 50.0,
+            startMs: 2.924, gateOffsetMs: 2.969, plateauMs: 50.0, rightMs: 20.0,
             placementLossDb: -50.8, ownArrivalLossDb: -63.3));
         Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
-            startMs: 4.739, gateOffsetMs: 2.969, plateauMs: 50.0,
+            startMs: 4.739, gateOffsetMs: 2.969, plateauMs: 50.0, rightMs: 20.0,
             placementLossDb: -65.7, ownArrivalLossDb: -50.7));
     }
 
@@ -77,16 +77,38 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
         // plateau still covers it, nothing of it lies ahead of the window and
         // nothing is missing behind it — that is the placement working.
         Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
-            startMs: 20.0, gateOffsetMs: 4.125, plateauMs: 50.0,
+            startMs: 20.0, gateOffsetMs: 4.125, plateauMs: 50.0, rightMs: 20.0,
             placementLossDb: -60.0, ownArrivalLossDb: -30.0));
     }
 
     [Fact]
-    public void AChannelBeyondThePlateauReadsAsAWindowThatClosedTooEarly()
+    public void AChannelInsideTheFadeOutIsNotReportedAsMissing()
+    {
+        // The fade-out is part of the window and starts at unity, so a front
+        // just past the plateau is attenuated, not absent — saying the window
+        // is over would be false. The session's own 20 ms shoulder makes the
+        // gap wide: a plateau ending at 8 ms with the window running to 28.
+        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
+            startMs: 9.0, gateOffsetMs: 4.0, plateauMs: 4.0, rightMs: 20.0,
+            placementLossDb: -60.0, ownArrivalLossDb: -30.0));
+        // Right up to the last sample of the fade.
+        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
+            startMs: 9.624, gateOffsetMs: 4.125, plateauMs: 4.0, rightMs: 1.5,
+            placementLossDb: -60.0, ownArrivalLossDb: -30.0));
+        // Where the window reaches zero, it holds none of the channel.
+        Assert.Equal(
+            VirtualCrossoverPanel.GateCutKind.ClosesBeforeArrival,
+            VirtualCrossoverPanel.JudgeGateCut(
+                startMs: 9.625, gateOffsetMs: 4.125, plateauMs: 4.0, rightMs: 1.5,
+                placementLossDb: -60.0, ownArrivalLossDb: -30.0));
+    }
+
+    [Fact]
+    public void AChannelBeyondTheWindowReadsAsAWindowThatClosedTooEarly()
     {
         // The same session with the DEFAULT gate (0.5/4/1.5 ms) and its tweeter
-        // delayed 20 ms: the Auto window's plateau is over at 11.11 ms and the
-        // driver lands at 24.12 ms, so its curve holds none of it. The
+        // delayed 20 ms: the Auto window is over at 12.61 ms and the driver
+        // lands at 24.12 ms, so its curve holds none of it. The
         // leading-edge figure not only fails to say so — it reads -282.0 dB
         // there, the BEST placement figure in that session, because a channel
         // past the window has nothing ahead of the plateau to lose either. That
@@ -94,18 +116,13 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
         Assert.Equal(
             VirtualCrossoverPanel.GateCutKind.ClosesBeforeArrival,
             VirtualCrossoverPanel.JudgeGateCut(
-                startMs: 24.119, gateOffsetMs: 7.115, plateauMs: 4.0,
+                startMs: 24.119, gateOffsetMs: 7.115, plateauMs: 4.0, rightMs: 1.5,
                 placementLossDb: -282.0, ownArrivalLossDb: -55.0));
         Assert.Equal(
             VirtualCrossoverPanel.GateCutKind.ClosesBeforeArrival,
             VirtualCrossoverPanel.JudgeGateCut(
-                startMs: 20.0, gateOffsetMs: 4.125, plateauMs: 4.0,
+                startMs: 20.0, gateOffsetMs: 4.125, plateauMs: 4.0, rightMs: 1.5,
                 placementLossDb: -60.0, ownArrivalLossDb: -30.0));
-        // The boundary belongs to the plateau: a front on its last sample is
-        // still inside the window.
-        Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
-            startMs: 8.125, gateOffsetMs: 4.125, plateauMs: 4.0,
-            placementLossDb: -60.0, ownArrivalLossDb: -30.0));
     }
 
     [Fact]
@@ -117,23 +134,23 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
         // placement fixes it — reporting it would stop the automatic commands
         // on something moving the gate cannot cure.
         Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
-            startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0,
+            startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0, rightMs: 1.5,
             placementLossDb: -19.4, ownArrivalLossDb: -19.4));
         // And two nearby offsets never read bit-identically on a real response,
         // so the margin — not a bare comparison — is what keeps that case out:
         // a hair's difference, and a difference no user can act on, both stay
         // below it.
         Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
-            startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0,
+            startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0, rightMs: 1.5,
             placementLossDb: -19.399, ownArrivalLossDb: -19.4));
         Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
-            startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0,
+            startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0, rightMs: 1.5,
             placementLossDb: -17.0, ownArrivalLossDb: -19.4));
         // Worse by the margin is a placement problem again.
         Assert.Equal(
             VirtualCrossoverPanel.GateCutKind.OpensAfterArrival,
             VirtualCrossoverPanel.JudgeGateCut(
-                startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0,
+                startMs: 3.0, gateOffsetMs: 4.0, plateauMs: 4.0, rightMs: 1.5,
                 placementLossDb: -12.7, ownArrivalLossDb: -19.4));
     }
 
@@ -161,6 +178,7 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
             var verdict = new VirtualCrossoverPanel.GatePlacementVerdict(
                 OffsetMs: 4.125,
                 PlateauMs: 4.0,
+                RightMs: 1.5,
                 Pinned: false,
                 RightSide: false,
                 Cut: new List<VirtualCrossoverPanel.GateCutChannel>
@@ -175,11 +193,14 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
             Assert.Contains("that curve holds none of it", warning);
 
             string detail = VirtualCrossoverPanel.FormatGateCutDetail(verdict);
+            // Both edges, because this channel was judged against the far one:
+            // the plateau's span AND where the fade-out reaches zero.
             Assert.Contains("plateau runs from 4.13 to 8.13 ms", detail);
-            Assert.Contains("the window is over before it starts", detail);
+            Assert.Contains("fade-out over at 9.63 ms", detail);
+            Assert.Contains("after the window closes at 9.63 ms", detail);
             // A longer window is the fix here; the leading-edge figure has
             // nothing to say about this one, so it is not quoted.
-            Assert.Contains("until it covers 19.11 ms", detail);
+            Assert.Contains("raise the plateau in Gate… past 19.11 ms", detail);
             Assert.DoesNotContain("leading-edge loss", detail);
         });
     }
@@ -223,6 +244,7 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
             var verdict = new VirtualCrossoverPanel.GatePlacementVerdict(
                 OffsetMs: 15.06,
                 PlateauMs: 50.0,
+                RightMs: 20.0,
                 Pinned: true,
                 RightSide: true,
                 Cut: new List<VirtualCrossoverPanel.GateCutChannel>
@@ -256,6 +278,7 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
         new(
             OffsetMs: 15.06,
             PlateauMs: 50.0,
+            RightMs: 20.0,
             Pinned: pinned,
             RightSide: true,
             Cut: new List<VirtualCrossoverPanel.GateCutChannel>

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverGatePlacementWarningTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverGatePlacementWarningTests.cs
@@ -76,7 +76,15 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
         // on something moving the gate cannot cure.
         Assert.False(VirtualCrossoverPanel.GateCutsChannel(
             startMs: 3.0, gateOffsetMs: 4.0, placementLossDb: -19.4, ownArrivalLossDb: -19.4));
-        // Measurably worse than its own arrival is a placement problem again.
+        // And two nearby offsets never read bit-identically on a real response,
+        // so the margin — not a bare comparison — is what keeps that case out:
+        // a hair's difference, and a difference no user can act on, both stay
+        // below it.
+        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 3.0, gateOffsetMs: 4.0, placementLossDb: -19.399, ownArrivalLossDb: -19.4));
+        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 3.0, gateOffsetMs: 4.0, placementLossDb: -17.0, ownArrivalLossDb: -19.4));
+        // Worse by the margin is a placement problem again.
         Assert.True(VirtualCrossoverPanel.GateCutsChannel(
             startMs: 3.0, gateOffsetMs: 4.0, placementLossDb: -12.7, ownArrivalLossDb: -19.4));
     }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverGatePlacementWarningTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverGatePlacementWarningTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// Pins when Virtual DSP reports the window it gates the shown side at as
+/// misplaced, and what it says about it. A gate offset is an ABSOLUTE time, so
+/// it outlives the measurements it was fitted on: the Passat session inherited
+/// 15.06 ms from another car's project and drew every driver's reverberant tail
+/// as its response — at full plausibility, because a tail has a magnitude too,
+/// which is why this has to be reported rather than looked at.
+/// <para>
+/// Every figure below is what the panel itself computes on that session: the
+/// estimated start of each PROCESSED channel, and
+/// <see cref="Resonalyze.Dsp.DataHelper.GateLeadingEdgeLossDb"/> at the
+/// placement in use against the same gate on that channel's own arrival
+/// (5/50/20 ms, the gate the session was saved with).
+/// </para>
+/// </summary>
+public sealed class VirtualCrossoverGatePlacementWarningTests
+{
+    [Fact]
+    public void AGateInheritedFromAnotherSessionReadsAsCutting()
+    {
+        // The right side, pinned at 15.06 ms: midbass, midrange and tweeter all
+        // arrive between 4.1 and 6.0 ms, and the window is 43 to 70 dB worse
+        // there than on their own arrivals.
+        Assert.True(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 5.967, gateOffsetMs: 15.06, placementLossDb: 1.0, ownArrivalLossDb: -42.9));
+        Assert.True(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 4.101, gateOffsetMs: 15.06, placementLossDb: 9.9, ownArrivalLossDb: -53.7));
+        Assert.True(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 4.119, gateOffsetMs: 15.06, placementLossDb: 15.2, ownArrivalLossDb: -55.0));
+        // Not the subwoofer of that same side: its own 65 Hz low-pass delays it
+        // to 10.4 ms and smears its front, so the same window discards only
+        // -21.3 dB of it. Over the ceiling is the test, not "arrives earlier".
+        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 10.388, gateOffsetMs: 15.06, placementLossDb: -21.3, ownArrivalLossDb: -34.9));
+    }
+
+    [Fact]
+    public void TheSameSessionOnTheAutoAnchorIsNotFlagged()
+    {
+        // The left side of that session, which was never pinned: the shared
+        // window sits on the earliest processed peak (2.97 ms). Two channels
+        // start before it — the anchor is a PEAK and their fronts precede it —
+        // and one of them is measurably worse there than on its own arrival,
+        // which is exactly why the ceiling is the other half of the test.
+        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 2.907, gateOffsetMs: 2.969, placementLossDb: -67.4, ownArrivalLossDb: -68.4));
+        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 2.924, gateOffsetMs: 2.969, placementLossDb: -50.8, ownArrivalLossDb: -63.3));
+        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 4.739, gateOffsetMs: 2.969, placementLossDb: -65.7, ownArrivalLossDb: -50.7));
+    }
+
+    [Fact]
+    public void AChannelDelayedPastTheGateIsNotFlagged()
+    {
+        // Alignment delays move a driver AFTER the window opens. Nothing of it
+        // lies ahead of the plateau then, which is the placement working, not
+        // failing — flagging it would fire on every aligned setup.
+        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 20.0, gateOffsetMs: 4.125, placementLossDb: -60.0, ownArrivalLossDb: -30.0));
+    }
+
+    [Fact]
+    public void AGateTooShortForTheChannelIsNotReportedAsAMisplacement()
+    {
+        // The v5 session's default gate (0.5/4/1.5 ms) cannot hold one period
+        // of a 55 Hz subwoofer wherever it sits: -19.4 dB at the shared window
+        // and -19.4 dB at the channel's own arrival. Over the ceiling, but no
+        // placement fixes it — reporting it would stop the automatic commands
+        // on something moving the gate cannot cure.
+        Assert.False(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 3.0, gateOffsetMs: 4.0, placementLossDb: -19.4, ownArrivalLossDb: -19.4));
+        // Measurably worse than its own arrival is a placement problem again.
+        Assert.True(VirtualCrossoverPanel.GateCutsChannel(
+            startMs: 3.0, gateOffsetMs: 4.0, placementLossDb: -12.7, ownArrivalLossDb: -19.4));
+    }
+
+    [Fact]
+    public void TheWarningNamesTheSideTheOffsetAndTheChannelsItCuts()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            string warning = VirtualCrossoverPanel.FormatGateCutWarning(PassatVerdict(pinned: true));
+
+            Assert.Contains("R gate at 15.06 ms", warning);
+            Assert.Contains("B, C, D", warning);
+            // The arrivals as a range, so the line stays one line however many
+            // channels the side holds.
+            Assert.Contains("4.10–5.97 ms", warning);
+        });
+    }
+
+    [Fact]
+    public void APinnedGateIsToldToGoBackToAuto()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            string detail = VirtualCrossoverPanel.FormatGateCutDetail(PassatVerdict(pinned: true));
+
+            Assert.Contains("plateau starts at 15.06 ms", detail);
+            Assert.Contains("press Auto", detail);
+            // Where Auto would put it: the figure the user is being asked to accept.
+            Assert.Contains("4.10 ms", detail);
+            // Every channel it cuts, with what the window costs that channel.
+            Assert.Contains("C — arrives 4.10 ms, leading-edge loss +9.9 dB", detail);
+            Assert.Contains("D — arrives 4.12 ms, leading-edge loss +15.2 dB", detail);
+            // The other side keeps its own placement, and only the shown side
+            // was judged, so the reader is sent to check it.
+            Assert.Contains("says nothing about L", detail);
+        });
+    }
+
+    [Fact]
+    public void AnAutoGateThatStillCutsIsToldToWidenTheShoulderInstead()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            string detail = VirtualCrossoverPanel.FormatGateCutDetail(PassatVerdict(pinned: false));
+
+            Assert.DoesNotContain("press Auto", detail);
+            Assert.Contains("widen the left fade", detail);
+        });
+    }
+
+    [Fact]
+    public void AWindowHoldingNoneOfAChannelSaysSoInsteadOfPrintingInfinity()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            var verdict = new VirtualCrossoverPanel.GatePlacementVerdict(
+                OffsetMs: 15.06,
+                Pinned: true,
+                RightSide: true,
+                AutoOffsetMs: 4.101,
+                Cut: new List<VirtualCrossoverPanel.GateCutChannel>
+                {
+                    new("D", 4.119, double.PositiveInfinity)
+                });
+
+            Assert.Contains(
+                "the window holds none of it",
+                VirtualCrossoverPanel.FormatGateCutDetail(verdict));
+        });
+    }
+
+    private static void RunWithInvariantCulture(Action assertions)
+    {
+        CultureInfo previous = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        try
+        {
+            assertions();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    // The verdict the panel produced on the Passat session's right side.
+    private static VirtualCrossoverPanel.GatePlacementVerdict PassatVerdict(bool pinned) =>
+        new(
+            OffsetMs: 15.06,
+            Pinned: pinned,
+            RightSide: true,
+            AutoOffsetMs: 4.101,
+            Cut: new List<VirtualCrossoverPanel.GateCutChannel>
+            {
+                new("B", 5.967, 1.0),
+                new("C", 4.101, 9.9),
+                new("D", 4.119, 15.2)
+            });
+}


### PR DESCRIPTION
## The defect

A pinned gate offset is an **absolute time**, so it outlives the measurements it was fitted on. A session built from a fresh set of records inherited `phaseGateRight.offsetMs = 15.06` from the previous project (the same `L {null, 18.78} / R {15.06, 15.08}` pair is stored in it), while every driver of the new car arrives at 4.1–6.0 ms. The window's left shoulder opens at 10.06 ms and its plateau at 15.06 ms, so each channel's response lies entirely ahead of it and the analysis reads the reverberant tail.

Nothing said so. A tail has a magnitude too, so the curves stay plausible — they just sit 10–25 dB low above 200 Hz and slightly HIGH at 20–40 Hz, where the modal tail outlives the gate. Bypass does not help (it swaps the DSP chain, not the window), and the Raw curve deliberately anchors on its own peak, so it ignores the pin and reads correctly — which makes the pair look like a level bug rather than a window one.

Measured on that session through `DataHelper.GetGatedPrimarySpectrumPair`, 1/6 octave:

| channel | placement | 30 Hz | 200 | 400 | 1600 | 6400 |
|---|---|---|---|---|---|---|
| midrange | own peak (= Raw) | −43.2 | **−9.4** | −18.7 | −22.1 | −24.7 |
| midrange | pinned 15.06 | −31.8 | **−20.9** | −42.7 | −31.3 | −36.9 |
| tweeter | own peak (= Raw) | −73.0 | −63.9 | −33.2 | **−12.4** | −12.3 |
| tweeter | pinned 15.06 | −84.7 | −75.4 | −62.9 | **−27.9** | −30.5 |

## The guard

`JudgeGatePlacement` puts the window the shown side is actually gated at to every processed channel, and `JudgeGateCut` reports the two ways a window can miss one — judged differently, because one instrument cannot answer both.

**It opens after the channel's front.** The placement question: the front lies ahead of the plateau, the leading-edge loss is over the `-20 dB` ceiling, *and* it is worse by at least 3 dB than the same gate on the channel's own arrival. That last margin is what keeps a gate too short to hold a 55 Hz driver (−19.4 dB wherever it sits) from being reported as a misplacement the user cannot fix by moving it — and why the comparison is not the bare one `AllowsPerCurvePhaseGate` makes, whose penalty for reading a hair's difference as significant is one curve falling back to the shared window rather than a refused command.

**It is over before the channel arrives.** Decided on the window's geometry — the front has to be inside the window, plateau AND fade-out, since the fade starts at unity and a front just behind the plateau is attenuated rather than absent. Geometry rather than the leading-edge figure, because that figure not only fails here — it points the wrong way. A channel past the window has nothing ahead of the plateau to lose either, so it scores as the *best* placement on offer: with the default 4 ms plateau and a tweeter delayed 20 ms, that channel measures **−282 dB** while its curve holds none of it. (`GateLeadingEdgeLossDb` reserves +∞ for "kept nothing", but that needs a bit-for-bit silent window, which a measured record does not give.) How far into a fade a front may land before the curve stops describing the channel is a continuum with nothing measured behind it, so it is left unjudged rather than guessed at.

On the reported session the four processed channels read `+1.0 / +9.9 / +15.2 dB` at the pin against `−42.9 / −53.7 / −55.0 dB` on their own arrivals; the subwoofer, delayed to 10.4 ms by its own 65 Hz low-pass, reads `−21.3 dB` and is correctly left alone. The other side, never pinned, reads `−50.8` to `−80.6 dB` and raises nothing.

A misplaced window then:

- draws an amber line under the plot (the existing warning row, which the crossover-spread warning keeps in red — the gate takes priority because it decides whether the curves describe the channels at all), and
- refuses **Auto crossover** and **Auto delay**. Neither search reads the gate itself: the wizard windows each raw response on its own peak and the alignment runs on the IRs through `AlignmentReprocessor`. What the gate builds is what both are *judged* on — the curves, the sum-loss read-out and Auto delay's outcome metric in the alignment log — so the refusal says exactly that. The dialog body and the line's tooltip are one formatter, so the plot and the dialogs cannot describe the same placement differently.

Both messages name which miss the reader has (the tail of the response, or none of it), the channels with their arrivals, the plateau's own span, and that **L and R keep separate placements** — only the shown side's channels are processed, so the other one has to be checked after switching. A window too short to reach a channel asks for a longer plateau; a misplaced one asks for Auto.

## Verification

- `VirtualCrossoverGatePlacementWarningTests` — both misses pinned on real figures from that session (opens-late, closes-early, a front inside the fade-out, and the window's own end), the not-cut cases (a channel inside the plateau, the never-pinned side, the short-gate case and the sub-margin differences), and the message forms.
- Driven end to end through the real panel in a scratchpad harness (loads a session, waits for the redraw, reads the label and the cached verdict): the amber line on the pinned side, nothing on the Auto side, and the closes-early wording on a variant of the same session with the default gate and a 20 ms delay.
- Full suite: 2263 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

