### PR TITLE
Split Live Spectrum into explicit Transfer/RTA modes, add noise-slope compensation and a dB SPL checkbox

### DIFF
--- a/dsp/NoiseTiltCompensation.cs
+++ b/dsp/NoiseTiltCompensation.cs
@@ -1,4 +1,128 @@
+using System.Numerics;
+
 namespace Resonalyze.Dsp;
+
+/// <summary>
+/// The coefficients of Paul Kellett's economical pink-noise filter bank — the one
+/// source of truth shared by the noise synthesis (the app's <c>NoiseSignal</c>
+/// drives white noise through this recurrence) and by
+/// <see cref="NoiseSpectralModel.KellettPink"/>, which must model the very filter
+/// the excitation was made with: the bank only approximates −3 dB/octave between
+/// its poles, and below the lowest pole's corner (~8 Hz at 44.1 kHz but ~35 Hz at
+/// 192 kHz — the poles live in normalized frequency) the response flattens.
+/// </summary>
+public static class KellettPinkFilter
+{
+    /// <summary>Per-pole (feedback A, input gain G): state' = A·state + G·white.</summary>
+    public static readonly IReadOnlyList<(double A, double G)> Poles =
+    [
+        (0.99886, 0.0555179),
+        (0.99332, 0.0750759),
+        (0.96900, 0.1538520),
+        (0.86650, 0.3104856),
+        (0.55000, 0.5329522),
+        (-0.7616, -0.0168980)
+    ];
+
+    /// <summary>The direct white-noise term added to the pole sum.</summary>
+    public const double DirectGain = 0.5362;
+
+    /// <summary>The one-sample-delayed white-noise term (the classic b6 state).</summary>
+    public const double DelayedGain = 0.115926;
+
+    /// <summary>
+    /// The exact magnitude response of the bank at a frequency, for the sample rate
+    /// the noise is generated at: <c>|Σ G/(1−A·z⁻¹) + direct + delayed·z⁻¹|</c>.
+    /// </summary>
+    public static double MagnitudeAt(double frequency, int sampleRate)
+    {
+        double omega = 2.0 * Math.PI * frequency / sampleRate;
+        Complex z1 = Complex.FromPolarCoordinates(1.0, -omega);
+        Complex response = DirectGain + DelayedGain * z1;
+        foreach ((double a, double g) in Poles)
+        {
+            response += g / (Complex.One - a * z1);
+        }
+
+        return response.Magnitude;
+    }
+}
+
+public enum NoiseSpectralModelKind
+{
+    PowerLaw,
+    LeakyIntegrator,
+    KellettPink
+}
+
+/// <summary>
+/// The spectral shape a noise excitation was actually SYNTHESISED with, as the tilt
+/// compensation must model it. An idealised per-octave slope is only honest for
+/// signals built that way (white; the periodic pink whose bins are exactly 1/√f);
+/// the filtered noises deviate from their nominal slope where their filters do —
+/// brown's leaky integrator flattens below its corner, Kellett pink below its
+/// lowest pole — and compensating the nominal slope there would print an artificial
+/// bass roll-off onto a correct measurement.
+/// </summary>
+/// <param name="Parameter">
+/// <see cref="NoiseSpectralModelKind.PowerLaw"/>: the PSD slope in dB per octave.
+/// <see cref="NoiseSpectralModelKind.LeakyIntegrator"/>: the corner frequency in Hz
+/// (the synthesis derives its leak from this and the sample rate; so does the model).
+/// Unused for <see cref="NoiseSpectralModelKind.KellettPink"/>.
+/// </param>
+public readonly record struct NoiseSpectralModel(
+    NoiseSpectralModelKind Kind,
+    double Parameter)
+{
+    public static NoiseSpectralModel PowerLaw(double psdSlopeDbPerOctave) =>
+        new(NoiseSpectralModelKind.PowerLaw, psdSlopeDbPerOctave);
+
+    /// <summary>Brown noise: white through a one-pole leaky integrator.</summary>
+    public static NoiseSpectralModel LeakyIntegrator(double cornerHz) =>
+        new(NoiseSpectralModelKind.LeakyIntegrator, cornerHz);
+
+    /// <summary>Random pink noise: white through the Kellett filter bank.</summary>
+    public static NoiseSpectralModel KellettPink { get; } =
+        new(NoiseSpectralModelKind.KellettPink, 0.0);
+
+    /// <summary>
+    /// The amplitude spectrum of the noise at a frequency (arbitrary overall gain —
+    /// every consumer normalizes at the pivot). The digital filter magnitudes use
+    /// the same leak/pole formulas as the synthesis, so the model stays exact from
+    /// the flattened low corners up to the near-Nyquist digital deviation.
+    /// </summary>
+    public double AmplitudeAt(double frequency, int sampleRate)
+    {
+        if (frequency <= 0.0)
+        {
+            return 0.0;
+        }
+
+        switch (Kind)
+        {
+            case NoiseSpectralModelKind.PowerLaw:
+                // PSD ∝ f^(α/(10·log10 2)) means amplitude ∝ f^(α/(20·log10 2)) —
+                // exactly 1/√f for pink (α = −3.01).
+                return Math.Pow(frequency, Parameter / (20.0 * Math.Log10(2.0)));
+
+            case NoiseSpectralModelKind.LeakyIntegrator:
+            {
+                // Mirrors the synthesis: value' = leak·value + (1−leak)·white with
+                // leak = 1 − 2π·fc/fs, so |H| = (1−leak)/|1 − leak·e^(−jω)|.
+                double leak = Math.Clamp(
+                    1.0 - 2.0 * Math.PI * Parameter / Math.Max(1, sampleRate),
+                    0.0,
+                    0.99999);
+                double omega = 2.0 * Math.PI * frequency / sampleRate;
+                return (1.0 - leak) / Math.Sqrt(
+                    1.0 - 2.0 * leak * Math.Cos(omega) + leak * leak);
+            }
+
+            default:
+                return KellettPinkFilter.MagnitudeAt(frequency, sampleRate);
+        }
+    }
+}
 
 /// <summary>
 /// Display-side compensation for the spectral tilt a noise excitation itself prints
@@ -11,15 +135,14 @@ namespace Resonalyze.Dsp;
 /// <remarks>
 /// The shape being subtracted depends on the DISPLAY PATH, not just the noise:
 /// <list type="bullet">
-/// <item>The per-bin dB display (constant absolute bin width) renders a noise of
-/// PSD slope α dB/octave as a straight α dB/octave line —
-/// <see cref="BinCompensationDb"/> is its mirror.</item>
+/// <item>The per-bin dB display (constant absolute bin width) renders the noise's
+/// amplitude spectrum directly — <see cref="BinCompensationDb"/> is its mirror.</item>
 /// <item>The band-power display (<see cref="DataHelper.LogarithmicPowerBandResample"/>)
 /// integrates power over bands of constant RELATIVE width, where pink renders flat
 /// and white renders +3 dB/octave — and switches to constant ABSOLUTE width where
 /// the window main lobe is wider than the reference band, restoring the per-bin
 /// slopes below that corner. <see cref="BandCompensationDb"/> follows every clamp
-/// and kink exactly by rendering the analytic noise spectrum through the very same
+/// and kink exactly by rendering the modelled noise spectrum through the very same
 /// resampler instead of restating its band law.</item>
 /// </list>
 /// </remarks>
@@ -33,25 +156,37 @@ public static class NoiseTiltCompensation
 
     /// <summary>
     /// The compensation for one point of the per-bin dB display: the mirrored
-    /// straight line of the noise's PSD slope, zero at the pivot.
+    /// modelled amplitude of the noise, zero at the pivot.
     /// </summary>
-    public static double BinCompensationDb(double psdSlopeDbPerOctave, double frequency) =>
-        frequency > 0.0
-            ? -psdSlopeDbPerOctave * Math.Log2(frequency / PivotFrequency)
+    public static double BinCompensationDb(
+        NoiseSpectralModel model,
+        double frequency,
+        int sampleRate)
+    {
+        if (frequency <= 0.0 || sampleRate <= 0)
+        {
+            return 0.0;
+        }
+
+        double amplitude = model.AmplitudeAt(frequency, sampleRate);
+        double pivot = model.AmplitudeAt(PivotFrequency, sampleRate);
+        return amplitude > 0.0 && pivot > 0.0
+            ? -20.0 * Math.Log10(amplitude / pivot)
             : 0.0;
+    }
 
     /// <summary>
     /// The per-point compensation for a band-power display curve produced by
     /// <see cref="DataHelper.LogarithmicPowerBandResample"/> with these same
-    /// parameters: the analytic spectrum of the noise is rendered through that
+    /// parameters: the modelled spectrum of the noise is rendered through that
     /// resampler and mirrored, so the result aligns index-for-index with the
     /// displayed curve (same grid, same clamps) and is exact across the
     /// relative-to-absolute bandwidth corner. Zero at the grid point nearest the
-    /// pivot. A slope of zero (white noise) still compensates — the band law
-    /// itself tilts a flat PSD by +3 dB/octave.
+    /// pivot. A flat model (white noise) still compensates — the band law itself
+    /// tilts a flat PSD by +3 dB/octave.
     /// </summary>
     public static double[] BandCompensationDb(
-        double psdSlopeDbPerOctave,
+        NoiseSpectralModel model,
         int binCount,
         int fftLength,
         int sampleRate,
@@ -64,7 +199,7 @@ public static class NoiseTiltCompensation
         bool psychoacoustic)
     {
         double[] reference = ReferenceAmplitudeSpectrum(
-            psdSlopeDbPerOctave, binCount, fftLength, sampleRate);
+            model, binCount, fftLength, sampleRate);
         List<SignalPoint> shape = DataHelper.LogarithmicPowerBandResample(
             reference,
             fftLength,
@@ -93,18 +228,15 @@ public static class NoiseTiltCompensation
     }
 
     /// <summary>
-    /// The amplitude spectrum a noise of the given PSD slope has, per FFT bin, with
-    /// unit amplitude at the pivot: PSD ∝ f^(α/(10·log10 2)) means amplitude
-    /// ∝ f^(α/(20·log10 2)) — exactly <c>1/√f</c> for pink (α = −3.01), which is
-    /// also bin-for-bin how the periodic pink excitation is synthesised.
+    /// The modelled amplitude spectrum of the noise, per FFT bin, at an arbitrary
+    /// overall gain (the compensation is pivot-normalized either way).
     /// </summary>
     private static double[] ReferenceAmplitudeSpectrum(
-        double psdSlopeDbPerOctave,
+        NoiseSpectralModel model,
         int binCount,
         int fftLength,
         int sampleRate)
     {
-        double exponent = psdSlopeDbPerOctave / (20.0 * Math.Log10(2.0));
         double binWidth = fftLength > 0 ? (double)sampleRate / fftLength : 0.0;
         var amplitude = new double[Math.Max(0, binCount)];
         if (binWidth <= 0.0)
@@ -112,11 +244,11 @@ public static class NoiseTiltCompensation
             return amplitude;
         }
 
-        // Bin 0 is DC: a sloped noise has no defined density there, and the band
+        // Bin 0 is DC: the sloped noises have no defined density there, and the band
         // resampler never reads it (it integrates from bin 1), so it stays zero.
         for (int bin = 1; bin < amplitude.Length; bin++)
         {
-            amplitude[bin] = Math.Pow(bin * binWidth / PivotFrequency, exponent);
+            amplitude[bin] = model.AmplitudeAt(bin * binWidth, sampleRate);
         }
 
         return amplitude;

--- a/dsp/NoiseTiltCompensation.cs
+++ b/dsp/NoiseTiltCompensation.cs
@@ -1,0 +1,142 @@
+namespace Resonalyze.Dsp;
+
+/// <summary>
+/// Display-side compensation for the spectral tilt a noise excitation itself prints
+/// onto a reference-free RTA: measured through a perfectly flat system, pink noise
+/// still draws −3 dB/octave on a per-bin dB axis, because the tilt belongs to the
+/// signal, not the system. Subtracting the noise's own rendered shape — pinned to
+/// 0 dB at <see cref="PivotFrequency"/> so the level does not jump — makes a flat
+/// system read flat whatever the excitation colour.
+/// </summary>
+/// <remarks>
+/// The shape being subtracted depends on the DISPLAY PATH, not just the noise:
+/// <list type="bullet">
+/// <item>The per-bin dB display (constant absolute bin width) renders a noise of
+/// PSD slope α dB/octave as a straight α dB/octave line —
+/// <see cref="BinCompensationDb"/> is its mirror.</item>
+/// <item>The band-power display (<see cref="DataHelper.LogarithmicPowerBandResample"/>)
+/// integrates power over bands of constant RELATIVE width, where pink renders flat
+/// and white renders +3 dB/octave — and switches to constant ABSOLUTE width where
+/// the window main lobe is wider than the reference band, restoring the per-bin
+/// slopes below that corner. <see cref="BandCompensationDb"/> follows every clamp
+/// and kink exactly by rendering the analytic noise spectrum through the very same
+/// resampler instead of restating its band law.</item>
+/// </list>
+/// </remarks>
+public static class NoiseTiltCompensation
+{
+    /// <summary>
+    /// The frequency the compensation is pinned to zero at, so switching it on
+    /// rotates the curve around a familiar anchor instead of shifting its level.
+    /// </summary>
+    public const double PivotFrequency = 1000.0;
+
+    /// <summary>
+    /// The compensation for one point of the per-bin dB display: the mirrored
+    /// straight line of the noise's PSD slope, zero at the pivot.
+    /// </summary>
+    public static double BinCompensationDb(double psdSlopeDbPerOctave, double frequency) =>
+        frequency > 0.0
+            ? -psdSlopeDbPerOctave * Math.Log2(frequency / PivotFrequency)
+            : 0.0;
+
+    /// <summary>
+    /// The per-point compensation for a band-power display curve produced by
+    /// <see cref="DataHelper.LogarithmicPowerBandResample"/> with these same
+    /// parameters: the analytic spectrum of the noise is rendered through that
+    /// resampler and mirrored, so the result aligns index-for-index with the
+    /// displayed curve (same grid, same clamps) and is exact across the
+    /// relative-to-absolute bandwidth corner. Zero at the grid point nearest the
+    /// pivot. A slope of zero (white noise) still compensates — the band law
+    /// itself tilts a flat PSD by +3 dB/octave.
+    /// </summary>
+    public static double[] BandCompensationDb(
+        double psdSlopeDbPerOctave,
+        int binCount,
+        int fftLength,
+        int sampleRate,
+        double windowEnbwBins,
+        double windowMainLobeBins,
+        double start,
+        double stop,
+        int steps,
+        double smoothingOctaves,
+        bool psychoacoustic)
+    {
+        double[] reference = ReferenceAmplitudeSpectrum(
+            psdSlopeDbPerOctave, binCount, fftLength, sampleRate);
+        List<SignalPoint> shape = DataHelper.LogarithmicPowerBandResample(
+            reference,
+            fftLength,
+            sampleRate,
+            windowEnbwBins,
+            windowMainLobeBins,
+            start,
+            stop,
+            steps,
+            smoothingOctaves,
+            psychoacoustic);
+
+        var compensation = new double[shape.Count];
+        if (shape.Count == 0)
+        {
+            return compensation;
+        }
+
+        double pivotDb = shape[NearestIndex(shape, PivotFrequency)].Y;
+        for (int i = 0; i < shape.Count; i++)
+        {
+            compensation[i] = pivotDb - shape[i].Y;
+        }
+
+        return compensation;
+    }
+
+    /// <summary>
+    /// The amplitude spectrum a noise of the given PSD slope has, per FFT bin, with
+    /// unit amplitude at the pivot: PSD ∝ f^(α/(10·log10 2)) means amplitude
+    /// ∝ f^(α/(20·log10 2)) — exactly <c>1/√f</c> for pink (α = −3.01), which is
+    /// also bin-for-bin how the periodic pink excitation is synthesised.
+    /// </summary>
+    private static double[] ReferenceAmplitudeSpectrum(
+        double psdSlopeDbPerOctave,
+        int binCount,
+        int fftLength,
+        int sampleRate)
+    {
+        double exponent = psdSlopeDbPerOctave / (20.0 * Math.Log10(2.0));
+        double binWidth = fftLength > 0 ? (double)sampleRate / fftLength : 0.0;
+        var amplitude = new double[Math.Max(0, binCount)];
+        if (binWidth <= 0.0)
+        {
+            return amplitude;
+        }
+
+        // Bin 0 is DC: a sloped noise has no defined density there, and the band
+        // resampler never reads it (it integrates from bin 1), so it stays zero.
+        for (int bin = 1; bin < amplitude.Length; bin++)
+        {
+            amplitude[bin] = Math.Pow(bin * binWidth / PivotFrequency, exponent);
+        }
+
+        return amplitude;
+    }
+
+    private static int NearestIndex(List<SignalPoint> points, double frequency)
+    {
+        int nearest = 0;
+        double best = double.PositiveInfinity;
+        for (int i = 0; i < points.Count; i++)
+        {
+            // The grid is logarithmic, so compare in octaves, not hertz.
+            double distance = Math.Abs(Math.Log2(points[i].X / frequency));
+            if (distance < best)
+            {
+                best = distance;
+                nearest = i;
+            }
+        }
+
+        return nearest;
+    }
+}

--- a/source/LiveSpectrum/LiveRtaRawCapture.cs
+++ b/source/LiveSpectrum/LiveRtaRawCapture.cs
@@ -29,12 +29,30 @@ internal static class LiveRtaRawCapture
     /// The raw samples of the relative (native dB) RTA: every FFT bin as (Hz, dB),
     /// uncalibrated. Mirrors the point construction inside the live magnitude resampler,
     /// so smoothing these with <see cref="RawCurveRenderer.Render"/> reproduces the trace.
+    /// An active noise-tilt compensation is BAKED IN, exactly as the display applies it
+    /// per bin before its resample: the captured overlay is a record of the compensated
+    /// curve the user saw, and stays that curve under the overlay's own smoothing.
     /// </summary>
     public static List<SignalPoint> BuildRelativeRaw(
         IReadOnlyList<double> amplitudeSpectrum,
         int fftLength,
-        int sampleRate) =>
+        int sampleRate,
+        double? tiltCompensationSlopeDbPerOctave = null)
+    {
         // The same bins-to-dB conversion the live magnitude resampler runs before it
         // smooths onto the display grid, so re-smoothing these reproduces the trace.
-        DataHelper.MagnitudeBinsToDecibels(amplitudeSpectrum, fftLength, sampleRate);
+        List<SignalPoint> bins =
+            DataHelper.MagnitudeBinsToDecibels(amplitudeSpectrum, fftLength, sampleRate);
+        if (tiltCompensationSlopeDbPerOctave is { } slope && slope != 0.0)
+        {
+            for (int i = 0; i < bins.Count; i++)
+            {
+                bins[i] = new SignalPoint(
+                    bins[i].X,
+                    bins[i].Y + NoiseTiltCompensation.BinCompensationDb(slope, bins[i].X));
+            }
+        }
+
+        return bins;
+    }
 }

--- a/source/LiveSpectrum/LiveRtaRawCapture.cs
+++ b/source/LiveSpectrum/LiveRtaRawCapture.cs
@@ -37,19 +37,20 @@ internal static class LiveRtaRawCapture
         IReadOnlyList<double> amplitudeSpectrum,
         int fftLength,
         int sampleRate,
-        double? tiltCompensationSlopeDbPerOctave = null)
+        NoiseSpectralModel? tiltCompensationModel = null)
     {
         // The same bins-to-dB conversion the live magnitude resampler runs before it
         // smooths onto the display grid, so re-smoothing these reproduces the trace.
         List<SignalPoint> bins =
             DataHelper.MagnitudeBinsToDecibels(amplitudeSpectrum, fftLength, sampleRate);
-        if (tiltCompensationSlopeDbPerOctave is { } slope && slope != 0.0)
+        if (tiltCompensationModel is { } model && sampleRate > 0)
         {
             for (int i = 0; i < bins.Count; i++)
             {
                 bins[i] = new SignalPoint(
                     bins[i].X,
-                    bins[i].Y + NoiseTiltCompensation.BinCompensationDb(slope, bins[i].X));
+                    bins[i].Y + NoiseTiltCompensation.BinCompensationDb(
+                        model, bins[i].X, sampleRate));
             }
         }
 

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -91,6 +91,13 @@ internal sealed class LiveSpectrumController : IDisposable
     public bool TimerEnabled => timer.Enabled;
 
     /// <summary>
+    /// Whether the configured input carries a loopback reference channel — the
+    /// prerequisite of the Transfer Function mode. The options panel colours its
+    /// Transfer choice amber by this when the selection cannot take effect.
+    /// </summary>
+    public bool HasConfiguredLoopback => measurement.HasConfiguredLoopback;
+
+    /// <summary>
     /// Whether the live plot currently has a curve to show — a running capture or a
     /// kept last snapshot — i.e. whether a view-only SPL scale would actually hide
     /// something. The options panel colours its dB SPL choice amber by this, so the
@@ -123,8 +130,11 @@ internal sealed class LiveSpectrumController : IDisposable
         RenderingSpl && plotModelFactory.LiveSplOffsetDb == null;
 
     // The plot shows only the reference-free RTA (no transfer function or coherence)
-    // when the SPL view is active OR the capture has no loopback reference at all.
-    private bool RtaOnly => RenderingSpl || measurement.IsRtaCapture;
+    // when the effective analysis mode is RTA — selected, or forced by a missing
+    // loopback reference. SPL no longer forces this: the scale is only effective in
+    // RTA mode to begin with (see PlotModelFactory.EffectiveLiveSpectrumScale).
+    private bool RtaOnly =>
+        plotModelFactory.EffectiveLiveAnalysisMode == LiveAnalysisMode.Rta;
 
     // The reference-free RTA is normally optional, but it IS the only curve in the
     // RTA-only views, so it is always computed there even if its checkbox is off.
