### PR TITLE
Draw both Time Alignment envelopes against one reference

### DIFF
--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -40,6 +40,18 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // The fade the Auto mode puts around the detected pass band.
     private const double AutoBandFadeOctaves = 0.5;
 
+    // Names the reference both envelope curves are drawn against, so a Compare
+    // curve sitting below Main reads as the level difference it is.
+    private const string EnvelopeDecibelAxisTitle = "dB re Main peak";
+
+    // How far under its own maximum one envelope curve is drawn before the
+    // floor takes over, and how tall the envelope plot opens: a Compare record
+    // tens of dB under Main (a sub against a tweeter) would otherwise squeeze
+    // the arrivals into a sliver. The axis still PANS to the full range —
+    // only the opening view is bounded.
+    private const double CurveFloorDb = 80.0;
+    private const double EnvelopeOpeningSpanDb = 100.0;
+
     public TimeAlignmentPanelController(
         Form owner,
         TimeAlignmentPanel panel,
@@ -557,11 +569,21 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentAnalysisResult? compareResult = null)
     {
         double[] envelope = result.EnvelopeSamples;
-        if (envelope.Length == 0 || result.EnvelopePeak <= 0 || sampleRate <= 0)
+        if (envelope.Length == 0 || result.StrongestEnvelopePeak <= 0 || sampleRate <= 0)
         {
             ClearEnvelopePreview();
             return;
         }
+
+        // ONE reference for both curves: the Main record's strongest peak.
+        // Normalizing each curve by its own first-arrival level (what this plot
+        // used to do) makes the dB axis mean something different per curve — a
+        // record whose pick sits 6 dB below its peak and one whose pick sits 25
+        // dB below get drawn on references 19 dB apart, so two measurements of
+        // the same level read as 19 dB apart on screen. The prominence of a pick
+        // is an analysis figure, not a property of the record; the strongest
+        // peak is, so it is the only reference that keeps levels comparable.
+        double referenceAmplitude = result.StrongestEnvelopePeak;
 
         int radius = Math.Min(
             envelope.Length / 2,
@@ -585,6 +607,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         int step = Math.Max(1, radius * 2 / 600);
         LineSeries mainSeries = CreateEnvelopeSeries(
             result,
+            referenceAmplitude,
             sampleRate,
             radius,
             step,
@@ -597,10 +620,8 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         var model = CreatePreviewPlotModel("Envelope Around Peak");
         model.Axes.Add(CreateMillisecondsAxis(minMilliseconds, maxMilliseconds));
         var dbAxis = CreateDecibelAxis();
-        dbAxis.AbsoluteMaximum = maxDb + 30;
-        dbAxis.AbsoluteMinimum = minDb - 10;
-        dbAxis.Maximum = maxDb + 2;
-        dbAxis.Minimum = minDb - 2;
+        dbAxis.Title = EnvelopeDecibelAxisTitle;
+        ApplyEnvelopeDecibelRange(dbAxis, maxDb, minDb);
         model.Axes.Add(dbAxis);
 
         model.Series.Add(mainSeries);
@@ -608,6 +629,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         {
             LineSeries compareSeries = CreateEnvelopeSeries(
                 compareResult.Value,
+                referenceAmplitude,
                 sampleRate,
                 radius,
                 step,
@@ -618,10 +640,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 out double compareMinDb);
             maxDb = Math.Max(maxDb, compareMaxDb);
             minDb = Math.Min(minDb, compareMinDb);
-            dbAxis.AbsoluteMaximum = maxDb + 30;
-            dbAxis.AbsoluteMinimum = minDb - 10;
-            dbAxis.Maximum = maxDb + 2;
-            dbAxis.Minimum = minDb - 2;
+            ApplyEnvelopeDecibelRange(dbAxis, maxDb, minDb);
             model.Series.Add(compareSeries);
         }
 
@@ -631,17 +650,32 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 model,
                 result,
                 compareResult.Value,
+                referenceAmplitude,
                 compareOffsetMilliseconds);
         }
         else
         {
-            AddMainPeakMarkers(model, result);
+            AddMainPeakMarkers(model, result, referenceAmplitude);
         }
         envelopePlotView.Model = model;
     }
 
