### PR TITLE
Window every junction by its band, probe it by rotation, and let the direct wavefronts break polarity ties

### DIFF
--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -387,7 +387,8 @@ public static class AutoAlignmentEngine
     /// <summary>
     /// The sample a junction's measurements anchor their direct-sound gate on:
     /// the earliest FRONT among the junction's own members, read inside the
-    /// junction's band (see <see cref="VirtualCrossoverAnalysis.FindGateAnchor"/>).
+    /// junction's band off their CHAIN-FREE responses (see
+    /// <see cref="VirtualCrossoverAnalysis.FindGateAnchor"/>).
     /// Two properties matter, and the old rule — the earliest PEAK across every
     /// channel of the run — bought them at a price this one does not pay.
     ///
@@ -395,7 +396,19 @@ public static class AutoAlignmentEngine
     /// which is what made a peak-anchored window misjudge a slow channel's
     /// phase (see the gate remarks in VirtualCrossoverAnalysis). A front says
     /// so directly; the earliest peak of the whole system only implied it, by
-    /// reaching for a channel that happened to arrive sooner.
+    /// reaching for a channel that happened to arrive sooner. And the front is
+    /// read BEFORE the chain, because a crossover's rise begins before the
+    /// front any detector can mark on its own output: the 55 Hz 36 dB/oct
+    /// low-pass in JunctionCorrelationCurveTests reads its filtered front
+    /// 12.8 ms behind the driver's, its woofer partner 8.6 ms behind, so an
+    /// anchor on the filtered front still cut into the very rise the window
+    /// exists to hold. Measured over the archived cabins by the panel's own
+    /// metric (the session battery in tests/Resonalyze.App.Tests): against the
+    /// sessions' saved tunings the proposal's average summation loss improves
+    /// by 0.127 dB per junction read off the chain-free front against 0.063 dB
+    /// off the filtered one, and it matches the old peak rule's alignments to
+    /// 0.003 dB on every junction of every cabin — that rule's margin, bought
+    /// by accident, recovered without reaching outside the pair for it.
     ///
     /// It is FIXED for everything compared through it — the candidates of one
     /// search, the cells of a co-move grid, the two renders its sub-band veto
@@ -423,13 +436,24 @@ public static class AutoAlignmentEngine
                 continue;
             }
 
+            // The BYPASSED response where the caller supplied one: it is the
+            // same measurement without the chain's own group delay, so its
+            // front is the driver's. It is also independent of the overrides
+            // under test, which makes the anchor constant for the whole run
+            // rather than merely for one search. Without one (a caller that
+            // renders no chain-free copy, e.g. a hand-built snapshot in a
+            // test) the processed response answers, as it did before.
+            Complex[] response = side.BypassedImpulseResponse ?? side.ImpulseResponse;
+            bool chainFree = side.BypassedImpulseResponse != null;
             anchor = Math.Min(anchor, VirtualCrossoverAnalysis.FindGateAnchor(
-                side.ImpulseResponse,
-                side.PeakIndex,
+                response,
+                chainFree
+                    ? VirtualCrossoverAnalysis.FindPeakIndex(response)
+                    : side.PeakIndex,
                 side.Channel.SampleRate,
                 bandLowHz,
                 bandHighHz,
-                side.ValidRange));
+                chainFree ? side.BypassedValidRange : side.ValidRange));
         }
 
         return anchor == int.MaxValue ? 0 : anchor;

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -393,6 +393,42 @@ public static class AutoAlignmentEngine
     // traveling windows made the shared choice moot).
 
     /// <summary>
+    /// The direct-coherence witness: at a junction where the summation score
+    /// cannot separate a lobe from its POLARITY partner (thin spectral
+    /// overlap ties them within hundredths of a dB — split corners like
+    /// 1500/1700 at 48 dB/oct leave half an octave of usable overlap), the
+    /// whitened correlation of the two channels' DIRECT sound
+    /// (<see cref="VirtualCrossoverAnalysis.CutDirectSound"/>) still
+    /// separates them: r at the lobe measures how well the direct
+    /// wavefronts' phase SLOPE matches across the whole overlap, which the
+    /// flip partner — phase-equivalent at the corner only — cannot fake. The
+    /// ear sides with this witness at these junctions: fusion and
+    /// localization above the bass follow the direct wavefront (precedence),
+    /// and on the reference car the owner's hand tune sits on the lobe this
+    /// figure prefers (r 0.89 against 0.81) while the summation score reads
+    /// the two as a 0.04 dB tie.
+    ///
+    /// The witness only arbitrates a TIE between polarity partners; a score
+    /// preference beyond <see cref="DirectCoherenceTieMarginDb"/> stands,
+    /// because the score reads the whole windowed sum the cabin will
+    /// actually produce. It stands down where "direct sound" is not a
+    /// measurable notion (below <see cref="DirectCoherenceMinCrossoverHz"/>
+    /// two crossover periods of cut span the room's own build-up — the
+    /// archived sub junctions read high r at delays whole periods away, room
+    /// geometry wearing a coherence figure), where a lock or policy already
+    /// pinned the lobe by stronger evidence, and where the coherence itself
+    /// is weak or the advantage inside its own noise. Field calibration
+    /// (2026-08-20, six cabins): genuine mid/tweeter discriminations read
+    /// |r| 0.74-0.96 with advantages from 0.08 up; 0.6 / 0.05 sit under
+    /// those with room to spare while a coherence-free junction (Passat C/D
+    /// reads r 0.07 at its current lobe) cannot vote at all.
+    /// </summary>
+    private const double DirectCoherenceMinCrossoverHz = 120;
+    private const double DirectCoherenceTieMarginDb = 0.3;
+    private const double DirectCoherenceMinR = 0.6;
+    private const double DirectCoherenceMinAdvantage = 0.05;
+
+    /// <summary>
     /// The minimum envelope peak-to-noise grade (dB) both channels' onset
     /// estimates must carry before the lock trusts them. The spread gate alone
     /// cannot refuse a noise-only record: random crossings can look stable
@@ -2022,6 +2058,103 @@ public static class AutoAlignmentEngine
                 }
             }
 
+            // The direct-coherence witness (see the DirectCoherence*
+            // constants): a polarity partner within the tie margin is
+            // re-judged on the whitened correlation of the two channels'
+            // direct sound. Guarded off wherever the lobe is already pinned
+            // by stronger evidence — a scene or onset lock, a forced
+            // polarity, a joint two-junction search whose combined band has
+            // no single junction to read.
+            string? directCoherenceDetail = null;
+            if (secondaryNeighbor == null &&
+                sceneLockToleranceMs == null &&
+                onsetAnchorMs == null &&
+                forcedPolarity == null &&
+                pair.CrossoverHz >= DirectCoherenceMinCrossoverHz)
+            {
+                AlignmentCandidate? rival = fineOptima
+                    .Concat(wideOptima)
+                    .Concat(retriedOptima)
+                    .Where(item => item.InvertPolarity != chosen.InvertPolarity &&
+                        Math.Abs(item.DelayMs - chosen.DelayMs)
+                            <= 1.5 * halfPeriodMs)
+                    .OrderByDescending(AcousticScore)
+                    .FirstOrDefault();
+                if (rival != null &&
+                    Math.Abs(AcousticScore(chosen) - AcousticScore(rival))
+                        <= DirectCoherenceTieMarginDb)
+                {
+                    // One curve serves both candidates: lag is the delay
+                    // added to the VARIABLE channel, the frame every
+                    // candidate's DelayMs lives in.
+                    double centerMs = (chosen.DelayMs + rival.DelayMs) / 2.0;
+                    List<SignalPoint> coherence =
+                        VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
+                            VirtualCrossoverAnalysis.CutDirectSound(
+                                neighborIrs[0], channel.SampleRate,
+                                bandLowHz, bandHighHz, pair.CrossoverHz),
+                            VirtualCrossoverAnalysis.CutDirectSound(
+                                variableIr, channel.SampleRate,
+                                bandLowHz, bandHighHz, pair.CrossoverHz),
+                            channel.SampleRate,
+                            pair.CrossoverHz,
+                            Math.Log2(bandHighHz / bandLowHz),
+                            Math.Abs(chosen.DelayMs - rival.DelayMs) / 2.0
+                                + halfPeriodMs,
+                            centerMs,
+                            phaseTransform: true);
+
+                    // A candidate's coherence: the best sign-consistent value
+                    // within a quarter period of its delay — its own lobe,
+                    // never the partner's half a period away.
+                    double CoherenceOf(AlignmentCandidate candidate)
+                    {
+                        double best = double.NegativeInfinity;
+                        foreach (SignalPoint point in coherence)
+                        {
+                            if (Math.Abs(point.X - candidate.DelayMs)
+                                <= 0.5 * halfPeriodMs)
+                            {
+                                best = Math.Max(best, candidate.InvertPolarity
+                                    ? -point.Y
+                                    : point.Y);
+                            }
+                        }
+
+                        return best;
+                    }
+
+                    double chosenR = CoherenceOf(chosen);
+                    double rivalR = CoherenceOf(rival);
+                    if (rivalR >= DirectCoherenceMinR &&
+                        rivalR >= chosenR + DirectCoherenceMinAdvantage)
+                    {
+                        log.AppendLine(
+                            $"  direct coherence: preferred " +
+                            $"{rival.DelayMs:0.000} ms" +
+                            $"{(rival.InvertPolarity ? " inv" : "")} " +
+                            $"(direct r {rivalR:0.00}) over " +
+                            $"{chosen.DelayMs:0.000} ms" +
+                            $"{(chosen.InvertPolarity ? " inv" : "")} " +
+                            $"(r {chosenR:0.00}) — scores tied within " +
+                            $"{DirectCoherenceTieMarginDb:0.00} dB, the " +
+                            "direct wavefronts decide the polarity.");
+                        directCoherenceDetail = string.Create(
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            $"direct coherence r {rivalR:0.00} vs " +
+                            $"{chosenR:0.00} decided the polarity tie");
+                        chosen = rival;
+                    }
+                    else if (chosenR > double.NegativeInfinity)
+                    {
+                        log.AppendLine(
+                            $"  direct coherence: {chosen.DelayMs:0.000} ms" +
+                            $" stands (r {chosenR:0.00} vs rival " +
+                            $"{rivalR:0.00})");
+                    }
+                }
+            }
+
             double newDelay = chosen.DelayMs;
             if (newDelay < 0)
             {
@@ -2078,6 +2211,10 @@ public static class AutoAlignmentEngine
                     onsetLocked: onsetAnchorMs != null,
                     sceneLocked: sceneLockToleranceMs != null,
                     overlapFraction);
+                if (directCoherenceDetail != null)
+                {
+                    AmendDecision(decisions, channel, directCoherenceDetail);
+                }
                 if (subPrecedenceBehindDb is { } precedenceBehindDb)
                 {
                     // The report must say the objective was deliberately

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1176,16 +1176,26 @@ public static class AutoAlignmentEngine
             if (lowerLatchedByPrediction || upperLatchedByPrediction)
             {
                 void LogConviction(
-                    AlignmentSnapshot side, double measuredMs, double predictedMs) =>
+                    AlignmentSnapshot side, double measuredMs, double predictedMs)
+                {
+                    double allowances = (measuredMs - predictedMs) /
+                        PredictedArrivalAllowanceMs(pair.BandLowHz, pair.BandHighHz);
+                    // Below the factor the predictor did not convict alone —
+                    // the comb arbitration above supplied the second witness
+                    // — and the line must not read as if it had.
+                    string basis = allowances >= PredictedArrivalConvictionFactor
+                        ? $"conviction needs {PredictedArrivalConvictionFactor:0.0}"
+                        : $"short of the predictor's own " +
+                          $"{PredictedArrivalConvictionFactor:0.0}, convicted by " +
+                          $"the comb's second witness";
                     log.AppendLine(
                         $"  {side.Channel.Name}: {measuredMs:0.000} ms in " +
                         $"{pair.BandLowHz:0}-{pair.BandHighHz:0} Hz but its " +
                         $"un-crossovered front, read through its own " +
                         $"chain, predicts {predictedMs:0.000} ms there (modal " +
                         $"latch behind the crossover; " +
-                        $"{(measuredMs - predictedMs) / PredictedArrivalAllowanceMs(pair.BandLowHz, pair.BandHighHz):0.0} " +
-                        $"allowances, conviction needs " +
-                        $"{PredictedArrivalConvictionFactor:0.0}) — re-anchored");
+                        $"{allowances:0.0} allowances, {basis}) — re-anchored");
+                }
                 if (lowerLatchedByPrediction)
                 {
                     LogConviction(pair.Lower, lowerArrival, lowerPrediction);

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -385,26 +385,55 @@ public static class AutoAlignmentEngine
     private const double OnsetLockMaxSpreadPeriods = 0.5;
 
     /// <summary>
-    /// The sample every junction measurement of a run anchors its direct-sound
-    /// gate on: the earliest peak across ALL the run's channels, rendered in
-    /// one frame. Two properties matter and neither is the pair's own peak.
+    /// The sample a junction's measurements anchor their direct-sound gate on:
+    /// the earliest FRONT among the junction's own members, read inside the
+    /// junction's band (see <see cref="VirtualCrossoverAnalysis.FindGateAnchor"/>).
+    /// Two properties matter, and the old rule — the earliest PEAK across every
+    /// channel of the run — bought them at a price this one does not pay.
     ///
-    /// It is EARLY — no channel's own rise can fall inside the window's
-    /// fade-in, which is what made a pair-anchored window misjudge a slow
-    /// channel's phase (see the gate remarks in VirtualCrossoverAnalysis).
+    /// It is EARLY — no member's own rise can fall inside the window's fade-in,
+    /// which is what made a peak-anchored window misjudge a slow channel's
+    /// phase (see the gate remarks in VirtualCrossoverAnalysis). A front says
+    /// so directly; the earliest peak of the whole system only implied it, by
+    /// reaching for a channel that happened to arrive sooner.
     ///
-    /// It is SHARED — one window for every junction, side and probe of a run,
-    /// so candidates, co-move cells and cross-side comparisons are all
-    /// measured through the same one. This is the same PLACEMENT RULE the
-    /// metric read-out follows (VirtualCrossoverMetrics.BuildCurves anchors on
-    /// its channel set's earliest peak), not the same sample: the read-out
-    /// runs on the applied delays and on the displayed side alone, so its
-    /// anchor lands wherever those put it. Matching it exactly is not the
-    /// goal and is not achievable mid-cascade — being early enough for every
-    /// channel, and the same for every comparison, is.
+    /// It is FIXED for everything compared through it — the candidates of one
+    /// search, the cells of a co-move grid, the two renders its sub-band veto
+    /// weighs. That is a property of the CALLER: each computes its junction's
+    /// anchor once, from a state it names, and passes that one sample to every
+    /// probe. What no
+    /// longer follows is one anchor for the whole run: losses are compared
+    /// within a junction (a candidate against a candidate, a cell against a
+    /// cell), and the co-move sums such differences over a side, where a
+    /// per-junction constant cancels. Junctions do NOT have to be measured
+    /// through the same window to be summed — they already carry different
+    /// bands — they have to be measured through a window that does not move
+    /// while they are being compared.
     /// </summary>
-    private static int SystemGateAnchor(IEnumerable<AlignmentSnapshot> scope) =>
-        scope.Min(item => item.PeakIndex);
+    private static int JunctionGateAnchor(
+        double bandLowHz,
+        double bandHighHz,
+        params AlignmentSnapshot?[] members)
+    {
+        int anchor = int.MaxValue;
+        foreach (AlignmentSnapshot? member in members)
+        {
+            if (member is not { } side)
+            {
+                continue;
+            }
+
+            anchor = Math.Min(anchor, VirtualCrossoverAnalysis.FindGateAnchor(
+                side.ImpulseResponse,
+                side.PeakIndex,
+                side.Channel.SampleRate,
+                bandLowHz,
+                bandHighHz,
+                side.ValidRange));
+        }
+
+        return anchor == int.MaxValue ? 0 : anchor;
+    }
 
     /// <summary>
     /// The minimum envelope peak-to-noise grade (dB) both channels' onset
@@ -1505,21 +1534,26 @@ public static class AutoAlignmentEngine
         AlignmentSnapshot primaryNeighborSnapshot =
             current.First(item => item.Channel == neighborChannel);
         Complex[] variableIr = variableSnapshot.ImpulseResponse;
-        // The gate anchor of every loss measurement below: the whole system's
-        // first arrival, NOT this pair's (see the gate remarks in
-        // VirtualCrossoverAnalysis). The metric read-out the user tunes by
-        // anchors there, and a pair-anchored window at a sub/woofer junction
-        // starts inside the sub's own rise and ranks the pair's alignments
-        // differently from what the panel then shows.
-        int gateAnchor = SystemGateAnchor(current);
+        AlignmentSnapshot? secondaryNeighborSnapshot = secondaryNeighbor != null
+            ? current.First(item => item.Channel == secondaryNeighbor)
+            : null;
+        // The gate anchor of every loss measurement below, taken ONCE here and
+        // handed to each of them: the earliest front among the channels this
+        // step measures, in the band it measures them over (see the gate
+        // remarks in VirtualCrossoverAnalysis). Computed on `current`, where
+        // the searched channel carries no delay yet — so every candidate of
+        // this search is scored through the same window, however far the
+        // candidate moves the channel.
+        int gateAnchor = JunctionGateAnchor(
+            bandLowHz, bandHighHz,
+            variableSnapshot, primaryNeighborSnapshot, secondaryNeighborSnapshot);
         var neighborIrs = new List<Complex[]>
         {
             primaryNeighborSnapshot.ImpulseResponse
         };
-        if (secondaryNeighbor != null)
+        if (secondaryNeighborSnapshot != null)
         {
-            neighborIrs.Add(current
-                .First(item => item.Channel == secondaryNeighbor).ImpulseResponse);
+            neighborIrs.Add(secondaryNeighborSnapshot.ImpulseResponse);
         }
 
         // The level match saturates at its cap; past it the residual
@@ -3462,15 +3496,10 @@ public static class AutoAlignmentEngine
             }
 
             IReadOnlyList<AlignmentSnapshot> current = reprocess(alignment);
+            AlignmentSnapshot SnapshotOf(IAlignmentChannel channel) =>
+                current.First(item => item.Channel == channel);
             Complex[] IrOf(IAlignmentChannel channel) =>
-                current.First(item => item.Channel == channel).ImpulseResponse;
-            // The same window the searches were decided through. Without it
-            // this pass would re-judge settled pairs on a pair-anchored
-            // surface — the very measurement the cascade stopped using — and
-            // it moves channels for as little as the co-move threshold, so a
-            // fraction-of-a-dB difference between the two windows is exactly
-            // the size of change it can make.
-            int gateAnchor = SystemGateAnchor(current);
+                SnapshotOf(channel).ImpulseResponse;
 
             // One evaluator per junction of the REFERENCE side. The move is
             // shared, so its criterion is a choice, and a mean over both sides
@@ -3494,6 +3523,15 @@ public static class AutoAlignmentEngine
                 IAlignmentChannel neighbor = lowerMoves
                     ? junction.Upper.Channel
                     : junction.Lower.Channel;
+                // This junction's own window, held for every delta the pass
+                // probes: it re-judges settled pairs, and it moves channels
+                // for as little as the co-move threshold, so a window that
+                // shifted between two probes would be exactly the size of
+                // change this pass can make. Rebuilt from `current` rather
+                // than carried from the search that settled the pair — the
+                // fronts it reads have since moved with the delays the
+                // cascade assigned, and the criterion is a difference over
+                // THIS pass's probes, all of which see this one window.
                 VirtualCrossoverAnalysis.SumLossEvaluator? evaluator =
                     VirtualCrossoverAnalysis.SumLossEvaluator.Create(
                         IrOf(mover),
@@ -3503,7 +3541,11 @@ public static class AutoAlignmentEngine
                         junction.BandHighHz,
                         levelMatch: true,
                         requireDelayEvidence: true,
-                        gateAnchor);
+                        JunctionGateAnchor(
+                            junction.BandLowHz,
+                            junction.BandHighHz,
+                            SnapshotOf(mover),
+                            SnapshotOf(neighbor)));
                 if (evaluator != null)
                 {
                     evaluators.Add(evaluator);
@@ -3744,10 +3786,19 @@ public static class AutoAlignmentEngine
             // polarity-invariant (it reads magnitudes), so one certification on
             // the current render covers every probe below.
             IReadOnlyList<AlignmentSnapshot> certified = reprocess(alignment);
+            int CertifiedGateAnchor(AlignmentJunction junction) =>
+                JunctionGateAnchor(
+                    junction.BandLowHz,
+                    junction.BandHighHz,
+                    certified.First(
+                        item => item.Channel == junction.Lower.Channel),
+                    certified.First(
+                        item => item.Channel == junction.Upper.Channel));
             AlignmentJunction? unmeasurable = junctions.FirstOrDefault(
                 junction => CellScore(
                     certified, junction, junction.BandLowHz, junction.BandHighHz,
-                    requireDelayEvidence: true) == null);
+                    requireDelayEvidence: true, CertifiedGateAnchor(junction))
+                    == null);
             if (unmeasurable is { } silent)
             {
                 IAlignmentChannel silentNeighbor =
@@ -3814,12 +3865,44 @@ public static class AutoAlignmentEngine
                         Math.Round(framedMonoMs + deltaMs, 2),
                         over.InvertPolarity ^ flip)
                 });
+
+            // The window every cell of this grid is measured through: read
+            // once, off the frame's own zero cell, per junction and band. The
+            // pass compares cells against each other — and its sub-band veto
+            // compares two whole renders of the same junction — so an anchor
+            // that followed the mono channel from cell to cell would compare
+            // them through different measurements. Read in the LIFTED frame,
+            // not off `certified`: the lift moves every channel together, and
+            // an anchor taken before it would sit that far ahead of every
+            // front the grid actually holds.
+            IReadOnlyList<AlignmentSnapshot> gridOrigin = Rendered(0, flip: false);
+            var gridAnchors =
+                new Dictionary<(AlignmentJunction Junction, double LowHz, double HighHz), int>();
+            int GridGateAnchor(
+                AlignmentJunction junction, double lowHz, double highHz)
+            {
+                if (!gridAnchors.TryGetValue((junction, lowHz, highHz),
+                    out int anchor))
+                {
+                    anchor = JunctionGateAnchor(
+                        lowHz,
+                        highHz,
+                        gridOrigin.First(
+                            item => item.Channel == junction.Lower.Channel),
+                        gridOrigin.First(
+                            item => item.Channel == junction.Upper.Channel));
+                    gridAnchors[(junction, lowHz, highHz)] = anchor;
+                }
+
+                return anchor;
+            }
             double? CellScore(
                 IReadOnlyList<AlignmentSnapshot> current,
                 AlignmentJunction junction,
                 double lowHz,
                 double highHz,
-                bool requireDelayEvidence)
+                bool requireDelayEvidence,
+                int gateAnchor)
             {
                 Complex[] IrOf(IAlignmentChannel channel) =>
                     current.First(item => item.Channel == channel).ImpulseResponse;
@@ -3835,11 +3918,7 @@ public static class AutoAlignmentEngine
                         highHz,
                         levelMatch: true,
                         requireDelayEvidence,
-                        // One system-anchored window, like the searches above:
-                        // the co-move compares cells of a grid, and a window
-                        // that moved with each cell's own pair would compare
-                        // them through different measurements.
-                        SystemGateAnchor(current));
+                        gateAnchor);
                 return loss is { } value
                     ? value.LossDb +
                         VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
@@ -3854,7 +3933,9 @@ public static class AutoAlignmentEngine
                 foreach (AlignmentJunction junction in junctions)
                 {
                     if (CellScore(current, junction, junction.BandLowHz,
-                        junction.BandHighHz, requireDelayEvidence: true)
+                        junction.BandHighHz, requireDelayEvidence: true,
+                        GridGateAnchor(
+                            junction, junction.BandLowHz, junction.BandHighHz))
                         is { } cell)
                     {
                         total += cell;
@@ -3863,12 +3944,12 @@ public static class AutoAlignmentEngine
                 }
 
                 // FAIL-CLOSED, not an average of the survivors: the upfront
-                // certification ran on one render, but every probe re-gates the
-                // IRs and the direct-sound window shifts with the probed delay,
-                // so a borderline junction can drop out mid-sweep and a mean over
-                // the rest would be the one-sided vote the certification exists
-                // to prevent. A probe that cannot measure EVERY junction is not
-                // a candidate.
+                // certification ran on one render, but the probed delay slides
+                // the mono channel inside the (fixed) direct-sound window and
+                // re-gates what of it the spectra see, so a borderline junction
+                // can drop out mid-sweep and a mean over the rest would be the
+                // one-sided vote the certification exists to prevent. A probe
+                // that cannot measure EVERY junction is not a candidate.
                 return measured == junctions.Count
                     ? total / measured
                     : double.NegativeInfinity;
@@ -3978,12 +4059,13 @@ public static class AutoAlignmentEngine
                         (double lowHz, double highHz) = upperHalf
                             ? (junction.CrossoverHz, junction.BandHighHz)
                             : (junction.BandLowHz, junction.CrossoverHz);
+                        int cellAnchor = GridGateAnchor(junction, lowHz, highHz);
                         double? polishCell = CellScore(
                             polishRender, junction, lowHz, highHz,
-                            requireDelayEvidence: true);
+                            requireDelayEvidence: true, cellAnchor);
                         double? hopCell = CellScore(
                             hopRender, junction, lowHz, highHz,
-                            requireDelayEvidence: true);
+                            requireDelayEvidence: true, cellAnchor);
                         if (polishCell is not { } polishCellScore ||
                             hopCell is not { } hopCellScore ||
                             hopCellScore >=
@@ -4103,17 +4185,18 @@ public static class AutoAlignmentEngine
         StringBuilder log)
     {
         IReadOnlyList<AlignmentSnapshot> current = reprocess(alignment);
-        Complex[] mono = current
-            .First(item => item.Channel == monoChannel).ImpulseResponse;
-        Complex[] other = current
-            .First(item => item.Channel == otherChannel).ImpulseResponse;
+        AlignmentSnapshot mono = current
+            .First(item => item.Channel == monoChannel);
+        AlignmentSnapshot other = current
+            .First(item => item.Channel == otherChannel);
         (double LossDb, double DipDb)? loss = VirtualCrossoverAnalysis.MeasureSumLoss(
-            mono,
-            new List<Complex[]> { other },
+            mono.ImpulseResponse,
+            new List<Complex[]> { other.ImpulseResponse },
             monoChannel.SampleRate,
             pair.BandLowHz,
             pair.BandHighHz,
-            gateAnchorSample: SystemGateAnchor(current));
+            gateAnchorSample: JunctionGateAnchor(
+                pair.BandLowHz, pair.BandHighHz, mono, other));
         if (loss is not { } measured)
         {
             log.AppendLine(

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -384,56 +384,13 @@ public static class AutoAlignmentEngine
     // search to a guess.
     private const double OnsetLockMaxSpreadPeriods = 0.5;
 
-    /// <summary>
-    /// The sample a junction's measurements anchor their direct-sound gate on:
-    /// the earliest FRONT among the junction's own members, read inside the
-    /// junction's band (see <see cref="VirtualCrossoverAnalysis.FindGateAnchor"/>).
-    /// Two properties matter, and the old rule — the earliest PEAK across every
-    /// channel of the run — bought them at a price this one does not pay.
-    ///
-    /// It is EARLY — no member's own rise can fall inside the window's fade-in,
-    /// which is what made a peak-anchored window misjudge a slow channel's
-    /// phase (see the gate remarks in VirtualCrossoverAnalysis). A front says
-    /// so directly; the earliest peak of the whole system only implied it, by
-    /// reaching for a channel that happened to arrive sooner.
-    ///
-    /// It is FIXED for everything compared through it — the candidates of one
-    /// search, the cells of a co-move grid, the two renders its sub-band veto
-    /// weighs. That is a property of the CALLER: each computes its junction's
-    /// anchor once, from a state it names, and passes that one sample to every
-    /// probe. What no
-    /// longer follows is one anchor for the whole run: losses are compared
-    /// within a junction (a candidate against a candidate, a cell against a
-    /// cell), and the co-move sums such differences over a side, where a
-    /// per-junction constant cancels. Junctions do NOT have to be measured
-    /// through the same window to be summed — they already carry different
-    /// bands — they have to be measured through a window that does not move
-    /// while they are being compared.
-    /// </summary>
-    private static int JunctionGateAnchor(
-        double bandLowHz,
-        double bandHighHz,
-        params AlignmentSnapshot?[] members)
-    {
-        int anchor = int.MaxValue;
-        foreach (AlignmentSnapshot? member in members)
-        {
-            if (member is not { } side)
-            {
-                continue;
-            }
-
-            anchor = Math.Min(anchor, VirtualCrossoverAnalysis.FindGateAnchor(
-                side.ImpulseResponse,
-                side.PeakIndex,
-                side.Channel.SampleRate,
-                bandLowHz,
-                bandHighHz,
-                side.ValidRange));
-        }
-
-        return anchor == int.MaxValue ? 0 : anchor;
-    }
+    // Junction measurements no longer share one gate anchor: every response
+    // is windowed at its own band-limited front and the cuts meet in one
+    // absolute-time frame (see BuildAlignmentBins in
+    // VirtualCrossoverAnalysis, and the gate remarks there for the full
+    // placement history — system peak, pair peak, pair front, chain-free
+    // front were each measured on the archived cabins before per-channel
+    // traveling windows made the shared choice moot).
 
     /// <summary>
     /// The minimum envelope peak-to-noise grade (dB) both channels' onset
@@ -1537,16 +1494,15 @@ public static class AutoAlignmentEngine
         AlignmentSnapshot? secondaryNeighborSnapshot = secondaryNeighbor != null
             ? current.First(item => item.Channel == secondaryNeighbor)
             : null;
-        // The gate anchor of every loss measurement below, taken ONCE here and
-        // handed to each of them: the earliest front among the channels this
-        // step measures, in the band it measures them over (see the gate
-        // remarks in VirtualCrossoverAnalysis). Computed on `current`, where
-        // the searched channel carries no delay yet — so every candidate of
-        // this search is scored through the same window, however far the
-        // candidate moves the channel.
-        int gateAnchor = JunctionGateAnchor(
-            bandLowHz, bandHighHz,
-            variableSnapshot, primaryNeighborSnapshot, secondaryNeighborSnapshot);
+        // Every loss measurement below windows each response at its OWN
+        // band-limited front and rotates the probes through those cuts (see
+        // BuildAlignmentBins) — the fronts are detected once per bins build,
+        // from the responses of THIS `current` render, so every candidate of
+        // this search is scored through the same windows, however far the
+        // candidate moves the channel. No shared anchor is needed, and none
+        // could serve: mid-cascade a settled neighbor's assigned delay can
+        // put it further from the searched channel than a band-sized window
+        // spans.
         var neighborIrs = new List<Complex[]>
         {
             primaryNeighborSnapshot.ImpulseResponse
@@ -1723,8 +1679,7 @@ public static class AutoAlignmentEngine
                     // Search-side level match: the lobe choice must not depend
                     // on the channels' playback gains (see BuildAlignmentBins).
                     levelMatch: true,
-                    out IReadOnlyList<AlignmentCandidate> allOptima,
-                    gateAnchorSample: gateAnchor);
+                    out IReadOnlyList<AlignmentCandidate> allOptima);
             return (candidates, allOptima, windowLowMs, windowHighMs);
         }
 
@@ -3540,12 +3495,7 @@ public static class AutoAlignmentEngine
                         junction.BandLowHz,
                         junction.BandHighHz,
                         levelMatch: true,