@@ -142,7 +152,8 @@ internal sealed class LiveSpectrumController : IDisposable
         bool RtaOnly,
         int SmoothingInverseOctaves,
         string? CalibrationId,
-        double? SplOffsetDb);
+        double? SplOffsetDb,
+        double? TiltSlopeDbPerOctave);
 
     private PeakHoldDisplayKey renderedPeakHoldKey;
 
@@ -152,7 +163,10 @@ internal sealed class LiveSpectrumController : IDisposable
         liveSpectrumOptions.SmoothingInverseOctaves,
         liveSpectrumOptions.CalibrationId,
         // The offset only shapes the display in SPL; in relative it is irrelevant.
-        RenderingSpl ? plotModelFactory.LiveSplOffsetDb : null);
+        RenderingSpl ? plotModelFactory.LiveSplOffsetDb : null,
+        // Null (off) and zero (white noise, band-law-only compensation) are
+        // different display transforms; the nullable keeps them distinct.
+        plotModelFactory.LiveTiltSlopeDbPerOctave);
 
     /// <summary>
     /// Clears the running average and peak-hold envelope without interrupting
@@ -300,103 +314,44 @@ internal sealed class LiveSpectrumController : IDisposable
     /// <summary>
     /// Reacts to any calibration change — an SPL anchor added/cleared, its offset
     /// re-measured, or a different microphone-correction file bound to the same mode.
-    /// This runs in EVERY app mode, not only while Live Spectrum is visible, because a
-    /// calibration change can force the signal either way — losing SPL normalizes a
-    /// <see cref="NoiseColor.Silent"/> RTA back to a real excitation, gaining it drops a
-    /// stale periodic-pink excitation back to Silent — and drops the now-incompatible
-    /// peak-hold envelope wherever the analyzer sits. It rebuilds the plot only when Live Spectrum is the visible
-    /// mode (a running one is restarted if a Silent capture must fall back; an idle one
-    /// simply re-renders). Returns whether the live signal type changed, so the caller
-    /// can persist the normalized options. Safe whether running or idle.
+    /// This runs in EVERY app mode, not only while Live Spectrum is visible, because
+    /// the change makes the peak-hold envelope incompatible wherever the analyzer
+    /// sits; the plot itself is rebuilt only when Live Spectrum is the visible mode.
+    /// The capture is never touched: the signal follows the ANALYSIS MODE, not the
+    /// calibration — a Silent RTA that loses SPL simply keeps running on the
+    /// relative axis. Safe whether running or idle.
     /// </summary>
-    public async Task<bool> RefreshCalibrationAsync()
+    public void RefreshCalibration()
     {
         InvalidateCalibration();
 
-        // A running capture whose signal no longer fits the effective scale must be
-        // restarted: a Silent RTA that lost SPL needs a real excitation, and a periodic
-        // pink capture that just gained SPL must drop its now-pointless excitation for
-        // the ambient mic-only RTA. Either way the playback and analysis path change, so
-        // stop it, normalize the signal, and restart on the corrected one.
-        bool restart = measurement.InProgress && SignalNeedsNormalization();
-        if (restart)
-        {
-            await StopAsync();
-        }
-
-        bool signalChanged = NormalizeSilentSignal();
-
-        if (restart && getCurrentMode() == Mode.LiveSpectrum)
-        {
-            await StartAsync();
-            return signalChanged;
-        }
-
-        // Only the VISIBLE Live Spectrum rebuilds its model here; in another mode the
-        // normalization above already removed the stale Silent, and the model is rebuilt
-        // when Live Spectrum next becomes visible (RestoreLastCurve).
         if (getCurrentMode() == Mode.LiveSpectrum)
         {
             RebuildModel();
         }
-
-        return signalChanged;
     }
 
-    // Forces the runtime signal to one the effective scale actually offers, so the
-    // stored NoiseColor never diverges from what the panel and the playback show. The
-    // two scale-exclusive signals swap symmetrically: Silent (an ambient RTA with no
-    // excitation) is SPL-only, so off SPL it falls back to periodic pink; periodic pink
-    // (the transfer-function reference) is relative-only, so under the reference-free
-    // SPL RTA it falls back to Silent — which also restores the original signal after a
-    // Silent→pink calibration-loss round-trip. The shared Pink/Brown/White colours are
-    // valid on both scales and are never touched.
-    internal static bool NormalizeSignalType(
-        LiveSpectrumOptions options,
-        MagnitudeScale effectiveScale)
+    // Forces the runtime signal to one the selected analysis mode actually offers, so
+    // the stored NoiseColor never diverges from what the panel and the playback show.
+    // Silent (an ambient RTA with no excitation) is the one mode-exclusive signal: a
+    // transfer function has nothing to correlate against without an excitation, so
+    // entering Transfer mode falls it back to periodic pink (the transfer reference).
+    // Every real excitation is valid in both modes and is never touched.
+    internal static bool NormalizeSignalType(LiveSpectrumOptions options)
     {
-        NoiseColor normalized = NormalizedSignalType(options.NoiseColor, effectiveScale);
-        if (normalized == options.NoiseColor)
+        if (options.AnalysisMode == LiveAnalysisMode.TransferFunction &&
+            options.NoiseColor == NoiseColor.Silent)
         {
-            return false;
+            options.NoiseColor = NoiseColor.PinkPeriodic;
+            return true;
         }
 
-        options.NoiseColor = normalized;
-        return true;
+        return false;
     }
-
-    private static NoiseColor NormalizedSignalType(
-        NoiseColor color,
-        MagnitudeScale effectiveScale)
-    {
-        bool spl = effectiveScale == MagnitudeScale.SoundPressureLevel;
-        if (color == NoiseColor.Silent && !spl)
-        {
-            return NoiseColor.PinkPeriodic;
-        }
-
-        if (color == NoiseColor.PinkPeriodic && spl)
-        {
-            return NoiseColor.Silent;
-        }
-
-        return color;
-    }
-
-    // Whether the current runtime signal is not valid for the effective scale and would
-    // be swapped by NormalizeSignalType. A running measurement must restart when it is,
-    // because either direction changes the playback (pink excitation ↔ zero) and the
-    // analysis path (transfer vs. mic-only RTA).
-    private bool SignalNeedsNormalization() =>
-        NormalizedSignalType(
-            liveSpectrumOptions.NoiseColor,
-            plotModelFactory.EffectiveLiveSpectrumScale) != liveSpectrumOptions.NoiseColor;
 
     private bool NormalizeSilentSignal()
     {
-        bool changed = NormalizeSignalType(
-            liveSpectrumOptions,
-            plotModelFactory.EffectiveLiveSpectrumScale);
+        bool changed = NormalizeSignalType(liveSpectrumOptions);
         if (changed)
         {
             measurement.RefreshPlaybackSignal();
@@ -586,11 +541,11 @@ internal sealed class LiveSpectrumController : IDisposable
             return;
         }
 
-        // The plot is the reference-free microphone (RTA) spectrum whenever the SPL
-        // view is active (the transfer function has no scalar SPL under noise) or the
-        // capture has no loopback at all (there is no transfer function to draw). In
-        // those RTA-only views the transfer function and coherence are hidden, the RTA
-        // is forced on, and the peak hold envelops it instead of the transfer curve.
+        // The plot is the reference-free microphone (RTA) spectrum whenever the
+        // effective analysis mode is RTA — selected, or forced by a capture with no
+        // loopback at all (there is no transfer function to draw). In the RTA-only
+        // views the transfer function and coherence are hidden, the RTA is forced
+        // on, and the peak hold envelops it instead of the transfer curve.
         bool rtaOnly = RtaOnly;
         renderedPeakHoldKey = CurrentPeakHoldKey();
 

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -153,7 +153,7 @@ internal sealed class LiveSpectrumController : IDisposable
         int SmoothingInverseOctaves,
         string? CalibrationId,
         double? SplOffsetDb,
-        double? TiltSlopeDbPerOctave);
+        NoiseSpectralModel? TiltModel);
 
     private PeakHoldDisplayKey renderedPeakHoldKey;
 
@@ -164,9 +164,9 @@ internal sealed class LiveSpectrumController : IDisposable
         liveSpectrumOptions.CalibrationId,
         // The offset only shapes the display in SPL; in relative it is irrelevant.
         RenderingSpl ? plotModelFactory.LiveSplOffsetDb : null,
-        // Null (off) and zero (white noise, band-law-only compensation) are
-        // different display transforms; the nullable keeps them distinct.
-        plotModelFactory.LiveTiltSlopeDbPerOctave);
+        // Null (off) and a flat model (white noise, band-law-only compensation)
+        // are different display transforms; the nullable keeps them distinct.
+        plotModelFactory.LiveTiltModel);
 
     /// <summary>
     /// Clears the running average and peak-hold envelope without interrupting

--- a/source/LiveSpectrum/LiveSpectrumController.cs
+++ b/source/LiveSpectrum/LiveSpectrumController.cs
@@ -303,6 +303,22 @@ internal sealed class LiveSpectrumController : IDisposable
     }
 
     /// <summary>
+    /// Discards the accumulated spectra and the remembered curve. The host calls
+    /// this when an acquisition parameter (analysis mode, signal colour, window,
+    /// FFT length, overlap) changes while the analyzer is STOPPED: the kept curve
+    /// is a record of the previous setup, and the display transform reads the
+    /// options live — redrawing old data under the new parameters would silently
+    /// re-interpret it (the slope compensation, for one, would re-tilt a stopped
+    /// pink RTA as if the excitation had been white). A running analyzer needs no
+    /// call — its restart already begins a fresh accumulation.
+    /// </summary>
+    public void DiscardCapturedData()
+    {
+        measurement.ResetAccumulation();
+        ForgetLastCurve();
+    }
+
+    /// <summary>
     /// Drops display state that is incompatible with any calibration change.
     /// This must run even while another mode owns the visible plot.
     /// </summary>

--- a/source/Measurements/LiveSpectrumOptions.cs
+++ b/source/Measurements/LiveSpectrumOptions.cs
@@ -150,26 +150,31 @@ namespace Resonalyze
     }
 
     /// <summary>
-    /// The power spectral density each excitation colour is synthesised with, as the
-    /// dB-per-octave slope the tilt compensation must undo (see
-    /// <see cref="Dsp.NoiseTiltCompensation"/>). The synthesis is exact enough to
-    /// compensate analytically: periodic pink is exactly <c>1/√k</c> per bin, and the
-    /// Kellett pink filter tracks −3 dB/octave within a fraction of a dB.
+    /// The spectral shape each excitation colour is actually SYNTHESISED with, as
+    /// the model the tilt compensation must undo (see
+    /// <see cref="Dsp.NoiseTiltCompensation"/>). Ideal power laws only where the
+    /// synthesis is one: periodic pink is exactly <c>1/√k</c> per bin and white is
+    /// flat, but random pink is the Kellett filter bank and brown a leaky
+    /// integrator — both flatten below their filter corners, and compensating a
+    /// nominal slope there would print an artificial bass roll-off onto a correct
+    /// measurement.
     /// </summary>
     internal static class NoiseColorTilt
     {
         /// <summary>
-        /// The PSD slope of the colour in dB per octave, or null when the excitation
-        /// spectrum is unknown (<see cref="NoiseColor.Silent"/> — an external source)
-        /// and no compensation can be honest.
+        /// The spectral model of the colour, or null when the excitation spectrum is
+        /// unknown (<see cref="NoiseColor.Silent"/> — an external source) and no
+        /// compensation can be honest.
         /// </summary>
-        public static double? PsdSlopeDbPerOctave(NoiseColor color) => color switch
+        public static NoiseSpectralModel? SpectralModel(NoiseColor color) => color switch
         {
-            // Pink: PSD ∝ 1/f → −10·log10(2) dB per octave.
-            NoiseColor.PinkPeriodic or NoiseColor.Pink => -10.0 * Math.Log10(2.0),
-            // Brown: PSD ∝ 1/f² → −20·log10(2) dB per octave.
-            NoiseColor.Brown => -20.0 * Math.Log10(2.0),
-            NoiseColor.White => 0.0,
+            // Exactly 1/√k per synthesised bin: PSD ∝ 1/f → −10·log10(2) dB/octave.
+            NoiseColor.PinkPeriodic =>
+                NoiseSpectralModel.PowerLaw(-10.0 * Math.Log10(2.0)),
+            NoiseColor.Pink => NoiseSpectralModel.KellettPink,
+            NoiseColor.Brown =>
+                NoiseSpectralModel.LeakyIntegrator(NoiseSignal.BrownCornerHz),
+            NoiseColor.White => NoiseSpectralModel.PowerLaw(0.0),
             _ => null
         };
     }

--- a/source/Measurements/LiveSpectrumOptions.cs
+++ b/source/Measurements/LiveSpectrumOptions.cs
@@ -40,10 +40,45 @@ namespace Resonalyze
         Infinite
     }
 
+    /// <summary>
+    /// What the live analyzer measures.
+    /// <list type="bullet">
+    /// <item><see cref="TransferFunction"/> — the dual-channel H1 estimate of
+    /// microphone over loopback reference, with coherence. Needs a configured
+    /// loopback channel; without one the analyzer can only run reference-free,
+    /// so the effective mode falls back to <see cref="Rta"/>.</item>
+    /// <item><see cref="Rta"/> — the reference-free magnitude spectrum of the
+    /// microphone input alone. The only mode that can show absolute dB SPL, and
+    /// the only mode where the <see cref="NoiseColor.Silent"/> (ambient) signal
+    /// makes sense.</item>
+    /// </list>
+    /// </summary>
+    public enum LiveAnalysisMode
+    {
+        TransferFunction,
+        Rta
+    }
+
     public sealed class LiveSpectrumOptions
     {
+        /// <summary>
+        /// The selected analysis mode. The invariant that <see cref="NoiseColor.Silent"/>
+        /// exists only in <see cref="LiveAnalysisMode.Rta"/> is enforced at settings load
+        /// and by <c>LiveSpectrumController.NormalizeSignalType</c>, never assumed here.
+        /// </summary>
+        public LiveAnalysisMode AnalysisMode { get; set; } = LiveAnalysisMode.TransferFunction;
+
         /// <summary>Spectral colour of the excitation noise played during measurement.</summary>
         public NoiseColor NoiseColor { get; set; } = NoiseColor.PinkPeriodic;
+
+        /// <summary>
+        /// Compensates the tilt the excitation noise itself prints onto the
+        /// reference-free RTA display (pink reads −3 dB/octave on the per-bin dB
+        /// axis even through a flat system), so a flat system reads flat. RTA mode
+        /// only — the transfer function divides the excitation out — and inert for
+        /// <see cref="NoiseColor.Silent"/>, whose excitation spectrum is unknown.
+        /// </summary>
+        public bool CompensateNoiseTilt { get; set; }
 
         /// <summary>
         /// Which microphone calibration corrects the live curves, by id (see
@@ -108,8 +143,34 @@ namespace Resonalyze
         /// Vertical scale of the live plot. In <see cref="MagnitudeScale.SoundPressureLevel"/>
         /// the reference-free RTA (microphone) spectrum is shown in absolute dB SPL
         /// (mic + calibration offset). The transfer function is a dimensionless ratio
-        /// with no scalar SPL under noise excitation, so it is not shown on the SPL axis.
+        /// with no scalar SPL under noise excitation, so the scale takes effect only in
+        /// <see cref="LiveAnalysisMode.Rta"/>; a transfer plot always renders relative.
         /// </summary>
         public MagnitudeScale MagnitudeScale { get; set; } = MagnitudeScale.Relative;
+    }
+
+    /// <summary>
+    /// The power spectral density each excitation colour is synthesised with, as the
+    /// dB-per-octave slope the tilt compensation must undo (see
+    /// <see cref="Dsp.NoiseTiltCompensation"/>). The synthesis is exact enough to
+    /// compensate analytically: periodic pink is exactly <c>1/√k</c> per bin, and the
+    /// Kellett pink filter tracks −3 dB/octave within a fraction of a dB.
+    /// </summary>
+    internal static class NoiseColorTilt
+    {
+        /// <summary>
+        /// The PSD slope of the colour in dB per octave, or null when the excitation
+        /// spectrum is unknown (<see cref="NoiseColor.Silent"/> — an external source)
+        /// and no compensation can be honest.
+        /// </summary>
+        public static double? PsdSlopeDbPerOctave(NoiseColor color) => color switch
+        {
+            // Pink: PSD ∝ 1/f → −10·log10(2) dB per octave.
+            NoiseColor.PinkPeriodic or NoiseColor.Pink => -10.0 * Math.Log10(2.0),
+            // Brown: PSD ∝ 1/f² → −20·log10(2) dB per octave.
+            NoiseColor.Brown => -20.0 * Math.Log10(2.0),
+            NoiseColor.White => 0.0,
+            _ => null
+        };
     }
 }

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -521,6 +521,13 @@ namespace Resonalyze
             return success;
         }
 
