### PR TITLE
Import a REW loopback-referenced impulse response (#90)

### DIFF
--- a/dsp/FractionalSampleShift.cs
+++ b/dsp/FractionalSampleShift.cs
@@ -1,0 +1,103 @@
+using System.Numerics;
+using MathNet.Numerics.IntegralTransforms;
+
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// Moving a signal along its own sample grid by an amount that need not be a whole
+/// sample.
+/// </summary>
+/// <remarks>
+/// Rounding a shift to the nearest sample costs up to half a sample — 5 µs at 96 kHz,
+/// 1.8 mm of path — which is the same order as the arrival times this library resolves,
+/// so anything that places several captures on one grid has to move them exactly. For a
+/// signal band-limited below Nyquist, and a sweep measured to 20 kHz at 96 kHz is one,
+/// a fractional shift is not an approximation at all: a linear phase ramp on the
+/// spectrum is sinc interpolation done exactly, with no kernel truncation to trade off.
+/// </remarks>
+public static class FractionalSampleShift
+{
+    /// <summary>
+    /// <c>y[k] = x[k + shiftSamples]</c> on a circular buffer, the shift given in
+    /// samples and allowed to be fractional. A whole-sample shift is a plain rotation
+    /// and returns the samples bit for bit; a fractional one goes through the spectrum.
+    /// </summary>
+    /// <remarks>
+    /// Circular, not zero-padded, and deliberately so: the caller is re-referencing a
+    /// buffer whose ends already meet — the pre-roll of a deconvolved sweep holds the
+    /// harmonic images that belong at negative time — so what leaves one end is exactly
+    /// what should arrive at the other.
+    /// </remarks>
+    public static double[] AdvanceCircular(IReadOnlyList<double> samples, double shiftSamples)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        if (samples.Count == 0)
+        {
+            throw new ArgumentException("Cannot shift an empty signal.", nameof(samples));
+        }
+
+        if (!double.IsFinite(shiftSamples))
+        {
+            throw new ArgumentException("The shift must be a finite number of samples.", nameof(shiftSamples));
+        }
+
+        int n = samples.Count;
+        int whole = (int)Math.Floor(shiftSamples);
+        double fraction = shiftSamples - whole;
+
+        var rotated = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            int source = (int)(((long)i + whole) % n);
+            if (source < 0)
+            {
+                source += n;
+            }
+
+            rotated[i] = samples[source];
+        }
+
+        // Exactly on the grid: leave the samples untouched rather than send them through
+        // a transform that would only add rounding noise.
+        if (Math.Abs(fraction) < 1e-12)
+        {
+            return rotated;
+        }
+
+        var spectrum = new Complex[n];
+        for (int i = 0; i < n; i++)
+        {
+            spectrum[i] = new Complex(rotated[i], 0.0);
+        }
+
+        Fourier.Forward(spectrum, FourierOptions.Matlab);
+
+        // Advancing by s multiplies bin k by exp(+i2*pi*k*s/n). Only the lower half is
+        // computed and the upper half mirrored, so the result stays real to the last bit
+        // instead of relying on an imaginary residue cancelling.
+        int half = n / 2;
+        for (int k = 1; k < (n + 1) / 2; k++)
+        {
+            Complex ramp = Complex.FromPolarCoordinates(1.0, 2.0 * Math.PI * k * fraction / n);
+            spectrum[k] *= ramp;
+            spectrum[n - k] = Complex.Conjugate(spectrum[k]);
+        }
+
+        if (n % 2 == 0)
+        {
+            // The Nyquist bin has no partner to be the conjugate of: a real signal's
+            // value there is real, and the ramp can only scale it by cos(pi*fraction).
+            spectrum[half] = new Complex(spectrum[half].Real * Math.Cos(Math.PI * fraction), 0.0);
+        }
+
+        Fourier.Inverse(spectrum, FourierOptions.Matlab);
+
+        var shifted = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            shifted[i] = spectrum[i].Real;
+        }
+
+        return shifted;
+    }
+}

--- a/dsp/RewImpulseResponseTextFile.cs
+++ b/dsp/RewImpulseResponseTextFile.cs
@@ -63,6 +63,15 @@ public sealed class RewImpulseResponseTextFile
     public int PeakIndex { get; private init; }
 
     /// <summary>
+    /// The arrival this header implies, in samples: the buffer's peak minus the
+    /// reference. For a loopback-referenced sweep it is the tract's delay, and it is
+    /// positive by physics — the microphone cannot hear the sweep before the reference
+    /// does. A file where it is not is on some other time base; see the refusal in
+    /// <see cref="TryParse"/>.
+    /// </summary>
+    public double ImpliedArrivalSamples => PeakIndex - TimeZeroIndex;
+
+    /// <summary>
     /// REW's peak before normalisation — <em>interpolated</em>, so it sits a little above
     /// the largest sample in the data (0.002 dB on the file this reader was written
     /// against). It is the sub-sample peak, not one of the numbers below it.
@@ -277,10 +286,29 @@ public sealed class RewImpulseResponseTextFile
         }
 
         double timeZero = -startTime * sampleRate;
+        int peakIndexValue = values.TryGetValue("Peak index", out double peakIndex)
+            ? (int)Math.Round(peakIndex)
+            : 0;
         if (!(timeZero >= 0) || timeZero >= samples.Count)
         {
             problem = $"t = 0 falls at sample {timeZero:0.###} of {samples.Count}, outside the " +
                 "buffer: these samples do not contain the reference arrival";
+            return false;
+        }
+
+        // REW's text export does not record a timing offset — the header of a
+        // measurement taken with one is word for word the header of one taken without,
+        // and the offset is simply baked into the start time. What it cannot hide is
+        // the consequence: a large enough offset pushes t = 0 past the buffer's peak,
+        // and an arrival before the reference is not something a loopback measurement
+        // can produce. Measured: a 4 ms offset on a 2.7 ms arrival puts t = 0 127
+        // samples after the peak, which REW's own API reports as a delay of -1.32 ms.
+        if (values.ContainsKey("Peak index") && peakIndexValue <= timeZero)
+        {
+            problem = $"the header puts the reference at sample {timeZero:0.###} and the " +
+                $"buffer's peak at {peakIndexValue}, so the arrival would precede the " +
+                "reference — which a loopback-referenced sweep cannot do. The usual cause " +
+                "is a timing offset applied in REW, which this export does not record";
             return false;
         }
 
@@ -291,9 +319,7 @@ public sealed class RewImpulseResponseTextFile
             SampleRate = sampleRate,
             SampleIntervalSeconds = interval,
             StartTimeSeconds = startTime,
-            PeakIndex = values.TryGetValue("Peak index", out double peakIndex)
-                ? (int)Math.Round(peakIndex)
-                : 0,
+            PeakIndex = peakIndexValue,
             PeakValueBeforeNormalisation =
                 values.TryGetValue("Peak value before normalisation", out double peak) ? peak : 0.0,
             DataOffsetDb = values.TryGetValue("Data offset (dB)", out double offset) ? offset : 0.0,

--- a/dsp/RewImpulseResponseTextFile.cs
+++ b/dsp/RewImpulseResponseTextFile.cs
@@ -316,7 +316,8 @@ public sealed class RewImpulseResponseTextFile
     {
         if (!TryParse(text, out RewImpulseResponseTextFile? file, out string? problem) || file == null)
         {
-            throw new FormatException($"This REW impulse-response export cannot be imported: {problem}.");
+            throw new FormatException(
+                $"This REW impulse-response export cannot be imported — {problem}.");
         }
 
         return file;

--- a/dsp/RewImpulseResponseTextFile.cs
+++ b/dsp/RewImpulseResponseTextFile.cs
@@ -358,19 +358,63 @@ public sealed class RewImpulseResponseTextFile
         }
     }
 
