### PR TITLE
Read the high junctions off their direct wavefronts

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1655,10 +1655,11 @@ and slope above ~1 kHz, the junction is a single crossover and its summing
 polarity is arithmetic rather than evidence. An odd-order Linkwitz-Riley (LR12,
 LR36) and a Butterworth 12 or 36 put their two halves 180° apart at the corner,
 so that pair only sums with one side flipped, while LR24/LR48 and Butterworth
-24/48 sum in phase. There the polarity is read off the filters and only the
-delay is searched. Two corners that merely meet are left to the search: they
-overlap across a region instead of crossing at a point, and carry no single
-phase relation to read.
+24/48 sum in phase. There the polarity is read off the filters — both answers,
+not only the flip — and only the delay is searched. A split whose filters answer
+neither way is left alone: a Butterworth 18 crosses at 90°, and two corners that
+merely meet overlap across a region instead of crossing at a point, so neither
+states a phase relation to read.
 
 Where two candidates of opposite polarity still score within a fraction of a
 decibel — at a mid/tweeter junction the summation metric frequently cannot tell

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1512,8 +1512,10 @@ and would otherwise read confident "coherence" off a crossover remnant the
 sum cannot hear. On junctions below 120 Hz a note warns that the long band
 windows let cabin modes rule the read: the ladder honestly reports that such
 a band is incoherent at the applied tune, but its Δt there is not a move
-recommendation. The mode is a diagnostic for manual work — Auto delay keeps
-its own guarded estimators and never reads this plot.
+recommendation. The mode is above all a diagnostic for manual work: Auto delay
+keeps its own guarded estimators, and reads this ladder in exactly one place —
+to settle a mid/tweeter lobe the direct-sound correlation can only call by a
+hair (see Auto delay above). It never takes a Δt from it as a move.
 
 A **Junction phase** block reads each adjacent pair's steady-state cross-phase in
 a time-sized window (~0.68 s of the processed IR) — the regime sustained program
@@ -1624,9 +1626,13 @@ actually achievable after the best per-junction delay.
 **Auto delay** aligns in two stages: band-limited first arrivals, refined by a
 GCC-PHAT cross-correlation whose dominant extremum of either polarity seeds the
 junction (an inverted junction — a subwoofer against its midbass is the classic
-— seeds from the trough, with the polarity decision left to the sum search);
-then a fractional-delay search minimizing the sum-loss metric at each junction,
-through a direct-sound window so late room reflections do not steer it. That
+— seeds from the trough); then a fractional-delay search minimizing the
+sum-loss metric at each junction, through a direct-sound window so late room
+reflections do not steer it. Above ~1 kHz the seeding correlation is taken on
+the two channels' **direct sound alone**: across a whole record a mid/tweeter
+handover's strongest extremum is often a reflection three to five periods from
+the arrival, and cutting to the wavefronts first is what keeps the seed on the
+right lobe. That
 window is the junction's own: it opens on the earliest **front** of the two
 channels being joined, read in their shared band (never later than the peak, and
 falling back to it where the band carries no measurable arrival), and it is
@@ -1643,6 +1649,28 @@ flip polarity without a real improvement. If the resulting delays span more
 than ~10 ms — usually one channel's crossover having excessive group delay — a
 banner flags the lagging driver.
 
+Polarity is normally the sum search's to decide, with one exception: where the
+lower channel's low-pass and the upper channel's high-pass share family, corner
+and slope above ~1 kHz, the junction is a single crossover and its summing
+polarity is arithmetic rather than evidence. An odd-order Linkwitz-Riley (LR12,
+LR36) and a Butterworth 12 or 36 put their two halves 180° apart at the corner,
+so that pair only sums with one side flipped, while LR24/LR48 and Butterworth
+24/48 sum in phase. There the polarity is read off the filters and only the
+delay is searched. Two corners that merely meet are left to the search: they
+overlap across a region instead of crossing at a point, and carry no single
+phase relation to read.
+
+Where two candidates of opposite polarity still score within a fraction of a
+decibel — at a mid/tweeter junction the summation metric frequently cannot tell
+a lobe from the flipped one half a period away at all — the **direct sound's
+whitened correlation** decides, the same curve the correlation view's direct
+twin draws. Where that advantage is itself slim, the junction's **coherence
+ladder** is asked whether its bands agree, and a decisive vote for the standing
+lobe keeps it: the correlation is one comb across the whole pair band, so it
+carries the polarity but separates neighbouring lobes poorly, while the ladder
+reads polarity not at all and counts how many bands actually want the upper
+channel where a candidate puts it.
+
 With stereo pairs, Auto delay tunes **both sides in one run**, and an
 **LHD / RHD** toggle says which seat you are tuning for. The driver's side is
 the reference: it aligns first, the top pair is bridged to it by band-limited
@@ -1654,7 +1682,10 @@ entered the same way, as a cut on the near side. The gain balance itself is
 alone until you tick **Balance channel gains (cut-only)**. Pairs whose shared band
 reaches the localization region are pinned to the scene, because the image
 outranks the handover there; a final scene-preserving pass may then shift both
-sides of a pair by one shared delta to recover what the pin cost.
+sides of a pair by one shared delta to recover what the pin cost. Each far-side
+channel may also leave its own scene position by up to 0.03 ms to buy back its
+junction's summation — below what the scene can resolve, and enough to close the
+skew the arithmetic bridge leaves behind.
 
 A run only proposes: the dialog answers with a report and nothing is written
 until **Apply**. It carries a row per channel — a value the run changes reads

--- a/dsp/AlignmentSelection.cs
+++ b/dsp/AlignmentSelection.cs
@@ -72,6 +72,18 @@ public static class AlignmentSelection
     /// "rescues" a mixed pair and pays for the cosmetics with a quarter period
     /// of delay, dragging the tweeter off the onset line its inverted twin
     /// sits on.
+    /// <para>
+    /// <paramref name="expectedRelativeInversion"/> STANDS THE PREFERENCE DOWN
+    /// where the crossover settings say a flipped pair is the designed state: a
+    /// matched odd-order Linkwitz-Riley split (LR12, LR36) or a Butterworth 12
+    /// or 36 puts the two filters 180° apart at the corner, so an inverted
+    /// junction is the crossover working rather than a wiring fault, and the
+    /// premise this margin rests on — "a real flip wins by several dB, an
+    /// impostor by fractions" — does not hold. The preference is withdrawn, not
+    /// reversed: the summation score then decides on its own. Reversing it would
+    /// defend the opposite lobe just as blindly, which measured 0.4 dB worse on
+    /// a real cabin's matched 180 Hz Butterworth 36 junction.
+    /// </para>
     /// </summary>
     public static AlignmentCandidate Select(
         IReadOnlyList<AlignmentCandidate> candidates,
@@ -79,7 +91,8 @@ public static class AlignmentSelection
         double invertPreferenceMarginDb = DefaultInvertPreferenceMarginDb,
         double invertPreferenceReachMs = DefaultInvertPreferenceReachMs,
         double delayTieMarginDb = DefaultDelayTieMarginDb,
-        bool neighborInverted = false)
+        bool neighborInverted = false,
+        bool expectedRelativeInversion = false)
     {
         ArgumentNullException.ThrowIfNull(candidates);
         if (candidates.Count == 0)
@@ -93,7 +106,7 @@ public static class AlignmentSelection
             .Where(item => item.ScoreDb >= candidates[0].ScoreDb - delayTieMarginDb)
             .OrderBy(item => Math.Abs(item.DelayMs - baseDeltaMs))
             .First();
-        if (best.InvertPolarity ^ neighborInverted)
+        if (!expectedRelativeInversion && (best.InvertPolarity ^ neighborInverted))
         {
             double bestDistanceMs = Math.Abs(best.DelayMs - baseDeltaMs);
             AlignmentCandidate? bestPure = candidates
@@ -129,7 +142,8 @@ public static class AlignmentSelection
         double invertPreferenceMarginDb = DefaultInvertPreferenceMarginDb,
         double invertPreferenceReachMs = DefaultInvertPreferenceReachMs,
         double delayTieMarginDb = DefaultDelayTieMarginDb,
-        bool neighborInverted = false)
+        bool neighborInverted = false,
+        bool expectedRelativeInversion = false)
     {
         ArgumentNullException.ThrowIfNull(candidates);
         if (candidates.Count == 0)
@@ -141,7 +155,7 @@ public static class AlignmentSelection
             .Where(item => item.ScoreDb >= candidates[0].ScoreDb - delayTieMarginDb)
             .OrderBy(item => Math.Abs(item.DelayMs - baseDeltaMs))
             .First();
-        if (best.InvertPolarity == neighborInverted)
+        if (expectedRelativeInversion || best.InvertPolarity == neighborInverted)
         {
             return null;
         }
@@ -231,7 +245,8 @@ public static class AlignmentSelection
         double anchorMs,
         double nearReachMs,
         double lobeHopMarginDb,
-        bool neighborInverted = false)
+        bool neighborInverted = false,
+        bool expectedRelativeInversion = false)
     {
         ArgumentNullException.ThrowIfNull(candidates);
         ArgumentNullException.ThrowIfNull(chosen);
@@ -250,7 +265,8 @@ public static class AlignmentSelection
         }
 
         AlignmentCandidate nearBest = Select(
-            near, anchorMs, neighborInverted: neighborInverted);
+            near, anchorMs, neighborInverted: neighborInverted,
+            expectedRelativeInversion: expectedRelativeInversion);
         return acousticScore(chosen) - acousticScore(nearBest) > lobeHopMarginDb
             ? chosen
             : nearBest;

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -517,6 +517,40 @@ public static class AutoAlignmentEngine
     private const double DirectCoherenceMinAdvantage = 0.05;
 
     /// <summary>
+    /// The second opinion on a mid/tweeter lobe: where the direct-sound
+    /// correlation's advantage is itself slim, the arrival-coherence ladder
+    /// votes, and a decisive vote for the STANDING lobe vetoes the swap.
+    /// <para>
+    /// The two witnesses read different things. The correlation is one
+    /// whitened comb over the pair's whole band, so it carries the polarity,
+    /// but its neighbouring lobes differ by very little; the ladder resolves
+    /// the band into sub-band probes, each re-cutting the direct sound at its
+    /// own scale, so it cannot see polarity at all (see the remarks by
+    /// <see cref="VirtualCrossoverAnalysis.ArrivalCoherencePoint"/>) but it
+    /// can say how many bands actually want the upper channel where a
+    /// candidate puts it. A slim correlation advantage together with a clear
+    /// disagreement across the bands is the one combination where the comb is
+    /// deciding on noise.
+    /// </para>
+    /// <para>
+    /// Only above <see cref="LadderVetoMinCrossoverHz"/>, where the ladder's
+    /// windows are short enough that a band's optimum is its driver's
+    /// wavefront rather than a cabin mode — the ladder's own remarks disclaim
+    /// low junctions for exactly that reason. Only bands the ladder itself
+    /// calls coherent vote, and the vote must carry
+    /// <see cref="LadderVetoMinBandMargin"/> bands: field calibration
+    /// (2026-08-27) has the archive's high junctions splitting 4 bands to 1
+    /// where the veto belongs (v3 L, whose swap the correlation asked for on a
+    /// 0.07 advantage while the summation score reads the two lobes 0.05 dB
+    /// apart) and 3 to 2 where it does not (v6 L, where the correlation is
+    /// decisive at 0.11 and never reaches this gate).
+    /// </para>
+    /// </summary>
+    private const double LadderVetoMaxAdvantage = 0.10;
+    private const double LadderVetoMinCrossoverHz = 1000;
+    private const int LadderVetoMinBandMargin = 2;
+
+    /// <summary>
     /// The minimum envelope peak-to-noise grade (dB) both channels' onset
     /// estimates must carry before the lock trusts them. The spread gate alone
     /// cannot refuse a noise-only record: random crossings can look stable
@@ -2659,7 +2693,68 @@ public static class AutoAlignmentEngine
 
                     double chosenR = CoherenceOf(chosen);
                     double rivalR = CoherenceOf(rival);
