### PR TITLE
Let Auto Tune fit shelves, and judge each one by finishing the fit both ways

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1018,7 +1018,15 @@ Nothing has to be selected, typed, or matched by hand, and no file changes hands
    acoustic nulls. **Max Q** caps how narrow a filter it may place (6.0 by default):
    below that ceiling the fit favours broader trends, the ones likelier to hold across
    the listening area, over notching a peak that may belong to where the microphone
-   stood. **From** and **To**
+   stood. **Shelves** is worth ticking when the target is shelved — a bass lift, a
+   downward tilt — or when a whole end of the measurement runs hot or shy: one shelf
+   then does what three or four bells were doing badly, and the slots it frees go to
+   real resonances. With **Cuts only** ticked it is safe to leave on: a shelf is kept
+   only where finishing the fit with it lands closer to the target than finishing it
+   without, so a response made of resonances alone gets none. With **Cuts only** off, a
+   boosting shelf lifts a whole end of the range and the total boost can pass **Max
+   Gain** — read **Headroom** on the scoreboard afterwards before you accept the tune.
+   **From** and **To**
    (outlined) arrived already filled in from this channel's crossover corners, so the
    fit stays inside the band the driver is actually used in.
 5. **Auto Tune** — run it once these are set.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1419,17 +1419,21 @@ error** between Source + EQ and Target, **Filters used**, **Peak boost** and
 as bells. A car target is a bass shelf plus a downward tilt, and a bell is the
 wrong shape for either: a stack of them spends slots on a trend that resonances
 needed, and rings between the centres. A shelf is kept only where it earns the
-slot: the rest of the fit is finished for each direction on offer and once with
-no shelf at all, and a shelf goes in only if its finished curve ends closer to
-the target than the shelf-free one — whichever direction finishes best, not
-whichever looks best before the bells are placed. So a response made of
-resonances alone gets none at all, and nothing changes for it.
+slot, and which shelf that is gets decided on the finished curve rather than on
+how the band reads by itself: every corner and knee of both directions is taken
+all the way through the rest of the fit, once more with no shelf at all, and the
+one that ends closest to the target goes in — if any of them beats placing none.
+A shelf that does not leave the fit shorter has to earn its filter by a margin
+you could see, so a response made of resonances alone gets none at all and
+nothing changes for it.
 Measured on synthetic responses, at the default Max Gain of 6 dB: a top end
 running uniformly hot took one shelf where four bells had been spent, at a third
-of the residual (0.04 dB RMS against 0.13); a car target with bass lift and tilt
-came out at 0.42 dB RMS against 1.28 with the same ten filters. At most one
-shelf per direction, and the fit re-runs its own search after placing the first,
-so a bass shelf and a treble shelf can describe one tilt between them.
+of the residual (0.04 dB RMS against 0.13); the same response with resonances on
+it came out at four filters against seven, for the same error; a car target with
+bass lift and tilt at 0.34 dB RMS against 1.28 with the same ten filters. At
+most one shelf per direction, and the fit re-runs its own search after placing
+the first, so a bass shelf and a treble shelf can describe one tilt between
+them.
 
 A shelf's knee is capped at **Q 0.7**, the steepest that still rises
 monotonically: above that an RBJ shelf overshoots its own gain before settling,
@@ -1446,8 +1450,8 @@ applies to a boosting bell deliberately does not apply to a shelf, since a
 shelf's plateau is the correction rather than spill from one. And a shelf is not
 counted against the cumulative boost the bells are held to, because it is a
 correction of the whole tail and not a stack of bands at one frequency: with a
-shelf placed, the **total** boost can exceed **Max Gain** (measured: +11 dB where
-Max Gain was +6), which is what the **Headroom** read-out is for. Each individual
+shelf placed, the **total** boost can exceed **Max Gain** (measured: +10.5 dB
+where Max Gain was +6), which is what the **Headroom** read-out is for. Each
 band still obeys **Max Gain**, and **Cuts only** rules all of this out.
 
 ### Import, export, and tuning sheet

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1372,7 +1372,8 @@ the chain check, but it is refused all the same).
 **Auto Tune** fits the whole EQ automatically: it works on the error between the
 target and the (smoothed) source, sets a preamp for the broadband level, then
 adds peaking bands greedily where the residual error is largest, choosing each
-band's frequency, gain, and the Q that reduces the error the most. It **chooses
+band's frequency, gain, and the Q that reduces the error the most — and, with
+**Shelves** ticked, may put a low and a high shelf in front of them. It **chooses
 the band count itself**, up to the **Max Filters** limit (4–32), while a
 cumulative-boost cap and minimum band spacing keep it from stacking maxed-out
 bands where the response simply cannot be corrected.
@@ -1392,16 +1393,17 @@ least stable over the volume that was averaged rather than a property of the
 spot the microphone stood in — or for a deliberately narrow correction of a mode
 you have identified.
 
-The fit is a magnitude fit, so the bells it places are all it can propose — and a
-run replaces the bank it found. If that bank holds **all-pass** bands, Auto Tune
-asks before starting: keep them and tune the remaining slots around them (the
-error curve never asked for them to go — they are flat), or let the fit replace
-the bank whole. Keeping takes their count off the **Max Filters** budget, which
-is a budget for the bank and not for the fit alone: keep three of eight and the
-fit places five. And "around them" is literal on a gated channel — the curve the
-fit corrects is the one with those bands already applied, because through a
-window an all-pass is not flat, and correcting a curve the bank never produces
-would leave the tune off by that difference.
+The fit is a magnitude fit, so bells and — with **Shelves** on — the two
+shelves are all it can propose, and a run replaces the bank it found. If that
+bank holds **all-pass** bands, Auto Tune asks before starting: keep them and
+tune the remaining slots around them (the error curve never asked for them to
+go — they are flat), or let the fit replace the bank whole. Keeping takes their
+count off the **Max Filters** budget, which is a budget for the bank and not
+for the fit alone: keep three of eight and the fit places five. And "around
+them" is literal on a gated channel — the curve the fit corrects is the one
+with those bands already applied, because through a window an all-pass is not
+flat, and correcting a curve the bank never produces would leave the tune off
+by that difference.
 
 **Cuts only** (on by default) is the safe choice for a car tune: a boost cannot
 fill a reflective cabin's interference null — it just burns amplifier headroom on
@@ -1412,6 +1414,39 @@ To** window limits where bands are placed and bounds the error metrics in the
 colour-coded **Tuning results** panel, which reports **RMS error** and **Max
 error** between Source + EQ and Target, **Filters used**, **Peak boost** and
 **Peak cut**, and **Headroom** (red when the EQ nets a boost that could clip).
+
+**Shelves** (off by default) lets the fit propose a low and a high shelf as well
+as bells. A car target is a bass shelf plus a downward tilt, and a bell is the
+wrong shape for either: a stack of them spends slots on a trend that resonances
+needed, and rings between the centres. A shelf is kept only where it earns the
+slot — the rest of the fit is run twice, once with the shelf and once without,
+and the shelf stays only if the finished curve ends closer to the target — so a
+response made of resonances alone gets none at all, and nothing changes for it.
+Measured on synthetic responses, at the default Max Gain of 6 dB: a top end
+running uniformly hot took one shelf where four bells had been spent, at a third
+of the residual (0.04 dB RMS against 0.13); a car target with bass lift and tilt
+came out at 0.42 dB RMS against 1.28 with the same ten filters. At most one
+shelf per direction, and the fit re-runs its own search after placing the first,
+so a bass shelf and a treble shelf can describe one tilt between them.
+
+A shelf's knee is capped at **Q 0.7**, the steepest that still rises
+monotonically: above that an RBJ shelf overshoots its own gain before settling,
+and on a cut that overshoot is a boost — which **Cuts only** promises never to
+produce. **Max Q** is not applied to a shelf; that number bounds how narrow a
+*bell* may be, and a shelf has no bandwidth to bound. You can still add, edit or
+delete a shelf by hand afterwards, and a re-run replaces it like any other band.
+
+Two things change with **Cuts only** unticked. A boosting shelf lifts a whole end
+of the range, nulls included, so it is offered only where at least three quarters
+of that end is measured and passes the boost mask — a tail that is mostly nulls
+or low coherence never gets shelved upwards, and the per-bin skirt guard that
+applies to a boosting bell deliberately does not apply to a shelf, since a
+shelf's plateau is the correction rather than spill from one. And a shelf is not
+counted against the cumulative boost the bells are held to, because it is a
+correction of the whole tail and not a stack of bands at one frequency: with a
+shelf placed, the **total** boost can exceed **Max Gain** (measured: +11 dB where
+Max Gain was +6), which is what the **Headroom** read-out is for. Each individual
+band still obeys **Max Gain**, and **Cuts only** rules all of this out.
 
 ### Import, export, and tuning sheet
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1419,9 +1419,11 @@ error** between Source + EQ and Target, **Filters used**, **Peak boost** and
 as bells. A car target is a bass shelf plus a downward tilt, and a bell is the
 wrong shape for either: a stack of them spends slots on a trend that resonances
 needed, and rings between the centres. A shelf is kept only where it earns the
-slot — the rest of the fit is run twice, once with the shelf and once without,
-and the shelf stays only if the finished curve ends closer to the target — so a
-response made of resonances alone gets none at all, and nothing changes for it.
+slot: the rest of the fit is finished for each direction on offer and once with
+no shelf at all, and a shelf goes in only if its finished curve ends closer to
+the target than the shelf-free one — whichever direction finishes best, not
+whichever looks best before the bells are placed. So a response made of
+resonances alone gets none at all, and nothing changes for it.
 Measured on synthetic responses, at the default Max Gain of 6 dB: a top end
 running uniformly hot took one shelf where four bells had been spent, at a third
 of the residual (0.04 dB RMS against 0.13); a car target with bass lift and tilt

--- a/TODO.md
+++ b/TODO.md
@@ -492,15 +492,23 @@ items below are what a car DSP tune actually needs, roughly in priority order.
   "driver band" it works inside is just the user's From/To window. Derive each
   driver's usable band from the measured roll-off or the crossover so the mask
   also blocks boosts outside it.
