### PR TITLE
Keep the configured sample rate when the ASIO probe says nothing (#92)

### DIFF
--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -2123,6 +2123,17 @@ namespace Resonalyze.Options
             {
                 RefreshSweepBandPreview();
             }
+
+            // The status line pairs a number taken from the selection with a verdict
+            // taken from the probe, so it can only be written once the selection has
+            // settled. RefreshAsioDriverInfo writes it before this method has filled the
+            // combo, when GetSelectedSampleRate still answers with its own fallback —
+            // which is how "96000" in the list came to sit above "44100 Hz supported"
+            // in green. Writing it again here is what keeps the two halves in step.
+            if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.Asio)
+            {
+                UpdateAsioStatusLabels();
+            }
         }
 
         private IReadOnlyList<int> GetSupportedSampleRates()

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -43,6 +43,10 @@ namespace Resonalyze.Options
         private IReadOnlyList<AudioEndpointDescriptor> wasapiRenderEndpoints = Array.Empty<AudioEndpointDescriptor>();
         private IReadOnlyList<AsioDeviceInfo> asioDrivers = Array.Empty<AsioDeviceInfo>();
         private AsioDriverInfo asioDriverInfo = AsioDeviceCatalog.EmptyDriverInfo;
+        // What the last rate probe amounted to, so the status line can say which of the
+        // three situations it is in rather than pronouncing on a rate it did not test.
+        private bool sampleRateProbeFailed;
+        private int? sampleRateFellBackFrom;
         private bool initializing;
         private string? microphoneCalibration0DegreesPath;
         private List<MicrophoneCalibrationDefinition> additionalMicrophoneCalibrations = [];
@@ -1499,12 +1503,30 @@ namespace Resonalyze.Options
             }
 
             int sampleRate = GetSelectedSampleRate();
-            labelAsioSampleRateStatus.Text = asioDriverInfo.SupportsSampleRate
-                ? $"{sampleRate} Hz supported"
-                : $"{sampleRate} Hz not supported";
-            labelAsioSampleRateStatus.ForeColor = asioDriverInfo.SupportsSampleRate
-                ? Color.LightGreen
-                : Color.LightSalmon;
+            if (sampleRateProbeFailed)
+            {
+                // The number is the live selection and the verdict came from the last
+                // probe; when that probe told us nothing the two must not be combined
+                // into a confident sentence about a rate nobody tested.
+                labelAsioSampleRateStatus.Text =
+                    $"{sampleRate} Hz kept — the driver did not report its rates";
+                labelAsioSampleRateStatus.ForeColor = Color.Khaki;
+            }
+            else if (sampleRateFellBackFrom is int previous)
+            {
+                labelAsioSampleRateStatus.Text =
+                    $"{previous} Hz is not offered by this driver — changed to {sampleRate} Hz";
+                labelAsioSampleRateStatus.ForeColor = Color.LightSalmon;
+            }
+            else
+            {
+                labelAsioSampleRateStatus.Text = asioDriverInfo.SupportsSampleRate
+                    ? $"{sampleRate} Hz supported"
+                    : $"{sampleRate} Hz not supported";
+                labelAsioSampleRateStatus.ForeColor = asioDriverInfo.SupportsSampleRate
+                    ? Color.LightGreen
+                    : Color.LightSalmon;
+            }
             labelAsioPlaybackLatencyValue.Text =
                 asioDriverInfo.PlaybackLatency > 0
                     ? $"{asioDriverInfo.PlaybackLatency} samples"
@@ -2063,15 +2085,23 @@ namespace Resonalyze.Options
 
         private void RefreshSampleRateOptions(int preferredSampleRate)
         {
-            int fallbackSampleRate = 44_100;
-            IReadOnlyList<int> supportedRates = GetSupportedSampleRates();
-            int[] availableRates = supportedRates.Count > 0
-                ? supportedRates.ToArray()
-                : [fallbackSampleRate];
+            SampleRateResolution resolution = SampleRateOptions.Resolve(
+                GetSupportedSampleRates(),
+                preferredSampleRate,
+                comboBoxSampleRate.Items.Count > 0);
+            sampleRateProbeFailed = resolution.ProbeFailed;
+            sampleRateFellBackFrom = resolution.FellBackFrom;
+            if (resolution.ProbeFailed)
+            {
+                // Nothing is rebuilt on the absence of an answer: the list and the
+                // user's selection stand, and the status line says the driver did not
+                // report. Rebuilding here is what used to replace a working 96 kHz with
+                // 44.1 and persist it on the next Apply.
+                return;
+            }
 
-            int selectedSampleRate = availableRates.Contains(preferredSampleRate)
-                ? preferredSampleRate
-                : availableRates[0];
+            int[] availableRates = resolution.Rates;
+            int selectedSampleRate = resolution.Selected;
 
             bool wasInitializing = initializing;
             initializing = true;

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -1255,6 +1255,14 @@ namespace Resonalyze.Options
                 return;
             }
 
+            // The user picked this rate, so nothing was taken away from them: the
+            // marker left by an earlier automatic fallback describes an action that is
+            // now over, and UpdateAsioStatusLabels would otherwise keep reporting
+            // "96000 Hz is not offered — changed to 48000 Hz" about a rate the user
+            // chose. The probe verdict is left alone; it is still the last thing the
+            // driver actually said.
+            sampleRateFellBackFrom = null;
+
             // The achieved band and its cycle-quantized duration depend on the
             // sample rate, so re-preview on any change (not just for ASIO). The
             // rate itself belongs to the audio backend group and is not applied
