### PR TITLE
Frequency fields step by a 96th of an octave, not a flat 10 Hz

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,9 +1287,11 @@ wherever it is taken. That is 1 Hz around 100 Hz, 7 Hz at 1 kHz and 145 Hz at
 20 kHz, in place of the flat 10 Hz these fields used to move by — which was
 nearly half an octave at 30 Hz and a rounding error at 15 kHz. Below about 69 Hz
 a 96th of an octave is under half a Hz, so the field steps by the 1 Hz it can
-show. Typing a frequency is unaffected, and a step up and straight back down
-always returns to the value it started from. The [Virtual DSP](#virtual-dsp)
-crossover corners and its **Auto crossover** frequency window take the same step.
+show. Typing a frequency is unaffected, and the steps walk a ladder anchored on
+wherever the value last came from — so a step and a step straight back always
+land on the value they left, whichever way round they are taken. The
+[Virtual DSP](#virtual-dsp) crossover corners and its **Auto crossover**
+frequency window take the same step.
 
 A band is one of five shapes, picked on the **"+" tile** — each zone adds its
 shape directly — or switched later by right-clicking the band's number: a

--- a/README.md
+++ b/README.md
@@ -1280,6 +1280,17 @@ overlay that band's contribution as a dashed curve. Each card carries its
 **frequency**, **Q**, and **gain**, and the panel adds a **Target Level**, a
 **Gain** (preamp), a **Bands** count, source **Smoothing**, and **Bypass**.
 
+Every **frequency** field here — a card's own, and the **From** / **To** of the
+fit range — steps logarithmically: one wheel notch, spin-button click or arrow
+key moves it a 96th of an octave, the same distance on the plot's frequency axis
+wherever it is taken. That is 1 Hz around 100 Hz, 7 Hz at 1 kHz and 145 Hz at
+20 kHz, in place of the flat 10 Hz these fields used to move by — which was
+nearly half an octave at 30 Hz and a rounding error at 15 kHz. Below about 69 Hz
+a 96th of an octave is under half a Hz, so the field steps by the 1 Hz it can
+show. Typing a frequency is unaffected, and a step up and straight back down
+always returns to the value it started from. The [Virtual DSP](#virtual-dsp)
+crossover corners and its **Auto crossover** frequency window take the same step.
+
 A band is one of five shapes, picked on the **"+" tile** — each zone adds its
 shape directly — or switched later by right-clicking the band's number: a
 **peaking bell (PK)**; a **high or low shelf (HS / LS)**, whose frequency is
@@ -1601,7 +1612,9 @@ Each channel runs through:
 - **Crossover** — Off, low-pass, high-pass, or band-pass; each edge picks
   **Butterworth** (6–48 dB/oct), **Linkwitz-Riley** (12/24/36/48 dB/oct),
   **Bessel** (6–48 dB/oct, near-constant group delay), or **Chebyshev**
-  (6–48 dB/oct, with a selectable passband **ripple**) with its own corner.
+  (6–48 dB/oct, with a selectable passband **ripple**) with its own corner, a
+  field that steps by a 96th of an octave per wheel notch the way the
+  [EQ Wizard's frequency fields](#eq-wizard) do.
   A Linkwitz-Riley pair sums flat only when its two halves are in phase:
   LR24 and LR48 are, LR12 and LR36 sit 180° apart, so one of the two
   channels needs **Invert** or the sum nulls at the corner

--- a/source/Tools/Eq/EqWizardPanel.Designer.cs
+++ b/source/Tools/Eq/EqWizardPanel.Designer.cs
@@ -246,6 +246,7 @@
             numericToHz.ForeColor = Color.White;
             numericToHz.Increment = new decimal(new int[] { 10, 0, 0, 0 });
             numericToHz.Location = new Point(93, 81);
+            numericToHz.LogarithmicFrequencyStep = true;
             numericToHz.Maximum = new decimal(new int[] { 20000, 0, 0, 0 });
             numericToHz.Minimum = new decimal(new int[] { 20, 0, 0, 0 });
             numericToHz.MinimumSize = new Size(36, 19);
@@ -265,6 +266,7 @@
             numericFromHz.ForeColor = Color.White;
             numericFromHz.Increment = new decimal(new int[] { 10, 0, 0, 0 });
             numericFromHz.Location = new Point(93, 56);
+            numericFromHz.LogarithmicFrequencyStep = true;
             numericFromHz.Maximum = new decimal(new int[] { 20000, 0, 0, 0 });
             numericFromHz.Minimum = new decimal(new int[] { 20, 0, 0, 0 });
             numericFromHz.MinimumSize = new Size(36, 19);

--- a/source/Tools/Eq/PeqSlotControl.Designer.cs
+++ b/source/Tools/Eq/PeqSlotControl.Designer.cs
@@ -173,6 +173,7 @@ namespace Resonalyze
             frequencyInput.Increment = new decimal(new int[] { 10, 0, 0, 0 });
             frequencyInput.InlineLabel = "F";
             frequencyInput.Location = new Point(1, 171);
+            frequencyInput.LogarithmicFrequencyStep = true;
             frequencyInput.Margin = new Padding(1);
             frequencyInput.Maximum = new decimal(new int[] { 20000, 0, 0, 0 });
             frequencyInput.Minimum = new decimal(new int[] { 10, 0, 0, 0 });

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoSetupDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoSetupDialog.Designer.cs
@@ -138,6 +138,7 @@ namespace Resonalyze
             minCrossover.Minimum = 20m;
             minCrossover.Maximum = 20000m;
             minCrossover.Increment = 10m;
+            minCrossover.LogarithmicFrequencyStep = true;
             minCrossover.DecimalPlaces = 0;
             minCrossover.MinimumSize = new Size(36, 19);
             minCrossover.Name = "minCrossover";
@@ -161,6 +162,7 @@ namespace Resonalyze
             maxCrossover.Minimum = 20m;
             maxCrossover.Maximum = 20000m;
             maxCrossover.Increment = 100m;
+            maxCrossover.LogarithmicFrequencyStep = true;
             maxCrossover.DecimalPlaces = 0;
             maxCrossover.MinimumSize = new Size(36, 19);
             maxCrossover.Name = "maxCrossover";

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
@@ -247,6 +247,7 @@ namespace Resonalyze
             numericHighPassHz.ForeColor = Color.White;
             numericHighPassHz.Increment = new decimal(new int[] { 10, 0, 0, 0 });
             numericHighPassHz.Location = new Point(70, 103);
+            numericHighPassHz.LogarithmicFrequencyStep = true;
             numericHighPassHz.Maximum = new decimal(new int[] { 24000, 0, 0, 0 });
             numericHighPassHz.Minimum = new decimal(new int[] { 10, 0, 0, 0 });
             numericHighPassHz.MinimumSize = new Size(36, 19);
@@ -295,6 +296,7 @@ namespace Resonalyze
             numericLowPassHz.ForeColor = Color.White;
             numericLowPassHz.Increment = new decimal(new int[] { 10, 0, 0, 0 });
             numericLowPassHz.Location = new Point(70, 129);
+            numericLowPassHz.LogarithmicFrequencyStep = true;
             numericLowPassHz.Maximum = new decimal(new int[] { 24000, 0, 0, 0 });
             numericLowPassHz.Minimum = new decimal(new int[] { 10, 0, 0, 0 });
             numericLowPassHz.MinimumSize = new Size(36, 19);

--- a/source/Ui/Controls/DarkNumericUpDown.cs
+++ b/source/Ui/Controls/DarkNumericUpDown.cs
@@ -14,6 +14,14 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
     private const int LogicalArrowHalfWidth = 4;
     private const int LogicalArrowHalfHeight = 2;
 
+    // One step of LogarithmicFrequencyStep is this fraction of an octave, which is
+    // what makes it the same distance everywhere on a logarithmic frequency axis.
+    private const int LogarithmicStepsPerOctave = 96;
+
+    // The ratio one such step multiplies (or divides) the value by.
+    private static readonly double LogarithmicStepRatio =
+        Math.Pow(2, 1.0 / LogarithmicStepsPerOctave);
+
     private readonly TextBox editor;
     private decimal minimum;
     private decimal maximum = 100;
@@ -145,6 +153,24 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
             increment = value <= 0 ? 1 : value;
         }
     }
+
+    /// <summary>
+    /// Makes one step — spin button, wheel or arrow key — a fixed fraction of an
+    /// octave (a 96th) rather than the fixed <see cref="Increment"/>, so one wheel
+    /// notch covers the same distance wherever it is taken on a logarithmic
+    /// frequency axis. It is meant for fields in Hz, where no absolute step fits
+    /// the whole band: the 10 Hz a crossover corner used to move by is nearly half
+    /// an octave at 30 Hz and a rounding error at 15 kHz. The step comes out at
+    /// 1 Hz at 100 Hz, 7 Hz at 1 kHz and 145 Hz at 20 kHz — rounded to what the
+    /// field can show and never below one unit of it, which is why a whole-Hz field
+    /// under about 69 Hz moves by 1 Hz and so covers more than a 96th of an octave
+    /// there. Off by default, which leaves the control stepping by
+    /// <see cref="Increment"/> as before.
+    /// </summary>
+    [Browsable(true)]
+    [DefaultValue(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    public bool LogarithmicFrequencyStep { get; set; }
 
     [Browsable(true)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
@@ -860,8 +886,45 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
         Value = defaultValue.Value;
     }
 
+    // One step up from a value: the fixed Increment, or a 96th of an octave scaled
+    // onto the value itself. The way down DIVIDES by the same ratio rather than
+    // subtracting what the way up added, and that is what makes a step up and a step
+    // straight back down land where they started: the rounding a field's resolution
+    // imposes stays inside half a unit, so dividing lands back on the value it came
+    // from instead of on a step re-measured from the new, wider place.
+    private decimal SteppedUp(decimal from)
+    {
+        if (!LogarithmicFrequencyStep)
+        {
+            return from + increment;
+        }
+
+        decimal stepped = RoundToDecimalPlaces((decimal)((double)from * LogarithmicStepRatio));
+        return stepped > from ? stepped : from + SmallestDisplayableStep;
+    }
+
+    private decimal SteppedDown(decimal from)
+    {
+        if (!LogarithmicFrequencyStep)
+        {
+            return from - increment;
+        }
+
+        decimal stepped = RoundToDecimalPlaces((decimal)((double)from / LogarithmicStepRatio));
+        return stepped < from ? stepped : from - SmallestDisplayableStep;
+    }
+
+    // Below about 69 Hz a 96th of an octave is under half a Hz, which a whole-Hz field
+    // rounds away entirely — and a spin button that moves nothing reads as a broken
+    // control, so the smallest change the field can show is the floor: 1, 0.1, 0.01 ...
+    // for its decimal places (the decimal constructor's scale argument is exactly that
+    // power of ten).
+    private decimal SmallestDisplayableStep => new decimal(1, 0, 0, false, (byte)decimalPlaces);
+
     // Commit first: stepping must apply to what the user typed, not overwrite
-    // uncommitted editor text with lastCommitted ± increment. A read-only field
+    // uncommitted editor text with lastCommitted ± the step — which, in logarithmic
+    // mode, is also measured off the committed value, so a typed 5 kHz steps by 5 kHz's
+    // own step and not by that of the value it replaced. A read-only field
     // ignores every step path alike (spin buttons, wheel, arrow keys, reset) — the
     // single choke point that makes ReadOnly a true lock, not just a typing block.
     private void StepUp()
@@ -872,7 +935,7 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
         }
 
         CommitEditorText();
-        Value += increment;
+        Value = SteppedUp(value);
     }
 
     private void StepDown()
@@ -883,7 +946,7 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
         }
 
         CommitEditorText();
-        Value -= increment;
+        Value = SteppedDown(value);
     }
 
     private void LayoutEditor()

