### PR TITLE
Read the front of the wave packet, not a ripple on its foot

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,11 +779,16 @@ It also refuses to read a **ripple on the foot of a wave packet** as that
 packet's arrival. A cabin's comb interference leaves small bumps a fraction of a
 millisecond ahead of a front; they are far too loud to be the transform's own
 ringing, so the rule above rightly keeps them, yet they are not the front. A
-candidate must reach a quarter of the strongest envelope level within one
-millisecond after it — the level the broadband onset calls the onset — or the
-packet's own front is taken instead. The window is deliberately one millisecond
-long, so a soft direct arrival sitting under a room mode milliseconds later still
-wins, which is what the search depth exists for. Without it two identical drivers
+candidate must reach a quarter of the strongest envelope level of its own packet
+— the level the broadband onset calls the onset — or the packet's own front is
+taken instead. The packet runs one millisecond forward and ends early at a null
+deep enough (20 dB) to resolve two events, because destructive interference nulls
+faster than an envelope rises: an earlier arrival separated from what follows by
+such a null is a separate arrival and keeps its own timing, however strong and
+however close the next packet is, and the rising edge of a later reflection can
+never be borrowed to dwarf the direct sound in front of it. A soft direct arrival
+sitting under a room mode milliseconds later still wins for the same reason,
+which is what the search depth exists for. Without this two identical drivers
 in opposite doors could be measured at different points of their fronts — one at
 its packet peak, the other 20 dB down its own foot — and the level difference
 lands in the reported delay: on a field pair, 0.31 ms of a 1.45 ms split.

--- a/README.md
+++ b/README.md
@@ -732,7 +732,13 @@ everywhere it is meaningful, always recomputed with the current mode's settings:
 
 - **Time Alignment** — the reference envelope is overlaid on the peak preview
   with its own markers, and the delay table gains a second block whose every
-  value shows the delta against the source (for example `1.006 (+0.010)`).
+  value shows the delta against the source (for example `1.006 (+0.010)`). In
+  **Auto** band mode the analysis band is then the one the two records SHARE —
+  the overlap of their own dominant bands, labelled `shared with Compare` —
+  because two arrivals are only comparable where both drivers play, and a band
+  taken from the source alone would make the delta depend on which of the pair
+  was loaded first. Records that barely overlap (a subwoofer against a tweeter)
+  keep the source's own band.
 - **Phase** and **Group Delay** — the reference curves use the identical
   gate/window and smoothing, drawn dashed and dimmed; Phase Auto detrend is
   resolved once from Main and reused, preserving their relative delay.
@@ -768,6 +774,19 @@ louder than that allows at a given distance, so a candidate above the ceiling is
 a genuine arrival no matter how the surroundings look (which keeps weak direct
 sound alive in reverberant bass), and one at or below it is confirmed as pre-ring
 by its mirror twin.
+
+It also refuses to read a **ripple on the foot of a wave packet** as that
+packet's arrival. A cabin's comb interference leaves small bumps a fraction of a
+millisecond ahead of a front; they are far too loud to be the transform's own
+ringing, so the rule above rightly keeps them, yet they are not the front. A
+candidate must reach a quarter of the strongest envelope level within one
+millisecond after it — the level the broadband onset calls the onset — or the
+packet's own front is taken instead. The window is deliberately one millisecond
+long, so a soft direct arrival sitting under a room mode milliseconds later still
+wins, which is what the search depth exists for. Without it two identical drivers
+in opposite doors could be measured at different points of their fronts — one at
+its packet peak, the other 20 dB down its own foot — and the level difference
+lands in the reported delay: on a field pair, 0.31 ms of a 1.45 ms split.
 
 The second stage is what makes the numbers trustworthy. The transfer IR's
 spectrum already carries the microphone-to-loopback cross-phase, so whitening it

--- a/dsp/SignalEnvelope.cs
+++ b/dsp/SignalEnvelope.cs
@@ -336,6 +336,18 @@ public static class SignalEnvelope
     // nobody's foot ripple and stays selected.
     private const double ArrivalPacketRiseRatio = 0.25;
 
+    // How deep the envelope must null between a candidate and a later stronger
+    // sample for the two to be RESOLVED events rather than one packet — the
+    // same 20 dB <see cref="TimeAlignmentAnalysis"/> calls a resolved valley,
+    // because destructive interference nulls faster than an envelope rises. The
+    // packet ends at the first such null: past it the record belongs to another
+    // arrival, and the rising edge of a reflection that peaks beyond the packet
+    // window must not be allowed to dwarf a genuine direct sound in front of it.
+    // Measured on the field cabin, real foot ripples dip at most 14.5 dB (the
+    // mid pair's own: 7.5 dB) before their packet's peak, so the two cases stay
+    // apart with margin.
+    internal const double ArrivalPacketResolvedValleyDb = 20.0;
+
     // Walks the threshold-passing local maxima from the latest to the earliest,
     // dropping every candidate that reads as a pre-ringing sidelobe of an
     // already-accepted later peak — a weak first arrival is itself a sidelobe
@@ -402,23 +414,34 @@ public static class SignalEnvelope
     }
 
     // Whether the candidate is the front of its own wave packet rather than a
-    // ripple on its foot: the strongest envelope sample within one packet span
-    // after it may stand no more than the rise ratio above it. The strongest
-    // peak of the record always passes (nothing outranks it inside its own
-    // window), so the walk can never come back empty because of this test.
+    // ripple on its foot: the strongest envelope sample of THAT PACKET may stand
+    // no more than the rise ratio above it. The packet runs one span forward and
+    // ends early at a null deep enough to resolve two events, so a genuine
+    // earlier arrival is never dwarfed by whatever rises after the null — the
+    // separate-arrival case, which keeps its own timing. The strongest peak of
+    // the record always passes (nothing outranks it inside its own packet), so
+    // the walk can never come back empty because of this test.
     private static bool RisesWithinItsPacket(
         IReadOnlyList<double> envelope,
         int candidateIndex,
         int packetSpanSamples)
     {
-        double packetPeak = envelope[candidateIndex];
+        double candidate = envelope[candidateIndex];
+        double resolvedFloor =
+            candidate * Math.Pow(10.0, -ArrivalPacketResolvedValleyDb / 20.0);
+        double packetPeak = candidate;
         int last = Math.Min(envelope.Count - 1, candidateIndex + packetSpanSamples);
         for (int i = candidateIndex + 1; i <= last; i++)
         {
+            if (envelope[i] < resolvedFloor)
+            {
+                break;
+            }
+
             packetPeak = Math.Max(packetPeak, envelope[i]);
         }
 
-        return envelope[candidateIndex] >= packetPeak * ArrivalPacketRiseRatio;
+        return candidate >= packetPeak * ArrivalPacketRiseRatio;
     }
 
     // The analysis kernel's envelope level at |offset| samples from its centre,

