### PR TITLE
Let the Virtual DSP copy pick what travels, share the block switches, and animate the update notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1245,7 +1245,8 @@ The **Virtual DSP** (under the **Tools** tab) is the summation-prediction
 workflow taken to its conclusion: measure each driver once, then design the whole
 DSP setup virtually. Channels (A, B, C, …) are stereo **L/R pairs**, each side
 picking its own measurement and running its own chain. **L / R** radios switch
-which side the controls edit, **L→R** / **R→L** copy chain settings across sides,
+which side the controls edit, **L→R** / **R→L** copy chain settings across sides
+(a dialog picks the channels and which parts travel — see below),
 and a **Mono** checkbox turns a pair into a single shared driver — the typical
 one-subwoofer car layout — feeding both sides' sums. The setup grows from two up
 to eight pairs, and **+/−** folds a block down to its header. Every channel in a
@@ -1271,9 +1272,21 @@ Each channel runs through:
 - **Mute** and **Bypass** — Mute removes a channel from the plots, sum, loss
   metric and Auto delay; Bypass keeps it in the sum but feeds its raw measured
   signal, for an A/B against the processed result (Auto delay refuses to run
-  while any participant is bypassed)
+  while any participant is bypassed). Both belong to the BLOCK: they are shared
+  by its two sides, so muting a driver mutes the pair rather than half of it
 - **IR polarity** — a measured Normal / Inverted / Unknown indicator read from the
   transfer IR, independent of the virtual polarity switch
+
+**L→R** / **R→L** ask before they act: a dialog lists the stereo pairs (mono
+pairs have a single settings set, so they never appear) and the parts of the
+chain to carry over — **Gain**, **Delay**, **Invert**, **Crossover**,
+**All-pass** and **PEQ**. The filters are ticked by default because they
+describe the driver; gain, delay and polarity start unticked, because each is
+tuned against that side's own level and geometry — a left tweeter's arrival is
+not a right tweeter's. Sources are never copied: every side keeps its own
+measurement. **Mute**, **Bypass** and the two curve toggles are absent from the
+list because they are shared by the two sides already — there is nothing to
+copy.
 
 Because every stage is linear and the measurements are loopback-referenced
 transfer IRs, multiplying each measurement by its chain and summing the results
@@ -1282,7 +1295,9 @@ capture after dialing those settings into the hardware. The filters are evaluate
 as the **digital biquad cascades a real DSP runs**, so the prediction matches
 miniDSP-class hardware up to Nyquist, not just an analog textbook curve.
 
-The acoustic plot shows raw and processed curves per channel for the active side,
+The acoustic plot shows raw and processed curves per channel for the active side
+(the two per-channel curve checkboxes belong to the block, so a side switch
+redraws the same curves from the other side's measurement),
 the complex **Sum**, the **opposite side's Sum** as a dashed translucent curve,
 and the **Sum loss** curve, with a **Phase view** toggle and a **Sum loss**
 read-out (avg / dip per junction plus a total). Its **Gate...** dialog exposes

--- a/README.md
+++ b/README.md
@@ -1283,13 +1283,14 @@ Each channel runs through:
 **L→R** / **R→L** ask before they act: a dialog lists the stereo pairs (mono
 pairs have a single settings set, so they never appear) and the parts of the
 chain to carry over — **Gain**, **Delay**, **Invert**, **Crossover**,
-**All-pass** and **PEQ**. The filters are ticked by default because they
-describe the driver; gain, delay and polarity start unticked, because each is
-tuned against that side's own level and geometry — a left tweeter's arrival is
-not a right tweeter's. Sources are never copied: every side keeps its own
-measurement. **Mute**, **Bypass** and the two curve toggles are absent from the
-list because they are shared by the two sides already — there is nothing to
-copy.
+**All-pass** and **PEQ**. The crossover and the PEQ are ticked by default,
+because the magnitude shape describes the driver. Everything that aligns a side
+against its own level and geometry starts unticked — gain, delay, polarity and
+the all-pass, which belongs with them precisely because it is the tool for a
+junction a delay and a polarity flip cannot fix, and that junction is the
+side's own. Sources are never copied: every side keeps its own measurement.
+**Mute**, **Bypass** and the two curve toggles are absent from the list because
+they are shared by the two sides already — there is nothing to copy.
 
 Because every stage is linear and the measurements are loopback-referenced
 transfer IRs, multiplying each measurement by its chain and summing the results

--- a/README.md
+++ b/README.md
@@ -158,8 +158,11 @@ data: by default every build keeps settings, history, overlays, Virtual DSP stat
 and logs in `%LocalAppData%\Resonalyze`. To make a `.zip` build fully portable,
 create an empty file named `portable.flag` next to `Resonalyze.exe`. When a newer
 release is detected, the version label in the title bar changes to **Update
-available**: installed builds can start an **Automatic Update**, portable builds
-offer a manual download.
+available** and breathes slowly between grey and blue so it is noticed on a bar
+nobody looks at: installed builds can start an **Automatic Update**, portable
+builds offer a manual download. The pulse pauses while the window is in the
+background, stops once you follow the link, and never starts at all when Windows
+is set to show no animations (Settings → Accessibility → Visual effects).
 
 > **Windows SmartScreen note:** the builds are not code-signed (certificates are
 > expensive for a free open-source project), so the first launch may show a

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
@@ -368,13 +368,15 @@ public partial class VirtualCrossoverChannelControl : UserControl
             buttonMute,
             "Mute the channel: exclude it from the sum, the loss,\r\n" +
             "the metric, Auto delay and both plots — a quick\r\n" +
-            "\"what changes without this driver\" check.");
+            "\"what changes without this driver\" check.\r\n" +
+            "Shared by both sides — the driver pair is muted as one.");
         toolTip.SetToolTip(
             checkBoxBypass,
             "Bypass the DSP chain: feed the raw measured signal with\r\n" +
             "no gain, delay, polarity, crossover, all-pass or PEQ —\r\n" +
             "the driver's natural band-pass, for an A/B against the\r\n" +
-            "processed result.");
+            "processed result.\r\n" +
+            "Shared by both sides, like Mute.");
         toolTip.SetToolTip(
             checkBoxMono,
             "One physical driver serving both sides (typically the\r\n" +
@@ -477,11 +479,15 @@ public partial class VirtualCrossoverChannelControl : UserControl
             checkBoxShowRaw,
             "Plot this channel's raw measured response — the driver\r\n" +
             "before the DSP chain, drawn translucent for an A/B\r\n" +
-            "against the processed trace.");
+            "against the processed trace.\r\n" +
+            "The toggle is shared by both sides; each side draws its\r\n" +
+            "own measurement.");
         toolTip.SetToolTip(
             checkBoxShowProcessed,
             "Plot this channel's processed response — the measured\r\n" +
-            "driver after gain, delay, polarity, the crossover and PEQ.");
+            "driver after gain, delay, polarity, the crossover and PEQ.\r\n" +
+            "The toggle is shared by both sides; each side draws its\r\n" +
+            "own measurement.");
     }
 
     /// <summary>

--- a/source/Tools/VirtualCrossover/VirtualCrossoverCopySideDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverCopySideDialog.cs
@@ -7,10 +7,13 @@ namespace Resonalyze;
 /// settings set by definition. Sources are never copied: each side picks its
 /// own measurement.
 /// <para>
-/// The default selection is the POSITION-INDEPENDENT part of the chain — the
-/// filter shape, which describes the driver. Gain, delay and polarity are
-/// offered too, but off by default: each is tuned against the side's own level
-/// and geometry, and a left tweeter's arrival is not a right tweeter's.
+/// The default selection is the crossover and the PEQ — the magnitude shape,
+/// which describes the driver. Everything that aligns one side against its own
+/// level and geometry is offered too but starts off: gain, delay, polarity and
+/// the all-pass. The all-pass belongs with them rather than with the filters,
+/// because it exists exactly where a delay and a polarity flip are too blunt —
+/// it is tuned against that side's own junction, and a left tweeter's arrival is
+/// not a right tweeter's.
 /// </para>
 /// </summary>
 internal sealed class VirtualCrossoverCopySideDialog : Form
