### PR TITLE
Keep the panels' padding out of the shell's scaling pass too

### DIFF
--- a/source/Tools/Eq/EqWizardPanel.Layout.cs
+++ b/source/Tools/Eq/EqWizardPanel.Layout.cs
@@ -51,8 +51,23 @@ public partial class EqWizardPanel
     protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
     {
         bool rearrangesChildren = AutoScaleDimensions != CurrentAutoScaleDimensions;
+        Padding padding = Padding;
+
         base.ScaleControl(factor, specified);
-        if (baselineClientSize.IsEmpty || !rearrangesChildren)
+
+        if (!rearrangesChildren)
+        {
+        // base.ScaleControl scales Padding along with the bounds, and the padding
+        // is part of the ARRANGEMENT: anchored controls are placed against the
+        // padded rectangle. So the pass that leaves the arrangement alone has to
+        // leave the padding alone too — scaled on both it doubles, 6 -> 12 -> 24
+        // at 192 DPI, and every anchored control ends up 12 px inside a rectangle
+        // that starts 12 px further in (#120).
+            Padding = padding;
+            return;
+        }
+
+        if (baselineClientSize.IsEmpty)
         {
             return;
         }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Layout.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Layout.cs
@@ -75,8 +75,23 @@ public partial class VirtualCrossoverPanel
     protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
     {
         bool rearrangesChildren = AutoScaleDimensions != CurrentAutoScaleDimensions;
+        Padding padding = Padding;
+
         base.ScaleControl(factor, specified);
-        if (baselineClientSize.IsEmpty || !rearrangesChildren)
+
+        if (!rearrangesChildren)
+        {
+        // base.ScaleControl scales Padding along with the bounds, and the padding
+        // is part of the ARRANGEMENT: anchored controls are placed against the
+        // padded rectangle. So the pass that leaves the arrangement alone has to
+        // leave the padding alone too — scaled on both it doubles, 6 -> 12 -> 24
+        // at 192 DPI, and every anchored control ends up 12 px inside a rectangle
+        // that starts 12 px further in (#120).
+            Padding = padding;
+            return;
+        }
+
+        if (baselineClientSize.IsEmpty)
         {
             return;
         }

--- a/tests/Resonalyze.App.Tests/EqWizardPanelLayoutTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardPanelLayoutTests.cs
@@ -153,6 +153,14 @@ public sealed class EqWizardPanelLayoutTests
 
         Assert.Equal(designedPadding.Left * 2, panel.Padding.Left);
         Assert.Equal(designedPadding.Top * 2, panel.Padding.Top);
+
+        // And the shell's cascade, which leaves the arrangement alone, must leave
+        // the padding alone with it: base.ScaleControl scales Padding on every
+        // pass, so counted twice it reads 24 where 12 was drawn.
+        ScaleBoundsOnly(panel, 2F);
+
+        Assert.Equal(designedPadding.Left * 2, panel.Padding.Left);
+        Assert.Equal(designedPadding.Top * 2, panel.Padding.Top);
         Assert.Equal(
             new Point(designedPadding.Left * 2, designedPadding.Top * 2),
             panel.DisplayRectangle.Location);

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverPanelLayoutTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverPanelLayoutTests.cs
@@ -196,6 +196,14 @@ public sealed class VirtualCrossoverPanelLayoutTests
 
         Assert.Equal(designedPadding.Left * 2, panel.Padding.Left);
         Assert.Equal(designedPadding.Top * 2, panel.Padding.Top);
+
+        // And the shell's cascade, which leaves the arrangement alone, must leave
+        // the padding alone with it: base.ScaleControl scales Padding on every
+        // pass, so counted twice it reads 24 where 12 was drawn.
+        ScaleBoundsOnly(panel, 2F);
+
+        Assert.Equal(designedPadding.Left * 2, panel.Padding.Left);
+        Assert.Equal(designedPadding.Top * 2, panel.Padding.Top);
         Assert.Equal(
             new Point(designedPadding.Left * 2, designedPadding.Top * 2),
             panel.DisplayRectangle.Location);


### PR DESCRIPTION
The tail of #120. #122 removed the shell's re-assignment of the tool panels' padding,
and the re-measure at 192 DPI came back with the anchored controls exactly where they
belong — `channelListPanel {12,12,694,1778}`, `buttonAddChannel {12,1810,316,48}`,
`buttonExport {716,1874,250,48}` — and `DisplayRectangle {24,24,…}`, a padding of 24
where the designer's 6 at that DPI should give 12.

The line #122 removed had been holding the padding right **by accident**. Taking it out
uncovered a second scaling underneath it.

## The cause

`Control.ScaleControl` scales `Padding` along with the bounds, on every pass. A docked
panel gets two of them — its own auto-scale, which rearranges everything inside it, and
the shell's cascade, which resizes the panel alone — so the padding doubles:

```
6 -> 12 -> 24
```

reproduced on both panels at factor 2, the arithmetic of 192 DPI without needing the
display. #119's gate keeps the layout baseline out of the second pass, but the padding
goes through `base.ScaleControl` before that gate is consulted.

## The fix

The padding belongs to the **arrangement**: anchored controls are placed against the
PADDED rectangle, which is exactly how this reached the channel column and the buttons
under it. So the pass that leaves the arrangement alone now puts the padding back where
it found it — the same rule the baseline already follows, applied to the one property
`base.ScaleControl` scales out from under it.

## Test

`ItsPadding_ScalesWithTheArrangement` in both layout suites now runs BOTH passes: the
panel's own auto-scale, then the shell's cascade (invoked the way WinForms invokes it,
through the protected `ScaleControl`). With the restore removed each reports 24 against
the 12 it expects.

## What this leaves

Nothing outstanding from #120 that has been measured. Its first half went in with #119,
the 6 px offset with #122, and this is the residue that removing the accidental
compensation exposed. As before I cannot verify at 192 DPI from here — 125% is what this
machine has — so the issue stays open for one more re-measure of
`panel.DisplayRectangle` before it closes.

Credit for the find goes to the reporter of #120: measuring `DisplayRectangle` after
#122, rather than only the three control bounds that had been asked for, is what showed
the second scaling at all.

Build clean (0 warnings), 1408 App + 1244 Dsp + 142 Audio tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
