### PR TITLE
Read a junction's arrival coherence per frequency, not just per lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1563,7 +1563,7 @@ delay on the lower channel that would maximize the overlap-band phase score,
 with `i` recommending a flip, `~` warning that a flip nearly ties, and `!`
 warning that the overlap band is too narrow to rule out a whole-period hop — so
 the fix is not to be trusted, and the junction's coherence ladder is the better
-read. A fix worth less than 10° of phase at the crossover (0.13 dB in the sum)
+read. A fix worth less than 10° of phase at the crossover (0.03 dB in the sum)
 shows as `·`: a settled tune has nothing to apply there, and a number would
 invite a correction that changes nothing. Last comes **score**, where the
 junction stands as it is — the band's phase-alignment score (−1…+1) that the

--- a/README.md
+++ b/README.md
@@ -1565,8 +1565,12 @@ warning that the overlap band is too narrow to rule out a whole-period hop — s
 the fix is not to be trusted, and the junction's coherence ladder is the better
 read. A fix worth less than 10° of phase at the crossover (0.13 dB in the sum)
 shows as `·`: a settled tune has nothing to apply there, and a number would
-invite a correction that changes nothing. The tooltip carries every fitted
-figure behind those two columns, including the lobe margin the `!` is drawn
+invite a correction that changes nothing. Last comes **score**, where the
+junction stands as it is — the band's phase-alignment score (−1…+1) that the
+fix maximizes: 1.00 is aligned across the overlap, 0 a wash, negative means the
+two drivers are subtracting. It moves while a delay is dragged, so it answers
+"is this getting better", which the fix alone cannot. The tooltip carries every
+fitted figure behind those columns, including the lobe margin the `!` is drawn
 from. A **Δ L−R** block
 below reports each pair's inter-side state — the two sides' band-limited envelope
 arrivals with their difference (positive means the right side leads, the scene

--- a/README.md
+++ b/README.md
@@ -1528,6 +1528,30 @@ inverted rival, the wavefronts within a period or two of the front decide it,
 because that is the part of the record the drivers made and the room had not yet
 answered.
 
+The plot's **Coherence** mode reads the same junction per frequency instead of
+per lag: a sub-band probe slides across the pair band (sixth-octave steps,
+2/3-octave width, each band's direct-sound cut sized to its own period), and
+per band the envelope of the band-limited GCC-PHAT gives **Δt to optimum** —
+the delay that would center this band's arrivals — with **r current** (the
+coherence the applied tune collects at lag 0) dotted against the shaded **r
+attainable** ceiling; the gap between them is what the tune leaves on the
+table, and it closes where a band is centered. A well-aligned junction draws a
+flat Δt near zero inside the dashed **±T/2** corridor; a junction that
+misses by whole periods draws a flat line *offset* from zero; a sloped or
+stepped Δt is dispersion — different bands arriving by different paths, which
+no single delay reconciles, so the tune is a compromise and this plot shows
+where it sits. Marker color reads the optimum's carrier polarity (circle:
+in polarity, square: inverted) and only inside the central lobe — past a
+quarter period the optimum sits between opposite-signed lobes and the marker
+stays neutral. Bands where one driver's level has fallen 25 dB below the
+other's are dropped rather than drawn: GCC-PHAT deliberately ignores level,
+and would otherwise read confident "coherence" off a crossover remnant the
+sum cannot hear. On junctions below 120 Hz a note warns that the long band
+windows let cabin modes rule the read: the ladder honestly reports that such
+a band is incoherent at the applied tune, but its Δt there is not a move
+recommendation. The mode is a diagnostic for manual work — Auto delay keeps
+its own guarded estimators and never reads this plot.
+
 A **Junction phase** block reads each adjacent pair's steady-state cross-phase in
 a time-sized window (~0.68 s of the processed IR) — the regime sustained program
 material actually sums in, deliberately not the direct-sound phase, because the

--- a/README.md
+++ b/README.md
@@ -1558,10 +1558,16 @@ material actually sums in, deliberately not the direct-sound phase, because the
 room adds several milliseconds of apparent group delay down low. Per junction it
 shows **φfc**, the lower channel's phase minus the upper at the crossover (≈0°
 means phase-aligned; ±180° does not by itself call for a flip, since an inverted
-channel and a half-period delay are identical at fc); **fix ms**, the extra delay
-on the lower channel that would maximize the overlap-band phase score, with `i`
-recommending a flip and `~` warning that a flip nearly ties; and **lobe**, how
-decisively that delay beats the nearest same-polarity rival. A **Δ L−R** block
+channel and a half-period delay are identical at fc); and **fix ms**, the extra
+delay on the lower channel that would maximize the overlap-band phase score,
+with `i` recommending a flip, `~` warning that a flip nearly ties, and `!`
+warning that the overlap band is too narrow to rule out a whole-period hop — so
+the fix is not to be trusted, and the junction's coherence ladder is the better
+read. A fix worth less than 10° of phase at the crossover (0.13 dB in the sum)
+shows as `·`: a settled tune has nothing to apply there, and a number would
+invite a correction that changes nothing. The tooltip carries every fitted
+figure behind those two columns, including the lobe margin the `!` is drawn
+from. A **Δ L−R** block
 below reports each pair's inter-side state — the two sides' band-limited envelope
 arrivals with their difference (positive means the right side leads, the scene
 offset's convention), plus a **Level Δ L−R** row for the by-ear gain trim that

--- a/README.md
+++ b/README.md
@@ -1540,10 +1540,15 @@ flat Δt near zero inside the dashed **±T/2** corridor; a junction that
 misses by whole periods draws a flat line *offset* from zero; a sloped or
 stepped Δt is dispersion — different bands arriving by different paths, which
 no single delay reconciles, so the tune is a compromise and this plot shows
-where it sits. Marker color reads the optimum's carrier polarity (circle:
-in polarity, square: inverted) and only inside the central lobe — past a
-quarter period the optimum sits between opposite-signed lobes and the marker
-stays neutral. Bands where one driver's level has fallen 25 dB below the
+where it sits. The ladder deliberately says nothing about POLARITY: a
+2/3-octave probe makes a coherence packet 4.3× wider than the spacing between
+comb lobes — at every frequency, since both scale with 1/f — so the
+opposite-signed lobes sit inside the packet's own plateau, and which one its
+maximum lands on is decided by noise. Measured across the archived cabins the
+envelope falls only 0–6% between a band's optimum and its neighbours, on
+sharply tuned junctions as much as on rough ones; polarity is what the
+correlation view answers instead, over the pair's whole band, where the lobes
+genuinely separate. Bands where one driver's level has fallen 25 dB below the
 other's are dropped rather than drawn: GCC-PHAT deliberately ignores level,
 and would otherwise read confident "coherence" off a crossover remnant the
 sum cannot hear. On junctions below 120 Hz a note warns that the long band

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1406,8 +1406,23 @@ public static class VirtualCrossoverAnalysis
         double LagMs,
         double PeakR,
         double CurrentR,
-        bool OptimumInverted,
         double HalfPeriodMs);
+
+    // A ladder band states no POLARITY, and cannot: polarity is a carrier
+    // read, and telling one lobe from the opposite-signed lobe half a period
+    // away needs an envelope that falls between them. It does not here, at any
+    // frequency. A probe band of B octaves around f is f·(2^(B/2) − 2^(−B/2))
+    // wide, so its coherence packet runs about 1/that, while the lobe spacing
+    // is 1/(2f) — the RATIO of the two is 2/(2^(B/2) − 2^(−B/2)), free of f. At
+    // the ladder's 2/3 octave that is 4.3: every neighbouring lobe sits deep
+    // inside the packet's plateau. Measured over the archived cabins the
+    // envelope falls 0–6% between a band's optimum and its neighbours — on
+    // every junction, including the sharply tuned ones — so a polarity read
+    // there reports noise, which is exactly what a sub/woofer junction showed
+    // when one band announced an inversion its neighbours contradicted.
+    // The correlation view answers polarity instead: its whitened comb spans
+    // the pair's WHOLE band (two octaves at that junction, ratio 1.3), where
+    // the lobes genuinely separate.
 
     /// <summary>
     /// The ladder's frequency grid: one probe every sixth of an octave across
@@ -1600,7 +1615,6 @@ public static class VirtualCrossoverAnalysis
             lagMs,
             Math.Min(1.0, bestValue),
             Math.Min(1.0, envelope[zeroIndex]),
-            curve[best].Y < 0,
             500.0 / frequency);
     }
 

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -694,12 +694,140 @@ public static class VirtualCrossoverAnalysis
             bandLowHz,
             bandHighHz,
             validRange);
+        var cut = new Complex[impulseResponse.Length];
+        WriteDirectSoundWindow(
+            impulseResponse, front, sampleRate, crossoverHz, cut,
+            destinationOffset: 0);
+        return cut;
+    }
+
+    /// <summary>
+    /// The direct-sound window's span for a front and a crossover: half a
+    /// period of fade each side of a two-period plateau, clamped to the
+    /// record. One definition for <see cref="CutDirectSound"/> and the
+    /// ladder's trimmed per-band cuts, so the two cannot window differently.
+    /// </summary>
+    private static (int Start, int End, int Fade, int Plateau)
+        DirectSoundWindowBounds(
+            int front, int sampleRate, double crossoverHz, int length)
+    {
         double periodSamples = sampleRate / crossoverHz;
         int fade = Math.Max(8, (int)Math.Round(0.5 * periodSamples));
         int plateau = (int)Math.Round(2.0 * periodSamples);
-        int start = Math.Max(0, front - fade);
-        int end = Math.Min(impulseResponse.Length, front + plateau + fade);
-        var cut = new Complex[impulseResponse.Length];
+        return (
+            Math.Max(0, front - fade),
+            Math.Min(length, front + plateau + fade),
+            fade,
+            plateau);
+    }
+
+    /// <summary>
+    /// Both channels of a junction cut to their direct sound and TRIMMED to
+    /// the union of the two window spans: the same windows
+    /// <see cref="CutDirectSound"/> applies, written into buffers sliced by
+    /// ONE shared offset — so every relative position, and therefore every
+    /// lag a correlation of the pair reads, is exactly what the full-length
+    /// cuts would give, while the FFTs downstream shrink from the record's
+    /// length to the window's. The buffers are sized to at least
+    /// <paramref name="searchRangeMs"/> (see the wrap remark on
+    /// <see cref="TrimmedDirectSoundPair"/>): pass the lag range the
+    /// correlation will be read over.
+    /// </summary>
+    public static (Complex[] Lower, Complex[] Upper) CutDirectSoundPair(
+        Complex[] lowerImpulseResponse,
+        Complex[] upperImpulseResponse,
+        int sampleRate,
+        double bandLowHz,
+        double bandHighHz,
+        double crossoverHz,
+        double searchRangeMs,
+        ValidSampleRange lowerValidRange = default,
+        ValidSampleRange upperValidRange = default)
+    {
+        ArgumentNullException.ThrowIfNull(lowerImpulseResponse);
+        ArgumentNullException.ThrowIfNull(upperImpulseResponse);
+        if (lowerImpulseResponse.Length == 0 || upperImpulseResponse.Length == 0)
+        {
+            throw new ArgumentException("The impulse response is empty.");
+        }
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+        if (!(crossoverHz > 0) || !(searchRangeMs > 0))
+        {
+            throw new ArgumentException("The cut settings are invalid.");
+        }
+
+        int lowerFront = FindGateAnchor(
+            lowerImpulseResponse, FindPeakIndex(lowerImpulseResponse),
+            sampleRate, bandLowHz, bandHighHz, lowerValidRange);
+        int upperFront = FindGateAnchor(
+            upperImpulseResponse, FindPeakIndex(upperImpulseResponse),
+            sampleRate, bandLowHz, bandHighHz, upperValidRange);
+        return TrimmedDirectSoundPair(
+            lowerImpulseResponse, upperImpulseResponse, sampleRate,
+            crossoverHz, lowerFront, upperFront, searchRangeMs);
+    }
+
+    // The trimming core behind CutDirectSoundPair and the coherence ladder's
+    // probes. The buffers must reach the searched lag range, not just the
+    // content: the correlation's transform is circular, and reading lag R
+    // stays wrap-free only while the padded length covers content + R —
+    // NextPowerOfTwo(2·length) guarantees that for length >= R. A
+    // high-band window of a few dozen samples read over a ±6 ms range
+    // otherwise aliases its own lobes into the far lags. The padding is
+    // zeros, so the correlation's values do not change — only the room
+    // the lags are read in. A pair whose windows land entirely outside the
+    // records comes back as zero buffers, which every downstream read treats
+    // as "nothing measurable".
+    private static (Complex[] Lower, Complex[] Upper) TrimmedDirectSoundPair(
+        Complex[] lowerImpulseResponse,
+        Complex[] upperImpulseResponse,
+        int sampleRate,
+        double crossoverHz,
+        int lowerFront,
+        int upperFront,
+        double searchRangeMs)
+    {
+        (int lowerStart, int lowerEnd, _, _) = DirectSoundWindowBounds(
+            lowerFront, sampleRate, crossoverHz, lowerImpulseResponse.Length);
+        (int upperStart, int upperEnd, _, _) = DirectSoundWindowBounds(
+            upperFront, sampleRate, crossoverHz, upperImpulseResponse.Length);
+        int spanStart = Math.Min(lowerStart, upperStart);
+        int spanEnd = Math.Max(lowerEnd, upperEnd);
+        int rangeSamples =
+            (int)Math.Ceiling(searchRangeMs / 1_000.0 * sampleRate) + 2;
+        int length = Math.Max(Math.Max(spanEnd - spanStart, rangeSamples), 1);
+        var cutLower = new Complex[length];
+        var cutUpper = new Complex[length];
+        if (spanEnd > spanStart)
+        {
+            WriteDirectSoundWindow(
+                lowerImpulseResponse, lowerFront, sampleRate, crossoverHz,
+                cutLower, spanStart);
+            WriteDirectSoundWindow(
+                upperImpulseResponse, upperFront, sampleRate, crossoverHz,
+                cutUpper, spanStart);
+        }
+
+        return (cutLower, cutUpper);
+    }
+
+    // Applies the direct-sound window around a precomputed front, writing the
+    // weighted samples into destination at (i - destinationOffset). The
+    // destination stays zero outside the window; a caller passing a trimmed
+    // destination must size it to hold the window's span.
+    private static void WriteDirectSoundWindow(
+        Complex[] impulseResponse,
+        int front,
+        int sampleRate,
+        double crossoverHz,
+        Complex[] destination,
+        int destinationOffset)
+    {
+        (int start, int end, int fade, int plateau) = DirectSoundWindowBounds(
+            front, sampleRate, crossoverHz, impulseResponse.Length);
         for (int i = start; i < end; i++)
         {
             double weight =
@@ -709,10 +837,8 @@ public static class VirtualCrossoverAnalysis
                         ? 0.5 + 0.5 * Math.Cos(
                             Math.PI * (i - front - plateau) / (double)fade)
                         : 1.0;
-            cut[i] = impulseResponse[i] * weight;
+            destination[i - destinationOffset] = impulseResponse[i] * weight;
         }
-
-        return cut;
     }
 
     /// <summary>
@@ -1261,6 +1387,294 @@ public static class VirtualCrossoverAnalysis
     }
 
     /// <summary>
