### PR TITLE
Anchor every magnitude window on the response start, not the IR peak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1436,7 +1436,12 @@ the ear hears with the cabin — and a junction-length gate cannot even contain 
 bass EQ band's own ringing, so under it a Q 5 cut at 100 Hz would draw at a
 fraction of its real depth. One window definition serves every magnitude curve
 here and in the [EQ Wizard](#eq-wizard), which is what keeps the two tools
-showing the same curve for the same channel.
+showing the same curve for the same channel. Every magnitude window — here, in
+the wizard and in Frequency Response mode — opens on the response's detected
+**start**, the same band-limited first-arrival front the phase gate's Auto
+offset snaps to, never on the IR peak: a woofer's peak trails its own onset by
+several milliseconds of group delay, so a peak-anchored window would open after
+the response has begun and read the record minus its direct arrival.
 
 A **Target** checkbox draws the EQ target over the prediction: the SAME target
 the EQ Wizard equalizes towards, shaped from either place through the same

--- a/dsp/DataHelper.Spectrum.cs
+++ b/dsp/DataHelper.Spectrum.cs
@@ -34,14 +34,26 @@ namespace Resonalyze.Dsp
         /// by GetSpectrum for its primary curve and directly for derived responses
         /// (e.g. the complex sum of two transfer impulse responses), where the
         /// per-curve visibility gating of GetSpectrum must not apply.
+        /// <para>
+        /// <paramref name="anchorIndex"/> overrides where the window opens. A
+        /// COMPOSITE record (a sum of arrivals) must pass the earliest of its
+        /// parts' own starts: run on the mixed record, the start estimator reads
+        /// the front of the record's dominant band, which a later, louder
+        /// arrival can own — the same reason the Virtual DSP tool anchors its
+        /// shared window at the min of per-channel starts
+        /// (ProcessedChannels.SharedStartAnchorIndex) rather than estimating on
+        /// the sum. Single records leave it null.
+        /// </para>
         /// </summary>
         public static AnalysisCurve GetPrimarySpectrum(
             IImpulseMeasurement measurement,
             FrequencyResponseOptions frequencyResponseOptions,
-            CalibrationFile? calibration)
+            CalibrationFile? calibration,
+            int? anchorIndex = null)
         {
             List<SignalPoint> data = LogarithmicResample(
-                GetOversampledPrimarySpectrum(measurement, frequencyResponseOptions),
+                GetOversampledPrimarySpectrum(
+                    measurement, frequencyResponseOptions, anchorIndex),
                 20,
                 20000,
                 1024,
@@ -63,19 +75,21 @@ namespace Resonalyze.Dsp
         /// </summary>
         public static List<SignalPoint> GetOversampledPrimarySpectrum(
             IImpulseMeasurement measurement,
-            FrequencyResponseOptions frequencyResponseOptions)
+            FrequencyResponseOptions frequencyResponseOptions,
+            int? anchorIndex = null)
         {
+            int anchor = anchorIndex ?? MagnitudeAnchorIndex(measurement);
             if (frequencyResponseOptions.MagnitudeWindowMode ==
                 PhaseWindowMode.FrequencyDependent)
             {
-                return GetFdwPrimarySpectrum(measurement, frequencyResponseOptions);
+                return GetFdwPrimarySpectrum(
+                    measurement, frequencyResponseOptions, anchor);
             }
 
             double leftTukeyWindow = (double)frequencyResponseOptions.LeftTukeyWindow / frequencyResponseOptions.Window * 2.0;
             double rightTukeyWindow = (double)frequencyResponseOptions.RightTukeyWindow / frequencyResponseOptions.Window * 2.0;
             double[] window = Windowing.TukeyWindow(frequencyResponseOptions.Window, leftTukeyWindow, rightTukeyWindow);
-            int h1Start = MagnitudeAnchorIndex(measurement) -
-                frequencyResponseOptions.LeftTukeyWindow;
+            int h1Start = anchor - frequencyResponseOptions.LeftTukeyWindow;
             return GetOversampledSpectrumData(measurement, h1Start, window);
         }
 
@@ -106,7 +120,8 @@ namespace Resonalyze.Dsp
         // of the settings record are phase-only and never reach the bank.
         private static List<SignalPoint> GetFdwPrimarySpectrum(
             IImpulseMeasurement measurement,
-            FrequencyResponseOptions options)
+            FrequencyResponseOptions options,
+            int anchorIndex)
         {
             double toMilliseconds = 1000.0 / measurement.SampleRate;
             int plateau = Math.Max(
@@ -116,7 +131,7 @@ namespace Resonalyze.Dsp
                 options.MagnitudeFdwCycles,
                 PhaseDetrendMode.Off,
                 ManualDetrendMilliseconds: 0.0,
-                GateOffsetMs: MagnitudeAnchorIndex(measurement) * toMilliseconds,
+                GateOffsetMs: anchorIndex * toMilliseconds,
                 LeftMs: options.LeftTukeyWindow * toMilliseconds,
                 PlateauMs: plateau * toMilliseconds,
                 RightMs: options.RightTukeyWindow * toMilliseconds,

--- a/dsp/DataHelper.Spectrum.cs
+++ b/dsp/DataHelper.Spectrum.cs
@@ -28,9 +28,9 @@ namespace Resonalyze.Dsp
         }
 
         /// <summary>
-        /// The primary (linear) response spectrum: windowed around the peak (fixed
-        /// Tukey or FDW), oversampled, log-resampled with optional calibration and
-        /// smoothing. Used
+        /// The primary (linear) response spectrum: windowed at the response's own
+        /// start (fixed Tukey or FDW), oversampled, log-resampled with optional
+        /// calibration and smoothing. Used
         /// by GetSpectrum for its primary curve and directly for derived responses
         /// (e.g. the complex sum of two transfer impulse responses), where the
         /// per-curve visibility gating of GetSpectrum must not apply.
@@ -55,7 +55,7 @@ namespace Resonalyze.Dsp
 
         /// <summary>
         /// The oversampled linear-frequency spectrum that feeds
-        /// <see cref="GetPrimarySpectrum"/>: Tukey-windowed around the peak (or
+        /// <see cref="GetPrimarySpectrum"/>: Tukey-windowed at the response start (or
         /// FDW-windowed, per <see cref="FrequencyResponseOptions.MagnitudeWindowMode"/>)
         /// and oversampled, BEFORE the logarithmic resample, calibration and smoothing.
         /// Overlays store this so they reproduce the mode's smoothing EXACTLY (the same
@@ -74,20 +74,36 @@ namespace Resonalyze.Dsp
             double leftTukeyWindow = (double)frequencyResponseOptions.LeftTukeyWindow / frequencyResponseOptions.Window * 2.0;
             double rightTukeyWindow = (double)frequencyResponseOptions.RightTukeyWindow / frequencyResponseOptions.Window * 2.0;
             double[] window = Windowing.TukeyWindow(frequencyResponseOptions.Window, leftTukeyWindow, rightTukeyWindow);
-            int h1Start = measurement.PeakIndex - frequencyResponseOptions.LeftTukeyWindow;
+            int h1Start = MagnitudeAnchorIndex(measurement) -
+                frequencyResponseOptions.LeftTukeyWindow;
             return GetOversampledSpectrumData(measurement, h1Start, window);
         }