-    private static LineSeries CreateEnvelopeSeries(
+    private static void ApplyEnvelopeDecibelRange(
+        LinearAxis axis,
+        double maxDb,
+        double minDb)
+    {
+        axis.AbsoluteMaximum = maxDb + 30;
+        axis.AbsoluteMinimum = minDb - 10;
+        axis.Maximum = maxDb + 2;
+        axis.Minimum = Math.Max(minDb - 2, maxDb - EnvelopeOpeningSpanDb);
+    }
+
+    // internal for the plot-construction tests: the reference both curves are
+    // drawn against is the whole point of this builder.
+    internal static LineSeries CreateEnvelopeSeries(
         TimeAlignmentAnalysisResult result,
+        double referenceAmplitude,
         int sampleRate,
         int radius,
         int step,
@@ -665,12 +699,11 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         {
             int index = DspMath.WrapIndex(result.EnvelopePeakIndex + offset, envelope.Length);
             double milliseconds = offset * 1000.0 / sampleRate + xOffsetMilliseconds;
-            double relativeAmplitude = envelope[index] / result.EnvelopePeak;
+            double relativeAmplitude = envelope[index] / referenceAmplitude;
             double decibels = DataHelper.AmplitudeToDecibels(relativeAmplitude);
-            double clampedDecibels = Math.Max(-80, decibels);
-            series.Points.Add(new DataPoint(milliseconds, clampedDecibels));
-            localMaxDb = Math.Max(localMaxDb, clampedDecibels);
-            localMinDb = Math.Min(localMinDb, clampedDecibels);
+            series.Points.Add(new DataPoint(milliseconds, decibels));
+            localMaxDb = Math.Max(localMaxDb, decibels);
+            localMinDb = Math.Min(localMinDb, decibels);
         }
 
         // Min/max pooling per decimation bucket: sampling every Nth value would
@@ -706,14 +739,30 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             }
         }
 
+        // The floor rides under THIS curve's own maximum rather than under the
+        // shared reference: it is there to stop a null from dragging the axis
+        // to the numeric floor, and a Compare record genuinely quieter than
+        // Main must still be drawn whole instead of flattened onto an absolute
+        // line 80 dB under Main's peak.
+        double floorDb = localMaxDb - CurveFloorDb;
+        for (int i = 0; i < series.Points.Count; i++)
+        {
+            DataPoint point = series.Points[i];
+            if (point.Y < floorDb)
+            {
+                series.Points[i] = new DataPoint(point.X, floorDb);
+            }
+        }
+
         maxDb = localMaxDb;
-        minDb = localMinDb;
+        minDb = Math.Max(localMinDb, floorDb);
         return series;
     }
 
     private static void AddMainPeakMarkers(
         PlotModel model,
-        TimeAlignmentAnalysisResult mainResult)
+        TimeAlignmentAnalysisResult mainResult,
+        double referenceAmplitude)
     {
         double strongestMilliseconds =
             mainResult.StrongestDelayMilliseconds -
@@ -722,7 +771,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             model,
             "M First",
             0.0,
-            GetPeakMarkerDecibels(mainResult, mainResult.EnvelopePeakIndex),
+            GetPeakMarkerDecibels(mainResult, referenceAmplitude, mainResult.EnvelopePeakIndex),
             OxyColor.FromRgb(255, 96, 96),
             PlotCalloutDirection.LeftUp);
         if (Math.Abs(strongestMilliseconds) > 0.001)
@@ -731,7 +780,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 model,
                 "M Peak",
                 strongestMilliseconds,