-                    if (rivalR >= DirectCoherenceMinR &&
+
+                    // The ladder's veto (see the LadderVeto* constants): a swap
+                    // the comb asks for by a hair, at a junction high enough for
+                    // the sub-band probes to read wavefronts, is refused when the
+                    // coherent bands decisively want the standing lobe instead.
+                    string? ladderVetoDetail = null;
+                    if (rivalR - chosenR < LadderVetoMaxAdvantage &&
+                        pair.CrossoverHz >= LadderVetoMinCrossoverHz)
+                    {
+                        // The ladder reads a pair AT its applied alignment: its
+                        // lag axis spans a few periods around zero, while the
+                        // variable channel here is still un-delayed against a
+                        // neighbor carrying its settled delay. So the variable is
+                        // first slid onto the standing candidate — a whole number
+                        // of samples, whose rounding is a fraction of the quarter
+                        // period the vote asks about — and every lag the ladder
+                        // reports is then a correction to THAT placement.
+                        int slideSamples = (int)Math.Round(
+                            chosen.DelayMs * channel.SampleRate / 1000.0);
+                        double slideMs = slideSamples * 1000.0 / channel.SampleRate;
+                        IReadOnlyList<VirtualCrossoverAnalysis.ArrivalCoherencePoint>
+                            ladder = VirtualCrossoverAnalysis.ArrivalCoherenceLadder(
+                                neighborIrs[0],
+                                SlideBySamples(variableIr, slideSamples),
+                                channel.SampleRate,
+                                bandLowHz,
+                                bandHighHz,
+                                pair.CrossoverHz,
+                                primaryNeighborSnapshot.ValidRange,
+                                SlideBySamples(
+                                    variableSnapshot.ValidRange, slideSamples));
+                        int chosenBands = VirtualCrossoverAnalysis.CountLadderAgreement(
+                            ladder, chosen.DelayMs - slideMs, halfPeriodMs / 2.0,
+                            DirectCoherenceMinR);
+                        int rivalBands = VirtualCrossoverAnalysis.CountLadderAgreement(
+                            ladder, rival.DelayMs - slideMs, halfPeriodMs / 2.0,
+                            DirectCoherenceMinR);
+                        log.AppendLine(
+                            $"  [diag] coherence ladder: {chosen.DelayMs:0.000} ms " +
+                            $"holds {chosenBands} bands, {rival.DelayMs:0.000} ms " +
+                            $"holds {rivalBands}, of " +
+                            $"{ladder.Count(point => point.PeakR >= DirectCoherenceMinR)} " +
+                            $"coherent of {ladder.Count} probed.");
+                        if (chosenBands - rivalBands >= LadderVetoMinBandMargin)
+                        {
+                            ladderVetoDetail = string.Create(
+                                System.Globalization.CultureInfo.InvariantCulture,
+                                $"the coherence ladder holds the lobe " +
+                                $"{chosenBands} bands to {rivalBands}");
+                            log.AppendLine(
+                                $"  direct coherence: the swap to " +
+                                $"{rival.DelayMs:0.000} ms" +
+                                $"{(rival.InvertPolarity ? " inv" : "")} is " +
+                                $"refused — r gains only " +
+                                $"{rivalR - chosenR:0.00}, and the coherence " +
+                                $"ladder wants {chosen.DelayMs:0.000} ms by " +
+                                $"{chosenBands} coherent bands to {rivalBands}.");
+                        }
+                    }
+
+                    if (ladderVetoDetail == null &&
+                        rivalR >= DirectCoherenceMinR &&
                         rivalR >= chosenR + DirectCoherenceMinAdvantage)
                     {
                         log.AppendLine(
@@ -2678,13 +2773,18 @@ public static class AutoAlignmentEngine
                             $"{chosenR:0.00} decided the polarity tie");
                         chosen = rival;
                     }
-                    else if (chosenR > double.NegativeInfinity)
+                    else if (ladderVetoDetail == null &&
+                        chosenR > double.NegativeInfinity)
                     {
                         log.AppendLine(
                             $"  direct coherence: {chosen.DelayMs:0.000} ms" +
                             $" stands (r {chosenR:0.00} vs rival " +
                             $"{rivalR:0.00})");
                     }
+
+                    // A veto is a decision too: the report should say the lobe
+                    // was held by the bands, not leave the swap unexplained.
+                    directCoherenceDetail ??= ladderVetoDetail;
                 }
             }
 
@@ -2923,6 +3023,33 @@ public static class AutoAlignmentEngine
     // way to "advance" a channel that would otherwise need a negative delay.
     // Uniformity is what preserves the alignment, so the scope must cover every
     // channel whose relative timing has already been settled.
+    /// <summary>
+    /// A response slid LATER by a whole number of samples, keeping its length:
+    /// the cheapest honest way to place an un-delayed channel at a candidate's
+    /// timing for a witness that reads a pair at its applied alignment. Whole
+    /// samples only — a fractional shift would need a resampling kernel, and
+    /// the readers that use this ask questions coarser than one sample.
+    /// </summary>
+    private static Complex[] SlideBySamples(Complex[] response, int samples)
+    {
+        if (samples <= 0)
+        {
+            return response;
+        }
+
+        var slid = new Complex[response.Length];
+        int copied = Math.Max(0, response.Length - samples);
+        Array.Copy(response, 0, slid, samples, copied);
+        return slid;
+    }
+
+    /// <summary>The same slide applied to a response's valid range.</summary>
+    private static ValidSampleRange SlideBySamples(
+        ValidSampleRange range, int samples) =>
+        range.IsKnown && samples > 0
+            ? new ValidSampleRange(
+                range.StartSample + samples, range.EndSample + samples)
+            : range;
     private static void ShiftAllExcept(
         IReadOnlyList<AlignmentSnapshot> scope,
         IAlignmentChannel except,

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1128,8 +1128,22 @@ public static class AutoAlignmentEngine
     /// crossover (and any PEQ, which does bend phase and belongs here).
     /// </para>
     /// </summary>
-    private static bool ExpectsRelativeInversion(AlignmentJunction pair) =>
-        FilterPolarityPreferenceDb(pair) > ExpectedInversionMarginDb;
+    private static bool? ExpectsRelativeInversion(AlignmentJunction pair)
+    {
+        double preferenceDb = FilterPolarityPreferenceDb(pair);
+        if (double.IsNaN(preferenceDb) ||
+            Math.Abs(preferenceDb) <= ExpectedInversionMarginDb)
+        {
+            // Either the filters do not pose the question (a staggered split,
+            // a channel with no crossover) or they answer it with a shrug
+            // (Butterworth 18's 90°, where neither polarity nulls). Both are
+            // the search's to decide, and must not be confused with a matched
+            // split that genuinely asks for IN PHASE.
+            return null;
+        }
+
+        return preferenceDb > 0;
+    }
 
     /// <summary>
     /// <see cref="ExpectsRelativeInversion"/>'s figure: how much better (dB) the
@@ -2037,18 +2051,28 @@ public static class AutoAlignmentEngine
         // moving up to a period rather than by flipping. Above 1 kHz the
         // crossover dominates its own band, which is where this rule can be
         // believed — and where the owner's LR36 test lives.
-        bool expectsInversion = ExpectsRelativeInversion(pair) &&
-            pair.CrossoverHz >= DirectSeedMinCrossoverHz;
-        if (forcedPolarity == null && expectsInversion && !wideSeed &&
-            secondaryNeighbor == null)
+        bool? filterPolarity = pair.CrossoverHz >= DirectSeedMinCrossoverHz
+            ? ExpectsRelativeInversion(pair)
+            : null;
+        bool expectsInversion = filterPolarity == true;
+        if (forcedPolarity == null && filterPolarity is bool expectedInversion &&
+            !wideSeed && secondaryNeighbor == null)
         {
+            // Both answers are forced, not just the flip: a matched LR24 sums
+            // in phase as decisively as a matched LR36 nulls there, and leaving
+            // the in-phase case to the search would let a comb lobe half a
+            // period away flip a pair whose crossover has already settled the
+            // question. Only the shrug (null) is the search's.
             forcedPolarity =
-                alignment.GetValueOrDefault(neighborChannel).InvertPolarity ^ true;
+                alignment.GetValueOrDefault(neighborChannel).InvertPolarity ^
+                expectedInversion;
             log.AppendLine(
-                $"  the matched {pair.CrossoverHz:0} Hz split nulls in phase — " +
-                $"{channel.Name} takes the opposite polarity to " +
-                $"{neighborChannel.Name} by construction; the search settles the " +
-                "delay alone");
+                $"  the matched {pair.CrossoverHz:0} Hz split sums " +
+                (expectedInversion ? "only inverted" : "in phase") +
+                $" — {channel.Name} takes the " +
+                (expectedInversion ? "opposite" : "same") +
+                $" polarity as {neighborChannel.Name} by construction; the " +
+                "search settles the delay alone");
         }
 
         // Reprocess so the settled neighbors participate with their new delays
@@ -2705,25 +2729,38 @@ public static class AutoAlignmentEngine
                         // The ladder reads a pair AT its applied alignment: its
                         // lag axis spans a few periods around zero, while the
                         // variable channel here is still un-delayed against a
-                        // neighbor carrying its settled delay. So the variable is
-                        // first slid onto the standing candidate — a whole number
-                        // of samples, whose rounding is a fraction of the quarter
-                        // period the vote asks about — and every lag the ladder
-                        // reports is then a correction to THAT placement.
+                        // neighbor carrying its settled delay. So the pair is
+                        // first placed at the standing candidate — a whole
+                        // number of samples, whose rounding is a fraction of the
+                        // quarter period the vote asks about — and every lag the
+                        // ladder reports is then a correction to THAT placement.
+                        // A candidate may be NEGATIVE (the cascade's own delays
+                        // are rebased later, so the search does not stop at
+                        // zero), and a channel cannot be slid earlier: the
+                        // NEIGHBOR is slid later instead, which is the same
+                        // relative placement and the same thing normalization
+                        // would do to the pair afterwards.
                         int slideSamples = (int)Math.Round(
                             chosen.DelayMs * channel.SampleRate / 1000.0);
                         double slideMs = slideSamples * 1000.0 / channel.SampleRate;
+                        (Complex[] placedNeighbor, Complex[] placedVariable) =
+                            PlacePairAt(
+                                neighborIrs[0], variableIr, slideSamples);
+                        (ValidSampleRange neighborRange,
+                            ValidSampleRange variableRange) = PlacePairAt(
+                                primaryNeighborSnapshot.ValidRange,
+                                variableSnapshot.ValidRange,
+                                slideSamples);
                         IReadOnlyList<VirtualCrossoverAnalysis.ArrivalCoherencePoint>
                             ladder = VirtualCrossoverAnalysis.ArrivalCoherenceLadder(
-                                neighborIrs[0],
-                                SlideBySamples(variableIr, slideSamples),
+                                placedNeighbor,
+                                placedVariable,
                                 channel.SampleRate,
                                 bandLowHz,
                                 bandHighHz,
                                 pair.CrossoverHz,
-                                primaryNeighborSnapshot.ValidRange,
-                                SlideBySamples(
-                                    variableSnapshot.ValidRange, slideSamples));
+                                neighborRange,
+                                variableRange);
                         int chosenBands = VirtualCrossoverAnalysis.CountLadderAgreement(
                             ladder, chosen.DelayMs - slideMs, halfPeriodMs / 2.0,
                             DirectCoherenceMinR);
@@ -3023,6 +3060,33 @@ public static class AutoAlignmentEngine
     // way to "advance" a channel that would otherwise need a negative delay.
     // Uniformity is what preserves the alignment, so the scope must cover every
     // channel whose relative timing has already been settled.
+    /// <summary>
+    /// A junction's two responses placed at a candidate's relative timing: the
+    /// upper channel <paramref name="slideSamples"/> later than the lower.
+    /// Neither response can be slid EARLIER without cutting its own front off,
+    /// so a negative placement moves the lower one later instead — the same
+    /// relative timing, and the same thing the cascade's own normalization does
+    /// to a pair that ended up with negative delays.
+    /// <para>
+    /// The distinction matters because a witness reading a pair "at its applied
+    /// alignment" states its findings relative to THIS placement; getting the
+    /// sign wrong leaves the responses where they were while the caller
+    /// believes they moved, and every lag it then reads is offset by the whole
+    /// candidate delay.
+    /// </para>
+    /// </summary>
+    internal static (Complex[] Lower, Complex[] Upper) PlacePairAt(
+        Complex[] lower, Complex[] upper, int slideSamples) =>
+        slideSamples >= 0
+            ? (lower, SlideBySamples(upper, slideSamples))
+            : (SlideBySamples(lower, -slideSamples), upper);
+
+    /// <summary>The same placement applied to the pair's valid ranges.</summary>
+    private static (ValidSampleRange Lower, ValidSampleRange Upper) PlacePairAt(
+        ValidSampleRange lower, ValidSampleRange upper, int slideSamples) =>
+        slideSamples >= 0
+            ? (lower, SlideBySamples(upper, slideSamples))
+            : (SlideBySamples(lower, -slideSamples), upper);
     /// <summary>
     /// A response slid LATER by a whole number of samples, keeping its length:
     /// the cheapest honest way to place an un-delayed channel at a candidate's
@@ -4608,13 +4672,24 @@ public static class AutoAlignmentEngine
                 return total / evaluators.Count;
             }
 
-            // The same span NormalizeAndVerifyFeasibility will judge: it
-            // rebases on the earliest channel of the WHOLE field, so the
-            // ceiling is read there — and re-read per channel, since an
-            // earlier polish may have moved the earliest one.
-            double ceilingMs = fullScope.Min(
-                item => alignment.GetValueOrDefault(item.Channel).DelayMs) +
-                MaxDelayMs;
+            // The span NormalizeAndVerifyFeasibility will judge, held by the
+            // REST of the field: it rebases on the earliest channel and then
+            // measures to the latest, so a trial has to be checked from both
+            // ends. Moving this channel later can outrun the earliest one, and
+            // moving it earlier can outrun the latest — a polish on the field's
+            // own minimum widens the spread just as surely as one on its
+            // maximum. Read per channel, since an earlier polish may already
+            // have moved either end.
+            List<double> othersMs = fullScope
+                .Where(item => item.Channel != channel)
+                .Select(item => alignment.GetValueOrDefault(item.Channel).DelayMs)
+                .ToList();
+            double othersMinMs = othersMs.Count > 0
+                ? othersMs.Min()
+                : double.PositiveInfinity;
+            double othersMaxMs = othersMs.Count > 0
+                ? othersMs.Max()
+                : double.NegativeInfinity;
             double baseline = Score(0);
             double bestDelta = 0;
             double bestScore = baseline;