-- [ ] ★ **Auto Tune still fits peaking bands only.** The bank, the preview and
-  the parsers carry shelves and all-pass bands now; the tuner does not. Car
-  targets are shelved (bass boost + downward tilt), which a stack of peaking
-  bands approximates poorly — wasted slots and ringing. Teach the greedy fit to
-  propose a low/high shelf where the residual is a slope rather than a bump.
-  (All-pass stays out of the FIT — it is flat, so the magnitude error can never
-  ask for one; a bank holding all-pass bands is instead offered to be kept, and
-  their count comes off the fit's budget.) HP/LP/notch are NOT needed here: the
-  Virtual DSP tool owns crossovers and time alignment.
+- [ ] **Decide whether the shelf stage should default on.** Auto Tune fits
+  low/high shelves now (`EqAutoTuner.Options.AllowShelves`, the wizard's
+  **Shelves** box), gated on finishing the whole fit both ways and landing
+  closer with the shelf than without. It is OFF by default because turning it on
+  changes the curve a fit returns, and the evidence so far is one-sided but
+  synthetic: a uniformly hot top end took one shelf where four bells had been
+  spent, at a third of the residual (0.04 dB RMS against 0.13); a car target with
+  bass lift and tilt came out at 0.42 dB RMS against 1.28 with the same ten
+  filters, at the cost of an 11.05 dB peak boost against 6.79 (a shelf is not
+  counted against the bells' cumulative boost ceiling — deliberate, and the
+  Headroom read-out is where it shows). Flip the default
+  once it has been run against real cabin measurements — there is no code left to
+  write for it, only the field check. (All-pass stays out of the FIT — it is
+  flat, so the magnitude error can never ask for one; a bank holding all-pass
+  bands is instead offered to be kept, and their count comes off the fit's
+  budget. HP/LP/notch are NOT needed here: the Virtual DSP tool owns crossovers
+  and time alignment.)
 - [ ] **Greedy fit redesign.** Band spacing ignores the chosen Q (fixed ±0.33/±1
   oct blocks); band gain is fixed from the peak residual before Q is searched; the
   preamp is rounded to integer dB *before* the fit; and the objective treats

--- a/TODO.md
+++ b/TODO.md
@@ -499,8 +499,8 @@ items below are what a car DSP tune actually needs, roughly in priority order.
   changes the curve a fit returns, and the evidence so far is one-sided but
   synthetic: a uniformly hot top end took one shelf where four bells had been
   spent, at a third of the residual (0.04 dB RMS against 0.13); a car target with
-  bass lift and tilt came out at 0.42 dB RMS against 1.28 with the same ten
-  filters, at the cost of an 11.05 dB peak boost against 6.79 (a shelf is not
+  bass lift and tilt came out at 0.34 dB RMS against 1.28 with the same ten
+  filters, at the cost of a 10.48 dB peak boost against 6.79 (a shelf is not
   counted against the bells' cumulative boost ceiling — deliberate, and the
   Headroom read-out is where it shows). Flip the default
   once it has been run against real cabin measurements — there is no code left to

--- a/dsp/EqAutoTuner.cs
+++ b/dsp/EqAutoTuner.cs
@@ -20,10 +20,11 @@ namespace Resonalyze.Dsp;
 /// </para>
 /// <para>
 /// Switching shelves on adds one stage in front of the greedy pass, which may place a
-/// low and a high shelf. Candidates are scored by the same objective the bells are
-/// scored by, and the winner is kept only if FINISHING the fit with it lands closer to
-/// the target than finishing it without — both runs made on scratch state, so a shelf
-/// that would cost more than the slot it takes is simply never applied.
+/// low and a high shelf. Which one — and whether either — is settled on the FINISHED
+/// curve: every corner and knee of both directions is carried through the rest of the
+/// fit on scratch state, and the candidate that ends closest to the target is placed,
+/// but only if it beats finishing with no shelf at all. A shelf that would cost more
+/// than the slot it takes is therefore never applied.
 /// </para>
 /// <para>
 /// All-pass bands are never fitted, whatever the options say: an all-pass is flat, so
@@ -141,11 +142,21 @@ public static class EqAutoTuner
         /// skirts leave between the centres. The stage is deliberately narrow: at most
         /// one shelf per direction, a knee capped at the steepest that still rises
         /// monotonically, and acceptance only when the rest of the fit, run to
-        /// exhaustion both ways, ends closer to the target with the shelf than without
-        /// it. Weaker rules were tried first and measured: an absolute "improves the
-        /// residual by X" bar, and beating the single bell the shelf displaces. Both
-        /// spent slots on shelves that left the finished fit worse, because a shelf acts
-        /// across octaves and changes what every later band has left to do.
+        /// exhaustion, ends closer to the target with that shelf than with none.
+        /// </para>
+        /// <para>
+        /// Three weaker rules were tried first and measured, and all three are worth
+        /// not repeating. An absolute "improves the residual by X" bar, and beating the
+        /// single bell the shelf displaces, both spent slots on shelves that left the
+        /// finished fit worse — a shelf acts across octaves and changes what every
+        /// later band has left to do, which no single-band figure can see. Ranking the
+        /// candidates by that single-band figure and running only the winner through
+        /// the finished fit is the same mistake one level up: on a tilted response with
+        /// a loud resonance on it, the best-reading candidate is a wide shelf that
+        /// shaves the resonance's skirt and finishes WORSE than placing none, while the
+        /// shelf that actually wins sits two and a half octaves away and is never
+        /// asked. Only the gain within a fixed corner and knee is still left to the
+        /// single-band objective, which is what keeps this affordable.
         /// </para>
         /// <para>
         /// A BOOSTING shelf is deliberately treated differently from a boosting bell by
@@ -241,6 +252,13 @@ public static class EqAutoTuner
     // Below this a shelf is not worth a slot. The search steps gain in the same tenth
     // of a dB the strips keep.
     private const double ShelfMinGainDb = 0.5;
+
+    // How much better the finished fit must be, as an RMS-equivalent in dB, for a shelf
+    // that does NOT shorten the fit to be worth the filter it adds. Two orders of
+    // magnitude below anything a tuner would notice on the plot, and four above the
+    // improvements an exhaustive search turns up on a response with no trend in it at
+    // all. A shelf that leaves the fit shorter skips this: it has paid for itself.
+    private const double ShelfSlotWorthDb = 0.01;
 
     /// <summary>
     /// Fits an equalization curve so that <paramref name="source"/> + curve best
@@ -633,10 +651,14 @@ public static class EqAutoTuner
         return sumSquares / fit.ValidCount;
     }
 
-    // Runs the greedy bell pass to exhaustion on scratch copies of the state and returns
-    // the score of what it ends with. Nothing the caller owns is touched, so this is how
-    // the shelf stage asks what the rest of the fit would look like either way.
-    private static double TrialFit(
+    // Runs the greedy bell pass to exhaustion on scratch copies of the state and reports
+    // the score of what it ends with, and how many bands it spent getting there. Nothing
+    // the caller owns is touched, so this is how the shelf stage asks what the rest of
+    // the fit would look like either way. The band count matters because the pass STOPS
+    // when nothing left is worth a filter (StopResidualDb): a trial that ends under its
+    // budget was not constrained by it, and a shelf that adds a slot there is adding a
+    // filter rather than spending one better.
+    private static (double Score, int Bands) TrialFit(
         Options opt,
         FitGrid fit,
         double[] qCandidates,
@@ -652,6 +674,7 @@ public static class EqAutoTuner
         var blocked = new bool[n];
         var contribution = new double[n];
         var bestContribution = new double[n];
+        int bands = 0;
         for (int placed = 0; placed < budget; placed++)
         {
             if (NextBell(
@@ -668,6 +691,7 @@ public static class EqAutoTuner
                 break;
             }
 
+            bands++;
             for (int i = 0; i < n; i++)
             {
                 if (fit.Valid[i])
@@ -679,7 +703,7 @@ public static class EqAutoTuner
             }
         }
 
-        return FinalScore(opt, fit, trialResidual, trialEqSum);
+        return (FinalScore(opt, fit, trialResidual, trialEqSum), bands);
     }
 
     /// <summary>
@@ -807,18 +831,20 @@ public static class EqAutoTuner
             // has left to correct. Both weaker rules were tried and both spent a slot
             // on a shelf that cost more than it bought.
             //
-            // EVERY direction still open is taken that far, and the finished score is
-            // what ranks them. Ranking the two by their single-band score first and
-            // only asking the winner would let a low shelf that reads better before the
-            // bells are placed suppress a high shelf that finishes closer, and would
-            // let one direction's rejection end the stage with the other never asked.
-            // The baseline is the same for both, so it is run once.
+            // EVERY viable candidate is taken that far — both directions, and every
+            // corner and knee within each — and the finished score is what ranks them
+            // against each other and against placing nothing. Deciding a shelf on the
+            // single-band score first and asking the lookahead only about that winner
+            // is the same near-sighted rule this stage exists to replace: a candidate
+            // that reads better before the bells are placed can finish further away,
+            // and its rejection would end the stage with everything else never asked.
+            // The baseline does not depend on the candidate, so it is run once.
             int remaining = opt.MaxBands - bands.Count;
-            double withoutShelf = TrialFit(
+            (double Score, int Bands) withoutShelf = TrialFit(
                 opt, fit, qCandidates, residual, eqSum, bellSum, remaining);
 
             PeqBand chosen = default;
-            double chosenFinal = withoutShelf;
+            double chosenFinal = withoutShelf.Score;
             bool found = false;
             foreach (PeqBandType type in ShelfDirections)
             {
@@ -827,59 +853,67 @@ public static class EqAutoTuner
                     continue;
                 }
 
-                // Which corner, knee and gain that direction offers is still settled by
-                // the single-band objective, the same one the bells pick their Q with.
-                // Ranking every corner x knee x gain by a finished fit instead is three
-                // orders of magnitude more work — a full greedy pass per candidate,
-                // roughly 1300 of them per direction per round, against the two runs
-                // here — so the shortlist is one candidate and the shape of the
-                // approximation is the same one the greedy pass already makes.
-                (PeqBand Band, double Score)? candidate = BestShelf(
-                    type,
-                    opt,
-                    fit,
-                    residual,
-                    contribution,
-                    candidateContribution);
-                if (candidate == null)
+                foreach (PeqBand candidate in
+                    ShelfCandidates(type, opt, fit, residual, contribution))
                 {
-                    continue;
-                }
-
-                for (int i = 0; i < n; i++)
-                {
-                    shelfResidual[i] = residual[i];
-                    shelfEqSum[i] = eqSum[i];
-                    if (fit.Valid[i])
+                    ScoreBand(
+                        candidate,
+                        opt,
+                        fit,
+                        residual,
+                        spillBase: null,
+                        candidateContribution,
+                        out _);
+                    for (int i = 0; i < n; i++)
                     {
-                        shelfResidual[i] -= candidateContribution[i];
-                        shelfEqSum[i] += candidateContribution[i];
+                        shelfResidual[i] = residual[i];
+                        shelfEqSum[i] = eqSum[i];
+                        if (fit.Valid[i])
+                        {
+                            shelfResidual[i] -= candidateContribution[i];
+                            shelfEqSum[i] += candidateContribution[i];
+                        }
                     }
+
+                    (double Score, int Bands) withShelf = TrialFit(
+                        opt,
+                        fit,
+                        qCandidates,
+                        shelfResidual,
+                        shelfEqSum,
+                        bellSum,
+                        remaining - 1);
+
+                    // Seeded with the no-shelf score, so this one comparison ranks the
+                    // candidates against each other AND refuses every one of them when
+                    // none beats placing no shelf at all.
+                    if (withShelf.Score >= chosenFinal)
+                    {
+                        continue;
+                    }
+
+                    // Beating the bells is not the same as being worth a filter. Where
+                    // the shelf leaves the fit SHORTER it has paid for itself by
+                    // definition. Where it does not, the improvement has to be one a
+                    // tuner could see: an exhaustive search always finds some shelf that
+                    // improves the fourth decimal, and without this a resonance-only
+                    // response quietly spends a slot on a half-dB shelf at the bottom of
+                    // the range for no change in the curve at all.
+                    if (withShelf.Bands + 1 >= withoutShelf.Bands &&
+                        Math.Sqrt(withoutShelf.Score) - Math.Sqrt(withShelf.Score) <
+                            ShelfSlotWorthDb)
+                    {
+                        continue;
+                    }
+
+                    found = true;
+                    chosen = candidate;
+                    chosenFinal = withShelf.Score;
+                    Array.Copy(candidateContribution, chosenContribution, n);
                 }
-
-                double withShelf = TrialFit(
-                    opt,
-                    fit,
-                    qCandidates,
-                    shelfResidual,
-                    shelfEqSum,
-                    bellSum,
-                    remaining - 1);
-
-                // Seeded with the no-shelf score, so this one comparison both ranks the
-                // directions and refuses a shelf that does not beat placing none.
-                if (withShelf >= chosenFinal)
-                {
-                    continue;
-                }
-
-                found = true;
-                chosen = candidate.Value.Band;
-                chosenFinal = withShelf;
-                Array.Copy(candidateContribution, chosenContribution, n);
             }
 
-            // A round in which no direction finishes ahead of the bells ends the stage:
+            // A round in which nothing finishes ahead of the bells ends the stage:
             // nothing was applied, so the next round would search the very same residual
             // and lose again.
             if (!found)
@@ -908,28 +942,38 @@ public static class EqAutoTuner
         }
     }
 
-    // The best shelf of one direction against the current residual, with its
-    // contribution left in winnerContribution; null when the fitting range cannot hold a
-    // corner of that direction, when no candidate has a plateau to stand on, or when the
+    // Every shelf of one direction worth taking to a finished fit: the best gain at
+    // each corner and knee the fitting range admits. Empty when the range cannot hold a
+    // corner of that direction, when no corner has a plateau to stand on, or when the
     // caller's QMin excludes every knee a shelf may take.
-    private static (PeqBand Band, double Score)? BestShelf(
+    //
+    // Gain is the one parameter left to the single-band objective, and deliberately:
+    // at a fixed corner and knee it is a level, and choosing it badly means
+    // over-correcting the plateau — which is exactly what that objective already
+    // charges for. Where the knee SITS is the choice that changes what the bells
+    // afterwards are left with, and no single-band score can see that, so every
+    // corner/knee pair is handed up and judged on a finished fit instead. The gain
+    // ladder is what would make this unaffordable if it were handed up too: a tenth of
+    // a dB across the whole gain range is a couple of hundred candidates per corner
+    // against the four knees here.
+    private static List<PeqBand> ShelfCandidates(
         PeqBandType type,
         Options opt,
         FitGrid fit,
         double[] residual,
-        double[] contribution,
-        double[] winnerContribution)
+        double[] contribution)
     {
+        var candidates = new List<PeqBand>();
         double[] qCandidates = ShelfCandidateQ.Where(q => q >= opt.QMin).ToArray();
         if (qCandidates.Length == 0)
         {
-            return null;
+            return candidates;
         }
 
         IReadOnlyList<double>? corners = ShelfCorners(fit, type);
         if (corners == null)
         {
-            return null;
+            return candidates;
         }
 
         // Gain is searched in the tenth of a dB the strips keep, coarsely first and then
@@ -942,11 +986,6 @@ public static class EqAutoTuner
         int deadTenths = (int)Math.Round(ShelfMinGainDb * 10);
         bool searchesBoosts = maxTenths >= deadTenths;
 
-        PeqBand best = default;
-        double bestScore = double.MaxValue;
-        bool found = false;
-        bool bestCutPlateau = false;
-        bool bestBoostPlateau = false;
         foreach (double cornerHz in corners)
         {
             double frequencyHz = Math.Round(cornerHz);
@@ -965,6 +1004,9 @@ public static class EqAutoTuner
 
             foreach (double q in qCandidates)
             {
+                PeqBand best = default;
+                double bestScore = double.MaxValue;
+                bool found = false;
                 for (int tenths = minTenths; tenths <= maxTenths; tenths += 10)
                 {
                     if (!IsSearchableGain(tenths, deadTenths, cutPlateau, boostPlateau))
@@ -972,62 +1014,82 @@ public static class EqAutoTuner
                         continue;
                     }
 
-                    if (ConsiderShelf(
+                    ConsiderShelf(
                         new PeqBand(frequencyHz, q, tenths / 10.0, type),
                         opt,
                         fit,
                         residual,
                         contribution,
-                        winnerContribution,
                         ref best,
                         ref bestScore,
-                        ref found))
-                    {
-                        bestCutPlateau = cutPlateau;
-                        bestBoostPlateau = boostPlateau;
-                    }
+                        ref found);
                 }
+
+                if (!found)
+                {
+                    continue;
+                }
+
+                // The coarse ladder walks in whole dB, so the true level sits within one
+                // step of the winner.
+                PeqBand coarse = best;
+                int coarseTenths = (int)Math.Round(coarse.GainDb * 10);
+                for (int tenths = coarseTenths - 10; tenths <= coarseTenths + 10; tenths++)
+                {
+                    if (tenths < minTenths || tenths > maxTenths ||
+                        !IsSearchableGain(tenths, deadTenths, cutPlateau, boostPlateau))
+                    {
+                        continue;
+                    }
+
+                    ConsiderShelf(
+                        coarse with { GainDb = tenths / 10.0 },
+                        opt,
+                        fit,
+                        residual,
+                        contribution,
+                        ref best,
+                        ref bestScore,
+                        ref found);
+                }
+
+                candidates.Add(best);
             }
         }
 
-        if (!found)
+        return candidates;
+    }
+
+    // Scores one shelf candidate and keeps it when it beats the running best. The skirt
+    // guard is deliberately not enforced here — a shelf's plateau is the correction, not
+    // spill; see Options.AllowShelves.
+    private static void ConsiderShelf(
+        PeqBand band,
+        Options opt,
+        FitGrid fit,
+        double[] residual,
+        double[] contribution,
+        ref PeqBand best,
+        ref double bestScore,
+        ref bool found)
+    {
+        double score = ScoreBand(
+            band, opt, fit, residual, spillBase: null, contribution, out _);
+        if (found && score >= bestScore)
         {
-            return null;
+            return;
         }
 
-        // The coarse ladder walks in whole dB, so the true level sits within one step of
-        // the winner. Corner and knee are kept: a tenth of a dB does not change which of
-        // those was right.
-        PeqBand coarse = best;
-        int coarseTenths = (int)Math.Round(coarse.GainDb * 10);
-        for (int tenths = coarseTenths - 10; tenths <= coarseTenths + 10; tenths++)
-        {
-            if (tenths < minTenths || tenths > maxTenths ||
-                !IsSearchableGain(tenths, deadTenths, bestCutPlateau, bestBoostPlateau))
-            {
-                continue;
-            }
-
-            ConsiderShelf(
-                coarse with { GainDb = tenths / 10.0 },
-                opt,
-                fit,
-                residual,
-                contribution,
-                winnerContribution,
-                ref best,
-                ref bestScore,
-                ref found);
-        }
-
-        return (best, bestScore);
+        found = true;
+        best = band;
+        bestScore = score;
     }
 
     // The corners of one direction worth trying: every one that leaves
     // ShelfSettledMarginOctaves of the fitting range untouched on the shelf's quiet side
     // and ShelfPlateauSpanOctaves of it under the plateau. The two are different numbers
     // sitting on opposite sides for the two directions, so the ladder is built per