+
+        // Where the magnitude window opens: the response's estimated START, not
+        // its peak. A driver's group delay puts the peak milliseconds behind the
+        // front (the archived Passat woofer peaks 5.4 ms after its onset), so a
+        // window whose fade-in ends at the peak starts AFTER the response has
+        // begun and discards the direct arrival — with the left fade a couple of
+        // milliseconds, entire octave bands misread by 10+ dB. The estimate is
+        // memoized per IR array; the peak remains the fallback when the
+        // estimator refuses the record.
+        private static int MagnitudeAnchorIndex(IImpulseMeasurement measurement) =>
+            measurement.ImpulseResponse is { Length: > 0 } impulseResponse
+                ? TransferIrStartCache.ResolveStartIndex(
+                    impulseResponse, measurement.SampleRate, measurement.PeakIndex)
+                : measurement.PeakIndex;
 
         // REW-style frequency-dependent window for the magnitude curve, built on
         // the SAME bank the FDW phase analysis uses (BuildAnalysisSpectrum), so
         // the two views read one analysis and share its per-impulse cache. The
         // fixed window's geometry maps directly onto the gate: its fade-in ends
-        // at the peak, so the gate offset is the peak time, and the configured
-        // window is the outer gate that FDW never exceeds — below the transition
-        // frequency (where MagnitudeFdwCycles periods outgrow the window) the
-        // curve is the fixed window's, above it the effective window shrinks as
-        // cycles/frequency. Detrend/unwrap/smoothing fields of the settings
-        // record are phase-only and never reach the bank.
+        // at the response start (MagnitudeAnchorIndex — the same anchor as the
+        // fixed window's), so the gate offset is the start time, and the
+        // configured window is the outer gate that FDW never exceeds — below
+        // the transition frequency (where MagnitudeFdwCycles periods outgrow
+        // the window) the curve is the fixed window's, above it the effective
+        // window shrinks as cycles/frequency. Detrend/unwrap/smoothing fields
+        // of the settings record are phase-only and never reach the bank.
         private static List<SignalPoint> GetFdwPrimarySpectrum(
             IImpulseMeasurement measurement,
             FrequencyResponseOptions options)
@@ -100,7 +116,7 @@ namespace Resonalyze.Dsp
                 options.MagnitudeFdwCycles,
                 PhaseDetrendMode.Off,
                 ManualDetrendMilliseconds: 0.0,
-                GateOffsetMs: measurement.PeakIndex * toMilliseconds,
+                GateOffsetMs: MagnitudeAnchorIndex(measurement) * toMilliseconds,
                 LeftMs: options.LeftTukeyWindow * toMilliseconds,
                 PlateauMs: plateau * toMilliseconds,
                 RightMs: options.RightTukeyWindow * toMilliseconds,

--- a/dsp/TransferIrStartCache.cs
+++ b/dsp/TransferIrStartCache.cs
@@ -1,40 +1,27 @@
+using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using Resonalyze.Dsp;
 
-namespace Resonalyze;
+namespace Resonalyze.Dsp;
 
 /// <summary>
 /// The shared "where does this transfer IR honestly start" answer behind every
-/// Auto gate-offset control (Phase, Group Delay) and the plot builds that
-/// consume it: <see cref="TransferIrDiagnostics.EstimateIrStart"/>, memoized
-/// per IR array so the dialogs and the plot factory read one figure computed
-/// once per measurement instead of re-running the band-limited analysis on
-/// every control change. Falls back to the transfer peak — the Fit figure —
-/// when the estimator refuses the record, so Auto is never worse than Fit.
+/// Auto gate-offset control (Phase, Group Delay), the plot builds that consume
+/// it and the plain magnitude extraction
+/// (<see cref="DataHelper.GetOversampledPrimarySpectrum"/>):
+/// <see cref="TransferIrDiagnostics.EstimateIrStart(Complex[], int, ValidSampleRange)"/>,
+/// memoized per IR array so the dialogs, the plot factory and the spectrum
+/// path read one figure computed once per measurement instead of re-running
+/// the band-limited analysis on every control change or redraw. Falls back to
+/// the transfer peak — the Fit figure — when the estimator refuses the
+/// record, so Auto is never worse than Fit.
 /// </summary>
-internal static class TransferIrStartCache
+public static class TransferIrStartCache
 {
     private sealed record CachedStart(
         int SampleRate, ValidSampleRange ValidRange, double StartMs);
 
     private static readonly ConditionalWeakTable<Complex[], CachedStart> cache = new();
-
-    /// <summary>
-    /// The estimated IR start (ms from the record start) of the measurement's
-    /// transfer IR; null when there is no transfer IR to read.
-    /// </summary>
-    public static double? ResolveStartMs(ExpSweepMeasurement measurement)
-    {
-        if (measurement.Transfer is not { ImpulseResponse.Length: > 0 } transfer ||
-            measurement.SampleRate <= 0)
-        {
-            return null;
-        }
-
-        return ResolveStartMs(
-            transfer.ImpulseResponse, measurement.SampleRate, transfer.PeakIndex);
-    }
 
     /// <summary>
     /// The same estimate for any analysis-layer measurement view (the Compare
@@ -53,8 +40,8 @@ internal static class TransferIrStartCache
     }
 
     /// <summary>
-    /// The same estimate for an IR held directly as an array (the Virtual DSP
-    /// processed channels); <paramref name="fallbackPeakIndex"/> answers when
+    /// The estimated IR start (ms from the record start) for an IR held
+    /// directly as an array; <paramref name="fallbackPeakIndex"/> answers when
     /// the estimator refuses the record.
     /// </summary>
     public static double ResolveStartMs(
@@ -78,4 +65,24 @@ internal static class TransferIrStartCache
             impulseResponse, new CachedStart(sampleRate, validRange, startMs));
         return startMs;
     }
