### PR TITLE
Tell the user that LR12 and LR36 need one channel inverted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1372,7 +1372,10 @@ Each channel runs through:
 - **Crossover** — Off, low-pass, high-pass, or band-pass; each edge picks
   **Butterworth** (6–48 dB/oct), **Linkwitz-Riley** (12/24/36/48 dB/oct),
   **Bessel** (6–48 dB/oct, near-constant group delay), or **Chebyshev**
-  (6–48 dB/oct, with a selectable passband **ripple**) with its own corner
+  (6–48 dB/oct, with a selectable passband **ripple**) with its own corner.
+  A Linkwitz-Riley pair sums flat only when its two halves are in phase:
+  LR24 and LR48 are, LR12 and LR36 sit 180° apart, so one of the two
+  channels needs **Invert** or the sum nulls at the corner
 - **All-pass** — 1st order (180° of phase swing) or 2nd order (360°, with a **Q**
   setting how abruptly it turns). Only phase moves, which makes it the tool for
   lining drivers up where a delay and a polarity flip are both too blunt — a

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
@@ -406,7 +406,8 @@ public partial class VirtualCrossoverChannelControl : UserControl
         const string familyTip =
             "Filter alignment for this edge:\r\n" +
             "Linkwitz-Riley — -6 dB at the corner, two edges sum flat\r\n" +
-            "(the car-audio default);\r\n" +
+            "(the car-audio default); LR12 and LR36 sum flat only with\r\n" +
+            "one side inverted — use Invert on one of the channels;\r\n" +
             "Butterworth — maximally flat passband, -3 dB at the corner;\r\n" +
             "Bessel — gentlest phase and transient, shallowest knee;\r\n" +
             "Chebyshev — steepest knee, at the cost of passband ripple.";


### PR DESCRIPTION
Follow-up to #110, addressing the Codex review there: the Linkwitz-Riley tooltip promised "two edges sum flat" and the README said nothing either, while an LR12 or LR36 pair — halves 180° apart — nulls at the corner unless one channel is inverted. The tooltip and the Virtual DSP crossover entry in the README now say so and point at **Invert**, the channel's own polarity setting; choosing the slope still flips nothing.

Also for the record: #110's squash carried an unrelated working-copy change the owner had staged, `OverlayTargetSettingsDialog.Designer.cs` raising the overlay target dialog's bass gain maximum from 18 to 30 dB. It is intentional and stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