-    // The band line is written with the exporting machine's thousands separator, so
-    // "19,999.9" and "19.999,9" are the same frequency on two different machines.
-    private static bool TryReadGrouped(string token, out double value) =>
-        double.TryParse(
-            token.Trim(),
-            NumberStyles.Float | NumberStyles.AllowThousands,
+    /// <summary>
+    /// Reads a number written with either grouping convention — "19,999.9" and
+    /// "19.999,9" are the same frequency on two different machines.
+    /// </summary>
+    /// <remarks>
+    /// The file was written somewhere else, so neither the invariant culture nor the
+    /// one this program is running under is the right authority: trying them in turn
+    /// gets "20,1" wrong twice over, once as 201 under a culture that groups by comma
+    /// and once by refusing it. The token itself says which character is the decimal
+    /// point — the rightmost of the two when both appear, and otherwise the only one,
+    /// unless it stands three digits from the end and alone, which is how a thousands
+    /// group looks in both conventions.
+    /// </remarks>
+    private static bool TryReadGrouped(string token, out double value)
+    {
+        value = 0;
+        string trimmed = token.Trim();
+        if (trimmed.Length == 0)
+        {
+            return false;
+        }
+
+        int lastDot = trimmed.LastIndexOf('.');
+        int lastComma = trimmed.LastIndexOf(',');
+        char? decimalSeparator;
+        if (lastDot >= 0 && lastComma >= 0)
+        {
+            decimalSeparator = lastDot > lastComma ? '.' : ',';
+        }
+        else if (lastDot >= 0 || lastComma >= 0)
+        {
+            char only = lastDot >= 0 ? '.' : ',';
+            int at = lastDot >= 0 ? lastDot : lastComma;
+            int occurrences = trimmed.Count(character => character == only);
+            bool looksGrouped = occurrences > 1 ||
+                (occurrences == 1 && trimmed.Length - at - 1 == 3);
+            decimalSeparator = looksGrouped ? null : only;
+        }
+        else
+        {
+            decimalSeparator = null;
+        }
+
+        string normalized = decimalSeparator is char separator
+            ? trimmed
+                .Replace(separator == '.' ? "," : ".", string.Empty, StringComparison.Ordinal)
+                .Replace(separator, '.')
+            : trimmed
+                .Replace(".", string.Empty, StringComparison.Ordinal)
+                .Replace(",", string.Empty, StringComparison.Ordinal);
+
+        return double.TryParse(
+            normalized,
+            NumberStyles.Float,
             CultureInfo.InvariantCulture,
-            out value) ||
-        double.TryParse(
-            token.Trim(),
-            NumberStyles.Float | NumberStyles.AllowThousands,
-            CultureInfo.CurrentCulture,
             out value);
+    }
 
     // "512k Log Swept Sine, 1 sweep at -10.0 dBFS using a loopback as a timing reference"
     private static (int? Length, int? Count) ReadExcitation(string? excitation)

--- a/dsp/RewImpulseResponseTextFile.cs
+++ b/dsp/RewImpulseResponseTextFile.cs
@@ -1,0 +1,412 @@
+using System.Globalization;
+
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// REW's <c>File → Export → Impulse response as text</c>, read back.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Of the ways REW can hand an impulse response to another program, this is the only one
+/// that carries the absolute time base: the header states the time of sample 0, so a
+/// measurement taken against a loopback reference can be put back on the base it was
+/// measured on. A WAV export carries the samples and no timing at all unless t = 0 is
+/// pinned to a whole sample on the way out — which cannot state a fractional zero, and
+/// which rewrites the measurement's own start time to make the cut.
+/// </para>
+/// <para>
+/// Two things in the header decide whether the file is usable, and both have a safe
+/// default that is not the one wanted here. An export made with <em>normalise</em> on has
+/// its peak scaled to one, so it holds no level relation to any other channel; an export
+/// with the IR window applied is not the impulse response but a view of it. Both are
+/// refused rather than read, because neither announces itself in the samples.
+/// </para>
+/// <para>
+/// The samples are fractions of full scale — the same numbers REW's API serves for
+/// <c>?normalised=false</c>, to float precision.
+/// </para>
+/// </remarks>
+public sealed class RewImpulseResponseTextFile
+{
+    private const string FileMarker = "Impulse Response data saved by REW";
+    private const string DataStartMarker = "* Data start";
+
+    private const string NoHeaders =
+        "not a REW impulse-response text export, or one written without its headers " +
+        "(the headers carry the time base, so a file without them cannot be placed in time)";
+
+    private RewImpulseResponseTextFile(double[] samples)
+    {
+        Samples = samples;
+    }
+
+    /// <summary>The impulse response as REW served it, as a fraction of full scale.</summary>
+    public double[] Samples { get; }
+
+    public int SampleRate { get; private init; }
+
+    public double SampleIntervalSeconds { get; private init; }
+
+    /// <summary>
+    /// The time of sample 0, negative for every loopback measurement: REW anchors the
+    /// buffer on the microphone peak and lets the reference arrival fall where it falls.
+    /// </summary>
+    public double StartTimeSeconds { get; private init; }
+
+    /// <summary>
+    /// Where t = 0 — the loopback arrival — sits in this buffer, in samples. Fractional
+    /// in general: REW pins the peak to a whole sample, not the reference.
+    /// </summary>
+    public double TimeZeroIndex => -StartTimeSeconds * SampleRate;
+
+    /// <summary>The largest sample's index, as REW states it.</summary>
+    public int PeakIndex { get; private init; }
+
+    /// <summary>
+    /// REW's peak before normalisation — <em>interpolated</em>, so it sits a little above
+    /// the largest sample in the data (0.002 dB on the file this reader was written
+    /// against). It is the sub-sample peak, not one of the numbers below it.
+    /// </summary>
+    public double PeakValueBeforeNormalisation { get; private init; }
+
+    /// <summary>The SPL offset REW would add to turn these samples into dB SPL.</summary>
+    public double DataOffsetDb { get; private init; }
+
+    /// <summary>The measurement's name in REW, if the header carried one.</summary>
+    public string? MeasurementName { get; private init; }
+
+    /// <summary>The capture device line, if the header carried one.</summary>
+    public string? Source { get; private init; }
+
+    /// <summary>The excitation line verbatim — sweep length, count, level and reference.</summary>
+    public string? Excitation { get; private init; }
+
+    /// <summary>
+    /// The swept band REW reports. Best effort: the header writes it in the exporting
+    /// machine's number format, so a file that cannot be read here still parses and
+    /// leaves this null rather than failing over metadata.
+    /// </summary>
+    public double? LowFrequencyHz { get; private init; }
+
+    public double? HighFrequencyHz { get; private init; }
+
+    /// <summary>
+    /// The sweep's length in samples, from the excitation line's <c>512k</c> / <c>1M</c>
+    /// label. The impulse response is often shorter than the sweep that produced it, so
+    /// this is the honest source for a sweep duration; null when the label is unfamiliar.
+    /// </summary>
+    public int? SweepLengthSamples { get; private init; }
+
+    /// <summary>How many sweeps REW averaged, from the excitation line.</summary>
+    public int? SweepCount { get; private init; }
+
+    /// <summary>
+    /// The impulse response re-referenced so that <b>sample 0 is the loopback arrival</b>,
+    /// which is the convention a transfer impulse response is stated in here. The whole
+    /// part of the offset is a rotation, the fractional part an exact shift; REW's
+    /// pre-roll wraps to the tail, where the harmonic images of a swept measurement
+    /// belong.
+    /// </summary>
+    public double[] ToLoopbackReferencedImpulseResponse() =>
+        FractionalSampleShift.AdvanceCircular(Samples, TimeZeroIndex);
+
+    /// <summary>
+    /// Reads an export, or explains in <paramref name="problem"/> why this one cannot be
+    /// trusted on the time base it claims.
+    /// </summary>
+    public static bool TryParse(string text, out RewImpulseResponseTextFile? file, out string? problem)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        file = null;
+        problem = null;
+
+        bool markerSeen = false;
+        bool dataStarted = false;
+        string? measurement = null;
+        string? source = null;
+        string? excitation = null;
+        double? low = null;
+        double? high = null;
+        var values = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+        var samples = new List<double>();
+
+        foreach (string rawLine in text.TrimStart('\uFEFF').Split('\n'))
+        {
+            string line = rawLine.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            if (dataStarted)
+            {
+                if (!EqTextNumbers.TryParse(line, out double sample) || !double.IsFinite(sample))
+                {
+                    problem = $"the data holds a value this reader cannot read: \"{Excerpt(line)}\"";
+                    return false;
+                }
+
+                samples.Add(sample);
+                continue;
+            }
+
+            if (line.StartsWith(DataStartMarker, StringComparison.OrdinalIgnoreCase))
+            {
+                dataStarted = true;
+                continue;
+            }
+
+            if (line.StartsWith('*'))
+            {
+                string note = line.TrimStart('*').Trim();
+                if (note.Contains(FileMarker, StringComparison.OrdinalIgnoreCase))
+                {
+                    markerSeen = true;
+                }
+                else if (Says(note, "IR is", "normalised") || Says(note, "IR is", "normalized"))
+                {
+                    // "IR is not normalised" is the export this reader wants; the other
+                    // one has had its peak scaled to 1 and cannot be levelled against
+                    // any other channel again.
+                    if (!note.Contains(" not ", StringComparison.OrdinalIgnoreCase))
+                    {
+                        problem = "the export is normalised: its peak has been scaled to one, " +
+                            "so it carries no level relation to any other measurement " +
+                            "(export again with normalisation off)";
+                        return false;
+                    }
+                }
+                else if (Says(note, "IR window", "applied"))
+                {
+                    if (!note.Contains(" not ", StringComparison.OrdinalIgnoreCase))
+                    {
+                        problem = "the IR window has been applied: this is a windowed view of the " +
+                            "impulse response, not the response (export again with the window off)";
+                        return false;
+                    }
+                }
+                else if (Says(note, "IR is", "min phase"))
+                {
+                    if (!note.Contains(" not ", StringComparison.OrdinalIgnoreCase))
+                    {
+                        problem = "the export is the minimum-phase version: its excess phase — the " +
+                            "arrival time and everything derived from it — has been removed";
+                        return false;
+                    }
+                }
+                else if (note.StartsWith("Measurement:", StringComparison.OrdinalIgnoreCase))
+                {
+                    measurement = note["Measurement:".Length..].Trim();
+                }
+                else if (note.StartsWith("Source:", StringComparison.OrdinalIgnoreCase))
+                {
+                    source = note["Source:".Length..].Trim();
+                }
+                else if (note.StartsWith("Excitation:", StringComparison.OrdinalIgnoreCase))
+                {
+                    excitation = note["Excitation:".Length..].Trim();
+                }
+                else if (note.StartsWith("Response measured over:", StringComparison.OrdinalIgnoreCase))
+                {
+                    ReadBand(note["Response measured over:".Length..], out low, out high);
+                }
+
+                continue;
+            }
+
+            // "<number> // <label>" — the header's numeric half.
+            int comment = line.IndexOf("//", StringComparison.Ordinal);
+            if (comment < 0)
+            {
+                problem = markerSeen
+                    ? $"unexpected line before the data: \"{Excerpt(line)}\""
+                    : NoHeaders;
+                return false;
+            }
+
+            string label = line[(comment + 2)..].Trim();
+            if (!EqTextNumbers.TryParse(line[..comment], out double value))
+            {
+                problem = $"the header's \"{Excerpt(label)}\" is not a number";
+                return false;
+            }
+
+            values[label] = value;
+        }
+
+        if (!markerSeen || !dataStarted)
+        {
+            problem = NoHeaders;
+            return false;
+        }
+
+        if (samples.Count == 0)
+        {
+            problem = "the export holds no samples";
+            return false;
+        }
+
+        if (!values.TryGetValue("Sample interval (seconds)", out double interval) || !(interval > 0))
+        {
+            problem = "the header states no usable sample interval";
+            return false;
+        }
+
+        double rate = 1.0 / interval;
+        int sampleRate = (int)Math.Round(rate);
+        if (Math.Abs(rate - sampleRate) > 1e-6 * Math.Max(1.0, rate))
+        {
+            problem = $"the sample interval states a rate of {rate:0.####} Hz, which is not a whole " +
+                "number of samples per second";
+            return false;
+        }
+
+        if (!values.TryGetValue("Start time (seconds)", out double startTime))
+        {
+            problem = "the header states no start time, so the samples cannot be placed in time " +
+                "(this is the field the whole import rests on)";
+            return false;
+        }
+
+        if (values.TryGetValue("Response length", out double declaredLength) &&
+            (int)Math.Round(declaredLength) != samples.Count)
+        {
+            problem = $"the header declares {(int)Math.Round(declaredLength)} samples and the file " +
+                $"holds {samples.Count}: the export is truncated or was edited";
+            return false;
+        }
+
+        double timeZero = -startTime * sampleRate;
+        if (!(timeZero >= 0) || timeZero >= samples.Count)
+        {
+            problem = $"t = 0 falls at sample {timeZero:0.###} of {samples.Count}, outside the " +
+                "buffer: these samples do not contain the reference arrival";
+            return false;
+        }
+
+        (int? sweepLength, int? sweepCount) = ReadExcitation(excitation);
+
+        file = new RewImpulseResponseTextFile([.. samples])
+        {
+            SampleRate = sampleRate,
+            SampleIntervalSeconds = interval,
+            StartTimeSeconds = startTime,
+            PeakIndex = values.TryGetValue("Peak index", out double peakIndex)
+                ? (int)Math.Round(peakIndex)
+                : 0,
+            PeakValueBeforeNormalisation =
+                values.TryGetValue("Peak value before normalisation", out double peak) ? peak : 0.0,
+            DataOffsetDb = values.TryGetValue("Data offset (dB)", out double offset) ? offset : 0.0,
+            MeasurementName = measurement,
+            Source = source,
+            Excitation = excitation,
+            LowFrequencyHz = low,
+            HighFrequencyHz = high,
+            SweepLengthSamples = sweepLength,
+            SweepCount = sweepCount
+        };
+
+        return true;
+    }
+
+    /// <summary>
+    /// Reads an export, throwing with the reason when it cannot be trusted.
+    /// </summary>
+    public static RewImpulseResponseTextFile Parse(string text)
+    {
+        if (!TryParse(text, out RewImpulseResponseTextFile? file, out string? problem) || file == null)
+        {
+            throw new FormatException($"This REW impulse-response export cannot be imported: {problem}.");
+        }
+
+        return file;
+    }
+
+    /// <summary>
+    /// Whether the excitation line says the sweep was measured against a loopback — the
+    /// only reference on which REW's t = 0 means what a synchronized-loopback capture
+    /// means here. An acoustic reference, or none, gives a shape whose position is its
+    /// own; it must not be placed on this base.
+    /// </summary>
+    public bool IsLoopbackReferenced =>
+        Excitation != null &&
+        Excitation.Contains("loopback", StringComparison.OrdinalIgnoreCase) &&
+        Excitation.Contains("timing reference", StringComparison.OrdinalIgnoreCase);
+
+    private static bool Says(string note, string head, string tail) =>
+        note.StartsWith(head, StringComparison.OrdinalIgnoreCase) &&
+        note.Contains(tail, StringComparison.OrdinalIgnoreCase);
+
+    private static void ReadBand(string text, out double? low, out double? high)
+    {
+        low = null;
+        high = null;
+        string trimmed = text.Replace("Hz", string.Empty, StringComparison.OrdinalIgnoreCase).Trim();
+        int to = trimmed.IndexOf(" to ", StringComparison.OrdinalIgnoreCase);
+        if (to < 0)
+        {
+            return;
+        }
+
+        if (TryReadGrouped(trimmed[..to], out double parsedLow) &&
+            TryReadGrouped(trimmed[(to + 4)..], out double parsedHigh) &&
+            parsedLow > 0 && parsedHigh > parsedLow)
+        {
+            low = parsedLow;
+            high = parsedHigh;
+        }
+    }
+
+    // The band line is written with the exporting machine's thousands separator, so
+    // "19,999.9" and "19.999,9" are the same frequency on two different machines.
+    private static bool TryReadGrouped(string token, out double value) =>
+        double.TryParse(
+            token.Trim(),
+            NumberStyles.Float | NumberStyles.AllowThousands,
+            CultureInfo.InvariantCulture,
+            out value) ||
+        double.TryParse(
+            token.Trim(),
+            NumberStyles.Float | NumberStyles.AllowThousands,
+            CultureInfo.CurrentCulture,
+            out value);
+
+    // "512k Log Swept Sine, 1 sweep at -10.0 dBFS using a loopback as a timing reference"
+    private static (int? Length, int? Count) ReadExcitation(string? excitation)
+    {
+        if (string.IsNullOrWhiteSpace(excitation))
+        {
+            return (null, null);
+        }
+
+        int? length = null;
+        int? count = null;
+        foreach (string token in excitation.Split([' ', ','], StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (length == null && token.Length > 1 &&
+                (token.EndsWith('k') || token.EndsWith('K') || token.EndsWith('M')) &&
+                int.TryParse(token[..^1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int scaled))
+            {
+                length = scaled * (token.EndsWith('M') ? 1024 * 1024 : 1024);
+            }
+        }
+
+        int sweeps = excitation.IndexOf(" sweep", StringComparison.OrdinalIgnoreCase);
+        if (sweeps > 0)
+        {
+            string before = excitation[..sweeps].Trim();
+            int space = before.LastIndexOf(' ');
+            string token = space < 0 ? before : before[(space + 1)..];
+            if (int.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed) &&
+                parsed > 0)
+            {
+                count = parsed;
+            }
+        }
+
+        return (length, count);
+    }
+
+    private static string Excerpt(string line) =>
+        line.Length <= 40 ? line : line[..40] + "…";
+}

--- a/dsp/RewImpulseResponseTextFile.cs
+++ b/dsp/RewImpulseResponseTextFile.cs
@@ -63,11 +63,13 @@ public sealed class RewImpulseResponseTextFile
     public int PeakIndex { get; private init; }
 
     /// <summary>
-    /// The arrival this header implies, in samples: the buffer's peak minus the
-    /// reference. For a loopback-referenced sweep it is the tract's delay, and it is
-    /// positive by physics — the microphone cannot hear the sweep before the reference
-    /// does. A file where it is not is on some other time base; see the refusal in
-    /// <see cref="TryParse"/>.
+    /// The arrival this header implies BEFORE any timing offset is taken out, in
+    /// samples: the buffer's peak minus the reference. For a loopback-referenced sweep
+    /// measured with no offset it is the tract's delay, and it is positive by physics —
+    /// the microphone cannot hear the sweep before the reference does. A NEGATIVE value
+    /// here is the shadow of a timing offset larger than the arrival, which is a
+    /// question for the importer rather than a reason to refuse the file; an offset
+    /// SMALLER than the arrival leaves this positive and says nothing at all.
     /// </summary>
     public double ImpliedArrivalSamples => PeakIndex - TimeZeroIndex;
 
@@ -117,7 +119,32 @@ public sealed class RewImpulseResponseTextFile
     /// belong.
     /// </summary>
     public double[] ToLoopbackReferencedImpulseResponse() =>
-        FractionalSampleShift.AdvanceCircular(Samples, TimeZeroIndex);
+        ToLoopbackReferencedImpulseResponse(0);
+
+    /// <summary>
+    /// The same re-referencing with a stated REW timing offset taken back out, in
+    /// seconds and with REW's own sign (positive delays the measurement).
+    /// </summary>
+    /// <remarks>
+    /// REW folds the offset into the export's start time and records it nowhere else,
+    /// so undoing it is a move of t = 0 and nothing more: the samples are untouched.
+    /// Measured on six captures — a 4 ms offset at 96 kHz is 384 whole samples, and
+    /// adding the offset back to the reported IR start reproduces the un-offset
+    /// arrival to the last digit — so the correction is <b>subtracted from the
+    /// reference index</b>, which moves the arrival LATER by the offset.
+    /// </remarks>
+    public double[] ToLoopbackReferencedImpulseResponse(double timingOffsetSeconds) =>
+        FractionalSampleShift.AdvanceCircular(
+            Samples,
+            ReferenceIndexWithOffset(timingOffsetSeconds));
+
+    /// <summary>Where t = 0 sits once a stated timing offset is taken back out.</summary>
+    public double ReferenceIndexWithOffset(double timingOffsetSeconds) =>
+        TimeZeroIndex - (timingOffsetSeconds * SampleRate);
+
+    /// <summary>The arrival once a stated timing offset is taken back out, in samples.</summary>
+    public double ArrivalSamplesWithOffset(double timingOffsetSeconds) =>
+        PeakIndex - ReferenceIndexWithOffset(timingOffsetSeconds);
 
     /// <summary>
     /// Reads an export, or explains in <paramref name="problem"/> why this one cannot be
@@ -296,22 +323,12 @@ public sealed class RewImpulseResponseTextFile
             return false;
         }
 