--- a/source/Ui/Controls/DarkNumericUpDown.cs
+++ b/source/Ui/Controls/DarkNumericUpDown.cs
@@ -39,6 +39,7 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
     private string inlineLabel = string.Empty;
     private string valueSuffix = string.Empty;
     private decimal logarithmicAnchor;
+    private decimal logarithmicRung;
     private int logarithmicPosition;
 
     public DarkNumericUpDown()
@@ -893,16 +894,19 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
     // left. A measured step cannot promise that: the ratio rounds one way going out
     // and another coming back, which sent 347 Hz down to 345 and back up to 348.
     // The ladder is rebuilt wherever the value came from something other than a step —
-    // typed, loaded with a session, fitted by Auto Tune — and a value that is no
-    // longer the rung the last step left on is exactly what says so.
-    private decimal NextRung(int direction)
+    // typed, loaded with a session, fitted by Auto Tune — and a value that is not the
+    // one the last step left behind is exactly what says so. A step the range clamped
+    // counts as a step: the ladder keeps its anchor and the position it climbed to, so
+    // the way back off the limit returns to the value that ran into it.
+    private decimal NextRung(int direction, out int position)
     {
-        if (value != RungValue(logarithmicPosition))
+        if (value != logarithmicRung || logarithmicAnchor <= 0)
         {
             logarithmicAnchor = value;
             logarithmicPosition = 0;
         }
 
+        position = logarithmicPosition;
         if (value <= 0)
         {
             // A logarithmic ladder says nothing about zero or below.
@@ -912,7 +916,6 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
         // Rungs that round onto the value we are already on are stepped over: below
         // about 69 Hz a 96th of an octave is under half a Hz, and a spin button that
         // moves nothing reads as a broken control.
-        int position = logarithmicPosition;
         decimal rung;
         do
         {
@@ -921,7 +924,6 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
         }
         while (direction > 0 ? rung <= value : rung >= value);
 
-        logarithmicPosition = position;
         return rung;
     }
 
@@ -952,17 +954,19 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
             return;
         }
 