--- a/dsp/SignalEnvelope.cs
+++ b/dsp/SignalEnvelope.cs
@@ -151,12 +151,15 @@ public static class SignalEnvelope
             }
         }
 
+        int packetSpanSamples = (int)Math.Round(
+            ArrivalPacketMilliseconds * sampleRate / 1000.0);
         int firstArrivalIndex = EliminatePreRingingSidelobes(
             view,
             candidates,
             options.AnalysisKernelEnvelope,
             threshold,
-            strongestPeak);
+            strongestPeak,
+            packetSpanSamples);
         if (firstArrivalIndex >= 0)
         {
             return new PeakSearchResult(
@@ -308,17 +311,46 @@ public static class SignalEnvelope
     private const double SidelobeSymmetryRatio = 0.5;
     private const int SidelobeMirrorNeighborhood = 2;
 
+    // How long after a candidate a stronger peak still belongs to the SAME wave
+    // packet rather than being a separate arrival — the complement of
+    // <see cref="TimeAlignmentAnalysis"/>'s separate-arrival rule, and the same
+    // 1 ms, so the two never disagree about what one arrival is.
+    internal const double ArrivalPacketMilliseconds = 1.0;
+
+    // The share of its own packet's peak amplitude a candidate must reach to be
+    // read as that packet's front rather than a ripple on its foot. A wave
+    // packet's leading edge carries interference structure — a comb null a
+    // fraction of a millisecond before the front leaves a small bump above the
+    // search threshold — and taking that bump as "the arrival" reports a time
+    // that depends on the record's ripple, not on its path: two identical
+    // drivers in opposite doors then read one arrival at its packet peak and the
+    // other 20 dB down its own foot, and the level difference enters the
+    // measured DELAY (field pair: 0.31 ms of a 1.45 ms split; a tweeter pair:
+    // 0.125 ms). Measured on that cabin, foot ripples sit 19-21 dB under their
+    // packet while genuine fronts stay within 7 dB, so 25 % (-12 dB) separates
+    // them with margin on both sides. It is the same 25 % the broadband onset
+    // (<see cref="VirtualCrossoverAnalysis.EstimateBroadbandOnset"/>) calls the
+    // onset level, and it is deliberately LOCAL: the packet window is one
+    // millisecond, so a soft direct arrival buried under a room mode
+    // milliseconds later — what the 25 dB search depth exists to find — is
+    // nobody's foot ripple and stays selected.
+    private const double ArrivalPacketRiseRatio = 0.25;
+
     // Walks the threshold-passing local maxima from the latest to the earliest,
     // dropping every candidate that reads as a pre-ringing sidelobe of an
     // already-accepted later peak — a weak first arrival is itself a sidelobe
     // reference, so its own pre-ring cannot masquerade as an even earlier
-    // arrival. Returns the earliest surviving candidate, or -1 when none pass.
+    // arrival. Returns the earliest surviving candidate that also rises far
+    // enough within its own packet, or -1 when none pass. A dwarfed candidate
+    // still joins the sidelobe references: it is a real bump in the envelope and
+    // rings like one, whatever it is called.
     private static int EliminatePreRingingSidelobes(
         IReadOnlyList<double> envelope,
         IReadOnlyList<int> candidates,
         IReadOnlyList<double>? kernelEnvelope,
         double threshold,
-        double strongestPeak)
+        double strongestPeak,
+        int packetSpanSamples)
     {
         // Beyond this offset not even the strongest peak can ring above the
         // candidate threshold, so no threshold-passing candidate can be anyone's
@@ -359,11 +391,34 @@ public static class SignalEnvelope
             if (!isSidelobe)
             {
                 accepted.Add(candidate);
-                firstArrival = candidate;
+                if (RisesWithinItsPacket(envelope, candidate, packetSpanSamples))
+                {
+                    firstArrival = candidate;
+                }
             }
         }
 
         return firstArrival;
+    }
+
+    // Whether the candidate is the front of its own wave packet rather than a
+    // ripple on its foot: the strongest envelope sample within one packet span
+    // after it may stand no more than the rise ratio above it. The strongest
+    // peak of the record always passes (nothing outranks it inside its own
+    // window), so the walk can never come back empty because of this test.
+    private static bool RisesWithinItsPacket(
+        IReadOnlyList<double> envelope,
+        int candidateIndex,
+        int packetSpanSamples)
+    {
+        double packetPeak = envelope[candidateIndex];
+        int last = Math.Min(envelope.Count - 1, candidateIndex + packetSpanSamples);
+        for (int i = candidateIndex + 1; i <= last; i++)
+        {
+            packetPeak = Math.Max(packetPeak, envelope[i]);
+        }
+
+        return envelope[candidateIndex] >= packetPeak * ArrivalPacketRiseRatio;
     }
 
     // The analysis kernel's envelope level at |offset| samples from its centre,

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -296,8 +296,11 @@ public static class TimeAlignmentAnalysis
 
     // How much later than the first arrival the strongest peak must sit before it
     // is called a separate arrival (reflection or room mode) rather than the same
-    // smeared direct sound.
-    private const double SeparateArrivalThresholdMilliseconds = 1.0;
+    // smeared direct sound. The peak search reads the same span from the other
+    // side — inside it, a candidate far below the packet's peak is that packet's
+    // foot, not an arrival — so both live on one constant.
+    private const double SeparateArrivalThresholdMilliseconds =
+        SignalEnvelope.ArrivalPacketMilliseconds;
 
     // How deep the envelope must dip between the two peaks before they count as
     // separate arrivals: two events have a real valley between them, one broad

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -309,8 +309,11 @@ public static class TimeAlignmentAnalysis
 
     // A valley this deep proves the two events resolved even when their
     // separation sits inside the analysis band's nominal ~1/BW blur —
