### PR TITLE
Carry the microphone calibration inside a Virtual DSP session, not as a machine-local id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1209,9 +1209,10 @@ curve is rendered in that plot's own dB frame, so one target means one height
 too — the curve hangs exactly where it hung a click ago.
 The **Calibration** selector comes up pinned to the Virtual DSP panel's choice
 and disabled: a PEQ fitted under one correction and summed under another would
-break the identity above, so the correction is changed where it lives. The
-wizard's standing calibration preference for impulse responses survives
-untouched.
+break the identity above, so the correction is changed where it lives. What is
+pinned is the curve the panel draws with — including one a loaded session carries
+that is in no list of yours — under the name the panel shows for it. The wizard's
+standing calibration preference for impulse responses survives untouched.
 
 **Return PEQ to Virtual DSP** — visible only during such a session — sends the
 finished bank (bands and preamp) back to the channel side it came from, named
@@ -1507,10 +1508,23 @@ finishes the centering.
 Editing a chain recomputes the prediction on a background task, so dragging a
 value stays responsive with several channels loaded. The **Mic cal** selector
 applies one of your configured microphone corrections to the magnitude curves; it
-defaults to Off because the measurements are loopback-referenced. The session
-stores WHICH calibration it was tuned with; opening it on a machine that has no
-such entry says so once and draws the curves uncalibrated, because the other
-machine's file describes its microphone, not yours.
+defaults to Off because the measurements are loopback-referenced.
+
+The session stores the calibration it was tuned with as the **curve itself**, not
+as a reference to your calibration list: a calibration describes the microphone
+the measurements were taken with, so it belongs with the measurements and travels
+with them. A session loaded on a machine that has no such file opens with that
+curve selected — listed in **Mic cal** as *name (from session)* — so the curves
+match the ones its author saw, and a dialog offers to **add it to your
+calibrations** (it lands in Record Settings → More calibrations, as a file entry
+like any other, and every view can then use it). Say yes when the measurements
+are the author's; a measurement you take with your own microphone needs its own
+calibration, and the selector is a click away. A machine that already has the
+same curve, under whatever name, simply selects that entry. Sessions written by
+older versions carry only the name of a calibration slot: one that matches an
+entry of the same name here is selected with a note that the two files are not
+known to agree, and one that matches nothing keeps whatever the selector already
+had rather than replacing a working choice with none.
 
 - **Auto crossover...** estimates each channel's usable band and driver type
   (subwoofer, woofer, midbass, midrange, tweeter), asks which filter families to
@@ -1644,8 +1658,11 @@ The views that read a magnitude — **Frequency Response**, **Live Spectrum**, t
 own selector; Phase and Group Delay read timing rather than level and apply no
 correction at all. A selection whose file went missing, or whose entry was
 deleted, stays selected and is marked rather than being silently rewritten to
-Off. For a source checkout, a legacy `source/calibration.txt` beside the
-executable is still honored as the 0° calibration.
+Off. A Virtual DSP session carries its calibration curve inside it and can add
+that curve to this list when loaded elsewhere (see [Virtual DSP](#virtual-dsp));
+such files are kept in the application data folder under `calibrations`. For a
+source checkout, a legacy `source/calibration.txt` beside the executable is
+still honored as the 0° calibration.
 
 ## Sound Pressure Level (dB SPL)
 

--- a/dsp/CalibrationFile.cs
+++ b/dsp/CalibrationFile.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -58,6 +58,144 @@ namespace Resonalyze.Dsp
             return new CalibrationFile(ParseText(text, sourceName));
         }
 
+        /// <summary>
+        /// Builds a calibration from (Hz, dB) points already in memory — the
+        /// curve a Virtual DSP session carries inside itself. The points go
+        /// through the same sort-and-merge as a parsed file, so a curve written
+        /// out by <see cref="Points"/> and read back here corrects identically.
+        /// </summary>
+        public static CalibrationFile FromPoints(
+            IEnumerable<CalibrationPoint> points,
+            string? sourceName = null)
+        {
+            ArgumentNullException.ThrowIfNull(points);
+            var signalPoints = new List<SignalPoint>();
+            foreach (CalibrationPoint point in points)
+            {
+                if (point.FrequencyHz > 0 &&
+                    double.IsFinite(point.FrequencyHz) &&
+                    double.IsFinite(point.Decibels))
+                {
+                    signalPoints.Add(new SignalPoint(
+                        point.FrequencyHz,
+                        DataHelper.DecibelsToAmplitude(point.Decibels)));
+                }
+            }
+
+            return new CalibrationFile(Normalize(signalPoints, sourceName));
+        }
+
+        /// <summary>
+        /// The curve as ascending (Hz, dB) points, which is what a file states
+        /// and what a session stores. A file-backed calibration returns its own
+        /// points; an angular estimate — a function, not a table — is sampled on
+        /// a 1/24-octave grid spanning the base file plus the base points
+        /// themselves, which reproduces <see cref="GetDecibelCorrection"/> at
+        /// every knot and to within the estimate's own smoothness between them.
+        /// Empty when nothing loaded.
+        /// </summary>
+        public IReadOnlyList<CalibrationPoint> Points
+        {
+            get
+            {
+                if (baseCalibration == null)
+                {
+                    return calibration
+                        .Select(point => new CalibrationPoint(
+                            point.X,
+                            DataHelper.AmplitudeToDecibels(point.Y)))
+                        .ToArray();
+                }
+
+                IReadOnlyList<CalibrationPoint> basePoints = baseCalibration.Points;
+                if (basePoints.Count == 0)
+                {
+                    return Array.Empty<CalibrationPoint>();
+                }
+
+                var frequencies = new SortedSet<double>(
+                    basePoints.Select(point => point.FrequencyHz));
+                double first = basePoints[0].FrequencyHz;
+                double last = basePoints[^1].FrequencyHz;
+                for (double frequency = first; frequency < last; frequency *= SampleGridStep)
+                {
+                    frequencies.Add(frequency);
+                }
+
+                return frequencies
+                    .Select(frequency => new CalibrationPoint(
+                        frequency,
+                        GetDecibelCorrection(frequency)))
+                    .ToArray();
+            }
+        }
+
+        // 1/24 octave: fine enough that the piecewise-linear reading of the
+        // sampled angular estimate stays within hundredths of a dB of the model.
+        private static readonly double SampleGridStep = Math.Pow(2.0, 1.0 / 24.0);
+
+        /// <summary>
+        /// Whether two calibrations correct identically: the same points, Hz and
+        /// dB alike, within rounding. Two nulls are the same (no correction), a
+        /// null and a curve are not. This — not an id — is what says whether a
+        /// curve that arrived inside a session is one the machine already has.
+        /// </summary>
+        public static bool SameCurve(CalibrationFile? left, CalibrationFile? right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+
+            if (left == null || right == null)
+            {
+                return false;
+            }
+
+            IReadOnlyList<CalibrationPoint> a = left.Points;
+            IReadOnlyList<CalibrationPoint> b = right.Points;
+            if (a.Count != b.Count)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < a.Count; i++)
+            {
+                if (Math.Abs(a[i].FrequencyHz - b[i].FrequencyHz) >
+                        FrequencyTolerance * Math.Abs(a[i].FrequencyHz) ||
+                    Math.Abs(a[i].Decibels - b[i].Decibels) > DecibelTolerance)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // Far below anything a calibration file states (three decimals at most)
+        // and far above the dB -> amplitude -> dB round trip the points take.
+        private const double FrequencyTolerance = 1e-9;
+        private const double DecibelTolerance = 1e-6;
+
+        /// <summary>
+        /// The curve as the plain two-column text every calibration reader —
+        /// this one included — accepts, one <c>frequency level</c> pair per line.
+        /// <see cref="Parse"/> of the result yields the same points.
+        /// </summary>
+        public string ToText()
+        {
+            var text = new System.Text.StringBuilder();
+            foreach (CalibrationPoint point in Points)
+            {
+                text.Append(point.FrequencyHz.ToString("R", CultureInfo.InvariantCulture))
+                    .Append(' ')
+                    .Append(point.Decibels.ToString("R", CultureInfo.InvariantCulture))
+                    .AppendLine();
+            }
+
+            return text.ToString();
+        }
+
         private static ParseResult LoadFromFile(string file)
         {
             if (!System.IO.File.Exists(file))
@@ -91,6 +229,13 @@ namespace Resonalyze.Dsp
                 }
             }
 
+            return Normalize(points, sourceName);
+        }
+
+        // The one path from raw points to a usable table, shared by the text
+        // parser and the in-memory constructor so both read identically.
+        private static ParseResult Normalize(List<SignalPoint> points, string? sourceName)
+        {
             points.Sort((left, right) => left.X.CompareTo(right.X));
 
             // Duplicate frequencies would make an interpolation segment
@@ -274,4 +419,7 @@ namespace Resonalyze.Dsp
             return lowDb + (highDb - lowDb) * position;
         }
     }
+
+    /// <summary>One calibration point: the correction the file states at a frequency.</summary>
+    public readonly record struct CalibrationPoint(double FrequencyHz, double Decibels);
 }

--- a/dsp/CalibrationFile.cs
+++ b/dsp/CalibrationFile.cs
@@ -89,10 +89,16 @@ namespace Resonalyze.Dsp
         /// The curve as ascending (Hz, dB) points, which is what a file states
         /// and what a session stores. A file-backed calibration returns its own
         /// points; an angular estimate — a function, not a table — is sampled on