-        decimal rung = NextRung(direction);
-        Value = rung;
-        if (value != rung)
-        {
-            // The range clamped the step; rebuild the ladder on where it actually
-            // landed rather than leave it pointing at a rung outside the range.
-            logarithmicAnchor = value;
-            logarithmicPosition = 0;
-        }
-    }
+        decimal previous = value;
+        Value = NextRung(direction, out int position);
 
+        // The climb is recorded only when the value actually moved, so a wheel held
+        // against a limit does not wind the position up past the rung that first
+        // reached it — which is the one a step back has to come off.
+        if (value != previous)
+        {
+            logarithmicPosition = position;
+        }
+
+        logarithmicRung = value;
+    }
     private void StepUp() => Step(1);
 
     private void StepDown() => Step(-1);

--- a/source/Ui/Controls/DarkNumericUpDown.cs
+++ b/source/Ui/Controls/DarkNumericUpDown.cs
@@ -18,10 +18,6 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
     // what makes it the same distance everywhere on a logarithmic frequency axis.
     private const int LogarithmicStepsPerOctave = 96;
 
-    // The ratio one such step multiplies (or divides) the value by.
-    private static readonly double LogarithmicStepRatio =
-        Math.Pow(2, 1.0 / LogarithmicStepsPerOctave);
-
     private readonly TextBox editor;
     private decimal minimum;
     private decimal maximum = 100;
