### PR TITLE
Aim Virtual DSP at the EQ Wizard's target and tidy the strip between its plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,16 @@ framing steps aside only where you took over, and **Home** hands an axis back to
 it. Frequency axes pan within 20 Hz – 20 kHz, the band the curves are computed
 over.
 
+Two Virtual DSP axes answer to their own rule on purpose. Its **Phase** view
+spans ±180°, the entire range a wrapped phase can occupy, so the height is
+locked: there is nothing above or below to travel to, and the limits dialog
+leaves that axis out rather than offering a range that would only push curves
+off screen. Its **Impulse** view zooms and pans in time — the millisecond around
+each arrival is the part worth reading, and the gate window it opens on is far
+wider — within that window, which stays the hard limit because the traces hold
+nothing outside it. Editing the gate re-frames the axis, since that is a new
+timeline; an ordinary redraw leaves your zoom alone.
+
 ## Mode Settings
 
 The **Mode Settings...** button opens the current mode's settings in a docked,
@@ -1282,16 +1292,35 @@ the side you are viewing, since the two sides' drivers sit at different
 distances; how the phase is READ stays project-wide, because two sides read
 through different windows could not be compared.
 
+A **Target** checkbox draws the EQ target over the prediction: the SAME target
+the EQ Wizard equalizes towards, shaped from either place through the same
+**Target...** dialog, so the tool that predicts the sum and the tool that
+corrects it aim at one curve rather than at two that drifted apart. These curves
+are transfer-function dB with no absolute reference, so the target has no level
+of its own here — the dB box beside the checkbox says where it hangs. The
+session stores both: that level, which belongs to this plot's dB reference and
+so stays put when the shape is retuned, and the target itself — the whole custom
+shape rather than a preset name, because a preset's numbers can change between
+versions while a session has to open aiming at the curve it was tuned against.
+Loading a session therefore sets the app's target to the one it carries, which
+is the same single target the EQ Wizard shows; a session written before targets
+were stored carries none, keeps yours, and starts carrying it. A target is a
+magnitude shape in dB, so it is offered on the Magnitude view only — and every
+curve toggle follows that rule, muted on the views that cannot draw its curve.
+The **Sum** keeps a separate answer per view, since the phase plot is usually one
+trace denser than you want it while the magnitude plot is where the sum is the
+whole point.
+
 A gate that opens **after** a driver has already arrived is refused rather than
 worked around. The panel judges the placement against every enabled channel and,
-when one falls outside the window, shows an amber line under the plot naming the
-side, the offset, and which channels are cut — with the whole arithmetic (the
-plateau, the fade-out, each channel's arrival and its leading-edge loss) in the
-tooltip. A curve gated that way is the reverberant tail rather than the driver,
-and the sum-loss read-out built from it describes nothing real, so **Auto delay**
-and **Auto crossover** decline to run until the gate is moved: an alignment
-computed through such a window would optimize the room's answer, not the
-loudspeaker.
+when one falls outside the window, shows an amber note in the top right corner —
+above the sum-loss read-out it invalidates — naming the side, the offset, and
+which channels are cut, with the whole arithmetic (the plateau, the fade-out,
+each channel's arrival and its leading-edge loss) in the tooltip. A curve gated
+that way is the reverberant tail rather than the driver, and the sum-loss
+read-out built from it describes nothing real, so **Auto delay** and **Auto
+crossover** decline to run until the gate is moved: an alignment computed
+through such a window would optimize the room's answer, not the loudspeaker.
 
 A second plot shows each DSP chain's own magnitude and phase (without the
 driver) — or, on its **Corr** mode, one adjacent pair's band-limited GCC-PHAT
@@ -1322,7 +1351,7 @@ offset's convention), plus a **Level Δ L−R** row for the by-ear gain trim tha
 finishes the centering.
 
 Editing a chain recomputes the prediction on a background task, so dragging a
-value stays responsive with several channels loaded. A **calibration** selector
+value stays responsive with several channels loaded. The **Mic cal** selector
 applies one of your configured microphone corrections to the magnitude curves; it
 defaults to Off because the measurements are loopback-referenced. The session
 stores WHICH calibration it was tuned with; opening it on a machine that has no

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -968,7 +968,7 @@ public sealed class Overlay
         {
             Color = OxyColor.FromArgb(alpha, color.R, color.G, color.B),
             StrokeThickness = thickness,
-            LineStyle = ToOxyLineStyle(style),
+            LineStyle = OverlayLineStyles.ToOxy(style),
             Title = title,
             Tag = GetTag(part)
         };
@@ -1069,7 +1069,7 @@ public sealed class Overlay
         {
             Color = lineColor,
             StrokeThickness = thickness,
-            LineStyle = ToOxyLineStyle(style),
+            LineStyle = OverlayLineStyles.ToOxy(style),
             Title = $"{title} (target)",
             Tag = GetTag("target")
         };
@@ -2931,17 +2931,6 @@ public sealed class Overlay
         model.InvalidatePlot(true);
         collection.PlotView.Refresh();
         collection.NotifyPlotChanged();
-    }
-
-    private static LineStyle ToOxyLineStyle(OverlayLineStyle value)
-    {
-        return value switch
-        {
-            OverlayLineStyle.Dash => LineStyle.Dash,
-            OverlayLineStyle.Dot => LineStyle.Dot,
-            OverlayLineStyle.DashDot => LineStyle.DashDot,
-            _ => LineStyle.Solid
-        };
     }
 
     private void ShowStorageError(string message, Exception exception)

--- a/source/Overlays/OverlayLineStyles.cs
+++ b/source/Overlays/OverlayLineStyles.cs
@@ -1,0 +1,20 @@
+using OxyPlot;
+
+namespace Resonalyze;
+
+/// <summary>
+/// The one mapping from a stored <see cref="OverlayLineStyle"/> to the OxyPlot
+/// <see cref="LineStyle"/> a plot draws it with. Overlays, the EQ Wizard target
+/// and the Virtual DSP target all render the same stored value, so they read it
+/// through here instead of each keeping a private switch.
+/// </summary>
+internal static class OverlayLineStyles
+{
+    public static LineStyle ToOxy(OverlayLineStyle value) => value switch
+    {
+        OverlayLineStyle.Dash => LineStyle.Dash,
+        OverlayLineStyle.Dot => LineStyle.Dot,
+        OverlayLineStyle.DashDot => LineStyle.DashDot,
+        _ => LineStyle.Solid
+    };
+}

--- a/source/Shell/Form1.Designer.cs
+++ b/source/Shell/Form1.Designer.cs
@@ -57,6 +57,7 @@ namespace Resonalyze
             virtualCrossoverPanel = new VirtualCrossoverPanel();
             eqResultsPanel = new EqResultsPanel();
             virtualDspMetricLabel = new Label();
+            virtualDspWarningLabel = new Label();
             overlays.SuspendLayout();
             overlayPanel1.SuspendLayout();
             (numericUpDown1).BeginInit();
@@ -422,6 +423,22 @@ namespace Resonalyze
             virtualDspMetricLabel.TabIndex = 31;
             virtualDspMetricLabel.Visible = false;
             // 
+            // virtualDspWarningLabel
+            // 
+            virtualDspWarningLabel.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            virtualDspWarningLabel.AutoSize = true;
+            virtualDspWarningLabel.BackColor = Color.FromArgb(20, 22, 30);
+            virtualDspWarningLabel.BorderStyle = BorderStyle.FixedSingle;
+            virtualDspWarningLabel.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            virtualDspWarningLabel.ForeColor = Color.FromArgb(235, 110, 95);
+            virtualDspWarningLabel.Location = new Point(1268, 52);
+            virtualDspWarningLabel.MaximumSize = new Size(214, 0);
+            virtualDspWarningLabel.MinimumSize = new Size(214, 0);
+            virtualDspWarningLabel.Name = "virtualDspWarningLabel";
+            virtualDspWarningLabel.Padding = new Padding(8);
+            virtualDspWarningLabel.TabIndex = 32;
+            virtualDspWarningLabel.Visible = false;
+            // 
             // Form1
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
@@ -431,6 +448,7 @@ namespace Resonalyze
             Controls.Add(overlays);
             Controls.Add(chromeTitleBar);
             Controls.Add(eqResultsPanel);
+            Controls.Add(virtualDspWarningLabel);
             Controls.Add(virtualDspMetricLabel);
             Controls.Add(virtualCrossoverPanel);
             Controls.Add(signalGeneratorPanel);
@@ -485,6 +503,7 @@ namespace Resonalyze
         private VirtualCrossoverPanel virtualCrossoverPanel;
         private EqResultsPanel eqResultsPanel;
         private Label virtualDspMetricLabel;
+        private Label virtualDspWarningLabel;
         private Button buttonCompare;
     }
 }

--- a/source/Shell/Form1.Plotting.cs
+++ b/source/Shell/Form1.Plotting.cs
@@ -207,6 +207,10 @@ public partial class Form1
         }
         virtualCrossoverPanel.Visible = descriptor.ShowsVirtualCrossoverPanel;
         virtualDspMetricLabel.Visible = descriptor.ShowsVirtualCrossoverPanel;
+        // The warning box only claims its corner when the panel has something to
+        // warn about; its text survives the mode switch that hid it.
+        virtualDspWarningLabel.Visible = descriptor.ShowsVirtualCrossoverPanel &&
+            virtualDspWarningLabel.Text.Length > 0;
         if (descriptor.ShowsVirtualCrossoverPanel)
         {
             virtualCrossoverPanel.OnPanelShown();

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -178,6 +178,7 @@ namespace Resonalyze
                 measurementSettings.TargetDspQConvention = eqWizardPanel.TargetDspQConvention;
                 virtualCrossoverPanel.TargetDspQConvention =
                     eqWizardPanel.TargetDspQConvention;
+                virtualCrossoverPanel.SetTargetCurve(eqWizardPanel.TargetCurve);
                 ScheduleMeasurementSettingsSave();
             };
             signalGeneratorPanel.PlaybackSettingsProvider = CreateSignalGeneratorPlaybackSettings;
@@ -187,34 +188,32 @@ namespace Resonalyze
                 measurementSettings.TargetDspQConvention;
             RefreshCalibrationConsumers();
             virtualCrossoverPanel.OverlayCaptureRequested = SaveVirtualCrossoverOverlay;
+            // One EQ target, two panels. The wizard owns and persists it, so the
+            // shell pushes the current shape into Virtual DSP and hands back
+            // whatever its own Target dialog produced. The wizard ignores a value
+            // equal to what it holds, so the write-back cannot loop through the
+            // SettingsChanged handler above.
+            virtualCrossoverPanel.SetTargetCurve(eqWizardPanel.TargetCurve);
+            virtualCrossoverPanel.TargetCurveChanged = eqWizardPanel.ApplyTargetCurve;
             virtualCrossoverPanel.MetricChanged = (text, detail) =>
             {
                 virtualDspMetricLabel.Text = text;
                 virtualDspMetricDetail = detail;
             };
-            // The metric breakdown is long, and the automatic ToolTip auto-pops
-            // after seconds (capped at ~32 s) — unreadable. Shown manually it
-            // stays until the mouse leaves the label. The tip is placed fully
-            // to the LEFT of the label on purpose: a tip under the cursor
-            // steals the mouse, fires MouseLeave and flickers in a
-            // show-hide-show loop.
-            virtualDspMetricLabel.MouseEnter += (_, _) =>
+            // The panel's warning goes in the free right-hand column, above the
+            // read-out it invalidates: the panel itself runs plot edge to plot
+            // edge. Its detail is shown manually like the metric's, and a
+            // WinForms tooltip never wraps prose by itself, so wrap it here.
+            virtualCrossoverPanel.WarningChanged = (text, detail, color) =>
             {
-                if (virtualDspMetricDetail.Length == 0)
-                {
-                    return;
-                }
-
-                Size tipSize = TextRenderer.MeasureText(
-                    virtualDspMetricDetail, SystemFonts.StatusFont ?? Font);
-                toolTip1.Show(
-                    virtualDspMetricDetail,
-                    virtualDspMetricLabel,
-                    -tipSize.Width - 16,
-                    0);
+                virtualDspWarningLabel.ForeColor = color;
+                virtualDspWarningLabel.Text = text;
+                virtualDspWarningDetail = ToolTipTextWrapper.Wrap(detail);
+                virtualDspWarningLabel.Visible =
+                    text.Length > 0 && virtualCrossoverPanel.Visible;
             };