-        // REW's text export does not record a timing offset — the header of a
-        // measurement taken with one is word for word the header of one taken without,
-        // and the offset is simply baked into the start time. What it cannot hide is
-        // the consequence: a large enough offset pushes t = 0 past the buffer's peak,
-        // and an arrival before the reference is not something a loopback measurement
-        // can produce. Measured: a 4 ms offset on a 2.7 ms arrival puts t = 0 127
-        // samples after the peak, which REW's own API reports as a delay of -1.32 ms.
-        if (values.ContainsKey("Peak index") && peakIndexValue <= timeZero)
-        {
-            problem = $"the header puts the reference at sample {timeZero:0.###} and the " +
-                $"buffer's peak at {peakIndexValue}, so the arrival would precede the " +
-                "reference — which a loopback-referenced sweep cannot do. The usual cause " +
-                "is a timing offset applied in REW, which this export does not record";
-            return false;
-        }
-
+        // An arrival that precedes the reference is NOT refused here any more. It is
+        // the signature of a timing offset applied in REW, and an offset is exactly
+        // what the importer now asks the user for: refusing the file at parse time
+        // would refuse the one case the question exists to answer. The reader states
+        // the arrival the header implies and leaves the judgement to whoever knows
+        // the offset — see ImpliedArrivalSamples and RewImportTiming.
         (int? sweepLength, int? sweepCount) = ReadExcitation(excitation);
 
         file = new RewImpulseResponseTextFile([.. samples])

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -203,9 +203,10 @@ namespace Resonalyze
             InitCore(configuration);
         }
 
-        // The body of Init without its guard, for the one caller that already
-        // holds the measurement busy itself (see ImportRecordedSweep) and would
-        // otherwise have to drop that claim across the call to re-enter here.
+        // The body of Init without its guard, for the callers that already hold
+        // the measurement busy themselves (see ImportRecordedSweep and
+        // RestoreImpulseResponse) and would otherwise have to drop that claim
+        // across the call to re-enter here.
         private void InitCore(SweepMeasurementConfiguration configuration)
         {
             SweepSignalConfiguration signal = configuration.Signal;
@@ -510,7 +511,7 @@ namespace Resonalyze
                 throw new ArgumentOutOfRangeException(nameof(transferPeakIndex));
             }
 
-            Init(new SweepMeasurementConfiguration(
+            InitCore(new SweepMeasurementConfiguration(
                 new SweepSignalConfiguration(
                     lowFrequencyHz,
                     highFrequencyHz,
@@ -537,7 +538,7 @@ namespace Resonalyze
                     AverageRunCount,
                     ConfirmEachAverageRun),
                 ProtectiveHighPass));
-            // Init just set these from the sweep it regenerated; the recorded
+            // InitCore just set these from the sweep it regenerated; the recorded
             // geometry wins, since that sweep is a reconstruction and this result
             // came from the original one. The length matters as much as the band:
             // generation is capped at MaxDurationSeconds while a stored sweep may

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -463,11 +463,29 @@ namespace Resonalyze
                     "Transfer impulse response is required for loopback transfer measurements.",
                     nameof(transferImpulseResponse));
             }
-            if (InProgress)
+            // A run blocks; a claim does not. The caller that decoded this file has
+            // usually been holding one across the read and the analysis so nothing
+            // could start a sweep underneath it, and it must still be able to publish
+            // the result it went to the trouble of protecting. Same shape as
+            // ImportRecordedSweep, which faced this first.
+            bool claimedHere = false;
+            lock (stateSync)
             {
-                throw new InvalidOperationException(
-                    "Cannot load an impulse response while a measurement is running.");
+                if (inProgress && !claimed)
+                {
+                    throw new InvalidOperationException(
+                        "Cannot load an impulse response while a measurement is running.");
+                }
+
+                if (!inProgress)
+                {
+                    inProgress = true;
+                    claimedHere = true;
+                }
             }