-        /// a 1/24-octave grid spanning the base file plus the base points
-        /// themselves, which reproduces <see cref="GetDecibelCorrection"/> at
-        /// every knot and to within the estimate's own smoothness between them.
-        /// Empty when nothing loaded.
+        /// a 1/24-octave grid plus the base points themselves, which reproduces
+        /// <see cref="GetDecibelCorrection"/> at every knot and to within the
+        /// estimate's own smoothness between them. The grid runs over the whole
+        /// range a calibration is ever read at (<see cref="SampleGridLowHz"/> to
+        /// <see cref="SampleGridHighHz"/>, widened to the base file when that
+        /// reaches further), not just over the base file: outside the file the
+        /// base holds its edge value while the angular difference keeps moving,
+        /// and a table cut at the file's edges would clamp the WHOLE correction
+        /// there — the audition FIR reads it up to Nyquist. Empty when nothing
+        /// loaded.
         /// </summary>
         public IReadOnlyList<CalibrationPoint> Points
         {
@@ -115,13 +121,14 @@ namespace Resonalyze.Dsp
 
                 var frequencies = new SortedSet<double>(
                     basePoints.Select(point => point.FrequencyHz));
-                double first = basePoints[0].FrequencyHz;
-                double last = basePoints[^1].FrequencyHz;
+                double first = Math.Min(basePoints[0].FrequencyHz, SampleGridLowHz);
+                double last = Math.Max(basePoints[^1].FrequencyHz, SampleGridHighHz);
                 for (double frequency = first; frequency < last; frequency *= SampleGridStep)
                 {
                     frequencies.Add(frequency);
                 }
 
+                frequencies.Add(last);
                 return frequencies
                     .Select(frequency => new CalibrationPoint(
                         frequency,
@@ -133,6 +140,13 @@ namespace Resonalyze.Dsp
         // 1/24 octave: fine enough that the piecewise-linear reading of the
         // sampled angular estimate stays within hundredths of a dB of the model.
         private static readonly double SampleGridStep = Math.Pow(2.0, 1.0 / 24.0);
+
+        // Below 1 Hz nothing is ever plotted or rendered; 192 kHz is the Nyquist
+        // frequency of a 384 kHz stream, above every rate the audition can run at.
+        // Beyond the grid the table holds its edge value, as the model itself
+        // holds its last tabulated value above its references.
+        private const double SampleGridLowHz = 1.0;
+        private const double SampleGridHighHz = 192_000.0;
 
         /// <summary>
         /// Whether two calibrations correct identically: the same points, Hz and

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -716,6 +716,22 @@ namespace Resonalyze.Options
             RaiseCalibrationChanged();
         }
 
+        /// <summary>
+        /// Replaces the working copy of the additional-calibration list with one
+        /// the shell changed behind this panel (a curve kept from a Virtual DSP
+        /// session), so the next Apply writes that list back rather than the one
+        /// this panel opened on.
+        /// </summary>
+        internal void AdoptAdditionalCalibrations(
+            IReadOnlyList<MicrophoneCalibrationDefinition> definitions)
+        {
+            ArgumentNullException.ThrowIfNull(definitions);
+            additionalMicrophoneCalibrations = definitions
+                .Select(definition => definition.Clone())
+                .ToList();
+            UpdateCalibrationButtons();
+        }
+
         private void buttonCalibrationExtra_Click(object? sender, EventArgs e)
         {
             using var dialog = new MicrophoneCalibrationsDialog(

--- a/source/Settings/MicrophoneCalibrationDefinition.cs
+++ b/source/Settings/MicrophoneCalibrationDefinition.cs
@@ -30,7 +30,11 @@ internal sealed class MicrophoneCalibrationDefinition
     /// <summary>
     /// The id the pre-list 90° slot migrates to. Fixed rather than generated so
     /// a Virtual DSP project written before the migration resolves to the same
-    /// entry the settings file created.
+    /// entry the settings file created. That makes it a SLOT id, minted on every
+    /// machine that had the slot: two machines' "90deg" entries are different
+    /// files. A session from another machine is therefore never trusted on this
+    /// id alone — it carries its calibration curve, and the curve decides (see
+    /// <c>VirtualCrossoverCalibrationSelection</c>).
     /// </summary>
     public const string LegacyNinetyDegreesId = "90deg";
 
@@ -118,6 +122,14 @@ internal sealed class MicrophoneCalibrationDefinition
         $"{angleDegrees:0.#}°";
 
     /// <summary>
+    /// Whether an id was minted by <see cref="CreateId"/>, and so names an entry
+    /// of exactly one machine — as opposed to the fixed slot ids (the 0° slot,
+    /// the migrated 90° slot), which every machine hands out.
+    /// </summary>
+    public static bool IsGeneratedId(string? id) =>
+        id?.StartsWith(GeneratedIdPrefix, StringComparison.OrdinalIgnoreCase) == true;
+
+    /// <summary>
     /// An id for a new entry that no other entry — present or DELETED — can
     /// ever have carried. A counted id would be handed out again after a
     /// deletion, and every place that outlives the list (a saved Virtual DSP
@@ -155,7 +167,12 @@ internal sealed class MicrophoneCalibrationDefinition
 /// no base curve. The entry stays selectable regardless — dropping it would move
 /// the selection to Off and the next save would erase the user's choice.
 /// </param>
+/// <param name="FileName">
+/// The name (no folder) of the file a file-backed entry reads, so a session that
+/// carries the curve can also say which file it was; null for an estimate.
+/// </param>
 internal sealed record MicrophoneCalibrationEntry(
     string Id,
     string Name,
-    bool Available);
+    bool Available,
+    string? FileName = null);

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -170,12 +170,66 @@ public partial class Form1
     {
         microphoneCalibration.InvalidateCache();
         IReadOnlyList<MicrophoneCalibrationEntry> entries = microphoneCalibration.GetEntries();
-        virtualCrossoverPanel?.ConfigureCalibration(microphoneCalibration.Get, entries);
+        virtualCrossoverPanel?.ConfigureCalibration(
+            microphoneCalibration.Get, entries, AddSessionCalibration);
         eqWizardPanel?.ConfigureCalibration(microphoneCalibration.Get, entries);
         dockedModeSettingsHost.InvokeIfOpen<Options.FROptions>(
             panel => panel.RefreshCalibrationEntries(entries));
         dockedModeSettingsHost.InvokeIfOpen<Options.LiveSpectrumOpt>(
             panel => panel.RefreshCalibrationEntries(entries));
+    }
+
+    // Adds a calibration curve a Virtual DSP session carried in to the configured
+    // list, as a file entry like any other: the curve is written to the application
+    // data folder under its original file name and an entry is created for it, so
+    // every view can pick it. Returns the new entry's id, or null when nothing was
+    // added.
+    private string? AddSessionCalibration(VirtualCrossoverSessionCalibration session)
+    {
+        List<MicrophoneCalibrationDefinition> definitions =
+            measurementSettings.Measurement.AdditionalMicrophoneCalibrations;
+        string path;
+        try
+        {
+            string directory = ApplicationDataPaths.Current.CalibrationsDirectory;
+            Directory.CreateDirectory(directory);
+            path = SessionCalibrationFiles.UniquePath(
+                directory,
+                session.FileName ?? session.Name,
+                File.Exists);
+            File.WriteAllText(path, session.Curve.ToText());
+        }
+        catch (Exception exception) when (
+            exception is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            MessageBox.Show(
+                this,
+                "The calibration could not be written to the application data folder." +
+                $"{Environment.NewLine}{Environment.NewLine}{exception.Message}",
+                "Virtual DSP",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return null;
+        }
+
+        var definition = new MicrophoneCalibrationDefinition
+        {
+            Id = MicrophoneCalibrationDefinition.CreateId(definitions),
+            Name = SessionCalibrationFiles.UniqueName(
+                session.Name,
+                definitions.Select(existing => existing.Name)),
+            Kind = MicrophoneCalibrationKind.File,
+            Path = path
+        };
+        definitions.Add(definition);
+        // An open Record Settings panel works on its own copy of the list and
+        // writes it back on Apply, so it has to learn about the entry or it would
+        // overwrite it.
+        dockedMeasurementSettingsHost.InvokeIfOpen<Options.MeasurementOptions>(
+            panel => panel.AdoptAdditionalCalibrations(definitions));
+        ScheduleMeasurementSettingsSave();
+        RefreshCalibrationConsumers();
+        return definition.Id;
     }
 
     private void WireFormEvents()

--- a/source/Shell/MicrophoneCalibrationService.cs
+++ b/source/Shell/MicrophoneCalibrationService.cs
@@ -51,19 +51,24 @@ internal sealed class MicrophoneCalibrationService
     public IReadOnlyList<MicrophoneCalibrationEntry> GetEntries()
     {
         MicrophoneCalibrationDefinition[] current = definitions;
+        string? zeroDegreePath = ResolveZeroDegreePath();
         var entries = new List<MicrophoneCalibrationEntry>(current.Length + 1)
         {
             new(
                 MicrophoneCalibrationIds.ZeroDegrees,
                 "0°",
-                HasUsableData(ResolveZeroDegreePath()))
+                HasUsableData(zeroDegreePath),
+                FileNameOf(zeroDegreePath))
         };
         foreach (MicrophoneCalibrationDefinition definition in current)
         {
             entries.Add(new MicrophoneCalibrationEntry(
                 definition.Id,
                 definition.Name,
-                IsAvailable(definition, current)));
+                IsAvailable(definition, current),
+                definition.Kind == MicrophoneCalibrationKind.File
+                    ? FileNameOf(definition.Path)
+                    : null));
         }
 
         return entries;
@@ -274,6 +279,26 @@ internal sealed class MicrophoneCalibrationService
 
     private static bool Exists(string? path) =>
         !string.IsNullOrWhiteSpace(path) && File.Exists(path);
+
+    private static string? FileNameOf(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            string name = Path.GetFileName(path);
+            return name.Length == 0 ? null : name;
+        }
+        catch (ArgumentException)
+        {
+            // A hand-edited settings file can hold a path no file system accepts;
+            // the entry then simply has no file name to report.
+            return null;
+        }
+    }
 
     private string? ResolveZeroDegreePath()
     {

--- a/source/Storage/ApplicationDataPaths.cs
+++ b/source/Storage/ApplicationDataPaths.cs
@@ -44,6 +44,12 @@ internal sealed class ApplicationDataPaths
     public string HistoryFile => Path.Combine(RootDirectory, "measurement-history.json");
     public string OverlaysDirectory => Path.Combine(RootDirectory, "overlays");
     public string ToolsDirectory => Path.Combine(RootDirectory, "tools");
+
+    /// <summary>
+    /// Calibration files the application wrote itself — a curve a Virtual DSP
+    /// session carried in, kept as a file so it is a file entry like any other.
+    /// </summary>
+    public string CalibrationsDirectory => Path.Combine(RootDirectory, "calibrations");
     public string CrashLogFile => Path.Combine(RootDirectory, "crash.log");
     public string MeasurementErrorLogFile =>
         Path.Combine(RootDirectory, "measurement-error.log");

--- a/source/Tools/Eq/EqWizardCalibration.cs
+++ b/source/Tools/Eq/EqWizardCalibration.cs
@@ -42,25 +42,35 @@ internal static class EqWizardCalibration
 /// How the microphone correction is applied to a source curve. This is the wizard's own
 /// choice rather than a plain calibration id: an imported curve can additionally re-use
 /// the correction frozen into it at capture time, which has no meaning for a live
-/// measurement.
+/// measurement, and a Virtual DSP channel is pinned to the curve its panel renders with,
+/// which need not be in the wizard's list at all.
 /// </summary>
 internal readonly record struct EqWizardCalibrationChoice
 {
-    private EqWizardCalibrationChoice(bool own, string? calibrationId)
+    private EqWizardCalibrationChoice(bool own, bool pinned, string? calibrationId)
     {
         Own = own;
+        Pinned = pinned;
         CalibrationId = calibrationId;
     }
 
     public static EqWizardCalibrationChoice Off => default;
 
     /// <summary>The correction the curve was captured with, stored alongside it.</summary>
-    public static EqWizardCalibrationChoice OwnCapture => new(true, null);
+    public static EqWizardCalibrationChoice OwnCapture => new(true, false, null);
+
+    /// <summary>
+    /// The correction the source arrived with (<see cref="EqWizardCurveSource.PinnedCalibration"/>),
+    /// applied as it is and not selectable away from.
+    /// </summary>
+    public static EqWizardCalibrationChoice PinnedToSource => new(false, true, null);
 
     public static EqWizardCalibrationChoice Microphone(string? calibrationId) =>
-        new(false, MicrophoneCalibrationIds.Normalize(calibrationId));
+        new(false, false, MicrophoneCalibrationIds.Normalize(calibrationId));
 
     public bool Own { get; }
+
+    public bool Pinned { get; }
 
     /// <summary>
     /// The configured calibration to apply, or null for Off and for Own — whose
@@ -69,11 +79,11 @@ internal readonly record struct EqWizardCalibrationChoice
     public string? CalibrationId { get; }
 
     /// <summary>
-    /// The measurement-layer selection this choice maps to: Own corrects with no
-    /// configured profile (its own correction is applied separately, on the
-    /// imported curve).
+    /// The measurement-layer selection this choice maps to: Own and Pinned correct
+    /// with no configured profile (their correction comes with the source and is
+    /// applied separately).
     /// </summary>
-    public string? MicrophoneCalibrationId => Own ? null : CalibrationId;
+    public string? MicrophoneCalibrationId => Own || Pinned ? null : CalibrationId;
 
-    public bool IsOff => !Own && MicrophoneCalibrationIds.IsOff(CalibrationId);
+    public bool IsOff => !Own && !Pinned && MicrophoneCalibrationIds.IsOff(CalibrationId);
 }

--- a/source/Tools/Eq/EqWizardCurveSource.cs
+++ b/source/Tools/Eq/EqWizardCurveSource.cs
@@ -70,10 +70,14 @@ internal sealed record EqWizardCurveSource
     /// The microphone calibration the Virtual DSP panel renders with, which this source
     /// is pinned to: the wizard applies it but disables its selector, because a PEQ
     /// fitted under one correction and summed under another would break the very
-    /// identity the handoff promises. Null (Off) is a real value. Meaningless for other
-    /// kinds.
+    /// identity the handoff promises. The curve itself rather than an id: the panel may
+    /// be drawing with a curve its session carries, which the wizard's own list cannot
+    /// resolve. Null (Off) is a real value. Meaningless for other kinds.
     /// </summary>
-    public string? PinnedCalibrationId { get; init; }
+    public CalibrationFile? PinnedCalibration { get; init; }
+
+    /// <summary>What the selector shows for <see cref="PinnedCalibration"/>.</summary>
+    public string? PinnedCalibrationName { get; init; }
 
     /// <summary>
     /// The channel's ORIGINAL measurement, before any of its chain — what the corrected
@@ -161,7 +165,7 @@ internal sealed record EqWizardCurveSource
     /// Without either, the correction is already fused into the numbers and applying
     /// another would double it. A Virtual DSP channel is deliberately absent: its
     /// correction is applied, but it is the DSP panel's choice
-    /// (<see cref="PinnedCalibrationId"/>) and its selector stays disabled here.
+    /// (<see cref="PinnedCalibration"/>) and its selector stays disabled here.
     /// </summary>
     public bool SupportsCalibration =>
         Kind == EqWizardSourceKind.ImpulseResponse || HasOwnCalibration;

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -365,10 +365,12 @@ public partial class EqWizardPanel
         // A Virtual DSP channel is pinned to the correction its panel renders with:
         // a PEQ fitted under one calibration and summed under another would break the
         // handoff's identity. The selector is disabled (SupportsCalibration is false)
-        // and the standing IR preference stays untouched.
+        // and the standing IR preference stays untouched. The panel's Off is Off.
         if (source.Kind == EqWizardSourceKind.VirtualDspChannel)
         {
-            return EqWizardCalibrationChoice.Microphone(source.PinnedCalibrationId);
+            return source.PinnedCalibration == null
+                ? EqWizardCalibrationChoice.Off
+                : EqWizardCalibrationChoice.PinnedToSource;
         }
 
         return EqWizardCalibrationChoice.Off;
@@ -410,8 +412,16 @@ public partial class EqWizardPanel
             source.Measurement!.PeakIndex,
             source.Measurement.SampleRate,
             source.GateSettings!,
-            calibrationResolver?.Invoke(calibrationChoice.MicrophoneCalibrationId),
+            ResolveChosenCalibration(),
             SourceSmoothingInverseOctaves);
+
+    // The curve the current choice corrects with: the one the source arrived pinned
+    // to, or the configured entry the choice names (none for Off and for Own, whose
+    // correction is read off the curve itself, see ResolveCurveCalibrationCorrection).
+    private CalibrationFile? ResolveChosenCalibration() =>
+        calibrationChoice.Pinned
+            ? loadedSource?.PinnedCalibration
+            : calibrationResolver?.Invoke(calibrationChoice.MicrophoneCalibrationId);
 
     private EqWizardCurve? ComputeSourceCurve()
     {
@@ -458,7 +468,7 @@ public partial class EqWizardPanel
             Offset = 0,
             CalibrationId = calibrationId
         };
-        CalibrationFile? calibration = calibrationResolver?.Invoke(calibrationId);
+        CalibrationFile? calibration = ResolveChosenCalibration();
 
         IReadOnlyList<AnalysisCurve> curves = DataHelper.GetSpectrum(
             source.Measurement!, options, calibration, SpectrumCurves.Primary);
@@ -502,7 +512,7 @@ public partial class EqWizardPanel
         return calibrationChoice.IsOff
             ? Array.Empty<double>()
             : EqWizardImportedCurve.SampleCorrection(
-                calibrationResolver?.Invoke(calibrationChoice.CalibrationId),
+                ResolveChosenCalibration(),
                 source.Points);
     }
 
@@ -519,7 +529,7 @@ public partial class EqWizardPanel
         return calibrationChoice.IsOff
             ? Array.Empty<double>()
             : RawCurveRenderer.CaptureCalibrationCorrection(
-                calibrationResolver?.Invoke(calibrationChoice.CalibrationId));
+                ResolveChosenCalibration());
     }
 
     // A measured curve keeps its NaN gaps: they mark bands the measurement could not
@@ -966,6 +976,16 @@ public partial class EqWizardPanel
         {
             options.Add(new EqWizardCalibrationOption(
                 EqWizardCalibrationChoice.OwnCapture, "Own (as captured)"));
+        }
+
+        // A Virtual DSP channel's correction is listed under the name its panel
+        // shows for it — which may be a curve the session carries, absent from the
+        // wizard's own list — so the disabled selector still says what applies.
+        if (loadedSource is { Kind: EqWizardSourceKind.VirtualDspChannel, PinnedCalibration: not null } pinned)
+        {
+            options.Add(new EqWizardCalibrationOption(
+                EqWizardCalibrationChoice.PinnedToSource,
+                pinned.PinnedCalibrationName ?? "Virtual DSP"));
         }
 
         foreach (MicrophoneCalibrationEntry entry in calibrationEntries)