@@ -1897,7 +1905,16 @@ namespace Resonalyze.Options
         private void ValidateSelectedWaveSampleRate(int sampleRate)
         {
             IReadOnlyList<int> supportedRates = GetSupportedSampleRates();
-            if (supportedRates.Count > 0 && !supportedRates.Contains(sampleRate))
+            // Empty is an answer here, never silence: a Wave pair reports no rate in
+            // common only when there is none. Skipping validation on it let the rate
+            // sitting in the combo through to a device that cannot open it.
+            if (supportedRates.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    "Wave devices report no sample rate in common for the current " +
+                    "configuration. Change the devices, the channel counts or the bit depth.");
+            }
+            if (!supportedRates.Contains(sampleRate))
             {
                 throw new InvalidOperationException(
                     $"Wave devices do not support {sampleRate} Hz for the current configuration.");
@@ -2092,7 +2109,7 @@ namespace Resonalyze.Options
                 IsAsioSampleRateProbeFailure());
             sampleRateProbeFailed = resolution.ProbeFailed;
             sampleRateFellBackFrom = resolution.FellBackFrom;
-            if (resolution.Rates.Length == 0)
+            if (resolution.Rates is null)
             {
                 // Nothing is rebuilt on the absence of an answer: the list and the
                 // user's selection stand, and the status line says the driver did not
@@ -2113,6 +2130,9 @@ namespace Resonalyze.Options
 
             int[] availableRates = resolution.Rates;
             int selectedSampleRate = resolution.Selected;
+            // An empty list is a real outcome, not a missing one: no rate works for this
+            // configuration, so the combo offers nothing and Apply refuses. Filling in the
+            // configured rate here is what used to hand the user a rate no device reported.
 
             bool wasInitializing = initializing;
             initializing = true;

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -2088,15 +2088,26 @@ namespace Resonalyze.Options
             SampleRateResolution resolution = SampleRateOptions.Resolve(
                 GetSupportedSampleRates(),
                 preferredSampleRate,
-                comboBoxSampleRate.Items.Count > 0);
+                comboBoxSampleRate.Items.Count > 0,
+                IsAsioSampleRateProbeFailure());
             sampleRateProbeFailed = resolution.ProbeFailed;
             sampleRateFellBackFrom = resolution.FellBackFrom;
-            if (resolution.ProbeFailed)
+            if (resolution.Rates.Length == 0)
             {
                 // Nothing is rebuilt on the absence of an answer: the list and the
                 // user's selection stand, and the status line says the driver did not
                 // report. Rebuilding here is what used to replace a working 96 kHz with
                 // 44.1 and persist it on the next Apply.
+                //
+                // The flags above have just changed, and the last thing to write the
+                // status line was RefreshAsioDriverInfo, before Resolve ran — so it is
+                // still rendered from the previous state and would keep a stale
+                // supported/not-supported sentence. Write it here too, exactly as the
+                // settled path below does.
+                if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.Asio)
+                {
+                    UpdateAsioStatusLabels();
+                }
                 return;
             }
 
@@ -2135,6 +2146,14 @@ namespace Resonalyze.Options
                 UpdateAsioStatusLabels();
             }
         }
+
+        // The driver name is what decides whether there is anything to preserve, the
+        // same test RefreshAsioDriverInfo uses for the saved channel routing.
+        private bool IsAsioSampleRateProbeFailure() =>
+            SampleRateOptions.IsProbeFailure(
+                comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.Asio,
+                asioDriverInfo.DriverName,
+                asioDriverInfo.SupportedSampleRates.Count);
 
         private IReadOnlyList<int> GetSupportedSampleRates()
         {

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -562,7 +562,23 @@ namespace Resonalyze.Options
                 wasapiRenderEndpointId = renderEndpoint.Id;
                 if (audioBackend == AudioBackend.WasapiShared)
                 {
+                    // Shared never takes the rate from the combo, so no fallback of the
+                    // combo's can reach the configuration through it.
                     sampleRate = captureEndpoint.PreferredFormat.SampleRate;
+                }
+                else if (audioBackend == AudioBackend.WasapiExclusive)
+                {
+                    // Exclusive does take it from the combo, and the combo can be empty:
+                    // an endpoint pair with no rate in common is a real answer, and
+                    // GetSelectedSampleRate then answers with its own 44.1 kHz fallback.
+                    // Persisting that is persisting a format the endpoints just refused.
+                    // Checked here, after the availability test above, so an endpoint that
+                    // is simply gone keeps its own message instead of being reported as a
+                    // rate mismatch.
+                    SampleRateOptions.ValidateSelectedRate(
+                        GetSupportedSampleRates(),
+                        sampleRate,
+                        "The WASAPI Exclusive endpoints");
                 }
             }
             if (audioBackend != AudioBackend.Asio &&
@@ -1259,8 +1275,9 @@ namespace Resonalyze.Options
             // marker left by an earlier automatic fallback describes an action that is
             // now over, and UpdateAsioStatusLabels would otherwise keep reporting
             // "96000 Hz is not offered — changed to 48000 Hz" about a rate the user
-            // chose. The probe verdict is left alone; it is still the last thing the
-            // driver actually said.
+            // chose. The probe verdict is not cleared here but re-taken below: the
+            // re-probe for the new rate is a fresh answer, and RefreshAsioDriverInfo
+            // settles the flag from it before the status line is written.
             sampleRateFellBackFrom = null;
 
             // The achieved band and its cycle-quantized duration depend on the
@@ -1454,6 +1471,13 @@ namespace Resonalyze.Options
                 ? asioDriver.DriverName
                 : null;
             asioDriverInfo = AsioDeviceCatalog.GetDriverInfo(driverName, sampleRate);
+            // The probe just happened, so its verdict is settled here rather than
+            // wherever the rate list is next rebuilt. Not every caller rebuilds one:
+            // a manual rate change re-probes for the latency figures alone, and
+            // leaving the flag behind let a probe that has since SUCCEEDED still be
+            // reported as "the driver did not report its rates". RefreshSampleRateOptions
+            // recomputes the same predicate for the resolution it acts on.
+            sampleRateProbeFailed = IsAsioSampleRateProbeFailure();
 
             comboBoxAsioInputChannel.Items.Clear();
             comboBoxAsioLoopbackChannel.Items.Clear();
@@ -1902,24 +1926,14 @@ namespace Resonalyze.Options
             }
         }
 