+
+    /// <summary>
+    /// <see cref="ResolveStartMs(Complex[], int, int, ValidSampleRange)"/> as a
+    /// sample index into the record — the ONE ms-to-index conversion every
+    /// window that anchors on the response start shares, so the Virtual DSP
+    /// plot, the handoffs and the plain spectrum extraction cannot round the
+    /// same figure to different samples.
+    /// </summary>
+    public static int ResolveStartIndex(
+        Complex[] impulseResponse,
+        int sampleRate,
+        int fallbackPeakIndex,
+        ValidSampleRange validRange = default) =>
+        Math.Clamp(
+            (int)Math.Floor(
+                ResolveStartMs(
+                    impulseResponse, sampleRate, fallbackPeakIndex, validRange)
+                / 1_000.0 * sampleRate),
+            0,
+            Math.Max(0, impulseResponse.Length - 1));
 }

--- a/source/Options/FROptions.cs
+++ b/source/Options/FROptions.cs
@@ -215,8 +215,9 @@ namespace Resonalyze.Options
                 (int)numericLeftWindow.Value,
                 (int)numericRightWindow.Value,
                 offset: 0,
-                // FR magnitude is now windowed on the transfer IR, so preview that window.
-                IrPreviewSource.Primary);
+                // FR magnitude is windowed on the transfer IR at its estimated
+                // START, so preview the window where the analysis opens it.
+                IrPreviewSource.PrimaryAtStart);
         }
 
         private void InitializeToolTips()

--- a/source/Options/ImpulsePreviewOptionsForm.cs
+++ b/source/Options/ImpulsePreviewOptionsForm.cs
@@ -194,10 +194,17 @@ public class ImpulsePreviewOptionsForm : Form
     protected void ApplyAutoGateOffset()
     {
         if (gate is { } g &&
-            Measurement is { } measurement &&
-            TransferIrStartCache.ResolveStartMs(measurement) is { } startMs)
+            Measurement is
+            {
+                Transfer.ImpulseResponse.Length: > 0,
+                SampleRate: > 0
+            } measurement)
         {
-            g.Offset.Value = g.Offset.ClampValue(startMs);
+            g.Offset.Value = g.Offset.ClampValue(
+                TransferIrStartCache.ResolveStartMs(
+                    measurement.Transfer.ImpulseResponse,
+                    measurement.SampleRate,
+                    measurement.Transfer.PeakIndex));
         }
     }
 

--- a/source/Options/ImpulseWindowPreview.cs
+++ b/source/Options/ImpulseWindowPreview.cs
@@ -12,6 +12,11 @@ internal enum IrPreviewSource
 {
     SweepDeconvolution,
     Primary,
+    // The transfer IR referenced at its estimated START — where the plain
+    // magnitude extraction actually opens its window (DataHelper's
+    // MagnitudeAnchorIndex). Primary above stays peak-referenced for the
+    // views whose own analysis anchors there (waterfall, burst decay).
+    PrimaryAtStart,
     TransferFromStart
 }
 
@@ -458,6 +463,19 @@ internal static class ImpulseWindowPreview
                         transferResult.ImpulseResponse,
                         0,
                         true,
+                        "Transfer IR Window")
+                    : SelectImpulseResponse(
+                        measurement,
+                        IrPreviewSource.SweepDeconvolution),
+            IrPreviewSource.PrimaryAtStart =>
+                measurement.Transfer is { ImpulseResponse.Length: > 0 } startTransferResult
+                    ? new IrSource(
+                        startTransferResult.ImpulseResponse,
+                        TransferIrStartCache.ResolveStartIndex(
+                            startTransferResult.ImpulseResponse,
+                            measurement.SampleRate,
+                            startTransferResult.PeakIndex),
+                        false,
                         "Transfer IR Window")
                     : SelectImpulseResponse(
                         measurement,

--- a/source/Plotting/MeasurementPlotContext.cs
+++ b/source/Plotting/MeasurementPlotContext.cs
@@ -42,7 +42,13 @@ internal sealed class MeasurementPlotContext
     /// <see cref="TransferIrStartCache"/>, shared with the options dialogs.
     /// </summary>
     public double? ResolveAutoGateOffsetMs() =>
-        TransferIrStartCache.ResolveStartMs(expSweepMeasurement);
+        expSweepMeasurement.Transfer is { ImpulseResponse.Length: > 0 } transfer &&
+        expSweepMeasurement.SampleRate > 0
+            ? TransferIrStartCache.ResolveStartMs(
+                transfer.ImpulseResponse,
+                expSweepMeasurement.SampleRate,
+                transfer.PeakIndex)
+            : null;
 
     /// <summary>
     /// The offset K that turns the loopback-referenced magnitude (dBr) into dB SPL:

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -2265,9 +2265,12 @@ internal sealed class PlotModelFactory
             sum[i] = value + sign * shifted;
         }
 
-        // Anchor the analysis window at the earlier of the two arrivals so the later
-        // impulse still falls inside the window plateau; the summed envelope peak
-        // could sit between them or vanish entirely under cancellation.
+        // The window anchors at the sum's own estimated start (the plain path's
+        // rule), which for two arrivals is the earlier front — so the later impulse
+        // still falls inside the window plateau. The peak passed here is only the
+        // estimator's fallback, and the summed envelope peak would be a poor anchor:
+        // it could sit between the arrivals or vanish entirely under cancellation,
+        // so the fallback is the earlier of the two records' own peaks instead.
         int mainPeak = Math.Clamp(expSweepMeasurement.TransferPeakIndex, 0, length - 1);
         int comparePeak = Math.Clamp(
             compare.TransferPeakIndex + (int)Math.Round(delaySamples),
@@ -2320,8 +2323,8 @@ internal sealed class PlotModelFactory
             return null;
         }
 