@@ -42,6 +38,8 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
     private bool initializing;
     private string inlineLabel = string.Empty;
     private string valueSuffix = string.Empty;
+    private decimal logarithmicAnchor;
+    private int logarithmicPosition;
 
     public DarkNumericUpDown()
     {
@@ -164,7 +162,9 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
     /// 1 Hz at 100 Hz, 7 Hz at 1 kHz and 145 Hz at 20 kHz — rounded to what the
     /// field can show and never below one unit of it, which is why a whole-Hz field
     /// under about 69 Hz moves by 1 Hz and so covers more than a 96th of an octave
-    /// there. Off by default, which leaves the control stepping by
+    /// there. The steps walk a ladder anchored on wherever the value last came from,
+    /// so a step and a step straight back always land on the value they left, whichever
+    /// way round they are taken. Off by default, which leaves the control stepping by
     /// <see cref="Increment"/> as before.
     /// </summary>
     [Browsable(true)]
@@ -886,48 +886,59 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
         Value = defaultValue.Value;
     }
 
-    // One step up from a value: the fixed Increment, or a 96th of an octave scaled
-    // onto the value itself. The way down DIVIDES by the same ratio rather than
-    // subtracting what the way up added, and that is what makes a step up and a step
-    // straight back down land where they started: the rounding a field's resolution
-    // imposes stays inside half a unit, so dividing lands back on the value it came
-    // from instead of on a step re-measured from the new, wider place.
-    private decimal SteppedUp(decimal from)
+    // The ladder a logarithmic step walks: rungs at anchor × 2 ^ (n / 96), rounded to
+    // what the field displays. Anchoring the ladder — rather than measuring a fresh
+    // step off the current value every time — is what makes the two directions exact
+    // opposites, so a step and a step straight back always land on the value they
+    // left. A measured step cannot promise that: the ratio rounds one way going out
+    // and another coming back, which sent 347 Hz down to 345 and back up to 348.
+    // The ladder is rebuilt wherever the value came from something other than a step —
+    // typed, loaded with a session, fitted by Auto Tune — and a value that is no
+    // longer the rung the last step left on is exactly what says so.
+    private decimal NextRung(int direction)
     {
-        if (!LogarithmicFrequencyStep)
+        if (value != RungValue(logarithmicPosition))
         {
-            return from + increment;
+            logarithmicAnchor = value;
+            logarithmicPosition = 0;
         }
 
-        decimal stepped = RoundToDecimalPlaces((decimal)((double)from * LogarithmicStepRatio));
-        return stepped > from ? stepped : from + SmallestDisplayableStep;
-    }
-
-    private decimal SteppedDown(decimal from)
-    {
-        if (!LogarithmicFrequencyStep)
+        if (value <= 0)
         {
-            return from - increment;
+            // A logarithmic ladder says nothing about zero or below.
+            return value + (direction * SmallestDisplayableStep);
         }
 
-        decimal stepped = RoundToDecimalPlaces((decimal)((double)from / LogarithmicStepRatio));
-        return stepped < from ? stepped : from - SmallestDisplayableStep;
+        // Rungs that round onto the value we are already on are stepped over: below
+        // about 69 Hz a 96th of an octave is under half a Hz, and a spin button that
+        // moves nothing reads as a broken control.
+        int position = logarithmicPosition;
+        decimal rung;
+        do
+        {
+            position += direction;
+            rung = RungValue(position);
+        }
+        while (direction > 0 ? rung <= value : rung >= value);
+
+        logarithmicPosition = position;
+        return rung;
     }
 
-    // Below about 69 Hz a 96th of an octave is under half a Hz, which a whole-Hz field
-    // rounds away entirely — and a spin button that moves nothing reads as a broken
-    // control, so the smallest change the field can show is the floor: 1, 0.1, 0.01 ...
-    // for its decimal places (the decimal constructor's scale argument is exactly that
-    // power of ten).
+    private decimal RungValue(int position) => RoundToDecimalPlaces((decimal)(
+        (double)logarithmicAnchor *
+        Math.Pow(2, position / (double)LogarithmicStepsPerOctave)));
+
+    // The smallest change the field can show: 1, 0.1, 0.01 ... for its decimal places
+    // (the decimal constructor's scale argument is exactly that power of ten).
     private decimal SmallestDisplayableStep => new decimal(1, 0, 0, false, (byte)decimalPlaces);
 
     // Commit first: stepping must apply to what the user typed, not overwrite