--- a/source/Tools/VirtualCrossover/SessionCalibrationFiles.cs
+++ b/source/Tools/VirtualCrossover/SessionCalibrationFiles.cs
@@ -1,0 +1,88 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Where a calibration curve that arrived inside a Virtual DSP session lands
+/// when the user keeps it: a file name safe for the file system, distinct from
+/// anything already there, and an entry name distinct from the configured ones.
+/// </summary>
+internal static class SessionCalibrationFiles
+{
+    private const string DefaultExtension = ".txt";
+    private const string FallbackName = "calibration";
+
+    /// <summary>
+    /// A path under <paramref name="directory"/> for a curve named
+    /// <paramref name="preferredName"/> (a file name or a free-form entry name):
+    /// characters the file system refuses become underscores, a missing extension
+    /// becomes <c>.txt</c>, and a taken name gets a counter before its extension.
+    /// </summary>
+    public static string UniquePath(
+        string directory,
+        string preferredName,
+        Func<string, bool> exists)
+    {
+        ArgumentNullException.ThrowIfNull(directory);
+        ArgumentNullException.ThrowIfNull(preferredName);
+        ArgumentNullException.ThrowIfNull(exists);
+
+        string fileName = Sanitize(preferredName);
+        string stem = Path.GetFileNameWithoutExtension(fileName);
+        string extension = Path.GetExtension(fileName);
+        if (stem.Length == 0)
+        {
+            stem = FallbackName;
+        }
+
+        if (extension.Length == 0)
+        {
+            extension = DefaultExtension;
+        }
+
+        string candidate = Path.Combine(directory, stem + extension);
+        for (int counter = 2; exists(candidate); counter++)
+        {
+            candidate = Path.Combine(directory, $"{stem} ({counter}){extension}");
+        }
+
+        return candidate;
+    }
+
+    /// <summary>
+    /// <paramref name="name"/>, or <c>name (2)</c>, <c>name (3)</c>… when an
+    /// entry of that name already exists (compared case-insensitively, as the
+    /// selectors show them).
+    /// </summary>
+    public static string UniqueName(string name, IEnumerable<string> existingNames)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(existingNames);
+
+        var taken = new HashSet<string>(existingNames, StringComparer.OrdinalIgnoreCase);
+        string stem = name.Trim();
+        if (stem.Length == 0)
+        {
+            stem = FallbackName;
+        }
+
+        string candidate = stem;
+        for (int counter = 2; taken.Contains(candidate); counter++)
+        {
+            candidate = $"{stem} ({counter})";
+        }
+
+        return candidate;
+    }
+
+    private static string Sanitize(string name)
+    {
+        char[] invalid = Path.GetInvalidFileNameChars();
+        var builder = new System.Text.StringBuilder(name.Length);
+        foreach (char character in name.Trim())
+        {
+            builder.Append(Array.IndexOf(invalid, character) >= 0 ? '_' : character);
+        }
+
+        // A name of only dots or spaces is not a file name on Windows.
+        return builder.ToString().Trim(' ', '.');
+    }
+}

--- a/source/Tools/VirtualCrossover/VirtualCrossoverCalibrationSelection.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverCalibrationSelection.cs
@@ -1,0 +1,263 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// A calibration curve a session carries inside itself and no configured entry
+/// matches: the Virtual DSP selector offers it as its own item, so a session
+/// that travels with its measurements is drawn with the correction its author
+/// saw on a machine that never configured that file.
+/// </summary>
+internal sealed record VirtualCrossoverSessionCalibration(
+    CalibrationFile Curve,
+    string Name,
+    string? FileName)
+{
+    public string DisplayName => $"{Name} (from session)";
+
+    /// <summary>What the author would recognize it by: the file, failing that the name.</summary>
+    public string Description =>
+        FileName is { } fileName && !string.Equals(
+            fileName, Name, StringComparison.OrdinalIgnoreCase)
+            ? $"'{Name}' ({fileName})"
+            : $"'{Name}'";
+
+    public VirtualCrossoverCalibrationSettings ToSettings() =>
+        VirtualCrossoverCalibrationSettings.From(Curve, Name, FileName);
+}
+
+/// <summary>What the panel tells the user, once, after a session was bound.</summary>
+internal enum VirtualCrossoverCalibrationNotice
+{
+    None,
+
+    /// <summary>
+    /// The session's own curve is selected because no configured entry has it;
+    /// the user may want it in their list.
+    /// </summary>
+    CarriedBySession,
+
+    /// <summary>
+    /// A session written before the curve travelled names a slot-style id
+    /// ("90deg") that this machine also minted. The ids agree; nothing says the
+    /// files do.
+    /// </summary>
+    MatchedBySlotName,
+
+    /// <summary>
+    /// A session written before the curve travelled names an entry this machine
+    /// does not have; the selection the panel already had was kept.
+    /// </summary>
+    KeptPrevious
+}
+
+/// <summary>
+/// The selector state a bound project starts on: which item is selected (a
+/// configured entry's id, <see cref="VirtualCrossoverCalibrationSelection.SessionId"/>
+/// for the session's own curve, or null for Off), the session curve to offer
+/// when there is one, and the notice to show.
+/// </summary>
+internal sealed record VirtualCrossoverCalibrationDecision(
+    string? SelectedId,
+    VirtualCrossoverSessionCalibration? Session,
+    VirtualCrossoverCalibrationNotice Notice);
+
+/// <summary>
+/// Decides how the Virtual DSP selector reads the calibration a project stores.
+/// The project carries the CURVE (and, as a hint, the id of the entry it mapped
+/// to where it was saved); ids are local to a machine — the migrated "90deg"
+/// id in particular exists on every machine that had a legacy 90° slot — so the
+/// curve, not the id, says whether this machine already has that calibration.
+/// </summary>
+internal static class VirtualCrossoverCalibrationSelection
+{
+    /// <summary>
+    /// The selector id of the curve the session carries. Never written to a
+    /// project: the persisted form of that selection is the curve with no id.
+    /// </summary>
+    public const string SessionId = "session-calibration";
+
+    public static bool IsSession(string? calibrationId) =>
+        string.Equals(calibrationId, SessionId, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Resolves the selection for a project being bound.
+    /// </summary>
+    /// <param name="imported">
+    /// True for a session the user loaded from a file — possibly written on
+    /// another machine — as opposed to the tool's own autosave, whose ids are
+    /// this machine's by construction.
+    /// </param>
+    /// <param name="previousSelectedId">The selector's selection before the bind.</param>
+    /// <param name="previousSession">The session curve the selector offered before the bind.</param>
+    public static VirtualCrossoverCalibrationDecision Resolve(
+        string? calibrationId,
+        VirtualCrossoverCalibrationSettings? calibration,
+        bool imported,
+        IReadOnlyList<MicrophoneCalibrationEntry> entries,
+        Func<string?, CalibrationFile?> resolve,
+        string? previousSelectedId,
+        VirtualCrossoverSessionCalibration? previousSession)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(resolve);
+
+        string? id = MicrophoneCalibrationIds.Normalize(calibrationId);
+        MicrophoneCalibrationEntry? named = Find(entries, id);
+
+        if (calibration is { } embedded)
+        {
+            CalibrationFile curve = embedded.ToCalibrationFile();
+            // The entry the session names, when it still holds the same curve.
+            if (named is { Available: true } &&
+                CalibrationFile.SameCurve(resolve(named.Id), curve))
+            {
+                return new VirtualCrossoverCalibrationDecision(
+                    named.Id, null, VirtualCrossoverCalibrationNotice.None);
+            }
+
+            // The tool's own autosave: the entry is the user's, and a curve that
+            // differs means they edited the file since — the entry follows the
+            // file, which is the point of an entry.
+            if (!imported && named is { Available: true })
+            {
+                return new VirtualCrossoverCalibrationDecision(
+                    named.Id, null, VirtualCrossoverCalibrationNotice.None);
+            }
+
+            // Any configured entry with that curve, under whatever id and name
+            // this machine gave it.
+            MicrophoneCalibrationEntry? same = entries.FirstOrDefault(entry =>
+                entry.Available && CalibrationFile.SameCurve(resolve(entry.Id), curve));
+            if (same != null)
+            {
+                return new VirtualCrossoverCalibrationDecision(
+                    same.Id, null, VirtualCrossoverCalibrationNotice.None);
+            }
+
+            return new VirtualCrossoverCalibrationDecision(
+                SessionId,
+                new VirtualCrossoverSessionCalibration(
+                    curve, embedded.Name, embedded.FileName),
+                imported
+                    ? VirtualCrossoverCalibrationNotice.CarriedBySession
+                    : VirtualCrossoverCalibrationNotice.None);
+        }
+
+        if (id == null)
+        {
+            return new VirtualCrossoverCalibrationDecision(
+                null, null, VirtualCrossoverCalibrationNotice.None);
+        }
+
+        // An id with no curve: a session written before the curve travelled, or
+        // one saved while its entry had no usable file. The autosave keeps it as
+        // it is — the selector marks a missing or unavailable entry rather than
+        // rewriting the choice.
+        if (!imported)
+        {
+            return new VirtualCrossoverCalibrationDecision(
+                id, null, VirtualCrossoverCalibrationNotice.None);
+        }
+
+        if (named is { Available: true })
+        {
+            // A generated id cannot be minted twice, so a foreign session naming
+            // one of this machine's means it came from this machine. A slot id
+            // ("90deg", "0deg") is minted everywhere, so the match is by name.
+            return new VirtualCrossoverCalibrationDecision(
+                id,
+                null,
+                MicrophoneCalibrationDefinition.IsGeneratedId(id)
+                    ? VirtualCrossoverCalibrationNotice.None
+                    : VirtualCrossoverCalibrationNotice.MatchedBySlotName);
+        }
+
+        // The entry is not here (or has no file): the one thing the session can
+        // tell us is which correction NOT to use, and replacing a working choice
+        // with nothing would cost the user the very selection they had.
+        return new VirtualCrossoverCalibrationDecision(
+            previousSelectedId,
+            IsSession(previousSelectedId) ? previousSession : null,
+            VirtualCrossoverCalibrationNotice.KeptPrevious);
+    }
+
+    /// <summary>
+    /// The selector's items: the configured entries plus, when there is one,
+    /// the session's own curve.
+    /// </summary>
+    public static IReadOnlyList<MicrophoneCalibrationEntry> EntriesWith(
+        IReadOnlyList<MicrophoneCalibrationEntry> entries,
+        VirtualCrossoverSessionCalibration? session)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        if (session == null)
+        {
+            return entries;
+        }
+
+        var withSession = new List<MicrophoneCalibrationEntry>(entries.Count + 1);
+        withSession.AddRange(entries);
+        withSession.Add(new MicrophoneCalibrationEntry(
+            SessionId, session.DisplayName, Available: true, session.FileName));
+        return withSession;
+    }
+
+    /// <summary>
+    /// What a selection persists as. A configured entry stores its id and its
+    /// curve; the session's own curve stores the curve and no id; Off stores
+    /// neither. An entry with no usable file right now (unplugged, deleted)
+    /// keeps the curve the project already held for that same entry — the
+    /// session was tuned with it, and a missing file must not erase the record
+    /// of what that was — and stores the id alone when there was none.
+    /// </summary>
+    /// <param name="storedId">The project's current stored id.</param>
+    /// <param name="stored">The project's current stored curve.</param>
+    public static (string? CalibrationId, VirtualCrossoverCalibrationSettings? Calibration)
+        Persist(
+            string? selectedId,
+            VirtualCrossoverSessionCalibration? session,
+            IReadOnlyList<MicrophoneCalibrationEntry> entries,
+            Func<string?, CalibrationFile?> resolve,
+            string? storedId,
+            VirtualCrossoverCalibrationSettings? stored)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(resolve);
+
+        if (IsSession(selectedId))
+        {
+            return (null, session?.ToSettings());
+        }
+
+        string? id = MicrophoneCalibrationIds.Normalize(selectedId);
+        if (id == null)
+        {
+            return (null, null);
+        }
+
+        CalibrationFile? curve = resolve(id);
+        if (curve is not { HasData: true })
+        {
+            return (
+                id,
+                string.Equals(id, storedId, StringComparison.OrdinalIgnoreCase)
+                    ? stored
+                    : null);
+        }
+
+        MicrophoneCalibrationEntry? entry = Find(entries, id);
+        return (
+            id,
+            VirtualCrossoverCalibrationSettings.From(
+                curve, entry?.Name ?? id, entry?.FileName));
+    }
+
+    private static MicrophoneCalibrationEntry? Find(
+        IReadOnlyList<MicrophoneCalibrationEntry> entries,
+        string? id) =>
+        id == null
+            ? null
+            : entries.FirstOrDefault(entry =>
+                string.Equals(entry.Id, id, StringComparison.OrdinalIgnoreCase));
+}

--- a/source/Tools/VirtualCrossover/VirtualCrossoverCalibrationSelection.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverCalibrationSelection.cs
@@ -118,8 +118,11 @@ internal static class VirtualCrossoverCalibrationSelection
 
             // The tool's own autosave: the entry is the user's, and a curve that
             // differs means they edited the file since — the entry follows the
-            // file, which is the point of an entry.
-            if (!imported && named is { Available: true })
+            // file, which is the point of an entry. An entry whose file is missing
+            // right now stays selected and marked, like every other view's
+            // selection does; Persist keeps the stored curve for it, so the record
+            // of what the session was tuned with survives the unplugged drive.
+            if (!imported && named != null)
             {
                 return new VirtualCrossoverCalibrationDecision(
                     named.Id, null, VirtualCrossoverCalibrationNotice.None);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Audition.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Audition.cs
@@ -90,9 +90,10 @@ public partial class VirtualCrossoverPanel
                 left.ChannelCount,
                 right.ChannelCount,
                 borrowedSide,
-                calibrationResolver,
-                calibrationEntries,
-                project.CalibrationId));
+                ResolveSelectedCalibration,
+                CalibrationEntriesWithSession(),
+                Options.MicrophoneCalibrationComboHelper.GetSelectedCalibrationId(
+                    comboBoxCalibration)));
         dialog.ShowDialog(FindForm());
     }
 }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -261,6 +261,20 @@ public partial class VirtualCrossoverPanel : UserControl
     private Func<string?, CalibrationFile?>? calibrationResolver;
     private IReadOnlyList<MicrophoneCalibrationEntry> calibrationEntries = [];
 
+    // Adds a curve to the host's calibration list and returns the new entry's id;
+    // supplied by the host form. Null until wired (the offer is then not made).
+    private Func<VirtualCrossoverSessionCalibration, string?>? calibrationAdder;
+
+    // The curve the bound project carries that no configured entry matches,
+    // offered in the selector as its own item (see
+    // VirtualCrossoverCalibrationSelection). Set when a project binds, dropped
+    // once a configured entry with the same curve appears.
+    private VirtualCrossoverSessionCalibration? sessionCalibration;
+
+    // What the last bind has to say about its calibration, shown once the import
+    // finishes (after the relink prompt, which is about the measurements).
+    private VirtualCrossoverCalibrationNotice pendingCalibrationNotice;
+
     /// <summary>
     /// Saves the given curve as a Captured Frequency Response overlay and returns
     /// the slot it landed in (null when all slots are taken). Wired by the host form.
@@ -374,7 +388,7 @@ public partial class VirtualCrossoverPanel : UserControl
         try
         {
             VirtualCrossoverProjectFile loaded = VirtualCrossoverProjectFile.LoadOrDefault();
-            await ApplyProjectAsync(loaded);
+            await ApplyProjectAsync(loaded, imported: false);
             NotifyIfProjectBackedUp(loaded.BackupNoticePath);
         }
         catch (Exception exception)
@@ -440,13 +454,15 @@ public partial class VirtualCrossoverPanel : UserControl
     }
 
     // Binds a project (the internal autosave or an imported session) to the UI:
