### PR TITLE
Lift the dark theme to readable contrast, and give the plots chrome

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -202,6 +202,68 @@ close.
 
 ## UI chrome
 
+- [ ] **A disabled panel leaves its check boxes as the brightest thing on it.**
+  `VirtualCrossoverPanel.SetProjectLoading` disables the whole panel while a
+  session loads, and WinForms then paints the standard `CheckBox`/`RadioButton`
+  glyphs itself: measured over the real panel, the label text drops
+  227,227,227 → 140,149,168 and every fill stays within 2 of where it was, but
+  the check box KEEPS its white box (255,255,255 → 240,240,240). Everything
+  fades except a dozen white squares, and the channel cards — five check boxes
+  each — carry most of them. Not a loading bug and not new: the white box is
+  the theme's normal look, it is simply the only thing left bright once the
+  text goes. `FlatStyle.Flat` fixes it (the box then follows `BackColor`:
+  147,154,172 live, 55,60,72 disabled) and five controls in the app already use
+  it — `GDOpt.checkAutoFit`, `PROpt.checkAutoFit`, `Form1.checkBox1`, the
+  Q-convention dialog's radios — but the other 52 check boxes and 22 radios
+  would change appearance everywhere, not just while loading. Owner looked at a
+  rendered comparison on 2026-08-24 and chose to leave it; take it as its own
+  change with its own visual pass, not as a rider on something else.
+- [ ] **A light theme is wanted eventually, and 626 colour assignments do not go
+  through `UiPalette`** — 487 `Color.FromArgb` literals across the 34
+  `.Designer.cs` files plus 139 `SystemColors.ControlLight` label foregrounds.
+  The contrast work (#116) named the roles the app paints with — `AccentFill`,
+  `TextDisabled`, the `Graph*` chrome — and put the graph surface and the accent
+  buttons' fill under the palette, so the SEAMS now exist:
+  `PlotModelStyle.ApplyChrome` is the one place a plot's colours are decided,
+  and `UiPaletteContrastTests` re-measures whatever values a second theme
+  brings. What is left for the theme itself is the designer sweep, and it is
+  smaller than the count suggests: only **37 distinct values** appear in those
+  files and four of them cover 313 of the 487, so a dark→light map plus a
+  runtime pass over the control tree covers most of it. The judgment part is
+  not the chrome but the CURVES: `OxyColors.White` sums, white THD traces,
+  light-grey source curves and the user's own overlay slot colours (persisted
+  as `ColorArgb` in overlay files, so they cannot be rewritten) all need a
+  second palette or a luminance-adaptive fallback before a light plot is
+  readable. Do not start this as a colour swap; start it as a curve-palette
+  design. Half the palette also still carries PHYSICAL names (`AccentBlueSoft`,
+  `TextSecondaryAlt`, `SuccessGreenSoft`): rename them to their roles as they
+  are touched rather than in one sweep — `AccentBlueSoft` is the accent MARK
+  (links, focus borders, selection markers), which is the one that matters.
+- [ ] **The app paints plots on FOUR different surfaces, three of them designer
+  literals.** `UiPalette.GraphSurface` (50,55,100) covers the main plot and the
+  EQ wizard; Virtual DSP's two views sit on (40,44,80)
+  (`VirtualCrossoverPanel.Designer.cs`), the option/Time Alignment/history
+  previews on (32,36,46), and the target preview on (55,58,65). Whether that is
+  intentional or drift, nobody decided it recently — and it is not cosmetic:
+  a FIXED chrome colour reads at a different strength on each (the first grid
+  measured 1.33:1 on the main plots and 1.59:1 on Virtual DSP, which is how it
+  looked). The grid and the plot border are white-with-alpha now, so they no
+  longer care; anything else added to a plot has to make the same choice, and a
+  light theme has to reach all four surfaces. Decide the count first: one
+  surface token, or a named few.
+- [ ] **The satellite plots still carry their own chrome literals.** The Time
+  Alignment previews, `AngleCalibrationDialog`, `ImpulseWindowPreview`,
+  `OverlayTargetSettingsDialog` and `MeasurementHistoryWindow` set their own
+  white text and grid colours rather than going through
+  `PlotModelStyle.ApplyChrome`. They are readable as they are, so this is
+  tidiness, not a defect — but they are the reason a plot colour still has more
+  than one home.
+- [ ] **`WarningRed` on a dark surface measures 4.3:1 as text.** It is a FILL
+  today (meter bars, the fader groove), where no text threshold applies, so
+  nothing is wrong now — but it reads as the palette's "red" and the next
+  status line that reaches for it would land under the floor. `ErrorSoft`
+  (already lifted to 4.6:1) is the text-carrying red; keep them apart, or give
+  `WarningRed` a text-safe sibling if it is ever needed for one.
 - [ ] **`ChromeTitleBar` caches the DPI scale once at `Initialize`.** No
   `DpiChanged` handling: moving the window to a monitor with different DPI
   (PerMonitorV2) leaves the bar height, button widths and tab layout at the old

--- a/source/Options/LiveSpectrumOpt.cs
+++ b/source/Options/LiveSpectrumOpt.cs
@@ -207,7 +207,7 @@ namespace Resonalyze.Options
         {
             bool rta = radioModeRta.Checked;
             labelSpl.ForeColor = !rta
-                ? UiPalette.TextMuted
+                ? UiPalette.TextDisabled
                 : splViewOnlyConflict
                     ? UiPalette.WarningAmber
                     : splChoiceReadyForeColor;

--- a/source/Overlays/OverlayOperationSettingsDialog.Designer.cs
+++ b/source/Overlays/OverlayOperationSettingsDialog.Designer.cs
@@ -408,7 +408,6 @@
             // 
             // saveButton
             // 
-            saveButton.BackColor = Color.FromArgb(64, 116, 255);
             saveButton.DialogResult = DialogResult.OK;
             saveButton.FlatAppearance.BorderSize = 0;
             saveButton.FlatStyle = FlatStyle.Flat;

--- a/source/Overlays/OverlayOperationSettingsDialog.cs
+++ b/source/Overlays/OverlayOperationSettingsDialog.cs
@@ -49,6 +49,9 @@ internal sealed partial class OverlayOperationSettingsDialog : Form
         selectedColor = color;
 
         InitializeComponent();
+        // The accent fill is a palette value, not a literal the designer keeps a
+        // copy of: the two drifted apart once already.
+        Ui.UiStyle.ApplySurfaceButton(saveButton, Ui.UiPalette.AccentFill);
         PopulateControls(availableSources, availableLiveCurves);
         WireEvents();
         InitializeToolTips();

--- a/source/Overlays/OverlaySettingsDialog.Designer.cs
+++ b/source/Overlays/OverlaySettingsDialog.Designer.cs
@@ -202,7 +202,6 @@ namespace Resonalyze
             //
             // saveButton
             //
-            saveButton.BackColor = Color.FromArgb(64, 116, 255);
             saveButton.DialogResult = DialogResult.OK;
             saveButton.FlatStyle = FlatStyle.Flat;
             saveButton.ForeColor = Color.White;

--- a/source/Overlays/OverlaySettingsDialog.cs
+++ b/source/Overlays/OverlaySettingsDialog.cs
@@ -1,4 +1,4 @@
-namespace Resonalyze;
+﻿namespace Resonalyze;
 
 internal sealed partial class OverlaySettingsDialog : Form
 {
@@ -32,6 +32,9 @@ internal sealed partial class OverlaySettingsDialog : Form
         selectedColor = color;
 
         InitializeComponent();
+        // The accent fill is a palette value, not a literal the designer keeps a
+        // copy of: the two drifted apart once already.
+        Ui.UiStyle.ApplySurfaceButton(saveButton, Ui.UiPalette.AccentFill);
         PopulateControls();
         WireEvents();
         InitializeToolTips();

--- a/source/Overlays/OverlayTargetSettingsDialog.Designer.cs
+++ b/source/Overlays/OverlayTargetSettingsDialog.Designer.cs
@@ -586,7 +586,6 @@ namespace Resonalyze
             // 
             // saveButton
             // 
-            saveButton.BackColor = Color.FromArgb(64, 116, 255);
             saveButton.DialogResult = DialogResult.OK;
             saveButton.FlatAppearance.BorderSize = 0;
             saveButton.FlatStyle = FlatStyle.Flat;

--- a/source/Overlays/OverlayTargetSettingsDialog.cs
+++ b/source/Overlays/OverlayTargetSettingsDialog.cs
@@ -1,4 +1,4 @@
-using OxyPlot;
+﻿using OxyPlot;
 using OxyPlot.Axes;
 using OxyPlot.Series;
 
@@ -42,6 +42,9 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
         selectedColor = color;
 
         InitializeComponent();
+        // The accent fill is a palette value, not a literal the designer keeps a
+        // copy of: the two drifted apart once already.
+        Ui.UiStyle.ApplySurfaceButton(saveButton, Ui.UiPalette.AccentFill);
         PopulateControls(availableSources);
         WireEvents();
         InitializeToolTips();
@@ -79,7 +82,14 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
     // do anything. The name, colour, thickness and line style still apply.
     private void ApplyIsolatedTargetMode()
     {
-        nameTextBox.Enabled = false;
+        // The name is muted by hand rather than disabled: Windows paints a DISABLED
+        // TextBox in its own grey whatever ForeColor says (2.5:1 here), and this
+        // field still shows the name the overlay will carry. Read-only and off the
+        // tab order does the disabling.
+        nameTextBox.ReadOnly = true;
+        nameTextBox.TabStop = false;
+        nameTextBox.BackColor = Ui.UiPalette.ButtonDisabledBackground;
+        nameTextBox.ForeColor = Ui.UiPalette.TextDisabled;
         toleranceInput.Enabled = false;
         deviationModeComboBox.Enabled = false;
         smoothingComboBox.Enabled = false;

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -730,7 +730,7 @@ internal sealed class PlotModelFactory
         }
 
         PlotModelStyle.AddFrequencyAxis(model);
-        model.Axes.Insert(0, new LinearAxis
+        PlotModelStyle.InsertAxis(model, 0, new LinearAxis
         {
             Key = PhaseAxisKey,
             Position = AxisPosition.Left,
@@ -973,7 +973,7 @@ internal sealed class PlotModelFactory
             msAxis.Minimum = minimum - 2;
             msAxis.Maximum = maximum + 2;
         }
-        model.Axes.Insert(0, msAxis);
+        PlotModelStyle.InsertAxis(model, 0, msAxis);
         return model;
     }
 
@@ -1116,8 +1116,8 @@ internal sealed class PlotModelFactory
         // itself the axis takes in whatever is drawn on it, live or attached later, which
         // is what makes the shared normalization readable.
         ApplyDecibelFloor(valueAxis, opt, stepOnLeft, drawn);
-        model.Axes.Add(timeAxis);
-        model.Axes.Add(valueAxis);
+        PlotModelStyle.AddAxis(model, timeAxis);
+        PlotModelStyle.AddAxis(model, valueAxis);
 
         // The counterpart axis is always in the model, visible only when something is
         // drawn against it. An overlay carries the axis key it was captured with, and a
@@ -1131,7 +1131,7 @@ internal sealed class PlotModelFactory
             Title = stepOnLeft ? ImpulseValueUnit(opt.AmplitudeScale) : "step",
             IsAxisVisible = !stepOnLeft && stepCurves.Count > 0,
         };
-        model.Axes.Add(counterpartAxis);
+        PlotModelStyle.AddAxis(model, counterpartAxis);
         return model;
     }
 
@@ -1520,14 +1520,14 @@ internal sealed class PlotModelFactory
             AddRequiresTransferIrAnnotation(model);
         }
 