+
+            try
+            {
             if (sweepDeconvolutionImpulseResponse.Length == 0)
             {
                 throw new ArgumentException(
@@ -555,6 +573,17 @@ namespace Resonalyze
                 AverageRunCount);
             LastError = null;
             Publish(ImpulseResponseChanged);
+            }
+            finally
+            {
+                if (claimedHere)
+                {
+                    lock (stateSync)
+                    {
+                        inProgress = false;
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/source/Measurements/RewImportTiming.cs
+++ b/source/Measurements/RewImportTiming.cs
@@ -1,0 +1,112 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Where an imported REW export's t = 0 lands, and what its arrival may be called.
+/// </summary>
+/// <param name="Reference">
+/// What the arrival is worth once the offset question is answered.
+/// </param>
+/// <param name="ReferenceIndex">
+/// The index in REW's buffer that becomes sample 0 of the transfer response.
+/// </param>
+/// <param name="ArrivalSamples">The arrival this plan implies, in samples.</param>
+/// <param name="OffsetSeconds">The offset taken back out; zero when none was stated.</param>
+internal sealed record RewImportTimingPlan(
+    TimingReference Reference,
+    double ReferenceIndex,
+    double ArrivalSamples,
+    double OffsetSeconds);
+
+/// <summary>
+/// Decides what a REW text import may claim about time, from the one thing the format
+/// cannot state and only the person who measured it knows: the timing offset REW was
+/// running with.
+/// </summary>
+/// <remarks>
+/// The design this replaces asked the wrong question. It tried to prove the offset was
+/// zero from the file, and the file cannot say: the header of a measurement taken with
+/// an offset is word for word the header of one taken without, and the offset is folded
+/// into the start time. The only visible consequence — an arrival that precedes the
+/// reference — appears exclusively when the offset is LARGER than the arrival, so it
+/// catches the loud cases and is blind to every quiet one.
+///
+/// So the offset is asked for instead, and the answer decides the reference: a value
+/// (zero included) is a user assertion, and the import is compensated and stamped
+/// <see cref="TimingReference.SynchronizedLoopback"/> on the strength of it; "I do not
+/// know" is not a failure but a different measurement — the shape is real, its position
+/// is not, which is exactly <see cref="TimingReference.RecordedSweep"/>.
+///
+/// Lives beside the enum rather than in the import method for the reason
+/// <c>SampleRateOptions.Resolve</c> does: it is decided without a window and can
+/// therefore be tested without one.
+/// </remarks>
+internal static class RewImportTiming
+{
+    /// <summary>
+    /// Builds the plan, or explains in <paramref name="problem"/> why the stated offset
+    /// cannot be true of this file.
+    /// </summary>
+    /// <param name="statedOffsetSeconds">
+    /// The offset REW was measuring with, as the user states it, or null for "unknown".
+    /// </param>
+    public static bool TryResolve(
+        double? statedOffsetSeconds,
+        double timeZeroIndex,
+        int peakIndex,
+        int sampleCount,
+        int sampleRate,
+        out RewImportTimingPlan? plan,
+        out string? problem)
+    {
+        plan = null;
+        problem = null;
+
+        if (statedOffsetSeconds is not { } offsetSeconds)
+        {
+            // Nothing is claimed, so nothing needs checking: the export is taken on its
+            // own terms and the arrival is not offered to anything that compares
+            // measurements. An arrival that precedes the reference is not refused here
+            // either — under RecordedSweep it is not a lie, only a number nobody may use.
+            plan = new RewImportTimingPlan(
+                TimingReference.RecordedSweep,
+                timeZeroIndex,
+                peakIndex - timeZeroIndex,
+                0);
+            return true;
+        }
+
+        if (!double.IsFinite(offsetSeconds))
+        {
+            problem = "the timing offset must be a number";
+            return false;
+        }
+
+        double referenceIndex = timeZeroIndex - (offsetSeconds * sampleRate);
+        if (!(referenceIndex >= 0) || referenceIndex >= sampleCount)
+        {
+            problem = FormattableString.Invariant(
+                $"with a {offsetSeconds * 1000.0:0.####} ms offset taken out, t = 0 falls at sample {referenceIndex:0.###} of {sampleCount} — outside the buffer, so these samples do not contain the reference arrival");
+            return false;
+        }
+
+        double arrivalSamples = peakIndex - referenceIndex;
+        if (arrivalSamples <= 0)
+        {
+            // The claim and the file disagree, and the file is not the one that can be
+            // wrong about this: sound does not reach the microphone before it reaches
+            // the loopback. Reporting the offset that WOULD make the arrival physical
+            // turns a refusal into the next thing to try.
+            double neededMs = (peakIndex - timeZeroIndex) / (double)sampleRate * -1000.0;
+            problem = FormattableString.Invariant(
+                $"with a {offsetSeconds * 1000.0:0.####} ms offset taken out the arrival would be {arrivalSamples / (double)sampleRate * 1000.0:0.####} ms, which a loopback-referenced sweep cannot produce — the microphone cannot hear the sweep before the reference does. This header needs an offset above {neededMs:0.####} ms to place the arrival after t = 0");
+            return false;
+        }
+
+        plan = new RewImportTimingPlan(
+            TimingReference.SynchronizedLoopback,
+            referenceIndex,
+            arrivalSamples,
+            offsetSeconds);
+        return true;
+    }
+}

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -318,71 +318,77 @@ public partial class Form1
     // its own curves is not in the impulse response — an imported IR is uncalibrated.
     private async Task ImportRewImpulseResponseAsync(string path)
     {
-        // Claimed before the read, not after it: parsing a few hundred thousand
-        // samples and running the fractional shift takes long enough for the record
-        // button to start a sweep in between, and this import would then arrive on
-        // top of it. The claim is held until the result is published.
-        using var claim = expSweepMeasurement.Claim();
-        string text = await File.ReadAllTextAsync(path);
-        RewImpulseResponseTextFile file = await Task.Run(
-            () => RewImpulseResponseTextFile.Parse(text));
-        // The sweep this result would be filed under is generated at the configured
-        // rate; a file at another rate is not describing the same signal, and the
-        // state applied afterwards would report a rate the measurement does not have.
-        int configuredSampleRate =
-            measurementSettings.Measurement.BuildConfiguration().Signal.SampleRate;
-        if (file.SampleRate != configuredSampleRate)
+        RewImpulseResponseTextFile file;
+        // Claimed BEFORE the read: parsing a few hundred thousand samples and
+        // running the fractional shift takes long enough for the record button to
+        // start a sweep in between, and this import would then arrive on top of it.
+        // Released once the result is published and before the redraw below — a busy
+        // measurement draws no curves, and the notice that follows is modal, so a
+        // claim held to the end of the method would outlast the dialog on screen.
+        using (expSweepMeasurement.Claim())
         {
-            throw new InvalidOperationException(
-                $"This export is {file.SampleRate} Hz while the measurement is configured " +
-                $"for {configuredSampleRate} Hz. Set the sample rate in Measurement Options " +
-                "to match the file, then import it again.");
+            string text = await File.ReadAllTextAsync(path);
+            file = await Task.Run(
+                () => RewImpulseResponseTextFile.Parse(text));
+            // The sweep this result would be filed under is generated at the configured
+            // rate; a file at another rate is not describing the same signal, and the
+            // state applied afterwards would report a rate the measurement does not have.
+            int configuredSampleRate =
+                measurementSettings.Measurement.BuildConfiguration().Signal.SampleRate;
+            if (file.SampleRate != configuredSampleRate)
+            {
+                throw new InvalidOperationException(
+                    $"This export is {file.SampleRate} Hz while the measurement is configured " +
+                    $"for {configuredSampleRate} Hz. Set the sample rate in Measurement Options " +
+                    "to match the file, then import it again.");
+            }
+
+            if (!file.IsLoopbackReferenced)
+            {
+                // The shape is real; the position is its own. Placing it here would give it
+                // an arrival time that means nothing and would be summed with real ones.
+                throw new InvalidOperationException(
+                    "This export was not measured against a loopback timing reference" +
+                    (string.IsNullOrWhiteSpace(file.Excitation)
+                        ? string.Empty
+                        : $" (REW says: \u201c{file.Excitation}\u201d)") +
+                    ". Its shape is real, but nothing ties its zero to anything outside its " +
+                    "own measurement, so it cannot be placed on this session's time base. " +
+                    "Measure it in REW with a loopback as the timing reference to import it.");
+            }
+
+            double[] samples = file.Samples;
+            double[] referenced = await Task.Run(file.ToLoopbackReferencedImpulseResponse);
+            // The band REW swept. A header without it is not worth refusing the file over,
+            // but the fallback is a guess and says so in the notes below.
+            double lowHz = file.LowFrequencyHz ?? DefaultImportedLowFrequencyHz;
+            double highHz = file.HighFrequencyHz ?? (file.SampleRate / 2.0);
+            // The sweep, not the impulse response: REW keeps the IR shorter than the sweep
+            // that produced it, and the harmonic geometry is keyed to the sweep's length.
+            double sweepSeconds =
+                (file.SweepLengthSamples ?? samples.Length) / (double)file.SampleRate;
+            expSweepMeasurement.RestoreImpulseResponse(
+                lowHz,
+                highHz,
+                file.SampleRate,
+                ImportedBitDepth,
+                sweepSeconds,
+                // REW does not say which output it played through, and guessing a side
+                // would put a channel name on a measurement that never carried one.
+                PlaybackChannel.Mono,
+                ToComplex(samples),
+                PeakIndexOf(samples),
+                SweepMeasurementMode.LoopbackTransfer,
+                ToComplex(referenced),
+                PeakIndexOf(referenced),
+                transferCoherence: null,
+                averageRunCount: file.SweepCount ?? 1,
+                acceptedAverageRunCount: file.SweepCount ?? 1,
+                achievedLowFrequencyHz: lowHz,
+                achievedHighFrequencyHz: highHz,
+                timingReference: TimingReference.SynchronizedLoopback);
         }
 
-        if (!file.IsLoopbackReferenced)
-        {
-            // The shape is real; the position is its own. Placing it here would give it
-            // an arrival time that means nothing and would be summed with real ones.
-            throw new InvalidOperationException(
-                "This export was not measured against a loopback timing reference" +
-                (string.IsNullOrWhiteSpace(file.Excitation)
-                    ? string.Empty
-                    : $" (REW says: \u201c{file.Excitation}\u201d)") +
-                ". Its shape is real, but nothing ties its zero to anything outside its " +
-                "own measurement, so it cannot be placed on this session's time base. " +
-                "Measure it in REW with a loopback as the timing reference to import it.");
-        }
-
-        double[] samples = file.Samples;
-        double[] referenced = await Task.Run(file.ToLoopbackReferencedImpulseResponse);
-        // The band REW swept. A header without it is not worth refusing the file over,
-        // but the fallback is a guess and says so in the notes below.
-        double lowHz = file.LowFrequencyHz ?? DefaultImportedLowFrequencyHz;
-        double highHz = file.HighFrequencyHz ?? (file.SampleRate / 2.0);
-        // The sweep, not the impulse response: REW keeps the IR shorter than the sweep
-        // that produced it, and the harmonic geometry is keyed to the sweep's length.
-        double sweepSeconds =
-            (file.SweepLengthSamples ?? samples.Length) / (double)file.SampleRate;
-        expSweepMeasurement.RestoreImpulseResponse(
-            lowHz,
-            highHz,
-            file.SampleRate,
-            ImportedBitDepth,
-            sweepSeconds,
-            // REW does not say which output it played through, and guessing a side
-            // would put a channel name on a measurement that never carried one.
-            PlaybackChannel.Mono,
-            ToComplex(samples),
-            PeakIndexOf(samples),
-            SweepMeasurementMode.LoopbackTransfer,
-            ToComplex(referenced),
-            PeakIndexOf(referenced),
-            transferCoherence: null,
-            averageRunCount: file.SweepCount ?? 1,
-            acceptedAverageRunCount: file.SweepCount ?? 1,
-            achievedLowFrequencyHz: lowHz,
-            achievedHighFrequencyHz: highHz,
-            timingReference: TimingReference.SynchronizedLoopback);
         // Like a recorded sweep and unlike a loaded file: nothing on disk holds this
         // impulse response in this program's terms, so it enters the session as a
         // measurement rather than as a file that could be saved back over its source.

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -1,4 +1,7 @@
-﻿namespace Resonalyze;
+﻿using System.Numerics;
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
 
 public partial class Form1
 {
@@ -95,24 +98,24 @@ public partial class Form1
             {
                 CheckFileExists = true,
                 Filter =
-                    "Measurements (*.json;*.wav)|*.json;*.wav|" +
+                    "Measurements (*.json;*.wav;*.txt)|*.json;*.wav;*.txt|" +
                     "Resonalyze impulse response (*.json)|*.json|" +
                     "Recorded sweep (*.wav)|*.wav|" +
+                    "REW impulse response export (*.txt)|*.txt|" +
                     "All files (*.*)|*.*",
                 InitialDirectory = GetImpulseResponseDialogDirectory(),
                 Multiselect = false,
                 RestoreDirectory = true,
-                Title = "Load impulse response or recorded sweep"
+                Title = "Load impulse response, recorded sweep or REW export"
             };
             if (dialog.ShowDialog(this) != DialogResult.OK)
             {
                 return;
             }
 
-            bool importRecording = string.Equals(
-                Path.GetExtension(dialog.FileName),
-                ".wav",
-                StringComparison.OrdinalIgnoreCase);
+            string extension = Path.GetExtension(dialog.FileName);
+            bool importRecording = string.Equals(extension, ".wav", StringComparison.OrdinalIgnoreCase);
+            bool importRewExport = string.Equals(extension, ".txt", StringComparison.OrdinalIgnoreCase);
             commandController.SetSaveAvailable(false);
             commandController.SetLoadAvailable(false);
             try
@@ -121,6 +124,10 @@ public partial class Form1
                 {
                     await ImportRecordedSweepAsync(dialog.FileName);
                 }
+                else if (importRewExport)
+                {
+                    await ImportRewImpulseResponseAsync(dialog.FileName);
+                }
                 else
                 {
                     await LoadImpulseResponseFileAsync(dialog.FileName);
@@ -128,12 +135,15 @@ public partial class Form1
             }
             catch (Exception exception)
             {
+                string failure = importRecording
+                    ? "Failed to import the recorded sweep."
+                    : importRewExport
+                        ? "Failed to import the REW impulse response."
+                        : "Failed to load the impulse response.";
                 MessageBox.Show(
                     this,
-                    importRecording
-                        ? $"Failed to import the recorded sweep.\r\n\r\n{exception.Message}"
-                        : $"Failed to load the impulse response.\r\n\r\n{exception.Message}",
-                    importRecording ? "Import failed" : "Load failed",
+                    $"{failure}\r\n\r\n{exception.Message}",
+                    importRecording || importRewExport ? "Import failed" : "Load failed",
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
             }
@@ -292,6 +302,148 @@ public partial class Form1
             commandController.SetSaveAvailable(expSweepMeasurement.HasImpulseResponse);
             FinalizeMeasurementCommandState();
         }
+    }
+
+    // A measurement made in REW, brought over on the time base it was measured on.
+    //
+    // REW's text export is the only one of its routes that states the time of sample 0,
+    // so a sweep it measured against a loopback can be placed on the same absolute base
+    // a measurement taken here sits on — which is the whole point: two programs' results
+    // are comparable only if their zeros mean the same thing. The reader does the
+    // reading and the re-referencing; what is decided here is what the format cannot
+    // say, and every one of those decisions is reported rather than assumed silently.
+    //
+    // Absent by nature, not by omission: a REW sweep export carries no coherence, no
+    // level snapshot and no SPL anchor, and the microphone calibration REW applies to
+    // its own curves is not in the impulse response — an imported IR is uncalibrated.
+    private async Task ImportRewImpulseResponseAsync(string path)
+    {
+        string text = await File.ReadAllTextAsync(path);
+        RewImpulseResponseTextFile file = await Task.Run(
+            () => RewImpulseResponseTextFile.Parse(text));
+        if (!file.IsLoopbackReferenced)
+        {
+            // The shape is real; the position is its own. Placing it here would give it
+            // an arrival time that means nothing and would be summed with real ones.
+            throw new InvalidOperationException(
+                "This export was not measured against a loopback timing reference" +
+                (string.IsNullOrWhiteSpace(file.Excitation)
+                    ? string.Empty
+                    : $" (REW says: \u201c{file.Excitation}\u201d)") +
+                ". Its shape is real, but nothing ties its zero to anything outside its " +
+                "own measurement, so it cannot be placed on this session's time base. " +
+                "Measure it in REW with a loopback as the timing reference to import it.");
+        }
+
+        double[] samples = file.Samples;
+        double[] referenced = await Task.Run(file.ToLoopbackReferencedImpulseResponse);
+        // The band REW swept. A header without it is not worth refusing the file over,
+        // but the fallback is a guess and says so in the notes below.
+        double lowHz = file.LowFrequencyHz ?? DefaultImportedLowFrequencyHz;
+        double highHz = file.HighFrequencyHz ?? (file.SampleRate / 2.0);
+        // The sweep, not the impulse response: REW keeps the IR shorter than the sweep
+        // that produced it, and the harmonic geometry is keyed to the sweep's length.
+        double sweepSeconds =
+            (file.SweepLengthSamples ?? samples.Length) / (double)file.SampleRate;
+        expSweepMeasurement.RestoreImpulseResponse(
+            lowHz,
+            highHz,
+            file.SampleRate,
+            ImportedBitDepth,
+            sweepSeconds,
+            // REW does not say which output it played through, and guessing a side
+            // would put a channel name on a measurement that never carried one.
+            PlaybackChannel.Mono,
+            ToComplex(samples),
+            PeakIndexOf(samples),
+            SweepMeasurementMode.LoopbackTransfer,
+            ToComplex(referenced),
+            PeakIndexOf(referenced),
+            transferCoherence: null,
+            averageRunCount: file.SweepCount ?? 1,
+            acceptedAverageRunCount: file.SweepCount ?? 1,
+            achievedLowFrequencyHz: lowHz,
+            achievedHighFrequencyHz: highHz,
+            timingReference: TimingReference.SynchronizedLoopback);
+        // Like a recorded sweep and unlike a loaded file: nothing on disk holds this
+        // impulse response in this program's terms, so it enters the session as a
+        // measurement rather than as a file that could be saved back over its source.
+        ApplyLoadedImpulseResponseState(path);
+        sessionTracker.MarkMeasurementCompleted(expSweepMeasurement);
+        dockedModeSettingsHost.InvokeIfOpen<Options.FROptions>(
+            panel => panel.RefreshSplAvailability());
+        NotifyRewImportDecisions(file);
+    }
+
+    // What REW's export could not say, and what was assumed in its place. Always worth
+    // showing: an imported measurement looks exactly like a measured one on screen, and
+    // these are the ways in which it is not.
+    private void NotifyRewImportDecisions(RewImpulseResponseTextFile file)
+    {
+        if (closingInProgress)
+        {
+            return;
+        }
+
+        var notes = new List<string>
+        {
+            FormattableString.Invariant(
+                $"Imported {file.Samples.Length} samples at {file.SampleRate} Hz. The loopback reference sits at sample {file.TimeZeroIndex:0.###} of REW's buffer and is now sample 0 of the transfer response; the fractional part was shifted, not rounded."),
+            "REW's sweep exports carry no coherence, no level meters and no SPL calibration, " +
+                "and REW applies a microphone calibration to its own curves rather than to the " +
+                "impulse response — so this measurement is uncalibrated here, whatever REW showed."
+        };
+        if (file.LowFrequencyHz == null || file.HighFrequencyHz == null)
+        {
+            notes.Add(FormattableString.Invariant(
+                $"The header did not state the swept band, so {DefaultImportedLowFrequencyHz:0.#} Hz to Nyquist was assumed. The harmonic geometry of this measurement follows that band, so set it right if the sweep was narrower."));
+        }
+
+        if (file.SweepLengthSamples == null)
+        {
+            notes.Add(
+                "The header did not state the sweep's length, so the impulse response's own " +
+                "length stands in for it.");
+        }
+
+        MessageBox.Show(
+            this,
+            string.Join("\r\n\r\n", notes),
+            "REW impulse response imported",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Information);
+    }
+
+    // REW's export states no bit depth: it is a text file of fractions of full scale,
+    // and by the time it is written the capture depth has left no trace. The value is
+    // carried only as the configuration's description of the sweep.
+    private const int ImportedBitDepth = 24;
+
+    private const double DefaultImportedLowFrequencyHz = 20.0;
+
+    private static Complex[] ToComplex(double[] samples)
+    {
+        var values = new Complex[samples.Length];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            values[i] = new Complex(samples[i], 0.0);
+        }
+
+        return values;
+    }
+
+    private static int PeakIndexOf(double[] samples)
+    {
+        int peak = 0;
+        for (int i = 1; i < samples.Length; i++)
+        {
+            if (Math.Abs(samples[i]) > Math.Abs(samples[peak]))
+            {
+                peak = i;
+            }
+        }
+
+        return peak;
     }
 
     // A sweep recorded elsewhere — a phone, a handheld recorder, a DAW — analyzed

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -318,9 +318,27 @@ public partial class Form1
     // its own curves is not in the impulse response — an imported IR is uncalibrated.
     private async Task ImportRewImpulseResponseAsync(string path)
     {
+        // Claimed before the read, not after it: parsing a few hundred thousand
+        // samples and running the fractional shift takes long enough for the record
+        // button to start a sweep in between, and this import would then arrive on
+        // top of it. The claim is held until the result is published.
+        using var claim = expSweepMeasurement.Claim();
         string text = await File.ReadAllTextAsync(path);
         RewImpulseResponseTextFile file = await Task.Run(
             () => RewImpulseResponseTextFile.Parse(text));
+        // The sweep this result would be filed under is generated at the configured
+        // rate; a file at another rate is not describing the same signal, and the
+        // state applied afterwards would report a rate the measurement does not have.
+        int configuredSampleRate =
+            measurementSettings.Measurement.BuildConfiguration().Signal.SampleRate;
+        if (file.SampleRate != configuredSampleRate)
+        {
+            throw new InvalidOperationException(
+                $"This export is {file.SampleRate} Hz while the measurement is configured " +
+                $"for {configuredSampleRate} Hz. Set the sample rate in Measurement Options " +
+                "to match the file, then import it again.");
+        }
+
         if (!file.IsLoopbackReferenced)
         {
             // The shape is real; the position is its own. Placing it here would give it

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -411,7 +411,9 @@ public partial class Form1
                 "and REW applies a microphone calibration to its own curves rather than to the " +
                 "impulse response — so this measurement is uncalibrated here, whatever REW showed.",
             FormattableString.Invariant(
-                $"The export states no bit depth and no playback channel: {ImportedBitDepth}-bit and Mono were assumed. Neither changes the samples — they describe the sweep this result is filed under.")
+                $"The export states no bit depth and no playback channel: {ImportedBitDepth}-bit and Mono were assumed. Neither changes the samples — they describe the sweep this result is filed under."),
+            FormattableString.Invariant(
+                $"REW's text export does not record a timing offset, so one smaller than the arrival cannot be told from a shorter path. The arrival this header implies is {file.ImpliedArrivalSamples / file.SampleRate * 1000.0:0.000} ms; if that is not what REW showed for this measurement, it was measured with an offset and does not belong on this session's time base.")
         };
         if (file.LowFrequencyHz == null || file.HighFrequencyHz == null)
         {

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -391,7 +391,9 @@ public partial class Form1
                 $"Imported {file.Samples.Length} samples at {file.SampleRate} Hz. The loopback reference sits at sample {file.TimeZeroIndex:0.###} of REW's buffer and is now sample 0 of the transfer response; the fractional part was shifted, not rounded."),
             "REW's sweep exports carry no coherence, no level meters and no SPL calibration, " +
                 "and REW applies a microphone calibration to its own curves rather than to the " +
-                "impulse response — so this measurement is uncalibrated here, whatever REW showed."
+                "impulse response — so this measurement is uncalibrated here, whatever REW showed.",
+            FormattableString.Invariant(
+                $"The export states no bit depth and no playback channel: {ImportedBitDepth}-bit and Mono were assumed. Neither changes the samples — they describe the sweep this result is filed under.")
         };
         if (file.LowFrequencyHz == null || file.HighFrequencyHz == null)
         {

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using Resonalyze.Dsp;
+using Resonalyze.Ui.Dialogs;
 
 namespace Resonalyze;
 
@@ -319,6 +320,7 @@ public partial class Form1
     private async Task ImportRewImpulseResponseAsync(string path)
     {
         RewImpulseResponseTextFile file;
+        RewImportTimingPlan plan;
         // Claimed BEFORE the read: parsing a few hundred thousand samples and
         // running the fractional shift takes long enough for the record button to
         // start a sweep in between, and this import would then arrive on top of it.
@@ -357,8 +359,18 @@ public partial class Form1
                     "Measure it in REW with a loopback as the timing reference to import it.");
             }
 
+            // The one fact the format cannot carry, asked for rather than guessed at.
+            // The question is put while the claim is still held: nothing has been
+            // published yet, so there is nothing on screen waiting to be redrawn, and
+            // the claim is exactly what stops a sweep starting while the dialog is up.
+            if (!TryPlanRewImportTiming(file, out plan))
+            {
+                return;
+            }
+
             double[] samples = file.Samples;
-            double[] referenced = await Task.Run(file.ToLoopbackReferencedImpulseResponse);
+            double[] referenced = await Task.Run(
+                () => file.ToLoopbackReferencedImpulseResponse(plan.OffsetSeconds));
             // The band REW swept. A header without it is not worth refusing the file over,
             // but the fallback is a guess and says so in the notes below.
             double lowHz = file.LowFrequencyHz ?? DefaultImportedLowFrequencyHz;
@@ -386,7 +398,7 @@ public partial class Form1
                 acceptedAverageRunCount: file.SweepCount ?? 1,
                 achievedLowFrequencyHz: lowHz,
                 achievedHighFrequencyHz: highHz,
-                timingReference: TimingReference.SynchronizedLoopback);
+                timingReference: plan.Reference);
         }
 
         // Like a recorded sweep and unlike a loaded file: nothing on disk holds this