-        // Individual magnitudes of the two transfer responses, each windowed around its own
-        // peak but log-resampled onto the same fixed frequency grid as the complex sum, so
+        // Individual magnitudes of the two transfer responses, each windowed at its own
+        // start but log-resampled onto the same fixed frequency grid as the complex sum, so
         // all three curves align index-by-index.
         AnalysisCurve mainMagnitude = DataHelper.GetPrimarySpectrum(
             new ImpulseMeasurementView(

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -2265,24 +2265,40 @@ internal sealed class PlotModelFactory
             sum[i] = value + sign * shifted;
         }
 
-        // The window anchors at the sum's own estimated start (the plain path's
-        // rule), which for two arrivals is the earlier front — so the later impulse
-        // still falls inside the window plateau. The peak passed here is only the
-        // estimator's fallback, and the summed envelope peak would be a poor anchor:
-        // it could sit between the arrivals or vanish entirely under cancellation,
-        // so the fallback is the earlier of the two records' own peaks instead.
-        int mainPeak = Math.Clamp(expSweepMeasurement.TransferPeakIndex, 0, length - 1);
-        int comparePeak = Math.Clamp(
-            compare.TransferPeakIndex + (int)Math.Round(delaySamples),
+        // The window anchors at the earlier of the two records' OWN estimated
+        // starts (the compare's shifted by the applied delay), so the later
+        // impulse still falls inside the window plateau — the same rule the
+        // Virtual DSP tool applies to its shared window
+        // (ProcessedChannels.SharedStartAnchorIndex). The anchor is passed
+        // EXPLICITLY: estimated on the summed record itself, the start would be
+        // the front of the sum's dominant band, which a later, louder driver can
+        // own — a window opening there cuts the earlier driver out of the sum
+        // while the individual curves keep it. Each record's estimate is read on
+        // its original array (memoized), falling back to that record's peak, and
+        // the summed envelope peak enters nowhere: it could sit between the
+        // arrivals or vanish entirely under cancellation.
+        int mainStart = Math.Clamp(
+            TransferIrStartCache.ResolveStartIndex(
+                mainIr,
+                expSweepMeasurement.SampleRate,
+                expSweepMeasurement.TransferPeakIndex),
             0,
             length - 1);
-        int peakIndex = Math.Min(mainPeak, comparePeak);
+        int compareStart = Math.Clamp(
+            TransferIrStartCache.ResolveStartIndex(
+                compareIr,
+                compare.SampleRate,
+                compare.TransferPeakIndex) + (int)Math.Round(delaySamples),
+            0,
+            length - 1);
+        int anchorIndex = Math.Min(mainStart, compareStart);
 
         FrequencyResponseOptions curveOptions = options ?? frequencyResponseOptions;
         return DataHelper.GetPrimarySpectrum(
-            new ImpulseMeasurementView(sum, peakIndex, expSweepMeasurement.SampleRate),
+            new ImpulseMeasurementView(sum, anchorIndex, expSweepMeasurement.SampleRate),
             curveOptions,
-            GetCalibration(curveOptions));
+            GetCalibration(curveOptions),
+            anchorIndex);
     }
 
     private static Complex SampleAt(Complex[] source, int index) =>

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -2293,9 +2293,19 @@ internal sealed class PlotModelFactory
             length - 1);
         int anchorIndex = Math.Min(mainStart, compareStart);
 
+        // The view's PeakIndex stays a PEAK — the earlier record's, the right
+        // fallback if the explicit anchor ever went away — rather than smuggling
+        // the anchor through a field that means something else.
+        int peakIndex = Math.Min(
+            Math.Clamp(expSweepMeasurement.TransferPeakIndex, 0, length - 1),
+            Math.Clamp(
+                compare.TransferPeakIndex + (int)Math.Round(delaySamples),
+                0,
+                length - 1));
+
         FrequencyResponseOptions curveOptions = options ?? frequencyResponseOptions;
         return DataHelper.GetPrimarySpectrum(
-            new ImpulseMeasurementView(sum, anchorIndex, expSweepMeasurement.SampleRate),
+            new ImpulseMeasurementView(sum, peakIndex, expSweepMeasurement.SampleRate),
             curveOptions,
             GetCalibration(curveOptions),
             anchorIndex);

--- a/source/Tools/VirtualCrossover/ProcessedChannel.cs
+++ b/source/Tools/VirtualCrossover/ProcessedChannel.cs
@@ -96,13 +96,8 @@ internal static class ProcessedChannels
         int peakIndex,
         int sampleRate,
         ValidSampleRange validRange = default) =>
-        Math.Clamp(
-            (int)Math.Floor(
-                TransferIrStartCache.ResolveStartMs(
-                    impulseResponse, sampleRate, peakIndex, validRange)
-                / 1_000.0 * sampleRate),
-            0,
-            Math.Max(0, impulseResponse.Length - 1));
+        TransferIrStartCache.ResolveStartIndex(
+            impulseResponse, sampleRate, peakIndex, validRange);
 
     /// <summary>
     /// The shared window's anchor for a channel set: the earliest

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4000,7 +4000,7 @@ public partial class VirtualCrossoverPanel : UserControl
     // shared earliest FRONT for channels and sums (one window is what keeps
     // the drawn Sum the exact vector sum of the drawn channels and the
     // sum-loss under its 0 dB ceiling; see VirtualCrossoverMetrics.BuildCurves)
-    // and the raw curve's own peak. Runs on PLINQ worker threads: reads only
+    // and the raw curve's own front. Runs on PLINQ worker threads: reads only
     // the immutable snapshot RequestRedraw refreshed.
     private GatedMagnitude BuildMagnitudeCurve(
         Complex[] impulseResponse,
@@ -4034,18 +4034,27 @@ public partial class VirtualCrossoverPanel : UserControl
     // A RAW channel curve lives in its own time: its arrival predates the
     // processed gate by the channel's delay, so even a pinned processed-view
     // offset would clip it into the left fade. Same gate durations and window
-    // mode, always anchored on the raw response's own peak.
+    // mode, anchored on the raw response's own START — the same rule as the
+    // processed curves. Its own PEAK was the anchor once, and with the short
+    // junction gate that was harmless; the steady-state window made it a
+    // defect: a woofer's peak trails its onset by more than the 2 ms fade-in
+    // (5.4 ms on the archived Passat woofer), so a peak-anchored window opened
+    // after the response had begun and read the record minus its direct
+    // arrival — octave bands off by 10+ dB against the same IR read from the
+    // front.
     private AnalysisCurve BuildRawMagnitudeCurve(
         Complex[] impulseResponse,
         int peakIndex,
         int sampleRate)
     {
+        int anchorIndex = ProcessedChannels.StartAnchorIndex(
+            impulseResponse, peakIndex, sampleRate);
         return BuildGatedMagnitudeCurve(
             magnitudeGate,
             impulseResponse,
-            peakIndex,
+            anchorIndex,
             sampleRate,
-            peakIndex * 1_000.0 / sampleRate).Display;
+            anchorIndex * 1_000.0 / sampleRate).Display;
     }
 
     // Both widths of one gated build: the smoothed curve the plot draws and the
@@ -5334,7 +5343,7 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         // The band read below is gate-independent (it windows each raw response
-        // on its own peak), but the proposal it writes is checked on the plot
+        // on its own front), but the proposal it writes is checked on the plot
         // and in the sum-loss read-out, both of which the gate builds — so a
         // misplaced window still has to be dealt with before the wizard runs.
         if (RefuseOnMisplacedGate("Auto crossover"))