-    // uncommitted editor text with lastCommitted ± the step — which, in logarithmic
-    // mode, is also measured off the committed value, so a typed 5 kHz steps by 5 kHz's
-    // own step and not by that of the value it replaced. A read-only field
+    // uncommitted editor text with lastCommitted ± the step — and in logarithmic mode
+    // that committed value is also what the ladder is rebuilt on. A read-only field
     // ignores every step path alike (spin buttons, wheel, arrow keys, reset) — the
     // single choke point that makes ReadOnly a true lock, not just a typing block.
-    private void StepUp()
+    private void Step(int direction)
     {
         if (readOnly)
         {
@@ -935,19 +946,26 @@ public sealed class DarkNumericUpDown : UserControl, ISupportInitialize
         }
 
         CommitEditorText();
-        Value = SteppedUp(value);
-    }
-
-    private void StepDown()
-    {
-        if (readOnly)
+        if (!LogarithmicFrequencyStep)
         {
+            Value = value + (direction * increment);
             return;
         }
 
-        CommitEditorText();
-        Value = SteppedDown(value);
+        decimal rung = NextRung(direction);
+        Value = rung;
+        if (value != rung)
+        {
+            // The range clamped the step; rebuild the ladder on where it actually
+            // landed rather than leave it pointing at a rung outside the range.
+            logarithmicAnchor = value;
+            logarithmicPosition = 0;
+        }
     }
+
+    private void StepUp() => Step(1);
+
+    private void StepDown() => Step(-1);
 
     private void LayoutEditor()
     {

--- a/tests/Resonalyze.App.Tests/DarkNumericUpDownLogarithmicStepTests.cs
+++ b/tests/Resonalyze.App.Tests/DarkNumericUpDownLogarithmicStepTests.cs
@@ -141,6 +141,58 @@ public sealed class DarkNumericUpDownLogarithmicStepTests
     }
 
     [Fact]
+    public void AStepTheMaximumCutShort_StillStepsBackToWhereItCameFrom()
+    {
+        // The wizard's From / To fields stop at 20 kHz, where the rung above 19 997 Hz
+        // does not exist. The value has to come back off the limit all the same.
+        using DarkNumericUpDown control = NewWizardRangeControl();
+        control.Value = 19_997;
+
+        PressUp(control);
+        Assert.Equal(20_000m, control.Value);
+
+        PressDown(control);
+        Assert.Equal(19_997m, control.Value);
+    }
+
+    [Fact]
+    public void HeldAgainstTheMaximum_TheWayBackIsStillOneStep()
+    {
+        using DarkNumericUpDown control = NewWizardRangeControl();
+        control.Value = 19_997;
+
+        // Three notches into a limit that only had room for none of them.
+        PressUp(control);
+        PressUp(control);
+        PressUp(control);
+        Assert.Equal(20_000m, control.Value);
+
+        PressDown(control);
+
+        Assert.Equal(19_997m, control.Value);
+    }
+
+    [Fact]
+    public void AStepTheMinimumCutShort_StillStepsBackToWhereItCameFrom()
+    {
+        using var control = new DarkNumericUpDown
+        {
+            DecimalPlaces = 0,
+            Minimum = 1000,
+            Maximum = 20_000,
+            LogarithmicFrequencyStep = true,
+            Value = 1001
+        };
+
+        PressDown(control);
+        Assert.Equal(1000m, control.Value);
+
+        PressUp(control);
+
+        Assert.Equal(1001m, control.Value);
+    }
+
+    [Fact]
     public void TheModeReplacesTheFixedIncrement()
     {
         using DarkNumericUpDown control = NewFrequencyControl();
@@ -245,6 +297,17 @@ public sealed class DarkNumericUpDownLogarithmicStepTests
         // 0.1449 Hz rounds to 0.1 here, where a whole-Hz field has to spend a whole Hz.
         Assert.Equal(20.1m, control.Value);
     }