@@ -396,13 +408,51 @@ public partial class Form1
         sessionTracker.MarkMeasurementCompleted(expSweepMeasurement);
         dockedModeSettingsHost.InvokeIfOpen<Options.FROptions>(
             panel => panel.RefreshSplAvailability());
-        NotifyRewImportDecisions(file);
+        NotifyRewImportDecisions(file, plan);
+    }
+
+    // Puts the timing-offset question and turns the answer into a plan, or explains why
+    // the answer cannot be true of this file. False means the user cancelled — which is
+    // not an error and gets no notice.
+    private bool TryPlanRewImportTiming(
+        RewImpulseResponseTextFile file,
+        out RewImportTimingPlan plan)
+    {
+        using var dialog = new RewTimingOffsetDialog(
+            file.ImpliedArrivalSamples / file.SampleRate * 1000.0);
+        RewTimingOffsetChoice choice = dialog.ShowDialog(this);
+        if (choice == RewTimingOffsetChoice.Cancel)
+        {
+            plan = null!;
+            return false;
+        }
+
+        double? statedOffsetSeconds =
+            choice == RewTimingOffsetChoice.Stated ? dialog.OffsetSeconds : null;
+        if (!RewImportTiming.TryResolve(
+                statedOffsetSeconds,
+                file.TimeZeroIndex,
+                file.PeakIndex,
+                file.Samples.Length,
+                file.SampleRate,
+                out RewImportTimingPlan? resolved,
+                out string? problem) ||
+            resolved == null)
+        {
+            throw new InvalidOperationException(
+                $"This REW impulse-response export cannot be imported — {problem}.");
+        }
+
+        plan = resolved;
+        return true;
     }
 
     // What REW's export could not say, and what was assumed in its place. Always worth
     // showing: an imported measurement looks exactly like a measured one on screen, and
     // these are the ways in which it is not.
-    private void NotifyRewImportDecisions(RewImpulseResponseTextFile file)
+    private void NotifyRewImportDecisions(
+        RewImpulseResponseTextFile file,
+        RewImportTimingPlan plan)
     {
         if (closingInProgress)
         {
@@ -418,8 +468,7 @@ public partial class Form1
                 "impulse response — so this measurement is uncalibrated here, whatever REW showed.",
             FormattableString.Invariant(
                 $"The export states no bit depth and no playback channel: {ImportedBitDepth}-bit and Mono were assumed. Neither changes the samples — they describe the sweep this result is filed under."),
-            FormattableString.Invariant(
-                $"REW's text export does not record a timing offset, so one smaller than the arrival cannot be told from a shorter path. The arrival this header implies is {file.ImpliedArrivalSamples / file.SampleRate * 1000.0:0.000} ms; if that is not what REW showed for this measurement, it was measured with an offset and does not belong on this session's time base.")
+            DescribeImportedTiming(file, plan)
         };
         if (file.LowFrequencyHz == null || file.HighFrequencyHz == null)
         {
@@ -440,6 +489,28 @@ public partial class Form1
             "REW impulse response imported",
             MessageBoxButtons.OK,
             MessageBoxIcon.Information);
+    }
+
+    // What the import was told about time, and what that makes the arrival worth. Said
+    // in the notice because an imported measurement looks like a measured one on screen
+    // and this is the difference between a delay and a number that resembles one.
+    private static string DescribeImportedTiming(
+        RewImpulseResponseTextFile file,
+        RewImportTimingPlan plan)
+    {
+        double arrivalMs = plan.ArrivalSamples / file.SampleRate * 1000.0;
+        if (plan.Reference == TimingReference.RecordedSweep)
+        {
+            return FormattableString.Invariant(
+                $"The timing offset was left unstated, so this is filed as a recorded sweep: its shape is real and its position is not. Delays within it still mean what they say — a reflection 8 ms after the direct sound is 8 ms — but its arrival cannot be compared with another measurement's. Re-import it with the offset REW was running to place it on this session's time base.");
+        }
+
+        string statedAs = plan.OffsetSeconds == 0
+            ? "You stated no timing offset"
+            : FormattableString.Invariant(
+                $"You stated a {plan.OffsetSeconds * 1000.0:0.####} ms timing offset, which was taken back out");
+        return FormattableString.Invariant(
+            $"{statedAs}, so this measurement is on the session's time base with an arrival of {arrivalMs:0.###} ms. The export itself cannot confirm that: REW folds the offset into the start time and records it nowhere else, so the arrival is true on your word rather than on the file's.");
     }
 
     // REW's export states no bit depth: it is a text file of fractions of full scale,

--- a/source/Ui/Dialogs/RewTimingOffsetDialog.cs
+++ b/source/Ui/Dialogs/RewTimingOffsetDialog.cs
@@ -1,0 +1,139 @@
+using Resonalyze.Ui;
+
+namespace Resonalyze.Ui.Dialogs;
+
+/// <summary>What the user answered about the export's timing offset.</summary>
+internal enum RewTimingOffsetChoice
+{
+    /// <summary>The import was abandoned.</summary>
+    Cancel,
+
+    /// <summary>An offset was stated — zero counts, and is the common answer.</summary>
+    Stated,
+
+    /// <summary>Nobody knows, so the position of this measurement is not claimed.</summary>
+    Unknown
+}
+
+/// <summary>
+/// Asks for the one fact REW's text export cannot carry: the timing offset the
+/// measurement was taken with.
+/// </summary>
+/// <remarks>
+/// Deliberately not a yes/no about a zero offset. The value is asked for because the
+/// answer decides what the measurement may be compared with, and "I do not know" is
+/// offered as an equal button rather than as a cancel: it is a valid outcome that
+/// imports the shape without claiming its position, not a failure to answer.
+/// </remarks>
+internal sealed class RewTimingOffsetDialog : Form
+{
+    private readonly DarkNumericUpDown offsetInput = new();
+
+    public RewTimingOffsetDialog(double impliedArrivalMs)
+    {
+        InitializeDialog(impliedArrivalMs);
+    }
+
+    /// <summary>The stated offset in seconds, meaningful only for <see cref="RewTimingOffsetChoice.Stated"/>.</summary>
+    public double OffsetSeconds => (double)offsetInput.Value / 1000.0;
+
+    public new RewTimingOffsetChoice ShowDialog(IWin32Window? owner)
+    {
+        return base.ShowDialog(owner) switch
+        {
+            DialogResult.OK => RewTimingOffsetChoice.Stated,
+            DialogResult.No => RewTimingOffsetChoice.Unknown,
+            _ => RewTimingOffsetChoice.Cancel
+        };
+    }
+
+    private void InitializeDialog(double impliedArrivalMs)
+    {
+        SuspendLayout();
+
+        UiStyle.ApplyDarkDialog(
+            this,
+            new Size(560, 300),
+            title: "REW timing offset",
+            fixedDialog: true,
+            padding: new Padding(20));
+
+        var titleLabel = UiStyle.CreateLabel(
+            "What timing offset was REW measuring with?",
+            new Point(20, 20),
+            UiPalette.TextPrimary,
+            new Font("Segoe UI", 12F, FontStyle.Bold));
+
+        var bodyLabel = UiStyle.CreateLabel(
+            "REW folds its timing offset into the export's start time and records it " +
+            "nowhere else, so this file cannot be asked. Stating it here takes it back " +
+            "out and places the measurement on this session's time base, where its " +
+            "arrival can be compared with every other measurement.\r\n\r\n" +
+            "Most measurements were taken with no offset: leave it at 0.",
+            new Point(20, 58),
+            UiPalette.TextHighlight,
+            new Font("Segoe UI", 9.5F),
+            autoSize: false);
+        bodyLabel.Size = new Size(520, 82);
+
+        var offsetLabel = UiStyle.CreateLabel(
+            "Timing offset (ms):",
+            new Point(20, 152),
+            UiPalette.TextSecondaryAlt,
+            new Font("Segoe UI", 9.5F));
+
+        offsetInput.BeginInit();
+        offsetInput.DecimalPlaces = 4;
+        offsetInput.Increment = 0.1M;
+        offsetInput.Minimum = -1000M;
+        offsetInput.Maximum = 1000M;
+        offsetInput.Value = 0M;
+        offsetInput.Location = new Point(160, 149);
+        offsetInput.Size = new Size(110, 26);
+        offsetInput.EndInit();
+
+        var arrivalLabel = UiStyle.CreateLabel(
+            FormattableString.Invariant(
+                $"Without an offset this file's arrival would be {impliedArrivalMs:0.###} ms. If that is not what REW showed, the difference is the offset."),
+            new Point(20, 184),
+            UiPalette.TextSecondary,
+            new Font("Segoe UI", 9F),
+            autoSize: false);
+        arrivalLabel.Size = new Size(520, 34);
+
+        Button unknownButton = UiStyle.CreateDialogButton(
+            "I don't know",
+            DialogResult.No,
+            accent: false,
+            new Size(120, 32));
+        unknownButton.Location = new Point(20, 232);
+
+        Button cancelButton = UiStyle.CreateDialogButton(
+            "Cancel",
+            DialogResult.Cancel,
+            accent: false,
+            new Size(100, 32));
+        cancelButton.Location = new Point(320, 232);
+
+        Button importButton = UiStyle.CreateDialogButton(
+            "Import",
+            DialogResult.OK,
+            accent: true,
+            new Size(100, 32));
+        importButton.Location = new Point(430, 232);
+
+        Controls.AddRange(
+            titleLabel,
+            bodyLabel,
+            offsetLabel,
+            offsetInput,
+            arrivalLabel,
+            unknownButton,
+            cancelButton,
+            importButton);
+
+        AcceptButton = importButton;
+        CancelButton = cancelButton;
+        ResumeLayout(performLayout: false);
+    }
+}