-    // direction rather than once — a high shelf at 10 kHz is an ordinary car correction,
+    // direction rather than once вЂ” a high shelf at 10 kHz is an ordinary car correction,
     // and one symmetric margin wide enough to keep a high shelf off the bottom of the
     // range would have excluded it. Null when the range is too narrow to hold either.
     private static IReadOnlyList<double>? ShelfCorners(FitGrid fit, PeqBandType type)
@@ -1047,34 +1109,6 @@ public static class EqAutoTuner
             2,
             64);
         return EqualizationCurve.LogFrequencyGrid(lowestHz, highestHz, count);
-    }
-
-    // Scores one shelf candidate and keeps it when it beats the running best, returning
-    // whether it did. The skirt guard is deliberately not enforced here — a shelf's
-    // plateau is the correction, not spill; see Options.AllowShelves.
-    private static bool ConsiderShelf(
-        PeqBand band,
-        Options opt,
-        FitGrid fit,
-        double[] residual,
-        double[] contribution,
-        double[] winnerContribution,
-        ref PeqBand best,
-        ref double bestScore,
-        ref bool found)
-    {
-        double score = ScoreBand(
-            band, opt, fit, residual, spillBase: null, contribution, out _);
-        if (found && score >= bestScore)
-        {
-            return false;
-        }
-
-        found = true;
-        best = band;
-        bestScore = score;
-        Array.Copy(contribution, winnerContribution, contribution.Length);
-        return true;
     }
 
     // A gain the shelf search may try at this corner: clear of the dead zone that is not

--- a/dsp/EqAutoTuner.cs
+++ b/dsp/EqAutoTuner.cs
@@ -1,17 +1,35 @@
+﻿using System.Numerics;
+
 namespace Resonalyze.Dsp;
 
 /// <summary>
-/// Automatically fits a set of peaking PEQ bands (plus a preamp) so that adding the
+/// Automatically fits a set of PEQ bands (plus a preamp) so that adding the
 /// resulting <see cref="EqualizationCurve"/> to a measured source curve approximates
 /// a target curve. The number of bands is chosen automatically: the fit adds bands
 /// greedily where the residual error is largest and stops once the remaining error
 /// is negligible or the band budget is exhausted.
 /// </summary>
 /// <remarks>
-/// Peaking bands only, by design: the fit places bells where the residual is worst,
-/// and a shelf is a decision about the whole top or bottom of the range that a
-/// tuner makes deliberately. Callers replace the whole bank with the result, so a
-/// shelf dialled in by hand does not survive a re-fit.
+/// <para>
+/// The bell is the fit's ordinary band, and with <see cref="Options.AllowShelves"/>
+/// off it is the only shape it places: the greedy pass puts a bell where the residual
+/// is worst, which is right for a resonance and wrong for a trend. A shelved target —
+/// a car curve is bass-lifted and tilted down — leaves whole octaves at one end of the
+/// residual off-target, and a stack of bells approximates that badly: slots spent on a
+/// trend, and skirts ringing between the centres.
+/// </para>
+/// <para>
+/// Switching shelves on adds one stage in front of the greedy pass, which may place a
+/// low and a high shelf. Candidates are scored by the same objective the bells are
+/// scored by, and the winner is kept only if FINISHING the fit with it lands closer to
+/// the target than finishing it without — both runs made on scratch state, so a shelf
+/// that would cost more than the slot it takes is simply never applied.
+/// </para>
+/// <para>
+/// All-pass bands are never fitted, whatever the options say: an all-pass is flat, so
+/// a magnitude error can never ask for one. Callers replace the whole bank with the
+/// result, so bands dialled in by hand — shelves included — do not survive a re-fit.
+/// </para>
 /// </remarks>
 public static class EqAutoTuner
 {
@@ -109,6 +127,42 @@ public static class EqAutoTuner
         /// restores the unguarded behaviour (skirt spill allowed).
         /// </summary>
         public double ForbiddenRegionMaxBoostDb { get; init; } = 0.5;
+
+        /// <summary>
+        /// Lets the fit place a low and a high shelf in front of the greedy bell pass.
+        /// Off by default, so a caller that says nothing gets the bells-only curve
+        /// earlier versions produced.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A shelf is the honest shape for the ends of a car correction — the target
+        /// itself is a bass shelf plus a downward tilt — and one of them replaces the
+        /// three or four bells a trend otherwise costs, along with the ringing their
+        /// skirts leave between the centres. The stage is deliberately narrow: at most
+        /// one shelf per direction, a knee capped at the steepest that still rises
+        /// monotonically, and acceptance only when the rest of the fit, run to
+        /// exhaustion both ways, ends closer to the target with the shelf than without
+        /// it. Weaker rules were tried first and measured: an absolute "improves the
+        /// residual by X" bar, and beating the single bell the shelf displaces. Both
+        /// spent slots on shelves that left the finished fit worse, because a shelf acts
+        /// across octaves and changes what every later band has left to do.
+        /// </para>
+        /// <para>
+        /// A BOOSTING shelf is deliberately treated differently from a boosting bell by
+        /// the reliability mask. <see cref="ForbiddenRegionMaxBoostDb"/> exists to stop
+        /// a band aimed at a reliable centre from quietly pouring gain into an adjacent
+        /// null through its SKIRT. A shelf has no skirt in that sense — its plateau IS
+        /// the correction, and it necessarily passes over whatever nulls that end of the
+        /// range holds — so applying the per-bin guard to one would refuse every
+        /// boosting shelf that could ever be proposed. A shelf is gated on being
+        /// JUSTIFIED instead: at least <see cref="ShelfPlateauUsableFraction"/> of its
+        /// plateau must be boost-allowed before a positive gain is even searched, and
+        /// the gain itself is still bounded by <see cref="BandGainMaxDb"/>. The bells
+        /// that follow keep the per-bin guard measured against THEIR own boost alone,
+        /// so a shelf's level does not lock them out of the region it covers.
+        /// </para>
+        /// </remarks>
+        public bool AllowShelves { get; init; }
     }
 
     // Quality factors tried for each band; the one that lowers the residual error
@@ -132,6 +186,61 @@ public static class EqAutoTuner
     // target) is always freely fixable and unpenalised.
     private const double CutsOnlyOverCorrectionWeight = 25.0;
     private const double CutsOnlyOverCutFreeDb = 1.0;
+
+    // Shelf policy (Options.AllowShelves). Every number here is about "is there really
+    // a trend at that end of the range": a shelf that is wrong is wrong across octaves,
+    // so none of these may be decided by a single point.
+
+    // The directions a shelf may take, in the order the stage searches them. Both are
+    // scored every round and the better one wins, so the order is not a preference.
+    private static readonly PeqBandType[] ShelfDirections =
+        { PeqBandType.LowShelf, PeqBandType.HighShelf };
+
+    // Knees a fitted shelf may take, in the one decimal the slot strips keep — a Q the
+    // strips would round is a shelf that is not the one that was scored. Capped at 0.7
+    // BY CONSTRUCTION rather than by the caller's QMax: above 1/sqrt(2) an RBJ shelf
+    // overshoots its own gain before settling on it, and an overshoot on a CUT is a
+    // boost — which cuts-only mode promises never to produce and which the reliability
+    // mask may well have refused at that frequency. Measured over the whole corner and
+    // gain ladder at 48 kHz, the most a cutting shelf lifts anywhere is 0.0000 dB at
+    // Q 0.70 and 0.0002 at 0.71, then 0.15 at 0.8, 0.90 at 1.0 and 2.69 at 1.4 — the
+    // boundary is exactly where the algebra says it is. QMax bounds how NARROW a BELL
+    // may be and says nothing about a knee, so it is not applied here; QMin is, because
+    // it is what the strips accept.
+    private static readonly double[] ShelfCandidateQ = { 0.3, 0.4, 0.5, 0.7 };
+
+    // How much of the fitting range must lie on a shelf's UNAFFECTED side — below a
+    // high shelf, above a low one. This is what separates a shelf from a level change:
+    // a high shelf sitting an octave off the bottom of the range lifts practically
+    // everything, which is a preamp wearing a filter slot, and the fit reached for
+    // exactly that when the mask refused it the shelf it actually wanted. Two octaves
+    // of untouched range is the price of calling the band a shelf.
+    private const double ShelfSettledMarginOctaves = 2.0;
+
+    // And how much must lie on the side it DOES act on, so there is a plateau to decide
+    // about rather than a corner hanging off the end of the range.
+    private const double ShelfPlateauSpanOctaves = 1.0;
+
+    // Where that plateau starts, measured outwards from the corner. Half an octave out,
+    // a shelf has reached 57% of its gain at the widest knee it may take and 78% at the
+    // narrowest — enough of it, at every Q, for the span beyond to be what the shelf is
+    // really deciding about rather than part of its transition.
+    private const double ShelfPlateauMarginOctaves = 0.5;
+
+    // How much of that plateau must carry usable data before the shelf may be fitted:
+    // measured points for a cut, boost-ALLOWED points for a boost. Three quarters, not
+    // a bare majority — measured, at three fifths the fit answered a mask that refused
+    // to lift an incoherent top by lifting nearly the whole range instead, through a
+    // shelf whose plateau cleared that bar by a single point.
+    private const double ShelfPlateauUsableFraction = 0.75;
+
+    // Corners tried per octave. A knee is broad: a third of an octave is already finer
+    // than the choice can be told apart at.
+    private const int ShelfCornersPerOctave = 3;
+
+    // Below this a shelf is not worth a slot. The search steps gain in the same tenth
+    // of a dB the strips keep.
+    private const double ShelfMinGainDb = 0.5;
 
     /// <summary>
     /// Fits an equalization curve so that <paramref name="source"/> + curve best
@@ -253,20 +362,133 @@ public static class EqAutoTuner
                 grid, sourceDb, valid, coherenceGrid, opt.BoostMask);
         }
 
+        // The unit-circle points every candidate's digital response is evaluated at.
+        // Pre-computed once so a candidate costs one biquad build plus a complex
+        // division per point, instead of rebuilding the same biquad at every frequency:
+        // the arithmetic is exactly what DigitalEqualizationResponse.MagnitudeDbAt
+        // performs, which is why the fit still sees the response the DSP will realize.
+        var z1 = new Complex[n];
+        var z2 = new Complex[n];
+        for (int i = 0; i < n; i++)
+        {
+            z1[i] = Complex.Exp(new Complex(0, -Math.Tau * grid[i] / opt.SampleRateHz));
+            z2[i] = z1[i] * z1[i];
+        }
+
+        var fit = new FitGrid(grid, z1, z2, valid, boostAllowed, validCount);
+
         var bands = new List<PeqBand>();
         var contribution = new double[n];
         var bestContribution = new double[n];
         // Running EQ magnitude of the placed bands, used to cap the cumulative boost.
         var eqSum = new double[n];
+        // The same running total for the BELLS alone. Both boost guards read this
+        // rather than eqSum, because both exist to stop BELLS from piling on each
+        // other, and a shelf is not a pile: its plateau is a deliberate correction of a
+        // whole end of the range. Charging the bells for it locks them out of every
+        // region a shelf covers — measured: a +6 dB bass shelf leaves zero headroom
+        // across the bass, every resonance under it is refused for want of it, and the
+        // finished fit is worse than the one with no shelf at all. Identical to eqSum
+        // whenever no shelf was placed, so a bells-only fit is unchanged. See
+        // Options.AllowShelves.
+        var bellSum = new double[n];
         // Frequencies excluded from further bands (already corrected as far as they
         // can be, or an unrecoverable boost deficit).
         var blocked = new bool[n];
