### PR TITLE
Refresh the panel's view of the device it just reconfigured

### DIFF
--- a/audio/Contracts/AudioSessionRequest.cs
+++ b/audio/Contracts/AudioSessionRequest.cs
@@ -65,6 +65,38 @@ public sealed record AudioCaptureRouting(
         }
     }
 
+    /// <summary>
+    /// Value equality over the channel list, which the generated one does not give.
+    /// </summary>
+    /// <remarks>
+    /// A record compares its FIELDS, and this one holds an array: two routings naming
+    /// the same channels held two different arrays and compared unequal. The empty
+    /// case hid it — `[]` is a singleton, so a routing without an array compared equal
+    /// and everything downstream looked right — while a routing WITH one never
+    /// did. The caller that suffers is the settings panel's live apply, which asks
+    /// whether the audio request actually changed before reopening the device: with an
+    /// array configured the answer was always yes, so every edit anywhere on the panel
+    /// paid for a device warm-up nothing had asked for.
+    /// </remarks>
+    public bool Equals(AudioCaptureRouting? other) =>
+        other is not null &&
+        MicrophoneChannel == other.MicrophoneChannel &&
+        LoopbackChannel == other.LoopbackChannel &&
+        ArrayChannels.SequenceEqual(other.ArrayChannels);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(MicrophoneChannel);
+        hash.Add(LoopbackChannel);
+        foreach (int channel in ArrayChannels)
+        {
+            hash.Add(channel);
+        }
+
+        return hash.ToHashCode();
+    }
+
     private int[] Validate(IReadOnlyList<int>? channels)
     {
         if (channels == null || channels.Count == 0)

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -2435,6 +2435,40 @@ namespace Resonalyze.Options
             UpdateAudioBackendControls();
         }
 
+        /// <summary>
+        /// Re-reads the audio device after the host has applied these settings to it.
+        /// </summary>
+        /// <remarks>
+        /// The panel's picture of the driver is a snapshot, taken when the panel opened
+        /// or when a control changed — and Apply reconfigures the device UNDER it while
+        /// it stays on screen. So a rate change probed the driver while it was still
+        /// open at the old rate, got "not supported", painted the status amber, and
+        /// kept it there: the driver was reinitialised at the new rate a moment later
+        /// and nothing asked it again. Reopening the panel was the only way to get a
+        /// straight answer, which is the tell that the view had gone stale rather than
+        /// the device being wrong.
+        /// </remarks>
+        internal void RefreshAudioDeviceView()
+        {
+            if (initializing || IsDisposed)
+            {
+                return;
+            }
+
+            int preferredSampleRate = GetSelectedSampleRate();
+            if (comboBoxAudioBackend.SelectedIndex == (int)AudioBackend.Asio)
+            {
+                RefreshAsioDriverInfo(
+                    preferredSampleRate,
+                    GetSelectedAsioInputChannelOffset(),
+                    GetSelectedAsioOutputChannelOffset(),
+                    GetSelectedAsioLoopbackInputChannelOffset());
+            }
+
+            RefreshSampleRateOptions(preferredSampleRate);
+            UpdateAudioBackendControls();
+        }
+
         private void RefreshSampleRateOptions(int preferredSampleRate)
         {
             SampleRateResolution resolution = SampleRateOptions.Resolve(

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -460,11 +460,26 @@ public partial class Form1
         }
     }
 
-    private void buttonRecordOpt_Click(object sender, EventArgs e)
+    private async void buttonRecordOpt_Click(object sender, EventArgs e)
     {
         if (dockedMeasurementSettingsHost.IsOpen)
         {
             dockedMeasurementSettingsHost.Close();
+            return;
+        }
+
+        // The panel OPENS the audio device: with ASIO its sample-rate list is read
+        // straight out of a driver probe, and a driver already open answers with the
+        // rate it is open at and nothing else. Every other place that touches the
+        // device waits for the startup warm-up first (see the record button and the
+        // live spectrum toggle); this one did not, so the first open after launch
+        // could land on a busy driver and offer one rate. Reopening the panel then
+        // fixed it, which is exactly what a timing collision looks like.
+        //
+        // Free once the warm-up has finished, which is every open but the first.
+        await startupAudioWarmup.WaitAsync();
+        if (IsDisposed || dockedMeasurementSettingsHost.IsOpen)
+        {
             return;
         }
 
@@ -495,6 +510,13 @@ public partial class Form1
                             CreateAudioWarmupRequest(measurementSettings.Measurement),
                             CancellationToken.None);
                     }