-            virtualDspMetricLabel.MouseLeave += (_, _) =>
-                toolTip1.Hide(virtualDspMetricLabel);
+            WirePersistentTooltip(virtualDspMetricLabel, () => virtualDspMetricDetail);
+            WirePersistentTooltip(virtualDspWarningLabel, () => virtualDspWarningDetail);
             modeDescriptors = CreateModeDescriptors();
             ApplyPersistedSettings();
             WireControllerEvents();
@@ -222,9 +221,32 @@ namespace Resonalyze
             WireFormEvents();
         }
 
-        // The full Virtual DSP metric breakdown, shown as a persistent tooltip
-        // by the MouseEnter wiring in the constructor.
+        // The full Virtual DSP metric breakdown and the warning's explanation,
+        // both shown as persistent tooltips by the wiring in the constructor.
         private string virtualDspMetricDetail = string.Empty;
+        private string virtualDspWarningDetail = string.Empty;
+
+        // These read-outs explain themselves at length, and an automatic ToolTip
+        // auto-pops after seconds (capped at ~32 s) — unreadable. Shown manually
+        // it stays until the mouse leaves the label. The tip is placed fully to
+        // the LEFT of the label on purpose: a tip under the cursor steals the
+        // mouse, fires MouseLeave and flickers in a show-hide-show loop.
+        private void WirePersistentTooltip(Control control, Func<string> detail)
+        {
+            control.MouseEnter += (_, _) =>
+            {
+                string text = detail();
+                if (text.Length == 0)
+                {
+                    return;
+                }
+
+                Size tipSize = TextRenderer.MeasureText(
+                    text, SystemFonts.StatusFont ?? Font);
+                toolTip1.Show(text, control, -tipSize.Width - 16, 0);
+            };
+            control.MouseLeave += (_, _) => toolTip1.Hide(control);
+        }
 
         // BeginInvoke can still throw if the handle is destroyed between the guard
         // and the call — measurement events arrive from audio worker threads while

--- a/source/Tools/Eq/EqTargetCurve.cs
+++ b/source/Tools/Eq/EqTargetCurve.cs
@@ -1,0 +1,30 @@
+namespace Resonalyze;
+
+/// <summary>
+/// The EQ target curve as one value: the shape plus how it is drawn. The EQ
+/// Wizard owns it and persists it in <see cref="MeasurementSettingsFile.
+/// EqWizardSettings"/>; the Virtual DSP tool borrows the same definition to draw
+/// the target over its predicted sum, and can edit it back through the host.
+/// One definition, two plots — a target tuned in either place is THE target.
+/// </summary>
+/// <remarks>
+/// The LEVEL the curve is anchored at is deliberately not part of this. A target
+/// shape is relative dB; where it sits belongs to the plot it is drawn on, and
+/// the two plots have unrelated level references (the wizard's source curve, the
+/// Virtual DSP transfer-function dB). Each side keeps its own anchor.
+/// <para>
+/// Tolerance, deviation mode and smoothing are carried unchanged rather than
+/// used by every consumer: the Virtual DSP plot draws the line alone, but it
+/// opens the shared settings dialog, which shows those fields, and passing them
+/// through keeps them from being silently reset by a visit to that dialog.
+/// </para>
+/// </remarks>
+internal sealed record EqTargetCurve(
+    TargetPreset Preset,
+    TargetCurveSpec Spec,
+    double ToleranceDb,
+    TargetDeviationMode DeviationMode,
+    Color Color,
+    double StrokeThickness,
+    OverlayLineStyle LineStyle,
+    int SmoothingInverseOctaves);

--- a/source/Tools/Eq/EqTargetCurve.cs
+++ b/source/Tools/Eq/EqTargetCurve.cs
@@ -27,4 +27,50 @@ internal sealed record EqTargetCurve(
     Color Color,
     double StrokeThickness,
     OverlayLineStyle LineStyle,
-    int SmoothingInverseOctaves);
+    int SmoothingInverseOctaves)
+{
+    /// <summary>
+    /// The same target with anything a stored file can hold but the UI cannot
+    /// take replaced by its default. Every target that arrives from disk goes
+    /// through this, because a target is not only drawn: it also fills the
+    /// settings dialog, where a non-finite number throws on the decimal cast
+    /// that clamps it into an input, and an enum value outside the list leaves a
+    /// combo box with no selection to read back. Both are reachable — the
+    /// session and settings files allow named floating-point literals, and the
+    /// enum converter accepts numbers as well as names.
+    /// </summary>
+    public EqTargetCurve Normalized()
+    {
+        TargetCurveSpec flat = TargetCurveSpec.FromPreset(TargetPreset.Flat);
+        return new EqTargetCurve(
+            Defined(Preset, TargetPreset.Flat),
+            new TargetCurveSpec(
+                Finite(Spec.TiltDbPerOctave, flat.TiltDbPerOctave),
+                Finite(Spec.BassShelfGainDb, flat.BassShelfGainDb),
+                Finite(Spec.BassShelfFrequencyHz, flat.BassShelfFrequencyHz),
+                Finite(Spec.BassShelfWidthOctaves, flat.BassShelfWidthOctaves),
+                Finite(Spec.TrebleShelfGainDb, flat.TrebleShelfGainDb),
+                Finite(Spec.TrebleShelfFrequencyHz, flat.TrebleShelfFrequencyHz),
+                Finite(Spec.TrebleShelfWidthOctaves, flat.TrebleShelfWidthOctaves),
+                Finite(Spec.PresenceGainDb, flat.PresenceGainDb),
+                Finite(Spec.PresenceFrequencyHz, flat.PresenceFrequencyHz),
+                Finite(Spec.PresenceWidthOctaves, flat.PresenceWidthOctaves)),
+            Finite(ToleranceDb, DefaultToleranceDb),
+            Defined(DeviationMode, TargetDeviationMode.Deviation),
+            Color,
+            Finite(StrokeThickness, DefaultStrokeThickness),
+            Defined(LineStyle, OverlayLineStyle.Dash),
+            SmoothingInverseOctaves);
+    }
+
+    // What a field the UI cannot take falls back to; the stored defaults.
+    private const double DefaultToleranceDb = 3;
+    private const double DefaultStrokeThickness = 2;
+
+    private static double Finite(double value, double fallback) =>
+        double.IsFinite(value) ? value : fallback;
+
+    private static T Defined<T>(T value, T fallback)
+        where T : struct, Enum =>
+        Enum.IsDefined(value) ? value : fallback;
+}

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -1052,24 +1052,28 @@ public partial class EqWizardPanel
         suppressSettingsSave = true;
         try
         {
-            targetPreset = settings.Preset;
-            targetSpec = new TargetCurveSpec(
-                settings.TiltDbPerOctave,
-                settings.BassShelfGainDb,
-                settings.BassShelfFrequencyHz,
-                settings.BassShelfWidthOctaves,
-                settings.TrebleShelfGainDb,
-                settings.TrebleShelfFrequencyHz,
-                settings.TrebleShelfWidthOctaves,
-                settings.PresenceGainDb,
-                settings.PresenceFrequencyHz,
-                settings.PresenceWidthOctaves);
-            targetToleranceDb = settings.ToleranceDb;
-            targetDeviationMode = settings.DeviationMode;
-            targetColor = Color.FromArgb(settings.TargetColorArgb);
-            targetStrokeThickness = settings.TargetStrokeThickness;
-            targetLineStyle = settings.TargetLineStyle;
-            targetSmoothingInverseOctaves = settings.TargetSmoothingInverseOctaves;
+            // Normalized like every target that comes off disk: the settings file
+            // can hold a non-finite number or an undefined enum, and this target
+            // goes on to fill the settings dialog, which cannot take either.
+            AssignTargetCurve(new EqTargetCurve(
+                settings.Preset,
+                new TargetCurveSpec(
+                    settings.TiltDbPerOctave,
+                    settings.BassShelfGainDb,
+                    settings.BassShelfFrequencyHz,
+                    settings.BassShelfWidthOctaves,
+                    settings.TrebleShelfGainDb,
+                    settings.TrebleShelfFrequencyHz,
+                    settings.TrebleShelfWidthOctaves,
+                    settings.PresenceGainDb,
+                    settings.PresenceFrequencyHz,
+                    settings.PresenceWidthOctaves),
+                settings.ToleranceDb,
+                settings.DeviationMode,
+                Color.FromArgb(settings.TargetColorArgb),
+                settings.TargetStrokeThickness,
+                settings.TargetLineStyle,
+                settings.TargetSmoothingInverseOctaves).Normalized());
             // Only the configured impulse-response preference is persisted: "own" belongs
             // to an imported curve, and no source is restored, so the effective choice
             // simply starts from that preference.

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -540,7 +540,7 @@ public partial class EqWizardPanel
             "Target",
             ToOxyColor(targetColor),
             targetStrokeThickness,
-            ToOxyLineStyle(targetLineStyle),
+            OverlayLineStyles.ToOxy(targetLineStyle),
             points);
     }
 
@@ -666,61 +666,92 @@ public partial class EqWizardPanel
         DrawSelectedCurves();
     }
 
+    /// <summary>
+    /// The target curve as one value. The wizard owns and persists it; the host
+    /// hands the same definition to the Virtual DSP tool, which draws it over
+    /// its predicted sum and can edit it back through
+    /// <see cref="ApplyTargetCurve"/>.
+    /// </summary>
+    internal EqTargetCurve TargetCurve => new(
+        targetPreset,
+        targetSpec,
+        targetToleranceDb,
+        targetDeviationMode,
+        targetColor,
+        targetStrokeThickness,
+        targetLineStyle,
+        targetSmoothingInverseOctaves);
+
+    /// <summary>
+    /// Takes a target edited elsewhere (the Virtual DSP tool's own Target
+    /// dialog). Redraws and persists exactly as an edit made here would, and
+    /// ignores a value equal to the current one, so the host can push on every
+    /// settings change without looping.
+    /// </summary>
+    internal void ApplyTargetCurve(EqTargetCurve value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        if (TargetCurve == value)
+        {
+            return;
+        }
+
+        AssignTargetCurve(value);
+        RaiseSettingsChanged();
+        DrawSelectedCurves();
+    }
+
+    private void AssignTargetCurve(EqTargetCurve value)
+    {
+        targetPreset = value.Preset;
+        targetSpec = value.Spec;
+        targetToleranceDb = value.ToleranceDb;
+        targetDeviationMode = value.DeviationMode;
+        targetColor = value.Color;
+        targetStrokeThickness = value.StrokeThickness;
+        targetLineStyle = value.LineStyle;
+        targetSmoothingInverseOctaves = value.SmoothingInverseOctaves;
+    }
+
     // Reuses the overlay target dialog in isolated mode (no source picker, no
     // overlay side effects); its live preview redraws the wizard plot. Cancel
     // reverts the previewed changes.
     private void OpenTargetSettings()
     {
-        (TargetPreset preset,
-            TargetCurveSpec spec,
-            double tolerance,
-            TargetDeviationMode deviation,
-            Color color,
-            double thickness,
-            OverlayLineStyle style,
-            int smoothing) before = (
-            targetPreset, targetSpec, targetToleranceDb, targetDeviationMode,
-            targetColor, targetStrokeThickness, targetLineStyle, targetSmoothingInverseOctaves);
-
+        EqTargetCurve before = TargetCurve;
         using var dialog = new OverlayTargetSettingsDialog(
             Mode.EqWizard,
             "EQ target",
             0,
-            targetPreset,
-            targetSpec,
-            targetToleranceDb,
-            targetDeviationMode,
-            targetColor,
-            targetStrokeThickness,
-            targetLineStyle,
+            before.Preset,
+            before.Spec,
+            before.ToleranceDb,
+            before.DeviationMode,
+            before.Color,
+            before.StrokeThickness,
+            before.LineStyle,
             100,
-            targetSmoothingInverseOctaves,
+            before.SmoothingInverseOctaves,
             Array.Empty<OverlaySlotOption>(),
             ApplyTargetPreview,
             isolatedTarget: true);
 
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK)
         {
-            targetPreset = before.preset;
-            targetSpec = before.spec;
-            targetToleranceDb = before.tolerance;
-            targetDeviationMode = before.deviation;
-            targetColor = before.color;
-            targetStrokeThickness = before.thickness;
-            targetLineStyle = before.style;
-            targetSmoothingInverseOctaves = before.smoothing;
+            AssignTargetCurve(before);
             DrawSelectedCurves();
             return;
         }
 