+
+        // Shelves first, and only where the residual has a trend at one end worth the
+        // slot: the greedy pass below then works on what they left, so a bell is never
+        // spent re-correcting a tilt a shelf already took out.
+        if (opt.AllowShelves)
+        {
+            PlaceShelves(
+                opt, fit, qCandidates, residual, eqSum, bellSum, bands);
+        }
+
         while (bands.Count < opt.MaxBands)
         {
-            int peakIndex = IndexOfLargestResidual(residual, valid, blocked);
-            if (peakIndex < 0 || Math.Abs(residual[peakIndex]) < opt.StopResidualDb)
+            (PeqBand Band, double Score)? bell = NextBell(
+                opt,
+                fit,
+                qCandidates,
+                residual,
+                eqSum,
+                bellSum,
+                blocked,
+                contribution,
+                bestContribution);
+            if (bell == null)
             {
                 break;
+            }
+
+            bands.Add(bell.Value.Band);
+            for (int i = 0; i < n; i++)
+            {
+                if (valid[i])
+                {
+                    residual[i] -= bestContribution[i];
+                    eqSum[i] += bestContribution[i];
+                    bellSum[i] += bestContribution[i];
+                }
+            }
+        }
+
+        // Digital-clipping guard: cap the preamp so preamp + the summed band
+        // boost never exceeds TotalGainMaxDb anywhere. Cuts leave bandPeak at
+        // 0, so a positive preamp survives only up to the ceiling itself.
+        if (double.IsFinite(opt.TotalGainMaxDb))
+        {
+            double bandPeak = 0;
+            for (int i = 0; i < n; i++)
+            {
+                if (valid[i])
+                {
+                    bandPeak = Math.Max(bandPeak, eqSum[i]);
+                }
+            }
+            preamp = Clamp(
+                Math.Min(preamp, Math.Floor(opt.TotalGainMaxDb - bandPeak)),
+                opt.PreampMinDb,
+                opt.PreampMaxDb);
+        }
+
+        return new EqualizationCurve(bands, preamp);
+    }
+
+    /// <summary>
+    /// The next bell the greedy pass would place against this residual, with its
+    /// contribution left in <paramref name="bestContribution"/> — or null when there is
+    /// nothing left it can do.
+    /// </summary>
+    /// <remarks>
+    /// Everything the pass decides about ONE band lives here: which peak to correct,
+    /// whether the mode or the reliability mask forbids it, how much boost headroom is
+    /// left, which Q fits best, and what footprint the choice sterilises. It stops short
+    /// of APPLYING the band, which is what lets the shelf stage ask what a slot would
+    /// buy as a bell without spending it — that call passes scratch copies of
+    /// <paramref name="blocked"/> and of the two contribution buffers, and throws the
+    /// answer away.
+    /// </remarks>
+    private static (PeqBand Band, double Score)? NextBell(
+        Options opt,
+        FitGrid fit,
+        double[] qCandidates,
+        double[] residual,
+        double[] eqSum,
+        double[] bellSum,
+        bool[] blocked,
+        double[] contribution,
+        double[] bestContribution)
+    {
+        IReadOnlyList<double> grid = fit.Hz;
+        int n = grid.Count;
+        while (true)
+        {
+            int peakIndex = IndexOfLargestResidual(residual, fit.Valid, blocked);
+            if (peakIndex < 0 || Math.Abs(residual[peakIndex]) < opt.StopResidualDb)
+            {
+                return null;
             }
 
             double desired = residual[peakIndex];
@@ -275,9 +497,10 @@ public static class EqAutoTuner
             // all: skip the contiguous FORBIDDEN deficit around it, but stop at the
             // first boost-allowed point so the reliable shoulders of a wide dip whose
             // core is a null still get their own bands.
-            if (desired > 0 && !boostAllowed[peakIndex])
+            if (desired > 0 && !fit.BoostAllowed[peakIndex])
             {
-                BlockForbiddenBoostRun(blocked, residual, boostAllowed, valid, peakIndex);
+                BlockForbiddenBoostRun(
+                    blocked, residual, fit.BoostAllowed, fit.Valid, peakIndex);
                 continue;
             }
 
@@ -285,10 +508,13 @@ public static class EqAutoTuner
             bool boostHeadroomLimited = false;
             if (desired > 0)
             {
-                // Limit the boost so the total EQ gain here never exceeds the boost
-                // ceiling; a roll-off that needs +30 dB gets one capped band, not a
-                // stack of them.
-                double headroom = opt.BandGainMaxDb - eqSum[peakIndex];
+                // Limit the boost so the bells' own summed gain here never exceeds the
+                // boost ceiling; a roll-off that needs +30 dB gets one capped band, not
+                // a stack of them. A shelf under it is not part of that stack (see the
+                // bellSum declaration), so a fit that placed one can boost past
+                // BandGainMaxDb in total — which is the caller's to bound through
+                // TotalGainMaxDb, and the EQ Wizard's to report as headroom.
+                double headroom = opt.BandGainMaxDb - bellSum[peakIndex];
                 double allowed = Math.Min(desired, Math.Max(0, headroom));
                 boostHeadroomLimited = allowed < desired - 0.05;
                 gainDb = Math.Round(allowed, 1);
@@ -315,57 +541,28 @@ public static class EqAutoTuner
             // region. Candidates that would are discarded from the search.
             bool isBoost = gainDb > 0;
             double bestQ = qCandidates[0];
-            double bestRms = double.MaxValue;
+            double bestScore = double.MaxValue;
             bool anyCandidateFits = false;
             foreach (double candidate in qCandidates)
             {
                 double q = Math.Round(candidate, 1);
-                var band = new PeqBand(frequencyHz, q, gainDb);
-                double sumSquares = 0;
-                bool spillsIntoForbidden = false;
-                for (int i = 0; i < n; i++)
-                {
-                    if (!valid[i])
-                    {
-                        continue;
-                    }
-
-                    double c = DigitalEqualizationResponse.MagnitudeDbAt(
-                        band, grid[i], opt.SampleRateHz);
-                    contribution[i] = c;
-                    if (isBoost && !boostAllowed[i] &&
-                        eqSum[i] + c > opt.ForbiddenRegionMaxBoostDb)
-                    {
-                        spillsIntoForbidden = true;
-                    }
-
-                    // In cuts-only, charge the part of this band's own cut that lands
-                    // below the target, past the free zone. See the constants above for
-                    // why the charge is on the band's contribution, never the depth the
-                    // point already had.
-                    double r = residual[i] - c;
-                    sumSquares += r * r;
-                    if (opt.CutsOnlyMode && c < 0)
-                    {
-                        double added = Math.Min(-c, Math.Max(0, r));
-                        if (added > CutsOnlyOverCutFreeDb)
-                        {
-                            double over = added - CutsOnlyOverCutFreeDb;
-                            sumSquares += CutsOnlyOverCorrectionWeight * over * over;
-                        }
-                    }
-                }
-
+                double score = ScoreBand(
+                    new PeqBand(frequencyHz, q, gainDb),
+                    opt,
+                    fit,
+                    residual,
+                    isBoost ? bellSum : null,
+                    contribution,
+                    out bool spillsIntoForbidden);
                 if (spillsIntoForbidden)
                 {
                     continue;
                 }
 
                 anyCandidateFits = true;
-                double rms = sumSquares / validCount;
-                if (rms < bestRms)
+                if (score < bestScore)
                 {
-                    bestRms = rms;
+                    bestScore = score;
                     bestQ = q;
                     Array.Copy(contribution, bestContribution, n);
                 }
@@ -380,16 +577,6 @@ public static class EqAutoTuner
                 continue;
             }
 
-            bands.Add(new PeqBand(frequencyHz, bestQ, gainDb));
-            for (int i = 0; i < n; i++)
-            {
-                if (valid[i])
-                {
-                    residual[i] -= bestContribution[i];
-                    eqSum[i] += bestContribution[i];
-                }
-            }
-
             // Sterilise only a narrow footprint around this band's centre — enough to
             // stop it re-nibbling the very same peak, but far smaller than the old
             // fixed spacing so a cluster of narrow peaks each keeps its own band. A
@@ -400,28 +587,515 @@ public static class EqAutoTuner
                 grid,
                 peakIndex,
                 boostHeadroomLimited ? opt.SaturatedBlockOctaves : opt.MinBandSpacingOctaves);
+            return (new PeqBand(frequencyHz, bestQ, gainDb), bestScore);
         }
+    }
 