-                GetPeakMarkerDecibels(mainResult, mainResult.StrongestEnvelopePeakIndex),
+                GetPeakMarkerDecibels(mainResult, referenceAmplitude, mainResult.StrongestEnvelopePeakIndex),
                 OxyColor.FromRgb(140, 170, 255),
                 PlotCalloutDirection.RightUp);
         }
@@ -741,12 +790,13 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         PlotModel model,
         TimeAlignmentAnalysisResult mainResult,
         TimeAlignmentAnalysisResult compareResult,
+        double referenceAmplitude,
         double compareFirstArrivalMilliseconds)
     {
         double mainFirstArrivalDecibels =
-            GetPeakMarkerDecibels(mainResult, mainResult.EnvelopePeakIndex);
+            GetPeakMarkerDecibels(mainResult, referenceAmplitude, mainResult.EnvelopePeakIndex);
         double compareFirstArrivalDecibels =
-            GetPeakMarkerDecibels(compareResult, compareResult.EnvelopePeakIndex);
+            GetPeakMarkerDecibels(compareResult, referenceAmplitude, compareResult.EnvelopePeakIndex);
         double mainStrongestMilliseconds =
             mainResult.StrongestDelayMilliseconds -
             mainResult.FirstArrivalDelayMilliseconds;
@@ -754,9 +804,9 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             compareResult.StrongestDelayMilliseconds -
             mainResult.FirstArrivalDelayMilliseconds;
         double mainStrongestDecibels =
-            GetPeakMarkerDecibels(mainResult, mainResult.StrongestEnvelopePeakIndex);
+            GetPeakMarkerDecibels(mainResult, referenceAmplitude, mainResult.StrongestEnvelopePeakIndex);
         double compareStrongestDecibels =
-            GetPeakMarkerDecibels(compareResult, compareResult.StrongestEnvelopePeakIndex);
+            GetPeakMarkerDecibels(compareResult, referenceAmplitude, compareResult.StrongestEnvelopePeakIndex);
 
         AddCalloutMarker(
             model,
@@ -822,18 +872,25 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         });
     }
 
-    private static double GetPeakMarkerDecibels(
+    internal static double GetPeakMarkerDecibels(
         TimeAlignmentAnalysisResult result,
+        double referenceAmplitude,
         int peakIndex)
     {
         if ((uint)peakIndex >= (uint)result.EnvelopeSamples.Length ||
-            result.EnvelopePeak <= 0)
+            referenceAmplitude <= 0)
         {
             return 0.0;
         }
 
-        double relativeAmplitude = result.EnvelopeSamples[peakIndex] / result.EnvelopePeak;
-        return Math.Max(-80, DataHelper.AmplitudeToDecibels(relativeAmplitude));
+        // Same floor the curve itself is drawn with, so a marker never parks
+        // under its own line on a record much quieter than the reference.
+        double peakDecibels = DataHelper.AmplitudeToDecibels(
+            result.StrongestEnvelopePeak / referenceAmplitude);
+        double relativeAmplitude = result.EnvelopeSamples[peakIndex] / referenceAmplitude;
+        return Math.Max(
+            peakDecibels - CurveFloorDb,
+            DataHelper.AmplitudeToDecibels(relativeAmplitude));
     }
 
     private void ClearEnvelopePreview()
@@ -846,6 +903,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         var model = CreatePreviewPlotModel("Envelope Around Peak");
         model.Axes.Add(CreateMillisecondsAxis(-50, 50));
         var dbAxis = CreateDecibelAxis();
+        dbAxis.Title = EnvelopeDecibelAxisTitle;
         dbAxis.AbsoluteMaximum = 0;
         dbAxis.AbsoluteMinimum = -80;
         dbAxis.Maximum = 0;