-        targetPreset = dialog.Preset;
-        targetSpec = dialog.Spec;
-        targetToleranceDb = dialog.ToleranceDb;
-        targetDeviationMode = dialog.DeviationMode;
-        targetColor = dialog.SelectedColor;
-        targetStrokeThickness = dialog.StrokeThickness;
-        targetLineStyle = dialog.LineStyle;
-        targetSmoothingInverseOctaves = dialog.SmoothingInverseOctaves;
+        AssignTargetCurve(new EqTargetCurve(
+            dialog.Preset,
+            dialog.Spec,
+            dialog.ToleranceDb,
+            dialog.DeviationMode,
+            dialog.SelectedColor,
+            dialog.StrokeThickness,
+            dialog.LineStyle,
+            dialog.SmoothingInverseOctaves));
         RaiseSettingsChanged();
         DrawSelectedCurves();
     }
@@ -1121,7 +1152,4 @@ public partial class EqWizardPanel
 
     private static OxyColor ToOxyColor(Color color) =>
         OxyColor.FromArgb(color.A, color.R, color.G, color.B);
-
-    private static LineStyle ToOxyLineStyle(OverlayLineStyle style) =>
-        Enum.TryParse(style.ToString(), out LineStyle parsed) ? parsed : LineStyle.Solid;
 }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAcousticPlot.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAcousticPlot.cs
@@ -71,6 +71,13 @@ internal sealed class VirtualCrossoverAcousticPlot
     private readonly LogarithmicAxis frequencyAxis;
     private readonly LinearAxis timeAxis;
 
+    // The display window the impulse time axis was last armed to, so a redraw
+    // that lands on the same window leaves the user's zoom alone. A move smaller
+    // than this is recomputation noise rather than a new window — it is orders
+    // of magnitude below one sample at any rate the app records at.
+    private const double WindowMoveEpsilonMs = 1e-6;
+    private (double StartMs, double EndMs)? impulseWindow;
+
     public VirtualCrossoverAcousticPlot(PlotView view, string hint, AcousticView initialView)
     {
         ArgumentNullException.ThrowIfNull(view);
@@ -79,17 +86,18 @@ internal sealed class VirtualCrossoverAcousticPlot
         var model = new PlotModel();
         PlotModelStyle.AddFrequencyAxis(model);
         frequencyAxis = (LogarithmicAxis)model.Axes[^1];
-        // The impulse view runs on an absolute-time axis; its range follows the
-        // gate window on every impulse redraw, so it is static like the gate
-        // dialog's preview instead of pannable.
+        // The impulse view runs on an absolute-time axis. It zooms and pans like
+        // any other: the interesting part of an impulse view is the millisecond
+        // around each front, and the gate window it opens on is far wider than
+        // that. The window stays its hard limit — outside it the
+        // traces hold no data — and DrawImpulse only re-arms the range when the
+        // window itself moves, so a zoom survives the constant redraws.
         timeAxis = new LinearAxis
         {
             Position = AxisPosition.Bottom,
             Title = "ms",
             MajorGridlineStyle = LineStyle.Solid,
-            MinorGridlineStyle = LineStyle.Dot,
-            IsPanEnabled = false,
-            IsZoomEnabled = false
+            MinorGridlineStyle = LineStyle.Dot
         };
         // The absolute pan/zoom limits live in ConfigureForView: they differ
         // between the magnitude (dB), phase (deg) and impulse (normalized) views.
@@ -125,8 +133,9 @@ internal sealed class VirtualCrossoverAcousticPlot
     }
 
     // Magnitude and phase reuse one value axis object so pan/zoom of the frequency
-    // axis survives the toggle; only the value scale is re-armed. The impulse view
-    // additionally swaps the bottom axis to the linear ms one.
+    // axis survives the toggle; only the value scale and its zoom lock are
+    // re-armed. The impulse view additionally swaps the bottom axis to the linear
+    // ms one.
     public void ConfigureForView(AcousticView acousticView)
     {
         if (acousticView == AcousticView.Impulse)
@@ -161,6 +170,16 @@ internal sealed class VirtualCrossoverAcousticPlot
             valueAxis.Maximum = double.NaN;
             valueAxis.MajorStep = double.NaN;
         }
+
+        // ±180° is the ENTIRE range a wrapped phase can occupy, so there is
+        // nothing above or below to travel to: zooming the height would only cut
+        // curves off screen while implying the rest is somewhere out of view.
+        // Locked rather than merely bounded, which also drops the axis from the
+        // double-click limits dialog (it offers the zoomable axes only) and
+        // leaves a drag panning the frequency axis alone.
+        bool phase = acousticView == AcousticView.Phase;
+        valueAxis.IsZoomEnabled = !phase;
+        valueAxis.IsPanEnabled = !phase;
 
         ConfigureBottomAxis(acousticView);
         valueAxis.Reset();
@@ -244,10 +263,20 @@ internal sealed class VirtualCrossoverAcousticPlot
             return;
         }
 
-        // The axis is static (no pan/zoom), so simply re-arm it to the display
-        // window the series were built for.
+        // The window the series were built for is the axis's hard limit either
+        // way. The RANGE, though, is re-armed only when that window actually
+        // moves: the axis zooms now, and every chain edit redraws this view, so
+        // re-arming each time would throw away the zoom the user just set.
         timeAxis.AbsoluteMinimum = bounds.StartMs;
         timeAxis.AbsoluteMaximum = bounds.EndMs;
+        if (impulseWindow is { } previous &&
+            Math.Abs(previous.StartMs - bounds.StartMs) < WindowMoveEpsilonMs &&
+            Math.Abs(previous.EndMs - bounds.EndMs) < WindowMoveEpsilonMs)
+        {
+            return;
+        }
+
+        impulseWindow = bounds;
         timeAxis.Minimum = bounds.StartMs;
         timeAxis.Maximum = bounds.EndMs;
         timeAxis.Reset();

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
@@ -40,6 +40,11 @@ namespace Resonalyze
             buttonCopyLeftToRight = new Button();
             buttonCopyRightToLeft = new Button();
             labelView = new Label();
+            labelCurves = new Label();
+            checkBoxShowTarget = new CheckBox();
+            numericTargetLevel = new DarkNumericUpDown();
+            buttonTargetSettings = new Button();
+            labelCalibration = new Label();
             checkBoxShowSum = new CheckBox();
             checkBoxShowLoss = new CheckBox();
             radioViewMagnitude = new RadioButton();
@@ -56,7 +61,6 @@ namespace Resonalyze
             buttonSessionImport = new Button();
             buttonSessionExport = new Button();
             buttonAudition = new Button();
-            labelCrossoverWarning = new Label();
             dspModePanel = new Panel();
             labelDspMode = new Label();
             radioDspMagnitude = new RadioButton();
@@ -66,6 +70,7 @@ namespace Resonalyze
             comboBoxCorrelationPair = new DarkComboBox();
             panel1 = new Panel();
             panel2 = new Panel();
+            (numericTargetLevel).BeginInit();
             sideSelectorPanel.SuspendLayout();
             dspModePanel.SuspendLayout();
             panel1.SuspendLayout();
@@ -88,10 +93,10 @@ namespace Resonalyze
             // dspPlotView
             // 
             dspPlotView.BackColor = Color.FromArgb(40, 44, 80);
-            dspPlotView.Location = new Point(490, 455);
+            dspPlotView.Location = new Point(490, 470);
             dspPlotView.Name = "dspPlotView";
             dspPlotView.PanCursor = Cursors.Hand;
-            dspPlotView.Size = new Size(739, 275);
+            dspPlotView.Size = new Size(739, 260);
             dspPlotView.TabIndex = 2;
             dspPlotView.Text = "plotView2";
             dspPlotView.ZoomHorizontalCursor = Cursors.SizeWE;
@@ -204,11 +209,74 @@ namespace Resonalyze
             labelView.AutoSize = true;
             labelView.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             labelView.ForeColor = Color.FromArgb(210, 214, 222);
-            labelView.Location = new Point(358, 414);
+            labelView.Location = new Point(358, 441);
             labelView.Name = "labelView";
             labelView.Size = new Size(33, 15);
             labelView.TabIndex = 6;
             labelView.Text = "View";
+            // 
+            // labelCurves
+            // 
+            labelCurves.AutoSize = true;
+            labelCurves.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            labelCurves.ForeColor = Color.FromArgb(210, 214, 222);
+            labelCurves.Location = new Point(358, 411);
+            labelCurves.Name = "labelCurves";
+            labelCurves.Size = new Size(42, 15);
+            labelCurves.TabIndex = 26;
+            labelCurves.Text = "Curves";
+            // 
+            // checkBoxShowTarget
+            // 
+            checkBoxShowTarget.AutoSize = true;
+            checkBoxShowTarget.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            checkBoxShowTarget.ForeColor = Color.FromArgb(55, 200, 160);
+            checkBoxShowTarget.Location = new Point(549, 409);
+            checkBoxShowTarget.Name = "checkBoxShowTarget";
+            checkBoxShowTarget.Size = new Size(59, 19);
+            checkBoxShowTarget.TabIndex = 27;
+            checkBoxShowTarget.Text = "Target";
+            checkBoxShowTarget.UseVisualStyleBackColor = true;
+            // 
+            // numericTargetLevel
+            // 
+            numericTargetLevel.BackColor = Color.FromArgb(55, 60, 72);
+            numericTargetLevel.DecimalPlaces = 0;
+            numericTargetLevel.ForeColor = Color.White;
+            numericTargetLevel.Increment = new decimal(new int[] { 1, 0, 0, 0 });
+            numericTargetLevel.Location = new Point(616, 409);
+            numericTargetLevel.Maximum = new decimal(new int[] { 60, 0, 0, 0 });
+            numericTargetLevel.Minimum = new decimal(new int[] { 120, 0, 0, int.MinValue });
+            numericTargetLevel.MinimumSize = new Size(36, 19);
+            numericTargetLevel.Name = "numericTargetLevel";
+            numericTargetLevel.Size = new Size(72, 19);
+            numericTargetLevel.TabIndex = 28;
+            numericTargetLevel.TextAlign = HorizontalAlignment.Right;
+            numericTargetLevel.ThousandsSeparator = false;
+            numericTargetLevel.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            numericTargetLevel.ValueSuffix = "dB";
+            // 
+            // buttonTargetSettings
+            // 
+            buttonTargetSettings.FlatStyle = FlatStyle.Popup;
+            buttonTargetSettings.ForeColor = Color.White;
+            buttonTargetSettings.Location = new Point(696, 407);
+            buttonTargetSettings.Name = "buttonTargetSettings";
+            buttonTargetSettings.Size = new Size(80, 24);
+            buttonTargetSettings.TabIndex = 29;
+            buttonTargetSettings.Text = "Target...";
+            buttonTargetSettings.UseVisualStyleBackColor = true;
+            // 
+            // labelCalibration
+            // 
+            labelCalibration.AutoSize = true;
+            labelCalibration.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            labelCalibration.ForeColor = Color.FromArgb(210, 214, 222);
+            labelCalibration.Location = new Point(800, 411);
+            labelCalibration.Name = "labelCalibration";
+            labelCalibration.Size = new Size(45, 15);
+            labelCalibration.TabIndex = 30;
+            labelCalibration.Text = "Mic cal";
             // 
             // checkBoxShowSum
             // 