-        // Digital-clipping guard: cap the preamp so preamp + the summed band
-        // boost never exceeds TotalGainMaxDb anywhere. Cuts leave bandPeak at
-        // 0, so a positive preamp survives only up to the ceiling itself.
-        if (double.IsFinite(opt.TotalGainMaxDb))
+    // How good a FINISHED fit is: the mean squared distance from the target, plus — in
+    // cuts-only — the same charge the band search makes for landing BELOW it, since a
+    // point pushed under the target can no longer be lifted back. Ranks the two
+    // candidate fits the shelf lookahead runs, so the decision is made on the state they
+    // end in rather than on the single band that starts them.
+    // The charge is on what the BANDS did, exactly as it is per band: eqSum is how far
+    // this fit pulled the point down, and only the part of that landing under the target
+    // is charged. Charging the depth itself instead — every point that ended below the
+    // target, whatever put it there — lets a pre-existing deficit the preamp could not
+    // absorb dominate the number, and the comparison then turns on a constant both
+    // candidates share. Measured: it rejected at a four-band budget the very shelf it
+    // had accepted at three, on a response where the shelf was plainly the better fit.
+    private static double FinalScore(
+        Options opt,
+        FitGrid fit,
+        double[] residual,
+        double[] eqSum)
+    {
+        double sumSquares = 0;
+        for (int i = 0; i < residual.Length; i++)
         {
-            double bandPeak = 0;
-            for (int i = 0; i < n; i++)
+            if (!fit.Valid[i])
             {
-                if (valid[i])
+                continue;
+            }
+
+            double r = residual[i];
+            sumSquares += r * r;
+            if (opt.CutsOnlyMode && eqSum[i] < 0)
+            {
+                double added = Math.Min(-eqSum[i], Math.Max(0, r));
+                if (added > CutsOnlyOverCutFreeDb)
                 {
-                    bandPeak = Math.Max(bandPeak, eqSum[i]);
+                    double over = added - CutsOnlyOverCutFreeDb;
+                    sumSquares += CutsOnlyOverCorrectionWeight * over * over;
                 }
             }
-            preamp = Clamp(
-                Math.Min(preamp, Math.Floor(opt.TotalGainMaxDb - bandPeak)),
-                opt.PreampMinDb,
-                opt.PreampMaxDb);
         }
 
-        return new EqualizationCurve(bands, preamp);
+        return sumSquares / fit.ValidCount;
+    }
+
+    // Runs the greedy bell pass to exhaustion on scratch copies of the state and returns
+    // the score of what it ends with. Nothing the caller owns is touched, so this is how
+    // the shelf stage asks what the rest of the fit would look like either way.
+    private static double TrialFit(
+        Options opt,
+        FitGrid fit,
+        double[] qCandidates,
+        double[] residual,
+        double[] eqSum,
+        double[] bellSum,
+        int budget)
+    {
+        int n = fit.Hz.Count;
+        var trialResidual = (double[])residual.Clone();
+        var trialEqSum = (double[])eqSum.Clone();
+        var trialBellSum = (double[])bellSum.Clone();
+        var blocked = new bool[n];
+        var contribution = new double[n];
+        var bestContribution = new double[n];
+        for (int placed = 0; placed < budget; placed++)
+        {
+            if (NextBell(
+                opt,
+                fit,
+                qCandidates,
+                trialResidual,
+                trialEqSum,
+                trialBellSum,
+                blocked,
+                contribution,
+                bestContribution) == null)
+            {
+                break;
+            }
+
+            for (int i = 0; i < n; i++)
+            {
+                if (fit.Valid[i])
+                {
+                    trialResidual[i] -= bestContribution[i];
+                    trialEqSum[i] += bestContribution[i];
+                    trialBellSum[i] += bestContribution[i];
+                }
+            }
+        }
+
+        return FinalScore(opt, fit, trialResidual, trialEqSum);
+    }
+
+    /// <summary>
+    /// The fixed part of a fit: the logarithmic frequency grid, the unit-circle points
+    /// the digital responses are evaluated at, and which of those points carry data a
+    /// band may be judged on at all (<see cref="Valid"/>) or boosted at
+    /// (<see cref="BoostAllowed"/>).
+    /// </summary>
+    private sealed record FitGrid(
+        IReadOnlyList<double> Hz,
+        Complex[] Z1,
+        Complex[] Z2,
+        bool[] Valid,
+        bool[] BoostAllowed,
+        int ValidCount);
+
+    // The fit's objective, and the one place a candidate band becomes numbers: fills
+    // contribution with the band's dB contribution at every valid grid point and
+    // returns the mean squared residual that would remain, plus the cuts-only
+    // over-correction charge described above the constants. Bells and shelves are both
+    // scored through here, so a shelf is never accepted on a softer test than the bell
+    // whose slot it takes.
+    //
+    // spillBase is the running boost the skirt guard measures this candidate against,
+    // or null when the guard does not apply — a cut, which can never fill a null, or a
+    // shelf, whose plateau is the correction rather than a skirt (see
+    // Options.AllowShelves).
+    private static double ScoreBand(
+        PeqBand band,
+        Options opt,
+        FitGrid fit,
+        double[] residual,
+        double[]? spillBase,
+        double[] contribution,
+        out bool spillsIntoForbidden)
+    {
+        // A degenerate band contributes nothing anywhere; PeqBiquad would still hand
+        // back coefficients, so the check DigitalEqualizationResponse makes per point is
+        // made once here instead.
+        bool transparent = band.IsTransparent;
+        BiquadCoefficients coefficients = transparent
+            ? default
+            : PeqBiquad.Compute(band, opt.SampleRateHz);
+
+        double sumSquares = 0;
+        spillsIntoForbidden = false;
+        for (int i = 0; i < fit.Hz.Count; i++)
+        {
+            if (!fit.Valid[i])
+            {
+                continue;
+            }
+
+            double c = transparent
+                ? 0
+                : 20.0 * Math.Log10(Math.Max(
+                    BiquadResponse.Evaluate(coefficients, fit.Z1[i], fit.Z2[i]).Magnitude,
+                    double.Epsilon));
+            contribution[i] = c;
+            if (spillBase != null && !fit.BoostAllowed[i] &&
+                spillBase[i] + c > opt.ForbiddenRegionMaxBoostDb)
+            {
+                spillsIntoForbidden = true;
+            }
+
+            // In cuts-only, charge the part of this band's own cut that lands below the
+            // target, past the free zone. See the constants above for why the charge is
+            // on the band's contribution, never the depth the point already had.
+            double r = residual[i] - c;
+            sumSquares += r * r;
+            if (opt.CutsOnlyMode && c < 0)
+            {
+                double added = Math.Min(-c, Math.Max(0, r));
+                if (added > CutsOnlyOverCutFreeDb)
+                {
+                    double over = added - CutsOnlyOverCutFreeDb;
+                    sumSquares += CutsOnlyOverCorrectionWeight * over * over;
+                }
+            }
+        }
+
+        return sumSquares / fit.ValidCount;
+    }
+
+    /// <summary>
+    /// Places at most one low and one high shelf against the residual, before the
+    /// greedy bell pass ever sees it, updating <paramref name="residual"/>,
+    /// <paramref name="eqSum"/> and <paramref name="bands"/> in place.
+    /// </summary>
+    /// <remarks>
+    /// One round per direction. Each searches every direction not yet placed, keeps the
+    /// single best candidate across both, and applies it only if that candidate beats
+    /// the bell the greedy pass would put in the same slot. Running the second round
+    /// against the residual the first one left is what lets a bass shelf and a treble
+    /// shelf describe one tilt together, instead of both being fitted to the same slope.
+    /// The stage never marks a frequency blocked: a shelf sterilises nothing, and the
+    /// bells are meant to work on top of it.
+    /// </remarks>
+    private static void PlaceShelves(
+        Options opt,
+        FitGrid fit,
+        double[] qCandidates,
+        double[] residual,
+        double[] eqSum,
+        double[] bellSum,
+        List<PeqBand> bands)
+    {
+        int n = fit.Hz.Count;
+        var contribution = new double[n];
+        var candidateContribution = new double[n];
+        var chosenContribution = new double[n];
+        var shelfResidual = new double[n];
+        var shelfEqSum = new double[n];
+        bool lowPlaced = false;
+        bool highPlaced = false;
+        for (int round = 0;
+            round < ShelfDirections.Length && bands.Count < opt.MaxBands;
+            round++)
+        {
+            PeqBand chosen = default;
+            double chosenScore = double.MaxValue;
+            bool found = false;
+            foreach (PeqBandType type in ShelfDirections)
+            {
+                if (type == PeqBandType.LowShelf ? lowPlaced : highPlaced)
+                {
+                    continue;
+                }
+
+                (PeqBand Band, double Score)? candidate = BestShelf(
+                    type,
+                    opt,
+                    fit,
+                    residual,
+                    contribution,
+                    candidateContribution);
+                if (candidate == null || (found && candidate.Value.Score >= chosenScore))
+                {
+                    continue;
+                }
+
+                found = true;
+                chosen = candidate.Value.Band;
+                chosenScore = candidate.Value.Score;
+                Array.Copy(candidateContribution, chosenContribution, n);
+            }
+
+            if (!found)
+            {
+                return;
+            }
+
+            // Whether the shelf is worth its slot is decided by finishing the fit BOTH
+            // ways on scratch state and comparing where the two end up. Nothing cheaper
+            // survived measurement. A shelf that lowers the objective on its own, or
+            // that beats the single bell it displaces, can still leave the whole fit
+            // worse: it acts across octaves, so it changes what every later band has
+            // left to correct, and only running the rest of the pass shows whether that
+            // trade came out ahead. Both weaker rules were tried and both spent a slot
+            // on a shelf that cost more than it bought.
+            int remaining = opt.MaxBands - bands.Count;
+            for (int i = 0; i < n; i++)
+            {
+                shelfResidual[i] = residual[i];
+                shelfEqSum[i] = eqSum[i];
+                if (fit.Valid[i])
+                {
+                    shelfResidual[i] -= chosenContribution[i];
+                    shelfEqSum[i] += chosenContribution[i];
+                }
+            }
+
+            double withShelf = TrialFit(
+                opt, fit, qCandidates, shelfResidual, shelfEqSum, bellSum, remaining - 1);
+            double withoutShelf = TrialFit(
+                opt, fit, qCandidates, residual, eqSum, bellSum, remaining);
+
+            // A round the lookahead turns down ends the stage: nothing was applied, so
+            // the next round would search the very same residual and lose again.
+            if (withShelf >= withoutShelf)
+            {
+                return;
+            }
+
+            bands.Add(chosen);
+            for (int i = 0; i < n; i++)
+            {
+                if (fit.Valid[i])
+                {
+                    residual[i] -= chosenContribution[i];
+                    eqSum[i] += chosenContribution[i];
+                }
+            }
+
+            if (chosen.Type == PeqBandType.LowShelf)
+            {
+                lowPlaced = true;
+            }
+            else
+            {
+                highPlaced = true;
+            }
+        }
+    }
+
+    // The best shelf of one direction against the current residual, with its
+    // contribution left in winnerContribution; null when the fitting range cannot hold a
+    // corner of that direction, when no candidate has a plateau to stand on, or when the
+    // caller's QMin excludes every knee a shelf may take.
+    private static (PeqBand Band, double Score)? BestShelf(
+        PeqBandType type,
+        Options opt,
+        FitGrid fit,
+        double[] residual,
+        double[] contribution,
+        double[] winnerContribution)
+    {
+        double[] qCandidates = ShelfCandidateQ.Where(q => q >= opt.QMin).ToArray();
+        if (qCandidates.Length == 0)
+        {
+            return null;
+        }
+
+        IReadOnlyList<double>? corners = ShelfCorners(fit, type);
+        if (corners == null)
+        {
+            return null;
+        }
+
+        // Gain is searched in the tenth of a dB the strips keep, coarsely first and then
+        // refined around the winner: the level is what decides whether a shelf
+        // over-corrects and is worth resolving, while its corner and knee are broad
+        // choices the ladders above already cover.
+        int minTenths = (int)Math.Round(opt.BandGainMinDb * 10);
+        int maxTenths = (int)Math.Round(
+            (opt.CutsOnlyMode ? Math.Min(0, opt.BandGainMaxDb) : opt.BandGainMaxDb) * 10);
+        int deadTenths = (int)Math.Round(ShelfMinGainDb * 10);
+        bool searchesBoosts = maxTenths >= deadTenths;
+
+        PeqBand best = default;
+        double bestScore = double.MaxValue;
+        bool found = false;
+        bool bestCutPlateau = false;
+        bool bestBoostPlateau = false;
+        foreach (double cornerHz in corners)
+        {
+            double frequencyHz = Math.Round(cornerHz);
+            if (frequencyHz < 1)
+            {
+                continue;
+            }
+
+            bool cutPlateau = HasUsablePlateau(fit, type, frequencyHz, boosting: false);
+            bool boostPlateau = searchesBoosts &&
+                HasUsablePlateau(fit, type, frequencyHz, boosting: true);
+            if (!cutPlateau && !boostPlateau)
+            {
+                continue;
+            }
+
+            foreach (double q in qCandidates)
+            {
+                for (int tenths = minTenths; tenths <= maxTenths; tenths += 10)
+                {
+                    if (!IsSearchableGain(tenths, deadTenths, cutPlateau, boostPlateau))
+                    {
+                        continue;
+                    }
+
+                    if (ConsiderShelf(
+                        new PeqBand(frequencyHz, q, tenths / 10.0, type),
+                        opt,
+                        fit,
+                        residual,
+                        contribution,
+                        winnerContribution,
+                        ref best,
+                        ref bestScore,
+                        ref found))
+                    {
+                        bestCutPlateau = cutPlateau;
+                        bestBoostPlateau = boostPlateau;
+                    }
+                }
+            }
+        }
+
+        if (!found)
+        {
+            return null;
+        }
+
+        // The coarse ladder walks in whole dB, so the true level sits within one step of
+        // the winner. Corner and knee are kept: a tenth of a dB does not change which of
+        // those was right.
+        PeqBand coarse = best;
+        int coarseTenths = (int)Math.Round(coarse.GainDb * 10);
+        for (int tenths = coarseTenths - 10; tenths <= coarseTenths + 10; tenths++)
+        {
+            if (tenths < minTenths || tenths > maxTenths ||
+                !IsSearchableGain(tenths, deadTenths, bestCutPlateau, bestBoostPlateau))
+            {
+                continue;
+            }
+
+            ConsiderShelf(
+                coarse with { GainDb = tenths / 10.0 },
+                opt,
+                fit,
+                residual,
+                contribution,
+                winnerContribution,
+                ref best,
+                ref bestScore,
+                ref found);
+        }
+
+        return (best, bestScore);
+    }
+
+    // The corners of one direction worth trying: every one that leaves
+    // ShelfSettledMarginOctaves of the fitting range untouched on the shelf's quiet side
+    // and ShelfPlateauSpanOctaves of it under the plateau. The two are different numbers
+    // sitting on opposite sides for the two directions, so the ladder is built per
+    // direction rather than once — a high shelf at 10 kHz is an ordinary car correction,
+    // and one symmetric margin wide enough to keep a high shelf off the bottom of the
+    // range would have excluded it. Null when the range is too narrow to hold either.
+    private static IReadOnlyList<double>? ShelfCorners(FitGrid fit, PeqBandType type)
+    {
+        bool low = type == PeqBandType.LowShelf;
+        double lowestHz = fit.Hz[0] *
+            Math.Pow(2, low ? ShelfPlateauSpanOctaves : ShelfSettledMarginOctaves);
+        double highestHz = fit.Hz[^1] /
+            Math.Pow(2, low ? ShelfSettledMarginOctaves : ShelfPlateauSpanOctaves);
+        if (highestHz <= lowestHz || lowestHz < 1)
+        {
+            return null;
+        }
+
+        int count = Math.Clamp(
+            (int)Math.Round(Math.Log2(highestHz / lowestHz) * ShelfCornersPerOctave) + 1,
+            2,
+            64);
+        return EqualizationCurve.LogFrequencyGrid(lowestHz, highestHz, count);
+    }
+
+    // Scores one shelf candidate and keeps it when it beats the running best, returning
+    // whether it did. The skirt guard is deliberately not enforced here — a shelf's
+    // plateau is the correction, not spill; see Options.AllowShelves.
+    private static bool ConsiderShelf(
+        PeqBand band,
+        Options opt,
+        FitGrid fit,
+        double[] residual,
+        double[] contribution,
+        double[] winnerContribution,
+        ref PeqBand best,
+        ref double bestScore,
+        ref bool found)
+    {
+        double score = ScoreBand(
+            band, opt, fit, residual, spillBase: null, contribution, out _);
+        if (found && score >= bestScore)
+        {
+            return false;
+        }
+
+        found = true;
+        best = band;
+        bestScore = score;
+        Array.Copy(contribution, winnerContribution, contribution.Length);
+        return true;
+    }
+
+    // A gain the shelf search may try at this corner: clear of the dead zone that is not
+    // worth a slot, and on a side the plateau justifies — a cut needs measured data
+    // under it, a boost needs data the reliability mask cleared.
+    private static bool IsSearchableGain(
+        int tenths,
+        int deadTenths,
+        bool cutPlateau,
+        bool boostPlateau) =>
+        Math.Abs(tenths) >= deadTenths && (tenths < 0 ? cutPlateau : boostPlateau);
+
+    // Whether the span beyond a shelf's knee, on the shelf's own side, carries enough
+    // data to decide a correction of that whole end of the range: measured points for a
+    // cut, boost-allowed points for a boost (see Options.AllowShelves). Two points is
+    // the floor whatever the grid size — one point is a bin, not a plateau.
+    private static bool HasUsablePlateau(
+        FitGrid fit,
+        PeqBandType type,
+        double cornerHz,
+        bool boosting)
+    {
+        bool low = type == PeqBandType.LowShelf;
+        int total = 0;
+        int usable = 0;
+        for (int i = 0; i < fit.Hz.Count; i++)
+        {
+            double octaves = Math.Log2(fit.Hz[i] / cornerHz);
+            bool inPlateau = low
+                ? octaves <= -ShelfPlateauMarginOctaves
+                : octaves >= ShelfPlateauMarginOctaves;
+            if (!inPlateau)
+            {
+                continue;
+            }
+
+            total++;
+            if (boosting ? fit.BoostAllowed[i] : fit.Valid[i])
+            {
+                usable++;
+            }
+        }
+
+        return total >= 2 && usable >= total * ShelfPlateauUsableFraction;
     }
 
     // Marks the contiguous run of masked-off boost-wanting points (residual > 0 AND

--- a/dsp/EqAutoTuner.cs
+++ b/dsp/EqAutoTuner.cs
@@ -799,8 +799,26 @@ public static class EqAutoTuner
             round < ShelfDirections.Length && bands.Count < opt.MaxBands;
             round++)
         {
+            // Whether a shelf is worth its slot is decided by finishing the fit BOTH
+            // ways on scratch state and comparing where the two end up. Nothing cheaper
+            // survived measurement: a shelf that lowers the objective on its own, or
+            // that beats the single bell it displaces, can still leave the whole fit
+            // worse, because it acts across octaves and changes what every later band
+            // has left to correct. Both weaker rules were tried and both spent a slot
+            // on a shelf that cost more than it bought.
+            //
+            // EVERY direction still open is taken that far, and the finished score is
+            // what ranks them. Ranking the two by their single-band score first and
+            // only asking the winner would let a low shelf that reads better before the
+            // bells are placed suppress a high shelf that finishes closer, and would
+            // let one direction's rejection end the stage with the other never asked.
+            // The baseline is the same for both, so it is run once.
+            int remaining = opt.MaxBands - bands.Count;
+            double withoutShelf = TrialFit(
+                opt, fit, qCandidates, residual, eqSum, bellSum, remaining);
+
             PeqBand chosen = default;
-            double chosenScore = double.MaxValue;
+            double chosenFinal = withoutShelf;
             bool found = false;
             foreach (PeqBandType type in ShelfDirections)
             {
@@ -809,6 +827,13 @@ public static class EqAutoTuner
                     continue;
                 }
 
+                // Which corner, knee and gain that direction offers is still settled by
+                // the single-band objective, the same one the bells pick their Q with.
+                // Ranking every corner x knee x gain by a finished fit instead is three
+                // orders of magnitude more work — a full greedy pass per candidate,
+                // roughly 1300 of them per direction per round, against the two runs
+                // here — so the shortlist is one candidate and the shape of the
+                // approximation is the same one the greedy pass already makes.
                 (PeqBand Band, double Score)? candidate = BestShelf(
                     type,
                     opt,
@@ -816,50 +841,48 @@ public static class EqAutoTuner
                     residual,
                     contribution,
                     candidateContribution);
-                if (candidate == null || (found && candidate.Value.Score >= chosenScore))
+                if (candidate == null)
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < n; i++)
+                {
+                    shelfResidual[i] = residual[i];
+                    shelfEqSum[i] = eqSum[i];
+                    if (fit.Valid[i])
+                    {
+                        shelfResidual[i] -= candidateContribution[i];
+                        shelfEqSum[i] += candidateContribution[i];
+                    }
+                }
+
+                double withShelf = TrialFit(
+                    opt,
+                    fit,
+                    qCandidates,
+                    shelfResidual,
+                    shelfEqSum,
+                    bellSum,
+                    remaining - 1);
+
+                // Seeded with the no-shelf score, so this one comparison both ranks the
+                // directions and refuses a shelf that does not beat placing none.
+                if (withShelf >= chosenFinal)
                 {
                     continue;
                 }
 
                 found = true;
                 chosen = candidate.Value.Band;