@@ -4625,16 +4700,18 @@ public static class AutoAlignmentEngine
                 delta <= FarSideJunctionPolishMs + 1e-9;
                 delta += 0.01)
             {
-                if (current.DelayMs + delta < 0 ||
-                    current.DelayMs + delta > ceilingMs)
+                double trialMs = current.DelayMs + delta;
+                if (trialMs < 0 ||
+                    Math.Max(othersMaxMs, trialMs) -
+                        Math.Min(othersMinMs, trialMs) > MaxDelayMs)
                 {
                     // Delays are non-negative and a polish never earns a
                     // uniform shift of the whole field. Nor may it widen the
                     // spread past what the DSP can realize: this is the only
-                    // pass that moves a channel LATER after the cascade has
-                    // settled, so on a system already at the range limit a
-                    // hundredth of a decibel would otherwise turn a valid
-                    // proposal into the feasibility check's refusal.
+                    // pass that moves a channel after the cascade has settled,
+                    // so on a system already at the range limit a hundredth of
+                    // a decibel would otherwise turn a valid proposal into the
+                    // feasibility check's refusal.
                     continue;
                 }
 

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -310,6 +310,47 @@ public static class AutoAlignmentEngine
     /// </summary>
     private const double PhatSeedMinRivalDominance = 0.05;
 
+    /// <summary>
+    /// The direct-cut seed witness runs at junctions this high. The full-record
+    /// PHAT correlates everything the record holds, and at a mid/tweeter junction
+    /// most of that is the cabin: across the archived cabins its dominant extremum
+    /// sat 3.4-4.7 periods from the owner's hand tune in HALF of the 1.3-2.9 kHz
+    /// junction cells — while passing every trust gate above (r, dominance, reach),
+    /// so the gates cannot catch it. The same PHAT on the direct-sound cuts
+    /// (<see cref="VirtualCrossoverAnalysis.CutDirectSoundPair"/>: 1-2 periods
+    /// behind each front — the drivers, not the room) read r 0.58-0.96 with zero
+    /// catastrophic misses on the same cells, reproduced two owner tunes to 6 us
+    /// on the junction that exposed this, and held its position to ~10 us across
+    /// record rates. Below ~1 kHz the cut does not isolate a wavefront (the same
+    /// physics as <see cref="DirectCoherenceMinCrossoverHz"/>) and the witness
+    /// stays out — the sub/bass junctions belong to the arrival envelope and the
+    /// modal-latch machinery, which the same bench measured as the better seeds
+    /// there.
+    /// </summary>
+    private const double DirectSeedMinCrossoverHz = 1000;
+
+    /// <summary>
+    /// The minimum |r| of the direct-cut extremum for the witness to speak at all.
+    /// Far above <see cref="PhatSeedMinCoefficient"/> deliberately: the cuts hold a
+    /// couple of periods of wavefront, so an honest pair correlates strongly there
+    /// (0.58 was the weakest field value) and a middling coefficient means the cut
+    /// caught reflections after all.
+    /// </summary>
+    private const double DirectSeedMinCoefficient = 0.5;
+
+    /// <summary>
+    /// When the trusted full-record extremum and the direct-cut extremum disagree
+    /// by more than half a period, the seed goes to whichever position carries the
+    /// higher JOINT support — the smaller of the two surfaces' |r| within a quarter
+    /// period — by at least this margin; otherwise the full-record extremum stands
+    /// (the least change). Field calibration: the four contested cells split 0.24
+    /// vs 0.02, 0.32 vs 0.02, 0.28 vs 0.20 and 0.13 vs 0.02 toward the owner's
+    /// lobe, while the one cell where the full extremum was right read 0.51 vs
+    /// 0.35 the other way — and the near-ties (0.03, 0.05) sat within one lobe
+    /// pair, where either pick's stage-2 window covers the truth.
+    /// </summary>
+    private const double DirectSeedJointTieMarginR = 0.05;
+
     // The sub-precedence margin: at a junction with the shared mono sub, a
     // near-tie between the comb lobe that leaves the sub TRAILING the stack and
     // the one that leaves it LEADING is not acoustically resolvable, but it is
@@ -1509,28 +1550,183 @@ public static class AutoAlignmentEngine
             }
             string? distrust = Distrust();
             bool trustPhat = distrust == null;
-            double increment =
-                trustPhat ? -seed.DelayMs : upperArrival - lowerArrival;
+
+            // The direct-cut witness (see DirectSeedMinCrossoverHz): the same
+            // whitened correlation on the two channels' direct-sound cuts, so the
+            // reflections that grow the full record's phantom lobes never enter
+            // it. It is subject to its own gates — an edge-pinned cut, a weak
+            // coefficient (the cuts caught reflections after all) or a position
+            // past the arrival's reach silence it, and the full-record path then
+            // behaves exactly as before this witness existed.
+            CorrelationAlignmentResult? directPhat = null;
+            CorrelationDelayCandidate? directSeed = null;
+            Complex[] lowerDirectCut = [];
+            Complex[] upperDirectCut = [];
+            if (pair.CrossoverHz >= DirectSeedMinCrossoverHz)
+            {
+                (lowerDirectCut, upperDirectCut) =
+                    VirtualCrossoverAnalysis.CutDirectSoundPair(
+                        pair.Lower.ImpulseResponse,
+                        pair.Upper.ImpulseResponse,
+                        pair.Lower.Channel.SampleRate,
+                        pair.BandLowHz,
+                        pair.BandHighHz,
+                        pair.CrossoverHz,
+                        SeedCorrelationRangeMs(pair.CrossoverHz),
+                        pair.Lower.ValidRange,
+                        pair.Upper.ValidRange);
+                directPhat = VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
+                    lowerDirectCut,
+                    upperDirectCut,
+                    pair.Lower.Channel.SampleRate,
+                    pair.CrossoverHz,
+                    passOctaves,
+                    SeedCorrelationRangeMs(pair.CrossoverHz),
+                    centerLagMs,
+                    phaseTransform: true);
+                CorrelationDelayCandidate directBest = directPhat.BestByMagnitude;
+                CorrelationDelayCandidate? directRival = directBest.InvertPolarity
+                    ? directPhat.NegativeRival
+                    : directPhat.PositiveRival;
+                // The same-sign rival gate matters here as much as on the full
+                // record: a cut holding a genuinely periodic front (an echo one
+                // period out at near-equal strength) ties its own lobes, and a
+                // witness deciding that by half a percent of r would hand the
+                // timeline a coin flip. Field margins of honest direct seeds
+                // run 0.10-0.47.
+                if (!directPhat.PositivePeak.EdgePinned &&
+                    !directPhat.NegativeTrough.EdgePinned &&
+                    Math.Abs(directBest.Coefficient) >= DirectSeedMinCoefficient &&
+                    (directRival == null ||
+                        Math.Abs(directBest.Coefficient) -
+                            Math.Abs(directRival.Coefficient) >=
+                        PhatSeedMinRivalDominance) &&
+                    Math.Abs(directBest.DelayMs - centerLagMs) <
+                        SeedReachMs(pair.CrossoverHz))
+                {
+                    directSeed = directBest;
+                }
+            }
+
+            // A trusted seed fixes WHERE the pair of adjacent lobes sits, not
+            // WHICH of them is right: the peak-vs-trough margin is a statement
+            // about the band's width, so the polarity partner a half period away
+            // is still a live candidate and the loss search is what settles it
+            // (see PhatSeedMinRivalDominance). That only holds if the fine
+            // window can reach the partner, and the fixed ±2.5 ms cap cannot
+            // below ~200 Hz: measured across the archived cabins, 10 of 13
+            // junctions under 400 Hz put their partner OUTSIDE it (7.57 ms out
+            // at 60 Hz, 3.18 at 150 against a 2.5 ms reach). So every
+            // non-arrival seed records how far its partner actually sits,
+            // measured on the SURFACE that produced the seed.
+            // A local alias: an out parameter cannot be captured by a local
+            // function, and the dictionary instance is what matters.
+            Dictionary<AlignmentJunction, double> partnerReachByPair =
+                seedPartnerDistanceMs;
+            void RecordPartnerReach(CorrelationAlignmentResult source)
+            {
+                if (LobeBoundaryMs(source) is > 0 and { } halfSpacingMs)
+                {
+                    partnerReachByPair[pair] = 2.0 * halfSpacingMs;
+                }
+            }
+
+            double halfPeriodAtFcMs = 500.0 / pair.CrossoverHz;
+            double increment;
+            string seedSource;
+            bool arrivalSeeded = false;
+            if (directSeed is { } adjudicated && trustPhat &&
+                Math.Abs(adjudicated.DelayMs - seed.DelayMs) > halfPeriodAtFcMs)
+            {
+                // Two trusted extrema on different lobes: adjudicate by JOINT
+                // support — the smaller of what the two surfaces read within a
+                // quarter period of each candidate. A phantom lobe is strong on
+                // the surface that manufactured it and near-zero on the other
+                // (0.02 against 0.20+ in every catastrophic field cell), while
+                // the true lobe carries both drivers' wavefronts and so shows on
+                // both. See DirectSeedJointTieMarginR for the calibration.
+                List<SignalPoint> fullCurve =
+                    VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
+                        pair.Lower.ImpulseResponse,
+                        pair.Upper.ImpulseResponse,
+                        pair.Lower.Channel.SampleRate,
+                        pair.CrossoverHz,
+                        passOctaves,
+                        SeedCorrelationRangeMs(pair.CrossoverHz),
+                        centerLagMs,
+                        phaseTransform: true);
+                List<SignalPoint> directCurve =
+                    VirtualCrossoverAnalysis.BandLimitedCorrelationCurve(
+                        lowerDirectCut,
+                        upperDirectCut,
+                        pair.Lower.Channel.SampleRate,
+                        pair.CrossoverHz,
+                        passOctaves,
+                        SeedCorrelationRangeMs(pair.CrossoverHz),
+                        centerLagMs,
+                        phaseTransform: true);
+                double SupportNear(List<SignalPoint> curve, double positionMs)
+                {
+                    double best = 0;
+                    foreach (SignalPoint point in curve)
+                    {
+                        if (Math.Abs(point.X - positionMs) <= halfPeriodAtFcMs / 2.0)
+                        {
+                            best = Math.Max(best, Math.Abs(point.Y));
+                        }
+                    }
+
+                    return best;
+                }
+                double fullJoint = Math.Min(
+                    SupportNear(fullCurve, seed.DelayMs),
+                    SupportNear(directCurve, seed.DelayMs));
+                double directJoint = Math.Min(
+                    SupportNear(fullCurve, adjudicated.DelayMs),
+                    SupportNear(directCurve, adjudicated.DelayMs));
+                if (directJoint > fullJoint + DirectSeedJointTieMarginR)
+                {
+                    increment = -adjudicated.DelayMs;
+                    seedSource = FormattableString.Invariant(
+                        $"direct-cut over phat (joint {directJoint:0.00} vs {fullJoint:0.00})");
+                    RecordPartnerReach(directPhat!);
+                }
+                else
+                {
+                    increment = -seed.DelayMs;
+                    seedSource = FormattableString.Invariant(
+                        $"phat (joint {fullJoint:0.00} vs direct {directJoint:0.00})");
+                    RecordPartnerReach(phat);
+                }
+            }
+            else if (trustPhat)
+            {
+                increment = -seed.DelayMs;
+                seedSource = directSeed != null ? "phat (direct-cut concurs)" : "phat";
+                RecordPartnerReach(phat);
+            }
+            else if (directSeed is { } rescue)
+            {
+                // The full-record extremum failed its own gates; before this
+                // witness the arrival envelope seeded here, and at these
+                // junctions it sat 0.6-1.2 periods off the owner's tunes in
+                // most field cells — recoverable only by luck of the onset
+                // lock. The direct front is the honest read.
+                increment = -rescue.DelayMs;
+                seedSource = FormattableString.Invariant(
+                    $"direct-cut (phat: {distrust})");
+                RecordPartnerReach(directPhat!);
+            }
+            else
+            {
+                increment = upperArrival - lowerArrival;
+                seedSource = FormattableString.Invariant($"arrival ({distrust})");
+                arrivalSeeded = true;
+            }
             timeline[pair.Upper.Channel] = timeline[pair.Lower.Channel] + increment;
-            if (!trustPhat)
+            if (arrivalSeeded)
             {
                 untrustedSeedJunctions.Add(pair);
-            }
-            else if (LobeBoundaryMs(phat) is > 0 and { } halfSpacingMs)
-            {
-                // A trusted seed fixes WHERE the pair of adjacent lobes sits,
-                // not WHICH of them is right: the peak-vs-trough margin is a
-                // statement about the band's width, so the polarity partner a
-                // half period away is still a live candidate and the loss
-                // search is what settles it (see PhatSeedMinRivalDominance).
-                // That only holds if the fine window can reach the partner, and
-                // the fixed ±2.5 ms cap cannot below ~200 Hz: measured across
-                // the archived cabins, 10 of 13 junctions under 400 Hz put
-                // their partner OUTSIDE it (7.57 ms out at 60 Hz, 3.18 at 150
-                // against a 2.5 ms reach). So a trusted junction records how
-                // far its partner actually sits and the fine window grows to
-                // cover it.
-                seedPartnerDistanceMs[pair] = 2.0 * halfSpacingMs;
             }
 
             // Full-band processed-IR peak times, a detector-independent arrival
@@ -1552,8 +1748,13 @@ public static class AutoAlignmentEngine
                 $"diff {upperArrival - lowerArrival:+0.000;-0.000} ms, " +
                 $"phat {seedLabel} {seed.DelayMs:+0.000;-0.000} ms " +
                 $"(r {seed.Coefficient:+0.000;-0.000}, " +
-                $"dom {phat.Confidence:0.000}) -> seed " +
-                $"{(trustPhat ? "phat" : $"arrival ({distrust})")}");
+                $"dom {phat.Confidence:0.000})" +
+                (directPhat is { } directForLog
+                    ? $", direct-cut {directForLog.BestByMagnitude.DelayMs:+0.000;-0.000} ms " +
+                      $"(r {directForLog.BestByMagnitude.Coefficient:+0.000;-0.000}" +
+                      $"{(directSeed == null ? ", unusable" : "")})"
+                    : "") +
+                $" -> seed {seedSource}");
         }
 
         return timeline;