+
+    // The EQ Wizard's From / To fields, whose 20 kHz ceiling a step can run into.
+    private static DarkNumericUpDown NewWizardRangeControl() => new()
+    {
+        DecimalPlaces = 0,
+        Minimum = 20,
+        Maximum = 20_000,
+        Increment = 10,
+        LogarithmicFrequencyStep = true,
+        Value = 1000
+    };
 
     private static DarkNumericUpDown NewFrequencyControl() => new()
     {

--- a/tests/Resonalyze.App.Tests/DarkNumericUpDownLogarithmicStepTests.cs
+++ b/tests/Resonalyze.App.Tests/DarkNumericUpDownLogarithmicStepTests.cs
@@ -73,10 +73,71 @@ public sealed class DarkNumericUpDownLogarithmicStepTests
         PressUp(control);
         PressDown(control);
 
-        // Why the way down divides rather than subtracting what the way up added: at
-        // 10 kHz the step is 72 Hz and grows by half a Hz across one step of its own,
-        // so a re-measured step would round to 73 and give the value back one Hz short.
+        // Why the steps walk an anchored ladder rather than measuring a fresh step off
+        // the value each time: at 10 kHz the step is 72 Hz and grows by half a Hz across
+        // one step of its own, so a re-measured step rounds to 73 coming back and hands
+        // the value back one Hz short.
         Assert.Equal(from, control.Value);
+    }
+
+    [Theory]
+    // 347 Hz is the case that showed the way down and the way up disagreeing: down to
+    // 345, and back up to 348. It is reachable by stepping, not only by typing — a
+    // step down from 350 lands on it.
+    [InlineData(347)]
+    [InlineData(1320)]
+    [InlineData(4100)]
+    [InlineData(18_000)]
+    [InlineData(20)]
+    [InlineData(63)]
+    [InlineData(1000)]
+    public void AStepDownAndStraightBackUp_LandsWhereItStarted(int from)
+    {
+        using DarkNumericUpDown control = NewFrequencyControl();
+        control.Value = from;
+
+        PressDown(control);
+        PressUp(control);
+
+        Assert.Equal(from, control.Value);
+    }
+
+    [Fact]
+    public void EveryWholeHzInTheBand_ReturnsFromAStepAndAStepBack_BothWaysRound()
+    {
+        // The range is opened up so nothing clamps: clamping is its own behaviour and
+        // would mask what this sweep is for.
+        using var control = new DarkNumericUpDown
+        {
+            DecimalPlaces = 0,
+            Minimum = 1,
+            Maximum = 1_000_000,
+            LogarithmicFrequencyStep = true
+        };
+        var upThenDown = new List<int>();
+        var downThenUp = new List<int>();
+
+        for (int frequency = 10; frequency <= 24_000; frequency++)
+        {
+            control.Value = frequency;
+            PressUp(control);
+            PressDown(control);
+            if (control.Value != frequency)
+            {
+                upThenDown.Add(frequency);
+            }
+
+            control.Value = frequency;
+            PressDown(control);
+            PressUp(control);
+            if (control.Value != frequency)
+            {
+                downThenUp.Add(frequency);
+            }
+        }
+
+        Assert.Empty(upThenDown);
+        Assert.Empty(downThenUp);
     }
 
     [Fact]
@@ -124,7 +185,8 @@ public sealed class DarkNumericUpDownLogarithmicStepTests
     {
         using DarkNumericUpDown control = NewFrequencyControl();
         control.Value = 20;
-        decimal previousStep = 0;
+        decimal firstStep = 0;
+        decimal lastStep = 0;
         int steps = 0;
 
         while (control.Value < 20_000m)
@@ -133,20 +195,27 @@ public sealed class DarkNumericUpDownLogarithmicStepTests
             PressUp(control);
             decimal step = control.Value - before;
 
-            // Either the ratio landed the value (within the half unit rounding takes)
-            // or the 1 Hz floor did, which is at most another half unit away from it.
+            // A rung sits within half a unit of the exact 96th of an octave at each end
+            // of the step, so the pair can be a shade over one unit apart. That is also
+            // why the whole-Hz width alternates — 1, 1, 2, 1, 2 either side of 141 Hz,
+            // where a 96th of an octave is 1.02 Hz — which is the field's resolution
+            // showing, not the spacing changing.
             Assert.True(
-                Math.Abs((double)control.Value - ((double)before * StepRatio)) <= 1.0,
+                Math.Abs((double)control.Value - ((double)before * StepRatio)) <= 1.01,
                 $"{before} Hz stepped to {control.Value} Hz, off a 96th of an octave.");
-            // The step never narrows on the way up: that is the same distance in pixels.
-            Assert.True(
-                step >= previousStep,
-                $"The step shrank from {previousStep} to {step} at {before} Hz.");
-            previousStep = step;
+            lastStep = step;
+            if (steps == 0)
+            {
+                firstStep = step;
+            }
+
             steps++;
             Assert.True(steps < 5_000, "Stepping up never reached the top of the band.");
         }
 
+        // The 1 Hz the field can show at the bottom, a 96th of an octave at the top.
+        Assert.Equal(1m, firstStep);
+        Assert.InRange(lastStep, 143m, 147m);
         // Ten octaves at 96 steps each, less the low end where the 1 Hz floor is wider.
         Assert.InRange(steps, 700, 900);
     }