-                chosenScore = candidate.Value.Score;
+                chosenFinal = withShelf;
                 Array.Copy(candidateContribution, chosenContribution, n);
             }
 
+            // A round in which no direction finishes ahead of the bells ends the stage:
+            // nothing was applied, so the next round would search the very same residual
+            // and lose again.
             if (!found)
-            {
-                return;
-            }
-
-            // Whether the shelf is worth its slot is decided by finishing the fit BOTH
-            // ways on scratch state and comparing where the two end up. Nothing cheaper
-            // survived measurement. A shelf that lowers the objective on its own, or
-            // that beats the single bell it displaces, can still leave the whole fit
-            // worse: it acts across octaves, so it changes what every later band has
-            // left to correct, and only running the rest of the pass shows whether that
-            // trade came out ahead. Both weaker rules were tried and both spent a slot
-            // on a shelf that cost more than it bought.
-            int remaining = opt.MaxBands - bands.Count;
-            for (int i = 0; i < n; i++)
-            {
-                shelfResidual[i] = residual[i];
-                shelfEqSum[i] = eqSum[i];
-                if (fit.Valid[i])
-                {
-                    shelfResidual[i] -= chosenContribution[i];
-                    shelfEqSum[i] += chosenContribution[i];
-                }
-            }
-
-            double withShelf = TrialFit(
-                opt, fit, qCandidates, shelfResidual, shelfEqSum, bellSum, remaining - 1);
-            double withoutShelf = TrialFit(
-                opt, fit, qCandidates, residual, eqSum, bellSum, remaining);
-
-            // A round the lookahead turns down ends the stage: nothing was applied, so
-            // the next round would search the very same residual and lose again.
-            if (withShelf >= withoutShelf)
             {
                 return;
             }

--- a/dsp/EqAutoTuner.cs
+++ b/dsp/EqAutoTuner.cs
@@ -794,9 +794,10 @@ public static class EqAutoTuner
     /// <paramref name="eqSum"/> and <paramref name="bands"/> in place.
     /// </summary>
     /// <remarks>
-    /// One round per direction. Each searches every direction not yet placed, keeps the
-    /// single best candidate across both, and applies it only if that candidate beats
-    /// the bell the greedy pass would put in the same slot. Running the second round
+    /// One round per direction. Each round takes every candidate of every direction not
+    /// yet placed — both shelves, every corner, every knee — through the rest of the fit
+    /// on scratch state, and applies the one that ends closest to the target, provided
+    /// it beats finishing the round with no shelf at all. Running the second round
     /// against the residual the first one left is what lets a bass shelf and a treble
     /// shelf describe one tilt together, instead of both being fitted to the same slope.
     /// The stage never marks a frequency blocked: a shelf sterilises nothing, and the
@@ -823,9 +824,10 @@ public static class EqAutoTuner
             round < ShelfDirections.Length && bands.Count < opt.MaxBands;
             round++)
         {
-            // Whether a shelf is worth its slot is decided by finishing the fit BOTH
-            // ways on scratch state and comparing where the two end up. Nothing cheaper
-            // survived measurement: a shelf that lowers the objective on its own, or
+            // Whether a shelf is worth its slot is decided by finishing the fit on
+            // scratch state WITH the candidate and without it, and comparing where the
+            // two end up. Nothing cheaper survived measurement: a shelf that lowers the
+            // objective on its own, or
             // that beats the single bell it displaces, can still leave the whole fit
             // worse, because it acts across octaves and changes what every later band
             // has left to correct. Both weaker rules were tried and both spent a slot

--- a/source/Settings/MeasurementSettingsFile.Schema.cs
+++ b/source/Settings/MeasurementSettingsFile.Schema.cs
@@ -706,6 +706,12 @@ internal sealed partial class MeasurementSettingsFile
         // EqAutoTuner.Options.CutsOnlyMode.
         public bool CutsOnly { get; set; } = true;
 
+        // Whether Auto Tune may fit low/high shelves as well as bells
+        // (EqAutoTuner.Options.AllowShelves). Off by default, which is what a file
+        // written before the stage existed restores to — and the curve those versions
+        // fitted.
+        public bool AllowShelves { get; set; }
+
         // The narrowest band Auto Tune may place (EqAutoTuner.Options.QMax). Well
         // below the 20 a strip accepts by hand: the fit reads a single microphone
         // position, and a sharp notch fitted to it is a filter for that position

--- a/source/Tools/Eq/EqWizardPanel.Designer.cs
+++ b/source/Tools/Eq/EqWizardPanel.Designer.cs
@@ -64,6 +64,7 @@
             checkBoxEqPhase = new ReleaseClickCheckBox();
             checkBoxEqCurve = new ReleaseClickCheckBox();
             checkBoxCutsOnly = new ReleaseClickCheckBox();
+            checkBoxShelves = new ReleaseClickCheckBox();
             panelAutoTune = new Panel();
             buttonOverlaySettings = new ReleaseClickButton();
             comboBoxCalibration = new DarkComboBox();
@@ -450,6 +451,18 @@
             checkBoxCutsOnly.Text = "Cuts only";
             checkBoxCutsOnly.UseVisualStyleBackColor = true;
             // 
+            // checkBoxShelves
+            // 
+            checkBoxShelves.AutoSize = true;
+            checkBoxShelves.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            checkBoxShelves.ForeColor = Color.FromArgb(210, 214, 222);
+            checkBoxShelves.Location = new Point(95, 157);
+            checkBoxShelves.Name = "checkBoxShelves";
+            checkBoxShelves.Size = new Size(66, 19);
+            checkBoxShelves.TabIndex = 69;
+            checkBoxShelves.Text = "Shelves";
+            checkBoxShelves.UseVisualStyleBackColor = true;
+            // 
             // panelAutoTune
             // 
             panelAutoTune.BackColor = Color.FromArgb(46, 51, 62);
@@ -467,6 +480,7 @@
             panelAutoTune.Controls.Add(labelBandsLimit);
             panelAutoTune.Controls.Add(comboBoxBandsLimit);
             panelAutoTune.Controls.Add(checkBoxCutsOnly);
+            panelAutoTune.Controls.Add(checkBoxShelves);
             panelAutoTune.Controls.Add(buttonAutoTune);
             panelAutoTune.Location = new Point(6, 550);
             panelAutoTune.Name = "panelAutoTune";
@@ -748,6 +762,7 @@
         private ReleaseClickCheckBox checkBoxEqPhase;
         private ReleaseClickCheckBox checkBoxEqCurve;
         private ReleaseClickCheckBox checkBoxCutsOnly;
+        private ReleaseClickCheckBox checkBoxShelves;
         private Panel panelAutoTune;
         private ReleaseClickButton buttonOverlaySettings;
         private DarkComboBox comboBoxCalibration;

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -1571,6 +1571,7 @@ public partial class EqWizardPanel
             numericGainMax.Value = numericGainMax.ClampValue(settings.GainMaxDb);
             numericQMax.Value = numericQMax.ClampValue(settings.AutoTuneMaxQ);
             checkBoxCutsOnly.Checked = settings.CutsOnly;
+            checkBoxShelves.Checked = settings.AllowShelves;
             checkBoxEqCurve.Checked = settings.ShowEqCurve;
             SetSourceSmoothing(settings.SourceSmoothingInverseOctaves);
             ApplyPersistedBank(settings);
@@ -1617,6 +1618,7 @@ public partial class EqWizardPanel
         CalibrationId = preferredIrCalibrationId,
         ManualSampleRateHz = manualSampleRateHz,
         CutsOnly = checkBoxCutsOnly.Checked,
+        AllowShelves = checkBoxShelves.Checked,
         AutoTuneMaxQ = (double)numericQMax.Value,
         ShowEqCurve = checkBoxEqCurve.Checked
     };

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -137,6 +137,13 @@ public partial class EqWizardPanel : UserControl
             autoTuneOrchestrator.Invalidate();
             RaiseSettingsChanged();
         };
+        checkBoxShelves.CheckedChanged += (_, _) =>
+        {
+            // Same contract as Cuts only: only the next fit reads it, but an in-flight
+            // one is orphaned so a result shaped by the previous setting cannot land.
+            autoTuneOrchestrator.Invalidate();
+            RaiseSettingsChanged();
+        };
         buttonAutoTune.Click += (_, _) => AutoTune();
         buttonReturnToDsp.Click += (_, _) => ReturnPeqToVirtualDsp();
         buttonBackToDsp.Click += (_, _) => BackToVirtualDsp();
@@ -402,6 +409,15 @@ public partial class EqWizardPanel : UserControl
             "(a boost cannot fill an interference null, it just burns headroom). " +
             "Uncheck to allow boosts, still limited to reliable regions: high " +
             "coherence and not inside a narrow, deep null.");
+        SetTip(checkBoxShelves,
+            "Let Auto Tune fit a low and a high shelf as well as bells. A car target " +
+            "is a bass shelf plus a downward tilt, and a stack of bells copies that " +
+            "badly — slots spent on a trend, and ringing between the centres. A shelf " +
+            "is kept only where finishing the fit with it beats finishing it without, " +
+            "so a response made of resonances alone gets none. Off by default: it " +
+            "changes what a fit returns, and with Cuts only unchecked a shelf can lift " +
+            "a whole end of the range, so the total boost may pass Max Gain — watch " +
+            "the headroom read-out.");
         SetTip(buttonAutoTune,
             "Automatically fit the bands and preamp so Source + EQ approaches the " +
             "target within the frequency window.");
@@ -1010,7 +1026,12 @@ public partial class EqWizardPanel : UserControl
             // than a cabin measurement justifies, so Max Q caps it well below what a
             // hand-typed strip accepts.
             QMin = PeqSlotControl.MinimumQ,
-            QMax = (double)numericQMax.Value
+            QMax = (double)numericQMax.Value,
+            // Shelves are the user's choice because they change the SHAPE of what comes
+            // back, not just its accuracy: Max Q above bounds a bell's narrowness and
+            // says nothing about a shelf's knee, and a boosting shelf lifts a whole end
+            // of the range at once.
+            AllowShelves = checkBoxShelves.Checked
         };
     }
 