-                        requireDelayEvidence: true,
-                        JunctionGateAnchor(
-                            junction.BandLowHz,
-                            junction.BandHighHz,
-                            SnapshotOf(mover),
-                            SnapshotOf(neighbor)));
+                        requireDelayEvidence: true);
                 if (evaluator != null)
                 {
                     evaluators.Add(evaluator);
@@ -3782,23 +3732,55 @@ public static class AutoAlignmentEngine
             // healthy upper one. A co-move judged by the measurable side alone
             // would merely re-optimize the left junction the walk already
             // settled, so with any junction unmeasurable the whole co-move
-            // abstains and the walk's placement stands. Evidence is delay- and
-            // polarity-invariant (it reads magnitudes), so one certification on
-            // the current render covers every probe below.
+            // abstains and the walk's placement stands.
+            //
+            // One render, one evaluator per junction (and one per half-band
+            // for the veto below): every probe of the grid rotates the mono
+            // channel's windowed cut through the SAME spectra
+            // (VirtualCrossoverAnalysis.SumLossEvaluator — the same probe the
+            // pair co-move and the drawn junction surface read). The windows
+            // travel with the channels they hold, so a probe cannot slide the
+            // mono out of anyone's window: evidence, level match and window
+            // placement are all fixed properties of this one render, exactly
+            // the consistency the old per-probe re-rendering bought with ~40
+            // reprocesses and still lost whenever a probe carried the mono
+            // into the fixed window's fade.
             IReadOnlyList<AlignmentSnapshot> certified = reprocess(alignment);
-            int CertifiedGateAnchor(AlignmentJunction junction) =>
-                JunctionGateAnchor(
-                    junction.BandLowHz,
-                    junction.BandHighHz,
-                    certified.First(
-                        item => item.Channel == junction.Lower.Channel),
-                    certified.First(
-                        item => item.Channel == junction.Upper.Channel));
-            AlignmentJunction? unmeasurable = junctions.FirstOrDefault(
-                junction => CellScore(
-                    certified, junction, junction.BandLowHz, junction.BandHighHz,
-                    requireDelayEvidence: true, CertifiedGateAnchor(junction))
-                    == null);
+            Complex[] CertifiedIrOf(IAlignmentChannel channel) =>
+                certified.First(item => item.Channel == channel).ImpulseResponse;
+            VirtualCrossoverAnalysis.SumLossEvaluator? Probe(
+                AlignmentJunction junction, double lowHz, double highHz)
+            {
+                IAlignmentChannel neighbor = junction.Lower.Channel == mono
+                    ? junction.Upper.Channel
+                    : junction.Lower.Channel;
+                return VirtualCrossoverAnalysis.SumLossEvaluator.Create(
+                    CertifiedIrOf(mono),
+                    new List<Complex[]> { CertifiedIrOf(neighbor) },
+                    mono.SampleRate,
+                    lowHz,
+                    highHz,
+                    levelMatch: true,
+                    requireDelayEvidence: true);
+            }
+
+            var fullBand =
+                new Dictionary<AlignmentJunction,
+                    VirtualCrossoverAnalysis.SumLossEvaluator>();
+            AlignmentJunction? unmeasurable = null;
+            foreach (AlignmentJunction junction in junctions)
+            {
+                if (Probe(junction, junction.BandLowHz, junction.BandHighHz)
+                    is { } evaluator)
+                {
+                    fullBand[junction] = evaluator;
+                }
+                else
+                {
+                    unmeasurable = junction;
+                    break;
+                }
+            }
             if (unmeasurable is { } silent)
             {
                 IAlignmentChannel silentNeighbor =
@@ -3840,119 +3822,24 @@ public static class AutoAlignmentEngine
             double maxDelta = Math.Min(
                 reachMs, MaxDelayMs - over.DelayMs + minOtherMs);
 
-            // The evaluation frame: one uniform lift of EVERY channel keeps
-            // all probe delays non-negative without touching any relation, so
-            // a probe below the mono's own zero needs no per-probe rebasing —
-            // only the mono re-renders per probe, the lifted rest renders
-            // once and stays cached. (Frame delays may exceed the UI ceiling;
-            // they are evaluation-only.)
-            double liftMs = Math.Max(0, -(over.DelayMs + minDelta));
-            var framed = new Dictionary<IAlignmentChannel, AlignmentOverride>();
-            foreach (AlignmentSnapshot item in shiftScope)
-            {
-                AlignmentOverride current = alignment.GetValueOrDefault(item.Channel);
-                framed[item.Channel] = current with
-                {
-                    DelayMs = Math.Round(current.DelayMs + liftMs, 2)
-                };
-            }
-
-            double framedMonoMs = framed[mono].DelayMs;
-            IReadOnlyList<AlignmentSnapshot> Rendered(double deltaMs, bool flip) =>
-                reprocess(new Dictionary<IAlignmentChannel, AlignmentOverride>(framed)
-                {
-                    [mono] = new AlignmentOverride(
-                        Math.Round(framedMonoMs + deltaMs, 2),
-                        over.InvertPolarity ^ flip)
-                });
-
-            // The window every cell of this grid is measured through: read
-            // once, off the frame's own zero cell, per junction and band. The
-            // pass compares cells against each other — and its sub-band veto
-            // compares two whole renders of the same junction — so an anchor
-            // that followed the mono channel from cell to cell would compare
-            // them through different measurements. Read in the LIFTED frame,
-            // not off `certified`: the lift moves every channel together, and
-            // an anchor taken before it would sit that far ahead of every
-            // front the grid actually holds.
-            IReadOnlyList<AlignmentSnapshot> gridOrigin = Rendered(0, flip: false);
-            var gridAnchors =
-                new Dictionary<(AlignmentJunction Junction, double LowHz, double HighHz), int>();
-            int GridGateAnchor(
-                AlignmentJunction junction, double lowHz, double highHz)
-            {
-                if (!gridAnchors.TryGetValue((junction, lowHz, highHz),
-                    out int anchor))
-                {
-                    anchor = JunctionGateAnchor(
-                        lowHz,
-                        highHz,
-                        gridOrigin.First(
-                            item => item.Channel == junction.Lower.Channel),
-                        gridOrigin.First(
-                            item => item.Channel == junction.Upper.Channel));
-                    gridAnchors[(junction, lowHz, highHz)] = anchor;
-                }
-
-                return anchor;
-            }
-            double? CellScore(
-                IReadOnlyList<AlignmentSnapshot> current,
-                AlignmentJunction junction,
-                double lowHz,
-                double highHz,
-                bool requireDelayEvidence,
-                int gateAnchor)
-            {
-                Complex[] IrOf(IAlignmentChannel channel) =>
-                    current.First(item => item.Channel == channel).ImpulseResponse;
-                IAlignmentChannel neighbor = junction.Lower.Channel == mono
-                    ? junction.Upper.Channel
-                    : junction.Lower.Channel;
-                (double LossDb, double DipDb)? loss =
-                    VirtualCrossoverAnalysis.MeasureSumLoss(
-                        IrOf(mono),
-                        new List<Complex[]> { IrOf(neighbor) },
-                        mono.SampleRate,
-                        lowHz,
-                        highHz,
-                        levelMatch: true,
-                        requireDelayEvidence,
-                        gateAnchor);
-                return loss is { } value
-                    ? value.LossDb +
-                        VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
-                        (value.DipDb - value.LossDb)
-                    : null;
-            }
             double Score(double deltaMs, bool flip)
             {
-                IReadOnlyList<AlignmentSnapshot> current = Rendered(deltaMs, flip);
+                // The mean the co-move optimizes: every junction's rotation
+                // probe at this delta, dip-penalized like every other junction
+                // score. No junction can drop out mid-sweep — measurability
+                // was settled once, above — so the mean is over all of them
+                // by construction.
                 double total = 0;
-                int measured = 0;
                 foreach (AlignmentJunction junction in junctions)
                 {
-                    if (CellScore(current, junction, junction.BandLowHz,
-                        junction.BandHighHz, requireDelayEvidence: true,
-                        GridGateAnchor(
-                            junction, junction.BandLowHz, junction.BandHighHz))
-                        is { } cell)
-                    {
-                        total += cell;
-                        measured++;
-                    }
+                    (double lossDb, double dipDb) =
+                        fullBand[junction].Evaluate(deltaMs, flip);
+                    total += lossDb +
+                        VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
+                        (dipDb - lossDb);
                 }
 
-                // FAIL-CLOSED, not an average of the survivors: the upfront
-                // certification ran on one render, but the probed delay slides
-                // the mono channel inside the (fixed) direct-sound window and
-                // re-gates what of it the spectra see, so a borderline junction
-                // can drop out mid-sweep and a mean over the rest would be the
-                // one-sided vote the certification exists to prevent. A probe
-                // that cannot measure EVERY junction is not a candidate.
-                return measured == junctions.Count
-                    ? total / measured
-                    : double.NegativeInfinity;
+                return total / junctions.Count;
             }
 
             double baseline = Score(0, flip: false);
@@ -4046,11 +3933,18 @@ public static class AutoAlignmentEngine
                 // near-flat loss is noise the level match amplifies toward
                 // parity. Losing a measurable cell means the full-band gain came
                 // from a mode rewarding a comb impostor, not from a better
-                // alignment of the direct sound.
-                IReadOnlyList<AlignmentSnapshot> hopRender =
-                    Rendered(bestDelta, bestFlip);
-                IReadOnlyList<AlignmentSnapshot> polishRender =
-                    Rendered(bestPolishDelta, false);
+                // alignment of the direct sound. Both candidates read through
+                // the SAME half-band evaluator, so the comparison cannot be
+                // biased by window placement.
+                //
+                // The reference is the better of the in-lobe polish and the
+                // INCUMBENT (no move at all): on a mode-dominated junction the
+                // polish itself can slide onto a modal trade — the archived
+                // 80 Hz reproduction polishes to -2.45 ms, where the clean
+                // lower half reads -6.6 dB — and a hop compared against that
+                // spot alone would "win" the very half it is ruining. What a
+                // hop must actually beat, cell by cell, is the best placement
+                // the channel has WITHOUT hopping.
                 bool vetoed = false;
                 foreach (AlignmentJunction junction in junctions)
                 {
@@ -4059,17 +3953,26 @@ public static class AutoAlignmentEngine
                         (double lowHz, double highHz) = upperHalf
                             ? (junction.CrossoverHz, junction.BandHighHz)
                             : (junction.BandLowHz, junction.CrossoverHz);
-                        int cellAnchor = GridGateAnchor(junction, lowHz, highHz);
-                        double? polishCell = CellScore(
-                            polishRender, junction, lowHz, highHz,
-                            requireDelayEvidence: true, cellAnchor);
-                        double? hopCell = CellScore(
-                            hopRender, junction, lowHz, highHz,
-                            requireDelayEvidence: true, cellAnchor);
-                        if (polishCell is not { } polishCellScore ||
-                            hopCell is not { } hopCellScore ||
-                            hopCellScore >=
-                                polishCellScore - MonoComoveSubBandVetoMarginDb)
+                        if (Probe(junction, lowHz, highHz) is not { } cell)
+                        {
+                            continue;
+                        }
+
+                        double CellScore(double deltaMs, bool flip)
+                        {
+                            (double lossDb, double dipDb) =
+                                cell.Evaluate(deltaMs, flip);
+                            return lossDb +
+                                VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
+                                (dipDb - lossDb);
+                        }
+
+                        double referenceCellScore = Math.Max(
+                            CellScore(bestPolishDelta, false),
+                            CellScore(0, false));
+                        double hopCellScore = CellScore(bestDelta, bestFlip);
+                        if (hopCellScore >=
+                            referenceCellScore - MonoComoveSubBandVetoMarginDb)
                         {
                             continue;
                         }
@@ -4085,8 +3988,8 @@ public static class AutoAlignmentEngine
                             $"by {bestScore - bestPolishScore:0.00} dB but loses " +
                             $"the {lowHz:0}-{highHz:0} Hz half vs " +
                             $"{neighbor.Name} by " +
-                            $"{polishCellScore - hopCellScore:0.00} dB — a true " +
-                            "lobe holds every measurable sub-band.");
+                            $"{referenceCellScore - hopCellScore:0.00} dB " +
+                            "— a true lobe holds every measurable sub-band.");
                         vetoed = true;
                         break;
                     }
@@ -4194,9 +4097,7 @@ public static class AutoAlignmentEngine
             new List<Complex[]> { other.ImpulseResponse },
             monoChannel.SampleRate,
             pair.BandLowHz,
-            pair.BandHighHz,
-            gateAnchorSample: JunctionGateAnchor(
-                pair.BandLowHz, pair.BandHighHz, mono, other));
+            pair.BandHighHz);
         if (loss is not { } measured)
         {
             log.AppendLine(

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -751,6 +751,31 @@ public static class AutoAlignmentEngine
     private const double PredictedArrivalConvictionFactor = 2.0;
 
     /// <summary>
+    /// The comb arbitration for the conviction factor's DEAD ZONE. The factor
+    /// exists because a prediction's own shaping error can reach 1.2
+    /// allowances, so a single witness may not convict below 2.0 — but at a
+    /// bass junction the allowance is ~half the crossover period, which puts
+    /// conviction at a FULL period: exactly where a modal latch lands. A read
+    /// in that zone (later than its prediction by more than one allowance,
+    /// short of two) used to withdraw the pair silently, and the upper-half
+    /// probe cannot examine a steeply low-passed reference that has nothing
+    /// above the corner — the archived Passat v2 sub read 26.8 ms against a
+    /// predicted 13.6 (1.7 allowances) and its latch anchored the whole
+    /// junction a period late. The whitened correlation of the pair breaks
+    /// the tie: it reads WHERE the two channels' shared content actually
+    /// aligns, so its strongest lobe within half a period of the
+    /// prediction-implied lag, beating the strongest within half a period of
+    /// the measured-implied lag by a real margin, is the second independent
+    /// witness a sub-conviction-strength discrepancy needs (on the Passat v2
+    /// junction: r 0.91 at the predicted family against 0.81 at the measured
+    /// one). The floor and the advantage mirror the direct-coherence
+    /// witness's field calibration; both lags must be measurable or the
+    /// arbitration stands down and the zone withdraws the pair as before.
+    /// </summary>
+    private const double LatchArbitrationMinR = 0.6;
+    private const double LatchArbitrationMinAdvantage = 0.05;
+
+    /// <summary>
     /// How far a processed read may sit from
     /// <see cref="PredictedFrontArrivalMs"/> before the side loses its
     /// certificate: half a period at the band's geometric center — one
@@ -1084,6 +1109,70 @@ public static class AutoAlignmentEngine
                 pairGradeable && lowerState == PredictionState.Latched;
             bool upperLatchedByPrediction =
                 pairGradeable && upperState == PredictionState.Latched;
+
+            // The dead zone (see LatchArbitrationMinR): a side LATER than its
+            // prediction by more than one allowance but short of the
+            // conviction factor, with both predictions in hand and the other
+            // side not itself refusing the grade. The whitened comb decides
+            // whether the pair's shared content sits with the predictions or
+            // with the measured arrivals.
+            bool lowerLateInZone =
+                lowerState == PredictionState.Inconsistent &&
+                lowerArrival > lowerPrediction;
+            bool upperLateInZone =
+                upperState == PredictionState.Inconsistent &&
+                upperArrival > upperPrediction;
+            if (!lowerLatchedByPrediction && !upperLatchedByPrediction &&
+                (lowerLateInZone || upperLateInZone) &&
+                lowerState != PredictionState.Unavailable &&
+                upperState != PredictionState.Unavailable &&
+                (lowerLateInZone || lowerState == PredictionState.Verified) &&
+                (upperLateInZone || upperState == PredictionState.Verified))
+            {
+                double periodMs = 1_000.0 / pair.CrossoverHz;
+                double measuredLagMs = lowerArrival - upperArrival;
+                double predictedLagMs = lowerPrediction - upperPrediction;
+                List<SignalPoint> comb =
+                    VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
+                        pair.Lower.ImpulseResponse,
+                        pair.Upper.ImpulseResponse,
+                        pair.Lower.Channel.SampleRate,
+                        pair.CrossoverHz,
+                        Math.Log2(pair.BandHighHz / pair.BandLowHz),
+                        Math.Abs(measuredLagMs - predictedLagMs) / 2.0
+                            + periodMs / 2.0,
+                        (measuredLagMs + predictedLagMs) / 2.0,
+                        phaseTransform: true);
+                double StrongestNear(double lagMs) => comb
+                    .Where(point => Math.Abs(point.X - lagMs) <= periodMs / 2.0)
+                    .Select(point => Math.Abs(point.Y))
+                    .DefaultIfEmpty(0.0)
+                    .Max();
+                double nearPredicted = StrongestNear(predictedLagMs);
+                double nearMeasured = StrongestNear(measuredLagMs);
+                if (nearPredicted >= LatchArbitrationMinR &&
+                    nearPredicted >= nearMeasured + LatchArbitrationMinAdvantage)
+                {
+                    log.AppendLine(
+                        $"  {(lowerLateInZone ? pair.Lower : pair.Upper).Channel.Name}: " +
+                        $"read sits in the conviction dead zone and the " +
+                        $"whitened comb sides with the prediction " +
+                        $"(r {nearPredicted:0.00} at the predicted family vs " +
+                        $"{nearMeasured:0.00} at the measured) — convicted by " +
+                        "arbitration");
+                    lowerLatchedByPrediction = lowerLateInZone;
+                    upperLatchedByPrediction = upperLateInZone;
+                }
+                else
+                {
+                    log.AppendLine(
+                        $"  latch arbitration stood down for " +
+                        $"{pair.Lower.Channel.Name}/{pair.Upper.Channel.Name}: " +
+                        $"comb r {nearPredicted:0.00} at the predicted family " +
+                        $"vs {nearMeasured:0.00} at the measured — no second " +
+                        "witness, the pair withdraws from the predictor.");
+                }
+            }
             if (lowerLatchedByPrediction || upperLatchedByPrediction)
             {
                 void LogConviction(

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -387,8 +387,7 @@ public static class AutoAlignmentEngine
     /// <summary>
     /// The sample a junction's measurements anchor their direct-sound gate on:
     /// the earliest FRONT among the junction's own members, read inside the
-    /// junction's band off their CHAIN-FREE responses (see
-    /// <see cref="VirtualCrossoverAnalysis.FindGateAnchor"/>).
+    /// junction's band (see <see cref="VirtualCrossoverAnalysis.FindGateAnchor"/>).
     /// Two properties matter, and the old rule — the earliest PEAK across every
     /// channel of the run — bought them at a price this one does not pay.
     ///
@@ -396,19 +395,7 @@ public static class AutoAlignmentEngine
     /// which is what made a peak-anchored window misjudge a slow channel's
     /// phase (see the gate remarks in VirtualCrossoverAnalysis). A front says
     /// so directly; the earliest peak of the whole system only implied it, by
-    /// reaching for a channel that happened to arrive sooner. And the front is
-    /// read BEFORE the chain, because a crossover's rise begins before the
-    /// front any detector can mark on its own output: the 55 Hz 36 dB/oct
-    /// low-pass in JunctionCorrelationCurveTests reads its filtered front
-    /// 12.8 ms behind the driver's, its woofer partner 8.6 ms behind, so an
-    /// anchor on the filtered front still cut into the very rise the window
-    /// exists to hold. Measured over the archived cabins by the panel's own
-    /// metric (the session battery in tests/Resonalyze.App.Tests): against the
-    /// sessions' saved tunings the proposal's average summation loss improves
-    /// by 0.127 dB per junction read off the chain-free front against 0.063 dB
-    /// off the filtered one, and it matches the old peak rule's alignments to
-    /// 0.003 dB on every junction of every cabin — that rule's margin, bought
-    /// by accident, recovered without reaching outside the pair for it.
+    /// reaching for a channel that happened to arrive sooner.
     ///
     /// It is FIXED for everything compared through it — the candidates of one
     /// search, the cells of a co-move grid, the two renders its sub-band veto
@@ -436,24 +423,13 @@ public static class AutoAlignmentEngine
                 continue;
             }
 
-            // The BYPASSED response where the caller supplied one: it is the
-            // same measurement without the chain's own group delay, so its
-            // front is the driver's. It is also independent of the overrides
-            // under test, which makes the anchor constant for the whole run
-            // rather than merely for one search. Without one (a caller that
-            // renders no chain-free copy, e.g. a hand-built snapshot in a
-            // test) the processed response answers, as it did before.
-            Complex[] response = side.BypassedImpulseResponse ?? side.ImpulseResponse;
-            bool chainFree = side.BypassedImpulseResponse != null;
             anchor = Math.Min(anchor, VirtualCrossoverAnalysis.FindGateAnchor(
-                response,
-                chainFree
-                    ? VirtualCrossoverAnalysis.FindPeakIndex(response)
-                    : side.PeakIndex,
+                side.ImpulseResponse,
+                side.PeakIndex,
                 side.Channel.SampleRate,
                 bandLowHz,
                 bandHighHz,
-                chainFree ? side.BypassedValidRange : side.ValidRange));
+                side.ValidRange));
         }
 
         return anchor == int.MaxValue ? 0 : anchor;

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1543,16 +1543,25 @@ public static class AutoAlignmentEngine
         {
             primaryNeighborSnapshot.ImpulseResponse
         };
+        // The snapshots' valid ranges travel with the responses into every
+        // bins build below: the per-channel front detection must not read a
+        // chain delay's silent prefix as arrival SNR.
+        var neighborRanges = new List<ValidSampleRange>
+        {
+            primaryNeighborSnapshot.ValidRange
+        };
         if (secondaryNeighborSnapshot != null)
         {
             neighborIrs.Add(secondaryNeighborSnapshot.ImpulseResponse);
+            neighborRanges.Add(secondaryNeighborSnapshot.ValidRange);
         }
 
         // The level match saturates at its cap; past it the residual
         // imbalance shrinks the junction contrast again, so the user should
         // level the gains and re-run — say so instead of degrading silently.
         if (VirtualCrossoverAnalysis.MeasureInBandImbalanceDb(
-                variableIr, neighborIrs, channel.SampleRate, bandLowHz, bandHighHz)
+                variableIr, neighborIrs, channel.SampleRate, bandLowHz, bandHighHz,
+                variableSnapshot.ValidRange, neighborRanges)
             is { } imbalanceDb &&
             Math.Abs(imbalanceDb) > VirtualCrossoverAnalysis.LevelMatchCapDb)
         {
@@ -1715,7 +1724,10 @@ public static class AutoAlignmentEngine
                     // Search-side level match: the lobe choice must not depend
                     // on the channels' playback gains (see BuildAlignmentBins).
                     levelMatch: true,
-                    out IReadOnlyList<AlignmentCandidate> allOptima);
+                    out IReadOnlyList<AlignmentCandidate> allOptima,
+                    gateAnchorSample: null,
+                    variableSnapshot.ValidRange,
+                    neighborRanges);
             return (candidates, allOptima, windowLowMs, windowHighMs);
         }
 
@@ -2092,10 +2104,12 @@ public static class AutoAlignmentEngine
                         VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
                             VirtualCrossoverAnalysis.CutDirectSound(
                                 neighborIrs[0], channel.SampleRate,
-                                bandLowHz, bandHighHz, pair.CrossoverHz),
+                                bandLowHz, bandHighHz, pair.CrossoverHz,
+                                primaryNeighborSnapshot.ValidRange),
                             VirtualCrossoverAnalysis.CutDirectSound(
                                 variableIr, channel.SampleRate,
-                                bandLowHz, bandHighHz, pair.CrossoverHz),
+                                bandLowHz, bandHighHz, pair.CrossoverHz,
+                                variableSnapshot.ValidRange),
                             channel.SampleRate,
                             pair.CrossoverHz,
                             Math.Log2(bandHighHz / bandLowHz),
@@ -2189,20 +2203,26 @@ public static class AutoAlignmentEngine
                 // (say 50-150 Hz) is not judged over five octaves it never
                 // overlaps. A fraction, not an octave count, so the threshold
                 // means the same across narrow and wide bands.
-                double OverlapFractionAgainst(AlignmentJunction junction, Complex[] neighborIr)
+                double OverlapFractionAgainst(
+                    AlignmentJunction junction,
+                    Complex[] neighborIr,
+                    ValidSampleRange neighborRange)
                 {
                     double nominal = Math.Log2(junction.BandHighHz / junction.BandLowHz);
                     double octaves = VirtualCrossoverAnalysis.EffectiveOverlapOctaves(
                         variableIr, [neighborIr], channel.SampleRate,
-                        junction.BandLowHz, junction.BandHighHz);
+                        junction.BandLowHz, junction.BandHighHz,
+                        variableSnapshot.ValidRange, [neighborRange]);
                     return nominal > 0 ? octaves / nominal : 0;
                 }
-                double overlapFraction = OverlapFractionAgainst(pair, neighborIrs[0]);
+                double overlapFraction = OverlapFractionAgainst(
+                    pair, neighborIrs[0], neighborRanges[0]);
                 if (secondaryPair != null && neighborIrs.Count > 1)
                 {
                     overlapFraction = Math.Min(
                         overlapFraction,
-                        OverlapFractionAgainst(secondaryPair, neighborIrs[1]));
+                        OverlapFractionAgainst(
+                            secondaryPair, neighborIrs[1], neighborRanges[1]));
                 }
                 decisions[channel] = BuildDecision(
                     chosen,
@@ -3592,6 +3612,8 @@ public static class AutoAlignmentEngine
                 current.First(item => item.Channel == channel);
             Complex[] IrOf(IAlignmentChannel channel) =>
                 SnapshotOf(channel).ImpulseResponse;
+                ValidSampleRange RangeOf(IAlignmentChannel channel) =>
+                    current.First(item => item.Channel == channel).ValidRange;
 
             // One evaluator per junction of the REFERENCE side. The move is
             // shared, so its criterion is a choice, and a mean over both sides
@@ -3632,7 +3654,10 @@ public static class AutoAlignmentEngine
                         junction.BandLowHz,
                         junction.BandHighHz,
                         levelMatch: true,
-                        requireDelayEvidence: true);
+                        requireDelayEvidence: true,
+                        gateAnchorSample: null,
+                        RangeOf(mover),
+                        new[] { RangeOf(neighbor) });
                 if (evaluator != null)
                 {
                     evaluators.Add(evaluator);
@@ -3885,6 +3910,8 @@ public static class AutoAlignmentEngine
             IReadOnlyList<AlignmentSnapshot> certified = reprocess(alignment);
             Complex[] CertifiedIrOf(IAlignmentChannel channel) =>
                 certified.First(item => item.Channel == channel).ImpulseResponse;
+            ValidSampleRange CertifiedRangeOf(IAlignmentChannel channel) =>
+                certified.First(item => item.Channel == channel).ValidRange;
             VirtualCrossoverAnalysis.SumLossEvaluator? Probe(
                 AlignmentJunction junction, double lowHz, double highHz)
             {
@@ -3898,7 +3925,10 @@ public static class AutoAlignmentEngine
                     lowHz,
                     highHz,
                     levelMatch: true,
-                    requireDelayEvidence: true);
+                    requireDelayEvidence: true,
+                    gateAnchorSample: null,
+                    CertifiedRangeOf(mono),
+                    new[] { CertifiedRangeOf(neighbor) });
             }
 
             var fullBand =
@@ -4234,7 +4264,9 @@ public static class AutoAlignmentEngine
             new List<Complex[]> { other.ImpulseResponse },
             monoChannel.SampleRate,
             pair.BandLowHz,
-            pair.BandHighHz);
+            pair.BandHighHz,
+            variableValidRange: mono.ValidRange,
+            fixedValidRanges: new[] { other.ValidRange });
         if (loss is not { } measured)
         {
             log.AppendLine(

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -527,10 +527,36 @@ public static class TransferIrDiagnostics
     /// </summary>
     public static IrStartEstimate? EstimateIrStart(
         IReadOnlyList<double> impulseResponse,
-        int sampleRate)
+        int sampleRate,
+        ValidSampleRange validRange = default)
     {
         ArgumentNullException.ThrowIfNull(impulseResponse);
-        if (impulseResponse.Count < IrStartMinimumSamples || sampleRate <= 0)
+        if (sampleRate <= 0)
+        {
+            return null;
+        }
+
+        // A known valid range restricts the ANALYSIS to the measured content
+        // while every reported time stays in the full record's coordinates:
+        // a chain delay's silent prefix would otherwise sink the noise-floor
+        // estimate and let a record the SNR gate should refuse pose as a
+        // credible front (measured: 25 ms of zeros ahead of a short noise
+        // record lift its grade from ~6 to ~26 dB, past the 20 dB floor).
+        int rangeStart = 0;
+        if (validRange.IsKnown)
+        {
+            rangeStart = Math.Clamp(
+                validRange.StartSample, 0, impulseResponse.Count);
+            int rangeEnd = Math.Clamp(
+                validRange.EndSample, rangeStart, impulseResponse.Count);
+            var window = new double[rangeEnd - rangeStart];
+            for (int i = 0; i < window.Length; i++)
+            {
+                window[i] = impulseResponse[rangeStart + i];
+            }
+            impulseResponse = window;
+        }
+        if (impulseResponse.Count < IrStartMinimumSamples)
         {
             return null;
         }
@@ -555,17 +581,34 @@ public static class TransferIrDiagnostics
                 BandpassPassOctaves = Math.Log2(band.HighHz / band.LowHz),
                 BandpassFadeOctaves = 0.25
             });
+        double offsetMs = rangeStart * 1_000.0 / sampleRate;
         if (IsCredible(inBand))
         {
-            return CrossingsOf(inBand, band, sampleRate, dominantBandLimited: true);
+            return Offset(
+                CrossingsOf(inBand, band, sampleRate, dominantBandLimited: true),
+                offsetMs);
         }
 
         TimeAlignmentAnalysisResult fullBand = TimeAlignmentAnalysis.Analyze(
             impulseResponse, sampleRate, new TimeAlignmentAnalysisOptions());
         return IsCredible(fullBand)
-            ? CrossingsOf(fullBand, band, sampleRate, dominantBandLimited: false)
+            ? Offset(
+                CrossingsOf(fullBand, band, sampleRate, dominantBandLimited: false),
+                offsetMs)
             : null;
     }
+
+    // Shifts an estimate computed on a range-restricted window back into the
+    // full record's coordinates.
+    private static IrStartEstimate Offset(IrStartEstimate estimate, double offsetMs) =>
+        offsetMs == 0
+            ? estimate
+            : estimate with
+            {
+                StartMs = estimate.StartMs + offsetMs,
+                EarlyMs = estimate.EarlyMs + offsetMs,
+                LateMs = estimate.LateMs + offsetMs
+            };
 
     /// <summary>
     /// How far below the smoothed spectrum's peak the band
@@ -617,16 +660,24 @@ public static class TransferIrDiagnostics
     /// </summary>
     public static IrStartEstimate? EstimateIrStart(
         IReadOnlyList<Complex> impulseResponse,
-        int sampleRate)
+        int sampleRate,
+        ValidSampleRange validRange = default)
     {
         ArgumentNullException.ThrowIfNull(impulseResponse);
-        int length = Math.Min(impulseResponse.Count, MaxAnalysisSamples);
+        // With a known range the head cap must count from the range's start,
+        // or a late-content record would be truncated before its own front;
+        // the double overload re-restricts in its own coordinates.
+        int rangeStart = validRange.IsKnown
+            ? Math.Clamp(validRange.StartSample, 0, impulseResponse.Count)
+            : 0;
+        int length = Math.Min(
+            impulseResponse.Count, rangeStart + MaxAnalysisSamples);
         var samples = new double[length];
         for (int i = 0; i < length; i++)
         {
             samples[i] = impulseResponse[i].Real;
         }
-        return EstimateIrStart(samples, sampleRate);
+        return EstimateIrStart(samples, sampleRate, validRange);
     }
 
     private static IrStartEstimate CrossingsOf(

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1601,10 +1601,43 @@ public static class VirtualCrossoverAnalysis
     // the 4096-sample / 256-fade window EXACTLY at 48 kHz. The analyzed span is
     // then zero-padded to a per-rate power-of-two FFT length — window and FFT
     // length kept separate so the physical window cannot jump across a
-    // power-of-two boundary (the same split as JunctionPhaseAlignment's).
+    // power-of-two boundary (the same split as JunctionPhaseAlignment's), and
+    // padded well past the window so the spectrum is SAMPLED densely enough to
+    // be read (see AlignmentFftInterpolationFactor).
     private const int AlignmentGateReferenceRate = 48_000;
     private const int AlignmentGateReferenceSamples = 4096;
     private const int AlignmentGateReferenceFadeSamples = 256;
+
+    /// <summary>
+    /// How many times the gate the analysed span is zero-padded to before the
+    /// FFT. This buys no RESOLUTION — that is the window's 1/T and nothing but
+    /// a longer window changes it — it buys SAMPLING: enough points to
+    /// represent the continuous spectrum the window actually measures.
+    /// <para>
+    /// Padded only to the gate (the length this used to be), a low junction is
+    /// barely sampled at all. At 96 kHz the gate is 8192 samples, so the bins
+    /// sit 11.7 Hz apart and a 33-130 Hz junction band holds NINE of them —
+    /// while the dip statistic is the minimum of a 1/6-octave moving average,
+    /// 7.7 Hz wide at 65 Hz. The "dip" was therefore the worst single bin, and
+    /// a cancellation notch falling between two bins was missed outright. Four
+    /// times the gate puts 34 bins in that band; the same grid already gave a
+    /// 750-3000 Hz junction ~190, which is why nothing above the bass ever
+    /// showed it.
+    /// </para>
+    /// <para>
+    /// Measured on the archived cabins, this moves LF verdicts by more than
+    /// any anchor rule does: on v3's 80 Hz junction the sweep's optimum went
+    /// from 9.6 ms away from the whitened-correlation extremum to 0.1 ms, and
+    /// on v5_exp's 65 Hz junction from 12.6 ms to 0.3 — the anchor untouched.
+    /// </para>
+    /// <para>
+    /// It does NOT make the LF dip trustworthy: 1/6 octave at 65 Hz is 7.7 Hz,
+    /// narrower than the 11.7 Hz the 85 ms window can resolve, so down there
+    /// the dip still reads the window's own kernel. Only a longer low-junction
+    /// window fixes that.
+    /// </para>
+    /// </summary>
+    private const int AlignmentFftInterpolationFactor = 4;
 
     private static int AlignmentGateSamples(int sampleRate) => (int)Math.Round(
         (double)AlignmentGateReferenceSamples * sampleRate / AlignmentGateReferenceRate);
@@ -1613,7 +1646,8 @@ public static class VirtualCrossoverAnalysis
         (double)AlignmentGateReferenceFadeSamples * sampleRate / AlignmentGateReferenceRate);
 
     private static int AlignmentFftLength(int sampleRate) =>
-        DspMath.NextPowerOfTwo(AlignmentGateSamples(sampleRate));
+        DspMath.NextPowerOfTwo(
+            AlignmentGateSamples(sampleRate) * AlignmentFftInterpolationFactor);
 
     /// <summary>
     /// The widest in-band level correction the search-side level match may

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1202,19 +1202,41 @@ public static class VirtualCrossoverAnalysis
     /// <summary>
     /// The junction summation loss as a function of an EXTRA delay applied to
     /// the variable channel — the prior-free acoustic surface of one junction,
-    /// as a drawable curve. Each probe is HONEST: the variable response is
-    /// delayed by rotating its FULL spectrum (an exact fractional delay of the
-    /// whole record) and the direct-sound gates are re-anchored on the delayed
-    /// response by <see cref="MeasureSumLoss"/>, unlike the
-    /// <see cref="SumLossEvaluator"/> rotation probe, whose gates stay pinned
-    /// where the responses originally sat and which misgrades multi-millisecond
-    /// deltas by whole dB. Both responses go into a guard-padded frame before
-    /// the rotation — a shared silent prefix and suffix covering the sweep
-    /// window — so no probed delay wraps record content circularly. Without the
-    /// prefix a negative delay on an early-peaked record carries the direct
-    /// sound to the END of the array, the shared gate (anchored at the fixed
-    /// channel) loses the variable channel entirely, and the "loss" of a
-    /// one-channel sum reads as a fake perfect 0 dB.
+    /// as a drawable curve. Both channels are windowed ONCE through the
+    /// junction's shared direct-sound gate (the caller's anchor — the pair's
+    /// earliest front, the same rule the Auto delay search gates by — or that
+    /// rule derived here when none is given), and every probe rotates the
+    /// variable channel's windowed cut by e^(−jωΔ): the same bins and the same
+    /// rotation the search's <see cref="SumLossEvaluator"/> reads, so the
+    /// drawn surface IS the search's surface, point for point at Δ = 0.
+    /// <para>
+    /// This replaced re-gating every probe through a STATIONARY window (the
+    /// variable response physically delayed, then windowed at the fixed
+    /// anchor). A stationary window only holds a moved channel for the few ms
+    /// between the channel's front and the window's opening; a panel sweep
+    /// spans ±1.5 crossover periods (±27 ms at a 55 Hz junction), and past
+    /// that margin the moved channel slid into the fade, the "sum"
+    /// degenerated toward one channel, and BOTH polarities converged to a
+    /// fake near-0 dB plateau — on the archived cabins the in-band level skew
+    /// grew from 3 to 19 dB across the sweep while the delay-evidence guard,
+    /// which reads the still-windowed content, saw nothing wrong. Rotation is
+    /// the model's statement that the window TRAVELS with the channel it
+    /// holds: the probed content is the same two cuts at every delay, the
+    /// level balance is delay-independent by construction, and the plateau
+    /// cannot form.
+    /// </para>
+    /// <para>
+    /// The windows deliberately do NOT sit on each channel's own front.
+    /// Measured on the 55 Hz 36 dB/oct pair the tests reproduce: per-own-front
+    /// windows read the current-timing loss at −4.27 dB where the shared
+    /// pair-front window reads −2.35 and a window opened at the drivers'
+    /// source (the truth this synthetic makes knowable) −1.89 — a crossover's
+    /// rise starts before any front detectable on its output (see the gate
+    /// remarks above), so the own-front placement cuts MORE rise, not less.
+    /// One shared window keeps the sweep consistent with the search and the
+    /// read-out; opening it earlier than the pair's front is the window-length
+    /// work's business, not the sweep's.
+    /// </para>
     /// </summary>
     public static List<JunctionSweepPoint> JunctionLossSweep(
         Complex[] variableImpulseResponse,
@@ -1243,59 +1265,48 @@ public static class VirtualCrossoverAnalysis
             throw new ArgumentException("The sweep window is invalid.");
         }
 
-        // The guard covers the widest probed shift in either direction (plus a
-        // few samples for the fractional-delay sinc tails). The SAME offset is
-        // applied to both channels, so their relative timing — the only thing
-        // the gate-re-anchoring measurement reads — is untouched.
-        int guardSamples = 8 + (int)Math.Ceiling(
-            Math.Max(Math.Abs(startDelayMs), Math.Abs(endDelayMs))
-            / 1000.0 * sampleRate);
-        int contentLength = Math.Max(
-            variableImpulseResponse.Length, fixedImpulseResponse.Length);
-        int fftLength = DspMath.NextPowerOfTwo(contentLength + 2 * guardSamples);
-        var variableFrame = new Complex[fftLength];
-        variableImpulseResponse.CopyTo(variableFrame, guardSamples);
-        var fixedFrame = new Complex[fftLength];
-        fixedImpulseResponse.CopyTo(fixedFrame, guardSamples);
-        Complex[] spectrum = ForwardSpectrum(variableFrame, fftLength);
+        int anchor = gateAnchorSample ?? Math.Min(
+            FindGateAnchor(
+                variableImpulseResponse,
+                FindPeakIndex(variableImpulseResponse),
+                sampleRate,
+                bandLowHz,
+                bandHighHz),
+            FindGateAnchor(
+                fixedImpulseResponse,
+                FindPeakIndex(fixedImpulseResponse),
+                sampleRate,
+                bandLowHz,
+                bandHighHz));
+        List<AlignmentBin> bins = BuildAlignmentBins(
+            variableImpulseResponse,
+            new List<Complex[]> { fixedImpulseResponse },
+            sampleRate,
+            bandLowHz,
+            bandHighHz,
+            startDelayMs,
+            endDelayMs,
+            levelMatch: false,
+            anchor);
         var points = new List<JunctionSweepPoint>();
-        var delayed = new Complex[fftLength];
+        if (bins.Count == 0)
+        {
+            return points;
+        }
+
+        double weightSum = 0;
+        foreach (AlignmentBin bin in bins)
+        {
+            weightSum += bin.LogWeight;
+        }
+
         for (double delayMs = startDelayMs;
             delayMs <= endDelayMs + 1e-9;
             delayMs += stepMs)
         {
-            double sign = invertVariable ? -1.0 : 1.0;
-            for (int k = 0; k < fftLength; k++)
-            {
-                // The rotation frequency follows the conjugate mirror above
-                // Nyquist, so the delayed sequence stays real.
-                double frequency = (double)k / fftLength * sampleRate;
-                if (frequency > sampleRate / 2.0)
-                {
-                    frequency -= sampleRate;
-                }
-
-                delayed[k] = sign * spectrum[k] * Complex.Exp(
-                    new Complex(0, -Math.Tau * frequency * delayMs / 1000.0));
-            }
-
-            Fourier.Inverse(delayed, FourierOptions.Matlab);
-            (double LossDb, double DipDb)? loss = MeasureSumLoss(
-                delayed,
-                new List<Complex[]> { fixedFrame },
-                sampleRate,
-                bandLowHz,
-                bandHighHz,
-                // The frame shifted both responses by the guard, so a caller's
-                // anchor (stated in the responses' own coordinates) shifts with
-                // them; without the guard offset the window would sit that far
-                // early and fade over content it must not touch.
-                gateAnchorSample: gateAnchorSample + guardSamples);
-            if (loss is { } value)
-            {
-                points.Add(new JunctionSweepPoint(
-                    delayMs, value.LossDb, value.DipDb));
-            }
+            (double lossDb, double dipDb) = DetailedLoss(
+                bins, weightSum, delayMs, invertVariable);
+            points.Add(new JunctionSweepPoint(delayMs, lossDb, dipDb));
         }
 
         return points;