@@ -3304,6 +3505,11 @@ public static class AutoAlignmentEngine
         // vote on the mono channel at all.
         ComoveMonoChannels(plan, reprocess, alignment, log, allChannels, decisions);
 
+        // The far side's own last word: every far channel may leave its scene
+        // position by at most FarSideJunctionPolishMs to buy its own junction
+        // summation back — see the method for why the scene can afford it.
+        PolishFarSideJunctions(plan, rightByBand, reprocess, alignment, log, decisions);
+
         NormalizeAndVerifyFeasibility(allChannels, alignment, log);
 
         // The invariant the user requires of automatic delay: no driver is ever
@@ -3534,6 +3740,20 @@ public static class AutoAlignmentEngine
     // comb lobe off its mid at a high junction.
     private const double PairComoveSearchRangeMs = 1.2;
     private const double PairComoveMinimumGainDb = 0.05;
+
+    // The far-side junction polish (see PolishFarSideJunctions): how far a far
+    // channel may leave the position the scene machinery assigned it, and the
+    // least mean dip-penalized gain that buys a move. The budget is a phase
+    // trim — 0.03 ms is a twentieth of a period at a 1.6 kHz junction and 17°
+    // of phase, an order of magnitude under interaural blur — so the scene
+    // stays perceptually intact while the far side's handovers stop paying
+    // full price for it. The gain threshold sits below the co-move's 0.05 dB
+    // deliberately: a 0.03 ms trim can only ever buy fractions of a dB, and a
+    // threshold sized for half-period moves would leave the stage dead —
+    // measured on the v6 cabin the honest gains ran 0.01-0.03 dB, so even
+    // 0.02 dB refused every one of them.
+    private const double FarSideJunctionPolishMs = 0.03;
+    private const double FarSidePolishMinimumGainDb = 0.01;
 
     // The mono-channel co-move (see ComoveMonoChannels): the search spans a
     // full half period of the mono channel's tightest junction to each side, in
@@ -3955,6 +4175,153 @@ public static class AutoAlignmentEngine
                     $"Co-move {link.Left.Name}+{link.Right.Name}: kept " +
                     $"(best gain {bestScore - baseline:0.00} dB below the " +
                     $"{PairComoveMinimumGainDb:0.00} dB threshold)");
+            }
+        }
+    }
+
+    // The far-side junction polish: the scene machinery pinned every far
+    // channel — the bridge by arithmetic with no search at all, the rest by
+    // scene locks around the cross-side target — and their OWN junction sums
+    // paid for it. With everything settled, each far channel may now leave its
+    // scene position by at most FarSideJunctionPolishMs to buy that summation
+    // back, judged by the mean dip-penalized loss of its own adjacent far-side
+    // junctions. The budget cannot hop a lobe (a twentieth of a period at the
+    // junctions it matters for), cannot smear the image (an order of magnitude
+    // under interaural blur), and is spent per channel from its scene position
+    // — one pass in band order from the bridge down, each channel judged
+    // against neighbors that already carry their own polish. Mono channels are
+    // shared with the reference side and never move here.
+    // Internal so the tests can pin the budget, the threshold and the mono
+    // exclusion directly, the way ComoveMonoChannels is pinned.
+    internal static void PolishFarSideJunctions(
+        StereoAlignmentPlan plan,
+        IReadOnlyList<AlignmentSnapshot> rightByBand,
+        AlignmentReprocessor reprocess,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        StringBuilder log,
+        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions)
+    {
+        foreach (AlignmentSnapshot entry in rightByBand
+            .OrderByDescending(item => plan.RightPairs
+                .Where(pair => pair.Lower.Channel == item.Channel ||
+                    pair.Upper.Channel == item.Channel)
+                .Select(pair => pair.CrossoverHz)
+                .DefaultIfEmpty(0)
+                .Max()))
+        {
+            IAlignmentChannel channel = entry.Channel;
+            if (plan.MonoChannels.Contains(channel))
+            {
+                continue;
+            }
+
+            List<AlignmentJunction> adjacent = plan.RightPairs
+                .Where(pair => pair.Lower.Channel == channel ||
+                    pair.Upper.Channel == channel)
+                .ToList();
+            if (adjacent.Count == 0)
+            {
+                continue;
+            }
+
+            AlignmentOverride current = alignment.GetValueOrDefault(channel);
+            IReadOnlyList<AlignmentSnapshot> snapshots = reprocess(alignment);
+            AlignmentSnapshot SnapshotOf(IAlignmentChannel member) =>
+                snapshots.First(item => item.Channel == member);
+
+            var evaluators = new List<VirtualCrossoverAnalysis.SumLossEvaluator>();
+            foreach (AlignmentJunction junction in adjacent)
+            {
+                IAlignmentChannel neighbor = junction.Lower.Channel == channel
+                    ? junction.Upper.Channel
+                    : junction.Lower.Channel;
+                VirtualCrossoverAnalysis.SumLossEvaluator? evaluator =
+                    VirtualCrossoverAnalysis.SumLossEvaluator.Create(
+                        SnapshotOf(channel).ImpulseResponse,
+                        new List<Complex[]>
+                        {
+                            SnapshotOf(neighbor).ImpulseResponse
+                        },
+                        channel.SampleRate,
+                        junction.BandLowHz,
+                        junction.BandHighHz,
+                        levelMatch: true,
+                        requireDelayEvidence: true,
+                        gateAnchorSample: null,
+                        SnapshotOf(channel).ValidRange,
+                        new[] { SnapshotOf(neighbor).ValidRange });
+                if (evaluator != null)
+                {
+                    evaluators.Add(evaluator);
+                }
+            }
+            if (evaluators.Count == 0)
+            {
+                continue;
+            }
+
+            double Score(double deltaMs)
+            {
+                double total = 0;
+                foreach (VirtualCrossoverAnalysis.SumLossEvaluator evaluator
+                    in evaluators)
+                {
+                    (double lossDb, double dipDb) = evaluator.Evaluate(deltaMs);
+                    total += lossDb +
+                        VirtualCrossoverAnalysis.DipExcessPenaltyWeight *
+                        (dipDb - lossDb);
+                }
+
+                return total / evaluators.Count;
+            }
+
+            double baseline = Score(0);
+            double bestDelta = 0;
+            double bestScore = baseline;
+            // The DSP's own 0.01 ms grid: the applied delay is rounded onto it
+            // anyway, so probing between its points would report gains no
+            // realizable delay can collect.
+            for (double delta = -FarSideJunctionPolishMs;
+                delta <= FarSideJunctionPolishMs + 1e-9;
+                delta += 0.01)
+            {
+                if (current.DelayMs + delta < 0)
+                {
+                    // Delays are non-negative and a polish never earns a
+                    // uniform shift of the whole field.
+                    continue;
+                }
+
+                double score = Score(delta);
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    bestDelta = delta;
+                }
+            }
+
+            if (bestDelta != 0 && bestScore > baseline + FarSidePolishMinimumGainDb)
+            {
+                alignment[channel] = current with
+                {
+                    DelayMs = Math.Round(current.DelayMs + bestDelta, 2)
+                };
+                log.AppendLine(
+                    $"Far-side polish {channel.Name}: " +
+                    $"{bestDelta:+0.00;-0.00} ms off the scene position " +
+                    $"(own-junction dip-penalized loss " +
+                    $"{baseline:0.00} -> {bestScore:0.00} dB)");
+                string amendment = FormattableString.Invariant(
+                    $"far-side polish {bestDelta:+0.00;-0.00} ms (scene spent, <= ") +
+                    FormattableString.Invariant($"{FarSideJunctionPolishMs:0.00} ms)");
+                AmendDecision(decisions, channel, amendment);
+            }
+            else
+            {
+                log.AppendLine(
+                    $"Far-side polish {channel.Name}: kept " +
+                    $"(best gain {bestScore - baseline:0.00} dB below the " +
+                    $"{FarSidePolishMinimumGainDb:0.00} dB threshold)");
             }
         }
     }

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -3839,7 +3839,8 @@ public static class AutoAlignmentEngine
         // The far side's own last word: every far channel may leave its scene
         // position by at most FarSideJunctionPolishMs to buy its own junction
         // summation back — see the method for why the scene can afford it.
-        PolishFarSideJunctions(plan, rightByBand, reprocess, alignment, log, decisions);
+        PolishFarSideJunctions(
+            plan, rightByBand, allChannels, reprocess, alignment, log, decisions);
 
         NormalizeAndVerifyFeasibility(allChannels, alignment, log);
 
@@ -4527,6 +4528,7 @@ public static class AutoAlignmentEngine
     internal static void PolishFarSideJunctions(
         StereoAlignmentPlan plan,
         IReadOnlyList<AlignmentSnapshot> rightByBand,
+        IReadOnlyList<AlignmentSnapshot> fullScope,
         AlignmentReprocessor reprocess,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         StringBuilder log,
@@ -4606,6 +4608,13 @@ public static class AutoAlignmentEngine
                 return total / evaluators.Count;
             }
 
+            // The same span NormalizeAndVerifyFeasibility will judge: it
+            // rebases on the earliest channel of the WHOLE field, so the
+            // ceiling is read there — and re-read per channel, since an
+            // earlier polish may have moved the earliest one.
+            double ceilingMs = fullScope.Min(
+                item => alignment.GetValueOrDefault(item.Channel).DelayMs) +
+                MaxDelayMs;
             double baseline = Score(0);
             double bestDelta = 0;
             double bestScore = baseline;
