### PR TITLE
Refuse an empty rate list without taking the settings window down

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,38 @@ source; **Test ASIO Inputs** captures a short diagnostic snapshot that verifies
 the microphone and loopback channels are truly separate and not mono-summed by
 the driver or the interface's control software.
 
+### WASAPI Shared and Exclusive
+
+Both WASAPI modes work with the Windows endpoints directly: you choose the output
+and input endpoint, the sample rate, the playback channel, and the microphone and
+loopback channels of the input endpoint (loopback required). The status line under
+the channel selection reports what the chosen pair will actually do.
+
+**Shared** runs alongside other applications and the endpoints' own mix format
+applies, so the line quotes that format and says when the two endpoints do not
+agree on a rate — Windows resamples the render side, while timing stays
+loopback-referenced.
+
+**Exclusive** hands the requested format to the endpoint unchanged, so the sample
+rate list offers only the rates BOTH endpoints accept for the exact format being
+asked for: the rate, the bit depth, and the channel counts that follow from the
+playback channel and the microphone/loopback routing. When a rate opens, the line
+confirms it:
+
+> Exclusive: 48 000 Hz / 24-bit opens directly on both endpoints.
+
+When none does, the list is deliberately **empty** — a rate no endpoint reported is
+not offered, and Apply refuses for the same reason — the achieved-range line reads
+`—`, and the status line names the format that was refused:
+
+> ⚠ No sample rate opens in Exclusive: 24-bit, 2-ch capture, 1-ch render. Mono asks
+> for a one-channel format most endpoints refuse — try Stereo.
+
+A `Mono` playback channel is the usual cause: it asks the output for a one-channel
+format, and an endpoint that accepts only its native stereo one then refuses at
+every rate. `Stereo`, `Left` and `Right` all open a two-channel format and usually
+fill the list; failing that, choose another endpoint pair or use **WASAPI Shared**.
+
 ## Input Level Meter
 
 The right-side control column includes a compact two-channel input meter for

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -1049,6 +1049,21 @@ namespace Resonalyze.Options
         // state (which is stale until the next run).
         private void RefreshSweepBandPreview()
         {
+            if (comboBoxSampleRate.SelectedItem is not int)
+            {
+                // Nothing is selected because nothing is offered: no rate opens for this
+                // configuration. GetSelectedSampleRate answers 44.1 kHz to callers that
+                // need a number anyway, and a band and duration computed from it would
+                // describe a sweep this configuration cannot run.
+                labelActualRangeCaption.Text = "—";
+                labelActualRangeCaption.ForeColor = Color.Gold;
+                deviceToolTip.SetToolTip(
+                    labelActualRangeCaption,
+                    "No sample rate opens for the current configuration, so there is " +
+                    "nothing to compute the sweep against.");
+                return;
+            }
+
             double lowHz = (double)numericUpDownLowFrequency.Value;
             double highHz = (double)numericUpDownHighFrequency.Value;
             double perOctaveSeconds = (double)numericUpDownRequestedDuration.Value * 0.001;
@@ -1303,6 +1318,17 @@ namespace Resonalyze.Options
             // rate itself belongs to the audio backend group and is not applied
             // until the Apply button commits it — only the preview moves here.
             RefreshSweepBandPreview();
+            if (IsSelectedWasapiBackend())
+            {
+                // The endpoint status line reports on the SELECTED rate, and picking
+                // another one out of a list that already holds it does not rebuild the
+                // list — so RefreshSampleRateOptions, the other place that rewrites the
+                // line, never runs here. Without this the line goes on naming the rate
+                // the user just moved away from. Only for WASAPI: the other branches of
+                // UpdateWaveLoopbackControls move the loopback selection, which would
+                // re-enter through its own SelectedIndexChanged.
+                UpdateWaveLoopbackControls();
+            }
             if (comboBoxAudioBackend.SelectedIndex != (int)AudioBackend.Asio)
             {
                 return;

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -1809,15 +1809,37 @@ namespace Resonalyze.Options
                 {
                     int selectedRate = GetSelectedSampleRate();
                     int bits = (int)numericUpDownBits.Value;
+                    int captureChannels = Math.Max(
+                        GetSelectedWaveInputChannelOffset(),
+                        GetSelectedWaveLoopbackChannelOffset() ?? 0) + 1;
+                    int renderChannels = GetSelectedPlaybackChannelCount();
+                    if (comboBoxSampleRate.Items.Count == 0)
+                    {
+                        // Not "that rate is unsupported": no rate is, so the combo is
+                        // empty and GetSelectedSampleRate is answering with its own
+                        // fallback — naming it here would report on a rate nobody
+                        // offered. What was refused is the format, and Exclusive hands
+                        // it to the endpoint unchanged, so the way out is to ask for a
+                        // different one. Mono is the usual reason: it asks for a
+                        // one-channel format, and endpoints that only accept their
+                        // native stereo one then refuse at every rate.
+                        labelWaveLoopbackStatus.Text =
+                            $"⚠ No sample rate opens in Exclusive: {bits}-bit, " +
+                            $"{captureChannels}-ch capture, {renderChannels}-ch render. " +
+                            (renderChannels < 2
+                                ? "Mono asks for a one-channel format most endpoints " +
+                                    "refuse — try Stereo."
+                                : "Try another endpoint pair, or Shared.");
+                        labelWaveLoopbackStatus.ForeColor = Color.LightSalmon;
+                        return;
+                    }
                     bool supported = IsExclusiveFormatSupported(
                         capture.Id,
                         render.Id,
                         selectedRate,
                         bits,
-                        Math.Max(
-                            GetSelectedWaveInputChannelOffset(),
-                            GetSelectedWaveLoopbackChannelOffset() ?? 0) + 1,
-                        GetSelectedPlaybackChannelCount());
+                        captureChannels,
+                        renderChannels);
                     labelWaveLoopbackStatus.Text = supported
                         ? $"Exclusive: {selectedRate:N0} Hz / {bits}-bit opens directly " +
                             "on both endpoints."
@@ -2168,15 +2190,25 @@ namespace Resonalyze.Options
 
             bool wasInitializing = initializing;
             initializing = true;
-            comboBoxSampleRate.Items.Clear();
-            comboBoxSampleRate.Items.AddRange(
-                availableRates
-                    .Select(rate => (object)rate)
-                    .ToArray());
-            comboBoxSampleRate.SelectedIndex = FindSampleRateIndex(
-                availableRates,
-                selectedSampleRate);
-            initializing = wasInitializing;
+            try
+            {
+                comboBoxSampleRate.Items.Clear();
+                comboBoxSampleRate.Items.AddRange(
+                    availableRates
+                        .Select(rate => (object)rate)
+                        .ToArray());
+                // -1 on the empty list, which is a list nobody can select from rather
+                // than a missing one. Asking for entry 0 there throws, and the throw
+                // used to escape mid-rebuild with the guard still raised, leaving every
+                // combo in the window deaf to selection until it was reopened.
+                comboBoxSampleRate.SelectedIndex = SampleRateOptions.FindRateIndex(
+                    availableRates,
+                    selectedSampleRate);
+            }
+            finally
+            {
+                initializing = wasInitializing;
+            }
             // A device/backend change can move the selected sample rate under the
             // initializing guard (so comboBoxSampleRate_SelectedIndexChanged is
             // suppressed); refresh the achieved-range and Compute Duration preview
@@ -2196,6 +2228,15 @@ namespace Resonalyze.Options
             if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.Asio)
             {
                 UpdateAsioStatusLabels();
+            }
+            else if (IsSelectedWasapiBackend())
+            {
+                // Same reason, for the endpoint status line: it reports on the rate list
+                // this method has just rebuilt. The playback channel and the microphone
+                // channel both rebuild it without going through UpdateAudioBackendControls,
+                // and those are exactly the two things the "no rate opens" line asks the
+                // user to change — so without this it would still say so afterwards.
+                UpdateWaveLoopbackControls();
             }
         }
 