-        private void ValidateSelectedWaveSampleRate(int sampleRate)
-        {
-            IReadOnlyList<int> supportedRates = GetSupportedSampleRates();
-            // Empty is an answer here, never silence: a Wave pair reports no rate in
-            // common only when there is none. Skipping validation on it let the rate
-            // sitting in the combo through to a device that cannot open it.
-            if (supportedRates.Count == 0)
-            {
-                throw new InvalidOperationException(
-                    "Wave devices report no sample rate in common for the current " +
-                    "configuration. Change the devices, the channel counts or the bit depth.");
-            }
-            if (!supportedRates.Contains(sampleRate))
-            {
-                throw new InvalidOperationException(
-                    $"Wave devices do not support {sampleRate} Hz for the current configuration.");
-            }
-        }
+        // Empty is an answer here, never silence: a Wave pair reports no rate in common
+        // only when there is none. Skipping validation on it let the rate sitting in the
+        // combo through to a device that cannot open it.
+        private void ValidateSelectedWaveSampleRate(int sampleRate) =>
+            SampleRateOptions.ValidateSelectedRate(
+                GetSupportedSampleRates(),
+                sampleRate,
+                "Wave devices");
 
         private static int FindInputChannelOptionIndex(
             DarkComboBox comboBox,

--- a/source/Options/SampleRateOptions.cs
+++ b/source/Options/SampleRateOptions.cs
@@ -4,7 +4,11 @@ namespace Resonalyze.Options;
 /// What a sample-rate probe amounted to, and what the rate list should therefore be.
 /// </summary>
 /// <param name="Rates">
-/// The rates to offer, or empty when the existing list should be left alone.
+/// The rates to offer. THREE outcomes, and they are not the same thing:
+/// <c>null</c> — nothing to rebuild, the list already on screen stands;
+/// empty — the probe answered and the answer is that NO rate works for this
+/// configuration, so nothing may be offered and Apply has to refuse;
+/// non-empty — offer exactly these.
 /// </param>
 /// <param name="Selected">The rate to select; the preferred one unless it fell back.</param>
 /// <param name="ProbeFailed">
@@ -17,7 +21,7 @@ namespace Resonalyze.Options;
 /// nothing was taken away from them.
 /// </param>
 internal readonly record struct SampleRateResolution(
-    int[] Rates,
+    int[]? Rates,
     int Selected,
     bool ProbeFailed,
     int? FellBackFrom);
@@ -73,23 +77,36 @@ internal static class SampleRateOptions
     {
         ArgumentNullException.ThrowIfNull(supportedRates);
 
-        if (probeFailed && hasExistingList)
+        if (probeFailed)
         {
-            return new SampleRateResolution([], preferredSampleRate, true, null);
+            // Silence. With a list on screen that list is the last real answer anyone
+            // got, and it stands. With nothing on screen there is nothing to stand, so
+            // the configured rate is offered alone — still reported as a failed probe,
+            // because no driver ever said it was supported.
+            if (hasExistingList)
+            {
+                return new SampleRateResolution(null, preferredSampleRate, true, null);
+            }
+
+            int synthesized = preferredSampleRate > 0 ? preferredSampleRate : FallbackSampleRate;
+            return new SampleRateResolution([synthesized], synthesized, true, null);
         }
 
-        int[] rates = supportedRates.Count > 0
-            ? [.. supportedRates]
-            : [preferredSampleRate > 0 ? preferredSampleRate : FallbackSampleRate];
+        if (supportedRates.Count == 0)
+        {
+            // An answer, and the answer is none: no rate works for this configuration.
+            // Offering the configured rate here would manufacture support that nobody
+            // reported, and Apply would go on to accept a rate the devices cannot open.
+            // Empty is the honest list, and refusing it belongs to Apply.
+            return new SampleRateResolution([], preferredSampleRate, false, null);
+        }
 
-        // A probe that failed with nothing on screen to keep still failed: the list
-        // below is the configured rate standing alone, not something a driver offered,
-        // and the status line has to say so rather than pronounce the rate supported.
+        int[] rates = [.. supportedRates];
         bool fellBack = !rates.Contains(preferredSampleRate);
         return new SampleRateResolution(
             rates,
             fellBack ? rates[0] : preferredSampleRate,
-            probeFailed,
+            false,
             fellBack ? preferredSampleRate : null);
     }
 }

--- a/source/Options/SampleRateOptions.cs
+++ b/source/Options/SampleRateOptions.cs
@@ -10,6 +10,7 @@ namespace Resonalyze.Options;
 /// <param name="ProbeFailed">
 /// The driver returned nothing usable. Not the same as "the configured rate is
 /// unsupported" — it is the absence of an answer, and nothing should be changed on it.