-        model.Axes.Add(new LinearAxis
+        PlotModelStyle.AddAxis(model, new LinearAxis
         {
             Key = TimeAxisKey,
             Position = AxisPosition.Bottom,
             MajorGridlineStyle = LineStyle.Solid,
             Title = "ms"
         });
-        model.Axes.Add(new LinearAxis
+        PlotModelStyle.AddAxis(model, new LinearAxis
         {
             Key = AutocorrelationAxisKey,
             Position = AxisPosition.Left,
@@ -2090,7 +2090,7 @@ internal sealed class PlotModelFactory
             return;
         }
 
-        model.Axes.Add(new LinearAxis
+        PlotModelStyle.AddAxis(model, new LinearAxis
         {
             Key = CoherenceAxisKey,
             Position = AxisPosition.Right,

--- a/source/Plotting/PlotModelStyle.cs
+++ b/source/Plotting/PlotModelStyle.cs
@@ -7,12 +7,108 @@ namespace Resonalyze;
 
 internal static class PlotModelStyle
 {
-    public static PlotModel CreateTitledModel(string title) =>
-        new()
+    // OxyPlot's own defaults are a LIGHT theme: black tick lines, a black-alpha
+    // grid, a black plot-area border, and axis text that follows PlotModel.TextColor
+    // — itself black. Nothing in the app ever said otherwise, so every plot built
+    // here drew its numbers in black on the dark plot surface, at 1.9:1 (#116): a
+    // reader who does not already know what the axis says cannot read it.
+    private static readonly OxyColor DefaultTicklineColor = OxyColors.Black;
+    private static readonly OxyColor DefaultMajorGridlineColor = OxyColor.FromArgb(0x40, 0, 0, 0);
+    private static readonly OxyColor DefaultMinorGridlineColor = OxyColor.FromArgb(0x20, 0, 0, 0);
+
+    public static PlotModel CreateTitledModel(string title)
+    {
+        var model = new PlotModel
         {
             Title = title,
             TitleFontSize = 14
         };
+        ApplyChrome(model);
+        return model;
+    }
+
+    /// <summary>
+    /// Gives a model the app's own axis furniture in place of OxyPlot's light-theme
+    /// defaults, and the one place a second theme would swap them.
+    /// </summary>
+    /// <remarks>
+    /// Only OxyPlot's DEFAULTS are replaced: an axis the caller coloured itself —
+    /// the EQ wizard's gain axis, Virtual DSP's sum-loss axis, both of which say
+    /// which curve they belong to by their colour — keeps what it was given, so
+    /// this can be applied to any model without overriding a deliberate choice.
+    /// LABEL colour needs no per-axis pass and no ordering care: an axis's text
+    /// colour is Automatic, so it follows the model's however late the axis joins.
+    /// Tick lines and gridlines are per-axis, and OxyPlot has deprecated both hooks
+    /// that would let a model style axes as they arrive (the collection's change
+    /// event and PlotModel.Updating), so an axis built by hand asks for
+    /// <see cref="StyleAxis"/> itself. The axis helpers below already do.
+    /// </remarks>
+    public static void ApplyChrome(PlotModel model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        model.TextColor = ToOxyColor(Ui.UiPalette.GraphAxisText);
+        model.PlotAreaBorderColor = ToOxyColor(Ui.UiPalette.GraphAreaBorder);
+
+        foreach (Axis axis in model.Axes)
+        {
+            StyleAxis(axis);
+        }
+    }
+
+    /// <summary>
+    /// Adds an axis to a model with the app's chrome on it. Use this rather than
+    /// <c>model.Axes.Add</c> for any axis on a dark plot — an axis added raw keeps
+    /// OxyPlot's black tick lines and black-alpha grid.
+    /// </summary>
+    public static void AddAxis(PlotModel model, Axis axis)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        StyleAxis(axis);
+        model.Axes.Add(axis);
+    }
+
+    /// <inheritdoc cref="AddAxis"/>
+    public static void InsertAxis(PlotModel model, int index, Axis axis)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        StyleAxis(axis);
+        model.Axes.Insert(index, axis);
+    }
+
+    /// <summary>
+    /// Replaces OxyPlot's default tick and gridline colours on one axis. A colour
+    /// the caller chose is left alone, so this is safe to call on any axis.
+    /// </summary>
+    public static void StyleAxis(Axis axis)
+    {
+        ArgumentNullException.ThrowIfNull(axis);
+
+        if (axis.TicklineColor == DefaultTicklineColor)
+        {
+            axis.TicklineColor = ToOxyColor(Ui.UiPalette.GraphTickline);
+        }
+
+        if (axis.AxislineColor == DefaultTicklineColor)
+        {
+            axis.AxislineColor = ToOxyColor(Ui.UiPalette.GraphTickline);
+        }
+
+        if (axis.MajorGridlineColor == DefaultMajorGridlineColor)
+        {
+            axis.MajorGridlineColor = ToOxyColor(Ui.UiPalette.GraphGridlineMajor);
+        }
+
+        if (axis.MinorGridlineColor == DefaultMinorGridlineColor)
+        {
+            axis.MinorGridlineColor = ToOxyColor(Ui.UiPalette.GraphGridlineMinor);
+        }
+    }
+
+    private static OxyColor ToOxyColor(Color color) =>
+        OxyColor.FromArgb(color.A, color.R, color.G, color.B);
 
     // The audio band is the DEFAULT view and the hard fence for panning, but not a
     // fixed scale: zoom is what lets a 40 Hz mode or a crossover region be read at
@@ -20,7 +116,7 @@ internal static class PlotModelStyle
     // curves are computed over, so a pan cannot wander off the data.
     public static void AddFrequencyAxis(PlotModel model)
     {
-        model.Axes.Add(new LogarithmicAxis
+        AddAxis(model, new LogarithmicAxis
         {
             Key = PlotModelFactory.FrequencyAxisKey,
             Position = AxisPosition.Bottom,
@@ -63,7 +159,7 @@ internal static class PlotModelStyle
         double absoluteMinimum = RelativeDecibelAbsoluteMinimum,
         double absoluteMaximum = RelativeDecibelAbsoluteMaximum)
     {
-        model.Axes.Insert(0, new LinearAxis
+        InsertAxis(model, 0, new LinearAxis
         {
             Key = PlotModelFactory.DecibelAxisKey,
             Position = AxisPosition.Left,
@@ -152,7 +248,7 @@ internal static class PlotModelStyle
     {
         PlotModel model = CreateTitledModel(title);
 
-        model.Axes.Add(new LinearAxis
+        AddAxis(model, new LinearAxis
         {
             Position = AxisPosition.Left,
             Minimum = -1.0,
@@ -161,7 +257,7 @@ internal static class PlotModelStyle
             IsPanEnabled = false,
             IsZoomEnabled = false,
         });
-        model.Axes.Add(new LogarithmicClipAxis
+        AddAxis(model, new LogarithmicClipAxis
         {
             Position = AxisPosition.Bottom,
             Minimum = 20,
@@ -171,7 +267,7 @@ internal static class PlotModelStyle
             IsZoomEnabled = false,
         });
 
-        model.Axes.Add(new LinearColorAxis
+        AddAxis(model, new LinearColorAxis
         {
             Position = AxisPosition.Left,
             Minimum = options.DbRange,

--- a/source/Shell/Form1.Designer.cs
+++ b/source/Shell/Form1.Designer.cs
@@ -83,8 +83,6 @@ namespace Resonalyze
             // plotView1
             // 
             plotView1.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
-            plotView1.BackColor = Color.FromArgb(50, 55, 100);
-            plotView1.ForeColor = Color.White;
             plotView1.Location = new Point(12, 52);
             plotView1.Name = "plotView1";
             plotView1.PanCursor = Cursors.Hand;

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -95,6 +95,12 @@ namespace Resonalyze
             expSweepMeasurement = new ExpSweepMeasurement(audioSessionFactory);
             noiseMeasurement = new NoiseMeasurement(audioSessionFactory);
             ConfigureToolTips();
+            // The surface the plots are drawn on, from the palette rather than a
+            // designer literal that has to be kept equal to it by hand. A PlotView
+            // paints no background of its own — WinForms does, from BackColor — and
+            // it never reads ForeColor either: the axis colours come from the model
+            // (PlotModelStyle.ApplyChrome), not from the control.
+            plotView1.BackColor = UiPalette.GraphSurface;
             PlotInteraction.Enable(plotView1);
             plotView1.Paint += (_, _) => AppProfiler.FrameMark("main-plot");
             measurementSettings = MeasurementSettingsFile.LoadOrDefault();

--- a/source/Shell/MainCommandController.cs
+++ b/source/Shell/MainCommandController.cs
@@ -96,7 +96,7 @@ internal sealed class MainCommandController
         {
             button.Enabled = false;
             button.BackColor = UiPalette.ButtonDisabledBackground;
-            button.ForeColor = UiPalette.TextMuted;
+            button.ForeColor = UiPalette.TextDisabled;
         }
         else
         {

--- a/source/TimeAlignment/TimeAlignmentPanel.cs
+++ b/source/TimeAlignment/TimeAlignmentPanel.cs
@@ -7,6 +7,10 @@ public partial class TimeAlignmentPanel : UserControl
     public TimeAlignmentPanel()
     {
         InitializeComponent();
+        // Below its designed size the panel scrolls on native scrollbars; theme
+        // them dark so they match the app instead of showing the default light
+        // bar, the way the Virtual DSP panel already does.
+        Ui.DarkScrollBars.Apply(this);
     }
 
     internal Label SourceSummaryLabel => sourceSummaryLabel;

--- a/source/Tools/Eq/EqWizardPanel.Layout.cs
+++ b/source/Tools/Eq/EqWizardPanel.Layout.cs
@@ -1,0 +1,119 @@
+namespace Resonalyze;
+
+public partial class EqWizardPanel
+{
+    // The designer's arrangement, captured before anything moves it: the panel's
+    // client size and the plot's size. Everything this pass does is a DELTA on
+    // these, never an absolute coordinate — the designer's numbers are the ones
+    // the font autoscale has already put into the running DPI's units, and a
+    // coordinate written here would be stuck at 96 DPI (see AGENTS.md).
+    private Size baselineClientSize;
+    private Size baselinePlotSize;
+
+    // The two blocks that sit at the bottom-left of the panel and keep their own
+    // size: the PEQ strip bank and the auto-tune box. Held as the designer's gap
+    // below the plot's bottom edge, so a taller window moves them down by exactly
+    // what the plot grew and the gaps are what survives every window size.
+    // Measured from the plot's CURRENT bottom on each pass, which keeps them right
+    // while the panel is scrolled (AutoScroll shifts the children out from under
+    // their own coordinates, and both ends of the offset shift together).
+    private readonly List<(Control Control, int Offset)> bottomRiders = [];
+
+    private bool layoutInProgress;
+
+    // Captured at the end of construction, when the controls still stand where the
+    // designer put them.
+    private void CaptureLayoutBaseline()
+    {
+        baselineClientSize = ClientSize;
+        baselinePlotSize = plotWizard.Size;
+        int bottom = plotWizard.Bottom;
+        foreach (Control control in new Control[] { panelPEQ, panelAutoTune })
+        {
+            bottomRiders.Add((control, control.Top - bottom));
+        }
+    }
+
+    // Container autoscaling (a font change, a DPI move) scales the controls; the
+    // baseline is in the same units and has to follow, or the next layout pass
+    // would add 96-DPI deltas to scaled controls.
+    protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
+    {
+        base.ScaleControl(factor, specified);
+        if (baselineClientSize.IsEmpty)
+        {
+            return;
+        }
+
+        baselineClientSize = Scale(baselineClientSize, factor);
+        baselinePlotSize = Scale(baselinePlotSize, factor);
+        for (int index = 0; index < bottomRiders.Count; index++)
+        {
+            (Control control, int offset) = bottomRiders[index];
+            bottomRiders[index] = (control, (int)Math.Round(offset * factor.Height));
+        }
+    }
+
+    private static Size Scale(Size size, SizeF factor) => new(
+        (int)Math.Round(size.Width * factor.Width),
+        (int)Math.Round(size.Height * factor.Height));
+
+    // BEFORE the base pass, not after: the base is what sizes the scrollable area
+    // from the children (AutoScroll) and settles the anchored ones, and it has to
+    // see the plot at its final size.
+    protected override void OnLayout(LayoutEventArgs e)
+    {
+        // Resizing a child re-enters this. The guard keeps the stretch itself from
+        // nesting, while the base pass below still runs for every one of those
+        // calls, which is what keeps the scroll area in step.
+        if (!layoutInProgress)
+        {
+            layoutInProgress = true;
+            try
+            {
+                ApplyStretchLayout();
+            }
+            finally
+            {
+                layoutInProgress = false;
+            }
+        }
+
+        base.OnLayout(e);
+    }
+
+    /// <summary>
+    /// Spends the room a bigger window gives the panel on the plot alone: it takes
+    /// the extra width out to the panel's right edge and the extra height down to
+    /// the PEQ bank, which rides down with it at the designer's gap. The bank and
+    /// the auto-tune box keep their size and stay in the bottom-left corner: the
+    /// bank is a FIXED 16x2 grid of strips on percent styles, so room given to it
+    /// would enlarge the strips rather than show more of them, and the curve being
+    /// equalized is what a bigger window is opened for. Below the designer's size
+    /// nothing shrinks: the panel scrolls instead (AutoScroll), the way it did
+    /// before it could stretch at all.
+    /// </summary>
+    private void ApplyStretchLayout()
+    {
+        if (baselineClientSize.IsEmpty || bottomRiders.Count == 0)
+        {
+            return;
+        }
+
+        int extraWidth = Math.Max(0, ClientSize.Width - baselineClientSize.Width);
+        int extraHeight = Math.Max(0, ClientSize.Height - baselineClientSize.Height);
+
+        plotWizard.SetBounds(
+            0,
+            0,
+            baselinePlotSize.Width + extraWidth,
+            baselinePlotSize.Height + extraHeight,
+            BoundsSpecified.Size);
+
+        int bottom = plotWizard.Bottom;
+        foreach ((Control control, int offset) in bottomRiders)
+        {
+            control.Top = bottom + offset;
+        }
+    }
+}

--- a/source/Tools/Eq/EqWizardPanel.Layout.cs
+++ b/source/Tools/Eq/EqWizardPanel.Layout.cs
@@ -37,10 +37,22 @@ public partial class EqWizardPanel
     // Container autoscaling (a font change, a DPI move) scales the controls; the
     // baseline is in the same units and has to follow, or the next layout pass
     // would add 96-DPI deltas to scaled controls.
+    //
+    // But only when the pass in question actually moves the children, and one of
+    // the two this panel gets does not. Its OWN auto-scale rearranges everything
+    // inside it; the shell's cascade afterwards resizes the panel ALONE, because
+    // ContainerControl.ScaleChildren is false for a container that declares an
+    // AutoScaleMode. Scaled on both, the baseline ends a whole factor ahead of the
+    // arrangement it is supposed to measure: at 125% it read 1.5625, so the stretch
+    // sized the plot for a panel a quarter wider than the one it sits in and the
+    // panel came up with both scrollbars and the plot cut off at the right.
+    // The panel's own pass is the one where its declared dimensions still differ
+    // from the current ones — the auto-scale is what brings them into step.
     protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
     {
+        bool rearrangesChildren = AutoScaleDimensions != CurrentAutoScaleDimensions;
         base.ScaleControl(factor, specified);
-        if (baselineClientSize.IsEmpty)
+        if (baselineClientSize.IsEmpty || !rearrangesChildren)
         {
             return;
         }

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -97,6 +97,9 @@ public partial class EqWizardPanel : UserControl
     public EqWizardPanel()
     {
         InitializeComponent();
+        // While the controls still stand where the designer put them: the layout
+        // pass stretches the plot by deltas on this (see the Layout partial).
+        CaptureLayoutBaseline();
         InitializePlotWizard();
         InitializePeqSlotTable();
         InitializeBandsComboBox();

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -426,13 +426,14 @@ public partial class EqWizardPanel : UserControl
         // Mirror the axis style used by the Frequency Response and Live Spectrum
         // plots: a logarithmic 20 Hz - 20 kHz frequency axis and a dB axis.
         PlotModel model = new PlotModel();
+        PlotModelStyle.ApplyChrome(model);
         PlotModelStyle.AddFrequencyAxis(model);
         // The starting bounds ARE the impulse-response ones, not a copy of their
         // numbers: an IR is what the wizard opens on, and a second set of
         // literals here is a set that can drift away from the one a loaded
         // source re-arms the axis with.
         EqWizardAxisRange initialRange = EqWizardPlotFit.ImpulseResponseRange;
-        model.Axes.Add(new LinearAxis
+        PlotModelStyle.AddAxis(model, new LinearAxis
         {
             Position = AxisPosition.Left,
             AbsoluteMinimum = initialRange.AbsoluteMinimum,
@@ -452,7 +453,7 @@ public partial class EqWizardPanel : UserControl
         // within it the axis zooms and pans like any other (hover it and scroll, or
         // drag), for reading a correction's fine structure without the whole budget's
         // height. A subtle 0-line marks unity gain.
-        model.Axes.Add(new LinearAxis
+        PlotModelStyle.AddAxis(model, new LinearAxis
         {
             Key = EqGainAxisKey,
             Position = AxisPosition.Right,

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -100,6 +100,10 @@ public partial class EqWizardPanel : UserControl
         // While the controls still stand where the designer put them: the layout
         // pass stretches the plot by deltas on this (see the Layout partial).
         CaptureLayoutBaseline();
+        // Below its designed size the panel scrolls on native scrollbars; theme
+        // them dark so they match the app instead of showing the default light
+        // bar, the way the Virtual DSP panel already does.
+        Ui.DarkScrollBars.Apply(this);
         InitializePlotWizard();
         InitializePeqSlotTable();
         InitializeBandsComboBox();

--- a/source/Tools/SignalGenerator/SignalGeneratorPanel.cs
+++ b/source/Tools/SignalGenerator/SignalGeneratorPanel.cs
@@ -31,6 +31,10 @@ public partial class SignalGeneratorPanel : UserControl
     public SignalGeneratorPanel()
     {
         InitializeComponent();
+        // Below its designed size the panel scrolls on native scrollbars; theme
+        // them dark so they match the app instead of showing the default light
+        // bar, the way the Virtual DSP panel already does.
+        Ui.DarkScrollBars.Apply(this);
         InitializeOptions();
         UpdateSignalControls();
         VisibleChanged += (_, _) => RefreshAudioSettings();

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAcousticPlot.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAcousticPlot.cs
@@ -115,6 +115,7 @@ internal sealed class VirtualCrossoverAcousticPlot
         this.view = view;
 
         var model = new PlotModel();
+        PlotModelStyle.ApplyChrome(model);
         PlotModelStyle.AddFrequencyAxis(model);
         frequencyAxis = (LogarithmicAxis)model.Axes[^1];
         // The impulse view runs on an absolute-time axis. It zooms and pans like
@@ -138,7 +139,7 @@ internal sealed class VirtualCrossoverAcousticPlot
             MajorGridlineStyle = LineStyle.Solid,
             MinorGridlineStyle = LineStyle.Dot
         };
-        model.Axes.Add(valueAxis);
+        PlotModelStyle.AddAxis(model, valueAxis);
         // After the value axis: the mouse and the on-graph buttons take the
         // first visible zoomable axis of an orientation as "the" vertical
         // scale (PlotAxisZoom.FindZoomableAxis), and that stays the dB axis on
@@ -160,7 +161,7 @@ internal sealed class VirtualCrossoverAcousticPlot
             ExtraGridlineStyle = LineStyle.Solid,
             IsAxisVisible = false
         };
-        model.Axes.Add(lossAxis);
+        PlotModelStyle.AddAxis(model, lossAxis);
 
         model.Annotations.Add(new PlotWatermarkAnnotation
         {
@@ -310,7 +311,7 @@ internal sealed class VirtualCrossoverAcousticPlot
         if (!model.Axes.Contains(wanted))
         {
             model.Axes.Remove(retired);
-            model.Axes.Add(wanted);
+            PlotModelStyle.AddAxis(model, wanted);
         }
     }
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverDspChainPlot.cs
@@ -120,10 +120,11 @@ internal sealed class VirtualCrossoverDspChainPlot
         this.view = view;
 
         var model = new PlotModel();
+        PlotModelStyle.ApplyChrome(model);
         PlotModelStyle.AddFrequencyAxis(model);
         // One value axis, reconfigured per plot mode (magnitude / phase / group
         // delay). A single axis keeps each mode readable on its own scale.
-        model.Axes.Add(new LinearAxis
+        PlotModelStyle.AddAxis(model, new LinearAxis
         {
             Key = ValueAxisKey,
             Position = AxisPosition.Left,
@@ -157,13 +158,14 @@ internal sealed class VirtualCrossoverDspChainPlot
         {
             IsLegendVisible = true
         };
+        PlotModelStyle.ApplyChrome(model);
         model.Legends.Add(new OxyPlot.Legends.Legend
         {
             LegendPosition = OxyPlot.Legends.LegendPosition.TopRight,
             LegendTextColor = OxyColor.FromRgb(210, 214, 222),
             LegendBackground = OxyColor.FromAColor(120, OxyColor.FromRgb(40, 44, 54))
         });
-        model.Axes.Add(new LinearAxis
+        PlotModelStyle.AddAxis(model, new LinearAxis
         {
             Key = LagAxisKey,
             Position = AxisPosition.Bottom,
@@ -171,7 +173,7 @@ internal sealed class VirtualCrossoverDspChainPlot
             MajorGridlineStyle = LineStyle.Solid,
             MinorGridlineStyle = LineStyle.Dot
         });
-        model.Axes.Add(new LinearAxis
+        PlotModelStyle.AddAxis(model, new LinearAxis
         {
             Key = CoefficientAxisKey,
             Position = AxisPosition.Left,
@@ -182,7 +184,7 @@ internal sealed class VirtualCrossoverDspChainPlot
             MajorGridlineStyle = LineStyle.Solid,
             MinorGridlineStyle = LineStyle.Dot
         });
-        model.Axes.Add(new LinearAxis
+        PlotModelStyle.AddAxis(model, new LinearAxis
         {
             Key = ScoreAxisKey,
             Position = AxisPosition.Right,
@@ -397,6 +399,7 @@ internal sealed class VirtualCrossoverDspChainPlot
         {
             IsLegendVisible = true
         };
+        PlotModelStyle.ApplyChrome(model);
         model.Legends.Add(new OxyPlot.Legends.Legend
         {
             LegendPosition = OxyPlot.Legends.LegendPosition.TopRight,
@@ -404,7 +407,7 @@ internal sealed class VirtualCrossoverDspChainPlot
             LegendBackground = OxyColor.FromAColor(120, OxyColor.FromRgb(40, 44, 54))
         });
         PlotModelStyle.AddFrequencyAxis(model);
-        model.Axes.Add(new LinearAxis
+        PlotModelStyle.AddAxis(model, new LinearAxis
         {
             Key = CoherenceLagAxisKey,
             Position = AxisPosition.Left,
@@ -412,7 +415,7 @@ internal sealed class VirtualCrossoverDspChainPlot
             MajorGridlineStyle = LineStyle.Solid,
             MinorGridlineStyle = LineStyle.Dot
         });
-        model.Axes.Add(new LinearAxis
+        PlotModelStyle.AddAxis(model, new LinearAxis
         {
             Key = CoherenceCoefficientAxisKey,
             Position = AxisPosition.Right,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Layout.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Layout.cs
@@ -61,10 +61,22 @@ public partial class VirtualCrossoverPanel
     // baseline is in the same units and has to follow, or the next layout pass
     // would add 96-DPI deltas to scaled controls. The same reason
     // VirtualCrossoverChannelControl scales its parked height.
+    //
+    // But only when the pass in question actually moves the children, and one of
+    // the two this panel gets does not. Its OWN auto-scale rearranges everything
+    // inside it; the shell's cascade afterwards resizes the panel ALONE, because
+    // ContainerControl.ScaleChildren is false for a container that declares an
+    // AutoScaleMode. Scaled on both, the baseline ends a whole factor ahead of the
+    // arrangement it is supposed to measure: at 125% it read 1.5625, so the stretch
+    // sized the plots for a panel a quarter wider than the one they sit in and the
+    // panel came up with both scrollbars and the plots cut off at the right.
+    // The panel's own pass is the one where its declared dimensions still differ
+    // from the current ones — the auto-scale is what brings them into step.
     protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
     {
+        bool rearrangesChildren = AutoScaleDimensions != CurrentAutoScaleDimensions;
         base.ScaleControl(factor, specified);
-        if (baselineClientSize.IsEmpty)
+        if (baselineClientSize.IsEmpty || !rearrangesChildren)
         {
             return;
         }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -1400,7 +1400,7 @@ public partial class VirtualCrossoverPanel : UserControl
     {
         bool magnitude = radioViewMagnitude.Checked;
         checkBoxShowTarget.ForeColor =
-            magnitude ? targetToggleColor : Ui.UiPalette.TextMuted;
+            magnitude ? targetToggleColor : Ui.UiPalette.TextDisabled;
         checkBoxShowTarget.AutoCheck = magnitude;
         checkBoxShowTarget.TabStop = magnitude;
     }

--- a/source/Ui/Controls/ChromeTitleBar.cs
+++ b/source/Ui/Controls/ChromeTitleBar.cs
@@ -484,7 +484,7 @@ internal sealed class ChromeTitleBar : Panel
             : UiPalette.AccentBlueMuted;
         button.FlatAppearance.MouseDownBackColor = text == "✕" // X
             ? UiPalette.AccentBlueMutedAlt
-            : UiPalette.AccentBlueStrong;
+            : UiPalette.AccentFill;
         button.Click += clickHandler;
         Controls.Add(button);
     }
@@ -802,14 +802,18 @@ internal sealed class ChromeTitleBar : Panel
         return Math.Max(form.DeviceDpi / 96.0f, graphics.DpiX / 96.0f);
     }
 
+    // The active tab keeps its fill under the pointer instead of lifting: its label
+    // is TitleBarTextSoft, and a blue light enough to read as a hover puts that
+    // label under 4.5:1 (see UiPalette.AccentFill). An inactive tab still lifts —
+    // it is the one a click would actually take you to.
     private static void SetModeTabStyle(Button button, bool active)
     {
         button.BackColor = active
-            ? UiPalette.AccentBlue
+            ? UiPalette.AccentFill
             : UiPalette.ButtonBackground;
         button.FlatAppearance.MouseOverBackColor = active
-            ? UiPalette.AccentBlueHover
+            ? UiPalette.AccentFill
             : UiPalette.ButtonHoverBackground;
-        button.FlatAppearance.MouseDownBackColor = UiPalette.AccentBlueStrong;
+        button.FlatAppearance.MouseDownBackColor = UiPalette.AccentFillPressed;
     }
 }

--- a/source/Ui/Controls/DarkComboBox.cs
+++ b/source/Ui/Controls/DarkComboBox.cs
@@ -605,7 +605,7 @@ public sealed class DarkComboBox : UserControl
         string text = modelComboBox.GetItemText(modelComboBox.SelectedItem) ?? string.Empty;
         Color textColor = Enabled
             ? UiPalette.TextPrimary
-            : UiPalette.TextMuted;
+            : UiPalette.TextDisabled;
         TextRenderer.DrawText(
             e.Graphics,
             text,
@@ -636,7 +636,7 @@ public sealed class DarkComboBox : UserControl
         int halfHeight = ScaleLogical(LogicalArrowHalfHeight);
         int centerX = bounds.Width / 2;
         int centerY = bounds.Height / 2 + ScaleLogical(1);
-        using var arrowBrush = new SolidBrush(Enabled ? UiPalette.TextPrimary : UiPalette.TextMuted);
+        using var arrowBrush = new SolidBrush(Enabled ? UiPalette.TextPrimary : UiPalette.TextDisabled);
         e.Graphics.FillPolygon(
             arrowBrush,
             [
@@ -659,7 +659,7 @@ public sealed class DarkComboBox : UserControl
         using var backgroundBrush = new SolidBrush(buttonColor);
         e.Graphics.FillRectangle(backgroundBrush, bounds);
 
-        Color glyphColor = Enabled ? UiPalette.TextPrimary : UiPalette.TextMuted;
+        Color glyphColor = Enabled ? UiPalette.TextPrimary : UiPalette.TextDisabled;
         TextRenderer.DrawText(
             e.Graphics,
             "R",
@@ -681,11 +681,11 @@ public sealed class DarkComboBox : UserControl
         e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
         bool selected = (e.State & DrawItemState.Selected) == DrawItemState.Selected;
         Color backgroundColor = selected
-            ? UiPalette.AccentBlueStrong
+            ? UiPalette.AccentFill
             : UiPalette.ControlSurface;
         Color textColor = Enabled
             ? UiPalette.TextPrimary
-            : UiPalette.TextMuted;
+            : UiPalette.TextDisabled;
 
         using var backgroundBrush = new SolidBrush(backgroundColor);
         e.Graphics.FillRectangle(backgroundBrush, e.Bounds);

--- a/source/Ui/Controls/DarkNumericUpDown.cs
+++ b/source/Ui/Controls/DarkNumericUpDown.cs
@@ -371,12 +371,13 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
     protected override void OnEnabledChanged(EventArgs e)
     {
         base.OnEnabledChanged(e);
-        // Keep the inner editor's own Enabled=true so the native EDIT paints its text in our
-        // muted colour instead of the system's dark disabled grey; the disabled parent still
-        // blocks all interaction. ReadOnly is a safety net against programmatic edits.
+        // A disabled control paints its own value (see UpdateEditorVisibility) — the
+        // native EDIT under a disabled parent is coloured by Windows, not by us.
+        // ReadOnly is a safety net against programmatic edits meanwhile.
         editor.ReadOnly = readOnly || !Enabled;
-        editor.ForeColor = Enabled ? ForeColor : UiPalette.TextMuted;
+        editor.ForeColor = Enabled ? ForeColor : UiPalette.TextDisabled;
         editor.BackColor = Enabled ? BackColor : UiPalette.ButtonDisabledBackground;
+        UpdateEditorVisibility();
         Invalidate();
     }
 
@@ -598,7 +599,7 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
                 resetBounds.Left,
                 Height - 2);
 
-            Color glyphColor = Enabled ? UiPalette.TextPrimarySoft : UiPalette.TextMuted;
+            Color glyphColor = Enabled ? UiPalette.TextPrimarySoft : UiPalette.TextDisabled;
             TextRenderer.DrawText(
                 e.Graphics,
                 "R",
@@ -610,28 +611,33 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
                 TextFormatFlags.NoPadding);
         }
 
-        // In inline-label mode the editor is hidden at rest, so paint the caption
-        // and value ourselves: the caption sits at the inner-left in a half-tone,
-        // the value is right-aligned across the whole field and drawn last so its
-        // digits cover the caption where they meet.
-        if (HasInlineLabel && !editor.Visible)
+        // Whenever the editor is hidden — inline-label mode at rest, or a disabled
+        // control, which hides it so the value is not left to the system's grey —
+        // paint the value here: the caption, if any, sits at the inner-left in a
+        // half-tone, and the value is right-aligned across the whole field and
+        // drawn last so its digits cover the caption where they meet.
+        if (!editor.Visible)
         {
             Rectangle textBounds = editor.Bounds;
-            TextRenderer.DrawText(
-                e.Graphics,
-                inlineLabel,
-                Font,
-                textBounds,
-                UiPalette.TextMuted,
-                TextFormatFlags.Left |
-                TextFormatFlags.VerticalCenter |
-                TextFormatFlags.NoPadding);
+            if (HasInlineLabel)
+            {
+                TextRenderer.DrawText(
+                    e.Graphics,
+                    inlineLabel,
+                    Font,
+                    textBounds,
+                    UiPalette.TextDisabled,
+                    TextFormatFlags.Left |
+                    TextFormatFlags.VerticalCenter |
+                    TextFormatFlags.NoPadding);
+            }
+
             TextRenderer.DrawText(
                 e.Graphics,
                 FormatValue(value),
                 Font,
                 textBounds,
-                Enabled ? ForeColor : UiPalette.TextMuted,
+                Enabled ? ForeColor : UiPalette.TextDisabled,
                 TextFormatFlags.Right |
                 TextFormatFlags.VerticalCenter |
                 TextFormatFlags.NoPadding);
@@ -649,7 +655,7 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
                 SuffixDisplay,
                 Font,
                 suffixBounds,
-                Enabled ? UiPalette.TextSecondary : UiPalette.TextMuted,
+                Enabled ? UiPalette.TextSecondary : UiPalette.TextDisabled,
                 TextFormatFlags.Left |
                 TextFormatFlags.VerticalCenter |
                 TextFormatFlags.NoPadding);
@@ -673,7 +679,13 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
     // inline label the editor is always visible and behaviour is unchanged.
     private void UpdateEditorVisibility()
     {
-        bool shouldShow = !HasInlineLabel || ContainsFocus;
+        // A disabled control hides the editor and paints the value itself. Keeping
+        // the inner EDIT's own Enabled=true is not enough: a native edit under a
+        // DISABLED PARENT is painted by Windows in the system's grey (109,109,109)
+        // whatever ForeColor says — 2.5:1 here, and it is the value in force that
+        // goes unreadable (#116). Self-painting is the only way the palette's
+        // colour actually reaches those digits.
+        bool shouldShow = Enabled && (!HasInlineLabel || ContainsFocus);
         if (editor.Visible != shouldShow)
         {
             editor.Visible = shouldShow;
@@ -965,7 +977,7 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
 
     private void DrawArrow(Graphics graphics, Rectangle bounds, bool up)
     {
-        Color color = Enabled ? UiPalette.TextPrimarySoft : UiPalette.TextMuted;
+        Color color = Enabled ? UiPalette.TextPrimarySoft : UiPalette.TextDisabled;
         float centerX = bounds.Left + bounds.Width / 2f;
         float centerY = bounds.Top + bounds.Height / 2f;
         float halfWidth = Math.Min(

--- a/source/Ui/Controls/GainFader.cs
+++ b/source/Ui/Controls/GainFader.cs
@@ -188,9 +188,9 @@ internal sealed class GainFader : Control
         }
 
         float labelRight = tickLeft - ScaleF(2);
-        Color maxColor = enabled ? UiPalette.SuccessGreenSoft : UiPalette.TextMuted;
-        Color zeroColor = enabled ? UiPalette.TextSecondary : UiPalette.TextMuted;
-        Color minColor = enabled ? UiPalette.ErrorSoft : UiPalette.TextMuted;
+        Color maxColor = enabled ? UiPalette.SuccessGreenSoft : UiPalette.TextDisabled;
+        Color zeroColor = enabled ? UiPalette.TextSecondary : UiPalette.TextDisabled;
+        Color minColor = enabled ? UiPalette.ErrorSoft : UiPalette.TextDisabled;
         DrawScaleLabel(graphics, FormatDb(maximum), track.Top, labelRight, maxColor);
         DrawScaleLabel(graphics, "0", zeroY, labelRight, zeroColor);
         DrawScaleLabel(graphics, FormatDb(minimum), track.Bottom, labelRight, minColor);
@@ -253,7 +253,7 @@ internal sealed class GainFader : Control
         // The bright grip line down the middle of the cap marks the exact value.
         Color gripColor = enabled
             ? Color.FromArgb(220, UiPalette.TextPrimarySoft)
-            : Color.FromArgb(120, UiPalette.TextMuted);
+            : Color.FromArgb(120, UiPalette.TextDisabled);
         using var gripPen = new Pen(gripColor, Math.Max(1f, ScaleF(1.4f)));
         graphics.DrawLine(gripPen, cap.Left + ScaleF(2), thumbY, cap.Right - ScaleF(2), thumbY);
     }

--- a/source/Ui/Controls/GainFader.cs
+++ b/source/Ui/Controls/GainFader.cs
@@ -129,7 +129,13 @@ internal sealed class GainFader : Control
     protected override void OnPaint(PaintEventArgs e)
     {
         Graphics graphics = e.Graphics;
-        graphics.Clear(Parent?.BackColor ?? BackColor);
+        // OUR OWN BackColor, which the strip keeps at its band tint
+        // (PeqSlotControl.ApplyStripColor). Not the parent's: this used to read it
+        // back when the strip's layout was the direct parent, and the fader host
+        // put between them since is Color.Transparent — clearing with an alpha-0
+        // colour writes black, which is what turned every strip's fader area into
+        // a black box.
+        graphics.Clear(BackColor);
         if (Width <= 4 || Height <= 4)
         {
             return;

--- a/source/Ui/Dialogs/ColorPickerDialog.cs
+++ b/source/Ui/Dialogs/ColorPickerDialog.cs
@@ -57,7 +57,7 @@ internal sealed class ColorPickerDialog : Form
         var subtitle = UiStyle.CreateLabel(
             "Choose a preset or create a custom color.",
             new Point(20, 42),
-            UiPalette.TextMutedSoft,
+            UiPalette.TextSecondary,
             Font);
 
         var presets = new FlowLayoutPanel

--- a/source/Ui/Dialogs/MeasurementHistoryWindow.cs
+++ b/source/Ui/Dialogs/MeasurementHistoryWindow.cs
@@ -290,7 +290,7 @@ internal partial class MeasurementHistoryWindow : Form
                 ? UiPalette.TextBright
                 : UiPalette.TextPrimary;
             row.DefaultCellStyle.SelectionBackColor = isActive
-                ? UiPalette.AccentBlueStrong
+                ? UiPalette.AccentFill
                 : UiPalette.ButtonPressedBackground;
             row.DefaultCellStyle.SelectionForeColor = UiPalette.TextPrimary;
             row.DefaultCellStyle.Font = isActive ? activeEntryFont : Font;

--- a/source/Ui/UiPalette.cs
+++ b/source/Ui/UiPalette.cs
@@ -2,6 +2,15 @@ using System.Drawing;
 
 namespace Resonalyze.Ui;
 
+/// <summary>
+/// Every colour the app paints itself with. The values below are one theme — the
+/// dark one — and the names are the roles, so a second theme means new values
+/// here rather than new call sites: a fill stays a fill and disabled text stays
+/// disabled text whatever the background under them becomes.
+/// Foreground/background pairs that carry text are held above the WCAG contrast
+/// thresholds (4.5:1 for text, 3:1 for a UI element) by
+/// <c>UiPaletteContrastTests</c>, which fails if a value drifts back under them.
+/// </summary>
 internal static class UiPalette
 {
     public static Color AppBackground => Color.FromArgb(45, 50, 60);
@@ -18,9 +27,19 @@ internal static class UiPalette
     public static Color TitleBarText => Color.FromArgb(168, 176, 190);
     public static Color TitleBarTextSoft => Color.FromArgb(220, 224, 232);
     public static Color TitleBarTextBright => Color.FromArgb(230, 232, 238);
-    public static Color AccentBlue => Color.FromArgb(64, 116, 255);
-    public static Color AccentBlueHover => Color.FromArgb(78, 130, 255);
-    public static Color AccentBlueStrong => Color.FromArgb(36, 86, 210);
+    // Accent as a FILL and accent as a MARK pull in opposite directions, so they
+    // are different colours: a fill carries near-white text ON it and has to be
+    // dark enough for that, while a link, a focus border or a selection marker
+    // sits ON a dark surface and has to be light enough to show against it. The
+    // fill is here; the mark is AccentBlueSoft just below.
+    // The fill used to be the vivid (64,116,255), which left the active mode tab's
+    // own label at 3.1:1 — this deeper blue reads it at 4.8:1, and it is the same
+    // blue the dropdowns and the history list already filled a selection with.
+    // A filled accent gets no hover lift: a blue light enough to read as one puts
+    // the label back under 4.5:1, and the active tab is where the pointer already
+    // is.
+    public static Color AccentFill => Color.FromArgb(36, 86, 210);
+    public static Color AccentFillPressed => Color.FromArgb(24, 60, 150);
     public static Color AccentBlueSoft => Color.FromArgb(106, 173, 255);
     public static Color AccentBlueSoftHover => Color.FromArgb(150, 210, 255);
     // The bright end of the title bar update notice pulse: pale enough to read as a
@@ -35,7 +54,15 @@ internal static class UiPalette
     public static Color TextSecondarySoft => Color.FromArgb(190, 195, 205);
     public static Color TextSecondaryAlt => Color.FromArgb(205, 210, 220);
     public static Color TextHighlight => Color.FromArgb(210, 214, 222);
-    public static Color TextMuted => Color.FromArgb(120, 125, 135);
+    // The colour of a control that cannot be edited right now — which in this app
+    // is not the same as a control with nothing to say: a greyed-out rate, gate or
+    // gain still shows the value in force, and that value has to stay READABLE.
+    // At the old (120,125,135) it measured 2.7:1 on the control surface and users
+    // reported working by guessing where a number should be (#116). The state is
+    // carried by the surface and border underneath as well (DarkComboBox and
+    // DarkNumericUpDown swap their background), so the text does not have to
+    // disappear to say "disabled".
+    public static Color TextDisabled => Color.FromArgb(165, 170, 180);
     public static Color TextBright => Color.FromArgb(235, 237, 240);
     public static Color ControlSurface => Color.FromArgb(55, 60, 72);
     public static Color InputSurface => Color.FromArgb(55, 58, 65);
@@ -43,7 +70,10 @@ internal static class UiPalette
     public static Color PlotTrack => Color.FromArgb(24, 28, 36);
     public static Color PlotBorder => Color.FromArgb(78, 84, 98);
     public static Color MeterText => Color.FromArgb(225, 230, 240);
-    public static Color MeterMutedText => Color.FromArgb(128, 135, 150);
+    // Names the input meter greys out when a channel is not available — the same
+    // "disabled but still informative" text as TextDisabled, and it was under the
+    // threshold for the same reason (4.0:1 on the meter surface, now 5.0:1).
+    public static Color MeterMutedText => Color.FromArgb(146, 153, 168);
     public static Color MeterPeakHold => Color.FromArgb(248, 248, 252);
     public static Color MeterLowAccent => Color.FromArgb(88, 182, 255);
     public static Color MeterDimFill => Color.FromArgb(80, 86, 100);
@@ -57,11 +87,42 @@ internal static class UiPalette
     public static Color WarningAmber => Color.FromArgb(255, 190, 80);
     public static Color WarningOrange => Color.FromArgb(255, 196, 76);
     public static Color WarningRed => Color.FromArgb(255, 96, 96);
-    public static Color ErrorSoft => Color.FromArgb(255, 110, 110);
+    // Error TEXT — the Time Alignment status lines, the fader's bottom label — so
+    // it is held above 4.5:1 on the surfaces it is written on; at (255,110,110) it
+    // measured 4.1:1 on the control surface. WarningRed stays where it is: it fills
+    // meter bars and fader grooves, and a fill answers to no text threshold.
+    public static Color ErrorSoft => Color.FromArgb(255, 130, 130);
     public static Color ErrorSoftTint => Color.FromArgb(255, 210, 210);
     // Light accents echoing the Time Alignment envelope markers: first arrival red,
     // strongest peak blue.
     public static Color TimeAlignmentFirstArrival => Color.FromArgb(236, 148, 148);
     public static Color TimeAlignmentStrongestPeak => Color.FromArgb(150, 180, 250);
-    public static Color TextMutedSoft => Color.FromArgb(165, 170, 180);
+
+    // Chrome of the OxyPlot graphs — the surface a plot is drawn on and the axis
+    // furniture on top of it. OxyPlot's own defaults are a light theme (black tick
+    // lines, a black-alpha grid, a black plot-area border, and axis labels that
+    // follow PlotModel.TextColor, itself black), so a model that says nothing
+    // renders its numbers at 1.9:1 on this surface. PlotModelStyle.ApplyChrome is
+    // what says otherwise; these are the values it says.
+    // Note the Plot* colours above are NOT these: they are the input meter and
+    // fader surfaces, which only look like plots.
+    public static Color GraphSurface => Color.FromArgb(50, 55, 100);
+    public static Color GraphAxisText => Color.FromArgb(228, 232, 240);
+    public static Color GraphTickline => Color.FromArgb(165, 172, 192);
+    // The lines drawn ON the surface are WHITE WITH ALPHA, not fixed colours, for
+    // the same reason OxyPlot's own defaults are black with alpha: GraphSurface is
+    // not the only plot background in the app. Virtual DSP's two views sit on
+    // (40,44,80) and the option previews on (32,36,46), both from their own
+    // designers, so one fixed grid colour reads at a different strength in every
+    // panel — measured 1.33:1 on the main plots against 1.59:1 on Virtual DSP,
+    // which is exactly how it looked: washed out in one place and loud in the
+    // other. As alpha the grid lands within 0.02 of itself on all four surfaces.
+    // The strength is chosen against the curves: the grid has to be followable to
+    // the axis and must not compete with a trace crossing it (2.0:1 and 1.5:1
+    // passes were both rejected on real measurements as foreground).
+    // Axis labels and tick lines are deliberately NOT alpha — they are ink, they
+    // belong with the text, and a darker panel making them clearer is only good.
+    public static Color GraphAreaBorder => Color.FromArgb(60, 255, 255, 255);
+    public static Color GraphGridlineMajor => Color.FromArgb(32, 255, 255, 255);
+    public static Color GraphGridlineMinor => Color.FromArgb(15, 255, 255, 255);
 }

--- a/source/Ui/UiStyle.cs
+++ b/source/Ui/UiStyle.cs
@@ -30,7 +30,7 @@ internal static class UiStyle
                 enabledForeColors.Add(control, control.ForeColor);
             }
 
-            control.ForeColor = UiPalette.TextMuted;
+            control.ForeColor = UiPalette.TextDisabled;
         }
 
         if (!interactive)
@@ -117,7 +117,7 @@ internal static class UiStyle
         var button = new Button
         {
             BackColor = accent
-                ? UiPalette.AccentBlue
+                ? UiPalette.AccentFill
                 : UiPalette.DialogSurfaceMuted,
             DialogResult = result,
             FlatStyle = FlatStyle.Flat,

--- a/tests/Resonalyze.App.Tests/CodeBuiltDialogScalingTests.cs
+++ b/tests/Resonalyze.App.Tests/CodeBuiltDialogScalingTests.cs
@@ -34,11 +34,12 @@ public sealed class CodeBuiltDialogScalingTests
     // scaling pass breaks it by the DPI factor, which is the point.
     [Theory]
     [InlineData(452, 448)]
-    public void ColorPickerDialog_ScalesItsDesignedSizeExactlyOnce(int width, int height)
-    {
-        using var dialog = new ColorPickerDialog(Color.Red);
-        AssertScaledOnce(dialog, new Size(width, height));
-    }
+    public void ColorPickerDialog_ScalesItsDesignedSizeExactlyOnce(int width, int height) =>
+        StaTest.Run(() =>
+        {
+            using var dialog = new ColorPickerDialog(Color.Red);
+            AssertScaledOnce(dialog, new Size(width, height));
+        });
 
     [Theory]
     [InlineData(true, 500, 235)]
@@ -46,13 +47,15 @@ public sealed class CodeBuiltDialogScalingTests
     public void ApplicationUpdateDialog_ScalesItsDesignedSizeExactlyOnce(
         bool supportsAutomaticUpdate,
         int width,
-        int height)
-    {
-        using var dialog = new ApplicationUpdateDialog(
-            "0.0.0", "0.1.0", supportsAutomaticUpdate);
-        AssertScaledOnce(dialog, new Size(width, height));
-    }
+        int height) =>
+        StaTest.Run(() =>
+        {
+            using var dialog = new ApplicationUpdateDialog(
+                "0.0.0", "0.1.0", supportsAutomaticUpdate);
+            AssertScaledOnce(dialog, new Size(width, height));
+        });
 
+    // Shown, so the dialog is built and realised on the caller's STA thread.
     // On a 100% display this says the dialog is its designed size; on a scaled
     // one it says the layout grew by the display's factor and no more. The
     // second pass this guards against squared it — 1.56x at 125%, which walks

--- a/tests/Resonalyze.App.Tests/EqWizardPanelLayoutTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardPanelLayoutTests.cs
@@ -1,0 +1,143 @@
+using System.Drawing;
+using System.Reflection;
+using System.Windows.Forms;
+using OxyPlot.WindowsForms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// What a bigger window buys the EQ wizard. The curve being equalized is what
+/// the tool is read on, so every pixel the window gains goes to the plot — out to
+/// the panel's right edge and down to the PEQ bank. The bank and the auto-tune
+/// box keep their size and ride down to the bottom-left corner: the bank is a
+/// fixed grid of strips on percent styles, so room given to it would only enlarge
+/// the strips.
+/// </summary>
+public sealed class EqWizardPanelLayoutTests
+{
+    [Fact]
+    public void TheDesignedSize_IsLeftExactlyAsTheDesignerDrewIt()
+    {
+        using var panel = new EqWizardPanel();
+        Rectangle plotDesign = Plot(panel).Bounds;
+        Rectangle bankDesign = Field<Control>(panel, "panelPEQ").Bounds;
+        Rectangle autoTuneDesign = Field<Control>(panel, "panelAutoTune").Bounds;
+
+        // Nothing below the designed size shrinks: the panel scrolls, the way it
+        // did before it could stretch at all.
+        panel.Size = new Size(panel.Width - 200, panel.Height - 200);
+
+        Assert.Equal(plotDesign, Plot(panel).Bounds);
+        Assert.Equal(bankDesign, Field<Control>(panel, "panelPEQ").Bounds);
+        Assert.Equal(autoTuneDesign, Field<Control>(panel, "panelAutoTune").Bounds);
+    }
+
+    [Fact]
+    public void ABiggerPanel_SpendsEveryAddedPixelOnThePlot()
+    {
+        using var panel = new EqWizardPanel();
+        PlotView plot = Plot(panel);
+        Size plotDesign = plot.Size;
+        Size design = panel.Size;
+
+        panel.Size = new Size(design.Width + 500, design.Height + 300);
+
+        Assert.Equal(plotDesign.Width + 500, plot.Width);
+        Assert.Equal(plotDesign.Height + 300, plot.Height);
+    }
+
+    [Fact]
+    public void ABiggerPanel_KeepsTheBankAndTheAutoTuneBoxAtTheBottomLeft()
+    {
+        using var panel = new EqWizardPanel();
+        PlotView plot = Plot(panel);
+        Control bank = Field<Control>(panel, "panelPEQ");
+        Control autoTune = Field<Control>(panel, "panelAutoTune");
+        Rectangle bankDesign = bank.Bounds;
+        Rectangle autoTuneDesign = autoTune.Bounds;
+        int bankGap = bank.Top - plot.Bottom;
+        int bottomGap = panel.ClientSize.Height - bank.Bottom;
+        Size design = panel.Size;
+
+        panel.Size = new Size(design.Width + 500, design.Height + 300);
+
+        // Same size, same left edge, moved down by exactly what the plot grew —
+        // which is what "anchored to the bottom-left corner" means here.
+        Assert.Equal(bankDesign.Size, bank.Size);
+        Assert.Equal(autoTuneDesign.Size, autoTune.Size);
+        Assert.Equal(bankDesign.Left, bank.Left);
+        Assert.Equal(autoTuneDesign.Left, autoTune.Left);
+        Assert.Equal(bankDesign.Top + 300, bank.Top);
+        Assert.Equal(autoTuneDesign.Top + 300, autoTune.Top);
+        // The gap under the plot is what stops the growing plot from running over
+        // the bank, and the gap under the bank is what keeps the pair on-screen.
+        Assert.Equal(bankGap, bank.Top - plot.Bottom);
+        Assert.Equal(bottomGap, panel.ClientSize.Height - bank.Bottom);
+        Assert.True(plot.Bottom < bank.Top);
+    }
+
+    [Fact]
+    public void ComingBackFromABiggerWindow_RestoresTheDesignedArrangement()
+    {
+        using var panel = new EqWizardPanel();
+        PlotView plot = Plot(panel);
+        Control bank = Field<Control>(panel, "panelPEQ");
+        Rectangle plotDesign = plot.Bounds;
+        Rectangle bankDesign = bank.Bounds;
+        Rectangle scrollableDesign = panel.DisplayRectangle;
+        Size design = panel.Size;
+
+        panel.Size = new Size(design.Width + 500, design.Height + 300);
+        panel.Size = design;
+
+        Assert.Equal(plotDesign, plot.Bounds);
+        Assert.Equal(bankDesign, bank.Bounds);
+        // The controls being right is only half of it: the scrollable area has to
+        // shrink back with them, or the panel comes back scrolled with its bars
+        // stuck on.
+        Assert.Equal(scrollableDesign, panel.DisplayRectangle);
+        Assert.Equal(Point.Empty, panel.AutoScrollPosition);
+    }
+
+    [Fact]
+    public void AScaledPanel_StretchesFromItsScaledSize()
+    {
+        using var panel = new EqWizardPanel();
+        PlotView plot = Plot(panel);
+        Control bank = Field<Control>(panel, "panelPEQ");
+
+        // What a 150% display does: the container scales every control, so the
+        // arrangement the stretch measures against has to scale with them.
+        // Measured against the designer's 96-DPI numbers instead, the panel would
+        // read its own scaled size as "the user enlarged the window" and blow the
+        // plot up by the scale factor on top of it.
+        panel.Scale(new SizeF(1.5f, 1.5f));
+        Size scaledPlot = plot.Size;
+        int scaledBankTop = bank.Top;
+        Size scaled = panel.Size;
+
+        panel.PerformLayout();
+        Assert.Equal(scaledPlot, plot.Size);
+        Assert.Equal(scaledBankTop, bank.Top);
+
+        panel.Size = new Size(scaled.Width + 500, scaled.Height + 300);
+        Assert.Equal(scaledPlot.Width + 500, plot.Width);
+        Assert.Equal(scaledPlot.Height + 300, plot.Height);
+        Assert.Equal(scaledBankTop + 300, bank.Top);
+
+        // And back: the scaled arrangement is what it must return to, not the
+        // designer's 96-DPI one.
+        panel.Size = scaled;
+        Assert.Equal(scaledPlot, plot.Size);
+        Assert.Equal(scaledBankTop, bank.Top);
+    }
+
+    private static PlotView Plot(EqWizardPanel panel) => Field<PlotView>(panel, "plotWizard");
+
+    // The panel's controls are private designer fields; the layout they end up
+    // with is the whole subject here, so the test reads them by name.
+    private static T Field<T>(EqWizardPanel panel, string name) =>
+        (T)typeof(EqWizardPanel)
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(panel)!;
+}

--- a/tests/Resonalyze.App.Tests/EqWizardPanelLayoutTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardPanelLayoutTests.cs
@@ -132,6 +132,50 @@ public sealed class EqWizardPanelLayoutTests
         Assert.Equal(scaledBankTop, bank.Top);
     }
 
+
+    [Fact]
+    public void TheShellsCascadeAfterItsOwnAutoScale_DoesNotScaleTheArrangementTwice()
+    {
+        using var panel = new EqWizardPanel();
+
+        // A real auto-scale pass, at whatever DPI the machine runs: declaring a
+        // lower source DPI makes the container scale itself by 96/76.8 = 1.25, the
+        // arithmetic a 125% display puts it through. The arrangement inside moves
+        // with it, and so must the baseline the stretch measures against.
+        panel.AutoScaleDimensions = new SizeF(76.8F, 76.8F);
+        Size scaledArrangement = Plot(panel).Size;
+        Size scaledPanel = panel.Size;
+
+        // Then the shell's own scale reaches the panel, and that pass resizes the
+        // PANEL ONLY — measured at a real 125%, a form scaling its children leaves
+        // the arrangement inside an auto-scaling container where it was. So the
+        // baseline must sit this one out: counted twice it ran a whole factor ahead
+        // and the stretch sized the plot for a panel a quarter wider than the one
+        // it is in, which is the field report — both scrollbars at 125%, the plot
+        // cut off at the right.
+        ScaleBoundsOnly(panel, 1.25F);
+        panel.Size = scaledPanel;
+
+        Assert.Equal(scaledArrangement, Plot(panel).Size);
+        Assert.True(
+            panel.DisplayRectangle.Width <= panel.ClientSize.Width,
+            $"content {panel.DisplayRectangle.Width} wide in a {panel.ClientSize.Width} client");
+        Assert.True(
+            panel.DisplayRectangle.Height <= panel.ClientSize.Height,
+            $"content {panel.DisplayRectangle.Height} tall in a {panel.ClientSize.Height} client");
+    }
+
+    // The pass a parent makes over this panel: Control.ScaleControl, the protected
+    // entry point WinForms itself calls, and the one the panel overrides.
+    private static void ScaleBoundsOnly(Control panel, float factor) =>
+        typeof(Control)
+            .GetMethod(
+                "ScaleControl",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                [typeof(SizeF), typeof(BoundsSpecified)])!
+            .Invoke(panel, [new SizeF(factor, factor), BoundsSpecified.All]);
+
+
     private static PlotView Plot(EqWizardPanel panel) => Field<PlotView>(panel, "plotWizard");
 
     // The panel's controls are private designer fields; the layout they end up

--- a/tests/Resonalyze.App.Tests/OverlayOperationSettingsDialogTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlayOperationSettingsDialogTests.cs
@@ -25,7 +25,7 @@ public sealed class OverlayOperationSettingsDialogTests
         OverlayOperation operation,
         bool coherenceOperands,
         bool expectedAmplitudeSpace,
-        bool expectedTilt)
+        bool expectedTilt) => StaTest.Run(() =>
     {
         using OverlayOperationSettingsDialog dialog =
             CreateDialog(operation, coherenceOperands);
@@ -36,18 +36,19 @@ public sealed class OverlayOperationSettingsDialogTests
         // either, or a slot saved before the operands changed would keep applying it.
         Assert.Equal(expectedAmplitudeSpace, dialog.UseAmplitudeSpace);
         Assert.Equal(expectedTilt, dialog.TiltEnabled);
-    }
+    });
 
     [Fact]
-    public void TiltInputs_AreDisabledWithTheirCheckBox()
+    public void TiltInputs_AreDisabledWithTheirCheckBox() => StaTest.Run(() =>
     {
         using OverlayOperationSettingsDialog dialog =
             CreateDialog(OverlayOperation.AMinusB, coherenceOperands: true);
 
         Assert.False(Control<Control>(dialog, "tiltPivotInput").Enabled);
         Assert.False(Control<Control>(dialog, "tiltSlopeInput").Enabled);
-    }
+    });
 
+    // CreateControl realises the handle, so every caller runs on an STA thread.
     private static OverlayOperationSettingsDialog CreateDialog(
         OverlayOperation operation,
         bool coherenceOperands)

--- a/tests/Resonalyze.App.Tests/OverlayOperationSettingsDialogTests.cs
+++ b/tests/Resonalyze.App.Tests/OverlayOperationSettingsDialogTests.cs
@@ -88,7 +88,7 @@ public sealed class OverlayOperationSettingsDialogTests
     private static bool IsOffered(OverlayOperationSettingsDialog dialog, string name)
     {
         CheckBox checkBox = Control<CheckBox>(dialog, name);
-        return checkBox.AutoCheck && checkBox.ForeColor != UiPalette.TextMuted;
+        return checkBox.AutoCheck && checkBox.ForeColor != UiPalette.TextDisabled;
     }
 
     private static T Control<T>(OverlayOperationSettingsDialog dialog, string name) =>

--- a/tests/Resonalyze.App.Tests/PeqSlotStripTests.cs
+++ b/tests/Resonalyze.App.Tests/PeqSlotStripTests.cs
@@ -1,0 +1,59 @@
+using System.Drawing;
+using System.Windows.Forms;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// A PEQ strip is told apart from its neighbours by its tint, and the fader is
+/// most of the strip's area — so the fader has to paint the tint, not something
+/// of its own. It painted a black box instead: it cleared its background with its
+/// PARENT's colour, correct while the strip's layout was the direct parent, and
+/// the fader host put between them for the group-delay readout is
+/// Color.Transparent. Clearing with an alpha-0 colour writes black, so every
+/// strip — peaking and both shelves alike — carried the same black rectangle and
+/// the palette that distinguishes the shapes was invisible where it mattered.
+/// </summary>
+public sealed class PeqSlotStripTests
+{
+    [Theory]
+    [InlineData(PeqBandType.Peaking)]
+    [InlineData(PeqBandType.LowShelf)]
+    [InlineData(PeqBandType.HighShelf)]
+    [InlineData(PeqBandType.AllPassFirstOrder)]
+    [InlineData(PeqBandType.AllPassSecondOrder)]
+    public void TheFaderArea_CarriesTheBandTint(PeqBandType type) => StaTest.Run(() =>
+    {
+        // Off-screen: the strip has to be SHOWN to paint, and a test has no
+        // business flashing a window over whatever the user is doing.
+        using var form = new Form
+        {
+            FormBorderStyle = FormBorderStyle.None,
+            ShowInTaskbar = false,
+            StartPosition = FormStartPosition.Manual,
+            Location = new Point(-4000, -4000)
+        };
+        using var strip = new PeqSlotControl { BandType = type };
+        form.ClientSize = strip.Size;
+        form.Controls.Add(strip);
+        form.Show();
+        Application.DoEvents();
+
+        Control fader = strip.Controls.Find("fader", searchAllChildren: true)[0];
+        using var bitmap = new Bitmap(fader.Width, fader.Height);
+        fader.DrawToBitmap(bitmap, new Rectangle(Point.Empty, fader.Size));
+
+        // A column clear of everything the fader draws on top: the groove and its
+        // cap run down the middle, the scale ticks and their labels sit to the
+        // left of it.
+        Color expected = PeqBandPalette.Strip(type);
+        for (int y = fader.Height / 3; y < fader.Height * 2 / 3; y++)
+        {
+            Color painted = bitmap.GetPixel(fader.Width - 3, y);
+            Assert.True(
+                painted.ToArgb() == expected.ToArgb(),
+                $"{type} fader at y={y} painted {painted.R},{painted.G},{painted.B}, " +
+                $"expected the strip tint {expected.R},{expected.G},{expected.B}.");
+        }
+    });
+}

--- a/tests/Resonalyze.App.Tests/StaTest.cs
+++ b/tests/Resonalyze.App.Tests/StaTest.cs
@@ -1,0 +1,50 @@
+using System.Runtime.ExceptionServices;
+using System.Windows.Forms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// Runs a test body on a fresh STA thread, which is what a WinForms control is
+/// entitled to expect and what xUnit does not give it: its threads are MTA.
+/// </summary>
+/// <remarks>
+/// Constructing controls on an MTA thread mostly works, which is why the suite
+/// got away with it — the trouble starts when a WINDOW HANDLE is created. A
+/// control that has asked for <c>AllowDrop</c> registers itself with OLE at that
+/// moment, and <c>RegisterDragDrop</c> fails outside an STA: the EQ wizard's PEQ
+/// strips are drop targets, so showing one raised "DragDrop registration failed".
+/// WinForms turns that into its modal unhandled-exception dialog, which a person
+/// can dismiss and CI cannot — a headless run would sit on it until the job
+/// times out, reporting nothing.
+/// So: any test that realises a handle — Show, CreateControl, DrawToBitmap —
+/// belongs in here. Tests that only construct and measure controls do not need
+/// it. The mode is set to rethrow so a WinForms exception fails the test with its
+/// own stack instead of raising that dialog at all.
+/// </remarks>
+internal static class StaTest
+{
+    public static void Run(Action body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+
+        ExceptionDispatchInfo? failure = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
+                body();
+            }
+            catch (Exception exception)
+            {
+                failure = ExceptionDispatchInfo.Capture(exception);
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.IsBackground = true;
+        thread.Start();
+        thread.Join();
+        failure?.Throw();
+    }
+}

--- a/tests/Resonalyze.App.Tests/UiPaletteContrastTests.cs
+++ b/tests/Resonalyze.App.Tests/UiPaletteContrastTests.cs
@@ -1,0 +1,137 @@
+using System.Drawing;
+using System.Reflection;
+using Resonalyze.Ui;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The palette's readability, pinned as numbers. A user with poor eyesight
+/// measured the theme and reported the two colours that failed (#116): muted text
+/// at 2.7:1 on the control surface, where a greyed-out control still shows the
+/// value in force, and the accent — which turned out never to be text at all, but
+/// the fill under the active tab's own label, at 3.1:1.
+///
+/// Nothing here judges taste: it only holds the pairs that CARRY TEXT above the
+/// WCAG floor (4.5:1 for text, 3:1 for a UI element such as a glyph or a tick
+/// line), so a later change of value cannot walk them back under without saying
+/// so. Every pair listed is one the app actually paints — a foreground measured
+/// against a background it is never drawn on proves nothing, which is precisely
+/// how the accent came to look worse than it was. When a light palette arrives it
+/// inherits this test unchanged: the roles are the same, only the values move.
+///
+/// Decorative colours are deliberately absent — gridlines, meter bars, fader
+/// grooves and curve colours answer to no threshold.
+/// </summary>
+public sealed class UiPaletteContrastTests
+{
+    /// <summary>Text on a background, and the ratio it has to clear.</summary>
+    public static TheoryData<string, string, double> Pairs => new()
+    {
+        // Body text on every surface it is written on.
+        { nameof(UiPalette.TextPrimary), nameof(UiPalette.AppBackground), 4.5 },
+        { nameof(UiPalette.TextPrimary), nameof(UiPalette.DialogBackground), 4.5 },
+        { nameof(UiPalette.TextPrimary), nameof(UiPalette.DialogSurface), 4.5 },
+        { nameof(UiPalette.TextPrimary), nameof(UiPalette.ControlSurface), 4.5 },
+        { nameof(UiPalette.TextPrimary), nameof(UiPalette.InputSurface), 4.5 },
+        { nameof(UiPalette.TextSecondary), nameof(UiPalette.AppBackground), 4.5 },
+        { nameof(UiPalette.TextSecondary), nameof(UiPalette.DialogBackground), 4.5 },
+        { nameof(UiPalette.TextSecondary), nameof(UiPalette.DialogSurface), 4.5 },
+        { nameof(UiPalette.TextSecondary), nameof(UiPalette.ControlSurface), 4.5 },
+
+        // The value of a control that cannot be edited right now. This is the row
+        // the issue was about: it is text a user has to READ, not a state cue.
+        { nameof(UiPalette.TextDisabled), nameof(UiPalette.AppBackground), 4.5 },
+        { nameof(UiPalette.TextDisabled), nameof(UiPalette.DialogBackground), 4.5 },
+        { nameof(UiPalette.TextDisabled), nameof(UiPalette.DialogSurface), 4.5 },
+        { nameof(UiPalette.TextDisabled), nameof(UiPalette.ControlSurface), 4.5 },
+        { nameof(UiPalette.TextDisabled), nameof(UiPalette.InputSurface), 4.5 },
+        { nameof(UiPalette.TextDisabled), nameof(UiPalette.ButtonDisabledBackground), 4.5 },
+        { nameof(UiPalette.MeterMutedText), nameof(UiPalette.PlotSurfaceDark), 4.5 },
+        { nameof(UiPalette.MeterMutedText), nameof(UiPalette.PlotTrack), 4.5 },
+
+        // Buttons, and the accent FILL under its own label: the dialog's accent
+        // button carries TextPrimary, the active mode tab carries TitleBarTextSoft.
+        { nameof(UiPalette.TextPrimary), nameof(UiPalette.ButtonBackground), 4.5 },
+        { nameof(UiPalette.TextPrimary), nameof(UiPalette.ButtonHoverBackground), 4.5 },
+        { nameof(UiPalette.TextPrimary), nameof(UiPalette.ButtonPressedBackground), 4.5 },
+        { nameof(UiPalette.TextPrimary), nameof(UiPalette.AccentFill), 4.5 },
+        { nameof(UiPalette.TitleBarTextSoft), nameof(UiPalette.AccentFill), 4.5 },
+        { nameof(UiPalette.TitleBarTextSoft), nameof(UiPalette.AccentFillPressed), 4.5 },
+        { nameof(UiPalette.TitleBarTextBright), nameof(UiPalette.ButtonBackground), 4.5 },
+
+        // The title bar: its own text, and the update notice's link colour.
+        { nameof(UiPalette.TitleBarText), nameof(UiPalette.TitleBarBackground), 4.5 },
+        { nameof(UiPalette.TitleBarTextSoft), nameof(UiPalette.TitleBarBackground), 4.5 },
+        { nameof(UiPalette.AccentBlueSoft), nameof(UiPalette.TitleBarBackground), 4.5 },
+
+        // Status text that means something by its colour.
+        { nameof(UiPalette.ErrorSoft), nameof(UiPalette.ControlSurface), 4.5 },
+        { nameof(UiPalette.ErrorSoft), nameof(UiPalette.AppBackground), 4.5 },
+        { nameof(UiPalette.WarningAmber), nameof(UiPalette.AppBackground), 4.5 },
+        { nameof(UiPalette.SuccessGreen), nameof(UiPalette.AppBackground), 4.5 },
+
+        // Axis numbers on the graph surface. These used to be OxyPlot's own black
+        // on the same surface — 1.9:1, the worst pair in the app.
+        { nameof(UiPalette.GraphAxisText), nameof(UiPalette.GraphSurface), 4.5 },
+
+        // Glyphs and tick lines are UI elements, not text: 3:1.
+        { nameof(UiPalette.GraphTickline), nameof(UiPalette.GraphSurface), 3.0 },
+        { nameof(UiPalette.TextDisabled), nameof(UiPalette.DialogSurfaceMuted), 3.0 },
+    };
+
+    [Theory]
+    [MemberData(nameof(Pairs))]
+    public void PaintedTextPairs_ClearTheContrastFloor(
+        string foreground, string background, double floor)
+    {
+        double ratio = ContrastRatio(PaletteColor(foreground), PaletteColor(background));
+
+        Assert.True(
+            ratio >= floor,
+            $"{foreground} on {background} is {ratio:0.00}:1, under the {floor:0.0}:1 floor.");
+    }
+
+    /// <summary>
+    /// Raising the disabled colour is only half the fix: it also has to stay
+    /// visibly BELOW live text, or "disabled" would be carried by nothing the eye
+    /// can catch. The surface and border under such a control say it too, so this
+    /// is a floor on the gap rather than on the darkness.
+    /// </summary>
+    [Fact]
+    public void DisabledText_StaysDimmerThanLiveText()
+    {
+        double disabled = RelativeLuminance(UiPalette.TextDisabled);
+
+        Assert.True(disabled < RelativeLuminance(UiPalette.TextSecondary));
+        Assert.True(RelativeLuminance(UiPalette.TextPrimary) / disabled >= 1.5);
+    }
+
+    private static Color PaletteColor(string name)
+    {
+        PropertyInfo? property = typeof(UiPalette).GetProperty(
+            name, BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(property);
+        return (Color)property!.GetValue(null)!;
+    }
+
+    // WCAG 2.x: (L1 + 0.05) / (L2 + 0.05) over the sRGB relative luminances.
+    private static double ContrastRatio(Color first, Color second)
+    {
+        double a = RelativeLuminance(first);
+        double b = RelativeLuminance(second);
+        return (Math.Max(a, b) + 0.05) / (Math.Min(a, b) + 0.05);
+    }
+
+    private static double RelativeLuminance(Color color) =>
+        (0.2126 * Linearize(color.R)) +
+        (0.7152 * Linearize(color.G)) +
+        (0.0722 * Linearize(color.B));
+
+    private static double Linearize(byte channel)
+    {
+        double value = channel / 255.0;
+        return value <= 0.03928
+            ? value / 12.92
+            : Math.Pow((value + 0.055) / 1.055, 2.4);
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverChannelControlCollapseTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverChannelControlCollapseTests.cs
@@ -141,7 +141,11 @@ public sealed class VirtualCrossoverChannelControlCollapseTests
     }
 
     [Fact]
-    public void FoldingInsideTheChannelList_NeverStacksOneBlockOverAnother()
+    // Shown, so the list is built and realised on one STA thread.
+    public void FoldingInsideTheChannelList_NeverStacksOneBlockOverAnother() =>
+        StaTest.Run(FoldEveryBlockInTurn);
+
+    private static void FoldEveryBlockInTurn()
     {
         // The field bug: with the size pin moved through an unbounded intermediate
         // state, the flow list laid out the FOLLOWING block against a block it read as

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverPanelLayoutTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverPanelLayoutTests.cs
@@ -175,6 +175,50 @@ public sealed class VirtualCrossoverPanelLayoutTests
         Assert.Equal(scaledDspHeight, dsp.Height);
     }
 
+
+    [Fact]
+    public void TheShellsCascadeAfterItsOwnAutoScale_DoesNotScaleTheArrangementTwice()
+    {
+        using var panel = new VirtualCrossoverPanel();
+
+        // A real auto-scale pass, at whatever DPI the machine runs: declaring a
+        // lower source DPI makes the container scale itself by 96/76.8 = 1.25, the
+        // arithmetic a 125% display puts it through. The arrangement inside moves
+        // with it, and so must the baseline the stretch measures against.
+        panel.AutoScaleDimensions = new SizeF(76.8F, 76.8F);
+        Size scaledArrangement = Plots(panel).Main.Size;
+        Size scaledPanel = panel.Size;
+
+        // Then the shell's own scale reaches the panel, and that pass resizes the
+        // PANEL ONLY — measured at a real 125%, a form scaling its children leaves
+        // the arrangement inside an auto-scaling container where it was. So the
+        // baseline must sit this one out: counted twice it ran a whole factor ahead
+        // and the stretch sized the plot for a panel a quarter wider than the one
+        // it is in, which is the field report — both scrollbars at 125%, the plot
+        // cut off at the right.
+        ScaleBoundsOnly(panel, 1.25F);
+        panel.Size = scaledPanel;
+
+        Assert.Equal(scaledArrangement, Plots(panel).Main.Size);
+        Assert.True(
+            panel.DisplayRectangle.Width <= panel.ClientSize.Width,
+            $"content {panel.DisplayRectangle.Width} wide in a {panel.ClientSize.Width} client");
+        Assert.True(
+            panel.DisplayRectangle.Height <= panel.ClientSize.Height,
+            $"content {panel.DisplayRectangle.Height} tall in a {panel.ClientSize.Height} client");
+    }
+
+    // The pass a parent makes over this panel: Control.ScaleControl, the protected
+    // entry point WinForms itself calls, and the one the panel overrides.
+    private static void ScaleBoundsOnly(Control panel, float factor) =>
+        typeof(Control)
+            .GetMethod(
+                "ScaleControl",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                [typeof(SizeF), typeof(BoundsSpecified)])!
+            .Invoke(panel, [new SizeF(factor, factor), BoundsSpecified.All]);
+
+
     private static (PlotView Main, PlotView Dsp) Plots(VirtualCrossoverPanel panel) =>
         (Field<PlotView>(panel, "mainPlotView"), Field<PlotView>(panel, "dspPlotView"));
 


### PR DESCRIPTION
Closes #116. Closes #121. Addresses the first half of #120 (see the end).

A user with poor eyesight measured the palette and reported what failed. This
fixes it, and fixes the pair that turned out to be worse than anything in the
report. No light theme — that stays a separate decision; what this does leave
behind is the seams one would need.

## The palette

| | before | after | measured on |
|---|---|---|---|
| `TextMuted` → **`TextDisabled`** | 2.67:1 | **4.74:1** | `ControlSurface` |
| accent fill under the active tab's label | 3.08:1 | **4.76:1** | `TitleBarTextSoft` on the fill |
| accent fill under a dialog button's label | 4.07:1 | **6.29:1** | white on the fill |
| `MeterMutedText` | 3.98:1 | **5.02:1** | the meter surface |
| `ErrorSoft` (status text) | 4.05:1 | **4.61:1** | `ControlSurface` |

**The accent's reported number was of a pairing that does not exist.**
`AccentBlue` is never text — two code sites and three designer literals, all
fills. Its real pairings were the active mode tab's own label at 3.08:1 and
white on a dialog's accent button at 4.07:1, and the suggested swap to
`AccentBlueSoft` would have taken that white down to 2.32:1. So the roles are
split — `AccentFill` / `AccentFillPressed` for a fill, `AccentBlueSoft` stays
the mark (links, focus borders, selection markers) — and the fill is the deeper
blue the dropdowns and the history list already filled a selection with.

`TextMuted` was NOT split into muted/disabled: all 18 of its call sites mean
"unavailable", so a second token would have been born with zero references.
`TextMutedSoft`, which had exactly one use, is gone in favour of `TextSecondary`.

## The plots

The worst pair in the app was not in the palette at all. OxyPlot's defaults are
a light theme — black tick lines, a black-alpha grid, and axis text following
`PlotModel.TextColor`, itself black — and nothing here ever said otherwise, so
every plot drew its numbers **black on the dark surface at 1.87:1**. Confirmed
by sampling the shipped screenshots (`fr.jpg`, `gd.jpg`, `waterfall.jpg`): the
darkest pixels of the axis labels are (0,0,0).

`PlotModelStyle.ApplyChrome` is now the single place a plot's colours are
decided, and the seam a light theme would swap. It replaces only OxyPlot's OWN
defaults, so an axis coloured by its caller — the EQ wizard's gain axis,
Virtual DSP's sum-loss axis — keeps what it was given. Axis labels now read at
9.16:1.

The grid and the plot border are **white with alpha**, not fixed colours, for
the same reason OxyPlot's defaults are black with alpha: the app paints plots on
four different surfaces (`GraphSurface` 50,55,100; Virtual DSP 40,44,80; the
option previews 32,36,46; the target preview 55,58,65 — the last three still
designer literals). A fixed grid colour read at 1.33:1 on the main plots against
1.59:1 on Virtual DSP, which is exactly how it looked. As alpha it lands within
0.02 of itself on all four. Strength was chosen against real measurements:
2.0:1 and 1.5:1 passes both read as foreground and competed with the traces.

Axis labels and tick lines are deliberately NOT alpha — they are ink, and a
darker panel making them clearer is only good.

## Two defects found by rendering, not by reading

- **A disabled `DarkNumericUpDown` showed its value in Windows' grey**
  (109,109,109, ~2.5:1) — a native EDIT under a disabled parent is coloured by
  the system whatever `ForeColor` says, and the comment in the code claimed the
  opposite. It now hides the editor and paints the value itself. This is the
  reporter's actual complaint: sample rate, capture time, bits and scene offset
  are all shown this way.
- Same for a plain disabled `TextBox` in the target dialog, now read-only and
  muted by hand.

## Test

`UiPaletteContrastTests` pins 35 pairs the app actually paints against the WCAG
floors (4.5:1 text, 3:1 UI element), plus a check that disabled text stays
visibly dimmer than live text. Pairs the app never paints are absent on purpose
— measuring one is how the accent came to look worse than it was. Decorative
colours (gridlines, meter bars, curve colours) are absent too: they answer to no
threshold, and a test would only fight the eye.

## Not in this change

- **A light theme.** `TODO.md` carries the estimate and the order of work: the
  designer sweep is smaller than it looks (626 assignments, but 37 distinct
  values, four of which cover 313), and the real work is the CURVE palette, not
  the chrome.
- **The white check-box glyphs on a disabled panel.** While a session loads,
  Virtual DSP disables itself and WinForms paints the standard glyphs: the label
  text drops to 140,149,168 while the box stays white, so everything fades
  except a dozen white squares. Pre-existing, not a loading bug, and
  `FlatStyle.Flat` fixes it — but it would change 74 controls app-wide.
  Filed in `TODO.md` with the measurements; deliberately left for its own
  change.

## Also here: the EQ wizard's plot stretches now

The Virtual DSP panel has spent a bigger window on its plots since it learned to;
the wizard's plot stayed at its designer size with the room left empty around it.
`EqWizardPanel.Layout.cs` mirrors `VirtualCrossoverPanel.Layout.cs` — the baseline
is captured while the controls still stand where the designer put them, and every
pass is a DELTA on it, so no coordinate here is stuck at 96 DPI.

The plot takes all of the extra room: the width out to the panel's right edge, the
height down to the PEQ bank. The bank and the auto-tune box keep their size and
ride down to the bottom-left corner at the designer's gap — the bank is a fixed
16x2 grid on percent styles, so room given to it would only enlarge the strips.

Measured on the real panel, hosted and resized in a harness:

| | client | plot | bank top | auto-tune top | gap under the plot | right margin |
|---|---|---|---|---|---|---|
| designer | 1244x768 | 1034x348 | 371 | 575 | 9 | 13 |
| +340 x +220 | 1584x988 | **1374x568** | 591 | 795 | 9 | 13 |
| 900x600 | 881x581 | 1034x348 (held) | 371 | 575 | 9 | — (scrolls) |

Below the designer size nothing shrinks and both scrollbars come up, as before.

---

## And two things the wizard work turned up

**The PEQ fader painted a black box over every strip's tint.** `GainFader`
cleared its background with its PARENT's colour — right while the strip's layout
was the direct parent. #118 put a fader host between them for the group-delay
readout, and that host is `Color.Transparent`: clearing with an alpha-0 colour
writes black. So the peaking, both shelves and the all-passes all carried the
same black rectangle, and the palette that tells the shapes apart was invisible
over most of the strip. It now clears with its own `BackColor`, which
`PeqSlotControl.ApplyStripColor` keeps at the band tint — and which the comment
there already claimed was what happened. Measured per shape at a pixel inside the
fader: peaking (44,50,60), low shelf (58,50,45), high shelf (40,56,62), all-pass
(53,47,64) — each its `PeqBandPalette.Strip` entry, all (0,0,0) before.

**The UI tests ran on MTA threads.** xUnit hands those out; WinForms is entitled
to STA. Constructing controls on MTA mostly works, so the suite got away with it
— until a handle is created: a control that asked for `AllowDrop` registers with
OLE then, and `RegisterDragDrop` fails outside an STA. Showing a PEQ strip raises
"DragDrop registration failed", which WinForms turns into its modal
unhandled-exception dialog. Dismissable by a person; on a headless runner it
would hold the job until it times out and report nothing. `StaTest.Run` gives a
body its own STA thread, rethrows what it caught with the original stack, and
sets the unhandled-exception mode to ThrowException so a WinForms failure is a
test failure rather than a dialog. The three suites that realise handles today go
through it; the ones that only construct and measure controls are untouched.

Two suites are added on that: `PeqSlotStripTests` pins the fader tint (all five
band types report (0,0,0) with the old clear restored), and
`EqWizardPanelLayoutTests` pins the stretch the way
`VirtualCrossoverPanelLayoutTests` pins Virtual DSP's — including that a scaled
panel stretches from its SCALED size. Neutralising the stretch fails three of its
five.

---

## On #120

Its first half is this branch's last commit: the layout baseline counted the DPI
scale twice. The mechanism the report describes is confirmed here — at a real
125%, `CaptureLayoutBaseline` already records SCALED units (client 1555x960,
main plot 1088x490, with the panel's declared auto-scale dimensions already equal
to the current ones), so every later `ScaleControl` pass must leave the baseline
alone. That is what the fix keys on: the panel's own auto-scale is the pass where
declared and current still differ, and it is the only one that moves the children.

Not the shape the report suggests (record the DPI the baseline was taken at and
rescale by `DeviceDpi / baselineDpi`) — that is a good design too, and its
objection to before/after comparisons is right, but this gate is not one: it asks
which pass is running, not what the pass did. The caveat about
`AScaledPanel_StretchesFromItsScaledSize` does not bite here either — that test
still passes, unmodified.

**The report's second half is NOT addressed**: bottom-anchored controls landing at
unscaled coordinates, with the channel column at `Height = 0`. It does not
reproduce on this machine. At a real 125%, with the fix in, every anchored control
sits exactly where its scaled designer coordinates put it — the channel column at
`{X=8,Y=8,Width=434,Height=853}` against a designer `{6,6,347,684}` — and neither
scrollbar comes up. The report's measurement was taken while the first bug was
live, so the panel was scrolled at the time and a scrolled panel reports its
children shifted; that would explain an unscaled-looking origin. It needs
re-measuring at 192 DPI with this branch before anyone can say whether a second
defect is there at all.

---

Build clean (0 warnings), 1404 App + 1244 Dsp + 142 Audio tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