+    /// One band of <see cref="ArrivalCoherenceLadder"/>: at
+    /// <see cref="FrequencyHz"/>, adding <see cref="LagMs"/> of delay to the
+    /// UPPER channel puts this band's arrivals at the center of their
+    /// coherence packet (the envelope maximum of the band-limited GCC-PHAT of
+    /// the direct cuts). <see cref="PeakR"/> is the envelope there — the
+    /// band's attainable coherence — and <see cref="CurrentR"/> is the
+    /// envelope at lag 0, the coherence the applied alignment actually
+    /// collects; the two coincide when the band is centered.
+    /// <see cref="OptimumInverted"/> is the carrier's sign at the optimum —
+    /// meaningful within the central lobe (|<see cref="LagMs"/>| under a
+    /// quarter period): near ±<see cref="HalfPeriodMs"/> the optimum sits
+    /// between lobes of opposite sign and the flag merely reports which one
+    /// the envelope grid landed on.
+    /// </summary>
+    public sealed record ArrivalCoherencePoint(
+        double FrequencyHz,
+        double LagMs,
+        double PeakR,
+        double CurrentR,
+        bool OptimumInverted,
+        double HalfPeriodMs);
+
+    /// <summary>
+    /// The ladder's frequency grid: one probe every sixth of an octave across
+    /// the pair band — fine enough that the 2/3-octave probe bands
+    /// (<see cref="ArrivalCoherenceBandOctaves"/>) overlap and the drawn
+    /// curve cannot alias a junction-wide trend between probes.
+    /// </summary>
+    public const double ArrivalCoherenceStepOctaves = 1.0 / 6;
+
+    /// <summary>
+    /// Each probe's raised-cosine band width. The trade is time against
+    /// frequency: a narrower band cannot localize its envelope peak (the
+    /// packet widens as 1/bandwidth), a wider one stops being a reading AT a
+    /// frequency. Two thirds of an octave keeps the envelope peak within a
+    /// fraction of the band's period while still resolving a dispersion trend
+    /// across a two-octave pair band.
+    /// </summary>
+    public const double ArrivalCoherenceBandOctaves = 2.0 / 3;
+
+    /// <summary>
+    /// How far apart (dB) the two channels' band-weighted direct-cut energies
+    /// may sit before the band is dropped as unmeasurable. At the pair band's
+    /// edges one driver is deep behind its crossover slope, and PHAT — which
+    /// deliberately ignores magnitude — would happily read "coherence" off
+    /// that channel's filtered remnant; measured on the archived cabins those
+    /// edge bands drew confident optima on content the sum cannot hear. Same
+    /// figure as <see cref="SumLossLevelGateDb"/>: both gates answer "is the
+    /// weaker channel still a participant here".
+    /// </summary>
+    public const double ArrivalCoherenceLevelGateDb = 25;
+
+    /// <summary>
+    /// The arrival-coherence ladder of one junction: a sub-band probe slid
+    /// across the pair band (see <see cref="ArrivalCoherenceStepOctaves"/>),
+    /// each probe re-cutting the direct sound AT ITS OWN SCALE — the front is
+    /// found once, in the pair band, but the window spans two periods of the
+    /// probe frequency, so the cut travels with what it measures (a fixed cut
+    /// would hold one period of the band's low edge and a dozen of its top).
+    /// Per band the cuts' band-limited GCC-PHAT is computed over twice the
+    /// displayed lag range (the envelope's transform edges stay out of the
+    /// read), and the analytic envelope's maximum gives the band's optimum:
+    /// its lag, its height, the height at lag 0, and the carrier polarity.
+    /// <para>
+    /// The channels enter PROCESSED (delays, polarity, filters applied), in
+    /// the correlation view's own frame: lag 0 is the applied alignment and
+    /// every <see cref="ArrivalCoherencePoint.LagMs"/> is a correction to the
+    /// UPPER (second) channel, matching the lag axis of
+    /// <see cref="BandLimitedCorrelationCurve"/>. Envelope readings are
+    /// clamped to 1: the PHAT normalizer counts only contributing bins, so
+    /// the analytic magnitude can overshoot unity by a few percent on a
+    /// clean packet, which would read as nonsense on a coherence axis.
+    /// </para>
+    /// <para>
+    /// A DIAGNOSTIC, deliberately not an input to the alignment search: on a
+    /// low junction the band windows are long enough for cabin modes to rule
+    /// the correlation (the archived v3 mid junction draws its whole mid-band
+    /// optimum on the mode the Auto delay sagas were fought over), so the
+    /// ladder there honestly reports "this band is not coherent at the
+    /// applied tune" while its lag is NOT a move recommendation. The engine
+    /// keeps its own guarded estimators.
+    /// </para>
+    /// </summary>
+    public static List<ArrivalCoherencePoint> ArrivalCoherenceLadder(
+        Complex[] lowerImpulseResponse,
+        Complex[] upperImpulseResponse,
+        int sampleRate,
+        double bandLowHz,
+        double bandHighHz,
+        double crossoverHz,
+        ValidSampleRange lowerValidRange = default,
+        ValidSampleRange upperValidRange = default)
+    {
+        ArgumentNullException.ThrowIfNull(lowerImpulseResponse);
+        ArgumentNullException.ThrowIfNull(upperImpulseResponse);
+        if (lowerImpulseResponse.Length == 0 || upperImpulseResponse.Length == 0)
+        {
+            throw new ArgumentException("Impulse responses are required.");
+        }
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+        if (!(crossoverHz > 0) ||
+            !(bandLowHz > 0) || !(bandHighHz > bandLowHz))
+        {
+            throw new ArgumentException("The junction band is invalid.");
+        }
+
+        // The fronts are band-INDEPENDENT — found in the pair band, only the
+        // window scales with the probe — so they are read once per channel
+        // rather than once per band, where the repeated detection was a
+        // sizeable share of the ladder's cost.
+        int lowerFront = FindGateAnchor(
+            lowerImpulseResponse, FindPeakIndex(lowerImpulseResponse),
+            sampleRate, bandLowHz, bandHighHz, lowerValidRange);
+        int upperFront = FindGateAnchor(
+            upperImpulseResponse, FindPeakIndex(upperImpulseResponse),
+            sampleRate, bandLowHz, bandHighHz, upperValidRange);
+
+        var frequencies = new List<double>();
+        double step = Math.Pow(2.0, ArrivalCoherenceStepOctaves);
+        for (double frequency = bandLowHz;
+            frequency <= bandHighHz * 1.0001;
+            frequency *= step)
+        {
+            frequencies.Add(frequency);
+        }
+
+        // The rungs are independent of each other; AsOrdered keeps the
+        // result on the grid's order whatever the scheduling.
+        return frequencies
+            .AsParallel()
+            .AsOrdered()
+            .Select(frequency => ProbeArrivalCoherenceBand(
+                lowerImpulseResponse, upperImpulseResponse, sampleRate,
+                frequency, lowerFront, upperFront))
+            .Where(point => point != null)
+            .Select(point => point!)
+            .ToList();
+    }
+
+    // One rung of the ladder. The cuts are TRIMMED to the union of the two
+    // window spans before correlating: the windows hold a few periods inside
+    // a search-crop-sized record, and correlating the records at full length
+    // padded every FFT a hundredfold for silence — seconds per junction at
+    // 96 kHz. Both cuts are sliced by the SAME offset, so every relative
+    // position — and therefore every lag the curve reads — is unchanged;
+    // only the FFT's bin grid over the band weight coarsens, within the
+    // estimator's own resolution.
+    private static ArrivalCoherencePoint? ProbeArrivalCoherenceBand(
+        Complex[] lowerImpulseResponse,
+        Complex[] upperImpulseResponse,
+        int sampleRate,
+        double frequency,
+        int lowerFront,
+        int upperFront)
+    {
+        double displayMs = Math.Max(3.0, 1.5 * 1000.0 / frequency);
+        (Complex[] cutLower, Complex[] cutUpper) = TrimmedDirectSoundPair(
+            lowerImpulseResponse, upperImpulseResponse, sampleRate, frequency,
+            lowerFront, upperFront, searchRangeMs: 2.0 * displayMs);
+        if (!ArrivalCoherenceBandBalanced(
+            cutLower, cutUpper, sampleRate, frequency))
+        {
+            return null;
+        }
+
+        List<SignalPoint> curve = BandLimitedCorrelationCurve(
+            cutLower, cutUpper, sampleRate, frequency,
+            ArrivalCoherenceBandOctaves, 2.0 * displayMs,
+            centerLagMs: 0, phaseTransform: true);
+        if (curve.Count < 3)
+        {
+            return null;
+        }
+
+        double[] envelope = SignalEnvelope.Envelope(
+            curve.Select(point => point.Y).ToList());
+        int best = -1;
+        double bestValue = 0;
+        int zeroIndex = 0;
+        double zeroDistance = double.MaxValue;
+        for (int i = 1; i < curve.Count - 1; i++)
+        {
+            double lag = curve[i].X;
+            if (Math.Abs(lag) < zeroDistance)
+            {
+                zeroDistance = Math.Abs(lag);
+                zeroIndex = i;
+            }
+
+            if (Math.Abs(lag) <= displayMs && envelope[i] > bestValue)
+            {
+                bestValue = envelope[i];
+                best = i;
+            }
+        }
+
+        if (best < 1 || bestValue <= 0)
+        {
+            return null;
+        }
+
+        double stepMs = curve[1].X - curve[0].X;
+        double lagMs = curve[best].X + stepMs *
+            SignalEnvelope.FindFractionalPeakOffset(
+                envelope[best - 1], envelope[best], envelope[best + 1]);
+        return new ArrivalCoherencePoint(
+            frequency,
+            lagMs,
+            Math.Min(1.0, bestValue),
+            Math.Min(1.0, envelope[zeroIndex]),
+            curve[best].Y < 0,
+            500.0 / frequency);
+    }
+
+    // The ladder's level gate: both direct cuts' energies under the probe's
+    // own raised-cosine band weight, compared as PROCESSED absolute levels
+    // (the same currency the sum reads). Bands where the weaker channel sits
+    // more than the gate below the stronger are dropped — see
+    // ArrivalCoherenceLevelGateDb.
+    private static bool ArrivalCoherenceBandBalanced(
+        Complex[] firstCut,
+        Complex[] secondCut,
+        int sampleRate,
+        double centerFrequencyHz)
+    {
+        double nyquist = sampleRate / 2.0;
+        double halfOctaves = ArrivalCoherenceBandOctaves / 2.0;
+        double lowHz = Math.Max(
+            20.0, centerFrequencyHz / Math.Pow(2.0, halfOctaves));
+        double highHz = Math.Min(
+            nyquist * 0.95, centerFrequencyHz * Math.Pow(2.0, halfOctaves));
+        if (highHz <= lowHz)
+        {
+            return false;
+        }
+
+        int fftLength = DspMath.NextPowerOfTwo(
+            Math.Max(firstCut.Length, secondCut.Length));
+        double firstEnergy = BandWeightedEnergy(
+            ForwardSpectrum(firstCut, fftLength), sampleRate, lowHz, highHz);
+        double secondEnergy = BandWeightedEnergy(
+            ForwardSpectrum(secondCut, fftLength), sampleRate, lowHz, highHz);
+        if (firstEnergy <= 0 || secondEnergy <= 0)
+        {
+            return false;
+        }
+
+        double balanceDb = 10.0 * Math.Log10(
+            Math.Min(firstEnergy, secondEnergy) /
+            Math.Max(firstEnergy, secondEnergy));
+        return balanceDb >= -ArrivalCoherenceLevelGateDb;
+    }
+
+    // Σ W²(f)·|S(f)|² over the full transform, bins above Nyquist read at
+    // their conjugate-mirror frequency — the same weighting walk as
+    // ComputeBandLimitedCorrelation, so the gate weighs exactly the band the
+    // correlation reads.
+    private static double BandWeightedEnergy(
+        Complex[] spectrum, int sampleRate, double lowHz, double highHz)
+    {
+        double nyquist = sampleRate / 2.0;
+        double energy = 0;
+        for (int k = 0; k < spectrum.Length; k++)
+        {
+            double frequency = (double)k / spectrum.Length * sampleRate;
+            if (frequency > nyquist)
+            {
+                frequency = sampleRate - frequency;
+            }
+
+            double weight = BandWeight(frequency, lowHz, highHz);
+            if (weight <= 0)
+            {
+                continue;
+            }
+
+            Complex value = spectrum[k];
+            energy += weight * weight *
+                (value.Real * value.Real + value.Imaginary * value.Imaginary);
+        }
+
+        return energy;
+    }
+
+    /// <summary>
     /// One probe of <see cref="JunctionLossSweep"/>: the junction's gated
     /// average loss and 1/6-octave dip with the variable channel delayed by
     /// <see cref="DelayMs"/> (and inverted, when the sweep's polarity is
@@ -1356,10 +1770,9 @@ public static class VirtualCrossoverAnalysis
             gateAnchorSample,
             variableValidRange,
             fixedValidRanges: new[] { fixedValidRange });
-        var points = new List<JunctionSweepPoint>();
         if (bins.Count == 0)
         {
-            return points;
+            return [];
         }
 
         double weightSum = 0;
@@ -1368,16 +1781,110 @@ public static class VirtualCrossoverAnalysis
             weightSum += bin.LogWeight;
         }
 
+        return SweepBins(
+            bins, weightSum,
+            SweepDelays(startDelayMs, endDelayMs, stepMs), invertVariable);
+    }
+
+    /// <summary>
+    /// Both polarities of <see cref="JunctionLossSweep"/> from ONE set of
+    /// alignment bins. The bins — the windowed cuts and their band FFTs, the
+    /// expensive part — do not depend on the probe's polarity (inversion is a
+    /// sign in the probe's sum), so the correlation view, which always draws
+    /// both score curves, must not build them twice. Same arguments, same
+    /// per-point arithmetic; the two lists are what two
+    /// <see cref="JunctionLossSweep"/> calls would return.
+    /// </summary>
+    public static (List<JunctionSweepPoint> Normal, List<JunctionSweepPoint> Inverted)
+        JunctionLossSweepBothPolarities(
+            Complex[] variableImpulseResponse,
+            Complex[] fixedImpulseResponse,
+            int sampleRate,
+            double bandLowHz,
+            double bandHighHz,
+            double startDelayMs,
+            double endDelayMs,
+            double stepMs,
+            int? gateAnchorSample = null,
+            bool levelMatch = false,
+            ValidSampleRange variableValidRange = default,
+            ValidSampleRange fixedValidRange = default)
+    {
+        ArgumentNullException.ThrowIfNull(variableImpulseResponse);
+        ArgumentNullException.ThrowIfNull(fixedImpulseResponse);
+        if (variableImpulseResponse.Length == 0 || fixedImpulseResponse.Length == 0)
+        {
+            throw new ArgumentException("Impulse responses are required.");
+        }
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+        if (!(stepMs > 0) || !(endDelayMs > startDelayMs))
+        {
+            throw new ArgumentException("The sweep window is invalid.");
+        }
+
+        List<AlignmentBin> bins = BuildAlignmentBins(
+            variableImpulseResponse,
+            new List<Complex[]> { fixedImpulseResponse },
+            sampleRate,
+            bandLowHz,
+            bandHighHz,
+            startDelayMs,
+            endDelayMs,
+            levelMatch,
+            gateAnchorSample,
+            variableValidRange,
+            fixedValidRanges: new[] { fixedValidRange });
+        if (bins.Count == 0)
+        {
+            return ([], []);
+        }
+
+        double weightSum = 0;
+        foreach (AlignmentBin bin in bins)
+        {
+            weightSum += bin.LogWeight;
+        }
+
+        List<double> delays = SweepDelays(startDelayMs, endDelayMs, stepMs);
+        return (
+            SweepBins(bins, weightSum, delays, invert: false),
+            SweepBins(bins, weightSum, delays, invert: true));
+    }
+
+    private static List<double> SweepDelays(
+        double startDelayMs, double endDelayMs, double stepMs)
+    {
+        var delays = new List<double>();
         for (double delayMs = startDelayMs;
             delayMs <= endDelayMs + 1e-9;
             delayMs += stepMs)
         {
-            (double lossDb, double dipDb) = DetailedLoss(
-                bins, weightSum, delayMs, invertVariable);
-            points.Add(new JunctionSweepPoint(delayMs, lossDb, dipDb));
+            delays.Add(delayMs);
         }
 
-        return points;
+        return delays;
+    }
+
+    // The probe loop of a sweep. Probes are independent reads of the same
+    // immutable bins (DetailedLoss allocates its own scratch), so they run
+    // across cores; the indexed writes keep the delays' order.
+    private static List<JunctionSweepPoint> SweepBins(
+        List<AlignmentBin> bins,
+        double weightSum,
+        List<double> delays,
+        bool invert)
+    {
+        var points = new JunctionSweepPoint[delays.Count];
+        Parallel.For(0, delays.Count, i =>
+        {
+            (double lossDb, double dipDb) = DetailedLoss(
+                bins, weightSum, delays[i], invert);
+            points[i] = new JunctionSweepPoint(delays[i], lossDb, dipDb);
+        });
+        return [.. points];
     }
 
     // The NEAREST opposite-sign local extremum beside a main one: walking out

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1395,11 +1395,9 @@ public static class VirtualCrossoverAnalysis
     /// band's attainable coherence — and <see cref="CurrentR"/> is the
     /// envelope at lag 0, the coherence the applied alignment actually
     /// collects; the two coincide when the band is centered.
