### PR TITLE
Stop the shell re-assigning the tool panels' padding at 96 DPI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -239,6 +239,18 @@ close.
   `TextSecondaryAlt`, `SuccessGreenSoft`): rename them to their roles as they
   are touched rather than in one sweep — `AccentBlueSoft` is the accent MARK
   (links, focus borders, selection markers), which is the one that matters.
+- [ ] **Do not let the shell re-assign a docked panel's `Padding`.** Both tool
+  panels declare `Padding = new Padding(6)` in their OWN designer, where it scales
+  with the rest of the arrangement; `Form1.Designer.cs` used to set the same
+  literal on them a second time, after the panel had already scaled its own to 12
+  at 192 DPI. The raw 6 won, and every anchored control — the channel column, the
+  buttons under it — landed 6 px off, since anchoring places them against the
+  padded rectangle (#120). Those two lines are gone, but the WinForms designer
+  will happily write them back if someone edits `Form1` in it: if a
+  `<panel>.Padding = new Padding(6)` line reappears in `Form1.Designer.cs`, that is
+  this defect returning. `ItsPadding_ScalesWithTheArrangement` in both layout
+  suites pins the panel's own half of it; nothing can pin the shell's.
+
 - [ ] **The app paints plots on FOUR different surfaces, three of them designer
   literals.** `UiPalette.GraphSurface` (50,55,100) covers the main plot and the
   EQ wizard; Virtual DSP's two views sit on (40,44,80)

--- a/source/Shell/Form1.Designer.cs
+++ b/source/Shell/Form1.Designer.cs
@@ -359,7 +359,6 @@ namespace Resonalyze
             eqWizardPanel.ForeColor = Color.White;
             eqWizardPanel.Location = new Point(12, 52);
             eqWizardPanel.Name = "eqWizardPanel";
-            eqWizardPanel.Padding = new Padding(6);
             eqWizardPanel.Size = new Size(1246, 768);
             eqWizardPanel.TabIndex = 28;
             eqWizardPanel.Visible = false;
@@ -388,7 +387,6 @@ namespace Resonalyze
             virtualCrossoverPanel.ForeColor = Color.White;
             virtualCrossoverPanel.Location = new Point(12, 52);
             virtualCrossoverPanel.Name = "virtualCrossoverPanel";
-            virtualCrossoverPanel.Padding = new Padding(6);
             virtualCrossoverPanel.Size = new Size(1246, 768);
             virtualCrossoverPanel.TabIndex = 31;
             virtualCrossoverPanel.Visible = false;

--- a/tests/Resonalyze.App.Tests/EqWizardPanelLayoutTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardPanelLayoutTests.cs
@@ -133,6 +133,34 @@ public sealed class EqWizardPanelLayoutTests
     }
 
 
+    /// <summary>
+    /// The panel's padding is part of the arrangement, and the anchored controls
+    /// are placed against it: the channel column and the buttons under it sit at
+    /// the padding's own corner. A padding left at the designer's 96-DPI number
+    /// while everything around it scaled put every one of them 6 px off at 192 DPI
+    /// (#120) — which is what the shell re-assigning `Padding = new Padding(6)`
+    /// after this panel had scaled its own did.
+    /// </summary>
+    [Fact]
+    public void ItsPadding_ScalesWithTheArrangement()
+    {
+        using var panel = new EqWizardPanel();
+        Padding designedPadding = panel.Padding;
+        Point designedCorner = Field<Control>(panel, "buttonSource").Location;
+
+        // Factor 2, the arithmetic of a 192 DPI display.
+        panel.AutoScaleDimensions = new SizeF(48F, 48F);
+
+        Assert.Equal(designedPadding.Left * 2, panel.Padding.Left);
+        Assert.Equal(designedPadding.Top * 2, panel.Padding.Top);
+        Assert.Equal(
+            new Point(designedPadding.Left * 2, designedPadding.Top * 2),
+            panel.DisplayRectangle.Location);
+        Assert.Equal(
+            new Point(designedCorner.X * 2, designedCorner.Y * 2),
+            Field<Control>(panel, "buttonSource").Location);
+    }
+
     [Fact]
     public void TheShellsCascadeAfterItsOwnAutoScale_DoesNotScaleTheArrangementTwice()
     {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverPanelLayoutTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverPanelLayoutTests.cs
@@ -176,6 +176,34 @@ public sealed class VirtualCrossoverPanelLayoutTests
     }
 
 