@@ -2348,21 +2389,6 @@ namespace Resonalyze.Options
             return comboBoxAsioLoopbackChannel.SelectedItem is InputChannelOption option
                 ? option.Offset
                 : null;
-        }
-
-        private static int FindSampleRateIndex(
-            IReadOnlyList<int> sampleRates,
-            int sampleRate)
-        {
-            for (int i = 0; i < sampleRates.Count; i++)
-            {
-                if (sampleRates[i] == sampleRate)
-                {
-                    return i;
-                }
-            }
-
-            return 0;
         }
     }
 }

--- a/source/Options/SampleRateOptions.cs
+++ b/source/Options/SampleRateOptions.cs
@@ -104,6 +104,32 @@ internal static class SampleRateOptions
         }
     }
 
+    /// <summary>
+    /// Which entry of a rate list to select, or -1 when there is nothing to select.
+    /// </summary>
+    /// <remarks>
+    /// The empty list is the case this exists for. It is a real outcome — no rate opens
+    /// for this configuration — and the combo that shows it has no entry to select, so
+    /// asking for entry 0 there throws where the panel cannot recover: the rebuild is
+    /// abandoned half-done and the settings window stops responding to selections. The
+    /// fallback to 0 on a non-empty list is defensive; <see cref="Resolve"/> only ever
+    /// names a rate the list contains.
+    /// </remarks>
+    public static int FindRateIndex(IReadOnlyList<int> rates, int sampleRate)
+    {
+        ArgumentNullException.ThrowIfNull(rates);
+
+        for (int i = 0; i < rates.Count; i++)
+        {
+            if (rates[i] == sampleRate)
+            {
+                return i;
+            }
+        }
+
+        return rates.Count > 0 ? 0 : -1;
+    }
+
     /// <param name="probeFailed">
     /// Whether the probe produced no answer at all. An empty <paramref name="supportedRates"/>
     /// cannot stand in for this: it is a real answer everywhere except ASIO — WASAPI Shared