-    // controls, view flags, and freshly re-resolved sources.
-    private async Task ApplyProjectAsync(VirtualCrossoverProjectFile newProject)
+    // controls, view flags, and freshly re-resolved sources. `imported` says which
+    // of the two it is: a session from a file may have been written on another
+    // machine, whose calibration ids mean nothing here.
+    private async Task ApplyProjectAsync(VirtualCrossoverProjectFile newProject, bool imported)
     {
         SetProjectLoading(true);
         try
         {
-            await BindProjectAsync(newProject);
+            await BindProjectAsync(newProject, imported);
         }
         finally
         {
@@ -460,8 +476,13 @@ public partial class VirtualCrossoverPanel : UserControl
         }
     }
 
-    private async Task BindProjectAsync(VirtualCrossoverProjectFile newProject)
+    private async Task BindProjectAsync(VirtualCrossoverProjectFile newProject, bool imported)
     {
+        // Read before the project is swapped: a legacy session naming a calibration
+        // this machine lacks keeps the selection the panel had.
+        string? previousCalibrationId =
+            MicrophoneCalibrationComboHelper.GetSelectedCalibrationId(comboBoxCalibration);
+        VirtualCrossoverSessionCalibration? previousSession = sessionCalibration;
         project = newProject;
         relinkDirectory = null;
         // A new project on the same blocks. The channel OBJECTS are reused when the
@@ -521,7 +542,7 @@ public partial class VirtualCrossoverPanel : UserControl
             suppressProjectEvents = false;
         }
 
-        RefreshCalibrationCombo();
+        BindCalibrationSelection(imported, previousCalibrationId, previousSession);
 
         await RestoreProjectSourcesAsync(
             channels,
@@ -634,28 +655,94 @@ public partial class VirtualCrossoverPanel : UserControl
     /// </summary>
     internal void ConfigureCalibration(
         Func<string?, CalibrationFile?> resolver,
-        IReadOnlyList<MicrophoneCalibrationEntry> entries)
+        IReadOnlyList<MicrophoneCalibrationEntry> entries,
+        Func<VirtualCrossoverSessionCalibration, string?>? addToList = null)
     {
         calibrationResolver = resolver;
         calibrationEntries = entries;
-        RefreshCalibrationCombo();
+        calibrationAdder = addToList ?? calibrationAdder;
+        ReconcileCalibrationSelection();
     }
 
-    // Rebuilds the selector's items from the configured calibrations and the
-    // persisted selection, then resolves the calibration the curves use. A
-    // selection that is no longer configured keeps its entry, marked, so the
-    // stored preference is not overwritten by the rebuild — the curves are simply
-    // drawn uncalibrated until the file comes back (an imported session says so
-    // once, see WarnAboutUnavailableCalibration).
-    private void RefreshCalibrationCombo()
+    // The selector after the configured list changed: the selection stays where
+    // it was, marked if its entry is gone or unusable, and a session-carried curve
+    // hands over to a configured entry the moment one holds the same curve — the
+    // user just added it (or already had it, and the list arrived after the
+    // project). The project's stored form follows, so an autosave written after
+    // the list changed says the same thing the selector shows.
+    private void ReconcileCalibrationSelection()
+    {
+        string? selectedId = comboBoxCalibration.Items.Count > 0
+            ? MicrophoneCalibrationComboHelper.GetSelectedCalibrationId(comboBoxCalibration)
+            : project.CalibrationId;
+        if (sessionCalibration is { } session && calibrationResolver is { } resolve)
+        {
+            MicrophoneCalibrationEntry? same = calibrationEntries.FirstOrDefault(entry =>
+                entry.Available &&
+                CalibrationFile.SameCurve(resolve(entry.Id), session.Curve));
+            if (same != null)
+            {
+                if (VirtualCrossoverCalibrationSelection.IsSession(selectedId))
+                {
+                    selectedId = same.Id;
+                }
+
+                sessionCalibration = null;
+            }
+        }
+
+        ApplyCalibrationSelection(selectedId);
+        // A handover (or a re-read of an edited file) changed what the session
+        // says; the autosave must not wait for an unrelated edit to learn it. Only
+        // once the project is the loaded one: before that this is the placeholder,
+        // and saving it would overwrite the real autosave before it was read.
+        if (PersistCalibrationSelection() && initialized)
+        {
+            ScheduleSave();
+        }
+    }
+
+    // The selector for a project that was just bound: the curve the project
+    // carries decides, the id it names is a hint, and a legacy id that resolves
+    // to nothing keeps what the panel had (see VirtualCrossoverCalibrationSelection).
+    private void BindCalibrationSelection(
+        bool imported,
+        string? previousSelectedId,
+        VirtualCrossoverSessionCalibration? previousSession)
+    {
+        Func<string?, CalibrationFile?> resolve = calibrationResolver ?? (_ => null);
+        VirtualCrossoverCalibrationDecision decision =
+            VirtualCrossoverCalibrationSelection.Resolve(
+                project.CalibrationId,
+                project.Calibration,
+                imported,
+                calibrationEntries,
+                resolve,
+                previousSelectedId,
+                previousSession);
+        sessionCalibration = decision.Session;
+        pendingCalibrationNotice = decision.Notice;
+        ApplyCalibrationSelection(decision.SelectedId);
+        // The bound project's own statement is re-derived from the selection:
+        // a kept previous choice or an entry matched by curve is what the
+        // session now says, and the next autosave must agree with the selector.
+        PersistCalibrationSelection();
+    }
+
+    // Rebuilds the selector's items — the configured calibrations plus the
+    // session's own curve, when it offers one — selects the given item, then
+    // resolves the calibration the curves use and redraws. A selection that is
+    // no longer configured keeps its entry, marked, so the stored preference is
+    // not overwritten by the rebuild.
+    private void ApplyCalibrationSelection(string? selectedId)
     {
         suppressProjectEvents = true;
         try
         {
             MicrophoneCalibrationComboHelper.Configure(
                 comboBoxCalibration,
-                project.CalibrationId,
-                calibrationEntries);
+                selectedId,
+                CalibrationEntriesWithSession());
         }
         finally
         {
@@ -666,12 +753,52 @@ public partial class VirtualCrossoverPanel : UserControl
         RedrawAll();
     }
 
-    // Sets the calibration file from the selector's current selection. Off (or an
-    // absent resolver) yields no calibration, matching the loopback-referenced
-    // default.
+    private IReadOnlyList<MicrophoneCalibrationEntry> CalibrationEntriesWithSession() =>
+        VirtualCrossoverCalibrationSelection.EntriesWith(calibrationEntries, sessionCalibration);
+
+    // Resolves the selector's selection to a curve: the session's own curve, one of
+    // the configured entries, or nothing for Off (and for an absent resolver),
+    // matching the loopback-referenced default.
+    private CalibrationFile? ResolveSelectedCalibration(string? calibrationId) =>
+        VirtualCrossoverCalibrationSelection.IsSession(calibrationId)
+            ? sessionCalibration?.Curve
+            : calibrationResolver?.Invoke(calibrationId);
+
     private void ResolveCalibration() =>
-        Calibration = calibrationResolver?.Invoke(
+        Calibration = ResolveSelectedCalibration(
             MicrophoneCalibrationComboHelper.GetSelectedCalibrationId(comboBoxCalibration));
+
+    // Writes the selector's selection into the project in its persisted form: the
+    // curve the session is tuned with, plus the id of the configured entry it came
+    // from (none for the session's own curve). Resolved through the SAME path the
+    // curves use, so what the file carries is what the plot shows. True when the
+    // stored form changed.
+    private bool PersistCalibrationSelection()
+    {
+        (string? id, VirtualCrossoverCalibrationSettings? calibration) =
+            VirtualCrossoverCalibrationSelection.Persist(
+                MicrophoneCalibrationComboHelper.GetSelectedCalibrationId(comboBoxCalibration),
+                sessionCalibration,
+                calibrationEntries,
+                calibrationResolver ?? (_ => null),
+                project.CalibrationId,
+                project.Calibration);
+        bool changed =
+            !string.Equals(id, project.CalibrationId, StringComparison.OrdinalIgnoreCase) ||
+            !SameStoredCurve(calibration, project.Calibration);
+        project.CalibrationId = id;
+        project.Calibration = calibration;
+        return changed;
+    }
+
+    private static bool SameStoredCurve(
+        VirtualCrossoverCalibrationSettings? left,
+        VirtualCrossoverCalibrationSettings? right) =>
+        ReferenceEquals(left, right) ||
+        (left != null && right != null &&
+            string.Equals(left.Name, right.Name, StringComparison.Ordinal) &&
+            string.Equals(left.FileName, right.FileName, StringComparison.Ordinal) &&
+            CalibrationFile.SameCurve(left.ToCalibrationFile(), right.ToCalibrationFile()));
 
     private void OnCalibrationChanged()
     {
@@ -680,12 +807,23 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
-        project.CalibrationId =
-            MicrophoneCalibrationComboHelper.GetSelectedCalibrationId(comboBoxCalibration);
+        PersistCalibrationSelection();
         ResolveCalibration();
         ScheduleSave();
         RedrawAll();
     }
+
+    // The calibration the EQ Wizard pins for a handoff: the curve itself, not an
+    // id, because the session's own curve has no id the wizard's list could
+    // resolve — and the identity the handoff promises is with the curve the plot
+    // draws, whatever it is called.
+    private string? SelectedCalibrationName() =>
+        MicrophoneCalibrationComboHelper.GetSelectedCalibrationId(comboBoxCalibration) is { } id
+            ? CalibrationEntriesWithSession()
+                .FirstOrDefault(entry =>
+                    string.Equals(entry.Id, id, StringComparison.OrdinalIgnoreCase))
+                ?.Name
+            : null;
 
     // ----------------------------------------------------------------- wiring
 
@@ -1905,7 +2043,8 @@ public partial class VirtualCrossoverPanel : UserControl
                 (double)numericTargetLevel.Minimum,
                 (double)numericTargetLevel.Maximum,
                 snapshot.SmoothingInverseOctaves,
-                project.CalibrationId,
+                Calibration,
+                SelectedCalibrationName(),
                 projectGeneration);
         }
         catch (InvalidOperationException)
@@ -1935,7 +2074,7 @@ public partial class VirtualCrossoverPanel : UserControl
                 token,
                 curve,
                 projectGeneration,
-                project.CalibrationId,
+                Calibration,
                 snapshot.Template,
                 snapshot.PinnedOffsetMs,
                 (double)numericTargetLevel.Value))
@@ -2252,8 +2391,10 @@ public partial class VirtualCrossoverPanel : UserControl
             "so it still moves those numbers in the Phase and Impulse\r\n" +
             "views, where no calibrated trace is drawn.\r\n" +
             "The measurement is loopback-referenced, so this is\r\n" +
-            "optional; 0° / 90° appear when their files are configured\r\n" +
-            "in Record Settings.");
+            "optional. The entries are the calibrations configured in\r\n" +
+            "Record Settings; a loaded session that carries its own\r\n" +
+            "curve adds it here as '(from session)'. The selection is\r\n" +
+            "saved into the session as the curve itself, so it travels.");
         toolTip.SetToolTip(
             buttonAutoDelay,
             "Open the Auto delay dialog: align the channels in two\r\n" +
@@ -5532,10 +5673,10 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
-        await ApplyProjectAsync(imported);
+        await ApplyProjectAsync(imported, imported: true);
         ScheduleSave();
         await RelinkMissingSourcesAsync();
-        WarnAboutUnavailableCalibration();
+        ShowCalibrationNotice();
     }
 
     // Offers to relink the sources an imported session could not find. The stored
@@ -5657,40 +5798,116 @@ public partial class VirtualCrossoverPanel : UserControl
             : $"{missing.Count} measurements were not found: {sides}.";
     }
 