--- a/tests/Resonalyze.App.Tests/DarkNumericUpDownLogarithmicStepTests.cs
+++ b/tests/Resonalyze.App.Tests/DarkNumericUpDownLogarithmicStepTests.cs
@@ -1,0 +1,213 @@
+using System.Globalization;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// A frequency field used to move by a fixed 10 Hz, which is nearly half an octave at
+/// 30 Hz and a rounding error at 15 kHz. With
+/// <see cref="DarkNumericUpDown.LogarithmicFrequencyStep"/> one step is a 96th of an
+/// octave instead — the same distance wherever it is taken on a logarithmic frequency
+/// axis — floored at the one unit a whole-Hz field can actually show.
+/// </summary>
+public sealed class DarkNumericUpDownLogarithmicStepTests
+{
+    // 2 ^ (1/96), the ratio one step multiplies the value by.
+    private const double StepRatio = 1.0072464014332754;
+
+    [Theory]
+    // Under about 69 Hz a 96th of an octave is less than half a Hz, so a whole-Hz
+    // field steps by the 1 Hz it can show.
+    [InlineData(10, 11)]
+    [InlineData(20, 21)]
+    [InlineData(50, 51)]
+    // Above it the ratio itself decides: 0.72 Hz at 100 Hz, 7.2 at 1 kHz, 145 at 20 kHz.
+    [InlineData(100, 101)]
+    [InlineData(500, 504)]
+    [InlineData(1000, 1007)]
+    [InlineData(10_000, 10_072)]
+    [InlineData(20_000, 20_145)]
+    public void StepUp_MovesTheValueBy_A96thOfAnOctave(int from, int expected)
+    {
+        using DarkNumericUpDown control = NewFrequencyControl();
+        control.Value = from;
+
+        PressUp(control);
+
+        Assert.Equal(expected, control.Value);
+    }
+
+    [Theory]
+    [InlineData(21, 20)]
+    [InlineData(101, 100)]
+    [InlineData(504, 500)]
+    [InlineData(1007, 1000)]
+    [InlineData(10_072, 10_000)]
+    [InlineData(20_145, 20_000)]
+    public void StepDown_DividesByTheSameRatio(int from, int expected)
+    {
+        using DarkNumericUpDown control = NewFrequencyControl();
+        control.Value = from;
+
+        PressDown(control);
+
+        Assert.Equal(expected, control.Value);
+    }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(20)]
+    [InlineData(63)]
+    [InlineData(100)]
+    [InlineData(347)]
+    [InlineData(1000)]
+    [InlineData(3150)]
+    [InlineData(9973)]
+    [InlineData(19_997)]
+    public void AStepUpAndStraightBackDown_LandsWhereItStarted(int from)
+    {
+        using DarkNumericUpDown control = NewFrequencyControl();
+        control.Value = from;
+
+        PressUp(control);
+        PressDown(control);
+
+        // Why the way down divides rather than subtracting what the way up added: at
+        // 10 kHz the step is 72 Hz and grows by half a Hz across one step of its own,
+        // so a re-measured step would round to 73 and give the value back one Hz short.
+        Assert.Equal(from, control.Value);
+    }
+
+    [Fact]
+    public void TheModeReplacesTheFixedIncrement()
+    {
+        using DarkNumericUpDown control = NewFrequencyControl();
+        control.Increment = 10;
+        control.Value = 100;
+
+        PressUp(control);
+
+        // 10 Hz is what this field carried before the mode existed.
+        Assert.Equal(101m, control.Value);
+    }
+
+    [Fact]
+    public void WithoutTheMode_TheFixedIncrementStillRules()
+    {
+        using DarkNumericUpDown control = NewFrequencyControl();
+        control.LogarithmicFrequencyStep = false;
+        control.Increment = 10;
+        control.Value = 100;
+
+        PressUp(control);
+
+        Assert.Equal(110m, control.Value);
+    }
+
+    [Fact]
+    public void TheStepFollowsTypedTextRatherThanTheValueItReplaced()
+    {
+        using DarkNumericUpDown control = NewFrequencyControl();
+        control.Value = 100;
+        // Typed but not yet committed: stepping commits first, so the step must be
+        // measured off 5000 (36 Hz) and not off the 100 Hz still held in Value.
+        Editor(control).Text = 5000.ToString(CultureInfo.CurrentCulture);
+
+        PressUp(control);
+
+        Assert.Equal(5036m, control.Value);
+    }
+
+    [Fact]
+    public void WalkingTheWholeBand_KeepsEveryStepOneRoundingUnitFromA96thOfAnOctave()
+    {
+        using DarkNumericUpDown control = NewFrequencyControl();
+        control.Value = 20;
+        decimal previousStep = 0;
+        int steps = 0;
+
+        while (control.Value < 20_000m)
+        {
+            decimal before = control.Value;
+            PressUp(control);
+            decimal step = control.Value - before;
+
+            // Either the ratio landed the value (within the half unit rounding takes)
+            // or the 1 Hz floor did, which is at most another half unit away from it.
+            Assert.True(
+                Math.Abs((double)control.Value - ((double)before * StepRatio)) <= 1.0,
+                $"{before} Hz stepped to {control.Value} Hz, off a 96th of an octave.");
+            // The step never narrows on the way up: that is the same distance in pixels.
+            Assert.True(
+                step >= previousStep,
+                $"The step shrank from {previousStep} to {step} at {before} Hz.");
+            previousStep = step;
+            steps++;
+            Assert.True(steps < 5_000, "Stepping up never reached the top of the band.");
+        }
+
+        // Ten octaves at 96 steps each, less the low end where the 1 Hz floor is wider.
+        Assert.InRange(steps, 700, 900);
+    }
+
+    [Fact]
+    public void AFieldWithDecimals_StepsOnItsOwnResolution()
+    {
+        using DarkNumericUpDown control = NewFrequencyControl();
+        control.DecimalPlaces = 1;
+        control.Value = 1000;
+
+        PressUp(control);
+
+        // A tenth-Hz field shows the 7.2464 Hz the ratio asks for as 7.2.
+        Assert.Equal(1007.2m, control.Value);
+    }
+
+    [Fact]
+    public void AFieldWithDecimals_StillMovesWhereWholeHzWouldNot()
+    {
+        using DarkNumericUpDown control = NewFrequencyControl();
+        control.DecimalPlaces = 1;
+        control.Value = 20;
+
+        PressUp(control);
+
+        // 0.1449 Hz rounds to 0.1 here, where a whole-Hz field has to spend a whole Hz.
+        Assert.Equal(20.1m, control.Value);
+    }
+
+    private static DarkNumericUpDown NewFrequencyControl() => new()
+    {
+        DecimalPlaces = 0,
+        Minimum = 10,
+        Maximum = 24_000,
+        Increment = 10,
+        LogarithmicFrequencyStep = true,
+        Value = 1000
+    };
+
+    private static TextBox Editor(DarkNumericUpDown control) =>
+        control.Controls.OfType<TextBox>().Single();
+
+    private static void PressUp(DarkNumericUpDown control) => PressKey(control, Keys.Up);
+
+    private static void PressDown(DarkNumericUpDown control) => PressKey(control, Keys.Down);
+
+    // ProcessCmdKey is the arrow-key route into the same StepUp/StepDown the spin
+    // buttons and the wheel take.
+    private static void PressKey(DarkNumericUpDown control, Keys key)
+    {
+        MethodInfo method = typeof(DarkNumericUpDown).GetMethod(
+            "ProcessCmdKey",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("ProcessCmdKey is missing.");
+        var message = new Message
+        {
+            Msg = 0x0100, // WM_KEYDOWN
+            WParam = (IntPtr)key
+        };
+        object[] arguments = [message, key];
+        Assert.True((bool)method.Invoke(control, arguments)!);
+    }
+}