--- a/tests/Resonalyze.App.Tests/TimeAlignmentEnvelopePlotTests.cs
+++ b/tests/Resonalyze.App.Tests/TimeAlignmentEnvelopePlotTests.cs
@@ -1,0 +1,149 @@
+using OxyPlot;
+using OxyPlot.Series;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+// Pins the dB reference of the Time Alignment "Envelope Around Peak" plot.
+// Both curves must be drawn against ONE amplitude (the Main record's strongest
+// peak). Normalizing each curve by its own first-arrival level — which the plot
+// used to do — makes the axis mean something different per curve, so two
+// equally loud records whose picks sit at different depths read as decades
+// apart on screen.
+public sealed class TimeAlignmentEnvelopePlotTests
+{
+    private const int SampleRate = 96_000;
+    private const int Radius = 300;
+
+    [Fact]
+    public void EnvelopeSeries_PicksAtDifferentDepths_KeepEqualPeaksLevel()
+    {
+        // Same peak amplitude, wildly different first-arrival prominence: a
+        // near-peak pick (-6 dB) against one on a broad leading edge (-25 dB).
+        TimeAlignmentAnalysisResult main = MakeResult(peak: 1.0, arrivalBelowPeakDb: 6);
+        TimeAlignmentAnalysisResult compare = MakeResult(peak: 1.0, arrivalBelowPeakDb: 25);
+
+        (double mainMax, _) = Draw(main, main.StrongestEnvelopePeak);
+        (double compareMax, _) = Draw(compare, main.StrongestEnvelopePeak);
+
+        Assert.Equal(0.0, mainMax, 3);
+        Assert.Equal(0.0, compareMax, 3);
+    }
+
+    [Fact]
+    public void EnvelopeSeries_QuieterCompareRecord_ShowsItsTrueLevelOffset()
+    {
+        TimeAlignmentAnalysisResult main = MakeResult(peak: 1.0, arrivalBelowPeakDb: 6);
+        // Half the amplitude, and a pick depth that differs from Main's on top
+        // of it: only the level difference may reach the plot.
+        TimeAlignmentAnalysisResult compare = MakeResult(peak: 0.5, arrivalBelowPeakDb: 25);
+
+        (double mainMax, _) = Draw(main, main.StrongestEnvelopePeak);
+        (double compareMax, _) = Draw(compare, main.StrongestEnvelopePeak);
+
+        Assert.Equal(0.0, mainMax, 3);
+        Assert.Equal(-6.02, compareMax, 2);
+    }
+
+    [Fact]
+    public void PeakMarkers_ShareTheSeriesReference()
+    {
+        TimeAlignmentAnalysisResult main = MakeResult(peak: 1.0, arrivalBelowPeakDb: 6);
+        TimeAlignmentAnalysisResult compare = MakeResult(peak: 0.5, arrivalBelowPeakDb: 25);
+        double reference = main.StrongestEnvelopePeak;
+
+        // A marker must land on its own curve: the compare peak marker at the
+        // compare curve's maximum, the compare arrival marker at its prominence
+        // below THAT — not at 0 dB, which is what a per-curve reference gave.
+        double comparePeakDb = TimeAlignmentPanelController.GetPeakMarkerDecibels(
+            compare, reference, compare.StrongestEnvelopePeakIndex);
+        double compareArrivalDb = TimeAlignmentPanelController.GetPeakMarkerDecibels(
+            compare, reference, compare.EnvelopePeakIndex);
+
+        (double compareMax, _) = Draw(compare, reference);
+        double prominenceDb = 20.0 * Math.Log10(
+            compare.EnvelopePeak / compare.StrongestEnvelopePeak);
+        Assert.Equal(compareMax, comparePeakDb, 3);
+        Assert.Equal(comparePeakDb + prominenceDb, compareArrivalDb, 3);
+    }
+
+    [Fact]
+    public void EnvelopeSeries_MuchQuieterCompareRecord_KeepsItsOwnFloor()
+    {
+        // A sub against a tweeter: 40 dB apart. The shared reference must move
+        // the Compare curve down, not flatten its lower 40 dB onto an absolute
+        // floor 80 dB under Main's peak.
+        TimeAlignmentAnalysisResult main = MakeResult(peak: 1.0, arrivalBelowPeakDb: 6);
+        TimeAlignmentAnalysisResult compare = MakeResult(peak: 0.01, arrivalBelowPeakDb: 6);
+
+        (double mainMax, double mainMin) = Draw(main, main.StrongestEnvelopePeak);
+        (double compareMax, double compareMin) = Draw(compare, main.StrongestEnvelopePeak);
+
+        Assert.Equal(0.0, mainMax, 3);
+        Assert.Equal(-80.0, mainMin, 1);
+        Assert.Equal(-40.0, compareMax, 1);
+        Assert.Equal(-120.0, compareMin, 1);
+    }
+
+    private static (double MaxDb, double MinDb) Draw(
+        TimeAlignmentAnalysisResult result,
+        double referenceAmplitude)
+    {
+        TimeAlignmentPanelController.CreateEnvelopeSeries(
+            result,
+            referenceAmplitude,
+            SampleRate,
+            Radius,
+            step: 1,
+            xOffsetMilliseconds: 0.0,
+            OxyColors.Yellow,
+            strokeThickness: 2,
+            out double maxDb,
+            out double minDb);
+        return (maxDb, minDb);
+    }
+
+    // An envelope with two humps: the arrival at index 400 and the strongest
+    // peak 100 samples later.
+    private static TimeAlignmentAnalysisResult MakeResult(
+        double peak,
+        double arrivalBelowPeakDb)
+    {
+        const int arrivalIndex = 400;
+        const int strongestIndex = 500;
+        var envelope = new double[2048];
+        double arrival = peak * Math.Pow(10.0, -arrivalBelowPeakDb / 20.0);
+        for (int i = 0; i < envelope.Length; i++)
+        {
+            // Pedestal 100 dB under this record's own peak, so the 80 dB
+            // curve floor is what the drawn minimum reports.
+            envelope[i] =
+                arrival * Hump(i - arrivalIndex) +
+                peak * Hump(i - strongestIndex) +
+                peak * 1e-5;
+        }
+
+        return new TimeAlignmentAnalysisResult(
+            envelope,
+            arrivalIndex,
+            envelope[arrivalIndex],
+            strongestIndex,
+            envelope[strongestIndex],
+            SignalToNoiseDecibels: 60.0,
+            FirstArrivalProminenceDecibels: -arrivalBelowPeakDb,
+            FirstArrivalPeakSample: arrivalIndex,
+            FirstArrivalDelayMilliseconds: arrivalIndex * 1000.0 / SampleRate,
+            StrongestPeakSample: strongestIndex,
+            StrongestDelayMilliseconds: strongestIndex * 1000.0 / SampleRate,
+            StrongestPeakSeparationMilliseconds:
+                (strongestIndex - arrivalIndex) * 1000.0 / SampleRate,
+            StrongestPeakIsSeparateArrival: true,
+            FirstArrivalConfidence: 0.5,
+            FirstArrivalRefinedByPhat: true,
+            StrongestConfidence: 0.5,
+            StrongestRefinedByPhat: true);
+    }
+
+    private static double Hump(int offset) =>
+        Math.Exp(-(offset * offset) / 200.0);
+}