-    /// <see cref="OptimumInverted"/> is the carrier's sign at the optimum —
-    /// meaningful within the central lobe (|<see cref="LagMs"/>| under a
-    /// quarter period): near ±<see cref="HalfPeriodMs"/> the optimum sits
-    /// between lobes of opposite sign and the flag merely reports which one
-    /// the envelope grid landed on.
+    /// <see cref="HalfPeriodMs"/> is the lag that separates neighbouring comb
+    /// lobes — the corridor a correction may stay inside before it belongs to
+    /// a different cycle. No polarity is reported: see the remarks below.
     /// </summary>
     public sealed record ArrivalCoherencePoint(
         double FrequencyHz,
@@ -1464,7 +1462,9 @@ public static class VirtualCrossoverAnalysis
     /// Per band the cuts' band-limited GCC-PHAT is computed over twice the
     /// displayed lag range (the envelope's transform edges stay out of the
     /// read), and the analytic envelope's maximum gives the band's optimum:
-    /// its lag, its height, the height at lag 0, and the carrier polarity.
+    /// its lag, its height, and the height at lag 0. Not its polarity — the
+    /// probe band is too narrow to separate opposite-signed lobes at all (see
+    /// the remarks by <see cref="ArrivalCoherencePoint"/>).
     /// <para>
     /// The channels enter PROCESSED (delays, polarity, filters applied), in
     /// the correlation view's own frame: lag 0 is the applied alignment and

--- a/source/Tools/VirtualCrossover/ProcessedChannel.cs
+++ b/source/Tools/VirtualCrossover/ProcessedChannel.cs
@@ -6,18 +6,31 @@ namespace Resonalyze;
 
 /// <summary>
 /// A channel's processed response ready for the metric, the complex sum and the
-/// plot: the applied-chain impulse response, its peak index, the channel's
-/// plot color and where the MEASURED content sits inside the processed record
-/// (<see cref="ValidRange"/> — the coordinator computes it with every render;
-/// front detections read it so a chain delay's silent prefix cannot pose as
-/// arrival SNR). Shared by the redraw, the metric read-out and the Auto delay
-/// search. The range defaults to unknown for callers without one — the
-/// analyses then fall back to their padding-signature heuristic.
+/// plot: the applied-chain impulse response, its peak index, the rate it was
+/// processed at, the channel's plot color and where the MEASURED content sits
+/// inside the processed record (<see cref="ValidRange"/> — the coordinator
+/// computes it with every render; front detections read it so a chain delay's
+/// silent prefix cannot pose as arrival SNR). Shared by the redraw, the metric
+/// read-out and the Auto delay search. The range defaults to unknown for
+/// callers without one — the analyses then fall back to their
+/// padding-signature heuristic.
+/// <para>
+/// <see cref="SampleRate"/> is CAPTURED with the response rather than read
+/// back through <see cref="Channel"/>: the record is a snapshot while the
+/// channel is live, and importing a session rebinds every channel's runtime
+/// state on the UI thread while renders and metric rebuilds are still in
+/// flight — a consumer that dereferenced the live channel mid-rebind read a
+/// ZERO rate against a real response (the ArgumentOutOfRangeException crash
+/// on opening a session over a loaded one). Everything derived from
+/// <see cref="ImpulseResponse"/> must take the rate from this snapshot; the
+/// live channel stays for its identity, settings and visibility flags.
+/// </para>
 /// </summary>
 internal sealed record ProcessedChannel(
     VirtualCrossoverChannel Channel,
     Complex[] ImpulseResponse,
     int PeakIndex,
+    int SampleRate,
     OxyColor Color,
     ValidSampleRange ValidRange = default);
 
@@ -109,7 +122,7 @@ internal static class ProcessedChannels
     public static int SharedStartAnchorIndex(
         IReadOnlyList<ProcessedChannel> processed) =>
         processed.Min(item => StartAnchorIndex(
-            item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate,
+            item.ImpulseResponse, item.PeakIndex, item.SampleRate,
             item.ValidRange));
 
     public static List<ProcessedChannel> OrderByBand(IReadOnlyList<ProcessedChannel> processed) =>

--- a/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
@@ -538,41 +538,20 @@ internal sealed class VirtualCrossoverDspChainPlot
         var lagLine = NewCoherenceLine(
             "Δt to optimum", OxyColor.FromAColor(200, OxyColors.White),
             CoherenceLagAxisKey, LineStyle.Solid, 1.2);
-        // Polarity is a carrier read and only means something inside the
-        // central lobe: within a quarter period of zero the optimum IS the
-        // lobe the tune sits on, past that the envelope peak lands between
-        // opposite-signed lobes and the sign merely reports the grid. The
-        // undecidable points stay neutral instead of flashing a polarity.
-        var inPolarity = new ScatterSeries
+        // One kind of marker, on purpose. Polarity would be a carrier read,
+        // and the ladder's 2/3-octave probe cannot make one: its coherence
+        // packet is 4.3x wider than the lobe spacing at EVERY frequency (see
+        // the remarks by ArrivalCoherencePoint), so the opposite-signed lobes
+        // sit inside the packet's plateau and whichever the maximum lands on
+        // is decided by noise. The correlation view reads polarity instead,
+        // over the pair's whole band, where the lobes separate.
+        var optimum = new ScatterSeries
         {
-            Title = "optimum in polarity",
+            Title = "optimum",
             Tag = SeriesTag,
             MarkerType = MarkerType.Circle,
             MarkerSize = 3.5,
             MarkerFill = OxyColor.FromRgb(79, 195, 247),
-            XAxisKey = PlotModelFactory.FrequencyAxisKey,
-            YAxisKey = CoherenceLagAxisKey,
-            TrackerFormatString = CoherenceTrackerFormat
-        };
-        var invertedPolarity = new ScatterSeries
-        {
-            Title = "optimum inverted",
-            Tag = SeriesTag,
-            MarkerType = MarkerType.Square,
-            MarkerSize = 3.5,
-            MarkerFill = OxyColor.FromRgb(255, 169, 79),
-            XAxisKey = PlotModelFactory.FrequencyAxisKey,
-            YAxisKey = CoherenceLagAxisKey,
-            TrackerFormatString = CoherenceTrackerFormat
-        };
-        var ambiguous = new ScatterSeries
-        {
-            Tag = SeriesTag,
-            MarkerType = MarkerType.Circle,
-            MarkerSize = 2.5,
-            MarkerFill = OxyColors.Transparent,
-            MarkerStroke = OxyColor.FromAColor(200, OxyColors.Gray),
-            MarkerStrokeThickness = 1,
             XAxisKey = PlotModelFactory.FrequencyAxisKey,
             YAxisKey = CoherenceLagAxisKey,
             TrackerFormatString = CoherenceTrackerFormat
@@ -588,11 +567,7 @@ internal sealed class VirtualCrossoverDspChainPlot
             currentR.Points.Add(
                 new DataPoint(point.FrequencyHz, point.CurrentR));
             lagLine.Points.Add(new DataPoint(point.FrequencyHz, point.LagMs));
-            ScatterSeries markers =
-                Math.Abs(point.LagMs) < point.HalfPeriodMs / 2.0
-                    ? point.OptimumInverted ? invertedPolarity : inPolarity
-                    : ambiguous;
-            markers.Points.Add(
+            optimum.Points.Add(
                 new ScatterPoint(point.FrequencyHz, point.LagMs));
         }
 
@@ -601,9 +576,7 @@ internal sealed class VirtualCrossoverDspChainPlot
         model.Series.Add(corridorLower);
         model.Series.Add(currentR);
         model.Series.Add(lagLine);
-        model.Series.Add(inPolarity);
-        model.Series.Add(invertedPolarity);
-        model.Series.Add(ambiguous);
+        model.Series.Add(optimum);
 
         model.Annotations.Add(new LineAnnotation
         {

--- a/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
@@ -101,12 +101,18 @@ internal sealed class VirtualCrossoverDspChainPlot
     // preserves the user's zoom/pan.
     private (string Pair, double WindowMs)? correlationAxisState;
 
-    // Same idea for the coherence axes. The lag range depends on the data (a
-    // misaligned junction pushes optima past the comb corridor), so it is
-    // bucketed to half-millisecond steps: a delay edit that keeps the ladder
-    // in the same bucket preserves the user's zoom, one that leaves it
-    // re-fits the axes instead of clipping the points that moved.
-    private (string Pair, double LagLimitMs)? coherenceAxisState;
+    // Same idea for the coherence axes, over everything they are placed from.
+    // The lag range depends on the data (a misaligned junction pushes optima
+    // past the comb corridor), so it is bucketed to half-millisecond steps: a
+    // delay edit that keeps the ladder in the same bucket preserves the user's
+    // zoom, one that leaves it re-fits the axes instead of clipping the points
+    // that moved. The BAND is here because the frequency axis is fitted from
+    // it: editing the pair's crossover keeps the pair title, and the new
+    // ladder's lag limit usually lands in the same bucket (both are typically
+    // at the 1 ms floor), so a state of title-and-lag alone would leave the
+    // frequency axis on the PREVIOUS band and clip most of the rebuilt ladder.
+    private (string Pair, double LagLimitMs, double BandLowHz, double BandHighHz)?
+        coherenceAxisState;
 
     public VirtualCrossoverDspChainPlot(PlotView view, DspPlotMode initialMode)
     {
@@ -480,9 +486,11 @@ internal sealed class VirtualCrossoverDspChainPlot
                 .DefaultIfEmpty(1.0)
                 .Max());
         double lagLimit = Math.Ceiling(needed * 2.0) / 2.0;
-        if (coherenceAxisState != (data.PairTitle, lagLimit))
+        if (coherenceAxisState !=
+            (data.PairTitle, lagLimit, data.BandLowHz, data.BandHighHz))
         {
-            coherenceAxisState = (data.PairTitle, lagLimit);
+            coherenceAxisState =
+                (data.PairTitle, lagLimit, data.BandLowHz, data.BandHighHz);
             foreach (Axis axis in model.Axes)
             {
                 if (axis.Key == CoherenceLagAxisKey)

--- a/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
@@ -47,14 +47,30 @@ internal sealed record JunctionCorrelationView(
     double ArrivalLagMs);
 
 /// <summary>
+/// The junction-coherence view's data: one junction's arrival-coherence
+/// ladder (see <see cref="VirtualCrossoverAnalysis.ArrivalCoherenceLadder"/>),
+/// computed off the UI thread from the same PROCESSED pair as the correlation
+/// view — lag 0 is the applied alignment, every band's lag a correction to
+/// the upper channel.
+/// </summary>
+internal sealed record JunctionCoherenceView(
+    string PairTitle,
+    string UpperName,
+    double CrossoverHz,
+    double BandLowHz,
+    double BandHighHz,
+    List<VirtualCrossoverAnalysis.ArrivalCoherencePoint> Ladder);
+
+/// <summary>
 /// The Virtual DSP lower plot: each enabled channel's DSP-chain response
 /// (magnitude / phase / group delay). The bulk delay is excluded — its timing
 /// effect shows on the acoustic plot, and drawing it here would wrap the phase
 /// into an unreadable sawtooth and swamp the filter group delay. Owns the
 /// PlotView's model, the single value axis it reconfigures per mode, and the
 /// drawn series; the panel supplies the mode and the per-channel curves.
-/// The junction-correlation mode swaps in its own, lag-domain model (see
-/// <see cref="DrawCorrelation"/>); the two models keep their axes' zoom/pan
+/// The junction modes swap in their own models — lag-domain correlation (see
+/// <see cref="DrawCorrelation"/>) and per-band coherence (see
+/// <see cref="DrawCoherence"/>); the models keep their axes' zoom/pan
 /// independently.
 /// </summary>
 internal sealed class VirtualCrossoverDspChainPlot
@@ -66,10 +82,14 @@ internal sealed class VirtualCrossoverDspChainPlot
     private const string CoefficientAxisKey = "corr-r";
     private const string ScoreAxisKey = "corr-score";
     private const string CorrelationTrackerFormat = "{0}\n{2:0.00} ms\n{4:0.00}";
+    private const string CoherenceLagAxisKey = "coh-lag";
+    private const string CoherenceCoefficientAxisKey = "coh-r";
+    private const string CoherenceTrackerFormat = "{0}\n{2:0} Hz\n{4:0.00}";
 
     private readonly PlotView view;
     private readonly PlotModel chainModel;
     private readonly PlotModel correlationModel;
+    private readonly PlotModel coherenceModel;
 
     // Tracks the mode the value axis range was last set for, so switching modes
     // resets the range to the new mode's default while an in-mode redraw (e.g.
@@ -80,6 +100,13 @@ internal sealed class VirtualCrossoverDspChainPlot
     // junction switch resets the ranges, an in-pair redraw (delay edits)
     // preserves the user's zoom/pan.
     private (string Pair, double WindowMs)? correlationAxisState;
+
+    // Same idea for the coherence axes. The lag range depends on the data (a
+    // misaligned junction pushes optima past the comb corridor), so it is
+    // bucketed to half-millisecond steps: a delay edit that keeps the ladder
+    // in the same bucket preserves the user's zoom, one that leaves it
+    // re-fits the axes instead of clipping the points that moved.
+    private (string Pair, double LagLimitMs)? coherenceAxisState;
 
     public VirtualCrossoverDspChainPlot(PlotView view, DspPlotMode initialMode)
     {
@@ -108,9 +135,13 @@ internal sealed class VirtualCrossoverDspChainPlot
         ConfigureValueAxis((LinearAxis)model.Axes[^1], initialMode);
         chainModel = model;
         correlationModel = CreateCorrelationModel();
-        view.Model = initialMode == DspPlotMode.Correlation
-            ? correlationModel
-            : chainModel;
+        coherenceModel = CreateCoherenceModel();
+        view.Model = initialMode switch
+        {
+            DspPlotMode.Correlation => correlationModel,
+            DspPlotMode.Coherence => coherenceModel,
+            _ => chainModel
+        };
         PlotInteraction.Enable(view);
     }
 
@@ -213,6 +244,19 @@ internal sealed class VirtualCrossoverDspChainPlot
             }
         }
 
+        // Each comb's analytic envelope first, as thin translucent ± guides
+        // in the parent curve's own color, under everything and out of the
+        // legend: the envelope's extremum is the coherence packet's center
+        // with the carrier lobes stripped — the group optimum the eye can
+        // read a lobe-skip against — while the carrier keeps answering which
+        // LOBE the tune sits on.
+        AddEnvelopeGuides(
+            model, "PHAT envelope", data.Whitened,
+            OxyColor.FromRgb(79, 195, 247));
+        AddEnvelopeGuides(
+            model, "PHAT direct envelope", data.WhitenedDirect,
+            OxyColor.FromRgb(200, 130, 255));
+
         // Four curves, each with its own question: PHAT — the whitened
         // full-record comb (the honest read at bass junctions, where "direct
         // sound" is not a measurable notion); PHAT direct — the drivers'
@@ -273,6 +317,46 @@ internal sealed class VirtualCrossoverDspChainPlot
         model.InvalidatePlot(true);
     }
 
+    // The ± analytic envelope of one correlation comb, as legend-less thin
+    // guides (the title still names them in the tracker). Computed over the
+    // displayed window: the transform's edge wobble stays confined to the
+    // outermost samples of a decayed comb, which a 35%-alpha guide is
+    // entitled to.
+    private static void AddEnvelopeGuides(
+        PlotModel model,
+        string title,
+        List<SignalPoint> points,
+        OxyColor color)
+    {
+        if (points.Count < 3)
+        {
+            return;
+        }
+
+        double[] envelope = SignalEnvelope.Envelope(
+            points.Select(point => point.Y).ToList());
+        foreach (int sign in new[] { 1, -1 })
+        {
+            var series = new LineSeries
+            {
+                Title = title,
+                RenderInLegend = false,
+                Color = OxyColor.FromAColor(90, color),
+                StrokeThickness = 1.0,
+                Tag = SeriesTag,
+                TrackerFormatString = CorrelationTrackerFormat,
+                XAxisKey = LagAxisKey,
+                YAxisKey = CoefficientAxisKey
+            };
+            for (int i = 0; i < points.Count; i++)
+            {
+                series.Points.Add(new DataPoint(points[i].X, sign * envelope[i]));
+            }
+
+            model.Series.Add(series);
+        }
+    }
+
     private static void AddCorrelationSeries(
         PlotModel model,
         string title,
@@ -300,6 +384,262 @@ internal sealed class VirtualCrossoverDspChainPlot
 
         model.Series.Add(series);
     }
+
+    private static PlotModel CreateCoherenceModel()
+    {
+        var model = new PlotModel
+        {
+            IsLegendVisible = true
+        };
+        model.Legends.Add(new OxyPlot.Legends.Legend
+        {
+            LegendPosition = OxyPlot.Legends.LegendPosition.TopRight,
+            LegendTextColor = OxyColor.FromRgb(210, 214, 222),
+            LegendBackground = OxyColor.FromAColor(120, OxyColor.FromRgb(40, 44, 54))
+        });
+        PlotModelStyle.AddFrequencyAxis(model);
+        model.Axes.Add(new LinearAxis
+        {
+            Key = CoherenceLagAxisKey,
+            Position = AxisPosition.Left,
+            Title = "delay to optimum (ms)",
+            MajorGridlineStyle = LineStyle.Solid,
+            MinorGridlineStyle = LineStyle.Dot
+        });
+        model.Axes.Add(new LinearAxis
+        {
+            Key = CoherenceCoefficientAxisKey,
+            Position = AxisPosition.Right,
+            Title = "envelope r",
+            Minimum = 0,
+            Maximum = 1.05,
+            MajorStep = 0.25,
+            MajorGridlineStyle = LineStyle.None,
+            MinorGridlineStyle = LineStyle.None
+        });
+        model.Annotations.Add(new PlotWatermarkAnnotation
+        {
+            Text = "Coherence",
+            TextColor = OxyColor.FromAColor(10, OxyColors.White),
+            FontSize = 40,
+            FontWeight = FontWeights.Bold
+        });
+        return model;
+    }
+
+    /// <summary>
+    /// Swaps in the frequency-domain coherence model and draws one junction's
+    /// arrival-coherence ladder. Null clears the view (no measurable pair);
+    /// a view whose ladder the level gate emptied draws the title alone, so
+    /// "nothing to measure" and "nothing selected" stay distinguishable.
+    /// </summary>
+    public void DrawCoherence(JunctionCoherenceView? data)
+    {
+        view.Model = coherenceModel;
+        PlotModel model = coherenceModel;
+        RemoveSeries(model);
+        for (int index = model.Annotations.Count - 1; index >= 0; index--)
+        {
+            if (Equals(model.Annotations[index].Tag, SeriesTag))
+            {
+                model.Annotations.RemoveAt(index);
+            }
+        }
+
+        if (data == null)
+        {
+            model.Title = null;
+            model.Subtitle = null;
+            model.InvalidatePlot(true);
+            return;
+        }
+
+        model.Title = $"{data.PairTitle}  ·  fc {data.CrossoverHz:0} Hz  ·  " +
+            $"{data.BandLowHz:0}-{data.BandHighHz:0} Hz";
+        model.TitleFontSize = 11;
+        model.TitleColor = OxyColor.FromRgb(210, 214, 222);
+        // Below the engine's own direct-coherence floor the band windows are
+        // long enough for cabin modes to rule the correlation: the ladder
+        // still reports HOW coherent the tune is, but its optima can sit on a
+        // mode rather than on the drivers, and the plot says so.
+        model.Subtitle = data.CrossoverHz < 120
+            ? "low junction: cabin modes can dominate this read"
+            : null;
+        model.SubtitleFontSize = 9;
+        model.SubtitleColor = OxyColor.FromAColor(170, OxyColor.FromRgb(240, 200, 90));
+
+        List<VirtualCrossoverAnalysis.ArrivalCoherencePoint> ladder = data.Ladder;
+        // The default lag range covers the comb corridor and every optimum,
+        // bucketed so in-place delay edits keep the user's zoom (see the
+        // state field).
+        double needed = Math.Max(
+            1.0,
+            1.15 * ladder
+                .Select(point => Math.Max(
+                    Math.Abs(point.LagMs), point.HalfPeriodMs))
+                .DefaultIfEmpty(1.0)
+                .Max());
+        double lagLimit = Math.Ceiling(needed * 2.0) / 2.0;
+        if (coherenceAxisState != (data.PairTitle, lagLimit))
+        {
+            coherenceAxisState = (data.PairTitle, lagLimit);
+            foreach (Axis axis in model.Axes)
+            {
+                if (axis.Key == CoherenceLagAxisKey)
+                {
+                    axis.Minimum = -lagLimit;
+                    axis.Maximum = lagLimit;
+                }
+                else if (axis.Key == PlotModelFactory.FrequencyAxisKey)
+                {
+                    axis.Minimum = data.BandLowHz / 1.12;
+                    axis.Maximum = data.BandHighHz * 1.12;
+                }
+
+                axis.Reset();
+            }
+        }
+
+        // The comb corridor: past half a period the optimum belongs to the
+        // NEXT lobe — that band's arrivals differ by a whole cycle and no
+        // single delay reconciles it with the bands inside the corridor.
+        var corridorUpper = NewCoherenceLine(
+            "±T/2 (next lobe)", OxyColor.FromAColor(150, OxyColors.Gray),
+            CoherenceLagAxisKey, LineStyle.Dash, 1.0);
+        var corridorLower = NewCoherenceLine(
+            null, OxyColor.FromAColor(150, OxyColors.Gray),
+            CoherenceLagAxisKey, LineStyle.Dash, 1.0);
+        // The attainable-versus-collected gap: the area between the envelope
+        // at the optimum and the envelope at lag 0 is the coherence the
+        // applied tune leaves on the table — zero-height where the band is
+        // centered.
+        var gap = new AreaSeries
+        {
+            Title = "r attainable",
+            Tag = SeriesTag,
+            Color = OxyColors.Transparent,
+            Color2 = OxyColors.Transparent,
+            Fill = OxyColor.FromAColor(50, OxyColor.FromRgb(124, 213, 124)),
+            XAxisKey = PlotModelFactory.FrequencyAxisKey,
+            YAxisKey = CoherenceCoefficientAxisKey,
+            TrackerFormatString = CoherenceTrackerFormat
+        };
+        var currentR = NewCoherenceLine(
+            "r current", OxyColor.FromRgb(124, 213, 124),
+            CoherenceCoefficientAxisKey, LineStyle.Dot, 1.8);
+        var lagLine = NewCoherenceLine(
+            "Δt to optimum", OxyColor.FromAColor(200, OxyColors.White),
+            CoherenceLagAxisKey, LineStyle.Solid, 1.2);
+        // Polarity is a carrier read and only means something inside the
+        // central lobe: within a quarter period of zero the optimum IS the
+        // lobe the tune sits on, past that the envelope peak lands between
+        // opposite-signed lobes and the sign merely reports the grid. The
+        // undecidable points stay neutral instead of flashing a polarity.
+        var inPolarity = new ScatterSeries
+        {
+            Title = "optimum in polarity",
+            Tag = SeriesTag,
+            MarkerType = MarkerType.Circle,
+            MarkerSize = 3.5,
+            MarkerFill = OxyColor.FromRgb(79, 195, 247),
+            XAxisKey = PlotModelFactory.FrequencyAxisKey,
+            YAxisKey = CoherenceLagAxisKey,
+            TrackerFormatString = CoherenceTrackerFormat
+        };
+        var invertedPolarity = new ScatterSeries
+        {
+            Title = "optimum inverted",
+            Tag = SeriesTag,
+            MarkerType = MarkerType.Square,
+            MarkerSize = 3.5,
+            MarkerFill = OxyColor.FromRgb(255, 169, 79),
+            XAxisKey = PlotModelFactory.FrequencyAxisKey,
+            YAxisKey = CoherenceLagAxisKey,
+            TrackerFormatString = CoherenceTrackerFormat
+        };
+        var ambiguous = new ScatterSeries
+        {
+            Tag = SeriesTag,
+            MarkerType = MarkerType.Circle,
+            MarkerSize = 2.5,
+            MarkerFill = OxyColors.Transparent,
+            MarkerStroke = OxyColor.FromAColor(200, OxyColors.Gray),
+            MarkerStrokeThickness = 1,
+            XAxisKey = PlotModelFactory.FrequencyAxisKey,
+            YAxisKey = CoherenceLagAxisKey,
+            TrackerFormatString = CoherenceTrackerFormat
+        };
+        foreach (VirtualCrossoverAnalysis.ArrivalCoherencePoint point in ladder)
+        {
+            corridorUpper.Points.Add(
+                new DataPoint(point.FrequencyHz, point.HalfPeriodMs));
+            corridorLower.Points.Add(
+                new DataPoint(point.FrequencyHz, -point.HalfPeriodMs));
+            gap.Points.Add(new DataPoint(point.FrequencyHz, point.PeakR));
+            gap.Points2.Add(new DataPoint(point.FrequencyHz, point.CurrentR));
+            currentR.Points.Add(
+                new DataPoint(point.FrequencyHz, point.CurrentR));
+            lagLine.Points.Add(new DataPoint(point.FrequencyHz, point.LagMs));
+            ScatterSeries markers =
+                Math.Abs(point.LagMs) < point.HalfPeriodMs / 2.0
+                    ? point.OptimumInverted ? invertedPolarity : inPolarity
+                    : ambiguous;
+            markers.Points.Add(
+                new ScatterPoint(point.FrequencyHz, point.LagMs));
+        }
+
+        model.Series.Add(gap);
+        model.Series.Add(corridorUpper);
+        model.Series.Add(corridorLower);
+        model.Series.Add(currentR);
+        model.Series.Add(lagLine);
+        model.Series.Add(inPolarity);
+        model.Series.Add(invertedPolarity);
+        model.Series.Add(ambiguous);
+
+        model.Annotations.Add(new LineAnnotation
+        {
+            Type = LineAnnotationType.Horizontal,
+            Y = 0,
+            YAxisKey = CoherenceLagAxisKey,
+            XAxisKey = PlotModelFactory.FrequencyAxisKey,
+            Color = OxyColor.FromAColor(160, OxyColors.White),
+            StrokeThickness = 1,
+            Tag = SeriesTag
+        });
+        model.Annotations.Add(new LineAnnotation
+        {
+            Type = LineAnnotationType.Vertical,
+            X = data.CrossoverHz,
+            XAxisKey = PlotModelFactory.FrequencyAxisKey,
+            YAxisKey = CoherenceLagAxisKey,
+            Color = OxyColor.FromAColor(120, OxyColors.Gray),
+            LineStyle = LineStyle.Dot,
+            StrokeThickness = 1,
+            Text = "fc",
+            TextColor = OxyColor.FromAColor(170, OxyColors.Gray),
+            Tag = SeriesTag
+        });
+
+        model.InvalidatePlot(true);
+    }
+
+    private static LineSeries NewCoherenceLine(
+        string? title,
+        OxyColor color,
+        string axisKey,
+        LineStyle style,
+        double thickness) => new()
+        {
+            Title = title,
+            Tag = SeriesTag,
+            Color = color,
+            LineStyle = style,
+            StrokeThickness = thickness,
+            XAxisKey = PlotModelFactory.FrequencyAxisKey,
+            YAxisKey = axisKey,
+            TrackerFormatString = CoherenceTrackerFormat
+        };
 
     public void Draw(DspPlotMode mode, IReadOnlyList<DspChainCurve> curves)
     {

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
@@ -230,15 +230,32 @@ internal static class VirtualCrossoverMetric
     // Below this lobe margin the compact line gets a "!" — the overlap band is
     // too narrow to rule out a whole-period hop, so the recommendation is
     // ambiguous. The field probe read ~0.19 on a healthy octave-wide junction
-    // and ~0.04 on a deliberately narrowed one.
+    // and ~0.04 on a deliberately narrowed one. The margin ITSELF is a tooltip
+    // figure rather than a column: it is a difference of two phase scores, so
+    // it carries no scale a reader can judge (is 0.21 good?), and the one
+    // thing it decides — trust the fix or not — is what this flag already
+    // says. Where the band IS wide enough to discriminate, the coherence
+    // ladder shows the same ambiguity per frequency, against its ±T/2
+    // corridor.
     private const double AmbiguousLobeMargin = 0.10;
+
+    // A fix is shown only when it is worth applying, measured where it acts:
+    // as PHASE at the crossover. Ten degrees costs the sum 0.13 dB — below the
+    // ear and below the measurement's own repeatability — so anything under it
+    // renders as "·" instead of a number inviting a correction. A settled tune
+    // otherwise fills the column with values like "-0.01" that read as data
+    // and mean nothing. The threshold is per junction on purpose: 0.05 ms is
+    // nothing at 65 Hz and most of a period at 4 kHz.
+    private const double SignificantFixDegrees = 10.0;
 
     /// <summary>
     /// Compact per-junction phase column for the host read-out panel: the phase
-    /// at the crossover, the score-maximizing extra delay on the lower channel
-    /// (with an "i" when flipping that channel's polarity scores clearly better,
-    /// "~" when a flip nearly ties), and the same-polarity lobe margin ("!" when
-    /// it is too small to rule out a whole-period hop).
+    /// at the crossover and the score-maximizing extra delay on the lower
+    /// channel (with an "i" when flipping that channel's polarity scores
+    /// clearly better, "~" when a flip nearly ties, and "!" when the
+    /// same-polarity lobe margin is too small to rule out a whole-period hop).
+    /// A fix too small to matter renders as "·"; the lobe margin itself, and
+    /// every other fitted figure, lives in <see cref="FormatPhaseDetail"/>.
     /// </summary>
     public static string FormatPhaseCompact(IReadOnlyList<PhaseEntry> entries)
     {
@@ -248,7 +265,7 @@ internal static class VirtualCrossoverMetric
         }
 
         var builder = new System.Text.StringBuilder(
-            "Junction phase\r\n       φfc  fix ms   lobe\r\n");
+            "Junction phase\r\n       φfc  fix ms\r\n");
         foreach (PhaseEntry entry in entries)
         {
             JunctionPhaseResult result = entry.Result;
@@ -262,7 +279,16 @@ internal static class VirtualCrossoverMetric
                 result.PhaseConsistency >= JunctionPhaseAlignment.MinimumPhaseConsistency
                     ? $"{result.PhaseAtCrossoverDeg,4:+0;-0;0}°"
                     : "    —";
-            string fix = $"{result.BestExtraDelayMs,6:+0.00;-0.00;0.00}";
+            // A delay is worth showing when it moves the phase at fc by more
+            // than SignificantFixDegrees; below that the column shows "·"
+            // rather than a number nobody should act on. The POLARITY mark
+            // still renders beside it — an inversion is not a matter of
+            // magnitude, and it stays actionable when the delay does not.
+            double significantMs =
+                SignificantFixDegrees / 360.0 * 1_000.0 / entry.CrossoverHz;
+            string fix = Math.Abs(result.BestExtraDelayMs) >= significantMs
+                ? $"{result.BestExtraDelayMs,6:+0.00;-0.00;0.00}"
+                : "     ·";
             // Polarity slot: "i" recommends flipping the lower channel; "~"
             // keeps the current polarity but flags that flipping nearly ties
             // (an inversion and a half-period delay sum alike here — common at
@@ -274,15 +300,12 @@ internal static class VirtualCrossoverMetric
                 : result.BestScore - result.OppositePolarityScore
                     < JunctionPhaseAlignment.PolarityFlipAdvantage ? "~"
                 : " ";
-            string lobe = result.LobeMargin.HasValue
-                ? $"{result.LobeMargin.Value,5:0.00}"
-                : "    —";
             string warning =
                 result.LobeMargin is { } margin && margin < AmbiguousLobeMargin
                     ? " !"
                     : string.Empty;
             builder.AppendLine(
-                $"{entry.Junction.PadRight(6)}{phase} {fix}{polarity} {lobe}{warning}");
+                $"{entry.Junction.PadRight(6)}{phase} {fix}{polarity}{warning}");
         }
 
         return builder.ToString().TrimEnd();
@@ -332,16 +355,19 @@ internal static class VirtualCrossoverMetric
             "alignment score,\r\nnot the magnitude coherence γ². fix: the delay " +
             "to add to the LOWER channel\r\nthat best aligns the band. A " +
             "negative fix advances the lower channel — apply\r\nit as a +delay " +
-            "on the UPPER one when the lower is already at 0. Polarity mark:" +
-            "\r\n\"i\" (or \"invert\") = flipping the lower channel scores " +
+            "on the UPPER one when the lower is already at 0. A fix worth less " +
+            "than\r\n10° of phase at fc (0.13 dB in the sum) shows as \"·\": " +
+            "there is nothing to apply.\r\nPolarity mark: " +
+            "\"i\" (or \"invert\") = flipping the lower channel scores " +
             "clearly better; \"~\" = the\r\ncurrent polarity is kept but a flip " +
             "nearly ties (an inversion and a half-period\r\ndelay sum alike, " +
             "common at a sub), so summation cannot settle the polarity —\r\nφ " +
             "near ±180° never settles it either. φ is a narrow circular mean " +
             "around fc;\r\nR (0..1) is how much its bins agree — a low R dashes " +
-            "it. lobe: how decisively\r\nthe best delay beats the nearest same-" +
-            "polarity whole-period rival; small margin\r\n(!) = the band is too " +
-            "narrow to rule that period hop out, so don't trust the fix.";
+            "it. The lobe margin above\r\nis how decisively the best delay beats " +
+            "the nearest same-polarity whole-period\r\nrival; a small one (!) " +
+            "means the band is too narrow to rule that period hop out,\r\nso " +
+            "don't trust the fix — read the junction's coherence ladder instead.";
     }
 
     /// <summary>

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
@@ -250,12 +250,20 @@ internal static class VirtualCrossoverMetric
 
     /// <summary>
     /// Compact per-junction phase column for the host read-out panel: the phase
-    /// at the crossover and the score-maximizing extra delay on the lower
-    /// channel (with an "i" when flipping that channel's polarity scores
-    /// clearly better, "~" when a flip nearly ties, and "!" when the
-    /// same-polarity lobe margin is too small to rule out a whole-period hop).
-    /// A fix too small to matter renders as "·"; the lobe margin itself, and
-    /// every other fitted figure, lives in <see cref="FormatPhaseDetail"/>.
+    /// at the crossover, the score-maximizing extra delay on the lower channel
+    /// (with an "i" when flipping that channel's polarity scores clearly
+    /// better, "~" when a flip nearly ties, and "!" when the same-polarity lobe
+    /// margin is too small to rule out a whole-period hop), and the phase score
+    /// the junction reaches AS IT STANDS. A fix too small to matter renders as
+    /// "·"; the lobe margin itself, and every other fitted figure, lives in
+    /// <see cref="FormatPhaseDetail"/>.
+    /// <para>
+    /// The score is the one column that reads without a legend: it is bounded
+    /// (−1..+1), it is the quantity the fix maximizes, and it moves while a
+    /// delay is being dragged — so it answers "is this getting better", which
+    /// the fix alone cannot (a fix of −1.30 ms says how far off the optimum
+    /// sits, not how much the junction currently loses to being there).
+    /// </para>
     /// </summary>
     public static string FormatPhaseCompact(IReadOnlyList<PhaseEntry> entries)
     {
@@ -265,7 +273,7 @@ internal static class VirtualCrossoverMetric
         }
 
         var builder = new System.Text.StringBuilder(
-            "Junction phase\r\n       φfc  fix ms\r\n");
+            "Junction phase\r\n       φfc  fix ms  score\r\n");
         foreach (PhaseEntry entry in entries)
         {
             JunctionPhaseResult result = entry.Result;
@@ -300,12 +308,18 @@ internal static class VirtualCrossoverMetric
                 : result.BestScore - result.OppositePolarityScore
                     < JunctionPhaseAlignment.PolarityFlipAdvantage ? "~"
                 : " ";
+            // Where the junction stands NOW, on the same score the fix
+            // maximizes: 1.00 is phase-aligned across the band, 0 is a wash,
+            // negative means the overlap is subtracting. Three sections
+            // because a negative score that rounds to zero would otherwise
+            // render "-0.00" as "-+0.00" (see the fix column).
+            string score = $"{result.CurrentScore,5:0.00;-0.00;0.00}";
             string warning =
                 result.LobeMargin is { } margin && margin < AmbiguousLobeMargin
                     ? " !"
                     : string.Empty;
             builder.AppendLine(
-                $"{entry.Junction.PadRight(6)}{phase} {fix}{polarity}{warning}");
+                $"{entry.Junction.PadRight(6)}{phase} {fix}{polarity} {score}{warning}");
         }
 
         return builder.ToString().TrimEnd();