--- a/source/Tools/VirtualCrossover/VirtualDspEqHandoff.cs
+++ b/source/Tools/VirtualCrossover/VirtualDspEqHandoff.cs
@@ -65,7 +65,7 @@ namespace Resonalyze;
 /// switch — re-windows the channel while the wizard keeps drawing the old result, and
 /// this PR has already produced enough windowing bugs to treat that as the same class
 /// as a replaced measurement. The pin applies to a CHAIN handoff only; a raw curve is
-/// anchored on its own peak and never read the pin.
+/// anchored on its own start and never read the pin.
 /// <para>
 /// What is deliberately NOT guarded is where an AUTO-placed window ended up: that
 /// offset is the earliest arrival across all channels, so another channel's edit can
@@ -140,7 +140,7 @@ internal static class VirtualDspEqHandoff
     /// curve is the side's measurement through its DSP chain WITHOUT the PEQ — gain,
     /// delay, polarity, crossover and all-pass stay — windowed by the gate the processed
     /// view draws with. Without it the curve is the raw measurement under the same gate
-    /// anchored on its own peak: exactly the panel's Raw curve.
+    /// anchored on its own start: exactly the panel's Raw curve.
     /// <para>
     /// The request also carries what the wizard needs to redraw the CORRECTED curve the
     /// same way the panel would (<see cref="EqWizardCurveSource.PreviewImpulseResponse"/>):
@@ -220,8 +220,12 @@ internal static class VirtualDspEqHandoff
         }
         else
         {
+            // The raw response in its own time: anchored on its own START, the
+            // same figure BuildRawMagnitudeCurve reads for the panel's Raw
+            // curve, so the wizard opens on the curve the user just left.
             response = state.TransferImpulseResponse;
-            anchorIndex = state.TransferPeakIndex;
+            anchorIndex = ProcessedChannels.StartAnchorIndex(
+                response, state.TransferPeakIndex, sampleRate);
             gateOffsetMs = anchorIndex * 1_000.0 / sampleRate;
         }
 
@@ -251,7 +255,7 @@ internal static class VirtualDspEqHandoff
                     : $" — {settings.DisplayName}") +
                 (withChain
                     ? "\r\nDSP chain applied (PEQ bypassed), windowed by the Virtual DSP gate."
-                    : "\r\nRaw measurement, windowed by the Virtual DSP gate at its own peak.") +
+                    : "\r\nRaw measurement, windowed by the Virtual DSP gate at its own arrival.") +
                 bypassNote,
             Measurement = new ImpulseMeasurementView(response, anchorIndex, sampleRate),
             Coherence = EqWizardSourceResolver.ExtractTransferCoherence(
@@ -370,7 +374,7 @@ internal static class VirtualDspEqHandoff
 
         // The window the curve was read through must still be where it was, and the
         // level it was fitted against must still be the panel's answer too. The PIN
-        // counts only for a chain handoff: a raw curve is anchored on its own peak
+        // counts only for a chain handoff: a raw curve is anchored on its own start
         // and ignores the processed view's pin by construction (see Build, and
         // VirtualCrossoverPanel.BuildRawMagnitudeCurve — a raw response lives in its
         // own time), so refusing a raw return because that pin moved would throw work

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -738,6 +738,104 @@ public sealed class PlotModelFactoryTests
     }
 
     [Fact]
+    public void ComplexSum_WindowsAtTheEarlierRecordsOwnStart_NotTheSumsDominantBand()
+    {
+        // Two drivers, the honest hard case: a quiet low-frequency arrival first,
+        // a louder high-frequency one 30 ms later. The summed record's dominant
+        // band belongs to the LOUD driver, so a start estimated on the sum itself
+        // reads the late front — and a window opening there cuts the early driver
+        // out of the sum while its own curve keeps it. The sum must window at the
+        // earlier of the two records' own starts instead.
+        const int sampleRate = 44_100;
+        var mainIr = new Complex[8_192];
+        int mainPeak = Wavelet(mainIr, onset: 441, hz: 300, amplitude: 0.05,
+            decaySeconds: 0.02, sampleRate);
+        var compareIr = new Complex[8_192];
+        int comparePeak = Wavelet(compareIr, onset: 1_764, hz: 3_000, amplitude: 1.0,
+            decaySeconds: 0.005, sampleRate);
+
+        using var measurement = CreateTransferMeasurement(mainIr, mainPeak, sampleRate);
+        using var noiseMeasurement = new NoiseMeasurement(new FakeAudioSessionFactory());
+        PlotModelFactory factory = CreateFactory(measurement, noiseMeasurement);
+        factory.SetCompareSourceProvider(
+            () => new CompareAnalysisSource(
+                "Reference", sampleRate, compareIr, comparePeak));
+
+        // The fixture must actually discriminate: on the summed record the
+        // estimator locks onto the loud driver's late front, past the early
+        // driver AND the window's whole fade-in.
+        var sum = new Complex[8_192];
+        for (int i = 0; i < sum.Length; i++)
+        {
+            sum[i] = mainIr[i] + compareIr[i];
+        }
+        int mainStart = TransferIrStartCache.ResolveStartIndex(
+            mainIr, sampleRate, mainPeak);
+        int sumStart = TransferIrStartCache.ResolveStartIndex(
+            sum, sampleRate, Math.Min(mainPeak, comparePeak));
+        var options = new FrequencyResponseOptions();
+        Assert.True(
+            sumStart > mainStart + options.LeftTukeyWindow,
+            $"fixture: the sum's own estimated start {sumStart} did not lock " +
+            $"onto the late driver (main starts at {mainStart})");
+
+        AnalysisCurve? summed = factory.TryBuildComplexSumCurve();
+        Assert.NotNull(summed);
+
+        // In the early driver's band the loud driver contributes next to
+        // nothing, so the sum must read the early driver's own level there — a
+        // window anchored on the sum's dominant band loses it by far more.
+        AnalysisCurve main = DataHelper.GetPrimarySpectrum(
+            new ImpulseMeasurementView(mainIr, mainPeak, sampleRate),
+            options,
+            calibration: null);
+        double summedAt300 = At(summed.Points, 300);
+        double mainAt300 = At(main.Points, 300);
+        Assert.True(
+            Math.Abs(summedAt300 - mainAt300) < 1.5,
+            $"the sum read {summedAt300:0.00} dB at 300 Hz against the early " +
+            $"driver's own {mainAt300:0.00} dB");
+    }
+
+    // A decaying wavelet from `onset`: returns the sample where the record peaks.
+    private static int Wavelet(
+        Complex[] impulse,
+        int onset,
+        double hz,
+        double amplitude,
+        double decaySeconds,
+        int sampleRate)
+    {
+        int peak = onset;
+        for (int i = 0; onset + i < impulse.Length; i++)
+        {
+            double t = i / (double)sampleRate;
+            impulse[onset + i] += amplitude * Math.Sin(2 * Math.PI * hz * t) *
+                Math.Exp(-t / decaySeconds);
+            if (impulse[onset + i].Magnitude > impulse[peak].Magnitude)
+            {
+                peak = onset + i;
+            }
+        }
+
+        return peak;
+    }
+
+    private static double At(IReadOnlyList<SignalPoint> points, double hz)
+    {
+        SignalPoint best = points[0];
+        foreach (SignalPoint point in points)
+        {
+            if (Math.Abs(point.X - hz) < Math.Abs(best.X - hz))
+            {
+                best = point;
+            }
+        }
+
+        return best.Y;
+    }
+
+    [Fact]
     public void ComplexSum_RequiresMatchingSampleRateAndTransferIr()
     {
         using var measurement = CreateTransferMeasurement();
@@ -1609,12 +1707,18 @@ public sealed class PlotModelFactoryTests
     {
         var transferImpulse = new Complex[2048];
         transferImpulse[peakSample] = Complex.One;
+        return CreateTransferMeasurement(transferImpulse, peakSample, 44_100);
+    }
+
+    private static ExpSweepMeasurement CreateTransferMeasurement(
+        Complex[] transferImpulse, int peakSample, int sampleRate)
+    {
 
         var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
         measurement.RestoreImpulseResponse(
             lowFrequencyHz: 20,
             highFrequencyHz: 20_000,
-            sampleRate: 44_100,
+            sampleRate: sampleRate,
             bits: 24,
             sweepDurationSeconds: 1.0,
             playChannel: PlaybackChannel.Mono,

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -795,6 +795,17 @@ public sealed class PlotModelFactoryTests
             Math.Abs(summedAt300 - mainAt300) < 1.5,
             $"the sum read {summedAt300:0.00} dB at 300 Hz against the early " +
             $"driver's own {mainAt300:0.00} dB");
+
+        // And the documented invariant survives the window bookkeeping: the loss
+        // divides the windowed sum by the individually windowed magnitudes, so a
+        // sum window that lost a driver the denominators kept would show up here
+        // as a loss far from the triangle inequality's <= 0. The epsilon covers
+        // the windows' different (per-record) placements, nothing more.
+        AnalysisCurve? loss = factory.TryBuildComplexSumLossCurve();
+        Assert.NotNull(loss);
+        Assert.All(loss.Points, point => Assert.True(
+            point.Y <= 0.1,
+            $"summation loss reads +{point.Y:0.000} dB at {point.X:0.#} Hz"));
     }
 
     // A decaying wavelet from `onset`: returns the sample where the record peaks.

--- a/tests/Resonalyze.App.Tests/VirtualDspEqHandoffTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualDspEqHandoffTests.cs
@@ -98,21 +98,29 @@ public sealed class VirtualDspEqHandoffTests
     }
 
     [Fact]