--- a/source/Options/SampleRateOptions.cs
+++ b/source/Options/SampleRateOptions.cs
@@ -92,9 +92,14 @@ internal static class SampleRateOptions
 
         if (supportedRates.Count == 0)
         {
+            // Only levers the panel actually offers. The bit depth is not one of them:
+            // its control is disabled, so the format the devices refused can be changed
+            // by the devices themselves and by the two things that decide the channel
+            // counts — the playback channel, and the microphone/loopback routing.
             throw new InvalidOperationException(
                 $"{deviceDescription} report no sample rate in common for the current " +
-                "configuration. Change the devices, the channel counts or the bit depth.");
+                "configuration. Change the devices, the playback channel, or the " +
+                "microphone and loopback channels.");
         }
 
         if (!supportedRates.Contains(sampleRate))

--- a/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
+++ b/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
@@ -150,6 +150,26 @@ public sealed class SampleRateOptionsTests
         Assert.Contains("Wave devices", error.Message);
     }
 
+    // The crash this round: WASAPI Exclusive with Mono playback asks both endpoints for
+    // a one-channel format, which endpoints that only take their native stereo format
+    // refuse at every rate. The empty list that answers is correct — and selecting entry
+    // 0 of it threw out of the rebuild, so the settings window went on ignoring every
+    // selection until it was closed and reopened.
+    [Fact]
+    public void AnEmptyListHasNothingToSelect()
+    {
+        Assert.Equal(-1, SampleRateOptions.FindRateIndex([], 48_000));
+    }
+
+    [Fact]
+    public void TheSelectedRateIsFoundWhereItSits()
+    {
+        Assert.Equal(0, SampleRateOptions.FindRateIndex([44_100, 48_000, 96_000], 44_100));
+        Assert.Equal(2, SampleRateOptions.FindRateIndex([44_100, 48_000, 96_000], 96_000));
+        // Defensive: Resolve only ever names a rate the list holds.
+        Assert.Equal(0, SampleRateOptions.FindRateIndex([44_100, 48_000], 192_000));
+    }
+
     [Fact]
     public void AReportedRatePasses()
     {

--- a/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
+++ b/tests/Resonalyze.App.Tests/SampleRateOptionsTests.cs
@@ -131,10 +131,13 @@ public sealed class SampleRateOptionsTests
                 "The WASAPI Exclusive endpoints"));
 
         // The way out is not another rate — there is none — so the message has to point
-        // at what can actually change.
+        // at what can actually change. Not the bit depth: that control is disabled, and
+        // the message named it for as long as nobody tried to follow the advice.
         Assert.Contains("no sample rate in common", error.Message);
         Assert.Contains("The WASAPI Exclusive endpoints", error.Message);
-        Assert.Contains("bit depth", error.Message);
+        Assert.Contains("playback channel", error.Message);
+        Assert.Contains("microphone and loopback channels", error.Message);
+        Assert.DoesNotContain("bit depth", error.Message);
     }
 
     [Fact]


### PR DESCRIPTION
Selecting **WASAPI Exclusive** in Measurement settings crashed with
`ArgumentOutOfRangeException: value ('0') must be less than '0'`, and after the dialog the
settings window silently ignored every further selection.

## What the endpoints actually say

Exclusive hands the requested format to the endpoint unchanged, and the panel asks for
exactly what the engine will open: Mono playback → a **one-channel** render format. Probed
`WasapiFormatSupport.CheckExclusive` over the default pair on the reporter's machine
(ICS-43434 capture → Focusrite render):

| format | 44.1k | 48k | 88.2k…384k |
| --- | --- | --- | --- |
| 24-bit, 2-ch capture / 2-ch render | — | **opens** | — |
| 24-bit, 1-ch on either side | — | — | — |
| 16-bit / 32-bit, any layout | — | — | — |