-    // The calibration a session asks for is a per-computer setting: the session
-    // stores WHICH calibration its curves were drawn with, but that calibration
-    // belongs to the machine's own microphone. The selector keeps the selection and
-    // marks it, yet the curves are then drawn with no calibration at all — a quiet
-    // difference from what the session's author saw, and worth one sentence at
-    // import time. Copying the other machine's file is NOT the fix: it describes
-    // their microphone, not this one.
-    private void WarnAboutUnavailableCalibration()
+    // One sentence, once, about the calibration an imported session arrived with.
+    // A calibration describes the microphone the MEASUREMENTS were taken with, so
+    // a session travelling with its data brings the right correction along and
+    // the selector starts on it; the user is told, and offered to keep it in their
+    // own list. A session written before the curve travelled can only name an
+    // entry, and an id is local to the machine that minted it — so a match by id
+    // alone is reported as exactly that, and a miss keeps the selection the panel
+    // already had rather than replacing a working choice with nothing.
+    private void ShowCalibrationNotice()
     {
-        if (MicrophoneCalibrationIds.IsOff(project.CalibrationId) || IsDisposed)
+        VirtualCrossoverCalibrationNotice notice = pendingCalibrationNotice;
+        pendingCalibrationNotice = VirtualCrossoverCalibrationNotice.None;
+        if (IsDisposed)
         {
             return;
         }
 
-        MicrophoneCalibrationEntry? entry = calibrationEntries.FirstOrDefault(item =>
-            string.Equals(item.Id, project.CalibrationId, StringComparison.OrdinalIgnoreCase));
-        if (entry is { Available: true })
+        switch (notice)
         {
+            case VirtualCrossoverCalibrationNotice.CarriedBySession
+                when sessionCalibration is { } session:
+                OfferSessionCalibration(session);
+                break;
+
+            case VirtualCrossoverCalibrationNotice.MatchedBySlotName:
+                MessageBox.Show(
+                    FindForm(),
+                    "This session names its microphone calibration by a slot only " +
+                    $"('{SelectedCalibrationName()}'), without the curve itself — it " +
+                    "was written by an older version. This computer's entry of the " +
+                    "same name is selected, but nothing says the two files agree: " +
+                    "check that it is the calibration of the microphone these " +
+                    "measurements were taken with.",
+                    "Virtual DSP",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+                break;
+
+            case VirtualCrossoverCalibrationNotice.KeptPrevious:
+                string kept = SelectedCalibrationName() is { } name
+                    ? $"The '{name}' calibration this panel already had is kept"
+                    : "The curves are drawn without any calibration, as before";
+                MessageBox.Show(
+                    FindForm(),
+                    "This session was tuned with a microphone calibration that is not " +
+                    "configured on this computer, and it was written by an older " +
+                    $"version that did not store the curve itself. {kept}; the " +
+                    "curves may not match the ones its author saw.",
+                    "Virtual DSP",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+                break;
+        }
+    }
+
+    // The session's own curve is selected and its curves match the author's; the
+    // one thing left to decide is whether it should live in this machine's list
+    // too — which is right when these are the author's measurements (the
+    // calibration is of the microphone that took them), and wrong for a
+    // measurement taken here with a different microphone.
+    private void OfferSessionCalibration(VirtualCrossoverSessionCalibration session)
+    {
+        if (calibrationAdder == null)
+        {
+            MessageBox.Show(
+                FindForm(),
+                $"This session carries the microphone calibration {session.Description} " +
+                "it was tuned with, and it is selected, so the curves match the ones " +
+                "its author saw.",
+                "Virtual DSP",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
             return;
         }
 
-        string profile = entry is null
-            ? "a"
-            : $"the '{entry.Name}'";
-        MessageBox.Show(
+        DialogResult answer = MessageBox.Show(
             FindForm(),
-            $"This session was tuned with {profile} microphone calibration, which " +
-            "is not configured on this computer, so its curves are drawn without any " +
-            "calibration and will not match the ones its author saw.\r\n\r\nConfigure " +
-            "the calibration of THIS microphone in the measurement settings — the " +
-            "other computer's file describes its own microphone, not yours.",
+            $"This session carries the microphone calibration {session.Description} " +
+            "it was tuned with, and it is selected, so the curves match the ones its " +
+            "author saw.\r\n\r\nAdd it to your calibrations (Record Settings → More " +
+            "calibrations) so the other views can use it too? Say yes if these " +
+            "measurements were taken with that microphone; a measurement you take " +
+            "with your own microphone needs its own calibration.",
             "Virtual DSP",
-            MessageBoxButtons.OK,
-            MessageBoxIcon.Information);
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+        if (answer != DialogResult.Yes)
+        {
+            return;
+        }
+
+        string? addedId = calibrationAdder(session);
+        if (addedId == null)
+        {
+            return;
+        }
+
+        // The host refreshed the consumers on adding, which hands the selection
+        // over to the new entry (ReconcileCalibrationSelection); this is only for a
+        // host that did not.
+        if (!string.Equals(
+                MicrophoneCalibrationComboHelper.GetSelectedCalibrationId(comboBoxCalibration),
+                addedId,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            sessionCalibration = null;
+            ApplyCalibrationSelection(addedId);
+            PersistCalibrationSelection();
+            ScheduleSave();
+        }
     }
 
     private void ShowError(string message, string details)

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -396,6 +396,66 @@ public sealed class VirtualCrossoverChannelPairSettings
 }
 
 /// <summary>
+/// The microphone calibration a session was tuned with, carried INSIDE the
+/// session as the curve itself rather than as a reference to the machine's
+/// calibration list. A calibration describes the microphone the measurements
+/// were taken with, so it belongs with the measurements: a session that travels
+/// with its data must arrive with the correction its author saw, on a machine
+/// that has never heard of that file. A few dozen (Hz, dB) points cost nothing
+/// next to the impulse responses the session already points at.
+/// </summary>
+public sealed class VirtualCrossoverCalibrationSettings
+{
+    /// <summary>The name the author's calibration list showed for it.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The file the curve came from, by name only — the folder means nothing on
+    /// another machine. Null for a curve that was estimated rather than read.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FileName { get; set; }
+
+    /// <summary>Ascending <c>[frequency Hz, correction dB]</c> pairs.</summary>
+    public List<double[]> Points { get; set; } = new();
+
+    public static VirtualCrossoverCalibrationSettings From(
+        CalibrationFile calibration,
+        string name,
+        string? fileName)
+    {
+        ArgumentNullException.ThrowIfNull(calibration);
+        return new VirtualCrossoverCalibrationSettings
+        {
+            Name = name,
+            FileName = fileName,
+            Points = calibration.Points
+                .Select(point => new[] { point.FrequencyHz, point.Decibels })
+                .ToList()
+        };
+    }
+
+    public CalibrationFile ToCalibrationFile() =>
+        CalibrationFile.FromPoints(
+            Points.Select(point => new CalibrationPoint(point[0], point[1])),
+            Name);
+
+    public void Validate()
+    {
+        Name = Name?.Trim() ?? string.Empty;
+        FileName = string.IsNullOrWhiteSpace(FileName) ? null : FileName.Trim();
+        if (Points.Count < 2 ||
+            Points.Any(point =>
+                point is not { Length: 2 } ||
+                !double.IsFinite(point[0]) || point[0] <= 0 ||
+                !double.IsFinite(point[1])))
+        {
+            throw new InvalidDataException("The session's calibration curve is invalid.");
+        }
+    }
+}
+
+/// <summary>
 /// Persists the Virtual DSP tool state (channel pairs, their DSP chains and
 /// the plot view flags) so a tuning session survives an application restart.
 /// The pair count is user-resizable in the tool, from two up to
@@ -623,11 +683,21 @@ public sealed class VirtualCrossoverProjectFile
             : mode;
     }
 
-    // Microphone calibration applied to the magnitude curves, by id. The
+    // The microphone calibration applied to the magnitude curves. The
     // measurement is loopback-referenced, so calibration is optional and off by
-    // default (null). Which calibration an id names is a property of the machine,
-    // not of the session — see WarnAboutUnavailableCalibration.
+    // default. Two fields state it: Calibration is the CURVE the session is tuned
+    // with and is what another machine reads; CalibrationId is the entry of THIS
+    // machine's calibration list the selection maps to — a local name for the
+    // same curve, null when the session is tuned with a curve it carries itself
+    // and no configured entry matches. An id alone (no curve) is how sessions
+    // were written before the curve travelled, and it is read as a hint, never
+    // as an identity: the "90deg" id is minted on every machine that migrated a
+    // legacy 90° slot, so two machines' ids agreeing says nothing about their
+    // files. See VirtualCrossoverCalibrationSelection.
     public string? CalibrationId { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public VirtualCrossoverCalibrationSettings? Calibration { get; set; }
 
     // Schema v5 payload, kept only so an older file deserializes for migration:
     // the selection used to be one of three fixed modes.
@@ -1075,6 +1145,7 @@ public sealed class VirtualCrossoverProjectFile
         {
             throw new InvalidDataException("The phase analysis mode is invalid.");
         }
+        Calibration?.Validate();
         if (PhaseFdwCycles is not (4 or 6 or 8))
         {
             PhaseFdwCycles = PhaseAnalysisSettings.DefaultFdwCycles;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -444,11 +444,14 @@ public sealed class VirtualCrossoverCalibrationSettings
     {
         Name = Name?.Trim() ?? string.Empty;
         FileName = string.IsNullOrWhiteSpace(FileName) ? null : FileName.Trim();
-        if (Points.Count < 2 ||
-            Points.Any(point =>
+        // Two DISTINCT frequencies: the reader merges duplicates into one knot,
+        // and a one-knot curve is no curve — it would load as "available", apply
+        // nothing, and fail this very check on the next save.
+        if (Points.Any(point =>
                 point is not { Length: 2 } ||
                 !double.IsFinite(point[0]) || point[0] <= 0 ||
-                !double.IsFinite(point[1])))
+                !double.IsFinite(point[1])) ||
+            Points.Select(point => point[0]).Distinct().Count() < 2)
         {
             throw new InvalidDataException("The session's calibration curve is invalid.");
         }

--- a/source/Tools/VirtualCrossover/VirtualDspEqHandoff.cs
+++ b/source/Tools/VirtualCrossover/VirtualDspEqHandoff.cs
@@ -81,12 +81,14 @@ namespace Resonalyze;
 /// before any of it, so chain edits cannot invalidate its bank — and its recorded
 /// chain is the identity, which would otherwise compare unequal to a real one.
 /// </param>
-/// <param name="CalibrationId">
-/// The microphone correction the curve was tuned under. The wizard's own selector is
-/// DISABLED during a handoff precisely because a bank fitted under one correction and
-/// summed under another is not the same bank — and the Virtual DSP panel's selector,
-/// reachable by a plain tab switch, would otherwise walk around that lock from the
-/// other side.
+/// <param name="Calibration">
+/// The microphone correction the curve was tuned under — the curve itself, compared
+/// by content on return: the panel may be drawing with a curve its session carries,
+/// which has no id, and a re-read of the same file is the same correction. The
+/// wizard's own selector is DISABLED during a handoff precisely because a bank fitted
+/// under one correction and summed under another is not the same bank — and the
+/// Virtual DSP panel's selector, reachable by a plain tab switch, would otherwise walk
+/// around that lock from the other side.
 /// </param>
 internal sealed record VirtualDspEqReturnToken(
     VirtualCrossoverChannel Channel,
@@ -100,7 +102,7 @@ internal sealed record VirtualDspEqReturnToken(
     double TargetLevelDb,
     PhaseAnalysisSettings GateTemplate,
     double? PinnedGateOffsetMs,
-    string? CalibrationId);
+    CalibrationFile? Calibration);
 
 /// <summary>
 /// Everything one Virtual DSP channel side sends into the EQ Wizard: the curve to
@@ -175,7 +177,8 @@ internal static class VirtualDspEqHandoff
         double targetLevelMinDb,
         double targetLevelMaxDb,
         int smoothingInverseOctaves,
-        string? calibrationId,
+        CalibrationFile? calibration,
+        string? calibrationName,
         long projectGeneration)
     {
         ArgumentNullException.ThrowIfNull(channel);
@@ -261,7 +264,8 @@ internal static class VirtualDspEqHandoff
             Coherence = EqWizardSourceResolver.ExtractTransferCoherence(
                 state.TransferCoherence, sampleRate),
             GateSettings = gateTemplate with { GateOffsetMs = gateOffsetMs },
-            PinnedCalibrationId = calibrationId,
+            PinnedCalibration = calibration,
+            PinnedCalibrationName = calibration == null ? null : calibrationName,
             // The ORIGINAL measurement and the chain around the bank, so the corrected
             // preview is one ApplyChain of the whole chain — the panel's own arithmetic
             // — rather than the bypassed response filtered a second time.
@@ -303,7 +307,7 @@ internal static class VirtualDspEqHandoff
                 targetLevelDb,
                 gateTemplate,
                 pinnedGateOffsetMs,
-                MicrophoneCalibrationIds.Normalize(calibrationId)));
+                calibration));
     }
 
     /// <summary>
@@ -311,7 +315,7 @@ internal static class VirtualDspEqHandoff
     /// when the channel is gone (removed) or the project it belonged to has been
     /// replaced since; the caller keeps the wizard open so the tune is not lost.
     /// </summary>
-    /// <param name="calibrationId">
+    /// <param name="calibration">
     /// The panel's CURRENT microphone calibration, compared against the one the bank
     /// was fitted under.
     /// </param>
@@ -336,7 +340,7 @@ internal static class VirtualDspEqHandoff
         VirtualDspEqReturnToken token,
         EqualizationCurve curve,
         long projectGeneration,
-        string? calibrationId,
+        CalibrationFile? calibration,
         PhaseAnalysisSettings gateTemplate,
         double? pinnedGateOffsetMs,
         double targetLevelDb)
@@ -356,10 +360,7 @@ internal static class VirtualDspEqHandoff
         // reason; the Virtual DSP panel's selector is reachable by a plain tab switch,
         // which a session deliberately survives, so the same rule has to hold here or
         // the lock is decorative.
-        if (!string.Equals(
-                token.CalibrationId,
-                MicrophoneCalibrationIds.Normalize(calibrationId),
-                StringComparison.OrdinalIgnoreCase))
+        if (!CalibrationFile.SameCurve(token.Calibration, calibration))
         {
             return false;
         }

--- a/tests/Resonalyze.App.Tests/EqWizardCalibrationTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardCalibrationTests.cs
@@ -18,6 +18,25 @@ public sealed class EqWizardCalibrationTests
         Assert.Null(EqWizardCalibrationChoice.OwnCapture.MicrophoneCalibrationId);
         Assert.False(EqWizardCalibrationChoice.OwnCapture.IsOff);
         Assert.True(EqWizardCalibrationChoice.Microphone("   ").IsOff);
+        // Pinned applies the curve the Virtual DSP source arrived with — which may be
+        // one its session carries, absent from the list — so it names no entry and is
+        // not Off either.
+        Assert.Null(EqWizardCalibrationChoice.PinnedToSource.MicrophoneCalibrationId);
+        Assert.False(EqWizardCalibrationChoice.PinnedToSource.IsOff);
+        Assert.True(EqWizardCalibrationChoice.PinnedToSource.Pinned);
+        Assert.NotEqual(EqWizardCalibrationChoice.PinnedToSource, EqWizardCalibrationChoice.OwnCapture);
+        Assert.NotEqual(EqWizardCalibrationChoice.PinnedToSource, EqWizardCalibrationChoice.Off);
+    }
+
+    [Fact]
+    public void UpdatedIrPreference_KeepsPreferenceWhenAVirtualDspChannelIsPinned()
+    {
+        string? next = EqWizardCalibration.UpdatedIrPreference(
+            current: "cal1",
+            loadedKind: EqWizardSourceKind.VirtualDspChannel,
+            chosen: EqWizardCalibrationChoice.PinnedToSource);
+
+        Assert.Equal("cal1", next);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/MicrophoneCalibrationServiceTests.cs
+++ b/tests/Resonalyze.App.Tests/MicrophoneCalibrationServiceTests.cs
@@ -252,6 +252,27 @@ public sealed class MicrophoneCalibrationServiceTests : IDisposable
             service.GetEntries().Select(entry => entry.Id));
     }
 
+    [Fact]
+    public void GetEntries_NamesTheFileOfEachFileBackedEntry()
+    {
+        // A Virtual DSP session that carries a curve also says which file it was, so
+        // the entries report theirs — by name only, the folder means nothing elsewhere.
+        zeroDegreePath = WriteFile("ECM8000_0deg.txt", ValidCalibration);
+        definitions.Add(new MicrophoneCalibrationDefinition
+        {
+            Id = "ninety",
+            Name = "90°",
+            Kind = MicrophoneCalibrationKind.File,
+            Path = WriteFile("ECM8000_90deg.txt", ValidCalibration)
+        });
+        definitions.Add(NewAngle("angle", 45));
+        MicrophoneCalibrationService service = CreateService();
+
+        Assert.Equal(
+            ["ECM8000_0deg.txt", "ECM8000_90deg.txt", null],
+            service.GetEntries().Select(entry => entry.FileName));
+    }
+
     private static MicrophoneCalibrationDefinition NewAngle(string id, double angleDegrees) =>
         new()
         {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverCalibrationSelectionTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverCalibrationSelectionTests.cs
@@ -134,14 +134,24 @@ public sealed class VirtualCrossoverCalibrationSelectionTests
     }
 
     [Fact]