@@ -20,7 +23,7 @@ internal sealed class VirtualCrossoverCopySideDialog : Form
     private readonly CheckBox delayBox = CreateScopeBox("Delay", checkedByDefault: false);
     private readonly CheckBox invertBox = CreateScopeBox("Invert", checkedByDefault: false);
     private readonly CheckBox crossoverBox = CreateScopeBox("Crossover", checkedByDefault: true);
-    private readonly CheckBox allPassBox = CreateScopeBox("All-pass", checkedByDefault: true);
+    private readonly CheckBox allPassBox = CreateScopeBox("All-pass", checkedByDefault: false);
     private readonly CheckBox peqBox = CreateScopeBox("PEQ", checkedByDefault: true);
     private readonly Button copyButton =
         UiStyle.CreateDialogButton("Copy", DialogResult.OK, accent: true);
@@ -55,8 +58,8 @@ internal sealed class VirtualCrossoverCopySideDialog : Form
             ForeColor = UiPalette.TextHighlight,
             Margin = new Padding(0, 0, 0, 12),
             Text = "Pick the channels, then the parts of the chain to copy.\n" +
-                "Sources always stay with their side; gain, delay and polarity\n" +
-                "are tuned per side, so they start off."
+                "Sources always stay with their side; gain, delay, polarity and\n" +
+                "the all-pass are tuned per side, so they start off."
         });
 
         layout.Controls.Add(CreateSectionLabel("Channels"));
@@ -85,8 +88,8 @@ internal sealed class VirtualCrossoverCopySideDialog : Form
         layout.Controls.Add(channelList);
 
         layout.Controls.Add(CreateSectionLabel("What to copy"));