-    // destructive interference nulls faster than the envelope's rise time.
-    private const double SeparateArrivalResolvedValleyDb = 20.0;
+    // destructive interference nulls faster than the envelope's rise time. The
+    // peak search ends a candidate's packet at the same null, for the same
+    // reason, so both live on one constant.
+    private const double SeparateArrivalResolvedValleyDb =
+        SignalEnvelope.ArrivalPacketResolvedValleyDb;
 
     // A peak position expressed in the search window's frame: its offset from
     // the window's start, which for a re-anchored (rotated) window is where

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -385,10 +385,10 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         if (options.BandMode == TimeAlignmentBandMode.AutoBand)
         {
             DominantBand band = DetectDominantBand(source);
-            if (compareSource is { } compare)
+            if (compareSource is { } compare &&
+                TryDetectDominantBand(compare, out DominantBand compareBand))
             {
-                (band, lastAutoBandIsShared) =
-                    SharedBand(band, DetectDominantBand(compare));
+                (band, lastAutoBandIsShared) = SharedBand(band, compareBand);
             }
 
             lastAutoBand = band;
@@ -415,6 +415,30 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             source.TransferImpulseResponse,
             source.SampleRate,
             coherence: source.TransferCoherence);
+
+    // A record whose coherence never clears the threshold has no dominant band,
+    // and the detector says so by throwing. For COMPARE that verdict must stay
+    // Compare's: before the band was agreed between the two records, such a
+    // failure was caught with the rest of the Compare handling and Main kept
+    // working, and it still has to — the band simply falls back to Main's own,
+    // which the label then stops calling shared. Main's own failure keeps
+    // reaching the refresh handler: with no band for the Main record there is
+    // no analysis to show.
+    internal static bool TryDetectDominantBand(
+        TimeAlignmentAnalysisSource source,
+        out DominantBand band)
+    {
+        try
+        {
+            band = DetectDominantBand(source);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            band = default;
+            return false;
+        }
+    }
 
     // The band the two records are read in when both are present: the overlap of
     // their own dominant bands. Two drivers are only comparable where both

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -35,6 +35,10 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // The band detected for the Auto mode on the last refresh (null when no
     // data or another mode is active); feeds the preview plot and the label.
     private DominantBand? lastAutoBand;
+    // Whether that band is the overlap of Main's and Compare's own bands rather
+    // than Main's alone; the label says which, because the two answer different
+    // questions ("where this driver plays" against "where these two meet").
+    private bool lastAutoBandIsShared;
     private bool disposed;
 
     // The fade the Auto mode puts around the detected pass band.
@@ -182,11 +186,21 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             TimeAlignmentAnalysisSource mainAnalysisSource =
                 CleanForAnalysis(mainSource, mainCrosstalk);
 
-            // One options object per refresh: the Auto mode detects the band
-            // from the MAIN record and the Compare measurement is analyzed
-            // in the same band, so the delta column compares like with like.
-            TimeAlignmentAnalysisOptions analysisOptions =
-                CreateAnalysisOptions(mainAnalysisSource, wrapPeakPositions: true);
+            // The Compare record is resolved and cleaned BEFORE the band is
+            // chosen: in the Auto mode the band is the one both records share,
+            // and a band taken from Main alone would make the delta depend on
+            // which of the two was loaded as Main (a field mid pair: 32.7-7671
+            // Hz one way, 75.5-4695 Hz the other, and 0.3 ms of delta with it).
+            TimeAlignmentAnalysisSource? compareSource = TryGetCompareSource(
+                mainSource,
+                out string? compareWarning,
+                out CrosstalkHeadGate? compareCrosstalk);
+
+            // One options object per refresh, and the Compare measurement is
+            // analyzed in the same band, so the delta column compares like with
+            // like.
+            TimeAlignmentAnalysisOptions analysisOptions = CreateAnalysisOptions(
+                mainAnalysisSource, compareSource, wrapPeakPositions: true);
             UpdateAutoBandLabel();
             UpdateBandpassPreview();
 
@@ -213,10 +227,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 mainResult,
                 mainAnalysisSource.TransferCoherence);
             TimeAlignmentCompareAnalysis? compareAnalysis = AnalyzeCompare(
-                mainSource,
-                analysisOptions,
-                out string? compareWarning,
-                out CrosstalkHeadGate? compareCrosstalk);
+                compareSource, analysisOptions, ref compareWarning);
             TimeAlignmentArrivalProbe? compareProbe = compareAnalysis == null
                 ? null
                 : TimeAlignmentAnalysis.ProbeArrivalHonesty(
@@ -363,18 +374,23 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
     private TimeAlignmentAnalysisOptions CreateAnalysisOptions(
         TimeAlignmentAnalysisSource source,
+        TimeAlignmentAnalysisSource? compareSource,
         bool wrapPeakPositions)
     {
         double centerHz = options.BandpassCenterHz;
         double passOctaves = options.BandpassPassOctaves;
         double fadeOctaves = options.BandpassFadeOctaves;
         lastAutoBand = null;
+        lastAutoBandIsShared = false;
         if (options.BandMode == TimeAlignmentBandMode.AutoBand)
         {
-            DominantBand band = TransferIrDiagnostics.DetectDominantBand(
-                source.TransferImpulseResponse,
-                source.SampleRate,
-                coherence: source.TransferCoherence);
+            DominantBand band = DetectDominantBand(source);
+            if (compareSource is { } compare)
+            {
+                (band, lastAutoBandIsShared) =
+                    SharedBand(band, DetectDominantBand(compare));
+            }
+
             lastAutoBand = band;
             centerHz = Math.Sqrt(band.LowHz * band.HighHz);
             passOctaves = Math.Log2(band.HighHz / band.LowHz);
@@ -392,6 +408,29 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             PeakSearchWindowMilliseconds = options.PeakSearchWindowMilliseconds,
             WrapPeakPositions = wrapPeakPositions
         };
+    }
+
+    private static DominantBand DetectDominantBand(TimeAlignmentAnalysisSource source) =>
+        TransferIrDiagnostics.DetectDominantBand(
+            source.TransferImpulseResponse,
+            source.SampleRate,
+            coherence: source.TransferCoherence);
+
+    // The band the two records are read in when both are present: the overlap of
+    // their own dominant bands. Two drivers are only comparable where both
+    // actually play — outside the overlap one of the curves is its own noise —
+    // and an overlap is symmetric, so loading the pair the other way round
+    // returns the same band and the same delta. Two records that share too
+    // little to carve a band (a subwoofer against a tweeter) keep MAIN's band:
+    // the reading is then Main's own, which the shared-band note says out loud.
+    internal static (DominantBand Band, bool Shared) SharedBand(
+        DominantBand main, DominantBand compare)
+    {
+        double low = Math.Max(main.LowHz, compare.LowHz);
+        double high = Math.Min(main.HighHz, compare.HighHz);
+        return high < low * VirtualCrossoverAnalysis.MinimumArrivalBandRatio
+            ? (main, false)
+            : (new DominantBand(low, high, Math.Clamp(main.PeakHz, low, high)), true);
     }
 
     private void ApplyOptionsToControls()
@@ -433,7 +472,8 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         autoBandLabel.Text = options.BandMode != TimeAlignmentBandMode.AutoBand
             ? "-"
             : lastAutoBand is { } band
-                ? $"detected: {band.LowHz:0}-{band.HighHz:0} Hz"
+                ? $"detected: {band.LowHz:0}-{band.HighHz:0} Hz" +
+                    (lastAutoBandIsShared ? " (shared with Compare)" : string.Empty)
                 : "detected: waiting for a record";
     }
 