@@ -351,8 +365,11 @@ internal static class VirtualCrossoverMetric
                     $"({FrequencyText.Format(entry.LowHz)} – " +
                     $"{FrequencyText.Format(entry.HighHz)})";
             })) +
-            "\r\nphase score: Σw·cos(Δφ)/Σw over the band (−1..+1), a phase-" +
-            "alignment score,\r\nnot the magnitude coherence γ². fix: the delay " +
+            "\r\nscore: Σw·cos(Δφ)/Σw over the band as the junction stands " +
+            "(−1..+1), a phase-\r\nalignment score, not the magnitude coherence " +
+            "γ² — 1.00 is aligned across the\r\nband, 0 a wash, negative means " +
+            "the overlap subtracts; it is what the fix\r\nmaximizes, so it " +
+            "moves while a delay is dragged. fix: the delay " +
             "to add to the LOWER channel\r\nthat best aligns the band. A " +
             "negative fix advances the lower channel — apply\r\nit as a +delay " +
             "on the UPPER one when the lower is already at 0. A fix worth less " +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
@@ -240,13 +240,24 @@ internal static class VirtualCrossoverMetric
     private const double AmbiguousLobeMargin = 0.10;
 
     // A fix is shown only when it is worth applying, measured where it acts:
-    // as PHASE at the crossover. Ten degrees costs the sum 0.13 dB — below the
-    // ear and below the measurement's own repeatability — so anything under it
-    // renders as "·" instead of a number inviting a correction. A settled tune
+    // as PHASE at the crossover. Ten degrees costs the sum 0.03 dB
+    // (20·log10(cos(φ/2)) for two equal contributions) — below the ear and
+    // below the measurement's own repeatability — so anything under it renders
+    // as "·" instead of a number inviting a correction. A settled tune
     // otherwise fills the column with values like "-0.01" that read as data
     // and mean nothing. The threshold is per junction on purpose: 0.05 ms is
     // nothing at 65 Hz and most of a period at 4 kHz.
     private const double SignificantFixDegrees = 10.0;
+
+    // Two decimals read best and match the other columns, but the threshold
+    // above is a PHASE: at 5.6 kHz ten degrees is already 0.005 ms, and higher
+    // still less, so a fix worth acting on can round to "0.00" — losing its
+    // sign with it. Below that boundary the value takes a third decimal
+    // instead of being rounded into nothing.
+    private static string FixText(double milliseconds) =>
+        Math.Abs(milliseconds) < 0.005
+            ? milliseconds.ToString("+0.000;-0.000;0.000")
+            : milliseconds.ToString("+0.00;-0.00;0.00");
 
     /// <summary>
     /// Compact per-junction phase column for the host read-out panel: the phase
@@ -295,7 +306,7 @@ internal static class VirtualCrossoverMetric
             double significantMs =
                 SignificantFixDegrees / 360.0 * 1_000.0 / entry.CrossoverHz;
             string fix = Math.Abs(result.BestExtraDelayMs) >= significantMs
-                ? $"{result.BestExtraDelayMs,6:+0.00;-0.00;0.00}"
+                ? $"{FixText(result.BestExtraDelayMs),6}"
                 : "     ·";
             // Polarity slot: "i" recommends flipping the lower channel; "~"
             // keeps the current polarity but flags that flipping nearly ties
@@ -358,7 +369,7 @@ internal static class VirtualCrossoverMetric
                     $"{phaseNote}; " +
                     $"phase score {result.CurrentScore:0.00} now, " +
                     $"best {result.BestScore:0.00} at " +
-                    $"{result.BestExtraDelayMs:+0.00;-0.00;0.00} ms " +
+                    $"{FixText(result.BestExtraDelayMs)} ms " +
                     $"on {entry.LowerChannel}{flip};\r\n   {rival}; " +
                     $"fit Δτ {result.FitDelayMs:+0.00;-0.00;0.00} ms, " +
                     $"rms {result.FitRmsDeg:0}° " +
@@ -373,7 +384,7 @@ internal static class VirtualCrossoverMetric
             "to add to the LOWER channel\r\nthat best aligns the band. A " +
             "negative fix advances the lower channel — apply\r\nit as a +delay " +
             "on the UPPER one when the lower is already at 0. A fix worth less " +
-            "than\r\n10° of phase at fc (0.13 dB in the sum) shows as \"·\": " +
+            "than\r\n10° of phase at fc (0.03 dB in the sum) shows as \"·\": " +
             "there is nothing to apply.\r\nPolarity mark: " +
             "\"i\" (or \"invert\") = flipping the lower channel scores " +
             "clearly better; \"~\" = the\r\ncurrent polarity is kept but a flip " +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -68,12 +68,12 @@ internal sealed class VirtualCrossoverMetrics
             .AsParallel()
             .AsOrdered()
             .Select(item => buildMagnitudeCurve(
-                item.ImpulseResponse, anchor, item.Channel.SampleRate))
+                item.ImpulseResponse, anchor, item.SampleRate))
             .ToList();
         Complex[] sum = VirtualCrossoverAnalysis.SumImpulseResponses(
             processed.Select(item => item.ImpulseResponse).ToList());
         GatedMagnitude sumCurve = buildMagnitudeCurve(
-            sum, anchor, processed[0].Channel.SampleRate);
+            sum, anchor, processed[0].SampleRate);
         List<SignalPoint> loss = VirtualCrossoverAnalysis.SumLossCurve(
             sumCurve.Unsmoothed.Points,
             magnitudes
@@ -162,7 +162,7 @@ internal sealed class VirtualCrossoverMetrics
             if (!spectra.TryGetValue(item, out Complex[]? spectrum))
             {
                 spectrum = JunctionPhaseAlignment.BuildAnalysisSpectrum(
-                    item.ImpulseResponse, item.Channel.SampleRate);
+                    item.ImpulseResponse, item.SampleRate);
                 spectra.Add(item, spectrum);
             }
 