-    public void AnUnavailableNamedEntry_DoesNotCaptureACarriedCurve()
+    public void TheAutosave_KeepsItsUnavailableEntrySelected_AndAnImportDoesNot()
     {
-        VirtualCrossoverCalibrationDecision decision =
+        // The user's own entry with its file unplugged: it stays selected and marked,
+        // as every view's selection does (Persist keeps the stored curve for it), so
+        // it is still the same selection when the file returns — even if the file
+        // was edited meanwhile and the curve alone would no longer find it.
+        VirtualCrossoverCalibrationDecision autosave =
             Decide("cal-gone", Carried(RecipientsCurve, name: "Unplugged"), imported: false);
 
-        // RecipientsCurve IS configured here, as "90deg" — so that wins over the
-        // unavailable entry the autosave named.
-        Assert.Equal("90deg", decision.SelectedId);
+        Assert.Equal("cal-gone", autosave.SelectedId);
+        Assert.Null(autosave.Session);
+
+        // An import has no such claim on an unavailable entry of the same id: the
+        // curve decides, and RecipientsCurve IS configured here, as "90deg".
+        VirtualCrossoverCalibrationDecision import =
+            Decide("cal-gone", Carried(RecipientsCurve, name: "Unplugged"), imported: true);
+
+        Assert.Equal("90deg", import.SelectedId);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverCalibrationSelectionTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverCalibrationSelectionTests.cs
@@ -1,0 +1,305 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// How the Virtual DSP selector reads the calibration a project stores — the four
+/// ways a session can arrive (its own curve; a curve this machine has under some
+/// name; a legacy id that resolves; a legacy id that does not) and what each
+/// persists as. The ids are deliberately the colliding ones: "90deg" exists on
+/// every machine that migrated a legacy 90° slot, and an id agreeing says nothing
+/// about the files.
+/// </summary>
+public sealed class VirtualCrossoverCalibrationSelectionTests
+{
+    private static readonly CalibrationFile AuthorsCurve =
+        CalibrationFile.Parse("20 0\n1000 1.5\n20000 -3\n");
+
+    private static readonly CalibrationFile RecipientsCurve =
+        CalibrationFile.Parse("20 0\n1000 -1.5\n20000 2\n");
+
+    private static readonly CalibrationFile ZeroCurve =
+        CalibrationFile.Parse("20 0\n20000 0\n");
+
+    // A curve no entry of the recipient's list resolves to.
+    private static readonly CalibrationFile ForeignCurve =
+        CalibrationFile.Parse("20 0\n1000 0.5\n20000 -6\n");
+
+    private static readonly MicrophoneCalibrationEntry[] Recipient =
+    [
+        new(MicrophoneCalibrationIds.ZeroDegrees, "0°", Available: true, "ECM8000_0deg.txt"),
+        new("90deg", "90°", Available: true, "other-mic-90.txt"),
+        new("cal-local", "Seat", Available: true, "seat.txt"),
+        new("cal-gone", "Unplugged", Available: false, "unplugged.txt")
+    ];
+
+    private static CalibrationFile? Resolve(string? id) => id switch
+    {
+        MicrophoneCalibrationIds.ZeroDegrees => ZeroCurve,
+        "90deg" => RecipientsCurve,
+        "cal-local" => AuthorsCurve,
+        _ => null
+    };
+
+    private static VirtualCrossoverCalibrationSettings Carried(
+        CalibrationFile curve, string name = "90°", string? fileName = "ECM8000_90deg.txt") =>
+        VirtualCrossoverCalibrationSettings.From(curve, name, fileName);
+
+    private static VirtualCrossoverCalibrationDecision Decide(
+        string? calibrationId,
+        VirtualCrossoverCalibrationSettings? calibration,
+        bool imported = true,
+        string? previousId = "cal-local",
+        VirtualCrossoverSessionCalibration? previousSession = null) =>
+        VirtualCrossoverCalibrationSelection.Resolve(
+            calibrationId, calibration, imported, Recipient, Resolve, previousId, previousSession);
+
+    [Fact]
+    public void ACarriedCurveNobodyHas_IsOfferedAndSelected_AndTheIdCollisionIsIgnored()
+    {
+        // The loud branch of #108 and the silent one at once: the session names
+        // "90deg", the recipient HAS a "90deg" — a different microphone's file.
+        VirtualCrossoverCalibrationDecision decision =
+            Decide("90deg", Carried(ForeignCurve));
+
+        Assert.Equal(VirtualCrossoverCalibrationSelection.SessionId, decision.SelectedId);
+        Assert.NotNull(decision.Session);
+        Assert.True(CalibrationFile.SameCurve(ForeignCurve, decision.Session.Curve));
+        Assert.Equal("90° (from session)", decision.Session.DisplayName);
+        Assert.Equal("'90°' (ECM8000_90deg.txt)", decision.Session.Description);
+        Assert.Equal(VirtualCrossoverCalibrationNotice.CarriedBySession, decision.Notice);
+    }
+
+    [Fact]
+    public void ACarriedCurveThisMachineHasUnderAnotherName_SelectsThatEntry()
+    {
+        // The author's own round trip, and a recipient who already kept the file:
+        // the curve is found under whatever id and name this machine gave it.
+        VirtualCrossoverCalibrationDecision decision =
+            Decide("cal-authors-id", Carried(AuthorsCurve));
+
+        Assert.Equal("cal-local", decision.SelectedId);
+        Assert.Null(decision.Session);
+        Assert.Equal(VirtualCrossoverCalibrationNotice.None, decision.Notice);
+    }
+
+    [Fact]
+    public void ACarriedCurveMatchingTheNamedEntry_WinsOverAnotherEntryWithTheSameCurve()
+    {
+        MicrophoneCalibrationEntry[] twoAlike =
+        [
+            new("cal-a", "A", Available: true),
+            new("cal-b", "B", Available: true)
+        ];
+
+        VirtualCrossoverCalibrationDecision decision =
+            VirtualCrossoverCalibrationSelection.Resolve(
+                "cal-b", Carried(AuthorsCurve), imported: true, twoAlike,
+                _ => AuthorsCurve, previousSelectedId: null, previousSession: null);
+
+        Assert.Equal("cal-b", decision.SelectedId);
+    }
+
+    [Fact]
+    public void TheAutosave_FollowsItsOwnEntryEvenWhenTheFileWasEditedSince()
+    {
+        // The autosave's id is this machine's by construction, and an entry exists
+        // so that editing the file updates every view reading it — the stored
+        // curve is the previous state of that file, not a rival to it.
+        VirtualCrossoverCalibrationDecision decision =
+            Decide("90deg", Carried(AuthorsCurve), imported: false);
+
+        Assert.Equal("90deg", decision.SelectedId);
+        Assert.Null(decision.Session);
+        Assert.Equal(VirtualCrossoverCalibrationNotice.None, decision.Notice);
+    }
+
+    [Fact]
+    public void TheAutosave_OffersItsOwnCurve_WhenTheEntryIsGone()
+    {
+        // An entry deleted after the session was tuned: the curve is still the
+        // session's, and it carries on drawing with it, silently — the user did
+        // this themselves.
+        VirtualCrossoverCalibrationDecision decision =
+            Decide("cal-deleted", Carried(AuthorsCurve, name: "Seat", fileName: "seat.txt"), imported: false);
+
+        // ...except that this machine still has the curve under "cal-local".
+        Assert.Equal("cal-local", decision.SelectedId);
+
+        VirtualCrossoverCalibrationDecision unmatched =
+            Decide("cal-deleted", Carried(ForeignCurve, name: "Old"), imported: false);
+        Assert.Equal(VirtualCrossoverCalibrationSelection.SessionId, unmatched.SelectedId);
+        Assert.Equal(VirtualCrossoverCalibrationNotice.None, unmatched.Notice);
+        Assert.Equal("Old", unmatched.Session!.Name);
+    }
+
+    [Fact]
+    public void AnUnavailableNamedEntry_DoesNotCaptureACarriedCurve()
+    {
+        VirtualCrossoverCalibrationDecision decision =
+            Decide("cal-gone", Carried(RecipientsCurve, name: "Unplugged"), imported: false);
+
+        // RecipientsCurve IS configured here, as "90deg" — so that wins over the
+        // unavailable entry the autosave named.
+        Assert.Equal("90deg", decision.SelectedId);
+    }
+
+    [Fact]
+    public void Off_IsOff()
+    {
+        VirtualCrossoverCalibrationDecision decision = Decide(null, null);
+
+        Assert.Null(decision.SelectedId);
+        Assert.Null(decision.Session);
+        Assert.Equal(VirtualCrossoverCalibrationNotice.None, decision.Notice);
+    }
+
+    [Fact]
+    public void ALegacySlotId_ThatResolvesHere_IsMatchedByNameAndSaysSo()
+    {
+        // A session written before the curve travelled, naming "90deg": the match is
+        // by slot name only, and the user is told rather than left to assume.
+        VirtualCrossoverCalibrationDecision decision = Decide("90deg", null);
+
+        Assert.Equal("90deg", decision.SelectedId);
+        Assert.Equal(VirtualCrossoverCalibrationNotice.MatchedBySlotName, decision.Notice);
+
+        VirtualCrossoverCalibrationDecision zero =
+            Decide(MicrophoneCalibrationIds.ZeroDegrees, null);
+        Assert.Equal(VirtualCrossoverCalibrationNotice.MatchedBySlotName, zero.Notice);
+    }
+
+    [Fact]
+    public void ALegacyGeneratedId_ThatResolvesHere_IsThisMachinesOwn()
+    {
+        VirtualCrossoverCalibrationDecision decision = Decide("cal-local", null);
+
+        Assert.Equal("cal-local", decision.SelectedId);
+        Assert.Equal(VirtualCrossoverCalibrationNotice.None, decision.Notice);
+    }
+
+    [Fact]
+    public void ALegacyId_ThatDoesNotResolve_KeepsWhatThePanelHad()
+    {
+        // The issue's first ask: a valid selection must not be lost to an invalid one.
+        VirtualCrossoverCalibrationDecision decision =
+            Decide("cal-authors-id", null, previousId: "cal-local");
+
+        Assert.Equal("cal-local", decision.SelectedId);
+        Assert.Equal(VirtualCrossoverCalibrationNotice.KeptPrevious, decision.Notice);
+
+        // ...including when what it had was a curve carried by the previous session.
+        var previousSession = new VirtualCrossoverSessionCalibration(AuthorsCurve, "Prev", null);
+        VirtualCrossoverCalibrationDecision kept = Decide(
+            "cal-gone", null,
+            previousId: VirtualCrossoverCalibrationSelection.SessionId,
+            previousSession: previousSession);
+        Assert.Equal(VirtualCrossoverCalibrationSelection.SessionId, kept.SelectedId);
+        Assert.Same(previousSession, kept.Session);
+
+        // ...and when it had nothing, nothing: the notice still says so.
+        VirtualCrossoverCalibrationDecision off = Decide("cal-authors-id", null, previousId: null);
+        Assert.Null(off.SelectedId);
+        Assert.Equal(VirtualCrossoverCalibrationNotice.KeptPrevious, off.Notice);
+    }
+
+    [Fact]
+    public void TheAutosave_KeepsAnUnresolvableId_ForTheSelectorToMark()
+    {
+        VirtualCrossoverCalibrationDecision decision =
+            Decide("cal-deleted", null, imported: false);
+
+        Assert.Equal("cal-deleted", decision.SelectedId);
+        Assert.Equal(VirtualCrossoverCalibrationNotice.None, decision.Notice);
+    }
+
+    [Fact]
+    public void EntriesWith_AppendsTheSessionCurveAsItsOwnItem()
+    {
+        var session = new VirtualCrossoverSessionCalibration(AuthorsCurve, "90°", "ECM8000_90deg.txt");
+
+        IReadOnlyList<MicrophoneCalibrationEntry> entries =
+            VirtualCrossoverCalibrationSelection.EntriesWith(Recipient, session);
+
+        Assert.Equal(Recipient.Length + 1, entries.Count);
+        MicrophoneCalibrationEntry last = entries[^1];
+        Assert.Equal(VirtualCrossoverCalibrationSelection.SessionId, last.Id);
+        Assert.Equal("90° (from session)", last.Name);
+        Assert.True(last.Available);
+        Assert.Equal("ECM8000_90deg.txt", last.FileName);
+        Assert.Same(Recipient, VirtualCrossoverCalibrationSelection.EntriesWith(Recipient, null));
+    }
+
+    [Fact]
+    public void Persist_WritesTheCurveForAnEntry_TheCurveAloneForTheSession_AndNothingForOff()
+    {
+        (string? id, VirtualCrossoverCalibrationSettings? curve) =
+            VirtualCrossoverCalibrationSelection.Persist(
+                "cal-local", null, Recipient, Resolve, storedId: null, stored: null);
+        Assert.Equal("cal-local", id);
+        Assert.NotNull(curve);
+        Assert.Equal("Seat", curve.Name);
+        Assert.Equal("seat.txt", curve.FileName);
+        Assert.True(CalibrationFile.SameCurve(AuthorsCurve, curve.ToCalibrationFile()));
+
+        var session = new VirtualCrossoverSessionCalibration(RecipientsCurve, "Theirs", "theirs.txt");
+        (id, curve) = VirtualCrossoverCalibrationSelection.Persist(
+            VirtualCrossoverCalibrationSelection.SessionId, session, Recipient, Resolve,
+            storedId: null, stored: null);
+        // No id: the persisted form of "the curve the session carries" is the curve
+        // itself, so an autosave re-read on this machine cannot be captured by an
+        // entry that merely shares a slot name.
+        Assert.Null(id);
+        Assert.Equal("Theirs", curve!.Name);
+        Assert.True(CalibrationFile.SameCurve(RecipientsCurve, curve.ToCalibrationFile()));
+
+        // An entry with no usable file: the id alone says what was meant...
+        (id, curve) = VirtualCrossoverCalibrationSelection.Persist(
+            "cal-gone", null, Recipient, Resolve, storedId: "cal-local", stored: Carried(AuthorsCurve));
+        Assert.Equal("cal-gone", id);
+        Assert.Null(curve);
+
+        // ...unless the project already held that entry's curve: an unplugged file
+        // must not erase the record of what the session was tuned with.
+        VirtualCrossoverCalibrationSettings held = Carried(RecipientsCurve, name: "Unplugged");
+        (id, curve) = VirtualCrossoverCalibrationSelection.Persist(
+            "cal-gone", null, Recipient, Resolve, storedId: "cal-gone", stored: held);
+        Assert.Equal("cal-gone", id);
+        Assert.Same(held, curve);
+
+        (id, curve) = VirtualCrossoverCalibrationSelection.Persist(
+            null, null, Recipient, Resolve, storedId: "cal-gone", stored: held);
+        Assert.Null(id);
+        Assert.Null(curve);
+    }
+
+    [Fact]
+    public void SessionCalibrationFiles_NameFilesAndEntriesWithoutCollisions()
+    {
+        string directory = Path.Combine("C:", "data");
+        var taken = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            Path.Combine(directory, "ECM8000_90deg.txt"),
+            Path.Combine(directory, "ECM8000_90deg (2).txt")
+        };
+
+        Assert.Equal(
+            Path.Combine(directory, "ECM8000_90deg (3).txt"),
+            SessionCalibrationFiles.UniquePath(directory, "ECM8000_90deg.txt", taken.Contains));
+        Assert.Equal(
+            Path.Combine(directory, "mic.cal"),
+            SessionCalibrationFiles.UniquePath(directory, "mic.cal", taken.Contains));
+        // A free-form entry name: file-system-safe, with an extension every reader takes.
+        Assert.Equal(
+            Path.Combine(directory, "90° seat_.txt"),
+            SessionCalibrationFiles.UniquePath(directory, "90° seat?", taken.Contains));
+        Assert.Equal(
+            Path.Combine(directory, "calibration.txt"),
+            SessionCalibrationFiles.UniquePath(directory, " ... ", taken.Contains));
+
+        Assert.Equal("90°", SessionCalibrationFiles.UniqueName("90°", ["0°", "Seat"]));
+        Assert.Equal("90° (2)", SessionCalibrationFiles.UniqueName("90°", ["90°"]));
+        Assert.Equal("90° (3)", SessionCalibrationFiles.UniqueName(" 90° ", ["90°", "90° (2)"]));
+        Assert.Equal("calibration", SessionCalibrationFiles.UniqueName("", []));
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -614,6 +614,18 @@ public sealed class VirtualCrossoverProjectFileTests
         };
         Assert.Throws<InvalidDataException>(() => tooFew.Validate());
 
+        // Two points at one frequency merge into one knot on reading: no curve, and
+        // the merged form would fail this check on the next save.
+        var oneFrequency = new VirtualCrossoverProjectFile
+        {
+            Calibration = new VirtualCrossoverCalibrationSettings
+            {
+                Name = "x",
+                Points = { new[] { 1000.0, 0.0 }, new[] { 1000.0, 1.0 } }
+            }
+        };
+        Assert.Throws<InvalidDataException>(() => oneFrequency.Validate());
+
         var badFrequency = new VirtualCrossoverProjectFile
         {
             Calibration = new VirtualCrossoverCalibrationSettings

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -554,6 +554,111 @@ public sealed class VirtualCrossoverProjectFileTests
     }
 
     [Fact]
+    public void SaveToAndLoadFrom_CarryTheCalibrationCurveItself()
+    {
+        // The session states the correction it was tuned with as the CURVE, so a
+        // machine that never configured that file draws what the author saw. The id
+        // travels too, but only as a hint.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            CalibrationFile curve = CalibrationFile.Parse("16 0\n1000 -0.75\n20000 3.5\n");
+            var original = new VirtualCrossoverProjectFile
+            {
+                CalibrationId = "90deg",
+                Calibration = VirtualCrossoverCalibrationSettings.From(
+                    curve, "90°", "ECM8000_90deg.txt")
+            };
+            string path = Path.Combine(root, "session.json");
+
+            original.SaveTo(path);
+            VirtualCrossoverProjectFile loaded = VirtualCrossoverProjectFile.LoadFrom(path);
+
+            Assert.Equal("90deg", loaded.CalibrationId);
+            Assert.NotNull(loaded.Calibration);
+            Assert.Equal("90°", loaded.Calibration.Name);
+            Assert.Equal("ECM8000_90deg.txt", loaded.Calibration.FileName);
+            Assert.True(CalibrationFile.SameCurve(curve, loaded.Calibration.ToCalibrationFile()));
+
+            // A curve from an estimate has no file: the name is what it has.
+            string json = File.ReadAllText(path);
+            Assert.Contains("\"calibration\"", json);
+            Assert.Contains("\"fileName\"", json);
+            original.Calibration.FileName = null;
+            original.SaveTo(path);
+            Assert.DoesNotContain("\"fileName\"", File.ReadAllText(path));
+            Assert.Null(VirtualCrossoverProjectFile.LoadFrom(path).Calibration!.FileName);
+
+            // Off, and a session written before the curve travelled, carry no block.
+            original.Calibration = null;
+            original.SaveTo(path);
+            Assert.DoesNotContain("\"calibration\"", File.ReadAllText(path));
+            Assert.Null(VirtualCrossoverProjectFile.LoadFrom(path).Calibration);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Validate_RejectsACalibrationCurveAFileCouldNotState()
+    {
+        var tooFew = new VirtualCrossoverProjectFile
+        {
+            Calibration = new VirtualCrossoverCalibrationSettings
+            {
+                Name = "x",
+                Points = { new[] { 1000.0, 0.0 } }
+            }
+        };
+        Assert.Throws<InvalidDataException>(() => tooFew.Validate());
+
+        var badFrequency = new VirtualCrossoverProjectFile
+        {
+            Calibration = new VirtualCrossoverCalibrationSettings
+            {
+                Name = "x",
+                Points = { new[] { 0.0, 0.0 }, new[] { 1000.0, 0.0 } }
+            }
+        };
+        Assert.Throws<InvalidDataException>(() => badFrequency.Validate());
+
+        var badShape = new VirtualCrossoverProjectFile
+        {
+            Calibration = new VirtualCrossoverCalibrationSettings
+            {
+                Name = "x",
+                Points = { new[] { 20.0 }, new[] { 1000.0, 0.0 } }
+            }
+        };
+        Assert.Throws<InvalidDataException>(() => badShape.Validate());
+
+        var badLevel = new VirtualCrossoverProjectFile
+        {
+            Calibration = new VirtualCrossoverCalibrationSettings
+            {
+                Name = "x",
+                Points = { new[] { 20.0, double.NaN }, new[] { 1000.0, 0.0 } }
+            }
+        };
+        Assert.Throws<InvalidDataException>(() => badLevel.Validate());
+
+        var fine = new VirtualCrossoverProjectFile
+        {
+            Calibration = new VirtualCrossoverCalibrationSettings
+            {
+                Name = "  x  ",
+                FileName = " ",
+                Points = { new[] { 20.0, 0.0 }, new[] { 1000.0, 0.0 } }
+            }
+        };
+        fine.Validate();
+        Assert.Equal("x", fine.Calibration.Name);
+        Assert.Null(fine.Calibration.FileName);
+    }
+
+    [Fact]
     public void Save_RejectsInvalidChannelValues()
     {
         var negativeDelay = new VirtualCrossoverProjectFile();

--- a/tests/Resonalyze.App.Tests/VirtualDspEqHandoffTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualDspEqHandoffTests.cs
@@ -318,8 +318,9 @@ public sealed class VirtualDspEqHandoffTests
         };
         channel.Settings.PeqPreampDb = -2.5;
 
+        CalibrationFile calibration = CalibrationFile.Parse("20 0\n20000 1.5\n");
         VirtualDspEqHandoffRequest request = Build(
-            channel, withChain: true, targetLevelDb: -41, calibrationId: "mic-1");
+            channel, withChain: true, targetLevelDb: -41, calibration: calibration);
 
         Assert.Equal(channel.Settings.PeqBands, request.BankSeed.Bands);
         Assert.Equal(-2.5, request.BankSeed.PreampDb);
@@ -327,7 +328,11 @@ public sealed class VirtualDspEqHandoffTests
         // that plot's own dB frame, so "one target" means one height too.
         Assert.Equal(-41, request.TargetLevelDb);
         Assert.Equal(EqWizardSourceKind.VirtualDspChannel, request.Source.Kind);
-        Assert.Equal("mic-1", request.Source.PinnedCalibrationId);
+        // The curve itself travels, not an id: the panel may be drawing with a curve
+        // its session carries, which the wizard's own list could never resolve.
+        Assert.Same(calibration, request.Source.PinnedCalibration);
+        Assert.Equal("mic-1", request.Source.PinnedCalibrationName);
+        Assert.Same(calibration, request.Token.Calibration);
         Assert.Equal(SampleRate, request.Source.SampleRateHz);
         // Pinned: the selector must come up disabled, yet smoothing stays live.
         Assert.False(request.Source.SupportsCalibration);
@@ -379,7 +384,7 @@ public sealed class VirtualDspEqHandoffTests
             new[] { new PeqBand(250, 3, -6) }, preampDb: -1.5);
 
         Assert.True(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, token, curve, projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { channel }, token, curve, projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
 
         VirtualCrossoverChannelSettings right = channel.Pair.SideFor(rightSide: true);
         Assert.Equal(curve.Bands, right.PeqBands);
@@ -402,7 +407,7 @@ public sealed class VirtualDspEqHandoffTests
 
         Assert.False(request.Token.RightSide);
         Assert.True(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, request.Token, curve, projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { channel }, request.Token, curve, projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Equal(curve.Bands, channel.Pair.SideFor(rightSide: false).PeqBands);
     }
 
@@ -418,7 +423,7 @@ public sealed class VirtualDspEqHandoffTests
         var curve = new EqualizationCurve(new[] { new PeqBand(250, 3, -6) });
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, token, curve, projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { channel }, token, curve, projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Empty(channel.Pair.SideFor(rightSide: false).PeqBands);
     }
 