--- a/tests/Resonalyze.App.Tests/RestoredImpulseResponseClaimTests.cs
+++ b/tests/Resonalyze.App.Tests/RestoredImpulseResponseClaimTests.cs
@@ -1,0 +1,95 @@
+using System.Numerics;
+using Resonalyze.Audio;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// Publishing a stored result through <c>RestoreImpulseResponse</c> while the
+/// measurement is busy. A run must still block it; a claim — which is what the
+/// caller that decoded the file has been holding across the read — must not,
+/// and with nothing held it takes its own for the publish and gives it back.
+/// </summary>
+public sealed class RestoredImpulseResponseClaimTests
+{
+    private const int SampleRate = 48_000;
+
+    private static void Restore(ExpSweepMeasurement measurement) =>
+        measurement.RestoreImpulseResponse(
+            lowFrequencyHz: 20,
+            highFrequencyHz: 20_000,
+            sampleRate: SampleRate,
+            bits: 24,
+            sweepDurationSeconds: 1.0,
+            playChannel: PlaybackChannel.Mono,
+            sweepDeconvolutionImpulseResponse: [Complex.Zero, Complex.One, Complex.Zero],
+            sweepDeconvolutionPeakIndex: 1);
+
+    // The plain case, and the one that regressed: nothing is held, so the restore
+    // claims for itself — and then has to configure the measurement THROUGH that
+    // claim, which the public Init refuses by design. A second restore is what
+    // proves the flag came back rather than merely reading false once.
+    [Fact]
+    public void RestoreWithNothingHeldPublishesAndReleases()
+    {
+        using var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        Assert.False(measurement.InProgress);
+
+        Restore(measurement);
+
+        Assert.True(measurement.HasImpulseResponse);
+        Assert.Equal(SampleRate, measurement.SampleRate);
+        Assert.False(measurement.InProgress);
+
+        Restore(measurement);
+        Assert.False(measurement.InProgress);
+    }
+
+    // The case the claim was added for: the file import claims before it reads,
+    // so the measurement is already busy by the time the decoded result arrives.
+    // The restore must go through, and must leave the claim to its owner.
+    [Fact]
+    public void RestoreUnderAnExternallyHeldClaimPublishesAndLeavesTheClaimStanding()
+    {
+        using var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+
+        using (measurement.Claim())
+        {
+            Assert.True(measurement.InProgress);
+
+            Restore(measurement);
+
+            Assert.True(measurement.HasImpulseResponse);
+            // Still the claim holder's, not handed back by the restore.
+            Assert.True(measurement.InProgress);
+        }
+
+        Assert.False(measurement.InProgress);
+    }
+
+    // The arguments are validated after the claim is taken, so a refused restore
+    // is the path that leaves the measurement busy forever if the release is not
+    // in a finally.
+    [Fact]
+    public void ARefusedRestoreGivesBackTheClaimItTook()
+    {
+        using var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+
+        Assert.Throws<ArgumentException>(() =>
+            measurement.RestoreImpulseResponse(
+                lowFrequencyHz: 20,
+                highFrequencyHz: 20_000,
+                sampleRate: SampleRate,
+                bits: 24,
+                sweepDurationSeconds: 1.0,
+                playChannel: PlaybackChannel.Mono,
+                sweepDeconvolutionImpulseResponse: [],
+                sweepDeconvolutionPeakIndex: 0));
+
+        Assert.False(measurement.InProgress);
+        Assert.False(measurement.HasImpulseResponse);
+
+        // And the measurement is still usable, which is the point of giving it back.
+        Restore(measurement);
+        Assert.True(measurement.HasImpulseResponse);
+    }
+}

--- a/tests/Resonalyze.App.Tests/RewImportTimingTests.cs
+++ b/tests/Resonalyze.App.Tests/RewImportTimingTests.cs
@@ -1,0 +1,118 @@
+namespace Resonalyze.App.Tests;
+
+// The trust boundary of the REW text import. The format cannot state the timing offset
+// REW was running with — the header of a measurement taken with one is word for word
+// the header of one taken without — so the import asks, and the answer decides whether
+// the arrival is a delay or merely a number. These are the four outcomes of that answer.
+public sealed class RewImportTimingTests
+{
+    private const int SampleRate = 96000;
+
+    [Fact]
+    public void AnUnknownOffsetImportsTheShapeAndClaimsNothingAboutTime()
+    {
+        // "I do not know" is an answer, not a failure. Nothing is compensated, the
+        // export keeps its own reference, and the result is stamped RecordedSweep —
+        // where the position is explicitly not comparable with anything else.
+        Assert.True(RewImportTiming.TryResolve(
+            statedOffsetSeconds: null,
+            timeZeroIndex: 96127.0,
+            peakIndex: 96000,
+            sampleCount: 262144,
+            sampleRate: SampleRate,
+            out RewImportTimingPlan? plan,
+            out string? problem));
+
+        Assert.Null(problem);
+        Assert.NotNull(plan);
+        Assert.Equal(TimingReference.RecordedSweep, plan!.Reference);
+        Assert.Equal(96127.0, plan.ReferenceIndex);
+        Assert.Equal(0, plan.OffsetSeconds);
+
+        // The arrival is reported as the file implies it — negative here, which is the
+        // shadow of the offset. Under RecordedSweep that is not a lie about the world,
+        // only a number nobody is allowed to compare.
+        Assert.Equal(-127.0, plan.ArrivalSamples);
+    }
+
+    [Fact]
+    public void AStatedOffsetIsTakenBackOutAndTrusted()
+    {
+        // The real measurement behind this: m-L exported with a 4 ms offset at 96 kHz.
+        // 4 ms is 384 whole samples, t = 0 sits at 96127 and the peak at 96000, so the
+        // file alone reads as an arrival of -1.32 ms — REW's own API says the same.
+        // Taking the offset out moves the reference to 95743 and the arrival to +257.
+        Assert.True(RewImportTiming.TryResolve(
+            statedOffsetSeconds: 0.004,
+            timeZeroIndex: 96127.0,
+            peakIndex: 96000,
+            sampleCount: 262144,
+            sampleRate: SampleRate,
+            out RewImportTimingPlan? plan,
+            out string? problem));
+
+        Assert.Null(problem);
+        Assert.Equal(TimingReference.SynchronizedLoopback, plan!.Reference);
+        Assert.Equal(95743.0, plan.ReferenceIndex);
+        Assert.Equal(257.0, plan.ArrivalSamples);
+        Assert.Equal(0.004, plan.OffsetSeconds);
+    }
+
+    [Fact]
+    public void ZeroIsAnAssertionLikeAnyOtherValue()
+    {
+        // The common answer, and the one the old design tried to prove from the file.
+        // It is trusted for the same reason 4 ms is: the user said so.
+        Assert.True(RewImportTiming.TryResolve(
+            statedOffsetSeconds: 0,
+            timeZeroIndex: 95743.0,
+            peakIndex: 96000,
+            sampleCount: 262144,
+            sampleRate: SampleRate,
+            out RewImportTimingPlan? plan,
+            out _));
+
+        Assert.Equal(TimingReference.SynchronizedLoopback, plan!.Reference);
+        Assert.Equal(95743.0, plan.ReferenceIndex);
+        Assert.Equal(257.0, plan.ArrivalSamples);
+    }
+
+    [Fact]
+    public void AStatedOffsetTheFileContradictsIsRefusedWithTheOneThatWouldWork()
+    {
+        // Claiming no offset for a file whose peak precedes its reference cannot be
+        // true: sound does not reach the microphone before it reaches the loopback.
+        // The refusal names the offset that would put the arrival after t = 0, so the
+        // next attempt is informed rather than a guess.
+        Assert.False(RewImportTiming.TryResolve(
+            statedOffsetSeconds: 0,
+            timeZeroIndex: 96127.0,
+            peakIndex: 96000,
+            sampleCount: 262144,
+            sampleRate: SampleRate,
+            out RewImportTimingPlan? plan,
+            out string? problem));
+
+        Assert.Null(plan);
+        Assert.Contains("cannot produce", problem);
+        Assert.Contains("1.3229", problem);
+    }
+
+    [Fact]
+    public void AnOffsetThatMovesTheReferenceOutOfTheBufferIsRefused()
+    {
+        // A mistyped offset — seconds where milliseconds were meant — would otherwise
+        // ask for a rotation by more than the buffer holds.
+        Assert.False(RewImportTiming.TryResolve(
+            statedOffsetSeconds: 4.0,
+            timeZeroIndex: 96127.0,
+            peakIndex: 96000,
+            sampleCount: 262144,
+            sampleRate: SampleRate,
+            out RewImportTimingPlan? plan,
+            out string? problem));
+
+        Assert.Null(plan);
+        Assert.Contains("outside the buffer", problem);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/FractionalSampleShiftTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FractionalSampleShiftTests.cs
@@ -1,0 +1,76 @@
+namespace Resonalyze.Dsp.Tests;
+
+// Moving a signal by part of a sample. The tests below check the two things that make
+// such a shift trustworthy: that a whole-sample shift changes nothing at all, and that a
+// fractional one lands exactly where the underlying continuous signal says it should —
+// including which direction "advance" means, since a sign error here is invisible in a
+// magnitude plot and moves every arrival by twice the offset.
+public sealed class FractionalSampleShiftTests
+{
+    [Fact]
+    public void AdvanceCircular_WithAWholeShift_MovesTheSamplesUntouched()
+    {
+        double[] signal = [1.0, 2.0, 3.0, 4.0, 5.0];
+
+        Assert.Equal([3.0, 4.0, 5.0, 1.0, 2.0], FractionalSampleShift.AdvanceCircular(signal, 2));
+        // A negative shift delays, and the tail wraps back to the head.
+        Assert.Equal([4.0, 5.0, 1.0, 2.0, 3.0], FractionalSampleShift.AdvanceCircular(signal, -2));
+        Assert.Equal(signal, FractionalSampleShift.AdvanceCircular(signal, 0));
+        Assert.Equal(signal, FractionalSampleShift.AdvanceCircular(signal, signal.Length));
+    }
+
+    [Fact]
+    public void AdvanceCircular_LandsWhereTheContinuousSignalIs()
+    {
+        // A band-limited signal is known everywhere between its samples, so there is an
+        // exact answer to compare against: three partials well below Nyquist, evaluated
+        // at the shifted times.
+        const int n = 128;
+        const double shift = 7.37;
+        (int Bin, double Amplitude, double Phase)[] partials =
+            [(3, 1.0, 0.4), (11, 0.5, -1.1), (29, 0.25, 2.2)];
+
+        double At(double t) => partials.Sum(p =>
+            p.Amplitude * Math.Cos((2.0 * Math.PI * p.Bin * t / n) + p.Phase));
+
+        double[] signal = [.. Enumerable.Range(0, n).Select(i => At(i))];
+
+        double[] shifted = FractionalSampleShift.AdvanceCircular(signal, shift);
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.Equal(At(i + shift), shifted[i], 10);
+        }
+    }
+
+    [Fact]
+    public void AdvanceCircular_ThereAndBack_ReturnsTheSignal()
+    {
+        const int n = 256;
+        var random = new Random(20260820);
+        // Band-limited by construction: energy only in the lower eighth of the spectrum,
+        // which is what a sweep measured to 20 kHz at 96 kHz looks like. A signal with
+        // energy at Nyquist could not survive this round trip and should not: that bin
+        // holds no phase to shift, so an exact shift can only scale it.
+        double[] amplitudes = [.. Enumerable.Range(0, (n / 8) + 1).Select(_ => random.NextDouble())];
+        double[] signal = [.. Enumerable.Range(0, n).Select(i =>
+            Enumerable.Range(1, n / 8).Sum(k =>
+                amplitudes[k] * Math.Cos((2.0 * Math.PI * k * i / n) + k)))];
+
+        double[] roundTrip = FractionalSampleShift.AdvanceCircular(
+            FractionalSampleShift.AdvanceCircular(signal, 0.37), -0.37);
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.Equal(signal[i], roundTrip[i], 9);
+        }
+    }
+
+    [Fact]
+    public void AdvanceCircular_RefusesWhatItCannotShift()
+    {
+        Assert.Throws<ArgumentNullException>(() => FractionalSampleShift.AdvanceCircular(null!, 1.0));
+        Assert.Throws<ArgumentException>(() => FractionalSampleShift.AdvanceCircular([], 1.0));
+        Assert.Throws<ArgumentException>(() => FractionalSampleShift.AdvanceCircular([1.0], double.NaN));
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/RewImpulseResponseTextFileTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/RewImpulseResponseTextFileTests.cs
@@ -21,7 +21,8 @@ public sealed class RewImpulseResponseTextFileTests
         string excitation =
             "* Excitation: 512k Log Swept Sine, 1 sweep at -10.0 dBFS using a loopback as a timing reference",
         int? declaredLength = null,
-        string band = "* Response measured over: 20.1 to 19,999.9 Hz")
+        string band = "* Response measured over: 20.1 to 19,999.9 Hz",
+        int? peakIndex = null)
     {
         var text = new StringBuilder();
         text.AppendLine("* Impulse Response data saved by REW V5.40 Beta 132");
@@ -34,7 +35,7 @@ public sealed class RewImpulseResponseTextFileTests
         text.AppendLine(excitation);
         text.AppendLine(band);
         text.AppendLine("0.0034054601565003395 // Peak value before normalisation");
-        text.AppendLine(Invariant(samples.Count > 0 ? Peak(samples) : 0) + " // Peak index");
+        text.AppendLine(Invariant(peakIndex ?? (samples.Count > 0 ? Peak(samples) : 0)) + " // Peak index");
         text.AppendLine(Invariant(declaredLength ?? samples.Count) + " // Response length");
         text.AppendLine("1.0416666666666666E-5 // Sample interval (seconds)");
         text.AppendLine(startTimeSeconds.ToString("R", CultureInfo.InvariantCulture) +
@@ -82,11 +83,30 @@ public sealed class RewImpulseResponseTextFileTests
         ];
     }
 