@@ -217,7 +285,7 @@ namespace Resonalyze
             checkBoxShowSum.CheckState = CheckState.Checked;
             checkBoxShowSum.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             checkBoxShowSum.ForeColor = Color.FromArgb(210, 214, 222);
-            checkBoxShowSum.Location = new Point(403, 412);
+            checkBoxShowSum.Location = new Point(408, 409);
             checkBoxShowSum.Name = "checkBoxShowSum";
             checkBoxShowSum.Size = new Size(51, 19);
             checkBoxShowSum.TabIndex = 7;
@@ -229,7 +297,7 @@ namespace Resonalyze
             checkBoxShowLoss.AutoSize = true;
             checkBoxShowLoss.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             checkBoxShowLoss.ForeColor = Color.FromArgb(210, 214, 222);
-            checkBoxShowLoss.Location = new Point(461, 412);
+            checkBoxShowLoss.Location = new Point(467, 409);
             checkBoxShowLoss.Name = "checkBoxShowLoss";
             checkBoxShowLoss.Size = new Size(74, 19);
             checkBoxShowLoss.TabIndex = 8;
@@ -279,7 +347,7 @@ namespace Resonalyze
             labelSmoothing.AutoSize = true;
             labelSmoothing.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             labelSmoothing.ForeColor = Color.FromArgb(210, 214, 222);
-            labelSmoothing.Location = new Point(779, 414);
+            labelSmoothing.Location = new Point(656, 441);
             labelSmoothing.Name = "labelSmoothing";
             labelSmoothing.Size = new Size(67, 15);
             labelSmoothing.TabIndex = 10;
@@ -289,7 +357,7 @@ namespace Resonalyze
             // 
             comboBoxSmoothing.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxSmoothing.ForeColor = Color.White;
-            comboBoxSmoothing.Location = new Point(853, 412);
+            comboBoxSmoothing.Location = new Point(731, 439);
             comboBoxSmoothing.MinimumSize = new Size(36, 19);
             comboBoxSmoothing.Name = "comboBoxSmoothing";
             comboBoxSmoothing.Size = new Size(100, 19);
@@ -300,7 +368,7 @@ namespace Resonalyze
             buttonAutoDelay.BackColor = Color.FromArgb(46, 51, 67);
             buttonAutoDelay.FlatStyle = FlatStyle.Popup;
             buttonAutoDelay.ForeColor = Color.White;
-            buttonAutoDelay.Location = new Point(359, 485);
+            buttonAutoDelay.Location = new Point(359, 500);
             buttonAutoDelay.Name = "buttonAutoDelay";
             buttonAutoDelay.Size = new Size(125, 24);
             buttonAutoDelay.TabIndex = 12;
@@ -312,7 +380,7 @@ namespace Resonalyze
             buttonAutoSetup.BackColor = Color.FromArgb(46, 51, 67);
             buttonAutoSetup.FlatStyle = FlatStyle.Popup;
             buttonAutoSetup.ForeColor = Color.White;
-            buttonAutoSetup.Location = new Point(359, 455);
+            buttonAutoSetup.Location = new Point(359, 470);
             buttonAutoSetup.Name = "buttonAutoSetup";
             buttonAutoSetup.Size = new Size(125, 24);
             buttonAutoSetup.TabIndex = 19;
@@ -345,7 +413,7 @@ namespace Resonalyze
             // 
             buttonPhaseGate.FlatStyle = FlatStyle.Popup;
             buttonPhaseGate.ForeColor = Color.White;
-            buttonPhaseGate.Location = new Point(959, 410);
+            buttonPhaseGate.Location = new Point(855, 437);
             buttonPhaseGate.Name = "buttonPhaseGate";
             buttonPhaseGate.Size = new Size(80, 24);
             buttonPhaseGate.TabIndex = 16;
@@ -356,7 +424,7 @@ namespace Resonalyze
             // 
             comboBoxCalibration.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxCalibration.ForeColor = Color.White;
-            comboBoxCalibration.Location = new Point(1047, 413);
+            comboBoxCalibration.Location = new Point(853, 409);
             comboBoxCalibration.MinimumSize = new Size(36, 19);
             comboBoxCalibration.Name = "comboBoxCalibration";
             comboBoxCalibration.Size = new Size(110, 19);
@@ -394,16 +462,6 @@ namespace Resonalyze
             buttonSessionExport.TabIndex = 18;
             buttonSessionExport.Text = "Save session...";
             buttonSessionExport.UseVisualStyleBackColor = true;
-            // 
-            // labelCrossoverWarning
-            // 
-            labelCrossoverWarning.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            labelCrossoverWarning.ForeColor = Color.FromArgb(235, 110, 95);
-            labelCrossoverWarning.Location = new Point(358, 434);
-            labelCrossoverWarning.Name = "labelCrossoverWarning";
-            labelCrossoverWarning.Size = new Size(870, 16);
-            labelCrossoverWarning.TabIndex = 19;
-            labelCrossoverWarning.Visible = false;
             // 
             // dspModePanel
             // 
@@ -496,7 +554,7 @@ namespace Resonalyze
             panel1.Controls.Add(radioViewMagnitude);
             panel1.Controls.Add(radioViewImpulse);
             panel1.Controls.Add(radioViewPhase);
-            panel1.Location = new Point(539, 410);
+            panel1.Location = new Point(399, 437);
             panel1.Name = "panel1";
             panel1.Size = new Size(233, 23);
             panel1.TabIndex = 24;
@@ -521,6 +579,11 @@ namespace Resonalyze
             Controls.Add(panel2);
             Controls.Add(panel1);
             Controls.Add(labelView);
+            Controls.Add(labelCurves);
+            Controls.Add(checkBoxShowTarget);
+            Controls.Add(numericTargetLevel);
+            Controls.Add(buttonTargetSettings);
+            Controls.Add(labelCalibration);
             Controls.Add(checkBoxShowSum);
             Controls.Add(checkBoxShowLoss);
             Controls.Add(labelSmoothing);
@@ -534,7 +597,6 @@ namespace Resonalyze
             Controls.Add(buttonSessionImport);
             Controls.Add(buttonSessionExport);
             Controls.Add(buttonAudition);
-            Controls.Add(labelCrossoverWarning);
             Controls.Add(dspModePanel);
             Controls.Add(channelListPanel);
             Controls.Add(buttonAddChannel);
@@ -547,6 +609,7 @@ namespace Resonalyze
             Name = "VirtualCrossoverPanel";
             Padding = new Padding(6);
             Size = new Size(1246, 770);
+            (numericTargetLevel).EndInit();
             sideSelectorPanel.ResumeLayout(false);
             sideSelectorPanel.PerformLayout();
             dspModePanel.ResumeLayout(false);
@@ -571,6 +634,11 @@ namespace Resonalyze
         private Button buttonCopyLeftToRight;
         private Button buttonCopyRightToLeft;
         private Label labelView;
+        private Label labelCurves;
+        private CheckBox checkBoxShowTarget;
+        private DarkNumericUpDown numericTargetLevel;
+        private Button buttonTargetSettings;
+        private Label labelCalibration;
         private CheckBox checkBoxShowSum;
         private CheckBox checkBoxShowLoss;
         private RadioButton radioViewMagnitude;
@@ -587,7 +655,6 @@ namespace Resonalyze
         private Button buttonSessionImport;
         private Button buttonSessionExport;
         private Button buttonAudition;
-        private Label labelCrossoverWarning;
         private Panel dspModePanel;
         private Label labelDspMode;
         private RadioButton radioDspMagnitude;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -2395,12 +2395,14 @@ public partial class VirtualCrossoverPanel : UserControl
             dialog.LineStyle,
             dialog.SmoothingInverseOctaves);
         ApplyTargetLocally(edited);
+        // Save is where the session learns about it — see ApplyTargetLocally.
+        StoreTargetInProject(edited);
         TargetCurveChanged?.Invoke(edited);
     }
 
     // The dialog's live preview. It reports every field except the preset (which
     // it names only on Save), so the current preset rides through untouched —
-    // nothing drawn here reads it.
+    // nothing drawn here reads it, and nothing stores it either.
     private void ApplyTargetPreview(OverlayTargetPreview preview)
     {
         if (targetCurve is not { } current)
@@ -2420,11 +2422,17 @@ public partial class VirtualCrossoverPanel : UserControl
         });
     }
 
+    // Memory and plot only, deliberately NOT the session: this runs on every
+    // twitch of the dialog's live preview, and the autosave timer keeps ticking
+    // inside a modal dialog's message loop — a couple of seconds spent dragging
+    // a shelf would write an uncommitted preview to disk, to be found by the
+    // next launch if the app never got to Cancel. The preview does not even
+    // carry a preset, so what landed there would be the old preset's name over
+    // the new shape. Save stores; Cancel has nothing to undo.
     private void ApplyTargetLocally(EqTargetCurve value)
     {
         targetCurve = value;
         targetToggleColor = value.Color;
-        StoreTargetInProject(value);
         UpdateTargetToggleLook();
         RedrawAll();
     }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -160,6 +160,15 @@ public partial class VirtualCrossoverPanel : UserControl
     private bool loadingProject;
     private int pendingSourceLoads;
 