+    /// <summary>
+    /// The panel's padding is part of the arrangement, and the anchored controls
+    /// are placed against it: the channel column and the buttons under it sit at
+    /// the padding's own corner. A padding left at the designer's 96-DPI number
+    /// while everything around it scaled put every one of them 6 px off at 192 DPI
+    /// (#120) — which is what the shell re-assigning `Padding = new Padding(6)`
+    /// after this panel had scaled its own did.
+    /// </summary>
+    [Fact]
+    public void ItsPadding_ScalesWithTheArrangement()
+    {
+        using var panel = new VirtualCrossoverPanel();
+        Padding designedPadding = panel.Padding;
+        Point designedCorner = Field<Control>(panel, "channelListPanel").Location;
+
+        // Factor 2, the arithmetic of a 192 DPI display.
+        panel.AutoScaleDimensions = new SizeF(48F, 48F);
+
+        Assert.Equal(designedPadding.Left * 2, panel.Padding.Left);
+        Assert.Equal(designedPadding.Top * 2, panel.Padding.Top);
+        Assert.Equal(
+            new Point(designedPadding.Left * 2, designedPadding.Top * 2),
+            panel.DisplayRectangle.Location);
+        Assert.Equal(
+            new Point(designedCorner.X * 2, designedCorner.Y * 2),
+            Field<Control>(panel, "channelListPanel").Location);
+    }
+
     [Fact]
     public void TheShellsCascadeAfterItsOwnAutoScale_DoesNotScaleTheArrangementTwice()
     {


### PR DESCRIPTION
The remaining half of #120, re-measured by the reporter on `main` at 192 DPI: every
anchored control in the Virtual DSP panel sits a uniform 6 px off — the channel column
and the buttons under it, in both axes. An anchor rectangle deflated by the UNSCALED 6
rather than the scaled 12 reproduces all six of their coordinates to the pixel.

## The cause

The shell overwrites the panel's own padding with a 96-DPI literal.

Both tool panels declare `Padding = new Padding(6)` in their **own** designer, where it
scales with the rest of their arrangement (to 12 at 192 DPI). `Form1.Designer.cs` then
set the same literal on them a **second** time — after that scaling had already
happened — and anchoring places anchored controls against the padded rectangle, so all
of them moved with it. The two lines were redundant at every DPI; at 100% they are
simply invisible.

Reproduced at factor 2 — the arithmetic of a 192 DPI display, without needing one — by
scaling the panel and then re-assigning the padding the way the shell did:

| | padding | `DisplayRectangle` | channel column | Add | Export |
|---|---|---|---|---|---|
| without the re-assignment | 12 | `{12,12,…}` | `{12,12,…}` | `{12,1402}` | `{716,1466}` |
| with it | 6 | `{6,6,…}` | `{6,6,…}` | `{6,1408}` | **`{710,1472}`** |

The second row is the report's own measurement, down to the odd 710 where 716 was
expected.

## What is pinned, and what cannot be

`ItsPadding_ScalesWithTheArrangement` in both layout suites pins the panel's half: after
a factor-2 auto-scale the padding, the display rectangle's origin and the anchored
corner control have all doubled.

The shell's half cannot be pinned by a test — the WinForms designer will write those
lines back if someone edits `Form1` in it, and no test reads designer source. `TODO.md`
therefore records what a returning `<panel>.Padding = new Padding(6)` line would mean.

## Not fixed here

Nothing else from #120 is outstanding. Its first half (the layout baseline counted the
DPI scale twice) went in with #119 and the reporter has confirmed it at 192 DPI; the
`Height = 0` on the channel column was withdrawn by the reporter as an artefact of a
local build of theirs with the clamp removed.

I cannot verify this one at 192 DPI — the display here is 125%, where the factor-2
reproduction above stands in for it — so it wants one more re-measure before #120 is
closed.

Build clean (0 warnings), 1408 App + 1244 Dsp + 142 Audio tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