@@ -2500,8 +2511,11 @@ public static class VirtualCrossoverAnalysis
     /// re-running the channels' full DSP chains per candidate delta.
     /// <c>Evaluate(0)</c> reproduces <see cref="MeasureSumLoss"/> on the same
     /// responses. The direct-sound gate stays anchored where the responses
-    /// currently sit, which is exact for the probes' small deltas (a fraction
-    /// of the gate length).
+    /// currently sit and the rotation carries the variable channel's windowed
+    /// cut — window and all — to the probed time: the model's reading of
+    /// "delay this driver", the same one <see cref="JunctionLossSweep"/> draws
+    /// (see the plateau remarks there for what re-gating a moved channel
+    /// through a stationary window did instead).
     /// </summary>
     public sealed class SumLossEvaluator
     {

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1761,10 +1761,13 @@ public static class VirtualCrossoverAnalysis
     /// millisecond — too short to hold a real driver's direct sound and its
     /// own fade structure); the ceiling bounds the FFT work where a band
     /// reaches toward 20 Hz, at the resolution cost the size rule would
-    /// otherwise pay there.
+    /// otherwise pay there. The ceiling is public because the Auto delay
+    /// search's shared crop must budget, in time at any sample rate, for the
+    /// longest window this rule can ask for (see AlignmentReprocessor's crop
+    /// sizing in the app).
     /// </summary>
     private const double MinimumAlignmentGateMs = 4.0;
-    private const double MaximumAlignmentGateMs = 350.0;
+    public const double MaximumAlignmentGateMs = 350.0;
 
     // The gate's fade share: the same 1/16 of the window the fixed
     // 4096/256-sample reference gate carried.

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1745,7 +1745,7 @@ public static class VirtualCrossoverAnalysis
     /// average at the band's low edge — its binding frequency — so the dip
     /// reads the SPECTRUM there instead of the window's own kernel. One
     /// scale-free rule sizes every junction: ~8.66 low-edge periods, which is
-    /// 133 ms for a 33–130 Hz sub band (the old fixed 85 ms was too short —
+    /// 262 ms for a 33–130 Hz sub band (the old fixed 85 ms was too short —
     /// the very kernel-reading this replaces) and 11.5 ms for a 750–3000 Hz
     /// mid/tweeter band, where 85 ms was mostly a car cabin's late
     /// reflections wearing a direct-sound gate's name.

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -376,13 +376,11 @@ public static class VirtualCrossoverAnalysis
     /// cannot see — typically the channel's other crossover junction.
     /// </summary>
     /// <param name="gateAnchorSample">
-    /// The sample the shared direct-sound gate anchors on. Null takes the
-    /// earliest peak of the responses passed in — right for a standalone
-    /// two-response question, WRONG for one junction of a multiway system,
-    /// where the pair's own peak places the window later than the read-out's
-    /// and can rank the junction's alignments differently (see the gate
-    /// constants' remarks). A caller aligning a system passes the whole
-    /// system's first arrival, the same anchor the metric read-out uses.
+    /// Null — the default, and what every engine site passes — windows each
+    /// response at its OWN band-limited front, the cuts meeting in one
+    /// absolute-time frame (see BuildAlignmentBins). A non-null sample forces
+    /// ONE shared window at that anchor instead: the read "through this
+    /// window", for displays and placement comparisons.
     /// </param>
     public static IReadOnlyList<AlignmentCandidate> FindAlignmentCandidates(
         Complex[] variableImpulseResponse,
@@ -396,12 +394,14 @@ public static class VirtualCrossoverAnalysis
         double priorSigmaMs = 0,
         bool? forcedPolarity = null,
         bool levelMatch = false,
-        int? gateAnchorSample = null) =>
+        int? gateAnchorSample = null,
+        ValidSampleRange variableValidRange = default,
+        IReadOnlyList<ValidSampleRange>? fixedValidRanges = null) =>
         FindAlignmentCandidates(
             variableImpulseResponse, fixedImpulseResponses, sampleRate,
             minFrequencyHz, maxFrequencyHz, minDelayMs, maxDelayMs,
             priorDelayMs, priorSigmaMs, forcedPolarity, levelMatch, out _,
-            gateAnchorSample);
+            gateAnchorSample, variableValidRange, fixedValidRanges);
 
     /// <summary>
     /// The overload that also reports EVERY refined local optimum (best
@@ -425,7 +425,9 @@ public static class VirtualCrossoverAnalysis
         bool? forcedPolarity,
         bool levelMatch,
         out IReadOnlyList<AlignmentCandidate> allOptima,
-        int? gateAnchorSample = null)
+        int? gateAnchorSample = null,
+        ValidSampleRange variableValidRange = default,
+        IReadOnlyList<ValidSampleRange>? fixedValidRanges = null)
     {
         List<AlignmentBin> bins = BuildAlignmentBins(
             variableImpulseResponse,
@@ -436,7 +438,9 @@ public static class VirtualCrossoverAnalysis
             minDelayMs,
             maxDelayMs,
             levelMatch,
-            gateAnchorSample);
+            gateAnchorSample,
+            variableValidRange,
+            fixedValidRanges);
         if (bins.Count == 0 || !HoldsDelayEvidence(bins))
         {
             allOptima = Array.Empty<AlignmentCandidate>();
@@ -665,7 +669,8 @@ public static class VirtualCrossoverAnalysis
         int sampleRate,
         double bandLowHz,
         double bandHighHz,
-        double crossoverHz)
+        double crossoverHz,
+        ValidSampleRange validRange = default)
     {
         ArgumentNullException.ThrowIfNull(impulseResponse);
         if (impulseResponse.Length == 0)
@@ -687,7 +692,8 @@ public static class VirtualCrossoverAnalysis
             FindPeakIndex(impulseResponse),
             sampleRate,
             bandLowHz,
-            bandHighHz);
+            bandHighHz,
+            validRange);
         double periodSamples = sampleRate / crossoverHz;
         int fade = Math.Max(8, (int)Math.Round(0.5 * periodSamples));
         int plateau = (int)Math.Round(2.0 * periodSamples);
@@ -1268,13 +1274,14 @@ public static class VirtualCrossoverAnalysis
     /// <summary>
     /// The junction summation loss as a function of an EXTRA delay applied to
     /// the variable channel — the prior-free acoustic surface of one junction,
-    /// as a drawable curve. Both channels are windowed ONCE through the
-    /// junction's shared direct-sound gate (the caller's anchor — the pair's
-    /// earliest front, the same rule the Auto delay search gates by — or that
-    /// rule derived here when none is given), and every probe rotates the
-    /// variable channel's windowed cut by e^(−jωΔ): the same bins and the same
-    /// rotation the search's <see cref="SumLossEvaluator"/> reads, so the
-    /// drawn surface IS the search's surface, point for point at Δ = 0.
+    /// as a drawable curve. Each channel is windowed ONCE — by default at its
+    /// OWN band-limited front, exactly as the Auto delay search windows it
+    /// (see BuildAlignmentBins; a non-null anchor forces one shared window
+    /// instead) — and every probe rotates the variable channel's windowed cut
+    /// by e^(−jωΔ): the same bins and the same rotation the search's
+    /// <see cref="SumLossEvaluator"/> reads, so with the search's own
+    /// settings (null anchor, levelMatch on) the drawn surface IS the
+    /// search's surface, point for point at Δ = 0.
     /// <para>
     /// This replaced re-gating every probe through a STATIONARY window (the
     /// variable response physically delayed, then windowed at the fixed
@@ -1314,7 +1321,10 @@ public static class VirtualCrossoverAnalysis
         double endDelayMs,
         double stepMs,
         bool invertVariable,
-        int? gateAnchorSample = null)
+        int? gateAnchorSample = null,
+        bool levelMatch = false,
+        ValidSampleRange variableValidRange = default,
+        ValidSampleRange fixedValidRange = default)
     {
         ArgumentNullException.ThrowIfNull(variableImpulseResponse);
         ArgumentNullException.ThrowIfNull(fixedImpulseResponse);
@@ -1331,19 +1341,13 @@ public static class VirtualCrossoverAnalysis
             throw new ArgumentException("The sweep window is invalid.");
         }
 
-        int anchor = gateAnchorSample ?? Math.Min(
-            FindGateAnchor(
-                variableImpulseResponse,
-                FindPeakIndex(variableImpulseResponse),
-                sampleRate,
-                bandLowHz,
-                bandHighHz),
-            FindGateAnchor(
-                fixedImpulseResponse,
-                FindPeakIndex(fixedImpulseResponse),
-                sampleRate,
-                bandLowHz,
-                bandHighHz));
+        // The anchor passes through UNTOUCHED: null must reach
+        // BuildAlignmentBins as null, where it means each response windowed
+        // at its own front — the same read the Auto search makes. Deriving a
+        // shared pair anchor here (as this once did) silently redirected the
+        // default onto a different window than the search's, and the drawn
+        // surface stopped being the searched one exactly where it matters —
+        // short high-frequency windows over separated arrivals.
         List<AlignmentBin> bins = BuildAlignmentBins(
             variableImpulseResponse,
             new List<Complex[]> { fixedImpulseResponse },
@@ -1352,8 +1356,10 @@ public static class VirtualCrossoverAnalysis
             bandHighHz,
             startDelayMs,
             endDelayMs,
-            levelMatch: false,
-            anchor);
+            levelMatch,
+            gateAnchorSample,
+            variableValidRange,
+            fixedValidRanges: new[] { fixedValidRange });
         var points = new List<JunctionSweepPoint>();
         if (bins.Count == 0)
         {
@@ -1828,7 +1834,9 @@ public static class VirtualCrossoverAnalysis
         IReadOnlyList<Complex[]> fixedImpulseResponses,
         int sampleRate,
         double minFrequencyHz,
-        double maxFrequencyHz)
+        double maxFrequencyHz,
+        ValidSampleRange variableValidRange = default,
+        IReadOnlyList<ValidSampleRange>? fixedValidRanges = null)
     {
         List<AlignmentBin> bins = BuildAlignmentBins(
             variableImpulseResponse,
@@ -1837,7 +1845,11 @@ public static class VirtualCrossoverAnalysis
             minFrequencyHz,
             maxFrequencyHz,
             minDelayMs: -1,
-            maxDelayMs: 1);
+            maxDelayMs: 1,
+            levelMatch: false,
+            gateAnchorSample: null,
+            variableValidRange,
+            fixedValidRanges);
         double variableLevel = 0;
         double fixedLevel = 0;
         foreach (AlignmentBin bin in bins)
@@ -1862,7 +1874,9 @@ public static class VirtualCrossoverAnalysis
         double minDelayMs,
         double maxDelayMs,
         bool levelMatch = false,
-        int? gateAnchorSample = null)
+        int? gateAnchorSample = null,
+        ValidSampleRange variableValidRange = default,
+        IReadOnlyList<ValidSampleRange>? fixedValidRanges = null)
     {
         ArgumentNullException.ThrowIfNull(variableImpulseResponse);
         ArgumentNullException.ThrowIfNull(fixedImpulseResponses);
@@ -1968,6 +1982,12 @@ public static class VirtualCrossoverAnalysis
             // settled neighbor can sit tens of ms behind a not-yet-delayed
             // channel, which the old shared fixed-length window only survived
             // by being 85 ms long.
+            // The front detector takes each response's valid range where the
+            // caller has one (the engine's snapshots always do): a chain's
+            // delay pads the record with a silent prefix that inflates the
+            // arrival SNR estimate, and an anchor certified by that inflation
+            // can open the window on the wrong event — the failure mode
+            // ValidSampleRange exists for.
             variableSpectrum = CutSpectrum(
                 variableImpulseResponse,
                 FindGateAnchor(
@@ -1975,14 +1995,20 @@ public static class VirtualCrossoverAnalysis
                     FindPeakIndex(variableImpulseResponse),
                     sampleRate,
                     minFrequencyHz,
-                    maxFrequencyHz));
-            foreach (Complex[] ir in fixedImpulseResponses)
+                    maxFrequencyHz,
+                    variableValidRange));
+            for (int index = 0; index < fixedImpulseResponses.Count; index++)
             {
+                Complex[] ir = fixedImpulseResponses[index];
                 Complex[] spectrum = CutSpectrum(
                     ir,
                     FindGateAnchor(
                         ir, FindPeakIndex(ir), sampleRate,
-                        minFrequencyHz, maxFrequencyHz));
+                        minFrequencyHz, maxFrequencyHz,
+                        fixedValidRanges != null &&
+                        index < fixedValidRanges.Count
+                            ? fixedValidRanges[index]
+                            : default));
                 for (int i = 0; i < length; i++)
                 {
                     fixedSpectrum[i] += spectrum[i];
@@ -2093,7 +2119,9 @@ public static class VirtualCrossoverAnalysis
         IReadOnlyList<Complex[]> fixedImpulseResponses,
         int sampleRate,
         double minFrequencyHz,
-        double maxFrequencyHz)
+        double maxFrequencyHz,
+        ValidSampleRange variableValidRange = default,
+        IReadOnlyList<ValidSampleRange>? fixedValidRanges = null)
     {
         // The delay bounds only shape BuildAlignmentBins' argument validation
         // (the bins themselves are delay-free); any valid span works, as in
@@ -2105,7 +2133,11 @@ public static class VirtualCrossoverAnalysis
             minFrequencyHz,
             maxFrequencyHz,
             minDelayMs: -1,
-            maxDelayMs: 1);
+            maxDelayMs: 1,
+            levelMatch: false,
+            gateAnchorSample: null,
+            variableValidRange,
+            fixedValidRanges);
         if (bins.Count < 2)
         {
             return 0.0;
@@ -2583,7 +2615,9 @@ public static class VirtualCrossoverAnalysis
         double maxFrequencyHz,
         bool levelMatch = false,
         bool requireDelayEvidence = false,
-        int? gateAnchorSample = null)
+        int? gateAnchorSample = null,
+        ValidSampleRange variableValidRange = default,
+        IReadOnlyList<ValidSampleRange>? fixedValidRanges = null)
     {
         // The delay window only gates parameter validation here — the
         // measurement itself evaluates the responses exactly as given.
@@ -2596,7 +2630,9 @@ public static class VirtualCrossoverAnalysis
             minDelayMs: -1,
             maxDelayMs: 1,
             levelMatch,
-            gateAnchorSample);
+            gateAnchorSample,
+            variableValidRange,
+            fixedValidRanges);
         // A caller COMPARING alignments across this band (rather than
         // reporting what a sum happens to measure) must not read a verdict
         // off a band where the delay is not observable: with one side only a
@@ -2733,7 +2769,9 @@ public static class VirtualCrossoverAnalysis
             double maxFrequencyHz,
             bool levelMatch = false,
             bool requireDelayEvidence = false,
-            int? gateAnchorSample = null)
+            int? gateAnchorSample = null,
+            ValidSampleRange variableValidRange = default,
+            IReadOnlyList<ValidSampleRange>? fixedValidRanges = null)
         {
             List<AlignmentBin> bins = BuildAlignmentBins(
                 variableImpulseResponse,
@@ -2744,7 +2782,9 @@ public static class VirtualCrossoverAnalysis
                 minDelayMs: -1,
                 maxDelayMs: 1,
                 levelMatch,
-                gateAnchorSample);
+                gateAnchorSample,
+                variableValidRange,
+                fixedValidRanges);
             if (bins.Count == 0 ||
                 (requireDelayEvidence && !HoldsDelayEvidence(bins)))
             {

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1299,16 +1299,12 @@ public static class VirtualCrossoverAnalysis
     /// cannot form.
     /// </para>
     /// <para>
-    /// The windows deliberately do NOT sit on each channel's own front.
-    /// Measured on the 55 Hz 36 dB/oct pair the tests reproduce: per-own-front
-    /// windows read the current-timing loss at −4.27 dB where the shared
-    /// pair-front window reads −2.35 and a window opened at the drivers'
-    /// source (the truth this synthetic makes knowable) −1.89 — a crossover's
-    /// rise starts before any front detectable on its output (see the gate
-    /// remarks above), so the own-front placement cuts MORE rise, not less.
-    /// One shared window keeps the sweep consistent with the search and the
-    /// read-out; opening it earlier than the pair's front is the window-length
-    /// work's business, not the sweep's.
+    /// (An earlier revision deliberately kept ONE shared window here, because
+    /// per-channel fronts under the then-fixed 85 ms gate cut into a
+    /// crossover's rise — measured −4.27 dB against the shared window's −2.35
+    /// on the 55 Hz reproduction. The band-sized windows retired that
+    /// objection along with the shared default; the figures live on in the
+    /// gate remarks above.)
     /// </para>
     /// </summary>
     public static List<JunctionSweepPoint> JunctionLossSweep(
@@ -2577,7 +2573,21 @@ public static class VirtualCrossoverAnalysis
     public static Complex[][] CropSharedDirectSoundWindow(
         IReadOnlyList<Complex[]> impulseResponses,
         int cropLength,
-        int prePeakSamples)
+        int prePeakSamples) =>
+        CropSharedDirectSoundWindow(
+            impulseResponses, cropLength, prePeakSamples, out _);
+
+    /// <summary>
+    /// The overload that also reports the shared offset the crop removed, so
+    /// a caller holding per-response metadata in the ORIGINAL frame — a
+    /// <see cref="ValidSampleRange"/> above all — can shift it into the
+    /// cropped one instead of silently dropping it.
+    /// </summary>
+    public static Complex[][] CropSharedDirectSoundWindow(
+        IReadOnlyList<Complex[]> impulseResponses,
+        int cropLength,
+        int prePeakSamples,
+        out int startSample)
     {
         ArgumentNullException.ThrowIfNull(impulseResponses);
         if (cropLength < 1)
@@ -2587,6 +2597,7 @@ public static class VirtualCrossoverAnalysis
 
         int earliestPeak = impulseResponses.Min(FindPeakIndex);
         int start = Math.Max(0, earliestPeak - Math.Max(0, prePeakSamples));
+        startSample = start;
         var cropped = new Complex[impulseResponses.Count][];
         for (int channel = 0; channel < impulseResponses.Count; channel++)
         {

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1579,19 +1579,35 @@ public static class VirtualCrossoverAnalysis
     // window happened to start — least of all one set by a channel that is not
     // in the junction.
     //
-    // The pair's own fronts must be read BEFORE its chains. On the 55 Hz
-    // reproduction in JunctionCorrelationCurveTests all four placements pick
-    // the same lobe (-3.5 ms, inverted), but the flatness each can read there
-    // differs: 0.00 dB through a window opened at the drivers' shared source,
-    // 0.00 dB through the pair's CHAIN-FREE fronts, -0.21 dB through their
-    // filtered fronts, -0.23 dB through their peaks. What separates the last
-    // two from the first is the crossover's own rise, which starts before the
-    // front any detector can mark on the filtered response — that 36 dB/oct
-    // low-pass reads its filtered front 12.8 ms after the driver's. So the
-    // callers read the anchor off the chain-free response
-    // (AutoAlignmentEngine.JunctionGateAnchor; PredictedFrontArrivalMs derives
-    // the same figure for a different purpose), which closes the gap without
-    // reaching outside the pair for the margin.
+    // The pair's own fronts recover PART of that margin, not all of it. On the
+    // 55 Hz reproduction in JunctionCorrelationCurveTests all four placements
+    // pick the same lobe (-3.5 ms, inverted), but the flatness each can read
+    // there differs: 0.00 dB through a window opened at the drivers' shared
+    // source, -0.21 dB through the pair's filtered fronts, -0.23 dB through
+    // the pair's peaks. What is left is the crossover's own rise, which starts
+    // before the filtered front any detector can mark — that 36 dB/oct low-pass
+    // reads its filtered front 12.8 ms after the driver's, its woofer partner
+    // 8.6 ms after.
+    //
+    // Reading the anchor off the CHAIN-FREE response closes that gap exactly
+    // (the fourth placement in the same test reads 0.00 dB, and
+    // PredictedFrontArrivalMs already derives the figure) — and it was
+    // MEASURED AND DECLINED, so it is not to be re-proposed on the strength of
+    // the reasoning above. Judged by the panel's own metric over the archived
+    // cabins (the session battery in tests/Resonalyze.App.Tests, every session
+    // read at its own Auto gate placement), a chain-free anchor moves only the
+    // LOWEST junction of a cabin, and there it moves the proposal AWAY from the
+    // owner's own tuning on the reference car — both of its saved sessions:
+    // v5's sub/bass junction reads -0.20 dB against the saved tuning and
+    // v5_exp's -0.13, where the filtered front reads +0.03 and +0.10, and the
+    // delay it proposes sits 0.74 ms off the manual one where the filtered
+    // front sits 0.11 ms off. Only v3 prefers it (+0.38 dB), and there
+    // it lands 1.56 ms from that session's own tuning — the LF metric is a
+    // 1/6-octave statistic narrower than the window can resolve (see
+    // AlignmentFftInterpolationFactor), so at the bottom junction it is the
+    // weaker witness of the two. What honestly needs the chain-free front is a
+    // reported FLATNESS trusted to a tenth of a dB; what must not follow it is
+    // the search.
     //
     // The window is sized in TIME, not samples. A fixed 4096 samples is ~85 ms
     // at 48 kHz but only 43 ms at 96 kHz and 21 ms at 192 kHz — the higher the

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -577,6 +577,73 @@ public static class VirtualCrossoverAnalysis
             .FirstArrivalDelayMilliseconds;
 
     /// <summary>
+    /// Where the direct-sound gate of a junction measurement must open for ONE
+    /// response: its band-limited first arrival inside the junction's own band,
+    /// as a sample index — the placement the gate remarks in
+    /// <see cref="BuildAlignmentBins"/> ask for, computed rather than
+    /// approximated by the peak.
+    /// <para>
+    /// A PEAK is the wrong estimator for this. It answers "where is this
+    /// channel loudest", and a crossover moves that answer by its own group
+    /// delay — in a band the junction may not even be judged in. On the
+    /// archived Passat right side a midrange band-passed at 250-2000 Hz peaks
+    /// 7.11 ms in, set by the group delay of its 250 Hz high-pass, while its
+    /// energy in the 1-4 kHz junction it shares with the tweeter is already
+    /// there at 4.28 ms; the subwoofer's peak sits 5.55 ms behind its own
+    /// 33-130 Hz arrival. A window anchored on the peak therefore opens after
+    /// the front it is supposed to hold, and its fade-in attenuates one
+    /// member's rise more than the other's — the very artifact the anchor
+    /// exists to prevent.
+    /// </para>
+    /// <para>
+    /// Two guards keep this honest where the estimate cannot be trusted. A
+    /// band that carries no measurable arrival (invalid, or below
+    /// <see cref="AutoAlignmentEngine.MinimumArrivalSnrDb"/>) falls back to the
+    /// peak, and the result is never LATER than the peak: the envelope search
+    /// can latch onto a room mode at a low junction, and a latched read is a
+    /// late one, so clamping to the peak means this can only ever move a
+    /// window EARLIER than the peak anchor it replaces — it cannot introduce a
+    /// cut that placement did not already have.
+    /// </para>
+    /// </summary>
+    public static int FindGateAnchor(
+        Complex[] impulseResponse,
+        int peakIndex,
+        int sampleRate,
+        double bandLowHz,
+        double bandHighHz,
+        ValidSampleRange validRange = default)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        if (impulseResponse.Length == 0)
+        {
+            throw new ArgumentException(
+                "The impulse response is empty.",
+                nameof(impulseResponse));
+        }
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+
+        int peak = Math.Clamp(peakIndex, 0, impulseResponse.Length - 1);
+        TimeAlignmentAnalysisResult arrival = AnalyzeBandLimitedArrival(
+            impulseResponse, sampleRate, bandLowHz, bandHighHz, validRange);
+        if (!arrival.IsValid ||
+            arrival.SignalToNoiseDecibels < AutoAlignmentEngine.MinimumArrivalSnrDb)
+        {
+            return peak;
+        }
+
+        // Floored, not rounded: half a sample earlier costs nothing (the
+        // fade-in covers the pre-arrival span) while half a sample later would
+        // start the plateau inside the front.
+        int front = (int)Math.Floor(
+            arrival.FirstArrivalDelayMilliseconds / 1_000.0 * sampleRate);
+        return Math.Clamp(Math.Min(front, peak), 0, impulseResponse.Length - 1);
+    }
+
+    /// <summary>
     /// The minimum band width (as a high/low frequency ratio: a third of an
     /// octave) a band-limited arrival analysis accepts. Narrower bands leave
     /// the envelope detector too few in-band periods to place an arrival, so
@@ -1484,27 +1551,46 @@ public static class VirtualCrossoverAnalysis
 
     // The direct-sound gate applied to every response before the alignment
     // spectra are taken: a cosine-faded Tukey window anchored one fade-length
-    // before the earliest channel peak. Reading the full IR instead would fold
-    // the entire room decay into every bin — hundreds of milliseconds of
-    // reverberation whose comb structure the alignment cannot change — so the
-    // search would optimize (and be misled by) reflections while the panel
-    // displays the gated direct sound. One gate shared by all channels, like
-    // the metric's shared anchor, so the loss keeps its 0 dB ceiling.
+    // before the earliest FRONT among the responses the caller named (see
+    // FindGateAnchor). Reading the full IR instead would fold the entire room
+    // decay into every bin — hundreds of milliseconds of reverberation whose
+    // comb structure the alignment cannot change — so the search would
+    // optimize (and be misled by) reflections while the panel displays the
+    // gated direct sound. One gate shared by both sides of a measurement, so
+    // the loss keeps its 0 dB ceiling.
     //
-    // WHICH channels set that anchor is a decision the caller owns
-    // (gateAnchorSample). Measuring one junction of a multiway system with an
-    // anchor taken from the PAIR alone places the window tens of milliseconds
-    // later than a window anchored on the whole system's first arrival — the
-    // placement the metric read-out uses (VirtualCrossoverMetrics.BuildCurves)
-    // — and at a sub/woofer junction the two then rank the same alignments
-    // differently:
-    // on a field cabin (LP/HP 55 Hz, 36 dB/oct) the pair-anchored window read
-    // the tuned alignment at -0.44 dB and preferred one 2 ms later, while the
-    // system-anchored window read it at -0.02 dB, the sharpest optimum of the
-    // sweep, agreeing with the panel and with the whitened correlation
-    // (r 0.99). A window whose fade-in cuts into the slow channel's own rise
-    // shifts that channel's apparent phase, and the junction search must not
-    // decide a lobe on an artifact of where the window happened to start.
+    // WHICH responses set that anchor is a decision the caller owns
+    // (gateAnchorSample), and the callers here name the JUNCTION's own members
+    // — not the whole system. What makes that safe is the anchor being a
+    // front. Anchoring a pair on its earlier PEAK is what once ranked
+    // alignments wrongly (a field cabin, LP/HP 55 Hz 36 dB/oct: the
+    // pair-and-peak window read the tuned alignment at -0.44 dB and preferred
+    // one 2 ms later, where a window anchored on the whole system's earliest
+    // peak read it at -0.02 dB, the sharpest optimum of the sweep, agreeing
+    // with the panel and with the whitened correlation, r 0.99) — because a
+    // low channel's peak trails its own rise by its crossover's group delay,
+    // so the window's fade-in cut into that rise and shifted the channel's
+    // apparent phase. Reaching outside the pair for an earlier peak fixed that
+    // by accident: it bought margin ahead of the rise at the price of a window
+    // that moved whenever an unrelated channel was enabled, muted or re-timed
+    // (on the archived Passat right side, muting the mid and tweeter moved the
+    // 65 Hz junction's window 8.96 ms and its own optimum by 14 ms). The
+    // junction search must not decide a lobe on an artifact of where the
+    // window happened to start — least of all one set by a channel that is not
+    // in the junction.
+    //
+    // The pair's own fronts recover PART of that margin, not all of it. On the
+    // 55 Hz reproduction in JunctionCorrelationCurveTests all three placements
+    // pick the same lobe (-3.5 ms, inverted), but the flatness each can read
+    // there differs: 0.00 dB through a window opened well ahead of both
+    // drivers, -0.15 dB through the pair's filtered fronts, -0.16 dB through
+    // the pair's peaks. What is left is the crossover's own rise, which starts
+    // before the filtered front any detector can mark — a 36 dB/oct low-pass
+    // reads its front 14 ms after the driver's. Closing that gap means reading
+    // the anchor off the chain-free response instead (PredictedFrontArrivalMs
+    // already derives exactly that figure), which is worth doing when the
+    // reported flatness of a steep low junction has to be trusted to a tenth
+    // of a dB; the lobe it lands on does not depend on it.
     //
     // The window is sized in TIME, not samples. A fixed 4096 samples is ~85 ms
     // at 48 kHz but only 43 ms at 96 kHz and 21 ms at 192 kHz — the higher the

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1579,18 +1579,19 @@ public static class VirtualCrossoverAnalysis
     // window happened to start — least of all one set by a channel that is not
     // in the junction.
     //
-    // The pair's own fronts recover PART of that margin, not all of it. On the
-    // 55 Hz reproduction in JunctionCorrelationCurveTests all three placements
-    // pick the same lobe (-3.5 ms, inverted), but the flatness each can read
-    // there differs: 0.00 dB through a window opened well ahead of both
-    // drivers, -0.15 dB through the pair's filtered fronts, -0.16 dB through
-    // the pair's peaks. What is left is the crossover's own rise, which starts
-    // before the filtered front any detector can mark — a 36 dB/oct low-pass
-    // reads its front 14 ms after the driver's. Closing that gap means reading
-    // the anchor off the chain-free response instead (PredictedFrontArrivalMs
-    // already derives exactly that figure), which is worth doing when the
-    // reported flatness of a steep low junction has to be trusted to a tenth
-    // of a dB; the lobe it lands on does not depend on it.
+    // The pair's own fronts must be read BEFORE its chains. On the 55 Hz
+    // reproduction in JunctionCorrelationCurveTests all four placements pick
+    // the same lobe (-3.5 ms, inverted), but the flatness each can read there
+    // differs: 0.00 dB through a window opened at the drivers' shared source,
+    // 0.00 dB through the pair's CHAIN-FREE fronts, -0.21 dB through their
+    // filtered fronts, -0.23 dB through their peaks. What separates the last
+    // two from the first is the crossover's own rise, which starts before the
+    // front any detector can mark on the filtered response — that 36 dB/oct
+    // low-pass reads its filtered front 12.8 ms after the driver's. So the
+    // callers read the anchor off the chain-free response
+    // (AutoAlignmentEngine.JunctionGateAnchor; PredictedFrontArrivalMs derives
+    // the same figure for a different purpose), which closes the gap without
+    // reaching outside the pair for the margin.
     //
     // The window is sized in TIME, not samples. A fixed 4096 samples is ~85 ms
     // at 48 kHz but only 43 ms at 96 kHz and 21 ms at 192 kHz — the higher the

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -644,6 +644,72 @@ public static class VirtualCrossoverAnalysis
     }
 
     /// <summary>
+    /// One channel's DIRECT sound, cut for a whitened junction comparison:
+    /// everything outside [front − T/2, front + 2T + T/2] is zeroed (T = one
+    /// period of the junction's crossover), with half-period raised-cosine
+    /// fades at both edges, the front being the channel's own band-limited
+    /// arrival (<see cref="FindGateAnchor"/>). Two crossover periods is the
+    /// span that reads the drivers: measured on the archived mid/tweeter
+    /// junctions, one period behind the front the whitened correlation of the
+    /// pair peaks at the drivers' timing (r ≈ 0.85 on the reference car),
+    /// from two-and-some periods on the cabin's early reflections take the
+    /// extremum over and carry it whole periods away (−2.5 ms on the same
+    /// junction, polarity alternating between adjacent lobes). The
+    /// correlation view's "PHAT direct" curve and the alignment engine's
+    /// direct-coherence witness both read pairs of these cuts — one
+    /// implementation, so the curve the user checks IS the figure the engine
+    /// weighed.
+    /// </summary>
+    public static Complex[] CutDirectSound(
+        Complex[] impulseResponse,
+        int sampleRate,
+        double bandLowHz,
+        double bandHighHz,
+        double crossoverHz)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        if (impulseResponse.Length == 0)
+        {
+            throw new ArgumentException(
+                "The impulse response is empty.", nameof(impulseResponse));
+        }
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+        if (!(crossoverHz > 0))
+        {
+            throw new ArgumentException("The crossover is invalid.");
+        }
+
+        int front = FindGateAnchor(
+            impulseResponse,
+            FindPeakIndex(impulseResponse),
+            sampleRate,
+            bandLowHz,
+            bandHighHz);
+        double periodSamples = sampleRate / crossoverHz;
+        int fade = Math.Max(8, (int)Math.Round(0.5 * periodSamples));
+        int plateau = (int)Math.Round(2.0 * periodSamples);
+        int start = Math.Max(0, front - fade);
+        int end = Math.Min(impulseResponse.Length, front + plateau + fade);
+        var cut = new Complex[impulseResponse.Length];
+        for (int i = start; i < end; i++)
+        {
+            double weight =
+                i < front
+                    ? 0.5 - 0.5 * Math.Cos(Math.PI * (i - start) / (double)fade)
+                    : i >= front + plateau
+                        ? 0.5 + 0.5 * Math.Cos(
+                            Math.PI * (i - front - plateau) / (double)fade)
+                        : 1.0;
+            cut[i] = impulseResponse[i] * weight;
+        }
+
+        return cut;
+    }
+
+    /// <summary>
     /// The minimum band width (as a high/low frequency ratio: a third of an
     /// octave) a band-limited arrival analysis accepts. Narrower bands leave
     /// the envelope detector too few in-band periods to place an arrival, so

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1659,14 +1659,71 @@ public static class VirtualCrossoverAnalysis
     /// on v5_exp's 65 Hz junction from 12.6 ms to 0.3 — the anchor untouched.
     /// </para>
     /// <para>
-    /// It does NOT make the LF dip trustworthy: 1/6 octave at 65 Hz is 7.7 Hz,
-    /// narrower than the 11.7 Hz the 85 ms window can resolve, so down there
-    /// the dip still reads the window's own kernel. Only a longer low-junction
-    /// window fixes that.
+    /// Sampling alone did NOT make the LF dip trustworthy: 1/6 octave at
+    /// 65 Hz is 7.7 Hz, narrower than the 11.7 Hz an 85 ms window can
+    /// resolve, so down there the dip still read the window's own kernel.
+    /// That took the band-sized window length below
+    /// (AlignmentGateBandLowEdgeCycles); the padding factor rides on top of
+    /// whatever length the band chooses, keeping ~4 spectrum samples per
+    /// dip width at the band's low edge.
     /// </para>
     /// </summary>
     private const int AlignmentFftInterpolationFactor = 4;
 
+    /// <summary>
+    /// How many periods of a junction band's LOW edge its direct-sound window
+    /// spans: the reciprocal of the dip statistic's own relative width. The
+    /// dip is the minimum of a 1/6-octave moving average, which at frequency f
+    /// is f·(2^(1/12) − 2^(−1/12)) ≈ 0.1155·f wide; a window of length
+    /// 1/(0.1155·f) is the shortest whose ~1/T kernel fits inside that
+    /// average at the band's low edge — its binding frequency — so the dip
+    /// reads the SPECTRUM there instead of the window's own kernel. One
+    /// scale-free rule sizes every junction: ~8.66 low-edge periods, which is
+    /// 133 ms for a 33–130 Hz sub band (the old fixed 85 ms was too short —
+    /// the very kernel-reading this replaces) and 11.5 ms for a 750–3000 Hz
+    /// mid/tweeter band, where 85 ms was mostly a car cabin's late
+    /// reflections wearing a direct-sound gate's name.
+    /// </summary>
+    private static readonly double AlignmentGateBandLowEdgeCycles =
+        1.0 / (Math.Pow(2, 1.0 / 12) - Math.Pow(2, -1.0 / 12));
+
+    /// <summary>
+    /// The band-sized window's bounds. The floor guards a degenerate
+    /// high-frequency band (8.66 periods of 20 kHz is under half a
+    /// millisecond — too short to hold a real driver's direct sound and its
+    /// own fade structure); the ceiling bounds the FFT work where a band
+    /// reaches toward 20 Hz, at the resolution cost the size rule would
+    /// otherwise pay there.
+    /// </summary>
+    private const double MinimumAlignmentGateMs = 4.0;
+    private const double MaximumAlignmentGateMs = 350.0;
+
+    // The gate's fade share: the same 1/16 of the window the fixed
+    // 4096/256-sample reference gate carried.
+    private const int AlignmentGateFadeFraction = 16;
+
+    private static int AlignmentGateSamples(int sampleRate, double bandLowHz)
+    {
+        double windowMs = Math.Clamp(
+            AlignmentGateBandLowEdgeCycles / bandLowHz * 1_000.0,
+            MinimumAlignmentGateMs,
+            MaximumAlignmentGateMs);
+        return (int)Math.Round(windowMs / 1_000.0 * sampleRate);
+    }
+
+    private static int AlignmentGateFadeSamples(int sampleRate, double bandLowHz) =>
+        AlignmentGateSamples(sampleRate, bandLowHz) / AlignmentGateFadeFraction;
+
+    private static int AlignmentFftLength(int sampleRate, double bandLowHz) =>
+        DspMath.NextPowerOfTwo(
+            AlignmentGateSamples(sampleRate, bandLowHz)
+            * AlignmentFftInterpolationFactor);
+
+    // The FIXED reference-length gate, kept for the band-level read
+    // (MeasureBandLevelDb): a level is an energy average, indifferent to the
+    // kernel-width story that sizes the junction windows above, and a channel
+    // band's low edge runs to 20 Hz, where the size rule pays its ceiling for
+    // resolution a level read does not need.
     private static int AlignmentGateSamples(int sampleRate) => (int)Math.Round(
         (double)AlignmentGateReferenceSamples * sampleRate / AlignmentGateReferenceRate);
 
