### PR TITLE
Six quality-of-life fixes, and two bugs in the EQ Wizard handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,7 @@ is set to show no animations (Settings → Accessibility → Visual effects).
   from the transfer function (harmonics and THD+N stay on the sweep
   deconvolution); Live Spectrum can additionally run as a reference-free RTA
 - **Multi-sweep averaging** (1–64 runs) as a cross-spectrum estimate with a
-  per-frequency **coherence** (γ²) curve, and an optional confirm-between-runs
-  pause for spatial averaging
+  per-frequency **coherence** (γ²) curve, the runs playing back to back
 - **Analysis views** — frequency response, phase, group delay, waterfall, Burst
   Decay, autocorrelation, harmonic distortion, THD and THD+N, with
   reliability-anchored phase unwrapping, Fixed/**FDW** phase windowing, and

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1112,7 +1112,11 @@ frequency.
 
 The plot shows, on shared frequency/dB axes: **Source** (with optional extra
 smoothing), **Target**, **Source + EQ**, the **EQ** filter response itself (on
-its own right-hand dB axis), and a shaded **error fill**. Click a band card to
+its own right-hand dB axis), and a shaded **error fill**. The fill stops where the
+measurement does: where the source curve has no level — under a protective
+high-pass, outside the band the driver was swept over, past the end of a capture's
+grid — that range is left unshaded rather than shaded as a deviation from a target
+nothing was measured against. Click a band card to
 overlay that band's contribution as a dashed curve, with a dotted vertical guide
 at its frequency in the same colour. The curve says what the filter does and the
 guide says where it sits, which the curve is bad at: a low-Q bell is a shape an
@@ -1278,6 +1282,14 @@ break the identity above, so the correction is changed where it lives. What is
 pinned is the curve the panel draws with — including one a loaded session carries
 that is in no list of yours — under the name the panel shows for it. The wizard's
 standing calibration preference for impulse responses survives untouched.
+
+A channel need not have a CURVE to be corrected, and under the panel's **Own (as
+measured)** it often does not: an impulse response taken before calibrations were
+stamped into files names none, while the moving-microphone capture beside it
+carries its own — two corrections for two curves, and the wizard reproduces each
+where it applies. The selector then reads *Own (as measured)*, the panel's own
+words, because the correction is whatever that capture was recorded through and no
+entry in the wizard's list need name it.
 
 The return guard covers this too: a bank fitted against the spatial average will
 not land on a panel that has gone back to its impulse responses, or onto a channel

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -683,6 +683,13 @@ to another entry and back restores the whole working context, not just the
 impulse response. Only a small rolling set of unsaved in-memory snapshots is
 retained.
 
+The list itself holds at most **30** entries. Past that the oldest `FILE` row is
+dropped — the file stays on disk untouched and opening it again brings the row
+back, with only the working state it had remembered lost. A `RAM` row is never
+dropped to make room for one: it is the measurement rather than a pointer to it,
+and it exists nowhere else. A store that arrives over depth, written before this
+was capped, is cut when it loads.
+
 ## Compare
 
 The **Compare** button overlays a second measurement on top of the current one,
@@ -1106,9 +1113,22 @@ frequency.
 The plot shows, on shared frequency/dB axes: **Source** (with optional extra
 smoothing), **Target**, **Source + EQ**, the **EQ** filter response itself (on
 its own right-hand dB axis), and a shaded **error fill**. Click a band card to
-overlay that band's contribution as a dashed curve. Each card carries its
+overlay that band's contribution as a dashed curve, with a dotted vertical guide
+at its frequency in the same colour. The curve says what the filter does and the
+guide says where it sits, which the curve is bad at: a low-Q bell is a shape an
+octave wide whose summit the eye places by guesswork, and a shelf or an all-pass
+has no summit to place at all. Both follow the card as it is edited, and the
+guide is drawn in the **Phase** view as well. Each card carries its
 **frequency**, **Q**, and **gain**, and the panel adds a **Target Level**, a
 **Gain** (preamp), a **Bands** count, source **Smoothing**, and **Bypass**.
+
+**EQ curve** draws the bank's own response — the white trace, in dB here and in
+degrees under **Phase**. Turning it off leaves the plot to the measurement and
+the target, which is what a crowded fit is read on; the filters keep working
+either way, and **Source + EQ** still carries them. The right-hand axis goes
+with the curve when nothing else is left on it: in the magnitude view it carries
+that curve alone, while in **Phase** every measured trace is on it and it stays.
+The choice is remembered between sessions.
 
 Every **frequency** field here — a card's own, and the **From** / **To** of the
 fit range — steps logarithmically: one wheel notch, spin-button click or arrow
@@ -2070,7 +2090,9 @@ various delimiters, and extra columns all handled.
 Beside it, **More calibrations → Manage...** holds any number of further
 calibrations, each with a name of your choosing:
 
-- a **file** — a second microphone, a different capsule, another chain;
+- a **file** — a second microphone, a different capsule, another chain. It
+  lands with the file's own name filled in and the row already open for renaming:
+  type over that suggestion, or keep it with Enter. **Rename** reopens it later;
 - an **angle** — a curve *estimated* for an angle of incidence between 0° and
   90°, derived from the 0° file (or from another file entry) plus the geometry
   of your microphone: the outer diameter of its front and whether the protection

--- a/audio/Internal/PcmCaptureSession.cs
+++ b/audio/Internal/PcmCaptureSession.cs
@@ -169,10 +169,11 @@ internal sealed class PcmCaptureSession : IAsyncDisposable, ISweepCaptureSession
 
     /// <summary>
     /// Stops appending captured samples while the device keeps running (and keeps
-    /// raising level meters) — used between averaged sweep runs, where a long
-    /// confirmation pause would otherwise grow the capture buffer without bound.
-    /// Stopping the device between runs is not an option — WASAPI cannot be
-    /// restarted — so packets are dropped instead. <see cref="Reset"/> resumes.
+    /// raising level meters) — used between averaged sweep runs, where the gap the
+    /// caller spends deconvolving and judging the run just captured would otherwise
+    /// grow the capture buffer without bound. Stopping the device between runs is
+    /// not an option — WASAPI cannot be restarted — so packets are dropped instead.
+    /// <see cref="Reset"/> resumes.
     /// </summary>
     public void Pause()
     {
@@ -227,7 +228,7 @@ internal sealed class PcmCaptureSession : IAsyncDisposable, ISweepCaptureSession
 
             // While paused (between averaged runs) the device keeps running so the
             // level meter stays live, but samples are dropped instead of appended —
-            // otherwise a long confirmation pause grows the buffer without bound.
+            // otherwise the gap between runs grows the buffer without bound.
             if (!paused && accumulator is { } activeAccumulator)
             {
                 activeAccumulator.Append(decodeScratch, decodedFrames);

--- a/audio/Sessions/AsioDuplexSession.cs
+++ b/audio/Sessions/AsioDuplexSession.cs
@@ -4,8 +4,8 @@
 /// Finite play-and-capture over a single ASIO driver session. The driver is
 /// opened once and kept running across averaging runs (re-initializing it per
 /// run costs seconds on slow drivers); each run resets the capture accumulator
-/// and rewinds the excitation. Capture is paused between runs so a long
-/// confirmation wait does not grow the buffer while the meter stays live.
+/// and rewinds the excitation. Capture is paused between runs so the gap between
+/// them does not grow the buffer while the meter stays live.
 /// </summary>
 internal sealed class AsioDuplexSession : IAudioDuplexSession
 {

--- a/audio/Sessions/PcmDuplexSession.cs
+++ b/audio/Sessions/PcmDuplexSession.cs
@@ -66,7 +66,7 @@ internal sealed class PcmDuplexSession : IAudioDuplexSession
             captureTailSamples,
             cancellationToken).ConfigureAwait(false);
         // Stop accumulating between runs: the device keeps running (meter stays
-        // live) but a long averaging confirmation pause no longer grows memory.
+        // live) but the gap between averaged runs no longer grows memory.
         // The next run's orchestrator Reset resumes capture.
         captureSession.Pause();
 

--- a/source/History/MeasurementHistoryService.cs
+++ b/source/History/MeasurementHistoryService.cs
@@ -5,6 +5,10 @@ namespace Resonalyze.History;
 internal sealed class MeasurementHistoryService
 {
     public const int MaxInMemoryHistoryEntries = 10;
+    // The whole list, saved rows included. Nothing bounded it before: the history
+    // gained a row for every file ever opened and kept it for as long as that file
+    // existed, so a few weeks of tuning left hundreds to scroll past.
+    public const int MaxHistoryEntries = 30;
 
     private readonly MeasurementHistoryPersistence persistence;
     private readonly List<MeasurementHistoryEntry> entries;
@@ -13,6 +17,13 @@ internal sealed class MeasurementHistoryService
     {
         this.persistence = persistence ?? new MeasurementHistoryPersistence();
         entries = this.persistence.Load().ToList();
+        // A store written before the cap existed, or by a build without it, arrives
+        // over depth; it is cut here rather than at the next mutation, which may
+        // never come — a session that only reads the history never saves it.
+        if (TrimEntries())
+        {
+            SaveTrimmedEntries();
+        }
     }
 
     public event Action? Changed;
@@ -31,7 +42,14 @@ internal sealed class MeasurementHistoryService
             sourceFilePath: null,
             snapshot);
         entries.Insert(0, entry);
-        TrimInMemoryEntries();
+        // Recording does not otherwise touch the store — an unsaved entry lives in
+        // memory alone — but the depth cap can push a SAVED row off the end, and
+        // that has to reach disk.
+        if (TrimEntries())
+        {
+            SaveTrimmedEntries();
+        }
+
         OnChanged();
         return entry.Id;
     }
@@ -65,6 +83,7 @@ internal sealed class MeasurementHistoryService
         }
 
         RetainSingleFileBackedSnapshot(entry);
+        TrimEntries();
         persistence.Save(entries);
         OnChanged();
         return entry.Id;
@@ -110,6 +129,7 @@ internal sealed class MeasurementHistoryService
         }
 
         RetainSingleFileBackedSnapshot(entry);
+        TrimEntries();
         persistence.Save(entries);
         OnChanged();
     }
@@ -336,7 +356,21 @@ internal sealed class MeasurementHistoryService
         };
     }
 
-    private void TrimInMemoryEntries()
+    // Two caps answering two different questions. The in-memory one is about
+    // MEMORY: an unsaved snapshot holds the complete impulse responses, so only a
+    // small rolling set of them is kept. The depth one is about the LIST, which a
+    // reader has to be able to find something in.
+    //
+    // Over the depth it is a FILE-BACKED row that goes, oldest first, even when an
+    // unsaved row is older. What such a row loses is its working state; the
+    // measurement itself is on disk and opening the file brings the row back, while
+    // an unsaved row IS the measurement — dropping it to keep a saved one would
+    // trade the irreplaceable for the recoverable. There is always one to drop: the
+    // memory cap runs first and leaves at most ten unsaved rows out of the thirty.
+    //
+    // Returns whether a PERSISTED row was removed, which is the caller's cue to
+    // rewrite the store even when it had no other reason to.
+    private bool TrimEntries()
     {
         while (entries.Count(entry => !entry.IsFileBacked) > MaxInMemoryHistoryEntries)
         {
@@ -347,6 +381,40 @@ internal sealed class MeasurementHistoryService
             }
 
             entries.Remove(oldestUnsaved);
+        }
+
+        bool removedPersisted = false;
+        while (entries.Count > MaxHistoryEntries)
+        {
+            MeasurementHistoryEntry? oldestSaved = entries.LastOrDefault(entry => entry.IsFileBacked);
+            if (oldestSaved == null)
+            {
+                break;
+            }
+
+            entries.Remove(oldestSaved);
+            removedPersisted = true;
+        }
+
+        return removedPersisted;
+    }
+
+    // Best effort, the way the store rewrite in MeasurementHistoryPersistence.Load
+    // is: the in-memory list is already cut, so a store that cannot be written this
+    // launch is written by the next mutation or cut again by the next launch. The
+    // two callers are why it is swallowed rather than raised — this is the only
+    // write either of them makes, and neither has anywhere to report it that would
+    // not cost the user the launch (a field initializer on the shell) or the sweep
+    // that just finished.
+    private void SaveTrimmedEntries()
+    {
+        try
+        {
+            persistence.Save(entries);
+        }
+        catch (Exception exception)
+            when (exception is IOException or UnauthorizedAccessException)
+        {
         }
     }
 

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -18,11 +18,9 @@ namespace Resonalyze
         private readonly object stateSync = new();
         private CancellationTokenSource? cancellationTokenSource;
         private Task<bool>? measurementTask;
-        private TaskCompletionSource<bool>? averageConfirmation;
         private volatile bool inProgress;
         // Whether inProgress is held by an outstanding Claim rather than by a run.
         private bool claimed;
-        private volatile bool waitingForAverageConfirmation;
         private bool disposed;
         // Results are published from the measurement worker and read by the UI
         // without locks. Each impulse response travels with its peak index as one
@@ -184,7 +182,6 @@ namespace Resonalyze
 
         public int AverageRunCount { get; private set; } = 1;
         public int AcceptedAverageRunCount { get; private set; } = 1;
-        public bool ConfirmEachAverageRun { get; private set; }
         public ProtectiveHighPassConfiguration ProtectiveHighPass { get; private set; } =
             ProtectiveHighPassConfiguration.Off;
 
@@ -279,7 +276,6 @@ namespace Resonalyze
         // a measurement ran (or when the result was restored from a file).
         internal SweepRunQualityReport? QualityReport { get; private set; }
         public Exception? LastError { get; private set; }
-        public bool WaitingForAverageConfirmation => waitingForAverageConfirmation;
         internal InputLevelMeterSnapshot CurrentLevels
         {
             get => (InputLevelMeterSnapshot)currentLevels;
@@ -368,7 +364,6 @@ namespace Resonalyze
             ImportedChannelIndex = 0;
             AverageRunCount = Math.Clamp(averaging.RunCount, 1, 64);
             AcceptedAverageRunCount = 0;
-            ConfirmEachAverageRun = averaging.ConfirmEachRun;
             ProtectiveHighPass = ProtectiveHighPassConfiguration.Normalize(
                 configuration.ProtectiveHighPass);
             QualityReport = null;
@@ -488,14 +483,6 @@ namespace Resonalyze
             public void Dispose()
             {
                 Interlocked.Exchange(ref owner, null)?.ReleaseClaim();
-            }
-        }
-
-        public void ContinueAverageRun()
-        {
-            lock (stateSync)
-            {
-                averageConfirmation?.TrySetResult(true);
             }
         }
 
@@ -651,9 +638,7 @@ namespace Resonalyze
                     WasapiBufferMilliseconds: WasapiBufferMilliseconds,
                     WaveArrayInputChannelOffsets: WaveArrayInputChannelOffsets,
                     AsioArrayInputChannelOffsets: AsioArrayInputChannelOffsets),
-                new SweepAveragingConfiguration(
-                    AverageRunCount,
-                    ConfirmEachAverageRun),
+                new SweepAveragingConfiguration(AverageRunCount),
                 ProtectiveHighPass));
             // InitCore just set these from the sweep it regenerated; the recorded
             // geometry wins, since that sweep is a reconstruction and this result
@@ -1357,8 +1342,7 @@ namespace Resonalyze
                     Publish(AverageProgressChanged, new SweepAverageProgress(
                         run,
                         requestedRuns,
-                        accumulator.AcceptedRuns,
-                        SweepAverageProgressState.Running));
+                        accumulator.AcceptedRuns));
                     AudioCaptureResult? captured = await CaptureOneAsync().ConfigureAwait(false);
                     IReadOnlyList<string> issues = AssessRunQuality(captured, sweep);
                     if (issues.Count > 0)
@@ -1377,15 +1361,6 @@ namespace Resonalyze
                     }
 
                     accumulator.Add(AnalyzeCapturedRun(captured, sweep));
-
-                    if (ConfirmEachAverageRun && run < requestedRuns)
-                    {
-                        await WaitForAverageConfirmationAsync(
-                            run,
-                            requestedRuns,
-                            accumulator.AcceptedRuns,
-                            cancellationToken).ConfigureAwait(false);
-                    }
                 }
 
                 QualityReport = new SweepRunQualityReport(
@@ -1447,49 +1422,12 @@ namespace Resonalyze
 
                 lock (stateSync)
                 {
-                    waitingForAverageConfirmation = false;
-                    averageConfirmation = null;
                     inProgress = false;
                 }
                 Publish(Completed, success);
             }
 
             return success;
-        }
-
-        private async Task WaitForAverageConfirmationAsync(
-            int completedRun,
-            int requestedRuns,
-            int acceptedRuns,
-            CancellationToken cancellationToken)
-        {
-            Task waitTask;
-            lock (stateSync)
-            {
-                averageConfirmation = new TaskCompletionSource<bool>(
-                    TaskCreationOptions.RunContinuationsAsynchronously);
-                waitingForAverageConfirmation = true;
-                waitTask = averageConfirmation.Task;
-            }
-
-            Publish(AverageProgressChanged, new SweepAverageProgress(
-                completedRun,
-                requestedRuns,
-                acceptedRuns,
-                SweepAverageProgressState.WaitingForConfirmation));
-
-            try
-            {
-                await waitTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                lock (stateSync)
-                {
-                    waitingForAverageConfirmation = false;
-                    averageConfirmation = null;
-                }
-            }
         }
 
         // The requested band (this.LowFrequencyHz/HighFrequencyHz) is fully
@@ -2767,13 +2705,4 @@ namespace Resonalyze
 public readonly record struct SweepAverageProgress(
     int CurrentRun,
     int TotalRuns,
-    int AcceptedRuns,
-    SweepAverageProgressState State);
-
-public enum SweepAverageProgressState
-{
-    Running,
-    WaitingForConfirmation,
-    // The run failed the capture quality checks and its single automatic
-    // retry is being captured.
-}
+    int AcceptedRuns);

--- a/source/Measurements/SweepMeasurementConfiguration.cs
+++ b/source/Measurements/SweepMeasurementConfiguration.cs
@@ -142,6 +142,4 @@ public sealed record SweepAudioConfiguration(
     IReadOnlyList<int>? WaveArrayInputChannelOffsets = null,
     IReadOnlyList<int>? AsioArrayInputChannelOffsets = null);
 
-public sealed record SweepAveragingConfiguration(
-    int RunCount = 1,
-    bool ConfirmEachRun = false);
+public sealed record SweepAveragingConfiguration(int RunCount = 1);

--- a/source/Options/MeasurementOptions.Designer.cs
+++ b/source/Options/MeasurementOptions.Designer.cs
@@ -57,7 +57,6 @@
             comboBoxAudioBackend = new DarkComboBox();
             labelAverageRunCount = new Label();
             numericUpDownAverageRunCount = new DarkNumericUpDown();
-            checkBoxConfirmEachAverageRun = new CheckBox();
             labelCalibration0 = new Label();
             buttonCalibration0 = new Button();
             buttonClearCalibration0 = new Button();
@@ -342,7 +341,7 @@
             audioBackendPanel.Controls.Add(label2);
             audioBackendPanel.Controls.Add(comboBoxSampleRate);
             audioBackendPanel.Controls.Add(label1);
-            audioBackendPanel.Location = new Point(8, 361);
+            audioBackendPanel.Location = new Point(8, 336);
             audioBackendPanel.Name = "audioBackendPanel";
             audioBackendPanel.Size = new Size(322, 343);
             audioBackendPanel.TabIndex = 39;
@@ -408,24 +407,12 @@
             numericUpDownAverageRunCount.ThousandsSeparator = false;
             numericUpDownAverageRunCount.Value = new decimal(new int[] { 2, 0, 0, 0 });
             numericUpDownAverageRunCount.ValueChanged += averagingSetting_Changed;
-            //
-            // checkBoxConfirmEachAverageRun
-            // 
-            checkBoxConfirmEachAverageRun.AutoSize = true;
-            checkBoxConfirmEachAverageRun.ForeColor = SystemColors.ControlLight;
-            checkBoxConfirmEachAverageRun.Location = new Point(154, 227);
-            checkBoxConfirmEachAverageRun.Name = "checkBoxConfirmEachAverageRun";
-            checkBoxConfirmEachAverageRun.Size = new Size(119, 19);
-            checkBoxConfirmEachAverageRun.TabIndex = 29;
-            checkBoxConfirmEachAverageRun.Text = "Confirm each run";
-            checkBoxConfirmEachAverageRun.UseVisualStyleBackColor = true;
-            checkBoxConfirmEachAverageRun.CheckedChanged += averagingSetting_Changed;
             // 
             // labelCalibration0
             // 
             labelCalibration0.AutoSize = true;
             labelCalibration0.ForeColor = SystemColors.ControlLight;
-            labelCalibration0.Location = new Point(17, 257);
+            labelCalibration0.Location = new Point(17, 232);
             labelCalibration0.Name = "labelCalibration0";
             labelCalibration0.Size = new Size(100, 15);
             labelCalibration0.TabIndex = 30;
@@ -435,7 +422,7 @@
             // 
             buttonCalibration0.FlatStyle = FlatStyle.Popup;
             buttonCalibration0.ForeColor = Color.White;
-            buttonCalibration0.Location = new Point(154, 252);
+            buttonCalibration0.Location = new Point(154, 227);
             buttonCalibration0.Name = "buttonCalibration0";
             buttonCalibration0.Size = new Size(143, 23);
             buttonCalibration0.TabIndex = 31;
@@ -447,7 +434,7 @@
             // 
             buttonClearCalibration0.FlatStyle = FlatStyle.Popup;
             buttonClearCalibration0.ForeColor = Color.White;
-            buttonClearCalibration0.Location = new Point(300, 252);
+            buttonClearCalibration0.Location = new Point(300, 227);
             buttonClearCalibration0.Name = "buttonClearCalibration0";
             buttonClearCalibration0.Size = new Size(24, 23);
             buttonClearCalibration0.TabIndex = 34;
@@ -459,7 +446,7 @@
             //
             labelCalibrationExtra.AutoSize = true;
             labelCalibrationExtra.ForeColor = SystemColors.ControlLight;
-            labelCalibrationExtra.Location = new Point(17, 282);
+            labelCalibrationExtra.Location = new Point(17, 257);
             labelCalibrationExtra.Name = "labelCalibrationExtra";
             labelCalibrationExtra.Size = new Size(106, 15);
             labelCalibrationExtra.TabIndex = 32;
@@ -469,7 +456,7 @@
             //
             buttonCalibrationExtra.FlatStyle = FlatStyle.Popup;
             buttonCalibrationExtra.ForeColor = Color.White;
-            buttonCalibrationExtra.Location = new Point(154, 277);
+            buttonCalibrationExtra.Location = new Point(154, 252);
             buttonCalibrationExtra.Name = "buttonCalibrationExtra";
             buttonCalibrationExtra.Size = new Size(170, 23);
             buttonCalibrationExtra.TabIndex = 33;
@@ -481,7 +468,7 @@
             // 
             labelSplCalibration.AutoSize = true;
             labelSplCalibration.ForeColor = SystemColors.ControlLight;
-            labelSplCalibration.Location = new Point(17, 307);
+            labelSplCalibration.Location = new Point(17, 282);
             labelSplCalibration.Name = "labelSplCalibration";
             labelSplCalibration.Size = new Size(85, 15);
             labelSplCalibration.TabIndex = 36;
@@ -491,7 +478,7 @@
             // 
             buttonSplCalibration.FlatStyle = FlatStyle.Popup;
             buttonSplCalibration.ForeColor = Color.White;
-            buttonSplCalibration.Location = new Point(154, 302);
+            buttonSplCalibration.Location = new Point(154, 277);
             buttonSplCalibration.Name = "buttonSplCalibration";
             buttonSplCalibration.Size = new Size(143, 23);
             buttonSplCalibration.TabIndex = 37;
@@ -503,7 +490,7 @@
             // 
             buttonClearSplCalibration.FlatStyle = FlatStyle.Popup;
             buttonClearSplCalibration.ForeColor = Color.White;
-            buttonClearSplCalibration.Location = new Point(300, 302);
+            buttonClearSplCalibration.Location = new Point(300, 277);
             buttonClearSplCalibration.Name = "buttonClearSplCalibration";
             buttonClearSplCalibration.Size = new Size(24, 23);
             buttonClearSplCalibration.TabIndex = 38;
@@ -515,7 +502,7 @@
             //
             labelArrayMicrophones.AutoSize = true;
             labelArrayMicrophones.ForeColor = SystemColors.ControlLight;
-            labelArrayMicrophones.Location = new Point(17, 337);
+            labelArrayMicrophones.Location = new Point(17, 312);
             labelArrayMicrophones.Name = "labelArrayMicrophones";
             labelArrayMicrophones.Size = new Size(110, 15);
             labelArrayMicrophones.TabIndex = 40;
@@ -525,7 +512,7 @@
             //
             buttonArrayMicrophones.FlatStyle = FlatStyle.Popup;
             buttonArrayMicrophones.ForeColor = Color.White;
-            buttonArrayMicrophones.Location = new Point(154, 332);
+            buttonArrayMicrophones.Location = new Point(154, 307);
             buttonArrayMicrophones.Name = "buttonArrayMicrophones";
             buttonArrayMicrophones.Size = new Size(170, 23);
             buttonArrayMicrophones.TabIndex = 41;
@@ -554,7 +541,7 @@
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             BackColor = Color.FromArgb(45, 50, 60);
-            ClientSize = new Size(334, 710);
+            ClientSize = new Size(334, 685);
             Controls.Add(audioBackendPanel);
             Controls.Add(buttonArrayMicrophones);
             Controls.Add(labelArrayMicrophones);
@@ -566,7 +553,6 @@
             Controls.Add(buttonClearCalibration0);
             Controls.Add(buttonCalibration0);
             Controls.Add(labelCalibration0);
-            Controls.Add(checkBoxConfirmEachAverageRun);
             Controls.Add(numericUpDownAverageRunCount);
             Controls.Add(labelAverageRunCount);
             Controls.Add(comboBoxChannel);
@@ -618,7 +604,6 @@
         private DarkComboBox comboBoxAudioBackend;
         private Label labelAverageRunCount;
         private DarkNumericUpDown numericUpDownAverageRunCount;
-        private CheckBox checkBoxConfirmEachAverageRun;
         private Label labelCalibration0;
         private Button buttonCalibration0;
         private Button buttonClearCalibration0;

--- a/source/Options/MeasurementOptions.cs
+++ b/source/Options/MeasurementOptions.cs
@@ -449,7 +449,6 @@ namespace Resonalyze.Options
             // Total duration and the achieved-range line are filled by the shared
             // preview at the end of Init, once the sample-rate control is settled.
             numericUpDownAverageRunCount.Value = Math.Clamp(settings.AverageRunCount, 1, 64);
-            checkBoxConfirmEachAverageRun.Checked = settings.ConfirmEachAverageRun;
             microphoneCalibration0DegreesPath = settings.MicrophoneCalibration0DegreesPath;
             additionalMicrophoneCalibrations = settings.AdditionalMicrophoneCalibrations
                 .Select(definition => definition.Clone())
@@ -562,7 +561,6 @@ namespace Resonalyze.Options
                     ? waveLoopback.Offset
                     : null;
             int averageRunCount = (int)numericUpDownAverageRunCount.Value;
-            bool confirmEachAverageRun = checkBoxConfirmEachAverageRun.Checked;
             string? wasapiCaptureEndpointId =
                 comboBoxRecordingDevice.SelectedItem is AudioEndpointDescriptor captureSelection
                     ? captureSelection.Id
@@ -666,9 +664,7 @@ namespace Resonalyze.Options
                     AsioArrayInputChannelOffsets: audioBackend == AudioBackend.Asio
                         ? SelectedReachableArrayChannels()
                         : []),
-                new SweepAveragingConfiguration(
-                    averageRunCount,
-                    confirmEachAverageRun),
+                new SweepAveragingConfiguration(averageRunCount),
                 ReadProtectiveHighPass()));
 
             settings.LowFrequencyHz = lowFrequencyHz;
@@ -718,7 +714,6 @@ namespace Resonalyze.Options
             settings.RequestedDurationSeconds = GetRequestedDurationSeconds(settings.SampleRate);
             settings.PlaybackChannel = GetSelectedPlaybackChannel();
             settings.AverageRunCount = (int)numericUpDownAverageRunCount.Value;
-            settings.ConfirmEachAverageRun = checkBoxConfirmEachAverageRun.Checked;
             ProtectiveHighPassConfiguration protectiveHighPass = ReadProtectiveHighPass();
             settings.ProtectiveHighPassKind = protectiveHighPass.Kind;
             settings.ProtectiveHighPassFrequencyHz = protectiveHighPass.FrequencyHz;

--- a/source/Options/MicrophoneCalibrationsDialog.cs
+++ b/source/Options/MicrophoneCalibrationsDialog.cs
@@ -67,6 +67,13 @@ internal sealed partial class MicrophoneCalibrationsDialog : Form
         definition.Normalize();
         definitions.Add(definition);
         RefreshList(definition.Id);
+        // The file's own name is a SUGGESTION, not the name: it is whatever the
+        // capsule's maker called the download, and the list is read by the person
+        // who owns the microphone. So the new row opens straight into its rename
+        // with that suggestion selected — type over it, or leave it with Enter or
+        // Escape. Naming an entry otherwise meant finding it again and pressing
+        // Rename, which is a second decision about a name already on screen.
+        BeginRename(definition.Id);
     }
 
     private void AddAngle()
@@ -133,8 +140,30 @@ internal sealed partial class MicrophoneCalibrationsDialog : Form
     {
         if (listViewCalibrations.SelectedItems.Count == 1)
         {
-            listViewCalibrations.SelectedItems[0].BeginEdit();
+            BeginRename(listViewCalibrations.SelectedItems[0]);
         }
+    }
+
+    private void BeginRename(string id)
+    {
+        foreach (ListViewItem item in listViewCalibrations.Items)
+        {
+            if (item.Tag is string itemId &&
+                string.Equals(itemId, id, StringComparison.OrdinalIgnoreCase))
+            {
+                BeginRename(item);
+                return;
+            }
+        }
+    }
+
+    private void BeginRename(ListViewItem item)
+    {
+        // The list has to hold the focus first: the edit box belongs to it, and
+        // both callers arrive with the focus on a button — one of them from a
+        // file dialog that took it away entirely.
+        listViewCalibrations.Focus();
+        item.BeginEdit();
     }
 
     private void RemoveSelected()

--- a/source/Settings/MeasurementSettingsFile.Schema.cs
+++ b/source/Settings/MeasurementSettingsFile.Schema.cs
@@ -52,7 +52,6 @@ internal sealed partial class MeasurementSettingsFile
         // Two runs by default: averaging is what the Measurements control offers
         // (its minimum is 2), and a lone sweep gives nothing to average away.
         public int AverageRunCount { get; set; } = 2;
-        public bool ConfirmEachAverageRun { get; set; }
         public ProtectiveHighPassKind ProtectiveHighPassKind { get; set; }
         public double ProtectiveHighPassFrequencyHz { get; set; } = 2_000.0;
         public int ProtectiveHighPassSlopeDbPerOctave { get; set; } = 24;
@@ -194,7 +193,6 @@ internal sealed partial class MeasurementSettingsFile
                 AsioLoopbackInputChannelOffset = measurement.AsioLoopbackInputChannelOffset,
                 AsioOutputChannelOffset = measurement.AsioOutputChannelOffset,
                 AverageRunCount = measurement.AverageRunCount,
-                ConfirmEachAverageRun = measurement.ConfirmEachAverageRun,
                 ProtectiveHighPassKind = measurement.ProtectiveHighPass.Kind,
                 ProtectiveHighPassFrequencyHz = measurement.ProtectiveHighPass.FrequencyHz,
                 ProtectiveHighPassSlopeDbPerOctave =
@@ -408,9 +406,7 @@ internal sealed partial class MeasurementSettingsFile
                         ReachableInput(
                             AudioBackend.Asio, AsioDriverName, sampleRate, captureEndpointId),
                         ArrayMatchesDevice(AsioArrayDeviceId, AsioDriverName))),
-                new SweepAveragingConfiguration(
-                    Clamp(AverageRunCount, 1, 64),
-                    ConfirmEachAverageRun),
+                new SweepAveragingConfiguration(Clamp(AverageRunCount, 1, 64)),
                 ToProtectiveHighPass());
         }
 
@@ -699,6 +695,12 @@ internal sealed partial class MeasurementSettingsFile
         // Auto Tune only cuts, never boosts. The safe default for a car tune; see
         // EqAutoTuner.Options.CutsOnlyMode.
         public bool CutsOnly { get; set; } = true;
+
+        // Whether the bank's own response is drawn on the plot's right-hand axis.
+        // A view preference, persisted the way the Impulse view persists which of
+        // its curves are shown: a user who cleared the plot of it does not want it
+        // back on the next launch.
+        public bool ShowEqCurve { get; set; } = true;
     }
 
     internal sealed class ImpulseResponseSettings

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -46,10 +46,7 @@ public partial class Form1
 
         if (expSweepMeasurement.HasImpulseResponse && !expSweepMeasurement.InProgress)
         {
-            if (liveSpectrumController.InProgress || liveSpectrumController.TimerEnabled)
-            {
-                await liveSpectrumController.AbortAsync();
-            }
+            await StopLiveCaptureAsync();
 
             using var dialog = new SaveFileDialog
             {
@@ -104,10 +101,7 @@ public partial class Form1
 
         if (!expSweepMeasurement.InProgress)
         {
-            if (liveSpectrumController.InProgress || liveSpectrumController.TimerEnabled)
-            {
-                await liveSpectrumController.AbortAsync();
-            }
+            await StopLiveCaptureAsync();
 
             using var dialog = new OpenFileDialog
             {
@@ -381,10 +375,7 @@ public partial class Form1
             return;
         }
 
-        if (liveSpectrumController.InProgress || liveSpectrumController.TimerEnabled)
-        {
-            await liveSpectrumController.AbortAsync();
-        }
+        await StopLiveCaptureAsync();
 
         await SelectModeAsync(ModeTab.Frequency);
         commandController.SetSaveAvailable(false);

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -281,6 +281,12 @@ public partial class Form1
             // not just success.
             dockedModeSettingsHost.InvokeIfOpen<Options.FROptions>(
                 panel => panel.RefreshSplAvailability());
+            // The same debt the live spectrum pays when it stops, and for the same
+            // reason: an Apply made while the sweep held the device left the settings
+            // panel's picture of the driver alone rather than probing a device it did
+            // not own. The run has just released it — after EVERY completion, since an
+            // aborted or failed run releases it exactly as a good one does.
+            RefreshOpenMeasurementSettingsDevice();
 
             if (success)
             {

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -312,12 +312,7 @@ public partial class Form1
     {
         TryBeginInvokeOnUiThread(() =>
         {
-            buttonRecord.Text = progress.State switch
-            {
-                SweepAverageProgressState.WaitingForConfirmation =>
-                    $"Next run ({progress.CurrentRun + 1}/{progress.TotalRuns})",
-                _ => $"Running {progress.CurrentRun}/{progress.TotalRuns}..."
-            };
+            buttonRecord.Text = $"Running {progress.CurrentRun}/{progress.TotalRuns}...";
         });
     }
 

--- a/source/Shell/Form1.LiveCapture.cs
+++ b/source/Shell/Form1.LiveCapture.cs
@@ -152,10 +152,7 @@ public partial class Form1
 
     private async Task LoadLiveCaptureAsync()
     {
-        if (liveSpectrumController.InProgress || liveSpectrumController.TimerEnabled)
-        {
-            await liveSpectrumController.AbortAsync();
-        }
+        await StopLiveCaptureAsync();
 
         // The same choice the main Load button offers. Which measurement a file holds
         // is the file's business, not the button's: refusing an impulse response here

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -122,6 +122,12 @@ public partial class Form1
 
             await liveSpectrumController.ToggleAsync();
             UpdateRecordButtonForCurrentMode();
+            // The capture owns the audio device while it runs, so an Apply during one
+            // deliberately leaves the settings panel's picture of the driver alone
+            // rather than probing a device it does not own. This is where that debt is
+            // paid: the moment the capture releases the device, an open panel gets the
+            // straight answer it was denied.
+            RefreshOpenMeasurementSettingsDevice();
             return;
         }
 
@@ -412,6 +418,21 @@ public partial class Form1
         }
     }
 
+    /// <summary>
+    /// Lets an open Record Settings panel re-read the audio device, once nothing is
+    /// holding it. A no-op when the panel is closed or a capture is still running.
+    /// </summary>
+    private void RefreshOpenMeasurementSettingsDevice()
+    {
+        if (liveSpectrumController.InProgress || expSweepMeasurement.InProgress)
+        {
+            return;
+        }
+
+        dockedMeasurementSettingsHost.InvokeIfOpen<MeasurementOptions>(
+            panel => panel.RefreshAudioDeviceView());
+    }
+
     private async Task ApplySweepSettingsAsync(MeasurementOptions dialog)
     {
         AudioSessionRequest requestBefore =
@@ -503,14 +524,25 @@ public partial class Form1
                         await audioSessionFactory.WarmUpAsync(
                             CreateAudioWarmupRequest(measurementSettings.Measurement),
                             CancellationToken.None);
-                    }
 
-                    // The panel stays on screen after Apply, and the device it is
-                    // describing has just been reconfigured under it. Its picture of
-                    // the driver is a snapshot, so without this a rate change leaves
-                    // the status amber against a driver that is now running at exactly
-                    // that rate, and the only cure is reopening the panel.
-                    dialog.RefreshAudioDeviceView();
+                        // The panel stays on screen after Apply, and the device it is
+                        // describing has just been reconfigured under it. Its picture
+                        // of the driver is a snapshot, so without this a rate change
+                        // leaves the status amber against a driver that is now running
+                        // at exactly that rate, and the only cure is reopening the
+                        // panel.
+                        //
+                        // Inside this branch and not after it: the condition is "the
+                        // device is ours to touch". Applying while the live spectrum
+                        // runs restarts that session, which OWNS the driver — and
+                        // probing it then opens a second AsioOut against a driver that
+                        // may refuse it or answer with only the rate it is running at,
+                        // which is the very short rate list this refresh exists to
+                        // prevent. A stale view is the smaller harm, and it is not
+                        // permanent: stopping the capture refreshes an open panel (see
+                        // the live spectrum toggle).
+                        dialog.RefreshAudioDeviceView();
+                    }
                 }
                 catch (InvalidOperationException exception)
                 {

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -84,7 +84,17 @@ public partial class Form1
             await timeAlignmentController.AbortAsync();
         }
 
+        bool liveCaptureWasRunning = liveSpectrumController.InProgress;
         await liveSpectrumController.AbortAsync();
+        if (liveCaptureWasRunning)
+        {
+            // Only when a capture was actually stopped. This runs on every mode
+            // switch, and a settings panel whose view was never denied has nothing
+            // to be paid back — probing the driver for it would open an AsioOut on
+            // each tab click. A switch to a Tools mode closes the panel anyway
+            // (SetCaptureControlsVisible), which the refresh reads as "nothing open".
+            RefreshOpenMeasurementSettingsDevice();
+        }
 
         CurrentMode = mode;
         plotViewports.Show(null, mode);
@@ -431,6 +441,26 @@ public partial class Form1
 
         dockedMeasurementSettingsHost.InvokeIfOpen<MeasurementOptions>(
             panel => panel.RefreshAudioDeviceView());
+    }
+
+    /// <summary>
+    /// Stops a live capture — running, or merely holding its redraw timer — and pays
+    /// the settings panel's device debt once it is stopped. Every path that takes the
+    /// device back from the analyzer goes through here, so an open Record Settings
+    /// panel is refreshed wherever the capture ends rather than only where the Record
+    /// button stopped it. A no-op, refresh included, when nothing was running: the
+    /// panel was never denied its answer, and probing an ASIO driver for nothing is
+    /// what the refresh is careful about in the first place.
+    /// </summary>
+    private async Task StopLiveCaptureAsync()
+    {
+        if (!liveSpectrumController.InProgress && !liveSpectrumController.TimerEnabled)
+        {
+            return;
+        }
+
+        await liveSpectrumController.AbortAsync();
+        RefreshOpenMeasurementSettingsDevice();
     }
 
     private async Task ApplySweepSettingsAsync(MeasurementOptions dialog)

--- a/source/Shell/Form1.Measurement.cs
+++ b/source/Shell/Form1.Measurement.cs
@@ -130,12 +130,6 @@ public partial class Form1
             await liveSpectrumController.AbortAsync();
         }
 
-        if (expSweepMeasurement.WaitingForAverageConfirmation)
-        {
-            expSweepMeasurement.ContinueAverageRun();
-            return;
-        }
-
         if (expSweepMeasurement.InProgress)
         {
             await expSweepMeasurement.AbortAsync();

--- a/source/Tools/Eq/EqWizardCurveSource.cs
+++ b/source/Tools/Eq/EqWizardCurveSource.cs
@@ -277,6 +277,25 @@ internal sealed record EqWizardCurveSource
         Kind == EqWizardSourceKind.ImpulseResponse || HasOwnCalibration;
 
     /// <summary>
+    /// Whether the Virtual DSP panel pinned a correction to this channel at all.
+    /// </summary>
+    /// <remarks>
+    /// TWO corrections travel with a channel and only one of them is a curve: the
+    /// impulse response's (<see cref="PinnedCalibration"/>, null when the file names
+    /// none) and the one the panel read the SPATIAL AVERAGE through, which is a MODE.
+    /// Under "Own (as measured)" that mode is a real correction — the capture's own —
+    /// while the impulse response beside it may name no file, and a capture is a
+    /// separate measurement through its own calibration. Asking only about the curve
+    /// is the collapse <see cref="SpatialAverageCalibrationMode"/> exists to prevent,
+    /// one layer up: it reads "no file on the measurement" as "no correction anywhere"
+    /// and hands the wizard the uncalibrated capture the panel never drew.
+    /// </remarks>
+    public bool PinsCorrection =>
+        PinnedCalibration != null ||
+        (SpatialAverage != null &&
+            SpatialAverageCalibration.Mode != SpatialAverageCalibrationMode.Off);
+
+    /// <summary>
     /// Whether the correction this curve carries is an AGGREGATE belonging to no
     /// single microphone: an array whose positions were corrected by different files.
     /// </summary>

--- a/source/Tools/Eq/EqWizardPanel.Designer.cs
+++ b/source/Tools/Eq/EqWizardPanel.Designer.cs
@@ -60,6 +60,7 @@
             labelGainMax = new Label();
             checkBoxBypass = new CheckBox();
             checkBoxEqPhase = new CheckBox();
+            checkBoxEqCurve = new CheckBox();
             checkBoxCutsOnly = new CheckBox();
             panelAutoTune = new Panel();
             buttonOverlaySettings = new Button();
@@ -388,6 +389,20 @@
             checkBoxEqPhase.Text = "Phase";
             checkBoxEqPhase.UseVisualStyleBackColor = true;
             // 
+            // checkBoxEqCurve
+            // 
+            checkBoxEqCurve.AutoSize = true;
+            checkBoxEqCurve.Checked = true;
+            checkBoxEqCurve.CheckState = CheckState.Checked;
+            checkBoxEqCurve.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            checkBoxEqCurve.ForeColor = Color.FromArgb(210, 214, 222);
+            checkBoxEqCurve.Location = new Point(13, 246);
+            checkBoxEqCurve.Name = "checkBoxEqCurve";
+            checkBoxEqCurve.Size = new Size(78, 19);
+            checkBoxEqCurve.TabIndex = 67;
+            checkBoxEqCurve.Text = "EQ curve";
+            checkBoxEqCurve.UseVisualStyleBackColor = true;
+            // 
             // checkBoxCutsOnly
             // 
             checkBoxCutsOnly.AutoSize = true;
@@ -505,10 +520,10 @@
             buttonPhaseGate.Enabled = false;
             buttonPhaseGate.FlatStyle = FlatStyle.Popup;
             buttonPhaseGate.ForeColor = Color.White;
-            buttonPhaseGate.Location = new Point(2, 246);
+            buttonPhaseGate.Location = new Point(2, 271);
             buttonPhaseGate.Name = "buttonPhaseGate";
             buttonPhaseGate.Size = new Size(186, 24);
-            buttonPhaseGate.TabIndex = 67;
+            buttonPhaseGate.TabIndex = 68;
             buttonPhaseGate.Text = "Phase gate...";
             buttonPhaseGate.UseVisualStyleBackColor = true;
             //
@@ -516,7 +531,7 @@
             //
             buttonImport.FlatStyle = FlatStyle.Popup;
             buttonImport.ForeColor = Color.White;
-            buttonImport.Location = new Point(2, 275);
+            buttonImport.Location = new Point(2, 300);
             buttonImport.Name = "buttonImport";
             buttonImport.Size = new Size(87, 24);
             buttonImport.TabIndex = 57;
@@ -527,7 +542,7 @@
             // 
             buttonExport.FlatStyle = FlatStyle.Popup;
             buttonExport.ForeColor = Color.White;
-            buttonExport.Location = new Point(101, 275);
+            buttonExport.Location = new Point(101, 300);
             buttonExport.Name = "buttonExport";
             buttonExport.Size = new Size(87, 24);
             buttonExport.TabIndex = 58;
@@ -538,7 +553,7 @@
             //
             buttonResetBands.FlatStyle = FlatStyle.Popup;
             buttonResetBands.ForeColor = Color.White;
-            buttonResetBands.Location = new Point(2, 304);
+            buttonResetBands.Location = new Point(2, 329);
             buttonResetBands.Name = "buttonResetBands";
             buttonResetBands.Size = new Size(186, 24);
             buttonResetBands.TabIndex = 59;
@@ -550,7 +565,7 @@
             buttonUndo.Enabled = false;
             buttonUndo.FlatStyle = FlatStyle.Popup;
             buttonUndo.ForeColor = Color.White;
-            buttonUndo.Location = new Point(2, 364);
+            buttonUndo.Location = new Point(2, 389);
             buttonUndo.Name = "buttonUndo";
             buttonUndo.Size = new Size(87, 24);
             buttonUndo.TabIndex = 62;
@@ -562,7 +577,7 @@
             buttonRedo.Enabled = false;
             buttonRedo.FlatStyle = FlatStyle.Popup;
             buttonRedo.ForeColor = Color.White;
-            buttonRedo.Location = new Point(101, 364);
+            buttonRedo.Location = new Point(101, 389);
             buttonRedo.Name = "buttonRedo";
             buttonRedo.Size = new Size(87, 24);
             buttonRedo.TabIndex = 63;
@@ -574,7 +589,7 @@
             buttonReturnToDsp.BackColor = Color.FromArgb(46, 51, 67);
             buttonReturnToDsp.FlatStyle = FlatStyle.Popup;
             buttonReturnToDsp.ForeColor = Color.White;
-            buttonReturnToDsp.Location = new Point(2, 400);
+            buttonReturnToDsp.Location = new Point(2, 425);
             buttonReturnToDsp.Name = "buttonReturnToDsp";
             buttonReturnToDsp.Size = new Size(186, 26);
             buttonReturnToDsp.TabIndex = 64;
@@ -586,7 +601,7 @@
             //
             buttonBackToDsp.FlatStyle = FlatStyle.Popup;
             buttonBackToDsp.ForeColor = Color.White;
-            buttonBackToDsp.Location = new Point(2, 430);
+            buttonBackToDsp.Location = new Point(2, 455);
             buttonBackToDsp.Name = "buttonBackToDsp";
             buttonBackToDsp.Size = new Size(186, 24);
             buttonBackToDsp.TabIndex = 65;
@@ -598,7 +613,7 @@
             //
             comboBoxQConvention.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxQConvention.ForeColor = Color.White;
-            comboBoxQConvention.Location = new Point(108, 336);
+            comboBoxQConvention.Location = new Point(108, 361);
             comboBoxQConvention.MinimumSize = new Size(36, 19);
             comboBoxQConvention.Name = "comboBoxQConvention";
             comboBoxQConvention.Size = new Size(80, 19);
@@ -609,7 +624,7 @@
             labelQConvention.AutoSize = true;
             labelQConvention.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             labelQConvention.ForeColor = Color.FromArgb(210, 214, 222);
-            labelQConvention.Location = new Point(9, 338);
+            labelQConvention.Location = new Point(9, 363);
             labelQConvention.Margin = new Padding(3);
             labelQConvention.Name = "labelQConvention";
             labelQConvention.Size = new Size(66, 15);
@@ -642,6 +657,7 @@
             Controls.Add(panelAutoTune);
             Controls.Add(checkBoxBypass);
             Controls.Add(checkBoxEqPhase);
+            Controls.Add(checkBoxEqCurve);
             Controls.Add(buttonPhaseGate);
             Controls.Add(labelGain);
             Controls.Add(NumericGain);
@@ -692,6 +708,7 @@
         private Label labelGainMax;
         private CheckBox checkBoxBypass;
         private CheckBox checkBoxEqPhase;
+        private CheckBox checkBoxEqCurve;
         private CheckBox checkBoxCutsOnly;
         private Panel panelAutoTune;
         private Button buttonOverlaySettings;

--- a/source/Tools/Eq/EqWizardPanel.Phase.cs
+++ b/source/Tools/Eq/EqWizardPanel.Phase.cs
@@ -354,6 +354,18 @@ public partial class EqWizardPanel
         }
     }
 
+    // Same rule for the right-hand axis, asked of the series rather than of the
+    // view: in magnitude it carries the EQ curve alone, so turning that curve off
+    // empties it, while in phase every measured curve is on it and it stays.
+    private void SetEqAxisVisible(bool visible)
+    {
+        if (plotWizard.Model?.Axes.FirstOrDefault(axis => axis.Key == EqGainAxisKey)
+            is { } eqAxis)
+        {
+            eqAxis.IsAxisVisible = visible;
+        }
+    }
+
     private void InvalidatePhaseCurves()
     {
         phaseOrchestrator.Invalidate();

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -1503,6 +1503,7 @@ public partial class EqWizardPanel
             numericGainMin.Value = numericGainMin.ClampValue(settings.GainMinDb);
             numericGainMax.Value = numericGainMax.ClampValue(settings.GainMaxDb);
             checkBoxCutsOnly.Checked = settings.CutsOnly;
+            checkBoxEqCurve.Checked = settings.ShowEqCurve;
             SetSourceSmoothing(settings.SourceSmoothingInverseOctaves);
             ApplyPersistedBank(settings);
 
@@ -1547,7 +1548,8 @@ public partial class EqWizardPanel
         SourceSmoothingInverseOctaves = SourceSmoothingInverseOctaves,
         CalibrationId = preferredIrCalibrationId,
         ManualSampleRateHz = manualSampleRateHz,
-        CutsOnly = checkBoxCutsOnly.Checked
+        CutsOnly = checkBoxCutsOnly.Checked,
+        ShowEqCurve = checkBoxEqCurve.Checked
     };
 
     private void RaiseSettingsChanged()

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -514,9 +514,14 @@ public partial class EqWizardPanel
         // and the standing IR preference stays untouched. The panel's Off is Off.
         if (source.Kind == EqWizardSourceKind.VirtualDspChannel)
         {
-            return source.PinnedCalibration == null
-                ? EqWizardCalibrationChoice.Off
-                : EqWizardCalibrationChoice.PinnedToSource;
+            // Pinned whenever the panel pinned ANY correction, curve or mode. Asking
+            // for the curve alone dropped the spatial average's own correction on
+            // every channel whose impulse response named no calibration file: the
+            // choice fell to Off, Off resolves the average to Uncalibrated, and the
+            // wizard fitted a curve the panel had never drawn.
+            return source.PinsCorrection
+                ? EqWizardCalibrationChoice.PinnedToSource
+                : EqWizardCalibrationChoice.Off;
         }
 
         return EqWizardCalibrationChoice.Off;
@@ -1211,11 +1216,18 @@ public partial class EqWizardPanel
         // A Virtual DSP channel's correction is listed under the name its panel
         // shows for it — which may be a curve the session carries, absent from the
         // wizard's own list — so the disabled selector still says what applies.
-        if (loadedSource is { Kind: EqWizardSourceKind.VirtualDspChannel, PinnedCalibration: not null } pinned)
+        if (loadedSource is { Kind: EqWizardSourceKind.VirtualDspChannel, PinsCorrection: true } pinned)
         {
             options.Add(new EqWizardCalibrationOption(
                 EqWizardCalibrationChoice.PinnedToSource,
-                pinned.PinnedCalibrationName ?? "Virtual DSP"));
+                // Nameless exactly when the pinned correction is the spatial average's
+                // own: it is whatever THAT capture was recorded through, which no file
+                // in this list need name. The panel's own words for it, so the disabled
+                // selector reads the same in both tools.
+                pinned.PinnedCalibrationName ??
+                    (pinned.SpatialAverageCalibration.Mode == SpatialAverageCalibrationMode.Own
+                        ? "Own (as measured)"
+                        : "Virtual DSP")));
         }
 
         // A curve whose correction is an aggregate of several microphones' files gets

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Numerics;
 using OxyPlot;
 using OxyPlot.Annotations;
@@ -1392,6 +1392,12 @@ public partial class EqWizardPanel : UserControl
         AddClampedFill(model, curveAug, targetAug, above: false, BelowTargetFill);
     }
 
+    // One area per RUN of frequencies where the curve actually exists. Where it does
+    // not — under a protective high-pass, outside the band a driver was swept over,
+    // past the end of a capture's grid — the level is NaN, and a NaN vertex used to go
+    // into the polygon like any other: the renderer then closed the shape across the
+    // gap and shaded whole octaves where nothing was measured, reading as a deviation
+    // from the target that no measurement supports.
     private static void AddClampedFill(
         PlotModel model,
         IReadOnlyList<DataPoint> curve,
@@ -1399,23 +1405,34 @@ public partial class EqWizardPanel : UserControl
         bool above,
         OxyColor fill)
     {
-        var area = new AreaSeries
-        {
-            Color = OxyColors.Transparent,
-            Fill = fill,
-            StrokeThickness = 0,
-            Tag = WizardSeriesTag
-        };
+        AreaSeries? area = null;
         for (int i = 0; i < curve.Count; i++)
         {
             double clamped = above
                 ? Math.Max(curve[i].Y, target[i].Y)
                 : Math.Min(curve[i].Y, target[i].Y);
+            if (!double.IsFinite(clamped) || !double.IsFinite(target[i].Y))
+            {
+                // The run ends here; the next finite pair starts a new one.
+                area = null;
+                continue;
+            }
+
+            if (area == null)
+            {
+                area = new AreaSeries
+                {
+                    Color = OxyColors.Transparent,
+                    Fill = fill,
+                    StrokeThickness = 0,
+                    Tag = WizardSeriesTag
+                };
+                model.Series.Add(area);
+            }
+
             area.Points.Add(new DataPoint(curve[i].X, clamped));
             area.Points2.Add(target[i]);
         }
-
-        model.Series.Add(area);
     }
 
     // Interpolates between two frequencies at fraction f in the log domain, matching

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -75,6 +75,7 @@ public partial class EqWizardPanel : UserControl
     private PlotWatermarkAnnotation hintAnnotation = null!;
     private LineAnnotation fromMarker = null!;
     private LineAnnotation toMarker = null!;
+    private LineAnnotation bandMarker = null!;
     private RectangleAnnotation rangeFill = null!;
     private EqTuneStats? lastStats;
     private bool suppressRedraw;
@@ -123,6 +124,11 @@ public partial class EqWizardPanel : UserControl
         NumericGain.ValueChanged += BankValueChanged;
         checkBoxBypass.CheckedChanged += (_, _) => DrawSelectedCurves();
         checkBoxEqPhase.CheckedChanged += (_, _) => DrawSelectedCurves();
+        checkBoxEqCurve.CheckedChanged += (_, _) =>
+        {
+            DrawSelectedCurves();
+            RaiseSettingsChanged();
+        };
         buttonPhaseGate.Click += (_, _) => OpenPhaseGateDialog();
         checkBoxCutsOnly.CheckedChanged += (_, _) =>
         {
@@ -370,6 +376,11 @@ public partial class EqWizardPanel : UserControl
             "Lower edge of the Auto Tune frequency window; also bounds the error metrics.");
         SetTip(labelToHz, numericToHz,
             "Upper edge of the Auto Tune frequency window; also bounds the error metrics.");
+        SetTip(checkBoxEqCurve,
+            "Draw the bank's own response — the white curve on the right-hand axis, " +
+            "in dB here and in degrees in Phase. Turning it off leaves the plot to " +
+            "the measurement and the target; the filters keep working either way. " +
+            "The right-hand axis goes with it when nothing else is left on it.");
         SetTip(checkBoxCutsOnly,
             "Auto Tune only cuts, never boosts — the safe default for a car tune " +
             "(a boost cannot fill an interference null, it just burns headroom). " +
@@ -512,6 +523,21 @@ public partial class EqWizardPanel : UserControl
         toMarker.X = (double)numericToHz.Value;
         rangeFill.MinimumX = fromMarker.X;
         rangeFill.MaximumX = toMarker.X;
+
+        // Where the selected band SITS, as against what it does. The band curve
+        // answers the second question and is a poor answer to the first: a low-Q
+        // bell is a shape an octave wide whose summit the eye places by guesswork,
+        // and a shelf or an all-pass has no summit to place at all.
+        // Held out of the model until a band is selected: this OxyPlot has no
+        // Visible on an annotation, so membership is the switch.
+        bandMarker = new LineAnnotation
+        {
+            Type = LineAnnotationType.Vertical,
+            Color = BandCurveColor,
+            StrokeThickness = 1,
+            LineStyle = LineStyle.Dot,
+            Layer = AnnotationLayer.AboveSeries
+        };
 
         plotWizard.Model = model;
         UpdateEqAxisRange();
@@ -691,6 +717,9 @@ public partial class EqWizardPanel : UserControl
 
         AddEqCurve(model, eq, render.Target);
         AddSelectedBandCurve(model, render.Target);
+        UpdateSelectedBandMarker(model);
+        SetEqAxisVisible(model.Series.Any(series =>
+            series is XYAxisSeries { YAxisKey: EqGainAxisKey }));
 
         plotLabels.Refresh();
         model.InvalidatePlot(true);
@@ -1140,16 +1169,30 @@ public partial class EqWizardPanel : UserControl
 
         if (PhaseMode)
         {
-            AddWizardSeries(
-                model,
-                new EqWizardCurve(
-                    "EQ phase",
-                    OxyColors.White,
-                    1.5,
-                    LineStyle.Solid,
-                    PhasePoints(eq.Bands, baseline)),
-                EqGainAxisKey,
-                PhaseTrackerFormat);
+            if (checkBoxEqCurve.Checked)
+            {
+                AddWizardSeries(
+                    model,
+                    new EqWizardCurve(
+                        "EQ phase",
+                        OxyColors.White,
+                        1.5,
+                        LineStyle.Solid,
+                        PhasePoints(eq.Bands, baseline)),
+                    EqGainAxisKey,
+                    PhaseTrackerFormat);
+            }
+
+            // Re-armed whether or not the curve is drawn: the measured phase curves
+            // share this axis, and it is here that it is told it carries degrees.
+            UpdateEqAxisRange();
+            return;
+        }
+
+        if (!checkBoxEqCurve.Checked)
+        {
+            // Back to the plain boost/cut budget: the range that was fitted to the
+            // curve belonged to a curve that is no longer drawn.
             UpdateEqAxisRange();
             return;
         }
@@ -1272,6 +1315,27 @@ public partial class EqWizardPanel : UserControl
                 2,
                 LineStyle.Dash,
                 points));
+    }
+
+    // Puts the vertical guide on the selected band's frequency, and hides it when
+    // no band is selected. Deliberately not part of AddSelectedBandCurve: that curve
+    // needs a baseline to lay the band's shape on, while a frequency is the band's
+    // own property and is worth drawing whether or not there is a curve under it.
+    // Both views get it — a phase band is placed by its corner exactly as a
+    // magnitude one is.
+    private void UpdateSelectedBandMarker(PlotModel model)
+    {
+        model.Annotations.Remove(bandMarker);
+        if (selectedSlot == null)
+        {
+            return;
+        }
+
+        // No guard against an unplaceable frequency: the strip's own field cannot
+        // be taken below 10 Hz, so there is no zero for the logarithmic axis to
+        // choke on.
+        bandMarker.X = ReadBand(selectedSlot).FrequencyHz;
+        model.Annotations.Add(bandMarker);
     }
 
     // Translucent fills for the deviation band between Source + EQ and the target:

--- a/tests/Resonalyze.App.Tests/EqWizardBandGuideTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardBandGuideTests.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using OxyPlot;
+using OxyPlot.Annotations;
+using OxyPlot.WindowsForms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The vertical guide the wizard draws at the selected band's frequency. The band
+/// curve beside it answers what the filter DOES; this answers where it sits, which
+/// a curve is bad at — a low-Q bell is a shape an octave wide, and a shelf or an
+/// all-pass has no summit to read a centre off at all.
+/// </summary>
+public sealed class EqWizardBandGuideTests
+{
+    [Fact]
+    public void SelectingABand_PutsTheGuideOnItsFrequency()
+    {
+        using var panel = new EqWizardPanel();
+        SetBandCount(panel, 3);
+        object slot = Slots(panel)[1];
+        SetFrequency(slot, 1_250m);
+
+        SelectSlot(panel, slot);
+
+        LineAnnotation guide = Guide(panel);
+        Assert.Contains(guide, Model(panel).Annotations);
+        Assert.Equal(1_250.0, guide.X);
+        Assert.Equal(LineAnnotationType.Vertical, guide.Type);
+    }
+
+    [Fact]
+    public void RetuningTheSelectedBand_MovesTheGuideWithIt()
+    {
+        using var panel = new EqWizardPanel();
+        SetBandCount(panel, 3);
+        object slot = Slots(panel)[1];
+        SetFrequency(slot, 1_250m);
+        SelectSlot(panel, slot);
+
+        SetFrequency(slot, 4_000m);
+
+        Assert.Equal(4_000.0, Guide(panel).X);
+    }
+
+    [Fact]
+    public void DeselectingTakesTheGuideOffThePlot()
+    {
+        using var panel = new EqWizardPanel();
+        SetBandCount(panel, 3);
+        object slot = Slots(panel)[1];
+        SetFrequency(slot, 1_250m);
+        SelectSlot(panel, slot);
+
+        Invoke(panel, "DeselectBand");
+
+        // This OxyPlot has no Visible on an annotation, so being off the plot is
+        // being out of the collection — the Auto Tune range guides stay.
+        Assert.DoesNotContain(Guide(panel), Model(panel).Annotations);
+    }
+
+    private static LineAnnotation Guide(EqWizardPanel panel) =>
+        Field<LineAnnotation>(panel, "bandMarker");
+
+    private static PlotModel Model(EqWizardPanel panel) =>
+        Field<PlotView>(panel, "plotWizard").Model!;
+
+    private static IReadOnlyList<PeqSlotControl> Slots(EqWizardPanel panel) =>
+        Field<List<PeqSlotControl>>(panel, "peqSlots");
+
+    private static void SetBandCount(EqWizardPanel panel, int count) =>
+        Invoke(panel, "SetBandCount", count);
+
+    private static void SelectSlot(EqWizardPanel panel, object slot) =>
+        Invoke(panel, "SelectSlot", slot);
+
+    // Through the control the user types into, so the edit travels the path a
+    // typed frequency travels: the strip raises its change, the bank redraws.
+    private static void SetFrequency(object slot, decimal frequencyHz) =>
+        ((PeqSlotControl)slot).FrequencyInput.Value = frequencyHz;
+
+    private static void Invoke(EqWizardPanel panel, string name, params object[] arguments) =>
+        typeof(EqWizardPanel)
+            .GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(panel, arguments);
+
+    private static T Field<T>(EqWizardPanel panel, string name) =>
+        (T)typeof(EqWizardPanel)
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(panel)!;
+}

--- a/tests/Resonalyze.App.Tests/EqWizardDeviationFillTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardDeviationFillTests.cs
@@ -1,0 +1,115 @@
+using System.Numerics;
+using System.Reflection;
+using OxyPlot;
+using OxyPlot.Series;
+using OxyPlot.WindowsForms;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The shaded deviation between Source + EQ and the target. It is a statement about a
+/// measurement, so it may only be drawn where there IS one: a driver swept over its
+/// own band, or a capture that measured nothing under a protective high-pass, has no
+/// level below its edge and nothing to deviate by.
+/// </summary>
+public sealed class EqWizardDeviationFillTests
+{
+    private const int SampleRate = 48_000;
+    private const double GapBelowHz = 600;
+
+    [Fact]
+    public void NothingIsShadedWhereTheSourceCurveDoesNotExist()
+    {
+        using var panel = new EqWizardPanel();
+
+        ApplySource(panel, GappedHandoff());
+
+        IReadOnlyList<AreaSeries> fills = Fills(panel);
+        Assert.NotEmpty(fills);
+        foreach (AreaSeries fill in fills)
+        {
+            // A NaN vertex used to enter the polygon like any other, and the renderer
+            // closed the shape across the gap: whole octaves came out shaded as a
+            // deviation from the target with no measurement under them.
+            Assert.All(fill.Points, point => Assert.True(double.IsFinite(point.Y)));
+            Assert.All(fill.Points2, point => Assert.True(double.IsFinite(point.Y)));
+            Assert.All(fill.Points, point => Assert.True(point.X >= GapBelowHz));
+        }
+    }
+
+    [Fact]
+    public void TheShadingStillCoversTheBandThatWasMeasured()
+    {
+        using var panel = new EqWizardPanel();
+
+        ApplySource(panel, GappedHandoff());
+
+        // Breaking the fill at the gap must not cost the part that belongs there:
+        // the run above the edge is still shaded end to end.
+        IReadOnlyList<AreaSeries> fills = Fills(panel);
+        Assert.All(fills, fill => Assert.True(fill.Points.Count > 100));
+        Assert.All(fills, fill => Assert.True(fill.Points[^1].X > 19_000));
+    }
+
+    // A tweeter handed over from Virtual DSP with a moving-microphone capture that
+    // measured nothing below 600 Hz — the shape a real session has.
+    private static EqWizardCurveSource GappedHandoff()
+    {
+        var response = new Complex[16_384];
+        for (int i = 0; i < 96; i++)
+        {
+            response[600 + i] = Math.Exp(-i / 20.0) * Math.Cos(2 * Math.PI * i / 24.0);
+        }
+
+        var curve = new double[1_024];
+        for (int i = 0; i < curve.Length; i++)
+        {
+            double hz = 20 * Math.Pow(1_000.0, i / (curve.Length - 1.0));
+            curve[i] = hz < GapBelowHz ? double.NaN : -42 + 3 * Math.Sin(i / 30.0);
+        }
+
+        return new EqWizardCurveSource
+        {
+            Kind = EqWizardSourceKind.VirtualDspChannel,
+            DisplayName = "Ch D · R (MMM)",
+            Description = "Spatial average, as measured with the DSP bypassed.",
+            Measurement = new ImpulseMeasurementView(response, 600, SampleRate),
+            PreviewImpulseResponse = response,
+            PreviewChain = DspChannelChain.Identity,
+            SpatialAverage = new LiveCaptureDocument
+            {
+                SavedAtUtc = DateTimeOffset.UnixEpoch,
+                Title = "r tw mmm",
+                Method = SpatialAverageMethod.MovingMic,
+                CurveDb = curve,
+                GridStartHz = 20,
+                GridStopHz = 20_000,
+                Recipe = new LiveCaptureRecipe
+                {
+                    AnalysisMode = LiveAnalysisMode.Mmm,
+                    SampleRateHz = SampleRate,
+                    MagnitudeScale = MagnitudeScale.SoundPressureLevel,
+                    SmoothingCode = 0,
+                    IntegratedSeconds = 42
+                }
+            },
+            SpatialAverageCalibration = SpatialAverageCalibration.Own,
+            SampleRateHz = SampleRate,
+            CurveKind = AnalysisCurveKind.Primary
+        };
+    }
+
+    private static IReadOnlyList<AreaSeries> Fills(EqWizardPanel panel) =>
+        Model(panel).Series.OfType<AreaSeries>().ToList();
+
+    private static PlotModel Model(EqWizardPanel panel) =>
+        ((PlotView)typeof(EqWizardPanel)
+            .GetField("plotWizard", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(panel)!).Model!;
+
+    private static void ApplySource(EqWizardPanel panel, EqWizardCurveSource source) =>
+        typeof(EqWizardPanel)
+            .GetMethod("ApplySource", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(panel, [source]);
+}

--- a/tests/Resonalyze.App.Tests/EqWizardEqCurveToggleTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardEqCurveToggleTests.cs
@@ -1,0 +1,111 @@
+using System.Reflection;
+using System.Windows.Forms;
+using OxyPlot.Axes;
+using OxyPlot.Series;
+using OxyPlot.WindowsForms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The EQ-curve toggle: whether the bank's own response is drawn on the plot's
+/// right-hand axis. It is a view preference, so it persists — and the axis it owns
+/// goes with it, but only while nothing else is drawn against that axis.
+/// </summary>
+public sealed class EqWizardEqCurveToggleTests
+{
+    private const string EqGainAxisKey = "eq-wizard:gain";
+
+    [Fact]
+    public void ByDefaultTheBanksCurveAndItsAxisAreDrawn()
+    {
+        using var panel = new EqWizardPanel();
+
+        Assert.True(Toggle(panel).Checked);
+        Assert.Contains("EQ", CurveTitles(panel));
+        Assert.True(EqAxis(panel).IsAxisVisible);
+    }
+
+    [Fact]
+    public void TurningItOffTakesTheCurveAndTheRightHandAxisWithIt()
+    {
+        using var panel = new EqWizardPanel();
+
+        Toggle(panel).Checked = false;
+
+        Assert.DoesNotContain("EQ", CurveTitles(panel));
+        // The axis carries that curve alone in this view, and a scale with no trace
+        // on it reads as a scale for the curves that ARE drawn — which belong to
+        // the left axis.
+        Assert.False(EqAxis(panel).IsAxisVisible);
+    }
+
+    [Fact]
+    public void InPhaseTheBanksOwnCurveGoesButTheSharedAxisStays()
+    {
+        using var panel = new EqWizardPanel();
+        SetBandCount(panel, 3);
+        SelectSlot(panel, Slots(panel)[1]);
+        Field<CheckBox>(panel, "checkBoxEqPhase").Checked = true;
+
+        Toggle(panel).Checked = false;
+
+        // Every phase curve is on the right axis, so emptying it takes more than
+        // turning this one off — here the selected band's phase is still there.
+        Assert.DoesNotContain("EQ phase", CurveTitles(panel));
+        Assert.Contains("Band 2 phase", CurveTitles(panel));
+        Assert.True(EqAxis(panel).IsAxisVisible);
+        // Re-armed even though the curve was not drawn: the axis has to be told it
+        // carries degrees, or it keeps a decibel title over a phase plot.
+        Assert.Equal("Phase (°)", EqAxis(panel).Title);
+    }
+
+    [Fact]
+    public void TheChoiceSurvivesASettingsRoundTrip()
+    {
+        using var saved = new EqWizardPanel();
+        Toggle(saved).Checked = false;
+
+        using var restored = new EqWizardPanel();
+        ApplyPersistedSettings(restored, saved.CaptureSettings());
+
+        Assert.False(Toggle(restored).Checked);
+        Assert.DoesNotContain("EQ", CurveTitles(restored));
+    }
+
+    private static CheckBox Toggle(EqWizardPanel panel) =>
+        Field<CheckBox>(panel, "checkBoxEqCurve");
+
+    private static Axis EqAxis(EqWizardPanel panel) =>
+        Field<PlotView>(panel, "plotWizard").Model!.Axes
+            .First(axis => axis.Key == EqGainAxisKey);
+
+    private static IReadOnlyList<string> CurveTitles(EqWizardPanel panel) =>
+        Field<PlotView>(panel, "plotWizard").Model!.Series
+            .OfType<XYAxisSeries>()
+            .Select(series => series.Title ?? string.Empty)
+            .ToList();
+
+    private static IReadOnlyList<PeqSlotControl> Slots(EqWizardPanel panel) =>
+        Field<List<PeqSlotControl>>(panel, "peqSlots");
+
+    private static void SetBandCount(EqWizardPanel panel, int count) =>
+        Invoke(panel, "SetBandCount", count);
+
+    private static void SelectSlot(EqWizardPanel panel, object slot) =>
+        Invoke(panel, "SelectSlot", slot);
+
+    private static void ApplyPersistedSettings(
+        EqWizardPanel panel,
+        MeasurementSettingsFile.EqWizardSettings settings) =>
+        Invoke(panel, "ApplyPersistedSettings", settings);
+
+    private static void Invoke(EqWizardPanel panel, string name, params object[] arguments) =>
+        typeof(EqWizardPanel)
+            .GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(panel, arguments);
+
+    private static T Field<T>(EqWizardPanel panel, string name) =>
+        (T)typeof(EqWizardPanel)
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(panel)!;
+}

--- a/tests/Resonalyze.App.Tests/EqWizardHandoffCalibrationTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardHandoffCalibrationTests.cs
@@ -1,0 +1,154 @@
+using System.Numerics;
+using System.Reflection;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// What a Virtual DSP handoff is corrected through once it reaches the wizard. Two
+/// corrections travel with a channel and only one of them is a curve: the impulse
+/// response's, and the MODE the panel read the spatial average through. The wizard
+/// has to reproduce both — a channel it draws through a different correction than the
+/// panel did is the one thing the handoff exists to prevent.
+/// </summary>
+public sealed class EqWizardHandoffCalibrationTests
+{
+    private const int SampleRate = 48_000;
+
+    /// <summary>
+    /// The field case: an impulse response measured before calibrations were stamped
+    /// into files, with a moving-microphone capture beside it taken through the
+    /// microphone's own 90° curve, and the panel on "Own (as measured)". The measured
+    /// correction reaches 2.4 dB across the tweeter's band, so reading the capture
+    /// uncalibrated is a different curve and a different tune.
+    /// </summary>
+    [Fact]
+    public void ACaptureKeepsItsOwnCorrectionWhenTheMeasurementNamesNoFile()
+    {
+        using var panel = new EqWizardPanel();
+        EqWizardCurveSource source = Handoff(
+            pinnedCalibration: null,
+            SpatialAverageCalibration.Own);
+
+        ApplySource(panel, source);
+
+        Assert.Equal(
+            SpatialAverageCalibration.Own,
+            ResolvedSpatialAverageCalibration(panel, source));
+        // And the disabled selector says so, in the panel's own words: the correction
+        // is whatever that capture was recorded through, which no entry in the
+        // wizard's list need name.
+        Assert.Contains("Own (as measured)", CalibrationOptionNames(panel));
+    }
+
+    [Fact]
+    public void ThePinnedCurveStillWinsWhenTheMeasurementCarriesOne()
+    {
+        using var panel = new EqWizardPanel();
+        CalibrationFile curve = CalibrationFile.Parse("20 0\n20000 -1.5\n");
+        EqWizardCurveSource source = Handoff(curve, SpatialAverageCalibration.Specific(curve));
+
+        ApplySource(panel, source);
+
+        Assert.Equal(
+            SpatialAverageCalibrationMode.Specific,
+            ResolvedSpatialAverageCalibration(panel, source).Mode);
+        Assert.Contains("mic 90", CalibrationOptionNames(panel));
+    }
+
+    [Fact]
+    public void APanelReadingTheCaptureUncalibratedIsReproducedAsOff()
+    {
+        using var panel = new EqWizardPanel();
+        EqWizardCurveSource source = Handoff(
+            pinnedCalibration: null,
+            SpatialAverageCalibration.Off);
+
+        ApplySource(panel, source);
+
+        // Nothing is invented in the other direction either: the panel applied no
+        // correction, and Off is what reproduces that exactly.
+        Assert.Equal(
+            SpatialAverageCalibration.Off,
+            ResolvedSpatialAverageCalibration(panel, source));
+    }
+
+    private static EqWizardCurveSource Handoff(
+        CalibrationFile? pinnedCalibration,
+        SpatialAverageCalibration spatialAverageCalibration)
+    {
+        var response = new Complex[16_384];
+        for (int i = 0; i < 96; i++)
+        {
+            response[600 + i] = Math.Exp(-i / 20.0) * Math.Cos(2 * Math.PI * i / 24.0);
+        }
+
+        return new EqWizardCurveSource
+        {
+            Kind = EqWizardSourceKind.VirtualDspChannel,
+            DisplayName = "Ch D · R (MMM)",
+            Description = "Spatial average, as measured with the DSP bypassed.",
+            Measurement = new ImpulseMeasurementView(response, 600, SampleRate),
+            PreviewImpulseResponse = response,
+            PreviewChain = DspChannelChain.Identity,
+            PinnedCalibration = pinnedCalibration,
+            PinnedCalibrationName = pinnedCalibration == null ? null : "mic 90",
+            SpatialAverage = Capture(),
+            SpatialAverageCalibration = spatialAverageCalibration,
+            SampleRateHz = SampleRate,
+            CurveKind = AnalysisCurveKind.Primary
+        };
+    }
+
+    private static LiveCaptureDocument Capture()
+    {
+        var curve = new double[1_024];
+        for (int i = 0; i < curve.Length; i++)
+        {
+            curve[i] = -40 + 2 * Math.Sin(i / 50.0);
+        }
+
+        return new LiveCaptureDocument
+        {
+            SavedAtUtc = DateTimeOffset.UnixEpoch,
+            Title = "r tw mmm",
+            Method = SpatialAverageMethod.MovingMic,
+            CurveDb = curve,
+            GridStartHz = 20,
+            GridStopHz = 20_000,
+            Recipe = new LiveCaptureRecipe
+            {
+                AnalysisMode = LiveAnalysisMode.Mmm,
+                SampleRateHz = SampleRate,
+                MagnitudeScale = MagnitudeScale.SoundPressureLevel,
+                SmoothingCode = 0,
+                IntegratedSeconds = 42
+            }
+        };
+    }
+
+    private static void ApplySource(EqWizardPanel panel, EqWizardCurveSource source) =>
+        typeof(EqWizardPanel)
+            .GetMethod("ApplySource", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(panel, [source]);
+
+    private static SpatialAverageCalibration ResolvedSpatialAverageCalibration(
+        EqWizardPanel panel,
+        EqWizardCurveSource source) =>
+        (SpatialAverageCalibration)typeof(EqWizardPanel)
+            .GetMethod(
+                "ResolveSpatialAverageCalibration",
+                BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(panel, [source])!;
+
+    private static IReadOnlyList<string> CalibrationOptionNames(EqWizardPanel panel) =>
+        ((System.Collections.IEnumerable)typeof(EqWizardPanel)
+            .GetMethod(
+                "BuildCalibrationOptions",
+                BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(panel, [])!)
+        .Cast<object>()
+        // The option renders itself into the combo through ToString.
+        .Select(option => option.ToString()!)
+        .ToList();
+}

--- a/tests/Resonalyze.App.Tests/MeasurementHistoryServiceTests.cs
+++ b/tests/Resonalyze.App.Tests/MeasurementHistoryServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Resonalyze.History;
 
 namespace Resonalyze.App.Tests;
@@ -103,6 +104,124 @@ public sealed class MeasurementHistoryServiceTests : IDisposable
         Assert.Same(file.SplCalibration, snapshot.SplCalibration);
         Assert.Equal(108.0, snapshot.SplOffsetDb!.Value, tolerance: 1e-9);
         Assert.Same(file.SplCalibration, snapshot.ToImpulseResponseFile().SplCalibration);
+    }
+
+    [Fact]
+    public async Task TheListIsCappedAtItsMaximumDepth_OldestFirst()
+    {
+        MeasurementHistoryService service = CreateService();
+        var added = new List<Guid>();
+        for (int index = 0; index < MeasurementHistoryService.MaxHistoryEntries + 3; index++)
+        {
+            string path = await CreateImpulseResponseFileAsync($"m{index}.json");
+            added.Add(service.AddOrUpdateLoadedFile(
+                path,
+                await ImpulseResponseFile.LoadAsync(path),
+                new MeasurementSessionSnapshot()));
+        }
+
+        Assert.Equal(MeasurementHistoryService.MaxHistoryEntries, service.Entries.Count);
+        // The three that fell off are the three opened first, and the newest is
+        // still at the top: the cap cuts the tail, it does not reorder the list.
+        Assert.Null(service.FindById(added[0]));
+        Assert.Null(service.FindById(added[1]));
+        Assert.Null(service.FindById(added[2]));
+        Assert.NotNull(service.FindById(added[3]));
+        Assert.Equal(added[^1], service.Entries[0].Id);
+    }
+
+    [Fact]
+    public async Task OverDepth_AnUnsavedEntryOutlivesAnOlderSavedOne()
+    {
+        MeasurementHistoryService service = CreateService();
+        string firstPath = await CreateImpulseResponseFileAsync("first.json");
+        Guid oldestSaved = service.AddOrUpdateLoadedFile(
+            firstPath,
+            await ImpulseResponseFile.LoadAsync(firstPath),
+            new MeasurementSessionSnapshot());
+        using ExpSweepMeasurement measurement = CreateMeasurement();
+        Guid unsaved = service.AddMeasurement(measurement, new MeasurementSessionSnapshot());
+        for (int index = 0; index < MeasurementHistoryService.MaxHistoryEntries - 1; index++)
+        {
+            string path = await CreateImpulseResponseFileAsync($"filler{index}.json");
+            service.AddOrUpdateLoadedFile(
+                path,
+                await ImpulseResponseFile.LoadAsync(path),
+                new MeasurementSessionSnapshot());
+        }
+
+        Assert.Equal(MeasurementHistoryService.MaxHistoryEntries, service.Entries.Count);
+        // The unsaved row is older than every filler and would have gone first on a
+        // plain tail cut. It is the measurement itself — the saved row it displaced
+        // is a pointer to a file still on disk.
+        Assert.NotNull(service.FindById(unsaved));
+        Assert.Null(service.FindById(oldestSaved));
+    }
+
+    [Fact]
+    public void AStoreOverDepthIsCutWhenItLoads_AndTheCutReachesDisk()
+    {
+        string storePath = Path.Combine(directory, "measurement-history.json");
+        new MeasurementHistoryPersistence(storePath).Save(OverDepthEntries());
+
+        var service = new MeasurementHistoryService(new MeasurementHistoryPersistence(storePath));
+
+        Assert.Equal(MeasurementHistoryService.MaxHistoryEntries, service.Entries.Count);
+        // Rewritten on load, not at the next mutation: a session that only reads
+        // the history never saves it, and the cut would not survive the launch.
+        Assert.Equal(
+            MeasurementHistoryService.MaxHistoryEntries,
+            new MeasurementHistoryPersistence(storePath).Load().Count);
+    }
+
+    [Fact]
+    public void AStoreThatCannotBeRewrittenStillOpens()
+    {
+        string storePath = Path.Combine(directory, "measurement-history.json");
+        new MeasurementHistoryPersistence(storePath).Save(OverDepthEntries());
+        // The trim's write fails on this exactly as it would against a store held
+        // by another instance or marked read-only by the user's backup tool.
+        File.SetAttributes(storePath, FileAttributes.ReadOnly);
+        try
+        {
+            // The list is cut in memory whatever the disk does; the launch is not
+            // the place to report that the cut could not be persisted, and the next
+            // launch tries again.
+            var service = new MeasurementHistoryService(
+                new MeasurementHistoryPersistence(storePath));
+
+            Assert.Equal(MeasurementHistoryService.MaxHistoryEntries, service.Entries.Count);
+            Assert.Equal(
+                MeasurementHistoryService.MaxHistoryEntries + 5,
+                new MeasurementHistoryPersistence(storePath).Load().Count);
+        }
+        finally
+        {
+            File.SetAttributes(storePath, FileAttributes.Normal);
+        }
+    }
+
+    private List<MeasurementHistoryEntry> OverDepthEntries()
+    {
+        var stored = new List<MeasurementHistoryEntry>();
+        for (int index = 0; index < MeasurementHistoryService.MaxHistoryEntries + 5; index++)
+        {
+            string path = Path.Combine(directory, $"stored{index}.json");
+            File.WriteAllText(path, "{}");
+            stored.Add(MeasurementHistoryPersistenceTests.CreateEntry(path));
+        }
+
+        return stored;
+    }
+
+    private static ExpSweepMeasurement CreateMeasurement()
+    {
+        var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        measurement.RestoreImpulseResponse(
+            20, 20_000, 48_000, 24, 1.0, PlaybackChannel.Mono,
+            [Complex.Zero, Complex.One, Complex.Zero],
+            sweepDeconvolutionPeakIndex: 1);
+        return measurement;
     }
 
     private MeasurementHistoryService CreateService() =>

--- a/tests/Resonalyze.App.Tests/SweepMeasurementConfigurationTests.cs
+++ b/tests/Resonalyze.App.Tests/SweepMeasurementConfigurationTests.cs
@@ -20,7 +20,7 @@ public sealed class SweepMeasurementConfigurationTests
                 AsioInputChannelOffset: 4,
                 AsioLoopbackInputChannelOffset: 5,
                 AsioOutputChannelOffset: 2),
-            new SweepAveragingConfiguration(3, ConfirmEachRun: true));
+            new SweepAveragingConfiguration(3));
 
         measurement.Init(configuration);
 
@@ -34,6 +34,5 @@ public sealed class SweepMeasurementConfigurationTests
         Assert.Equal(5, measurement.AsioLoopbackInputChannelOffset);
         Assert.Equal(2, measurement.AsioOutputChannelOffset);
         Assert.Equal(3, measurement.AverageRunCount);
-        Assert.True(measurement.ConfirmEachAverageRun);
     }
 }

--- a/tools/Resonalyze.Screenshots/Shots.cs
+++ b/tools/Resonalyze.Screenshots/Shots.cs
@@ -369,7 +369,12 @@ internal static class Shots
         figure.Gutter(52, onLeft: true, sample: new Point(100, 600))
               .Region(Box(14, 62, 204, 93), "1", new Point(26, 77), leader: true)
               .Region(Box(14, 120, 204, 270), "2", new Point(26, 195), leader: true)
-              .Region(Box(14, 450, 204, 510), "3", new Point(26, 480), leader: true)
+              // The two DSP-handoff buttons, 25 px lower than they were: the panel
+              // gained an EQ-curve checkbox under Bypass/Phase and the column below
+              // it moved down by one row. These boxes are figure pixels and the shot
+              // is captured 1:1 (window chrome puts the panel's y=0 at 46), so the
+              // designer's 25 is 25 here too.
+              .Region(Box(14, 475, 204, 535), "3", new Point(26, 505), leader: true)
               .Region(Box(14, 832, 206, 982), "4", new Point(26, 907), leader: true)
               .Region(Box(18, 985, 202, 1014), "5", new Point(26, 999), leader: true)
               .Detail(Box(18, 883, 200, 935))


### PR DESCRIPTION
Six quality-of-life fixes and two bugs found while using them. None of the six
touches what a measurement means; both bugs did.

**Averaged sweep runs no longer wait to be confirmed.** The *Confirm each run*
checkbox is gone and so is everything behind it: the completion source and the
waiting flag in `ExpSweepMeasurement`, the progress state the Record button read
as a second role (it said *Next run (2/4)* and consumed the click), and the
setting in the settings file. The runs play back to back. `SweepAverageProgress`
loses its `State` — `Running` was all that was left of the enum. An old settings
file carrying the flag still loads: the property is simply unknown and drops on
the next save.

**A calibration added from a file opens for renaming straight away**, with the
file's own name filled in as the suggestion — type over it, or keep it with Enter
or Escape. Naming an entry used to mean finding it again in the list and pressing
*Rename*, a second decision about a name already on screen. The inline editor is
the one that button already used; both callers now go through it, and it takes
the focus first, since one of them arrives from a file dialog that took it away.

**The measurement history is capped at 30 entries.** Nothing bounded it before —
the list gained a row for every file ever opened and kept it for as long as that
file existed. Over the cap it is the oldest FILE row that goes, even when an
unsaved one is older: such a row loses only its working state, and opening the
file brings it back, while a RAM row IS the measurement and exists nowhere else.
There is always one to drop — the in-memory cap runs first and leaves at most ten
unsaved rows out of the thirty. A store that arrives over depth is cut when it
loads, because a session that only reads the history never saves it; that write
is best effort, the way the store rewrite in `Load` already is, so a store that
cannot be written cannot cost the user the launch or the sweep that just finished.

**The EQ Wizard draws a vertical guide at the selected band's frequency.** The
band curve says what the filter does; the guide says where it sits, which the
curve is bad at — a low-Q bell is a shape an octave wide whose summit the eye
places by guesswork, and a shelf or an all-pass has no summit to place at all.
Both views get it, and it follows the card as it is edited.

**An EQ curve checkbox turns the bank's own response off** — the white trace on
the right-hand axis, in dB or in degrees under Phase. The plot is left to the
measurement and the target, which is what a crowded fit is read on; the filters
keep working either way. The right-hand axis goes with the curve when nothing
else is left on it, which is asked of the series rather than of the view: in
magnitude it carries that curve alone, in Phase every measured trace is on it.
The choice persists.

**The settings panel's device view is refreshed wherever the device is released**,
rather than while something still owns it. The refresh after Apply
moves inside the branch that already asks whether anything is holding the audio
device — applying during a live spectrum restarts that session, which OWNS the
driver, and probing it then opens a second AsioOut against a driver that may
refuse it or answer with only the rate it is running at, which is the very short
rate list the refresh exists to prevent. The debt is paid where the device comes
back instead: a finished sweep pays it after every completion, and for the live
capture `StopLiveCaptureAsync` pays it wherever the capture actually ends — the
Record button, a mode switch, Save, Load, Compare, a capture load — rather than at
the button alone. Nothing running means no refresh and no probe; the abort that
hands the device straight to a sweep, and the one on shutdown, are left alone.

**A Virtual DSP channel keeps its correction across the handoff.** Two corrections
travel with a channel and only one is a curve: the impulse response's, and the MODE
the panel read the spatial average through. The wizard decided between pinned and
Off by asking about the curve alone, so a channel whose measurement named no
calibration file arrived as Off — and for a capture Off does not mean "no
correction", it means UNCALIBRATED: the average's own correction was divided back
out and the wizard fitted a curve the panel had never drawn. Under "Own (as
measured)" that is the ordinary case for a measurement taken before calibrations
were stamped into files. On the owner's v6 tweeter the dropped correction ran from
−2.4 dB at 8.9 kHz to +2.2 dB at 20 kHz.

**The deviation fill stops where the measurement does.** A missing source level is
NaN, a NaN vertex went into the polygon like any other, and the renderer closed the
shape across the gap — shading whole octaves below a tweeter's band as a deviation
from the target with nothing measured under them.

Docs: `REFERENCE.md` gains the history depth, the band guide and the EQ-curve
toggle; `README.md` drops the confirm-between-runs line. Three comments in
`audio/` explained the between-run capture pause by the confirmation wait and now
explain it by what is actually there.

**Figures.** The Record Settings and EQ Wizard panels both changed shape, so
`measurement-options`, `eq_wizard`, `eq_wizard_phase`, `manual/eq-wizard-handoff`
and `manual/eq-wizard-tuned` want re-shooting (the first needs the interface
attached); `assets/images/manual/record-settings.png` is a committed artifact and
has to be re-taken by hand. The one hard-coded annotation box that moves with the
wizard's left column is already adjusted in `Shots.cs`.

Tests: the history cap (depth, which row is sacrificed, the cut on load, and an
unwritable store), the band guide, the EQ-curve toggle including its settings round
trip, what a handed-over channel is corrected through in all three combinations, and
that the fill breaks at a gap without losing the band that was measured. Each was
checked against the unfixed code first. The device-view lifecycle has none: it lives
in Form1, which this repository does not test.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