+        // An RTA capture opens the microphone ALONE even when a loopback reference is
+        // configured: the reference-free analysis never reads it, and requesting it
+        // is not merely a wasted channel — WASAPI refuses to open an endpoint with
+        // fewer channels than the mic+loopback routing requires, and ASIO widens the
+        // captured channel window to span from the mic to the reference. The
+        // configured offsets themselves are kept (HasConfiguredLoopback still gates
+        // the Transfer mode's availability); only this session request drops them.
         private AudioSessionRequest BuildSessionRequest() =>
             AudioSessionRequestBuilder.Build(
                 AudioBackend,
@@ -528,9 +535,9 @@ namespace Resonalyze
                 Bits,
                 PlaybackChannel,
                 WaveInputChannelOffset,
-                WaveLoopbackInputChannelOffset,
+                IsRtaCapture ? null : WaveLoopbackInputChannelOffset,
                 AsioInputChannelOffset,
-                AsioLoopbackInputChannelOffset,
+                IsRtaCapture ? null : AsioLoopbackInputChannelOffset,
                 AsioOutputChannelOffset,
                 OutputDeviceNumber,
                 InputDeviceNumber,

--- a/source/Measurements/NoiseMeasurement.cs
+++ b/source/Measurements/NoiseMeasurement.cs
@@ -90,8 +90,13 @@ namespace Resonalyze
         /// </summary>
         public bool IsMicOnly => !HasConfiguredLoopback;
 
+        // The analysis path follows the SELECTED mode, forced to RTA when no loopback
+        // reference exists to form a transfer function from. Not keyed on the signal:
+        // Silent is RTA-exclusive by invariant (settings load and the options panel
+        // both enforce it), and a mode change always restarts the capture (it is part
+        // of Form1's LiveSpectrumRestartSnapshot), so this cannot flip mid-run.
         public bool IsRtaCapture =>
-            IsMicOnly || LiveSpectrumOptions.NoiseColor == NoiseColor.Silent;
+            IsMicOnly || LiveSpectrumOptions.AnalysisMode == LiveAnalysisMode.Rta;
 
         /// <summary>
         /// The digital identity of the microphone input this analyzer is configured

--- a/source/Measurements/NoiseSignal.cs
+++ b/source/Measurements/NoiseSignal.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using MathNet.Numerics.IntegralTransforms;
+using Resonalyze.Dsp;
 using Resonalyze.Options;
 
 namespace Resonalyze;
@@ -89,21 +90,25 @@ public sealed class NoiseSignal : IDisposable
 
     // Pink noise (-3 dB/octave) via Paul Kellett's economical filter bank, then
     // normalized to the same 0.5 peak as the white path so playback level matches.
+    // The coefficients live in Dsp.KellettPinkFilter, shared with the noise-tilt
+    // compensation, which must model this exact filter (the bank flattens below its
+    // lowest pole's corner) — a drifted copy would silently mis-compensate.
     private void FillPink(Random random)
     {
-        double b0 = 0, b1 = 0, b2 = 0, b3 = 0, b4 = 0, b5 = 0, b6 = 0;
+        IReadOnlyList<(double A, double G)> poles = KellettPinkFilter.Poles;
+        var states = new double[poles.Count];
+        double delayed = 0;
         double peak = 0;
         for (int sampleIndex = 0; sampleIndex < Samples; sampleIndex++)
         {
             double white = random.NextDouble() * 2.0 - 1.0;
-            b0 = 0.99886 * b0 + white * 0.0555179;
-            b1 = 0.99332 * b1 + white * 0.0750759;
-            b2 = 0.96900 * b2 + white * 0.1538520;
-            b3 = 0.86650 * b3 + white * 0.3104856;
-            b4 = 0.55000 * b4 + white * 0.5329522;
-            b5 = -0.7616 * b5 - white * 0.0168980;
-            double pink = b0 + b1 + b2 + b3 + b4 + b5 + b6 + white * 0.5362;
-            b6 = white * 0.115926;
+            double pink = KellettPinkFilter.DirectGain * white + delayed;
+            for (int pole = 0; pole < states.Length; pole++)
+            {
+                states[pole] = poles[pole].A * states[pole] + poles[pole].G * white;
+                pink += states[pole];
+            }
+            delayed = KellettPinkFilter.DelayedGain * white;
 
             FloatData[sampleIndex] = (float)pink;
             double magnitude = Math.Abs(pink);
@@ -174,7 +179,9 @@ public sealed class NoiseSignal : IDisposable
     // the −6 dB/oct slope flattens): a fixed 0.99 coefficient put that corner
     // at ~76 Hz at 48 kHz but ~305 Hz at 192 kHz — the same "Brown" mode
     // changed its spectral shape with the sample rate.
-    private const double BrownCornerHz = 76.0;
+    // Shared with the noise-tilt compensation, whose leaky-integrator model must
+    // derive the same leak from the same corner.
+    internal const double BrownCornerHz = 76.0;
 
     private void FillBrown(Random random)
     {

--- a/source/Options/LiveSpectrumOpt.Designer.cs
+++ b/source/Options/LiveSpectrumOpt.Designer.cs
@@ -28,6 +28,9 @@ namespace Resonalyze.Options
         /// </summary>
         private void InitializeComponent()
         {
+            labelAnalysisMode = new Label();
+            radioModeTransfer = new RadioButton();
+            radioModeRta = new RadioButton();
             comboCalibration = new DarkComboBox();
             label2 = new Label();
             labelSignalType = new Label();
@@ -49,9 +52,10 @@ namespace Resonalyze.Options
             label10 = new Label();
             coherenceLimitComboBox = new DarkComboBox();
             buttonResetAverage = new Button();
-            labelScale = new Label();
-            radioMagnitudeRelative = new RadioButton();
-            radioMagnitudeSpl = new RadioButton();
+            labelSpl = new Label();
+            checkSpl = new CheckBox();
+            labelTilt = new Label();
+            checkTilt = new CheckBox();
             labelCurves = new Label();
             labelMainCurve = new Label();
             checkMainCurve = new CheckBox();
@@ -59,32 +63,45 @@ namespace Resonalyze.Options
             checkInputMagnitude = new CheckBox();
             SuspendLayout();
             //
-            // comboCalibration
+            // labelAnalysisMode
             //
-            comboCalibration.BackColor = Color.FromArgb(55, 60, 72);
-            comboCalibration.ForeColor = Color.White;
-            comboCalibration.Location = new Point(132, 214);
-            comboCalibration.Margin = new Padding(0);
-            comboCalibration.MinimumSize = new Size(36, 19);
-            comboCalibration.Name = "comboCalibration";
-            comboCalibration.Size = new Size(121, 23);
-            comboCalibration.TabIndex = 47;
+            labelAnalysisMode.AutoSize = true;
+            labelAnalysisMode.ForeColor = SystemColors.ControlLight;
+            labelAnalysisMode.Location = new Point(12, 13);
+            labelAnalysisMode.Name = "labelAnalysisMode";
+            labelAnalysisMode.Size = new Size(38, 15);
+            labelAnalysisMode.TabIndex = 74;
+            labelAnalysisMode.Text = "Mode";
             //
-            // label2
+            // radioModeTransfer
             //
-            label2.AutoSize = true;
-            label2.ForeColor = SystemColors.ControlLight;
-            label2.Location = new Point(12, 217);
-            label2.Name = "label2";
-            label2.Size = new Size(65, 15);
-            label2.TabIndex = 46;
-            label2.Text = "Calibration";
+            radioModeTransfer.AutoSize = true;
+            radioModeTransfer.Checked = true;
+            radioModeTransfer.ForeColor = SystemColors.ControlLight;
+            radioModeTransfer.Location = new Point(85, 11);
+            radioModeTransfer.Name = "radioModeTransfer";
+            radioModeTransfer.Size = new Size(67, 19);
+            radioModeTransfer.TabIndex = 75;
+            radioModeTransfer.TabStop = true;
+            radioModeTransfer.Text = "Transfer";
+            radioModeTransfer.UseVisualStyleBackColor = true;
+            //
+            // radioModeRta
+            //
+            radioModeRta.AutoSize = true;
+            radioModeRta.ForeColor = SystemColors.ControlLight;
+            radioModeRta.Location = new Point(168, 11);
+            radioModeRta.Name = "radioModeRta";
+            radioModeRta.Size = new Size(46, 19);
+            radioModeRta.TabIndex = 76;
+            radioModeRta.Text = "RTA";
+            radioModeRta.UseVisualStyleBackColor = true;
             //
             // labelSignalType
             //
             labelSignalType.AutoSize = true;
             labelSignalType.ForeColor = SystemColors.ControlLight;
-            labelSignalType.Location = new Point(12, 14);
+            labelSignalType.Location = new Point(12, 43);
             labelSignalType.Name = "labelSignalType";
             labelSignalType.Size = new Size(64, 15);
             labelSignalType.TabIndex = 37;
@@ -94,18 +111,39 @@ namespace Resonalyze.Options
             //
             signalTypeComboBox.BackColor = Color.FromArgb(55, 60, 72);
             signalTypeComboBox.ForeColor = Color.White;
-            signalTypeComboBox.Location = new Point(132, 11);
+            signalTypeComboBox.Location = new Point(132, 40);
             signalTypeComboBox.Margin = new Padding(0);
             signalTypeComboBox.MinimumSize = new Size(36, 19);
             signalTypeComboBox.Name = "signalTypeComboBox";
             signalTypeComboBox.Size = new Size(121, 23);
             signalTypeComboBox.TabIndex = 48;
             //
+            // label6
+            //
+            label6.AutoSize = true;
+            label6.ForeColor = SystemColors.ControlLight;
+            label6.Location = new Point(12, 72);
+            label6.Name = "label6";
+            label6.Size = new Size(48, 15);
+            label6.TabIndex = 55;
+            label6.Text = "Window";
+            //
+            // windowComboBox
+            //
+            windowComboBox.BackColor = Color.FromArgb(55, 60, 72);
+            windowComboBox.ForeColor = Color.White;
+            windowComboBox.Location = new Point(132, 69);
+            windowComboBox.Margin = new Padding(0);
+            windowComboBox.MinimumSize = new Size(36, 19);
+            windowComboBox.Name = "windowComboBox";
+            windowComboBox.Size = new Size(121, 23);
+            windowComboBox.TabIndex = 56;
+            //
             // label3
             //
             label3.AutoSize = true;
             label3.ForeColor = SystemColors.ControlLight;
-            label3.Location = new Point(12, 72);
+            label3.Location = new Point(12, 101);
             label3.Name = "label3";
             label3.Size = new Size(98, 15);
             label3.TabIndex = 49;
@@ -115,7 +153,7 @@ namespace Resonalyze.Options
             //
             sequenceLengthComboBox.BackColor = Color.FromArgb(55, 60, 72);
             sequenceLengthComboBox.ForeColor = Color.White;
-            sequenceLengthComboBox.Location = new Point(132, 69);
+            sequenceLengthComboBox.Location = new Point(132, 98);
             sequenceLengthComboBox.Margin = new Padding(0);
             sequenceLengthComboBox.MinimumSize = new Size(36, 19);
             sequenceLengthComboBox.Name = "sequenceLengthComboBox";
@@ -126,7 +164,7 @@ namespace Resonalyze.Options
             //
             label4.AutoSize = true;
             label4.ForeColor = SystemColors.ControlLight;
-            label4.Location = new Point(12, 101);
+            label4.Location = new Point(12, 130);
             label4.Name = "label4";
             label4.Size = new Size(48, 15);
             label4.TabIndex = 51;
@@ -136,7 +174,7 @@ namespace Resonalyze.Options
             //
             overlapComboBox.BackColor = Color.FromArgb(55, 60, 72);
             overlapComboBox.ForeColor = Color.White;
-            overlapComboBox.Location = new Point(132, 98);
+            overlapComboBox.Location = new Point(132, 127);
             overlapComboBox.Margin = new Padding(0);
             overlapComboBox.MinimumSize = new Size(36, 19);
             overlapComboBox.Name = "overlapComboBox";
@@ -147,7 +185,7 @@ namespace Resonalyze.Options
             //
             label5.AutoSize = true;
             label5.ForeColor = SystemColors.ControlLight;
-            label5.Location = new Point(12, 130);
+            label5.Location = new Point(12, 159);
             label5.Name = "label5";
             label5.Size = new Size(62, 15);
             label5.TabIndex = 53;
@@ -157,39 +195,18 @@ namespace Resonalyze.Options
             //
             comboSmoothingInverseOctaves.BackColor = Color.FromArgb(55, 60, 72);
             comboSmoothingInverseOctaves.ForeColor = Color.White;
-            comboSmoothingInverseOctaves.Location = new Point(132, 127);
+            comboSmoothingInverseOctaves.Location = new Point(132, 156);
             comboSmoothingInverseOctaves.Margin = new Padding(0);
             comboSmoothingInverseOctaves.MinimumSize = new Size(36, 19);
             comboSmoothingInverseOctaves.Name = "comboSmoothingInverseOctaves";
             comboSmoothingInverseOctaves.Size = new Size(121, 23);
             comboSmoothingInverseOctaves.TabIndex = 54;
             //
-            // label6
-            //
-            label6.AutoSize = true;
-            label6.ForeColor = SystemColors.ControlLight;
-            label6.Location = new Point(12, 43);
-            label6.Name = "label6";
-            label6.Size = new Size(48, 15);
-            label6.TabIndex = 55;
-            label6.Text = "Window";
-            //
-            // windowComboBox
-            //
-            windowComboBox.BackColor = Color.FromArgb(55, 60, 72);
-            windowComboBox.ForeColor = Color.White;
-            windowComboBox.Location = new Point(132, 40);
-            windowComboBox.Margin = new Padding(0);
-            windowComboBox.MinimumSize = new Size(36, 19);
-            windowComboBox.Name = "windowComboBox";
-            windowComboBox.Size = new Size(121, 23);
-            windowComboBox.TabIndex = 56;
-            //
             // label7
             //
             label7.AutoSize = true;
             label7.ForeColor = SystemColors.ControlLight;
-            label7.Location = new Point(12, 159);
+            label7.Location = new Point(12, 188);
             label7.Name = "label7";
             label7.Size = new Size(60, 15);
             label7.TabIndex = 57;
@@ -199,58 +216,18 @@ namespace Resonalyze.Options
             //
             averagingComboBox.BackColor = Color.FromArgb(55, 60, 72);
             averagingComboBox.ForeColor = Color.White;
-            averagingComboBox.Location = new Point(132, 156);
+            averagingComboBox.Location = new Point(132, 185);
             averagingComboBox.Margin = new Padding(0);
             averagingComboBox.MinimumSize = new Size(36, 19);
             averagingComboBox.Name = "averagingComboBox";
             averagingComboBox.Size = new Size(121, 23);
             averagingComboBox.TabIndex = 58;
             //
-            // label8
-            //
-            label8.AutoSize = true;
-            label8.ForeColor = SystemColors.ControlLight;
-            label8.Location = new Point(12, 360);
-            label8.Name = "label8";
-            label8.Size = new Size(60, 15);
-            label8.TabIndex = 59;
-            label8.Text = "Peak Hold";
-            //
-            // checkPeakHold
-            //
-            checkPeakHold.AutoSize = true;
-            checkPeakHold.ForeColor = SystemColors.ControlLight;
-            checkPeakHold.Location = new Point(238, 360);
-            checkPeakHold.Name = "checkPeakHold";
-            checkPeakHold.Size = new Size(15, 14);
-            checkPeakHold.TabIndex = 60;
-            checkPeakHold.UseVisualStyleBackColor = true;
-            //
-            // label9
-            //
-            label9.AutoSize = true;
-            label9.ForeColor = SystemColors.ControlLight;
-            label9.Location = new Point(12, 337);
-            label9.Name = "label9";
-            label9.Size = new Size(64, 15);
-            label9.TabIndex = 62;
-            label9.Text = "Coherence";
-            //
-            // checkCoherence
-            //
-            checkCoherence.AutoSize = true;
-            checkCoherence.ForeColor = SystemColors.ControlLight;
-            checkCoherence.Location = new Point(238, 337);
-            checkCoherence.Name = "checkCoherence";
-            checkCoherence.Size = new Size(15, 14);
-            checkCoherence.TabIndex = 63;
-            checkCoherence.UseVisualStyleBackColor = true;
-            //
             // label10
             //
             label10.AutoSize = true;
             label10.ForeColor = SystemColors.ControlLight;
-            label10.Location = new Point(12, 188);
+            label10.Location = new Point(12, 217);
             label10.Name = "label10";
             label10.Size = new Size(95, 15);
             label10.TabIndex = 64;
@@ -260,64 +237,79 @@ namespace Resonalyze.Options
             //
             coherenceLimitComboBox.BackColor = Color.FromArgb(55, 60, 72);
             coherenceLimitComboBox.ForeColor = Color.White;
-            coherenceLimitComboBox.Location = new Point(132, 185);
+            coherenceLimitComboBox.Location = new Point(132, 214);
             coherenceLimitComboBox.Margin = new Padding(0);
             coherenceLimitComboBox.MinimumSize = new Size(36, 19);
             coherenceLimitComboBox.Name = "coherenceLimitComboBox";
             coherenceLimitComboBox.Size = new Size(121, 23);
             coherenceLimitComboBox.TabIndex = 65;
             //
-            // buttonResetAverage
+            // label2
             //
-            buttonResetAverage.BackColor = Color.FromArgb(50, 55, 80);
-            buttonResetAverage.FlatStyle = FlatStyle.Popup;
-            buttonResetAverage.ForeColor = Color.White;
-            buttonResetAverage.Location = new Point(12, 386);
-            buttonResetAverage.Name = "buttonResetAverage";
-            buttonResetAverage.Size = new Size(241, 23);
-            buttonResetAverage.TabIndex = 61;
-            buttonResetAverage.Text = "Reset Average";
-            buttonResetAverage.UseVisualStyleBackColor = false;
+            label2.AutoSize = true;
+            label2.ForeColor = SystemColors.ControlLight;
+            label2.Location = new Point(12, 246);
+            label2.Name = "label2";
+            label2.Size = new Size(65, 15);
+            label2.TabIndex = 46;
+            label2.Text = "Calibration";
             //
-            // labelScale
+            // comboCalibration
             //
-            labelScale.AutoSize = true;
-            labelScale.ForeColor = SystemColors.ControlLight;
-            labelScale.Location = new Point(12, 245);
-            labelScale.Name = "labelScale";
-            labelScale.Size = new Size(35, 15);
-            labelScale.TabIndex = 71;
-            labelScale.Text = "Scale";
+            comboCalibration.BackColor = Color.FromArgb(55, 60, 72);
+            comboCalibration.ForeColor = Color.White;
+            comboCalibration.Location = new Point(132, 243);
+            comboCalibration.Margin = new Padding(0);
+            comboCalibration.MinimumSize = new Size(36, 19);
+            comboCalibration.Name = "comboCalibration";
+            comboCalibration.Size = new Size(121, 23);
+            comboCalibration.TabIndex = 47;
             //
-            // radioMagnitudeRelative
+            // labelSpl
             //
-            radioMagnitudeRelative.AutoSize = true;
-            radioMagnitudeRelative.Checked = true;
-            radioMagnitudeRelative.ForeColor = SystemColors.ControlLight;
-            radioMagnitudeRelative.Location = new Point(85, 243);
-            radioMagnitudeRelative.Name = "radioMagnitudeRelative";
-            radioMagnitudeRelative.Size = new Size(70, 19);
-            radioMagnitudeRelative.TabIndex = 72;
-            radioMagnitudeRelative.TabStop = true;
-            radioMagnitudeRelative.Text = "Relative";
-            radioMagnitudeRelative.UseVisualStyleBackColor = true;
+            labelSpl.AutoSize = true;
+            labelSpl.ForeColor = SystemColors.ControlLight;
+            labelSpl.Location = new Point(12, 275);
+            labelSpl.Name = "labelSpl";
+            labelSpl.Size = new Size(43, 15);
+            labelSpl.TabIndex = 77;
+            labelSpl.Text = "dB SPL";
             //
-            // radioMagnitudeSpl
+            // checkSpl
             //
-            radioMagnitudeSpl.AutoSize = true;
-            radioMagnitudeSpl.ForeColor = SystemColors.ControlLight;
-            radioMagnitudeSpl.Location = new Point(168, 243);
-            radioMagnitudeSpl.Name = "radioMagnitudeSpl";
-            radioMagnitudeSpl.Size = new Size(66, 19);
-            radioMagnitudeSpl.TabIndex = 73;
-            radioMagnitudeSpl.Text = "dB SPL";
-            radioMagnitudeSpl.UseVisualStyleBackColor = true;
+            checkSpl.AutoSize = true;
+            checkSpl.ForeColor = SystemColors.ControlLight;
+            checkSpl.Location = new Point(238, 275);
+            checkSpl.Name = "checkSpl";
+            checkSpl.Size = new Size(15, 14);
+            checkSpl.TabIndex = 78;
+            checkSpl.UseVisualStyleBackColor = true;
+            //
+            // labelTilt
+            //
+            labelTilt.AutoSize = true;
+            labelTilt.ForeColor = SystemColors.ControlLight;
+            labelTilt.Location = new Point(12, 298);
+            labelTilt.Name = "labelTilt";
+            labelTilt.Size = new Size(110, 15);
+            labelTilt.TabIndex = 79;
+            labelTilt.Text = "Slope compensation";
+            //
+            // checkTilt
+            //
+            checkTilt.AutoSize = true;
+            checkTilt.ForeColor = SystemColors.ControlLight;
+            checkTilt.Location = new Point(238, 298);
+            checkTilt.Name = "checkTilt";
+            checkTilt.Size = new Size(15, 14);
+            checkTilt.TabIndex = 80;
+            checkTilt.UseVisualStyleBackColor = true;
             //
             // labelCurves
             //
             labelCurves.AutoSize = true;
             labelCurves.ForeColor = Color.FromArgb(150, 170, 205);
-            labelCurves.Location = new Point(12, 268);
+            labelCurves.Location = new Point(12, 321);
             labelCurves.Name = "labelCurves";
             labelCurves.Size = new Size(48, 15);
             labelCurves.TabIndex = 66;
@@ -327,7 +319,7 @@ namespace Resonalyze.Options
             //
             labelMainCurve.AutoSize = true;
             labelMainCurve.ForeColor = SystemColors.ControlLight;
-            labelMainCurve.Location = new Point(12, 291);
+            labelMainCurve.Location = new Point(12, 344);
             labelMainCurve.Name = "labelMainCurve";
             labelMainCurve.Size = new Size(67, 15);
             labelMainCurve.TabIndex = 67;
@@ -337,7 +329,7 @@ namespace Resonalyze.Options
             //
             checkMainCurve.AutoSize = true;
             checkMainCurve.ForeColor = SystemColors.ControlLight;
-            checkMainCurve.Location = new Point(238, 291);
+            checkMainCurve.Location = new Point(238, 344);
             checkMainCurve.Name = "checkMainCurve";
             checkMainCurve.Size = new Size(15, 14);
             checkMainCurve.TabIndex = 68;
@@ -347,7 +339,7 @@ namespace Resonalyze.Options
             //
             labelInputMagnitude.AutoSize = true;
             labelInputMagnitude.ForeColor = SystemColors.ControlLight;
-            labelInputMagnitude.Location = new Point(12, 314);
+            labelInputMagnitude.Location = new Point(12, 367);
             labelInputMagnitude.Name = "labelInputMagnitude";
             labelInputMagnitude.Size = new Size(67, 15);
             labelInputMagnitude.TabIndex = 69;
@@ -357,23 +349,79 @@ namespace Resonalyze.Options
             //
             checkInputMagnitude.AutoSize = true;
             checkInputMagnitude.ForeColor = SystemColors.ControlLight;
-            checkInputMagnitude.Location = new Point(238, 314);
+            checkInputMagnitude.Location = new Point(238, 367);
             checkInputMagnitude.Name = "checkInputMagnitude";
             checkInputMagnitude.Size = new Size(15, 14);
             checkInputMagnitude.TabIndex = 70;
             checkInputMagnitude.UseVisualStyleBackColor = true;
+            //
+            // label9
+            //
+            label9.AutoSize = true;
+            label9.ForeColor = SystemColors.ControlLight;
+            label9.Location = new Point(12, 390);
+            label9.Name = "label9";
+            label9.Size = new Size(64, 15);
+            label9.TabIndex = 62;
+            label9.Text = "Coherence";
+            //
+            // checkCoherence
+            //
+            checkCoherence.AutoSize = true;
+            checkCoherence.ForeColor = SystemColors.ControlLight;
+            checkCoherence.Location = new Point(238, 390);
+            checkCoherence.Name = "checkCoherence";
+            checkCoherence.Size = new Size(15, 14);
+            checkCoherence.TabIndex = 63;
+            checkCoherence.UseVisualStyleBackColor = true;
+            //
+            // label8
+            //
+            label8.AutoSize = true;
+            label8.ForeColor = SystemColors.ControlLight;
+            label8.Location = new Point(12, 413);
+            label8.Name = "label8";
+            label8.Size = new Size(60, 15);
+            label8.TabIndex = 59;
+            label8.Text = "Peak Hold";
+            //
+            // checkPeakHold
+            //
+            checkPeakHold.AutoSize = true;
+            checkPeakHold.ForeColor = SystemColors.ControlLight;
+            checkPeakHold.Location = new Point(238, 413);
+            checkPeakHold.Name = "checkPeakHold";
+            checkPeakHold.Size = new Size(15, 14);
+            checkPeakHold.TabIndex = 60;
+            checkPeakHold.UseVisualStyleBackColor = true;
+            //
+            // buttonResetAverage
+            //
+            buttonResetAverage.BackColor = Color.FromArgb(50, 55, 80);
+            buttonResetAverage.FlatStyle = FlatStyle.Popup;
+            buttonResetAverage.ForeColor = Color.White;
+            buttonResetAverage.Location = new Point(12, 439);
+            buttonResetAverage.Name = "buttonResetAverage";
+            buttonResetAverage.Size = new Size(241, 23);
+            buttonResetAverage.TabIndex = 61;
+            buttonResetAverage.Text = "Reset Average";
+            buttonResetAverage.UseVisualStyleBackColor = false;
             //
             // LiveSpectrumOpt
             //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.FromArgb(45, 50, 60);
-            ClientSize = new Size(265, 421);
+            ClientSize = new Size(265, 474);
+            Controls.Add(labelAnalysisMode);
+            Controls.Add(radioModeTransfer);
+            Controls.Add(radioModeRta);
             Controls.Add(signalTypeComboBox);
             Controls.Add(labelSignalType);
-            Controls.Add(labelScale);
-            Controls.Add(radioMagnitudeRelative);
-            Controls.Add(radioMagnitudeSpl);
+            Controls.Add(labelSpl);
+            Controls.Add(checkSpl);
+            Controls.Add(labelTilt);
+            Controls.Add(checkTilt);
             Controls.Add(checkInputMagnitude);
             Controls.Add(labelInputMagnitude);
             Controls.Add(checkMainCurve);
@@ -410,6 +458,9 @@ namespace Resonalyze.Options
         }
 
         #endregion
+        private Label labelAnalysisMode;
+        private RadioButton radioModeTransfer;
+        private RadioButton radioModeRta;
         private DarkComboBox comboCalibration;
         private Label label2;
         private Label labelSignalType;
@@ -431,9 +482,10 @@ namespace Resonalyze.Options
         private Label label10;
         private DarkComboBox coherenceLimitComboBox;
         private Button buttonResetAverage;
-        private Label labelScale;
-        private RadioButton radioMagnitudeRelative;
-        private RadioButton radioMagnitudeSpl;
+        private Label labelSpl;
+        private CheckBox checkSpl;
+        private Label labelTilt;
+        private CheckBox checkTilt;
         private Label labelCurves;
         private Label labelMainCurve;
         private CheckBox checkMainCurve;

--- a/source/Options/LiveSpectrumOpt.cs
+++ b/source/Options/LiveSpectrumOpt.cs
@@ -18,21 +18,34 @@ namespace Resonalyze.Options
         private WindowType userWindowType = WindowType.Hann;
         private int userOverlapPercent = 50;
 
-        // The user's RTA (input magnitude) choice, tracked independently so the SPL
-        // mode — which forces the RTA on and locks its checkbox — can restore the
-        // real preference when the plot returns to the relative scale.
+        // The user's RTA (input magnitude) choice, tracked independently so RTA mode
+        // — which forces the RTA on and locks its checkbox, it being the only curve
+        // there — can restore the real preference when the panel returns to Transfer
+        // mode.
         private bool userShowInputMagnitude;
 
-        // The user's last chosen signal, remembered so a scale switch keeps it when the
-        // new scale still offers it, and restores it on the way back. The two scales
-        // differ only by their exclusive signal: periodic pink (the transfer function's
-        // reference) is relative-only, Silent (an ambient RTA with no excitation) is
-        // SPL-only; the plain Pink/Brown/White excitations are shared.
+        // The user's last chosen signal, remembered so a mode switch keeps it when
+        // the new mode still offers it, and restores it on the way back. Silent (an
+        // ambient RTA with no excitation) is the one mode-exclusive signal — a
+        // transfer function has nothing to correlate against without an excitation —
+        // so it exists in RTA mode only; every real noise colour is shared.
         private NoiseColor userSignalType = NoiseColor.PinkPeriodic;
 
-        // The designer's normal dB SPL text colour, restored when the choice leaves
-        // the amber view-only state.
+        // The designer's normal text colours, restored when a choice leaves its
+        // amber conflict state.
         private readonly Color splChoiceReadyForeColor;
+        private readonly Color transferChoiceReadyForeColor;
+
+        // Whether the configured input carries a loopback reference — the
+        // prerequisite of Transfer mode. Without one the effective mode falls back
+        // to RTA, and a SELECTED Transfer choice is coloured amber to say so. Kept
+        // as a field so mode clicks can recolour between availability refreshes.
+        private bool hasTransferReference = true;
+
+        // Whether dB SPL currently has no matching calibration while a live curve
+        // exists that the view-only state would hide — the one situation the SPL
+        // choice is coloured amber for. Kept as a field for the same reason.
+        private bool splViewOnlyConflict;
 
         /// <summary>
         /// Raised when the user clicks Reset Average. Handled live (without an
@@ -43,7 +56,8 @@ namespace Resonalyze.Options
         public LiveSpectrumOpt()
         {
             InitializeComponent();
-            splChoiceReadyForeColor = radioMagnitudeSpl.ForeColor;
+            splChoiceReadyForeColor = labelSpl.ForeColor;
+            transferChoiceReadyForeColor = radioModeTransfer.ForeColor;
             SmoothingPresetOptions.Configure(
                 comboSmoothingInverseOctaves, includePsychoacoustic: true);
             buttonResetAverage.Click += (_, _) => ResetAverageRequested?.Invoke();
@@ -51,10 +65,11 @@ namespace Resonalyze.Options
             {
                 CaptureUserSignalType();
                 UpdatePeriodicPinkControls();
+                UpdateTiltAvailability();
             };
             windowComboBox.SelectionChangeCommitted += (_, _) => CaptureUserWindow();
             overlapComboBox.SelectionChangeCommitted += (_, _) => CaptureUserOverlap();
-            radioMagnitudeSpl.CheckedChanged += (_, _) => UpdateScaleDependentControls();
+            radioModeRta.CheckedChanged += (_, _) => UpdateModeDependentControls();
             checkInputMagnitude.Click += (_, _) => CaptureUserInputMagnitude();
             InitializeToolTips();
             Disposed += (_, _) => toolTip.Dispose();
@@ -64,10 +79,11 @@ namespace Resonalyze.Options
             LiveSpectrumOptions options,
             IReadOnlyList<MicrophoneCalibrationEntry> calibrationEntries,
             bool isSplAvailable,
-            bool hasLiveCurve)
+            bool hasLiveCurve,
+            bool hasTransferReference)
         {
-            // The signal list is populated per scale in UpdateScaleDependentControls
-            // below; remember the stored signal so it survives a scale round-trip.
+            // The signal list is populated per mode in UpdateModeDependentControls
+            // below; remember the stored signal so it survives a mode round-trip.
             signalTypeComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
             userSignalType = options.NoiseColor;
 
@@ -122,15 +138,19 @@ namespace Resonalyze.Options
             userShowInputMagnitude = options.ShowInputMagnitude;
             checkPeakHold.Checked = options.PeakHold;
             checkCoherence.Checked = options.ShowCoherence;
+            checkTilt.Checked = options.CompensateNoiseTilt;
 
             // The selection follows the options verbatim: dB SPL is choosable even
-            // without a matching calibration (view-only), so it must not be
-            // silently rewritten to relative here.
-            RefreshSplAvailability(isSplAvailable, hasLiveCurve);
-            bool spl = options.MagnitudeScale == MagnitudeScale.SoundPressureLevel;
-            radioMagnitudeSpl.Checked = spl;
-            radioMagnitudeRelative.Checked = !spl;
-            UpdateScaleDependentControls();
+            // without a matching calibration (view-only), and Transfer even without
+            // a loopback (effective mode falls back to RTA) — neither is silently
+            // rewritten here; amber and the tooltips do the explaining.
+            RefreshAvailability(isSplAvailable, hasLiveCurve, hasTransferReference);
+            checkSpl.Checked =
+                options.MagnitudeScale == MagnitudeScale.SoundPressureLevel;
+            bool rta = options.AnalysisMode == LiveAnalysisMode.Rta;
+            radioModeRta.Checked = rta;
+            radioModeTransfer.Checked = !rta;
+            UpdateModeDependentControls();
 
             MicrophoneCalibrationComboHelper.Configure(
                 comboCalibration,
@@ -151,35 +171,84 @@ namespace Resonalyze.Options
                 calibrationEntries);
 
         /// <summary>
-        /// Recolours the dB SPL choice, in both directions, without disturbing the
-        /// selection: the scale stays selectable either way and is merely view-only
+        /// Recolours the dB SPL and Transfer choices, in both directions, without
+        /// disturbing the selections: dB SPL stays selectable and is merely view-only
         /// (overlays, no live curves) until a matching SPL calibration exists for the
-        /// live input. The host calls this when the configured calibration changes
-        /// while the panel is open.
+        /// live input, and Transfer stays selectable while a missing loopback merely
+        /// forces the effective mode to RTA. The host calls this when the configured
+        /// calibration or the audio routing changes while the panel is open.
         /// </summary>
-        public void RefreshSplAvailability(bool isSplAvailable, bool hasLiveCurve)
+        public void RefreshAvailability(
+            bool isSplAvailable,
+            bool hasLiveCurve,
+            bool hasTransferReference)
         {
-            // The choice is never locked: without a calibration the dB SPL axis is
-            // still useful for VIEWING overlays captured in SPL, so it stays
+            // The SPL choice is never locked: without a calibration the dB SPL axis
+            // is still useful for VIEWING overlays captured in SPL, so it stays
             // clickable. Amber flags a REAL conflict only — a live curve exists that
             // the view-only state would hide. On a freshly started application there
             // is nothing to hide and nothing to warn about, so the choice keeps its
             // normal colour and the tooltip does the explaining.
-            bool viewOnlyConflict = !isSplAvailable && hasLiveCurve;
-            radioMagnitudeSpl.ForeColor = viewOnlyConflict
-                ? UiPalette.WarningAmber
-                : splChoiceReadyForeColor;
+            splViewOnlyConflict = !isSplAvailable && hasLiveCurve;
+            this.hasTransferReference = hasTransferReference;
+            UpdateSplChoiceColor();
+            UpdateTransferChoiceColor();
+            string splDescription = DescribeSplChoice(isSplAvailable, splViewOnlyConflict);
+            toolTip.SetToolTip(labelSpl, splDescription);
+            toolTip.SetToolTip(checkSpl, splDescription);
+        }
+
+        // Colour precedence for the dB SPL row: muted (not applicable in Transfer
+        // mode) → amber (a real view-only conflict) → normal. The label's colour is
+        // managed manually rather than through SetTextEnabledLook, which memorizes
+        // whatever colour it mutes and would hand a stale amber back on restore; the
+        // textless checkbox only needs its AutoCheck toggled.
+        private void UpdateSplChoiceColor()
+        {
+            bool rta = radioModeRta.Checked;
+            labelSpl.ForeColor = !rta
+                ? UiPalette.TextMuted
+                : splViewOnlyConflict
+                    ? UiPalette.WarningAmber
+                    : splChoiceReadyForeColor;
+            UiStyle.SetTextEnabledLook(checkSpl, rta, interactive: true);
+        }
+
+        // Amber flags a real, ACTIVE override only: Transfer is selected but the
+        // input has no loopback reference, so the analyzer actually runs as an RTA.
+        // An unselected Transfer choice keeps its normal colour; the tooltip warns.
+        private void UpdateTransferChoiceColor()
+        {
+            radioModeTransfer.ForeColor =
+                radioModeTransfer.Checked && !hasTransferReference
+                    ? UiPalette.WarningAmber
+                    : transferChoiceReadyForeColor;
             toolTip.SetToolTip(
-                radioMagnitudeSpl,
-                DescribeSplChoice(isSplAvailable, viewOnlyConflict));
+                radioModeTransfer, DescribeTransferChoice(hasTransferReference));
+        }
+
+        private static string DescribeTransferChoice(bool hasTransferReference)
+        {
+            const string Base =
+                "Dual-channel transfer function: the microphone divided by the " +
+                "loopback reference, with coherence.";
+            if (hasTransferReference)
+            {
+                return Base;
+            }
+
+            return Base + "\r\n" +
+                "No loopback reference channel is configured (Measurement Options), " +
+                "so the analyzer runs as a reference-free RTA regardless of this " +
+                "choice.";
         }
 
         private static string DescribeSplChoice(bool isSplAvailable, bool viewOnlyConflict)
         {
             const string Base =
-                "Absolute dB SPL. Shows the microphone (RTA) spectrum from the SPL " +
-                "calibration; the transfer function is a dimensionless ratio with no " +
-                "scalar SPL under noise, so it is hidden.";
+                "Shows the RTA in absolute dB SPL (microphone plus the SPL " +
+                "calibration offset). RTA mode only: the transfer function is a " +
+                "dimensionless ratio with no scalar SPL under noise excitation.";
             if (isSplAvailable)
             {
                 return Base;
@@ -204,14 +273,17 @@ namespace Resonalyze.Options
         }
 
         /// <summary>
-        /// Drops the scale selection back to relative. The host calls this when the
-        /// analyzer starts (or loses its calibration mid-run) while the display is
-        /// view-only SPL; switching back to SPL afterwards stays available.
+        /// Unchecks the dB SPL scale. The host calls this when the analyzer starts
+        /// (or loses its calibration mid-run) while the display is view-only SPL;
+        /// checking it again afterwards stays available.
         /// </summary>
-        public void ForceRelativeScale() => radioMagnitudeRelative.Checked = true;
+        public void ForceSplScaleOff() => checkSpl.Checked = false;
 
         public void SetOptions(LiveSpectrumOptions options)
         {
+            options.AnalysisMode = radioModeRta.Checked
+                ? LiveAnalysisMode.Rta
+                : LiveAnalysisMode.TransferFunction;
             options.NoiseColor =
                 signalTypeComboBox.SelectedItem is NoiseColorOption noiseColorOption
                     ? noiseColorOption.NoiseColor
@@ -237,7 +309,7 @@ namespace Resonalyze.Options
                     : AveragingSpeed.Medium;
             options.ShowMainCurve = checkMainCurve.Checked;
             // Persist the user's real RTA choice, not the value forced (and locked) on
-            // while SPL mode is selected.
+            // while RTA mode is selected.
             options.ShowInputMagnitude = userShowInputMagnitude;
             options.PeakHold = checkPeakHold.Checked;
             options.ShowCoherence = checkCoherence.Checked;
@@ -245,7 +317,11 @@ namespace Resonalyze.Options
                 coherenceLimitComboBox.SelectedItem is CoherenceLimitOption limitOption
                     ? limitOption.Percent
                     : CoherenceLimits[0];
-            options.MagnitudeScale = radioMagnitudeSpl.Checked
+            // The SPL and tilt checkboxes are merely muted (never rewritten) in
+            // Transfer mode, so these persist the user's real RTA-mode choices; the
+            // effective scale and tilt ignore them while Transfer is selected.
+            options.CompensateNoiseTilt = checkTilt.Checked;
+            options.MagnitudeScale = checkSpl.Checked
                 ? MagnitudeScale.SoundPressureLevel
                 : MagnitudeScale.Relative;
         }
@@ -307,62 +383,80 @@ namespace Resonalyze.Options
             }
         }
 
-        // In SPL mode the plot is the absolute microphone (RTA) spectrum. The transfer
-        // function and coherence are dimensionless ratios with no SPL under noise
-        // excitation, so their curve controls are disabled. The RTA is the one shown
-        // curve, so it is forced on and locked; its relative-mode preference is kept in
-        // userShowInputMagnitude and restored when the scale returns to relative.
-        private void UpdateScaleDependentControls()
+        // In RTA mode the plot is the reference-free microphone spectrum. The
+        // transfer function and coherence do not exist there, so their curve
+        // controls are muted; the RTA is the one shown curve, forced on and locked,
+        // its Transfer-mode preference kept in userShowInputMagnitude and restored
+        // on the way back. The dB SPL scale and the noise-slope compensation are
+        // properties of the RTA and are muted in Transfer mode instead.
+        private void UpdateModeDependentControls()
         {
-            bool spl = radioMagnitudeSpl.Checked;
-            UpdateSignalTypesForScale(spl);
+            bool rta = radioModeRta.Checked;
+            UpdateSignalTypesForMode(rta);
 
             // Mute (rather than WinForms-disable) the transfer/coherence controls so
             // they read as the theme's muted colour, not the near-black system grey.
-            UiStyle.SetTextEnabledLook(labelMainCurve, !spl);
-            UiStyle.SetTextEnabledLook(checkMainCurve, !spl, interactive: true);
-            UiStyle.SetTextEnabledLook(labelInputMagnitude, !spl);
-            UiStyle.SetTextEnabledLook(checkInputMagnitude, !spl, interactive: true);
-            UiStyle.SetTextEnabledLook(label9, !spl);
-            UiStyle.SetTextEnabledLook(checkCoherence, !spl, interactive: true);
-            UiStyle.SetTextEnabledLook(label10, !spl);
+            UiStyle.SetTextEnabledLook(labelMainCurve, !rta);
+            UiStyle.SetTextEnabledLook(checkMainCurve, !rta, interactive: true);
+            UiStyle.SetTextEnabledLook(labelInputMagnitude, !rta);
+            UiStyle.SetTextEnabledLook(checkInputMagnitude, !rta, interactive: true);
+            UiStyle.SetTextEnabledLook(label9, !rta);
+            UiStyle.SetTextEnabledLook(checkCoherence, !rta, interactive: true);
+            UiStyle.SetTextEnabledLook(label10, !rta);
             // The coherence-limit combo is a DarkComboBox, which mutes itself on Enabled.
-            coherenceLimitComboBox.Enabled = !spl;
+            coherenceLimitComboBox.Enabled = !rta;
 
-            checkInputMagnitude.Checked = spl || userShowInputMagnitude;
+            UpdateSplChoiceColor();
+            UpdateTiltAvailability();
+            UpdateTransferChoiceColor();
+
+            checkInputMagnitude.Checked = rta || userShowInputMagnitude;
         }
 
-        // The signal list follows the scale, differing only by the one scale-exclusive
-        // signal. SPL is a reference-free RTA, so periodic pink — which exists only to
-        // converge the transfer function fast — is dropped and Silent (an ambient RTA
-        // with no excitation) is offered alongside the plain Pink/Brown/White colours
-        // you can still play and measure the SPL of. The relative scale needs a known
-        // reference, so it drops Silent and offers periodic pink. The last signal is
-        // kept when the new scale still has it (Pink/Brown/White carry across), so a
-        // scale round-trip does not silently swap the excitation.
-        private void UpdateSignalTypesForScale(bool spl)
+        // The compensation needs a KNOWN excitation spectrum, so it is offered in
+        // RTA mode with a real noise signal only: the transfer function divides the
+        // excitation out, and Silent means an external source of unknown colour.
+        private void UpdateTiltAvailability()
+        {
+            bool applicable =
+                radioModeRta.Checked && SelectedNoiseColor() != NoiseColor.Silent;
+            UiStyle.SetTextEnabledLook(labelTilt, applicable);
+            UiStyle.SetTextEnabledLook(checkTilt, applicable, interactive: true);
+        }
+
+        private NoiseColor SelectedNoiseColor() =>
+            signalTypeComboBox.SelectedItem is NoiseColorOption option
+                ? option.NoiseColor
+                : NoiseColor.PinkPeriodic;
+
+        // The signal list follows the analysis mode. Silent (an ambient RTA with no
+        // excitation) is RTA-only — a transfer function has nothing to correlate
+        // against without an excitation — while every real noise colour, periodic
+        // pink included, is valid in both modes (in RTA it is simply a known
+        // excitation, and the one whose spectrum the slope compensation knows
+        // exactly). The last signal is kept when the new mode still has it, so a
+        // mode round-trip does not silently swap the excitation.
+        private void UpdateSignalTypesForMode(bool rta)
         {
             signalTypeComboBox.Items.Clear();
-            if (spl)
+            if (rta)
             {
                 signalTypeComboBox.Items.Add(new NoiseColorOption(NoiseColor.Silent, "Silent"));
             }
-            else
-            {
-                signalTypeComboBox.Items.Add(
-                    new NoiseColorOption(NoiseColor.PinkPeriodic, "Pink noise (periodic)"));
-            }
 
+            signalTypeComboBox.Items.Add(
+                new NoiseColorOption(NoiseColor.PinkPeriodic, "Pink noise (periodic)"));
             signalTypeComboBox.Items.Add(new NoiseColorOption(NoiseColor.Pink, "Pink noise"));
             signalTypeComboBox.Items.Add(new NoiseColorOption(NoiseColor.Brown, "Brown / red noise"));
             signalTypeComboBox.Items.Add(new NoiseColorOption(NoiseColor.White, "White noise"));
 
-            // Keep the remembered signal if this scale offers it; otherwise use the
-            // scale's exclusive default (Silent for SPL, periodic pink for relative).
+            // Keep the remembered signal if this mode offers it. Only Silent can be
+            // missing (leaving RTA for Transfer): fall back to the transfer
+            // reference, matching the controller's normalization.
             int index = TryFindNoiseColorIndex(userSignalType);
             if (index < 0)
             {
-                index = FindNoiseColorIndex(spl ? NoiseColor.Silent : NoiseColor.PinkPeriodic);
+                index = FindNoiseColorIndex(NoiseColor.PinkPeriodic);
             }
 
             signalTypeComboBox.SelectedIndex = index;
@@ -379,9 +473,9 @@ namespace Resonalyze.Options
             }
         }
 
-        // Only a real user toggle updates the remembered RTA preference. In SPL mode the
-        // checkbox is muted (AutoCheck off), so a click cannot change it — guard on that
-        // rather than Enabled, which stays true for the muted look.
+        // Only a real user toggle updates the remembered RTA preference. In RTA mode
+        // the checkbox is muted (AutoCheck off), so a click cannot change it — guard on
+        // that rather than Enabled, which stays true for the muted look.
         private void CaptureUserInputMagnitude()
         {
             if (checkInputMagnitude.AutoCheck)
@@ -523,12 +617,20 @@ namespace Resonalyze.Options
         private void InitializeToolTips()
         {
             toolTip.SetToolTip(
+                radioModeRta,
+                "Reference-free RTA: the magnitude spectrum of the microphone input " +
+                "alone, no loopback division. The only mode with an absolute dB SPL " +
+                "scale and the noise slope compensation.");
+            // radioModeTransfer's tooltip is owned by UpdateTransferChoiceColor: it
+            // names the loopback availability, which a static line here cannot.
+            toolTip.SetToolTip(
                 signalTypeComboBox,
                 "Excitation noise played during the measurement.\r\n" +
                 "• Pink noise (periodic): one FFT-length period of exactly pink noise, looped. Deterministic and leakage-free, so the transfer function converges fastest. Recommended.\r\n" +
                 "• Pink noise: continuous random pink noise, -3 dB/octave.\r\n" +
                 "• Brown / red noise: -6 dB/octave, more low-frequency drive for subwoofer and room-mode work.\r\n" +
-                "• White noise: equal energy per hertz.");
+                "• White noise: equal energy per hertz.\r\n" +
+                "• Silent (RTA mode only): no excitation — measures whatever the microphone hears (ambient noise or an external source).");
             toolTip.SetToolTip(
                 sequenceLengthComboBox,
                 "Sets the FFT block size. Longer sequences give finer frequency resolution but slower visual updates.");
@@ -565,13 +667,16 @@ namespace Resonalyze.Options
             toolTip.SetToolTip(
                 comboCalibration,
                 "Applies the selected microphone calibration file to Live Spectrum.");
-            toolTip.SetToolTip(
-                labelScale,
-                "Vertical scale of the live plot.");
-            toolTip.SetToolTip(
-                radioMagnitudeRelative,
-                "Native scale: the transfer function and RTA in relative dB.");
-            // radioMagnitudeSpl's tooltip is owned by RefreshSplAvailability: it
+            string tiltDescription =
+                "Compensates the spectral slope of the excitation noise itself, so a " +
+                "flat system reads flat whatever the noise colour (pink otherwise " +
+                "falls -3 dB per octave on the per-bin dB axis, and even a flat white " +
+                "PSD tilts +3 dB per octave on the banded dB SPL display). Pinned to " +
+                "the level at 1 kHz. Unavailable for Silent, whose excitation " +
+                "spectrum is unknown.";
+            toolTip.SetToolTip(labelTilt, tiltDescription);
+            toolTip.SetToolTip(checkTilt, tiltDescription);
+            // labelSpl's / checkSpl's tooltip is owned by RefreshAvailability: it
             // names the current availability state, which a static line here cannot.
         }
     }

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -115,15 +115,44 @@ internal sealed class PlotModelFactory
     }
 
     /// <summary>