@@ -1757,44 +1814,113 @@ public static class VirtualCrossoverAnalysis
             throw new ArgumentException("The search window is invalid.");
         }
 
-        int anchor;
-        if (gateAnchorSample is { } shared)
+        // The window is sized by the junction's own band (see
+        // AlignmentGateBandLowEdgeCycles): long enough at its LOW edge that
+        // the dip statistic reads the spectrum rather than the window's
+        // kernel, and no longer — above the bass that sheds the late cabin
+        // reflections the fixed 85 ms reference length used to admit. The
+        // earliest content a window holds must land on its plateau, never
+        // inside the fade-in: a fade would attenuate the channels' arrivals
+        // unequally and bias the loss; when a front sits closer to the start
+        // than a full fade, the fade shrinks to fit.
+        int gateSamples = AlignmentGateSamples(sampleRate, minFrequencyHz);
+        int fadeSamples = AlignmentGateFadeSamples(sampleRate, minFrequencyHz);
+        int length = AlignmentFftLength(sampleRate, minFrequencyHz);
+
+        // One windowed cut per response, restored to ABSOLUTE time by the
+        // linear phase of its window's start, so cuts taken at different
+        // positions still interfere at the timing the records actually carry.
+        Complex[] CutSpectrum(Complex[] impulseResponse, int anchor)
         {
-            anchor = Math.Clamp(shared, 0, variableImpulseResponse.Length - 1);
+            int clamped = Math.Clamp(anchor, 0, impulseResponse.Length - 1);
+            int leftFadeSamples = Math.Min(fadeSamples, clamped);
+            int gateStart = clamped - leftFadeSamples;
+            double[] gate = Windowing.TukeyWindow(
+                gateSamples,
+                2.0 * leftFadeSamples / gateSamples,
+                2.0 * fadeSamples / gateSamples);
+            Complex[] spectrum = ForwardSpectrum(
+                GateDirectSound(impulseResponse, gateStart, gate), length);
+            if (gateStart > 0)
+            {
+                double startSeconds = (double)gateStart / sampleRate;
+                for (int bin = 1; bin <= length / 2; bin++)
+                {
+                    double frequencyHz = bin * (double)sampleRate / length;
+                    Complex rotation = Complex.Exp(
+                        new Complex(0, -Math.Tau * frequencyHz * startSeconds));
+                    spectrum[bin] *= rotation;
+                    if (bin < length / 2)
+                    {
+                        spectrum[length - bin] *= Complex.Conjugate(rotation);
+                    }
+                }
+            }
+
+            return spectrum;
+        }
+
+        Complex[] variableSpectrum;
+        var fixedSpectrum = new Complex[length];
+        if (gateAnchorSample is { } sharedAnchor)
+        {
+            // One SHARED window at the caller's anchor for every response —
+            // the read "through this window": what a display drawing several
+            // channels through one placement measures, and what the placement
+            // tests compare. The cuts are co-located, so no absolute-time
+            // restoration is needed (a common linear phase cancels in every
+            // magnitude and interference term).
+            int anchor = Math.Clamp(
+                sharedAnchor, 0, variableImpulseResponse.Length - 1);
+            int leftFadeSamples = Math.Min(fadeSamples, anchor);
+            int gateStart = anchor - leftFadeSamples;
+            double[] gate = Windowing.TukeyWindow(
+                gateSamples,
+                2.0 * leftFadeSamples / gateSamples,
+                2.0 * fadeSamples / gateSamples);
+            variableSpectrum = ForwardSpectrum(
+                GateDirectSound(variableImpulseResponse, gateStart, gate), length);
+            foreach (Complex[] ir in fixedImpulseResponses)
+            {
+                Complex[] spectrum = ForwardSpectrum(
+                    GateDirectSound(ir, gateStart, gate), length);
+                for (int i = 0; i < length; i++)
+                {
+                    fixedSpectrum[i] += spectrum[i];
+                }
+            }
         }
         else
         {
-            anchor = FindPeakIndex(variableImpulseResponse);
+            // The default: every response is windowed at its OWN band-limited
+            // front (never later than its peak — FindGateAnchor's guards), and
+            // the cuts meet in one absolute-time frame. This is the model's
+            // junction measurement — the window belongs to the channel it
+            // holds and travels with it — and it is what lets a junction be
+            // measured at all once the members' assigned delays spread them
+            // further apart than one band-sized window spans: mid-cascade a
+            // settled neighbor can sit tens of ms behind a not-yet-delayed
+            // channel, which the old shared fixed-length window only survived
+            // by being 85 ms long.
+            variableSpectrum = CutSpectrum(
+                variableImpulseResponse,
+                FindGateAnchor(
+                    variableImpulseResponse,
+                    FindPeakIndex(variableImpulseResponse),
+                    sampleRate,
+                    minFrequencyHz,
+                    maxFrequencyHz));
             foreach (Complex[] ir in fixedImpulseResponses)
             {
-                anchor = Math.Min(anchor, FindPeakIndex(ir));
-            }
-        }
-
-        // The earliest arrival must land on the window's plateau, never inside
-        // the fade-in: a fade would attenuate the channels' arrivals unequally
-        // (they sit at different fade depths) and bias the loss. When the peak
-        // sits closer to the start than a full fade, the fade shrinks to fit.
-        int gateSamples = AlignmentGateSamples(sampleRate);
-        int fadeSamples = AlignmentGateFadeSamples(sampleRate);
-        int leftFadeSamples = Math.Min(fadeSamples, anchor);
-        int gateStart = anchor - leftFadeSamples;
-        double[] gate = Windowing.TukeyWindow(
-            gateSamples,
-            2.0 * leftFadeSamples / gateSamples,
-            2.0 * fadeSamples / gateSamples);
-
-        int length = AlignmentFftLength(sampleRate);
-        Complex[] variableSpectrum = ForwardSpectrum(
-            GateDirectSound(variableImpulseResponse, gateStart, gate), length);
-        var fixedSpectrum = new Complex[length];
-        foreach (Complex[] ir in fixedImpulseResponses)
-        {
-            Complex[] spectrum = ForwardSpectrum(
-                GateDirectSound(ir, gateStart, gate), length);
-            for (int i = 0; i < length; i++)
-            {
-                fixedSpectrum[i] += spectrum[i];
+                Complex[] spectrum = CutSpectrum(
+                    ir,
+                    FindGateAnchor(
+                        ir, FindPeakIndex(ir), sampleRate,
+                        minFrequencyHz, maxFrequencyHz));
+                for (int i = 0; i < length; i++)
+                {
+                    fixedSpectrum[i] += spectrum[i];
+                }
             }
         }
 
@@ -2570,10 +2696,13 @@ public static class VirtualCrossoverAnalysis
 
         /// <summary>
         /// The in-band average loss and 1/6-octave dip with the variable
-        /// channel delayed by <paramref name="extraDelayMs"/> more.
+        /// channel delayed by <paramref name="extraDelayMs"/> more (and
+        /// inverted, when <paramref name="invertVariable"/> asks — the
+        /// polarity half of the same probe, for searches that weigh both).
         /// </summary>
-        public (double LossDb, double DipDb) Evaluate(double extraDelayMs) =>
-            DetailedLoss(bins, weightSum, extraDelayMs, invert: false);
+        public (double LossDb, double DipDb) Evaluate(
+            double extraDelayMs, bool invertVariable = false) =>
+            DetailedLoss(bins, weightSum, extraDelayMs, invertVariable);
     }
 
     private static Complex[] GateDirectSound(

--- a/source/Measurements/TransferIrStartCache.cs
+++ b/source/Measurements/TransferIrStartCache.cs
@@ -15,7 +15,8 @@ namespace Resonalyze;
 /// </summary>
 internal static class TransferIrStartCache
 {
-    private sealed record CachedStart(int SampleRate, double StartMs);
+    private sealed record CachedStart(
+        int SampleRate, ValidSampleRange ValidRange, double StartMs);
 
     private static readonly ConditionalWeakTable<Complex[], CachedStart> cache = new();
 
@@ -59,19 +60,22 @@ internal static class TransferIrStartCache
     public static double ResolveStartMs(
         Complex[] impulseResponse,
         int sampleRate,
-        int fallbackPeakIndex)
+        int fallbackPeakIndex,
+        ValidSampleRange validRange = default)
     {
         if (cache.TryGetValue(impulseResponse, out CachedStart? cached) &&
-            cached.SampleRate == sampleRate)
+            cached.SampleRate == sampleRate &&
+            cached.ValidRange == validRange)
         {
             return cached.StartMs;
         }
 
         double startMs = TransferIrDiagnostics.EstimateIrStart(
-            impulseResponse, sampleRate) is { } estimate
+            impulseResponse, sampleRate, validRange) is { } estimate
                 ? estimate.StartMs
                 : fallbackPeakIndex * 1_000.0 / sampleRate;
-        cache.AddOrUpdate(impulseResponse, new CachedStart(sampleRate, startMs));
+        cache.AddOrUpdate(
+            impulseResponse, new CachedStart(sampleRate, validRange, startMs));
         return startMs;
     }
 }

--- a/source/Tools/VirtualCrossover/AlignmentReprocessor.cs
+++ b/source/Tools/VirtualCrossover/AlignmentReprocessor.cs
@@ -38,6 +38,61 @@ internal sealed class AlignmentReprocessor
     private readonly Complex[]?[] bypassedImpulseResponses;
     private readonly ValidSampleRange[] bypassedValidRanges;
 
+    /// <summary>
+    /// The shared search crop, sized by TIME. The base length was tuned when
+    /// every field rate was 48 or 96 kHz (1.4 / 0.7 s of decay); the
+    /// band-sized alignment windows made the requirement explicit — after
+    /// the pre-peak reserve (1/8 of the crop) the crop must still hold the
+    /// longest window the band sizing can ask for
+    /// (<see cref="VirtualCrossoverAnalysis.MaximumAlignmentGateMs"/>) plus
+    /// the channels' arrival/delay spread (the fleet's worst measured is
+    /// ~46 ms; 175 ms of reserve): 8/7 · 525 = 600 ms. At 48/96 kHz the base
+    /// length already exceeds that and is kept EXACTLY, so archived results
+    /// do not move; higher rates double it until the budget fits (192 kHz →
+    /// 131_072, 384 kHz → 262_144 — where the fixed length left 149 ms after
+    /// the reserve, less than a single sub-band window).
+    /// </summary>
+    internal const int BaseSearchCropLength = 65_536;
+    private const double SearchCropSpreadReserveMs = 175.0;
+
+    internal static int SearchCropLength(int sampleRate)
+    {
+        double requiredSamples = sampleRate / 1_000.0 *
+            (VirtualCrossoverAnalysis.MaximumAlignmentGateMs +
+                SearchCropSpreadReserveMs) * 8.0 / 7.0;
+        int length = BaseSearchCropLength;
+        while (length < requiredSamples)
+        {
+            length *= 2;
+        }
+        return length;
+    }
+
+    /// <summary>The pre-peak reserve: the crop's own 1/8, at every rate.</summary>
+    internal static int SearchCropPrePeakSamples(int sampleRate) =>
+        SearchCropLength(sampleRate) / 8;
+
+    /// <summary>
+    /// The production constructor: the crop sizes itself from the inputs'
+    /// sample rate (see <see cref="SearchCropLength"/>), so a high-rate
+    /// session cannot silently truncate the low junctions' windows.
+    /// </summary>
+    public AlignmentReprocessor(IReadOnlyList<AlignmentReprocessInput> inputs)
+        : this(
+            inputs,
+            SearchCropLength(MaxSampleRate(inputs)),
+            SearchCropPrePeakSamples(MaxSampleRate(inputs)))
+    {
+    }
+
+    private static int MaxSampleRate(IReadOnlyList<AlignmentReprocessInput> inputs)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        return inputs.Select(input => input.SampleRate)
+            .DefaultIfEmpty(48_000)
+            .Max();
+    }
+
     public AlignmentReprocessor(
         IReadOnlyList<AlignmentReprocessInput> inputs,
         int cropLength,

--- a/source/Tools/VirtualCrossover/ProcessedChannel.cs
+++ b/source/Tools/VirtualCrossover/ProcessedChannel.cs
@@ -68,6 +68,42 @@ internal static class ProcessedChannels
         VirtualCrossoverJunctions.GetCrossoverWindow(
             processed.Select(item => item.Channel.Settings));
 
+    /// <summary>
+    /// Where one channel lets a shared window open: its estimated response
+    /// START, as a sample index, falling back to its peak when the estimator
+    /// refuses the record (see <see cref="TransferIrStartCache"/>, which
+    /// memoizes the estimate per IR — the gate-placement guard reads the same
+    /// figure for the same channels on the same redraw).
+    /// <para>
+    /// A peak would be the wrong figure to share: a crossover's group delay
+    /// puts a filtered channel's peak milliseconds behind its own front — on
+    /// the archived Passat right side the subwoofer peaks 5.6 ms after its
+    /// band's arrival — so a window anchored on the earliest PEAK can still
+    /// open after an earlier channel's front. The phase view's Auto placement
+    /// has always used the start; this is the same rule for the magnitude
+    /// window, and for the junction gate the Auto delay search places
+    /// (VirtualCrossoverAnalysis.FindGateAnchor).
+    /// </para>
+    /// </summary>
+    public static int StartAnchorIndex(
+        Complex[] impulseResponse, int peakIndex, int sampleRate) =>
+        Math.Clamp(
+            (int)Math.Floor(
+                TransferIrStartCache.ResolveStartMs(
+                    impulseResponse, sampleRate, peakIndex)
+                / 1_000.0 * sampleRate),
+            0,
+            Math.Max(0, impulseResponse.Length - 1));
+
+    /// <summary>
+    /// The shared window's anchor for a channel set: the earliest
+    /// <see cref="StartAnchorIndex"/> among them.
+    /// </summary>
+    public static int SharedStartAnchorIndex(
+        IReadOnlyList<ProcessedChannel> processed) =>
+        processed.Min(item => StartAnchorIndex(
+            item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate));
+
     public static List<ProcessedChannel> OrderByBand(IReadOnlyList<ProcessedChannel> processed) =>
         processed
             .OrderBy(item => VirtualCrossoverJunctions.BandCenterHz(item.Channel.Settings))

--- a/source/Tools/VirtualCrossover/ProcessedChannel.cs
+++ b/source/Tools/VirtualCrossover/ProcessedChannel.cs
@@ -92,23 +92,30 @@ internal static class ProcessedChannels
     /// </para>
     /// </summary>
     public static int StartAnchorIndex(
-        Complex[] impulseResponse, int peakIndex, int sampleRate) =>
+        Complex[] impulseResponse,
+        int peakIndex,
+        int sampleRate,
+        ValidSampleRange validRange = default) =>
         Math.Clamp(
             (int)Math.Floor(
                 TransferIrStartCache.ResolveStartMs(
-                    impulseResponse, sampleRate, peakIndex)
+                    impulseResponse, sampleRate, peakIndex, validRange)
                 / 1_000.0 * sampleRate),
             0,
             Math.Max(0, impulseResponse.Length - 1));
 
     /// <summary>
     /// The shared window's anchor for a channel set: the earliest
-    /// <see cref="StartAnchorIndex"/> among them.
+    /// <see cref="StartAnchorIndex"/> among them, each read within its own
+    /// <see cref="ProcessedChannel.ValidRange"/> — a chain delay's silent
+    /// prefix must not certify a front here any more than in the junction
+    /// gates.
     /// </summary>
     public static int SharedStartAnchorIndex(
         IReadOnlyList<ProcessedChannel> processed) =>
         processed.Min(item => StartAnchorIndex(
-            item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate));
+            item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate,
+            item.ValidRange));
 
     public static List<ProcessedChannel> OrderByBand(IReadOnlyList<ProcessedChannel> processed) =>
         processed

--- a/source/Tools/VirtualCrossover/ProcessedChannel.cs
+++ b/source/Tools/VirtualCrossover/ProcessedChannel.cs
@@ -6,14 +6,20 @@ namespace Resonalyze;
 
 /// <summary>
 /// A channel's processed response ready for the metric, the complex sum and the
-/// plot: the applied-chain impulse response, its peak index and the channel's
-/// plot color. Shared by the redraw, the metric read-out and the Auto delay search.
+/// plot: the applied-chain impulse response, its peak index, the channel's
+/// plot color and where the MEASURED content sits inside the processed record
+/// (<see cref="ValidRange"/> — the coordinator computes it with every render;
+/// front detections read it so a chain delay's silent prefix cannot pose as
+/// arrival SNR). Shared by the redraw, the metric read-out and the Auto delay
+/// search. The range defaults to unknown for callers without one — the
+/// analyses then fall back to their padding-signature heuristic.
 /// </summary>
 internal sealed record ProcessedChannel(
     VirtualCrossoverChannel Channel,
     Complex[] ImpulseResponse,
     int PeakIndex,
-    OxyColor Color);
+    OxyColor Color,
+    ValidSampleRange ValidRange = default);
 
 /// <summary>
 /// One gated magnitude curve at the two widths the tool needs, from a single gate

--- a/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
@@ -23,11 +23,14 @@ internal readonly record struct DspChainCurve(
 /// The junction-correlation view's data, computed off the UI thread from two
 /// adjacent PROCESSED channels (current delays, polarity, filters applied, so
 /// lag 0 is "as currently aligned" and every lag reads as a correction to the
-/// upper channel). Correlation and its GCC-PHAT twin show WHERE the comb
-/// lobes sit (negative lobes: the same alignment with the upper channel
-/// inverted); the two score curves show what the alignment engine THINKS of
-/// every lag — the dip-penalized junction loss, honestly re-gated per point,
-/// for both polarities. <see cref="ArrivalLagMs"/> marks the band-limited
+/// upper channel). The whitened correlation shows WHERE the comb lobes sit on
+/// the full records (negative lobes: the same alignment with the upper
+/// channel inverted); its DIRECT twin reads the same comb on the channels'
+/// direct sound alone — the drivers' wavefronts, the engine's polarity
+/// witness; the two score curves show what the alignment engine THINKS of
+/// every lag — the dip-penalized junction loss, probed by rotating the
+/// windowed cuts, for both polarities.
+/// <see cref="ArrivalLagMs"/> marks the band-limited
 /// envelope arrival difference — the physics-first estimate the searches
 /// anchor on.
 /// </summary>
@@ -37,7 +40,6 @@ internal sealed record JunctionCorrelationView(
     double CrossoverHz,
     double BandLowHz,
     double BandHighHz,
-    List<SignalPoint> Correlation,
     List<SignalPoint> Whitened,
     List<SignalPoint> WhitenedDirect,
     List<SignalPoint> ScoreNormal,
@@ -193,8 +195,8 @@ internal sealed class VirtualCrossoverDspChainPlot
 
         // A junction switch (or a window change from new crossover settings)
         // resets the axes; an in-pair redraw keeps the zoom.
-        double windowMs = data.Correlation.Count > 0
-            ? Math.Abs(data.Correlation[^1].X)
+        double windowMs = data.Whitened.Count > 0
+            ? Math.Abs(data.Whitened[^1].X)
             : 3.0;
         if (correlationAxisState != (data.PairTitle, windowMs))
         {
@@ -211,10 +213,14 @@ internal sealed class VirtualCrossoverDspChainPlot
             }
         }
 
-        AddCorrelationSeries(
-            model, "corr", data.Correlation,
-            OxyColor.FromRgb(130, 138, 152), CoefficientAxisKey,
-            LineStyle.Solid, 1.2);
+        // Four curves, each with its own question: PHAT — the whitened
+        // full-record comb (the honest read at bass junctions, where "direct
+        // sound" is not a measurable notion); PHAT direct — the drivers'
+        // wavefronts (the polarity witness); score both ways — the summation
+        // surface the search optimizes. The raw amplitude-weighted
+        // correlation used to be drawn too and answered nothing the others
+        // do not: its weighting hands the lag to whatever the cabin plays
+        // loudest, which is neither the comb, nor the drivers, nor the sum.
         AddCorrelationSeries(
             model, "PHAT", data.Whitened,
             OxyColor.FromRgb(79, 195, 247), CoefficientAxisKey,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
@@ -39,6 +39,7 @@ internal sealed record JunctionCorrelationView(
     double BandHighHz,
     List<SignalPoint> Correlation,
     List<SignalPoint> Whitened,
+    List<SignalPoint> WhitenedDirect,
     List<SignalPoint> ScoreNormal,
     List<SignalPoint> ScoreInverted,
     double ArrivalLagMs);
@@ -218,6 +219,15 @@ internal sealed class VirtualCrossoverDspChainPlot
             model, "PHAT", data.Whitened,
             OxyColor.FromRgb(79, 195, 247), CoefficientAxisKey,
             LineStyle.Solid, 1.8);
+        // The same whitened read on the DIRECT sound alone: each channel cut
+        // to a couple of crossover periods behind its own front, so the comb
+        // shows the drivers' timing where the full-record twin shows whatever
+        // the cabin's reflections correlate best (on a thin-overlap junction
+        // the two disagree by whole periods).
+        AddCorrelationSeries(
+            model, "PHAT direct", data.WhitenedDirect,
+            OxyColor.FromRgb(200, 130, 255), CoefficientAxisKey,
+            LineStyle.Solid, 1.4);
         AddCorrelationSeries(
             model, "score", data.ScoreNormal,
             OxyColor.FromRgb(124, 213, 124), ScoreAxisKey,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -52,7 +52,14 @@ internal sealed class VirtualCrossoverMetrics
         // Auto-placement fallback. The magnitude always reads the FIXED gate —
         // FDW would need per-channel windows here, exactly what the shared
         // window exists to prevent — so FDW shapes the phase view only.)
-        int anchor = processed.Min(item => item.PeakIndex);
+        // The arrival is each channel's estimated START, not its peak: a
+        // crossover's group delay puts the peak behind the front, and the
+        // window has to open ahead of every channel's front, not of its
+        // loudest moment (see ProcessedChannels.StartAnchorIndex). The phase
+        // view's Auto placement and the junction gate the Auto delay search
+        // places both read the front too, so the three no longer differ in
+        // RULE — only in span, which is what each of them is for.
+        int anchor = ProcessedChannels.SharedStartAnchorIndex(processed);
         // One gated build per channel, resampled at both widths; the panel's
         // magnitude builder reads only its immutable UI-thread snapshots and the
         // calibration, so the channels' spectra compute across cores. AsOrdered
@@ -530,7 +537,10 @@ internal sealed class VirtualCrossoverMetrics
             jobs.Select(side => side.ProcessedIr!).ToList());
         return new VirtualCrossoverSideSum(
             sum,
-            jobs.Min(side => side.ProcessedPeak),
+            // The same placement rule as the shown side's (see BuildCurves):
+            // the earliest FRONT of the channels that went into this sum.
+            jobs.Min(side => ProcessedChannels.StartAnchorIndex(
+                side.ProcessedIr!, side.ProcessedPeak, side.SampleRate)),
             jobs[0].SampleRate,
             jobs.Count);
     }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -540,7 +540,8 @@ internal sealed class VirtualCrossoverMetrics
             // The same placement rule as the shown side's (see BuildCurves):
             // the earliest FRONT of the channels that went into this sum.
             jobs.Min(side => ProcessedChannels.StartAnchorIndex(
-                side.ProcessedIr!, side.ProcessedPeak, side.SampleRate)),
+                side.ProcessedIr!, side.ProcessedPeak, side.SampleRate,
+                side.ProcessedValidRange)),
             jobs[0].SampleRate,
             jobs.Count);
     }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4410,10 +4410,6 @@ public partial class VirtualCrossoverPanel : UserControl
         // in view even at an 80 Hz junction.
         double windowMs = Math.Max(3.0, 1.5 * 1000.0 / pair.CrossoverHz);
         double passOctaves = Math.Log2(pair.BandHighHz / pair.BandLowHz);
-        List<SignalPoint> correlation =
-            VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
-                lower, upper, sampleRate, pair.CrossoverHz, passOctaves,
-                windowMs, centerLagMs: 0, phaseTransform: false);
         List<SignalPoint> whitened =
             VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
                 lower, upper, sampleRate, pair.CrossoverHz, passOctaves,
@@ -4469,7 +4465,6 @@ public partial class VirtualCrossoverPanel : UserControl
             pair.CrossoverHz,
             pair.BandLowHz,
             pair.BandHighHz,
-            correlation,
             whitened,
             whitenedDirect,
             ScoreSweep(invert: false),

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4379,7 +4379,9 @@ public partial class VirtualCrossoverPanel : UserControl
     // relative timing intact; it no longer decides anything the score reads,
     // the anchor being derived from the pair's own content rather than from
     // an index into the crop.
-    private static JunctionCorrelationView BuildCorrelationView(
+    // Internal so the correlation-view harness can render the exact product
+    // curves without constructing the panel.
+    internal static JunctionCorrelationView BuildCorrelationView(
         AdjacentPair pair, IReadOnlyList<ProcessedChannel> scope)
     {
         using var _ = AppProfiler.Zone("VirtualDSP.BuildCorrelationView");
@@ -4417,6 +4419,24 @@ public partial class VirtualCrossoverPanel : UserControl
                 lower, upper, sampleRate, pair.CrossoverHz, passOctaves,
                 windowMs, centerLagMs: 0, phaseTransform: true);
 
+        // The whitened curve again, on the DIRECT sound alone (see
+        // VirtualCrossoverAnalysis.CutDirectSound — the same cut the
+        // engine's direct-coherence witness reads, so this curve shows the
+        // very figure the search weighed). The full-record curves above read
+        // the whole capture — reflections included, which on a thin-overlap
+        // junction outvote the drivers — while this one answers the question
+        // the view is usually opened with: where do the DRIVERS align.
+        List<SignalPoint> whitenedDirect =
+            VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
+                VirtualCrossoverAnalysis.CutDirectSound(
+                    lower, sampleRate,
+                    pair.BandLowHz, pair.BandHighHz, pair.CrossoverHz),
+                VirtualCrossoverAnalysis.CutDirectSound(
+                    upper, sampleRate,
+                    pair.BandLowHz, pair.BandHighHz, pair.CrossoverHz),
+                sampleRate, pair.CrossoverHz, passOctaves,
+                windowMs, centerLagMs: 0, phaseTransform: true);
+
         // The score comb repeats per crossover period, so the step must
         // resolve THAT scale — a fixed points-per-window count aliased at
         // high junctions (at a 20 kHz-class split, window/60 equals a whole
@@ -4451,6 +4471,7 @@ public partial class VirtualCrossoverPanel : UserControl
             pair.BandHighHz,
             correlation,
             whitened,
+            whitenedDirect,
             ScoreSweep(invert: false),
             ScoreSweep(invert: true),
             arrivalLagMs);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -2162,7 +2162,13 @@ public partial class VirtualCrossoverPanel : UserControl
                     ? magnitudes[i]
                     : BuildMagnitudeCurve(
                         item.ImpulseResponse,
-                        item.PeakIndex,
+                        // No shared anchor to follow (BuildCurves yields no
+                        // metric below two channels), so the channel opens on
+                        // its own front — the same rule, one channel wide.
+                        ProcessedChannels.StartAnchorIndex(
+                            item.ImpulseResponse,
+                            item.PeakIndex,
+                            item.Channel.SampleRate),
                         item.Channel.SampleRate).Display;
                 curves.Add(new AcousticCurve(
                     item.Channel.Name, curve.Points, item.Color, 1.8, LineStyle.Solid));
@@ -3317,8 +3323,8 @@ public partial class VirtualCrossoverPanel : UserControl
     // the metrics — always through the FIXED gate (see the snapshot refresh:
     // FDW is phase-only, it cannot hold a multi-arrival sum). A pinned (or
     // pinned-previewed) offset is one absolute window for every curve;
-    // unpinned (Auto), the window anchors at the peak the CALLER passes — the
-    // shared earliest arrival for channels and sums (one window is what keeps
+    // unpinned (Auto), the window anchors at the sample the CALLER passes — the
+    // shared earliest FRONT for channels and sums (one window is what keeps
     // the drawn Sum the exact vector sum of the drawn channels and the
     // sum-loss under its 0 dB ceiling; see VirtualCrossoverMetrics.BuildCurves)
     // and the raw curve's own peak. Runs on PLINQ worker threads: reads only
@@ -3758,12 +3764,13 @@ public partial class VirtualCrossoverPanel : UserControl
     /// tail has a magnitude too. The magnitude placement is the one judged
     /// (mirroring <see cref="VirtualCrossoverMetrics.BuildCurves"/>'s shared
     /// anchor): it is what the drawn curves, the Sum and the sum-loss read-out
-    /// are built from, and it is never the earlier of the two — it anchors on
-    /// the earliest processed PEAK where the phase view's shared placement
-    /// anchors on the earliest estimated START — so a magnitude window that
-    /// opens in time answers for that one as well. The phase view's per-curve
-    /// placements keep their own guard in
-    /// <see cref="ResolvePhaseGateOffsets"/>.
+    /// are built from, and both shared placements now open at the same sample
+    /// — the earliest estimated START of the processed channels — so judging
+    /// this one answers for the phase view's shared placement as well. (It
+    /// used to anchor on the earliest PEAK, which is never the earlier of the
+    /// two and so also answered for it; the rules were unified when the
+    /// junction gate moved to fronts.) The phase view's per-curve placements
+    /// keep their own guard in <see cref="ResolvePhaseGateOffsets"/>.
     /// </summary>
     private GatePlacementVerdict? JudgeGatePlacement(
         IReadOnlyList<ProcessedChannel> processed)
@@ -3776,7 +3783,9 @@ public partial class VirtualCrossoverPanel : UserControl
         MagnitudeGateSnapshot snapshot = magnitudeGate;
         int sampleRate = processed[0].Channel.SampleRate;
         double offsetMs = snapshot.ResolveGateOffsetMs(
-            oppositeSide: false, processed.Min(item => item.PeakIndex), sampleRate);
+            oppositeSide: false,
+            ProcessedChannels.SharedStartAnchorIndex(processed),
+            sampleRate);
         var cut = new List<GateCutChannel>();
         foreach (ProcessedChannel item in processed)
         {
@@ -4034,12 +4043,14 @@ public partial class VirtualCrossoverPanel : UserControl
         if (detrendMode == PhaseDetrendMode.Manual)
         {
             return gatePreview?.DetrendMs ?? ResolveDetrendMs(
-                processed.Min(item => item.PeakIndex), sampleRate);
+                ProcessedChannels.SharedStartAnchorIndex(processed), sampleRate);
         }
 
-        // Estimate once from the existing common anchor (earliest processed
-        // arrival), then apply that exact value to every driver and the sum.
-        ProcessedChannel anchor = processed.MinBy(item => item.PeakIndex)!;
+        // Estimate once from the existing common anchor (the earliest
+        // processed FRONT, the same channel the shared window opens on), then
+        // apply that exact value to every driver and the sum.
+        ProcessedChannel anchor = processed.MinBy(item => ProcessedChannels.StartAnchorIndex(
+            item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate))!;
         var view = new ImpulseMeasurementView(anchor.ImpulseResponse, 0, sampleRate);
         PhaseAnalysisSettings settings = CreateVirtualPhaseSettings(
             gateOffsetMs,
@@ -4120,7 +4131,7 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         int sampleRate = processed[0].Channel.SampleRate;
-        int reference = processed.Min(item => item.PeakIndex);
+        int reference = ProcessedChannels.SharedStartAnchorIndex(processed);
         double fitOffsetMs = EarliestStartMs(processed, sampleRate);
 
         var traces = processed
@@ -4357,12 +4368,14 @@ public partial class VirtualCrossoverPanel : UserControl
     // The off-thread compute of one junction's correlation view. Both
     // channels enter PROCESSED (delays, polarity, filters applied), so lag 0
     // is the current alignment and every reading is a correction to the
-    // UPPER channel. The WHOLE side is cropped and anchored, not just the
-    // pair: crop and gate follow the alignment engine's own basis, so the
-    // drawn score is the surface Auto delay searches and the read-out
-    // reports — a pair-anchored window would draw a different one (see the
-    // gate remarks in VirtualCrossoverAnalysis). The sweep's per-point
-    // inverse FFTs shrink from the capture length to the crop.
+    // UPPER channel. The gate follows the alignment engine's own basis — the
+    // pair's earliest front, in the pair's band (see the gate remarks in
+    // VirtualCrossoverAnalysis) — so the drawn score is the surface Auto
+    // delay searches. The crop still spans the whole side, because a shared
+    // offset is what keeps the channels' relative timing intact; it no longer
+    // decides anything the score reads, the anchor being derived from the
+    // pair's own content rather than from an index into the crop. The sweep's
+    // per-point inverse FFTs shrink from the capture length to the crop.
     private static JunctionCorrelationView BuildCorrelationView(
         AdjacentPair pair, IReadOnlyList<ProcessedChannel> scope)
     {
@@ -4377,11 +4390,20 @@ public partial class VirtualCrossoverPanel : UserControl
             AutoDelaySearchCropPrePeakSamples);
         Complex[] lower = cropped[all.IndexOf(pair.Lower)];
         Complex[] upper = cropped[all.IndexOf(pair.Upper)];
-        // The displayed side's first arrival — the same placement rule the
-        // read-out beside this plot uses, over the same channel set and the
-        // same applied delays, so the drawn score and the read-out's numbers
-        // come from one window.
-        int gateAnchor = cropped.Min(VirtualCrossoverAnalysis.FindPeakIndex);
+        // The pair's own earliest front, read in the pair's band: the rule
+        // every junction measurement of an Auto delay run follows. The
+        // read-out beside this plot keeps its own, shared placement (one
+        // window for the drawn channels, their Sum and the loss curve, which
+        // is what makes the Sum the sum of what is drawn) — the two answer
+        // different questions and always did: the read-out measures the WHOLE
+        // sum inside the pair band, this measures the pair.
+        int gateAnchor = Math.Min(
+            VirtualCrossoverAnalysis.FindGateAnchor(
+                lower, VirtualCrossoverAnalysis.FindPeakIndex(lower), sampleRate,
+                pair.BandLowHz, pair.BandHighHz),
+            VirtualCrossoverAnalysis.FindGateAnchor(
+                upper, VirtualCrossoverAnalysis.FindPeakIndex(upper), sampleRate,
+                pair.BandLowHz, pair.BandHighHz));
 
         // The window spans 1.5 crossover periods to each side (floored at the
         // fixed diagnostic span), so the neighboring comb lobes both ways are

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3666,7 +3666,8 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             var view = new ImpulseMeasurementView(item.ImpulseResponse, 0, sampleRate);
             double startMs = TransferIrStartCache.ResolveStartMs(
-                item.ImpulseResponse, sampleRate, item.PeakIndex);
+                item.ImpulseResponse, sampleRate, item.PeakIndex,
+                item.ValidRange);
             if (!AllowsPerCurvePhaseGate(
                     DataHelper.GateLeadingEdgeLossDb(
                         view, startMs, leftMs, plateauMs, rightMs),
@@ -3792,7 +3793,8 @@ public partial class VirtualCrossoverPanel : UserControl
         foreach (ProcessedChannel item in processed)
         {
             double startMs = TransferIrStartCache.ResolveStartMs(
-                item.ImpulseResponse, sampleRate, item.PeakIndex);
+                item.ImpulseResponse, sampleRate, item.PeakIndex,
+                item.ValidRange);
             var view = new ImpulseMeasurementView(item.ImpulseResponse, 0, sampleRate);
             double lossDb = Loss(offsetMs);
             if (JudgeGateCut(

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4488,9 +4488,9 @@ public partial class VirtualCrossoverPanel : UserControl
             .ToList();
 
         double arrivalLagMs = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                lower, sampleRate, pair.BandLowHz, pair.BandHighHz)
+                lower, sampleRate, pair.BandLowHz, pair.BandHighHz, lowerRange)
             - VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                upper, sampleRate, pair.BandLowHz, pair.BandHighHz);
+                upper, sampleRate, pair.BandLowHz, pair.BandHighHz, upperRange);
 
         return new JunctionCorrelationView(
             $"{pair.Lower.Channel.Name}-{pair.Upper.Channel.Name}",

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -2169,7 +2169,8 @@ public partial class VirtualCrossoverPanel : UserControl
                         ProcessedChannels.StartAnchorIndex(
                             item.ImpulseResponse,
                             item.PeakIndex,
-                            item.Channel.SampleRate),
+                            item.Channel.SampleRate,
+                            item.ValidRange),
                         item.Channel.SampleRate).Display;
                 curves.Add(new AcousticCurve(
                     item.Channel.Name, curve.Points, item.Color, 1.8, LineStyle.Solid));