@@ -172,7 +172,7 @@ internal sealed class VirtualCrossoverMetrics
         foreach (AdjacentPair pair in ProcessedChannels.GetAdjacentPairs(
             ProcessedChannels.OrderByBand(processed)))
         {
-            if (pair.Lower.Channel.SampleRate != pair.Upper.Channel.SampleRate)
+            if (pair.Lower.SampleRate != pair.Upper.SampleRate)
             {
                 continue;
             }
@@ -180,7 +180,7 @@ internal sealed class VirtualCrossoverMetrics
             JunctionPhaseResult? result = JunctionPhaseAlignment.AnalyzeSpectra(
                 SpectrumOf(pair.Lower),
                 SpectrumOf(pair.Upper),
-                pair.Lower.Channel.SampleRate,
+                pair.Lower.SampleRate,
                 pair.CrossoverHz,
                 pair.BandLowHz,
                 pair.BandHighHz);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -340,7 +340,7 @@ internal sealed class VirtualCrossoverMetrics
         bool anyArrivalWork = jobs.Any(job => job.Sides.Any(side => side.Arrival == null));
         if (anyArrivalWork)
         {
-            object? arrivalCompleted = await coordinator.RunAuxiliaryAsync(
+            object? arrivalCompleted = await coordinator.RunAuxiliaryAsync<object>(
                 revision,
                 cancellationToken =>
             {
@@ -348,7 +348,14 @@ internal sealed class VirtualCrossoverMetrics
                 {
                     foreach (SideProcessJob side in job.Sides)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
+                        // Silent cancellation (see RunAuxiliaryAsync): null
+                        // says "superseded", and the caller drops the read-out
+                        // exactly as it did for the thrown version.
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            return null;
+                        }
+
                         if (side.Arrival == null)
                         {
                             side.Arrival =

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
@@ -67,6 +67,7 @@ namespace Resonalyze
             radioDspPhase = new RadioButton();
             radioDspGroupDelay = new RadioButton();
             radioDspCorrelation = new RadioButton();
+            radioDspCoherence = new RadioButton();
             comboBoxCorrelationPair = new DarkComboBox();
             panel1 = new Panel();
             panel2 = new Panel();
@@ -542,13 +543,25 @@ namespace Resonalyze
             radioDspCorrelation.TabIndex = 3;
             radioDspCorrelation.Text = "Correlation";
             radioDspCorrelation.UseVisualStyleBackColor = true;
+            //
+            // radioDspCoherence
+            //
+            radioDspCoherence.AutoSize = true;
+            radioDspCoherence.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            radioDspCoherence.ForeColor = Color.FromArgb(210, 214, 222);
+            radioDspCoherence.Location = new Point(88, 1);
+            radioDspCoherence.Name = "radioDspCoherence";
+            radioDspCoherence.Size = new Size(82, 19);
+            radioDspCoherence.TabIndex = 4;
+            radioDspCoherence.Text = "Coherence";
+            radioDspCoherence.UseVisualStyleBackColor = true;
             // 
             // comboBoxCorrelationPair
             // 
             comboBoxCorrelationPair.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxCorrelationPair.Enabled = false;
             comboBoxCorrelationPair.ForeColor = Color.White;
-            comboBoxCorrelationPair.Location = new Point(93, 1);
+            comboBoxCorrelationPair.Location = new Point(178, 1);
             comboBoxCorrelationPair.MinimumSize = new Size(36, 19);
             comboBoxCorrelationPair.Name = "comboBoxCorrelationPair";
             comboBoxCorrelationPair.Size = new Size(74, 19);
@@ -570,10 +583,11 @@ namespace Resonalyze
             panel2.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
             panel2.BorderStyle = BorderStyle.FixedSingle;
             panel2.Controls.Add(radioDspCorrelation);
+            panel2.Controls.Add(radioDspCoherence);
             panel2.Controls.Add(comboBoxCorrelationPair);
             panel2.Location = new Point(798, 733);
             panel2.Name = "panel2";
-            panel2.Size = new Size(170, 23);
+            panel2.Size = new Size(255, 23);
             panel2.TabIndex = 25;
             // 
             // VirtualCrossoverPanel
@@ -668,6 +682,7 @@ namespace Resonalyze
         private RadioButton radioDspPhase;
         private RadioButton radioDspGroupDelay;
         private RadioButton radioDspCorrelation;
+        private RadioButton radioDspCoherence;
         private DarkComboBox comboBoxCorrelationPair;
         private Panel panel1;
         private Panel panel2;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -530,7 +530,9 @@ public partial class VirtualCrossoverPanel : UserControl
                 project.EffectiveDspPlotMode == DspPlotMode.GroupDelay;
             radioDspCorrelation.Checked =
                 project.EffectiveDspPlotMode == DspPlotMode.Correlation;
-            comboBoxCorrelationPair.Enabled = radioDspCorrelation.Checked &&
+            radioDspCoherence.Checked =
+                project.EffectiveDspPlotMode == DspPlotMode.Coherence;
+            comboBoxCorrelationPair.Enabled = JunctionPlotModeSelected() &&
                 comboBoxCorrelationPair.Items.Count > 0;
 
             for (int i = 0; i < channels.Count; i++)
@@ -873,6 +875,19 @@ public partial class VirtualCrossoverPanel : UserControl
         radioDspCorrelation.CheckedChanged += (_, _) =>
         {
             if (radioDspCorrelation.Checked)
+            {
+                radioDspMagnitude.Checked = false;
+                radioDspPhase.Checked = false;
+                radioDspGroupDelay.Checked = false;
+                OnDspPlotModeChanged();
+            }
+        };
+        // Coherence shares the correlation radio's container, so WinForms
+        // already excludes the two junction modes against each other; only
+        // the chain trio needs clearing by hand.
+        radioDspCoherence.CheckedChanged += (_, _) =>
+        {
+            if (radioDspCoherence.Checked)
             {
                 radioDspMagnitude.Checked = false;
                 radioDspPhase.Checked = false;
@@ -2252,21 +2267,32 @@ public partial class VirtualCrossoverPanel : UserControl
         radioDspPhase.Checked ? DspPlotMode.Phase
         : radioDspGroupDelay.Checked ? DspPlotMode.GroupDelay
         : radioDspCorrelation.Checked ? DspPlotMode.Correlation
+        : radioDspCoherence.Checked ? DspPlotMode.Coherence
         : DspPlotMode.Magnitude;
 
+    // The two junction modes share everything around the plot itself — the
+    // pair selector, the async rebuild loop, the processed-pair inputs — so
+    // every gate that used to ask "is this the correlation view" asks this.
+    private bool JunctionPlotModeSelected() =>
+        radioDspCorrelation.Checked || radioDspCoherence.Checked;
+
+    private static bool IsJunctionMode(DspPlotMode mode) =>
+        mode is DspPlotMode.Correlation or DspPlotMode.Coherence;
+
     // One of the chain-view radios (magnitude / phase / group delay) became
-    // checked: retract the cross-container Correlation radio before acting —
-    // its own container cannot do it (see the wiring comment).
+    // checked: retract the cross-container junction radios before acting —
+    // their own container cannot do it (see the wiring comment).
     private void OnChainDspModeChecked()
     {
         radioDspCorrelation.Checked = false;
+        radioDspCoherence.Checked = false;
         OnDspPlotModeChanged();
     }
 
     private void OnDspPlotModeChanged()
     {
         comboBoxCorrelationPair.Enabled =
-            radioDspCorrelation.Checked && comboBoxCorrelationPair.Items.Count > 0;
+            JunctionPlotModeSelected() && comboBoxCorrelationPair.Items.Count > 0;
         if (suppressProjectEvents)
         {
             return;
@@ -2659,6 +2685,7 @@ public partial class VirtualCrossoverPanel : UserControl
                 channel,
                 result.ImpulseResponse,
                 result.PeakIndex,
+                result.SampleRate,
                 color,
                 result.ValidRange));
         }
@@ -3001,9 +3028,9 @@ public partial class VirtualCrossoverPanel : UserControl
                         ProcessedChannels.StartAnchorIndex(
                             item.ImpulseResponse,
                             item.PeakIndex,
-                            item.Channel.SampleRate,
+                            item.SampleRate,
                             item.ValidRange),
-                        item.Channel.SampleRate).Display;
+                        item.SampleRate).Display;
                 curves.Add(new AcousticCurve(
                     item.Channel.Name, curve.Points, item.Color, 1.8, LineStyle.Solid));
             }
@@ -4239,7 +4266,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // exact as long as no window cuts into its own channel — the condition
         // ResolvePhaseGateOffsets enforces before it hands out per-curve
         // placements.
-        int sampleRate = processed[0].Channel.SampleRate;
+        int sampleRate = processed[0].SampleRate;
         double referenceOffsetMs = gatePreview?.OffsetMs
             ?? ResolveGateOffsetMs(processed, sampleRate);
         double detrendMs = ResolveCommonDetrendMs(
@@ -4369,7 +4396,7 @@ public partial class VirtualCrossoverPanel : UserControl
             return null;
         }
 
-        int sampleRate = shown[0].Channel.SampleRate;
+        int sampleRate = shown[0].SampleRate;
         double gateOffsetMs = gatePreview?.OffsetMs
             ?? ResolveGateOffsetMs(shown, sampleRate);
 
@@ -4610,7 +4637,7 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         MagnitudeGateSnapshot snapshot = magnitudeGate;
-        int sampleRate = processed[0].Channel.SampleRate;
+        int sampleRate = processed[0].SampleRate;
         double offsetMs = snapshot.ResolveGateOffsetMs(
             oppositeSide: false,
             ProcessedChannels.SharedStartAnchorIndex(processed),
@@ -4880,7 +4907,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // processed FRONT, the same channel the shared window opens on), then
         // apply that exact value to every driver and the sum.
         ProcessedChannel anchor = processed.MinBy(item => ProcessedChannels.StartAnchorIndex(
-            item.ImpulseResponse, item.PeakIndex, item.Channel.SampleRate,
+            item.ImpulseResponse, item.PeakIndex, item.SampleRate,
             item.ValidRange))!;
         var view = new ImpulseMeasurementView(anchor.ImpulseResponse, 0, sampleRate);
         PhaseAnalysisSettings settings = CreateVirtualPhaseSettings(
@@ -4961,7 +4988,7 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
-        int sampleRate = processed[0].Channel.SampleRate;
+        int sampleRate = processed[0].SampleRate;
         int reference = ProcessedChannels.SharedStartAnchorIndex(processed);
         double fitOffsetMs = EarliestStartMs(processed, sampleRate);
 
@@ -5044,7 +5071,7 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private void RedrawDspPlot()
     {
-        if (CurrentDspPlotMode() == DspPlotMode.Correlation)
+        if (IsJunctionMode(CurrentDspPlotMode()))
         {
             UpdateCorrelationPairChoices();
             RequestCorrelationRedraw();
@@ -5127,7 +5154,7 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         comboBoxCorrelationPair.Enabled =
-            radioDspCorrelation.Checked && labels.Count > 0;
+            JunctionPlotModeSelected() && labels.Count > 0;
     }
 
     // Runs on the UI thread. Starts the rebuild loop, or — when one is
@@ -5151,48 +5178,78 @@ public partial class VirtualCrossoverPanel : UserControl
             await RedrawCorrelationPlotAsync();
         }
         while (correlationRebuildPending && !dspPlotView.IsDisposed &&
-            CurrentDspPlotMode() == DspPlotMode.Correlation);
+            IsJunctionMode(CurrentDspPlotMode()));
 
         correlationRebuildTask = null;
     }
 
+    // One iteration of the junction rebuild loop, for BOTH junction modes:
+    // same pair, same processed inputs, one data build off the UI thread —
+    // only WHAT is computed and which model is drawn differ by mode. The
+    // result is dropped when the user left for the other junction mode
+    // mid-compute (the pending flag restarts the loop with the new mode).
     private async Task RedrawCorrelationPlotAsync()
     {
+        DspPlotMode mode = CurrentDspPlotMode();
         List<AdjacentPair> pairs = CurrentCorrelationPairs();
         if (pairs.Count == 0)
         {
-            dspChainPlot.DrawCorrelation(null);
+            if (mode == DspPlotMode.Coherence)
+            {
+                dspChainPlot.DrawCoherence(null);
+            }
+            else
+            {
+                dspChainPlot.DrawCorrelation(null);
+            }
+
             return;
         }
 
         AdjacentPair pair = pairs[Math.Clamp(
             project.CorrelationPairIndex, 0, pairs.Count - 1)];
-        JunctionCorrelationView? data = null;
+        JunctionCorrelationView? correlation = null;
+        JunctionCoherenceView? coherence = null;
         try
         {
             List<ProcessedChannel> scope = lastProcessedRender is { } render
                 ? render.Channels.ToList()
                 : [pair.Lower, pair.Upper];
-            data = await Task.Run(() => BuildCorrelationView(pair, scope));
+            if (mode == DspPlotMode.Coherence)
+            {
+                coherence = await Task.Run(() => BuildCoherenceView(pair, scope));
+            }
+            else
+            {
+                correlation = await Task.Run(() => BuildCorrelationView(pair, scope));
+            }
         }
         catch (Exception exception)
         {
             // Best-effort like every redraw: keep the last frame.
             System.Diagnostics.Debug.WriteLine(
-                $"Correlation view rebuild failed: {exception}");
+                $"Junction view rebuild failed: {exception}");
         }
 
-        if (dspPlotView.IsDisposed ||
-            CurrentDspPlotMode() != DspPlotMode.Correlation)
+        if (dspPlotView.IsDisposed || CurrentDspPlotMode() != mode)
         {
             return;
         }
 
         // A request that arrived mid-compute means this result is already
         // stale: skip the draw, the loop is about to recompute anyway.
-        if (data != null && !correlationRebuildPending)
+        if (correlationRebuildPending)
         {
-            dspChainPlot.DrawCorrelation(data);
+            return;
+        }
+
+        if (coherence != null)
+        {
+            dspChainPlot.DrawCoherence(coherence);
+        }
+        else if (correlation != null)
+        {
+            dspChainPlot.DrawCorrelation(correlation);
         }
     }
 
@@ -5216,34 +5273,10 @@ public partial class VirtualCrossoverPanel : UserControl
         AdjacentPair pair, IReadOnlyList<ProcessedChannel> scope)
     {
         using var _ = AppProfiler.Zone("VirtualDSP.BuildCorrelationView");
-        int sampleRate = pair.Lower.Channel.SampleRate;
-        List<ProcessedChannel> all = scope.Contains(pair.Lower)
-            ? scope.ToList()
-            : [pair.Lower, pair.Upper];
-        Complex[][] cropped = VirtualCrossoverAnalysis.CropSharedDirectSoundWindow(
-            all.Select(item => item.ImpulseResponse).ToList(),
-            AlignmentReprocessor.SearchCropLength(sampleRate),
-            AlignmentReprocessor.SearchCropPrePeakSamples(sampleRate),
-            out int cropStart);
-        Complex[] lower = cropped[all.IndexOf(pair.Lower)];
-        Complex[] upper = cropped[all.IndexOf(pair.Upper)];
-        // The channels' valid ranges, shifted into the crop's frame: the
-        // front detections behind the sweep and the direct cuts take them, so
-        // the drawn surface reads the same fronts the search reads — on a
-        // clean capture the heuristic fallback agrees anyway, but a delayed
-        // or glitch-headed record is exactly where the two paths must not
-        // part.
-        ValidSampleRange Shifted(ProcessedChannel item, Complex[] croppedIr) =>
-            item.ValidRange.IsKnown
-                ? new ValidSampleRange(
-                    Math.Max(0, item.ValidRange.StartSample - cropStart),
-                    Math.Clamp(
-                        item.ValidRange.EndSample - cropStart,
-                        0,
-                        croppedIr.Length))
-                : item.ValidRange;
-        ValidSampleRange lowerRange = Shifted(pair.Lower, lower);
-        ValidSampleRange upperRange = Shifted(pair.Upper, upper);
+        int sampleRate = pair.Lower.SampleRate;
+        (Complex[] lower, Complex[] upper,
+            ValidSampleRange lowerRange, ValidSampleRange upperRange) =
+            CropJunctionPair(pair, scope, sampleRate);
         // No gate anchor is passed: the sweep windows each channel at its own
         // band-limited front, exactly as every junction measurement of an
         // Auto delay run does (see BuildAlignmentBins), so the drawn score
@@ -5259,30 +5292,6 @@ public partial class VirtualCrossoverPanel : UserControl
         // in view even at an 80 Hz junction.
         double windowMs = Math.Max(3.0, 1.5 * 1000.0 / pair.CrossoverHz);
         double passOctaves = Math.Log2(pair.BandHighHz / pair.BandLowHz);
-        List<SignalPoint> whitened =
-            VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
-                lower, upper, sampleRate, pair.CrossoverHz, passOctaves,
-                windowMs, centerLagMs: 0, phaseTransform: true);
-
-        // The whitened curve again, on the DIRECT sound alone (see
-        // VirtualCrossoverAnalysis.CutDirectSound — the same cut the
-        // engine's direct-coherence witness reads, so this curve shows the
-        // very figure the search weighed). The full-record curves above read
-        // the whole capture — reflections included, which on a thin-overlap
-        // junction outvote the drivers — while this one answers the question
-        // the view is usually opened with: where do the DRIVERS align.
-        List<SignalPoint> whitenedDirect =
-            VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
-                VirtualCrossoverAnalysis.CutDirectSound(
-                    lower, sampleRate,
-                    pair.BandLowHz, pair.BandHighHz, pair.CrossoverHz,
-                    lowerRange),
-                VirtualCrossoverAnalysis.CutDirectSound(
-                    upper, sampleRate,
-                    pair.BandLowHz, pair.BandHighHz, pair.CrossoverHz,
-                    upperRange),
-                sampleRate, pair.CrossoverHz, passOctaves,
-                windowMs, centerLagMs: 0, phaseTransform: true);
 
         // The score comb repeats per crossover period, so the step must
         // resolve THAT scale — a fixed points-per-window count aliased at
@@ -5293,30 +5302,67 @@ public partial class VirtualCrossoverPanel : UserControl
         double stepMs = Math.Max(
             Math.Min(windowMs / 60.0, 100.0 / pair.CrossoverHz),
             Math.Max(0.005, windowMs / 300.0));
-        List<SignalPoint> ScoreSweep(bool invert) =>
-            VirtualCrossoverAnalysis.JunctionLossSweep(
-                upper, lower, sampleRate,
-                pair.BandLowHz, pair.BandHighHz,
-                -windowMs, windowMs, stepMs, invert,
-                // The search's own settings, or the drawn surface is not the
-                // searched one: per-channel windows (null anchor) and the
-                // search-side level match, whose absence re-shapes the lobes
-                // whenever the two channels sit at different gains.
-                gateAnchorSample: null,
-                levelMatch: true,
-                variableValidRange: upperRange,
-                fixedValidRange: lowerRange)
-            .Select(point => new SignalPoint(
-                point.DelayMs,
-                point.LossDb +
-                    VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
-                    (point.DipDb - point.LossDb)))
-            .ToList();
 
-        double arrivalLagMs = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                lower, sampleRate, pair.BandLowHz, pair.BandHighHz, lowerRange)
-            - VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
-                upper, sampleRate, pair.BandLowHz, pair.BandHighHz, upperRange);
+        // The view's four reads are independent computations over the same
+        // immutable pair, so they run side by side; each block's meaning is
+        // stated at its own site below.
+        List<SignalPoint> whitened = null!;
+        List<SignalPoint> whitenedDirect = null!;
+        List<SignalPoint> scoreNormal = null!;
+        List<SignalPoint> scoreInverted = null!;
+        double lowerArrivalMs = 0;
+        double upperArrivalMs = 0;
+        Parallel.Invoke(
+            // The whitened full-record comb: deliberately UNTRIMMED — the
+            // whole capture, reflections included, is this curve's subject
+            // (the honest read at bass junctions, where "direct sound" is not
+            // a measurable notion).
+            () => whitened = VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
+                lower, upper, sampleRate, pair.CrossoverHz, passOctaves,
+                windowMs, centerLagMs: 0, phaseTransform: true),
+            // The whitened curve again, on the DIRECT sound alone — the same
+            // cut the engine's direct-coherence witness reads, so this curve
+            // shows the very figure the search weighed; where the full-record
+            // twin follows whatever the cabin's reflections correlate best,
+            // this one answers where the DRIVERS align. The pair cut is
+            // trimmed to the windows' span (relative lags preserved — see
+            // CutDirectSoundPair), sized for the ±windowMs read.
+            () =>
+            {
+                (Complex[] directLower, Complex[] directUpper) =
+                    VirtualCrossoverAnalysis.CutDirectSoundPair(
+                        lower, upper, sampleRate,
+                        pair.BandLowHz, pair.BandHighHz, pair.CrossoverHz,
+                        searchRangeMs: windowMs, lowerRange, upperRange);
+                whitenedDirect = VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
+                    directLower, directUpper, sampleRate,
+                    pair.CrossoverHz, passOctaves,
+                    windowMs, centerLagMs: 0, phaseTransform: true);
+            },
+            // Both polarities of the summation score from ONE set of bins,
+            // with the search's own settings — per-channel windows (null
+            // anchor) and the search-side level match, whose absence
+            // re-shapes the lobes whenever the two channels sit at different
+            // gains — or the drawn surface is not the searched one.
+            () =>
+            {
+                (List<VirtualCrossoverAnalysis.JunctionSweepPoint> normal,
+                    List<VirtualCrossoverAnalysis.JunctionSweepPoint> inverted) =
+                    VirtualCrossoverAnalysis.JunctionLossSweepBothPolarities(
+                        upper, lower, sampleRate,
+                        pair.BandLowHz, pair.BandHighHz,
+                        -windowMs, windowMs, stepMs,
+                        gateAnchorSample: null,
+                        levelMatch: true,
+                        variableValidRange: upperRange,
+                        fixedValidRange: lowerRange);
+                scoreNormal = Penalized(normal);
+                scoreInverted = Penalized(inverted);
+            },
+            () => lowerArrivalMs = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+                lower, sampleRate, pair.BandLowHz, pair.BandHighHz, lowerRange),
+            () => upperArrivalMs = VirtualCrossoverAnalysis.FindBandLimitedArrivalMs(
+                upper, sampleRate, pair.BandLowHz, pair.BandHighHz, upperRange));
 
         return new JunctionCorrelationView(
             $"{pair.Lower.Channel.Name}-{pair.Upper.Channel.Name}",
@@ -5326,9 +5372,81 @@ public partial class VirtualCrossoverPanel : UserControl
             pair.BandHighHz,
             whitened,
             whitenedDirect,
-            ScoreSweep(invert: false),
-            ScoreSweep(invert: true),
-            arrivalLagMs);
+            scoreNormal,
+            scoreInverted,
+            lowerArrivalMs - upperArrivalMs);
+    }
+
+    private static List<SignalPoint> Penalized(
+        List<VirtualCrossoverAnalysis.JunctionSweepPoint> sweep) =>
+        sweep
+            .Select(point => new SignalPoint(
+                point.DelayMs,
+                point.LossDb +
+                    VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
+                    (point.DipDb - point.LossDb)))
+            .ToList();
+
+    // The off-thread compute of one junction's coherence view: the same
+    // cropped PROCESSED pair as the correlation view, handed to the dsp
+    // ladder (see VirtualCrossoverAnalysis.ArrivalCoherenceLadder for what a
+    // band reading means and why the edges are gated). Internal for the same
+    // harness reason as BuildCorrelationView.
+    internal static JunctionCoherenceView BuildCoherenceView(
+        AdjacentPair pair, IReadOnlyList<ProcessedChannel> scope)
+    {
+        using var _ = AppProfiler.Zone("VirtualDSP.BuildCoherenceView");
+        int sampleRate = pair.Lower.SampleRate;
+        (Complex[] lower, Complex[] upper,
+            ValidSampleRange lowerRange, ValidSampleRange upperRange) =
+            CropJunctionPair(pair, scope, sampleRate);
+        return new JunctionCoherenceView(
+            $"{pair.Lower.Channel.Name}-{pair.Upper.Channel.Name}",
+            pair.Upper.Channel.Name,
+            pair.CrossoverHz,
+            pair.BandLowHz,
+            pair.BandHighHz,
+            VirtualCrossoverAnalysis.ArrivalCoherenceLadder(
+                lower, upper, sampleRate,
+                pair.BandLowHz, pair.BandHighHz, pair.CrossoverHz,
+                lowerRange, upperRange));
+    }
+
+    // The junction views' shared preparation: one shared direct-sound crop
+    // across the whole processed side (a shared offset is what keeps the
+    // channels' relative timing intact; it decides nothing the analyses
+    // read, their anchors being derived from the pair's own content), and
+    // the channels' valid ranges shifted into the crop's frame — the front
+    // detections behind the direct cuts and the score sweep take them, so
+    // the drawn surfaces read the same fronts the search reads. On a clean
+    // capture the heuristic fallback agrees anyway, but a delayed or
+    // glitch-headed record is exactly where the two paths must not part.
+    private static (Complex[] Lower, Complex[] Upper,
+        ValidSampleRange LowerRange, ValidSampleRange UpperRange)
+        CropJunctionPair(
+            AdjacentPair pair, IReadOnlyList<ProcessedChannel> scope, int sampleRate)
+    {
+        List<ProcessedChannel> all = scope.Contains(pair.Lower)
+            ? scope.ToList()
+            : [pair.Lower, pair.Upper];
+        Complex[][] cropped = VirtualCrossoverAnalysis.CropSharedDirectSoundWindow(
+            all.Select(item => item.ImpulseResponse).ToList(),
+            AlignmentReprocessor.SearchCropLength(sampleRate),
+            AlignmentReprocessor.SearchCropPrePeakSamples(sampleRate),
+            out int cropStart);
+        Complex[] lower = cropped[all.IndexOf(pair.Lower)];
+        Complex[] upper = cropped[all.IndexOf(pair.Upper)];
+        ValidSampleRange Shifted(ProcessedChannel item, Complex[] croppedIr) =>
+            item.ValidRange.IsKnown
+                ? new ValidSampleRange(
+                    Math.Max(0, item.ValidRange.StartSample - cropStart),
+                    Math.Clamp(
+                        item.ValidRange.EndSample - cropStart,
+                        0,
+                        croppedIr.Length))
+                : item.ValidRange;
+        return (lower, upper,
+            Shifted(pair.Lower, lower), Shifted(pair.Upper, upper));
     }
 
     // ------------------------------------------------------- capture / export
@@ -5355,7 +5473,7 @@ public partial class VirtualCrossoverPanel : UserControl
         AnalysisCurve sumCurve = BuildMagnitudeCurve(
             sum,
             processed.Min(item => item.PeakIndex),
-            processed[0].Channel.SampleRate).Display;
+            processed[0].SampleRate).Display;
 
         string title = "vDSP Sum " + string.Join(
             "+",

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProcessingCoordinator.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProcessingCoordinator.cs
@@ -102,6 +102,7 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
                         channel.Id,
                         entry.ImpulseResponse,
                         entry.PeakIndex,
+                        channel.SampleRate,
                         VirtualCrossoverAnalysis.ChainValidRange(
                             channel.Source.SampleCount,
                             channel.Chain,
@@ -148,6 +149,7 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
                                 pending.Channel.Id,
                                 response,
                                 VirtualCrossoverAnalysis.FindPeakIndex(response),
+                                pending.Channel.SampleRate,
                                 VirtualCrossoverAnalysis.ChainValidRange(
                                     pending.Channel.Source.SampleCount,
                                     pending.Channel.Chain,
@@ -524,10 +526,15 @@ internal sealed class VirtualCrossoverProcessingSnapshot
     public IReadOnlyList<VirtualCrossoverChannelSnapshot> Channels => channels;
 }
 
+// SampleRate is the rate the response was PROCESSED at, carried with the
+// result: consumers must not read it back off the live channel, which a
+// session import rebinds (and momentarily zeroes) while a render is still in
+// flight — see ProcessedChannel.
 internal sealed record VirtualCrossoverProcessedChannel(
     int Id,
     Complex[] ImpulseResponse,
     int PeakIndex,
+    int SampleRate,
     ValidSampleRange ValidRange);
 
 internal sealed record VirtualCrossoverRenderResult(

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProcessingCoordinator.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProcessingCoordinator.cs
@@ -178,6 +178,14 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
                 });
             }
 