--- a/tests/Resonalyze.App.Tests/TimeAlignmentEnvelopePlotTests.cs
+++ b/tests/Resonalyze.App.Tests/TimeAlignmentEnvelopePlotTests.cs
@@ -23,11 +23,11 @@ public sealed class TimeAlignmentEnvelopePlotTests
         TimeAlignmentAnalysisResult main = MakeResult(peak: 1.0, arrivalBelowPeakDb: 6);
         TimeAlignmentAnalysisResult compare = MakeResult(peak: 1.0, arrivalBelowPeakDb: 25);
 
-        (double mainMax, _) = Draw(main, main.StrongestEnvelopePeak);
-        (double compareMax, _) = Draw(compare, main.StrongestEnvelopePeak);
+        DrawnCurve mainCurve = Draw(main, main.StrongestEnvelopePeak);
+        DrawnCurve compareCurve = Draw(compare, main.StrongestEnvelopePeak);
 
-        Assert.Equal(0.0, mainMax, 3);
-        Assert.Equal(0.0, compareMax, 3);
+        Assert.Equal(0.0, mainCurve.PointsMaxDb, 3);
+        Assert.Equal(0.0, compareCurve.PointsMaxDb, 3);
     }
 
     [Fact]
@@ -38,11 +38,11 @@ public sealed class TimeAlignmentEnvelopePlotTests
         // of it: only the level difference may reach the plot.
         TimeAlignmentAnalysisResult compare = MakeResult(peak: 0.5, arrivalBelowPeakDb: 25);
 