@@ -435,7 +440,7 @@ public sealed class VirtualDspEqHandoffTests
         var curve = new EqualizationCurve(new[] { new PeqBand(250, 3, -6) });
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, token, curve, projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { channel }, token, curve, projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
     }
 
@@ -448,23 +453,27 @@ public sealed class VirtualDspEqHandoffTests
         // which a session deliberately survives — so the same rule has to hold on the
         // way back, or that lock is decorative.
         VirtualCrossoverChannel channel = BuildChannel();
+        CalibrationFile fitted = CalibrationFile.Parse("20 0\n20000 1.5\n");
         VirtualDspEqReturnToken token =
-            TokenFor(channel, rightSide: false) with { CalibrationId = "0deg" };
+            TokenFor(channel, rightSide: false) with { Calibration = fitted };
         var curve = new EqualizationCurve(new[] { new PeqBand(250, 3, -6) });
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, token, curve, projectGeneration: 1, calibrationId: "90deg", GateTemplate, null, TargetLevel));
+            new[] { channel }, token, curve, projectGeneration: 1,
+            CalibrationFile.Parse("20 0\n20000 -1.5\n"), GateTemplate, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
 
         // Turning it off entirely is a change too — not a way back to "no opinion".
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, token, curve, projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { channel }, token, curve, projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
 
-        // The same correction, differently spelled, is the same correction: the ids
-        // are normalized and compared without case, exactly as the selector stores them.
+        // The same correction, re-read (a settings refresh hands the panel a fresh
+        // instance of the same file), is the same correction: curves compare by
+        // content, never by reference or by the name this machine gives them.
         Assert.True(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, token, curve, projectGeneration: 1, calibrationId: " 0DEG ", GateTemplate, null, TargetLevel));
+            new[] { channel }, token, curve, projectGeneration: 1,
+            CalibrationFile.Parse("20 0\n20000 1.5\n"), GateTemplate, null, TargetLevel));
         Assert.Equal(curve.Bands, channel.Settings.PeqBands);
     }
 
@@ -483,7 +492,7 @@ public sealed class VirtualDspEqHandoffTests
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, token, curve,
-            projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Equal(newer, channel.Settings.PeqBands);
 
         // Cleared counts the same: an empty bank is a state, not an absence.
@@ -492,7 +501,7 @@ public sealed class VirtualDspEqHandoffTests
         channel.Settings.PeqPreampDb = 0;
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, second, curve,
-            projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
     }
 
@@ -508,13 +517,13 @@ public sealed class VirtualDspEqHandoffTests
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, token, curve,
-            projectGeneration: 1, calibrationId: null,
+            projectGeneration: 1, calibration: null,
             GateTemplate with { PlateauMs = 400 }, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, token, curve,
-            projectGeneration: 1, calibrationId: null,
+            projectGeneration: 1, calibration: null,
             GateTemplate, pinnedGateOffsetMs: 12.5, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
     }
@@ -531,7 +540,7 @@ public sealed class VirtualDspEqHandoffTests
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, token, curve,
-            projectGeneration: 1, calibrationId: null,
+            projectGeneration: 1, calibration: null,
             GateTemplate, null, targetLevelDb: TargetLevel + 5));
         Assert.Empty(channel.Settings.PeqBands);
     }
@@ -549,7 +558,7 @@ public sealed class VirtualDspEqHandoffTests
         var curve = new EqualizationCurve(new[] { new PeqBand(250, 3, -6) });
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, token, curve, projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { channel }, token, curve, projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
     }
 
@@ -565,14 +574,14 @@ public sealed class VirtualDspEqHandoffTests
         var curve = new EqualizationCurve(new[] { new PeqBand(250, 3, -6) });
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, token, curve, projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { channel }, token, curve, projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
 
         // Switching it off entirely is a change too.
         VirtualDspEqReturnToken fresh = TokenFor(channel, rightSide: false);
         channel.Settings.CrossoverKind = CrossoverKind.Off;
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, fresh, curve, projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { channel }, fresh, curve, projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
     }
 
@@ -589,13 +598,13 @@ public sealed class VirtualDspEqHandoffTests
         var curve = new EqualizationCurve(new[] { new PeqBand(250, 3, -6) });
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, delayToken, curve,
-            projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
 
         VirtualDspEqReturnToken apToken = TokenFor(channel, rightSide: false);
         channel.Settings.AllPassQ = 20;
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, apToken, curve,
-            projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
     }
 
@@ -611,7 +620,7 @@ public sealed class VirtualDspEqHandoffTests
         var curve = new EqualizationCurve(new[] { new PeqBand(250, 3, -6) });
 
         Assert.True(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, token, curve, projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { channel }, token, curve, projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Equal(curve.Bands, channel.Settings.PeqBands);
     }
 
@@ -633,7 +642,7 @@ public sealed class VirtualDspEqHandoffTests
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, request.Token, curve,
-            projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
     }
 
@@ -650,7 +659,7 @@ public sealed class VirtualDspEqHandoffTests
 
         Assert.True(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, token, curve,
-            projectGeneration: 1, calibrationId: null,
+            projectGeneration: 1, calibration: null,
             GateTemplate with
             {
                 FdwCycles = 8,
@@ -673,7 +682,7 @@ public sealed class VirtualDspEqHandoffTests
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, token, curve,
-            projectGeneration: 1, calibrationId: null,
+            projectGeneration: 1, calibration: null,
             GateTemplate with { PlateauMs = 400 }, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
     }
@@ -704,7 +713,7 @@ public sealed class VirtualDspEqHandoffTests
 
         Assert.True(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, request.Token, curve,
-            projectGeneration: 1, calibrationId: null,
+            projectGeneration: 1, calibration: null,
             GateTemplate, pinnedGateOffsetMs: 12.5, TargetLevel));
         Assert.Equal(curve.Bands, channel.Settings.PeqBands);
     }
@@ -720,7 +729,7 @@ public sealed class VirtualDspEqHandoffTests
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, request.Token, curve,
-            projectGeneration: 1, calibrationId: null,
+            projectGeneration: 1, calibration: null,
             GateTemplate, pinnedGateOffsetMs: 12.5, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
     }