-    public void Raw_HandsTheMeasurementItself_AnchoredOnItsOwnPeak()
+    public void Raw_HandsTheMeasurementItself_AnchoredOnItsOwnStart()
     {
         VirtualCrossoverChannel channel = BuildChannel();
 
         // A pin belongs to the processed view's time; the panel's Raw curve ignores
-        // it and so must the raw handoff.
+        // it and so must the raw handoff. Like the panel's Raw curve, the window
+        // anchors on the raw response's own START (the peak only answers when the
+        // estimator refuses the record) — a woofer's peak trails its onset by more
+        // than the steady-state window's 2 ms fade-in, so a peak anchor would hand
+        // the wizard the record minus its direct arrival.
         VirtualDspEqHandoffRequest request = Build(
             channel, withChain: false, pinnedGateOffsetMs: 12.5, renderAnchorIndex: 480);
 
         Assert.Same(
             channel.TransferImpulseResponse,
             request.Source.Measurement!.ImpulseResponse);
-        Assert.Equal(channel.TransferPeakIndex, request.Source.Measurement.PeakIndex);
+        int expectedAnchor = ProcessedChannels.StartAnchorIndex(
+            channel.TransferImpulseResponse!,
+            channel.TransferPeakIndex,
+            SampleRate);
+        Assert.Equal(expectedAnchor, request.Source.Measurement.PeakIndex);
         Assert.Equal(
-            channel.TransferPeakIndex * 1_000.0 / SampleRate,
+            expectedAnchor * 1_000.0 / SampleRate,
             request.Source.GateSettings!.GateOffsetMs,
             6);
     }