-    /// The scale the Live Spectrum plot renders in — simply the selected one, like
-    /// the Frequency Response scale. Without a matching SPL calibration the plot no
-    /// longer falls back to the native dB view: it keeps the dB SPL axis in a
-    /// view-only state — overlays captured in dB SPL show, live curves are not drawn
-    /// (see LiveSpectrumController) — and the record button drops the display back
-    /// to relative before an actual run starts.
+    /// The analysis mode the live plot actually renders: the selected one, forced to
+    /// RTA when no loopback reference is configured — a transfer function cannot
+    /// exist then, and the options panel colours the Transfer choice amber to say
+    /// why. The single source both the plot and the controller read, so the two can
+    /// never disagree about which curves the mode has.
+    /// </summary>
+    public LiveAnalysisMode EffectiveLiveAnalysisMode =>
+        noiseMeasurement.IsMicOnly
+            ? LiveAnalysisMode.Rta
+            : liveSpectrumOptions.AnalysisMode;
+
+    /// <summary>
+    /// The scale the Live Spectrum plot renders in. In RTA mode it is simply the
+    /// selected one, like the Frequency Response scale: without a matching SPL
+    /// calibration the plot does not fall back to the native dB view but keeps the
+    /// dB SPL axis in a view-only state — overlays captured in dB SPL show, live
+    /// curves are not drawn (see LiveSpectrumController) — and the record button
+    /// drops the display back to relative before an actual run starts. A transfer
+    /// function is a dimensionless ratio with no scalar SPL under noise excitation,
+    /// so in Transfer mode the selection is overridden to relative.
     /// </summary>
     public MagnitudeScale EffectiveLiveSpectrumScale =>