-        // Two columns that read as the split they are: what belongs to the side
-        // (left, off) against what belongs to the driver (right, on).
+        // Two columns that read as the split they are: what aligns this side
+        // (left, off) against what shapes the driver (right, on).
         var scopeTable = new TableLayoutPanel
         {
             AutoSize = true,
@@ -97,9 +100,9 @@ internal sealed class VirtualCrossoverCopySideDialog : Form
         scopeTable.Controls.Add(gainBox, 0, 0);
         scopeTable.Controls.Add(crossoverBox, 1, 0);
         scopeTable.Controls.Add(delayBox, 0, 1);
-        scopeTable.Controls.Add(allPassBox, 1, 1);
+        scopeTable.Controls.Add(peqBox, 1, 1);
         scopeTable.Controls.Add(invertBox, 0, 2);
-        scopeTable.Controls.Add(peqBox, 1, 2);
+        scopeTable.Controls.Add(allPassBox, 0, 3);
         foreach (CheckBox box in ScopeBoxes)
         {
             box.CheckedChanged += (_, _) => UpdateCopyEnabled();

--- a/source/Tools/VirtualCrossover/VirtualCrossoverCopySideDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverCopySideDialog.cs
@@ -1,15 +1,29 @@
 namespace Resonalyze;
 
 /// <summary>
-/// The channel picker behind the Virtual DSP "L→R" / "R→L" commands: which
-/// pairs have their DSP settings (gain, crossover, PEQ) copied from one side
-/// onto the other. Mono pairs never appear here — they have a single settings
-/// set by definition. Sources and delays are deliberately not copied: each
-/// side has its own measurement and its own arrival timing.
+/// The picker behind the Virtual DSP "L→R" / "R→L" commands: which pairs have
+/// their settings copied from one side onto the other, and which parts of the
+/// chain travel with them. Mono pairs never appear here — they have a single
+/// settings set by definition. Sources are never copied: each side picks its
+/// own measurement.
+/// <para>
+/// The default selection is the POSITION-INDEPENDENT part of the chain — the
+/// filter shape, which describes the driver. Gain, delay and polarity are
+/// offered too, but off by default: each is tuned against the side's own level
+/// and geometry, and a left tweeter's arrival is not a right tweeter's.
+/// </para>
 /// </summary>
 internal sealed class VirtualCrossoverCopySideDialog : Form
 {
     private readonly List<CheckBox> channelBoxes = new();
+    private readonly CheckBox gainBox = CreateScopeBox("Gain", checkedByDefault: false);
+    private readonly CheckBox delayBox = CreateScopeBox("Delay", checkedByDefault: false);
+    private readonly CheckBox invertBox = CreateScopeBox("Invert", checkedByDefault: false);
+    private readonly CheckBox crossoverBox = CreateScopeBox("Crossover", checkedByDefault: true);
+    private readonly CheckBox allPassBox = CreateScopeBox("All-pass", checkedByDefault: true);
+    private readonly CheckBox peqBox = CreateScopeBox("PEQ", checkedByDefault: true);
+    private readonly Button copyButton =
+        UiStyle.CreateDialogButton("Copy", DialogResult.OK, accent: true);
 
     public VirtualCrossoverCopySideDialog(
         bool fromRightToLeft,
@@ -18,65 +32,102 @@ internal sealed class VirtualCrossoverCopySideDialog : Form
         ArgumentNullException.ThrowIfNull(channelLabels);
 
         SuspendLayout();
-        Text = fromRightToLeft ? "Copy R → L" : "Copy L → R";
-        FormBorderStyle = FormBorderStyle.FixedDialog;
-        MaximizeBox = false;
-        MinimizeBox = false;
-        ShowInTaskbar = false;
-        StartPosition = FormStartPosition.CenterParent;
-        BackColor = Color.FromArgb(40, 44, 54);
-        ForeColor = Color.White;
-        Font = new Font("Segoe UI", 9F);
-        AutoScaleMode = AutoScaleMode.Font;
+        UiStyle.ApplyDarkDialog(
+            this,
+            new Size(340, 300),
+            fromRightToLeft ? "Copy R → L" : "Copy L → R");
+        // The channel list is as long as the project has stereo pairs, so the
+        // dialog sizes itself around the finished layout instead of around
+        // hand-computed 96-DPI coordinates that a scaled font would overrun.
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
 
-        var caption = new Label
+        var layout = new TableLayoutPanel
         {
             AutoSize = true,
-            ForeColor = Color.FromArgb(210, 214, 222),
-            Location = new Point(12, 12),
-            Text = "Copy gain, crossover and PEQ for the selected channels.\n" +
-                "Sources and delays stay with their side."
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            ColumnCount = 1,
+            Dock = DockStyle.Fill
         };
-        Controls.Add(caption);
+        layout.Controls.Add(new Label
+        {
+            AutoSize = true,
+            ForeColor = UiPalette.TextHighlight,
+            Margin = new Padding(0, 0, 0, 12),
+            Text = "Pick the channels, then the parts of the chain to copy.\n" +
+                "Sources always stay with their side; gain, delay and polarity\n" +
+                "are tuned per side, so they start off."
+        });
 
-        int y = 52;
+        layout.Controls.Add(CreateSectionLabel("Channels"));
+        var channelList = new FlowLayoutPanel
+        {
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            FlowDirection = FlowDirection.TopDown,
+            Margin = new Padding(4, 0, 0, 12),
+            WrapContents = false
+        };
         foreach (string label in channelLabels)
         {
             var box = new CheckBox
             {
                 AutoSize = true,
                 Checked = true,
-                Location = new Point(16, y),
+                Margin = new Padding(0, 2, 0, 2),
                 Text = label
             };
+            box.CheckedChanged += (_, _) => UpdateCopyEnabled();
             channelBoxes.Add(box);
-            Controls.Add(box);
-            y += 25;
+            channelList.Controls.Add(box);
         }
 
-        var okButton = new Button
+        layout.Controls.Add(channelList);
+
+        layout.Controls.Add(CreateSectionLabel("What to copy"));
+        // Two columns that read as the split they are: what belongs to the side
+        // (left, off) against what belongs to the driver (right, on).
+        var scopeTable = new TableLayoutPanel
         {
-            BackColor = Color.FromArgb(46, 51, 67),
-            DialogResult = DialogResult.OK,
-            FlatStyle = FlatStyle.Popup,
-            Location = new Point(160, y + 10),
-            Size = new Size(80, 26),
-            Text = "Copy"
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            ColumnCount = 2,
+            Margin = new Padding(4, 0, 0, 12)
         };
-        var cancelButton = new Button
+        scopeTable.Controls.Add(gainBox, 0, 0);
+        scopeTable.Controls.Add(crossoverBox, 1, 0);
+        scopeTable.Controls.Add(delayBox, 0, 1);
+        scopeTable.Controls.Add(allPassBox, 1, 1);
+        scopeTable.Controls.Add(invertBox, 0, 2);
+        scopeTable.Controls.Add(peqBox, 1, 2);
+        foreach (CheckBox box in ScopeBoxes)
         {
-            BackColor = Color.FromArgb(46, 51, 67),
-            DialogResult = DialogResult.Cancel,
-            FlatStyle = FlatStyle.Popup,
-            Location = new Point(248, y + 10),
-            Size = new Size(80, 26),
-            Text = "Cancel"
+            box.CheckedChanged += (_, _) => UpdateCopyEnabled();
+        }
+
+        layout.Controls.Add(scopeTable);
+
+        var buttons = new FlowLayoutPanel
+        {
+            Anchor = AnchorStyles.Right,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            FlowDirection = FlowDirection.RightToLeft,
+            Margin = new Padding(0),
+            WrapContents = false
         };
-        Controls.Add(okButton);
-        Controls.Add(cancelButton);
-        AcceptButton = okButton;
+        Button cancelButton = UiStyle.CreateDialogButton(
+            "Cancel",
+            DialogResult.Cancel,
+            accent: false);
+        buttons.Controls.Add(cancelButton);
+        buttons.Controls.Add(copyButton);
+        layout.Controls.Add(buttons);
+
+        Controls.Add(layout);
+        AcceptButton = copyButton;
         CancelButton = cancelButton;
-        ClientSize = new Size(340, y + 46);
+        UpdateCopyEnabled();
         ResumeLayout(false);
         PerformLayout();
     }
@@ -87,4 +138,63 @@ internal sealed class VirtualCrossoverCopySideDialog : Form
         .Where(item => item.Checked)
         .Select(item => item.index)
         .ToList();
+
+    /// <summary>The parts of the chain the user asked to carry over.</summary>
+    public VirtualCrossoverCopyScope Scope => new(
+        Gain: gainBox.Checked,
+        Delay: delayBox.Checked,
+        InvertPolarity: invertBox.Checked,
+        Crossover: crossoverBox.Checked,
+        AllPass: allPassBox.Checked,
+        Peq: peqBox.Checked);
+
+    private IEnumerable<CheckBox> ScopeBoxes =>
+        [gainBox, delayBox, invertBox, crossoverBox, allPassBox, peqBox];
+
+    private static CheckBox CreateScopeBox(string text, bool checkedByDefault)
+    {
+        return new CheckBox
+        {
+            AutoSize = true,
+            Checked = checkedByDefault,
+            Margin = new Padding(0, 2, 20, 2),
+            Text = text
+        };
+    }
+
+    private static Label CreateSectionLabel(string text)
+    {
+        return new Label
+        {
+            AutoSize = true,
+            Font = new Font("Segoe UI Semibold", 9F),
+            ForeColor = UiPalette.TextSecondary,
+            Margin = new Padding(0, 0, 0, 6),
+            Text = text
+        };
+    }
+
+    // A copy with no channel or no part selected would do nothing at all, which
+    // is worth saying with the button rather than with a silent no-op.
+    private void UpdateCopyEnabled()
+    {
+        copyButton.Enabled = channelBoxes.Exists(box => box.Checked) && !Scope.IsEmpty;
+    }
+}
+
+/// <summary>
+/// Which parts of a channel's chain a side-to-side copy carries. Everything the
+/// user did not tick is left as the target side had it.
+/// </summary>
+internal readonly record struct VirtualCrossoverCopyScope(
+    bool Gain,
+    bool Delay,
+    bool InvertPolarity,
+    bool Crossover,
+    bool AllPass,
+    bool Peq)
+{
+    /// <summary>True when the copy would carry nothing.</summary>
+    public bool IsEmpty =>
+        !Gain && !Delay && !InvertPolarity && !Crossover && !AllPass && !Peq;
 }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -219,19 +219,23 @@ internal sealed class VirtualCrossoverMetrics
             VirtualCrossoverChannel channel = channels[channelIndex];
             bool mono = channel.Pair.Mono;
 
+            // Mute and Bypass belong to the block, so they answer for both sides at
+            // once; only the measurements are per side.
+            if (!channel.Pair.Enabled || channel.Pair.Bypass)
+            {
+                continue;
+            }
+
             VirtualCrossoverChannelSettings leftSettings = channel.SideSettings(false);
             VirtualCrossoverChannelState leftState = channel.PhysicalSideState(false);
-            if (!leftSettings.Enabled || leftSettings.Bypass ||
-                leftState.ProcessingSource is not { } leftSource)
+            if (leftState.ProcessingSource is not { } leftSource)
             {
                 continue;
             }
 
             VirtualCrossoverChannelSettings rightSettings = channel.SideSettings(true);
             VirtualCrossoverChannelState rightState = channel.PhysicalSideState(true);
-            if (!mono &&
-                (!rightSettings.Enabled || rightSettings.Bypass ||
-                    rightState.ProcessingSource is not { }))
+            if (!mono && rightState.ProcessingSource is not { })
             {
                 continue;
             }
@@ -483,13 +487,13 @@ internal sealed class VirtualCrossoverMetrics
             VirtualCrossoverChannelSettings settings =
                 channel.SideSettings(rightSide);
             VirtualCrossoverChannelState state = channel.SideState(rightSide);
-            if (!settings.Enabled ||
+            if (!channel.Pair.Enabled ||
                 state.ProcessingSource is not { } source)
             {
                 continue;
             }
 
-            DspChannelChain chain = settings.Bypass
+            DspChannelChain chain = channel.Pair.Bypass
                 ? DspChannelChain.Identity
                 : settings.ToChain();
             jobs.Add(new SideProcessJob

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -745,11 +745,11 @@ public partial class VirtualCrossoverPanel : UserControl
         RedrawAll();
     }
 
-    // The "L→R" / "R→L" commands: copy the DSP-chain part of one side's
-    // settings (gain, crossover, PEQ) onto the other for the channels the user
-    // picks. Sources and delays stay side-specific — each side has its own
-    // measurement and its own arrival — and polarity stays with the alignment.
-    // Mono pairs have one settings set and are not offered.
+    // The "L→R" / "R→L" commands: copy one side's chain onto the other for the
+    // channels AND the chain parts the user picks in the dialog (see
+    // VirtualCrossoverCopySideDialog for what is ticked by default and why).
+    // The source is never copied — each side has its own measurement — and mono
+    // pairs, having one settings set, are not offered.
     private void CopySideSettings(bool fromRight)
     {
         List<VirtualCrossoverChannel> candidates = channels
@@ -772,18 +772,21 @@ public partial class VirtualCrossoverPanel : UserControl
             .ToList();
         using var dialog = new VirtualCrossoverCopySideDialog(fromRight, labels);
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
-            dialog.SelectedIndices.Count == 0)
+            dialog.SelectedIndices.Count == 0 ||
+            dialog.Scope.IsEmpty)
         {
             return;
         }
 
+        VirtualCrossoverCopyScope scope = dialog.Scope;
         bool targetSideShown = project.ActiveSideRight == !fromRight;
         foreach (int index in dialog.SelectedIndices)
         {
             VirtualCrossoverChannel channel = candidates[index];
             CopyChainSettings(
                 channel.SideSettings(fromRight),
-                channel.SideSettings(!fromRight));
+                channel.SideSettings(!fromRight),
+                scope);
             if (targetSideShown)
             {
                 ApplySettingsToControl(channel);
@@ -794,22 +797,53 @@ public partial class VirtualCrossoverPanel : UserControl
         RedrawAll();
     }
 
-    // The POSITION-INDEPENDENT part of one side, copied onto the other: the settings
-    // that describe the driver rather than where it sits. Delay, polarity and the
-    // all-pass are deliberately not among them — each aligns a driver against its own
-    // side's geometry, and a left tweeter's phase correction is not a right tweeter's.
+    // The parts of one side's chain the dialog ticked, written onto the other side;
+    // everything else is left as the target had it. The default ticks are the
+    // POSITION-INDEPENDENT settings — the ones that describe the driver rather than
+    // where it sits — while gain, delay and polarity are opt-in, because each aligns
+    // a driver against its own side's level and geometry, and a left tweeter's arrival
+    // is not a right tweeter's. The source measurement is never among them.
     // PeqBand is an immutable record, so a fresh list is a deep enough copy.
     private static void CopyChainSettings(
         VirtualCrossoverChannelSettings from,
-        VirtualCrossoverChannelSettings to)
+        VirtualCrossoverChannelSettings to,
+        VirtualCrossoverCopyScope scope)
     {
-        to.GainDb = from.GainDb;
-        to.CrossoverKind = from.CrossoverKind;
-        to.HighPassEdge = from.HighPassEdge;
-        to.LowPassEdge = from.LowPassEdge;
-        to.PeqPreampDb = from.PeqPreampDb;
-        to.PeqBands = from.PeqBands.ToList();
-        to.PeqSourceName = from.PeqSourceName;
+        if (scope.Gain)
+        {
+            to.GainDb = from.GainDb;
+        }
+
+        if (scope.Delay)
+        {
+            to.DelayMs = from.DelayMs;
+        }
+
+        if (scope.InvertPolarity)
+        {
+            to.InvertPolarity = from.InvertPolarity;
+        }
+
+        if (scope.Crossover)
+        {
+            to.CrossoverKind = from.CrossoverKind;
+            to.HighPassEdge = from.HighPassEdge;
+            to.LowPassEdge = from.LowPassEdge;
+        }
+
+        if (scope.AllPass)
+        {
+            to.AllPassType = from.AllPassType;
+            to.AllPassFrequencyHz = from.AllPassFrequencyHz;
+            to.AllPassQ = from.AllPassQ;
+        }
+
+        if (scope.Peq)
+        {
+            to.PeqPreampDb = from.PeqPreampDb;
+            to.PeqBands = from.PeqBands.ToList();
+            to.PeqSourceName = from.PeqSourceName;
+        }
     }
 
     // The side radios double as source indicators (● has at least one source,
@@ -1216,11 +1250,13 @@ public partial class VirtualCrossoverPanel : UserControl
             control.AllPassFrequencyInput.Value = control.AllPassFrequencyInput
                 .ClampValue(settings.AllPassFrequencyHz);
             control.AllPassQInput.Value = control.AllPassQInput.ClampValue(settings.AllPassQ);
-            control.ShowRawCheckBox.Checked = settings.ShowRawCurve;
-            control.ShowProcessedCheckBox.Checked = settings.ShowProcessedCurve;
-            control.BypassCheckBox.Checked = settings.Bypass;
+            // The four block-wide switches come off the PAIR, so the block keeps
+            // showing the same answer whichever side is on screen.
+            control.ShowRawCheckBox.Checked = channel.Pair.ShowRawCurve;
+            control.ShowProcessedCheckBox.Checked = channel.Pair.ShowProcessedCurve;
+            control.BypassCheckBox.Checked = channel.Pair.Bypass;
             control.MonoCheckBox.Checked = channel.Pair.Mono;
-            control.Muted = !settings.Enabled;
+            control.Muted = !channel.Pair.Enabled;
             control.Collapsed = channel.Pair.Collapsed;
         });
 
