### PR TITLE
Stop the waterfall from throwing while answering a hit test

### DIFF
--- a/source/Plotting/WaterfallSeries.cs
+++ b/source/Plotting/WaterfallSeries.cs
@@ -68,8 +68,6 @@ namespace Resonalyze
     {
         public WaterfallSeries()
         {
-            // {0} is the series title by convention; the coordinates are {1}/{2}.
-            TrackerFormatString = "X: {1:0.000}\r\nY: {2:0.000}";
             RawSlices = new List<Slice>();
             ResampleSlices = new List<Slice>();
             GenerateOptions = new WaterfallGenerateOptions();
@@ -102,29 +100,19 @@ namespace Resonalyze
         public WaterfallGenerateOptions GenerateOptions { get; set; }
 
         /// <summary>
-        /// Gets the point on the series that is nearest the specified point.
+        /// No point: a waterfall is a projected surface rather than a curve, so the
+        /// cursor is never over a measured point. Its X is a per-slice projection of
+        /// frequency and its Y is the hidden -1..1 axis that projection is drawn
+        /// against, so a readout of either would describe the drawing rather than
+        /// the measurement.
+        ///
+        /// This answer has to be safe on a plain click, not only while tracking:
+        /// <c>ControllerBase.HandleMouseDown</c> lets the model hit-test its series
+        /// before any binding is consulted, so throwing in here took the app down on
+        /// any mouse press over the plot.
         /// </summary>
-        /// <param name="point">The point.</param>
-        /// <param name="interpolate">Interpolate the series if this flag is set to <c>true</c>.</param>
-        /// <returns>A TrackerHitResult for the current hit.</returns>
-        public override TrackerHitResult GetNearestPoint(ScreenPoint point, bool interpolate)
-        {
-            var p = this.InverseTransform(point);
-            //var it = this.Solve(p.X, p.Y, (int)this.ColorAxis.ActualMaximum + 1);
-            return new TrackerHitResult
-            {
-                Series = this,
-                DataPoint = p,
-                Position = point,
-                Index = -1,
-                Text = StringHelper.Format(
-                    this.ActualCulture,
-                    this.TrackerFormatString,
-                    string.Empty,
-                    p.X,
-                    p.Y)
-            };
-        }
+        public override TrackerHitResult? GetNearestPoint(ScreenPoint point, bool interpolate) =>
+            null;
 
         /// <summary>
         /// Renders the series on the specified render context.

--- a/tests/Resonalyze.App.Tests/WaterfallHitTestTests.cs
+++ b/tests/Resonalyze.App.Tests/WaterfallHitTestTests.cs
@@ -1,0 +1,58 @@
+using OxyPlot;
+using OxyPlot.WindowsForms;
+
+namespace Resonalyze.App.Tests;
+
+// Pressing a mouse button over a plot makes OxyPlot hit-test its series before any
+// binding gets a look in (ControllerBase.HandleMouseDown asks the model first), so
+// a series that throws while answering "what is under the cursor" takes the whole
+// app down on a click.
+public sealed class WaterfallHitTestTests
+{
+    [Fact]
+    public void GetNearestPoint_OnTheWaterfall_AnswersWithoutThrowing()
+    {
+        var series = new WaterfallSeries();
+        PlotModel model = PlotModelStyle.CreateWaterfallModel(
+            "Fourier Waterfall",
+            new WaterfallGenerateOptions());
+        model.Series.Add(series);
+        ((IPlotModel)model).Update(false);
+
+        // The waterfall draws a projected surface: the cursor is not over a data
+        // point of a curve, so there is nothing to report.
+        Assert.Null(series.GetNearestPoint(new ScreenPoint(200, 150), interpolate: false));
+        Assert.Null(series.GetNearestPoint(new ScreenPoint(200, 150), interpolate: true));
+    }
+
+    [Theory]
+    [InlineData(OxyMouseButton.Left)]
+    [InlineData(OxyMouseButton.Middle)]
+    [InlineData(OxyMouseButton.Right)]
+    public void MouseDownOverTheWaterfall_DoesNotThrow(OxyMouseButton button)
+    {
+        using var view = new PlotView();
+        PlotInteraction.Enable(view);
+        PlotModel model = PlotModelStyle.CreateWaterfallModel(
+            "Fourier Waterfall",
+            new WaterfallGenerateOptions());
+        model.Series.Add(new WaterfallSeries());
+        view.Model = model;
+        ((IPlotModel)model).Update(false);
+
+        view.ActualController.HandleMouseDown(
+            view,
+            new OxyMouseDownEventArgs
+            {
+                ChangedButton = button,
+                ClickCount = 1,
+                Position = new ScreenPoint(200, 150),
+            });
+        view.ActualController.HandleMouseMove(
+            view,
+            new OxyMouseEventArgs { Position = new ScreenPoint(260, 120) });
+        view.ActualController.HandleMouseUp(
+            view,
+            new OxyMouseEventArgs { Position = new ScreenPoint(260, 120) });
+    }
+}


### PR DESCRIPTION
Pressing any mouse button over a waterfall or burst decay plot crashed the app.
From `crash.log`:

```
System.FormatException: Index (zero based) must be greater than or equal to zero
and less than the size of the argument list.
   at OxyPlot.StringHelper.Format(...)
   at Resonalyze.WaterfallSeries.GetNearestPoint(...)
   at OxyPlot.Series.Series.HitTestOverride(...)
   at OxyPlot.Model.HandleMouseDown(...)
   at OxyPlot.ControllerBase.HandleMouseDown(...)
```

`GetNearestPoint` built its tracker text from `"X: {1:0.000}\r\nY: {2:0.000}"` but
passed `StringHelper.Format` two values after the item, so `{2}` was always past
the end of the list. It has been that way since 12a5169 (2026-07-07), which also
means the readout it was formatting has never once appeared on screen.

This is not a tracking-only path. `ControllerBase.HandleMouseDown` lets the model
hit-test its series before it looks for a binding, so the throw happened on a
plain press with **any** button — the theory in the test covers left, middle and
right, and all three failed before the fix.

A waterfall is a projected surface rather than a curve: its X is a per-slice
projection of frequency and its Y is the hidden -1..1 axis the projection is
drawn against, so there is no measured point under the cursor worth reporting.
`GetNearestPoint` now answers with none, which is what OxyPlot expects for "no
hit", and the tracker format goes with it.

Found while testing #99: the middle button is the variable zoom now, so the
waterfall finally got clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