--- a/tests/Resonalyze.App.Tests/EqWizardAutoTuneShelvesTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardAutoTuneShelvesTests.cs
@@ -1,0 +1,148 @@
+﻿using System.Drawing;
+using System.Reflection;
+using System.Windows.Forms;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The Auto Tune Shelves switch. It changes the SHAPE of what a fit returns — a low
+/// and a high shelf may join the bells — so it is the user's to make, off unless they
+/// ask, and it has to survive a restart the way the rest of the fit's settings do.
+/// </summary>
+public sealed class EqWizardAutoTuneShelvesTests : IDisposable
+{
+    private readonly string directory = Path.Combine(
+        Path.GetTempPath(),
+        $"resonalyze-eq-shelves-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void TheFitIsBellsOnlyUntilTheUserAsksOtherwise()
+    {
+        using var panel = new EqWizardPanel();
+
+        Assert.False(ShelvesBox(panel).Checked);
+        Assert.False(Options(panel).AllowShelves);
+    }
+
+    [Fact]
+    public void TickingTheBoxIsWhatTheFitIsGiven()
+    {
+        using var panel = new EqWizardPanel();
+
+        ShelvesBox(panel).Checked = true;
+
+        Assert.True(Options(panel).AllowShelves);
+    }
+
+    [Fact]
+    public void TheChoiceSurvivesASettingsRoundTrip()
+    {
+        using var saved = new EqWizardPanel();
+        ShelvesBox(saved).Checked = true;
+
+        using var restored = new EqWizardPanel();
+        Invoke(restored, "ApplyPersistedSettings", saved.CaptureSettings());
+
+        Assert.True(ShelvesBox(restored).Checked);
+        Assert.True(Options(restored).AllowShelves);
+    }
+
+    [Fact]
+    public void AFileFromBeforeTheSwitchExistedOpensWithBellsOnly()
+    {
+        // Turning shelves on changes the curve a fit returns, so an existing
+        // installation must not find its Auto Tune quietly fitting a new shape.
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "measurement-settings.json");
+        File.WriteAllText(
+            path,
+            "{ \"SchemaVersion\": 12, \"EqWizard\": { \"CutsOnly\": true } }");
+
+        MeasurementSettingsFile settings = MeasurementSettingsFile.LoadOrDefault(path);
+
+        Assert.Null(settings.LoadWarning);
+        Assert.False(settings.EqWizard.AllowShelves);
+    }
+
+    [Theory]
+    [InlineData(1.0f)]
+    [InlineData(1.25f)]
+    [InlineData(1.5f)]
+    [InlineData(2.0f)]
+    public void TheBoxSitsBesideCutsOnlyWithoutTouchingIt(float scale)
+    {
+        // Shelves shares the row with Cuts only because the Auto Tune box has no room
+        // left below its button. Both are placed at designer coordinates and both
+        // auto-size to their text, and text grows faster than the slack between them
+        // does — which is exactly how the high-DPI overlaps in this app happened — so
+        // the row is measured at the scales a real display uses rather than at 96 DPI
+        // alone.
+        using var panel = new EqWizardPanel();
+        if (scale != 1.0f)
+        {
+            panel.Scale(new SizeF(scale, scale));
+        }
+
+        var box = (Control)Field(panel, "panelAutoTune");
+        var cutsOnly = (Control)Field(panel, "checkBoxCutsOnly");
+        Control shelves = ShelvesBox(panel);
+
+        Assert.Same(box, cutsOnly.Parent);
+        Assert.Same(box, shelves.Parent);
+        Assert.False(
+            cutsOnly.Bounds.IntersectsWith(shelves.Bounds),
+            $"at {scale:0.00}x the two checkboxes overlap: {cutsOnly.Bounds} and " +
+            $"{shelves.Bounds}.");
+        Assert.True(
+            box.ClientRectangle.Contains(shelves.Bounds),
+            $"at {scale:0.00}x Shelves ({shelves.Bounds}) leaves the Auto Tune box " +
+            $"({box.ClientRectangle}).");
+
+        // Control.Scale moves the boxes without regrowing their text, so the loop above
+        // proves the positions separate and no more. What protects the row on a real
+        // 150% display is that DPI autoscaling grows the coordinates and the glyphs by
+        // the SAME factor, which preserves whatever proportion of slack the designer
+        // left — so the slack is what gets pinned, at the one scale where the text is
+        // measured honestly.
+        if (scale == 1.0f)
+        {
+            Assert.True(
+                shelves.Left - cutsOnly.Right >= 8,
+                $"only {shelves.Left - cutsOnly.Right} px between the two checkboxes: " +
+                "too little to survive being scaled with the text.");
+            Assert.True(
+                box.ClientRectangle.Right - shelves.Right >= 8,
+                $"only {box.ClientRectangle.Right - shelves.Right} px between Shelves " +
+                "and the edge of the Auto Tune box.");
+        }
+    }
+
+    private static ReleaseClickCheckBox ShelvesBox(EqWizardPanel panel) =>
+        (ReleaseClickCheckBox)Field(panel, "checkBoxShelves");
+
+    private static object Field(EqWizardPanel panel, string name) =>
+        typeof(EqWizardPanel)
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(panel)!;
+
+    private static EqAutoTuner.Options Options(EqWizardPanel panel) =>
+        (EqAutoTuner.Options)typeof(EqWizardPanel)
+            .GetMethod(
+                "CreateAutoTuneOptions",
+                BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(panel, [0])!;
+
+    private static void Invoke(EqWizardPanel panel, string name, params object[] arguments) =>
+        typeof(EqWizardPanel)
+            .GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(panel, arguments);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/EqAutoTunerShelfTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EqAutoTunerShelfTests.cs
@@ -159,6 +159,37 @@ public sealed class EqAutoTunerShelfTests
     }
 
     [Fact]
+    public void Tune_BothEndsSloped_TakesAShelfAtEach()
+    {
+        // Each direction is carried to a finished fit of its own and ranked on where
+        // that fit ends, so a response sloped at both ends gets both shelves — the
+        // second searched against the residual the first one left, which is what lets
+        // the two describe one tilt between them. Ranking the directions by their
+        // single-band score first would let the stronger end decide for both, and one
+        // direction losing would end the stage with the other never asked.
+        IReadOnlyList<SignalPoint> source = Grid(f =>
+            StepAbove(f, 3_000, 12) - StepBelow(f, 150, 8));
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+
+        EqualizationCurve bells = EqAutoTuner.Tune(source, target, Boosting);
+        EqualizationCurve shelved = EqAutoTuner.Tune(
+            source, target, Boosting with { AllowShelves = true });
+
+        Assert.Contains(shelved.Bands, band => band.Type == PeqBandType.LowShelf);
+        Assert.Contains(shelved.Bands, band => band.Type == PeqBandType.HighShelf);
+        Assert.True(
+            shelved.Bands.Count < bells.Bands.Count,
+            $"the shelves saved no slot: {shelved.Bands.Count} bands against " +
+            $"{bells.Bands.Count} without them.");
+        double shelvedRms = FitRmsDb(shelved, source, target);
+        double bellsRms = FitRmsDb(bells, source, target);
+        Assert.True(
+            shelvedRms < bellsRms,
+            $"two shelves fitted worse than bells: {shelvedRms:0.00} dB against " +
+            $"{bellsRms:0.00} dB.");
+    }
+
+    [Fact]
     public void Tune_BumpsOnly_SpendsNoSlotOnAShelf()
     {
         // Nothing here is a trend: three resonances on an otherwise flat response. A

--- a/tests/Resonalyze.Dsp.Tests/EqAutoTunerShelfTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EqAutoTunerShelfTests.cs
@@ -1,0 +1,319 @@
+﻿namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The optional shelf stage (<see cref="EqAutoTuner.Options.AllowShelves"/>): when it
+/// places a shelf, when it refuses to, and what it may never do while placing one.
+/// </summary>
+public sealed class EqAutoTunerShelfTests
+{
+    private const double Rate = 48_000;
+
+    private static IReadOnlyList<SignalPoint> Grid(
+        Func<double, double> valueDb,
+        int count = 400)
+    {
+        IReadOnlyList<double> frequencies =
+            EqualizationCurve.LogFrequencyGrid(20, 20_000, count);
+        return frequencies.Select(f => new SignalPoint(f, valueDb(f))).ToList();
+    }
+
+    // A smooth step: gainDb above cornerHz and nothing below it, over about two
+    // octaves of transition — the shape a shelf exists for, and the one a bell cannot
+    // make.
+    private static double StepAbove(double f, double cornerHz, double gainDb) =>
+        gainDb / (1.0 + Math.Pow(f / cornerHz, -2.0));
+
+    // Its mirror: gainDb below cornerHz, nothing above it.
+    private static double StepBelow(double f, double cornerHz, double gainDb) =>
+        gainDb / (1.0 + Math.Pow(f / cornerHz, 2.0));
+
+    private static double Bump(double f, double centreHz, double octaves, double gainDb) =>
+        gainDb * Math.Exp(-Math.Pow(Math.Log2(f / centreHz) / octaves, 2));
+
+    // The most the finished EQ lifts anything in the top two octaves of the range.
+    private static double TopLiftDb(EqualizationCurve curve) =>
+        EqualizationCurve
+            .LogFrequencyGrid(6_000, 20_000, 200)
+            .Max(f => DigitalEqualizationResponse.MagnitudeDbAt(curve, f, Rate));
+
+    private static double FitRmsDb(
+        EqualizationCurve curve,
+        IReadOnlyList<SignalPoint> source,
+        IReadOnlyList<SignalPoint> target)
+    {
+        double sumSquares = 0;
+        for (int i = 0; i < source.Count; i++)
+        {
+            double corrected = source[i].Y +
+                DigitalEqualizationResponse.MagnitudeDbAt(curve, source[i].X, Rate);
+            double residual = target[i].Y - corrected;
+            sumSquares += residual * residual;
+        }
+
+        return Math.Sqrt(sumSquares / source.Count);
+    }
+
+    private static EqAutoTuner.Options CutsOnly => new()
+    {
+        MaxBands = 10,
+        SampleRateHz = Rate,
+        QMin = 0.1,
+        QMax = 6.0,
+        CutsOnlyMode = true,
+        TotalGainMaxDb = 0
+    };
+
+    private static EqAutoTuner.Options Boosting => new()
+    {
+        MaxBands = 10,
+        SampleRateHz = Rate,
+        QMin = 0.1,
+        QMax = 6.0,
+        BandGainMinDb = -15,
+        BandGainMaxDb = 8,
+        PreampMinDb = 0,
+        PreampMaxDb = 0
+    };
+
+    [Fact]
+    public void Tune_ShelvesOffByDefault_PlacesBellsOnly()
+    {
+        // The option has to default off: a caller that says nothing — and every curve
+        // fitted before the stage existed — keeps the bells-only result.
+        IReadOnlyList<SignalPoint> source = Grid(f => StepAbove(f, 4_000, 8));
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+
+        EqualizationCurve curve = EqAutoTuner.Tune(source, target, CutsOnly);
+
+        Assert.NotEmpty(curve.Bands);
+        Assert.All(curve.Bands, band => Assert.Equal(PeqBandType.Peaking, band.Type));
+    }
+
+    [Fact]
+    public void Tune_HotTopEnd_TakesOneShelfWhereBellsNeededSeveral()
+    {
+        // The case the stage is for: the top of the range runs uniformly hot against the
+        // target. Bells can only nibble at a plateau — each one leaves the shoulders of
+        // the last — while one high shelf is the shape of the error.
+        IReadOnlyList<SignalPoint> source = Grid(f => StepAbove(f, 4_000, 8));
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+
+        EqualizationCurve bells = EqAutoTuner.Tune(source, target, CutsOnly);
+        EqualizationCurve shelved = EqAutoTuner.Tune(
+            source, target, CutsOnly with { AllowShelves = true });
+
+        PeqBand shelf = Assert.Single(shelved.Bands, band => band.Type.IsShelving());
+        Assert.Equal(PeqBandType.HighShelf, shelf.Type);
+        Assert.True(
+            shelved.Bands.Count < bells.Bands.Count,
+            $"the shelf saved no slot: {shelved.Bands.Count} bands against " +
+            $"{bells.Bands.Count} without it.");
+        double shelvedRms = FitRmsDb(shelved, source, target);
+        double bellsRms = FitRmsDb(bells, source, target);
+        Assert.True(
+            shelvedRms <= bellsRms + 0.01,
+            $"the shelf fit is worse: {shelvedRms:0.00} dB against {bellsRms:0.00} dB.");
+    }
+
+    [Fact]
+    public void Tune_BassDeficit_FitsALowShelfWhenBoostsAreAllowed()
+    {
+        // The boosting half of the same case, and the one a car target asks for: the
+        // bottom of the range sits below the target across whole octaves. With the
+        // preamp pinned, only a low shelf can lift it.
+        IReadOnlyList<SignalPoint> source = Grid(f => -StepBelow(f, 120, 6));
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+
+        EqualizationCurve curve = EqAutoTuner.Tune(
+            source, target, Boosting with { AllowShelves = true });
+
+        PeqBand shelf = Assert.Single(curve.Bands, band => band.Type.IsShelving());
+        Assert.Equal(PeqBandType.LowShelf, shelf.Type);
+        Assert.True(shelf.GainDb > 0, $"the shelf cuts ({shelf.GainDb:0.0} dB).");
+    }
+
+    [Fact]
+    public void Tune_CarTarget_ShelvesFitCloserThanBellsAlone()
+    {
+        // What a car target is made of — a bass shelf and a downward tilt — against a
+        // cabin with resonances of its own, on the same band budget both ways. The bass
+        // shelf is where a shelf earns its slot; a constant-slope tilt on its own is a
+        // shape no shelf reproduces, so it is deliberately not what this asks about.
+        IReadOnlyList<SignalPoint> source = Grid(f =>
+            Bump(f, 45, 0.3, 5) + Bump(f, 95, 0.25, -6) + Bump(f, 300, 0.4, 3) +
+            Bump(f, 2_500, 0.5, -3) + Bump(f, 8_000, 0.6, 4));
+        IReadOnlyList<SignalPoint> target = Grid(f =>
+            StepBelow(f, 80, 6) - 0.8 * Math.Log2(f / 1_000));
+
+        EqualizationCurve bells = EqAutoTuner.Tune(source, target, Boosting);
+        EqualizationCurve shelved = EqAutoTuner.Tune(
+            source, target, Boosting with { AllowShelves = true });
+
+        Assert.Contains(shelved.Bands, band => band.Type.IsShelving());
+        double shelvedRms = FitRmsDb(shelved, source, target);
+        double bellsRms = FitRmsDb(bells, source, target);
+        Assert.True(
+            shelvedRms < bellsRms,
+            $"shelves did not help the tilt: {shelvedRms:0.00} dB against " +
+            $"{bellsRms:0.00} dB.");
+    }
+
+    [Fact]
+    public void Tune_BumpsOnly_SpendsNoSlotOnAShelf()
+    {
+        // Nothing here is a trend: three resonances on an otherwise flat response. A
+        // shelf would have to move everything beside a bump to reach it, and the stage
+        // has to see that and stay out.
+        IReadOnlyList<SignalPoint> source = Grid(f =>
+            Bump(f, 120, 0.2, 8) + Bump(f, 900, 0.25, -6) + Bump(f, 5_000, 0.3, 5));
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+
+        EqualizationCurve cuts = EqAutoTuner.Tune(
+            source, target, CutsOnly with { AllowShelves = true });
+        EqualizationCurve boosts = EqAutoTuner.Tune(
+            source, target, Boosting with { AllowShelves = true });
+
+        Assert.DoesNotContain(cuts.Bands, band => band.Type.IsShelving());
+        Assert.DoesNotContain(boosts.Bands, band => band.Type.IsShelving());
+    }
+
+    [Fact]
+    public void Tune_CutsOnly_AShelfNeverLiftsTheCurveAnywhere()
+    {
+        // Cuts-only promises a profile that never boosts. A shelf keeps that promise
+        // only while its knee stays at or below 1/sqrt(2): a sharper one overshoots the
+        // shelf gain before settling on it, and on a cut that overshoot IS a boost.
+        IReadOnlyList<SignalPoint> source = Grid(f =>
+            StepAbove(f, 4_000, 10) + Bump(f, 80, 0.3, 5) + Bump(f, 400, 0.3, -4));
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+
+        EqualizationCurve curve = EqAutoTuner.Tune(
+            source, target, CutsOnly with { AllowShelves = true });
+
+        Assert.Contains(curve.Bands, band => band.Type.IsShelving());
+        foreach (PeqBand band in curve.Bands.Where(band => band.Type.IsShelving()))
+        {
+            Assert.True(band.GainDb < 0, $"cuts-only fitted a +{band.GainDb:0.0} dB shelf.");
+            Assert.True(band.Q <= 0.7, $"shelf Q {band.Q:0.0} overshoots.");
+        }
+
+        double peak = EqualizationCurve
+            .LogFrequencyGrid(20, 23_000, 2_000)
+            .Max(f => DigitalEqualizationResponse.MagnitudeDbAt(curve, f, Rate));
+        Assert.True(peak <= 1e-6, $"the cuts-only profile boosts by {peak:0.000000} dB.");
+    }
+
+    [Fact]
+    public void Tune_LowCoherentTail_IsNotShelvedUpwards()
+    {
+        // The mask policy for shelves. A boosting shelf lifts its whole plateau, nulls
+        // and all, so it is gated on that plateau being measured rather than on each bin
+        // (the per-bin skirt guard would refuse every shelf that could be proposed). The
+        // same deficit is shelved when the tail is coherent and refused when it is not.
+        IReadOnlyList<SignalPoint> source = Grid(f => -StepAbove(f, 4_000, 7));
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+        IReadOnlyList<SignalPoint> coherent = Grid(_ => 0.99);
+        IReadOnlyList<SignalPoint> incoherentTop = Grid(f => f > 2_000 ? 0.1 : 0.99);
+
+        EqualizationCurve trusted = EqAutoTuner.Tune(
+            source, target, Boosting with { AllowShelves = true }, coherent);
+        EqualizationCurve doubted = EqAutoTuner.Tune(
+            source, target, Boosting with { AllowShelves = true }, incoherentTop);
+
+        Assert.Contains(
+            trusted.Bands,
+            band => band.Type == PeqBandType.HighShelf && band.GainDb > 0);
+
+        // Judged on what reaches the top of the range rather than on the band list: the
+        // question is whether the deficit up there got lifted, and a shelf is not the
+        // only band that could have done it.
+        double trustedLift = TopLiftDb(trusted);
+        double doubtedLift = TopLiftDb(doubted);
+        Assert.True(
+            trustedLift > 4,
+            $"the coherent tail was left {trustedLift:0.0} dB short of its deficit.");
+        Assert.True(
+            doubtedLift < 1.0,
+            $"the incoherent tail was lifted by {doubtedLift:0.0} dB.");
+    }
+
+    [Fact]
+    public void Tune_ShelvesObeyTheBandBudgetAndTheGainRange()
+    {
+        // A shelf takes a slot like any other band, and the strips it is written into
+        // accept nothing outside the configured gain range. Both ends of the range are
+        // sloped here, so both directions are on offer at every budget.
+        IReadOnlyList<SignalPoint> source = Grid(f =>
+            StepAbove(f, 3_000, 12) - StepBelow(f, 150, 8));
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+
+        foreach (int budget in new[] { 1, 2, 3, 10 })
+        {
+            EqualizationCurve curve = EqAutoTuner.Tune(
+                source,
+                target,
+                Boosting with { AllowShelves = true, MaxBands = budget });
+
+            Assert.True(
+                curve.Bands.Count <= budget,
+                $"budget {budget} produced {curve.Bands.Count} bands.");
+            Assert.True(
+                curve.Bands.Count(band => band.Type == PeqBandType.LowShelf) <= 1,
+                $"budget {budget} produced more than one low shelf.");
+            Assert.True(
+                curve.Bands.Count(band => band.Type == PeqBandType.HighShelf) <= 1,
+                $"budget {budget} produced more than one high shelf.");
+            Assert.All(curve.Bands, band => Assert.InRange(band.GainDb, -15, 8));
+        }
+    }
+
+    [Fact]
+    public void Tune_FittingWindowTooNarrowForAPlateau_PlacesNoShelf()
+    {
+        // A corner needs an octave of range on each side before the span beyond its knee
+        // means anything. A window narrower than that leaves the stage nothing to stand
+        // on — and it must not throw on the way to finding that out.
+        IReadOnlyList<SignalPoint> source = Grid(f => StepAbove(f, 300, 8));
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+
+        EqualizationCurve curve = EqAutoTuner.Tune(
+            source,
+            target,
+            CutsOnly with
+            {
+                AllowShelves = true,
+                MinFrequencyHz = 200,
+                MaxFrequencyHz = 400
+            });
+
+        Assert.DoesNotContain(curve.Bands, band => band.Type.IsShelving());
+    }
+
+    [Fact]
+    public void Tune_ShelfIsFittedAgainstTheProcessorRate()
+    {
+        // The shelf is scored through the same digital response the DSP will run, so the
+        // curve fitted for a 96 kHz processor corrects at 96 kHz — it is not the 48 kHz
+        // one relabelled. Checked by realizing each at its own rate.
+        Func<double, double> shape = f => StepAbove(f, 4_000, 8);
+        IReadOnlyList<SignalPoint> source = Grid(shape);
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+
+        foreach (double rate in new[] { 48_000.0, 96_000.0 })
+        {
+            EqualizationCurve curve = EqAutoTuner.Tune(
+                source, target, CutsOnly with { AllowShelves = true, SampleRateHz = rate });
+
+            PeqBand shelf = Assert.Single(curve.Bands, band => band.Type.IsShelving());
+            Assert.Equal(PeqBandType.HighShelf, shelf.Type);
+
+            double worst = EqualizationCurve
+                .LogFrequencyGrid(8_000, 20_000, 200)
+                .Max(f => Math.Abs(
+                    shape(f) + DigitalEqualizationResponse.MagnitudeDbAt(curve, f, rate)));
+            Assert.True(
+                worst < 2.0,
+                $"the {rate / 1000:0} kHz fit leaves {worst:0.0} dB across the plateau.");
+        }
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/EqAutoTunerShelfTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EqAutoTunerShelfTests.cs
@@ -190,6 +190,42 @@ public sealed class EqAutoTunerShelfTests
     }
 
     [Fact]
+    public void Tune_ShelfThatOnlyWinsOnTheFinishedFit_IsStillFound()
+    {
+        // The case the finished-fit rule exists for, and the one a pre-filter on the
+        // single-band score hides. Against a gently tilted response carrying a loud
+        // narrow resonance, the shelf that scores best on its own is a wide low shelf
+        // at 631 Hz: it shaves the resonance's skirt, which reads well before any bell
+        // is placed and wrecks what the bells then have to do — finished, it lands at
+        // 1.276 against 1.275 for placing no shelf at all. The shelf that actually wins
+        // is a different band entirely, two and a half octaves lower, and it only turns
+        // up because every candidate is taken to a finished fit. Filter by the
+        // single-band score first and the stage is offered the 631 Hz one, the lookahead
+        // refuses it, and no shelf is placed at all.
+        IReadOnlyList<SignalPoint> source = Grid(f =>
+            -0.6 * Math.Log2(f / 1_000) + Bump(f, 2_000, 0.3, 8));
+        IReadOnlyList<SignalPoint> target = Grid(_ => 0.0);
+        EqAutoTuner.Options options = CutsOnly with { MaxBands = 2 };
+
+        EqualizationCurve bells = EqAutoTuner.Tune(source, target, options);
+        EqualizationCurve shelved = EqAutoTuner.Tune(
+            source, target, options with { AllowShelves = true });
+
+        PeqBand shelf = Assert.Single(shelved.Bands, band => band.Type.IsShelving());
+        Assert.Equal(PeqBandType.LowShelf, shelf.Type);
+        Assert.True(
+            shelf.FrequencyHz < 300,
+            $"the shelf landed at {shelf.FrequencyHz:0} Hz — the corner the single-band " +
+            "score prefers is 631 Hz, and that one finishes worse than placing none.");
+        double shelvedRms = FitRmsDb(shelved, source, target);
+        double bellsRms = FitRmsDb(bells, source, target);
+        Assert.True(
+            shelvedRms < bellsRms - 0.1,
+            $"the shelf bought nothing: {shelvedRms:0.000} dB against " +
+            $"{bellsRms:0.000} dB.");
+    }
+
+    [Fact]
     public void Tune_BumpsOnly_SpendsNoSlotOnAShelf()
     {
         // Nothing here is a trend: three resonances on an otherwise flat response. A


### PR DESCRIPTION
Closes the TODO item **"Auto Tune still fits peaking bands only."**

A car target is a bass shelf plus a downward tilt, and a bell is the wrong shape
for either: a stack of them spends slots on a trend that resonances needed, and
rings between the centres. Auto Tune can now propose a low and a high shelf.
Optional — `EqAutoTuner.Options.AllowShelves`, the wizard's **Shelves** box,
**off by default**.

All the shelf math already existed (`ShelvingBiquad`, the `PeqBiquad` dispatch,
`WriteBand` writing the type into a strip). The work was entirely about *which
shelf to place, and whether to place one at all*.

## The acceptance rule, and the four that failed

Five were implemented and measured, in this order:

| rule | outcome |
| --- | --- |
| "the shelf lowers the residual by ≥ 0.25 dB RMS" | placed shelves that left the **whole fit worse** — car target with boosts: 1.43 dB RMS against 1.28 with no shelf |
| "the shelf beats the single bell it displaces" | principled but myopic — same failure, because a shelf acts across octaves |
| finish the fit both ways, but only for the direction that reads best as a single band | a low shelf that reads better before the bells are placed suppressed a high shelf that finishes closer, and its rejection ended the stage with the other direction never asked |
| the same, one candidate per direction | the identical mistake within a direction |
| **finish the fit for EVERY candidate — both directions, every corner, every knee — and place the one that ends closest to the target, if it beats placing none** | shipped |

The last two steps were the Codex P2 and the follow-up the owner asked for. The
failure mode is easy to hit and is pinned by
`Tune_ShelfThatOnlyWinsOnTheFinishedFit_IsStillFound`: on a tilted response with
a loud narrow resonance, the candidate that reads best on its own is a wide low
shelf at 631 Hz that shaves the resonance's skirt. Finished, it lands at 1.276
against 1.275 for placing no shelf at all. The shelf that actually wins sits at
100 Hz, two and a half octaves away, and under the earlier rules was never asked.

One approximation is left, deliberately: the **gain** at a fixed corner and knee
is still chosen by the single-band objective, and only that gain goes to the
lookahead. Gain is a level, and choosing it badly means over-correcting the
plateau — which that objective already charges for — while the corner and the
knee are the structural choices no single-band figure can judge. Handing the gain
ladder up as well multiplies the trial fits by the couple of hundred tenths of a
dB in the range. Named at the place it is made.

## `ShelfSlotWorthDb`

An exhaustive search always finds *some* shelf that improves the fourth decimal,
which the earlier pre-filter had been suppressing by accident: a resonance-only
response started spending a slot on a −0.5 dB shelf at the bottom of the range
for no visible change, and at a five-band budget the shelf fit used five filters
where the bells used four for the same error.

`TrialFit` now also reports how many bands it spent. A shelf that leaves the fit
**shorter** has paid for itself and is accepted on any improvement; one that does
not must improve the finished RMS-equivalent by at least **0.01 dB** — two orders
of magnitude below anything visible on the plot, four above the noise floor of
the search.

## Boost accounting — the one behavioural trade-off

`headroom` for a bell is measured against a bells-only accumulator rather than
the whole EQ sum. A +6 dB bass shelf otherwise leaves **zero** headroom across
the bass, every resonance under it is refused, and the finished fit comes out
worse than with no shelf at all. The accumulator equals the old one whenever no
shelf was placed, so **a bells-only fit is unchanged** — which is why all 1343
pre-existing DSP tests passed untouched.

The cost, stated plainly: with boosts allowed and a shelf placed, the **total**
boost can pass **Max Gain**. Measured on the car target — peak **+10.48 dB**
against Max Gain 6, where the bells-only fit peaked at 6.79. Every individual
band still obeys Max Gain, `TotalGainMaxDb` still caps the profile, **Cuts only**
(the default) rules it out entirely, and the **Headroom** read-out is where it
shows. Documented in REFERENCE.md and in the tooltip.

## Mask policy for a boosting shelf

The per-bin skirt guard (`ForbiddenRegionMaxBoostDb`) deliberately does **not**
apply to a shelf: a plateau necessarily crosses whatever nulls that end of the
range holds, so the guard would refuse every boosting shelf that could ever be
proposed. A shelf is gated on being *justified* instead — at least three quarters
of its plateau must be boost-allowed.

Three fifths was tried and is leaky: the fit answered a mask that refused to lift
an incoherent top by lifting nearly the whole range with a high shelf at 40 Hz.
Hence also the asymmetric corner margins — two octaves of untouched range on the
shelf's quiet side (a shelf nearer the edge is a preamp wearing a filter slot)
and one under the plateau, with the corner ladder built per direction so a high
shelf at 10 kHz, an ordinary car correction, is still reachable.

The knee is capped at **Q 0.7** by construction, not by the caller's `QMax`.
Measured across the whole corner and gain ladder at 48 kHz, the most a cutting
shelf lifts anywhere is 0.0000 dB at Q 0.70 and 0.0002 at 0.71, then 0.15 at 0.8,
0.90 at 1.0 and 2.69 at 1.4 — the 1/sqrt(2) boundary is exactly where the algebra
says it is, and an overshoot on a cut is a boost that **Cuts only** promises never
to produce.

## Measured (synthetic, 48 kHz, Max Gain 6)

| response | bells | with shelves |
| --- | --- | --- |
| uniformly hot top end, cuts only | 4 bands, 0.13 dB RMS | **1 band, 0.04** |
| the same plus resonances | 7 bands, 0.80 | **4 bands, 0.79** |
| bass deficit, boosts allowed | 3 bands, 0.06 | **2 bands, 0.01** |
| car target (bass shelf + tilt), boosts | 10 bands, 1.28 | **10 bands, 0.34** |
| both ends sloped, boosts | 8 bands, 0.24 | **8 bands, 0.09** |
| resonances only | — | no shelf placed, at any budget |

A 32-band fit with shelves on costs **121 ms**, against 1 ms for bells alone —
the price of the exhaustive lookahead, paid on a worker thread while only the
Auto Tune button is disabled.

Honest limit: a constant log-linear tilt across ten octaves is not a shelf's
shape. The win is where the residual has a step or a plateau at one end — which
is what a car target has.

## Elsewhere

- **Shelves** checkbox beside **Cuts only**, persisted as
  `EqWizardSettings.AllowShelves`; a settings file written before it restores off.
- The bell pass was extracted into `NextBell` (unchanged behaviour) so the shelf
  stage can ask what a slot would buy without spending it. Candidate scoring moved
  into one `ScoreBand`, which also builds each biquad once per candidate instead of
  once per grid point.
- 12 DSP tests + 5 app tests. The load-bearing ones are "shelves off ⇒ bells only",
  which pins the old behaviour, and the finished-fit regression above.
- REFERENCE.md, MANUAL.md and TODO.md updated; every figure quoted in them was
  re-measured against the final code.

## Left open, deliberately

The default is **off**: all the evidence above is synthetic. `TODO.md` now carries
a single item — run it against real cabin measurements and flip the default. There
is no code left to write for that.

## Testing

`dotnet test source/Resonalyze.sln -c Release --filter "Category!=Hardware"` —
3263 passed, 0 failed, 0 warnings (Audio 159, App 1749, Dsp 1355).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