@@ -1242,10 +1278,10 @@ public partial class VirtualCrossoverPanel : UserControl
         settings.AllPassType = allPass.Type;
         settings.AllPassFrequencyHz = allPass.FrequencyHz;
         settings.AllPassQ = allPass.Q;
-        settings.ShowRawCurve = control.ShowRawCheckBox.Checked;
-        settings.ShowProcessedCurve = control.ShowProcessedCheckBox.Checked;
-        settings.Enabled = !control.Muted;
-        settings.Bypass = control.BypassCheckBox.Checked;
+        channel.Pair.ShowRawCurve = control.ShowRawCheckBox.Checked;
+        channel.Pair.ShowProcessedCurve = control.ShowProcessedCheckBox.Checked;
+        channel.Pair.Enabled = !control.Muted;
+        channel.Pair.Bypass = control.BypassCheckBox.Checked;
         channel.Pair.Mono = control.MonoCheckBox.Checked;
     }
 
@@ -1936,16 +1972,18 @@ public partial class VirtualCrossoverPanel : UserControl
             "● — at least one source is loaded on this side.");
         toolTip.SetToolTip(
             buttonCopyLeftToRight,
-            "Copy the LEFT side's gain, crossover and PEQ onto the\r\n" +
-            "RIGHT side for the channels you pick. Sources, delay,\r\n" +
-            "polarity and all-pass stay with their side; mono channels\r\n" +
-            "are not offered.");
+            "Copy the LEFT side onto the RIGHT side: a dialog picks the\r\n" +
+            "channels and the parts of the chain — crossover, all-pass\r\n" +
+            "and PEQ by default, gain, delay and polarity on request.\r\n" +
+            "Sources stay with their side; mono channels are not\r\n" +
+            "offered.");
         toolTip.SetToolTip(
             buttonCopyRightToLeft,
-            "Copy the RIGHT side's gain, crossover and PEQ onto the\r\n" +
-            "LEFT side for the channels you pick. Sources, delay,\r\n" +
-            "polarity and all-pass stay with their side; mono channels\r\n" +
-            "are not offered.");
+            "Copy the RIGHT side onto the LEFT side: a dialog picks the\r\n" +
+            "channels and the parts of the chain — crossover, all-pass\r\n" +
+            "and PEQ by default, gain, delay and polarity on request.\r\n" +
+            "Sources stay with their side; mono channels are not\r\n" +
+            "offered.");
         toolTip.SetToolTip(
             buttonAutoSetup,
             "Crossover wizard: detect each channel's driver type from\r\n" +
@@ -2120,13 +2158,13 @@ public partial class VirtualCrossoverPanel : UserControl
             {
                 VirtualCrossoverChannel channel = channels[i];
                 VirtualCrossoverChannelState state = channel.SideState(channel.ActiveRight);
-                if (!channel.Settings.Enabled ||
+                if (!channel.Pair.Enabled ||
                     state.ProcessingSource is not { } source)
                 {
                     continue;
                 }
 
-                DspChannelChain chain = channel.Settings.Bypass
+                DspChannelChain chain = channel.Pair.Bypass
                     ? DspChannelChain.Identity
                     : channel.Settings.ToChain();
                 snapshots.Add(new VirtualCrossoverChannelSnapshot(
@@ -2473,7 +2511,7 @@ public partial class VirtualCrossoverPanel : UserControl
         for (int i = 0; i < processed.Count; i++)
         {
             ProcessedChannel item = processed[i];
-            if (item.Channel.Settings.ShowRawCurve)
+            if (item.Channel.Pair.ShowRawCurve)
             {
                 AnalysisCurve raw = BuildRawMagnitudeCurve(
                     item.Channel.TransferImpulseResponse!,
@@ -2487,7 +2525,7 @@ public partial class VirtualCrossoverPanel : UserControl
                     LineStyle.Solid));
             }
 
-            if (item.Channel.Settings.ShowProcessedCurve)
+            if (item.Channel.Pair.ShowProcessedCurve)
             {
                 AnalysisCurve curve = magnitudes != null
                     ? magnitudes[i]
@@ -2640,7 +2678,7 @@ public partial class VirtualCrossoverPanel : UserControl
     private void UpdateCrossoverWarning(List<ProcessedChannel> processed)
     {
         List<ProcessedChannel> active = processed
-            .Where(item => !item.Channel.Settings.Bypass)
+            .Where(item => !item.Channel.Pair.Bypass)
             .ToList();
         if (active.Count < 2)
         {
@@ -2712,7 +2750,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // AlignmentReprocessor.
         List<VirtualCrossoverChannel> participants = channels
             .Where(channel =>
-                channel.Settings.Enabled && channel.TransferImpulseResponse != null)
+                channel.Pair.Enabled && channel.TransferImpulseResponse != null)
             .ToList();
         if (participants.Count < 2)
         {
@@ -2727,7 +2765,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // now and applies later, once bypass is switched off. Refuse the run
         // instead of computing an alignment that is wrong on both counts.
         List<VirtualCrossoverChannel> bypassed = participants
-            .Where(channel => channel.Settings.Bypass)
+            .Where(channel => channel.Pair.Bypass)
             .ToList();
         if (bypassed.Count > 0)
         {
@@ -3207,7 +3245,7 @@ public partial class VirtualCrossoverPanel : UserControl
         var right = new List<VirtualCrossoverSideAlignmentChannel>();
         foreach (VirtualCrossoverChannel channel in channels)
         {
-            if (channel.SideSettings(false).Enabled &&
+            if (channel.Pair.Enabled &&
                 channel.SideState(false).TransferImpulseResponse != null)
             {
                 var side = new VirtualCrossoverSideAlignmentChannel(channel, false);
@@ -3219,7 +3257,7 @@ public partial class VirtualCrossoverPanel : UserControl
             }
 
             if (!channel.Pair.Mono &&
-                channel.SideSettings(true).Enabled &&
+                channel.Pair.Enabled &&
                 channel.SideState(true).TransferImpulseResponse != null)
             {
                 right.Add(new VirtualCrossoverSideAlignmentChannel(channel, true));
@@ -3243,11 +3281,12 @@ public partial class VirtualCrossoverPanel : UserControl
             .Distinct()
             .ToList();
 
-        // Same reasoning as the single-side run: a bypassed side processes
+        // Same reasoning as the single-side run: a bypassed channel processes
         // through the identity chain, so the computed delay would silently not
-        // apply — refuse instead of proposing a wrong alignment.
+        // apply — refuse instead of proposing a wrong alignment. Bypass belongs
+        // to the block, so it takes both of its sides out at once.
         List<VirtualCrossoverSideAlignmentChannel> bypassed = union
-            .Where(item => item.Settings.Bypass)
+            .Where(item => item.Runtime.Pair.Bypass)
             .ToList();
         if (bypassed.Count > 0)
         {
@@ -3740,7 +3779,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // the Sum off, hidden channels' banks are skipped entirely.
         bool includeSum = processed.Count >= 2 && checkBoxShowSum.Checked;
         List<ProcessedChannel> gatedChannels = processed
-            .Where(item => includeSum || item.Channel.Settings.ShowProcessedCurve)
+            .Where(item => includeSum || item.Channel.Pair.ShowProcessedCurve)
             .ToList();
 
         // Read the gate and project state ONCE, here on the UI thread; the
@@ -3773,7 +3812,7 @@ public partial class VirtualCrossoverPanel : UserControl
         foreach ((ProcessedChannel item, Complex[] spectrum, int extractionStart)
             in gated)
         {
-            if (item.Channel.Settings.ShowProcessedCurve)
+            if (item.Channel.Pair.ShowProcessedCurve)
             {
                 jobs.Add((
                     item.Channel.Name, item.Color, 1.8, spectrum, extractionStart));
@@ -3848,7 +3887,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // Only the shown traces set the gate offset and the ms-axis window, so
         // an auto gate never centers on a channel whose curve is hidden.
         List<ProcessedChannel> shown = processed
-            .Where(item => item.Channel.Settings.ShowProcessedCurve)
+            .Where(item => item.Channel.Pair.ShowProcessedCurve)
             .ToList();
         if (shown.Count == 0)
         {
@@ -4542,7 +4581,7 @@ public partial class VirtualCrossoverPanel : UserControl
         for (int i = 0; i < channels.Count; i++)
         {
             VirtualCrossoverChannel channel = channels[i];
-            if (!channel.Settings.Enabled || channel.TransferImpulseResponse == null)
+            if (!channel.Pair.Enabled || channel.TransferImpulseResponse == null)
             {
                 continue;
             }
@@ -4552,7 +4591,7 @@ public partial class VirtualCrossoverPanel : UserControl
             // unreadable sawtooth and swamp the filter group delay (its effect is
             // visible on the acoustic plot). A bypassed channel draws its flat
             // identity chain.
-            DspChannelChain chain = channel.Settings.Bypass
+            DspChannelChain chain = channel.Pair.Bypass
                 ? DspChannelChain.Identity
                 : channel.Settings.ToChain() with { DelayMs = 0 };
             curves.Add(new DspChainCurve(
@@ -4965,7 +5004,7 @@ public partial class VirtualCrossoverPanel : UserControl
     private void OpenAutoSetupWizard()
     {
         var participating = channels
-            .Where(channel => channel.Settings.Enabled &&
+            .Where(channel => channel.Pair.Enabled &&
                 channel.TransferImpulseResponse != null)
             .ToList();
         if (participating.Count < 2)

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -799,9 +799,9 @@ public partial class VirtualCrossoverPanel : UserControl
 
     // The parts of one side's chain the dialog ticked, written onto the other side;
     // everything else is left as the target had it. The default ticks are the
-    // POSITION-INDEPENDENT settings — the ones that describe the driver rather than
-    // where it sits — while gain, delay and polarity are opt-in, because each aligns
-    // a driver against its own side's level and geometry, and a left tweeter's arrival
+    // crossover and the PEQ — the magnitude shape, which describes the driver —
+    // while gain, delay, polarity and the all-pass are opt-in, because each aligns a
+    // driver against its own side's level and geometry, and a left tweeter's arrival
     // is not a right tweeter's. The source measurement is never among them.
     // PeqBand is an immutable record, so a fresh list is a deep enough copy.
     private static void CopyChainSettings(
@@ -1973,15 +1973,15 @@ public partial class VirtualCrossoverPanel : UserControl
         toolTip.SetToolTip(
             buttonCopyLeftToRight,
             "Copy the LEFT side onto the RIGHT side: a dialog picks the\r\n" +
-            "channels and the parts of the chain — crossover, all-pass\r\n" +
-            "and PEQ by default, gain, delay and polarity on request.\r\n" +
+            "channels and the parts of the chain — crossover and PEQ by\r\n" +
+            "default, gain, delay, polarity and the all-pass on request.\r\n" +
             "Sources stay with their side; mono channels are not\r\n" +
             "offered.");
         toolTip.SetToolTip(
             buttonCopyRightToLeft,
             "Copy the RIGHT side onto the LEFT side: a dialog picks the\r\n" +
-            "channels and the parts of the chain — crossover, all-pass\r\n" +
-            "and PEQ by default, gain, delay and polarity on request.\r\n" +
+            "channels and the parts of the chain — crossover and PEQ by\r\n" +
+            "default, gain, delay, polarity and the all-pass on request.\r\n" +
             "Sources stay with their side; mono channels are not\r\n" +
             "offered.");
         toolTip.SetToolTip(

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -157,14 +157,24 @@ public sealed class VirtualCrossoverTargetSettings
 /// </summary>
 public sealed class VirtualCrossoverChannelSettings
 {
-    public bool Enabled { get; set; } = true;
-
-    /// <summary>
-    /// When set (and the channel is enabled), the channel contributes its raw
-    /// measured signal with the whole DSP chain bypassed — no gain, delay,
-    /// polarity, crossover or PEQ — for an A/B against the processed result.
-    /// </summary>
-    public bool Bypass { get; set; }
+    // Schema v6 payload, kept only so an older file deserializes for migration:
+    // Mute, Bypass and the two curve toggles describe the BLOCK rather than one
+    // side's measurement, so v7 moved them onto the pair (see
+    // VirtualCrossoverChannelPairSettings and the migration that folds these up).
+    // Nullable purely to tell "absent" from a real value; nothing but Migrate
+    // reads them, and it clears them once the pair carries the answer.
+    [JsonPropertyName("enabled")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? LegacyEnabled { get; set; }
+    [JsonPropertyName("bypass")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? LegacyBypass { get; set; }
+    [JsonPropertyName("showRawCurve")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? LegacyShowRawCurve { get; set; }
+    [JsonPropertyName("showProcessedCurve")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? LegacyShowProcessedCurve { get; set; }
 
     public string DisplayName { get; set; } = string.Empty;
     public string? SourceFilePath { get; set; }
@@ -221,10 +231,6 @@ public sealed class VirtualCrossoverChannelSettings
     public List<PeqBand> PeqBands { get; set; } = new();
     /// <summary>The PEQ file the bands came from; display only.</summary>
     public string? PeqSourceName { get; set; }
-
-    // Per-channel curve visibility on the acoustic plot.
-    public bool ShowRawCurve { get; set; }
-    public bool ShowProcessedCurve { get; set; } = true;
 
     public bool HasSource =>
         HistoryEntryId.HasValue || !string.IsNullOrWhiteSpace(SourceFilePath);
@@ -351,6 +357,27 @@ public sealed class VirtualCrossoverChannelPairSettings
     /// </summary>
     public bool Collapsed { get; set; }
 
+    /// <summary>
+    /// Whether the channel takes part at all — Mute in the tool. Shared by both
+    /// sides, like everything below: these four switches describe the BLOCK, not a
+    /// measurement. A driver pair is one part of the system, and muting the left
+    /// tweeter while the right one still plays describes no setup worth predicting;
+    /// per side they also made a side switch quietly change what the plot drew.
+    /// Moved here in schema v7 (see the migration).
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// When set (and the channel is enabled), the channel contributes its raw
+    /// measured signal with the whole DSP chain bypassed — no gain, delay,
+    /// polarity, crossover or PEQ — for an A/B against the processed result.
+    /// </summary>
+    public bool Bypass { get; set; }
+
+    // Curve visibility on the acoustic plot, per channel block.
+    public bool ShowRawCurve { get; set; }
+    public bool ShowProcessedCurve { get; set; } = true;
+
     public VirtualCrossoverChannelSettings Left { get; set; } = new();
     public VirtualCrossoverChannelSettings Right { get; set; } = new();
 
@@ -382,7 +409,7 @@ public sealed class VirtualCrossoverProjectFile
     // step in Migrate below. Files from a NEWER version (a downgraded app)
     // are never migrated: LoadOrDefault backs them up and starts fresh,
     // LoadFrom rejects them with an explicit error.
-    public const int CurrentVersion = 6;
+    public const int CurrentVersion = 7;
     public const int MaximumChannelCount = 8;
     private const string FileName = "virtual-crossover.json";
 
@@ -872,6 +899,44 @@ public sealed class VirtualCrossoverProjectFile
                 legacyUseCalibration: false);
             file.CalibrationMode = null;
             file.Version = 6;
+        }
+        if (file.Version == 6)
+        {
+            // v6 kept Mute, Bypass and the two curve toggles per SIDE, so switching
+            // sides could silently change what the block contributed and what the plot
+            // drew. They belong to the block, and v7 moves them onto the pair.
+            // The pair inherits the sides that actually carry a measurement — the single
+            // left slot of a mono pair, the one loaded side of a half-loaded pair — so
+            // every project that could not disagree opens exactly as it looked. Where two
+            // loaded sides DID disagree the louder answer wins: muted, bypassed and
+            // "curve shown" each survive, because a mute lost in a migration is the one
+            // outcome the tuner has no way to see coming.
+            foreach (VirtualCrossoverChannelPairSettings pair in file.Pairs)
+            {
+                VirtualCrossoverChannelSettings[] both = [pair.Left, pair.Right];
+                List<VirtualCrossoverChannelSettings> sides = pair.Mono
+                    ? [pair.Left]
+                    : both.Where(side => side.HasSource).ToList();
+                if (sides.Count == 0)
+                {
+                    sides = [pair.Left];
+                }
+
+                pair.Enabled = sides.TrueForAll(side => side.LegacyEnabled ?? true);
+                pair.Bypass = sides.Exists(side => side.LegacyBypass ?? false);
+                pair.ShowRawCurve = sides.Exists(side => side.LegacyShowRawCurve ?? false);
+                pair.ShowProcessedCurve =
+                    sides.Exists(side => side.LegacyShowProcessedCurve ?? true);
+                foreach (VirtualCrossoverChannelSettings side in both)
+                {
+                    side.LegacyEnabled = null;
+                    side.LegacyBypass = null;
+                    side.LegacyShowRawCurve = null;
+                    side.LegacyShowProcessedCurve = null;
+                }
+            }
+
+            file.Version = 7;
         }
 
         // The scene offset's wire SIGN and the layout flag state one fact

--- a/source/Ui/Controls/ChromeTitleBar.cs
+++ b/source/Ui/Controls/ChromeTitleBar.cs
@@ -25,6 +25,17 @@ internal sealed class ChromeTitleBar : Panel
     private const int HtBottomLeft = 16;
     private const int HtBottomRight = 17;
 
+    // Windows" "Show animations in Windows" switch - the platform reduced-motion
+    // setting (SPI_GETCLIENTAREAANIMATION).
+    private const int SpiGetClientAreaAnimation = 0x1042;
+
+    // The update notice breathes instead of sitting still: a slow fade between the
+    // version label ordinary grey and the accent blue catches the eye on a title
+    // bar nobody is looking at, without a blink flashing. The period is long
+    // enough to read as breathing rather than as a warning light.
+    private const int UpdatePulsePeriodMs = 1_800;
+    private const int UpdatePulseIntervalMs = 40;
+
     private readonly Dictionary<ModeTab, Button> modeTabButtons = new();
 
     private Form form = null!;
@@ -34,6 +45,8 @@ internal sealed class ChromeTitleBar : Panel
     private Button? toolsDropDownButton;
     private ContextMenuStrip? toolsMenu;
     private ModeTab lastToolsTab = ModeTab.ToolsVirtualCrossover;
+    private System.Windows.Forms.Timer? updatePulseTimer;
+    private int updatePulseElapsedMs;
     private float dpiScale = 1f;
     private int titleBarHeight = BarHeight;
     private int windowButtonWidth;
@@ -129,6 +142,14 @@ internal sealed class ChromeTitleBar : Panel
         IntPtr wParam,
         IntPtr lParam);
 
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SystemParametersInfo(
+        uint action,
+        uint parameter,
+        ref bool value,
+        uint update);
+
     public void SetActiveModeTab(ModeTab activeTab)
     {
         if (IsToolsTab(activeTab))
@@ -154,6 +175,7 @@ internal sealed class ChromeTitleBar : Panel
         UpdateVersionLabel(
             $"{ApplicationVersionInfo.GetDisplayVersion()}  Update available",
             releaseUrl);
+        StartUpdatePulse();
     }
 
     public static Point GetPointFromLParam(IntPtr lParam)
@@ -387,6 +409,7 @@ internal sealed class ChromeTitleBar : Panel
         if (disposing)
         {
             toolsMenu?.Dispose();
+            DetachUpdatePulse();
         }
 
         base.Dispose(disposing);
@@ -618,6 +641,107 @@ internal sealed class ChromeTitleBar : Panel
         UpdateTabBarLayout(tabBar);
     }
 
+    // Runs until the user follows the link - once they have opened the release
+    // page the notice has done its job and settles on the plain accent colour.
+    // Skipped entirely when Windows is set to show no animations.
+    private void StartUpdatePulse()
+    {
+        if (updatePulseTimer != null || !AnimationsEnabled())
+        {
+            return;
+        }
+
+        updatePulseTimer = new System.Windows.Forms.Timer
+        {
+            Interval = UpdatePulseIntervalMs
+        };
+        updatePulseTimer.Tick += UpdatePulseTick;
+        // Nobody reads a title bar that sits behind another window, and this repaints
+        // 25 times a second: the pulse follows the window's focus and parks on the
+        // plain accent colour meanwhile, so the notice is still highlighted there.
+        form.Activated += ResumeUpdatePulse;
+        form.Deactivate += SuspendUpdatePulse;
+        updatePulseTimer.Start();
+    }
+
+    private void ResumeUpdatePulse(object? sender, EventArgs e)
+    {
+        updatePulseTimer?.Start();
+    }
+
+    private void SuspendUpdatePulse(object? sender, EventArgs e)
+    {
+        if (updatePulseTimer == null)
+        {
+            return;
+        }
+
+        updatePulseTimer.Stop();
+        SetUpdateLinkColor(UiPalette.AccentBlueSoft);
+    }
+
+    private void UpdatePulseTick(object? sender, EventArgs e)
+    {
+        updatePulseElapsedMs =
+            (updatePulseElapsedMs + UpdatePulseIntervalMs) % UpdatePulsePeriodMs;
+        // A raised cosine, so the fade eases in and out instead of turning around
+        // at a corner the eye reads as a flicker.
+        double amount = 0.5 - 0.5 * Math.Cos(
+            2 * Math.PI * updatePulseElapsedMs / UpdatePulsePeriodMs);
+        SetUpdateLinkColor(Blend(
+            UiPalette.AccentBlueGlow, UiPalette.TitleBarText, amount));
+    }
+
+    private void StopUpdatePulse()
+    {
+        if (updatePulseTimer == null)
+        {
+            return;
+        }
+
+        DetachUpdatePulse();
+        SetUpdateLinkColor(UiPalette.AccentBlueSoft);
+    }
+
+    // Releases the timer and the form subscriptions without touching the label, so
+    // it is also safe from Dispose.
+    private void DetachUpdatePulse()
+    {
+        if (updatePulseTimer == null)
+        {
+            return;
+        }
+
+        form.Activated -= ResumeUpdatePulse;
+        form.Deactivate -= SuspendUpdatePulse;
+        updatePulseTimer.Stop();
+        updatePulseTimer.Dispose();
+        updatePulseTimer = null;
+    }
+
+    // ActiveLinkColor stays put: it paints while the link is held down, and a
+    // pressed link that keeps fading reads as a rendering glitch.
+    private void SetUpdateLinkColor(Color color)
+    {
+        versionLabel.LinkColor = color;
+        versionLabel.VisitedLinkColor = color;
+    }
+
+    private static Color Blend(Color foreground, Color background, double amount) =>
+        Color.FromArgb(
+            (int)(foreground.R * amount + background.R * (1 - amount)),
+            (int)(foreground.G * amount + background.G * (1 - amount)),
+            (int)(foreground.B * amount + background.B * (1 - amount)));
+
+    // Assume animations are welcome when the query fails: a missing answer is no
+    // reason to drop a notice the user asked the app to show.
+    private static bool AnimationsEnabled()
+    {
+        bool enabled = true;
+        return !SystemParametersInfo(SpiGetClientAreaAnimation, 0, ref enabled, 0) ||
+            enabled;
+    }
+
     private int GetModeTabWidth(string text) =>
         Math.Max(
             Scale(70),
@@ -639,13 +763,14 @@ internal sealed class ChromeTitleBar : Panel
             titleBarHeight - Scale(5));
     }
 
-    private static void VersionLabelLinkClicked(object? sender, LinkLabelLinkClickedEventArgs e)
+    private void VersionLabelLinkClicked(object? sender, LinkLabelLinkClickedEventArgs e)
     {
         if (e.Link?.LinkData is not string url || string.IsNullOrWhiteSpace(url))
         {
             return;
         }
 
+        StopUpdatePulse();
         Form? owner = sender is Control control
             ? control.FindForm()
             : null;

--- a/source/Ui/Controls/ChromeTitleBar.cs
+++ b/source/Ui/Controls/ChromeTitleBar.cs
@@ -661,7 +661,18 @@ internal sealed class ChromeTitleBar : Panel
         // plain accent colour meanwhile, so the notice is still highlighted there.
         form.Activated += ResumeUpdatePulse;
         form.Deactivate += SuspendUpdatePulse;
-        updatePulseTimer.Start();
+        // The check that brings this notice runs asynchronously at startup, so it can
+        // land while the user is already in another application — and the Deactivate
+        // that would have parked the pulse fired long before there was one. Start
+        // suspended in that case and let the next Activated pick it up.
+        if (Form.ActiveForm == form)
+        {
+            updatePulseTimer.Start();
+        }
+        else
+        {
+            SetUpdateLinkColor(UiPalette.AccentBlueSoft);
+        }
     }
 
     private void ResumeUpdatePulse(object? sender, EventArgs e)

--- a/source/Ui/UiPalette.cs
+++ b/source/Ui/UiPalette.cs
@@ -23,6 +23,9 @@ internal static class UiPalette
     public static Color AccentBlueStrong => Color.FromArgb(36, 86, 210);
     public static Color AccentBlueSoft => Color.FromArgb(106, 173, 255);
     public static Color AccentBlueSoftHover => Color.FromArgb(150, 210, 255);
+    // The bright end of the title bar update notice pulse: pale enough to read as a
+    // glow against the near-black bar, still blue enough to stay the link colour.
+    public static Color AccentBlueGlow => Color.FromArgb(196, 228, 255);
     public static Color AccentBlueMuted => Color.FromArgb(54, 58, 68);
     public static Color AccentBlueMutedAlt => Color.FromArgb(150, 32, 22);
     public static Color AccentBlueWarning => Color.FromArgb(196, 43, 28);

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -198,8 +198,8 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
         seen.Add(fingerprint, name);
         List<VirtualCrossoverChannel> participants = channels
             .Where(channel =>
-                channel.Settings.Enabled &&
-                !channel.Settings.Bypass &&
+                channel.Pair.Enabled &&
+                !channel.Pair.Bypass &&
                 channel.TransferImpulseResponse != null)
             .ToList();
         report.AppendLine();

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -332,10 +332,13 @@ public sealed class VirtualCrossoverProjectFileTests
             original.StereoLevelDifferenceDb = -1.5;
             original.ActiveSideRight = true;
             original.Pairs[0].Mono = true;
+            // Mute, Bypass and the curve toggles belong to the PAIR, not to a side.
+            original.Pairs[0].Enabled = false;
+            original.Pairs[0].Bypass = true;
+            original.Pairs[0].ShowRawCurve = true;
+            original.Pairs[0].ShowProcessedCurve = false;
             original.Pairs[0].Left = new VirtualCrossoverChannelSettings
             {
-                Enabled = false,
-                Bypass = true,
                 DisplayName = "Woofer",
                 SourceFilePath = @"C:\measurements\woofer.json",
                 HistoryEntryId = Guid.NewGuid(),
@@ -347,9 +350,7 @@ public sealed class VirtualCrossoverProjectFileTests
                     CrossoverFilterFamily.Butterworth, 1_800, 18),
                 PeqPreampDb = -1.5,
                 PeqBands = [new PeqBand(120, 2.0, -4.0), new PeqBand(900, 1.0, 2.0)],
-                PeqSourceName = "woofer-peq.txt",
-                ShowRawCurve = true,
-                ShowProcessedCurve = false
+                PeqSourceName = "woofer-peq.txt"
             };
 
             original.Save(root);
@@ -382,11 +383,16 @@ public sealed class VirtualCrossoverProjectFileTests
             Assert.Equal(original.ActiveSideRight, loaded.ActiveSideRight);
             Assert.Equal(original.Pairs.Count, loaded.Pairs.Count);
             Assert.True(loaded.Pairs[0].Mono);
+            Assert.Equal(original.Pairs[0].Enabled, loaded.Pairs[0].Enabled);
+            Assert.Equal(original.Pairs[0].Bypass, loaded.Pairs[0].Bypass);
+            Assert.Equal(
+                original.Pairs[0].ShowRawCurve, loaded.Pairs[0].ShowRawCurve);
+            Assert.Equal(
+                original.Pairs[0].ShowProcessedCurve,
+                loaded.Pairs[0].ShowProcessedCurve);
 
             VirtualCrossoverChannelSettings expected = original.Pairs[0].Left;
             VirtualCrossoverChannelSettings actual = loaded.Pairs[0].Left;
-            Assert.Equal(expected.Enabled, actual.Enabled);
-            Assert.Equal(expected.Bypass, actual.Bypass);
             Assert.Equal(expected.DisplayName, actual.DisplayName);
             Assert.Equal(expected.SourceFilePath, actual.SourceFilePath);
             Assert.Equal(expected.HistoryEntryId, actual.HistoryEntryId);
@@ -399,8 +405,6 @@ public sealed class VirtualCrossoverProjectFileTests
             Assert.Equal(expected.PeqPreampDb, actual.PeqPreampDb);
             Assert.Equal(expected.PeqBands, actual.PeqBands);
             Assert.Equal(expected.PeqSourceName, actual.PeqSourceName);
-            Assert.Equal(expected.ShowRawCurve, actual.ShowRawCurve);
-            Assert.Equal(expected.ShowProcessedCurve, actual.ShowProcessedCurve);
         }
         finally
         {
@@ -1045,6 +1049,105 @@ public sealed class VirtualCrossoverProjectFileTests
 
             Assert.True(loaded.ShowTargetCurve);
             Assert.Equal(-38.5, loaded.TargetLevelDb);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadOrDefault_V6Project_ReadsTheSwitchesOffTheLoadedSides()
+    {
+        // v6 kept Mute, Bypass and the curve toggles per side. The pair inherits the
+        // sides that actually carry a measurement, so a mono pair (its right slot is
+        // unreachable and still holds the defaults) opens exactly as it looked.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var saved = new VirtualCrossoverProjectFile();
+            saved.Save(root);
+
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            JsonNode file = JsonNode.Parse(File.ReadAllText(path))!;
+            file["version"] = 6;
+            JsonObject pair = file["pairs"]![0]!.AsObject();
+            pair["mono"] = true;
+            foreach (string moved in
+                new[] { "enabled", "bypass", "showRawCurve", "showProcessedCurve" })
+            {
+                pair.Remove(moved);
+            }
+
+            JsonObject left = pair["left"]!.AsObject();
+            left["sourceFilePath"] = @"C:\measurements\sub.json";
+            left["enabled"] = false;
+            left["bypass"] = true;
+            left["showRawCurve"] = true;
+            left["showProcessedCurve"] = false;
+            // The unreachable right slot still holds v6 defaults; they must not win.
+            JsonObject right = pair["right"]!.AsObject();
+            right["enabled"] = true;
+            right["bypass"] = false;
+            right["showRawCurve"] = false;
+            right["showProcessedCurve"] = true;
+            File.WriteAllText(path, file.ToJsonString());
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.Equal(VirtualCrossoverProjectFile.CurrentVersion, loaded.Version);
+            Assert.False(loaded.Pairs[0].Enabled);
+            Assert.True(loaded.Pairs[0].Bypass);
+            Assert.True(loaded.Pairs[0].ShowRawCurve);
+            Assert.False(loaded.Pairs[0].ShowProcessedCurve);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadOrDefault_V6ProjectWhoseSidesDisagree_KeepsTheLouderAnswer()
+    {
+        // Two loaded sides could hold opposite switches, and one answer has to win.
+        // Muted, bypassed and "curve shown" each survive: a mute lost in a migration
+        // is the one outcome the tuner has no way to see coming.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var saved = new VirtualCrossoverProjectFile();
+            saved.Save(root);
+
+            string path = VirtualCrossoverProjectFile.GetPath(root);
+            JsonNode file = JsonNode.Parse(File.ReadAllText(path))!;
+            file["version"] = 6;
+            JsonObject pair = file["pairs"]![0]!.AsObject();
+            foreach (string moved in
+                new[] { "enabled", "bypass", "showRawCurve", "showProcessedCurve" })
+            {
+                pair.Remove(moved);
+            }
+
+            JsonObject left = pair["left"]!.AsObject();
+            left["sourceFilePath"] = @"C:\measurements	weeter-l.json";
+            left["enabled"] = false;
+            left["bypass"] = false;
+            left["showRawCurve"] = true;
+            JsonObject right = pair["right"]!.AsObject();
+            right["sourceFilePath"] = @"C:\measurements	weeter-r.json";
+            right["enabled"] = true;
+            right["bypass"] = true;
+            right["showRawCurve"] = false;
+            File.WriteAllText(path, file.ToJsonString());
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.False(loaded.Pairs[0].Enabled);
+            Assert.True(loaded.Pairs[0].Bypass);
+            Assert.True(loaded.Pairs[0].ShowRawCurve);
         }
         finally
         {


### PR DESCRIPTION
Two independent changes, one per commit.

## Virtual DSP: the copy asks what travels, the block owns its switches

**L→R / R→L.** The dialog listed the channels; it now also lists the parts of the
chain, six checkboxes beside them: **Gain**, **Delay**, **Invert**, **Crossover**,
**All-pass**, **PEQ**. Crossover, all-pass and PEQ are ticked by default because
they describe the driver; gain, delay and polarity start unticked, because each is
tuned against that side's own level and geometry, and a left tweeter's arrival is
not a right tweeter's.

- **Behaviour change:** gain used to be copied unconditionally, and the all-pass
  could not be copied at all. Both are now the user's call.
- Copy is disabled while nothing would travel (no channel or no part ticked)
  rather than being a silent no-op.
- The dialog is rebuilt on `TableLayoutPanel`/`FlowLayoutPanel` and the shared
  `UiStyle`/`UiPalette` instead of the hand-computed 96-DPI coordinates it grew up
  with, so it scales with the font.

**Mute, Bypass, Raw, Processed.** These were stored per SIDE, so a side switch
quietly changed what a channel contributed to the sum and what the plot drew — and
muting the left tweeter while the right one plays describes no setup worth
predicting. They move onto the pair, beside `Mono` and `Collapsed`.

**Schema v7.** Older sessions migrate by reading the sides that carry a
measurement — the single left slot of a mono pair, the one loaded side of a
half-loaded pair — so every project that could not disagree opens exactly as it
looked. (The unreachable right slot of a mono pair still holds v6 defaults,
including `showProcessedCurve: true`; those must not win.) Where two loaded sides
did disagree, the louder answer survives: muted, bypassed and "curve shown" each
carry over, because a mute lost in a migration is the one outcome the tuner has no
way to see coming.

## Title bar: the update notice breathes

"Update available" was a static link on a bar nobody looks at. It now fades
between the label's ordinary grey and a pale accent glow — a raised cosine over
1.8 s, so each end eases instead of cornering into a flicker.

Three limits keep it from becoming noise: the pulse follows the window's focus
(parked on the plain accent colour in the background — still highlighted, just
still), stops for good once the link is followed, and never starts when Windows is
set to show no animations (`SPI_GETCLIENTAREAANIMATION`).

## Verification

- `dotnet test` with `Category!=Hardware`: **2476 passed, 0 failed, 0 warnings.**
- Two new migration tests pin the v6→v7 rule (a mono pair whose right slot holds
  stale defaults; two loaded sides that disagree); the round-trip test moves to the
  pair.
- The live Virtual DSP panel was driven through a scratchpad harness (with a
  `portable.flag` beside it so the autosave could not touch a real session): edits
  made on the left view read back unchanged after a side switch, un-muting from the
  right clears the block on both sides, and the saved v7 project carries the
  pair-level answer.
- The real `ChromeTitleBar` was driven the same way: the link colour walks
  `#A8B0BE → #C4E4FF` and back, deactivating stops the timer and parks the colour,
  activating resumes, following the link settles it with the timer disposed.

README updated in both commits. No screenshot needs re-capturing: the channel
block's controls are unchanged, the copy dialog is not in `assets/images/`, and the
title bar only pulses when an update actually exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