@@ -504,9 +544,12 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         return model;
     }
 
-    private TimeAlignmentCompareAnalysis? AnalyzeCompare(
+    // Resolves the Compare record into an analysis-ready source: the same
+    // hygiene Main gets (its own crosstalk detection on the raw IR, cleaned
+    // analysis in the banded modes), and no analysis yet — the band still has
+    // to be agreed between the two records.
+    private TimeAlignmentAnalysisSource? TryGetCompareSource(
         TimeAlignmentAnalysisSource mainSource,
-        TimeAlignmentAnalysisOptions analysisOptions,
         out string? warning,
         out CrosstalkHeadGate? crosstalk)
     {
@@ -538,23 +581,41 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         {
             TimeAlignmentAnalysisSource compareSource =
                 CreateCompareSource(compareValue, snapshot);
-            // The Compare record gets the same hygiene as Main: its own
-            // detection on the raw IR, cleaned analysis in the banded modes.
             crosstalk = TransferIrDiagnostics.DetectCrosstalkHead(
                 compareSource.TransferImpulseResponse, compareSource.SampleRate);
-            compareSource = CleanForAnalysis(compareSource, crosstalk);
+            return CleanForAnalysis(compareSource, crosstalk);
+        }
+        catch (Exception exception)
+        {
+            warning = exception.Message;
+            return null;
+        }
+    }
+
+    private TimeAlignmentCompareAnalysis? AnalyzeCompare(
+        TimeAlignmentAnalysisSource? compareSource,
+        TimeAlignmentAnalysisOptions analysisOptions,
+        ref string? warning)
+    {
+        if (compareSource is not { } source)
+        {
+            return null;
+        }
+
+        try
+        {
             TimeAlignmentAnalysisResult compareResult = TimeAlignmentAnalysis.Analyze(
-                compareSource.TransferImpulseResponse,
-                compareSource.SampleRate,
+                source.TransferImpulseResponse,
+                source.SampleRate,
                 analysisOptions,
-                compareSource.TransferCoherence);
+                source.TransferCoherence);
             if (!compareResult.IsValid)
             {
                 warning = "Compare: no signal in the analysis band.";
                 return null;
             }
 
-            return new TimeAlignmentCompareAnalysis(compareSource, compareResult);
+            return new TimeAlignmentCompareAnalysis(source, compareResult);
         }
         catch (Exception exception)
         {

--- a/tests/Resonalyze.App.Tests/TimeAlignmentSharedBandTests.cs
+++ b/tests/Resonalyze.App.Tests/TimeAlignmentSharedBandTests.cs
@@ -1,0 +1,71 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+// The Auto band with a Compare record loaded. Two arrivals are only comparable
+// where both drivers actually play, and — the reason this exists — a band taken
+// from Main alone makes the delta depend on which of the two records was loaded
+// first: a field mid pair detected 32.7-7671 Hz one way and 75.5-4695 Hz the
+// other, and the reported split moved 0.3 ms with it.
+public sealed class TimeAlignmentSharedBandTests
+{
+    [Fact]
+    public void SharedBand_IsTheOverlapOfBothRecordsOwnBands()
+    {
+        var main = new DominantBand(32.7, 7671.3, 174.5);
+        var compare = new DominantBand(75.5, 4695.1, 261.4);
+
+        (DominantBand band, bool shared) =
+            TimeAlignmentPanelController.SharedBand(main, compare);
+
+        Assert.True(shared);
+        Assert.Equal(75.5, band.LowHz, precision: 6);
+        Assert.Equal(4695.1, band.HighHz, precision: 6);
+    }
+
+    [Fact]
+    public void SharedBand_ReadsTheSameEitherWayRound()
+    {
+        var main = new DominantBand(32.7, 7671.3, 174.5);
+        var compare = new DominantBand(75.5, 4695.1, 261.4);
+
+        (DominantBand forward, _) =
+            TimeAlignmentPanelController.SharedBand(main, compare);
+        (DominantBand reversed, _) =
+            TimeAlignmentPanelController.SharedBand(compare, main);
+
+        Assert.Equal(forward.LowHz, reversed.LowHz, precision: 9);
+        Assert.Equal(forward.HighHz, reversed.HighHz, precision: 9);
+    }
+
+    [Fact]
+    public void SharedBand_KeepsThePeakInsideTheBandItReturns()
+    {
+        // Main's own peak can sit outside the overlap (a woofer against a mid):
+        // the band's peak must stay a frequency of that band.
+        var main = new DominantBand(30.0, 900.0, 45.0);
+        var compare = new DominantBand(200.0, 4000.0, 800.0);
+
+        (DominantBand band, bool shared) =
+            TimeAlignmentPanelController.SharedBand(main, compare);
+
+        Assert.True(shared);
+        Assert.InRange(band.PeakHz, band.LowHz, band.HighHz);
+    }
+
+    [Fact]
+    public void SharedBand_KeepsMainsBandWhenTheTwoRecordsBarelyOverlap()
+    {
+        // A subwoofer against a tweeter: the overlap is narrower than the
+        // third-octave floor the arrival analysis needs, so there is no shared
+        // band to read them in and Main's own band stands.
+        var main = new DominantBand(25.0, 160.0, 60.0);
+        var compare = new DominantBand(150.0, 18_000.0, 3_000.0);
+
+        (DominantBand band, bool shared) =
+            TimeAlignmentPanelController.SharedBand(main, compare);
+
+        Assert.False(shared);
+        Assert.Equal(main, band);
+    }
+}

--- a/tests/Resonalyze.App.Tests/TimeAlignmentSharedBandTests.cs
+++ b/tests/Resonalyze.App.Tests/TimeAlignmentSharedBandTests.cs
@@ -54,6 +54,54 @@ public sealed class TimeAlignmentSharedBandTests
     }
 
     [Fact]
+    public void TryDetectDominantBand_ReportsFailureInsteadOfThrowing()
+    {
+        // A record whose coherence never clears the trust threshold has no
+        // dominant band, and the detector says so by throwing. Asking for
+        // COMPARE's band must not take Main's analysis down with it, so the
+        // question is answered with false and Main's own band stands.
+        TimeAlignmentAnalysisSource source = Source(coherent: false);
+
+        bool detected = TimeAlignmentPanelController.TryDetectDominantBand(
+            source, out DominantBand band);
+
+        Assert.False(detected);
+        Assert.Equal(default, band);
+    }
+
+    [Fact]
+    public void TryDetectDominantBand_ReturnsTheBandOfAMeasurableRecord()
+    {
+        TimeAlignmentAnalysisSource source = Source(coherent: true);
+
+        bool detected = TimeAlignmentPanelController.TryDetectDominantBand(
+            source, out DominantBand band);
+
+        Assert.True(detected);
+        Assert.True(band.HighHz > band.LowHz);
+    }
+
+    private static TimeAlignmentAnalysisSource Source(bool coherent)
+    {
+        const int sampleRate = 48_000;
+        var impulseResponse = new double[8_192];
+        impulseResponse[100] = 1.0;
+        double[] coherence =
+            Enumerable.Repeat(coherent ? 1.0 : 0.0, sampleRate / 2).ToArray();
+        return new TimeAlignmentAnalysisSource(
+            "Compare",
+            "compare",
+            sampleRate,
+            24,
+            1.0,
+            PlaybackChannel.Mono,
+            SweepMeasurementMode.LoopbackTransfer,
+            impulseResponse,
+            coherence,
+            default);
+    }
+
+    [Fact]
     public void SharedBand_KeepsMainsBandWhenTheTwoRecordsBarelyOverlap()
     {
         // A subwoofer against a tweeter: the overlap is narrower than the

--- a/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
@@ -284,32 +284,38 @@ public sealed class SignalEnvelopeTests
         Assert.Equal(100, relaxed.SelectedIndex);  // bump accepted as the first arrival
     }
 
+    // The mirror pair below runs at 8 kHz so the bump sits 10 samples — 1.25 ms —
+    // ahead of the peak: BEYOND the one-millisecond wave packet, where the
+    // packet-rise floor does not apply and the symmetry rule alone decides. A
+    // bump inside the packet would be settled by the floor first (with the bare
+    // Hilbert skirt the two rules overlap at short range), and these two tests
+    // would stop testing what they are named for.
     [Fact]
     public void FindPeak_RejectsASymmetricPreRingingSidelobeOfAStrongerPeak()
     {
-        // A zero-phase kernel rings symmetrically: the early bump at 14 has an
-        // equal-height mirror at 26 around the main peak at 20, so it must be
+        // A zero-phase kernel rings symmetrically: the early bump at 10 has an
+        // equal-height mirror at 30 around the main peak at 20, so it must be
         // read as pre-ringing, not as an earlier arrival.
         var envelope = new double[64];
-        envelope[13] = 0.05;
-        envelope[14] = 0.2;
-        envelope[15] = 0.05;
+        envelope[9] = 0.02;
+        envelope[10] = 0.1;
+        envelope[11] = 0.02;
         envelope[19] = 0.5;
         envelope[20] = 1.0;
         envelope[21] = 0.5;
-        envelope[25] = 0.05;
-        envelope[26] = 0.2;
-        envelope[27] = 0.05;
+        envelope[29] = 0.02;
+        envelope[30] = 0.1;
+        envelope[31] = 0.02;
 
         PeakSearchResult result = SignalEnvelope.FindPeak(
             envelope,
-            sampleRate: 48_000,
+            sampleRate: 8_000,
             new PeakSearchOptions
             {
                 Mode = PeakSearchMode.FirstArrival,
                 FirstPeakThresholdBelowMaxDb = 25,
                 FirstPeakMinimumSnrDb = 0,
-                SearchWindowMilliseconds = 1
+                SearchWindowMilliseconds = 8
             });
 
         Assert.Equal(20, result.SelectedIndex);
@@ -322,12 +328,40 @@ public sealed class SignalEnvelopeTests
         // Same early bump, but nothing at the mirrored position after the main
         // peak — a genuine earlier arrival, so it must stay the first arrival.
         var envelope = new double[64];
-        envelope[13] = 0.05;
-        envelope[14] = 0.2;
-        envelope[15] = 0.05;
+        envelope[9] = 0.02;
+        envelope[10] = 0.1;
+        envelope[11] = 0.02;
         envelope[19] = 0.5;
         envelope[20] = 1.0;
         envelope[21] = 0.5;
+
+        PeakSearchResult result = SignalEnvelope.FindPeak(
+            envelope,
+            sampleRate: 8_000,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                FirstPeakThresholdBelowMaxDb = 25,
+                FirstPeakMinimumSnrDb = 0,
+                SearchWindowMilliseconds = 8
+            });
+
+        Assert.Equal(10, result.SelectedIndex);
+        Assert.False(result.FallbackUsed);
+    }
+
+    [Fact]
+    public void FindPeak_RejectsARippleOnTheFootOfItsOwnWavePacket()
+    {
+        // A ripple 20 dB under the packet it belongs to, 0.6 ms ahead of that
+        // packet's peak: too loud to be the transform's own pre-ringing (the
+        // symmetry rule keeps it) and too quiet to be the front. Reading it as
+        // the arrival is what made two identical drivers incomparable — one
+        // measured at its packet peak, the other 20 dB down its own foot.
+        var envelope = new double[4_096];
+        envelope[500] = 0.1;
+        envelope[520] = 0.5;
+        envelope[540] = 1.0;
 
         PeakSearchResult result = SignalEnvelope.FindPeak(
             envelope,
@@ -336,11 +370,58 @@ public sealed class SignalEnvelopeTests
             {
                 Mode = PeakSearchMode.FirstArrival,
                 FirstPeakThresholdBelowMaxDb = 25,
-                FirstPeakMinimumSnrDb = 0,
-                SearchWindowMilliseconds = 1
+                FirstPeakMinimumSnrDb = 0
             });
 
-        Assert.Equal(14, result.SelectedIndex);
+        Assert.Equal(520, result.SelectedIndex);
+        Assert.False(result.FallbackUsed);
+    }
+
+    [Fact]
+    public void FindPeak_KeepsASoftArrivalWhenTheStrongPeakIsMillisecondsLater()
+    {
+        // The same 20 dB gap, but the strong peak sits 4.2 ms later — a room
+        // mode, not this arrival's own packet. The soft direct sound the 25 dB
+        // search depth exists to find must survive: the packet floor is local.
+        var envelope = new double[4_096];
+        envelope[500] = 0.1;
+        envelope[700] = 1.0;
+
+        PeakSearchResult result = SignalEnvelope.FindPeak(
+            envelope,
+            sampleRate: 48_000,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                FirstPeakThresholdBelowMaxDb = 25,
+                FirstPeakMinimumSnrDb = 0
+            });
+
+        Assert.Equal(500, result.SelectedIndex);
+        Assert.False(result.FallbackUsed);
+    }
+
+    [Fact]
+    public void FindPeak_KeepsAFrontThatReachesAQuarterOfItsPacketPeak()
+    {
+        // The floor is a quarter of the packet's amplitude: a front at 0.3 of a
+        // 1.0 packet is the packet's own leading edge and stays selected, so the
+        // guard cannot quietly promote every arrival to its strongest lobe.
+        var envelope = new double[4_096];
+        envelope[500] = 0.3;
+        envelope[540] = 1.0;
+
+        PeakSearchResult result = SignalEnvelope.FindPeak(
+            envelope,
+            sampleRate: 48_000,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                FirstPeakThresholdBelowMaxDb = 25,
+                FirstPeakMinimumSnrDb = 0
+            });
+
+        Assert.Equal(500, result.SelectedIndex);
         Assert.False(result.FallbackUsed);
     }
 