+/// Reported by the caller, which is the only place that can tell the two apart.
 /// </param>
 /// <param name="FellBackFrom">
 /// The rate the user had, when the driver answered and did not offer it. Null when
@@ -37,14 +38,42 @@ internal static class SampleRateOptions
     /// <summary>The rate used when there is nothing else to go on at all.</summary>
     public const int FallbackSampleRate = 44_100;
 
+    /// <summary>
+    /// Whether a probe answered with SILENCE rather than with an empty answer — the
+    /// distinction <see cref="Resolve"/> cannot make for itself.
+    /// </summary>
+    /// <remarks>
+    /// Only ASIO can fall silent. Every other backend derives its list from device
+    /// descriptors, where empty is a real answer — WASAPI Shared endpoints whose mix
+    /// rates differ, an Exclusive or Wave pair with no rate in common — and the list
+    /// must be rebuilt from it rather than left standing. A named ASIO driver is the
+    /// one case where empty cannot be an answer: a driver that opens accepts at least
+    /// one standard rate, so naming none is silence, which is what a driver refusing a
+    /// second open produces. With no driver selected there is nothing to preserve.
+    /// </remarks>
+    public static bool IsProbeFailure(
+        bool isAsioBackend,
+        string? asioDriverName,
+        int reportedRateCount) =>
+        isAsioBackend &&
+        !string.IsNullOrWhiteSpace(asioDriverName) &&
+        reportedRateCount == 0;
+
+    /// <param name="probeFailed">
+    /// Whether the probe produced no answer at all. An empty <paramref name="supportedRates"/>
+    /// cannot stand in for this: it is a real answer everywhere except ASIO — WASAPI Shared
+    /// endpoints whose mix rates differ, an Exclusive or Wave pair with no rate in common —
+    /// and rebuilding the list from it is then correct. Only the caller knows which it has.
+    /// </param>
     public static SampleRateResolution Resolve(
         IReadOnlyList<int> supportedRates,
         int preferredSampleRate,
-        bool hasExistingList)
+        bool hasExistingList,
+        bool probeFailed)
     {
         ArgumentNullException.ThrowIfNull(supportedRates);
 
-        if (supportedRates.Count == 0 && hasExistingList)
+        if (probeFailed && hasExistingList)
         {
             return new SampleRateResolution([], preferredSampleRate, true, null);
         }
@@ -53,11 +82,14 @@ internal static class SampleRateOptions
             ? [.. supportedRates]
             : [preferredSampleRate > 0 ? preferredSampleRate : FallbackSampleRate];
 
+        // A probe that failed with nothing on screen to keep still failed: the list
+        // below is the configured rate standing alone, not something a driver offered,
+        // and the status line has to say so rather than pronounce the rate supported.
         bool fellBack = !rates.Contains(preferredSampleRate);
         return new SampleRateResolution(
             rates,
             fellBack ? rates[0] : preferredSampleRate,
-            false,
+            probeFailed,
             fellBack ? preferredSampleRate : null);
     }
 }

--- a/source/Options/SampleRateOptions.cs
+++ b/source/Options/SampleRateOptions.cs
@@ -63,6 +63,47 @@ internal static class SampleRateOptions
         !string.IsNullOrWhiteSpace(asioDriverName) &&
         reportedRateCount == 0;
 
+    /// <summary>
+    /// Refuses, on the way to configuration, a rate the devices never reported.
+    /// </summary>
+    /// <remarks>
+    /// For the backends that derive their list by asking the devices — Wave, and WASAPI
+    /// Exclusive — an empty list is an ANSWER: no rate works for this configuration. The
+    /// combo is then empty, and an empty combo is where the panel's own
+    /// <c>GetSelectedSampleRate</c> falls back to <see cref="FallbackSampleRate"/>. Without
+    /// this check that fallback becomes configuration: Apply persists 44.1 kHz for an
+    /// endpoint pair that has just said it cannot open it. ASIO must not be routed through
+    /// here — there an empty list can be a driver that refused to open, which is the
+    /// silence <see cref="IsProbeFailure"/> exists to tell apart, and refusing on it would
+    /// block a configuration that works.
+    /// </remarks>
+    /// <param name="deviceDescription">
+    /// How to name the devices in the message; the sentence continues from it.
+    /// </param>
+    /// <exception cref="InvalidOperationException">
+    /// The list is empty, or the rate is not in it.
+    /// </exception>
+    public static void ValidateSelectedRate(
+        IReadOnlyList<int> supportedRates,
+        int sampleRate,
+        string deviceDescription)
+    {
+        ArgumentNullException.ThrowIfNull(supportedRates);
+
+        if (supportedRates.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"{deviceDescription} report no sample rate in common for the current " +
+                "configuration. Change the devices, the channel counts or the bit depth.");
+        }
+
+        if (!supportedRates.Contains(sampleRate))
+        {
+            throw new InvalidOperationException(
+                $"{deviceDescription} do not support {sampleRate} Hz for the current configuration.");
+        }
+    }
+
     /// <param name="probeFailed">
     /// Whether the probe produced no answer at all. An empty <paramref name="supportedRates"/>
     /// cannot stand in for this: it is a real answer everywhere except ASIO — WASAPI Shared