-        liveSpectrumOptions.MagnitudeScale;
+        EffectiveLiveAnalysisMode == LiveAnalysisMode.Rta
+            ? liveSpectrumOptions.MagnitudeScale
+            : MagnitudeScale.Relative;
+
+    /// <summary>
+    /// The PSD slope (dB/octave) the live RTA display compensates, or null when the
+    /// compensation is off, the mode is not RTA (the transfer function divides the
+    /// excitation out), or the signal is Silent (unknown excitation spectrum). Zero
+    /// is a real value — white noise still needs the band-power display compensated.
+    /// The peak-hold display key includes this, so toggling it drops the envelope.
+    /// </summary>
+    public double? LiveTiltSlopeDbPerOctave =>
+        liveSpectrumOptions.CompensateNoiseTilt &&
+        EffectiveLiveAnalysisMode == LiveAnalysisMode.Rta
+            ? NoiseColorTilt.PsdSlopeDbPerOctave(liveSpectrumOptions.NoiseColor)
+            : null;
 
     // The dB offset applied to the live RTA / peak-hold curves when the plot is in
     // SPL mode; zero in the native (relative) view. The transfer function is never
@@ -214,7 +243,8 @@ internal sealed class PlotModelFactory
         List<SignalPoint> spectrum = LiveRtaRawCapture.BuildRelativeRaw(
             inputMagnitude,
             noiseMeasurement.SequenceLength,
-            noiseMeasurement.SampleRate);
+            noiseMeasurement.SampleRate,
+            LiveTiltSlopeDbPerOctave);
         if (spectrum.Count < 2)
         {
             return DescribeWithoutRawForm(
@@ -1045,26 +1075,28 @@ internal sealed class PlotModelFactory
         return model;
     }
 
-    // The reference-free RTA is the only trace when the plot is in SPL, or when the
-    // capture has no loopback reference to form a transfer function from.
+    // The reference-free RTA is the only trace when the effective analysis mode is
+    // RTA — selected, or forced by a missing loopback reference.
     private bool LiveRtaOnly =>
-        EffectiveLiveSpectrumScale == MagnitudeScale.SoundPressureLevel ||
-        noiseMeasurement.IsMicOnly;
+        EffectiveLiveAnalysisMode == LiveAnalysisMode.Rta;
 
     public PlotModel CreateLiveSpectrum()
     {
-        // In SPL mode the whole plot is the absolute microphone (RTA) spectrum in
-        // dB SPL; a mic-only capture shows the RTA in the native scale. Either way the
-        // transfer function and its coherence are absent, so the title, axis and
-        // (absent) coherence axis follow the RTA.
+        // In RTA mode the whole plot is the reference-free microphone spectrum — in
+        // dB SPL when that scale is selected, in the native scale otherwise. The
+        // transfer function and its coherence exist only in Transfer mode, so the
+        // title, axis and (absent) coherence axis follow the mode. An active tilt
+        // compensation is named in the title: the level is reshaped by the
+        // excitation's own spectrum and must not be read as the plain measurement.
         bool renderSpl =
             EffectiveLiveSpectrumScale == MagnitudeScale.SoundPressureLevel;
         bool rtaOnly = LiveRtaOnly;
+        string tiltSuffix = LiveTiltSlopeDbPerOctave != null ? " (noise-compensated)" : "";
         PlotModel model = PlotModelStyle.CreateTitledModel(
             renderSpl
-                ? "Live Spectrum — dB SPL"
+                ? "Live Spectrum — dB SPL" + tiltSuffix
                 : rtaOnly
-                    ? "Live Spectrum (RTA)"
+                    ? "Live Spectrum (RTA)" + tiltSuffix
                     : "Live Transfer Function");
 
         PlotModelStyle.AddFrequencyAxis(model);
@@ -1169,15 +1201,21 @@ internal sealed class PlotModelFactory
     // The RTA trace. In SPL mode it is a true, FFT-size-independent band level: bin
     // power is integrated per display band, the microphone calibration is applied per
     // band, and the SPL offset lifts it to dB SPL. In the native (relative) view it
-    // stays the amplitude-averaged spectrum in dB.
+    // stays the amplitude-averaged spectrum in dB. Either way an active tilt
+    // compensation subtracts the excitation's own rendered shape — per bin on the
+    // native path, per display band on the SPL path, whose band law tilts differently
+    // (see NoiseTiltCompensation).
     private List<SignalPoint> ResampleLiveRta(double[] amplitudeSpectrum)
     {
+        double? tiltSlope = LiveTiltSlopeDbPerOctave;
         if (EffectiveLiveSpectrumScale != MagnitudeScale.SoundPressureLevel)
         {
-            return ResampleLiveSpectrumMagnitude(amplitudeSpectrum, 0.0);
+            return ResampleLiveSpectrumMagnitude(amplitudeSpectrum, 0.0, tiltSlope);
         }
 
         double smoothingOctaves = SpectrumSmoothing.SmoothingOctaves(
+            liveSpectrumOptions.SmoothingInverseOctaves);
+        bool psychoacoustic = SpectrumSmoothing.IsPsychoacoustic(
             liveSpectrumOptions.SmoothingInverseOctaves);
         List<SignalPoint> bands = DataHelper.LogarithmicPowerBandResample(
             amplitudeSpectrum,
@@ -1189,8 +1227,7 @@ internal sealed class PlotModelFactory
             20000,
             1024,
             smoothingOctaves,
-            psychoacoustic: SpectrumSmoothing.IsPsychoacoustic(
-                liveSpectrumOptions.SmoothingInverseOctaves));
+            psychoacoustic);
 
         double offsetDb = LiveSplRenderOffset;
         CalibrationFile? calibration = GetCalibration(liveSpectrumOptions);
@@ -1203,7 +1240,60 @@ internal sealed class PlotModelFactory
             bands[i] = new SignalPoint(bands[i].X, bands[i].Y - correction + offsetDb);
         }
 
+        if (tiltSlope is { } bandSlope)
+        {
+            // Rendered by the same resampler with the same parameters, so the grids
+            // align index-for-index; a length mismatch would mean the parameters
+            // diverged and the compensation would be misaligned — skip it then.
+            double[] compensation = LiveTiltBandCompensation(
+                bandSlope, amplitudeSpectrum.Length, smoothingOctaves, psychoacoustic);
+            if (compensation.Length == bands.Count)
+            {
+                for (int i = 0; i < bands.Count; i++)
+                {
+                    bands[i] = new SignalPoint(bands[i].X, bands[i].Y + compensation[i]);
+                }
+            }
+        }
+
         return bands;
+    }
+
+    // The band compensation is one full render of the analytic noise spectrum through
+    // the band resampler — far too heavy for every ~30 fps tick — and depends only on
+    // these parameters, so the last result is memoized until one of them changes.
+    private double[]? liveTiltBandCompensation;
+    private (double Slope, int BinCount, int FftLength, int SampleRate,
+        double EnbwBins, double MainLobeBins, double SmoothingOctaves, bool Psycho)
+        liveTiltBandKey;
+
+    private double[] LiveTiltBandCompensation(
+        double slope,
+        int binCount,
+        double smoothingOctaves,
+        bool psychoacoustic)
+    {
+        var key = (slope, binCount, noiseMeasurement.SequenceLength,
+            noiseMeasurement.SampleRate, noiseMeasurement.AnalysisWindowEnbwBins,
+            noiseMeasurement.AnalysisWindowMainLobeBins, smoothingOctaves, psychoacoustic);
+        if (liveTiltBandCompensation == null || !key.Equals(liveTiltBandKey))
+        {
+            liveTiltBandCompensation = NoiseTiltCompensation.BandCompensationDb(
+                slope,
+                binCount,
+                noiseMeasurement.SequenceLength,
+                noiseMeasurement.SampleRate,
+                noiseMeasurement.AnalysisWindowEnbwBins,
+                noiseMeasurement.AnalysisWindowMainLobeBins,
+                20,
+                20000,
+                1024,
+                smoothingOctaves,
+                psychoacoustic);
+            liveTiltBandKey = key;
+        }
+
+        return liveTiltBandCompensation;
     }
 
     private static void FillPoints(LineSeries series, List<SignalPoint> points)