+            // The external contract, checked AFTER the work as well as before
+            // it: a caller's own token cancelling mid-computation must still
+            // raise, and the silent path cannot tell the two cancellations
+            // apart — both land in the linked source, and the delegate reports
+            // either of them by returning null. Only the revision-driven one
+            // is silent, so the external token is re-examined on its own here.
+            cancellationToken.ThrowIfCancellationRequested();
+
             lock (sync)
             {
                 if (disposed || snapshot.Revision != revision ||
@@ -218,9 +226,13 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
             return null;
         }
         catch (AggregateException aggregate) when (
-            !cancellationToken.IsCancellationRequested &&
             aggregate.InnerExceptions.All(inner => inner is OperationCanceledException))
         {
+            // The external contract again: a delegate that threw because the
+            // CALLER's token cancelled must surface as a cancellation, not as
+            // an aggregate — the pre-silence code raised one from the parallel
+            // loop itself, and callers were entitled to it.
+            cancellationToken.ThrowIfCancellationRequested();
             // Backstops the OTHER convention: a processing delegate is still
             // free to report cancellation by throwing, and without a token on
             // the ParallelOptions those throws reach here aggregated rather
@@ -266,6 +278,9 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
             try
             {
                 T? result = await Task.Run(() => operation(linked.Token));
+                // As in ProcessAsync: a null can mean either cancellation, and
+                // the caller's own token still owes an exception.
+                cancellationToken.ThrowIfCancellationRequested();
                 return result != null && IsCurrent(candidateRevision) ? result : null;
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProcessingCoordinator.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProcessingCoordinator.cs
@@ -13,7 +13,7 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
     private readonly object sync = new();
     private readonly Dictionary<ProcessingSlotId, CacheEntry> cache = new();
     private readonly Func<VirtualCrossoverSourceSnapshot, DspChannelChain, int,
-        CancellationToken, Complex[]> processChannel;
+        CancellationToken, Complex[]?> processChannel;
     private CancellationTokenSource revisionCancellation = new();
     private long revision;
     private bool disposed;
@@ -25,7 +25,7 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
 
     internal VirtualCrossoverProcessingCoordinator(
         Func<VirtualCrossoverSourceSnapshot, DspChannelChain, int,
-            CancellationToken, Complex[]> processChannel)
+            CancellationToken, Complex[]?> processChannel)
     {
         this.processChannel = processChannel ?? throw new ArgumentNullException(nameof(processChannel));
     }
@@ -117,6 +117,11 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
         }
         try
         {
+            // EXTERNAL cancellation still propagates as an exception: a caller
+            // that passed its own token asked to be told, and that is the
+            // framework's convention. Only the internal, revision-driven
+            // cancellation — the one every delay edit triggers — is silent.
+            cancellationToken.ThrowIfCancellationRequested();
             if (misses.Count > 0)
             {
                 await Task.Run(() =>
@@ -128,23 +133,37 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
                     // scheduling worker; the per-channel zones time each
                     // chain's FFTs on whichever pool thread runs it.
                     using var _ = AppProfiler.Zone("VirtualDSP.ProcessChannels");
+                    // A cancelled batch STOPS the loop instead of throwing out
+                    // of it (see ProcessChannel): ParallelLoopState.Stop keeps
+                    // the "schedule no further iterations" behaviour the
+                    // ParallelOptions token used to give, without an exception
+                    // crossing the TPL boundary on every stale render. The
+                    // abandoned entries stay null in results, which the guard
+                    // below turns into a dropped render.
                     Parallel.For(
                         0,
                         misses.Count,
-                        new ParallelOptions
-                        {
-                            CancellationToken = processingCancellation.Token
-                        },
-                        index =>
+                        (index, state) =>
                         {
                             using var __ = AppProfiler.Zone("VirtualDSP.ProcessChannel");
+                            if (processingCancellation.IsCancellationRequested)
+                            {
+                                state.Stop();
+                                return;
+                            }
+
                             PendingChannel pending = misses[index];
-                            Complex[] response = processChannel(
+                            Complex[]? response = processChannel(
                                 pending.Channel.Source,
                                 pending.Channel.Chain,
                                 pending.Channel.SampleRate,
                                 processingCancellation.Token);
-                            processingCancellation.Token.ThrowIfCancellationRequested();
+                            if (response == null)
+                            {
+                                state.Stop();
+                                return;
+                            }
+
                             results[pending.ResultIndex] = new VirtualCrossoverProcessedChannel(
                                 pending.Channel.Id,
                                 response,
@@ -156,7 +175,7 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
                                     pending.Channel.SampleRate,
                                     response.Length));
                         });
-                }, processingCancellation.Token);
+                });
             }
 
             lock (sync)
@@ -165,6 +184,19 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
                     processingCancellation.IsCancellationRequested)
                 {
                     return null;
+                }
+
+                // A channel the loop abandoned leaves its slot null. The
+                // cancellation check above is what normally catches that, but
+                // the two are read at different moments, so the render is only
+                // published once every slot is actually filled — never with a
+                // hole in it.
+                foreach (VirtualCrossoverProcessedChannel? result in results)
+                {
+                    if (result == null)
+                    {
+                        return null;
+                    }
                 }
 
                 foreach (PendingChannel pending in misses)
@@ -185,15 +217,32 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
         {
             return null;
         }
+        catch (AggregateException aggregate) when (
+            !cancellationToken.IsCancellationRequested &&
+            aggregate.InnerExceptions.All(inner => inner is OperationCanceledException))
+        {
+            // Backstops the OTHER convention: a processing delegate is still
+            // free to report cancellation by throwing, and without a token on
+            // the ParallelOptions those throws reach here aggregated rather
+            // than as a bare OperationCanceledException.
+            return null;
+        }
         finally
         {
             processingCancellation.Dispose();
         }
     }
 
+    /// <summary>
+    /// Runs one auxiliary computation against a revision, returning null when
+    /// it was superseded. The operation reports its own cancellation by
+    /// RETURNING NULL — same reason as <see cref="ProcessChannel"/>: a stale
+    /// computation is routine, and throwing for it stops a Just My Code
+    /// debugger on every edit.
+    /// </summary>
     public async Task<T?> RunAuxiliaryAsync<T>(
         long candidateRevision,
-        Func<CancellationToken, T> operation,
+        Func<CancellationToken, T?> operation,
         CancellationToken cancellationToken = default)
         where T : class
     {
@@ -216,11 +265,13 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
         {
             try
             {
-                T result = await Task.Run(() => operation(linked.Token), linked.Token);
-                return IsCurrent(candidateRevision) ? result : null;
+                T? result = await Task.Run(() => operation(linked.Token));
+                return result != null && IsCurrent(candidateRevision) ? result : null;
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
+                // Kept as a backstop: an operation is free to throw for
+                // cancellation, it just no longer has to.
                 return null;
             }
         }
@@ -257,16 +308,25 @@ internal sealed class VirtualCrossoverProcessingCoordinator : IDisposable
         }
     }
 
-    private static Complex[] ProcessChannel(
+    // Cancellation is reported by RETURNING NULL rather than by throwing: a
+    // stale render is an ordinary event here — every delay edit makes one —
+    // and an exception thrown out of this delegate crosses the TPL boundary,
+    // which a debugger with Just My Code enabled stops on as "user-unhandled"
+    // even though ProcessAsync catches it a frame later. Null means "this
+    // response was abandoned"; the caller drops the whole render.
+    private static Complex[]? ProcessChannel(
         VirtualCrossoverSourceSnapshot source,
         DspChannelChain chain,
         int sampleRate,
         CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
+
         Complex[] response = source.Apply(chain, sampleRate);
-        cancellationToken.ThrowIfCancellationRequested();
-        return response;
+        return cancellationToken.IsCancellationRequested ? null : response;
     }
 
     private sealed record PendingChannel(

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -6,9 +6,11 @@ namespace Resonalyze;
 
 /// <summary>
 /// What the Virtual DSP lower plot shows: one curve per channel's DSP chain
-/// (magnitude / phase / group delay), or the junction-correlation view of one
-/// adjacent channel pair. <see cref="Correlation"/> never reaches the stored
-/// project field — it persists as an additive flag (see
+/// (magnitude / phase / group delay), or one adjacent channel pair's junction
+/// view — the lag-domain correlation (<see cref="Correlation"/>) or the
+/// per-band arrival-coherence ladder (<see cref="Coherence"/>). Neither
+/// junction mode ever reaches the stored project field — each persists as an
+/// additive flag (see
 /// <see cref="VirtualCrossoverProjectFile.SetDspPlotMode"/>) so older builds
 /// open such a session on the magnitude view instead of rejecting an unknown
 /// enum value.
@@ -18,7 +20,8 @@ public enum DspPlotMode
     Magnitude,
     Phase,
     GroupDelay,
-    Correlation
+    Correlation,
+    Coherence
 }
 
 /// <summary>
@@ -664,24 +667,34 @@ public sealed class VirtualCrossoverProjectFile
     // string. No file version bump.
     public bool DspPlotCorrelationView { get; set; }
 
-    // Which adjacent channel pair the correlation view analyzes, as an index
-    // into the by-band-ordered pair list (0 = the lowest junction). Additive.
+    // The junction-coherence ladder of the lower plot — the second junction
+    // mode, additive for the same reason. Correlation wins if a hand-edited
+    // file sets both (see EffectiveDspPlotMode).
+    public bool DspPlotCoherenceView { get; set; }
+
+    // Which adjacent channel pair the junction views (correlation and
+    // coherence — they share the selector) analyze, as an index into the
+    // by-band-ordered pair list (0 = the lowest junction). Additive.
     public int CorrelationPairIndex { get; set; }
 
     /// <summary>
-    /// The in-memory lower-plot mode: <see cref="DspPlotMode.Correlation"/>
-    /// when the flag is set, the stored enum value otherwise. Write through
-    /// <see cref="SetDspPlotMode"/> so the dual representation cannot
+    /// The in-memory lower-plot mode: <see cref="DspPlotMode.Correlation"/> or
+    /// <see cref="DspPlotMode.Coherence"/> when the matching flag is set, the
+    /// stored enum value otherwise. Write through
+    /// <see cref="SetDspPlotMode"/> so the multi-field representation cannot
     /// half-apply.
     /// </summary>
     [JsonIgnore]
     public DspPlotMode EffectiveDspPlotMode =>
-        DspPlotCorrelationView ? DspPlotMode.Correlation : DspPlotMode;
+        DspPlotCorrelationView ? DspPlotMode.Correlation
+        : DspPlotCoherenceView ? DspPlotMode.Coherence
+        : DspPlotMode;
 
     public void SetDspPlotMode(DspPlotMode mode)
     {
         DspPlotCorrelationView = mode == DspPlotMode.Correlation;
-        DspPlotMode = mode == DspPlotMode.Correlation
+        DspPlotCoherenceView = mode == DspPlotMode.Coherence;
+        DspPlotMode = mode is DspPlotMode.Correlation or DspPlotMode.Coherence
             ? DspPlotMode.Magnitude
             : mode;
     }

--- a/tests/Resonalyze.App.Tests/ProcessedChannelsTests.cs
+++ b/tests/Resonalyze.App.Tests/ProcessedChannelsTests.cs
@@ -14,7 +14,7 @@ public sealed class ProcessedChannelsTests
     private static ProcessedChannel Channel(string name, VirtualCrossoverChannelSettings settings)
     {
         var channel = new VirtualCrossoverChannel(name) { Pair = { Left = settings } };
-        return new ProcessedChannel(channel, [Complex.One], 0, OxyColors.White);
+        return new ProcessedChannel(channel, [Complex.One], 0, 48_000, OxyColors.White);
     }
 
     private static VirtualCrossoverChannelSettings LowPass(double hz) => new()
@@ -115,7 +115,7 @@ public sealed class ProcessedChannelsTests
             var channel = new VirtualCrossoverChannel("x") { SampleRate = 48_000 };
             return new ProcessedChannel(
                 channel, ir, VirtualCrossoverAnalysis.FindPeakIndex(ir),
-                OxyColors.White, range);
+                48_000, OxyColors.White, range);
         }
 
         int anchor = ProcessedChannels.SharedStartAnchorIndex(

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -469,6 +469,7 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
                 channel,
                 response,
                 VirtualCrossoverAnalysis.FindPeakIndex(response),
+                state.SampleRate,
                 OxyColors.White,
                 VirtualCrossoverAnalysis.ChainValidRange(
                     state.ProcessingSource.SampleCount,

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverCorrelationViewTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverCorrelationViewTests.cs
@@ -133,6 +133,38 @@ public sealed class VirtualCrossoverCorrelationViewTests
     }
 
     [Fact]
+    public void DrawCoherence_DrawsOneKindOfOptimumMarkerAndClaimsNoPolarity()
+    {
+        // The ladder states no polarity: its 2/3-octave probe makes a packet
+        // 4.3x wider than the lobe spacing at every frequency, so the
+        // opposite-signed lobes sit inside the plateau and the carrier's sign
+        // at the maximum is noise (measured 0-6% of envelope contrast across
+        // every archived junction). One marker series, and nothing in the
+        // legend promising a polarity.
+        var view = new JunctionCoherenceView("C-D", "D", 65, 33, 130,
+        [
+            new VirtualCrossoverAnalysis.ArrivalCoherencePoint(
+                103.2, 1.27, 0.981, 0.979, 4.85),
+            new VirtualCrossoverAnalysis.ArrivalCoherencePoint(
+                115.8, -0.40, 0.981, 0.500, 4.32)
+        ]);
+
+        using var plotView = new OxyPlot.WindowsForms.PlotView();
+        var plot = new VirtualCrossoverDspChainPlot(plotView, DspPlotMode.Coherence);
+        plot.DrawCoherence(view);
+        var model = (PlotModel)plotView.Model;
+
+        OxyPlot.Series.ScatterSeries markers = Assert.Single(
+            model.Series.OfType<OxyPlot.Series.ScatterSeries>());
+        Assert.Equal("optimum", markers.Title);
+        Assert.Equal([103.2, 115.8], markers.Points.Select(point => point.X));
+        Assert.DoesNotContain(
+            model.Series.Where(series => series.RenderInLegend),
+            series => series.Title?.Contains("polarity") == true ||
+                series.Title?.Contains("inverted") == true);
+    }
+
+    [Fact]
     public void DrawCoherence_RefitsTheFrequencyAxisWhenTheBandChanges()
     {
         // Editing the pair's crossover keeps the pair title, and both ladders
@@ -143,9 +175,9 @@ public sealed class VirtualCrossoverCorrelationViewTests
             new("C-D", "D", Math.Sqrt(lowHz * highHz), lowHz, highHz,
             [
                 new VirtualCrossoverAnalysis.ArrivalCoherencePoint(
-                    lowHz, 0.0, 0.9, 0.9, false, 500.0 / lowHz),
+                    lowHz, 0.0, 0.9, 0.9, 500.0 / lowHz),
                 new VirtualCrossoverAnalysis.ArrivalCoherencePoint(
-                    highHz, 0.0, 0.9, 0.9, false, 500.0 / highHz)
+                    highHz, 0.0, 0.9, 0.9, 500.0 / highHz)
             ]);
 
         using var plotView = new OxyPlot.WindowsForms.PlotView();
@@ -187,7 +219,6 @@ public sealed class VirtualCrossoverCorrelationViewTests
                 Math.Abs(point.LagMs) < 0.05,
                 $"band {point.FrequencyHz:0} Hz optimum at {point.LagMs:0.000} ms " +
                 "on an aligned pair");
-            Assert.False(point.OptimumInverted);
             Assert.True(
                 point.PeakR - point.CurrentR < 0.05,
                 $"band {point.FrequencyHz:0} Hz leaves coherence on the table " +

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverCorrelationViewTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverCorrelationViewTests.cs
@@ -26,7 +26,7 @@ public sealed class VirtualCrossoverCorrelationViewTests
         var channel = new VirtualCrossoverChannel(name) { SampleRate = SampleRate };
         return new ProcessedChannel(
             channel, ir, VirtualCrossoverAnalysis.FindPeakIndex(ir),
-            OxyColors.White, range);
+            SampleRate, OxyColors.White, range);
     }
 
     [Fact]
@@ -82,5 +82,89 @@ public sealed class VirtualCrossoverCorrelationViewTests
         // ...and the blind marker parks on the artifact, 10 ms early on the
         // upper side — the false front a dropped range would draw.
         Assert.InRange(blindView.ArrivalLagMs, 9.0, 11.0);
+    }
+
+    [Fact]
+    public void DrawCorrelation_AddsEnvelopeGuidesOutsideTheLegend()
+    {
+        // The ± envelope guides ride under each comb in its own color but
+        // must not join the legend — four named curves is what the legend
+        // says, and what it must keep saying.
+        var ir = new Complex[IrLength];
+        ir[FrontSample] = 1.0;
+        var range = new ValidSampleRange(FrontSample - 96, IrLength);
+        ProcessedChannel lower = Channel("C", ir, range);
+        ProcessedChannel upper = Channel("D", (Complex[])ir.Clone(), range);
+        JunctionCorrelationView view = VirtualCrossoverPanel.BuildCorrelationView(
+            new AdjacentPair(lower, upper, 1_500, 750, 3_000),
+            [lower, upper]);
+
+        using var plotView = new OxyPlot.WindowsForms.PlotView();
+        var plot = new VirtualCrossoverDspChainPlot(
+            plotView, DspPlotMode.Correlation);
+        plot.DrawCorrelation(view);
+        var model = (PlotModel)plotView.Model;
+
+        List<OxyPlot.Series.LineSeries> guides = model.Series
+            .OfType<OxyPlot.Series.LineSeries>()
+            .Where(series => series.Title is "PHAT envelope" or "PHAT direct envelope")
+            .ToList();
+        // A +/- pair per comb.
+        Assert.Equal(4, guides.Count);
+        Assert.All(guides, series => Assert.False(series.RenderInLegend));
+        // The +/- twins mirror each other around zero.
+        foreach (string title in new[] { "PHAT envelope", "PHAT direct envelope" })
+        {
+            List<OxyPlot.Series.LineSeries> pair = guides
+                .Where(series => series.Title == title)
+                .ToList();
+            Assert.Equal(2, pair.Count);
+            Assert.Equal(
+                pair[0].Points.Select(point => point.Y),
+                pair[1].Points.Select(point => -point.Y));
+        }
+
+        Assert.Equal(
+            ["PHAT", "PHAT direct", "score", "score inv"],
+            model.Series
+                .Where(series => series.RenderInLegend)
+                .Select(series => series.Title)
+                .ToList());
+    }
+
+    [Fact]
+    public void BuildCoherenceView_ReadsTheProcessedPairInTheCorrelationFrame()
+    {
+        // An aligned delta pair through the same crop the correlation view
+        // uses: every surviving band's optimum sits at lag 0 with nothing
+        // left on the table, in the correlation view's own lag convention
+        // (the crop and valid-range plumbing is shared — see
+        // VirtualCrossoverPanel.CropJunctionPair — so a shift bug there
+        // would move these lags off zero).
+        var ir = new Complex[IrLength];
+        ir[FrontSample] = 1.0;
+        var range = new ValidSampleRange(FrontSample - 96, IrLength);
+        ProcessedChannel lower = Channel("C", ir, range);
+        ProcessedChannel upper = Channel("D", (Complex[])ir.Clone(), range);
+
+        JunctionCoherenceView view = VirtualCrossoverPanel.BuildCoherenceView(
+            new AdjacentPair(lower, upper, 1_500, 750, 3_000),
+            [lower, upper]);
+
+        Assert.Equal("C-D", view.PairTitle);
+        Assert.NotEmpty(view.Ladder);
+        Assert.All(view.Ladder, point =>
+        {
+            Assert.InRange(point.FrequencyHz, 750, 3_100);
+            Assert.True(
+                Math.Abs(point.LagMs) < 0.05,
+                $"band {point.FrequencyHz:0} Hz optimum at {point.LagMs:0.000} ms " +
+                "on an aligned pair");
+            Assert.False(point.OptimumInverted);
+            Assert.True(
+                point.PeakR - point.CurrentR < 0.05,
+                $"band {point.FrequencyHz:0} Hz leaves coherence on the table " +
+                "while aligned");
+        });
     }
 }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverCorrelationViewTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverCorrelationViewTests.cs