--- a/source/Options/SampleRateOptions.cs
+++ b/source/Options/SampleRateOptions.cs
@@ -1,0 +1,63 @@
+namespace Resonalyze.Options;
+
+/// <summary>
+/// What a sample-rate probe amounted to, and what the rate list should therefore be.
+/// </summary>
+/// <param name="Rates">
+/// The rates to offer, or empty when the existing list should be left alone.
+/// </param>
+/// <param name="Selected">The rate to select; the preferred one unless it fell back.</param>
+/// <param name="ProbeFailed">
+/// The driver returned nothing usable. Not the same as "the configured rate is
+/// unsupported" — it is the absence of an answer, and nothing should be changed on it.
+/// </param>
+/// <param name="FellBackFrom">
+/// The rate the user had, when the driver answered and did not offer it. Null when
+/// nothing was taken away from them.
+/// </param>
+internal readonly record struct SampleRateResolution(
+    int[] Rates,
+    int Selected,
+    bool ProbeFailed,
+    int? FellBackFrom);
+
+/// <summary>
+/// Decides the rate list from a probe, separately from the panel that displays it.
+/// </summary>
+/// <remarks>
+/// The distinction this exists to keep is between a driver that says "not that rate"
+/// and a driver that says nothing at all. Some ASIO drivers refuse to be opened a
+/// second time moments after the first, which is what closing and reopening the
+/// settings window does, and their answer to "which rates do you support" is then an
+/// empty list. Treating that as an answer replaces the user's configured rate with a
+/// fallback constant, and the next Apply persists it.
+/// </remarks>
+internal static class SampleRateOptions
+{
+    /// <summary>The rate used when there is nothing else to go on at all.</summary>
+    public const int FallbackSampleRate = 44_100;
+
+    public static SampleRateResolution Resolve(
+        IReadOnlyList<int> supportedRates,
+        int preferredSampleRate,
+        bool hasExistingList)
+    {
+        ArgumentNullException.ThrowIfNull(supportedRates);
+
+        if (supportedRates.Count == 0 && hasExistingList)
+        {
+            return new SampleRateResolution([], preferredSampleRate, true, null);
+        }
+
+        int[] rates = supportedRates.Count > 0
+            ? [.. supportedRates]
+            : [preferredSampleRate > 0 ? preferredSampleRate : FallbackSampleRate];
+
+        bool fellBack = !rates.Contains(preferredSampleRate);
+        return new SampleRateResolution(
+            rates,
+            fellBack ? rates[0] : preferredSampleRate,
+            false,
+            fellBack ? preferredSampleRate : null);
+    }
+}

--- a/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
+++ b/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
@@ -116,4 +116,46 @@ public sealed class SampleRateOptionsTests
             expected,
             SampleRateOptions.IsProbeFailure(isAsio, driverName, reportedRateCount));
     }
+
+    // The other end of the same rule, and the round-three finding. An empty list left
+    // the combo empty, where the panel answers with its own 44.1 kHz fallback — so
+    // Apply has to refuse it, or the fallback becomes the saved configuration for an
+    // endpoint pair that just said it cannot open it.
+    [Fact]
+    public void AnEmptyListIsRefusedOnTheWayToConfiguration()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => SampleRateOptions.ValidateSelectedRate(
+                [],
+                SampleRateOptions.FallbackSampleRate,
+                "The WASAPI Exclusive endpoints"));
+
+        // The way out is not another rate — there is none — so the message has to point
+        // at what can actually change.
+        Assert.Contains("no sample rate in common", error.Message);
+        Assert.Contains("The WASAPI Exclusive endpoints", error.Message);
+        Assert.Contains("bit depth", error.Message);
+    }
+
+    [Fact]
+    public void ARateNobodyReportedIsRefusedAndNamed()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => SampleRateOptions.ValidateSelectedRate(
+                [44_100, 48_000],
+                96_000,
+                "Wave devices"));
+
+        Assert.Contains("96000 Hz", error.Message);
+        Assert.Contains("Wave devices", error.Message);
+    }
+
+    [Fact]
+    public void AReportedRatePasses()
+    {
+        SampleRateOptions.ValidateSelectedRate(
+            [44_100, 48_000, 96_000],
+            96_000,
+            "Wave devices");
+    }
 }

--- a/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
+++ b/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
@@ -12,7 +12,8 @@ public sealed class SampleRateOptionsTests
     [Fact]
     public void AFailedProbeChangesNothing()
     {
-        SampleRateResolution resolution = SampleRateOptions.Resolve([], 96_000, hasExistingList: true);
+        SampleRateResolution resolution = SampleRateOptions.Resolve(
+            [], 96_000, hasExistingList: true, probeFailed: true);
 
         Assert.True(resolution.ProbeFailed);
         Assert.Empty(resolution.Rates);
@@ -20,11 +21,28 @@ public sealed class SampleRateOptionsTests
         Assert.Null(resolution.FellBackFrom);
     }
 