@@ -4616,10 +4625,16 @@ public static class AutoAlignmentEngine
                 delta <= FarSideJunctionPolishMs + 1e-9;
                 delta += 0.01)
             {
-                if (current.DelayMs + delta < 0)
+                if (current.DelayMs + delta < 0 ||
+                    current.DelayMs + delta > ceilingMs)
                 {
                     // Delays are non-negative and a polish never earns a
-                    // uniform shift of the whole field.
+                    // uniform shift of the whole field. Nor may it widen the
+                    // spread past what the DSP can realize: this is the only
+                    // pass that moves a channel LATER after the cascade has
+                    // settled, so on a system already at the range limit a
+                    // hundredth of a decibel would otherwise turn a valid
+                    // proposal into the feasibility check's refusal.
                     continue;
                 }
 

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -351,6 +351,41 @@ public static class AutoAlignmentEngine
     /// </summary>
     private const double DirectSeedJointTieMarginR = 0.05;
 
+    /// <summary>
+    /// How far from the arrival estimate the FULL-RECORD extremum may sit, in
+    /// junction periods, while the direct-cut witness offers a usable seed of its
+    /// own. <see cref="SeedReachMs"/>'s fixed 3 ms floor is sized for low
+    /// junctions and amounts to four or five periods at a mid/tweeter split,
+    /// where it therefore vetoes nothing. Field: across the archived cabins the
+    /// full-record extrema that agreed with the owner's tune sit within 1.15
+    /// periods of the arrival, while the phantoms grown by correlated cabin
+    /// reflections sit from 1.66 out (to 3.9) — so a period and a half separates
+    /// them with room on both sides.
+    /// </summary>
+    private const double DirectSeedTrustReachPeriods = 1.5;
+
+    /// <summary>
+    /// How far two corners may sit apart (Hz) and still count as ONE crossover
+    /// for <see cref="FilterPolarityPreferenceDb"/>. A hair of tolerance only —
+    /// the corners come from the same UI fields and are typed, not measured, so
+    /// they either match or the split was deliberately staggered.
+    /// </summary>
+    private const double MatchedSplitToleranceHz = 0.5;
+
+    /// <summary>
+    /// How much better the inverted sum of the two channels' FILTERS must be,
+    /// across the junction band, before the search expects the pair to be
+    /// relatively inverted (see <see cref="ExpectsRelativeInversion"/>). The
+    /// question is not close for the shapes that matter — an odd-order
+    /// Linkwitz-Riley (LR12, LR36) or a Butterworth 12 puts the two filters
+    /// exactly 180° apart at the corner, so one polarity nulls where the other
+    /// sums — and the margin exists only so that a junction whose filters say
+    /// nothing (Butterworth 18's 90°, a channel with no crossover at all, an
+    /// asymmetric pair of corners) keeps the historical in-phase expectation
+    /// rather than flipping on rounding noise.
+    /// </summary>
+    private const double ExpectedInversionMarginDb = 1.0;
+
     // The sub-precedence margin: at a junction with the shared mono sub, a
     // near-tie between the comb lobe that leaves the sub TRAILING the stack and
     // the one that leaves it LEADING is not acoustically resolvable, but it is
@@ -1031,6 +1066,102 @@ public static class AutoAlignmentEngine
     // pairwise differences chain into one relative timeline. Only the
     // differences matter downstream, so the anchor value of the first channel
     // is arbitrary (zero).
+    /// <summary>
+    /// Whether the junction's own FILTERS ask for the two channels to be
+    /// relatively inverted — computed from the crossover settings alone, with no
+    /// measurement involved: the two chains' responses are summed across the
+    /// junction band in both relative polarities, and the inverted sum has to
+    /// win by <see cref="ExpectedInversionMarginDb"/>.
+    /// <para>
+    /// This is the piece the search could not see before. A crossover's summing
+    /// polarity is a property of its order: LR24 and LR48 sum in phase, LR12 and
+    /// LR36 sum INVERTED (their filters sit 180° apart at the corner), Butterworth
+    /// 12 likewise. Where the filters are that explicit, an inverted junction is
+    /// the crossover working as designed, and the invert preference in
+    /// <see cref="AlignmentSelection"/> — written for "a flipped driver is a
+    /// wiring fault worth several dB" — has to defend the OTHER polarity, or it
+    /// spends its 0.5 dB defending the null. Measured on the v6 cabin with the
+    /// mid/tweeter split set to LR36: on the correct alignment the in-phase sum
+    /// runs 4.8-5.8 dB below the inverted one, yet once each polarity is allowed
+    /// its own optimum delay the gap between them is only 0.28-0.49 dB, so the
+    /// undefended margin decided it — one side of the same cabin came out right
+    /// and the other wrong.
+    /// </para>
+    /// <para>
+    /// The gain, delay and polarity of each chain are neutralized first: gain
+    /// would weight one channel's filter over the other's, and delay and polarity
+    /// are exactly what the search is about to decide. What remains is the
+    /// crossover (and any PEQ, which does bend phase and belongs here).
+    /// </para>
+    /// </summary>
+    private static bool ExpectsRelativeInversion(AlignmentJunction pair) =>
+        FilterPolarityPreferenceDb(pair) > ExpectedInversionMarginDb;
+
+    /// <summary>
+    /// <see cref="ExpectsRelativeInversion"/>'s figure: how much better (dB) the
+    /// junction's own two filters sum AT THE CORNER when one channel is inverted.
+    /// Positive means the crossover asks for the flip. NaN — "the filters say
+    /// nothing" — whenever the question is not well posed.
+    /// <para>
+    /// It is well posed only for a MATCHED split: the lower channel's low-pass
+    /// and the upper channel's high-pass sharing family, corner and slope. Then
+    /// the pair is one crossover, its summing polarity is a designed property of
+    /// the order (LR12 and LR36 sum inverted, LR24 and LR48 in phase; Butterworth
+    /// 12 and 36 inverted, 24 and 48 in phase, 18 indifferent at 90°), and it is
+    /// read at the corner where both halves are at −6 dB and the answer is exact.
+    /// </para>
+    /// <para>
+    /// Any other arrangement returns NaN, and deliberately so. A split with two
+    /// different corners or slopes has no single phase relation to state: its
+    /// filters overlap across a region rather than crossing at a point, and its
+    /// best relative delay is not zero — so summing them AS THEY STAND answers a
+    /// question nobody asked. Measured: the v2 cabin's 1500/1900 Hz Butterworth
+    /// 36 split reads "inverted, +1 dB" that way, while the real junction, each
+    /// polarity allowed its own optimum delay, prefers IN PHASE by 3.3 dB at the
+    /// owner's setting. Same for the LR24-against-LR48 splits in the 3RC and
+    /// Passat cabins. Those junctions keep the historical in-phase expectation
+    /// and are decided, as before, by the summation search.
+    /// </para>
+    /// </summary>
+    private static double FilterPolarityPreferenceDb(AlignmentJunction pair)
+    {
+        if (pair.Lower.ProcessingChain?.Crossover is not { } lowerCrossover ||
+            pair.Upper.ProcessingChain?.Crossover is not { } upperCrossover ||
+            lowerCrossover.LowPassEdge is not { } lowPass ||
+            upperCrossover.HighPassEdge is not { } highPass ||
+            lowerCrossover.Kind is not (CrossoverKind.LowPass or CrossoverKind.BandPass) ||
+            upperCrossover.Kind is not (CrossoverKind.HighPass or CrossoverKind.BandPass))
+        {
+            return double.NaN;
+        }
+
+        // One crossover, or two filters that merely meet? Only the first has a
+        // polarity to speak of.
+        if (lowPass.Family != highPass.Family ||
+            lowPass.SlopeDbPerOctave != highPass.SlopeDbPerOctave ||
+            Math.Abs(lowPass.FrequencyHz - highPass.FrequencyHz) >
+                MatchedSplitToleranceHz)
+        {
+            return double.NaN;
+        }
+
+        int rate = pair.Lower.Channel.ProcessorSampleRate;
+        double cornerHz = 0.5 * (lowPass.FrequencyHz + highPass.FrequencyHz);
+        Complex low = CrossoverFilter.Response(
+            new CrossoverSpec(CrossoverKind.LowPass, LowPassEdge: lowPass),
+            cornerHz,
+            rate);
+        Complex high = CrossoverFilter.Response(
+            new CrossoverSpec(CrossoverKind.HighPass, HighPassEdge: highPass),
+            cornerHz,
+            rate);
+        double same = (low + high).Magnitude;
+        double inverted = (low - high).Magnitude;
+        return same > 0 && inverted > 0
+            ? 20.0 * Math.Log10(inverted / same)
+            : double.NaN;
+    }
+
     private static Dictionary<IAlignmentChannel, double> BuildArrivalTimeline(
         IReadOnlyList<AlignmentSnapshot> byBand,
         IReadOnlyList<AlignmentJunction> pairs,
@@ -1487,6 +1618,13 @@ public static class AutoAlignmentEngine
                 seed.InvertPolarity ? phat.NegativeRival : phat.PositiveRival;
             string seedLabel = seed.InvertPolarity ? "trough" : "peak";
             double seedOffsetMs = seed.DelayMs - centerLagMs;
+            // Declared ahead of the trust gate below, which reads the witness
+            // (a local function cannot capture a variable declared after it).
+            CorrelationAlignmentResult? directPhat = null;
+            CorrelationDelayCandidate? directSeed = null;
+            Complex[] lowerDirectCut = [];
+            Complex[] upperDirectCut = [];
+
             string? Distrust()
             {
                 if (phat.PositivePeak.EdgePinned || phat.NegativeTrough.EdgePinned)
@@ -1540,6 +1678,23 @@ public static class AutoAlignmentEngine
                 // A gate must not be tightened by evidence fifteen times coarser
                 // than the distance it decides.
                 double reachMs = SeedReachMs(pair.CrossoverHz);
+                // Where the DIRECT-CUT witness produced a usable extremum, that
+                // reach is tightened to a period and a half. The fixed 3 ms floor
+                // above is sized for low junctions; at a mid/tweeter split it is
+                // four to five periods, so it admits anything — which is exactly
+                // how the full-record extremum passed every gate while sitting
+                // 1.7-3.9 periods from the arrival on five of the archived
+                // cabins. The honest full-record extrema measured there sit
+                // within 1.15 periods, the phantoms from 1.66 out, so the bound
+                // separates them; and it only applies when there is a measured
+                // direct front to seed from instead, never leaving the junction
+                // with nothing but the envelope.
+                if (directSeed != null)
+                {
+                    reachMs = Math.Min(
+                        reachMs, DirectSeedTrustReachPeriods * 1000.0 / pair.CrossoverHz);
+                }
+
                 // At the boundary itself the two lobes are equidistant, so
                 // the extremum is refused rather than admitted.
                 if (!arrivalReanchored && Math.Abs(seedOffsetMs) >= reachMs)
@@ -1548,9 +1703,6 @@ public static class AutoAlignmentEngine
                 }
                 return null;
             }
-            string? distrust = Distrust();
-            bool trustPhat = distrust == null;
-
             // The direct-cut witness (see DirectSeedMinCrossoverHz): the same
             // whitened correlation on the two channels' direct-sound cuts, so the
             // reflections that grow the full record's phantom lobes never enter
@@ -1558,10 +1710,6 @@ public static class AutoAlignmentEngine
             // coefficient (the cuts caught reflections after all) or a position
             // past the arrival's reach silence it, and the full-record path then
             // behaves exactly as before this witness existed.
-            CorrelationAlignmentResult? directPhat = null;
-            CorrelationDelayCandidate? directSeed = null;
-            Complex[] lowerDirectCut = [];
-            Complex[] upperDirectCut = [];
             if (pair.CrossoverHz >= DirectSeedMinCrossoverHz)
             {
                 (lowerDirectCut, upperDirectCut) =
@@ -1607,6 +1755,9 @@ public static class AutoAlignmentEngine
                     directSeed = directBest;
                 }
             }
+
+            string? distrust = Distrust();
+            bool trustPhat = distrust == null;
 
             // A trusted seed fixes WHERE the pair of adjacent lobes sits, not
             // WHICH of them is right: the peak-vs-trough margin is a statement
@@ -1823,6 +1974,48 @@ public static class AutoAlignmentEngine
         // of the quadratic lobe deterrent: between the two coarse bases when
         // both junctions constrain the channel.
         double anchorMs = priorOverrideMs ?? (primaryBase + secondaryBase) / 2.0;
+
+        // A matched odd-order split (LR12/LR36, Butterworth 12/36) sums to a NULL
+        // at its corner unless one channel is flipped — the crossover is designed
+        // that way, and nothing measured can overrule arithmetic. So the polarity
+        // is settled here, from the settings, and the search below is left to do
+        // only what it is good at: find the delay. Measured on the v6 cabin with
+        // its mid/tweeter split set to LR36, letting the summation decide instead
+        // gave the two sides opposite answers, each on a 0.2-0.5 dB margin — the
+        // in-phase option buys nearly all of the null back by sliding a quarter
+        // period, so the score cannot see what the corner makes obvious.
+        // A caller-supplied polarity (the stereo descent inheriting its
+        // counterpart's) outranks this: there the whole point is that the two
+        // sides of one driver never differ.
+        // ... and only where the search knows WHICH lobe it is on. Under a wide
+        // seed the coarse offset can be half a period out, the window spans
+        // several lobes, and the recovery machinery (the edge retry, the
+        // wide-window promotion) navigates by comparing candidates of both
+        // polarities; removing half of them there does not fix the polarity, it
+        // strands the delay — measured on the v4 cabin's wide-seeded 180 Hz
+        // Butterworth 36 junction, forcing the (correct) flip moved the channel
+        // a whole period off the lobe the free search had found.
+        // ... and only above DirectSeedMinCrossoverHz. Lower down the cabin's
+        // modes, not the crossover, shape the junction band: the sum there is a
+        // room response with a filter in it, the arrivals need the modal-latch
+        // machinery to be read at all, and the archived cabins' two matched
+        // Butterworth 36 splits (70 and 180 Hz) answer the polarity question by
+        // moving up to a period rather than by flipping. Above 1 kHz the
+        // crossover dominates its own band, which is where this rule can be
+        // believed — and where the owner's LR36 test lives.
+        bool expectsInversion = ExpectsRelativeInversion(pair) &&
+            pair.CrossoverHz >= DirectSeedMinCrossoverHz;
+        if (forcedPolarity == null && expectsInversion && !wideSeed &&
+            secondaryNeighbor == null)
+        {
+            forcedPolarity =
+                alignment.GetValueOrDefault(neighborChannel).InvertPolarity ^ true;
+            log.AppendLine(
+                $"  the matched {pair.CrossoverHz:0} Hz split nulls in phase — " +
+                $"{channel.Name} takes the opposite polarity to " +
+                $"{neighborChannel.Name} by construction; the search settles the " +
+                "delay alone");
+        }
 
         // Reprocess so the settled neighbors participate with their new delays
         // and polarities. The searched channel is dropped from the override map
@@ -2086,9 +2279,15 @@ public static class AutoAlignmentEngine
             // the onset line its inverted twin sits on.
             bool neighborInverted =
                 alignment.GetValueOrDefault(neighborChannel).InvertPolarity;