@@ -739,7 +748,7 @@ public sealed class VirtualDspEqHandoffTests
         Assert.False(request.Token.WithChain);
         Assert.True(VirtualDspEqHandoff.TryApplyReturn(
             new[] { channel }, request.Token, curve,
-            projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Equal(curve.Bands, channel.Settings.PeqBands);
     }
 
@@ -758,7 +767,7 @@ public sealed class VirtualDspEqHandoffTests
         var curve = new EqualizationCurve(new[] { new PeqBand(250, 3, -6) });
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { channel }, token, curve, projectGeneration: 5, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { channel }, token, curve, projectGeneration: 5, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Empty(channel.Settings.PeqBands);
 
         // The generation ALONE is what refuses it: an untouched channel of the same
@@ -768,9 +777,9 @@ public sealed class VirtualDspEqHandoffTests
         VirtualDspEqReturnToken control =
             TokenFor(untouched, rightSide: false) with { ProjectGeneration = 4 };
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { untouched }, control, curve, projectGeneration: 5, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { untouched }, control, curve, projectGeneration: 5, calibration: null, GateTemplate, null, TargetLevel));
         Assert.True(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { untouched }, control, curve, projectGeneration: 4, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { untouched }, control, curve, projectGeneration: 4, calibration: null, GateTemplate, null, TargetLevel));
         Assert.Equal(curve.Bands, untouched.Settings.PeqBands);
     }
 
@@ -783,7 +792,7 @@ public sealed class VirtualDspEqHandoffTests
         var curve = new EqualizationCurve(new[] { new PeqBand(250, 3, -6) });
 
         Assert.False(VirtualDspEqHandoff.TryApplyReturn(
-            new[] { survivor }, token, curve, projectGeneration: 1, calibrationId: null, GateTemplate, null, TargetLevel));
+            new[] { survivor }, token, curve, projectGeneration: 1, calibration: null, GateTemplate, null, TargetLevel));
 
         Assert.Empty(removed.Settings.PeqBands);
         Assert.Empty(survivor.Settings.PeqBands);
@@ -809,7 +818,7 @@ public sealed class VirtualDspEqHandoffTests
             TargetLevel,
             GateTemplate,
             PinnedGateOffsetMs: null,
-            CalibrationId: null);
+            Calibration: null);
 
     private static EqWizardGatedPreviewRequest Preview(
         VirtualDspEqHandoffRequest request, EqualizationCurve? bank) =>
@@ -829,7 +838,7 @@ public sealed class VirtualDspEqHandoffTests
         double? pinnedGateOffsetMs = null,
         int? renderAnchorIndex = 480,
         double targetLevelDb = -41,
-        string? calibrationId = null,
+        CalibrationFile? calibration = null,
         long projectGeneration = 1) =>
         VirtualDspEqHandoff.Build(
             channel,
@@ -842,7 +851,8 @@ public sealed class VirtualDspEqHandoffTests
             targetLevelMinDb: -120,
             targetLevelMaxDb: 60,
             smoothingInverseOctaves: 0,
-            calibrationId,
+            calibration,
+            calibrationName: calibration == null ? null : "mic-1",
             projectGeneration);
 
     // A channel whose left side holds a synthetic measurement: a decaying wavelet

--- a/tests/Resonalyze.Dsp.Tests/CalibrationFileTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CalibrationFileTests.cs
@@ -389,11 +389,39 @@ public sealed class CalibrationFileTests
         IReadOnlyList<CalibrationPoint> points = angled.Points;
         CalibrationFile sampled = CalibrationFile.FromPoints(points);
 
-        Assert.Equal(20.0, points[0].FrequencyHz);
-        Assert.Equal(20000.0, points[^1].FrequencyHz);
+        Assert.Equal(1.0, points[0].FrequencyHz);
+        Assert.Equal(192_000.0, points[^1].FrequencyHz);
         Assert.Contains(points, point => point.FrequencyHz == 2000.0);
-        Assert.InRange(points.Count, 200, 400);
+        Assert.InRange(points.Count, 400, 500);
         foreach (double frequency in new[] { 20.0, 33.0, 500.0, 2000.0, 12345.0, 20000.0 })
+        {
+            Assert.Equal(
+                angled.GetDecibelCorrection(frequency),
+                sampled.GetDecibelCorrection(frequency),
+                precision: 2);
+        }
+
+        Assert.True(CalibrationFile.SameCurve(angled, sampled));
+    }
+
+    [Fact]
+    public void Points_OfAnAngledEstimate_KeepMovingOutsideTheBaseFile()
+    {
+        // Outside the base file the base holds its edge value while the angular
+        // difference keeps changing — and the audition FIR reads the correction up
+        // to Nyquist. A table cut at the file's edges would clamp the whole
+        // correction there; the carried curve has to reproduce the estimate over
+        // the whole range it is read at, not just over the file.
+        CalibrationFile narrowBase = CalibrationFile.Parse("100 0\n1000 1\n10000 -2\n");
+        static double Delta(double frequency) => -6.0 * Math.Log10(frequency / 100.0);
+        CalibrationFile angled = CalibrationFile.CreateAngled(narrowBase, Delta);
+        CalibrationFile sampled = CalibrationFile.FromPoints(angled.Points);
+
+        // The model's own values, for the record: held base + moving delta.
+        Assert.Equal(-2.0 + Delta(20_000.0), angled.GetDecibelCorrection(20_000.0), precision: 9);
+        Assert.Equal(0.0 + Delta(20.0), angled.GetDecibelCorrection(20.0), precision: 9);
+
+        foreach (double frequency in new[] { 5.0, 20.0, 50.0, 100.0, 5_000.0, 10_000.0, 20_000.0, 48_000.0, 96_000.0, 192_000.0 })
         {
             Assert.Equal(
                 angled.GetDecibelCorrection(frequency),

--- a/tests/Resonalyze.Dsp.Tests/CalibrationFileTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/CalibrationFileTests.cs
@@ -330,6 +330,116 @@ public sealed class CalibrationFileTests
         Assert.Throws<ArgumentNullException>(() => CalibrationFile.Parse(null!));
     }
 
+    // ------------------------------------------------------ points and identity
+
+    [Fact]
+    public void Points_StateTheFileInOrder_AndFromPointsReadsThemBack()
+    {
+        // What a Virtual DSP session stores is the curve itself; it has to come
+        // back correcting exactly as the file did, duplicates merged and all.
+        var parsed = CalibrationFile.Parse("1000 6\n20 -1.25\n1000 0\n20000 3.5\n");
+
+        IReadOnlyList<CalibrationPoint> points = parsed.Points;
+
+        Assert.Equal(new[] { 20.0, 1000.0, 20000.0 }, points.Select(point => point.FrequencyHz));
+        Assert.Equal(-1.25, points[0].Decibels, precision: 9);
+        Assert.Equal(3.5, points[2].Decibels, precision: 9);
+
+        CalibrationFile rebuilt = CalibrationFile.FromPoints(points, "session");
+        Assert.True(rebuilt.HasData);
+        Assert.Null(rebuilt.LoadError);
+        foreach (double frequency in new[] { 10.0, 20.0, 150.0, 1000.0, 7000.0, 30000.0 })
+        {
+            Assert.Equal(
+                parsed.GetDecibelCorrection(frequency),
+                rebuilt.GetDecibelCorrection(frequency),
+                precision: 9);
+        }
+    }
+
+    [Fact]
+    public void FromPoints_DropsWhatAFileCouldNotState_AndReportsTooFew()
+    {
+        CalibrationFile calibration = CalibrationFile.FromPoints(
+            new[]
+            {
+                new CalibrationPoint(0, 1),
+                new CalibrationPoint(double.NaN, 1),
+                new CalibrationPoint(1000, double.PositiveInfinity),
+                new CalibrationPoint(1000, 2)
+            },
+            "session");
+
+        Assert.False(calibration.HasData);
+        Assert.Contains("session", calibration.LoadError);
+        Assert.Throws<ArgumentNullException>(() => CalibrationFile.FromPoints(null!));
+    }
+
+    [Fact]
+    public void Points_OfAnAngledEstimate_ReproduceTheEstimate()
+    {
+        // An estimate is a function, not a table. Its points are a sampling dense
+        // enough that a file written from them reads back as the same correction —
+        // which is what lets a session carry an angle entry, and what lets a machine
+        // recognize its own angle entry in an arriving session.
+        CalibrationFile zero = CalibrationFile.Parse("20 0\n2000 1\n20000 -2\n");
+        CalibrationFile angled = CalibrationFile.CreateAngled(
+            zero, frequency => -3.0 * Math.Pow(Math.Log10(frequency / 20.0) / 3.0, 2));
+
+        IReadOnlyList<CalibrationPoint> points = angled.Points;
+        CalibrationFile sampled = CalibrationFile.FromPoints(points);
+
+        Assert.Equal(20.0, points[0].FrequencyHz);
+        Assert.Equal(20000.0, points[^1].FrequencyHz);
+        Assert.Contains(points, point => point.FrequencyHz == 2000.0);
+        Assert.InRange(points.Count, 200, 400);
+        foreach (double frequency in new[] { 20.0, 33.0, 500.0, 2000.0, 12345.0, 20000.0 })
+        {
+            Assert.Equal(
+                angled.GetDecibelCorrection(frequency),
+                sampled.GetDecibelCorrection(frequency),
+                precision: 2);
+        }
+
+        Assert.True(CalibrationFile.SameCurve(angled, sampled));
+    }
+
+    [Fact]
+    public void SameCurve_ComparesContent_NotIdentityOrSpelling()
+    {
+        CalibrationFile a = CalibrationFile.Parse("20 0\n1000 1.5\n20000 -3\n");
+        CalibrationFile sameText = CalibrationFile.Parse("20,0\n1000,1.5\n20000,-3\n");
+        CalibrationFile differentLevel = CalibrationFile.Parse("20 0\n1000 1.6\n20000 -3\n");
+        CalibrationFile extraPoint = CalibrationFile.Parse("20 0\n500 0.75\n1000 1.5\n20000 -3\n");
+
+        Assert.True(CalibrationFile.SameCurve(a, a));
+        Assert.True(CalibrationFile.SameCurve(a, sameText));
+        Assert.True(CalibrationFile.SameCurve(a, CalibrationFile.FromPoints(a.Points)));
+        Assert.False(CalibrationFile.SameCurve(a, differentLevel));
+        // Collinear, yet not the same file: a curve is its points.
+        Assert.False(CalibrationFile.SameCurve(a, extraPoint));
+        Assert.True(CalibrationFile.SameCurve(null, null));
+        Assert.False(CalibrationFile.SameCurve(a, null));
+        Assert.False(CalibrationFile.SameCurve(null, a));
+    }
+
+    [Fact]
+    public void ToText_RoundTripsThroughParse()
+    {
+        CalibrationFile original = CalibrationFile.Parse(
+            "16 0.125\n1000 -0.3333333333333333\n20000 12.5\n");
+
+        string text = original.ToText();
+        CalibrationFile reread = CalibrationFile.Parse(text);
+
+        Assert.Equal(3, text.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
+        Assert.True(CalibrationFile.SameCurve(original, reread));
+        Assert.Equal(
+            original.GetDecibelCorrection(1000),
+            reread.GetDecibelCorrection(1000),
+            precision: 12);
+    }
+
     private static string WriteCalibrationFile(string text)
     {
         string path = Path.Combine(


### PR DESCRIPTION
Fixes #108.

A Virtual DSP session stored `calibrationId`, an index into the calibration list
of the machine that saved it. Loaded elsewhere, that id either resolved to nothing
— the recipient's working selection replaced by "Deleted calibration (missing)"
and the curves drawn uncalibrated — or, worse, to the recipient's *own* entry of
the same name: the migrated 90° slot is minted as `"90deg"` on every machine, so
an arriving `"90deg"` matched whatever file the recipient had there, and
`WarnAboutUnavailableCalibration` saw an available entry and said nothing. The
dialog for the first case also gave the wrong advice: a session that travels with
its measurements was tuned on *those* measurements, taken with *that* microphone,
so the author's calibration is the right one for the data — not "the other
computer's file describes its microphone, not yours".

**The session now carries the curve.** `VirtualCrossoverProjectFile.Calibration`
holds `{ name, fileName, points[[Hz, dB]] }` — the correction the session is
tuned with (an ECM8000 file is 33 points, 554 bytes). `CalibrationId` stays, as
the id of the entry the selection maps to *on the machine that saved*, and is
read as a hint, never as an identity. No schema bump: the block is optional and
an older build ignores it.

**The curve decides, the id only helps** (`VirtualCrossoverCalibrationSelection`,
pure and tested):

- A carried curve that a configured entry holds — the named one first, then any —
  selects that entry, under whatever name this machine gave it. That is the
  author's own round trip, and the recipient who already kept the file.
- A carried curve nobody has becomes its own item in **Mic cal**, *name (from
  session)*, selected: the curves match the author's. The import dialog says so
  and offers to **add it to your calibrations** — the curve is written to
  `<app data>/calibrations/<original file name>` and becomes a file entry like
  any other (an open Record Settings panel adopts the list, since it works on a
  copy). Once an entry with the same curve exists the session item hands over
  to it and disappears.
- The persisted form of "the session's own curve" is the curve with **no id**:
  an autosave that said `"90deg"` plus a foreign curve would be captured by the
  local `"90deg"` on the next start.
- A legacy session (id, no curve) that names a slot id (`"90deg"`, `"0deg"`)
  which exists here is selected with a note that the match is by name only; a
  generated `cal-…` id cannot be minted twice, so it matches silently; an id
  that resolves to nothing **keeps the selection the panel already had** and
  names it — the issue's first ask.
- The tool's own autosave trusts its ids (they are this machine's by
  construction): an entry whose file was edited since follows the file, which is
  what an entry is for.

**The EQ Wizard pins the curve, not an id.** The handoff carries
`PinnedCalibration` (a `CalibrationFile`) plus the selector's label, the wizard's
new `PinnedToSource` choice applies it directly, and the return guard compares
curves by content (`CalibrationFile.SameCurve`) — a settings refresh hands the
panel a fresh instance of the same file, and the session's own curve has no id
the wizard's list could resolve.

dsp: `CalibrationFile.Points` (an angular estimate is sampled on a 1/24-octave
grid plus its base points, so it round-trips within hundredths of a dB),
`FromPoints`, `SameCurve`, `ToText`, `CalibrationPoint`.
`MicrophoneCalibrationEntry` gained `FileName`; `MicrophoneCalibrationDefinition.
IsGeneratedId` tells a slot id from a minted one.

Tests: the decision matrix (14), project-file round trip and validation, the
handoff pin and content-compared return, wizard choice mapping, service file
names, dsp points/identity/text. A scratchpad live-panel harness drove the real
panel through all of it (41 checks: import, selection, persisted form, autosave
round trip, handover after adding, the wizard pin/return) and through the owner's
actual `Passat v2` session: legacy `90deg` → matched by name with the note →
re-export carries the 33-point ECM8000 curve → a recipient whose entry has a
generated id finds it by curve, silently. The harness is not in the repo (as
before); the MessageBox paths are the one thing it does not click through.

README: the Virtual DSP calibration paragraph rewritten, the wizard pin and the
Calibration section updated. No screenshot changes.