--- a/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
@@ -284,38 +284,32 @@ public sealed class SignalEnvelopeTests
         Assert.Equal(100, relaxed.SelectedIndex);  // bump accepted as the first arrival
     }
 
-    // The mirror pair below runs at 8 kHz so the bump sits 10 samples — 1.25 ms —
-    // ahead of the peak: BEYOND the one-millisecond wave packet, where the
-    // packet-rise floor does not apply and the symmetry rule alone decides. A
-    // bump inside the packet would be settled by the floor first (with the bare
-    // Hilbert skirt the two rules overlap at short range), and these two tests
-    // would stop testing what they are named for.
     [Fact]
     public void FindPeak_RejectsASymmetricPreRingingSidelobeOfAStrongerPeak()
     {
-        // A zero-phase kernel rings symmetrically: the early bump at 10 has an
-        // equal-height mirror at 30 around the main peak at 20, so it must be
+        // A zero-phase kernel rings symmetrically: the early bump at 14 has an
+        // equal-height mirror at 26 around the main peak at 20, so it must be
         // read as pre-ringing, not as an earlier arrival.
         var envelope = new double[64];
-        envelope[9] = 0.02;
-        envelope[10] = 0.1;
-        envelope[11] = 0.02;
+        envelope[13] = 0.05;
+        envelope[14] = 0.2;
+        envelope[15] = 0.05;
         envelope[19] = 0.5;
         envelope[20] = 1.0;
         envelope[21] = 0.5;
-        envelope[29] = 0.02;
-        envelope[30] = 0.1;
-        envelope[31] = 0.02;
+        envelope[25] = 0.05;
+        envelope[26] = 0.2;
+        envelope[27] = 0.05;
 
         PeakSearchResult result = SignalEnvelope.FindPeak(
             envelope,
-            sampleRate: 8_000,
+            sampleRate: 48_000,
             new PeakSearchOptions
             {
                 Mode = PeakSearchMode.FirstArrival,
                 FirstPeakThresholdBelowMaxDb = 25,
                 FirstPeakMinimumSnrDb = 0,
-                SearchWindowMilliseconds = 8
+                SearchWindowMilliseconds = 1
             });
 
         Assert.Equal(20, result.SelectedIndex);
@@ -327,41 +321,48 @@ public sealed class SignalEnvelopeTests
     {
         // Same early bump, but nothing at the mirrored position after the main
         // peak — a genuine earlier arrival, so it must stay the first arrival.
+        // It is also 14 dB under a stronger peak 0.125 ms later: the envelope
+        // nulls to zero between them, which resolves the two as separate events,
+        // so the packet-rise floor has no say here.
         var envelope = new double[64];
-        envelope[9] = 0.02;
-        envelope[10] = 0.1;
-        envelope[11] = 0.02;
+        envelope[13] = 0.05;
+        envelope[14] = 0.2;
+        envelope[15] = 0.05;
         envelope[19] = 0.5;
         envelope[20] = 1.0;
         envelope[21] = 0.5;
 
         PeakSearchResult result = SignalEnvelope.FindPeak(
             envelope,
-            sampleRate: 8_000,
+            sampleRate: 48_000,
             new PeakSearchOptions
             {
                 Mode = PeakSearchMode.FirstArrival,
                 FirstPeakThresholdBelowMaxDb = 25,
                 FirstPeakMinimumSnrDb = 0,
-                SearchWindowMilliseconds = 8
+                SearchWindowMilliseconds = 1
             });
 
-        Assert.Equal(10, result.SelectedIndex);
+        Assert.Equal(14, result.SelectedIndex);
         Assert.False(result.FallbackUsed);
     }
 
     [Fact]
     public void FindPeak_RejectsARippleOnTheFootOfItsOwnWavePacket()
     {
-        // A ripple 20 dB under the packet it belongs to, 0.6 ms ahead of that
-        // packet's peak: too loud to be the transform's own pre-ringing (the
-        // symmetry rule keeps it) and too quiet to be the front. Reading it as
-        // the arrival is what made two identical drivers incomparable — one
-        // measured at its packet peak, the other 20 dB down its own foot.
+        // A ripple 20 dB under the packet it belongs to, 0.83 ms ahead of that
+        // packet's peak, riding a foot that only dips 4 dB behind it — the comb
+        // structure a cabin leaves on a leading edge. It is too loud to be the
+        // transform's own pre-ringing (the symmetry rule keeps it) and too quiet,
+        // with nothing resolving it from the rise it sits on, to be the front.
+        // Reading it as the arrival is what made two identical drivers
+        // incomparable: one measured at its packet peak, the other 20 dB down
+        // its own foot.
         var envelope = new double[4_096];
-        envelope[500] = 0.1;
-        envelope[520] = 0.5;
-        envelope[540] = 1.0;
+        Ramp(envelope, 480, 500, 0.0, 0.10);   // foot rising to the ripple
+        Ramp(envelope, 500, 510, 0.10, 0.06);  // the ripple's own shallow dip
+        Ramp(envelope, 510, 540, 0.06, 1.0);   // on into the packet's peak
+        Ramp(envelope, 540, 600, 1.0, 0.0);
 
         PeakSearchResult result = SignalEnvelope.FindPeak(
             envelope,
@@ -373,8 +374,78 @@ public sealed class SignalEnvelopeTests
                 FirstPeakMinimumSnrDb = 0
             });
 
-        Assert.Equal(520, result.SelectedIndex);
+        Assert.Equal(540, result.SelectedIndex);
         Assert.False(result.FallbackUsed);
+    }
+
+    [Fact]
+    public void FindPeak_KeepsADirectArrivalResolvedFromTheNextPacketByANull()
+    {
+        // The same 20 dB gap inside the same millisecond, but the envelope nulls
+        // to nothing between the two: destructive interference resolves them, so
+        // these are two arrivals and the earlier one is the direct sound. Its
+        // timing must survive — the packet ends at the null, and what rises
+        // after it is somebody else's packet.
+        var envelope = new double[4_096];
+        Ramp(envelope, 480, 500, 0.0, 0.10);
+        Ramp(envelope, 500, 515, 0.10, 0.0);   // resolved: a null, not a dip
+        Ramp(envelope, 520, 540, 0.0, 1.0);
+        Ramp(envelope, 540, 600, 1.0, 0.0);
+
+        PeakSearchResult result = SignalEnvelope.FindPeak(
+            envelope,
+            sampleRate: 48_000,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                FirstPeakThresholdBelowMaxDb = 25,
+                FirstPeakMinimumSnrDb = 0
+            });
+
+        Assert.Equal(500, result.SelectedIndex);
+        Assert.False(result.FallbackUsed);
+    }
+
+    [Fact]
+    public void FindPeak_KeepsADirectArrivalWhenOnlyALaterPacketsRisingEdgeIsInReach()
+    {
+        // A reflection that PEAKS 1.25 ms after the direct sound — a separate
+        // arrival by every rule here — but whose rising edge is already inside
+        // the one-millisecond packet window, and by its end stands seven times
+        // the direct arrival. The look-ahead must not borrow that edge to dwarf
+        // the arrival in front of it.
+        var envelope = new double[4_096];
+        Ramp(envelope, 480, 500, 0.0, 0.10);
+        Ramp(envelope, 500, 515, 0.10, 0.0);
+        Ramp(envelope, 520, 560, 0.0, 1.0);    // rising through the window, peaking past it
+        Ramp(envelope, 560, 640, 1.0, 0.0);
+
+        PeakSearchResult result = SignalEnvelope.FindPeak(
+            envelope,
+            sampleRate: 48_000,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                FirstPeakThresholdBelowMaxDb = 25,
+                FirstPeakMinimumSnrDb = 0
+            });
+
+        Assert.Equal(500, result.SelectedIndex);
+        Assert.False(result.FallbackUsed);
+    }
+
+    // Writes a linear segment into the envelope, endpoints included, so a test
+    // can shape a real leading edge instead of isolated spikes: whether two
+    // bumps are one packet or two arrivals is a question about what lies
+    // BETWEEN them.
+    private static void Ramp(
+        double[] envelope, int from, int to, double fromValue, double toValue)
+    {
+        for (int i = from; i <= to; i++)
+        {
+            double position = (double)(i - from) / (to - from);
+            envelope[i] = fromValue + (toValue - fromValue) * position;
+        }
     }
 
     [Fact]