@@ -1217,10 +1307,25 @@ internal sealed class PlotModelFactory
 
     private List<SignalPoint> ResampleLiveSpectrumMagnitude(
         double[] magnitude,
-        double offsetDb = 0.0)
+        double offsetDb = 0.0,
+        double? tiltCompensationSlope = null)
     {
         List<SignalPoint> bins = DataHelper.MagnitudeBinsToDecibels(
             magnitude, noiseMeasurement.SequenceLength, noiseMeasurement.SampleRate, offsetDb);
+
+        // Tilt compensation, per bin BEFORE the display resample — the same spot the
+        // raw-curve capture bakes it in (LiveRtaRawCapture), so re-smoothing a
+        // captured raw curve reproduces this trace exactly. A zero slope is an exact
+        // identity on the per-bin display and skips the pass.
+        if (tiltCompensationSlope is { } slope && slope != 0.0)
+        {
+            for (int i = 0; i < bins.Count; i++)
+            {
+                bins[i] = new SignalPoint(
+                    bins[i].X,
+                    bins[i].Y + NoiseTiltCompensation.BinCompensationDb(slope, bins[i].X));
+            }
+        }
 
         return DataHelper.LogarithmicResample(
             bins,

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -142,16 +142,17 @@ internal sealed class PlotModelFactory
             : MagnitudeScale.Relative;
 
     /// <summary>
-    /// The PSD slope (dB/octave) the live RTA display compensates, or null when the
-    /// compensation is off, the mode is not RTA (the transfer function divides the
-    /// excitation out), or the signal is Silent (unknown excitation spectrum). Zero
-    /// is a real value — white noise still needs the band-power display compensated.
-    /// The peak-hold display key includes this, so toggling it drops the envelope.
+    /// The spectral model of the excitation the live RTA display compensates, or
+    /// null when the compensation is off, the mode is not RTA (the transfer function
+    /// divides the excitation out), or the signal is Silent (unknown excitation
+    /// spectrum). A flat model (white) is a real value — the band-power display
+    /// still needs compensating. The peak-hold display key includes this, so
+    /// toggling it drops the envelope.
     /// </summary>
-    public double? LiveTiltSlopeDbPerOctave =>
+    public NoiseSpectralModel? LiveTiltModel =>
         liveSpectrumOptions.CompensateNoiseTilt &&
         EffectiveLiveAnalysisMode == LiveAnalysisMode.Rta
-            ? NoiseColorTilt.PsdSlopeDbPerOctave(liveSpectrumOptions.NoiseColor)
+            ? NoiseColorTilt.SpectralModel(liveSpectrumOptions.NoiseColor)
             : null;
 
     // The dB offset applied to the live RTA / peak-hold curves when the plot is in
@@ -244,7 +245,7 @@ internal sealed class PlotModelFactory
             inputMagnitude,
             noiseMeasurement.SequenceLength,
             noiseMeasurement.SampleRate,
-            LiveTiltSlopeDbPerOctave);
+            LiveTiltModel);
         if (spectrum.Count < 2)
         {
             return DescribeWithoutRawForm(
@@ -1091,7 +1092,7 @@ internal sealed class PlotModelFactory
         bool renderSpl =
             EffectiveLiveSpectrumScale == MagnitudeScale.SoundPressureLevel;
         bool rtaOnly = LiveRtaOnly;
-        string tiltSuffix = LiveTiltSlopeDbPerOctave != null ? " (noise-compensated)" : "";
+        string tiltSuffix = LiveTiltModel != null ? " (noise-compensated)" : "";
         PlotModel model = PlotModelStyle.CreateTitledModel(
             renderSpl
                 ? "Live Spectrum — dB SPL" + tiltSuffix
@@ -1207,10 +1208,10 @@ internal sealed class PlotModelFactory
     // (see NoiseTiltCompensation).
     private List<SignalPoint> ResampleLiveRta(double[] amplitudeSpectrum)
     {
-        double? tiltSlope = LiveTiltSlopeDbPerOctave;
+        NoiseSpectralModel? tiltModel = LiveTiltModel;
         if (EffectiveLiveSpectrumScale != MagnitudeScale.SoundPressureLevel)
         {
-            return ResampleLiveSpectrumMagnitude(amplitudeSpectrum, 0.0, tiltSlope);
+            return ResampleLiveSpectrumMagnitude(amplitudeSpectrum, 0.0, tiltModel);
         }
 
         double smoothingOctaves = SpectrumSmoothing.SmoothingOctaves(
@@ -1240,13 +1241,13 @@ internal sealed class PlotModelFactory
             bands[i] = new SignalPoint(bands[i].X, bands[i].Y - correction + offsetDb);
         }
 
-        if (tiltSlope is { } bandSlope)
+        if (tiltModel is { } bandModel)
         {
             // Rendered by the same resampler with the same parameters, so the grids
             // align index-for-index; a length mismatch would mean the parameters
             // diverged and the compensation would be misaligned — skip it then.
             double[] compensation = LiveTiltBandCompensation(
-                bandSlope, amplitudeSpectrum.Length, smoothingOctaves, psychoacoustic);
+                bandModel, amplitudeSpectrum.Length, smoothingOctaves, psychoacoustic);
             if (compensation.Length == bands.Count)
             {
                 for (int i = 0; i < bands.Count; i++)
@@ -1263,23 +1264,23 @@ internal sealed class PlotModelFactory
     // the band resampler — far too heavy for every ~30 fps tick — and depends only on
     // these parameters, so the last result is memoized until one of them changes.
     private double[]? liveTiltBandCompensation;
-    private (double Slope, int BinCount, int FftLength, int SampleRate,
+    private (NoiseSpectralModel Model, int BinCount, int FftLength, int SampleRate,
         double EnbwBins, double MainLobeBins, double SmoothingOctaves, bool Psycho)
         liveTiltBandKey;
 
     private double[] LiveTiltBandCompensation(
-        double slope,
+        NoiseSpectralModel model,
         int binCount,
         double smoothingOctaves,
         bool psychoacoustic)
     {
-        var key = (slope, binCount, noiseMeasurement.SequenceLength,
+        var key = (model, binCount, noiseMeasurement.SequenceLength,
             noiseMeasurement.SampleRate, noiseMeasurement.AnalysisWindowEnbwBins,
             noiseMeasurement.AnalysisWindowMainLobeBins, smoothingOctaves, psychoacoustic);
         if (liveTiltBandCompensation == null || !key.Equals(liveTiltBandKey))
         {
             liveTiltBandCompensation = NoiseTiltCompensation.BandCompensationDb(
-                slope,
+                model,
                 binCount,
                 noiseMeasurement.SequenceLength,
                 noiseMeasurement.SampleRate,
@@ -1308,22 +1309,22 @@ internal sealed class PlotModelFactory
     private List<SignalPoint> ResampleLiveSpectrumMagnitude(
         double[] magnitude,
         double offsetDb = 0.0,
-        double? tiltCompensationSlope = null)
+        NoiseSpectralModel? tiltCompensationModel = null)
     {
         List<SignalPoint> bins = DataHelper.MagnitudeBinsToDecibels(
             magnitude, noiseMeasurement.SequenceLength, noiseMeasurement.SampleRate, offsetDb);
 
         // Tilt compensation, per bin BEFORE the display resample — the same spot the
         // raw-curve capture bakes it in (LiveRtaRawCapture), so re-smoothing a
-        // captured raw curve reproduces this trace exactly. A zero slope is an exact
-        // identity on the per-bin display and skips the pass.
-        if (tiltCompensationSlope is { } slope && slope != 0.0)
+        // captured raw curve reproduces this trace exactly.
+        if (tiltCompensationModel is { } model)
         {
             for (int i = 0; i < bins.Count; i++)
             {
                 bins[i] = new SignalPoint(
                     bins[i].X,
-                    bins[i].Y + NoiseTiltCompensation.BinCompensationDb(slope, bins[i].X));
+                    bins[i].Y + NoiseTiltCompensation.BinCompensationDb(
+                        model, bins[i].X, noiseMeasurement.SampleRate));
             }
         }
 

--- a/source/Settings/MeasurementSettingsFile.Schema.cs
+++ b/source/Settings/MeasurementSettingsFile.Schema.cs
@@ -579,7 +579,12 @@ internal sealed partial class MeasurementSettingsFile
 
     internal sealed class LiveSpectrumSettings
     {
+        // Null when the file predates the explicit analysis mode; ApplyTo infers it
+        // from what used to imply an RTA session (see there).
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public LiveAnalysisMode? AnalysisMode { get; set; }
         public NoiseColor NoiseColor { get; set; } = NoiseColor.PinkPeriodic;
+        public bool CompensateNoiseTilt { get; set; }
         // See FrequencyResponseSettings for the id and the two legacy fields.
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? CalibrationId { get; set; }
@@ -603,9 +608,13 @@ internal sealed partial class MeasurementSettingsFile
             LiveSpectrumOptions options) =>
             new()
             {
+                AnalysisMode = Enum.IsDefined(options.AnalysisMode)
+                    ? options.AnalysisMode
+                    : LiveAnalysisMode.TransferFunction,
                 NoiseColor = Enum.IsDefined(options.NoiseColor)
                     ? options.NoiseColor
                     : NoiseColor.PinkPeriodic,
+                CompensateNoiseTilt = options.CompensateNoiseTilt,
                 CalibrationId = options.CalibrationId,
                 SequenceLength = NormalizeSequenceLength(options.SequenceLength),
                 OverlapPercent = NormalizeOverlapPercent(options.OverlapPercent),
@@ -631,6 +640,26 @@ internal sealed partial class MeasurementSettingsFile
             options.NoiseColor = Enum.IsDefined(NoiseColor)
                 ? NoiseColor
                 : NoiseColor.PinkPeriodic;
+            // Settings written before the explicit mode existed: the SPL scale and
+            // the Silent signal were both RTA-exclusive back then, so either marks
+            // an RTA session; everything else was the transfer analyzer.
+            options.AnalysisMode = AnalysisMode is { } mode && Enum.IsDefined(mode)
+                ? mode
+                : MagnitudeScale == MagnitudeScale.SoundPressureLevel ||
+                    options.NoiseColor == NoiseColor.Silent
+                    ? LiveAnalysisMode.Rta
+                    : LiveAnalysisMode.TransferFunction;
+            // The invariant the panel and the controller both rely on: Silent exists
+            // only in RTA mode (a transfer function has nothing to correlate against
+            // without an excitation). Only a hand-edited file can break it — repair
+            // the signal, keeping the explicitly stated mode.
+            if (options.AnalysisMode == LiveAnalysisMode.TransferFunction &&
+                options.NoiseColor == NoiseColor.Silent)
+            {
+                options.NoiseColor = NoiseColor.PinkPeriodic;
+            }
+
+            options.CompensateNoiseTilt = CompensateNoiseTilt;
             options.CalibrationId = ResolveCalibrationId(
                 CalibrationId,
                 CalibrationMode,

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -172,12 +172,13 @@ public partial class Form1
 
     // The Live Spectrum mirror of ResetSplViewOnlyDisplayForRun below: an analyzer
     // started while the display is view-only SPL would draw no curves at all, so
-    // drop the display to relative first (StartAsync then normalizes a Silent
-    // signal into a real excitation for the relative scale). Also called when a
-    // RUNNING analyzer loses its calibration, where staying in SPL would blank it.
+    // drop the display to relative first. Also called when a RUNNING analyzer loses
+    // its calibration, where staying in SPL would blank it. The signal is left
+    // alone — it follows the analysis mode, not the scale.
     private void ResetLiveSplViewOnlyDisplayForRun()
     {
-        if (liveSpectrumOptions.MagnitudeScale != Dsp.MagnitudeScale.SoundPressureLevel ||
+        if (plotModelFactory.EffectiveLiveSpectrumScale !=
+                Dsp.MagnitudeScale.SoundPressureLevel ||
             plotModelFactory.LiveSplOffsetDb.HasValue)
         {
             return;
@@ -188,7 +189,7 @@ public partial class Form1
         // An open panel must follow the reset, or its next apply-on-change would
         // write SPL right back into the options.
         dockedModeSettingsHost.InvokeIfOpen<Options.LiveSpectrumOpt>(
-            panel => panel.ForceRelativeScale());
+            panel => panel.ForceSplScaleOff());
     }
 
     // A sweep started in dB SPL only stays there when the RUN AHEAD can supply SPL —
@@ -270,29 +271,23 @@ public partial class Form1
             ResetLiveSplViewOnlyDisplayForRun();
         }
         dockedModeSettingsHost.InvokeIfOpen<Options.LiveSpectrumOpt>(
-            panel => panel.RefreshSplAvailability(
+            panel => panel.RefreshAvailability(
                 plotModelFactory.LiveSplOffsetDb.HasValue,
-                liveSpectrumController.HasDisplayableCurve));
+                liveSpectrumController.HasDisplayableCurve,
+                liveSpectrumController.HasConfiguredLoopback));
         // Persist the calibration itself up front so it survives even if the redraw
-        // below fails; the normalized live options are re-saved afterwards.
+        // below fails.
         ScheduleMeasurementSettingsSave();
 
         IReadOnlyList<AxisViewport> viewports = CaptureAxisViewports();
         try
         {
-            // Normalize Live Spectrum for the calibration change in EVERY mode — drop
-            // its stale peak hold, and fall a Silent RTA back to a real excitation once
-            // SPL is gone — not only while it is the visible mode; it rebuilds its own
-            // model only when visible, so any other mode still refreshes below.
-            bool liveSignalChanged = await liveSpectrumController.RefreshCalibrationAsync();
-
-            // If the live signal was normalized (Silent → periodic pink), capture the
-            // options so the change reaches disk: a plain schedule serializes the
-            // un-captured LiveSpectrum settings and would keep the stale Silent.
-            if (liveSignalChanged)
-            {
-                SaveMeasurementSettings();
-            }
+            // Refresh Live Spectrum for the calibration change in EVERY mode — drop
+            // its now-stale peak hold — not only while it is the visible mode; it
+            // rebuilds its own model only when visible, so any other mode still
+            // refreshes below. The capture and its signal are untouched: they
+            // follow the analysis mode, which a calibration cannot change.
+            liveSpectrumController.RefreshCalibration();
 
             if (CurrentMode != Mode.LiveSpectrum)
             {

--- a/source/Shell/Form1.ModeSettings.cs
+++ b/source/Shell/Form1.ModeSettings.cs
@@ -155,6 +155,16 @@ public partial class Form1
         if (before != after)
         {
             await ApplyMeasurementConfigurationToControllersAsync();
+            // The snapshot names the ACQUISITION parameters. A running analyzer was
+            // just restarted onto a fresh accumulation; a stopped one still holds
+            // the previous setup's curve, which must not be redrawn under the new
+            // parameters — the display transform reads the options live, so e.g.
+            // the slope compensation would re-tilt a stopped pink RTA as if the
+            // excitation had been white.
+            if (!liveSpectrumController.InProgress)
+            {
+                liveSpectrumController.DiscardCapturedData();
+            }
         }
         else
         {

--- a/source/Shell/Form1.ModeSettings.cs
+++ b/source/Shell/Form1.ModeSettings.cs
@@ -137,7 +137,8 @@ public partial class Form1
                     liveSpectrumOptions,
                     microphoneCalibration.GetEntries(),
                     plotModelFactory.LiveSplOffsetDb.HasValue,
-                    liveSpectrumController.HasDisplayableCurve);
+                    liveSpectrumController.HasDisplayableCurve,
+                    liveSpectrumController.HasConfiguredLoopback);
                 opt.ResetAverageRequested += liveSpectrumController.ResetAverage;
             },
             ApplyLiveSpectrumOptionsAsync,
@@ -319,6 +320,10 @@ public partial class Form1
         double Maximum);
 
     private sealed record LiveSpectrumRestartSnapshot(
+        // The analysis mode switches both the playback role of the signal and the
+        // accumulation path (transfer vs. mic-only), so changing it must restart a
+        // running capture — it must never flip mid-run under the accumulators.
+        LiveAnalysisMode AnalysisMode,
         NoiseColor NoiseColor,
         WindowType WindowType,
         int SequenceLength,
@@ -326,6 +331,7 @@ public partial class Form1
     {
         public static LiveSpectrumRestartSnapshot Capture(LiveSpectrumOptions options) =>
             new(
+                options.AnalysisMode,
                 options.NoiseColor,
                 options.WindowType,
                 options.SequenceLength,

--- a/source/Shell/Form1.Plotting.cs
+++ b/source/Shell/Form1.Plotting.cs
@@ -245,9 +245,10 @@ public partial class Form1
         // becomes (or stops being) a real conflict. Follow it on the open panel, so
         // the amber state is not frozen at whatever was true when the panel opened.
         dockedModeSettingsHost.InvokeIfOpen<Options.LiveSpectrumOpt>(
-            panel => panel.RefreshSplAvailability(
+            panel => panel.RefreshAvailability(
                 plotModelFactory.LiveSplOffsetDb.HasValue,
-                liveSpectrumController.HasDisplayableCurve));
+                liveSpectrumController.HasDisplayableCurve,
+                liveSpectrumController.HasConfiguredLoopback));
     }
 
     private void UpdatePlotLabelsPanel()

--- a/source/Shell/Form1.State.cs
+++ b/source/Shell/Form1.State.cs
@@ -12,6 +12,14 @@ public partial class Form1
     {
         await liveSpectrumController.ReconfigureFromAsync(measurementSettings.Measurement);
         timeAlignmentController.RefreshConfiguration();
+        // The audio routing may have gained or lost the loopback reference — the
+        // prerequisite of the live Transfer mode — so an open live panel re-evaluates
+        // its amber states here, the one chokepoint every routing change passes.
+        dockedModeSettingsHost.InvokeIfOpen<Options.LiveSpectrumOpt>(
+            panel => panel.RefreshAvailability(
+                plotModelFactory.LiveSplOffsetDb.HasValue,
+                liveSpectrumController.HasDisplayableCurve,
+                liveSpectrumController.HasConfiguredLoopback));
     }
 
     private void PrepareSweepMeasurementForRun()

--- a/tests/Resonalyze.App.Tests/LiveAnalysisModeTests.cs
+++ b/tests/Resonalyze.App.Tests/LiveAnalysisModeTests.cs
@@ -54,6 +54,49 @@ public sealed class LiveAnalysisModeTests
         Assert.Contains(
             session!.LastPlaybackSignal!.MonoSamples,
             sample => sample != 0.0f);
+
+        // Mic-only in CAPTURE too, not just in analysis: the session request must
+        // not ask the backend for the loopback channel — WASAPI refuses an endpoint
+        // with fewer channels than the routing requires, and ASIO widens the
+        // captured window to span from the mic to the reference.
+        Assert.NotNull(factory.LastRequest);
+        Assert.Equal(0, factory.LastRequest!.Routing.MicrophoneChannel);
+        Assert.Null(factory.LastRequest.Routing.LoopbackChannel);
+    }
+
+    [Fact]
+    public async Task TransferCapture_StillRequestsTheLoopbackChannel()
+    {
+        // The counterpart pin: dropping the loopback from the request is an
+        // RTA-only behavior — the transfer capture must keep asking for it.
+        var factory = new FakeAudioSessionFactory(
+            streamingFactory: _ => new RecordingStreamingSession(
+                framesToRaise: 1,
+                failAfterFrames: false));
+        using var measurement = new NoiseMeasurement(factory);
+        measurement.Init(
+            44_100,
+            24,
+            0.5,
+            PlaybackChannel.Mono,
+            sequenceLength: 1024,
+            waveInputChannelOffset: 0,
+            waveLoopbackInputChannelOffset: 1,
+            liveSpectrumOptions: new LiveSpectrumOptions
+            {
+                AnalysisMode = LiveAnalysisMode.TransferFunction
+            });
+
+        Task<bool> running = measurement.RunAsync();
+        for (int attempt = 0; attempt < 100 && factory.LastRequest == null; attempt++)
+        {
+            await Task.Delay(10);
+        }
+        await measurement.AbortAsync();
+
+        Assert.True(await running, measurement.LastError?.ToString());
+        Assert.NotNull(factory.LastRequest);
+        Assert.Equal(1, factory.LastRequest!.Routing.LoopbackChannel);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/LiveAnalysisModeTests.cs
+++ b/tests/Resonalyze.App.Tests/LiveAnalysisModeTests.cs
@@ -1,0 +1,206 @@
+using Resonalyze.Dsp;
+using Resonalyze.Options;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class LiveAnalysisModeTests
+{
+    [Fact]
+    public async Task RtaModeWithLoopback_UsesMicOnlyAnalysisAndKeepsTheExcitation()
+    {
+        // The decoupling the explicit mode buys: an RTA capture stays reference-free
+        // even when a loopback IS configured — and unlike Silent it still plays its
+        // excitation. Before the split, RTA analysis existed only as a side effect of
+        // the Silent signal or a missing loopback.
+        RecordingStreamingSession? session = null;
+        var factory = new FakeAudioSessionFactory(
+            streamingFactory: _ => session = new RecordingStreamingSession(
+                framesToRaise: 20,
+                failAfterFrames: false));
+        using var measurement = new NoiseMeasurement(factory);
+        var options = new LiveSpectrumOptions
+        {
+            AnalysisMode = LiveAnalysisMode.Rta,
+            NoiseColor = NoiseColor.PinkPeriodic
+        };
+        measurement.Init(
+            44_100,
+            24,
+            0.5,
+            PlaybackChannel.Mono,
+            sequenceLength: 1024,
+            waveInputChannelOffset: 0,
+            waveLoopbackInputChannelOffset: 1,
+            liveSpectrumOptions: options);
+
+        Assert.True(measurement.HasConfiguredLoopback);
+        Assert.True(measurement.IsRtaCapture);
+
+        Task<bool> running = measurement.RunAsync();
+        LiveSpectrumSnapshot? snapshot = null;
+        for (int attempt = 0; attempt < 100 && snapshot == null; attempt++)
+        {
+            await Task.Delay(10);
+            snapshot = measurement.GetAccumulatedSpectrumSnapshot();
+        }
+        await measurement.AbortAsync();
+
+        Assert.True(await running, measurement.LastError?.ToString());
+        Assert.NotNull(snapshot);
+        Assert.Empty(snapshot.Magnitude);
+        Assert.Null(snapshot.Coherence);
+        Assert.NotNull(snapshot.InputMagnitude);
+        Assert.NotNull(session?.LastPlaybackSignal);
+        Assert.Contains(
+            session!.LastPlaybackSignal!.MonoSamples,
+            sample => sample != 0.0f);
+    }
+
+    [Fact]
+    public void TransferModeWithLoopback_StaysTheTransferAnalyzer()
+    {
+        using var measurement = new NoiseMeasurement(new FakeAudioSessionFactory());
+        measurement.Init(
+            44_100,
+            24,
+            0.5,
+            PlaybackChannel.Mono,
+            sequenceLength: 1024,
+            waveInputChannelOffset: 0,
+            waveLoopbackInputChannelOffset: 1,
+            liveSpectrumOptions: new LiveSpectrumOptions
+            {
+                AnalysisMode = LiveAnalysisMode.TransferFunction
+            });
+
+        Assert.False(measurement.IsRtaCapture);
+    }
+
+    [Fact]
+    public void TransferModeWithoutLoopback_FallsBackToRtaAnalysis()
+    {
+        using var measurement = new NoiseMeasurement(new FakeAudioSessionFactory());
+        measurement.Init(
+            44_100,
+            24,
+            0.5,
+            PlaybackChannel.Mono,
+            sequenceLength: 1024,
+            liveSpectrumOptions: new LiveSpectrumOptions
+            {
+                AnalysisMode = LiveAnalysisMode.TransferFunction
+            });
+
+        Assert.True(measurement.IsMicOnly);
+        Assert.True(measurement.IsRtaCapture);
+    }
+
+    // ----- settings migration: files written before the explicit mode existed -----
+
+    [Fact]
+    public void LegacySplScale_MigratesToRtaMode()
+    {
+        // Before the split, dB SPL was only reachable as an RTA, so a legacy file
+        // with the SPL scale selected marks an RTA session.
+        var legacy = new MeasurementSettingsFile.LiveSpectrumSettings
+        {
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel,
+            NoiseColor = NoiseColor.Pink
+        };
+
+        var options = new LiveSpectrumOptions();
+        legacy.ApplyTo(options);
+
+        Assert.Equal(LiveAnalysisMode.Rta, options.AnalysisMode);
+        Assert.Equal(NoiseColor.Pink, options.NoiseColor);
+        Assert.Equal(MagnitudeScale.SoundPressureLevel, options.MagnitudeScale);
+    }
+
+    [Fact]
+    public void LegacySilentSignal_MigratesToRtaModeKeepingSilent()
+    {
+        var legacy = new MeasurementSettingsFile.LiveSpectrumSettings
+        {
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel,
+            NoiseColor = NoiseColor.Silent
+        };
+
+        var options = new LiveSpectrumOptions();
+        legacy.ApplyTo(options);
+
+        Assert.Equal(LiveAnalysisMode.Rta, options.AnalysisMode);
+        Assert.Equal(NoiseColor.Silent, options.NoiseColor);
+    }
+
+    [Fact]
+    public void LegacyRelativeTransfer_MigratesToTransferMode()
+    {
+        var legacy = new MeasurementSettingsFile.LiveSpectrumSettings
+        {
+            MagnitudeScale = MagnitudeScale.Relative,
+            NoiseColor = NoiseColor.PinkPeriodic
+        };
+
+        var options = new LiveSpectrumOptions();
+        legacy.ApplyTo(options);
+
+        Assert.Equal(LiveAnalysisMode.TransferFunction, options.AnalysisMode);
+    }
+
+    [Fact]
+    public void ExplicitMode_WinsOverTheLegacyInference()
+    {
+        // A new file stores the mode explicitly; a stored SPL scale is then just the
+        // remembered RTA-mode checkbox preference, not evidence of an RTA session.
+        var stored = new MeasurementSettingsFile.LiveSpectrumSettings
+        {
+            AnalysisMode = LiveAnalysisMode.TransferFunction,
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel,
+            NoiseColor = NoiseColor.PinkPeriodic
+        };
+
+        var options = new LiveSpectrumOptions();
+        stored.ApplyTo(options);
+
+        Assert.Equal(LiveAnalysisMode.TransferFunction, options.AnalysisMode);
+        Assert.Equal(MagnitudeScale.SoundPressureLevel, options.MagnitudeScale);
+    }
+
+    [Fact]
+    public void HandEditedSilentInTransferMode_RepairsTheSignal()
+    {
+        // Only a hand-edited file can pair Silent with an explicit Transfer mode; the
+        // invariant (Silent is RTA-only) is repaired on load, keeping the stated mode.
+        var stored = new MeasurementSettingsFile.LiveSpectrumSettings
+        {
+            AnalysisMode = LiveAnalysisMode.TransferFunction,
+            NoiseColor = NoiseColor.Silent
+        };
+
+        var options = new LiveSpectrumOptions();
+        stored.ApplyTo(options);
+
+        Assert.Equal(LiveAnalysisMode.TransferFunction, options.AnalysisMode);
+        Assert.Equal(NoiseColor.PinkPeriodic, options.NoiseColor);
+    }
+
+    [Fact]
+    public void ModeAndTilt_SurviveACaptureRoundTrip()
+    {
+        var options = new LiveSpectrumOptions
+        {
+            AnalysisMode = LiveAnalysisMode.Rta,
+            NoiseColor = NoiseColor.White,
+            CompensateNoiseTilt = true
+        };
+
+        MeasurementSettingsFile.LiveSpectrumSettings captured =
+            MeasurementSettingsFile.LiveSpectrumSettings.Capture(options);
+        var restored = new LiveSpectrumOptions();
+        captured.ApplyTo(restored);
+
+        Assert.Equal(LiveAnalysisMode.Rta, restored.AnalysisMode);
+        Assert.Equal(NoiseColor.White, restored.NoiseColor);
+        Assert.True(restored.CompensateNoiseTilt);
+    }
+}

--- a/tests/Resonalyze.App.Tests/LiveRtaRawCaptureTests.cs
+++ b/tests/Resonalyze.App.Tests/LiveRtaRawCaptureTests.cs
@@ -61,7 +61,7 @@ public sealed class LiveRtaRawCaptureTests
         // same spot the display path applies it (before the resample), so a captured
         // overlay stays the compensated curve the user saw under any re-smoothing.
         double[] spectrum = CreateSpectrum();
-        double pinkSlope = -10.0 * Math.Log10(2.0);
+        NoiseSpectralModel pink = NoiseSpectralModel.PowerLaw(-10.0 * Math.Log10(2.0));
 
         foreach (int smoothing in new[] { 0, 6 })
         {
@@ -72,7 +72,7 @@ public sealed class LiveRtaRawCaptureTests
                 compensatedBins[i] = new SignalPoint(
                     compensatedBins[i].X,
                     compensatedBins[i].Y + NoiseTiltCompensation.BinCompensationDb(
-                        pinkSlope, compensatedBins[i].X));
+                        pink, compensatedBins[i].X, SampleRate));
             }
 
             List<SignalPoint> drawn = DataHelper.LogarithmicResample(
@@ -85,7 +85,7 @@ public sealed class LiveRtaRawCaptureTests
                 psychoacoustic: SpectrumSmoothing.IsPsychoacoustic(smoothing));
 
             List<SignalPoint> raw = LiveRtaRawCapture.BuildRelativeRaw(
-                spectrum, FftLength, SampleRate, pinkSlope);
+                spectrum, FftLength, SampleRate, pink);
             List<SignalPoint> rendered = RawCurveRenderer.Render(
                 raw,
                 RawCurveRenderer.CaptureCalibrationCorrection(null),

--- a/tests/Resonalyze.App.Tests/LiveRtaRawCaptureTests.cs
+++ b/tests/Resonalyze.App.Tests/LiveRtaRawCaptureTests.cs
@@ -55,6 +55,51 @@ public sealed class LiveRtaRawCaptureTests
     }
 
     [Fact]
+    public void RelativeRawWithTilt_BakesTheCompensationTheDisplayApplies()
+    {
+        // The noise-tilt compensation is baked into the raw capture per bin, at the
+        // same spot the display path applies it (before the resample), so a captured
+        // overlay stays the compensated curve the user saw under any re-smoothing.
+        double[] spectrum = CreateSpectrum();
+        double pinkSlope = -10.0 * Math.Log10(2.0);
+
+        foreach (int smoothing in new[] { 0, 6 })
+        {
+            // What the plot draws: bins to dB, per-bin compensation, then the resample.
+            List<SignalPoint> compensatedBins = BuildBinCurve(spectrum);
+            for (int i = 0; i < compensatedBins.Count; i++)
+            {
+                compensatedBins[i] = new SignalPoint(
+                    compensatedBins[i].X,
+                    compensatedBins[i].Y + NoiseTiltCompensation.BinCompensationDb(
+                        pinkSlope, compensatedBins[i].X));
+            }
+
+            List<SignalPoint> drawn = DataHelper.LogarithmicResample(
+                compensatedBins,
+                RawCurveRenderer.StartFrequency,
+                RawCurveRenderer.StopFrequency,
+                RawCurveRenderer.PointCount,
+                calibration: null,
+                SpectrumSmoothing.SmoothingOctaves(smoothing),
+                psychoacoustic: SpectrumSmoothing.IsPsychoacoustic(smoothing));
+
+            List<SignalPoint> raw = LiveRtaRawCapture.BuildRelativeRaw(
+                spectrum, FftLength, SampleRate, pinkSlope);
+            List<SignalPoint> rendered = RawCurveRenderer.Render(
+                raw,
+                RawCurveRenderer.CaptureCalibrationCorrection(null),
+                smoothing);
+
+            Assert.Equal(drawn.Count, rendered.Count);
+            for (int i = 0; i < drawn.Count; i++)
+            {
+                Assert.Equal(drawn[i].Y, rendered[i].Y, precision: 9);
+            }
+        }
+    }
+
+    [Fact]
     public void RelativeRaw_IsTheUncalibratedBinSpectrumWithoutDc()
     {
         double[] spectrum = CreateSpectrum();

--- a/tests/Resonalyze.App.Tests/LiveSpectrumControllerTests.cs
+++ b/tests/Resonalyze.App.Tests/LiveSpectrumControllerTests.cs
@@ -80,6 +80,56 @@ public sealed class LiveSpectrumControllerTests
     }
 
     [Fact]
+    public async Task DiscardCapturedData_ClearsTheAccumulationAndTheKeptCurve()
+    {
+        // The idle-recolour hole: a stopped curve is a record of the PREVIOUS
+        // acquisition setup, while the display transform (the slope compensation
+        // above all) reads the options live. When an acquisition parameter changes
+        // without a restart, the host discards the stale data instead of letting
+        // the next redraw silently re-interpret it as the new excitation.
+        var factory = new FakeAudioSessionFactory(
+            streamingFactory: _ => new RecordingStreamingSession(
+                framesToRaise: 20,
+                failAfterFrames: false));
+        using var noise = new NoiseMeasurement(factory);
+        noise.Init(
+            44_100,
+            24,
+            0.5,
+            PlaybackChannel.Mono,
+            sequenceLength: 1024,
+            liveSpectrumOptions: new LiveSpectrumOptions
+            {
+                AnalysisMode = LiveAnalysisMode.Rta,
+                NoiseColor = NoiseColor.Pink
+            });
+
+        Task<bool> running = noise.RunAsync();
+        LiveSpectrumSnapshot? snapshot = null;
+        for (int attempt = 0; attempt < 100 && snapshot == null; attempt++)
+        {
+            await Task.Delay(10);
+            snapshot = noise.GetAccumulatedSpectrumSnapshot();
+        }
+        await noise.AbortAsync();
+        Assert.True(await running, noise.LastError?.ToString());
+        Assert.NotNull(snapshot);
+
+        var controller = (LiveSpectrumController)RuntimeHelpers.GetUninitializedObject(
+            typeof(LiveSpectrumController));
+        SetField(controller, "measurement", noise);
+        SetField(controller, "plotView", new OxyPlot.WindowsForms.PlotView());
+        SetField(controller, "lastSnapshot", snapshot);
+
+        controller.DiscardCapturedData();
+
+        Assert.Null(noise.GetAccumulatedSpectrumSnapshot());
+        Assert.Null(typeof(LiveSpectrumController)
+            .GetField("lastSnapshot", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(controller));
+    }
+
+    [Fact]
     public void TiltToggle_ChangesThePeakHoldDisplayKey()
     {
         // The peak-hold envelope holds FINISHED display values; toggling the noise

--- a/tests/Resonalyze.App.Tests/LiveSpectrumControllerTests.cs
+++ b/tests/Resonalyze.App.Tests/LiveSpectrumControllerTests.cs
@@ -8,81 +8,57 @@ namespace Resonalyze.App.Tests;
 public sealed class LiveSpectrumControllerTests
 {
     [Fact]
-    public void MissingEffectiveSplCalibration_NormalizesSilentToPeriodicPink()
+    public void SilentEnteringTransferMode_NormalizesToPeriodicPink()
     {
+        // Silent is the one mode-exclusive signal: a transfer function has nothing to
+        // correlate against without an excitation, so entering Transfer mode swaps it
+        // for the transfer reference.
         var options = new LiveSpectrumOptions
         {
-            MagnitudeScale = MagnitudeScale.SoundPressureLevel,
+            AnalysisMode = LiveAnalysisMode.TransferFunction,
             NoiseColor = NoiseColor.Silent
         };
 
-        bool changed = LiveSpectrumController.NormalizeSignalType(
-            options,
-            MagnitudeScale.Relative);
+        bool changed = LiveSpectrumController.NormalizeSignalType(options);
 
         Assert.True(changed);
         Assert.Equal(NoiseColor.PinkPeriodic, options.NoiseColor);
     }
 
     [Fact]
-    public void NormalizeSignalType_KeepsSilentWhileSplIsEffective()
+    public void NormalizeSignalType_KeepsSilentInRtaMode()
     {
-        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.Silent };
-
-        bool changed = LiveSpectrumController.NormalizeSignalType(
-            options,
-            MagnitudeScale.SoundPressureLevel);
-
-        Assert.False(changed);
-        Assert.Equal(NoiseColor.Silent, options.NoiseColor);
-    }
-
-    [Fact]
-    public void NormalizeSignalType_LeavesANonSilentSignalUntouched()
-    {
-        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.Pink };
-
-        bool changed = LiveSpectrumController.NormalizeSignalType(
-            options,
-            MagnitudeScale.Relative);
-
-        Assert.False(changed);
-        Assert.Equal(NoiseColor.Pink, options.NoiseColor);
-    }
-
-    [Fact]
-    public void RestoredEffectiveSpl_NormalizesPeriodicPinkBackToSilent()
-    {
-        // The symmetric half of the fallback: after a Silent→pink calibration-loss the
-        // stored signal is periodic pink while the requested scale is still SPL. When SPL
-        // becomes effective again, periodic pink is invalid there (it is the transfer
-        // reference, pointless in the reference-free RTA), so it must swap back to Silent
-        // — never left playing an excitation the SPL panel cannot even display.
+        // In RTA mode Silent is valid at EITHER scale — an ambient RTA in dBFS is a
+        // legitimate display — so nothing (calibration changes included) swaps it.
         var options = new LiveSpectrumOptions
         {
-            MagnitudeScale = MagnitudeScale.SoundPressureLevel,
-            NoiseColor = NoiseColor.PinkPeriodic
+            AnalysisMode = LiveAnalysisMode.Rta,
+            NoiseColor = NoiseColor.Silent
         };
 
-        bool changed = LiveSpectrumController.NormalizeSignalType(
-            options,
-            MagnitudeScale.SoundPressureLevel);
+        bool changed = LiveSpectrumController.NormalizeSignalType(options);
 
-        Assert.True(changed);
+        Assert.False(changed);
         Assert.Equal(NoiseColor.Silent, options.NoiseColor);
     }
 
-    [Fact]
-    public void NormalizeSignalType_KeepsPeriodicPinkOnTheRelativeScale()
+    [Theory]
+    [InlineData(LiveAnalysisMode.TransferFunction, NoiseColor.Pink)]
+    [InlineData(LiveAnalysisMode.TransferFunction, NoiseColor.PinkPeriodic)]
+    [InlineData(LiveAnalysisMode.Rta, NoiseColor.PinkPeriodic)]
+    [InlineData(LiveAnalysisMode.Rta, NoiseColor.White)]
+    public void NormalizeSignalType_LeavesRealExcitationsUntouched(
+        LiveAnalysisMode mode,
+        NoiseColor color)
     {
-        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.PinkPeriodic };
+        // Every real excitation is valid in both modes — periodic pink included: in
+        // RTA it is simply a known (deterministic) excitation to measure.
+        var options = new LiveSpectrumOptions { AnalysisMode = mode, NoiseColor = color };
 
-        bool changed = LiveSpectrumController.NormalizeSignalType(
-            options,
-            MagnitudeScale.Relative);
+        bool changed = LiveSpectrumController.NormalizeSignalType(options);
 
         Assert.False(changed);
-        Assert.Equal(NoiseColor.PinkPeriodic, options.NoiseColor);
+        Assert.Equal(color, options.NoiseColor);
     }
 
     [Fact]
@@ -102,6 +78,54 @@ public sealed class LiveSpectrumControllerTests
 
         Assert.Null(peakHoldField.GetValue(controller));
     }
+
+    [Fact]
+    public void TiltToggle_ChangesThePeakHoldDisplayKey()
+    {
+        // The peak-hold envelope holds FINISHED display values; toggling the noise
+        // tilt compensation reshapes the display, so it must change the display key
+        // (ApplyDisplayOptions then drops the stale envelope instead of max-ing the
+        // old values against tilted ones).
+        using var sweep = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+        var options = new LiveSpectrumOptions
+        {
+            AnalysisMode = LiveAnalysisMode.Rta,
+            NoiseColor = NoiseColor.Pink
+        };
+        var controller = (LiveSpectrumController)RuntimeHelpers.GetUninitializedObject(
+            typeof(LiveSpectrumController));
+        SetField(controller, "measurement", noise);
+        SetField(controller, "liveSpectrumOptions", options);
+        SetField(controller, "plotModelFactory", new PlotModelFactory(
+            sweep,
+            noise,
+            _ => null,
+            new PlotPresentationOptions(
+                FrequencyResponse: new FrequencyResponseOptions(),
+                PhaseResponse: new FrequencyResponseOptions(),
+                GroupDelay: new FrequencyResponseOptions(),
+                FrequencyResponseVisibility: new CurveVisibilityOptions(),
+                PhaseResponseVisibility: new CurveVisibilityOptions(),
+                GroupDelayVisibility: new CurveVisibilityOptions(),
+                ImpulseResponse: new ImpulseResponseOptions(),
+                LiveSpectrum: options,
+                Waterfall: new WaterfallGenerateOptions(),
+                BurstDecay: new WaterfallGenerateOptions())));
+
+        object before = CurrentPeakHoldKey(controller);
+        options.CompensateNoiseTilt = true;
+        object after = CurrentPeakHoldKey(controller);
+
+        Assert.NotEqual(before, after);
+    }
+
+    private static object CurrentPeakHoldKey(LiveSpectrumController controller) =>
+        typeof(LiveSpectrumController)
+            .GetMethod(
+                "CurrentPeakHoldKey",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(controller, [])!;
 
     [Fact]
     public void ViewOnlySpl_ExplainsTheSuppressedCurveInsteadOfAnEmptyPlot()

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -1507,6 +1507,7 @@ public sealed class PlotModelFactoryTests
         measurement.SplCalibration = LiveAnchorMatching(noise, 94, -16);
         var options = new LiveSpectrumOptions
         {
+            AnalysisMode = LiveAnalysisMode.Rta,
             MagnitudeScale = MagnitudeScale.SoundPressureLevel
         };
 
@@ -1531,6 +1532,7 @@ public sealed class PlotModelFactoryTests
         using NoiseMeasurement noise = CreateLiveAnalyzer();
         var options = new LiveSpectrumOptions
         {
+            AnalysisMode = LiveAnalysisMode.Rta,
             MagnitudeScale = MagnitudeScale.SoundPressureLevel
         };
         PlotModelFactory factory =
@@ -1569,6 +1571,7 @@ public sealed class PlotModelFactoryTests
         measurement.SplCalibration = LiveAnchorMatching(noise, 94, -16);
         var options = new LiveSpectrumOptions
         {
+            AnalysisMode = LiveAnalysisMode.Rta,
             CalibrationId = null,
             SmoothingInverseOctaves = 6,
             MagnitudeScale = MagnitudeScale.SoundPressureLevel
@@ -1642,6 +1645,7 @@ public sealed class PlotModelFactoryTests
         // must move the identical power-band curve by exactly the offset difference.
         var options = new LiveSpectrumOptions
         {
+            AnalysisMode = LiveAnalysisMode.Rta,
             CalibrationId = null,
             SmoothingInverseOctaves = 0,
             MagnitudeScale = MagnitudeScale.SoundPressureLevel
@@ -1664,5 +1668,139 @@ public sealed class PlotModelFactoryTests
             Assert.Equal(lower.Points[i].X, higher.Points[i].X, precision: 9);
             Assert.Equal(lower.Points[i].Y + 10.0, higher.Points[i].Y, precision: 6);
         }
+    }
+
+    [Fact]
+    public void LiveRtaTilt_FlattensPinkOnTheRelativeAxis()
+    {
+        using ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        using NoiseMeasurement noise = CreateLiveAnalyzer();
+        var options = new LiveSpectrumOptions
+        {
+            AnalysisMode = LiveAnalysisMode.Rta,
+            NoiseColor = NoiseColor.Pink,
+            CompensateNoiseTilt = true,
+            SmoothingInverseOctaves = 0
+        };
+        PlotModelFactory factory =
+            CreateFactory(measurement, noise, liveSpectrumOptions: options);
+
+        // An exactly pink spectrum (amplitude ∝ 1/√f) through a flat system: with
+        // the compensation on, the relative RTA must read flat — the per-bin line
+        // mirrors the noise exactly.
+        var magnitude = new double[(noise.SequenceLength / 2) + 1];
+        for (int k = 1; k < magnitude.Length; k++)
+        {
+            magnitude[k] = 0.1 / Math.Sqrt(k);
+        }
+
+        LineSeries compensated = factory.BuildInputMagnitudeSeries(magnitude);
+        Assert.NotEmpty(compensated.Points);
+        double reference = compensated.Points[0].Y;
+        Assert.All(
+            compensated.Points,
+            point => Assert.Equal(reference, point.Y, precision: 6));
+
+        // The same input with the compensation off keeps the noise's own slope, so
+        // the checkbox demonstrably does something: -3.01 dB per octave.
+        options.CompensateNoiseTilt = false;
+        LineSeries plain = factory.BuildInputMagnitudeSeries(magnitude);
+        OxyPlot.DataPoint low = PointNear(plain, 1000.0);
+        OxyPlot.DataPoint high = PointNear(plain, 4000.0);
+        // The grid points sit near, not exactly at, the probe frequencies, so the
+        // expected drop follows the actual span: amplitude ~ 1/sqrt(f).
+        // precision 2: the resample interpolates linearly between bins, which for a
+        // 1/sqrt(f) curve deviates from the analytic value by a few thousandths of a dB.
+        Assert.Equal(-10.0 * Math.Log10(high.X / low.X), high.Y - low.Y, precision: 2);
+    }
+
+    [Fact]
+    public void LiveRtaTilt_IsInertInTransferMode()
+    {
+        // The transfer function divides the excitation out, so the compensation must
+        // not touch the RTA overlay drawn inside Transfer mode even when its
+        // checkbox is stored on.
+        using ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        using NoiseMeasurement noise = CreateLiveAnalyzer();
+        var options = new LiveSpectrumOptions
+        {
+            AnalysisMode = LiveAnalysisMode.TransferFunction,
+            NoiseColor = NoiseColor.Pink,
+            CompensateNoiseTilt = true,
+            SmoothingInverseOctaves = 0
+        };
+        PlotModelFactory factory =
+            CreateFactory(measurement, noise, liveSpectrumOptions: options);
+
+        Assert.Null(factory.LiveTiltSlopeDbPerOctave);
+
+        var magnitude = new double[(noise.SequenceLength / 2) + 1];
+        for (int k = 1; k < magnitude.Length; k++)
+        {
+            magnitude[k] = 0.1 / Math.Sqrt(k);
+        }
+
+        LineSeries series = factory.BuildInputMagnitudeSeries(magnitude);
+        OxyPlot.DataPoint low = PointNear(series, 1000.0);
+        OxyPlot.DataPoint high = PointNear(series, 4000.0);
+        // precision 2: the resample interpolates linearly between bins, which for a
+        // 1/sqrt(f) curve deviates from the analytic value by a few thousandths of a dB.
+        Assert.Equal(-10.0 * Math.Log10(high.X / low.X), high.Y - low.Y, precision: 2);
+    }
+
+    [Fact]
+    public void LiveSplTilt_FlattensWhiteOnTheBandAxis()
+    {
+        // The band-power (SPL) display tilts even a flat white PSD by +3 dB/octave
+        // (band power grows with bandwidth), so the compensation there must follow
+        // the BAND law, not the per-bin line — a zero PSD slope still compensates.
+        using ExpSweepMeasurement measurement = CreateTransferMeasurement();
+        using NoiseMeasurement noise = CreateLiveAnalyzer();
+        measurement.SplCalibration = LiveAnchorMatching(noise, 94, -16);
+        var options = new LiveSpectrumOptions
+        {
+            AnalysisMode = LiveAnalysisMode.Rta,
+            MagnitudeScale = MagnitudeScale.SoundPressureLevel,
+            NoiseColor = NoiseColor.White,
+            CompensateNoiseTilt = true,
+            CalibrationId = null,
+            SmoothingInverseOctaves = 0
+        };
+        PlotModelFactory factory =
+            CreateFactory(measurement, noise, liveSpectrumOptions: options);
+
+        var magnitude = new double[(noise.SequenceLength / 2) + 1];
+        Array.Fill(magnitude, 0.1);
+
+        LineSeries compensated = factory.BuildInputMagnitudeSeries(magnitude);
+        Assert.NotEmpty(compensated.Points);
+        // The compensation renders the same flat spectrum through the same band
+        // resampler and subtracts, so the cancellation is exact per point.
+        double reference = compensated.Points[0].Y;
+        Assert.All(
+            compensated.Points,
+            point => Assert.Equal(reference, point.Y, precision: 6));
+
+        options.CompensateNoiseTilt = false;
+        LineSeries plain = factory.BuildInputMagnitudeSeries(magnitude);
+        double at2K = PointNear(plain, 2000.0).Y;
+        double at8K = PointNear(plain, 8000.0).Y;
+        // Uncompensated white climbs ~3.01 dB per octave on the band axis.
+        Assert.Equal(2.0 * 10.0 * Math.Log10(2.0), at8K - at2K, precision: 1);
+    }
+
+    private static OxyPlot.DataPoint PointNear(LineSeries series, double frequency)
+    {
+        OxyPlot.DataPoint nearest = series.Points[0];
+        foreach (OxyPlot.DataPoint point in series.Points)
+        {
+            if (Math.Abs(Math.Log2(point.X / frequency)) <
+                Math.Abs(Math.Log2(nearest.X / frequency)))
+            {
+                nearest = point;
+            }
+        }
+
+        return nearest;
     }
 }

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -1675,10 +1675,13 @@ public sealed class PlotModelFactoryTests
     {
         using ExpSweepMeasurement measurement = CreateTransferMeasurement();
         using NoiseMeasurement noise = CreateLiveAnalyzer();
+        // Periodic pink: the one colour whose synthesis is an exact power law, so
+        // its model is the mirrored straight line and the cancellation is exact.
+        // (Random pink models the Kellett bank instead — pinned in the dsp tests.)
         var options = new LiveSpectrumOptions
         {
             AnalysisMode = LiveAnalysisMode.Rta,
-            NoiseColor = NoiseColor.Pink,
+            NoiseColor = NoiseColor.PinkPeriodic,
             CompensateNoiseTilt = true,
             SmoothingInverseOctaves = 0
         };
@@ -1732,7 +1735,7 @@ public sealed class PlotModelFactoryTests
         PlotModelFactory factory =
             CreateFactory(measurement, noise, liveSpectrumOptions: options);
 
-        Assert.Null(factory.LiveTiltSlopeDbPerOctave);
+        Assert.Null(factory.LiveTiltModel);
 
         var magnitude = new double[(noise.SequenceLength / 2) + 1];
         for (int k = 1; k < magnitude.Length; k++)

--- a/tests/Resonalyze.App.Tests/SilentLiveSpectrumTests.cs
+++ b/tests/Resonalyze.App.Tests/SilentLiveSpectrumTests.cs
@@ -6,7 +6,7 @@ namespace Resonalyze.App.Tests;
 public sealed class SilentLiveSpectrumTests
 {
     [Fact]
-    public async Task EffectiveSplFallback_RebuildsPlaybackAsPeriodicPink()
+    public async Task SilentEnteringTransferMode_RebuildsPlaybackAsPeriodicPink()
     {
         RecordingStreamingSession? session = null;
         var factory = new FakeAudioSessionFactory(
@@ -14,7 +14,13 @@ public sealed class SilentLiveSpectrumTests
                 framesToRaise: 1,
                 failAfterFrames: false));
         using var measurement = new NoiseMeasurement(factory);
-        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.Silent };
+        // A hand-off from an RTA session: the stored signal is still Silent while the
+        // selected mode is now Transfer, which needs a real excitation to reference.
+        var options = new LiveSpectrumOptions
+        {
+            AnalysisMode = LiveAnalysisMode.TransferFunction,
+            NoiseColor = NoiseColor.Silent
+        };
         measurement.Init(
             44_100,
             24,
@@ -23,9 +29,7 @@ public sealed class SilentLiveSpectrumTests
             sequenceLength: 1024,
             liveSpectrumOptions: options);
 
-        Assert.True(LiveSpectrumController.NormalizeSignalType(
-            options,
-            MagnitudeScale.Relative));
+        Assert.True(LiveSpectrumController.NormalizeSignalType(options));
         measurement.RefreshPlaybackSignal();
 
         Task<bool> running = measurement.RunAsync();
@@ -48,10 +52,15 @@ public sealed class SilentLiveSpectrumTests
     public void NormalizedSilentSignal_IsCapturedAsPeriodicPinkForPersistence()
     {
         // The persistence follow-up: once the runtime signal is normalized away from
-        // Silent (SPL lost), capturing the live options for the settings file must
-        // record the normalized value, so a stale Silent cannot return on next launch.
-        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.Silent };
-        LiveSpectrumController.NormalizeSignalType(options, MagnitudeScale.Relative);
+        // Silent (Transfer mode selected), capturing the live options for the settings
+        // file must record the normalized value, so a stale Silent cannot return on
+        // next launch.
+        var options = new LiveSpectrumOptions
+        {
+            AnalysisMode = LiveAnalysisMode.TransferFunction,
+            NoiseColor = NoiseColor.Silent
+        };
+        LiveSpectrumController.NormalizeSignalType(options);
 
         MeasurementSettingsFile.LiveSpectrumSettings captured =
             MeasurementSettingsFile.LiveSpectrumSettings.Capture(options);
@@ -68,7 +77,13 @@ public sealed class SilentLiveSpectrumTests
                 framesToRaise: 20,
                 failAfterFrames: false));
         using var measurement = new NoiseMeasurement(factory);
-        var options = new LiveSpectrumOptions { NoiseColor = NoiseColor.Silent };
+        // Silent lives in RTA mode only (the invariant NormalizeSignalType keeps), so
+        // the capture is configured the way the app would actually run it.
+        var options = new LiveSpectrumOptions
+        {
+            AnalysisMode = LiveAnalysisMode.Rta,
+            NoiseColor = NoiseColor.Silent
+        };
         measurement.Init(
             44_100,
             24,

--- a/tests/Resonalyze.Dsp.Tests/NoiseTiltCompensationTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/NoiseTiltCompensationTests.cs
@@ -1,3 +1,6 @@
+using System.Numerics;
+using MathNet.Numerics.IntegralTransforms;
+
 namespace Resonalyze.Dsp.Tests;
 
 public sealed class NoiseTiltCompensationTests
@@ -6,29 +9,37 @@ public sealed class NoiseTiltCompensationTests
     private const int SampleRate = 48_000;
     private const double PinkSlope = -3.0102999566398120; // -10·log10(2)
 
+    private static readonly NoiseSpectralModel Pink =
+        NoiseSpectralModel.PowerLaw(PinkSlope);
+    private static readonly NoiseSpectralModel White =
+        NoiseSpectralModel.PowerLaw(0.0);
+
     [Fact]
-    public void BinCompensation_MirrorsTheSlopeAroundThePivot()
+    public void BinCompensation_MirrorsThePowerLawAroundThePivot()
     {
         // Pink falls 3.01 dB/octave on the per-bin display, so the compensation
         // rises by exactly that per octave, zero at the pivot.
-        Assert.Equal(0.0, NoiseTiltCompensation.BinCompensationDb(PinkSlope, 1000.0), 12);
+        Assert.Equal(
+            0.0, NoiseTiltCompensation.BinCompensationDb(Pink, 1000.0, SampleRate), 12);
         Assert.Equal(
             -PinkSlope,
-            NoiseTiltCompensation.BinCompensationDb(PinkSlope, 2000.0),
+            NoiseTiltCompensation.BinCompensationDb(Pink, 2000.0, SampleRate),
             precision: 9);
         Assert.Equal(
             PinkSlope,
-            NoiseTiltCompensation.BinCompensationDb(PinkSlope, 500.0),
+            NoiseTiltCompensation.BinCompensationDb(Pink, 500.0, SampleRate),
             precision: 9);
         // White is flat on the per-bin display: identity.
-        Assert.Equal(0.0, NoiseTiltCompensation.BinCompensationDb(0.0, 20.0), 12);
-        Assert.Equal(0.0, NoiseTiltCompensation.BinCompensationDb(0.0, 20_000.0), 12);
+        Assert.Equal(
+            0.0, NoiseTiltCompensation.BinCompensationDb(White, 20.0, SampleRate), 12);
+        Assert.Equal(
+            0.0, NoiseTiltCompensation.BinCompensationDb(White, 20_000.0, SampleRate), 12);
     }
 
     [Fact]
     public void BandCompensation_AlignsWithTheDisplayGridAndPinsThePivot()
     {
-        double[] compensation = BandCompensation(PinkSlope);
+        double[] compensation = BandCompensation(Pink);
         List<SignalPoint> grid = DisplayGrid();
 
         // Same resampler, same parameters: the compensation must line up with the
@@ -48,7 +59,7 @@ public sealed class NoiseTiltCompensationTests
         // pink flat on its own — the compensation there must be (near) zero, not the
         // per-bin +3 dB/octave line. This is the assertion that distinguishes the
         // band-law compensation from naively reusing the per-bin straight line.
-        double[] compensation = BandCompensation(PinkSlope);
+        double[] compensation = BandCompensation(Pink);
         List<SignalPoint> grid = DisplayGrid();
 
         double at2k = compensation[NearestIndex(grid, 2000.0)];
@@ -64,7 +75,7 @@ public sealed class NoiseTiltCompensationTests
         // A flat white PSD tilts +3.01 dB/octave on the band-power display (band
         // power grows with bandwidth), so its compensation must FALL by that per
         // octave in the constant-relative region — even though the PSD slope is zero.
-        double[] compensation = BandCompensation(0.0);
+        double[] compensation = BandCompensation(White);
         List<SignalPoint> grid = DisplayGrid();
 
         double at2k = compensation[NearestIndex(grid, 2000.0)];
@@ -82,7 +93,7 @@ public sealed class NoiseTiltCompensationTests
         // band, the integrator switches to constant ABSOLUTE bandwidth and pink
         // renders rising toward LF again (+6 dB per two octaves) — the compensation
         // must mirror that, falling toward LF instead of staying flat.
-        double[] compensation = BandCompensation(PinkSlope);
+        double[] compensation = BandCompensation(Pink);
         List<SignalPoint> grid = DisplayGrid();
 
         double at40 = compensation[NearestIndex(grid, 40.0)];
@@ -93,9 +104,100 @@ public sealed class NoiseTiltCompensationTests
             $"corner, got {at40:0.000} at 40 Hz vs {at160:0.000} at 160 Hz");
     }
 
-    private static double[] BandCompensation(double slope) =>
+    [Fact]
+    public void LeakyIntegratorModel_MatchesTheSynthesisRecurrence()
+    {
+        // The brown model must be the very filter the synthesis runs — value' =
+        // leak·value + (1−leak)·white — not an idealised −6 dB/octave line, which
+        // the filter only follows above its corner. Drive the recurrence with a
+        // unit impulse and compare the DFT of the response against the model.
+        const double CornerHz = 76.0;
+        double leak = 1.0 - 2.0 * Math.PI * CornerHz / SampleRate;
+        int n = 1 << 17;
+        var response = new Complex[n];
+        double value = 0.0;
+        for (int i = 0; i < n; i++)
+        {
+            value = leak * value + (1.0 - leak) * (i == 0 ? 1.0 : 0.0);
+            response[i] = value;
+        }
+
+        Fourier.Forward(response, FourierOptions.NoScaling);
+
+        var model = NoiseSpectralModel.LeakyIntegrator(CornerHz);
+        for (int bin = 1; bin < n / 2; bin *= 2)
+        {
+            double frequency = bin * (double)SampleRate / n;
+            double measured = response[bin].Magnitude;
+            double modelled = model.AmplitudeAt(frequency, SampleRate);
+            Assert.Equal(0.0, 20.0 * Math.Log10(measured / modelled), precision: 3);
+        }
+    }
+
+    [Fact]
+    public void KellettPinkModel_MatchesTheSynthesisRecurrence()
+    {
+        // Same contract for random pink: the model is the exact Kellett bank the
+        // synthesis runs (from the shared coefficient table), which flattens below
+        // its lowest pole — at 192 kHz that corner sits near 35 Hz, well inside the
+        // display range, so an idealised 1/√f model would over-compensate the bass.
+        foreach (int sampleRate in new[] { SampleRate, 192_000 })
+        {
+            int n = 1 << 17;
+            var response = new Complex[n];
+            var states = new double[KellettPinkFilter.Poles.Count];
+            double delayed = 0.0;
+            for (int i = 0; i < n; i++)
+            {
+                double white = i == 0 ? 1.0 : 0.0;
+                double pink = KellettPinkFilter.DirectGain * white + delayed;
+                for (int pole = 0; pole < states.Length; pole++)
+                {
+                    (double a, double g) = KellettPinkFilter.Poles[pole];
+                    states[pole] = a * states[pole] + g * white;
+                    pink += states[pole];
+                }
+                delayed = KellettPinkFilter.DelayedGain * white;
+                response[i] = pink;
+            }
+
+            Fourier.Forward(response, FourierOptions.NoScaling);
+
+            for (int bin = 1; bin < n / 2; bin *= 2)
+            {
+                double frequency = bin * (double)sampleRate / n;
+                double measured = response[bin].Magnitude;
+                double modelled =
+                    NoiseSpectralModel.KellettPink.AmplitudeAt(frequency, sampleRate);
+                Assert.Equal(0.0, 20.0 * Math.Log10(measured / modelled), precision: 3);
+            }
+        }
+    }
+
+    [Fact]
+    public void BrownCompensation_FlattensBelowTheFilterCorner()
+    {
+        // The point of modelling the synthesis: below the leaky integrator's 76 Hz
+        // corner the excitation is (nearly) flat, so the compensation must flatten
+        // with it. The idealised −6 dB/octave slope would keep falling — another
+        // 11.6 dB between 76 and 20 Hz — and print that as an artificial bass
+        // roll-off onto a correct measurement.
+        var brown = NoiseSpectralModel.LeakyIntegrator(76.0);
+        double at20 = NoiseTiltCompensation.BinCompensationDb(brown, 20.0, SampleRate);
+        double at76 = NoiseTiltCompensation.BinCompensationDb(brown, 76.0, SampleRate);
+
+        // Still a real brown compensation above the corner...
+        Assert.True(at76 < -15.0, $"expected a deep brown compensation at 76 Hz, got {at76:0.0}");
+        // ...but only the corner's own curvature below it, nowhere near the ideal
+        // slope's further 11.6 dB.
+        Assert.True(
+            at20 - at76 > -4.0,
+            $"compensation must flatten below the corner: {at20:0.0} at 20 Hz vs {at76:0.0} at 76 Hz");
+    }
+
+    private static double[] BandCompensation(NoiseSpectralModel model) =>
         NoiseTiltCompensation.BandCompensationDb(
-            slope,
+            model,
             (FftLength / 2) + 1,
             FftLength,
             SampleRate,

--- a/tests/Resonalyze.Dsp.Tests/NoiseTiltCompensationTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/NoiseTiltCompensationTests.cs
@@ -1,0 +1,143 @@
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class NoiseTiltCompensationTests
+{
+    private const int FftLength = 2048;
+    private const int SampleRate = 48_000;
+    private const double PinkSlope = -3.0102999566398120; // -10·log10(2)
+
+    [Fact]
+    public void BinCompensation_MirrorsTheSlopeAroundThePivot()
+    {
+        // Pink falls 3.01 dB/octave on the per-bin display, so the compensation
+        // rises by exactly that per octave, zero at the pivot.
+        Assert.Equal(0.0, NoiseTiltCompensation.BinCompensationDb(PinkSlope, 1000.0), 12);
+        Assert.Equal(
+            -PinkSlope,
+            NoiseTiltCompensation.BinCompensationDb(PinkSlope, 2000.0),
+            precision: 9);
+        Assert.Equal(
+            PinkSlope,
+            NoiseTiltCompensation.BinCompensationDb(PinkSlope, 500.0),
+            precision: 9);
+        // White is flat on the per-bin display: identity.
+        Assert.Equal(0.0, NoiseTiltCompensation.BinCompensationDb(0.0, 20.0), 12);
+        Assert.Equal(0.0, NoiseTiltCompensation.BinCompensationDb(0.0, 20_000.0), 12);
+    }
+
+    [Fact]
+    public void BandCompensation_AlignsWithTheDisplayGridAndPinsThePivot()
+    {
+        double[] compensation = BandCompensation(PinkSlope);
+        List<SignalPoint> grid = DisplayGrid();
+
+        // Same resampler, same parameters: the compensation must line up with the
+        // displayed band curve index for index.
+        Assert.Equal(grid.Count, compensation.Length);
+
+        // Exactly zero at the grid point nearest the pivot, so switching the
+        // compensation on rotates the curve instead of shifting its level.
+        int pivot = NearestIndex(grid, NoiseTiltCompensation.PivotFrequency);
+        Assert.Equal(0.0, compensation[pivot], precision: 12);
+    }
+
+    [Fact]
+    public void BandCompensation_IsFlatForPinkWhereBandsAreConstantRelative()
+    {
+        // In the constant-relative-bandwidth region the band-power display renders
+        // pink flat on its own — the compensation there must be (near) zero, not the
+        // per-bin +3 dB/octave line. This is the assertion that distinguishes the
+        // band-law compensation from naively reusing the per-bin straight line.
+        double[] compensation = BandCompensation(PinkSlope);
+        List<SignalPoint> grid = DisplayGrid();
+
+        double at2k = compensation[NearestIndex(grid, 2000.0)];
+        double at8k = compensation[NearestIndex(grid, 8000.0)];
+        Assert.True(
+            Math.Abs(at8k - at2k) < 0.3,
+            $"pink band compensation should be flat 2k..8k, drifted {at8k - at2k:0.000} dB");
+    }
+
+    [Fact]
+    public void BandCompensation_UndoesTheBandLawTiltForWhite()
+    {
+        // A flat white PSD tilts +3.01 dB/octave on the band-power display (band
+        // power grows with bandwidth), so its compensation must FALL by that per
+        // octave in the constant-relative region — even though the PSD slope is zero.
+        double[] compensation = BandCompensation(0.0);
+        List<SignalPoint> grid = DisplayGrid();
+
+        double at2k = compensation[NearestIndex(grid, 2000.0)];
+        double at8k = compensation[NearestIndex(grid, 8000.0)];
+        double perOctave = (at8k - at2k) / 2.0;
+        Assert.True(
+            Math.Abs(perOctave - PinkSlope) < 0.15,
+            $"white band compensation should fall ~3.01 dB/octave, got {perOctave:0.000}");
+    }
+
+    [Fact]
+    public void BandCompensation_FollowsTheResolutionCornerAtLowFrequencies()
+    {
+        // Below the corner where the window main lobe is wider than the reference
+        // band, the integrator switches to constant ABSOLUTE bandwidth and pink
+        // renders rising toward LF again (+6 dB per two octaves) — the compensation
+        // must mirror that, falling toward LF instead of staying flat.
+        double[] compensation = BandCompensation(PinkSlope);
+        List<SignalPoint> grid = DisplayGrid();
+
+        double at40 = compensation[NearestIndex(grid, 40.0)];
+        double at160 = compensation[NearestIndex(grid, 160.0)];
+        Assert.True(
+            at160 - at40 > 3.0,
+            $"pink band compensation should fall toward LF below the resolution " +
+            $"corner, got {at40:0.000} at 40 Hz vs {at160:0.000} at 160 Hz");
+    }
+
+    private static double[] BandCompensation(double slope) =>
+        NoiseTiltCompensation.BandCompensationDb(
+            slope,
+            (FftLength / 2) + 1,
+            FftLength,
+            SampleRate,
+            Windowing.EquivalentNoiseBandwidthBins(WindowType.Hann, FftLength),
+            Windowing.MainLobeWidthBins(WindowType.Hann),
+            20,
+            20_000,
+            1024,
+            smoothingOctaves: 1.0 / 6.0,
+            psychoacoustic: false);
+
+    // The very grid the display's band resampler produces for the same parameters,
+    // rendered from an arbitrary spectrum — only the frequencies matter here.
+    private static List<SignalPoint> DisplayGrid()
+    {
+        var flat = new double[(FftLength / 2) + 1];
+        Array.Fill(flat, 1.0);
+        return DataHelper.LogarithmicPowerBandResample(
+            flat,
+            FftLength,
+            SampleRate,
+            Windowing.EquivalentNoiseBandwidthBins(WindowType.Hann, FftLength),
+            Windowing.MainLobeWidthBins(WindowType.Hann),
+            20,
+            20_000,
+            1024,
+            smoothingOctaves: 1.0 / 6.0,
+            psychoacoustic: false);
+    }
+
+    private static int NearestIndex(List<SignalPoint> points, double frequency)
+    {
+        int nearest = 0;
+        for (int i = 1; i < points.Count; i++)
+        {
+            if (Math.Abs(Math.Log2(points[i].X / frequency)) <
+                Math.Abs(Math.Log2(points[nearest].X / frequency)))
+            {
+                nearest = i;
+            }
+        }
+
+        return nearest;
+    }
+}


### PR DESCRIPTION
## Why

The live analyzer's RTA behavior was implied by side effects rather than stated: the SPL scale forced an RTA view, the Silent signal forced mic-only analysis, a missing loopback forced both — and the "is this an RTA?" condition was derived differently in `LiveSpectrumController`, `PlotModelFactory` and `NoiseMeasurement` (the factory's variant did not account for Silent). The SPL scale also dragged the signal list and capture restarts behind it: losing an SPL calibration swapped a running Silent RTA to periodic pink, gaining one swapped it back.

## What changed

### Explicit Transfer / RTA mode

- `LiveAnalysisMode { TransferFunction, Rta }` on `LiveSpectrumOptions`, selected by a **Mode** radio pair at the top of the panel.
- One effective-mode source: `PlotModelFactory.EffectiveLiveAnalysisMode` — the selection, forced to RTA when no loopback reference is configured. The controller and the plot both read it; `NoiseMeasurement.IsRtaCapture` applies the same condition to the analysis path.
- **Transfer without a loopback stays selectable but is coloured amber** (with an explaining tooltip), mirroring how the SPL view-only conflict is shown. The amber refreshes from the one chokepoint every routing change passes (`ApplyMeasurementConfigurationToControllersAsync`).
- Signals follow the mode, not the scale: **Silent is RTA-exclusive** (a transfer function has nothing to correlate against without an excitation) and now works on *both* scales — an ambient RTA in relative dBFS was previously unreachable. Periodic pink is allowed in RTA (a deterministic excitation, and the one whose spectrum the compensation knows exactly).
- This dissolves the calibration-driven normalization machinery: `RefreshCalibrationAsync` (stop/normalize/restart) shrinks to a synchronous `RefreshCalibration()` (drop peak hold, redraw). A Silent RTA that loses its SPL anchor keeps running on the relative axis. The one remaining rule: entering Transfer mode with Silent falls back to periodic pink.
- The mode is part of `LiveSpectrumRestartSnapshot`, so changing it restarts a running capture — the analysis path can never flip mid-run under the accumulators.
- Settings migration: files written before the explicit mode infer it from what used to imply an RTA session (`MagnitudeScale == SPL` or `NoiseColor == Silent`); an explicit stored mode wins; a hand-edited `Silent + Transfer` pairing is repaired on load.

### Noise slope compensation (new checkbox, RTA mode only)

Pink noise through a perfectly flat system still draws −3 dB/octave on the per-bin dB axis — the tilt belongs to the excitation, not the system. The new **Slope compensation** checkbox subtracts the noise's own rendered shape, pinned to 0 dB at 1 kHz, so a flat system reads flat whatever the noise colour.

The shape depends on the *display path*, not just the noise (`dsp/NoiseTiltCompensation`):

- **Relative (per-bin) display**: a straight mirrored line of the PSD slope, applied per bin before the display resample.
- **dB SPL (band-power) display**: bands of constant *relative* width render pink flat and white +3 dB/octave, and switch to constant *absolute* width below the window's resolution corner. The compensation renders the analytic noise spectrum through the **same** `LogarithmicPowerBandResample` with the same parameters and subtracts point-for-point — every clamp and kink is followed exactly, no band-law constants are restated, and a zero PSD slope (white) still compensates. The result is memoized per parameter set, not recomputed per 30 fps tick.
- Inert for Silent (unknown excitation spectrum) and in Transfer mode (the division removes the excitation); the RTA overlay drawn inside Transfer mode is left untouched.
- **Baked into overlay captures**: the relative raw capture applies the same per-bin correction at the same pipeline spot, so a captured overlay stays the compensated curve the user saw under any re-smoothing (pinned by a bit-exact roundtrip test). The SPL capture stores the drawn curve as before, which already carries the compensation.
- Participates in the peak-hold display key, so toggling it drops the stale envelope; the plot title gains a "(noise-compensated)" suffix so the level is not read as the plain measurement.

### dB SPL as a checkbox

- The Relative/dB SPL radio pair becomes a **dB SPL** checkbox, active in RTA mode only. A transfer function is a dimensionless ratio with no scalar SPL under noise excitation, so in Transfer mode the effective scale is forced relative — which the overlay gate follows automatically.
- The view-only machinery is unchanged: SPL stays selectable without a calibration (overlays show, live curves suppressed with the explaining notice), amber marks a real conflict only, and the record button drops the scale before a run (`ForceRelativeScale` → `ForceSplScaleOff`).
- An SPL toggle no longer restarts the capture — it is pure display now.

## Tests

2344 green (App 1065, Dsp 1127, Audio 142). New coverage:

- `NoiseTiltCompensationTests` (dsp): per-bin line values; band compensation flat for pink in the constant-relative region, −3.01 dB/octave for white there, following the resolution corner at LF, zero at the pivot, grid-aligned.
- `PlotModelFactoryTests`: compensated pink flat on the relative axis (and sloped with the checkbox off), compensated white flat on the SPL band axis, compensation inert in Transfer mode; existing SPL tests now state `AnalysisMode = Rta` explicitly.
- `LiveAnalysisModeTests`: RTA with a configured loopback stays mic-only *and keeps its excitation*; Transfer with/without loopback; six settings-migration cases; mode+tilt persistence roundtrip.
- `LiveRtaRawCaptureTests`: raw-with-tilt reproduces the drawn trace bit-exactly under re-smoothing.
- `LiveSpectrumControllerTests`: mode-based normalization (replacing the four scale-based tests), tilt in the peak-hold display key.

The options panel was rendered via a screenshot harness in all five distinct states (Transfer default, RTA+tilt, RTA+Silent, amber Transfer, amber dB SPL) to verify the layout, mutes and amber colouring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)