@@ -133,6 +133,33 @@ public sealed class VirtualCrossoverCorrelationViewTests
     }
 
     [Fact]
+    public void DrawCoherence_RefitsTheFrequencyAxisWhenTheBandChanges()
+    {
+        // Editing the pair's crossover keeps the pair title, and both ladders
+        // below sit at the lag axis's 1 ms floor — so an invalidation state of
+        // title-and-lag alone would leave the frequency axis fitted to the
+        // FIRST band and clip most of the rebuilt ladder.
+        static JunctionCoherenceView View(double lowHz, double highHz) =>
+            new("C-D", "D", Math.Sqrt(lowHz * highHz), lowHz, highHz,
+            [
+                new VirtualCrossoverAnalysis.ArrivalCoherencePoint(
+                    lowHz, 0.0, 0.9, 0.9, false, 500.0 / lowHz),
+                new VirtualCrossoverAnalysis.ArrivalCoherencePoint(
+                    highHz, 0.0, 0.9, 0.9, false, 500.0 / highHz)
+            ]);
+
+        using var plotView = new OxyPlot.WindowsForms.PlotView();
+        var plot = new VirtualCrossoverDspChainPlot(plotView, DspPlotMode.Coherence);
+        plot.DrawCoherence(View(750, 3_000));
+        plot.DrawCoherence(View(1_500, 6_000));
+
+        OxyPlot.Axes.Axis frequency = ((PlotModel)plotView.Model).Axes
+            .Single(axis => axis.Key == PlotModelFactory.FrequencyAxisKey);
+        Assert.InRange(frequency.Minimum, 1_300, 1_400);
+        Assert.InRange(frequency.Maximum, 6_600, 6_800);
+    }
+
+    [Fact]
     public void BuildCoherenceView_ReadsTheProcessedPairInTheCorrelationFrame()
     {
         // An aligned delta pair through the same crop the correlation view

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -235,17 +235,38 @@ public sealed class VirtualCrossoverMetricTests
     {
         RunWithInvariantCulture(() =>
         {
-            // Two columns: the lobe margin moved to the tooltip. A bare
-            // difference of two phase scores carries no scale a reader can
-            // act on, and the only decision it drives is the "!" beside the
+            // Three columns, each one a reader can act on: where the phase
+            // stands at fc, the delay worth applying, and the score the
+            // junction reaches as it stands. The lobe margin moved to the
+            // tooltip — a bare difference of two phase scores carries no
+            // scale, and the only decision it drives is the "!" beside the
             // fix.
             string text = VirtualCrossoverMetric.FormatPhaseCompact([PhaseJunction()]);
 
             Assert.Equal(
                 "Junction phase\r\n" +
-                "       φfc  fix ms\r\n" +
-                "A/B     -3°  -1.30",
+                "       φfc  fix ms  score\r\n" +
+                "A/B     -3°  -1.30   0.96",
                 text);
+        });
+    }
+
+    [Fact]
+    public void FormatPhaseCompact_ShowsWhereTheJunctionStandsNow()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            // The score column reads the junction AS IT STANDS, on the scale
+            // the fix maximizes — bounded, so it needs no legend, and negative
+            // when the overlap is subtracting rather than adding.
+            VirtualCrossoverMetric.PhaseEntry cancelling = PhaseJunction() with
+            {
+                Result = PhaseJunction().Result with { CurrentScore = -0.42 }
+            };
+
+            Assert.Contains(
+                "A/B     -3°  -1.30  -0.42",
+                VirtualCrossoverMetric.FormatPhaseCompact([cancelling]));
         });
     }
 
@@ -312,7 +333,7 @@ public sealed class VirtualCrossoverMetricTests
             string text = VirtualCrossoverMetric.FormatPhaseCompact(
                 [PhaseJunction(lobeMargin: 0.04)]);
 
-            Assert.Contains("A/B     -3°  -1.30  !", text);
+            Assert.Contains("A/B     -3°  -1.30   0.96 !", text);
         });
     }
 

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -208,7 +208,8 @@ public sealed class VirtualCrossoverMetricTests
         double? rivalScore = 0.78,
         double phaseConsistency = 0.93,
         bool bestInvert = false,
-        double oppositePolarityScore = 0.42) =>
+        double oppositePolarityScore = 0.42,
+        double bestExtraDelayMs = -1.30) =>
         new(
             "A/B",
             "A",
@@ -219,7 +220,7 @@ public sealed class VirtualCrossoverMetricTests
                 CurrentScore: 0.96,
                 PhaseAtCrossoverDeg: -3.4,
                 PhaseConsistency: phaseConsistency,
-                BestExtraDelayMs: -0.30,
+                BestExtraDelayMs: bestExtraDelayMs,
                 BestInvert: bestInvert,
                 BestScore: 0.97,
                 OppositePolarityScore: oppositePolarityScore,
@@ -230,17 +231,56 @@ public sealed class VirtualCrossoverMetricTests
                 FitRmsDeg: 10.3));
 
     [Fact]
-    public void FormatPhaseCompact_RendersPhaseFixAndMargin()
+    public void FormatPhaseCompact_RendersPhaseAndFix()
     {
         RunWithInvariantCulture(() =>
         {
+            // Two columns: the lobe margin moved to the tooltip. A bare
+            // difference of two phase scores carries no scale a reader can
+            // act on, and the only decision it drives is the "!" beside the
+            // fix.
             string text = VirtualCrossoverMetric.FormatPhaseCompact([PhaseJunction()]);
 
             Assert.Equal(
                 "Junction phase\r\n" +
-                "       φfc  fix ms   lobe\r\n" +
-                "A/B     -3°  -0.30   0.19",
+                "       φfc  fix ms\r\n" +
+                "A/B     -3°  -1.30",
                 text);
+        });
+    }
+
+    [Fact]
+    public void FormatPhaseCompact_MutesAFixTooSmallToMatter()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            // 0.05 ms at this 80 Hz junction is 1.4° of phase — nothing to
+            // apply, and a settled tune fills the column with such values.
+            string text = VirtualCrossoverMetric.FormatPhaseCompact(
+                [PhaseJunction(bestExtraDelayMs: -0.05)]);
+
+            Assert.Contains("A/B     -3°      ·", text);
+            Assert.DoesNotContain("-0.05", text);
+
+            // The same delay at a 4 kHz junction is most of a period, so it
+            // stays: the threshold is phase at fc, not milliseconds.
+            VirtualCrossoverMetric.PhaseEntry high =
+                PhaseJunction(bestExtraDelayMs: -0.05) with { CrossoverHz = 4_000 };
+            Assert.Contains("-0.05", VirtualCrossoverMetric.FormatPhaseCompact([high]));
+        });
+    }
+
+    [Fact]
+    public void FormatPhaseCompact_KeepsThePolarityMarkOnAMutedFix()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            // An inversion is not a matter of magnitude: it stays actionable
+            // exactly when the delay beside it does not.
+            string text = VirtualCrossoverMetric.FormatPhaseCompact(
+                [PhaseJunction(bestInvert: true, bestExtraDelayMs: -0.05)]);
+
+            Assert.Contains("A/B     -3°      ·i", text);
         });
     }
 
@@ -252,14 +292,14 @@ public sealed class VirtualCrossoverMetricTests
             // Since the .NET Core 3.0 signed-zero change, a negative value that
             // rounds to zero renders through a TWO-section format as "-+0.00";
             // the three-section form must show a plain unsigned zero.
-            VirtualCrossoverMetric.PhaseEntry entry = PhaseJunction() with
-            {
-                Result = PhaseJunction().Result with { BestExtraDelayMs = -0.004 }
-            };
+            // Read at a 16 kHz junction, where 0.004 ms is still 23° of phase
+            // and therefore shown rather than muted.
+            VirtualCrossoverMetric.PhaseEntry entry =
+                PhaseJunction(bestExtraDelayMs: -0.004) with { CrossoverHz = 16_000 };
 
             string text = VirtualCrossoverMetric.FormatPhaseCompact([entry]);
 
-            Assert.Contains("A/B     -3°   0.00   0.19", text);
+            Assert.Contains("A/B     -3°   0.00", text);
             Assert.DoesNotContain("-+", text);
         });
     }
@@ -272,12 +312,12 @@ public sealed class VirtualCrossoverMetricTests
             string text = VirtualCrossoverMetric.FormatPhaseCompact(
                 [PhaseJunction(lobeMargin: 0.04)]);
 
-            Assert.Contains("A/B     -3°  -0.30   0.04 !", text);
+            Assert.Contains("A/B     -3°  -1.30  !", text);
         });
     }
 
     [Fact]
-    public void FormatPhaseCompact_DashesAMissingRivalLobe()
+    public void FormatPhaseCompact_RaisesNoFlagWithoutARivalLobe()
     {
         RunWithInvariantCulture(() =>
         {
@@ -285,7 +325,7 @@ public sealed class VirtualCrossoverMetricTests
                 [PhaseJunction(
                     lobeMargin: null, rivalExtraMs: null, rivalScore: null)]);
 
-            Assert.Contains("A/B     -3°  -0.30      —", text);
+            Assert.Contains("A/B     -3°  -1.30", text);
             Assert.DoesNotContain("!", text);
         });
     }
@@ -300,7 +340,7 @@ public sealed class VirtualCrossoverMetricTests
             string text = VirtualCrossoverMetric.FormatPhaseCompact(
                 [PhaseJunction(phaseConsistency: 0.31)]);
 
-            Assert.Contains("A/B       —  -0.30   0.19", text);
+            Assert.Contains("A/B       —  -1.30", text);
         });
     }
 
@@ -327,7 +367,7 @@ public sealed class VirtualCrossoverMetricTests
             string text = VirtualCrossoverMetric.FormatPhaseCompact(
                 [PhaseJunction(bestInvert: true)]);
 
-            Assert.Contains("A/B     -3°  -0.30i  0.19", text);
+            Assert.Contains("A/B     -3°  -1.30i", text);
         });
     }
 
@@ -341,7 +381,7 @@ public sealed class VirtualCrossoverMetricTests
             string text = VirtualCrossoverMetric.FormatPhaseCompact(
                 [PhaseJunction(oppositePolarityScore: 0.96)]);
 
-            Assert.Contains("A/B     -3°  -0.30~  0.19", text);
+            Assert.Contains("A/B     -3°  -1.30~", text);
             Assert.DoesNotContain("!", text);
         });
     }
@@ -355,7 +395,7 @@ public sealed class VirtualCrossoverMetricTests
             // current polarity is clearly right, so no mark.
             string text = VirtualCrossoverMetric.FormatPhaseCompact([PhaseJunction()]);
 
-            Assert.Contains("A/B     -3°  -0.30   0.19", text);
+            Assert.Contains("A/B     -3°  -1.30", text);
         });
     }
 
@@ -400,7 +440,7 @@ public sealed class VirtualCrossoverMetricTests
 
             Assert.Contains(
                 "A/B @ 80 Hz: φ -3° at fc (R 0.93); phase score 0.96 now, " +
-                "best 0.97 at -0.30 ms on A (flip scores 0.42);",
+                "best 0.97 at -1.30 ms on A (flip scores 0.42);",
                 text);
             Assert.Contains(
                 "rival lobe 0.78 at -12.20 ms (margin 0.19); " +

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -306,22 +306,32 @@ public sealed class VirtualCrossoverMetricTests
     }
 
     [Fact]
-    public void FormatPhaseCompact_RendersARoundedZeroFixUnsigned()
+    public void FormatPhaseCompact_KeepsASmallButSignificantFixReadable()
     {
         RunWithInvariantCulture(() =>
         {
-            // Since the .NET Core 3.0 signed-zero change, a negative value that
-            // rounds to zero renders through a TWO-section format as "-+0.00";
-            // the three-section form must show a plain unsigned zero.
-            // Read at a 16 kHz junction, where 0.004 ms is still 23° of phase
-            // and therefore shown rather than muted.
+            // The mute threshold is a PHASE, so above roughly 5.6 kHz a fix
+            // worth acting on is smaller than 0.005 ms: at 16 kHz these
+            // 0.004 ms are 23° at the crossover. Two decimals would render
+            // that as "0.00" — a significant correction shown as nothing, its
+            // sign lost with it — so such a value takes a third decimal.
             VirtualCrossoverMetric.PhaseEntry entry =
                 PhaseJunction(bestExtraDelayMs: -0.004) with { CrossoverHz = 16_000 };
 
             string text = VirtualCrossoverMetric.FormatPhaseCompact([entry]);
 
-            Assert.Contains("A/B     -3°   0.00", text);
+            // Six characters wide, so a three-decimal value fills the column
+            // exactly and the separating space comes from the phase field.
+            Assert.Contains("A/B     -3° -0.004", text);
+            Assert.DoesNotContain("0.00 ", text);
+            // Since the .NET Core 3.0 signed-zero change, a negative value
+            // that rounds to zero renders through a TWO-section format as
+            // "-+0.00"; every fix format here stays three-section.
             Assert.DoesNotContain("-+", text);
+            // The tooltip quotes the same value and must not round it away
+            // either.
+            Assert.Contains(
+                "-0.004 ms", VirtualCrossoverMetric.FormatPhaseDetail([entry]));
         });
     }
 

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -27,7 +27,7 @@ public sealed class VirtualCrossoverMetricsTests
     private static ProcessedChannel Processed(string name, Complex[] ir, int peak, int rate)
     {
         var channel = new VirtualCrossoverChannel(name) { SampleRate = rate };
-        return new ProcessedChannel(channel, ir, peak, OxyColors.White);
+        return new ProcessedChannel(channel, ir, peak, rate, OxyColors.White);
     }
 
     // A channel with a resolved source on its LEFT side (the default active side).
@@ -38,6 +38,38 @@ public sealed class VirtualCrossoverMetricsTests
         left.TransferImpulseResponse = Impulse();
         left.SampleRate = rate;
         return channel;
+    }
+
+    [Fact]
+    public void BuildCurves_ReadsTheSnapshotRate_NotTheLiveChannel()
+    {
+        // Importing a session rebinds every channel's runtime state on the UI
+        // thread while a metric rebuild is still in flight, so the LIVE
+        // channel can momentarily report a zero rate against a real processed
+        // response — the ArgumentOutOfRangeException crash on opening a
+        // session over a loaded one. The render is a snapshot: zeroing the
+        // live channel after processing must change nothing the metric reads.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var seenRates = new ConcurrentBag<int>();
+        var metrics = new VirtualCrossoverMetrics(
+            coordinator,
+            (_, _, sampleRate) =>
+            {
+                seenRates.Add(sampleRate);
+                return EmptyMagnitude;
+            });
+        ProcessedChannel first = Processed("A", Impulse(), 10, 48_000);
+        ProcessedChannel second = Processed("B", Impulse(), 10, 48_000);
+        first.Channel.SampleRate = 0;
+        second.Channel.SampleRate = 0;
+
+        (List<AnalysisCurve>? magnitudes, AnalysisCurve? sum, _) =
+            metrics.BuildCurves([first, second], 0);
+
+        Assert.NotNull(magnitudes);
+        Assert.NotNull(sum);
+        Assert.NotEmpty(seenRates);
+        Assert.All(seenRates, rate => Assert.Equal(48_000, rate));
     }
 
     [Fact]
@@ -163,7 +195,8 @@ public sealed class VirtualCrossoverMetricsTests
         Complex[] ir = VirtualCrossoverAnalysis.ApplyChain(
             impulse, channel.Settings.ToChain(), 48_000);
         return new ProcessedChannel(
-            channel, ir, VirtualCrossoverAnalysis.FindPeakIndex(ir), OxyColors.White);
+            channel, ir, VirtualCrossoverAnalysis.FindPeakIndex(ir), 48_000,
+            OxyColors.White);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProcessingCoordinatorTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProcessingCoordinatorTests.cs
@@ -404,6 +404,59 @@ public sealed class VirtualCrossoverProcessingCoordinatorTests
     }
 
     [Fact]
+    public async Task ProcessAsync_CancellationReportedByNullDropsTheRenderSilently()
+    {
+        // The production delegate reports a superseded render by RETURNING
+        // NULL rather than throwing (see ProcessChannel): every delay edit
+        // supersedes one, and an exception thrown out of the parallel body
+        // stops a Just My Code debugger even though this method catches it.
+        // The render must be dropped just as thoroughly, and no exception may
+        // escape or be raised on the way.
+        using var pool = new PoolHeadroom(parking: 3);
+        using var entered = new CountdownEvent(1);
+        using var release = new ManualResetEventSlim();
+        int thrown = 0;
+        using var coordinator = new VirtualCrossoverProcessingCoordinator(
+            (source, chain, sampleRate, cancellationToken) =>
+            {
+                entered.Signal();
+                Assert.True(release.Wait(RendezvousTimeout));
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return null;
+                }
+
+                Interlocked.Increment(ref thrown);
+                return source.Apply(chain, sampleRate);
+            });
+        long revision = coordinator.Invalidate();
+
+        Task<VirtualCrossoverRenderResult?> render = coordinator.ProcessAsync(
+            CreateSnapshot(revision, 0, false, 3));
+        Assert.True(entered.Wait(RendezvousTimeout));
+        coordinator.Invalidate();
+        release.Set();
+
+        Assert.Null(await render);
+        Assert.Equal(0, thrown);
+
+        // ...and nothing partial was committed: the next render for the same
+        // channel recomputes rather than serving a cached half-result.
+        release.Reset();
+        entered.Reset(1);
+        long next = coordinator.CurrentRevision;
+        Task<VirtualCrossoverRenderResult?> second = coordinator.ProcessAsync(
+            CreateSnapshot(next, 0, false, 3));
+        Assert.True(entered.Wait(RendezvousTimeout));
+        release.Set();
+
+        VirtualCrossoverRenderResult? result = await second;
+        Assert.NotNull(result);
+        Assert.Equal(1, thrown);
+        Assert.InRange(result.Channels[0].ImpulseResponse[3].Real, 0.999, 1.001);
+    }
+
+    [Fact]
     public async Task InvalidateDuringCompletedComputation_DropsResultAtCommitGuard()
     {
         VirtualCrossoverProcessingCoordinator? coordinator = null;

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProcessingCoordinatorTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProcessingCoordinatorTests.cs
@@ -573,6 +573,67 @@ public sealed class VirtualCrossoverProcessingCoordinatorTests
     }
 
     [Fact]
+    public async Task ProcessAsync_ExternalCancellationDuringTheWorkIsPropagated()
+    {
+        // The discriminating case: cancelling BEFORE the call is caught by the
+        // entry guard, so a token cancelled mid-computation is what actually
+        // tests the contract. The silent path cannot tell an external
+        // cancellation from a revision one — the delegate returns null for
+        // both — so without an explicit re-check this call would quietly
+        // answer null and the caller would never learn its own token fired.
+        using var pool = new PoolHeadroom(parking: 3);
+        using var entered = new CountdownEvent(1);
+        using var release = new ManualResetEventSlim();
+        using var coordinator = new VirtualCrossoverProcessingCoordinator(
+            (source, chain, sampleRate, cancellationToken) =>
+            {
+                entered.Signal();
+                Assert.True(release.Wait(RendezvousTimeout));
+                return cancellationToken.IsCancellationRequested
+                    ? null
+                    : source.Apply(chain, sampleRate);
+            });
+        long liveRevision = coordinator.Invalidate();
+        using var midFlight = new CancellationTokenSource();
+
+        Task<VirtualCrossoverRenderResult?> render = coordinator.ProcessAsync(
+            CreateSnapshot(liveRevision, 0, false, 3), midFlight.Token);
+        Assert.True(entered.Wait(RendezvousTimeout));
+        midFlight.Cancel();
+        release.Set();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => render);
+    }
+
+    [Fact]
+    public async Task RunAuxiliaryAsync_ExternalCancellationDuringTheWorkIsPropagated()
+    {
+        // Same contract on the auxiliary path, where an operation following
+        // the new convention also reports cancellation by returning null.
+        using var pool = new PoolHeadroom(parking: 3);
+        using var entered = new CountdownEvent(1);
+        using var release = new ManualResetEventSlim();
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        long revision = coordinator.Invalidate();
+        using var midFlight = new CancellationTokenSource();
+
+        Task<object?> work = coordinator.RunAuxiliaryAsync<object>(
+            revision,
+            token =>
+            {
+                entered.Signal();
+                Assert.True(release.Wait(RendezvousTimeout));
+                return token.IsCancellationRequested ? null : new object();
+            },
+            midFlight.Token);
+        Assert.True(entered.Wait(RendezvousTimeout));
+        midFlight.Cancel();
+        release.Set();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => work);
+    }
+
+    [Fact]
     public async Task ProcessAsync_ExternalCancellationIsPropagated()
     {
         using var coordinator = new VirtualCrossoverProcessingCoordinator();

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -1002,6 +1002,44 @@ public sealed class VirtualCrossoverProjectFileTests
     }
 
     [Fact]