+    // The regression this round is about: an empty list is a REAL answer everywhere
+    // except ASIO. WASAPI Shared endpoints whose mix rates differ produce it, and so
+    // does an Exclusive or Wave pair with no rate in common. Keeping the previous
+    // device's list there would offer — and on the next Apply persist — a rate that
+    // belongs to another configuration entirely.
+    [Fact]
+    public void AnEmptyAnswerIsStillAnAnswerWhenTheProbeDidNotFail()
+    {
+        SampleRateResolution resolution = SampleRateOptions.Resolve(
+            [], 48_000, hasExistingList: true, probeFailed: false);
+
+        Assert.False(resolution.ProbeFailed);
+        Assert.Equal([48_000], resolution.Rates);
+        Assert.Equal(48_000, resolution.Selected);
+        Assert.Null(resolution.FellBackFrom);
+    }
+
     [Fact]
     public void ADriverThatOffersTheConfiguredRateKeepsIt()
     {
-        SampleRateResolution resolution =
-            SampleRateOptions.Resolve([44_100, 48_000, 96_000], 96_000, hasExistingList: true);
+        SampleRateResolution resolution = SampleRateOptions.Resolve(
+            [44_100, 48_000, 96_000], 96_000, hasExistingList: true, probeFailed: false);
 
         Assert.False(resolution.ProbeFailed);
         Assert.Null(resolution.FellBackFrom);
@@ -38,8 +56,8 @@ public sealed class SampleRateOptionsTests
         // A real fallback: the driver answered, and what it offers does not include the
         // configured rate. The rate changes and the caller is told which one was lost,
         // so the panel can show it rather than swap the number quietly.
-        SampleRateResolution resolution =
-            SampleRateOptions.Resolve([44_100, 48_000], 96_000, hasExistingList: true);
+        SampleRateResolution resolution = SampleRateOptions.Resolve(
+            [44_100, 48_000], 96_000, hasExistingList: true, probeFailed: false);
 
         Assert.False(resolution.ProbeFailed);
         Assert.Equal(96_000, resolution.FellBackFrom);
@@ -53,15 +71,56 @@ public sealed class SampleRateOptionsTests
         // keeping what is there, because nothing is. The configured rate stands as the
         // single option — still not the 44.1 constant, which is only for having nothing
         // at all to go on.
-        SampleRateResolution kept =
-            SampleRateOptions.Resolve([], 96_000, hasExistingList: false);
+        SampleRateResolution kept = SampleRateOptions.Resolve(
+            [], 96_000, hasExistingList: false, probeFailed: false);
         Assert.False(kept.ProbeFailed);
         Assert.Equal([96_000], kept.Rates);
         Assert.Equal(96_000, kept.Selected);
         Assert.Null(kept.FellBackFrom);
 
-        SampleRateResolution nothing =
-            SampleRateOptions.Resolve([], 0, hasExistingList: false);
+        SampleRateResolution nothing = SampleRateOptions.Resolve(
+            [], 0, hasExistingList: false, probeFailed: false);
         Assert.Equal([SampleRateOptions.FallbackSampleRate], nothing.Rates);
+    }
+
+    // A failed probe with nothing on screen to keep still failed. The list it produces
+    // is the configured rate standing alone — not something a driver offered — so the
+    // status line must say the driver did not report rather than call the rate
+    // supported on the strength of a probe that never answered.
+    [Fact]
+    public void AFailedProbeWithNothingToKeepIsStillReportedAsFailed()
+    {
+        SampleRateResolution resolution = SampleRateOptions.Resolve(
+            [], 96_000, hasExistingList: false, probeFailed: true);
+
+        Assert.True(resolution.ProbeFailed);
+        Assert.Equal([96_000], resolution.Rates);
+        Assert.Equal(96_000, resolution.Selected);
+        Assert.Null(resolution.FellBackFrom);
+    }
+
+    // Which probes can fall silent at all. This is the scoping the review asked for:
+    // the keep-the-list behaviour must not be reachable from a backend whose empty
+    // answer is a real one.
+    [Theory]
+    // ASIO with a named driver that reported nothing — silence, the #92 case.
+    [InlineData(true, "Focusrite USB ASIO", 0, true)]
+    // The same driver, answering. Not a failure however few rates it names.
+    [InlineData(true, "Focusrite USB ASIO", 1, false)]
+    // ASIO with no driver selected: nothing was asked, so nothing is preserved.
+    [InlineData(true, "", 0, false)]
+    [InlineData(true, null, 0, false)]
+    // Every non-ASIO backend, whose empty list is an answer and must rebuild.
+    [InlineData(false, null, 0, false)]
+    [InlineData(false, "Focusrite USB ASIO", 0, false)]
+    public void OnlyANamedAsioDriverCanFallSilent(
+        bool isAsio,
+        string? driverName,
+        int reportedRateCount,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            SampleRateOptions.IsProbeFailure(isAsio, driverName, reportedRateCount));
     }
 }

--- a/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
+++ b/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
@@ -1,0 +1,67 @@
+using Resonalyze.Options;
+
+namespace Resonalyze.App.Tests;
+
+// The difference between a driver that says "not that rate" and a driver that says
+// nothing. Some ASIO drivers refuse a second open moments after the first — closing
+// and reopening the settings window is exactly that — and answer the rate query with
+// an empty list. Read as an answer, that silently replaced a configured 96 kHz with
+// 44.1 and the next Apply persisted it.
+public sealed class SampleRateOptionsTests
+{
+    [Fact]
+    public void AFailedProbeChangesNothing()
+    {
+        SampleRateResolution resolution = SampleRateOptions.Resolve([], 96_000, hasExistingList: true);
+
+        Assert.True(resolution.ProbeFailed);
+        Assert.Empty(resolution.Rates);
+        Assert.Equal(96_000, resolution.Selected);
+        Assert.Null(resolution.FellBackFrom);
+    }
+
+    [Fact]
+    public void ADriverThatOffersTheConfiguredRateKeepsIt()
+    {
+        SampleRateResolution resolution =
+            SampleRateOptions.Resolve([44_100, 48_000, 96_000], 96_000, hasExistingList: true);
+
+        Assert.False(resolution.ProbeFailed);
+        Assert.Null(resolution.FellBackFrom);
+        Assert.Equal(96_000, resolution.Selected);
+        Assert.Equal([44_100, 48_000, 96_000], resolution.Rates);
+    }
+
+    [Fact]
+    public void ADriverThatDoesNotOfferItSaysSo()
+    {
+        // A real fallback: the driver answered, and what it offers does not include the
+        // configured rate. The rate changes and the caller is told which one was lost,
+        // so the panel can show it rather than swap the number quietly.
+        SampleRateResolution resolution =
+            SampleRateOptions.Resolve([44_100, 48_000], 96_000, hasExistingList: true);
+
+        Assert.False(resolution.ProbeFailed);
+        Assert.Equal(96_000, resolution.FellBackFrom);
+        Assert.Equal(44_100, resolution.Selected);
+    }
+
+    [Fact]
+    public void TheFirstPopulationHasNoListToKeep()
+    {
+        // Startup, before anything is in the combo: an empty probe cannot be resolved by
+        // keeping what is there, because nothing is. The configured rate stands as the
+        // single option — still not the 44.1 constant, which is only for having nothing
+        // at all to go on.
+        SampleRateResolution kept =
+            SampleRateOptions.Resolve([], 96_000, hasExistingList: false);
+        Assert.False(kept.ProbeFailed);
+        Assert.Equal([96_000], kept.Rates);
+        Assert.Equal(96_000, kept.Selected);
+        Assert.Null(kept.FellBackFrom);
+
+        SampleRateResolution nothing =
+            SampleRateOptions.Resolve([], 0, hasExistingList: false);
+        Assert.Equal([SampleRateOptions.FallbackSampleRate], nothing.Rates);
+    }
+}