+    // Sub-sample position of the largest peak, so a fractional shift can be asserted.
+    private static double ArgMaxParabolic(double[] x)
+    {
+        int i = 0;
+        for (int k = 1; k < x.Length; k++)
+        {
+            if (Math.Abs(x[k]) > Math.Abs(x[i]))
+            {
+                i = k;
+            }
+        }
+
+        double a = Math.Abs(x[(i - 1 + x.Length) % x.Length]);
+        double b = Math.Abs(x[i]);
+        double c = Math.Abs(x[(i + 1) % x.Length]);
+        double denominator = a - (2 * b) + c;
+        return i + (denominator == 0 ? 0 : 0.5 * (a - c) / denominator);
+    }
+
     [Fact]
     public void Parse_ReadsTheHeaderRewWrites()
     {
         RewImpulseResponseTextFile file = RewImpulseResponseTextFile.Parse(
-            Export(ImpulseAt(64, 20.25), -20.25 / SampleRate));
+            Export(ImpulseAt(64, 34.0), -20.25 / SampleRate));
 
         Assert.Equal(SampleRate, file.SampleRate);
         Assert.Equal(64, file.Samples.Length);
@@ -108,20 +128,21 @@ public sealed class RewImpulseResponseTextFileTests
     {
         // t = 0 at sample 20.25: rounding it to 20 would move the arrival by a quarter of
         // a sample — 2.6 us, 0.9 mm — on every channel placed this way.
-        double[] samples = ImpulseAt(64, 20.25);
+        double[] samples = ImpulseAt(64, 34.0);
         RewImpulseResponseTextFile file = RewImpulseResponseTextFile.Parse(
             Export(samples, -20.25 / SampleRate));
 
         double[] referenced = file.ToLoopbackReferencedImpulseResponse();
 
-        // The same pulse, now centred on sample 0 rather than on 20.25.
-        double[] expected = ImpulseAt(64, 0.0);
+        // The same pulse, now 13.75 samples after the reference rather than 34 after
+        // the buffer's start: 34 − 20.25, with the quarter sample carried not rounded.
+        double[] expected = ImpulseAt(64, 13.75);
         for (int i = 0; i < referenced.Length; i++)
         {
             Assert.Equal(expected[i], referenced[i], 9);
         }
 
-        Assert.Equal(1.0, referenced[0], 9);
+        Assert.Equal(13.75, ArgMaxParabolic(referenced), 1);
 
         // The samples themselves are untouched by reading: they stay REW's buffer, which
         // is what a raw deconvolution looks like on this side too.
@@ -131,7 +152,7 @@ public sealed class RewImpulseResponseTextFileTests
     [Fact]
     public void Parse_RefusesAnExportThatCannotCarryWhatItClaims()
     {
-        double[] samples = ImpulseAt(64, 20.25);
+        double[] samples = ImpulseAt(64, 34.0);
         double startTime = -20.25 / SampleRate;
 
         // Normalised: the peak has been scaled to 1, so the file holds no level relation
@@ -178,7 +199,7 @@ public sealed class RewImpulseResponseTextFileTests
         // decides whether to refuse it or import it as a recorded sweep — but it must not
         // be silently treated as the loopback base.
         RewImpulseResponseTextFile file = RewImpulseResponseTextFile.Parse(Export(
-            ImpulseAt(64, 20.25),
+            ImpulseAt(64, 34.0),
             -20.25 / SampleRate,
             excitation: "* Excitation: 256k Log Swept Sine, 4 sweeps at -12.0 dBFS using an " +
                 "acoustic timing reference"));
@@ -194,7 +215,7 @@ public sealed class RewImpulseResponseTextFileTests
         // culture nor the one this program runs under is the authority on what "20,1"
         // means. Both conventions must read the same, whichever culture is current —
         // and trying invariant-then-current would read "20,1" as 201.
-        double[] samples = ImpulseAt(64, 20.25);
+        double[] samples = ImpulseAt(64, 34.0);
         double startTime = -20.25 / SampleRate;
         CultureInfo original = CultureInfo.CurrentCulture;
         try
@@ -232,5 +253,31 @@ public sealed class RewImpulseResponseTextFileTests
         {
             CultureInfo.CurrentCulture = original;
         }
+    }
+    [Fact]
+    public void Parse_RefusesAnArrivalThatPrecedesTheReference()
+    {
+        // A timing offset applied in REW is invisible in this format: the header of a
+        // measurement taken with one is word for word the header of one taken without,
+        // and the offset is simply baked into the start time. What it cannot hide is
+        // the consequence. Measured on REW 5.40 Beta 132: the same channel exported
+        // with a 4 ms offset carries "96000 // Peak index" against a start time of
+        // -1.0013229166666666 s, which puts t = 0 at sample 96127 — 127 samples after
+        // the peak — and REW's own API reports that measurement's delay as -1.32 ms.
+        // Sound does not reach the microphone before it reaches the loopback.
+        double[] samples = ImpulseAt(64, 34.0);
+
+        Assert.False(RewImpulseResponseTextFile.TryParse(
+            Export(samples, -20.25 / SampleRate, peakIndex: 20),
+            out _,
+            out string? problem));
+        Assert.Contains("precede the reference", problem);
+
+        // The honest limit: an offset smaller than the arrival keeps the peak after
+        // t = 0 and is indistinguishable from a shorter path. This one still imports,
+        // and the notice says the arrival it implies so a user can catch it.
+        RewImpulseResponseTextFile file = RewImpulseResponseTextFile.Parse(
+            Export(samples, -20.25 / SampleRate, peakIndex: 40));
+        Assert.Equal(19.75, file.ImpliedArrivalSamples, 6);
     }
 }

--- a/tests/Resonalyze.Dsp.Tests/RewImpulseResponseTextFileTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/RewImpulseResponseTextFileTests.cs
@@ -20,7 +20,8 @@ public sealed class RewImpulseResponseTextFileTests
         string minPhase = "* IR is not the min phase version",
         string excitation =
             "* Excitation: 512k Log Swept Sine, 1 sweep at -10.0 dBFS using a loopback as a timing reference",
-        int? declaredLength = null)
+        int? declaredLength = null,
+        string band = "* Response measured over: 20.1 to 19,999.9 Hz")
     {
         var text = new StringBuilder();
         text.AppendLine("* Impulse Response data saved by REW V5.40 Beta 132");
@@ -31,7 +32,7 @@ public sealed class RewImpulseResponseTextFileTests
         text.AppendLine("* Dated: Jun 15, 2026, 2:47:02 PM");
         text.AppendLine("* Measurement: w-L_01 (sw)");
         text.AppendLine(excitation);
-        text.AppendLine("* Response measured over: 20.1 to 19,999.9 Hz");
+        text.AppendLine(band);
         text.AppendLine("0.0034054601565003395 // Peak value before normalisation");
         text.AppendLine(Invariant(samples.Count > 0 ? Peak(samples) : 0) + " // Peak index");
         text.AppendLine(Invariant(declaredLength ?? samples.Count) + " // Response length");
@@ -185,5 +186,51 @@ public sealed class RewImpulseResponseTextFileTests
         Assert.False(file.IsLoopbackReferenced);
         Assert.Equal(4, file.SweepCount);
         Assert.Equal(256 * 1024, file.SweepLengthSamples);
+    }
+    [Fact]
+    public void Parse_ReadsTheBandInEitherGroupingConvention()
+    {
+        // The file was written on someone else's machine, so neither the invariant
+        // culture nor the one this program runs under is the authority on what "20,1"
+        // means. Both conventions must read the same, whichever culture is current —
+        // and trying invariant-then-current would read "20,1" as 201.
+        double[] samples = ImpulseAt(64, 20.25);
+        double startTime = -20.25 / SampleRate;
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try
+        {
+            foreach (string culture in new[] { "en-US", "de-DE" })
+            {
+                CultureInfo.CurrentCulture = new CultureInfo(culture);
+
+                RewImpulseResponseTextFile dotted = RewImpulseResponseTextFile.Parse(
+                    Export(samples, startTime, band: "* Response measured over: 20.1 to 19,999.9 Hz"));
+                RewImpulseResponseTextFile commaed = RewImpulseResponseTextFile.Parse(
+                    Export(samples, startTime, band: "* Response measured over: 20,1 to 19.999,9 Hz"));
+
+                Assert.Equal(20.1, dotted.LowFrequencyHz);
+                Assert.Equal(19999.9, dotted.HighFrequencyHz);
+                Assert.Equal(20.1, commaed.LowFrequencyHz);
+                Assert.Equal(19999.9, commaed.HighFrequencyHz);
+            }
+
+            // A lone separator three digits from the end is a thousands group in both
+            // conventions; anything else is a decimal point.
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            RewImpulseResponseTextFile grouped = RewImpulseResponseTextFile.Parse(
+                Export(samples, startTime, band: "* Response measured over: 1,250 to 12.500 Hz"));
+            Assert.Equal(1250.0, grouped.LowFrequencyHz);
+            Assert.Equal(12500.0, grouped.HighFrequencyHz);
+
+            // A band it cannot read leaves the band absent rather than failing the file.
+            RewImpulseResponseTextFile unreadable = RewImpulseResponseTextFile.Parse(
+                Export(samples, startTime, band: "* Response measured over: unknown"));
+            Assert.Null(unreadable.LowFrequencyHz);
+            Assert.Null(unreadable.HighFrequencyHz);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
     }
 }