@@ -3697,7 +3698,7 @@ public partial class VirtualCrossoverPanel : UserControl
         IReadOnlyList<ProcessedChannel> processed,
         int sampleRate) =>
         processed.Min(item => TransferIrStartCache.ResolveStartMs(
-            item.ImpulseResponse, sampleRate, item.PeakIndex));
+            item.ImpulseResponse, sampleRate, item.PeakIndex, item.ValidRange));
 
     /// <summary>Which way the window fails a channel.</summary>
     internal enum GateCutKind
@@ -4051,7 +4052,8 @@ public partial class VirtualCrossoverPanel : UserControl
         // processed FRONT, the same channel the shared window opens on), then
         // apply that exact value to every driver and the sum.
         ProcessedChannel anchor = processed.MinBy(item => ProcessedChannels.StartAnchorIndex(
-            item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate))!;
+            item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate,
+            item.ValidRange))!;
         var view = new ImpulseMeasurementView(anchor.ImpulseResponse, 0, sampleRate);
         PhaseAnalysisSettings settings = CreateVirtualPhaseSettings(
             gateOffsetMs,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4393,20 +4393,15 @@ public partial class VirtualCrossoverPanel : UserControl
             AutoDelaySearchCropPrePeakSamples);
         Complex[] lower = cropped[all.IndexOf(pair.Lower)];
         Complex[] upper = cropped[all.IndexOf(pair.Upper)];
-        // The pair's own earliest front, read in the pair's band: the rule
-        // every junction measurement of an Auto delay run follows. The
-        // read-out beside this plot keeps its own, shared placement (one
-        // window for the drawn channels, their Sum and the loss curve, which
-        // is what makes the Sum the sum of what is drawn) — the two answer
-        // different questions and always did: the read-out measures the WHOLE
-        // sum inside the pair band, this measures the pair.
-        int gateAnchor = Math.Min(
-            VirtualCrossoverAnalysis.FindGateAnchor(
-                lower, VirtualCrossoverAnalysis.FindPeakIndex(lower), sampleRate,
-                pair.BandLowHz, pair.BandHighHz),
-            VirtualCrossoverAnalysis.FindGateAnchor(
-                upper, VirtualCrossoverAnalysis.FindPeakIndex(upper), sampleRate,
-                pair.BandLowHz, pair.BandHighHz));
+        // No gate anchor is passed: the sweep windows each channel at its own
+        // band-limited front, exactly as every junction measurement of an
+        // Auto delay run does (see BuildAlignmentBins), so the drawn score
+        // stays the search's surface. The read-out beside this plot keeps its
+        // own, shared placement (one window for the drawn channels, their Sum
+        // and the loss curve, which is what makes the Sum the sum of what is
+        // drawn) — the two answer different questions and always did: the
+        // read-out measures the WHOLE sum inside the pair band, this
+        // measures the pair.
 
         // The window spans 1.5 crossover periods to each side (floored at the
         // fixed diagnostic span), so the neighboring comb lobes both ways are
@@ -4435,7 +4430,7 @@ public partial class VirtualCrossoverPanel : UserControl
             VirtualCrossoverAnalysis.JunctionLossSweep(
                 upper, lower, sampleRate,
                 pair.BandLowHz, pair.BandHighHz,
-                -windowMs, windowMs, stepMs, invert, gateAnchor)
+                -windowMs, windowMs, stepMs, invert)
             .Select(point => new SignalPoint(
                 point.DelayMs,
                 point.LossDb +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4446,7 +4446,13 @@ public partial class VirtualCrossoverPanel : UserControl
             VirtualCrossoverAnalysis.JunctionLossSweep(
                 upper, lower, sampleRate,
                 pair.BandLowHz, pair.BandHighHz,
-                -windowMs, windowMs, stepMs, invert)
+                -windowMs, windowMs, stepMs, invert,
+                // The search's own settings, or the drawn surface is not the
+                // searched one: per-channel windows (null anchor) and the
+                // search-side level match, whose absence re-shapes the lobes
+                // whenever the two channels sit at different gains.
+                gateAnchorSample: null,
+                levelMatch: true)
             .Select(point => new SignalPoint(
                 point.DelayMs,
                 point.LossDb +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4370,12 +4370,15 @@ public partial class VirtualCrossoverPanel : UserControl
     // is the current alignment and every reading is a correction to the
     // UPPER channel. The gate follows the alignment engine's own basis — the
     // pair's earliest front, in the pair's band (see the gate remarks in
-    // VirtualCrossoverAnalysis) — so the drawn score is the surface Auto
-    // delay searches. The crop still spans the whole side, because a shared
-    // offset is what keeps the channels' relative timing intact; it no longer
-    // decides anything the score reads, the anchor being derived from the
-    // pair's own content rather than from an index into the crop. The sweep's
-    // per-point inverse FFTs shrink from the capture length to the crop.
+    // VirtualCrossoverAnalysis) — and the sweep probes it by rotating the
+    // windowed cut, the same bins and rotation the search's SumLossEvaluator
+    // reads, so the drawn score IS the surface Auto delay searches (see the
+    // plateau remarks on JunctionLossSweep for what re-gating each probe
+    // through the stationary window drew instead). The crop still spans the
+    // whole side, because a shared offset is what keeps the channels'
+    // relative timing intact; it no longer decides anything the score reads,
+    // the anchor being derived from the pair's own content rather than from
+    // an index into the crop.
     private static JunctionCorrelationView BuildCorrelationView(
         AdjacentPair pair, IReadOnlyList<ProcessedChannel> scope)
     {

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -2002,7 +2002,8 @@ public partial class VirtualCrossoverPanel : UserControl
                 channel,
                 result.ImpulseResponse,
                 result.PeakIndex,
-                color));
+                color,
+                result.ValidRange));
         }
         return new ProcessedRender(render.Revision, processed);
     }
@@ -4392,9 +4393,27 @@ public partial class VirtualCrossoverPanel : UserControl
         Complex[][] cropped = VirtualCrossoverAnalysis.CropSharedDirectSoundWindow(
             all.Select(item => item.ImpulseResponse).ToList(),
             AutoDelaySearchCropLength,
-            AutoDelaySearchCropPrePeakSamples);
+            AutoDelaySearchCropPrePeakSamples,
+            out int cropStart);
         Complex[] lower = cropped[all.IndexOf(pair.Lower)];
         Complex[] upper = cropped[all.IndexOf(pair.Upper)];
+        // The channels' valid ranges, shifted into the crop's frame: the
+        // front detections behind the sweep and the direct cuts take them, so
+        // the drawn surface reads the same fronts the search reads — on a
+        // clean capture the heuristic fallback agrees anyway, but a delayed
+        // or glitch-headed record is exactly where the two paths must not
+        // part.
+        ValidSampleRange Shifted(ProcessedChannel item, Complex[] croppedIr) =>
+            item.ValidRange.IsKnown
+                ? new ValidSampleRange(
+                    Math.Max(0, item.ValidRange.StartSample - cropStart),
+                    Math.Clamp(
+                        item.ValidRange.EndSample - cropStart,
+                        0,
+                        croppedIr.Length))
+                : item.ValidRange;
+        ValidSampleRange lowerRange = Shifted(pair.Lower, lower);
+        ValidSampleRange upperRange = Shifted(pair.Upper, upper);
         // No gate anchor is passed: the sweep windows each channel at its own
         // band-limited front, exactly as every junction measurement of an
         // Auto delay run does (see BuildAlignmentBins), so the drawn score
@@ -4426,10 +4445,12 @@ public partial class VirtualCrossoverPanel : UserControl
             VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
                 VirtualCrossoverAnalysis.CutDirectSound(
                     lower, sampleRate,
-                    pair.BandLowHz, pair.BandHighHz, pair.CrossoverHz),
+                    pair.BandLowHz, pair.BandHighHz, pair.CrossoverHz,
+                    lowerRange),
                 VirtualCrossoverAnalysis.CutDirectSound(
                     upper, sampleRate,
-                    pair.BandLowHz, pair.BandHighHz, pair.CrossoverHz),
+                    pair.BandLowHz, pair.BandHighHz, pair.CrossoverHz,
+                    upperRange),
                 sampleRate, pair.CrossoverHz, passOctaves,
                 windowMs, centerLagMs: 0, phaseTransform: true);
 
@@ -4452,7 +4473,9 @@ public partial class VirtualCrossoverPanel : UserControl
                 // search-side level match, whose absence re-shapes the lobes
                 // whenever the two channels sit at different gains.
                 gateAnchorSample: null,
-                levelMatch: true)
+                levelMatch: true,
+                variableValidRange: upperRange,
+                fixedValidRange: lowerRange)
             .Select(point => new SignalPoint(
                 point.DelayMs,
                 point.LossDb +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -2843,9 +2843,7 @@ public partial class VirtualCrossoverPanel : UserControl
                     channel.TransferImpulseResponse!,
                     channel.SampleRate,
                     channel.Settings.ToChain())).ToList(),
-                log),
-            AutoDelaySearchCropLength,
-            AutoDelaySearchCropPrePeakSamples);
+                log));
 
         IReadOnlyList<AlignmentSnapshot> initial = reprocessor.Reprocess(
             new Dictionary<IAlignmentChannel, AlignmentOverride>());
@@ -2873,14 +2871,6 @@ public partial class VirtualCrossoverPanel : UserControl
             decisions);
         return reprocessor;
     }
-
-    // The Auto delay search reads only the gated direct sound, so it runs on
-    // a shared crop of the measured IRs (one offset for every channel keeps
-    // the inter-channel timing intact). 64k samples keep well over a second
-    // of decay at 44.1 kHz — conservative headroom over the 4096-sample
-    // evaluation gate and the low-band arrival envelopes.
-    private const int AutoDelaySearchCropLength = 65_536;
-    private const int AutoDelaySearchCropPrePeakSamples = 8_192;
 
     // The per-side participants of a stereo Auto delay run: every enabled
     // channel side with a resolved measurement. A mono pair contributes ONE
@@ -3211,9 +3201,7 @@ public partial class VirtualCrossoverPanel : UserControl
                     side.State.TransferImpulseResponse!,
                     side.State.SampleRate,
                     side.Settings.ToChain())).ToList(),
-                log),
-            AutoDelaySearchCropLength,
-            AutoDelaySearchCropPrePeakSamples);
+                log));
 
         IReadOnlyList<AlignmentSnapshot> initialSnapshots = reprocessor.Reprocess(
             new Dictionary<IAlignmentChannel, AlignmentOverride>());
@@ -4396,8 +4384,8 @@ public partial class VirtualCrossoverPanel : UserControl
             : [pair.Lower, pair.Upper];
         Complex[][] cropped = VirtualCrossoverAnalysis.CropSharedDirectSoundWindow(
             all.Select(item => item.ImpulseResponse).ToList(),
-            AutoDelaySearchCropLength,
-            AutoDelaySearchCropPrePeakSamples,
+            AlignmentReprocessor.SearchCropLength(sampleRate),
+            AlignmentReprocessor.SearchCropPrePeakSamples(sampleRate),
             out int cropStart);
         Complex[] lower = cropped[all.IndexOf(pair.Lower)];
         Complex[] upper = cropped[all.IndexOf(pair.Upper)];

--- a/tests/Resonalyze.App.Tests/AlignmentReprocessorTests.cs
+++ b/tests/Resonalyze.App.Tests/AlignmentReprocessorTests.cs
@@ -14,10 +14,14 @@ public sealed class AlignmentReprocessorTests
 {
     private sealed class FakeChannel : IAlignmentChannel
     {
-        public FakeChannel(string name) => Name = name;
+        public FakeChannel(string name, int sampleRate = 48_000)
+        {
+            Name = name;
+            SampleRate = sampleRate;
+        }
 
         public string Name { get; }
-        public int SampleRate => 48_000;
+        public int SampleRate { get; }
     }
 
     private static Complex[] Impulse(int peak)
@@ -64,6 +68,76 @@ public sealed class AlignmentReprocessorTests
 
         Assert.Same(first[0].ImpulseResponse, second[0].ImpulseResponse);
         Assert.Same(first[1].ImpulseResponse, second[1].ImpulseResponse);
+    }
+
+    // The crop is sized by TIME: after the 1/8 pre-peak reserve it must
+    // still hold the longest window the band sizing can ask for (the 350 ms
+    // clamp) plus the channels' arrival/delay spread. The base 65_536 stays
+    // EXACT at the archived fleet's 48/96 kHz — results there may not move —
+    // and doubles at the rates where the fixed length used to truncate a
+    // sub junction's window.
+    [Theory]
+    [InlineData(44_100, 65_536)]
+    [InlineData(48_000, 65_536)]
+    [InlineData(96_000, 65_536)]
+    [InlineData(176_400, 131_072)]
+    [InlineData(192_000, 131_072)]
+    [InlineData(352_800, 262_144)]
+    [InlineData(384_000, 262_144)]
+    public void SearchCrop_HoldsTheLongestAlignmentWindowAtEveryRate(
+        int sampleRate, int expectedLength)
+    {
+        int length = AlignmentReprocessor.SearchCropLength(sampleRate);
+        int prePeak = AlignmentReprocessor.SearchCropPrePeakSamples(sampleRate);
+
+        Assert.Equal(expectedLength, length);
+        Assert.Equal(length / 8, prePeak);
+        double afterReserveMs = (length - prePeak) * 1_000.0 / sampleRate;
+        Assert.True(
+            afterReserveMs >=
+                VirtualCrossoverAnalysis.MaximumAlignmentGateMs + 175.0,
+            $"only {afterReserveMs:0} ms left after the pre-peak reserve " +
+            $"at {sampleRate} Hz");
+    }
+
+    // The regression the sizing exists for, end to end through the
+    // production constructor: at 384 kHz a front cropped to the pre-peak
+    // reserve must keep the full 350 ms window clamp of MEASURED record
+    // after it. The old fixed crop left 149 ms there — a 33 Hz junction's
+    // 262 ms window read synthesized filter tail instead of the room.
+    [Fact]
+    public void Reprocess_At384kHz_TheCropHoldsAFullLowBandWindow()
+    {
+        const int Rate = 384_000;
+        const int PeakSample = 100_000;
+        var source = new Complex[524_288];
+        source[PeakSample] = Complex.One;
+        var channel = new FakeChannel("SUB", Rate);
+        var reprocessor = new AlignmentReprocessor(
+            [new AlignmentReprocessInput(
+                channel, source, Rate, DspChannelChain.Identity)]);
+
+        AlignmentSnapshot snapshot = reprocessor.Reprocess(NoOverrides)[0];
+
+        int windowSamples = (int)Math.Round(
+            VirtualCrossoverAnalysis.MaximumAlignmentGateMs / 1_000.0 * Rate);
+        // The MEASURED span inside the processed record is the crop's length
+        // (ApplyChain pads beyond it with synthesized filter tail, which no
+        // window may mistake for the room) — the valid range is what says so.
+        Assert.Equal(
+            AlignmentReprocessor.SearchCropLength(Rate),
+            snapshot.ValidRange.EndSample);
+        Assert.Equal(
+            AlignmentReprocessor.SearchCropPrePeakSamples(Rate),
+            snapshot.PeakIndex);
+        Assert.True(
+            snapshot.ValidRange.EndSample - snapshot.PeakIndex >= windowSamples,
+            $"{snapshot.ValidRange.EndSample - snapshot.PeakIndex} measured " +
+            $"samples after the front cannot hold a {windowSamples}-sample window");
+        // The discriminating figure: the fixed base crop could not.
+        Assert.True(
+            AlignmentReprocessor.BaseSearchCropLength -
+                AlignmentReprocessor.BaseSearchCropLength / 8 < windowSamples);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/ProcessedChannelsTests.cs
+++ b/tests/Resonalyze.App.Tests/ProcessedChannelsTests.cs
@@ -88,4 +88,40 @@ public sealed class ProcessedChannelsTests
                 [low.Channel.Settings, high.Channel.Settings]),
             ProcessedChannels.GetCrossoverWindow([low, high]));
     }
+    [Fact]
+    public void SharedStartAnchorIndex_ReadsEachChannelWithinItsValidRange()
+    {
+        // A clean channel fronting at ~41.7 ms beside a noise channel whose
+        // chain delay manufactured a 25 ms silent prefix. Blind, the prefix
+        // inflates the noise record's SNR and the start estimator "finds" a
+        // front in the middle of the noise, ~22.5 ms — EARLIER than the clean
+        // channel's, so it would take over the shared display anchor. With
+        // the channels' valid ranges honored the noise record is refused,
+        // falls back to its (late) peak, and the clean front anchors.
+        var cleanIr = new Complex[8_192];
+        cleanIr[2_000] = Complex.One;
+        var random = new Random(20_260_724);
+        var noise = new Complex[4_096];
+        for (int i = 0; i < noise.Length; i++)
+        {
+            noise[i] = new Complex(random.NextDouble() * 2.0 - 1.0, 0.0);
+        }
+        Complex[] noisy = VirtualCrossoverAnalysis.ApplyChain(
+            noise, new DspChannelChain(DelayMs: 25), 48_000,
+            out ValidSampleRange noisyRange);
+
+        ProcessedChannel Item(Complex[] ir, ValidSampleRange range)
+        {
+            var channel = new VirtualCrossoverChannel("x") { SampleRate = 48_000 };
+            return new ProcessedChannel(
+                channel, ir, VirtualCrossoverAnalysis.FindPeakIndex(ir),
+                OxyColors.White, range);
+        }
+
+        int anchor = ProcessedChannels.SharedStartAnchorIndex(
+            [Item(cleanIr, default), Item(noisy, noisyRange)]);
+
+        Assert.InRange(anchor, 1_900, 2_005);
+    }
+
 }

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -471,7 +471,12 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
                 channel,
                 response,
                 VirtualCrossoverAnalysis.FindPeakIndex(response),
-                OxyColors.White));
+                OxyColors.White,
+                VirtualCrossoverAnalysis.ChainValidRange(
+                    state.ProcessingSource.SampleCount,
+                    chain,
+                    state.SampleRate,
+                    response.Length)));
         }
 
         return processed;

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -97,6 +97,9 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
     // is a path under the root; the session file's own folder is what its
     // measurements are resolved against (VirtualCrossoverSourceLocator), so a
     // session whose stored absolute paths have gone stale still loads.
+    // The reference car is v5_exp — the owner deleted the older v5 session of
+    // the same car (2026-08-20) and distrusts v2's tuning, so a verdict that
+    // rests on either of those alone is not a verdict.
     private static readonly string[] DefaultSessions =
     [
         @"3RC\virtual-dsp-session.json",
@@ -105,7 +108,6 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
         @"v2\head_90_grad\virtual-dsp-session.json",
         @"v3\virtual-dsp-session.json",
         @"v4\virtual-dsp-session.json",
-        @"v5\virtual-dsp-session-manual.json",
         @"v5_exp\virtual-dsp-session-manual.json"
     ];
 
@@ -212,8 +214,10 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
         report.AppendLine(
             $"  side {(rightSide ? "R" : "L")}, {participants.Count} channels, " +
             $"{participants[0].SampleRate} Hz, gate " +
-            $"{(AutoGate ? "AUTO (pin ignored)" : null)}" +
-            $"{gate.OffsetMs?.ToString("0.00", CultureInfo.InvariantCulture) ?? "auto"} " +
+            (AutoGate && gate.OffsetMs is { } ignoredPin
+                ? FormattableString.Invariant($"auto (pin {ignoredPin:0.00} ignored) ")
+                : $"{gate.OffsetMs?.ToString(
+                    "0.00", CultureInfo.InvariantCulture) ?? "auto"} ") +
             $"+ {project.PhaseGateLeftMs:0.#}/{project.PhaseGatePlateauMs:0.#}/" +
             $"{project.PhaseGateRightMs:0.#} ms, smoothing " +
             $"{OverlaySmoothing.GetLabel(project.SmoothingCode)}");

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -1,0 +1,547 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Numerics;
+using System.Text;
+using OxyPlot;
+using Resonalyze.Dsp;
+using Resonalyze.History;
+using Xunit.Abstractions;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// A <see cref="FactAttribute"/> that reports the battery as SKIPPED, with a
+/// reason, unless a folder of archived Virtual DSP sessions is named in the
+/// environment. The measurements are field records that do not live in the
+/// repository (and must not): CI has no folder to point at, so the runner is
+/// skipped there and runs only on a machine that carries the cabins.
+/// </summary>
+public sealed class SessionBatteryFactAttribute : FactAttribute
+{
+    public const string RootVariable = "RESONALYZE_SESSION_BATTERY";
+
+    public SessionBatteryFactAttribute()
+    {
+        if (string.IsNullOrWhiteSpace(SessionBatteryHarness.RootDirectory))
+        {
+            Skip =
+                $"Set {RootVariable} to the folder holding the archived cabins " +
+                "(each session's measurements beside its session file) to run " +
+                "the Auto delay battery.";
+        }
+    }
+}
+
+/// <summary>
+/// The Auto delay battery: every archived cabin's session is loaded exactly as
+/// the tool loads it, the Auto delay proposal is computed on the session's own
+/// chains, and BOTH the proposal and the session's SAVED settings are judged by
+/// the panel's own metric (<see cref="VirtualCrossoverMetrics.BuildCurves"/> +
+/// <see cref="VirtualCrossoverMetrics.BuildEntries"/>: the per-junction average
+/// summation loss and its dip, read through the session's own gate and
+/// smoothing).
+/// <para>
+/// It exists because the engine's alignment rules cannot be judged by
+/// |optimum − PHAT| on a low junction: that figure is noisy, and it answers a
+/// question about one probe rather than about the read-out the tuner actually
+/// looks at. The saved settings are the owner's own tuning, so a rule change
+/// that moves the proposal TOWARD them on the metric is an improvement in the
+/// only currency the panel reports.
+/// </para>
+/// <para>
+/// Output goes to the test output and to a text file (see
+/// <see cref="OutputVariable"/>), one fixed-format ROW line per junction, so
+/// two builds can be diffed line by line.
+/// </para>
+/// <para>
+/// This is a RUNNER, not a pinned expectation: it asserts only that every named
+/// session was found, loaded and judged. What its numbers mean is a reading, and
+/// the reading belongs in the branch's notes — not in an assert that would
+/// freeze one build's arithmetic into the suite.
+/// </para>
+/// </summary>
+public sealed class SessionBatteryHarness(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Where the report is written; defaults to a file in the temporary folder.
+    /// The archive folder is the owner's measurement data — the battery reads
+    /// it and writes nothing into it.
+    /// </summary>
+    public const string OutputVariable = "RESONALYZE_SESSION_BATTERY_OUT";
+
+    /// <summary>
+    /// A semicolon-separated list of session files to run instead of the
+    /// default set, each either absolute or relative to the root.
+    /// </summary>
+    public const string SessionsVariable = "RESONALYZE_SESSION_BATTERY_SESSIONS";
+
+    // The archived cabins, in the order the branch's notes list them. Each entry
+    // is a path under the root; the session file's own folder is what its
+    // measurements are resolved against (VirtualCrossoverSourceLocator), so a
+    // session whose stored absolute paths have gone stale still loads.
+    private static readonly string[] DefaultSessions =
+    [
+        @"3RC\virtual-dsp-session.json",
+        @"Passat\virtual-dsp-session.json",
+        @"v2\virtual-dsp-session.json",
+        @"v2\head_90_grad\virtual-dsp-session.json",
+        @"v3\virtual-dsp-session.json",
+        @"v4\virtual-dsp-session.json",
+        @"v5\virtual-dsp-session-manual.json",
+        @"v5_exp\virtual-dsp-session-manual.json"
+    ];
+
+    // The Auto delay search's crop, straight from the panel: the search reads
+    // only the gated direct sound, so it runs on a shared crop of the measured
+    // IRs (one offset for every channel keeps the inter-channel timing intact).
+    private const int SearchCropLength = 65_536;
+    private const int SearchCropPrePeakSamples = 8_192;
+
+    internal static string? RootDirectory =>
+        Environment.GetEnvironmentVariable(SessionBatteryFactAttribute.RootVariable);
+
+    [SessionBatteryFact]
+    public void JudgeAutoDelayAgainstSavedSettings()
+    {
+        string root = RootDirectory!;
+        // One locale for the report whatever the machine runs in: the tables
+        // are compared between builds line by line, and a decimal comma on one
+        // machine against a point on another is a diff on every row.
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        var report = new StringBuilder();
+        var summary = new List<JunctionComparison>();
+        // Two of the archived session files describe the SAME cabin (the v2
+        // folder holds no measurements of its own: its session points at the
+        // head_90_grad records, so the two files are the same session saved
+        // twice). Judging both would count that cabin twice in the summary, so
+        // a session whose resolved measurements and saved settings are already
+        // in the battery is named and skipped.
+        var seen = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string session in ResolveSessions(root))
+        {
+            Assert.True(File.Exists(session), $"Session file not found: {session}");
+            summary.AddRange(RunSession(session, report, seen));
+        }
+
+        Assert.NotEmpty(summary);
+        WriteSummary(report, summary);
+        string text = report.ToString();
+        output.WriteLine(text);
+        string reportPath = Environment.GetEnvironmentVariable(OutputVariable)
+            ?? Path.Combine(Path.GetTempPath(), "resonalyze-session-battery.txt");
+        File.WriteAllText(reportPath, text);
+        output.WriteLine($"Report written to {reportPath}");
+    }
+
+    private static IEnumerable<string> ResolveSessions(string root)
+    {
+        string? configured = Environment.GetEnvironmentVariable(SessionsVariable);
+        IEnumerable<string> names = string.IsNullOrWhiteSpace(configured)
+            ? DefaultSessions
+            : configured.Split(';', StringSplitOptions.RemoveEmptyEntries |
+                StringSplitOptions.TrimEntries);
+        return names.Select(name =>
+            Path.IsPathFullyQualified(name) ? name : Path.Combine(root, name));
+    }
+
+    // One cabin: load, propose, judge. Every number printed here is read off the
+    // same code paths the panel runs — the chains through
+    // VirtualCrossoverChannelSettings.ToChain, the proposal through
+    // AutoAlignmentEngine, the metric through VirtualCrossoverMetrics — so a
+    // disagreement with the tool on screen is a defect in one of them, not in
+    // the harness's own arithmetic.
+    private List<JunctionComparison> RunSession(
+        string sessionPath,
+        StringBuilder report,
+        Dictionary<string, string> seen)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        VirtualCrossoverProjectFile project = VirtualCrossoverProjectFile.LoadFrom(sessionPath);
+        bool rightSide = project.ActiveSideRight;
+        List<VirtualCrossoverChannel> channels = LoadChannels(project, out string fingerprint);
+        string name = Path.GetFileName(Path.GetDirectoryName(sessionPath)!);
+        if (seen.TryGetValue(fingerprint, out string? original))
+        {
+            report.AppendLine();
+            report.AppendLine($"=== {name}  ({sessionPath})");
+            report.AppendLine(
+                $"  skipped: the same measurements and settings as {original}.");
+            return [];
+        }
+
+        seen.Add(fingerprint, name);
+        List<VirtualCrossoverChannel> participants = channels
+            .Where(channel =>
+                channel.Settings.Enabled &&
+                !channel.Settings.Bypass &&
+                channel.TransferImpulseResponse != null)
+            .ToList();
+        report.AppendLine();
+        report.AppendLine($"=== {name}  ({sessionPath})");
+        if (participants.Count < 2)
+        {
+            report.AppendLine(
+                $"  skipped: {participants.Count} participating channel(s) resolved " +
+                "on the active side.");
+            return [];
+        }
+
+        VirtualCrossoverPhaseGateSettings gate = project.PhaseGateFor(rightSide);
+        report.AppendLine(
+            $"  side {(rightSide ? "R" : "L")}, {participants.Count} channels, " +
+            $"{participants[0].SampleRate} Hz, gate " +
+            $"{gate.OffsetMs?.ToString("0.00", CultureInfo.InvariantCulture) ?? "auto"} " +
+            $"+ {project.PhaseGateLeftMs:0.#}/{project.PhaseGatePlateauMs:0.#}/" +
+            $"{project.PhaseGateRightMs:0.#} ms, smoothing " +
+            $"{OverlaySmoothing.GetLabel(project.SmoothingCode)}");
+
+        var log = new StringBuilder();
+        Dictionary<IAlignmentChannel, AlignmentOverride> proposal =
+            ComputeProposal(participants, log);
+
+        // The judged sets differ ONLY in delay and polarity: gains, filters and
+        // PEQ stay the session's own, on both sides of the comparison, because
+        // the proposal moves nothing else.
+        List<ProcessedChannel> saved = Process(participants, _ => null);
+        List<ProcessedChannel> proposed = Process(
+            participants,
+            channel => proposal.GetValueOrDefault(channel));
+        foreach (VirtualCrossoverChannel channel in participants)
+        {
+            AlignmentOverride over = proposal.GetValueOrDefault(channel);
+            report.AppendLine(
+                $"    {channel.Name} {Describe(channel.Settings.DisplayName),-24} " +
+                $"saved {channel.Settings.DelayMs,7:0.00} ms " +
+                $"{(channel.Settings.InvertPolarity ? "INV" : "   ")}    " +
+                $"proposed {over.DelayMs,7:0.00} ms " +
+                $"{(over.InvertPolarity ? "INV" : "   ")}");
+        }
+
+        List<VirtualCrossoverMetric.Entry> savedEntries = Judge(project, saved);
+        List<VirtualCrossoverMetric.Entry> proposedEntries = Judge(project, proposed);
+        var comparisons = new List<JunctionComparison>();
+        report.AppendLine(
+            "    junction              band Hz        saved avg/dip     " +
+            "proposed avg/dip      Δavg    Δdip");
+        foreach (VirtualCrossoverMetric.Entry savedEntry in savedEntries)
+        {
+            // Matched by junction label: the two sets carry the same channels in
+            // the same band order (only their delays differ), so the labels line
+            // up one to one.
+            VirtualCrossoverMetric.Entry? match = proposedEntries
+                .Cast<VirtualCrossoverMetric.Entry?>()
+                .FirstOrDefault(entry => entry!.Value.Junction == savedEntry.Junction);
+            if (match is not { } proposedEntry)
+            {
+                continue;
+            }
+
+            var comparison = new JunctionComparison(
+                name,
+                savedEntry.Junction,
+                savedEntry.IsTotal,
+                savedEntry.LowHz,
+                savedEntry.HighHz,
+                savedEntry.AverageDb,
+                savedEntry.DipDb,
+                proposedEntry.AverageDb,
+                proposedEntry.DipDb);
+            comparisons.Add(comparison);
+            report.AppendLine(
+                $"    {savedEntry.Junction,-18} {savedEntry.LowHz,6:0} - " +
+                $"{savedEntry.HighHz,-6:0}  {savedEntry.AverageDb,7:0.00} / " +
+                $"{Format(savedEntry.DipDb),-7}  {proposedEntry.AverageDb,7:0.00} / " +
+                $"{Format(proposedEntry.DipDb),-7}  {comparison.AverageDelta,7:+0.00;-0.00} " +
+                $"{Format(comparison.DipDelta, "+0.00;-0.00"),7}");
+            report.AppendLine(comparison.Row());
+        }
+
+        foreach (string line in log.ToString().Split('\n'))
+        {
+            if (line.Contains("latch") || line.Contains("veto") ||
+                line.Contains("re-anchored") || line.Contains("lobe hop"))
+            {
+                report.AppendLine("    | " + line.Trim());
+            }
+        }
+
+        report.AppendLine($"    ({stopwatch.Elapsed.TotalSeconds:0.0} s)");
+        return comparisons;
+    }
+
+    private static string Describe(string displayName) =>
+        string.IsNullOrWhiteSpace(displayName)
+            ? "(unnamed)"
+            : displayName.Length > 24 ? displayName[..24] : displayName;
+
+    private static string Format(double? value, string format = "0.00") =>
+        value?.ToString(format, CultureInfo.InvariantCulture) ?? "-";
+
+    // The panel's single-side Auto delay, verbatim: order along the spectrum by
+    // band center, one shared direct-sound crop, crosstalk heads cleaned, then
+    // the engine's cascade over the adjacent junctions. The session's own
+    // delays and polarities are deliberately NOT fed in — the run ignores them,
+    // exactly as the tool's own run does.
+    private static Dictionary<IAlignmentChannel, AlignmentOverride> ComputeProposal(
+        List<VirtualCrossoverChannel> participants,
+        StringBuilder log)
+    {
+        List<VirtualCrossoverChannel> ordered = participants
+            .OrderBy(channel => VirtualCrossoverJunctions.BandCenterHz(channel.Settings))
+            .ToList();
+        var reprocessor = new AlignmentReprocessor(
+            CleanCrosstalkHeads(
+                ordered.Select(channel => new AlignmentReprocessInput(
+                    channel,
+                    channel.TransferImpulseResponse!,
+                    channel.SampleRate,
+                    channel.Settings.ToChain())).ToList(),
+                log),
+            SearchCropLength,
+            SearchCropPrePeakSamples);
+        IReadOnlyList<AlignmentSnapshot> initial = reprocessor.Reprocess(
+            new Dictionary<IAlignmentChannel, AlignmentOverride>());
+        var snapshots = ordered
+            .Select((channel, i) => (channel, snapshot: initial[i]))
+            .ToDictionary(item => item.channel, item => item.snapshot);
+        var junctions = new List<AlignmentJunction>();
+        for (int i = 0; i < ordered.Count - 1; i++)
+        {
+            double pairHz = VirtualCrossoverJunctions.GetPairCrossoverHz(
+                ordered[i].Settings, ordered[i + 1].Settings);
+            (double bandLowHz, double bandHighHz) =
+                VirtualCrossoverJunctions.OverlapBand(pairHz);
+            junctions.Add(new AlignmentJunction(
+                snapshots[ordered[i]], snapshots[ordered[i + 1]],
+                pairHz, bandLowHz, bandHighHz));
+        }
+
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        AutoAlignmentEngine.Compute(
+            ordered.Select(channel => snapshots[channel]).ToList(),
+            junctions,
+            reprocessor.Reprocess,
+            alignment,
+            log,
+            new Dictionary<IAlignmentChannel, AlignmentDecision>());
+        return alignment;
+    }
+
+    // The panel's head gate for the playback-crosstalk click (an electrical copy
+    // of the playback ahead of any acoustic arrival, present in every record of
+    // the v3 session): without it the battery would judge a search the tool
+    // never runs.
+    private static List<AlignmentReprocessInput> CleanCrosstalkHeads(
+        List<AlignmentReprocessInput> inputs,
+        StringBuilder log) =>
+        inputs.Select(input =>
+        {
+            double[] real = Array.ConvertAll(
+                input.MeasuredImpulseResponse, sample => sample.Real);
+            if (TransferIrDiagnostics.DetectCrosstalkHead(real, input.SampleRate)
+                is not { } convicted)
+            {
+                return input;
+            }
+
+            log.AppendLine(
+                $"{input.Channel.Name}: playback-crosstalk click at " +
+                $"{convicted.BurstTimeMs:0.00} ms removed before the search");
+            return input with
+            {
+                MeasuredImpulseResponse = TransferIrDiagnostics.CleanCrosstalkHead(
+                    input.MeasuredImpulseResponse, input.SampleRate, convicted)
+            };
+        }).ToList();
+
+    // The panel's redraw, reduced to what the metric reads: each channel's
+    // source run through its chain (the session's, or the session's with the
+    // proposal's delay and polarity on top) by the same snapshot the tool
+    // processes through, so the head crop and the FFT are the tool's.
+    private static List<ProcessedChannel> Process(
+        List<VirtualCrossoverChannel> participants,
+        Func<VirtualCrossoverChannel, AlignmentOverride?> overrideFor)
+    {
+        var processed = new List<ProcessedChannel>(participants.Count);
+        foreach (VirtualCrossoverChannel channel in participants)
+        {
+            VirtualCrossoverChannelState state = channel.SideState(channel.ActiveRight);
+            DspChannelChain chain = channel.Settings.ToChain();
+            if (overrideFor(channel) is { } over)
+            {
+                chain = chain with
+                {
+                    DelayMs = over.DelayMs,
+                    InvertPolarity = over.InvertPolarity
+                };
+            }
+
+            Complex[] response = state.ProcessingSource!.Apply(chain, state.SampleRate);
+            processed.Add(new ProcessedChannel(
+                channel,
+                response,
+                VirtualCrossoverAnalysis.FindPeakIndex(response),
+                OxyColors.White));
+        }
+
+        return processed;
+    }
+
+    // The judge itself: the panel's metric, gated and smoothed the way THIS
+    // session is (the pinned offset when it has one, its own Tukey shoulders,
+    // its own smoothing code) — never a default invented here. Calibration is
+    // null: it belongs to the machine that measured, not to the session, and
+    // it applies identically to both sides of the comparison anyway.
+    private static List<VirtualCrossoverMetric.Entry> Judge(
+        VirtualCrossoverProjectFile project,
+        List<ProcessedChannel> processed)
+    {
+        var template = new PhaseAnalysisSettings(
+            // The magnitude always reads the FIXED gate, whatever the session's
+            // window mode says — FDW cannot hold a summed response (see
+            // VirtualCrossoverPanel.RequestRedraw).
+            PhaseWindowMode.Fixed,
+            project.PhaseFdwCycles,
+            PhaseDetrendMode.Off,
+            ManualDetrendMilliseconds: 0.0,
+            GateOffsetMs: 0.0,
+            project.PhaseGateLeftMs,
+            project.PhaseGatePlateauMs,
+            project.PhaseGateRightMs,
+            Unwrap: false,
+            SmoothingInverseOctaves: 0.0);
+        double? pinnedOffsetMs = project.PhaseGateFor(project.ActiveSideRight).OffsetMs;
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(
+            coordinator,
+            (impulseResponse, anchorIndex, sampleRate) =>
+            {
+                PhaseAnalysisSettings gate = template with
+                {
+                    GateOffsetMs = pinnedOffsetMs
+                        ?? anchorIndex * 1_000.0 / sampleRate
+                };
+                (AnalysisCurve display, AnalysisCurve unsmoothed) =
+                    DataHelper.GetGatedPrimarySpectrumPair(
+                        new ImpulseMeasurementView(impulseResponse, anchorIndex, sampleRate),
+                        gate,
+                        calibration: null,
+                        project.SmoothingCode);
+                return new GatedMagnitude(display, unsmoothed);
+            });
+        (_, _, List<SignalPoint>? loss) = metrics.BuildCurves(
+            processed, project.SmoothingCode);
+        return metrics.BuildEntries(processed, loss);
+    }
+
+    // The session's channels, resolved the way the tool resolves an imported
+    // session: the stored path first, then the same measurement beside the
+    // session file (VirtualCrossoverSourceLocator), which is what makes an
+    // archived cabin load on a machine that never measured it.
+    private static List<VirtualCrossoverChannel> LoadChannels(
+        VirtualCrossoverProjectFile project,
+        out string fingerprint)
+    {
+        var channels = new List<VirtualCrossoverChannel>();
+        var identity = new StringBuilder();
+        for (int i = 0; i < project.Pairs.Count; i++)
+        {
+            var channel = new VirtualCrossoverChannel(VirtualCrossoverSheet.ChannelName(i))
+            {
+                Pair = project.Pairs[i],
+                ActiveRight = project.ActiveSideRight
+            };
+            channels.Add(channel);
+            VirtualCrossoverChannelSettings settings =
+                channel.SideSettings(channel.ActiveRight);
+            if (!settings.HasSource ||
+                VirtualCrossoverSourceLocator.Locate(
+                    settings.SourceFilePath,
+                    settings.SourceRelativePath,
+                    project.ProjectDirectory) is not { } path)
+            {
+                continue;
+            }
+
+            ImpulseResponseFile file = ImpulseResponseFile.LoadAsync(path)
+                .GetAwaiter().GetResult();
+            ResolvedVirtualDspSource.FromSnapshot(
+                MeasurementHistoryService.CreateSnapshot(file))
+                ?.ApplyTo(channel.SideState(channel.ActiveRight));
+            identity.Append(path).Append('|')
+                .Append(settings.DelayMs.ToString("0.000", CultureInfo.InvariantCulture))
+                .Append(settings.InvertPolarity ? "-inv;" : ";");
+        }
+
+        fingerprint = identity.ToString();
+        return channels;
+    }
+
+    // The battery's bottom line: how the proposal stands against the owner's own
+    // tuning across every junction of every cabin. Junction rows and the
+    // per-session totals are counted apart — a total is not an independent
+    // junction, it is the same bands read together.
+    private static void WriteSummary(
+        StringBuilder report, List<JunctionComparison> comparisons)
+    {
+        report.AppendLine();
+        report.AppendLine("=== summary (proposal against the session's saved settings)");
+        foreach (bool totals in new[] { false, true })
+        {
+            List<JunctionComparison> rows = comparisons
+                .Where(item => item.IsTotal == totals)
+                .ToList();
+            if (rows.Count == 0)
+            {
+                continue;
+            }
+
+            List<double> dips = rows
+                .Where(item => item.DipDelta.HasValue)
+                .Select(item => item.DipDelta!.Value)
+                .ToList();
+            report.AppendLine(
+                $"  {(totals ? "totals  " : "junctions")} {rows.Count,3}: " +
+                $"avg {rows.Average(item => item.AverageDelta),+7:+0.000;-0.000} dB " +
+                $"({rows.Count(item => item.AverageDelta > 0.005)} better / " +
+                $"{rows.Count(item => item.AverageDelta < -0.005)} worse), " +
+                $"dip {(dips.Count > 0 ? dips.Average() : 0),+7:+0.000;-0.000} dB " +
+                $"({dips.Count(value => value > 0.005)} better / " +
+                $"{dips.Count(value => value < -0.005)} worse)");
+        }
+    }
+
+    // One judged junction, both readings side by side. Positive deltas mean the
+    // proposal loses LESS than the saved settings do.
+    private sealed record JunctionComparison(
+        string Session,
+        string Junction,
+        bool IsTotal,
+        double LowHz,
+        double HighHz,
+        double SavedAverageDb,
+        double? SavedDipDb,
+        double ProposedAverageDb,
+        double? ProposedDipDb)
+    {
+        public double AverageDelta => ProposedAverageDb - SavedAverageDb;
+
+        public double? DipDelta => SavedDipDb.HasValue && ProposedDipDb.HasValue
+            ? ProposedDipDb.Value - SavedDipDb.Value
+            : null;
+
+        // The line two builds are diffed on: fixed field order, invariant
+        // formatting, six decimals — enough that a change of rule shows and a
+        // rounding wobble does not.
+        public string Row() => string.Join('\t',
+            "ROW",
+            Session,
+            Junction,
+            LowHz.ToString("0.0", CultureInfo.InvariantCulture),
+            HighHz.ToString("0.0", CultureInfo.InvariantCulture),
+            SavedAverageDb.ToString("0.000000", CultureInfo.InvariantCulture),
+            SavedDipDb?.ToString("0.000000", CultureInfo.InvariantCulture) ?? "-",
+            ProposedAverageDb.ToString("0.000000", CultureInfo.InvariantCulture),
+            ProposedDipDb?.ToString("0.000000", CultureInfo.InvariantCulture) ?? "-");
+    }
+}

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -104,6 +104,11 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
     [
         @"3RC\virtual-dsp-session.json",
         @"Passat\virtual-dsp-session.json",
+        // The same car re-measured and re-tuned by the owner (2026-08-20).
+        // Its A/B junction is the conviction dead zone's field case: the
+        // sub's band arrival latches 1.7 allowances late and only the comb
+        // arbitration lands the pair on the owner's inverted earlier lobe.
+        @"Passat v2\virtual-dsp-session-sq-v10-7-opt.json",
         @"v2\virtual-dsp-session.json",
         @"v2\head_90_grad\virtual-dsp-session.json",
         @"v3\virtual-dsp-session.json",
@@ -344,7 +349,7 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
         {
             if (line.Contains("latch") || line.Contains("veto") ||
                 line.Contains("re-anchored") || line.Contains("lobe hop") ||
-                line.Contains("direct coherence"))
+                line.Contains("direct coherence") || line.Contains("arbitration"))
             {
                 report.AppendLine("    | " + line.Trim());
             }

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -108,7 +108,10 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
         @"v2\head_90_grad\virtual-dsp-session.json",
         @"v3\virtual-dsp-session.json",
         @"v4\virtual-dsp-session.json",
-        @"v5_exp\virtual-dsp-session-manual.json"
+        // manual-2 supersedes manual: the owner's 2026-08-20 re-tune, made
+        // after auditioning the engine's proposal (it adopts the proposal's
+        // bass/mid lobe and polarity structure and re-tunes around them).
+        @"v5_exp\virtual-dsp-session-manual-2.json"
     ];
 
     // The Auto delay search's crop, straight from the panel: the search reads

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -356,7 +356,8 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
 
     private static double FrontMs(ProcessedChannel item) =>
         ProcessedChannels.StartAnchorIndex(
-            item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate)
+            item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate,
+            item.ValidRange)
         * 1_000.0 / item.Channel.SampleRate;
 
     private static string Describe(string displayName) =>

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -75,6 +75,24 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
     /// </summary>
     public const string SessionsVariable = "RESONALYZE_SESSION_BATTERY_SESSIONS";
 