--- a/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
+++ b/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
@@ -2,39 +2,66 @@ using Resonalyze.Options;
 
 namespace Resonalyze.App.Tests;
 
-// The difference between a driver that says "not that rate" and a driver that says
-// nothing. Some ASIO drivers refuse a second open moments after the first — closing
-// and reopening the settings window is exactly that — and answer the rate query with
-// an empty list. Read as an answer, that silently replaced a configured 96 kHz with
-// 44.1 and the next Apply persisted it.
+// The difference between a driver that says "not that rate", a driver that says
+// nothing, and a configuration for which no rate exists. Some ASIO drivers refuse a
+// second open moments after the first — closing and reopening the settings window is
+// exactly that — and answer the rate query with an empty list. Read as an answer, that
+// silently replaced a configured 96 kHz with 44.1 and the next Apply persisted it.
+// Read as silence everywhere, it manufactures support nobody reported.
 public sealed class SampleRateOptionsTests
 {
     [Fact]
-    public void AFailedProbeChangesNothing()
+    public void AFailedProbeLeavesTheListOnScreenAlone()
     {
         SampleRateResolution resolution = SampleRateOptions.Resolve(
             [], 96_000, hasExistingList: true, probeFailed: true);
 
         Assert.True(resolution.ProbeFailed);
-        Assert.Empty(resolution.Rates);
+        // Null, not empty: nothing to rebuild, as opposed to nothing to offer.
+        Assert.Null(resolution.Rates);
         Assert.Equal(96_000, resolution.Selected);
         Assert.Null(resolution.FellBackFrom);
     }
 
-    // The regression this round is about: an empty list is a REAL answer everywhere
-    // except ASIO. WASAPI Shared endpoints whose mix rates differ produce it, and so
-    // does an Exclusive or Wave pair with no rate in common. Keeping the previous
-    // device's list there would offer — and on the next Apply persist — a rate that
-    // belongs to another configuration entirely.
     [Fact]
-    public void AnEmptyAnswerIsStillAnAnswerWhenTheProbeDidNotFail()
+    public void AFailedProbeWithNothingToKeepOffersTheConfiguredRateAndStillSaysItFailed()
     {
         SampleRateResolution resolution = SampleRateOptions.Resolve(
-            [], 48_000, hasExistingList: true, probeFailed: false);
+            [], 96_000, hasExistingList: false, probeFailed: true);
 
+        Assert.NotNull(resolution.Rates);
+        Assert.Equal([96_000], resolution.Rates);
+        Assert.Equal(96_000, resolution.Selected);
+        // The rate stands alone because nothing answered, not because anything offered
+        // it — so the status line must not call it supported.
+        Assert.True(resolution.ProbeFailed);
+        Assert.Null(resolution.FellBackFrom);
+
+        // With no configured rate either, the constant is all that is left.
+        SampleRateResolution nothing = SampleRateOptions.Resolve(
+            [], 0, hasExistingList: false, probeFailed: true);
+        Assert.NotNull(nothing.Rates);
+        Assert.Equal([SampleRateOptions.FallbackSampleRate], nothing.Rates);
+        Assert.Equal(SampleRateOptions.FallbackSampleRate, nothing.Selected);
+    }
+
+    // The regression from this round. An empty list is a REAL answer everywhere except
+    // ASIO: WASAPI Shared endpoints whose mix rates differ produce it, and so does an
+    // Exclusive or Wave pair with no rate in common. Offering the configured rate there
+    // manufactures support nobody reported, and Apply would go on to accept it.
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AGenuineEmptyAnswerOffersNothingAtAll(bool hasExistingList)
+    {
+        SampleRateResolution resolution = SampleRateOptions.Resolve(
+            [], 48_000, hasExistingList, probeFailed: false);
+
+        // Empty, not null: there IS an answer, and it is that nothing works here.
+        Assert.NotNull(resolution.Rates);
+        Assert.Empty(resolution.Rates);
         Assert.False(resolution.ProbeFailed);
-        Assert.Equal([48_000], resolution.Rates);
-        Assert.Equal(48_000, resolution.Selected);
+        // Nothing was taken away from the user; there was never anything to take.
         Assert.Null(resolution.FellBackFrom);
     }
 