### PR DESCRIPTION
A crossover corner moved by 10 Hz whatever it read, which is nearly half an
octave at 30 Hz and a rounding error at 15 kHz. `DarkNumericUpDown` gains an
optional `LogarithmicFrequencyStep`: one wheel notch, spin-button click or arrow
key is a 96th of an octave, so the value travels the same distance wherever it is
taken on a logarithmic frequency axis. That is 1 Hz up to 200 Hz, 4 Hz at 500 Hz,
7 Hz at 1 kHz, 36 Hz at 5 kHz and 145 Hz at 20 kHz.

The steps walk a **ladder** — rungs at anchor × 2 ^ (n / 96), rounded to what the
field displays — rather than measuring a fresh step off the current value each
time. That is what makes the two directions exact opposites: a step and a step
straight back always land on the value they left, whichever way round they are
taken. Arithmetic steps cannot promise that, because the ratio rounds one way
going out and another coming back — 347 Hz went down to 345 and back up to 348,
and 347 Hz is reachable by stepping down from 350, not only by typing. The ladder
is rebuilt whenever the value arrives from somewhere other than a step: typed,
loaded with a session, fitted by Auto Tune.

A step the range cuts short counts as a step: the ladder keeps the rung it
climbed to, so coming back off a limit lands on the value that ran into it —
19 997 Hz in a field that stops at 20 kHz steps up to 20 000 and back down to
19 997. The climb is recorded only when the value actually moved, so a wheel held
against a limit does not wind the position up past the rung that first reached it.

Rungs that round onto the value we are already on are stepped over, so below
about 69 Hz — where a 96th of an octave is under half a Hz — a whole-Hz field
steps by the 1 Hz it can show rather than standing still. A field with decimals
steps on its own resolution (0.1 Hz at 20 Hz). Typing a frequency is unaffected,
and stepping still commits the editor first, so a typed 5 kHz steps by 5 kHz's own
step and not by that of the value it replaced.

Turned on for the frequency fields the tune is dialled in through: the EQ
Wizard's band cards and its From / To fit range, the Virtual DSP high-pass and
low-pass corners, and the Auto crossover frequency window. The property is off by
default, so every other field keeps stepping by its fixed `Increment`.

Tests pin the step across the band, both round trips at a spread of frequencies,
and a sweep of every whole Hz from 10 to 24 000 checking that a step and a step
back return exactly, up-then-down and down-then-up alike. On a fixture carrying
the wizard's own 20 Hz – 20 kHz range: a step the maximum cut short, three
notches held against it, and the mirror at the minimum. Also the low-frequency
floor, the precedence over `Increment`, the step following typed text, and a walk
of the whole band asserting every step stays within one rounding unit of a 96th
of an octave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