+            // ... and "pure" itself is what the junction's FILTERS ask for: an
+            // odd-order Linkwitz-Riley (LR12, LR36) or a Butterworth 12 sums
+            // INVERTED, so there the preference must defend the flipped pair
+            // instead (see ExpectsRelativeInversion).
+
             AlignmentCandidate? selected = candidates.Count > 0
                 ? AlignmentSelection.Select(candidates, anchorMs,
-                    neighborInverted: neighborInverted)
+                    neighborInverted: neighborInverted,
+                    expectedRelativeInversion: expectsInversion)
                 : null;
             if (selected is { } fineSelected && fineSelected != candidates[0])
             {
@@ -2100,9 +2299,11 @@ public static class AutoAlignmentEngine
                     $"(margin {candidates[0].ScoreDb - fineSelected.ScoreDb:0.00} dB)");
             }
             else if (selected is { } keptPick &&
+                !expectsInversion &&
                 keptPick.InvertPolarity != neighborInverted &&
                 AlignmentSelection.DeclinedInvertRescue(candidates, anchorMs,
-                    neighborInverted: neighborInverted)
+                    neighborInverted: neighborInverted,
+                    expectedRelativeInversion: expectsInversion)
                     is { } rescue)
             {
                 log.AppendLine(
@@ -2143,7 +2344,8 @@ public static class AutoAlignmentEngine
             if (selected == null && wide.Count > 0)
             {
                 selected = AlignmentSelection.Select(wide, anchorMs,
-                    neighborInverted: neighborInverted);
+                    neighborInverted: neighborInverted,
+                    expectedRelativeInversion: expectsInversion);
                 log.AppendLine(
                     $"  fine window empty — adopted {selected.DelayMs:0.000} ms" +
                     $"{(selected.InvertPolarity ? " inv" : "")} from the wide sweep");
@@ -2207,7 +2409,8 @@ public static class AutoAlignmentEngine
                     // the result to a (flip + half-period) impostor that the
                     // invert margin and the arrival tie-break exist to reject.
                     chosen = AlignmentSelection.Select(retried, anchorMs,
-                        neighborInverted: neighborInverted);
+                        neighborInverted: neighborInverted,
+                        expectedRelativeInversion: expectsInversion);
                 }
 
                 log.AppendLine(
@@ -2230,7 +2433,7 @@ public static class AutoAlignmentEngine
                 AlignmentCandidate gated = AlignmentSelection.GateWideSeedLobe(
                     candidates, chosen, AcousticScore, anchorMs,
                     trustedReachMs, WideWindowPromotionMarginDb,
-                    neighborInverted);
+                    neighborInverted, expectsInversion);
                 if (gated != chosen)
                 {
                     log.AppendLine(
@@ -2263,7 +2466,8 @@ public static class AutoAlignmentEngine
             {
                 AlignmentCandidate wideChosen =
                     AlignmentSelection.Select(wide, anchorMs,
-                        neighborInverted: neighborInverted);
+                        neighborInverted: neighborInverted,
+                        expectedRelativeInversion: expectsInversion);
                 // Only a lobe's reach from the arrival pick: past that the "better"
                 // score is a comb alias the summation cannot distinguish, so the
                 // envelope stays authoritative (see PromotionReachPeriods). Inside

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1490,13 +1490,16 @@ public static class VirtualCrossoverAnalysis
     /// clean packet, which would read as nonsense on a coherence axis.
     /// </para>
     /// <para>
-    /// A DIAGNOSTIC, deliberately not an input to the alignment search: on a
-    /// low junction the band windows are long enough for cabin modes to rule
-    /// the correlation (the archived v3 mid junction draws its whole mid-band
-    /// optimum on the mode the Auto delay sagas were fought over), so the
-    /// ladder there honestly reports "this band is not coherent at the
-    /// applied tune" while its lag is NOT a move recommendation. The engine
-    /// keeps its own guarded estimators.
+    /// Chiefly a DIAGNOSTIC: on a low junction the band windows are long
+    /// enough for cabin modes to rule the correlation (the archived v3 mid
+    /// junction draws its whole mid-band optimum on the mode the Auto delay
+    /// sagas were fought over), so the ladder there honestly reports "this
+    /// band is not coherent at the applied tune" while its lag is NOT a move
+    /// recommendation. The engine keeps its own guarded estimators and takes
+    /// no Δt from here; its single use of the ladder is to COUNT how many
+    /// coherent bands stand with a candidate above a kilohertz, where the
+    /// direct-sound correlation can only separate two lobes by a hair (see
+    /// <see cref="CountLadderAgreement"/>).
     /// </para>
     /// </summary>
     public static List<ArrivalCoherencePoint> ArrivalCoherenceLadder(
@@ -1717,7 +1720,7 @@ public static class VirtualCrossoverAnalysis
     /// a witness that carries it.
     /// </para>
     /// </summary>
-    public static int CountLadderAgreement(
+    internal static int CountLadderAgreement(
         IReadOnlyList<ArrivalCoherencePoint> ladder,
         double delayMs,
         double quarterPeriodMs,

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -1703,6 +1703,41 @@ public static class VirtualCrossoverAnalysis
     }
 
     /// <summary>
+    /// How many of a ladder's COHERENT bands want the upper channel where a
+    /// candidate delay puts it — within a quarter period of the junction, the
+    /// widest miss that still leaves the two channels adding rather than
+    /// fighting. Bands below <paramref name="minPeakR"/> do not vote: the
+    /// ladder reports a lag for every band it probes, and where the probe found
+    /// no coherence that lag is noise wearing a number.
+    /// <para>
+    /// A count, deliberately, not an average miss: one band far out drags a
+    /// mean across the whole junction, while what a lobe question needs is how
+    /// many independent bands agree. Polarity is not read here and cannot be
+    /// (see <see cref="ArrivalCoherencePoint"/>) — the caller pairs this with
+    /// a witness that carries it.
+    /// </para>
+    /// </summary>
+    public static int CountLadderAgreement(
+        IReadOnlyList<ArrivalCoherencePoint> ladder,
+        double delayMs,
+        double quarterPeriodMs,
+        double minPeakR)
+    {
+        ArgumentNullException.ThrowIfNull(ladder);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(quarterPeriodMs);
+        int agreeing = 0;
+        foreach (ArrivalCoherencePoint point in ladder)
+        {
+            if (point.PeakR >= minPeakR &&
+                Math.Abs(point.LagMs - delayMs) <= quarterPeriodMs)
+            {
+                agreeing++;
+            }
+        }
+
+        return agreeing;
+    }
+    /// <summary>
     /// One probe of <see cref="JunctionLossSweep"/>: the junction's gated
     /// average loss and 1/6-octave dip with the variable channel delayed by
     /// <see cref="DelayMs"/> (and inverted, when the sweep's polarity is

--- a/tests/Resonalyze.Dsp.Tests/ArrivalCoherenceLadderTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/ArrivalCoherenceLadderTests.cs
@@ -20,6 +20,74 @@ public sealed class ArrivalCoherenceLadderTests
     private const double BandLowHz = 750;
     private const double BandHighHz = 3_000;
 
+    private static VirtualCrossoverAnalysis.ArrivalCoherencePoint Band(
+        double frequencyHz, double lagMs, double peakR) =>
+        new(frequencyHz, lagMs, peakR, CurrentR: 0, HalfPeriodMs: 0.5);
+
+    [Fact]
+    public void CountLadderAgreement_CountsTheBandsWithinAQuarterPeriod()
+    {
+        var ladder = new[]
+        {
+            Band(1_000, lagMs: 0.20, peakR: 0.9),
+            Band(1_200, lagMs: 0.30, peakR: 0.9),
+            Band(1_500, lagMs: 0.55, peakR: 0.9),
+            Band(2_000, lagMs: -0.40, peakR: 0.9)
+        };
+
+        // A quarter period of a 1500 Hz junction is 0.167 ms: the first two
+        // bands sit inside it around 0.25 ms, the other two do not.
+        Assert.Equal(
+            2,
+            VirtualCrossoverAnalysis.CountLadderAgreement(
+                ladder, delayMs: 0.25, quarterPeriodMs: 0.167, minPeakR: 0.6));
+    }
+
+    [Fact]
+    public void CountLadderAgreement_LeavesTheIncoherentBandsOutOfTheVote()
+    {
+        var ladder = new[]
+        {
+            Band(1_000, lagMs: 0.25, peakR: 0.9),
+            // Right where the candidate is, and worthless: the ladder reports
+            // a lag for every band it probes, coherent or not.
+            Band(1_200, lagMs: 0.25, peakR: 0.2)
+        };
+
+        Assert.Equal(
+            1,
+            VirtualCrossoverAnalysis.CountLadderAgreement(
+                ladder, delayMs: 0.25, quarterPeriodMs: 0.167, minPeakR: 0.6));
+    }
+
+    [Fact]
+    public void CountLadderAgreement_SeparatesTwoCandidatesAHalfPeriodApart()
+    {
+        // The shape the veto reads: the bands agree on one lobe, and the
+        // opposite-polarity candidate half a period away collects almost none.
+        var ladder = new[]
+        {
+            Band(1_000, lagMs: 0.24, peakR: 0.9),
+            Band(1_200, lagMs: 0.28, peakR: 0.9),
+            Band(1_500, lagMs: 0.31, peakR: 0.9),
+            Band(2_000, lagMs: -0.05, peakR: 0.9)
+        };
+
+        int onTheLobe = VirtualCrossoverAnalysis.CountLadderAgreement(
+            ladder, delayMs: 0.28, quarterPeriodMs: 0.167, minPeakR: 0.6);
+        int halfAPeriodEarly = VirtualCrossoverAnalysis.CountLadderAgreement(
+            ladder, delayMs: -0.05, quarterPeriodMs: 0.167, minPeakR: 0.6);
+        Assert.Equal(3, onTheLobe);
+        Assert.Equal(1, halfAPeriodEarly);
+    }
+
+    [Fact]
+    public void CountLadderAgreement_RefusesAWindowlessQuarterPeriod()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            VirtualCrossoverAnalysis.CountLadderAgreement(
+                [], delayMs: 0, quarterPeriodMs: 0, minPeakR: 0.6));
+    }
     private static Complex[] Impulse(double offsetMs = 0, double amplitude = 1.0)
     {
         var ir = new Complex[IrLength];

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -52,10 +52,10 @@ public sealed class AutoAlignmentEngineTests
             bypassed);
     }
 
-    private static Complex[] UnitImpulse(int position)
+    private static Complex[] UnitImpulse(int position, double amplitude = 1.0)
     {
         var ir = new Complex[IrLength];
-        ir[position] = Complex.One;
+        ir[position] = amplitude;
         return ir;
     }
 
@@ -442,9 +442,66 @@ public sealed class AutoAlignmentEngineTests
             expectInverted,
             alignment.GetValueOrDefault(lower).InvertPolarity !=
                 alignment.GetValueOrDefault(upper).InvertPolarity);
-        Assert.Equal(expectInverted, log.ToString().Contains("nulls in phase"));
+        // The force fires either way now — what changes is which answer it
+        // states — so the log is checked for the direction, not for presence.
+        Assert.Contains("by construction", log.ToString());
+        Assert.Contains(
+            expectInverted ? "sums only inverted" : "sums in phase",
+            log.ToString());
     }
 
+    [Fact]
+    public void Compute_MatchedEvenOrderSplit_KeepsInPhaseAgainstTheSumsWishes()
+    {
+        // The in-phase half of the rule, pinned where it can actually be seen.
+        // The tweeter's impulse is NEGATIVE, so the summation search has a
+        // decisive reason to invert it — several dB, not the fractions the
+        // matched-split argument is about. A matched LR24 sums in phase by
+        // construction, so the engine takes that and leaves the flip alone.
+        //
+        // The trade is deliberate and worth stating: a driver genuinely wired
+        // backwards behind a matched even-order split is NOT corrected by Auto
+        // delay, the same way a matched odd-order split's forced flip is not
+        // undone by one. Both are the price of reading a polarity the sum
+        // cannot resolve off the crossover that defines it, and both are fenced
+        // to junctions above a kilohertz under a trusted seed.
+        var log = new StringBuilder();
+        (Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+            IAlignmentChannel lower,
+            IAlignmentChannel upper) = RunFilteredJunction(
+                CrossoverFilterFamily.LinkwitzRiley, 24, upperCornerHz: 2_000,
+                log: log, upperAmplitude: -1.0);
+
+        Assert.Equal(
+            alignment.GetValueOrDefault(lower).InvertPolarity,
+            alignment.GetValueOrDefault(upper).InvertPolarity);
+        Assert.Contains("sums in phase", log.ToString());
+    }
+    [Theory]
+    [InlineData(37)]
+    [InlineData(0)]
+    [InlineData(-37)]
+    public void PlacePairAt_PutsTheUpperChannelThatMuchLaterEitherWay(
+        int slideSamples)
+    {
+        // The coordinate contract a witness that reads "the applied alignment"
+        // depends on: whichever way the candidate points, the pair comes back
+        // with the upper channel exactly slideSamples behind the lower. A
+        // negative candidate is ordinary — the cascade rebases its delays only
+        // at the end — and moving the upper channel earlier would cut its own
+        // front off, so the lower one moves later instead.
+        Complex[] lower = UnitImpulse(BasePosition);
+        Complex[] upper = UnitImpulse(BasePosition);
+
+        (Complex[] placedLower, Complex[] placedUpper) =
+            AutoAlignmentEngine.PlacePairAt(lower, upper, slideSamples);
+
+        int lowerPeak = VirtualCrossoverAnalysis.FindPeakIndex(placedLower);
+        int upperPeak = VirtualCrossoverAnalysis.FindPeakIndex(placedUpper);
+        Assert.Equal(slideSamples, upperPeak - lowerPeak);
+        Assert.Equal(lower.Length, placedLower.Length);
+        Assert.Equal(upper.Length, placedUpper.Length);
+    }
     [Fact]
     public void Compute_StaggeredSplit_LeavesThePolarityToTheSearch()
     {
@@ -459,7 +516,7 @@ public sealed class AutoAlignmentEngineTests
         RunFilteredJunction(
             CrossoverFilterFamily.LinkwitzRiley, 36, upperCornerHz: 2_400, log: log);
 
-        Assert.DoesNotContain("nulls in phase", log.ToString());
+        Assert.DoesNotContain("by construction", log.ToString());
     }
 
     // A synthetic junction made of FILTERS: one impulse per channel, the lower
@@ -471,7 +528,8 @@ public sealed class AutoAlignmentEngineTests
         CrossoverFilterFamily family,
         int slopeDbPerOctave,
         double upperCornerHz,
-        StringBuilder log)
+        StringBuilder log,
+        double upperAmplitude = 1.0)
     {
         const double lowerCornerHz = 2_000;
         var lowPass = new DspChannelChain(Crossover: new CrossoverSpec(
@@ -482,7 +540,8 @@ public sealed class AutoAlignmentEngineTests
             HighPassEdge: new CrossoverEdge(family, upperCornerHz, slopeDbPerOctave)));
 
         AlignmentSnapshot lower = PredictableSnapshot("W", UnitImpulse(BasePosition), lowPass);
-        AlignmentSnapshot upper = PredictableSnapshot("T", UnitImpulse(BasePosition), highPass);
+        AlignmentSnapshot upper = PredictableSnapshot(
+            "T", UnitImpulse(BasePosition, upperAmplitude), highPass);
         var junction = new AlignmentJunction(
             lower, upper, lowerCornerHz, lowerCornerHz / 2, lowerCornerHz * 2);
 

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -414,6 +414,112 @@ public sealed class AutoAlignmentEngineTests
         Assert.DoesNotContain("promoted", log.ToString());
     }
 