@@ -405,11 +476,14 @@ public sealed class SignalEnvelopeTests
     public void FindPeak_KeepsAFrontThatReachesAQuarterOfItsPacketPeak()
     {
         // The floor is a quarter of the packet's amplitude: a front at 0.3 of a
-        // 1.0 packet is the packet's own leading edge and stays selected, so the
-        // guard cannot quietly promote every arrival to its strongest lobe.
+        // 1.0 packet — connected to it, no null between them — is that packet's
+        // own leading edge and stays selected, so the guard cannot quietly
+        // promote every arrival to its strongest lobe.
         var envelope = new double[4_096];
-        envelope[500] = 0.3;
-        envelope[540] = 1.0;
+        Ramp(envelope, 480, 500, 0.0, 0.3);
+        Ramp(envelope, 500, 510, 0.3, 0.25);
+        Ramp(envelope, 510, 540, 0.25, 1.0);
+        Ramp(envelope, 540, 600, 1.0, 0.0);
 
         PeakSearchResult result = SignalEnvelope.FindPeak(
             envelope,

--- a/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
@@ -607,4 +607,42 @@ public sealed class TimeAlignmentAnalysisTests
         Assert.Equal(baseline.FirstArrivalConfidence, weighted.FirstArrivalConfidence);
         Assert.Equal(baseline.StrongestConfidence, weighted.StrongestConfidence);
     }
+
+    [Fact]
+    public void Analyze_ReadsAPairOfIdenticalDriversAtTheSamePointOfTheirFronts()
+    {
+        // Two identical drivers in opposite doors, 1.5 ms of path apart. Each
+        // front is followed by a stronger cabin reflection 0.625 ms later — the
+        // shape a door mid really has — and ONE of the two also carries a small
+        // ripple on the foot of its packet, 0.6 ms ahead of its front, which is
+        // exactly how a cabin's comb interference shows up. Reading that ripple
+        // as an arrival used to report 2.125 ms for a 1.5 ms split, and to mark
+        // the two curves at levels 20 dB apart while calling both "First".
+        var near = new double[8_192];
+        near[470] = 0.06; // foot ripple, ~24 dB under the packet
+        near[500] = 0.6;  // front
+        near[530] = 1.0;  // cabin reflection
+        var far = new double[8_192];
+        far[572] = 0.6;
+        far[602] = 1.0;
+
+        TimeAlignmentAnalysisResult nearResult = TimeAlignmentAnalysis.Analyze(
+            near, SampleRate, new TimeAlignmentAnalysisOptions());
+        TimeAlignmentAnalysisResult farResult = TimeAlignmentAnalysis.Analyze(
+            far, SampleRate, new TimeAlignmentAnalysisOptions());
+
+        double splitMs =
+            farResult.FirstArrivalDelayMilliseconds -
+            nearResult.FirstArrivalDelayMilliseconds;
+        // (572 - 500) samples at 48 kHz = 1.5 ms.
+        Assert.InRange(splitMs, 1.45, 1.55);
+        // And the two figures are the same observable: both picks sit at the
+        // same depth under their own packet, so the delta is path, not level.
+        Assert.InRange(
+            Math.Abs(
+                nearResult.FirstArrivalProminenceDecibels -
+                farResult.FirstArrivalProminenceDecibels),
+            0.0,
+            1.0);
+    }
 }