--- a/tests/Resonalyze.Dsp.Tests/RewImpulseResponseTextFileTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/RewImpulseResponseTextFileTests.cs
@@ -1,0 +1,189 @@
+using System.Globalization;
+using System.Text;
+
+namespace Resonalyze.Dsp.Tests;
+
+// REW's text impulse-response export, read back. The header lines below are the ones REW
+// 5.40 Beta 132 actually wrote for a loopback-referenced car measurement (96 kHz, one
+// sweep) — kept in that shape because the two lines that decide whether the file is
+// usable at all say so in prose ("IR is not normalised", "IR window has not been
+// applied"), and because the start time is the only place the absolute time base exists.
+public sealed class RewImpulseResponseTextFileTests
+{
+    private const int SampleRate = 96000;
+
+    private static string Export(
+        IReadOnlyList<double> samples,
+        double startTimeSeconds,
+        string normalised = "* IR is not normalised",
+        string window = "* IR window has not been applied",
+        string minPhase = "* IR is not the min phase version",
+        string excitation =
+            "* Excitation: 512k Log Swept Sine, 1 sweep at -10.0 dBFS using a loopback as a timing reference",
+        int? declaredLength = null)
+    {
+        var text = new StringBuilder();
+        text.AppendLine("* Impulse Response data saved by REW V5.40 Beta 132");
+        text.AppendLine(normalised);
+        text.AppendLine(window);
+        text.AppendLine(minPhase);
+        text.AppendLine("* Source: Scarlett 2i2 4th Gen, Scarlett 2i2 4th Gen , 1, volume: no control");
+        text.AppendLine("* Dated: Jun 15, 2026, 2:47:02 PM");
+        text.AppendLine("* Measurement: w-L_01 (sw)");
+        text.AppendLine(excitation);
+        text.AppendLine("* Response measured over: 20.1 to 19,999.9 Hz");
+        text.AppendLine("0.0034054601565003395 // Peak value before normalisation");
+        text.AppendLine(Invariant(samples.Count > 0 ? Peak(samples) : 0) + " // Peak index");
+        text.AppendLine(Invariant(declaredLength ?? samples.Count) + " // Response length");
+        text.AppendLine("1.0416666666666666E-5 // Sample interval (seconds)");
+        text.AppendLine(startTimeSeconds.ToString("R", CultureInfo.InvariantCulture) +
+            " // Start time (seconds)");
+        text.AppendLine("120.0 // Data offset (dB)");
+        text.AppendLine("* Data start");
+        foreach (double sample in samples)
+        {
+            text.AppendLine(sample.ToString("R", CultureInfo.InvariantCulture));
+        }
+
+        return text.ToString();
+    }
+
+    private static string Invariant(int value) => value.ToString(CultureInfo.InvariantCulture);
+
+    private static int Peak(IReadOnlyList<double> samples)
+    {
+        int peak = 0;
+        for (int i = 1; i < samples.Count; i++)
+        {
+            if (Math.Abs(samples[i]) > Math.Abs(samples[peak]))
+            {
+                peak = i;
+            }
+        }
+
+        return peak;
+    }
+
+    // A band-limited pulse centred at a fractional position — what a loopback arrival
+    // actually is, since REW pins its buffer to the microphone peak and lets the
+    // reference fall where it may. Band-limited rather than a bare sample spike, because
+    // a spike carries energy at Nyquist, where there is no phase to shift and therefore
+    // no meaningful fractional position.
+    private static double[] ImpulseAt(int length, double position)
+    {
+        int highest = length / 4;
+        double peak = (2 * highest) + 1;
+        return
+        [
+            .. Enumerable.Range(0, length).Select(i =>
+                (1.0 + Enumerable.Range(1, highest).Sum(k =>
+                    2.0 * Math.Cos(2.0 * Math.PI * k * (i - position) / length))) / peak)
+        ];
+    }
+
+    [Fact]
+    public void Parse_ReadsTheHeaderRewWrites()
+    {
+        RewImpulseResponseTextFile file = RewImpulseResponseTextFile.Parse(
+            Export(ImpulseAt(64, 20.25), -20.25 / SampleRate));
+
+        Assert.Equal(SampleRate, file.SampleRate);
+        Assert.Equal(64, file.Samples.Length);
+        Assert.Equal(20.25, file.TimeZeroIndex, 9);
+        Assert.Equal(120.0, file.DataOffsetDb);
+        Assert.Equal(0.0034054601565003395, file.PeakValueBeforeNormalisation);
+        Assert.Equal("w-L_01 (sw)", file.MeasurementName);
+        Assert.Equal(20.1, file.LowFrequencyHz);
+        Assert.Equal(19999.9, file.HighFrequencyHz);
+        // The sweep is longer than the impulse response it produced, so the sweep's own
+        // length is worth reading rather than inferring from the buffer.
+        Assert.Equal(512 * 1024, file.SweepLengthSamples);
+        Assert.Equal(1, file.SweepCount);
+        Assert.True(file.IsLoopbackReferenced);
+    }
+
+    [Fact]
+    public void ToLoopbackReferencedImpulseResponse_PutsTheReferenceArrivalOnSampleZero()
+    {
+        // t = 0 at sample 20.25: rounding it to 20 would move the arrival by a quarter of
+        // a sample — 2.6 us, 0.9 mm — on every channel placed this way.
+        double[] samples = ImpulseAt(64, 20.25);
+        RewImpulseResponseTextFile file = RewImpulseResponseTextFile.Parse(
+            Export(samples, -20.25 / SampleRate));
+
+        double[] referenced = file.ToLoopbackReferencedImpulseResponse();
+
+        // The same pulse, now centred on sample 0 rather than on 20.25.
+        double[] expected = ImpulseAt(64, 0.0);
+        for (int i = 0; i < referenced.Length; i++)
+        {
+            Assert.Equal(expected[i], referenced[i], 9);
+        }
+
+        Assert.Equal(1.0, referenced[0], 9);
+
+        // The samples themselves are untouched by reading: they stay REW's buffer, which
+        // is what a raw deconvolution looks like on this side too.
+        Assert.Equal(samples, file.Samples);
+    }
+
+    [Fact]
+    public void Parse_RefusesAnExportThatCannotCarryWhatItClaims()
+    {
+        double[] samples = ImpulseAt(64, 20.25);
+        double startTime = -20.25 / SampleRate;
+
+        // Normalised: the peak has been scaled to 1, so the file holds no level relation
+        // to any other channel — and nothing in the samples says so.
+        Assert.False(RewImpulseResponseTextFile.TryParse(
+            Export(samples, startTime, normalised: "* IR is normalised"), out _, out string? problem));
+        Assert.Contains("normalised", problem);
+
+        // Windowed: a view of the response, not the response.
+        Assert.False(RewImpulseResponseTextFile.TryParse(
+            Export(samples, startTime, window: "* IR window has been applied"), out _, out problem));
+        Assert.Contains("window", problem);
+
+        // Minimum phase: the arrival time has been removed, which is the one thing this
+        // import exists to preserve.
+        Assert.False(RewImpulseResponseTextFile.TryParse(
+            Export(samples, startTime, minPhase: "* IR is the min phase version"), out _, out problem));
+        Assert.Contains("minimum-phase", problem);
+
+        // Headers off: the samples are fine and unplaceable.
+        Assert.False(RewImpulseResponseTextFile.TryParse(
+            string.Join('\n', samples.Select(s => s.ToString("R", CultureInfo.InvariantCulture))),
+            out _,
+            out problem));
+        Assert.Contains("headers", problem);
+
+        // Truncated: the header says how many samples there should be.
+        Assert.False(RewImpulseResponseTextFile.TryParse(
+            Export(samples[..40], startTime, declaredLength: 64), out _, out problem));
+        Assert.Contains("truncated", problem);
+
+        // A start time that puts t = 0 outside the buffer: the reference arrival is not
+        // in these samples, so nothing can be referenced to it.
+        Assert.False(RewImpulseResponseTextFile.TryParse(
+            Export(samples, 0.5), out _, out problem));
+        Assert.Contains("outside the buffer", problem);
+    }
+
+    [Fact]
+    public void Parse_ReadsButDoesNotPlaceASweepOffTheLoopbackBase()
+    {
+        // An acoustic reference gives a real impulse response whose position means
+        // something only within its own measurement. The file still reads — the caller
+        // decides whether to refuse it or import it as a recorded sweep — but it must not
+        // be silently treated as the loopback base.
+        RewImpulseResponseTextFile file = RewImpulseResponseTextFile.Parse(Export(
+            ImpulseAt(64, 20.25),
+            -20.25 / SampleRate,
+            excitation: "* Excitation: 256k Log Swept Sine, 4 sweeps at -12.0 dBFS using an " +
+                "acoustic timing reference"));
+
+        Assert.False(file.IsLoopbackReferenced);
+        Assert.Equal(4, file.SweepCount);
+        Assert.Equal(256 * 1024, file.SweepLengthSamples);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/RewImpulseResponseTextFileTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/RewImpulseResponseTextFileTests.cs
@@ -255,7 +255,7 @@ public sealed class RewImpulseResponseTextFileTests
         }
     }
     [Fact]
-    public void Parse_RefusesAnArrivalThatPrecedesTheReference()
+    public void Parse_KeepsAnArrivalThatPrecedesTheReference()
     {
         // A timing offset applied in REW is invisible in this format: the header of a
         // measurement taken with one is word for word the header of one taken without,
@@ -264,20 +264,51 @@ public sealed class RewImpulseResponseTextFileTests
         // with a 4 ms offset carries "96000 // Peak index" against a start time of
         // -1.0013229166666666 s, which puts t = 0 at sample 96127 — 127 samples after
         // the peak — and REW's own API reports that measurement's delay as -1.32 ms.
-        // Sound does not reach the microphone before it reaches the loopback.
+        //
+        // This USED to be refused at parse time. It is not any more: it is the very
+        // file the importer's offset question exists to rescue, and refusing it here
+        // would mean the question could never be asked. The reader states the arrival
+        // and leaves the judgement to whoever knows the offset.
         double[] samples = ImpulseAt(64, 34.0);
 
-        Assert.False(RewImpulseResponseTextFile.TryParse(
-            Export(samples, -20.25 / SampleRate, peakIndex: 20),
-            out _,
-            out string? problem));
-        Assert.Contains("precede the reference", problem);
+        RewImpulseResponseTextFile offsetFile = RewImpulseResponseTextFile.Parse(
+            Export(samples, -20.25 / SampleRate, peakIndex: 20));
+        Assert.Equal(-0.25, offsetFile.ImpliedArrivalSamples, 6);
 
-        // The honest limit: an offset smaller than the arrival keeps the peak after
-        // t = 0 and is indistinguishable from a shorter path. This one still imports,
-        // and the notice says the arrival it implies so a user can catch it.
+        // An offset SMALLER than the arrival leaves the arrival positive and is
+        // indistinguishable from a shorter path — the case no check can reach.
         RewImpulseResponseTextFile file = RewImpulseResponseTextFile.Parse(
             Export(samples, -20.25 / SampleRate, peakIndex: 40));
         Assert.Equal(19.75, file.ImpliedArrivalSamples, 6);
+    }
+
+    [Fact]
+    public void StatedOffsetMovesTheReferenceAndTheArrival()
+    {
+        // Undoing a stated offset is a move of t = 0 and nothing else: the samples are
+        // untouched. REW's sign is that a positive offset delays the measurement, so
+        // taking it out moves the reference EARLIER in the buffer and the arrival later
+        // by the same amount. Confirmed against six real captures: at 96 kHz a 4 ms
+        // offset is 384 whole samples, and adding it back to the reported IR start
+        // reproduces the un-offset arrival to the last digit.
+        double[] samples = ImpulseAt(64, 34.0);
+        RewImpulseResponseTextFile file = RewImpulseResponseTextFile.Parse(
+            Export(samples, -20.25 / SampleRate, peakIndex: 20));
+
+        double offsetSeconds = 8.0 / SampleRate;
+        Assert.Equal(12.25, file.ReferenceIndexWithOffset(offsetSeconds), 6);
+        Assert.Equal(7.75, file.ArrivalSamplesWithOffset(offsetSeconds), 6);
+
+        // Zero is the identity, and the no-argument overload is that same case.
+        Assert.Equal(file.TimeZeroIndex, file.ReferenceIndexWithOffset(0), 12);
+        Assert.Equal(
+            file.ToLoopbackReferencedImpulseResponse(),
+            file.ToLoopbackReferencedImpulseResponse(0));
+
+        // The shift really is applied to the samples: the pulse sits 8 samples later
+        // once the offset is taken out than it does without it.
+        double[] uncorrected = file.ToLoopbackReferencedImpulseResponse();
+        double[] corrected = file.ToLoopbackReferencedImpulseResponse(offsetSeconds);
+        Assert.Equal(Peak(uncorrected) + 8, Peak(corrected));
     }
 }


### PR DESCRIPTION
Implements #90 — the REW → Resonalyze import path, in the shape you asked for: the text export first, a live HTTP client left out.

## What it does

A `.txt` alongside the `.json` and `.wav` the Load dialog already takes. The reader lives in `Resonalyze.Dsp` so the part worth testing is testable on any platform; the app side is thin wiring.

**Why the text export and not the WAV.** Of REW's three routes out, it is the only one that states the time of sample 0. A WAV carries the samples and no timing unless t = 0 is pinned to a whole sample on the way out — which cannot express a fractional zero, and which rewrites the measurement's own start time to make the cut (measured: one of our eight channels moved by 0.033 sample when exported that way).

**The fractional zero.** REW anchors its buffer on the microphone peak, an integer sample, and lets the loopback arrival fall where it falls: for the eight channels of the set behind this work, `-startTime · fs` came out as 95072.000, 95541.000, 95522.000, 95720.967, 95604.082, 95713.793, 95599.417, 95629.073. Rounding that away costs up to half a sample — 5 µs at 96 kHz — which is the resolution your arrival estimator works at. So `FractionalSampleShift.AdvanceCircular` moves the whole part as a rotation and the fractional part as a linear phase ramp, which for a band-limited signal is not an approximation but the exact interpolation. It is circular on purpose: the pre-roll of a deconvolved sweep holds the harmonic images that belong at negative time, and they wrap to the tail rather than being cut.

**What is refused, and why it has to be.** Two header lines decide whether a file is usable at all and neither shows in the samples: an export made with *normalise* on has had its peak scaled to one and holds no level relation to any other channel, and an export with the IR window applied is a view of the response rather than the response. The minimum-phase version is refused too — its excess phase is the one thing this import exists to keep. A file written without headers is refused because the headers are where the time base is.

Whether the sweep was loopback-referenced is **read but not enforced in the DSP layer** — that is a routing decision, so the reader exposes `IsLoopbackReferenced` and the app refuses on it, quoting REW's own excitation line back to the user.

**What is assumed, and said out loud rather than assumed silently.** The import posts a notice naming: the bit depth (a text file of fractions of full scale keeps no trace of it), the playback channel (REW does not say which output it played through, so `Mono` rather than a side it never carried), and — only when the header lacks them — the swept band and the sweep's length. The sweep length is read from the excitation line's `512k` where present, because REW keeps the impulse response shorter than the sweep that made it and the harmonic geometry follows the sweep. The notice also states what the format cannot carry at all: no coherence, no level meters, no SPL anchor, and no microphone calibration — REW applies that to its own curves, not to the impulse response, so an imported IR is uncalibrated whatever REW showed.

The result lands as a **measurement**, like a recorded sweep and unlike a loaded file: nothing on disk holds it in this program's terms, so it must not become a save target pointing back at the user's REW export.

## Checking

Against a real 262144-sample export of a car measurement, read here and compared with the same measurement converted from REW's API by a separate implementation in another language: **max |difference| 1.9e-10** on both the raw buffer and the re-referenced one — float32 text rounding, 5.6e-8 of peak — and the same transfer peak index.

`Resonalyze.Dsp.Tests` 1117/1117 on macOS arm64; the solution builds clean with `-p:EnableWindowsTargeting=true`.

The fixtures behind every timing claim are published (CC BY 4.0) next to the dataset, if you want to check the reader against REW's own bytes rather than against my description:
https://github.com/ayukhno/autosound-measurements/tree/main/cars/vw-passat-b8-sedan-lhd/2026-06-15_front-set-01/rew-export-samples

## What I have not done

**The UI path has not been run yet** — the logic it leans on is covered in the Dsp suite, but no one has actually clicked Load on a `.txt` in a running Resonalyze. I have a Windows VM now and will exercise it before this is asked to be merged; say if you would rather I do that first and you review afterwards.

Two decisions I would rather you make than guess:

1. **Non-loopback exports are refused outright.** #90 raised importing them as `RecordedSweep` instead — shape real, position its own. I left that out because it adds a second meaning to one menu item, but it is a small change if you want it.
2. **Protective high-passes.** A file-based import has no capture moment at which to remove them, so nothing is de-embedded here. Asking on import (a per-channel `ProtectiveHighPassConfiguration`) or accepting a declaration alongside the file are both possible; our own published sets carry the declaration per channel.

Reverse bridge (Resonalyze → REW) next, investigated before it is written, as agreed in #90.