+    /// <summary>
+    /// Set to judge every session through the gate dialog's AUTO placement
+    /// (each set of settings windowed at its own earliest front) instead of
+    /// through the offset the session pinned.
+    /// <para>
+    /// A pinned gate is one ABSOLUTE window, so it does not follow a proposal
+    /// that moves a channel: on the archived v5 cabin the pin opens the window
+    /// at 10.06 ms and the saved tuning puts the mid and tweeter fronts at
+    /// 18.4/18.1 ms — inside the plateau — while the proposal brings them to
+    /// 12.6/12.4 ms, inside the window's own fade-in. Their level in the sum is
+    /// then set by the window, and the metric compares a windowing artifact.
+    /// The pinned reading is what the panel shows before the gate is re-placed,
+    /// so it stays the default; this switch is how the SAME comparison is read
+    /// with the window off the scales.
+    /// </para>
+    /// </summary>
+    public const string AutoGateVariable = "RESONALYZE_SESSION_BATTERY_AUTOGATE";
+
     // The archived cabins, in the order the branch's notes list them. Each entry
     // is a path under the root; the session file's own folder is what its
     // measurements are resolved against (VirtualCrossoverSourceLocator), so a
@@ -99,6 +117,10 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
 
     internal static string? RootDirectory =>
         Environment.GetEnvironmentVariable(SessionBatteryFactAttribute.RootVariable);
+
+    private static bool AutoGate =>
+        !string.IsNullOrWhiteSpace(
+            Environment.GetEnvironmentVariable(AutoGateVariable));
 
     [SessionBatteryFact]
     public void JudgeAutoDelayAgainstSavedSettings()
@@ -190,6 +212,7 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
         report.AppendLine(
             $"  side {(rightSide ? "R" : "L")}, {participants.Count} channels, " +
             $"{participants[0].SampleRate} Hz, gate " +
+            $"{(AutoGate ? "AUTO (pin ignored)" : null)}" +
             $"{gate.OffsetMs?.ToString("0.00", CultureInfo.InvariantCulture) ?? "auto"} " +
             $"+ {project.PhaseGateLeftMs:0.#}/{project.PhaseGatePlateauMs:0.#}/" +
             $"{project.PhaseGateRightMs:0.#} ms, smoothing " +
@@ -216,6 +239,24 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
                 $"proposed {over.DelayMs,7:0.00} ms " +
                 $"{(over.InvertPolarity ? "INV" : "   ")}");
         }
+
+        // Where each set's fronts land against the window they are judged
+        // through. A PINNED gate is one absolute window for both sets, so a
+        // proposal that moves a channel far enough can put its own front into
+        // the window's left fade — and then the metric is reading the window,
+        // not the alignment. Printed so that bias is visible instead of
+        // silently deciding a comparison.
+        double leftEdgeMs = !AutoGate && gate.OffsetMs is { } pinned
+            ? pinned - project.PhaseGateLeftMs
+            : double.NaN;
+        report.AppendLine(
+            "    fronts (ms): " + string.Join(", ", saved.Select((item, index) =>
+                $"{item.Channel.Name} {FrontMs(item):0.00}->" +
+                $"{FrontMs(proposed[index]):0.00}")) +
+            (double.IsNaN(leftEdgeMs)
+                ? "   (gate follows the earliest front)"
+                : $"   (window opens {leftEdgeMs:0.00} ms, plateau to " +
+                  $"{gate.OffsetMs!.Value + project.PhaseGatePlateauMs:0.00} ms)"));
 
         List<VirtualCrossoverMetric.Entry> savedEntries = Judge(project, saved);
         List<VirtualCrossoverMetric.Entry> proposedEntries = Judge(project, proposed);
@@ -268,6 +309,11 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
         report.AppendLine($"    ({stopwatch.Elapsed.TotalSeconds:0.0} s)");
         return comparisons;
     }
+
+    private static double FrontMs(ProcessedChannel item) =>
+        ProcessedChannels.StartAnchorIndex(
+            item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate)
+        * 1_000.0 / item.Channel.SampleRate;
 
     private static string Describe(string displayName) =>
         string.IsNullOrWhiteSpace(displayName)
@@ -410,7 +456,9 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
             project.PhaseGateRightMs,
             Unwrap: false,
             SmoothingInverseOctaves: 0.0);
-        double? pinnedOffsetMs = project.PhaseGateFor(project.ActiveSideRight).OffsetMs;
+        double? pinnedOffsetMs = AutoGate
+            ? null
+            : project.PhaseGateFor(project.ActiveSideRight).OffsetMs;
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
         var metrics = new VirtualCrossoverMetrics(
             coordinator,

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -265,6 +265,42 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
                 : $"   (window opens {leftEdgeMs:0.00} ms, plateau to " +
                   $"{gate.OffsetMs!.Value + project.PhaseGatePlateauMs:0.00} ms)"));
 
+        // The direct-sound whitened correlation of each junction, for the
+        // saved tune and the proposal — the read the correlation view's
+        // "PHAT direct" curve draws and the engine's direct-coherence witness
+        // weighs. Per junction: the extremum nearest zero lag (the lobe the
+        // setting sits on) and the curve's global extremum. A signed r:
+        // negative means the coherent alignment is the INVERTED one.
+        void DirectPhat(string label, List<ProcessedChannel> set)
+        {
+            foreach (AdjacentPair pair in ProcessedChannels.GetAdjacentPairs(
+                ProcessedChannels.OrderByBand(set)))
+            {
+                JunctionCorrelationView view =
+                    VirtualCrossoverPanel.BuildCorrelationView(pair, set);
+                if (view.WhitenedDirect.Count == 0)
+                {
+                    continue;
+                }
+
+                SignalPoint best = view.WhitenedDirect
+                    .MaxBy(point => Math.Abs(point.Y));
+                SignalPoint near = view.WhitenedDirect
+                    .Where(point => Math.Abs(point.X) <= 500.0 / pair.CrossoverHz)
+                    .DefaultIfEmpty(best)
+                    .MaxBy(point => Math.Abs(point.Y));
+                // The runner already pinned the invariant culture.
+                report.AppendLine(
+                    $"    direct-PHAT {label,-8} " +
+                    $"{pair.Lower.Channel.Name}/{pair.Upper.Channel.Name}: " +
+                    $"on-lobe r {near.Y:+0.00;-0.00} @ {near.X:+0.00;-0.00} ms; " +
+                    $"best r {best.Y:+0.00;-0.00} @ {best.X:+0.00;-0.00} ms");
+            }
+        }
+
+        DirectPhat("saved", saved);
+        DirectPhat("proposed", proposed);
+
         List<VirtualCrossoverMetric.Entry> savedEntries = Judge(project, saved);
         List<VirtualCrossoverMetric.Entry> proposedEntries = Judge(project, proposed);
         var comparisons = new List<JunctionComparison>();
@@ -307,7 +343,8 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
         foreach (string line in log.ToString().Split('\n'))
         {
             if (line.Contains("latch") || line.Contains("veto") ||
-                line.Contains("re-anchored") || line.Contains("lobe hop"))
+                line.Contains("re-anchored") || line.Contains("lobe hop") ||
+                line.Contains("direct coherence"))
             {
                 report.AppendLine("    | " + line.Trim());
             }

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -119,12 +119,6 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
         @"v5_exp\virtual-dsp-session-manual-2.json"
     ];
 
-    // The Auto delay search's crop, straight from the panel: the search reads
-    // only the gated direct sound, so it runs on a shared crop of the measured
-    // IRs (one offset for every channel keeps the inter-channel timing intact).
-    private const int SearchCropLength = 65_536;
-    private const int SearchCropPrePeakSamples = 8_192;
-
     internal static string? RootDirectory =>
         Environment.GetEnvironmentVariable(SessionBatteryFactAttribute.RootVariable);
 
@@ -392,9 +386,7 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
                     channel.TransferImpulseResponse!,
                     channel.SampleRate,
                     channel.Settings.ToChain())).ToList(),
-                log),
-            SearchCropLength,
-            SearchCropPrePeakSamples);
+                log));
         IReadOnlyList<AlignmentSnapshot> initial = reprocessor.Reprocess(
             new Dictionary<IAlignmentChannel, AlignmentOverride>());
         var snapshots = ordered

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverCorrelationViewTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverCorrelationViewTests.cs
@@ -56,23 +56,31 @@ public sealed class VirtualCrossoverCorrelationViewTests
                 [lower, upper]);
         }
 
-        SignalPoint guarded = View(honest).WhitenedDirect
+        JunctionCorrelationView guardedView = View(honest);
+        SignalPoint guarded = guardedView.WhitenedDirect
             .MaxBy(point => Math.Abs(point.Y));
         Assert.InRange(guarded.X, -0.2, 0.2);
         Assert.True(
             guarded.Y > 0.8,
             $"with the range honored the aligned fronts should cohere " +
             $"strongly, got r {guarded.Y:0.00} at {guarded.X:0.00} ms");
+        // The arrival marker is the same read the search anchors on: with the
+        // range honored it sees the aligned fronts, not the artifact.
+        Assert.InRange(guardedView.ArrivalLagMs, -0.5, 0.5);
 
         // The discriminating control: the SAME channels with an
         // all-permissive range on the artifact-bearing one. If the view ever
         // stops passing ranges (or shifts them wrongly enough to void them),
         // this is what the guarded read degenerates to.
-        SignalPoint blind = View(wide).WhitenedDirect
+        JunctionCorrelationView blindView = View(wide);
+        SignalPoint blind = blindView.WhitenedDirect
             .MaxBy(point => Math.Abs(point.Y));
         Assert.True(
             Math.Abs(blind.Y) < 0.5,
             $"with the artifact anchoring the cut no strong lobe should " +
             $"survive in view, got r {blind.Y:0.00} at {blind.X:0.00} ms");
+        // ...and the blind marker parks on the artifact, 10 ms early on the
+        // upper side — the false front a dropped range would draw.
+        Assert.InRange(blindView.ArrivalLagMs, 9.0, 11.0);
     }
 }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverCorrelationViewTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverCorrelationViewTests.cs
@@ -1,0 +1,78 @@
+using System.Numerics;
+using OxyPlot;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The correlation view's data build (<see cref="VirtualCrossoverPanel.BuildCorrelationView"/>):
+/// the channels' <see cref="ValidSampleRange"/> must reach the front
+/// detections behind the "PHAT direct" cuts and the score sweep — shifted
+/// into the crop's frame, since the view crops the responses first — so the
+/// diagnostic curves read the same fronts the Auto search reads.
+/// </summary>
+public sealed class VirtualCrossoverCorrelationViewTests
+{
+    private const int SampleRate = 48_000;
+    private const int IrLength = 32_768;
+    // Far enough in that the shared direct-sound crop removes a non-zero
+    // prefix (peak − 8192), so an unshifted original-frame range could not
+    // quietly pass for a shifted one.
+    private const int FrontSample = 14_000;
+
+    private static ProcessedChannel Channel(
+        string name, Complex[] ir, ValidSampleRange range)
+    {
+        var channel = new VirtualCrossoverChannel(name) { SampleRate = SampleRate };
+        return new ProcessedChannel(
+            channel, ir, VirtualCrossoverAnalysis.FindPeakIndex(ir),
+            OxyColors.White, range);
+    }
+
+    [Fact]
+    public void BuildCorrelationView_DirectCurveHonorsTheValidRanges()
+    {
+        // The upper channel carries an in-band artifact 10 ms AHEAD of its
+        // valid range — the shape a chain delay's padding or a capture glitch
+        // leaves. With the range honored, the direct cut windows the real
+        // front and the "PHAT direct" comb peaks at the pair's true (aligned)
+        // timing; with the range dropped, the artifact anchors the cut, the
+        // real fronts sit 10 ms apart — far outside the ±3 ms view — and no
+        // strong lobe survives near zero.
+        var lowerIr = new Complex[IrLength];
+        lowerIr[FrontSample] = 1.0;
+        var upperIr = new Complex[IrLength];
+        upperIr[FrontSample] = 1.0;
+        upperIr[FrontSample - 480] = 0.6; // 10 ms early, in-band
+        var honest = new ValidSampleRange(FrontSample - 96, IrLength);
+        var wide = new ValidSampleRange(0, IrLength);
+
+        JunctionCorrelationView View(ValidSampleRange upperRange)
+        {
+            ProcessedChannel lower = Channel("C", lowerIr, wide);
+            ProcessedChannel upper = Channel("D", upperIr, upperRange);
+            return VirtualCrossoverPanel.BuildCorrelationView(
+                new AdjacentPair(lower, upper, 1_500, 750, 3_000),
+                [lower, upper]);
+        }
+
+        SignalPoint guarded = View(honest).WhitenedDirect
+            .MaxBy(point => Math.Abs(point.Y));
+        Assert.InRange(guarded.X, -0.2, 0.2);
+        Assert.True(
+            guarded.Y > 0.8,
+            $"with the range honored the aligned fronts should cohere " +
+            $"strongly, got r {guarded.Y:0.00} at {guarded.X:0.00} ms");
+
+        // The discriminating control: the SAME channels with an
+        // all-permissive range on the artifact-bearing one. If the view ever
+        // stops passing ranges (or shifts them wrongly enough to void them),
+        // this is what the guarded read degenerates to.
+        SignalPoint blind = View(wide).WhitenedDirect
+            .MaxBy(point => Math.Abs(point.Y));
+        Assert.True(
+            Math.Abs(blind.Y) < 0.5,
+            $"with the artifact anchoring the cut no strong lobe should " +
+            $"survive in view, got r {blind.Y:0.00} at {blind.X:0.00} ms");
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverGatePlacementWarningTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverGatePlacementWarningTests.cs
@@ -52,13 +52,16 @@ public sealed class VirtualCrossoverGatePlacementWarningTests
     }
 
     [Fact]
-    public void TheSameSessionOnTheAutoAnchorIsNotFlagged()
+    public void AWindowOpeningJustAfterTheEarliestFrontIsNotFlagged()
     {
-        // The left side of that session, which was never pinned: the shared
-        // window sits on the earliest processed peak (2.97 ms). Two channels
-        // start before it — the anchor is a PEAK and their fronts precede it —
-        // and one of them is measurably worse there than on its own arrival,
-        // which is exactly why the ceiling is the other half of the test.
+        // The left side of that session, measured at 2.969 ms — a sliver after
+        // the earliest front (2.907 ms). Two channels start ahead of the
+        // window and one of them is measurably worse there than on its own
+        // arrival, and still none of it is worth reporting: being late is not
+        // the test, being late ENOUGH to lose the response is, which is why
+        // the ceiling is the other half of the test. (The Auto placement now
+        // anchors on the earliest front itself, so this gap is what a PINNED
+        // offset a hair off the arrival looks like.)
         Assert.Null(VirtualCrossoverPanel.JudgeGateCut(
             startMs: 2.907, gateOffsetMs: 2.969, plateauMs: 50.0, rightMs: 20.0,
             placementLossDb: -67.4, ownArrivalLossDb: -68.4));

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -55,7 +55,40 @@ public sealed class VirtualCrossoverMetricsTests
     }
 
     [Fact]
-    public void BuildCurves_AnchorsEveryCurveToTheEarliestPeakAndSumsTheResponses()
+    public void BuildCurves_AnchorsEveryCurveToTheEarliestFront()
+    {
+        // A channel whose peak is a later, louder feature than its front: the
+        // shared window must open at the FRONT, or it opens after part of the
+        // response it is supposed to measure. (The other channel arrives after
+        // both, so the anchor is the first one's front either way — what is
+        // pinned here is front vs peak, not which channel wins.)
+        var early = new Complex[1_024];
+        early[300] = 1.0;
+        early[400] = 2.0;
+        var late = new Complex[1_024];
+        late[600] = 1.0;
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var captured = new ConcurrentBag<(Complex[] Ir, int Peak, int Rate)>();
+        var metrics = new VirtualCrossoverMetrics(
+            coordinator,
+            (ir, peak, rate) =>
+            {
+                captured.Add((ir, peak, rate));
+                return EmptyMagnitude;
+            });
+
+        metrics.BuildCurves(
+        [
+            Processed("A", early, peak: 400, rate: 48_000),
+            Processed("B", late, peak: 600, rate: 48_000)
+        ],
+        0);
+
+        Assert.All(captured, entry => Assert.InRange(entry.Peak, 250, 320));
+    }
+
+    [Fact]
+    public void BuildCurves_AnchorsEveryCurveToOneSampleAndSumsTheResponses()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();
         var captured = new ConcurrentBag<(Complex[] Ir, int Peak, int Rate)>();
@@ -79,9 +112,12 @@ public sealed class VirtualCrossoverMetricsTests
         Assert.NotNull(magnitudes);
         Assert.Equal(2, magnitudes.Count);
         Assert.NotNull(sum);
-        // Two channel spectra + one sum spectrum, all anchored to the earliest
-        // peak: one shared window is what keeps the drawn Sum the vector sum
-        // of the drawn channels and the loss under its 0 dB ceiling.
+        // Two channel spectra + one sum spectrum, all anchored to the SAME
+        // sample: one shared window is what keeps the drawn Sum the vector sum
+        // of the drawn channels and the loss under its 0 dB ceiling. These
+        // records are 64 samples — too short for the front estimator, which
+        // refuses rather than guesses — so the anchor falls back to the
+        // earliest declared peak, the rule this one used to follow outright.
         Assert.Equal(3, captured.Count);
         Assert.All(captured, entry => Assert.Equal(2, entry.Peak));
         // One of the calls built the complex sum of the two responses.

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -1349,6 +1349,190 @@ public sealed class AutoAlignmentEngineTests
             $"the seed should have been refused conservatively:\r\n{trace}");
     }
 
+    // The dead-zone shape (see LatchArbitrationMinR in the engine): one SHORT-
+    // tailed mode close behind the front. The long-tailed build-ups above
+    // carry the band read whole periods late — past the conviction factor,
+    // where the predictor convicts alone. A short tail near the front drags
+    // the read late by BETWEEN one and two allowances instead: Inconsistent,
+    // which used to withdraw the pair silently.
+    private static Complex[] FrontUnderShortMode(
+        int length, double modeHz, double modeMs, double amplitude)
+    {
+        Complex[] ir = VirtualCrossoverAnalysis.ApplyChain(
+            SingleImpulse(length, BasePosition),
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.BandPass,
+                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 300, 24),
+                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 25, 24))),
+            SampleRate);
+        int start = BasePosition + (int)Math.Round(modeMs / 1000.0 * SampleRate);
+        const double AttackSeconds = 0.002;
+        const double DecaySeconds = 0.012;
+        for (int i = start; i < ir.Length; i++)
+        {
+            double t = (i - start) / (double)SampleRate;
+            ir[i] += amplitude *
+                (1 - Math.Exp(-t / AttackSeconds)) *
+                Math.Exp(-t / DecaySeconds) *
+                Math.Sin(2 * Math.PI * modeHz * t);
+        }
+        return ir;
+    }
+
+    private static (string Trace, AlignmentOverride Woofer) RunDeadZonePair(
+        AlignmentSnapshot sub, Complex[] subBypassed, DspChannelChain subChain,
+        AlignmentSnapshot woofer, Complex[] wooferBypassed,
+        DspChannelChain wooferChain)
+    {
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides)
+        {
+            AlignmentSnapshot One(
+                AlignmentSnapshot side, Complex[] bypassed, DspChannelChain chain)
+            {
+                AlignmentOverride over = overrides.GetValueOrDefault(side.Channel);
+                Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(
+                    bypassed,
+                    chain with
+                    {
+                        DelayMs = over.DelayMs,
+                        InvertPolarity = over.InvertPolarity
+                    },
+                    SampleRate,
+                    out ValidSampleRange range);
+                return side with
+                {
+                    ImpulseResponse = processed,
+                    PeakIndex = VirtualCrossoverAnalysis.FindPeakIndex(processed),
+                    ValidRange = range
+                };
+            }
+
+            return
+            [
+                One(sub, subBypassed, subChain),
+                One(woofer, wooferBypassed, wooferChain)
+            ];
+        }
+
+        var log = new StringBuilder();
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        AutoAlignmentEngine.Compute(
+            [sub, woofer],
+            [new AlignmentJunction(sub, woofer, 55, 27.5, 110)],
+            Reprocess,
+            alignment,
+            log);
+        return (log.ToString(), alignment.GetValueOrDefault(woofer.Channel));
+    }
+
+    // The archived Passat v2 defect: the sub's band read latched onto a mode
+    // 1.7 allowances past its prediction — inside the conviction dead zone,
+    // where the predictor may not convict alone (its own shaping error can
+    // reach 1.2 allowances) — and the silently withdrawn pair anchored the
+    // junction a period late. The whitened comb is the second witness: the
+    // pair's shared content sits with the prediction, so the read is
+    // convicted and the junction lands on the true front family.
+    [Fact]
+    public void Compute_DeadZoneLatch_IsConvictedByTheWhitenedCombArbitration()
+    {
+        const int Length = 32_768;
+        var subChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.LowPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 48)));
+        var wooferChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.BandPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 300, 48),
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 48)));
+        Complex[] subBypassed = FrontUnderShortMode(Length, 40.0, 4.0, 0.10);
+        Complex[] wooferBypassed = SingleImpulse(Length, BasePosition);
+        AlignmentSnapshot sub = PredictableSnapshot("SUB", subBypassed, subChain);
+        AlignmentSnapshot woofer = PredictableSnapshot(
+            "W", wooferBypassed, wooferChain);
+
+        // The fixture must actually sit in the dead zone: the sub's read
+        // LATER than its prediction by one-to-two allowances (Inconsistent —
+        // the predictor alone would withdraw the pair), the woofer verified.
+        double Read(AlignmentSnapshot side) =>
+            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                side.ImpulseResponse, SampleRate, 27.5, 110, side.ValidRange)
+                .FirstArrivalDelayMilliseconds;
+        double subRead = Read(sub);
+        Assert.Equal(
+            AutoAlignmentEngine.PredictionState.Inconsistent,
+            AutoAlignmentEngine.GradeAgainstPrediction(
+                sub, subRead, 27.5, 110, out double subPrediction));
+        double allowance = AutoAlignmentEngine.PredictedArrivalAllowanceMs(
+            27.5, 110);
+        Assert.InRange((subRead - subPrediction) / allowance, 1.0, 2.0);
+        Assert.Equal(
+            AutoAlignmentEngine.PredictionState.Verified,
+            AutoAlignmentEngine.GradeAgainstPrediction(
+                woofer, Read(woofer), 27.5, 110, out _));
+
+        (string trace, AlignmentOverride over) = RunDeadZonePair(
+            sub, subBypassed, subChain, woofer, wooferBypassed, wooferChain);
+
+        Assert.Contains("SUB: read sits in the conviction dead zone", trace);
+        Assert.Contains("convicted by arbitration", trace);
+        Assert.Contains("modal latch behind the crossover", trace);
+        Assert.Contains("seed phat", trace);
+        // The junction lands on the true front family (the clean-sum optimum
+        // sits at ~8 ms, the latched family a lobe later at ~14+ ms inv).
+        Assert.False(over.InvertPolarity);
+        Assert.InRange(over.DelayMs, 6.0, 10.0);
+    }
+
+    // The arbitration's other verdict, and the fleet's common one: when the
+    // woofer carries its own late build-up, the comb reads as strongly at the
+    // measured family as at the predicted one — the two are indistinguishable,
+    // so there is no second witness and the conviction-strength discrepancy
+    // may not be acted on. The pair withdraws from the predictor exactly as
+    // it did before the arbitration existed.
+    [Fact]
+    public void Compute_DeadZoneLatch_ArbitrationStandsDownWithoutASecondWitness()
+    {
+        const int Length = 32_768;
+        var subChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.LowPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 48)));
+        var wooferChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.BandPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 300, 24),
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 24)));
+        Complex[] subBypassed = FrontUnderShortMode(Length, 40.0, 4.0, 0.06);
+        Complex[] wooferBypassed = FrontUnderShortMode(Length, 70.0, 4.0, 0.35);
+        AlignmentSnapshot sub = PredictableSnapshot("SUB", subBypassed, subChain);
+        AlignmentSnapshot woofer = PredictableSnapshot(
+            "W", wooferBypassed, wooferChain);
+
+        // Same dead zone as the conviction case; the woofer's build-up stays
+        // inside its own allowance, so the woofer still verifies.
+        double Read(AlignmentSnapshot side) =>
+            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                side.ImpulseResponse, SampleRate, 27.5, 110, side.ValidRange)
+                .FirstArrivalDelayMilliseconds;
+        double subRead = Read(sub);
+        Assert.Equal(
+            AutoAlignmentEngine.PredictionState.Inconsistent,
+            AutoAlignmentEngine.GradeAgainstPrediction(
+                sub, subRead, 27.5, 110, out double subPrediction));
+        double allowance = AutoAlignmentEngine.PredictedArrivalAllowanceMs(
+            27.5, 110);
+        Assert.InRange((subRead - subPrediction) / allowance, 1.0, 2.0);
+        Assert.Equal(
+            AutoAlignmentEngine.PredictionState.Verified,
+            AutoAlignmentEngine.GradeAgainstPrediction(
+                woofer, Read(woofer), 27.5, 110, out _));
+
+        (string trace, _) = RunDeadZonePair(
+            sub, subBypassed, subChain, woofer, wooferBypassed, wooferChain);
+
+        Assert.Contains("latch arbitration stood down for SUB/W", trace);
+        Assert.DoesNotContain("convicted by arbitration", trace);
+        Assert.DoesNotContain("modal latch behind the crossover", trace);
+    }
+
     [Fact]
     public void PredictedArrival_GradesEveryState()
     {

--- a/tests/Resonalyze.Dsp.Tests/DirectCoherenceTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/DirectCoherenceTests.cs
@@ -60,6 +60,43 @@ public sealed class DirectCoherenceTests
     }
 
     [Fact]