--- a/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
@@ -611,25 +611,32 @@ public sealed class TimeAlignmentAnalysisTests
     [Fact]
     public void Analyze_ReadsAPairOfIdenticalDriversAtTheSamePointOfTheirFronts()
     {
-        // Two identical drivers in opposite doors, 1.5 ms of path apart. Each
-        // front is followed by a stronger cabin reflection 0.625 ms later — the
-        // shape a door mid really has — and ONE of the two also carries a small
-        // ripple on the foot of its packet, 0.6 ms ahead of its front, which is
-        // exactly how a cabin's comb interference shows up. Reading that ripple
-        // as an arrival used to report 2.125 ms for a 1.5 ms split, and to mark
-        // the two curves at levels 20 dB apart while calling both "First".
+        // Two identical drivers in opposite doors, 1.5 ms of path apart, each
+        // front followed by a stronger cabin reflection — 0.625 ms on one side,
+        // 0.5 ms on the other, because the two doors are not mirror images. No
+        // ripple is placed by hand: band-limiting these two wavefronts is what
+        // leaves comb structure on the leading edge, and on the near record one
+        // of those bumps clears the search threshold 0.27 ms before its front.
+        // Reading it as the arrival reports 1.771 ms for a 1.5 ms split.
         var near = new double[8_192];
-        near[470] = 0.06; // foot ripple, ~24 dB under the packet
-        near[500] = 0.6;  // front
-        near[530] = 1.0;  // cabin reflection
+        near[500] = 0.6;
+        near[530] = 1.0;
         var far = new double[8_192];
         far[572] = 0.6;
-        far[602] = 1.0;
+        far[596] = 1.0;
+        // The band the field pair was read in (33-7671 Hz), as centre and width.
+        var options = new TimeAlignmentAnalysisOptions
+        {
+            UseBandpassWindow = true,
+            BandpassCenterHz = 500,
+            BandpassPassOctaves = 7.9,
+            BandpassFadeOctaves = 0.5
+        };
 
         TimeAlignmentAnalysisResult nearResult = TimeAlignmentAnalysis.Analyze(
-            near, SampleRate, new TimeAlignmentAnalysisOptions());
+            near, SampleRate, options);
         TimeAlignmentAnalysisResult farResult = TimeAlignmentAnalysis.Analyze(
-            far, SampleRate, new TimeAlignmentAnalysisOptions());
+            far, SampleRate, options);
 
         double splitMs =
             farResult.FirstArrivalDelayMilliseconds -