+    [Theory]
+    // A matched odd-order split nulls in phase at its corner, so the pair is
+    // inverted BY CONSTRUCTION and the engine must not leave that to the
+    // summation score (which, once each polarity is allowed its own delay, sees
+    // only fractions of a dB either way).
+    [InlineData(CrossoverFilterFamily.LinkwitzRiley, 36, true)]
+    [InlineData(CrossoverFilterFamily.LinkwitzRiley, 12, true)]
+    [InlineData(CrossoverFilterFamily.Butterworth, 12, true)]
+    // ... while the even-order ones sum in phase and must stay that way.
+    [InlineData(CrossoverFilterFamily.LinkwitzRiley, 24, false)]
+    [InlineData(CrossoverFilterFamily.LinkwitzRiley, 48, false)]
+    public void Compute_MatchedSplit_TakesThePolarityItsFiltersAskFor(
+        CrossoverFilterFamily family,
+        int slopeDbPerOctave,
+        bool expectInverted)
+    {
+        var log = new StringBuilder();
+        (Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+            IAlignmentChannel lower,
+            IAlignmentChannel upper) = RunFilteredJunction(
+                family, slopeDbPerOctave, upperCornerHz: 2_000, log: log);
+
+        // The reference channel of a two-channel walk carries no override at
+        // all, which reads as "not inverted" — the same thing the panel applies.
+        Assert.Equal(
+            expectInverted,
+            alignment.GetValueOrDefault(lower).InvertPolarity !=
+                alignment.GetValueOrDefault(upper).InvertPolarity);
+        Assert.Equal(expectInverted, log.ToString().Contains("nulls in phase"));
+    }
+
+    [Fact]
+    public void Compute_StaggeredSplit_LeavesThePolarityToTheSearch()
+    {
+        // Two corners that merely meet (2000 against 2400 Hz) are not one
+        // crossover: they overlap across a region instead of crossing at a
+        // point, and their best relative delay is not zero — so the filters have
+        // no single phase relation to state and the rule must stay out. The
+        // archived cabins' staggered Butterworth 36 and LR24-against-LR48 splits
+        // are exactly this shape, and reading them as "inverted" moved four
+        // channels of the field battery.
+        var log = new StringBuilder();
+        RunFilteredJunction(
+            CrossoverFilterFamily.LinkwitzRiley, 36, upperCornerHz: 2_400, log: log);
+
+        Assert.DoesNotContain("nulls in phase", log.ToString());
+    }
+
+    // A synthetic junction made of FILTERS: one impulse per channel, the lower
+    // through a low-pass and the upper through a high-pass, both arriving
+    // together. The snapshots carry their chains, which is what lets the engine
+    // read the split's designed polarity.
+    private static (Dictionary<IAlignmentChannel, AlignmentOverride> Alignment,
+        IAlignmentChannel Lower, IAlignmentChannel Upper) RunFilteredJunction(
+        CrossoverFilterFamily family,
+        int slopeDbPerOctave,
+        double upperCornerHz,
+        StringBuilder log)
+    {
+        const double lowerCornerHz = 2_000;
+        var lowPass = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.LowPass,
+            LowPassEdge: new CrossoverEdge(family, lowerCornerHz, slopeDbPerOctave)));
+        var highPass = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.HighPass,
+            HighPassEdge: new CrossoverEdge(family, upperCornerHz, slopeDbPerOctave)));
+
+        AlignmentSnapshot lower = PredictableSnapshot("W", UnitImpulse(BasePosition), lowPass);
+        AlignmentSnapshot upper = PredictableSnapshot("T", UnitImpulse(BasePosition), highPass);
+        var junction = new AlignmentJunction(
+            lower, upper, lowerCornerHz, lowerCornerHz / 2, lowerCornerHz * 2);
+
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides)
+        {
+            AlignmentSnapshot Apply(AlignmentSnapshot snapshot, DspChannelChain chain)
+            {
+                AlignmentOverride over = overrides.GetValueOrDefault(snapshot.Channel);
+                Complex[] ir = VirtualCrossoverAnalysis.ApplyChain(
+                    snapshot.BypassedImpulseResponse!,
+                    chain with
+                    {
+                        DelayMs = over.DelayMs,
+                        InvertPolarity = over.InvertPolarity
+                    },
+                    SampleRate,
+                    SampleRate,
+                    out ValidSampleRange range);
+                return new AlignmentSnapshot(
+                    snapshot.Channel,
+                    ir,
+                    VirtualCrossoverAnalysis.FindPeakIndex(ir),
+                    range,
+                    chain,
+                    snapshot.BypassedImpulseResponse);
+            }
+
+            return [Apply(lower, lowPass), Apply(upper, highPass)];
+        }
+
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        AutoAlignmentEngine.Compute(
+            [lower, upper], [junction], Reprocess, alignment, log);
+        return (alignment, lower.Channel, upper.Channel);
+    }
+
     [Fact]
     public void Compute_UntrustedPhatAtAHighJunction_DirectCutWitnessSeeds()
     {
@@ -441,19 +547,19 @@ public sealed class AutoAlignmentEngineTests
     }
 
     [Fact]
-    public void Compute_TrustedPhantomLobe_JointSupportSeedsFromTheDirectCut()
+    public void Compute_ReflectionPhantomFarFromTheArrival_IsRefusedForTheDirectCut()
     {
         // The catastrophic field shape: both channels carry one strong LATE
-        // reflection off the cabin's shared geometry, and the reflection
-        // pair's whitened-correlation lobe DOMINATES the full record — a
-        // separated, high-r extremum every full-record trust gate accepts,
-        // 2.5 ms (five periods) from the true front alignment. Measured across
-        // the archived cabins this passed the gates with the extremum 3.4-4.7
-        // periods off the owner's tune in half of the mid/tweeter cells. The
-        // direct cuts exclude the reflections, and the JOINT-support
-        // adjudication (see DirectSeedJointTieMarginR) reads the phantom's
-        // absence from the direct surface — near-zero there against real
-        // support at the front lobe — and seeds from the direct cut.
+        // reflection off the cabin's shared geometry, and the reflection pair's
+        // whitened-correlation lobe DOMINATES the full record — a separated,
+        // high-r extremum that r, dominance and the OLD 3 ms reach all accepted,
+        // sitting five periods from the true front alignment. Measured across
+        // the archived cabins this passed every gate with the extremum 3.4-4.7
+        // periods off the owner's tune in half of the mid/tweeter cells; the
+        // honest ones sit within 1.15. With a usable direct-cut witness in hand
+        // the reach tightens to a period and a half, which is what refuses this
+        // one — and the direct front, which never sees the reflections, seeds
+        // instead.
         var woofer = new TestChannel("W", ReflectedFront(1.0, 3.0, 1.4));
         var tweeter = new TestChannel("T", ReflectedFront(0.0, 5.5, 1.4));
         var log = new StringBuilder();
@@ -462,7 +568,8 @@ public sealed class AutoAlignmentEngineTests
             Run([woofer, tweeter], [2_000], log, bands: [(700, 5_600)]);
 
         Assert.InRange(alignment[tweeter].DelayMs, 0.9, 1.1);
-        Assert.Contains("seed direct-cut over phat (joint", log.ToString());
+        Assert.Contains(
+            "seed direct-cut (phat: peak beyond the arrival's reach)", log.ToString());
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -80,6 +80,37 @@ public sealed class AutoAlignmentEngineTests
         return ir;
     }
 
+    // A genuinely PERIODIC front: three near-equal copies one period apart.
+    // Every correlation witness ties its own same-sign rivals on such a front —
+    // the full-record PHAT and the direct-sound cut alike — so the seed honestly
+    // falls back to the arrival envelope, and the onset lock is the one
+    // authority left that reads something other than a correlation lobe.
+    private static Complex[] PeriodicFront(double periodMs)
+    {
+        var ir = new Complex[IrLength];
+        int period = (int)Math.Round(periodMs / 1000.0 * SampleRate);
+        ir[BasePosition] = 0.995;
+        ir[BasePosition + period] = 1.0;
+        ir[BasePosition + (2 * period)] = 0.995;
+        return ir;
+    }
+
+    // A clean front with one strong LATE reflection — late enough to stay
+    // outside the direct-sound cut. Two channels whose reflections correlate
+    // (the cabin's shared geometry) grow a whitened-correlation lobe at the
+    // REFLECTION pair's lag: a phantom the full-record trust gates cannot see
+    // through, since it is a genuine, dominant, separated extremum.
+    private static Complex[] ReflectedFront(
+        double frontMs, double reflectionAfterMs, double reflectionAmplitude)
+    {
+        var ir = new Complex[IrLength];
+        ir[BasePosition + (int)Math.Round(frontMs / 1000.0 * SampleRate)] = 1.0;
+        ir[BasePosition +
+            (int)Math.Round((frontMs + reflectionAfterMs) / 1000.0 * SampleRate)] =
+            reflectionAmplitude;
+        return ir;
+    }
+
     // A SOFT band-limited front under a strong late resonant build-up BELOW
     // the pair band — the field shape of the modal latch. The front is an
     // impulse smeared by a band-pass (a real driver through its crossover has
@@ -349,9 +380,10 @@ public sealed class AutoAlignmentEngineTests
     [Fact]
     public void Compute_SeedErrorAtASharpJunction_OnsetLockRecoversDirectly()
     {
-        // A 2 kHz junction whose seed is NOT trusted — the tweeter carries a
-        // near-equal copy a full period out, so the whitened correlation's
-        // same-polarity rival ties and the coarse offset falls back to the
+        // A 2 kHz junction whose seed is NOT trusted — the tweeter's front is
+        // genuinely PERIODIC (three near-equal copies one period apart), so
+        // the same-polarity rivals tie on the full-record PHAT and on the
+        // direct-sound cut alike, and the coarse offset falls back to the
         // arrival envelope. That envelope says 1.0 ms while the search-time
         // optimum is +0.4 ms, 1.2 periods off and beyond the fine window
         // around it. Above the lock's frequency gate the broadband onsets of
@@ -359,7 +391,41 @@ public sealed class AutoAlignmentEngineTests
         // optimum is found directly: no edge retry, no promotion, and the
         // chosen delay lands on the front-aligned lobe. (With a TRUSTED seed
         // the lock stands down — it replaces an arrival anchor, and a measured
-        // extremum is the better witness; see Compute_ReportsPerChannelDecisions.)
+        // extremum is the better witness; see Compute_ReportsPerChannelDecisions.
+        // A SINGLE competing copy no longer reaches the lock: the direct-cut
+        // witness resolves it — see
+        // Compute_UntrustedPhatAtAHighJunction_DirectCutWitnessSeeds.)
+        var woofer = new TestChannel("W", DelayedImpulse(1.0));
+        var tweeter = new TestChannel(
+            "T", PeriodicFront(0.5),
+            reprocessIr: DelayedImpulse(0.6));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([woofer, tweeter], [2_000], log, bands: [(700, 5_600)]);
+
+        Assert.InRange(alignment[tweeter].DelayMs, 0.35, 0.45);
+        Assert.Contains("ONSET-LOCKED", log.ToString());
+        Assert.Contains("onset gap after", log.ToString());
+        Assert.Contains("direct-cut", log.ToString());
+        Assert.Contains("unusable", log.ToString());
+        Assert.DoesNotContain(
+            "WARNING: fine result at the search edge", log.ToString());
+        Assert.DoesNotContain("promoted", log.ToString());
+    }
+
+    [Fact]
+    public void Compute_UntrustedPhatAtAHighJunction_DirectCutWitnessSeeds()
+    {
+        // The rescue the direct-cut witness exists for. The tweeter carries a
+        // slightly stronger copy one period behind its front, so the
+        // full-record PHAT's same-polarity rivals tie and its extremum fails
+        // the trust gates. Before the witness this junction fell back to the
+        // arrival envelope; measured across the archived cabins that fallback
+        // sat 0.6-1.2 periods off the owner's tunes at mid/tweeter junctions.
+        // The direct-sound cut tapers the copy against the front and resolves
+        // a usable extremum, which seeds the stage-2 window onto the correct
+        // lobe directly — no onset lock, no recovery machinery.
         var woofer = new TestChannel("W", DelayedImpulse(1.0));
         var tweeter = new TestChannel(
             "T", ImpulseWithEcho(0.0, 0.995, 0.5, 1.0),
@@ -370,11 +436,33 @@ public sealed class AutoAlignmentEngineTests
             Run([woofer, tweeter], [2_000], log, bands: [(700, 5_600)]);
 
         Assert.InRange(alignment[tweeter].DelayMs, 0.35, 0.45);
-        Assert.Contains("ONSET-LOCKED", log.ToString());
-        Assert.Contains("onset gap after", log.ToString());
-        Assert.DoesNotContain(
-            "WARNING: fine result at the search edge", log.ToString());
-        Assert.DoesNotContain("promoted", log.ToString());
+        Assert.Contains("seed direct-cut (phat:", log.ToString());
+        Assert.DoesNotContain("ONSET-LOCKED", log.ToString());
+    }
+
+    [Fact]
+    public void Compute_TrustedPhantomLobe_JointSupportSeedsFromTheDirectCut()
+    {
+        // The catastrophic field shape: both channels carry one strong LATE
+        // reflection off the cabin's shared geometry, and the reflection
+        // pair's whitened-correlation lobe DOMINATES the full record — a
+        // separated, high-r extremum every full-record trust gate accepts,
+        // 2.5 ms (five periods) from the true front alignment. Measured across
+        // the archived cabins this passed the gates with the extremum 3.4-4.7
+        // periods off the owner's tune in half of the mid/tweeter cells. The
+        // direct cuts exclude the reflections, and the JOINT-support
+        // adjudication (see DirectSeedJointTieMarginR) reads the phantom's
+        // absence from the direct surface — near-zero there against real
+        // support at the front lobe — and seeds from the direct cut.
+        var woofer = new TestChannel("W", ReflectedFront(1.0, 3.0, 1.4));
+        var tweeter = new TestChannel("T", ReflectedFront(0.0, 5.5, 1.4));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([woofer, tweeter], [2_000], log, bands: [(700, 5_600)]);
+
+        Assert.InRange(alignment[tweeter].DelayMs, 0.9, 1.1);
+        Assert.Contains("seed direct-cut over phat (joint", log.ToString());
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -1179,11 +1179,21 @@ public sealed class StereoAlignmentTests
     // positions — the shape the scene locks and the arithmetic bridge leave
     // behind on a real far side. Returns the two delays after the polish.
     private static (double MidDelayMs, double TwrDelayMs, string Log)
-        RunFarSidePolish(double twrLateMs, bool midIsMono = false)
+        RunFarSidePolish(
+            double twrLateMs,
+            bool midIsMono = false,
+            double baseDelayMs = 1.0,
+            bool withFieldFloor = false)
     {
         var farMid = new TestChannel("R mid", ImpulseAtMs(5.0));
         var farTwr = new TestChannel("R twr", ImpulseAtMs(5.0 + twrLateMs));
-        TestChannel[] all = [farMid, farTwr];
+        // A stand-in for the rest of the field: it carries no right junction, so
+        // the polish walks past it, but it is what the realizable span is
+        // measured FROM — the earliest channel of the whole system.
+        var fieldFloor = new TestChannel("L ref", ImpulseAtMs(5.0));
+        TestChannel[] all = withFieldFloor
+            ? [farMid, farTwr, fieldFloor]
+            : [farMid, farTwr];
 
         IReadOnlyList<AlignmentSnapshot> Reprocess(
             IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
@@ -1204,12 +1214,18 @@ public sealed class StereoAlignmentTests
             farMid, farTwr, 1_250, 5_000, SceneOffsetMs: 0);
         var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
         {
-            [farMid] = new(1.0, false),
-            [farTwr] = new(1.0, false)
+            [farMid] = new(baseDelayMs, false),
+            [farTwr] = new(baseDelayMs, false)
         };
+        if (withFieldFloor)
+        {
+            alignment[fieldFloor] = new(0.0, false);
+        }
+
         var log = new StringBuilder();
         AutoAlignmentEngine.PolishFarSideJunctions(
-            plan, snapshots, Reprocess, alignment, log, decisions: null);
+            plan, snapshots, snapshots, Reprocess, alignment, log,
+            decisions: null);
         return (alignment[farMid].DelayMs, alignment[farTwr].DelayMs, log.ToString());
     }
 
@@ -1244,6 +1260,20 @@ public sealed class StereoAlignmentTests
         Assert.True(twrDelay < 1.0, $"twr did not move earlier ({twrDelay:0.000})");
     }
 