-        (double mainMax, _) = Draw(main, main.StrongestEnvelopePeak);
-        (double compareMax, _) = Draw(compare, main.StrongestEnvelopePeak);
+        DrawnCurve mainCurve = Draw(main, main.StrongestEnvelopePeak);
+        DrawnCurve compareCurve = Draw(compare, main.StrongestEnvelopePeak);
 
-        Assert.Equal(0.0, mainMax, 3);
-        Assert.Equal(-6.02, compareMax, 2);
+        Assert.Equal(0.0, mainCurve.PointsMaxDb, 3);
+        Assert.Equal(-6.02, compareCurve.PointsMaxDb, 2);
     }
 
     [Fact]
@@ -60,10 +60,10 @@ public sealed class TimeAlignmentEnvelopePlotTests
         double compareArrivalDb = TimeAlignmentPanelController.GetPeakMarkerDecibels(
             compare, reference, compare.EnvelopePeakIndex);
 
-        (double compareMax, _) = Draw(compare, reference);
+        DrawnCurve compareCurve = Draw(compare, reference);
         double prominenceDb = 20.0 * Math.Log10(
             compare.EnvelopePeak / compare.StrongestEnvelopePeak);
-        Assert.Equal(compareMax, comparePeakDb, 3);
+        Assert.Equal(compareCurve.PointsMaxDb, comparePeakDb, 3);
         Assert.Equal(comparePeakDb + prominenceDb, compareArrivalDb, 3);
     }
 
@@ -76,20 +76,26 @@ public sealed class TimeAlignmentEnvelopePlotTests
         TimeAlignmentAnalysisResult main = MakeResult(peak: 1.0, arrivalBelowPeakDb: 6);
         TimeAlignmentAnalysisResult compare = MakeResult(peak: 0.01, arrivalBelowPeakDb: 6);
 
-        (double mainMax, double mainMin) = Draw(main, main.StrongestEnvelopePeak);
-        (double compareMax, double compareMin) = Draw(compare, main.StrongestEnvelopePeak);
+        DrawnCurve mainCurve = Draw(main, main.StrongestEnvelopePeak);
+        DrawnCurve compareCurve = Draw(compare, main.StrongestEnvelopePeak);
 
-        Assert.Equal(0.0, mainMax, 3);
-        Assert.Equal(-80.0, mainMin, 1);
-        Assert.Equal(-40.0, compareMax, 1);
-        Assert.Equal(-120.0, compareMin, 1);
+        Assert.Equal(0.0, mainCurve.PointsMaxDb, 3);
+        Assert.Equal(-80.0, mainCurve.PointsMinDb, 1);
+        Assert.Equal(-40.0, compareCurve.PointsMaxDb, 1);
+        Assert.Equal(-120.0, compareCurve.PointsMinDb, 1);
+
+        // The axis figures must describe the line that was actually drawn:
+        // clamping only the reported minimum would leave the plot wrong while
+        // every assertion above still passed.
+        Assert.Equal(compareCurve.PointsMinDb, compareCurve.MinDb, 6);
+        Assert.Equal(compareCurve.PointsMaxDb, compareCurve.MaxDb, 6);
     }
 