@@ -47,6 +74,7 @@ public sealed class SampleRateOptionsTests
         Assert.False(resolution.ProbeFailed);
         Assert.Null(resolution.FellBackFrom);
         Assert.Equal(96_000, resolution.Selected);
+        Assert.NotNull(resolution.Rates);
         Assert.Equal([44_100, 48_000, 96_000], resolution.Rates);
     }
 
@@ -62,41 +90,6 @@ public sealed class SampleRateOptionsTests
         Assert.False(resolution.ProbeFailed);
         Assert.Equal(96_000, resolution.FellBackFrom);
         Assert.Equal(44_100, resolution.Selected);
-    }
-
-    [Fact]
-    public void TheFirstPopulationHasNoListToKeep()
-    {
-        // Startup, before anything is in the combo: an empty probe cannot be resolved by
-        // keeping what is there, because nothing is. The configured rate stands as the
-        // single option — still not the 44.1 constant, which is only for having nothing
-        // at all to go on.
-        SampleRateResolution kept = SampleRateOptions.Resolve(
-            [], 96_000, hasExistingList: false, probeFailed: false);
-        Assert.False(kept.ProbeFailed);
-        Assert.Equal([96_000], kept.Rates);
-        Assert.Equal(96_000, kept.Selected);
-        Assert.Null(kept.FellBackFrom);
-
-        SampleRateResolution nothing = SampleRateOptions.Resolve(
-            [], 0, hasExistingList: false, probeFailed: false);
-        Assert.Equal([SampleRateOptions.FallbackSampleRate], nothing.Rates);
-    }
-
-    // A failed probe with nothing on screen to keep still failed. The list it produces
-    // is the configured rate standing alone — not something a driver offered — so the
-    // status line must say the driver did not report rather than call the rate
-    // supported on the strength of a probe that never answered.
-    [Fact]
-    public void AFailedProbeWithNothingToKeepIsStillReportedAsFailed()
-    {
-        SampleRateResolution resolution = SampleRateOptions.Resolve(
-            [], 96_000, hasExistingList: false, probeFailed: true);
-
-        Assert.True(resolution.ProbeFailed);
-        Assert.Equal([96_000], resolution.Rates);
-        Assert.Equal(96_000, resolution.Selected);
-        Assert.Null(resolution.FellBackFrom);
     }
 
     // Which probes can fall silent at all. This is the scoping the review asked for:


### PR DESCRIPTION
Fixes #92. Verified on the setup that produced it — Windows 11 arm64 in Parallels, Focusrite USB ASIO — and the repro no longer reproduces.

## What was wrong

Two faults that happened to sit on top of each other, which is why the visible symptom was a contradiction.

**The rate list was rebuilt from a probe that is allowed to fail.** In `RefreshSampleRateOptions`:

```csharp
int[] availableRates = supportedRates.Count > 0
    ? supportedRates.ToArray()
    : [fallbackSampleRate];        // 44100, hard-coded

int selectedSampleRate = availableRates.Contains(preferredSampleRate)
    ? preferredSampleRate
    : availableRates[0];
```

An empty probe became a list of one constant, the configured rate was not in it, and the selection fell to 44100 — silently, with the next Apply persisting it. Your own comment in `GetSupportedSampleRates` already names the cause: some ASIO drivers refuse a second open moments after the first. Closing the settings window and reopening it is exactly that.

**The status line was written before the selection existed.** `RefreshAsioDriverInfo` writes it at the end of the probe, which runs *before* `RefreshSampleRateOptions` fills the combo — and at that moment `GetSelectedSampleRate()` answers with its own 44100 fallback, because nothing is selected yet. Filling the combo afterwards changed a number nobody re-read. That is how `96000` in the list came to sit above `44100 Hz supported` in green, and it survived fixing the fallback itself: the first build I tested still showed it.

## What it does now

**An empty probe is treated as the absence of an answer, not as an answer.** The list and the user's selection stand, and the line says the driver did not report rather than pronouncing on a rate nobody tested.

**A real fallback is shown as one.** When the driver *does* answer and does not offer the configured rate, the rate still changes — but the line names the one that was taken away: `96000 Hz is not offered by this driver — changed to 44100 Hz`, in salmon.

**The line is written after the selection settles**, so its number and its verdict can no longer come from different moments.

The three cases are decided in `SampleRateOptions.Resolve` rather than inside the panel, so they are testable without a window — `SampleRateOptionsTests` covers a failed probe changing nothing, a driver that offers the rate keeping it, a driver that does not saying so, and the first population (nothing in the combo yet) resolving to the configured rate rather than to the constant. The constant is now reserved for having nothing at all to go on.

## Verification

Same machine, same driver, same repro: ASIO → Focusrite USB ASIO → 96000 → Apply → close the settings window → reopen.

- **Before:** the combo came back at 44100 with `44100 Hz supported` under it, and Apply would have persisted it.
- **After:** the combo comes back at **96000**, and the line under it reads **96000 Hz supported**.

## One thing I did not touch

While verifying, the **Playback latency** line behaves oddly on this setup: it does not change when the sample rate is changed in the combo, but shows a different value after the window is closed and reopened (509 samples at one opening, 419 at another). There is no caching in `GetDriverInfo` — each call opens the driver afresh — so my guess is that NAudio's `PlaybackLatency` reports the device's *current* buffer rather than one implied by the rate being probed, and the probe asks whether a rate is supported without putting the device on it.

That is a guess about a driver, not about your code, and it is outside what this PR claims to fix. Flagging it rather than changing anything blind — you will know immediately whether it is expected.