+    public void CoherencePlotMode_RoundTripsAsALegacyValuePlusFlag()
+    {
+        // The second junction mode follows the correlation mode's additive
+        // pattern, on its own flag; switching between the two junction modes
+        // must move exactly one flag at a time — a file with both set would
+        // silently open on the correlation view.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            var original = new VirtualCrossoverProjectFile();
+            original.SetDspPlotMode(DspPlotMode.Coherence);
+            Assert.Equal(DspPlotMode.Magnitude, original.DspPlotMode);
+            Assert.True(original.DspPlotCoherenceView);
+            Assert.False(original.DspPlotCorrelationView);
+            Assert.Equal(DspPlotMode.Coherence, original.EffectiveDspPlotMode);
+
+            original.Save(root);
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.Equal(DspPlotMode.Coherence, loaded.EffectiveDspPlotMode);
+
+            loaded.SetDspPlotMode(DspPlotMode.Correlation);
+            Assert.True(loaded.DspPlotCorrelationView);
+            Assert.False(loaded.DspPlotCoherenceView);
+
+            loaded.SetDspPlotMode(DspPlotMode.Magnitude);
+            Assert.False(loaded.DspPlotCorrelationView);
+            Assert.False(loaded.DspPlotCoherenceView);
+            Assert.Equal(DspPlotMode.Magnitude, loaded.DspPlotMode);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ShowSumCurveOnPhase_WithNoAnswerOfItsOwn_InheritsTheMagnitudeOne()
     {
         // A session written before the two views answered separately carries one

--- a/tests/Resonalyze.Dsp.Tests/ArrivalCoherenceLadderTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/ArrivalCoherenceLadderTests.cs
@@ -7,8 +7,9 @@ namespace Resonalyze.Dsp.Tests;
 /// The junction coherence view's band ladder
 /// (<see cref="VirtualCrossoverAnalysis.ArrivalCoherenceLadder"/>): per band,
 /// the envelope optimum of the direct cuts' band-limited GCC-PHAT — its lag
-/// convention (a correction to the UPPER channel), the carrier polarity flag,
-/// and the level gate that drops bands one channel no longer participates in.
+/// convention (a correction to the UPPER channel), the coherence it reaches
+/// against what the applied alignment collects, and the level gate that drops
+/// bands one channel no longer participates in.
 /// </summary>
 public sealed class ArrivalCoherenceLadderTests
 {
@@ -63,12 +64,13 @@ public sealed class ArrivalCoherenceLadderTests
     }
 
     [Fact]
-    public void Ladder_FlagsAnInvertedOptimumAndCollectsItAtLagZero()
+    public void Ladder_ReadsAnInvertedPairAsCenteredAtLagZero()
     {
-        // Time-aligned but inverted: the optimum stays at lag 0 (the envelope
-        // is polarity-blind), the carrier there is negative, and the band
-        // collects its full coherence at the applied alignment — CurrentR
-        // equals PeakR.
+        // Time-aligned but INVERTED: the envelope is polarity-blind, so the
+        // optimum stays at lag 0 and the band already collects its full
+        // coherence there — CurrentR equals PeakR. The ladder reports no
+        // polarity of its own (its probe band cannot separate opposite-signed
+        // lobes); that an inversion does not move the optimum is exactly why.
         List<VirtualCrossoverAnalysis.ArrivalCoherencePoint> ladder =
             Ladder(Impulse(), Impulse(0, -1.0));
 

--- a/tests/Resonalyze.Dsp.Tests/ArrivalCoherenceLadderTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/ArrivalCoherenceLadderTests.cs
@@ -54,7 +54,6 @@ public sealed class ArrivalCoherenceLadderTests
                 Math.Abs(point.LagMs - 0.15) < 0.05,
                 $"band {point.FrequencyHz:0} Hz read {point.LagMs:0.000} ms " +
                 "instead of the +0.15 ms correction");
-            Assert.False(point.OptimumInverted);
             Assert.True(
                 point.PeakR > 0.8,
                 $"band {point.FrequencyHz:0} Hz peak r {point.PeakR:0.00}");
@@ -79,7 +78,6 @@ public sealed class ArrivalCoherenceLadderTests
             Assert.True(
                 Math.Abs(point.LagMs) < 0.05,
                 $"band {point.FrequencyHz:0} Hz optimum at {point.LagMs:0.000} ms");
-            Assert.True(point.OptimumInverted);
             Assert.True(
                 point.PeakR - point.CurrentR < 0.05,
                 $"band {point.FrequencyHz:0} Hz leaves " +

--- a/tests/Resonalyze.Dsp.Tests/ArrivalCoherenceLadderTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/ArrivalCoherenceLadderTests.cs
@@ -1,0 +1,201 @@
+using System.Numerics;
+using MathNet.Numerics.IntegralTransforms;
+
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The junction coherence view's band ladder
+/// (<see cref="VirtualCrossoverAnalysis.ArrivalCoherenceLadder"/>): per band,
+/// the envelope optimum of the direct cuts' band-limited GCC-PHAT — its lag
+/// convention (a correction to the UPPER channel), the carrier polarity flag,
+/// and the level gate that drops bands one channel no longer participates in.
+/// </summary>
+public sealed class ArrivalCoherenceLadderTests
+{
+    private const int SampleRate = 48_000;
+    private const int IrLength = 16_384;
+    private const int BasePosition = 2_048;
+    private const double CrossoverHz = 1_500;
+    private const double BandLowHz = 750;
+    private const double BandHighHz = 3_000;
+
+    private static Complex[] Impulse(double offsetMs = 0, double amplitude = 1.0)
+    {
+        var ir = new Complex[IrLength];
+        ir[BasePosition + (int)Math.Round(offsetMs / 1000.0 * SampleRate)] =
+            amplitude;
+        return ir;
+    }
+
+    private static List<VirtualCrossoverAnalysis.ArrivalCoherencePoint> Ladder(
+        Complex[] lower, Complex[] upper) =>
+        VirtualCrossoverAnalysis.ArrivalCoherenceLadder(
+            lower, upper, SampleRate, BandLowHz, BandHighHz, CrossoverHz);
+
+    [Fact]
+    public void Ladder_ReadsAPureDelayFlatAcrossTheBand()
+    {
+        // The upper channel arrives 0.15 ms EARLY: every band's optimum is
+        // the same +0.15 ms correction to the upper channel — the ladder of a
+        // dispersion-free junction is a flat line at the misalignment, in the
+        // correlation view's own lag convention.
+        List<VirtualCrossoverAnalysis.ArrivalCoherencePoint> ladder =
+            Ladder(Impulse(), Impulse(-0.15));
+
+        Assert.NotEmpty(ladder);
+        // The grid spans the pair band on sixth-octave steps.
+        Assert.Equal(BandLowHz, ladder[0].FrequencyHz, 6);
+        Assert.True(
+            ladder[^1].FrequencyHz > BandHighHz / Math.Pow(2, 1.0 / 6) - 1,
+            "the ladder must reach the band's top");
+        foreach (VirtualCrossoverAnalysis.ArrivalCoherencePoint point in ladder)
+        {
+            Assert.True(
+                Math.Abs(point.LagMs - 0.15) < 0.05,
+                $"band {point.FrequencyHz:0} Hz read {point.LagMs:0.000} ms " +
+                "instead of the +0.15 ms correction");
+            Assert.False(point.OptimumInverted);
+            Assert.True(
+                point.PeakR > 0.8,
+                $"band {point.FrequencyHz:0} Hz peak r {point.PeakR:0.00}");
+            Assert.True(point.PeakR <= 1.0 && point.CurrentR <= 1.0);
+            Assert.Equal(500.0 / point.FrequencyHz, point.HalfPeriodMs, 9);
+        }
+    }
+
+    [Fact]
+    public void Ladder_FlagsAnInvertedOptimumAndCollectsItAtLagZero()
+    {
+        // Time-aligned but inverted: the optimum stays at lag 0 (the envelope
+        // is polarity-blind), the carrier there is negative, and the band
+        // collects its full coherence at the applied alignment — CurrentR
+        // equals PeakR.
+        List<VirtualCrossoverAnalysis.ArrivalCoherencePoint> ladder =
+            Ladder(Impulse(), Impulse(0, -1.0));
+
+        Assert.NotEmpty(ladder);
+        foreach (VirtualCrossoverAnalysis.ArrivalCoherencePoint point in ladder)
+        {
+            Assert.True(
+                Math.Abs(point.LagMs) < 0.05,
+                $"band {point.FrequencyHz:0} Hz optimum at {point.LagMs:0.000} ms");
+            Assert.True(point.OptimumInverted);
+            Assert.True(
+                point.PeakR - point.CurrentR < 0.05,
+                $"band {point.FrequencyHz:0} Hz leaves " +
+                $"{point.PeakR - point.CurrentR:0.00} r on the table while " +
+                "sitting on its optimum");
+        }
+    }
+
+    [Fact]
+    public void Ladder_DropsBandsWhereOneChannelStopsParticipating()
+    {
+        // 40 dB down, the upper channel is a crossover remnant everywhere in
+        // the band: PHAT would still read "coherence" off it, so the level
+        // gate must empty the ladder. 20 dB down it participates and the
+        // ladder reads normally — the gate sits between, at the sum-loss
+        // curve's own 25 dB.
+        Assert.Empty(Ladder(Impulse(), Impulse(0, 0.01)));
+        Assert.NotEmpty(Ladder(Impulse(), Impulse(0, 0.1)));
+    }
+
+    [Fact]
+    public void Ladder_ResolvesADispersiveJunction()
+    {
+        // The upper channel's band content arrives in two pieces: its lower
+        // part aligned with the lower channel, its upper part half a
+        // millisecond EARLY — the two-path shape a tweeter with a different
+        // acoustic path draws. One delay cannot reconcile them, and the
+        // ladder must say so: low bands read ~0, high bands read ~+0.5 ms.
+        // The paths are kept spectrally apart so the asserted probe bands
+        // each see exactly one arrival; where a probe band straddles both,
+        // the envelope reads their interference — real content, not a
+        // defect, and not what this test pins.
+        Complex[] lower = Impulse();
+        Complex[] upper = BandPulse(600, 1_200, 0)
+            .Zip(BandPulse(1_900, 3_600, -0.5), (a, b) => a + b)
+            .ToArray();
+
+        List<VirtualCrossoverAnalysis.ArrivalCoherencePoint> ladder =
+            Ladder(lower, upper);
+
+        List<VirtualCrossoverAnalysis.ArrivalCoherencePoint> low = ladder
+            .Where(point => point.FrequencyHz <= 850)
+            .ToList();
+        List<VirtualCrossoverAnalysis.ArrivalCoherencePoint> high = ladder
+            .Where(point => point.FrequencyHz >= 2_600)
+            .ToList();
+        Assert.NotEmpty(low);
+        Assert.NotEmpty(high);
+        Assert.All(low, point => Assert.True(
+            Math.Abs(point.LagMs) < 0.12,
+            $"band {point.FrequencyHz:0} Hz read {point.LagMs:0.000} ms " +
+            "for the aligned low path"));
+        Assert.All(high, point => Assert.True(
+            Math.Abs(point.LagMs - 0.5) < 0.12,
+            $"band {point.FrequencyHz:0} Hz read {point.LagMs:0.000} ms " +
+            "for the +0.5 ms high path"));
+    }
+
+    // A linear-phase band-limited pulse: UNIT spectral density over
+    // [lowHz, highHz] (half-octave raised-cosine skirts) with its energy
+    // centered at BasePosition + offsetMs. Unit density on purpose — it
+    // matches the unit delta's density bin for bin, so the level gate sees
+    // two equal participants and only the timing differs.
+    private static Complex[] BandPulse(double lowHz, double highHz, double offsetMs)
+    {
+        var spectrum = new Complex[IrLength];
+        double center = BasePosition + offsetMs / 1000.0 * SampleRate;
+        for (int k = 0; k < IrLength; k++)
+        {
+            double frequency = (double)k / IrLength * SampleRate;
+            if (frequency > SampleRate / 2.0)
+            {
+                continue;
+            }
+
+            double weight = SkirtedBandWeight(frequency, lowHz, highHz);
+            if (weight <= 0)
+            {
+                continue;
+            }
+
+            double phase = -Math.Tau * frequency * center / SampleRate;
+            spectrum[k] = weight * Complex.FromPolarCoordinates(1.0, phase);
+            if (k > 0 && k < IrLength / 2)
+            {
+                spectrum[IrLength - k] = Complex.Conjugate(spectrum[k]);
+            }
+        }
+
+        Fourier.Inverse(spectrum, FourierOptions.Matlab);
+        return spectrum
+            .Select(sample => (Complex)sample.Real)
+            .ToArray();
+    }
+
+    private static double SkirtedBandWeight(
+        double frequency, double lowHz, double highHz)
+    {
+        if (frequency <= 0)
+        {
+            return 0;
+        }
+
+        double skirt = 0.5; // octaves
+        double Edge(double edgeHz, bool rising)
+        {
+            double octaves = Math.Log2(frequency / edgeHz);
+            double position = rising ? octaves / skirt : -octaves / skirt;
+            return position switch
+            {
+                >= 0 => 1.0,
+                <= -1 => 0.0,
+                _ => 0.5 + 0.5 * Math.Cos(Math.PI * position)
+            };
+        }
+
+        return Edge(lowHz, rising: true) * Edge(highHz, rising: false);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/JunctionCorrelationCurveTests.cs
@@ -94,6 +94,34 @@ public sealed class JunctionCorrelationCurveTests
     }
 
     [Fact]
+    public void JunctionLossSweepBothPolarities_MatchesTwoSingleSweepsExactly()
+    {
+        // The both-polarity sweep exists so the correlation view builds the
+        // (expensive, polarity-independent) alignment bins once — it must be
+        // a pure factoring: every point equal, bit for bit, to what the two
+        // single-polarity calls return.
+        Complex[] fixedIr = ImpulseAtMs(2.0);
+        Complex[] variableIr = ImpulseAtMs(0.5);
+
+        (List<VirtualCrossoverAnalysis.JunctionSweepPoint> normal,
+            List<VirtualCrossoverAnalysis.JunctionSweepPoint> inverted) =
+            VirtualCrossoverAnalysis.JunctionLossSweepBothPolarities(
+                variableIr, fixedIr, SampleRate,
+                bandLowHz: 800, bandHighHz: 1_250,
+                startDelayMs: 0.0, endDelayMs: 3.0, stepMs: 0.05);
+
+        List<VirtualCrossoverAnalysis.JunctionSweepPoint> Single(bool invert) =>
+            VirtualCrossoverAnalysis.JunctionLossSweep(
+                variableIr, fixedIr, SampleRate,
+                bandLowHz: 800, bandHighHz: 1_250,
+                startDelayMs: 0.0, endDelayMs: 3.0, stepMs: 0.05,
+                invertVariable: invert);
+
+        Assert.Equal(Single(invert: false), normal);
+        Assert.Equal(Single(invert: true), inverted);
+    }
+
+    [Fact]
     public void JunctionLossSweep_IsMinimalAtTheTrueOffsetAndCyclicAround()
     {
         // Two identical 1 kHz-band impulses 1.5 ms apart: the loss bottoms out


### PR DESCRIPTION
## What this adds

A **Coherence** mode beside Correlation on the Virtual DSP junction plot, reading the same junction *per frequency* instead of per lag.

A sub-band probe slides across the pair band (sixth-octave steps, 2/3-octave width, each band's direct-sound cut sized to its own period, so the window travels with the frequency it measures). Per band the envelope of the band-limited GCC-PHAT gives:

- **Δt to optimum** — the delay that would center that band's arrivals, drawn inside the dashed **±T/2** comb corridor;
- **r current** (dotted) against the shaded **r attainable** ceiling — the gap is what the applied tune leaves on the table, and it closes where a band is centered.

Reading it: a flat Δt at zero is a settled junction; a flat line *offset* from zero is a junction that missed by whole periods; a sloped or stepped one is dispersion that no single delay reconciles.

The ladder deliberately reports **no polarity**. A 2/3-octave probe makes a coherence packet `2 / (2^(B/2) − 2^(−B/2))` ≈ **4.3×** wider than the spacing between opposite-signed comb lobes — the ratio is free of frequency — so those lobes sit inside the packet's own plateau and the carrier's sign at the maximum is noise. Measured across all twenty archived junctions the envelope falls 0–6% between a band's optimum and its neighbours, on sharply tuned junctions as much as on rough ones. Polarity is what the **correlation view** answers, over the pair's whole band, where the lobes genuinely separate.

The correlation view also gains each comb's **± analytic envelope** as thin translucent guides in the parent curve's color, kept out of the legend — the coherence packet's center, readable against the carrier lobes it is made of.

## Guards

- Bands where one driver has fallen **25 dB** below the other are dropped: GCC-PHAT ignores level by design and would otherwise read confident "coherence" off a crossover remnant the sum cannot hear.
- Junctions below **120 Hz** carry a note that the long band windows let cabin modes rule the read.
- The mode is a **diagnostic for manual tuning**: Auto delay keeps its own guarded estimators and never reads this plot.
- Persists as an additive flag, so an older build opens such a session on the magnitude view.

## Junction phase read-out, trimmed to what a tuner can act on

`φfc  fix ms  score`, replacing `φfc  fix ms  lobe`:

- the **lobe margin** left for the tooltip — a difference of two phase scores has no scale a reader can judge, and its one decision (trust the fix or not) is already the `!` flag;
- a **fix** worth less than 10° of phase at fc (0.03 dB in the sum) renders `·` instead of a number inviting a correction that changes nothing; above ~5.6 kHz such a fix is smaller than 0.005 ms, so it takes a third decimal rather than rounding to "0.00";
- **score** is new: the band's phase-alignment score as the junction STANDS (−1…+1), the quantity the fix maximizes. It reads without a legend and moves while a delay is dragged. On the archive it separates junctions the old block rendered alike — the owner's re-tuned Passat v2 reads 0.89 / 0.93, while v2's 220 Hz junction reads 0.01 beside a −5.68 ms inverted fix.

## Performance

Both junction modes were too slow to tune against. Measured on the archived cabins at 96 kHz:

| | before | after |
|---|---|---|
| coherence ladder | seconds | **140–302 ms** |
| correlation view | 930–1250 ms | **167–372 ms** |

The ladder finds each channel's front once per channel (not per band) and correlates direct-sound cuts **trimmed to the windows' own span** — both channels sliced by ONE shared offset, so every relative position, and therefore every lag, is unchanged while the FFTs shrink from the record's length to the window's; bands run in parallel. The correlation view builds its alignment bins **once for both score polarities** (a bit-exact factoring, pinned by a test), probes them in parallel, trims the direct twin the same way, and computes its four independent reads side by side. The full-record PHAT deliberately stays untrimmed — the whole capture is that curve's subject.

Trimming caught its own trap on the way in: a short buffer's circular correlation aliases its lobes into the far lags (+2.75 ms on a synthetic pure delay). The buffers are padded to the searched lag range, and the pure-delay test is what fails without it.

## Fixes found along the way

- **Crash on opening a session over a loaded one** (older than this branch): importing rebinds every channel's runtime state on the UI thread while renders are in flight, so a consumer reading the sample rate off the **live** channel saw a zero against a real response. `ProcessedChannel` now carries the rate it was processed at.
- **Silent cancellation**: a stale render is reported by returning `null` instead of throwing out of a parallel body, which a Just My Code debugger stopped on at every delay edit (25 exceptions per edit burst, now zero). External cancellation still propagates — including when it arrives mid-computation, which the entry guard used to hide.
- **Coherence frequency axis** re-fits when the junction's band changes; the invalidation state records the band, not just the pair and the lag bucket.

## Verification

- CI on the branch: **2650 passed, 1 skipped, 0 failed** (142 Audio + 1203 DSP + 1305 App), plus publish and installer.
- New tests: ladder behaviour (pure delay → flat, inverted pair stays centered, level gate, dispersive junction), `BuildCoherenceView` in the correlation view's frame, one-kind-of-marker with no polarity series, axis re-fit on a band change, both-polarity sweep equality, envelope guides outside the legend, coherence-mode persistence round-trip, snapshot-rate regression, and two mid-flight cancellation contracts.
- Every behavioural fix was falsified before shipping: the pin was run against the pre-fix code and observed to fail.
- The archived cabins were re-rendered through the **product** code path (`DrawCoherence` / `DrawCorrelation`) after every change, and the reports diffed.

README documents the mode, the polarity caveat and the read-out in the Virtual DSP section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