+    [Fact]
+    public void PolishFarSideJunctions_StaysInsideTheRealizableDelaySpan()
+    {
+        // The field already spans the DSP's whole range with the earliest
+        // channel at zero. The polish is the only pass that moves a channel
+        // LATER after the cascade settles, so without a ceiling it would spend
+        // a hundredth of a decibel to make the proposal unrealizable — and the
+        // feasibility check would then refuse the whole run.
+        (double midDelay, double twrDelay, string _) = RunFarSidePolish(
+            0.02, baseDelayMs: 50.0, withFieldFloor: true);
+
+        Assert.InRange(midDelay, 0, 50.0);
+        Assert.InRange(twrDelay, 0, 50.0);
+    }
     [Fact]
     public void PolishFarSideJunctions_NeverMovesAMonoChannel()
     {

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -1183,7 +1183,8 @@ public sealed class StereoAlignmentTests
             double twrLateMs,
             bool midIsMono = false,
             double baseDelayMs = 1.0,
-            bool withFieldFloor = false)
+            bool withFieldFloor = false,
+            double fieldChannelMs = 0.0)
     {
         var farMid = new TestChannel("R mid", ImpulseAtMs(5.0));
         var farTwr = new TestChannel("R twr", ImpulseAtMs(5.0 + twrLateMs));
@@ -1219,7 +1220,7 @@ public sealed class StereoAlignmentTests
         };
         if (withFieldFloor)
         {
-            alignment[fieldFloor] = new(0.0, false);
+            alignment[fieldFloor] = new(fieldChannelMs, false);
         }
 
         var log = new StringBuilder();
@@ -1273,6 +1274,21 @@ public sealed class StereoAlignmentTests
 
         Assert.InRange(midDelay, 0, 50.0);
         Assert.InRange(twrDelay, 0, 50.0);
+    }
+    [Fact]
+    public void PolishFarSideJunctions_StaysInsideTheSpanFromTheEarlyEndToo()
+    {
+        // The mirror of the case above: here the far channels ARE the field's
+        // earliest, and the rest of the system sits at the far end of the
+        // range. Polishing them earlier widens the spread exactly as polishing
+        // the latest channel later does — normalization rebases on whichever
+        // end moved — so the guard has to read the span, not an absolute
+        // ceiling.
+        (double midDelay, double twrDelay, string _) = RunFarSidePolish(
+            0.02, baseDelayMs: 1.0, withFieldFloor: true, fieldChannelMs: 51.0);
+
+        Assert.InRange(51.0 - midDelay, 0, 50.0);
+        Assert.InRange(51.0 - twrDelay, 0, 50.0);
     }
     [Fact]
     public void PolishFarSideJunctions_NeverMovesAMonoChannel()

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -1171,4 +1171,89 @@ public sealed class StereoAlignmentTests
 
         Assert.Equal(AutoAlignmentEngine.CrossSideLockTier.None, tier);
     }
+
+    // ------------------------------------------------- far-side junction polish
+
+    // A bare polish bench: two far channels 1.0 ms of assigned delay each, whose
+    // junction (fc 2500, band 1250-5000) is left SKEWED by the scene-assigned
+    // positions — the shape the scene locks and the arithmetic bridge leave
+    // behind on a real far side. Returns the two delays after the polish.
+    private static (double MidDelayMs, double TwrDelayMs, string Log)
+        RunFarSidePolish(double twrLateMs, bool midIsMono = false)
+    {
+        var farMid = new TestChannel("R mid", ImpulseAtMs(5.0));
+        var farTwr = new TestChannel("R twr", ImpulseAtMs(5.0 + twrLateMs));
+        TestChannel[] all = [farMid, farTwr];
+
+        IReadOnlyList<AlignmentSnapshot> Reprocess(
+            IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> overrides) =>
+            all.Select(channel =>
+                Snapshot(channel, overrides.GetValueOrDefault(channel))).ToList();
+
+        List<AlignmentSnapshot> snapshots = all
+            .Select(channel => Snapshot(channel, default))
+            .ToList();
+        AlignmentJunction pair = Junction(snapshots[0], snapshots[1], 2_500);
+        // The left-role fields are structural dummies: the polish reads only the
+        // right pairs and the mono set.
+        var plan = new StereoAlignmentPlan(
+            snapshots, [pair], snapshots, [pair],
+            midIsMono
+                ? new HashSet<IAlignmentChannel> { farMid }
+                : new HashSet<IAlignmentChannel>(),
+            farMid, farTwr, 1_250, 5_000, SceneOffsetMs: 0);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [farMid] = new(1.0, false),
+            [farTwr] = new(1.0, false)
+        };
+        var log = new StringBuilder();
+        AutoAlignmentEngine.PolishFarSideJunctions(
+            plan, snapshots, Reprocess, alignment, log, decisions: null);
+        return (alignment[farMid].DelayMs, alignment[farTwr].DelayMs, log.ToString());
+    }
+
+    [Fact]
+    public void PolishFarSideJunctions_ClawsBackASmallSceneSkewExactly()
+    {
+        // The scene positions leave the far junction 0.02 ms out of alignment —
+        // inside the polish budget, so the pass closes it completely and the
+        // pair's arrivals meet.
+        (double midDelay, double twrDelay, string log) = RunFarSidePolish(0.02);
+
+        double residualMs = Math.Abs((5.0 + midDelay) - (5.02 + twrDelay));
+        Assert.True(
+            residualMs <= 0.005,
+            $"the junction skew survived the polish ({residualMs:0.000} ms)");
+        Assert.Contains("Far-side polish", log);
+        Assert.Contains("off the scene position", log);
+    }
+
+    [Fact]
+    public void PolishFarSideJunctions_NeverSpendsMoreThanTheBudgetPerChannel()
+    {
+        // A 0.10 ms skew: each channel may close at most its own 0.03 ms of it.
+        // The point is the ceiling, not the residual — a polish that chased the
+        // whole skew would be a second alignment pass wearing a polish's name.
+        (double midDelay, double twrDelay, string _) = RunFarSidePolish(0.10);
+
+        Assert.InRange(Math.Abs(midDelay - 1.0), 0, 0.03 + 1e-9);
+        Assert.InRange(Math.Abs(twrDelay - 1.0), 0, 0.03 + 1e-9);
+        // And both spent their budgets TOWARD each other: mid later, twr earlier.
+        Assert.True(midDelay > 1.0, $"mid did not move later ({midDelay:0.000})");
+        Assert.True(twrDelay < 1.0, $"twr did not move earlier ({twrDelay:0.000})");
+    }
+
+    [Fact]
+    public void PolishFarSideJunctions_NeverMovesAMonoChannel()
+    {
+        // The mono channel is shared with the reference side — moving it would
+        // re-time the left walk's junctions behind their backs. The polish must
+        // spend the tweeter's budget instead and leave the mono exactly put.
+        (double midDelay, double twrDelay, string _) =
+            RunFarSidePolish(0.02, midIsMono: true);
+
+        Assert.Equal(1.0, midDelay, 3);
+        Assert.InRange(twrDelay, 0.97, 0.99);
+    }
 }


### PR DESCRIPTION
Three findings about how a mid/tweeter junction picks its lobe, each measured
on the archived cabins before it became code.

## 1. Seed the high junctions from the direct wavefronts, and let the far side breathe

The full-record GCC-PHAT extremum is catastrophically wrong on half of the
archive's high junctions — it sits 3.4 to 4.7 periods from the hand tune,
having grown on a reflection rather than the arrival. Cutting both channels to
their direct sound first repairs four cycle skips and leaves v6 untouched, so
above a kilohertz the seed now takes a direct-cut witness where the coefficient
supports one.

The far side of a stereo pass also stops being pinned rigidly. It may move up
to 0.03 ms off the arrival bridge when that buys the junction a better sum,
which the honest cases use for gains of 0.01 to 0.03 dB.

## 2. Let the crossover settle its own polarity, and stop trusting distant phantoms

Where the lower channel's low-pass and the upper channel's high-pass share
family, corner and slope, the junction is ONE crossover and its summing
polarity is arithmetic, not evidence: LR12/LR36 and Butterworth 12/36 null in
phase, LR24/LR48 and Butterworth 24/48 do not. The search used to decide it
from a summation score defended by a 0.5 dB invert preference, and on a real
cabin set to LR36 that put the two sides of one system on opposite answers —
the left found the flip with 0.63 dB to spare, the right missed it by 0.01.
The polarity is now read off the filters and forced, fenced three ways: matched
splits only, above a kilohertz only, and under a trusted seed only, each fence
measured rather than assumed.

The seed's reach gate also did not gate: its 3 ms floor is four to five periods
at a mid/tweeter junction, so a reflection-grown phantom passed it as easily as
an honest extremum. Where the direct-cut witness offers a seed of its own the
reach now tightens to a period and a half — the honest field extrema sit within
1.15, the phantoms from 1.66 out.

## 3. Let the coherence bands veto a lobe swap decided on a hair

**The summation metric does not judge this junction at all.** The panel's own
score reads the v3 L hand tune at −1.37 dB average and −8.73 dB dip against
−1.42 and −8.76 for the alias half a period away with the polarity flipped; v6
L reads −0.65/−4.01 against −0.77/−3.71, where the alias has the shallower dip
of the two. That holds through every window from two periods to twenty-four,
level-matched or not.

So the junction is judged by the correlation views, and they are two witnesses
that see different things. The direct-sound correlation is one whitened comb
across the pair's whole band — it carries the polarity, but its neighbouring
lobes differ by very little. The arrival-coherence ladder resolves the band
into sub-band probes, each re-cutting the direct sound at its own scale — it
cannot see polarity at all, and it can say how many bands actually want the
upper channel where a candidate puts it.

Above a kilohertz, a swap the comb asks for by less than 0.10 of coefficient is
now put to the bands, and refused when the coherent ones hold the standing lobe
by two or more. The ladder reads a pair at its APPLIED alignment, so the
variable channel is first slid onto the standing candidate by a whole number of
samples; without that it is handed two channels fourteen milliseconds apart and
honestly answers with zero coherence in every band.

## Field results

Across the seven archived cabins the battery changes on exactly one side.

| | before | after | hand tune |
|---|---|---|---|
| v3 L tweeter, relative to the mid | −0.060 ms inverted | **+0.250 ms in phase** | +0.280 ms in phase |
| v3 L junction through the truncated window | −7.29 dB | **−2.62 dB** | −1.37 dB |

On v6 — the cabin whose tune is trusted most — both sides are untouched: the
correlation is decisive there at 0.11 and 0.14 and the gate is never reached,
which is as it should be, since the ladder's vote on v6 L is 3 bands to 2 the
other way, short of the margin. The engine already reproduces that cabin's tune
to 10 µs at every junction but one.

Two traps worth recording, both met while calibrating this: comparing two tunes
through a short window needs the cascade's overall latency normalised first, or
a junction reproduced to forty microseconds reads as a four decibel regression
against a gate pinned in absolute time; and even then the SUM's window anchor
depends on the other channels, so only a one-junction-at-a-time sweep is
trustworthy.

## Tests

A filtered synthetic junction pins the crossover polarity per family and slope
(LR36/LR12/BW12 inverted, LR24/LR48 in phase) and a staggered-corner variant
pins that the rule stays out; a periodic front and a reflected front pin the
direct-cut seed and its tightened reach; the far-side polish has three tests of
its own; and the ladder vote is pinned on the band count over a quarter period,
on incoherent bands being kept out, on two candidates half a period apart
separating 3 to 1, and on a windowless quarter period being refused.

Full suite green: 2944 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