+
+                    // The panel stays on screen after Apply, and the device it is
+                    // describing has just been reconfigured under it. Its picture of
+                    // the driver is a snapshot, so without this a rate change leaves
+                    // the status amber against a driver that is now running at exactly
+                    // that rate, and the only cure is reopening the panel.
+                    dialog.RefreshAudioDeviceView();
                 }
                 catch (InvalidOperationException exception)
                 {

--- a/tests/Resonalyze.Audio.Tests/AudioCaptureRoutingEqualityTests.cs
+++ b/tests/Resonalyze.Audio.Tests/AudioCaptureRoutingEqualityTests.cs
@@ -1,0 +1,62 @@
+namespace Resonalyze.Audio.Tests;
+
+/// <summary>
+/// Two routings that name the same channels are the same routing.
+/// </summary>
+/// <remarks>
+/// A record compares its FIELDS, and this one holds an array of array channels: two
+/// routings built separately held two different arrays and compared unequal. The
+/// empty case hid it, because `[]` is a singleton — so a routing without an array
+/// compared equal and nothing looked wrong until one had an array.
+/// <para>
+/// What suffers is the settings panel's live apply, which asks whether the audio
+/// request actually changed before reopening the device. With an array configured the
+/// answer was always yes, so every edit anywhere on the panel paid for a device
+/// warm-up nothing had asked for — and on ASIO an unnecessary open is not free: the
+/// panel's own driver probe can land on a driver that is busy and get a shorter
+/// answer than the truth.
+/// </para>
+/// </remarks>
+public sealed class AudioCaptureRoutingEqualityTests
+{
+    [Fact]
+    public void SameChannelsAreEqualWithAnArray()
+    {
+        var first = new AudioCaptureRouting(0, 1) { ArrayChannels = [2, 3, 4] };
+        var second = new AudioCaptureRouting(0, 1) { ArrayChannels = [2, 3, 4] };
+
+        Assert.Equal(first, second);
+        Assert.True(first == second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    [Fact]
+    public void SameChannelsAreEqualWithoutOne()
+    {
+        Assert.Equal(new AudioCaptureRouting(0, 1), new AudioCaptureRouting(0, 1));
+    }
+
+    [Fact]
+    public void DifferentChannelsAreNotEqual()
+    {
+        var routing = new AudioCaptureRouting(0, 1) { ArrayChannels = [2, 3] };
+
+        Assert.NotEqual(routing, new AudioCaptureRouting(0, 1) { ArrayChannels = [2, 4] });
+        Assert.NotEqual(routing, new AudioCaptureRouting(0, 1) { ArrayChannels = [2, 3, 4] });
+        Assert.NotEqual(routing, new AudioCaptureRouting(0, 1));
+        // A routing refuses to put the microphone or the loopback on an array
+        // channel, so the differing pair moves to channels the array does not hold.
+        Assert.NotEqual(routing, new AudioCaptureRouting(0, 6) { ArrayChannels = [2, 3] });
+        Assert.NotEqual(routing, new AudioCaptureRouting(5, 1) { ArrayChannels = [2, 3] });
+    }
+
+    [Fact]
+    public void OrderIsPartOfTheRouting()
+    {
+        // The channels are positional: the i-th is the i-th configured microphone, so
+        // two orders are two different arrays and the device is reopened for the swap.
+        Assert.NotEqual(
+            new AudioCaptureRouting(0, 1) { ArrayChannels = [2, 3] },
+            new AudioCaptureRouting(0, 1) { ArrayChannels = [3, 2] });
+    }
+}


### PR DESCRIPTION
Three field reports from the first day with the microphone array, and only one of
them was the array's doing.

## The panel's picture of the driver

Both reports about the sample rate have one root: the settings panel holds a
**snapshot** of the audio driver, and neither the moment it is taken nor the moment
it goes stale was guarded.

**Taken too early.** The panel opens the device — with ASIO its sample-rate list is
read straight out of a driver probe, and a driver that is already open answers with
the rate it is open at and nothing else. Every other place that touches the device
waits for the startup warm-up first, the record button and the live spectrum toggle
among them; opening the panel did not. So the first open after launch could land on
a busy driver and offer a single rate. Reopening fixed it, which is what a timing
collision looks like rather than a device that cannot do better.

**Never refreshed.** Apply reconfigures the device while the panel stays on screen —
it is the host's apply callback, not a close. So changing the rate probed the driver
while it was still open at the old one, got "not supported", painted the status amber
and kept it there: the driver was reinitialised at the new rate a moment later and
nothing asked it again. Reopening the panel was the only cure, which is the tell that
the view had gone stale rather than the device being wrong. The panel now re-reads
the device the host has just reconfigured under it.

Neither is the array's doing, and that was worth establishing rather than assuming:
the ASIO rate list comes from `IsSampleRateSupported` per candidate rate with no
channel count anywhere near it, the probe's minimum rate is a constant, and both
reports reproduce with no array configured.

## A routing that did not know it was the same routing

The one defect that IS the array's. `AudioCaptureRouting` is a record, a record
compares its FIELDS, and the array feature added an array of channels to it. Two
routings naming the same channels held two different arrays and compared unequal.
Proved before it was fixed: without an array `true`, with one `false`.

The empty case hid it — `[]` is a singleton, so a routing without an array compared
equal and nothing looked wrong until one had an array.

What suffers is the live apply, which asks whether the audio request actually changed
before reopening the device. With an array configured the answer was always yes, so
every edit anywhere on the panel — a sweep length, a bit depth, the protective
high-pass — paid for a device warm-up nothing had asked for. On ASIO an unnecessary
open is not free, which is what makes this the same story as the two above: it made
the collision far more likely for exactly the users who had just configured an array.

Four tests pin the routing's equality, including that the channel ORDER is part of it
— the i-th channel is the i-th configured microphone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