-    private static (double MaxDb, double MinDb) Draw(
+    private static DrawnCurve Draw(
         TimeAlignmentAnalysisResult result,
         double referenceAmplitude)
     {
-        TimeAlignmentPanelController.CreateEnvelopeSeries(
+        LineSeries series = TimeAlignmentPanelController.CreateEnvelopeSeries(
             result,
             referenceAmplitude,
             SampleRate,
@@ -100,7 +106,18 @@ public sealed class TimeAlignmentEnvelopePlotTests
             strokeThickness: 2,
             out double maxDb,
             out double minDb);
-        return (maxDb, minDb);
+        return new DrawnCurve(series, maxDb, minDb);
+    }
+
+    // The points are what the user sees; MaxDb/MinDb only size the axis. Every
+    // assertion below reads the points, and the floor test also pins the two to
+    // each other — a reported range that no longer described the drawn line
+    // would leave the plot wrong with the axis still looking right.
+    private sealed record DrawnCurve(LineSeries Series, double MaxDb, double MinDb)
+    {
+        public double PointsMaxDb => Series.Points.Max(point => point.Y);
+
+        public double PointsMinDb => Series.Points.Min(point => point.Y);
     }
 
     // An envelope with two humps: the arrival at index 400 and the strongest


### PR DESCRIPTION
## What was wrong

The "Envelope Around Peak" preview normalized **each** curve by its own
first-arrival level (`result.EnvelopePeak`, which is the envelope value at the
selected arrival — not the peak its name suggests). So the dB axis meant
something different for every curve on the plot.

A field pair made it visible: a Passat's left and right door woofers, converted
from REW. Their IR peaks are 4.2 dB apart (−49.4 vs −45.1 dBFS) and their
frequency responses match, but the panel drew them ~19 dB apart, because one
pick landed 5.9 dB under its peak (a genuine early arrival) and the other 24.9 dB
under it (on a broad low-frequency rise). Nothing about the records differed by
19 dB — only the depth of the two picks did.

The prominence of a pick is an analysis figure; the strongest peak is a property
of the record. So the peak is the only reference that keeps two curves
comparable, and both curves now share the **Main** record's.

Same two records, same product `CreateEnvelopeSeries`, before and after:

| before | after |
| --- | --- |
| noise floors 6 dB apart with 4 dB between the records | floors coincide, the honest 1.8 dB between the envelope peaks remains |

## Knock-on: the floor had to stop being absolute

Curves were clamped at a hard −80 dB. That was harmless while every curve was
referenced to itself; against a shared reference it flattens a Compare record
that is genuinely quieter — a sub against a tweeter runs 40 dB down in these
sessions, so its whole lower half would collapse onto one line.

The floor now rides 80 dB under **that curve's** own maximum, and the opening
view of the dB axis is bounded to 100 dB so a large level offset cannot squeeze
the arrivals into a sliver. `AbsoluteMinimum` is untouched, so the axis still
pans to the full range. The peak markers took the same floor; they had been
reading an absolute −80 that no longer matched the line they sit on.

## Tests

`TimeAlignmentEnvelopePlotTests` pins the reference through the plot builder
(made `internal` for the test, per the plot-model-construction convention in
`AGENTS.md`):

- equal-level records with picks at −6 dB and −25 dB prominence draw at the
  same height — the regression this PR fixes;
- a Compare record 6 dB quieter draws 6 dB lower, pick depth notwithstanding;
- peak markers land on their own curve, at their record's own prominence;
- a Compare record 40 dB quieter keeps its full 80 dB of range instead of
  flattening onto Main's floor.

Full suite: 2314 passed, 0 failed (1 skip — the env-gated session battery).

## Not in scope

The two woofer records really do pick differently, and that is the data, not a
defect: `w_L` carries a low-passed arrival ~0.94 ms before its main peak (−5.9 dB,
rolling off above ~1 kHz), `w_R` has nothing there (−38 dB). REW agrees — its own
`timeOfIrStart` is 3.6458 ms for the left and 4.7708 ms for the right. The
conversion is a pure rotation of REW's IR onto the loopback zero, verified
sample-for-sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