+    public void CutDirectSound_HonorsTheValidRange()
+    {
+        // An in-band artifact ahead of the record's valid content — the shape
+        // a chain's group-delay padding or a capture glitch leaves. Without
+        // the range the front detector marks the artifact and the cut windows
+        // the wrong event; with the range the artifact is outside the
+        // analysis and the cut lands on the real front. The engine's
+        // snapshots always carry the range — this pins that the cut actually
+        // takes it.
+        Complex[] ir = Impulse(amplitude: 1.0);              // real front
+        Complex[] artifact = Impulse(-10.0, amplitude: 0.6); // 10 ms earlier
+        for (int i = 0; i < ir.Length; i++)
+        {
+            ir[i] += artifact[i];
+        }
+        int artifactAt = BasePosition - (int)Math.Round(10.0 / 1000 * SampleRate);
+        var validRange = new ValidSampleRange(
+            BasePosition - (int)Math.Round(2.0 / 1000 * SampleRate), IrLength);
+
+        Complex[] blind = VirtualCrossoverAnalysis.CutDirectSound(
+            ir, SampleRate, 750, 3_000, 1_500);
+        Complex[] guarded = VirtualCrossoverAnalysis.CutDirectSound(
+            ir, SampleRate, 750, 3_000, 1_500, validRange);
+
+        // Blind, the window opens on the artifact and the real front sits
+        // 10 ms behind it — far outside a two-period cut at 1.5 kHz.
+        Assert.True(
+            blind[artifactAt].Magnitude > 0.5,
+            "without the range the artifact should anchor the cut");
+        Assert.Equal(0.0, blind[BasePosition].Magnitude, 6);
+        // Guarded, the artifact region is invisible to the detector and the
+        // cut holds the real front at full weight.
+        Assert.Equal(0.0, guarded[artifactAt].Magnitude, 6);
+        Assert.Equal(1.0, guarded[BasePosition].Magnitude, 2);
+    }
+
+    [Fact]
     public void Compute_WeighsTheDirectCoherenceOnAPolarityTie()
     {
         // The archived C/D geometry: split corners (LP 1500, HP 1700, both

--- a/tests/Resonalyze.Dsp.Tests/DirectCoherenceTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/DirectCoherenceTests.cs
@@ -1,0 +1,154 @@
+using System.Numerics;
+using System.Text;
+
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The direct-sound cut behind the correlation view's "PHAT direct" curve and
+/// the alignment engine's direct-coherence witness
+/// (<see cref="VirtualCrossoverAnalysis.CutDirectSound"/>), and the witness's
+/// bearing on a junction search.
+/// </summary>
+public sealed class DirectCoherenceTests
+{
+    private const int SampleRate = 48_000;
+    private const int IrLength = 16_384;
+    private const int BasePosition = 2_048;
+
+    private sealed class Channel(string name) : IAlignmentChannel
+    {
+        public string Name { get; } = name;
+        public int SampleRate => DirectCoherenceTests.SampleRate;
+    }
+
+    private static Complex[] Impulse(double offsetMs = 0, double amplitude = 1.0)
+    {
+        var ir = new Complex[IrLength];
+        ir[BasePosition + (int)Math.Round(offsetMs / 1000.0 * SampleRate)] += amplitude;
+        return ir;
+    }
+
+    [Fact]
+    public void CutDirectSound_KeepsTheFrontAndDropsTheReflection()
+    {
+        // A direct front with a strong reflection 4 crossover periods behind
+        // it (2.67 ms at 1.5 kHz): the cut must keep the front at full weight
+        // and remove the reflection entirely — that reflection owning the
+        // whitened extremum is the very failure the cut exists to prevent.
+        Complex[] ir = Impulse();
+        Complex[] reflection = Impulse(4.0 * 1000.0 / 1_500, 0.9);
+        for (int i = 0; i < ir.Length; i++)
+        {
+            ir[i] += reflection[i];
+        }
+
+        Complex[] cut = VirtualCrossoverAnalysis.CutDirectSound(
+            ir, SampleRate, 750, 3_000, 1_500);
+
+        int reflectionAt = BasePosition + (int)Math.Round(
+            4.0 / 1_500 * SampleRate);
+        Assert.Equal(1.0, cut[BasePosition].Magnitude, 2);
+        Assert.Equal(0.0, cut[reflectionAt].Magnitude, 6);
+        // One period behind the front is still inside the two-period plateau.
+        int onePeriod = BasePosition + (int)Math.Round(
+            1.0 / 1_500 * SampleRate);
+        Assert.True(
+            Math.Abs(1.0 - VirtualCrossoverAnalysis.CutDirectSound(
+                Impulse(1000.0 / 1_500), SampleRate, 750, 3_000, 1_500)[onePeriod]
+                .Magnitude) < 0.01,
+            "content one period behind the front must pass at full weight");
+    }
+
+    [Fact]
+    public void Compute_WeighsTheDirectCoherenceOnAPolarityTie()
+    {
+        // The archived C/D geometry: split corners (LP 1500, HP 1700, both
+        // 48 dB/oct Butterworth) leave the pair half an octave of usable
+        // overlap, where the summation score reads a lobe and its polarity
+        // partner as a near-tie. The witness must be ON at such a junction —
+        // its verdict in the log — and the settled lobe must never LOSE the
+        // direct-coherence comparison by the witness's own acting margin:
+        // whichever way the tie fell, the direct wavefronts agreed to within
+        // it. (What the witness is worth on junctions where the full record
+        // and the direct sound disagree is the session battery's business —
+        // rooms do that, chains alone do not.)
+        var midChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.LowPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 1_500, 48)));
+        var twChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.HighPass,
+            HighPassEdge: new CrossoverEdge(
+                CrossoverFilterFamily.Butterworth, 1_700, 48)));
+        Complex[] midSrc = Impulse();
+        Complex[] twSrc = Impulse();
+        var mid = new Channel("C");
+        var tw = new Channel("D");
+
+        AlignmentSnapshot Snap(
+            Channel channel, Complex[] source, DspChannelChain chain,
+            AlignmentOverride over)
+        {
+            Complex[] ir = VirtualCrossoverAnalysis.ApplyChain(
+                source,
+                chain with
+                {
+                    DelayMs = over.DelayMs,
+                    InvertPolarity = over.InvertPolarity
+                },
+                SampleRate, out ValidSampleRange range);
+            return new AlignmentSnapshot(
+                channel, ir, VirtualCrossoverAnalysis.FindPeakIndex(ir), range);
+        }
+
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            [
+                Snap(mid, midSrc, midChain, overrides.GetValueOrDefault(mid)),
+                Snap(tw, twSrc, twChain, overrides.GetValueOrDefault(tw))
+            ];
+
+        IReadOnlyList<AlignmentSnapshot> initial = Reprocess(
+            new Dictionary<IAlignmentChannel, AlignmentOverride>());
+        var junctions = new List<AlignmentJunction>
+        {
+            new(initial[0], initial[1], 1_500, 750, 3_000)
+        };
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        var log = new StringBuilder();
+        AutoAlignmentEngine.Compute(initial, junctions, Reprocess, alignment, log);
+
+        Assert.Contains("direct coherence", log.ToString());
+
+        // Recompute the witness's own figures for the SETTLED state through
+        // the public APIs: the applied lobe against its polarity partner half
+        // a period away, both read on the direct cuts.
+        IReadOnlyList<AlignmentSnapshot> final = Reprocess(alignment);
+        List<SignalPoint> curve = VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
+            VirtualCrossoverAnalysis.CutDirectSound(
+                final[0].ImpulseResponse, SampleRate, 750, 3_000, 1_500),
+            VirtualCrossoverAnalysis.CutDirectSound(
+                final[1].ImpulseResponse, SampleRate, 750, 3_000, 1_500),
+            SampleRate, 1_500, Math.Log2(3_000.0 / 750.0),
+            searchRangeMs: 1.0, centerLagMs: 0, phaseTransform: true);
+        double halfPeriodMs = 500.0 / 1_500;
+        double Coherence(bool inverted, double centerMs) => curve
+            .Where(point => Math.Abs(point.X - centerMs) <= halfPeriodMs / 2)
+            .Select(point => inverted ? -point.Y : point.Y)
+            .DefaultIfEmpty(double.NegativeInfinity)
+            .Max();
+        bool settledInverted =
+            alignment.GetValueOrDefault(mid).InvertPolarity
+            ^ alignment.GetValueOrDefault(tw).InvertPolarity;
+        double settled = Coherence(settledInverted, 0);
+        double partner = Math.Max(
+            Coherence(!settledInverted, halfPeriodMs),
+            Coherence(!settledInverted, -halfPeriodMs));
+        Assert.True(
+            settled > 0.85,
+            $"the settled lobe's direct coherence reads only {settled:0.00}");
+        Assert.True(
+            partner - settled < 0.05,
+            $"the settled lobe loses the direct comparison by " +
+            $"{partner - settled:0.00} — past the witness's own acting margin");
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
@@ -14,6 +14,9 @@ public sealed class JunctionCorrelationCurveTests
     private const int IrLength = 16_384;
     private const int BasePosition = 2_048;
 
+    private static int Samples(double milliseconds) =>
+        (int)Math.Round(milliseconds / 1000.0 * SampleRate);
+
     private static Complex[] ImpulseAtMs(double offsetMs, double amplitude = 1.0)
     {
         var ir = new Complex[IrLength];
@@ -190,9 +193,10 @@ public sealed class JunctionCorrelationCurveTests
         // arithmetic, with no room to blame. A window opened at the drivers'
         // shared source finds exactly that; one opened on the pair's own peaks
         // — its fade-in cutting into both drivers' rise — cannot see a flat sum
-        // anywhere. How much of the difference the shipped anchor rule
-        // (VirtualCrossoverAnalysis.FindGateAnchor, the pair's filtered fronts)
-        // recovers is pinned below.
+        // anywhere. Four placements are put to that record below: the source,
+        // the shipped rule (the pair's CHAIN-FREE fronts, which is what
+        // AutoAlignmentEngine.JunctionGateAnchor reads), the pair's FILTERED
+        // fronts, and the pair's peaks.
         Complex[] sub = Filtered(new CrossoverSpec(
             CrossoverKind.LowPass,
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
@@ -221,22 +225,45 @@ public sealed class JunctionCorrelationCurveTests
             $"the peak-anchored window cannot read the flat sum: " +
             $"avg {peakAnchored.LossDb:0.00}, dip {peakAnchored.DipDb:0.00} dB");
 
-        // The shipped rule sits between the two, and the lobe is the same
-        // through all three: the anchor decides how honestly the junction's
-        // flatness READS, not which alignment wins. The remaining gap is the
-        // 36 dB/oct low-pass's own rise, which starts ~14 ms before the front
-        // the detector can mark on the filtered response (see the gate remarks
-        // in VirtualCrossoverAnalysis).
-        AlignmentCandidate frontAnchored = Best(Math.Min(
+        // Reading the pair's own fronts off the FILTERED responses recovers
+        // part of the difference and no more: the lobe is the same, but the
+        // flatness it can read there is still a windowing artifact. What is
+        // left is the crossover's own rise, which begins before the front any
+        // detector can mark on its output — this pair's 36 dB/oct low-pass
+        // reads its filtered front 12.8 ms behind the driver's, and even the
+        // earlier of the two members 8.6 ms behind.
+        int filteredFront = Math.Min(
             VirtualCrossoverAnalysis.FindGateAnchor(
                 sub, VirtualCrossoverAnalysis.FindPeakIndex(sub),
                 SampleRate, 27.5, 110),
             VirtualCrossoverAnalysis.FindGateAnchor(
                 woofer, VirtualCrossoverAnalysis.FindPeakIndex(woofer),
-                SampleRate, 27.5, 110)));
+                SampleRate, 27.5, 110));
+        AlignmentCandidate frontAnchored = Best(filteredFront);
         Assert.True(frontAnchored.InvertPolarity);
         Assert.InRange(frontAnchored.DelayMs, -4.5, -2.5);
         Assert.InRange(frontAnchored.LossDb, peakAnchored.LossDb, -0.05);
+
+        // The SHIPPED rule reads those same fronts off the pair's CHAIN-FREE
+        // responses instead — here the bare impulse both drivers were fired
+        // from — and so lands on the source itself and reads the flat sum:
+        // this placement gives back the whole 0.21 dB the window was
+        // inventing. It is what AutoAlignmentEngine.JunctionGateAnchor hands
+        // every probe of a junction; what it is worth on real cabins is the
+        // session battery's business (tests/Resonalyze.App.Tests).
+        int chainFreeFront = VirtualCrossoverAnalysis.FindGateAnchor(
+            ImpulseAtMs(0), BasePosition, SampleRate, 27.5, 110);
+        Assert.InRange(chainFreeFront, BasePosition - 2, BasePosition);
+        Assert.True(
+            filteredFront - chainFreeFront > Samples(5.0),
+            $"the filtered front sat only " +
+            $"{(filteredFront - chainFreeFront) * 1000.0 / SampleRate:0.0} ms " +
+            "behind the driver's — too little to tell the placements apart");
+        AlignmentCandidate chainFreeAnchored = Best(chainFreeFront);
+        Assert.True(chainFreeAnchored.InvertPolarity);
+        Assert.InRange(chainFreeAnchored.DelayMs, -4.5, -2.5);
+        Assert.InRange(chainFreeAnchored.LossDb, -0.02, 0.0);
+        Assert.InRange(chainFreeAnchored.DipDb, -0.05, 0.0);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
@@ -183,20 +183,29 @@ public sealed class JunctionCorrelationCurveTests
             ImpulseAtMs(0), new DspChannelChain(Crossover: crossover), SampleRate);
 
     [Fact]