+    // The shared EQ target, null until the host wires it (and in the designer).
+    private EqTargetCurve? targetCurve;
+
+    // The colour the Target toggle wears while it is live: its curve's own, the
+    // way the Sum and Sum loss toggles wear theirs. Seeded from the designer and
+    // following the shared target from then on, so muting the toggle for a view
+    // that cannot show it has a colour to come back to.
+    private Color targetToggleColor;
+
     public VirtualCrossoverPanel()
     {
         InitializeComponent();
@@ -176,6 +185,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // Same idea for the shared curves: the toggles wear their plot colors.
         checkBoxShowSum.ForeColor = Color.FromArgb(SumColor.R, SumColor.G, SumColor.B);
         checkBoxShowLoss.ForeColor = Color.FromArgb(LossColor.R, LossColor.G, LossColor.B);
+        targetToggleColor = checkBoxShowTarget.ForeColor;
 
         metrics = new VirtualCrossoverMetrics(processingCoordinator, BuildMagnitudeCurve);
         acousticPlot = new VirtualCrossoverAcousticPlot(
@@ -192,6 +202,7 @@ public partial class VirtualCrossoverPanel : UserControl
         buttonCaptureOverlay.Click += async (_, _) => await CaptureSumToOverlayAsync();
         buttonExport.Click += async (_, _) => await ExportTuningSheetAsync();
         buttonPhaseGate.Click += async (_, _) => await OpenPhaseGateDialogAsync();
+        buttonTargetSettings.Click += (_, _) => OpenTargetSettings();
         buttonSessionImport.Click += async (_, _) => await ImportSessionAsync();
         buttonSessionExport.Click += (_, _) => ExportSession();
         buttonAudition.Click += async (_, _) => await AuditionTrackAsync();
@@ -259,6 +270,54 @@ public partial class VirtualCrossoverPanel : UserControl
     [System.ComponentModel.DesignerSerializationVisibility(
         System.ComponentModel.DesignerSerializationVisibility.Hidden)]
     internal Action<string, string>? MetricChanged { get; set; }
+
+    /// <summary>
+    /// Pushes the one warning line to the host: the text to show, the whole
+    /// explanation for its tooltip, and the colour to draw the text in. An empty
+    /// text means there is nothing to warn about and the host hides the line.
+    /// Wired by the host form, which shows it above the sum-loss read-out: a
+    /// warning belongs beside the numbers it invalidates, and the panel's own
+    /// area is plot and controls edge to edge.
+    /// </summary>
+    [System.ComponentModel.Browsable(false)]
+    [System.ComponentModel.DesignerSerializationVisibility(
+        System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+    internal Action<string, string, Color>? WarningChanged { get; set; }
+
+    /// <summary>
+    /// The EQ target curve this tool can draw over its predicted sum. Pushed by
+    /// the host, which holds the one definition shared with the EQ Wizard. A
+    /// value equal to the current one is ignored, so the host may push it on
+    /// every settings change without costing a redraw.
+    /// </summary>
+    internal void SetTargetCurve(EqTargetCurve value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        if (targetCurve == value)
+        {
+            return;
+        }
+
+        targetCurve = value;
+        targetToggleColor = value.Color;
+        StoreTargetInProject(value);
+        UpdateTargetToggleLook();
+        if (checkBoxShowTarget.Checked && radioViewMagnitude.Checked)
+        {
+            RedrawAll();
+        }
+    }
+
+    /// <summary>
+    /// Raised when this tool's own Target dialog edited the shared curve. The
+    /// host writes it back to the EQ Wizard, which owns and persists it — that
+    /// write-back is what makes the two panels show one target rather than two
+    /// that drifted apart.
+    /// </summary>
+    [System.ComponentModel.Browsable(false)]
+    [System.ComponentModel.DesignerSerializationVisibility(
+        System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+    internal Action<EqTargetCurve>? TargetCurveChanged { get; set; }
 
     /// <summary>
     /// Called by the host whenever the tool tab becomes active. The first call
@@ -382,13 +441,19 @@ public partial class VirtualCrossoverPanel : UserControl
         suppressProjectEvents = true;
         try
         {
-            checkBoxShowSum.Checked = project.ShowSumCurve;
             checkBoxShowLoss.Checked = project.ShowLossCurve;
+            checkBoxShowTarget.Checked = project.ShowTargetCurve;
+            numericTargetLevel.Value =
+                numericTargetLevel.ClampValue(project.TargetLevelDb);
             radioViewImpulse.Checked = project.ShowImpulseView;
             radioViewPhase.Checked =
                 !project.ShowImpulseView && project.ShowPhaseView;
             radioViewMagnitude.Checked =
                 !project.ShowImpulseView && !project.ShowPhaseView;
+            // After the radios: the Sum is remembered per view, so which answer
+            // applies is decided by the view this project opens on.
+            ApplySumToggleForView();
+            ApplyProjectTarget();
             radioSideRight.Checked = project.ActiveSideRight;
             radioSideLeft.Checked = !project.ActiveSideRight;
             acousticPlot.ConfigureForView(CurrentAcousticView());
@@ -591,6 +656,8 @@ public partial class VirtualCrossoverPanel : UserControl
     {
         checkBoxShowSum.CheckedChanged += (_, _) => OnViewChanged();
         checkBoxShowLoss.CheckedChanged += (_, _) => OnViewChanged();
+        checkBoxShowTarget.CheckedChanged += (_, _) => OnViewChanged();
+        numericTargetLevel.ValueChanged += (_, _) => OnViewChanged();
         // Three-radio group: each fires on both the check and the uncheck, so
         // act only on the one that became checked to run the switch exactly
         // once per mode change.
@@ -1026,10 +1093,69 @@ public partial class VirtualCrossoverPanel : UserControl
     private void OnViewModeChanged()
     {
         acousticPlot.ConfigureForView(CurrentAcousticView());
-        // Fractional-octave smoothing shapes only the frequency-domain curves;
-        // grey it out in the impulse view where it has no effect.
-        comboBoxSmoothing.Enabled = !radioViewImpulse.Checked;
+        UpdateViewDependentControls();
+        // Before the write-back below: the toggle has to be carrying the new
+        // view's answer, or OnViewChanged would copy the old view's into it.
+        ApplySumToggleForView();
         OnViewChanged();
+    }
+
+    // Each curve toggle is muted on the views that cannot draw that curve: the
+    // Sum exists on the magnitude and phase plots but not among the impulse
+    // traces, the sum loss and the target are magnitude-only (a target is a dB
+    // shape — the same rule OverlayTargets.SupportsMode applies to overlay
+    // targets). Fractional-octave smoothing shapes the frequency-domain curves,
+    // so it is dead in the impulse view alone. The Target... button stays live
+    // everywhere: it switches to the view its dialog can preview on rather than
+    // sitting there greyed.
+    private void UpdateViewDependentControls()
+    {
+        comboBoxSmoothing.Enabled = !radioViewImpulse.Checked;
+        // These two wear a fixed plot colour, so the shared helper — which
+        // memorizes the colour it mutes — is safe for them.
+        Ui.UiStyle.SetTextEnabledLook(
+            checkBoxShowSum, !radioViewImpulse.Checked, interactive: true);
+        Ui.UiStyle.SetTextEnabledLook(
+            checkBoxShowLoss, radioViewMagnitude.Checked, interactive: true);
+        UpdateTargetToggleLook();
+        // DarkNumericUpDown paints its own disabled state in the palette's muted
+        // text, so this one can simply be disabled.
+        numericTargetLevel.Enabled = radioViewMagnitude.Checked;
+    }
+
+    // A CheckBox WinForms has disabled paints its text in a system grey that
+    // reads as near-black on this theme, so the toggle is muted the way
+    // UiStyle.SetTextEnabledLook mutes one — kept enabled, coloured by hand,
+    // with AutoCheck and TabStop carrying the disabling. Not through that helper
+    // itself: it memorizes the colour it muted, and this toggle is recoloured
+    // whenever the shared target is, so what came back could be a stale target's
+    // colour.
+    private void UpdateTargetToggleLook()
+    {
+        bool magnitude = radioViewMagnitude.Checked;
+        checkBoxShowTarget.ForeColor =
+            magnitude ? targetToggleColor : Ui.UiPalette.TextMuted;
+        checkBoxShowTarget.AutoCheck = magnitude;
+        checkBoxShowTarget.TabStop = magnitude;
+    }
+
+    // The Sum toggle carries one answer per view (see VirtualCrossoverProjectFile).
+    // The impulse view has no sum trace, so it writes nothing and shows the
+    // magnitude answer while its toggle is muted.
+    private void ApplySumToggleForView()
+    {
+        bool suppressed = suppressProjectEvents;
+        suppressProjectEvents = true;
+        try
+        {
+            checkBoxShowSum.Checked = radioViewPhase.Checked
+                ? project.ShowSumCurveOnPhase
+                : project.ShowSumCurve;
+        }
+        finally
+        {
+            suppressProjectEvents = suppressed;
+        }
     }
 
     private void OnViewChanged()
@@ -1039,8 +1165,18 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
-        project.ShowSumCurve = checkBoxShowSum.Checked;
+        if (radioViewPhase.Checked)
+        {
+            project.ShowSumCurveOnPhase = checkBoxShowSum.Checked;
+        }
+        else if (radioViewMagnitude.Checked)
+        {
+            project.ShowSumCurve = checkBoxShowSum.Checked;
+        }
+
         project.ShowLossCurve = checkBoxShowLoss.Checked;
+        project.ShowTargetCurve = checkBoxShowTarget.Checked;
+        project.TargetLevelDb = (double)numericTargetLevel.Value;
         project.ShowPhaseView = radioViewPhase.Checked;
         project.ShowImpulseView = radioViewImpulse.Checked;
         project.SetSmoothingCode(comboBoxSmoothing.SelectedItem is int value
@@ -1749,6 +1885,25 @@ public partial class VirtualCrossoverPanel : UserControl
             "Which adjacent channel pair the correlation view analyzes\r\n" +
             "(active side, ordered along the spectrum).");
         toolTip.SetToolTip(
+            checkBoxShowTarget,
+            "Draw the EQ target over the predicted sum: the SAME target the\r\n" +
+            "EQ Wizard is set to, so a shape tuned in either place is the\r\n" +
+            "one shape this app aims at. It is a magnitude reference, so it\r\n" +
+            "is offered on the Magnitude view only.");
+        toolTip.SetToolTip(
+            numericTargetLevel,
+            "The level the target hangs at. These curves are transfer-function\r\n" +
+            "dB with no absolute reference, so the target has no level of its\r\n" +
+            "own here: set it where you read the sum. Stored with the session,\r\n" +
+            "not with the target, so retuning the shape leaves it where it is.");
+        toolTip.SetToolTip(
+            buttonTargetSettings,
+            "Shape the target: preset, tilt, bass and treble shelves,\r\n" +
+            "presence, colour and line style, previewed live on this plot\r\n" +
+            "(which switches to the Magnitude view, the only one a dB shape\r\n" +
+            "means anything on). Saving writes the SAME target the EQ Wizard\r\n" +
+            "equalizes towards.");
+        toolTip.SetToolTip(
             comboBoxCalibration,
             "Microphone calibration applied to the magnitude curves —\r\n" +
             "and to the curves the Sum loss read-out is measured from,\r\n" +
@@ -2129,6 +2284,167 @@ public partial class VirtualCrossoverPanel : UserControl
             null);
     }
 
+    // The target travels with the session. It is handed to the HOST rather than
+    // kept here, because the app aims at one target: the EQ Wizard owns and
+    // persists it, and this panel gets it straight back through SetTargetCurve.
+    // A session written before targets were stored carries none — then the
+    // current target stays, and this session starts carrying it.
+    private void ApplyProjectTarget()
+    {
+        if (project.Target is { } stored)
+        {
+            TargetCurveChanged?.Invoke(stored.ToCurve());
+            return;
+        }
+
+        if (targetCurve is { } current)
+        {
+            project.Target = VirtualCrossoverTargetSettings.FromCurve(current);
+        }
+    }
+
+    // The frequency grid the target shape is drawn on. A target is parametric
+    // over frequency, not a measurement, so it spans the audio band on its own
+    // grid instead of borrowing whatever the loaded channels happen to cover.
+    private const double TargetGridLowHz = 20;
+    private const double TargetGridHighHz = 20_000;
+    private const int TargetGridPoints = 512;
+
+    // The EQ target as an acoustic curve: the shared shape (relative dB) hung at
+    // the level this session set. The level is asked for rather than fitted to
+    // the sum because Virtual DSP curves are transfer-function dB with no
+    // absolute reference — there is no level here that a fit could be honest
+    // about, so the one the user reads the sum at is the one that counts.
+    private AcousticCurve? BuildTargetCurve()
+    {
+        if (!checkBoxShowTarget.Checked || targetCurve is not { } target)
+        {
+            return null;
+        }
+
+        double level = (double)numericTargetLevel.Value;
+        IReadOnlyList<double> grid = EqualizationCurve.LogFrequencyGrid(
+            TargetGridLowHz, TargetGridHighHz, TargetGridPoints);
+        var points = new SignalPoint[grid.Count];
+        for (int i = 0; i < grid.Count; i++)
+        {
+            points[i] = new SignalPoint(
+                grid[i], level + target.Spec.Evaluate(grid[i]));
+        }
+
+        return new AcousticCurve(
+            "Target",
+            points,
+            OxyColor.FromArgb(
+                target.Color.A, target.Color.R, target.Color.G, target.Color.B),
+            target.StrokeThickness,
+            OverlayLineStyles.ToOxy(target.LineStyle));
+    }
+
+    // The same isolated target dialog the EQ Wizard opens (no source picker, no
+    // overlay side effects), previewing on THIS plot. Cancel puts back what was
+    // there; Save hands the curve to the host, and that hand-off is what carries
+    // the edit to the wizard.
+    private void OpenTargetSettings()
+    {
+        if (targetCurve is not { } before)
+        {
+            return;
+        }
+
+        // Settings for an invisible curve are settings for nothing, so opening
+        // the dialog puts the target on screen: the Magnitude view, the only one
+        // a dB shape means anything on, with the curve shown. Both stay that way
+        // afterwards — the view radios and the checkbox are right there.
+        radioViewMagnitude.Checked = true;
+        checkBoxShowTarget.Checked = true;
+        // Opened as the EQ Wizard's dialog, not as this tool's: the mode is what
+        // decides which smoothing vocabulary the dialog offers, and one target
+        // edited from two places must not come back different depending on which
+        // button opened it.
+        using var dialog = new OverlayTargetSettingsDialog(
+            Mode.EqWizard,
+            "EQ target",
+            0,
+            before.Preset,
+            before.Spec,
+            before.ToleranceDb,
+            before.DeviationMode,
+            before.Color,
+            before.StrokeThickness,
+            before.LineStyle,
+            100,
+            before.SmoothingInverseOctaves,
+            [],
+            ApplyTargetPreview,
+            isolatedTarget: true);
+
+        if (dialog.ShowDialog(FindForm()) != DialogResult.OK)
+        {
+            ApplyTargetLocally(before);
+            return;
+        }
+
+        var edited = new EqTargetCurve(
+            dialog.Preset,
+            dialog.Spec,
+            dialog.ToleranceDb,
+            dialog.DeviationMode,
+            dialog.SelectedColor,
+            dialog.StrokeThickness,
+            dialog.LineStyle,
+            dialog.SmoothingInverseOctaves);
+        ApplyTargetLocally(edited);
+        TargetCurveChanged?.Invoke(edited);
+    }
+
+    // The dialog's live preview. It reports every field except the preset (which
+    // it names only on Save), so the current preset rides through untouched —
+    // nothing drawn here reads it.
+    private void ApplyTargetPreview(OverlayTargetPreview preview)
+    {
+        if (targetCurve is not { } current)
+        {
+            return;
+        }
+
+        ApplyTargetLocally(current with
+        {
+            Spec = preview.Spec,
+            ToleranceDb = preview.ToleranceDb,
+            DeviationMode = preview.DeviationMode,
+            Color = preview.Color,
+            StrokeThickness = preview.StrokeThickness,
+            LineStyle = preview.LineStyle,
+            SmoothingInverseOctaves = preview.SmoothingInverseOctaves
+        });
+    }
+
+    private void ApplyTargetLocally(EqTargetCurve value)
+    {
+        targetCurve = value;
+        targetToggleColor = value.Color;
+        StoreTargetInProject(value);
+        UpdateTargetToggleLook();
+        RedrawAll();
+    }
+
+    // The session stores the target it was tuned against, shape and all. Nothing
+    // is written before the project has loaded: the host pushes the app's target
+    // in while the form is built, long before this tool is first opened, and
+    // storing it then would schedule a save of the default project over the real
+    // one on disk.
+    private void StoreTargetInProject(EqTargetCurve value)
+    {
+        if (!initialized)
+        {
+            return;
+        }
+
+        project.Target = VirtualCrossoverTargetSettings.FromCurve(value);
+        ScheduleSave();
+    }
+
     private List<AcousticCurve> BuildMagnitudeCurves(
         List<ProcessedChannel> processed,
         List<AnalysisCurve>? magnitudes,
@@ -2140,6 +2456,12 @@ public partial class VirtualCrossoverPanel : UserControl
         // curve is spectrum-built right here, one channel after another.
         using var _ = AppProfiler.Zone("VirtualDSP.BuildMagnitudeCurves");
         var curves = new List<AcousticCurve>();
+        // First, so the measured curves and the sum read on top of the reference
+        // rather than under it.
+        if (BuildTargetCurve() is { } target)
+        {
+            curves.Add(target);
+        }
         for (int i = 0; i < processed.Count; i++)
         {
             ProcessedChannel item = processed[i];
@@ -2261,11 +2583,11 @@ public partial class VirtualCrossoverPanel : UserControl
         MetricChanged?.Invoke(compact, detail);
     }
 
-    // One warning line under the plot, and only one: the gate placement comes
-    // first because it decides whether the curves describe the channels at all
-    // — a window that opens after the drivers arrive turns every one of them
-    // into its own reverberant tail, and the crossover spread below is read off
-    // the applied delays, which stay true meanwhile.
+    // One warning line for the host to show, and only one: the gate placement
+    // comes first because it decides whether the curves describe the channels
+    // at all — a window that opens after the drivers arrive turns every one of
+    // them into its own reverberant tail, and the crossover spread below is
+    // read off the applied delays, which stay true meanwhile.
     private void UpdateWarnings(List<ProcessedChannel> processed)
     {
         gatePlacement = JudgeGatePlacement(processed);
@@ -2281,19 +2603,13 @@ public partial class VirtualCrossoverPanel : UserControl
         UpdateCrossoverWarning(processed);
     }
 
-    private void ShowWarning(string text, string detail, Color color)
-    {
-        labelCrossoverWarning.ForeColor = color;
-        labelCrossoverWarning.Text = text;
-        toolTip.SetToolTip(labelCrossoverWarning, detail);
-        labelCrossoverWarning.Visible = true;
-    }
+    private void ShowWarning(string text, string detail, Color color) =>
+        WarningChanged?.Invoke(text, detail, color);
 
-    private void HideWarning()
-    {
-        labelCrossoverWarning.Visible = false;
-        toolTip.SetToolTip(labelCrossoverWarning, string.Empty);
-    }
+    // The colour rides along with the empty text so the host needs one handler
+    // and no separate "clear" call; with nothing to say, it is never painted.
+    private void HideWarning() =>
+        WarningChanged?.Invoke(string.Empty, string.Empty, CrossoverWarningColor);
 
     // Amber for the gate: it says the view cannot be read yet, not that the
     // tuning is wrong. The crossover spread keeps the red it always had.
@@ -3847,7 +4163,7 @@ public partial class VirtualCrossoverPanel : UserControl
     /// them with. <see cref="AllowsPerCurvePhaseGate"/> makes the same
     /// comparison with no margin at all, which is right THERE: its penalty for
     /// reading a hair's difference as significant is one curve falling back to
-    /// the shared window. Here the penalty is an amber line and two refused
+    /// the shared window. Here the penalty is an amber note and two refused
     /// commands, so the difference has to be one the user can act on.
     /// </para>
     /// </summary>

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -72,10 +72,11 @@ public sealed class VirtualCrossoverPhaseGateSettings
 /// aiming at exactly the curve it was tuned against.
 /// </summary>
 /// <remarks>
-/// Nothing here is validated. A target is drawn, not applied — TargetCurveSpec.
-/// Evaluate already guards every divisor, so the worst a hand-corrupted field
-/// can do is make the curve invisible until it is reshaped. Throwing instead
-/// would move the whole session aside over a decoration.
+/// A bad field here does not fail the load: <see cref="ToCurve"/> normalizes it
+/// away instead, because moving a whole tuning session aside over a decoration
+/// would be the worse answer. Normalizing is not optional though — a target is
+/// not only drawn, it also fills the settings dialog, and this file allows
+/// named floating-point literals (see EqTargetCurve.Normalized).
 /// </remarks>
 public sealed class VirtualCrossoverTargetSettings
 {
@@ -97,7 +98,10 @@ public sealed class VirtualCrossoverTargetSettings
     public OverlayLineStyle LineStyle { get; set; } = OverlayLineStyle.Dash;
     public int SmoothingInverseOctaves { get; set; }
 
-    internal EqTargetCurve ToCurve() => new(
+    // Normalized on the way out, never on the way in: what the app produces is
+    // already sound, and the file is the only place a NaN or an undefined enum
+    // can enter from.
+    internal EqTargetCurve ToCurve() => new EqTargetCurve(
         Preset,
         new TargetCurveSpec(
             TiltDbPerOctave,
@@ -115,7 +119,7 @@ public sealed class VirtualCrossoverTargetSettings
         Color.FromArgb(ColorArgb),
         StrokeThickness,
         LineStyle,
-        SmoothingInverseOctaves);
+        SmoothingInverseOctaves).Normalized();
 
     internal static VirtualCrossoverTargetSettings FromCurve(EqTargetCurve curve)
     {

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -66,6 +66,84 @@ public sealed class VirtualCrossoverPhaseGateSettings
 }
 
 /// <summary>
+/// The EQ target as a session stores it. A flat mirror of the shape and the
+/// styling, deliberately not a reference to a preset: presets are a starting
+/// point whose numbers can change between versions, while a session has to open
+/// aiming at exactly the curve it was tuned against.
+/// </summary>
+/// <remarks>
+/// Nothing here is validated. A target is drawn, not applied — TargetCurveSpec.
+/// Evaluate already guards every divisor, so the worst a hand-corrupted field
+/// can do is make the curve invisible until it is reshaped. Throwing instead
+/// would move the whole session aside over a decoration.
+/// </remarks>
+public sealed class VirtualCrossoverTargetSettings
+{
+    public TargetPreset Preset { get; set; } = TargetPreset.Flat;
+    public double TiltDbPerOctave { get; set; }
+    public double BassShelfGainDb { get; set; }
+    public double BassShelfFrequencyHz { get; set; } = 100;
+    public double BassShelfWidthOctaves { get; set; } = 1.5;
+    public double TrebleShelfGainDb { get; set; }
+    public double TrebleShelfFrequencyHz { get; set; } = 5_000;
+    public double TrebleShelfWidthOctaves { get; set; } = 1.5;
+    public double PresenceGainDb { get; set; }
+    public double PresenceFrequencyHz { get; set; } = 3_000;
+    public double PresenceWidthOctaves { get; set; } = 1.0;
+    public double ToleranceDb { get; set; } = 3;
+    public TargetDeviationMode DeviationMode { get; set; } = TargetDeviationMode.Deviation;
+    public int ColorArgb { get; set; } = unchecked((int)0xFF37C8A0);
+    public double StrokeThickness { get; set; } = 2;
+    public OverlayLineStyle LineStyle { get; set; } = OverlayLineStyle.Dash;
+    public int SmoothingInverseOctaves { get; set; }
+
+    internal EqTargetCurve ToCurve() => new(
+        Preset,
+        new TargetCurveSpec(
+            TiltDbPerOctave,
+            BassShelfGainDb,
+            BassShelfFrequencyHz,
+            BassShelfWidthOctaves,
+            TrebleShelfGainDb,
+            TrebleShelfFrequencyHz,
+            TrebleShelfWidthOctaves,
+            PresenceGainDb,
+            PresenceFrequencyHz,
+            PresenceWidthOctaves),
+        ToleranceDb,
+        DeviationMode,
+        Color.FromArgb(ColorArgb),
+        StrokeThickness,
+        LineStyle,
+        SmoothingInverseOctaves);
+
+    internal static VirtualCrossoverTargetSettings FromCurve(EqTargetCurve curve)
+    {
+        ArgumentNullException.ThrowIfNull(curve);
+        return new VirtualCrossoverTargetSettings
+        {
+            Preset = curve.Preset,
+            TiltDbPerOctave = curve.Spec.TiltDbPerOctave,
+            BassShelfGainDb = curve.Spec.BassShelfGainDb,
+            BassShelfFrequencyHz = curve.Spec.BassShelfFrequencyHz,
+            BassShelfWidthOctaves = curve.Spec.BassShelfWidthOctaves,
+            TrebleShelfGainDb = curve.Spec.TrebleShelfGainDb,
+            TrebleShelfFrequencyHz = curve.Spec.TrebleShelfFrequencyHz,
+            TrebleShelfWidthOctaves = curve.Spec.TrebleShelfWidthOctaves,
+            PresenceGainDb = curve.Spec.PresenceGainDb,
+            PresenceFrequencyHz = curve.Spec.PresenceFrequencyHz,
+            PresenceWidthOctaves = curve.Spec.PresenceWidthOctaves,
+            ToleranceDb = curve.ToleranceDb,
+            DeviationMode = curve.DeviationMode,
+            ColorArgb = curve.Color.ToArgb(),
+            StrokeThickness = curve.StrokeThickness,
+            LineStyle = curve.LineStyle,
+            SmoothingInverseOctaves = curve.SmoothingInverseOctaves
+        };
+    }
+}
+
+/// <summary>
 /// One channel of the virtual crossover: which measurement feeds it and the DSP
 /// chain applied before the virtual sum. The source is re-resolved on load — by
 /// history entry first, then by file path, and finally beside the imported session
@@ -407,14 +485,53 @@ public sealed class VirtualCrossoverProjectFile
     public bool ActiveSideRight { get; set; }
 
     // Acoustic-plot view state shared by all channels.
+    //
+    // The Sum is answered PER VIEW. On the magnitude plot the sum is the point
+    // of the whole tool; on the phase plot it is one more trace across an
+    // already dense picture, and the same session usually wants it there and not
+    // here. The impulse view draws no sum at all, so it has no flag. This one
+    // stays the magnitude answer, so a file written by this build still opens
+    // the way it looks here in a build that knows the single flag only; the
+    // phase answer is additive and inherits it when the file predates it (see
+    // ShowSumCurveOnPhase).
     public bool ShowSumCurve { get; set; } = true;
+    public bool? ShowSumCurvePhase { get; set; }
     public bool ShowLossCurve { get; set; }
+
+    /// <summary>
+    /// Whether the Sum is drawn on the PHASE view. A file written before the two
+    /// views answered separately carries no such flag and inherits the magnitude
+    /// answer, which is exactly what it used to draw.
+    /// </summary>
+    [JsonIgnore]
+    public bool ShowSumCurveOnPhase
+    {
+        get => ShowSumCurvePhase ?? ShowSumCurve;
+        set => ShowSumCurvePhase = value;
+    }
     public bool ShowPhaseView { get; set; }
     // The main plot's impulse view (the gated IR preview promoted to the main
     // plot). Additive: older files lack it, and when set it wins over
     // ShowPhaseView. Kept as a second flag so files written by this version
     // still open in older builds (which fall back to magnitude/phase).
     public bool ShowImpulseView { get; set; }
+
+    // The EQ target curve drawn over the acoustic plot: whether it is shown, the
+    // level (dB) it hangs at, and the target itself. Additive: older files lack
+    // all three and open with the curve hidden, on the app's current target.
+    public bool ShowTargetCurve { get; set; }
+    public double TargetLevelDb { get; set; }
+
+    /// <summary>
+    /// The EQ target this session was tuned against — the whole custom shape,
+    /// not a preset name, so a session that travels aims at the curve its owner
+    /// drew rather than at whatever the receiving machine happened to have set.
+    /// Loading a session applies it as the app's target (the EQ Wizard owns and
+    /// persists that one definition); null in a file written before the target
+    /// was stored, and then the current target is kept and written on the next
+    /// save.
+    /// </summary>
+    public VirtualCrossoverTargetSettings? Target { get; set; }
     public int SmoothingInverseOctaves { get; set; } = 12;
 
     // The psychoacoustic magnitude smoothing mode (see SpectrumSmoothing in

--- a/tests/Resonalyze.App.Tests/EqTargetCurveNormalizationTests.cs
+++ b/tests/Resonalyze.App.Tests/EqTargetCurveNormalizationTests.cs
@@ -1,0 +1,117 @@
+using System.Drawing;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// A target read from a file is not only drawn — it also fills the target
+/// settings dialog, which clamps every number into a control by casting it to
+/// decimal and reads its enums back out of combo boxes. A non-finite number
+/// throws on that cast and an undefined enum leaves a box with no selection, and
+/// both are reachable: the session and settings files allow named
+/// floating-point literals, and the enum converter accepts numbers as well as
+/// names. So every target that comes off disk is normalized first.
+/// </summary>
+public sealed class EqTargetCurveNormalizationTests
+{
+    [Fact]
+    public void Normalized_ReplacesWhatTheUiCannotTake()
+    {
+        var corrupt = new EqTargetCurve(
+            (TargetPreset)999,
+            new TargetCurveSpec(
+                double.NaN,
+                double.PositiveInfinity,
+                double.NaN,
+                1.5,
+                0,
+                5_000,
+                double.NegativeInfinity,
+                0,
+                3_000,
+                1.0),
+            ToleranceDb: double.NaN,
+            (TargetDeviationMode)42,
+            Color.FromArgb(255, 240, 120, 40),
+            StrokeThickness: double.NaN,
+            (OverlayLineStyle)7,
+            SmoothingInverseOctaves: 6);
+
+        EqTargetCurve clean = corrupt.Normalized();
+
+        TargetCurveSpec flat = TargetCurveSpec.FromPreset(TargetPreset.Flat);
+        Assert.Equal(TargetPreset.Flat, clean.Preset);
+        Assert.Equal(flat.TiltDbPerOctave, clean.Spec.TiltDbPerOctave);
+        Assert.Equal(flat.BassShelfGainDb, clean.Spec.BassShelfGainDb);
+        Assert.Equal(flat.BassShelfFrequencyHz, clean.Spec.BassShelfFrequencyHz);
+        Assert.Equal(flat.TrebleShelfWidthOctaves, clean.Spec.TrebleShelfWidthOctaves);
+        Assert.Equal(3, clean.ToleranceDb);
+        Assert.Equal(TargetDeviationMode.Deviation, clean.DeviationMode);
+        Assert.Equal(2, clean.StrokeThickness);
+        Assert.Equal(OverlayLineStyle.Dash, clean.LineStyle);
+        // Only the unusable fields move. The colour, the smoothing and the
+        // finite numbers are the user's and are left exactly as they were.
+        Assert.Equal(Color.FromArgb(255, 240, 120, 40), clean.Color);
+        Assert.Equal(6, clean.SmoothingInverseOctaves);
+        Assert.Equal(1.5, clean.Spec.BassShelfWidthOctaves);
+        Assert.Equal(5_000, clean.Spec.TrebleShelfFrequencyHz);
+    }
+
+    [Fact]
+    public void Normalized_LeavesAWellFormedTargetAlone()
+    {
+        var curve = new EqTargetCurve(
+            TargetPreset.Car,
+            TargetCurveSpec.FromPreset(TargetPreset.Car),
+            ToleranceDb: 2.5,
+            TargetDeviationMode.Deviation,
+            Color.FromArgb(255, 55, 200, 160),
+            StrokeThickness: 3.5,
+            OverlayLineStyle.DashDot,
+            SmoothingInverseOctaves: 0);
+
+        Assert.Equal(curve, curve.Normalized());
+    }
+
+    [Fact]
+    public void ASessionTargetThatCameBackCorrupt_StillOpensTheSettingsDialog()
+    {
+        // The end of the path the file feeds. Without the normalization the
+        // dialog's constructor throws on the decimal cast, so the button that
+        // shapes the target would be dead until the file was hand-repaired.
+        var stored = new VirtualCrossoverTargetSettings
+        {
+            Preset = (TargetPreset)999,
+            TiltDbPerOctave = double.NaN,
+            BassShelfGainDb = double.PositiveInfinity,
+            ToleranceDb = double.NaN,
+            DeviationMode = (TargetDeviationMode)42,
+            StrokeThickness = double.NaN,
+            LineStyle = (OverlayLineStyle)7
+        };
+
+        EqTargetCurve curve = stored.ToCurve();
+
+        using var dialog = new OverlayTargetSettingsDialog(
+            Mode.EqWizard,
+            "EQ target",
+            0,
+            curve.Preset,
+            curve.Spec,
+            curve.ToleranceDb,
+            curve.DeviationMode,
+            curve.Color,
+            curve.StrokeThickness,
+            curve.LineStyle,
+            100,
+            curve.SmoothingInverseOctaves,
+            [],
+            null,
+            isolatedTarget: true);
+
+        // And it reads back, rather than leaving a combo box with no selection
+        // for the Save path to dereference.
+        Assert.Equal(TargetPreset.Flat, dialog.Preset);
+        Assert.Equal(OverlayLineStyle.Dash, dialog.LineStyle);
+        Assert.Equal(TargetDeviationMode.Deviation, dialog.DeviationMode);
+    }
+}

--- a/tests/Resonalyze.App.Tests/EqTargetCurveSharingTests.cs
+++ b/tests/Resonalyze.App.Tests/EqTargetCurveSharingTests.cs
@@ -1,0 +1,65 @@
+using System.Drawing;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The EQ target is one definition shared by the EQ Wizard, which owns and
+/// persists it, and the Virtual DSP tool, which draws it over its predicted sum
+/// and can edit it back through the host. These pin the wizard's end of that
+/// contract: the round trip has to carry every field, and a push of the value
+/// the wizard already holds must not look like an edit — the host pushes on
+/// every settings change, so a false edit there would loop.
+/// </summary>
+public sealed class EqTargetCurveSharingTests
+{
+    [Fact]
+    public void ApplyTargetCurve_ReadsBackEveryFieldItWasGiven()
+    {
+        using var panel = new EqWizardPanel();
+        var curve = new EqTargetCurve(
+            TargetPreset.Car,
+            new TargetCurveSpec(-0.7, 9.2, 105, 0.9, -3, 10_000, 0.7, 1.5, 2_800, 1.2),
+            ToleranceDb: 2.5,
+            TargetDeviationMode.Deviation,
+            Color.FromArgb(255, 200, 120, 40),
+            StrokeThickness: 3.5,
+            OverlayLineStyle.DashDot,
+            SmoothingInverseOctaves: 6);
+
+        panel.ApplyTargetCurve(curve);
+
+        // Value equality on the record is the whole point: a field the setter
+        // forgot would silently reset that part of the user's target on the
+        // first visit to the Virtual DSP Target dialog.
+        Assert.Equal(curve, panel.TargetCurve);
+    }
+
+    [Fact]
+    public void ApplyTargetCurve_WithTheCurrentValue_IsNotAnEdit()
+    {
+        using var panel = new EqWizardPanel();
+        int changes = 0;
+        panel.SettingsChanged += () => changes++;
+
+        panel.ApplyTargetCurve(panel.TargetCurve);
+
+        Assert.Equal(0, changes);
+    }
+
+    [Fact]
+    public void ApplyTargetCurve_WithADifferentValue_ReportsTheChange()
+    {
+        using var panel = new EqWizardPanel();
+        int changes = 0;
+        panel.SettingsChanged += () => changes++;
+
+        panel.ApplyTargetCurve(panel.TargetCurve with
+        {
+            Spec = TargetCurveSpec.FromPreset(TargetPreset.HarmanRoom),
+            Preset = TargetPreset.HarmanRoom
+        });
+
+        Assert.Equal(1, changes);
+        Assert.Equal(TargetPreset.HarmanRoom, panel.TargetCurve.Preset);
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAcousticPlotZoomTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAcousticPlotZoomTests.cs
@@ -1,0 +1,118 @@
+using System.Numerics;
+using OxyPlot;
+using OxyPlot.Axes;
+using OxyPlot.WindowsForms;
+using Resonalyze.Options;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// What the Virtual DSP acoustic plot lets the mouse do per view. Phase is a
+/// wrapped angle, so its height is the whole range there is and stays locked;
+/// the impulse view's time axis zooms, which only works if the constant redraws
+/// stop re-arming it behind the user's back.
+/// </summary>
+public sealed class VirtualCrossoverAcousticPlotZoomTests
+{
+    private const int SampleRate = 48_000;
+
+    [Fact]
+    public void PhaseView_LocksTheHeightAndLeavesTheOtherViewsFree()
+    {
+        using var view = new PlotView();
+        var plot = new VirtualCrossoverAcousticPlot(view, "hint", AcousticView.Magnitude);
+        Axis value = ValueAxis(view);
+
+        Assert.True(value.IsZoomEnabled);
+        Assert.True(value.IsPanEnabled);
+
+        plot.ConfigureForView(AcousticView.Phase);
+        Assert.False(value.IsZoomEnabled);
+        Assert.False(value.IsPanEnabled);
+
+        // Locked for the phase view only — the toggle back must give the dB and
+        // the normalized impulse axes their zoom again.
+        plot.ConfigureForView(AcousticView.Magnitude);
+        Assert.True(value.IsZoomEnabled);
+        Assert.True(value.IsPanEnabled);
+
+        plot.ConfigureForView(AcousticView.Impulse);
+        Assert.True(value.IsZoomEnabled);
+    }
+
+    [Fact]
+    public void ImpulseView_RedrawnOnTheSameWindow_KeepsTheZoom()
+    {
+        using var view = new PlotView();
+        var plot = new VirtualCrossoverAcousticPlot(view, "hint", AcousticView.Impulse);
+        plot.Draw(Render(gateOffsetMs: 10));
+
+        Axis time = TimeAxis(view);
+        Assert.True(time.IsZoomEnabled);
+
+        time.Zoom(9.8, 10.2);
+        Update(view);
+        Assert.Equal(9.8, time.ActualMinimum, 6);
+        Assert.Equal(10.2, time.ActualMaximum, 6);
+
+        // Every chain edit redraws this view. The window has not moved, so the
+        // zoom must still be there afterwards.
+        plot.Draw(Render(gateOffsetMs: 10));
+        Update(view);
+
+        Assert.Equal(9.8, time.ActualMinimum, 6);
+        Assert.Equal(10.2, time.ActualMaximum, 6);
+    }
+
+    [Fact]
+    public void ImpulseView_RedrawnOnAMovedWindow_ReArmsToIt()
+    {
+        using var view = new PlotView();
+        var plot = new VirtualCrossoverAcousticPlot(view, "hint", AcousticView.Impulse);
+        plot.Draw(Render(gateOffsetMs: 10));
+
+        Axis time = TimeAxis(view);
+        time.Zoom(9.8, 10.2);
+        Update(view);
+
+        // A gate move is a new timeline, not a redraw of the old one: the zoom
+        // was taken on a window that no longer exists.
+        plot.Draw(Render(gateOffsetMs: 25));
+        Update(view);
+
+        Assert.True(time.ActualMaximum - time.ActualMinimum > 1);
+        Assert.Equal(time.AbsoluteMinimum, time.ActualMinimum, 6);
+        Assert.Equal(time.AbsoluteMaximum, time.ActualMaximum, 6);
+    }
+
+    private static AcousticRender Render(double gateOffsetMs)
+    {
+        var impulse = new AcousticImpulseRender(
+            [MakeTrace("A", peakSample: 480), MakeTrace("B", peakSample: 960)],
+            SampleRate,
+            gateOffsetMs,
+            LeftMs: 0.5,
+            PlateauMs: 15,
+            RightMs: 5);
+        return new AcousticRender(string.Empty, [], impulse);
+    }
+
+    private static IrPreviewTrace MakeTrace(string title, int peakSample)
+    {
+        var samples = new Complex[4096];
+        samples[peakSample] = new Complex(1.0, 0);
+        return new IrPreviewTrace(samples, title, OxyColors.White);
+    }
+
+    private static Axis ValueAxis(PlotView view) =>
+        view.Model!.Axes.First(axis => axis.Position == AxisPosition.Left);
+
+    private static Axis TimeAxis(PlotView view) =>
+        view.Model!.Axes.First(axis =>
+            axis.Position == AxisPosition.Bottom && axis is LinearAxis);
+
+    // ActualMinimum/Maximum are only recomputed while the model updates, which
+    // a headless test never triggers by painting.
+    private static void Update(PlotView view) =>
+        ((IPlotModel)view.Model!).Update(false);
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -880,6 +880,178 @@ public sealed class VirtualCrossoverProjectFileTests
         }
     }
 
+    [Fact]
+    public void ShowSumCurveOnPhase_WithNoAnswerOfItsOwn_InheritsTheMagnitudeOne()
+    {
+        // A session written before the two views answered separately carries one
+        // flag, and that is what it used to draw on BOTH plots. Inheriting it is
+        // what makes such a file open looking the way it was left.
+        var project = new VirtualCrossoverProjectFile { ShowSumCurve = false };
+        Assert.Null(project.ShowSumCurvePhase);
+        Assert.False(project.ShowSumCurveOnPhase);
+
+        project.ShowSumCurve = true;
+        Assert.True(project.ShowSumCurveOnPhase);
+    }
+
+    [Fact]
+    public void ShowSumCurveOnPhase_OnceAnswered_StopsFollowingTheMagnitudeOne()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var saved = new VirtualCrossoverProjectFile
+            {
+                ShowSumCurve = false,
+                ShowSumCurveOnPhase = true
+            };
+            Assert.False(saved.ShowSumCurve);
+            Assert.True(saved.ShowSumCurveOnPhase);
+
+            saved.Save(root);
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.False(loaded.ShowSumCurve);
+            Assert.True(loaded.ShowSumCurveOnPhase);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadOrDefault_ProjectWithoutATarget_LoadsWithTheCurveHidden()
+    {
+        // The EQ target on the acoustic plot is additive, like the all-pass above:
+        // a session written before it existed carries neither key. Where its
+        // absence lands matters — a target the user never asked for must not
+        // appear over their sum, and it must not appear at some inherited level.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var saved = new VirtualCrossoverProjectFile
+            {
+                ShowTargetCurve = true,
+                TargetLevelDb = -38
+            };
+            saved.Save(root);
+
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            JsonNode file = JsonNode.Parse(File.ReadAllText(path))!;
+            JsonObject project = file.AsObject();
+            Assert.True(project.Remove("showTargetCurve"));
+            Assert.True(project.Remove("targetLevelDb"));
+            File.WriteAllText(path, file.ToJsonString());
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.False(loaded.ShowTargetCurve);
+            Assert.Equal(0, loaded.TargetLevelDb);
+            loaded.Validate();
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Save_CarriesTheCustomTargetShapeUnchanged()
+    {
+        // The shape itself, not a preset name: a preset's numbers can change
+        // between versions, while a session has to open aiming at exactly the
+        // curve it was tuned against.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var curve = new EqTargetCurve(
+                TargetPreset.Custom,
+                new TargetCurveSpec(
+                    -0.65, 7.5, 92, 0.8, -2.5, 9_500, 0.65, 1.25, 2_650, 1.1),
+                ToleranceDb: 2.5,
+                TargetDeviationMode.Deviation,
+                System.Drawing.Color.FromArgb(255, 240, 120, 40),
+                StrokeThickness: 3.5,
+                OverlayLineStyle.DashDot,
+                SmoothingInverseOctaves: 6);
+            var saved = new VirtualCrossoverProjectFile
+            {
+                Target = VirtualCrossoverTargetSettings.FromCurve(curve)
+            };
+            saved.Save(root);
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.NotNull(loaded.Target);
+            // Value equality on the record is the check: a field the mapping
+            // dropped would hand back a different curve than the one tuned.
+            Assert.Equal(curve, loaded.Target!.ToCurve());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadOrDefault_ProjectWithoutATarget_CarriesNone()
+    {
+        // Absence is a real state, and it means "no target of its own" rather
+        // than a default one: the panel keeps the app's current target and
+        // starts storing it, instead of retuning it to a flat line.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            new VirtualCrossoverProjectFile { ShowTargetCurve = true }.Save(root);
+
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            JsonNode file = JsonNode.Parse(File.ReadAllText(path))!;
+            file.AsObject().Remove("target");
+            File.WriteAllText(path, file.ToJsonString());
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.Null(loaded.Target);
+            loaded.Validate();
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Save_KeepsTheTargetVisibilityAndLevel()
+    {
+        // The target SHAPE is the EQ Wizard's and is deliberately not stored
+        // here; the level is, because it belongs to this plot's dB reference.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var saved = new VirtualCrossoverProjectFile
+            {
+                ShowTargetCurve = true,
+                TargetLevelDb = -38.5
+            };
+            saved.Save(root);
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.True(loaded.ShowTargetCurve);
+            Assert.Equal(-38.5, loaded.TargetLevelDb);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static string CreateTemporaryDirectory()
     {
         string path = Path.Combine(


### PR DESCRIPTION
## The target

The tool that predicts the sum and the tool that corrects it now aim at one
curve. The EQ target moves into `EqTargetCurve` — one definition the EQ Wizard
owns and persists — and the shell pushes it into Virtual DSP and takes back
whatever its own **Target...** dialog produced. Both sides ignore a value equal
to what they hold, so the write-back cannot loop through `SettingsChanged`.

- The dialog is the wizard's own `OverlayTargetSettingsDialog` in isolated mode,
  previewing live on the Virtual DSP plot. It is opened as `Mode.EqWizard`, not
  as this tool's mode: the mode decides which smoothing vocabulary the dialog
  offers, and one target edited from two places must not come back different
  depending on which button opened it.
- The session carries the target too — the whole custom shape rather than a
  preset name, because a preset's numbers can change between versions while a
  session has to open aiming at the curve it was tuned against. Loading a session
  applies it as the app's target; a session written before targets were stored
  carries none, keeps the current one, and starts carrying it.
- The level is a session property, not a target property: these curves are
  transfer-function dB with no absolute reference, so a dB box beside the
  checkbox says where the target hangs and that number stays with the
  measurement set. Auto-fitting it to the Sum was considered and declined.

## The strip between the plots

The row under the acoustic plot mixed what is drawn with how it is read, and the
calibration selector had no caption at all. It is now a labelled **Curves** row
(Sum, Sum loss, Target, its level and dialog, Mic cal) over a **View** row (the
quantity radios, Smoothing, Gate), with even 8 px gaps inside a group and 24 px
between groups. The lower plot lost 15 px and the two Auto buttons moved down to
make room. Layout was picked from renders of the real panel, not from a
description.

Each curve toggle is muted on the views that cannot draw its curve — the Sum
survives on the phase plot but not among the impulse traces, sum loss and target
are magnitude-only. Muted rather than disabled, because WinForms paints a
disabled CheckBox in a system grey that reads as near-black on this theme; the
Target toggle is coloured by hand rather than through
`UiStyle.SetTextEnabledLook`, which memorizes the colour it mutes and would hand
back a stale target's colour. The **Target...** button is never disabled: it
switches to the Magnitude view instead, the only one its preview means anything
on.

The **Sum** now keeps a separate answer per view. The phase answer is additive
and inherits the magnitude one, so an older session opens looking the way it was
left.

## Axes

- **Phase height locked.** ±180° is the entire range a wrapped phase can occupy,
  so zooming it would only push curves off screen while implying there is more
  out of view. Locked rather than bounded, which also drops the axis from the
  double-click limits dialog and leaves a drag panning frequency alone.
- **Impulse time axis zooms and pans** within its gate window. That needed the
  redraw path to stop re-arming the range on every redraw — every chain edit is
  one — so it now re-arms only when the window itself moves.

## Also

- The gate/crossover warning moved out of the panel into the shell's right-hand
  column, above the sum-loss read-out it invalidates. That is what freed the
  strip. The panel reports the line through a callback and no longer owns a
  label; the manual-tooltip wiring both read-outs need is one helper now.
- Third copy of the `OverlayLineStyle` → OxyPlot `LineStyle` mapping removed:
  overlays, the wizard and Virtual DSP share `OverlayLineStyles.ToOxy`.

## Testing

`dotnet build` clean (warnings are errors) and `dotnet test` green: 1162 App +
1167 Dsp + 142 Audio.

New tests pin the contracts a silent drop would ruin: the wizard's target round
trip across all eight fields, the loop guard on an equal push, the session round
trip of a custom shape, the additive flags' inheritance, and the two axis rules
(the impulse zoom test was checked against the old behaviour and fails there).

UI behaviour that is not unit-testable was driven through the real panel in a
scratchpad harness: the target curve's points at a set level (Car preset at
−38 dB reads −28.85 dB at 20 Hz, −37.99 at 1 kHz, −40.84 at 20 kHz), the muted
colours, the toggle's colour round trip across a recolour while muted, the
per-view Sum memory, and the session write path including the guard that stops
it writing before the project is read.

⚠️ `assets/images/visual_dsp.png` in the README is now stale — the strip is
regrouped and the warning has moved. It needs re-capturing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