### PR DESCRIPTION
## The defect

Two identical door mids, `l mid` / `r mid` of the archived `v5_exp` cabin, read as
non-comparable in Time Alignment: `M First` sat on one record's packet peak (0.0 dB)
while `C First` sat **20.7 dB down the other record's own foot**, 0.31 ms ahead of its
front. Whether a record gets a foot pick depends on where its comb ripples fall, not on
when its wavefront arrives, so the level difference entered the measured DELAY.

The Auto band made it worse: it was detected from Main alone, so swapping which record
was loaded first changed the band (32.7-7671 Hz one way, 75.5-4695 Hz the other) and the
answer with it.

| pair | before (Main=L / Main=R) | after | field truth\* |
|---|---|---|---|
| mids | 1.437 / **1.716** | **1.437 / 1.437** | 1.49 |
| tweeters | 1.318 / 1.318 | **1.458 / 1.458** | 1.42 |
| woofers | 2.604 / 1.379 | 2.604 / 2.604 | 1.42 |

\* the owner's own hand-tuned delays minus `stereoSceneOffsetMs` (0.26): mids 9.84/8.09,
tweeters 10.07/8.39, woofers 2.43/0.75 — three pairs in the same doors give one cabin
split, which is what any arrival detector has to reproduce.

The woofer pair stays wrong but is now symmetric: its `r bass` read is a modal latch and
the existing arrival probe already flags it `Latched`, so the panel paints it red and
withholds the recommendation. That is a pre-existing low-frequency problem, untouched here.

## The change

- **`SignalEnvelope.FindPeak`** — a candidate must reach a quarter of the strongest
  envelope level within one millisecond after it, or the packet's own front is taken
  instead. The threshold is measured, not chosen: across six records and eight bands,
  foot ripples sit 19.1-20.7 dB under their packet while genuine fronts stay within
  7.0 dB. The window is deliberately one millisecond — a soft direct arrival under a
  room mode milliseconds later is nobody's foot ripple, which is what the 25 dB search
  depth exists for. It is the complement of the separate-arrival rule, so both now live
  on one constant.
- **`TimeAlignmentPanelController`** — Compare is resolved before the band is chosen, and
  in Auto mode the band is the overlap of both records' dominant bands (labelled
  `shared with Compare`). Records that barely overlap (a subwoofer against a tweeter)
  keep Main's own band.

## Verification

- **Session battery, all 7 cabins / 20 junctions: the reports match line for line** — the
  Auto delay proposals are unchanged, even though the arrival reader itself moves inside
  the engine's bands (`l mid` in 750-3000 Hz: 4.771 ms -> 5.677 ms). Neutrality measured,
  not assumed.
- Dsp 1134, App 1071, Audio 142 — all green.
- New: `FindPeak_RejectsARippleOnTheFootOfItsOwnWavePacket`,
  `FindPeak_KeepsASoftArrivalWhenTheStrongPeakIsMillisecondsLater`,
  `FindPeak_KeepsAFrontThatReachesAQuarterOfItsPacketPeak`,
  `Analyze_ReadsAPairOfIdenticalDriversAtTheSamePointOfTheirFronts` (reads 1.948 ms for a
  1.5 ms split without the guard), and `TimeAlignmentSharedBandTests`.
- The two pre-ringing mirror tests moved to 8 kHz: their subject is the symmetry rule, and
  at 48 kHz the new floor would settle them first, so they would stop testing what they
  are named for.

## Measured and rejected

- **Pairwise GCC-PHAT between Main and Compare** as the headline delta — it inherits the
  same lobe ambiguity (0.30 / 0.87 / 1.45 / 1.83 ms depending on band and window).
- **Requiring PHAT corroboration of the candidate** (trust >= 0.2) — it promotes the
  strongest coherent lobe, i.e. the reflection (0.72 ms for the mid pair).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