@@ -687,7 +695,7 @@ public sealed class VirtualDspEqHandoffTests
     [Fact]
     public void ARawSessionIsImmuneToTheProcessedGatePin()
     {
-        // A raw handoff anchors on the measurement's own peak and never reads the
+        // A raw handoff anchors on the measurement's own start and never reads the
         // processed view's pin, so moving that pin cannot have changed its curve —
         // refusing the return would cost the user a finished tune for nothing.
         VirtualCrossoverChannel channel = BuildChannel();

--- a/tests/Resonalyze.Dsp.Tests/FrequencyDependentMagnitudeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/FrequencyDependentMagnitudeTests.cs
@@ -84,10 +84,13 @@ public sealed class FrequencyDependentMagnitudeTests
     {
         // The gate-driven magnitude (the Virtual DSP view) and the Frequency
         // Response mode's FDW curve must be ONE analysis when their gates
-        // coincide — the FR window maps onto a peak-anchored gate. Bit-equal,
-        // not approximate: both paths must run through the same bank and the
-        // same resample, or the two views drift apart.
+        // coincide — the FR window maps onto a gate anchored at the response's
+        // own START (TransferIrStartCache, the anchor every magnitude window
+        // shares). Bit-equal, not approximate: both paths must run through the
+        // same bank and the same resample, or the two views drift apart.
         SyntheticMeasurement measurement = ReflectedImpulse();
+        int anchor = TransferIrStartCache.ResolveStartIndex(
+            measurement.ImpulseResponse!, SampleRate, measurement.PeakIndex);
         FrequencyResponseOptions options =
             Options(PhaseWindowMode.FrequencyDependent);
         double toMilliseconds = 1_000.0 / SampleRate;
@@ -96,7 +99,7 @@ public sealed class FrequencyDependentMagnitudeTests
             FdwCycles: 6,
             PhaseDetrendMode.Off,
             ManualDetrendMilliseconds: 0.0,
-            GateOffsetMs: 480 * toMilliseconds,
+            GateOffsetMs: anchor * toMilliseconds,
             LeftMs: 256 * toMilliseconds,
             PlateauMs: (4_096 - 512) * toMilliseconds,
             RightMs: 256 * toMilliseconds,

--- a/tests/Resonalyze.Dsp.Tests/SteadyStateWindowTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SteadyStateWindowTests.cs
@@ -103,6 +103,122 @@ public sealed class SteadyStateWindowTests
     }
 
     [Fact]
+    public void ThePlainWindowOpensOnTheResponseStart_NotItsPeak()
+    {
+        // The Passat woofer defect, synthetic: a low-frequency driver's envelope
+        // peaks MILLISECONDS after its onset (group delay), while the plain
+        // window's fade-in is only 2 ms — anchored on the peak it opened after
+        // the response had begun and read the record minus its direct arrival.
+        // The plain path must anchor on the estimated START instead, i.e. read
+        // the same curve as the gated carve placed at that start.
+        const int sampleRate = 48_000;
+        const int onset = 960; // 20 ms
+        var impulse = new Complex[65_536];
+        int peak = 0;
+        for (int i = 0; onset + i < impulse.Length; i++)
+        {
+            double t = i / (double)sampleRate;
+            // A 60 Hz burst whose envelope rises over ~3 ms and decays over
+            // ~80 ms: the envelope maximum lands ~10 ms after the onset.
+            impulse[onset + i] = Math.Sin(2 * Math.PI * 60 * t) *
+                (1 - Math.Exp(-t / 0.003)) * Math.Exp(-t / 0.080);
+            if (impulse[onset + i].Magnitude > impulse[peak].Magnitude)
+            {
+                peak = onset + i;
+            }
+        }
+
+        var measurement = new WindowMeasurement(impulse, peak, sampleRate);
+        int anchor = TransferIrStartCache.ResolveStartIndex(
+            impulse, sampleRate, peak);
+        (int window, int left, int right) =
+            FrequencyResponseOptions.SteadyStateWindowSamples(sampleRate);
+        double toMs = 1_000.0 / sampleRate;
+
+        // The fixture parts the two anchors by more than the fade-in — without
+        // that, peak and start anchoring would read the same and prove nothing.
+        Assert.True(
+            peak - anchor > left,
+            $"fixture: peak {peak} is only {peak - anchor} samples past the " +
+            $"estimated start {anchor}, within the {left}-sample fade-in");
+
+        var options = new FrequencyResponseOptions
+        {
+            Window = window,
+            LeftTukeyWindow = left,
+            RightTukeyWindow = right,
+            SmoothingInverseOctaves = 0,
+            UseCalibration = false
+        };
+        AnalysisCurve plain = DataHelper.GetPrimarySpectrum(
+            measurement, options, calibration: null);
+        AnalysisCurve atStart = Carved(measurement, anchor * toMs,
+            left * toMs, (window - left - right) * toMs, right * toMs);
+        AnalysisCurve atPeak = Carved(measurement, peak * toMs,
+            left * toMs, (window - left - right) * toMs, right * toMs);
+
+        // Judged where the fixture has content; elsewhere both read noise floor.
+        for (int i = 0; i < plain.Points.Count; i++)
+        {
+            if (plain.Points[i].X is < 30 or > 120)
+            {
+                continue;
+            }
+
+            Assert.True(
+                Math.Abs(plain.Points[i].Y - atStart.Points[i].Y) < 0.05,
+                $"plain read {plain.Points[i].Y:0.000} dB at " +
+                $"{plain.Points[i].X:0.#} Hz against the start-anchored carve's " +
+                $"{atStart.Points[i].Y:0.000} dB");
+        }
+
+        // And the anchor matters: at the band centre the peak-anchored window
+        // reads a different level — the reading the bug reports showed.
+        double at60Start = AtHz(atStart, 60);
+        double at60Peak = AtHz(atPeak, 60);
+        Assert.True(
+            Math.Abs(at60Start - at60Peak) > 0.5,
+            $"fixture: start- and peak-anchored windows read within " +
+            $"{Math.Abs(at60Start - at60Peak):0.000} dB of each other at 60 Hz");
+    }
+
+    private static AnalysisCurve Carved(
+        IImpulseMeasurement measurement,
+        double gateOffsetMs,
+        double leftMs,
+        double plateauMs,
+        double rightMs) =>
+        DataHelper.GetGatedPrimarySpectrum(
+            measurement,
+            new PhaseAnalysisSettings(
+                PhaseWindowMode.Fixed,
+                PhaseAnalysisSettings.DefaultFdwCycles,
+                PhaseDetrendMode.Off,
+                ManualDetrendMilliseconds: 0.0,
+                gateOffsetMs,
+                leftMs,
+                plateauMs,
+                rightMs,
+                Unwrap: false,
+                SmoothingInverseOctaves: 0.0),
+            calibration: null,
+            smoothingInverseOctaves: 0);
+
+    private static double AtHz(AnalysisCurve curve, double hz)
+    {
+        SignalPoint best = curve.Points[0];
+        foreach (SignalPoint point in curve.Points)
+        {
+            if (Math.Abs(point.X - hz) < Math.Abs(best.X - hz))
+            {
+                best = point;
+            }
+        }
+
+        return best.Y;
+    }
+
+    [Fact]
     public void TheWindowBeatsTheJunctionGateItReplaced()
     {
         // The claim that justifies the whole change, at the rate where the steady-state

--- a/tests/Resonalyze.Dsp.Tests/SteadyStateWindowTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SteadyStateWindowTests.cs
@@ -113,20 +113,7 @@ public sealed class SteadyStateWindowTests
         // the same curve as the gated carve placed at that start.
         const int sampleRate = 48_000;
         const int onset = 960; // 20 ms
-        var impulse = new Complex[65_536];
-        int peak = 0;
-        for (int i = 0; onset + i < impulse.Length; i++)
-        {
-            double t = i / (double)sampleRate;
-            // A 60 Hz burst whose envelope rises over ~3 ms and decays over
-            // ~80 ms: the envelope maximum lands ~10 ms after the onset.
-            impulse[onset + i] = Math.Sin(2 * Math.PI * 60 * t) *
-                (1 - Math.Exp(-t / 0.003)) * Math.Exp(-t / 0.080);
-            if (impulse[onset + i].Magnitude > impulse[peak].Magnitude)
-            {
-                peak = onset + i;
-            }
-        }
+        (Complex[] impulse, int peak) = RisingBurst(sampleRate, onset);
 
         var measurement = new WindowMeasurement(impulse, peak, sampleRate);
         int anchor = TransferIrStartCache.ResolveStartIndex(
@@ -180,6 +167,70 @@ public sealed class SteadyStateWindowTests
             Math.Abs(at60Start - at60Peak) > 0.5,
             $"fixture: start- and peak-anchored windows read within " +
             $"{Math.Abs(at60Start - at60Peak):0.000} dB of each other at 60 Hz");
+    }
+
+    [Fact]
+    public void AnExplicitAnchorOverridesTheEstimator()
+    {
+        // The contract a COMPOSITE caller stands on (the Compare complex sum):
+        // the anchor it passes is where the window opens, estimator or not —
+        // run on a mixed record, the estimator would read the dominant band's
+        // front, which a later, louder arrival can own.
+        const int sampleRate = 48_000;
+        const int onset = 960;
+        (Complex[] impulse, int peak) = RisingBurst(sampleRate, onset);
+        var measurement = new WindowMeasurement(impulse, peak, sampleRate);
+        int estimated = TransferIrStartCache.ResolveStartIndex(
+            impulse, sampleRate, peak);
+        Assert.NotEqual(peak, estimated); // the override must actually differ
+
+        (int window, int left, int right) =
+            FrequencyResponseOptions.SteadyStateWindowSamples(sampleRate);
+        double toMs = 1_000.0 / sampleRate;
+        var options = new FrequencyResponseOptions
+        {
+            Window = window,
+            LeftTukeyWindow = left,
+            RightTukeyWindow = right,
+            SmoothingInverseOctaves = 0,
+            UseCalibration = false
+        };
+        AnalysisCurve overridden = DataHelper.GetPrimarySpectrum(
+            measurement, options, calibration: null, anchorIndex: peak);
+        AnalysisCurve atPeak = Carved(measurement, peak * toMs,
+            left * toMs, (window - left - right) * toMs, right * toMs);
+
+        Assert.True(
+            Math.Abs(AtHz(overridden, 60) - AtHz(atPeak, 60)) < 0.05,
+            $"the explicit anchor read {AtHz(overridden, 60):0.000} dB against " +
+            $"the same anchor's carve at {AtHz(atPeak, 60):0.000} dB");
+        Assert.NotEqual(
+            AtHz(atPeak, 60),
+            AtHz(DataHelper.GetPrimarySpectrum(
+                measurement, options, calibration: null), 60),
+            precision: 1);
+    }
+
+    // A 60 Hz burst whose envelope rises over ~3 ms and decays over ~80 ms:
+    // the envelope maximum lands ~10 ms after the onset — the LF-driver shape
+    // whose peak-anchored window discards the direct arrival.
+    private static (Complex[] Impulse, int Peak) RisingBurst(
+        int sampleRate, int onset)
+    {
+        var impulse = new Complex[65_536];
+        int peak = 0;
+        for (int i = 0; onset + i < impulse.Length; i++)
+        {
+            double t = i / (double)sampleRate;
+            impulse[onset + i] = Math.Sin(2 * Math.PI * 60 * t) *
+                (1 - Math.Exp(-t / 0.003)) * Math.Exp(-t / 0.080);
+            if (impulse[onset + i].Magnitude > impulse[peak].Magnitude)
+            {
+                peak = onset + i;
+            }
+        }
+
+        return (impulse, peak);
     }
 
     private static AnalysisCurve Carved(


### PR DESCRIPTION
## The report

A channel whose crossover was OFF looked different in the EQ Wizard opened the ordinary way versus through **Edit raw in EQ Wizard** (`Passat v2`, `…_w_L.json`, 96 kHz).

## The diagnosis

The handoff was innocent — it faithfully mirrored the panel's Raw curve, bit-for-bit equal to a normal wizard load. What differed was the **chain** variant, and not because of the chain: it anchors its window on the response **start** (309 ≈ 3.22 ms) while the raw/plain paths anchored on the **peak** (827 ≈ 8.61 ms). On this woofer the peak trails the onset by **5.40 ms** of group delay against the steady-state window's **2 ms** fade-in, so the peak-anchored window opened after the response had begun and read the record minus its direct arrival:

| octave band | 31.5 | 63 | 125 | 250 | 500 | 1k | 2k | 4k |
|---|---|---|---|---|---|---|---|---|
| windowed at the peak | −7.3 | −7.5 | 6.7 | −10.4 | −19.0 | 1.2 | −3.9 | −16.2 |
| windowed at the onset | −7.1 | 2.6 | 7.2 | 4.9 | −9.9 | 3.7 | 1.0 | −9.1 |

Peak anchoring predates this branch and was harmless under the short junction gate (which read only the direct sound anyway); the long steady-state window turned it into "read everything except the direct arrival".

## The fix

The rule **"the front, not the peak"** moves into the plain spectrum path itself, instead of being each caller's job to remember:

- `TransferIrStartCache` moves from the app layer into **dsp**, gaining `ResolveStartIndex` — the one ms-to-sample conversion every start-anchored window now shares (`ProcessedChannels.StartAnchorIndex` delegates to it).
- `GetOversampledPrimarySpectrum` — fixed and FDW alike — anchors on `MagnitudeAnchorIndex`: the estimated start, with the peak remaining the estimator's fallback. This fixes the wizard's ordinary IR load, Frequency Response mode, freshly captured overlays, the Compare curves and the auto-crossover band read **without touching their callers**.
- The Virtual DSP **Raw** curve (`BuildRawMagnitudeCurve`) and the **raw handoff** switch to the same `StartAnchorIndex` by hand — the wizard still opens on exactly the curve the user just left.
- The FR options' impulse-window preview drew the window at the peak while the analysis now opens it at the start — new `IrPreviewSource.PrimaryAtStart` keeps the preview honest. **Waterfall and burst decay deliberately stay peak-anchored**: slicing from the peak is their own instrument, and their previews keep `Primary`.

## What to know

- Overlays captured before this change store their finished spectrum; next to fresh curves of low-frequency channels they will part. Expected, not a defect.
- README gains one sentence stating the anchor rule.

## Verification

- The repro harness on the reported measurement: normal load, raw handoff, and the chain handoff at 0 and at 5.49 ms now agree on the front-anchored curve.
- New dsp test `ThePlainWindowOpensOnTheResponseStart_NotItsPeak`: a 60 Hz burst whose envelope peaks ~10 ms after its onset — plain path must match a start-anchored carve and must differ from the peak-anchored one.
- The FDW parity test and the raw-handoff anchor test re-derived around the shared start figure.
- Full suite: 2527 tests green; the field session battery over all archived cabins passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)