So with Mono nothing opens at any rate, and the empty rate list is the honest answer —
`SampleRateOptions.Resolve` already returns it deliberately. What was wrong is what the
panel did with it.

## The two defects

1. `comboBoxSampleRate.SelectedIndex = FindSampleRateIndex(...)` returned 0 for an empty
   list, and entry 0 of an empty combo throws.
2. The throw escaped mid-rebuild, past `initializing = wasInitializing`. The guard stayed
   raised, so every `SelectedIndexChanged` in the window was suppressed until it was
   closed and reopened — the part the crash dialog does not mention.

## The change

- `SampleRateOptions.FindRateIndex` makes -1 the answer for an empty list, next to the
  `Resolve` it belongs with, and is unit-tested there.
- The rebuild restores its guard in a `finally`.
- The Exclusive status line no longer pronounces on `GetSelectedSampleRate`'s 44.1 kHz
  fallback (a rate the empty combo never offered). It names the format that was refused and
  the lever that changes it:
  `⚠ No sample rate opens in Exclusive: 24-bit, 2-ch capture, 1-ch render. Mono asks for a one-channel format most endpoints refuse — try Stereo.`
- That line is now rewritten whenever the rate list is. The playback channel and the
  microphone channel both rebuild the list without going through
  `UpdateAudioBackendControls`, and they are exactly what the message asks the user to
  change — without this it would still say "no sample rate opens" after they did.

## Verification

Full `Resonalyze.App.Tests` suite: 1251 passed, 7 skipped (hardware), 0 failed.

Driven through a harness holding the real `MeasurementOptions` form against the real
endpoints:

```
WASAPI Shared -> Exclusive: rates=[] initializing=False  "⚠ No sample rate opens…try Stereo."
  status box: needs 277x45 in 311x60          (the label is a fixed box; not clipped)
  Stereo playback: rates=[48000]  "Exclusive: 48 000 Hz / 24-bit opens directly on both endpoints."
  back to Mono:    rates=[]       "⚠ No sample rate opens…"
Exclusive -> MME / -> Exclusive / -> Shared / -> ASIO: no exception, guard down every time
```

## Review round (second commit)

- **README.** `AGENTS.md` requires a user-visible warning to be documented in the same
  change, and neither WASAPI mode had a section at all — the backend table names them,
  the per-backend sections covered only MME and ASIO. Added **WASAPI Shared and
  Exclusive**: what the Exclusive rate list is, what an empty one means, the two status
  lines verbatim, and the `Mono → Stereo` / another endpoint pair / Shared way out.
- **Stale status line on a manual rate change.** Picking another rate out of a list that
  already holds it does not rebuild the list, so `RefreshSampleRateOptions` — the other
  place that rewrites the line — never ran, and the line kept naming the rate the user
  had left (`Exclusive: 44 100 Hz …` above a combo showing 48 000). The handler now
  refreshes it for WASAPI only; the other branches of `UpdateWaveLoopbackControls` move
  the loopback selection and would re-enter through its own `SelectedIndexChanged`.
- **The empty-list edge case.** With nothing selected, `GetSelectedSampleRate` answers
  44.1 kHz to callers that need a number, so the achieved-range line described a sweep at
  a rate the configuration cannot open. It reads `—` now, with the reason in its tooltip.

Re-verified against the real endpoints:

```
achieved range with no rate: "—"
Stereo playback:   rates=[48000]  "Exclusive: 48 000 Hz / 24-bit opens directly on both endpoints."
manual 44 100 Hz:  "⚠ Exclusive format 44 100 Hz / 24-bit is not supported by both endpoints."
                   range="13,9–22047 Hz · 10,64 oct · 4,26 s"
back to 48 000 Hz: "Exclusive: 48 000 Hz / 24-bit opens directly on both endpoints."
```

Full `Resonalyze.App.Tests` after the second commit: 1251 passed, 7 skipped, 0 failed.

## Third commit: the refusal names only reachable controls

Apply's refusal for an empty list ended in "Change the devices, the channel counts or
the **bit depth**" — and `numericUpDownBits` is `Enabled = false, ReadOnly = true`, so
that third of the advice was never followable. It now names the devices, the playback
channel, and the microphone and loopback channels: the devices themselves plus the two
controls that decide the channel counts the devices refused. The test that pinned the
old wording moves with it and asserts the absence too.

## Not addressed here

Exclusive + Mono stays unusable on endpoints that only accept their native stereo format —
the panel now explains it instead of crashing. Opening the render side in stereo and
duplicating the mono signal would make it work, but it would also put the sweep in both
speakers, so that is a measurement-behaviour decision rather than a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