-    public void AlignmentCandidates_JudgeTheJunctionThroughTheGivenAnchor()
+    public void AlignmentCandidates_ReadTheFlatSumHonestlyByDefault()
     {
         // A subwoofer and its woofer partner fired from the SAME impulse
-        // through the field cabin's edges (55 Hz, 36 dB/oct Butterworth; the
-        // woofer's own 180 Hz low-pass is what puts the optimum a couple of
-        // milliseconds early). Two filtered copies of one impulse in a silent
-        // record CAN sum flat: at the right delay and polarity the junction is
-        // arithmetic, with no room to blame. A window opened at the drivers'
-        // shared source finds exactly that; one opened on the pair's own peaks
-        // — its fade-in cutting into both drivers' rise — cannot see a flat sum
-        // anywhere. Four placements are put to that record below: the source,
-        // the shipped rule (VirtualCrossoverAnalysis.FindGateAnchor over the
-        // pair's filtered fronts), the pair's peaks, and the chain-free fronts
-        // that were measured against the shipped rule and declined.
+        // through the field cabin's edges (55 Hz, 36 dB/oct Butterworth):
+        // two filtered copies of one impulse in a silent record CAN sum
+        // flat, so any honest read of the true alignment must say so. This
+        // junction spent two generations of window placement being misread —
+        // a window on the pair's PEAKS started inside both drivers' rises
+        // and settled the field junction a half period out; a window on the
+        // pair's filtered FRONTS still cut the rise a 36 dB/oct filter
+        // spreads 8-13 ms ahead of any detectable front and invented
+        // -0.21 dB at the optimum (the placements were measured against each
+        // other here before the band-sized window; see the gate remarks in
+        // VirtualCrossoverAnalysis for the full history and figures).
+        //
+        // The band-sized window closed the question at a bass junction: at
+        // 27.5-110 Hz the window is ~315 ms with a ~20 ms fade-in, so every
+        // placement — even the peaks — admits the whole rise, and the
+        // default per-channel-front read and a deliberately peak-anchored
+        // shared window now agree on the flat sum to a few hundredths of a
+        // dB. Placement still matters where windows are short; what holds it
+        // to the front there is the detector itself (JunctionGateAnchorTests
+        // pins front-vs-peak directly).
         Complex[] sub = Filtered(new CrossoverSpec(
             CrossoverKind.LowPass,
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
@@ -211,98 +220,30 @@ public sealed class JunctionCorrelationCurveTests
                 priorDelayMs: null, priorSigmaMs: 0, forcedPolarity: null,
                 levelMatch: true, out _, gateAnchorSample: anchor)[0];
 
-        AlignmentCandidate sourceAnchored = Best(BasePosition);
+        // The default read: each channel windowed at its own front. The
+        // 36 dB/oct edges at one corner hand over inverted, and the flat sum
+        // reads flat.
+        AlignmentCandidate byDefault = Best(null);
         Assert.True(
-            sourceAnchored.InvertPolarity,
+            byDefault.InvertPolarity,
             "36 dB/oct edges at one corner hand over inverted");
-        Assert.InRange(sourceAnchored.DelayMs, -4.5, -2.5);
-        Assert.InRange(sourceAnchored.LossDb, -0.02, 0.0);
-        Assert.InRange(sourceAnchored.DipDb, -0.05, 0.0);
+        Assert.InRange(byDefault.DelayMs, -4.5, -2.5);
+        Assert.InRange(byDefault.LossDb, -0.05, 0.0);
+        Assert.InRange(byDefault.DipDb, -0.10, 0.0);
 
-        AlignmentCandidate peakAnchored = Best(null);
-        Assert.True(
-            peakAnchored.LossDb < -0.10 && peakAnchored.DipDb < -0.3,
-            $"the peak-anchored window cannot read the flat sum: " +
-            $"avg {peakAnchored.LossDb:0.00}, dip {peakAnchored.DipDb:0.00} dB");
-
-        // The shipped rule sits between the two, and the lobe is the same
-        // through all three: the anchor decides how honestly the junction's
-        // flatness READS, not which alignment wins. The remaining gap is the
-        // 36 dB/oct low-pass's own rise, which starts before the front the
-        // detector can mark on the filtered response — 12.8 ms before it for
-        // this sub, 8.6 ms for its woofer partner (see the gate remarks in
-        // VirtualCrossoverAnalysis).
-        int filteredFront = Math.Min(
-            VirtualCrossoverAnalysis.FindGateAnchor(
-                sub, VirtualCrossoverAnalysis.FindPeakIndex(sub),
-                SampleRate, 27.5, 110),
-            VirtualCrossoverAnalysis.FindGateAnchor(
-                woofer, VirtualCrossoverAnalysis.FindPeakIndex(woofer),
-                SampleRate, 27.5, 110));
-        AlignmentCandidate frontAnchored = Best(filteredFront);
-        Assert.True(frontAnchored.InvertPolarity);
-        Assert.InRange(frontAnchored.DelayMs, -4.5, -2.5);
-        Assert.InRange(frontAnchored.LossDb, peakAnchored.LossDb, -0.05);
-
-        // The fourth placement, and the reason the third one is still what the
-        // engine uses. Reading those same fronts off the pair's CHAIN-FREE
-        // responses — here the bare impulse both drivers were fired from —
-        // lands on the source and gives back the whole 0.21 dB the window was
-        // inventing. Tempting, and measured on the archived cabins: it moves
-        // the lowest junction of a cabin away from the owner's own tuning (see
-        // the gate remarks), so the flatness it reads is honest while the
-        // alignment it picks is not better. Pinned here so the option stays
-        // measured rather than re-proposed from the reasoning.
-        int chainFreeFront = VirtualCrossoverAnalysis.FindGateAnchor(
-            ImpulseAtMs(0), BasePosition, SampleRate, 27.5, 110);
-        Assert.InRange(chainFreeFront, BasePosition - 2, BasePosition);
-        Assert.True(
-            filteredFront - chainFreeFront > Samples(5.0),
-            "the filtered front sat only " +
-            $"{(filteredFront - chainFreeFront) * 1000.0 / SampleRate:0.0} ms " +
-            "behind the driver's — too little to tell the placements apart");
-        AlignmentCandidate chainFreeAnchored = Best(chainFreeFront);
-        Assert.True(chainFreeAnchored.InvertPolarity);
-        Assert.InRange(chainFreeAnchored.DelayMs, -4.5, -2.5);
-        Assert.InRange(chainFreeAnchored.LossDb, -0.02, 0.0);
-        Assert.InRange(chainFreeAnchored.DipDb, -0.05, 0.0);
-    }
-
-    [Fact]
-    public void AlignmentCandidates_PeakAnchoredWindowMisreadsTheSameJunction()
-    {
-        // The same junction with the anchor left to the pair's PEAKS: the
-        // window then starts inside the drivers' own rise, and what it reads
-        // there is a windowing artifact rather than the junction — this is what
-        // let a field sub/woofer junction (55 Hz, 36 dB/oct) be settled a half
-        // period out. Pinned so the placements cannot silently converge and
-        // hide the distinction.
-        Complex[] sub = Filtered(new CrossoverSpec(
-            CrossoverKind.LowPass,
-            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
-        Complex[] woofer = Filtered(new CrossoverSpec(
-            CrossoverKind.BandPass,
-            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 180, 36),
-            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
-
-        // The true alignment itself — zero delay, the woofer inverted — read
-        // through each window.
-        Complex[] inverted = woofer.Select(value => -value).ToArray();
-        (double LossDb, double DipDb)? peakAnchored =
-            VirtualCrossoverAnalysis.MeasureSumLoss(
-                inverted, [sub], SampleRate, 27.5, 110, levelMatch: true);
-        (double LossDb, double DipDb)? sourceAnchored =
-            VirtualCrossoverAnalysis.MeasureSumLoss(
-                inverted, [sub], SampleRate, 27.5, 110, levelMatch: true,
-                gateAnchorSample: BasePosition);
-
-        Assert.NotNull(peakAnchored);
-        Assert.NotNull(sourceAnchored);
-        Assert.True(
-            sourceAnchored.Value.LossDb > peakAnchored.Value.LossDb + 0.05,
-            $"a window opened ahead of both rises must read the truth more " +
-            $"honestly: {sourceAnchored.Value.LossDb:0.00} vs " +
-            $"{peakAnchored.Value.LossDb:0.00} dB");
+        // The shared window forced onto the pair's earliest PEAK — the
+        // placement that once drew this junction as antiphase — now reads the
+        // same optimum at the same flatness: the window's length, not its
+        // placement, is what buys the honesty at a bass junction.
+        int pairPeak = Math.Min(
+            VirtualCrossoverAnalysis.FindPeakIndex(sub),
+            VirtualCrossoverAnalysis.FindPeakIndex(woofer));
+        AlignmentCandidate peakAnchored = Best(pairPeak);
+        Assert.True(peakAnchored.InvertPolarity);
+        Assert.InRange(
+            Math.Abs(peakAnchored.DelayMs - byDefault.DelayMs), 0, 0.3);
+        Assert.InRange(
+            Math.Abs(peakAnchored.LossDb - byDefault.LossDb), 0, 0.1);
     }
 
     [Fact]
@@ -341,9 +282,11 @@ public sealed class JunctionCorrelationCurveTests
         // 1: no plateau anywhere in the panel's own sweep. With the two
         // channels within a few dB of each other in-band, the parallelogram
         // law |F+V|² + |F−V|² = 2(|F|²+|V|²) forbids both polarities summing
-        // flat at once — at least one must always be losing audibly. The
-        // stationary-window sweep violated this across the whole negative
-        // half, both polarities reading ≈ 0 with the woofer faded out.
+        // flat at once — at least one must always be losing audibly (the
+        // band-sized window reads the shallowest min at -1.44 dB, far off the
+        // optimum where partial decorrelation softens the comb; the plateau
+        // this guards against read ≈ 0 for BOTH). The stationary-window sweep
+        // violated this across the whole negative half, the woofer faded out.
         List<VirtualCrossoverAnalysis.JunctionSweepPoint> normal =
             Sweep(false, pairFront);
         List<VirtualCrossoverAnalysis.JunctionSweepPoint> inverted =
@@ -352,7 +295,7 @@ public sealed class JunctionCorrelationCurveTests
         for (int i = 0; i < normal.Count; i++)
         {
             Assert.True(
-                Math.Min(normal[i].LossDb, inverted[i].LossDb) < -1.5,
+                Math.Min(normal[i].LossDb, inverted[i].LossDb) < -1.0,
                 $"both polarities read flat at {normal[i].DelayMs:0.0} ms " +
                 $"({normal[i].LossDb:0.00} / {inverted[i].LossDb:0.00} dB) — " +
                 "the plateau of a window the moved channel left");

--- a/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
@@ -372,6 +372,106 @@ public sealed class JunctionCorrelationCurveTests
     }
 
     [Fact]
+    public void JunctionLossSweep_DefaultReadsTheSearchsOwnWindows()
+    {
+        // Two channels whose fronts sit 12 ms apart — further than the
+        // 800-1250 Hz band's 10.8 ms window spans. Windowed per channel (the
+        // search's default) each cut holds its channel wherever it sits;
+        // forced through one shared window at the earliest front, the late
+        // channel is lost off the window's end. The sweep once derived that
+        // shared anchor whenever the caller passed none, so the drawn surface
+        // silently stopped being the searched one exactly on such pairs; the
+        // null anchor must now reach the bins untouched, making the sweep
+        // point-identical to the evaluator the search reads.
+        Complex[] variable = ImpulseAtSample(96);        // 2 ms
+        Complex[] fixedIr = ImpulseAtSample(96 + 576);   // 14 ms
+
+        List<VirtualCrossoverAnalysis.JunctionSweepPoint> sweep =
+            VirtualCrossoverAnalysis.JunctionLossSweep(
+                variable, fixedIr, SampleRate, 800, 1_250,
+                startDelayMs: 10.0, endDelayMs: 14.0, stepMs: 0.5,
+                invertVariable: false);
+        VirtualCrossoverAnalysis.SumLossEvaluator? evaluator =
+            VirtualCrossoverAnalysis.SumLossEvaluator.Create(
+                variable, [fixedIr], SampleRate, 800, 1_250);
+
+        Assert.NotNull(evaluator);
+        foreach (VirtualCrossoverAnalysis.JunctionSweepPoint point in sweep)
+        {
+            (double lossDb, double dipDb) = evaluator.Evaluate(point.DelayMs);
+            Assert.Equal(lossDb, point.LossDb, 9);
+            Assert.Equal(dipDb, point.DipDb, 9);
+        }
+
+        // And the distinction is real on this pair: the shared window at the
+        // early channel's front cannot even hold the late channel, so the
+        // same probes read a different surface through it.
+        int sharedFront = VirtualCrossoverAnalysis.FindGateAnchor(
+            variable, VirtualCrossoverAnalysis.FindPeakIndex(variable),
+            SampleRate, 800, 1_250);
+        List<VirtualCrossoverAnalysis.JunctionSweepPoint> shared =
+            VirtualCrossoverAnalysis.JunctionLossSweep(
+                variable, fixedIr, SampleRate, 800, 1_250,
+                startDelayMs: 10.0, endDelayMs: 14.0, stepMs: 0.5,
+                invertVariable: false, sharedFront);
+        double worst = sweep
+            .Zip(shared, (own, one) => Math.Abs(own.LossDb - one.LossDb))
+            .Max();
+        Assert.True(
+            worst > 0.5,
+            $"the two window rules read this pair {worst:0.00} dB apart at " +
+            "most — too close to prove the anchor pass-through matters");
+    }
+
+    [Fact]
+    public void JunctionLossSweep_LevelMatchReshapesUnequalChannels()
+    {
+        // The Auto search always scores through the level match
+        // (FindAlignmentCandidates, levelMatch: true): the lobe choice must
+        // not depend on the channels' playback gains. A sweep drawn without
+        // it shows a different surface whenever the pair sits at different
+        // levels — equal-amplitude synthetics hid this. With the match ON the
+        // sweep must again be point-identical to the matched evaluator.
+        Complex[] variable = ImpulseAtMs(0.5, amplitude: 0.25); // -12 dB
+        Complex[] fixedIr = ImpulseAtMs(2.0);
+
+        List<VirtualCrossoverAnalysis.JunctionSweepPoint> matched =
+            VirtualCrossoverAnalysis.JunctionLossSweep(
+                variable, fixedIr, SampleRate, 800, 1_250,
+                startDelayMs: 0.0, endDelayMs: 3.0, stepMs: 0.25,
+                invertVariable: false, gateAnchorSample: null,
+                levelMatch: true);
+        VirtualCrossoverAnalysis.SumLossEvaluator? evaluator =
+            VirtualCrossoverAnalysis.SumLossEvaluator.Create(
+                variable, [fixedIr], SampleRate, 800, 1_250,
+                levelMatch: true);
+
+        Assert.NotNull(evaluator);
+        foreach (VirtualCrossoverAnalysis.JunctionSweepPoint point in matched)
+        {
+            (double lossDb, double dipDb) = evaluator.Evaluate(point.DelayMs);
+            Assert.Equal(lossDb, point.LossDb, 9);
+            Assert.Equal(dipDb, point.DipDb, 9);
+        }
+
+        // A 12 dB imbalance flattens the unmatched surface: at the aligned
+        // probe the matched pair cancels ~fully where the unmatched one
+        // cannot lose more than the weak channel contributes.
+        List<VirtualCrossoverAnalysis.JunctionSweepPoint> unmatched =
+            VirtualCrossoverAnalysis.JunctionLossSweep(
+                variable, fixedIr, SampleRate, 800, 1_250,
+                startDelayMs: 0.0, endDelayMs: 3.0, stepMs: 0.25,
+                invertVariable: false);
+        double worst = matched
+            .Zip(unmatched, (a, b) => Math.Abs(a.LossDb - b.LossDb))
+            .Max();
+        Assert.True(
+            worst > 3.0,
+            $"a 12 dB pair reads only {worst:0.00} dB apart with and " +
+            "without the match — the surfaces should differ starkly");
+    }
+
+    [Fact]
     public void JunctionLossSweep_InvertedPolarityShiftsTheCombByHalfAPeriod()
     {
         // With the variable channel inverted the comb flips: the optimum moves

--- a/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
@@ -306,6 +306,129 @@ public sealed class JunctionCorrelationCurveTests
     }
 
     [Fact]
+    public void JunctionLossSweep_RotationKeepsTheMovedChannelInTheWindow()
+    {
+        // The field plateau, reproduced: a 55 Hz sub/woofer junction swept the
+        // panel's full ±1.5 crossover periods. Re-gating each probe through
+        // the STATIONARY pair window lost the moved woofer into the fade a few
+        // ms out, the "sum" degenerated toward the sub alone, and both
+        // polarities converged to a fake near-0 dB plateau (the in-band level
+        // skew grew 3 → 19 dB across the sweep on the archived cabins). The
+        // rotation sweep reads the same two windowed cuts at every probe; three
+        // properties pin it.
+        Complex[] sub = Filtered(new CrossoverSpec(
+            CrossoverKind.LowPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
+        Complex[] woofer = Filtered(new CrossoverSpec(
+            CrossoverKind.BandPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 180, 36),
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
+        int pairFront = Math.Min(
+            VirtualCrossoverAnalysis.FindGateAnchor(
+                woofer, VirtualCrossoverAnalysis.FindPeakIndex(woofer),
+                SampleRate, 27.5, 110),
+            VirtualCrossoverAnalysis.FindGateAnchor(
+                sub, VirtualCrossoverAnalysis.FindPeakIndex(sub),
+                SampleRate, 27.5, 110));
+
+        List<VirtualCrossoverAnalysis.JunctionSweepPoint> Sweep(
+            bool invert, int anchor) =>
+            VirtualCrossoverAnalysis.JunctionLossSweep(
+                woofer, sub, SampleRate, 27.5, 110,
+                startDelayMs: -25.0, endDelayMs: 25.0, stepMs: 0.25,
+                invertVariable: invert, anchor);
+
+        // 1: no plateau anywhere in the panel's own sweep. With the two
+        // channels within a few dB of each other in-band, the parallelogram
+        // law |F+V|² + |F−V|² = 2(|F|²+|V|²) forbids both polarities summing
+        // flat at once — at least one must always be losing audibly. The
+        // stationary-window sweep violated this across the whole negative
+        // half, both polarities reading ≈ 0 with the woofer faded out.
+        List<VirtualCrossoverAnalysis.JunctionSweepPoint> normal =
+            Sweep(false, pairFront);
+        List<VirtualCrossoverAnalysis.JunctionSweepPoint> inverted =
+            Sweep(true, pairFront);
+        Assert.Equal(normal.Count, inverted.Count);
+        for (int i = 0; i < normal.Count; i++)
+        {
+            Assert.True(
+                Math.Min(normal[i].LossDb, inverted[i].LossDb) < -1.5,
+                $"both polarities read flat at {normal[i].DelayMs:0.0} ms " +
+                $"({normal[i].LossDb:0.00} / {inverted[i].LossDb:0.00} dB) — " +
+                "the plateau of a window the moved channel left");
+        }
+
+        // 2: Δ = 0 is the pair's current alignment, and the drawn surface
+        // must agree with the read-out's measurement of it exactly — same
+        // anchor rule, same bins, same rotation as the search.
+        (double LossDb, double DipDb)? atRest =
+            VirtualCrossoverAnalysis.MeasureSumLoss(
+                woofer, [sub], SampleRate, 27.5, 110,
+                gateAnchorSample: pairFront);
+        VirtualCrossoverAnalysis.JunctionSweepPoint zero = normal
+            .MinBy(point => Math.Abs(point.DelayMs))!;
+        Assert.NotNull(atRest);
+        Assert.InRange(
+            zero.LossDb, atRest.Value.LossDb - 1e-6, atRest.Value.LossDb + 1e-6);
+        Assert.InRange(
+            zero.DipDb, atRest.Value.DipDb - 1e-6, atRest.Value.DipDb + 1e-6);
+
+        // 3: through one and the same window, rotation equals physical
+        // construction at every probe — the channel actually delayed through
+        // its chain (the probed delay on the woofer; its magnitude on the sub
+        // when negative — only the relative offset matters), measured by
+        // MeasureSumLoss through that window. Anchored at the drivers' shared
+        // source so the window holds every rise at every probe and the
+        // reference is the truth this synthetic makes knowable. Compared as
+        // LINEAR amplitude ratios — the quantity the estimator computes —
+        // because dB magnifies the floor: near a deep null a 0.016 linear
+        // disagreement (the construction's fixed window end truncating the
+        // ringing tail the traveling cut keeps) reads as a whole dB. Measured
+        // worst across ±25 ms, both polarities: 0.011 linear on the loss,
+        // 0.016 on the dip. What remains outside this equality is window
+        // PLACEMENT — the anchor work's business, not the sweep's: the sweep
+        // must read the search's window, wherever that rule puts it.
+        static double Linear(double decibels) => Math.Pow(10.0, decibels / 20.0);
+        foreach (bool invert in new[] { false, true })
+        {
+            foreach (VirtualCrossoverAnalysis.JunctionSweepPoint point in
+                Sweep(invert, BasePosition))
+            {
+                Complex[] variable = VirtualCrossoverAnalysis.ApplyChain(
+                    woofer,
+                    new DspChannelChain(
+                        DelayMs: Math.Max(0.0, point.DelayMs),
+                        InvertPolarity: invert),
+                    SampleRate);
+                Complex[] fixedIr = VirtualCrossoverAnalysis.ApplyChain(
+                    sub,
+                    new DspChannelChain(DelayMs: Math.Max(0.0, -point.DelayMs)),
+                    SampleRate);
+                (double LossDb, double DipDb)? reference =
+                    VirtualCrossoverAnalysis.MeasureSumLoss(
+                        variable, [fixedIr], SampleRate, 27.5, 110,
+                        gateAnchorSample: BasePosition);
+
+                Assert.NotNull(reference);
+                Assert.True(
+                    Math.Abs(
+                        Linear(point.LossDb) - Linear(reference.Value.LossDb))
+                        < 0.025,
+                    $"loss at {point.DelayMs:0.0} ms{(invert ? " inv" : "")}: " +
+                    $"sweep {point.LossDb:0.00} vs constructed " +
+                    $"{reference.Value.LossDb:0.00} dB");
+                Assert.True(
+                    Math.Abs(
+                        Linear(point.DipDb) - Linear(reference.Value.DipDb))
+                        < 0.025,
+                    $"dip at {point.DelayMs:0.0} ms{(invert ? " inv" : "")}: " +
+                    $"sweep {point.DipDb:0.00} vs constructed " +
+                    $"{reference.Value.DipDb:0.00} dB");
+            }
+        }
+    }
+
+    [Fact]
     public void JunctionLossSweep_InvertedPolarityShiftsTheCombByHalfAPeriod()
     {
         // With the variable channel inverted the comb flips: the optimum moves

--- a/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
@@ -194,9 +194,9 @@ public sealed class JunctionCorrelationCurveTests
         // shared source finds exactly that; one opened on the pair's own peaks
         // — its fade-in cutting into both drivers' rise — cannot see a flat sum
         // anywhere. Four placements are put to that record below: the source,
-        // the shipped rule (the pair's CHAIN-FREE fronts, which is what
-        // AutoAlignmentEngine.JunctionGateAnchor reads), the pair's FILTERED
-        // fronts, and the pair's peaks.
+        // the shipped rule (VirtualCrossoverAnalysis.FindGateAnchor over the
+        // pair's filtered fronts), the pair's peaks, and the chain-free fronts
+        // that were measured against the shipped rule and declined.
         Complex[] sub = Filtered(new CrossoverSpec(
             CrossoverKind.LowPass,
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
@@ -225,13 +225,13 @@ public sealed class JunctionCorrelationCurveTests
             $"the peak-anchored window cannot read the flat sum: " +
             $"avg {peakAnchored.LossDb:0.00}, dip {peakAnchored.DipDb:0.00} dB");
 
-        // Reading the pair's own fronts off the FILTERED responses recovers
-        // part of the difference and no more: the lobe is the same, but the
-        // flatness it can read there is still a windowing artifact. What is
-        // left is the crossover's own rise, which begins before the front any
-        // detector can mark on its output — this pair's 36 dB/oct low-pass
-        // reads its filtered front 12.8 ms behind the driver's, and even the
-        // earlier of the two members 8.6 ms behind.
+        // The shipped rule sits between the two, and the lobe is the same
+        // through all three: the anchor decides how honestly the junction's
+        // flatness READS, not which alignment wins. The remaining gap is the
+        // 36 dB/oct low-pass's own rise, which starts before the front the
+        // detector can mark on the filtered response — 12.8 ms before it for
+        // this sub, 8.6 ms for its woofer partner (see the gate remarks in
+        // VirtualCrossoverAnalysis).
         int filteredFront = Math.Min(
             VirtualCrossoverAnalysis.FindGateAnchor(
                 sub, VirtualCrossoverAnalysis.FindPeakIndex(sub),
@@ -244,19 +244,21 @@ public sealed class JunctionCorrelationCurveTests
         Assert.InRange(frontAnchored.DelayMs, -4.5, -2.5);
         Assert.InRange(frontAnchored.LossDb, peakAnchored.LossDb, -0.05);
 
-        // The SHIPPED rule reads those same fronts off the pair's CHAIN-FREE
-        // responses instead — here the bare impulse both drivers were fired
-        // from — and so lands on the source itself and reads the flat sum:
-        // this placement gives back the whole 0.21 dB the window was
-        // inventing. It is what AutoAlignmentEngine.JunctionGateAnchor hands
-        // every probe of a junction; what it is worth on real cabins is the
-        // session battery's business (tests/Resonalyze.App.Tests).
+        // The fourth placement, and the reason the third one is still what the
+        // engine uses. Reading those same fronts off the pair's CHAIN-FREE
+        // responses — here the bare impulse both drivers were fired from —
+        // lands on the source and gives back the whole 0.21 dB the window was
+        // inventing. Tempting, and measured on the archived cabins: it moves
+        // the lowest junction of a cabin away from the owner's own tuning (see
+        // the gate remarks), so the flatness it reads is honest while the
+        // alignment it picks is not better. Pinned here so the option stays
+        // measured rather than re-proposed from the reasoning.
         int chainFreeFront = VirtualCrossoverAnalysis.FindGateAnchor(
             ImpulseAtMs(0), BasePosition, SampleRate, 27.5, 110);
         Assert.InRange(chainFreeFront, BasePosition - 2, BasePosition);
         Assert.True(
             filteredFront - chainFreeFront > Samples(5.0),
-            $"the filtered front sat only " +
+            "the filtered front sat only " +
             $"{(filteredFront - chainFreeFront) * 1000.0 / SampleRate:0.0} ms " +
             "behind the driver's — too little to tell the placements apart");
         AlignmentCandidate chainFreeAnchored = Best(chainFreeFront);

--- a/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
@@ -180,16 +180,19 @@ public sealed class JunctionCorrelationCurveTests
             ImpulseAtMs(0), new DspChannelChain(Crossover: crossover), SampleRate);
 
     [Fact]
-    public void AlignmentCandidates_JudgeTheJunctionThroughTheGivenSystemAnchor()
+    public void AlignmentCandidates_JudgeTheJunctionThroughTheGivenAnchor()
     {
         // A subwoofer and its woofer partner fired from the SAME impulse
         // through the field cabin's edges (55 Hz, 36 dB/oct Butterworth; the
         // woofer's own 180 Hz low-pass is what puts the optimum a couple of
         // milliseconds early). Two filtered copies of one impulse in a silent
         // record CAN sum flat: at the right delay and polarity the junction is
-        // arithmetic, with no room to blame. The system-anchored window finds
-        // exactly that; the pair-anchored one — its fade-in cutting into both
-        // drivers' rise — cannot see a flat sum anywhere.
+        // arithmetic, with no room to blame. A window opened at the drivers'
+        // shared source finds exactly that; one opened on the pair's own peaks
+        // — its fade-in cutting into both drivers' rise — cannot see a flat sum
+        // anywhere. How much of the difference the shipped anchor rule
+        // (VirtualCrossoverAnalysis.FindGateAnchor, the pair's filtered fronts)
+        // recovers is pinned below.
         Complex[] sub = Filtered(new CrossoverSpec(
             CrossoverKind.LowPass,
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
@@ -204,29 +207,47 @@ public sealed class JunctionCorrelationCurveTests
                 priorDelayMs: null, priorSigmaMs: 0, forcedPolarity: null,
                 levelMatch: true, out _, gateAnchorSample: anchor)[0];
 
-        AlignmentCandidate systemAnchored = Best(BasePosition);
+        AlignmentCandidate sourceAnchored = Best(BasePosition);
         Assert.True(
-            systemAnchored.InvertPolarity,
+            sourceAnchored.InvertPolarity,
             "36 dB/oct edges at one corner hand over inverted");
-        Assert.InRange(systemAnchored.DelayMs, -4.5, -2.5);
-        Assert.InRange(systemAnchored.LossDb, -0.02, 0.0);
-        Assert.InRange(systemAnchored.DipDb, -0.05, 0.0);
+        Assert.InRange(sourceAnchored.DelayMs, -4.5, -2.5);
+        Assert.InRange(sourceAnchored.LossDb, -0.02, 0.0);
+        Assert.InRange(sourceAnchored.DipDb, -0.05, 0.0);
 
-        AlignmentCandidate pairAnchored = Best(null);
+        AlignmentCandidate peakAnchored = Best(null);
         Assert.True(
-            pairAnchored.LossDb < -0.10 && pairAnchored.DipDb < -0.3,
-            $"the pair-anchored window cannot read the flat sum: " +
-            $"avg {pairAnchored.LossDb:0.00}, dip {pairAnchored.DipDb:0.00} dB");
+            peakAnchored.LossDb < -0.10 && peakAnchored.DipDb < -0.3,
+            $"the peak-anchored window cannot read the flat sum: " +
+            $"avg {peakAnchored.LossDb:0.00}, dip {peakAnchored.DipDb:0.00} dB");
+
+        // The shipped rule sits between the two, and the lobe is the same
+        // through all three: the anchor decides how honestly the junction's
+        // flatness READS, not which alignment wins. The remaining gap is the
+        // 36 dB/oct low-pass's own rise, which starts ~14 ms before the front
+        // the detector can mark on the filtered response (see the gate remarks
+        // in VirtualCrossoverAnalysis).
+        AlignmentCandidate frontAnchored = Best(Math.Min(
+            VirtualCrossoverAnalysis.FindGateAnchor(
+                sub, VirtualCrossoverAnalysis.FindPeakIndex(sub),
+                SampleRate, 27.5, 110),
+            VirtualCrossoverAnalysis.FindGateAnchor(
+                woofer, VirtualCrossoverAnalysis.FindPeakIndex(woofer),
+                SampleRate, 27.5, 110)));
+        Assert.True(frontAnchored.InvertPolarity);
+        Assert.InRange(frontAnchored.DelayMs, -4.5, -2.5);
+        Assert.InRange(frontAnchored.LossDb, peakAnchored.LossDb, -0.05);
     }
 
     [Fact]
-    public void AlignmentCandidates_PairAnchoredWindowMisreadsTheSameJunction()
+    public void AlignmentCandidates_PeakAnchoredWindowMisreadsTheSameJunction()
     {
-        // The same junction with the anchor left to the pair: the window then
-        // starts inside the drivers' own rise and the surface it measures is
-        // not the one the read-out shows — this is what let a field sub/woofer
-        // junction (55 Hz, 36 dB/oct) be settled a half period out. Pinned so
-        // the two anchors cannot silently converge and hide the distinction.
+        // The same junction with the anchor left to the pair's PEAKS: the
+        // window then starts inside the drivers' own rise, and what it reads
+        // there is a windowing artifact rather than the junction — this is what
+        // let a field sub/woofer junction (55 Hz, 36 dB/oct) be settled a half
+        // period out. Pinned so the placements cannot silently converge and
+        // hide the distinction.
         Complex[] sub = Filtered(new CrossoverSpec(
             CrossoverKind.LowPass,
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
@@ -238,20 +259,21 @@ public sealed class JunctionCorrelationCurveTests
         // The true alignment itself — zero delay, the woofer inverted — read
         // through each window.
         Complex[] inverted = woofer.Select(value => -value).ToArray();
-        (double LossDb, double DipDb)? pairAnchored =
+        (double LossDb, double DipDb)? peakAnchored =
             VirtualCrossoverAnalysis.MeasureSumLoss(
                 inverted, [sub], SampleRate, 27.5, 110, levelMatch: true);
-        (double LossDb, double DipDb)? systemAnchored =
+        (double LossDb, double DipDb)? sourceAnchored =
             VirtualCrossoverAnalysis.MeasureSumLoss(
                 inverted, [sub], SampleRate, 27.5, 110, levelMatch: true,
                 gateAnchorSample: BasePosition);
 
-        Assert.NotNull(pairAnchored);
-        Assert.NotNull(systemAnchored);
+        Assert.NotNull(peakAnchored);
+        Assert.NotNull(sourceAnchored);
         Assert.True(
-            systemAnchored.Value.LossDb > pairAnchored.Value.LossDb + 0.05,
-            $"the system-anchored window must read the truth more honestly: " +
-            $"{systemAnchored.Value.LossDb:0.00} vs {pairAnchored.Value.LossDb:0.00} dB");
+            sourceAnchored.Value.LossDb > peakAnchored.Value.LossDb + 0.05,
+            $"a window opened ahead of both rises must read the truth more " +
+            $"honestly: {sourceAnchored.Value.LossDb:0.00} vs " +
+            $"{peakAnchored.Value.LossDb:0.00} dB");
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/JunctionGateAnchorTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/JunctionGateAnchorTests.cs
@@ -155,4 +155,28 @@ public sealed class JunctionGateAnchorTests
                 new Complex[IrLength], peakIndex: 7, SampleRate,
                 bandLowHz: 1_000, bandHighHz: 4_000));
     }
+
+    [Fact]
+    public void SumLoss_FindsACancellationNotchBetweenTheOldBins()
+    {
+        // Two equal arrivals 12.2 ms apart cancel completely at 41 Hz (and at
+        // every odd multiple), which a 33-130 Hz junction band must report as
+        // a deep dip. Padded only to the 85 ms gate, the bins sat 11.7 Hz
+        // apart at 96 kHz — 35.2, 46.9, 58.6 Hz — and this notch fell straight
+        // between two of them, so the dip read a fraction of its depth. The
+        // measurement is the same; only how densely it is sampled changed.
+        const int Rate = 96_000;
+        var first = new Complex[65_536];
+        var second = new Complex[65_536];
+        first[16_384] = 1.0;
+        second[16_384 + (int)Math.Round(0.0122 * Rate)] = 1.0;
+
+        (double LossDb, double DipDb)? loss = VirtualCrossoverAnalysis.MeasureSumLoss(
+            second, [first], Rate, 33, 130);
+
+        Assert.NotNull(loss);
+        Assert.True(
+            loss.Value.DipDb < -20.0,
+            $"the 41 Hz cancellation read only {loss.Value.DipDb:0.0} dB deep");
+    }
 }

--- a/tests/Resonalyze.Dsp.Tests/JunctionGateAnchorTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/JunctionGateAnchorTests.cs
@@ -1,0 +1,158 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// Where a junction measurement opens its direct-sound window
+/// (<see cref="VirtualCrossoverAnalysis.FindGateAnchor"/>). The rule it
+/// replaced — the earliest PEAK of the channels in play — answers "where is
+/// this loudest", which a crossover's group delay and a strong late feature
+/// both move away from the front the window has to hold; these pin that the
+/// front is what the anchor now reads, and that neither guard around it lets
+/// the answer land later than the peak it replaces.
+/// </summary>
+public sealed class JunctionGateAnchorTests
+{
+    private const int SampleRate = 48_000;
+    private const int IrLength = 16_384;
+    private const int FrontSample = 2_048;
+
+    // The alignment gate's fade at 48 kHz (see the gate remarks in
+    // VirtualCrossoverAnalysis): the window's plateau starts this far behind
+    // its anchor, so content before that point is what a placement discards.
+    private const int GateFadeSamples = 256;
+
+    private static int Samples(double milliseconds) =>
+        (int)Math.Round(milliseconds / 1000.0 * SampleRate);
+
+    private static Complex[] Taps(params (double OffsetMs, double Amplitude)[] taps)
+    {
+        var ir = new Complex[IrLength];
+        foreach ((double offsetMs, double amplitude) in taps)
+        {
+            ir[FrontSample + Samples(offsetMs)] += amplitude;
+        }
+
+        return ir;
+    }
+
+    private static Complex[] Filtered(CrossoverSpec crossover) =>
+        VirtualCrossoverAnalysis.ApplyChain(
+            Taps((0, 1.0)),
+            new DspChannelChain(Crossover: crossover),
+            SampleRate);
+
+    // The share of a response's energy that falls AHEAD of a placement's
+    // plateau (dB against its total): what that window throws away of the very
+    // channel it is measuring.
+    private static double EnergyAheadOfPlateauDb(Complex[] impulseResponse, int anchor)
+    {
+        double ahead = 0;
+        double total = 0;
+        for (int i = 0; i < impulseResponse.Length; i++)
+        {
+            double energy = impulseResponse[i].Real * impulseResponse[i].Real;
+            total += energy;
+            if (i < anchor - GateFadeSamples)
+            {
+                ahead += energy;
+            }
+        }
+
+        return 10 * Math.Log10(Math.Max(ahead / total, 1e-15));
+    }
+
+    [Fact]
+    public void Anchor_MarksTheFront_WhereThePeakIsALaterFeature()
+    {
+        // A direct front with a stronger reflection 6 ms behind it — the shape
+        // of every channel whose peak is not its arrival, whether the delay
+        // comes from a cabin boundary or from the channel's own crossover.
+        Complex[] ir = Taps((0, 1.0), (6.0, 2.0));
+        int peak = VirtualCrossoverAnalysis.FindPeakIndex(ir);
+        Assert.Equal(FrontSample + Samples(6.0), peak);
+
+        int anchor = VirtualCrossoverAnalysis.FindGateAnchor(
+            ir, peak, SampleRate, bandLowHz: 1_000, bandHighHz: 4_000);
+
+        // The front, to a hundredth of a millisecond — six milliseconds ahead
+        // of the peak the old rule would have anchored on.
+        Assert.InRange(
+            (anchor - FrontSample) * 1000.0 / SampleRate, -0.10, 0.10);
+        // And that is what it buys: anchored on the peak this window opens
+        // past the front and discards a fifth of the channel's own energy
+        // (-7 dB against what it keeps); anchored on the front it discards
+        // none of it.
+        Assert.InRange(EnergyAheadOfPlateauDb(ir, peak), -8.0, -6.0);
+        Assert.True(
+            EnergyAheadOfPlateauDb(ir, anchor) < -100.0,
+            "the front-anchored window discarded part of the response");
+    }
+
+    [Fact]
+    public void Anchor_OnAChannelWhosePeakIsItsFront_StaysWhereThePeakIs()
+    {
+        // The other half of the claim: this is not a blanket shift. A clean
+        // band-passed arrival peaks at its own front, and the anchor agrees
+        // with the peak rule to a fraction of a millisecond.
+        Complex[] midrange = Filtered(new CrossoverSpec(
+            CrossoverKind.BandPass,
+            new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 2_000, 24),
+            new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 250, 24)));
+        int peak = VirtualCrossoverAnalysis.FindPeakIndex(midrange);
+
+        int anchor = VirtualCrossoverAnalysis.FindGateAnchor(
+            midrange, peak, SampleRate, bandLowHz: 1_000, bandHighHz: 4_000);
+
+        Assert.InRange((peak - anchor) * 1000.0 / SampleRate, 0.0, 0.1);
+    }
+
+    [Fact]
+    public void Anchor_IsNeverLaterThanThePeak()
+    {
+        // A tweeter read in a band it only leaks residue into: the envelope
+        // there fronts 0.4 ms BEHIND the channel's peak. A window opening
+        // after the peak is exactly what this whole placement exists to
+        // prevent — at a low junction the same late read is what a room mode
+        // produces — so the peak caps the answer.
+        Complex[] tweeter = Filtered(new CrossoverSpec(
+            CrossoverKind.HighPass,
+            HighPassEdge: new CrossoverEdge(
+                CrossoverFilterFamily.LinkwitzRiley, 2_000, 48)));
+        int peak = VirtualCrossoverAnalysis.FindPeakIndex(tweeter);
+        double lateArrivalMs = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+            tweeter, SampleRate, 32.5, 130);
+        Assert.True(
+            lateArrivalMs > peak * 1000.0 / SampleRate,
+            $"the arrival ({lateArrivalMs:0.00} ms) was expected behind the peak");
+
+        Assert.Equal(
+            peak,
+            VirtualCrossoverAnalysis.FindGateAnchor(
+                tweeter, peak, SampleRate, bandLowHz: 32.5, bandHighHz: 130));
+    }
+
+    [Fact]
+    public void Anchor_WithoutAMeasurableArrival_FallsBackToThePeak()
+    {
+        Complex[] tweeter = Filtered(new CrossoverSpec(
+            CrossoverKind.HighPass,
+            HighPassEdge: new CrossoverEdge(
+                CrossoverFilterFamily.LinkwitzRiley, 2_000, 48)));
+        int peak = VirtualCrossoverAnalysis.FindPeakIndex(tweeter);
+
+        // A band narrower than MinimumArrivalBandRatio is refused by the
+        // detector rather than silently widened, and silence carries no
+        // arrival at all. Both fall back to the peak — the rule this
+        // replaced — instead of anchoring on a fabricated front.
+        Assert.Equal(
+            peak,
+            VirtualCrossoverAnalysis.FindGateAnchor(
+                tweeter, peak, SampleRate, bandLowHz: 1_000, bandHighHz: 1_050));
+        Assert.Equal(
+            7,
+            VirtualCrossoverAnalysis.FindGateAnchor(
+                new Complex[IrLength], peakIndex: 7, SampleRate,
+                bandLowHz: 1_000, bandHighHz: 4_000));
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -854,17 +854,27 @@ public sealed class StereoAlignmentTests
         // The field failure this pins (an 80 Hz sub junction): both woofers
         // carry a strong inverted narrowband build-up in the junction band's
         // UPPER half, half a period behind their direct front. Through the
-        // full-band mean the sub then "gains" by flipping onto that build-up
+        // full-band mean the sub then "gains" by moving onto that build-up
         // (a comb impostor the margin gate cannot refuse), while the clean
         // LOWER half — direct sound only — plainly loses. The sub-band
         // consistency veto is the cross-check narrow-band ranging disciplines
         // converge on: a true lobe holds every half of the band, an impostor
         // wins one half and loses the other.
+        //
+        // The build-up has to be genuinely strong (-6 dB) to fool the mean.
+        // At -10 dB it once did, but only through a window that moved with
+        // the probe: the grid's anchor was the earliest peak of the whole
+        // field, which the probed sub itself set, so a cell that carried the
+        // sub earlier also carried the window earlier and won ~0.5 dB of that
+        // move rather than of the summation. With the window held for the
+        // whole grid (see JunctionGateAnchor) the same impostor gains 0.02 dB
+        // and is refused by the hop margin long before the veto — the guard
+        // this test exists for needs a build-up that wins on merit.
         Complex[] WooferIr()
         {
             Complex[] ir = ImpulseAtMs(8.0);
             Complex[] mode = VirtualCrossoverAnalysis.ApplyChain(
-                ImpulseAtMs(8.0 + 6.25, -10.0),
+                ImpulseAtMs(8.0 + 6.25, -6.0),
                 new DspChannelChain(Crossover: new CrossoverSpec(
                     CrossoverKind.BandPass,
                     new CrossoverEdge(CrossoverFilterFamily.Butterworth, 150, 36),

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -715,22 +715,21 @@ public sealed class StereoAlignmentTests
     {
         // The engine's cost unit is one reprocess: every channel's full DSP
         // chain re-run. The junction walks legitimately spend a couple per
-        // channel; the PAIR co-move must spend ONE per linked pair (its delta
-        // scan is an analytic spectrum rotation, not a re-render — the old
-        // implementation burned ~40 per pair). The MONO co-move is the
-        // deliberate exception: at its multi-millisecond deltas the rotation
-        // probe's fixed gate anchoring misgrades candidates by whole dB, so
-        // each of its ~30-60 probes honestly re-renders the one mono channel
-        // (every other channel is a cache hit). The ceiling still breaks
-        // loudly if per-delta re-rendering creeps into the pair co-move or
-        // the walks.
+        // channel; BOTH co-moves spend ONE per pass — their delta scans are
+        // spectrum rotations through per-channel windowed cuts, never
+        // re-renders. (The mono co-move once re-rendered every one of its
+        // ~30-60 probes, on the belief that rotation through a fixed shared
+        // gate misgrades multi-millisecond deltas — true of that gate, and
+        // repealed with it: the windows travel with the channels now, so the
+        // rotation IS the honest read.) The ceiling breaks loudly if
+        // per-delta re-rendering creeps back into any of them.
         int[] count = [0];
         RunStereo(
             sceneOffsetMs: 0.25,
             linkBands: UserLinkBands,
             reprocessCount: count);
 
-        Assert.InRange(count[0], 1, 110);
+        Assert.InRange(count[0], 1, 40);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -262,6 +262,49 @@ public sealed class TransferIrDiagnosticsTests
         Assert.Null(TransferIrDiagnostics.DetectCrosstalkHead(impulseResponse, SampleRate));
     }
 
+    [Fact]
+    public void EstimateIrStart_DelayPrefixDoesNotInflateTheSnr()
+    {
+        // The same review catch already pinned for the broadband onset and
+        // the band-limited arrival, now for the IR-start estimator behind
+        // every Auto gate placement: a chain DELAY manufactures a silent
+        // prefix that sinks the noise-floor estimate, and a noise record the
+        // 20 dB SNR gate rightly refuses comes back "credible" with a start
+        // in the middle of the noise (measured here: refused raw, 22.5 ms
+        // through the blind read). The valid range restricts the analysis to
+        // the measured content while every reported time stays in the full
+        // record's coordinates.
+        var random = new Random(20_260_724);
+        var raw = new Complex[4_096];
+        for (int i = 0; i < raw.Length; i++)
+        {
+            raw[i] = new Complex(random.NextDouble() * 2.0 - 1.0, 0.0);
+        }
+        Complex[] processed = VirtualCrossoverAnalysis.ApplyChain(
+            raw, new DspChannelChain(DelayMs: 25), 48_000,
+            out ValidSampleRange validRange);
+
+        Assert.Null(TransferIrDiagnostics.EstimateIrStart(raw, 48_000));
+        Assert.NotNull(TransferIrDiagnostics.EstimateIrStart(processed, 48_000));
+        Assert.Null(TransferIrDiagnostics.EstimateIrStart(
+            processed, 48_000, validRange));
+
+        // And a genuine front survives the guard with its position read in
+        // the FULL record's frame: the raw start plus the 25 ms delay.
+        var front = new Complex[8_192];
+        front[480] = Complex.One;
+        Complex[] frontDelayed = VirtualCrossoverAnalysis.ApplyChain(
+            front, new DspChannelChain(DelayMs: 25), 48_000,
+            out ValidSampleRange frontRange);
+        IrStartEstimate? plain =
+            TransferIrDiagnostics.EstimateIrStart(front, 48_000);
+        IrStartEstimate? guarded = TransferIrDiagnostics.EstimateIrStart(
+            frontDelayed, 48_000, frontRange);
+        Assert.NotNull(plain);
+        Assert.NotNull(guarded);
+        Assert.Equal(plain.Value.StartMs + 25.0, guarded.Value.StartMs, 2);
+    }
+
     [Theory]
     [InlineData(0.09)]
     [InlineData(0.15)]

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -1186,12 +1186,16 @@ public sealed class VirtualCrossoverAnalysisTests
     [Fact]
     public void MeasureBandLevelDb_BandWithoutBinsReturnsNull()
     {
-        // 23 990 - 23 999 Hz at 48 kHz falls between the last usable FFT bin
-        // and Nyquist: no bins, no level.
+        // A band above the last usable FFT bin and below Nyquist holds no
+        // bins, so there is no level to report. The gap is one bin wide, and
+        // the analysis grid is 2.93 Hz at 48 kHz (the gate padded by
+        // AlignmentFftInterpolationFactor), which puts the last bin at
+        // 23 997.1 Hz — so the band has to start above that, not merely
+        // near Nyquist.
         Complex[] ir = UnitImpulse(8_192, 480);
 
         Assert.Null(VirtualCrossoverAnalysis.MeasureBandLevelDb(
-            ir, SampleRate, 23_990, 23_999));
+            ir, SampleRate, 23_999, 23_999.9));
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -1046,46 +1046,58 @@ public sealed class VirtualCrossoverAnalysisTests
     [Fact]
     public void FindAlignmentCandidates_DipExcessOutranksASlightlyBetterAverage()
     {
-        // An asymmetric junction (LR 12 dB high-pass vs Butterworth 48 dB
-        // low-pass) with an in-band reflection on the woofer. The raw-average
-        // optimum is an inverted lobe whose good average hides a deep smoothed
-        // notch; a neighbouring non-inverted lobe averages slightly worse but
-        // stays much flatter. Ranked by average alone the notched impostor
-        // would reach the selection tie-breaks as the winner; the dip-excess
-        // penalty must put the flat lobe first.
-        var tweeterIr = new Complex[8_192];
-        tweeterIr[480] = Complex.One;
-        Complex[] tweeter = VirtualCrossoverAnalysis.ApplyChain(
-            tweeterIr,
+        // A bass junction whose woofer carries a strong inverted narrowband
+        // build-up behind its direct front (the modal shape of the archived
+        // 80 Hz failure). The lobe that stays on the DIRECT sound averages
+        // better across the band, but the un-cancelled build-up leaves it a
+        // deeper 1/6-octave notch; the lobe that follows the build-up
+        // averages slightly worse and notches less. Ranked by average alone
+        // the direct lobe wins; the dip-excess penalty must outrank the
+        // difference. (WHICH lobe deserves to win the junction is not this
+        // test's question — that is the mono co-move's sub-band veto — this
+        // pins only that the score orders by dip excess, not by average.)
+        //
+        // An earlier construction (an asymmetric LR12/BW48 pair with an
+        // in-band reflection) lost its meaning with per-channel windows: the
+        // "notch" its impostor carried was the shared peak-anchored window
+        // cutting the woofer's group-delayed content, and with each channel
+        // windowed at its own front the same candidate reads genuinely flat
+        // and wins on merit.
+        Complex[] woofer = ImpulseAt(8.0);
+        Complex[] mode = VirtualCrossoverAnalysis.ApplyChain(
+            ImpulseAt(8.0 + 6.25, -6.0),
             new DspChannelChain(Crossover: new CrossoverSpec(
-                CrossoverKind.HighPass,
-                HighPassEdge: new CrossoverEdge(
-                    CrossoverFilterFamily.LinkwitzRiley, 1_000, 12))),
+                CrossoverKind.BandPass,
+                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 150, 36),
+                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 100, 36))),
             SampleRate);
-
-        var wooferIr = new Complex[8_192];
-        wooferIr[480] = Complex.One;
-        wooferIr[480 + 96] = new Complex(0.7, 0); // reflection 2 ms after the arrival
-        Complex[] woofer = VirtualCrossoverAnalysis.ApplyChain(
-            wooferIr,
-            new DspChannelChain(Crossover: new CrossoverSpec(
-                CrossoverKind.LowPass,
-                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 1_000, 48))),
-            SampleRate);
+        for (int i = 0; i < woofer.Length; i++)
+        {
+            woofer[i] += mode[i];
+        }
+        Complex[] sub = ImpulseAt(8.0);
 
         IReadOnlyList<AlignmentCandidate> candidates =
             VirtualCrossoverAnalysis.FindAlignmentCandidates(
-                tweeter, [woofer], SampleRate, 500, 2_000, -3, 3);
+                sub, [woofer], SampleRate, 40, 160, -9, 9,
+                priorDelayMs: null, priorSigmaMs: 0, forcedPolarity: null,
+                levelMatch: true, out _);
 
         AlignmentCandidate winner = candidates[0];
         AlignmentCandidate notched = candidates.Single(item =>
-            item.InvertPolarity && Math.Abs(item.DelayMs - 0.73) < 0.15);
-        Assert.False(winner.InvertPolarity);
-        Assert.InRange(winner.DelayMs, 1.1, 1.4);
-        // The impostor averages better yet notches deeper — and loses.
+            !item.InvertPolarity && Math.Abs(item.DelayMs + 1.0) < 0.5);
+        Assert.True(winner.InvertPolarity);
+        // The direct lobe averages better yet notches deeper — and loses.
         Assert.True(notched.LossDb > winner.LossDb);
         Assert.True(notched.DipDb < winner.DipDb);
         Assert.True(notched.ScoreDb < winner.ScoreDb);
+    }
+
+    private static Complex[] ImpulseAt(double offsetMs, double amplitude = 1.0)
+    {
+        var ir = new Complex[16_384];
+        ir[480 + (int)Math.Round(offsetMs / 1000.0 * SampleRate)] = amplitude;
+        return ir;
     }
 
     [Fact]


### PR DESCRIPTION
A rework of how the Auto delay engine windows, probes and judges a junction, plus the correlation view that came out of it. Twenty-two commits, each measured on the archived cabins before landing; the judge throughout is the new session battery (the panel's own summation metric, proposal vs the owner's saved tune, all cabins).

## What changed, in dependency order

**Junction gate anchor** (5e21bbd, c01baf4). The direct-sound gate used to anchor on the earliest peak across *every* enabled channel — a pair's score depended on channels that were not in it (muting the Passat mid+tweeter moved the 65 Hz junction's optimum by 14 ms). The anchor moved to the pair's own fronts, and the analysed spectrum got 4× zero-padding so a 33–130 Hz band holds 34 bins instead of 9 (the "dip" of every bass junction used to be its worst single bin).

**Session battery** (9e7bb90, 42dce83, 09ce00c, ba6b206). A skip-unless-configured runner in `Resonalyze.App.Tests` that loads each archived session exactly as the tool does, computes the Auto delay proposal, and judges both the proposal and the saved tune by the panel metric. `RESONALYZE_SESSION_BATTERY` points at the cabins; `…_AUTOGATE=1` judges both settings at the gate dialog's Auto placement (a pinned gate is one absolute window and does not follow a proposal that moves a channel — judging through it scores the window, not the alignment). CI never runs it: the field measurements are not in the repo.

**Chain-free anchor: measured and declined** (ab57050 reverted by d364ec4). Reading the anchor off the bypassed response closes the last 0.2 dB of window-invented loss on a synthetic, but on the reference car it moves the proposal *away* from the owner's tune on both witnesses. The measurement is kept in the gate remarks and pinned in `JunctionCorrelationCurveTests` so the option stays measured rather than re-proposed.

**Rotation instead of re-gating** (ceb25b3). The correlation view's score sweep physically delayed the channel per probe and re-gated it through a stationary window; past a few ms the moved channel slid into the fade and both polarity curves converged to a fake ~0 dB plateau (in-band level skew grew 3→19 dB across the sweep). The sweep now cuts both channels once and rotates the spectrum — the same bins as `SumLossEvaluator`, so the drawn surface *is* the search's surface, and Δ=0 reproduces `MeasureSumLoss` exactly. Two FFTs total instead of IFFT+2FFT per point.

**Band-sized traveling windows** (4197c08) — the core change. A junction's window now spans ~8.66 periods of its band's low edge instead of a fixed 85 ms (262 ms for a 33–130 Hz sub band, whose dip used to read the window's kernel; 11.5 ms for a 750–3000 Hz mid/tweeter band, whose 85 ms used to be mostly cabin reflections), and every response is windowed at its *own* band-limited front, the cuts meeting in one absolute-time frame. The two land together because they only work together: a short HF window cannot hold a neighbor carrying 46 ms of assigned delay (per-channel windows dissolve the spread), and per-channel placement under the old fixed fade cut more of a crossover's rise than the shared window did. The mono co-move's ~40 per-probe re-renders — which existed to keep a moved channel honest against a stationary window — collapse to one render plus rotation, and its sub-band veto gains the incumbent as a second reference. Several tests were recalibrated because their *subject* moved: the window-placement contrast tests pin the convergence the long window produces, and the old DipExcess impostor turned out to be the shared peak-anchored window cutting group-delayed content — read honestly, that candidate is genuinely flat.

**Direct-coherence witness + "PHAT direct" curve** (3068675, d8642eb). Found by the owner on the new correlation view: on a thin-overlap junction (corners split 1500/1700 Hz at 48 dB/oct → half an octave of usable overlap) the summation score ties a lobe with its polarity partner within 0.04 dB, while the whitened correlation of the pair's *direct sound* separates them (r 0.89 vs 0.81 — the owner's hand-preferred lobe wins). `CutDirectSound` (front−T/2 … front+2.5T, cosine fades) is one implementation shared by the view's new curve and the engine's witness, so the curve the user checks is the figure the engine weighed. The witness arbitrates only a tie (≤0.3 dB), needs r ≥ 0.6 and an advantage ≥ 0.05, and stands down below 120 Hz and under any stronger lock. The raw amplitude-weighted correlation curve retired from the view — it answered nothing the other four curves don't, and was the misleading one.

## Landed during review

**`ValidSampleRange` through every front detector** (8776519, c8c199d, a55f21b, c39762a — review rounds 1–4). A chain delay's silent prefix used to sink a record's noise-floor estimate enough to "certify" pure noise as a front (SNR 6→26 dB, fake start at ~22.5 ms). The channels' valid ranges now reach every front detection — the engine's reads, the correlation view (shifted into its crop frame, with `ProcessedChannel` carrying the coordinator's range), `EstimateIrStart` and the shared display anchor, the per-curve phase gates and the gate-placement judge — and `TransferIrStartCache` keys its memo on the range. The same rounds gave `JunctionLossSweep` an explicit `gateAnchorSample` pass-through and `levelMatch` parity with the search. Pinned at estimator, anchor and view level; battery bit-identical throughout.

**Conviction dead-zone arbitration** (ada2576). The predictor may not convict a modal latch below 2.0 allowances, but at a bass junction the allowance is ~half the crossover period — conviction sits at a full period, exactly where a latch lands, and a read 1–2 allowances late used to withdraw the pair silently (the archived Passat v2 sub: 26.8 ms measured vs 13.6 predicted, 1.7 allowances; the junction anchored a period late). The whitened comb of the pair now arbitrates the zone: its strongest lobe within half a period of the prediction-implied lag must beat the measured-implied family by a real margin (r ≥ 0.6, advantage ≥ 0.05) to convict; a tie stands down and withdraws the pair as before (the fleet's two dead-zone pairs tie at 0.91/0.91 and 0.95/0.95 — honest stand-downs). On the Passat the arbitrated run lands on the owner's hand tune (B 5.49 ms with the pair inverted, −0.19 dB against the old proposal's −0.83); that cabin joined the battery's default set (c5c3f2f). Pinned both ways on a synthetic 55 Hz pair.

**Time-sized Auto crop** (0d8b7cc — review round 5). The shared search crop was a fixed 65 536 samples, tuned for the old 4096-sample gate; the band-sized windows ask for up to 350 ms of *time*, which a 384 kHz crop (170.7 ms) cannot hold. `AlignmentReprocessor` now sizes the crop from the inputs' rate — after the 1/8 pre-peak reserve it must hold the 350 ms gate clamp plus 175 ms of arrival/delay spread, doubling the base until that fits — through a production constructor the panel, the view and the battery all use. 44.1–96 kHz keep exactly 65 536 (battery ROW-identical). The correlation view's arrival marker also reads within the valid ranges now (260618e), closing the last blind front read the review found.

## Deviations from previous behavior

- Every junction measurement (search, co-moves, veto cells, drawn sweep) reads per-channel band-sized traveling windows; the shared-anchor read survives only behind an explicit `gateAnchorSample` for displays and tests. `AutoAlignmentEngine.JunctionGateAnchor` is gone.
- Auto delay proposals change on real cabins — that is the point. Battery, Auto-gated, proposal vs saved tune: mean per junction **+0.080 → +0.138 dB** (measured from the branch's front-anchor state; the pre-branch engine was not battery-measured — the battery itself is part of this branch); the reference car (v5_exp, the owner's post-audition re-tune) sits at tie level (−0.008 dB), with the one remaining disagreement (sub↔stack) halved to 0.52 ms. Largest single move: v3's sub junction −0.054 → +0.322. Known small regression: v4 mid/tweeter +0.101 → −0.015.
- A full cascade costs ~8–9 s per cabin against ~4–5 before (LF windows quadruple their FFT lengths).
- The mono co-move no longer re-renders per probe; the reprocess-budget test ceiling tightened 110 → 40.
- The correlation view: +"PHAT direct", −raw correlation; the score curves are now exactly the search's surface.

## Tests

Dsp 1102, App 1043 (+7 hardware-skipped), Audio 142 — all green locally; App/Audio suites execute on the Windows CI. New suites: `JunctionGateAnchorTests`, `DirectCoherenceTests`, the four-placement and plateau pins in `JunctionCorrelationCurveTests`, the battery runner; from the review rounds, the range-guarded estimator/anchor/view pins, the dead-zone arbitration pair and the crop-sizing pins in `AlignmentReprocessorTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
