### PR TITLE
Let the EQ target be a house curve imported from a file

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -947,12 +947,16 @@ which one is the odd one out.
 ### Set the target once, in Virtual DSP
 
 The EQ target is shared between Virtual DSP and the EQ Wizard. It is one curve, edited
-from either place through the same **Target...** dialog, so setting it here means every
+from either place through the same **Target...** menu, so setting it here means every
 channel you tune afterwards aims at the same thing.
 
-Tick **Target** under the main graph, open **Target...**, and select one of the Car
-presets. The Car presets mainly differ in bass lift, so this is where the overall tonal
-balance of the system begins to take shape.
+Tick **Target** under the main graph, open **Target... → Parametric shape…**, and
+select one of the Car presets. The Car presets mainly differ in bass lift, so this is
+where the overall tonal balance of the system begins to take shape.
+
+If you already tune to a house curve of your own, **Target... → Import from file…**
+takes it instead — a text file of `frequency level` pairs, read as relative dB and hung
+at the level you set below. Everything after this point works the same way.
 
 ![The shared target editor, with its preview at the bottom](assets/images/manual/eq-target.png)
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ is set to show no animations (Settings → Accessibility → Visual effects).
   Phase, Group Delay, Frequency Response and Impulse Response, and **overlays** —
   captured, calculated and target curves with styling, curve math,
   import/export, saved per-mode state, and a live editing preview
-- **EQ Wizard** — up to 32 PEQ bands toward its own target, from an IR, an
+- **EQ Wizard** — up to 32 PEQ bands toward its own target (a parametric shape,
+  or a house curve of your own imported from a text file), from an IR, an
   overlay slot, a text curve or a Virtual DSP channel handed over for editing
   (and returned with one click), with Auto Tune, cross-tool import/export and a
   printable tuning-sheet PDF

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -35,6 +35,7 @@ read-out refuses rather than guesses, what a number was measured against.
   - [Import and export](#import-and-export)
   - [Complex (vector) sum](#complex-vector-sum)
 - [EQ Wizard](#eq-wizard)
+  - [The target curve](#the-target-curve)
   - [Choosing what to equalize](#choosing-what-to-equalize)
   - [Editing a Virtual DSP channel's PEQ](#editing-a-virtual-dsp-channels-peq)
   - [Auto Tune](#auto-tune)
@@ -1030,7 +1031,9 @@ overlay opens on `Car`. `X-curve (cinema)` follows ISO 2969 / SMPTE ST 202 —
 flat to 2 kHz, then ≈-3 dB/oct. The deviation curve is **Deviation**
 (`measurement − target`), **EQ correction** (`target − measurement`, the gain to
 dial into an equalizer), or **None**. Target overlays are available in Frequency
-Response and Live Spectrum.
+Response and Live Spectrum, and their shape is always one of these parametric
+ones; the separate target the [EQ Wizard](#the-target-curve) and
+[Virtual DSP](#virtual-dsp) share can also be a curve imported from a file.
 
 ![Target overlay settings](assets/images/target_overlay.png)
 
@@ -1087,9 +1090,47 @@ The **EQ Wizard** (under the **Tools** tab) designs a parametric equalizer — u
 to 32 bands plus a preamp — that moves a measured response toward a
 target. It owns its own target curve, edited through the same dialog the Target
 overlays use but stored with the wizard's own settings, so tuning here never
-disturbs your overlay slots.
+disturbs your overlay slots — and it need not be one of the shapes that dialog
+builds, as the next section describes.
 
 ![EQ Wizard mode](assets/images/eq_wizard.png)
+
+### The target curve
+
+**Target Curve…** drops a menu of the two shapes a target can have, ticking the
+one in force:
+
+- **Parametric shape…** opens the settings dialog described under
+  [Target curves](#target-curves) — a tilt, two shelves and a presence bump, from
+  a preset or edited by hand.
+- **Import from file…** loads a **house curve of your own**: a plain-text file of
+  `frequency level` pairs, one per line, read as leniently as an overlay text
+  import (any separator, extra columns ignored, comment and header lines skipped).
+  A REW target file, a curve exported from an overlay slot and a pair of columns
+  out of a spreadsheet all load. The menu entry then names the file, and its
+  tooltip says how many points the curve holds and what band it covers.
+
+An imported curve is read as **relative dB**, exactly like a parametric shape:
+whatever it reads at 1 kHz is subtracted from it, so a file written around 75 dB
+SPL and the same shape written around 0 dB become one target, hung at the
+**Target Level** you set. Between its points it runs straight in log frequency
+and dB; **outside its range it holds its end values** rather than continuing
+their slope — a curve that stops at 200 Hz says nothing about 10 kHz, and
+inventing a target there is something Auto Tune would spend real filters chasing.
+A file denser than 1024 points is thinned onto a log grid across its own range,
+because the curve is stored by value (see below) and a full-resolution export
+runs to tens of thousands of lines. A **deviation** or **EQ correction** curve is
+refused: it is the difference between a response and a target, not a target.
+
+The imported curve is stored with the wizard's settings and in a
+[Virtual DSP](#virtual-dsp) session — as the curve itself, not as a path to where
+it was imported from, so it survives the file being moved, renamed or edited. It
+also rides through the parametric dialog: it appears as the first entry of the
+**Preset** list, keeping the tilt and shelf fields disabled while it is selected,
+so editing the tolerance, the colour or the line style does not quietly drop it.
+Picking any real preset there is the way back to a parametric shape, and the
+imported entry stays in the list until the dialog is closed, so trying a preset
+against your own curve does not cost you the curve.
 
 ### Choosing what to equalize
 
@@ -1853,7 +1894,8 @@ the response has begun and read the record minus its direct arrival.
 
 A **Target** checkbox draws the EQ target over the prediction: the SAME target
 the EQ Wizard equalizes towards, shaped from either place through the same
-**Target...** dialog, so the tool that predicts the sum and the tool that
+**Target...** menu — a [parametric shape or a house curve imported from a
+file](#the-target-curve) — so the tool that predicts the sum and the tool that
 corrects it aim at one curve rather than at two that drifted apart. These curves
 are transfer-function dB with no absolute reference, so the target has no level
 of its own here — the dB box beside the checkbox says where it hangs. The
@@ -1861,6 +1903,8 @@ session stores both: that level, which belongs to this plot's dB reference and
 so stays put when the shape is retuned, and the target itself — the whole custom
 shape rather than a preset name, because a preset's numbers can change between
 versions while a session has to open aiming at the curve it was tuned against.
+An imported house curve travels the same way, as its points rather than as a path
+to the file, for the same reason.
 Loading a session therefore sets the app's target to the one it carries, which
 is the same single target the EQ Wizard shows; a session written before targets
 were stored carries none, keeps yours, and starts carrying it. A target is a

--- a/TODO.md
+++ b/TODO.md
@@ -492,6 +492,17 @@ items below are what a car DSP tune actually needs, roughly in priority order.
   "driver band" it works inside is just the user's From/To window. Derive each
   driver's usable band from the measured roll-off or the crossover so the mask
   also blocks boosts outside it.
+- [ ] **The imported target trusts the file to be a magnitude.**
+  `TargetCurveImport` refuses only the two roles that are differences
+  (`Deviation`, `EqCorrection`); it never looks at `AnalysisCurveKind`, so a
+  phase or group-delay export loads as a target and its degrees or milliseconds
+  are read as dB. Borrowing `EqWizardSourceResolver.IsEqualizableResponse` would
+  close it for our OWN labelled exports and nothing more: a file from another
+  tool declares no kind at all, and `null` is permitted on purpose, so a
+  spreadsheet column of group delay still passes. `Primary` alone does not say
+  "magnitude" either. The real fix is in what the text header can state, not in
+  a pair of `if`s at the import — which is why this is a note rather than a
+  patch (raised in the #143 review).
 - [ ] **Decide whether the shelf stage should default on.** Auto Tune fits
   low/high shelves now (`EqAutoTuner.Options.AllowShelves`, the wizard's
   **Shelves** box), gated on finishing the whole fit both ways and landing

--- a/TODO.md
+++ b/TODO.md
@@ -532,9 +532,11 @@ items below are what a car DSP tune actually needs, roughly in priority order.
 Deliberately out of scope for car DSP tuning (do not add here): FIR/convolution
 export (car DSPs are biquad), the DECOMPOSED phase views — minimum phase, excess
 phase and group delay, which are the analysis tabs' subject — real-time PC audio
-preview (you listen in the car after loading the profile), arbitrary target-curve
-import (the Car / CarMild / XCurve presets cover it), and HP/LP filter types
-(crossover tool). The wizard's Phase mode is not one of these and is IN scope: it
+preview (you listen in the car after loading the profile), and HP/LP filter types
+(crossover tool). Arbitrary target-curve import used to be on this list, on the
+grounds that the Car / CarMild / XCurve presets cover it; it is now shipped
+(**Target Curve… → Import from file…**), because a tuner who already has a house
+curve of their own has nothing to gain from a preset that resembles it. The wizard's Phase mode is not one of these and is IN scope: it
 draws the measured phase of the channel being tuned against the neighbours it was
 handed, which is the only way to see what an all-pass band did — a magnitude plot
 shows it as flat by construction.

--- a/source/Overlays/ImportedTargetCurve.cs
+++ b/source/Overlays/ImportedTargetCurve.cs
@@ -70,9 +70,10 @@ public sealed class ImportedTargetCurve : IEquatable<ImportedTargetCurve>
     public double HighFrequencyHz => frequencies[^1];
 
     /// <summary>
-    /// The curve the given pairs describe, or <c>null</c> when fewer than two
-    /// usable points survive the cleaning above — one point is a level, not a
-    /// shape. Every path that builds a curve goes through here, including the one
+    /// The curve the given pairs describe, or <c>null</c> when it cannot be a
+    /// target: fewer than two usable points survive the cleaning above (one point
+    /// is a level, not a shape), or the anchoring overflows what a dB level can
+    /// hold. Every path that builds a curve goes through here, including the one
     /// that reads a stored one back: a file is where a NaN or an unordered pair
     /// can enter, and the anchoring is idempotent, so re-running it costs nothing.
     /// </summary>
@@ -129,6 +130,22 @@ public sealed class ImportedTargetCurve : IEquatable<ImportedTargetCurve>
             for (int index = 0; index < gridDb.Length; index++)
             {
                 gridDb[index] -= anchor;
+            }
+        }
+
+        // Anchoring is a subtraction, and a file can hold levels big enough for it
+        // to overflow: ±1e308 is a finite number the reading above accepts, and the
+        // difference of the two is not. What comes out is not a target — it would
+        // draw as a broken line, hand Auto Tune an infinite goal, and the settings
+        // file cannot even write it (that serializer refuses named floating-point
+        // literals, so saving would throw where the curve is only decoration). It
+        // is refused here rather than repaired, because there is nothing left to
+        // repair toward.
+        foreach (double level in gridDb)
+        {
+            if (!double.IsFinite(level))
+            {
+                return null;
             }
         }
 

--- a/source/Overlays/ImportedTargetCurve.cs
+++ b/source/Overlays/ImportedTargetCurve.cs
@@ -1,0 +1,275 @@
+namespace Resonalyze;
+
+/// <summary>
+/// A target shape read from a file — a house curve — used INSTEAD of the
+/// parametric terms of <see cref="TargetCurveSpec"/>. Its points are relative dB
+/// over frequency, exactly like the parametric shape, so the level it hangs at
+/// stays the plot's own (see <see cref="EqTargetCurve"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three things happen on the way in, and they are what make an arbitrary file
+/// usable as a target rather than merely readable:
+/// </para>
+/// <list type="bullet">
+/// <item>the pairs are cleaned and ordered — non-finite values and frequencies at
+/// or below zero are dropped, points are sorted, and duplicates of one frequency
+/// are averaged, because the curve is interpolated by frequency and two values at
+/// one frequency have no order to interpolate along;</item>
+/// <item>the shape is anchored: whatever the curve reads at <see cref="AnchorHz"/>
+/// is subtracted from it, so a file written around 75 dB SPL and one written
+/// around 0 dB become the same target. The level a target hangs at belongs to the
+/// plot and not to the shape, and this is the same 1 kHz pivot the parametric tilt
+/// turns around;</item>
+/// <item>a dense file is thinned to <see cref="MaximumPoints"/>. The curve is
+/// carried BY VALUE into the settings file and into a Virtual DSP session — a
+/// stored path would break the moment the file moved — and a full-resolution
+/// export runs to tens of thousands of lines, which is a target stated far finer
+/// than a target means anything at.</item>
+/// </list>
+/// <para>
+/// Between its points the curve is straight in log frequency and dB. OUTSIDE its
+/// range it HOLDS its end values instead of continuing their slope: a house curve
+/// that stops at 200 Hz says nothing about 10 kHz, and extending the last slope
+/// there would invent a target the file never stated — one the auto-tuner would
+/// then dutifully chase.
+/// </para>
+/// </remarks>
+public sealed class ImportedTargetCurve : IEquatable<ImportedTargetCurve>
+{
+    /// <summary>
+    /// The frequency the imported shape is anchored to 0 dB at — the pivot the
+    /// parametric tilt turns around, so both kinds of target mean the same thing
+    /// by "relative dB".
+    /// </summary>
+    public const double AnchorHz = TargetCurveSpec.PivotHz;
+
+    /// <summary>
+    /// The most points a stored target keeps; a denser file is resampled onto a
+    /// log grid of this size across its own range.
+    /// </summary>
+    public const int MaximumPoints = 1024;
+
+    private readonly double[] frequencies;
+    private readonly double[] levelsDb;
+
+    private ImportedTargetCurve(string name, double[] frequencies, double[] levelsDb)
+    {
+        Name = name;
+        this.frequencies = frequencies;
+        this.levelsDb = levelsDb;
+    }
+
+    /// <summary>Where the curve came from — a file name, kept as a label.</summary>
+    public string Name { get; }
+
+    public int PointCount => frequencies.Length;
+
+    public double LowFrequencyHz => frequencies[0];
+
+    public double HighFrequencyHz => frequencies[^1];
+
+    /// <summary>
+    /// The curve the given pairs describe, or <c>null</c> when fewer than two
+    /// usable points survive the cleaning above — one point is a level, not a
+    /// shape. Every path that builds a curve goes through here, including the one
+    /// that reads a stored one back: a file is where a NaN or an unordered pair
+    /// can enter, and the anchoring is idempotent, so re-running it costs nothing.
+    /// </summary>
+    public static ImportedTargetCurve? FromPoints(
+        string name,
+        IEnumerable<OverlayPoint> points)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(points);
+
+        List<OverlayPoint> usable = points
+            .Where(point =>
+                point.X > 0 && double.IsFinite(point.X) && double.IsFinite(point.Y))
+            .OrderBy(point => point.X)
+            .ToList();
+        if (usable.Count < 2)
+        {
+            return null;
+        }
+
+        var frequencies = new List<double>(usable.Count);
+        var levels = new List<double>(usable.Count);
+        for (int index = 0; index < usable.Count;)
+        {
+            double frequency = usable[index].X;
+            double sum = 0;
+            int count = 0;
+            while (index < usable.Count && usable[index].X == frequency)
+            {
+                sum += usable[index].Y;
+                count++;
+                index++;
+            }
+
+            frequencies.Add(frequency);
+            levels.Add(sum / count);
+        }
+
+        if (frequencies.Count < 2)
+        {
+            return null;
+        }
+
+        double[] gridHz = frequencies.ToArray();
+        double[] gridDb = levels.ToArray();
+        if (gridHz.Length > MaximumPoints)
+        {
+            (gridHz, gridDb) = Resample(gridHz, gridDb);
+        }
+
+        double anchor = Interpolate(gridHz, gridDb, AnchorHz);
+        if (anchor != 0)
+        {
+            for (int index = 0; index < gridDb.Length; index++)
+            {
+                gridDb[index] -= anchor;
+            }
+        }
+
+        return new ImportedTargetCurve(name, gridHz, gridDb);
+    }
+
+    /// <summary>Relative target level (dB) at the given frequency.</summary>
+    public double Evaluate(double frequencyHz) =>
+        frequencyHz > 0 ? Interpolate(frequencies, levelsDb, frequencyHz) : 0;
+
+    /// <summary>
+    /// The curve as the flat "frequency, level, frequency, level, …" array the
+    /// settings file and a Virtual DSP session store it as. One array rather than
+    /// an object per point: this is a plain list of numbers, and at up to
+    /// <see cref="MaximumPoints"/> pairs the shape of the JSON is what decides
+    /// whether the file is still readable by a person.
+    /// </summary>
+    public double[] ToStorage()
+    {
+        var stored = new double[frequencies.Length * 2];
+        for (int index = 0; index < frequencies.Length; index++)
+        {
+            stored[index * 2] = frequencies[index];
+            stored[index * 2 + 1] = levelsDb[index];
+        }
+
+        return stored;
+    }
+
+    /// <summary>
+    /// Reads back what <see cref="ToStorage"/> wrote, or <c>null</c> when the file
+    /// carries no curve — or carries one nothing usable survives. A trailing half
+    /// pair is dropped rather than refused, in the spirit of the text import: what
+    /// is readable is read.
+    /// </summary>
+    public static ImportedTargetCurve? FromStorage(string? name, double[]? stored)
+    {
+        if (stored is not { Length: >= 4 })
+        {
+            return null;
+        }
+
+        var points = new List<OverlayPoint>(stored.Length / 2);
+        for (int index = 0; index + 1 < stored.Length; index += 2)
+        {
+            points.Add(new OverlayPoint(stored[index], stored[index + 1]));
+        }
+
+        return FromPoints(
+            string.IsNullOrWhiteSpace(name) ? DefaultName : name,
+            points);
+    }
+
+    /// <summary>What the curve is, for a menu tooltip or a dialog label.</summary>
+    public string Describe() =>
+        $"{Name} — {PointCount} points, " +
+        $"{FormatFrequency(LowFrequencyHz)} … {FormatFrequency(HighFrequencyHz)}";
+
+    public bool Equals(ImportedTargetCurve? other)
+    {
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return other != null &&
+            Name == other.Name &&
+            frequencies.AsSpan().SequenceEqual(other.frequencies) &&
+            levelsDb.AsSpan().SequenceEqual(other.levelsDb);
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as ImportedTargetCurve);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(Name, frequencies.Length, frequencies[0], frequencies[^1]);
+
+    // The name a stored curve falls back to when the file did not record one.
+    private const string DefaultName = "Imported curve";
+
+    // Straight in log frequency and dB between points, held flat outside the range
+    // (see the remarks above). Shared by Evaluate and by the resampling below, so a
+    // thinned curve is the same reading of the file as an unthinned one.
+    private static double Interpolate(
+        double[] gridHz,
+        double[] gridDb,
+        double frequencyHz)
+    {
+        if (frequencyHz <= gridHz[0])
+        {
+            return gridDb[0];
+        }
+
+        if (frequencyHz >= gridHz[^1])
+        {
+            return gridDb[^1];
+        }
+
+        int found = Array.BinarySearch(gridHz, frequencyHz);
+        if (found >= 0)
+        {
+            return gridDb[found];
+        }
+
+        int upper = ~found;
+        int lower = upper - 1;
+        double span = Math.Log10(gridHz[upper]) - Math.Log10(gridHz[lower]);
+        if (!(span > 0))
+        {
+            return gridDb[lower];
+        }
+
+        double position = (Math.Log10(frequencyHz) - Math.Log10(gridHz[lower])) / span;
+        return gridDb[lower] + position * (gridDb[upper] - gridDb[lower]);
+    }
+
+    private static (double[] Frequencies, double[] LevelsDb) Resample(
+        double[] gridHz,
+        double[] gridDb)
+    {
+        var frequencies = new double[MaximumPoints];
+        var levels = new double[MaximumPoints];
+        double logLow = Math.Log10(gridHz[0]);
+        double logStep = (Math.Log10(gridHz[^1]) - logLow) / (MaximumPoints - 1);
+        for (int index = 0; index < MaximumPoints; index++)
+        {
+            double frequency = Math.Pow(10, logLow + index * logStep);
+            frequencies[index] = frequency;
+            levels[index] = Interpolate(gridHz, gridDb, frequency);
+        }
+
+        // The ends are the file's own, not what rounding put just inside or outside
+        // them: the thinned curve must still cover exactly the band it stated.
+        frequencies[0] = gridHz[0];
+        frequencies[^1] = gridHz[^1];
+        levels[0] = gridDb[0];
+        levels[^1] = gridDb[^1];
+        return (frequencies, levels);
+    }
+
+    private static string FormatFrequency(double frequencyHz) =>
+        frequencyHz >= 1_000
+            ? $"{frequencyHz / 1_000:0.###} kHz"
+            : $"{frequencyHz:0.##} Hz";
+}

--- a/source/Overlays/OverlayFile.cs
+++ b/source/Overlays/OverlayFile.cs
@@ -698,10 +698,12 @@ public enum TargetPreset
 }
 
 /// <summary>
-/// A parametric target response shape (relative dB) built from an overall tilt
-/// around a 1 kHz pivot, a low-frequency shelf, a high-frequency shelf, and a
-/// presence bump. Presets are just parameter sets the user can edit, and the
-/// four terms cover room, car, home-theater (X-curve), and voicing targets.
+/// A target response shape (relative dB). By default it is parametric: an overall
+/// tilt around a 1 kHz pivot, a low-frequency shelf, a high-frequency shelf, and a
+/// presence bump. Presets are just parameter sets the user can edit, and the four
+/// terms cover room, car, home-theater (X-curve), and voicing targets. When
+/// <see cref="Imported"/> is set the shape is a curve read from a file instead,
+/// and the parametric terms are carried along untouched but unused.
 /// </summary>
 public sealed record TargetCurveSpec(
     double TiltDbPerOctave,
@@ -716,6 +718,16 @@ public sealed record TargetCurveSpec(
     double PresenceWidthOctaves)
 {
     public const double PivotHz = 1_000.0;
+
+    /// <summary>
+    /// A shape read from a file, which REPLACES the parametric terms while it is
+    /// set. It rides inside the spec rather than beside it so that everything
+    /// already passing a target shape around — the settings dialog and its live
+    /// preview, the overlay math, the wizard plot, the Virtual DSP plot and the
+    /// auto-tuner behind it — keeps working through the one <see cref="Evaluate"/>
+    /// they all ask, and so that a target has exactly one shape at a time.
+    /// </summary>
+    public ImportedTargetCurve? Imported { get; init; }
 
     public static TargetCurveSpec FromPreset(TargetPreset preset) => preset switch
     {
@@ -755,6 +767,11 @@ public sealed record TargetCurveSpec(
         if (!(frequencyHz > 0))
         {
             return 0;
+        }
+
+        if (Imported != null)
+        {
+            return Imported.Evaluate(frequencyHz);
         }
 
         double value = TiltDbPerOctave * Math.Log2(frequencyHz / PivotHz);

--- a/source/Overlays/OverlayTargetSettingsDialog.cs
+++ b/source/Overlays/OverlayTargetSettingsDialog.cs
@@ -16,6 +16,14 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
     // captured/operation dialogs.
     private readonly bool includePsychoacousticSmoothing;
     private readonly bool initialized;
+    // The shape the dialog opened on when it is a file, and the preset that came
+    // with it. An imported curve is offered as an extra entry in the preset list —
+    // that entry is what keeps it selected while the tolerance, colour or line
+    // style are edited, and picking a real preset is how the user drops it. The
+    // preset itself rides through untouched meanwhile: it names the parametric
+    // shape, which is still there behind the imported one.
+    private readonly ImportedTargetCurve? importedCurve;
+    private readonly TargetPreset incomingPreset;
     private Color selectedColor;
     private bool suppressEvents;
 
@@ -40,6 +48,8 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
         this.isolatedTarget = isolatedTarget;
         includePsychoacousticSmoothing = OverlayMath.SupportsAmplitudeSpace(mode);
         selectedColor = color;
+        importedCurve = spec.Imported;
+        incomingPreset = preset;
 
         InitializeComponent();
         // The accent fill is a palette value, not a literal the designer keeps a
@@ -52,7 +62,9 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
         suppressEvents = true;
         nameTextBox.Text = name;
         SelectSource(sourceSlot);
-        presetComboBox.SelectedItem = OverlayTargets.ResolvePreset(preset, spec);
+        presetComboBox.SelectedItem = importedCurve != null
+            ? presetComboBox.Items[0]
+            : OverlayTargets.ResolvePreset(preset, spec);
         ApplySpec(spec);
         toleranceInput.Value = ClampToRange(toleranceInput, toleranceDb);
         deviationModeComboBox.SelectedItem = deviationMode;
@@ -67,6 +79,7 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
         UpdateColorButton();
         UpdateOpacityLabel();
         UpdatePresetTooltip();
+        UpdateShapeInputs();
         UpdatePreview();
         initialized = true;
 
@@ -98,7 +111,13 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
 
     public string OverlayName => nameTextBox.Text.Trim();
     public int SourceSlot => ((TargetSourceOption)sourceComboBox.SelectedItem!).Slot;
-    public TargetPreset Preset => (TargetPreset)presetComboBox.SelectedItem!;
+    // While the imported entry is selected there is no preset to read off the list,
+    // and the one the dialog opened with is the honest answer: it still names the
+    // parametric shape the inputs hold, which is what the user goes back to by
+    // picking a preset here.
+    public TargetPreset Preset => presetComboBox.SelectedItem is TargetPreset preset
+        ? preset
+        : incomingPreset;
     public double ToleranceDb => (double)toleranceInput.Value;
     public TargetDeviationMode DeviationMode =>
         (TargetDeviationMode)deviationModeComboBox.SelectedItem!;
@@ -119,7 +138,13 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
         (double)trebleWidthInput.Value,
         (double)presenceGainInput.Value,
         (double)presenceFrequencyInput.Value,
-        (double)presenceWidthInput.Value);
+        (double)presenceWidthInput.Value)
+    {
+        Imported = SelectedImportedCurve
+    };
+
+    private ImportedTargetCurve? SelectedImportedCurve =>
+        presetComboBox.SelectedItem is ImportedShapeOption option ? option.Curve : null;
 
     private void PopulateControls(IReadOnlyList<OverlaySlotOption> availableSources)
     {
@@ -141,6 +166,14 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
             }
         }
 
+        // The imported shape leads the list when there is one, and stays in it for
+        // the dialog's lifetime: a user who tries a preset against their house
+        // curve has to be able to get back to it without importing the file again.
+        if (importedCurve != null)
+        {
+            presetComboBox.Items.Add(new ImportedShapeOption(importedCurve));
+        }
+
         foreach (TargetPreset value in Enum.GetValues<TargetPreset>())
         {
             presetComboBox.Items.Add(value);
@@ -150,6 +183,10 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
             if (args.ListItem is TargetPreset value)
             {
                 args.Value = GetPresetLabel(value);
+            }
+            else if (args.ListItem is ImportedShapeOption option)
+            {
+                args.Value = option.Label;
             }
         };
 
@@ -193,13 +230,7 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
         presetComboBox.SelectedIndexChanged += PresetChanged;
 
         // Editing the curve shape switches the preset to Custom and redraws.
-        foreach (DarkNumericUpDown shape in new[]
-        {
-            tiltInput,
-            bassGainInput, bassFrequencyInput, bassWidthInput,
-            trebleGainInput, trebleFrequencyInput, trebleWidthInput,
-            presenceGainInput, presenceFrequencyInput, presenceWidthInput
-        })
+        foreach (DarkNumericUpDown shape in ShapeInputs)
         {
             shape.ValueChanged += ParameterChanged;
         }
@@ -276,7 +307,36 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
         {
             toolTip.SetToolTip(presetComboBox, GetPresetDescription(preset));
         }
+        else if (presetComboBox.SelectedItem is ImportedShapeOption option)
+        {
+            toolTip.SetToolTip(
+                presetComboBox,
+                $"{option.Curve.Describe()}\r\nRelative dB, anchored at " +
+                $"{ImportedTargetCurve.AnchorHz:0} Hz and held flat outside its " +
+                "range. Pick a preset to go back to a parametric shape.");
+        }
     }
+
+    // The ten parametric inputs describe nothing while an imported shape is
+    // selected, so they are disabled rather than left there to be edited into a
+    // curve the plot does not draw. They keep their values: they are what the user
+    // returns to by choosing a preset.
+    private void UpdateShapeInputs()
+    {
+        bool parametric = SelectedImportedCurve == null;
+        foreach (DarkNumericUpDown input in ShapeInputs)
+        {
+            input.Enabled = parametric;
+        }
+    }
+
+    private DarkNumericUpDown[] ShapeInputs =>
+    [
+        tiltInput,
+        bassGainInput, bassFrequencyInput, bassWidthInput,
+        trebleGainInput, trebleFrequencyInput, trebleWidthInput,
+        presenceGainInput, presenceFrequencyInput, presenceWidthInput
+    ];
 
     private void ApplySpec(TargetCurveSpec spec)
     {
@@ -295,6 +355,7 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
     private void PresetChanged(object? sender, EventArgs e)
     {
         UpdatePresetTooltip();
+        UpdateShapeInputs();
         if (suppressEvents ||
             presetComboBox.SelectedItem is not TargetPreset preset ||
             preset == TargetPreset.Custom)
@@ -567,6 +628,17 @@ internal sealed partial class OverlayTargetSettingsDialog : Form
     private sealed record TargetSourceOption(int Slot, string Display)
     {
         public override string ToString() => Display;
+    }
+
+    // The imported shape as an entry in the preset list. It is not a preset — a
+    // preset is a set of numbers for the terms below it, and this replaces them —
+    // but it belongs in the same selector, because the list answers the one
+    // question "what shape is this target".
+    private sealed record ImportedShapeOption(ImportedTargetCurve Curve)
+    {
+        public string Label => MenuText.Trim($"Imported: {Curve.Name}");
+
+        public override string ToString() => Label;
     }
 }
 

--- a/source/Overlays/TargetCurveImport.cs
+++ b/source/Overlays/TargetCurveImport.cs
@@ -1,0 +1,82 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Loading a target shape from a file — a house curve — for the two places that
+/// share one target: the EQ Wizard and Virtual DSP. Both ask through here so a
+/// curve imported from either button is the same curve, refused for the same
+/// reasons and named the same way.
+/// </summary>
+internal static class TargetCurveImport
+{
+    private const string DialogTitle = "Import target curve";
+
+    /// <summary>
+    /// Asks for a file and returns the target shape it holds, or <c>null</c> when
+    /// the user cancelled or the file cannot be a target — in which case the
+    /// reason has already been shown.
+    /// </summary>
+    public static ImportedTargetCurve? Prompt(IWin32Window? owner)
+    {
+        using var dialog = new OpenFileDialog
+        {
+            CheckFileExists = true,
+            Filter = "Target curve (*.txt;*.csv)|*.txt;*.csv|All files (*.*)|*.*",
+            Title = DialogTitle
+        };
+        if (dialog.ShowDialog(owner) != DialogResult.OK)
+        {
+            return null;
+        }
+
+        OverlayTextCurve file;
+        try
+        {
+            file = OverlayTextFile.ImportCurve(dialog.FileName);
+        }
+        catch (Exception exception)
+        {
+            Refuse(owner, $"The curve could not be read.\r\n{exception.Message}");
+            return null;
+        }
+
+        // A deviation or an EQ correction is a difference between two curves, not a
+        // goal: equalizing toward one would chase the error rather than remove it.
+        // Every other role is a legitimate target — a curve exported from a target
+        // slot, and equally a measured response somebody wants to voice toward.
+        if (file.Metadata.Role is OverlayCurveRole.Deviation or OverlayCurveRole.EqCorrection)
+        {
+            string role = file.Metadata.Role == OverlayCurveRole.EqCorrection
+                ? "EQ correction"
+                : "deviation";
+            Refuse(
+                owner,
+                $"This file holds a {role} curve, which is a difference from a " +
+                "target rather than a target. Import the curve you want the " +
+                "response to look like instead.");
+            return null;
+        }
+
+        ImportedTargetCurve? curve = ImportedTargetCurve.FromPoints(
+            Path.GetFileName(dialog.FileName),
+            file.Points);
+        if (curve == null)
+        {
+            Refuse(
+                owner,
+                "No usable target curve was found in this file. A target needs at " +
+                "least two \"frequency level\" pairs — for example \"63 4.5\", one " +
+                "per line, with frequencies in Hz and levels in dB.");
+            return null;
+        }
+
+        return curve;
+    }
+
+    private static void Refuse(IWin32Window? owner, string message) =>
+        MessageBox.Show(
+            owner,
+            message,
+            DialogTitle,
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Warning);
+}

--- a/source/Overlays/TargetCurveMenu.cs
+++ b/source/Overlays/TargetCurveMenu.cs
@@ -1,0 +1,48 @@
+namespace Resonalyze;
+
+/// <summary>
+/// The menu the Target button drops, in both places that share one target (the EQ
+/// Wizard and Virtual DSP). Two entries, because a target has two possible
+/// shapes: the parametric one the settings dialog edits, and a curve imported
+/// from a file. The tick says which one is being drawn.
+/// </summary>
+internal static class TargetCurveMenu
+{
+    public static ContextMenuStrip Build(
+        ImportedTargetCurve? imported,
+        Action openParametric,
+        Action import)
+    {
+        ArgumentNullException.ThrowIfNull(openParametric);
+        ArgumentNullException.ThrowIfNull(import);
+
+        var menu = new ContextMenuStrip();
+        menu.Items.Add(new ToolStripMenuItem(
+            "Parametric shape…",
+            null,
+            (_, _) => openParametric())
+        {
+            Checked = imported == null,
+            ToolTipText = ToolTipTextWrapper.Wrap(
+                "A tilt, two shelves and a presence bump, from a preset or edited " +
+                "by hand.")
+        });
+
+        menu.Items.Add(new ToolStripMenuItem(
+            imported == null
+                ? "Import from file…"
+                : MenuText.Trim($"Imported: {imported.Name}"),
+            null,
+            (_, _) => import())
+        {
+            Checked = imported != null,
+            ToolTipText = ToolTipTextWrapper.Wrap(imported == null
+                ? "A house curve of your own: a text file of \"frequency level\" " +
+                    "pairs, one per line — a REW target file, a curve exported from " +
+                    "an overlay slot, or a column pair out of a spreadsheet."
+                : $"{imported.Describe()}\r\nClick to import another file.")
+        });
+
+        return menu;
+    }
+}

--- a/source/Settings/MeasurementSettingsFile.Schema.cs
+++ b/source/Settings/MeasurementSettingsFile.Schema.cs
@@ -656,6 +656,14 @@ internal sealed partial class MeasurementSettingsFile
         public double PresenceGainDb { get; set; }
         public double PresenceFrequencyHz { get; set; } = 3000;
         public double PresenceWidthOctaves { get; set; } = 1.0;
+        // An imported target shape, which replaces the parametric terms above
+        // while it is there (they are still stored: picking a preset in the
+        // settings dialog is how the user goes back to them). The curve travels by
+        // value, as the flat "frequency, level, …" list ImportedTargetCurve writes
+        // — a path would name a file the settings cannot promise is still there —
+        // and the name beside it is the label the menu shows, nothing more.
+        public string? TargetImportedName { get; set; }
+        public double[]? TargetImportedCurve { get; set; }
         public double ToleranceDb { get; set; } = 3;
         public TargetDeviationMode DeviationMode { get; set; } = TargetDeviationMode.Deviation;
         public int TargetColorArgb { get; set; } = unchecked((int)0xFF37C8A0);

--- a/source/Tools/Eq/EqTargetCurve.cs
+++ b/source/Tools/Eq/EqTargetCurve.cs
@@ -54,7 +54,14 @@ internal sealed record EqTargetCurve(
                 Finite(Spec.TrebleShelfWidthOctaves, flat.TrebleShelfWidthOctaves),
                 Finite(Spec.PresenceGainDb, flat.PresenceGainDb),
                 Finite(Spec.PresenceFrequencyHz, flat.PresenceFrequencyHz),
-                Finite(Spec.PresenceWidthOctaves, flat.PresenceWidthOctaves)),
+                Finite(Spec.PresenceWidthOctaves, flat.PresenceWidthOctaves))
+            {
+                // An imported shape needs no repair here: nothing can build one
+                // except ImportedTargetCurve, which drops what it cannot use and
+                // refuses to exist at all below two points. Dropping it instead
+                // would silently turn a user's house curve back into a preset.
+                Imported = Spec.Imported
+            },
             Finite(ToleranceDb, DefaultToleranceDb),
             Defined(DeviationMode, TargetDeviationMode.Deviation),
             Color,

--- a/source/Tools/Eq/EqWizardPanel.Designer.cs
+++ b/source/Tools/Eq/EqWizardPanel.Designer.cs
@@ -20,6 +20,8 @@
                 // owned by the designer container and would otherwise leak its handle.
                 sourceMenu?.Dispose();
                 sourceMenu = null;
+                targetMenu?.Dispose();
+                targetMenu = null;
                 bandTypeMenu?.Dispose();
                 bandTypeMenu = null;
                 // Created in code (see EqWizardPanel.Bank.cs), so it is not in the

--- a/source/Tools/Eq/EqWizardPanel.Source.cs
+++ b/source/Tools/Eq/EqWizardPanel.Source.cs
@@ -43,6 +43,7 @@ public partial class EqWizardPanel
     private bool sourceCurveDirty = true;
     private int sourceLoadGeneration;
     private ContextMenuStrip? sourceMenu;
+    private ContextMenuStrip? targetMenu;
 
     private TargetPreset targetPreset = TargetPreset.Flat;
     private TargetCurveSpec targetSpec = TargetCurveSpec.FromPreset(TargetPreset.Flat);
@@ -1124,9 +1125,46 @@ public partial class EqWizardPanel
         targetSmoothingInverseOctaves = value.SmoothingInverseOctaves;
     }
 
+    // Opened from the target button. A target is either a parametric shape or a
+    // curve imported from a file, and this is where that choice is made; the menu
+    // is rebuilt on every click because both the tick and the imported file's name
+    // change with the target itself.
+    private void ShowTargetMenu()
+    {
+        if (targetMenu is { Visible: true })
+        {
+            targetMenu.Close();
+            return;
+        }
+
+        targetMenu?.Dispose();
+        targetMenu = TargetCurveMenu.Build(
+            targetSpec.Imported,
+            OpenTargetSettings,
+            ImportTargetCurve);
+        DropDownMenu.ShowUnder(buttonOverlaySettings, targetMenu);
+    }
+
+    private void ImportTargetCurve()
+    {
+        if (TargetCurveImport.Prompt(FindForm()) is not { } imported)
+        {
+            return;
+        }
+
+        // Through the same door a Virtual DSP edit comes in by, so the import is
+        // drawn, persisted and handed on exactly like any other target change.
+        ApplyTargetCurve(TargetCurve with
+        {
+            Spec = targetSpec with { Imported = imported }
+        });
+    }
+
     // Reuses the overlay target dialog in isolated mode (no source picker, no
     // overlay side effects); its live preview redraws the wizard plot. Cancel
-    // reverts the previewed changes.
+    // reverts the previewed changes. An imported curve rides through the dialog as
+    // an entry in its preset list, so editing the tolerance or the colour does not
+    // silently drop it — see OverlayTargetSettingsDialog.
     private void OpenTargetSettings()
     {
         EqTargetCurve before = TargetCurve;
@@ -1549,7 +1587,16 @@ public partial class EqWizardPanel
                     settings.TrebleShelfWidthOctaves,
                     settings.PresenceGainDb,
                     settings.PresenceFrequencyHz,
-                    settings.PresenceWidthOctaves),
+                    settings.PresenceWidthOctaves)
+                {
+                    // Rebuilt through the importer, which is what makes a stored
+                    // curve safe: the file can hold anything, and what cannot be
+                    // read as a shape comes back as no shape at all — the
+                    // parametric terms beside it.
+                    Imported = ImportedTargetCurve.FromStorage(
+                        settings.TargetImportedName,
+                        settings.TargetImportedCurve)
+                },
                 settings.ToleranceDb,
                 settings.DeviationMode,
                 Color.FromArgb(settings.TargetColorArgb),
@@ -1602,6 +1649,8 @@ public partial class EqWizardPanel
         PresenceGainDb = targetSpec.PresenceGainDb,
         PresenceFrequencyHz = targetSpec.PresenceFrequencyHz,
         PresenceWidthOctaves = targetSpec.PresenceWidthOctaves,
+        TargetImportedName = targetSpec.Imported?.Name,
+        TargetImportedCurve = targetSpec.Imported?.ToStorage(),
         ToleranceDb = targetToleranceDb,
         DeviationMode = targetDeviationMode,
         TargetColorArgb = targetColor.ToArgb(),

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -147,7 +147,7 @@ public partial class EqWizardPanel : UserControl
         buttonAutoTune.Click += (_, _) => AutoTune();
         buttonReturnToDsp.Click += (_, _) => ReturnPeqToVirtualDsp();
         buttonBackToDsp.Click += (_, _) => BackToVirtualDsp();
-        buttonOverlaySettings.Click += (_, _) => OpenTargetSettings();
+        buttonOverlaySettings.Click += (_, _) => ShowTargetMenu();
         buttonImport.Click += (_, _) => ImportPeq();
         buttonExport.Click += (_, _) => ExportPeq();
         buttonResetBands.Click += (_, _) => ResetBands();
@@ -346,8 +346,9 @@ public partial class EqWizardPanel : UserControl
             "clicking the Virtual DSP tab instead keeps this session open for " +
             "coming back.)");
         SetTip(buttonOverlaySettings,
-            "Edit the target curve this mode corrects toward (isolated to the EQ " +
-            "Wizard; not tied to any overlay).");
+            "The target curve this mode corrects toward (isolated to the EQ " +
+            "Wizard; not tied to any overlay): a parametric shape to edit, or a " +
+            "house curve of your own imported from a text file.");
         SetTip(labelCalibration, comboBoxCalibration,
             "Microphone calibration applied to the source curve. \"Own\" re-uses the " +
             "correction stored with an imported curve; unavailable when the curve " +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
@@ -16,6 +16,10 @@ namespace Resonalyze
             if (disposing)
             {
                 components?.Dispose();
+                // Rebuilt on every open (see ShowTargetMenu), so the last one is not
+                // owned by the designer container and would otherwise leak its handle.
+                targetMenu?.Dispose();
+                targetMenu = null;
             }
 
             base.Dispose(disposing);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -172,6 +172,7 @@ public partial class VirtualCrossoverPanel : UserControl
 
     // The shared EQ target, null until the host wires it (and in the designer).
     private EqTargetCurve? targetCurve;
+    private ContextMenuStrip? targetMenu;
 
     // The colour the Target toggle wears while it is live: its curve's own, the
     // way the Sum and Sum loss toggles wear theirs. Seeded from the designer and
@@ -220,7 +221,7 @@ public partial class VirtualCrossoverPanel : UserControl
         buttonCaptureOverlay.Click += async (_, _) => await CaptureSumToOverlayAsync();
         buttonExport.Click += async (_, _) => await ExportTuningSheetAsync();
         buttonPhaseGate.Click += async (_, _) => await OpenPhaseGateDialogAsync();
-        buttonTargetSettings.Click += (_, _) => OpenTargetSettings();
+        buttonTargetSettings.Click += (_, _) => ShowTargetMenu();
         buttonSessionImport.Click += async (_, _) => await ImportSessionAsync();
         buttonSessionExport.Click += (_, _) => ExportSession();
         buttonAudition.Click += async (_, _) => await AuditionTrackAsync();
@@ -2722,11 +2723,12 @@ public partial class VirtualCrossoverPanel : UserControl
             "not with the target, so retuning the shape leaves it where it is.");
         toolTip.SetToolTip(
             buttonTargetSettings,
-            "Shape the target: preset, tilt, bass and treble shelves,\r\n" +
-            "presence, colour and line style, previewed live on this plot\r\n" +
-            "(which switches to the Magnitude view, the only one a dB shape\r\n" +
-            "means anything on). Saving writes the SAME target the EQ Wizard\r\n" +
-            "equalizes towards.");
+            "Shape the target: a parametric shape (preset, tilt, bass and\r\n" +
+            "treble shelves, presence, colour and line style) previewed live\r\n" +
+            "on this plot (which switches to the Magnitude view, the only one\r\n" +
+            "a dB shape means anything on), or a house curve of your own\r\n" +
+            "imported from a text file. Either way it is the SAME target the\r\n" +
+            "EQ Wizard equalizes towards.");
         toolTip.SetToolTip(
             comboBoxCalibration,
             "Microphone calibration applied to the magnitude curves —\r\n" +
@@ -3245,6 +3247,53 @@ public partial class VirtualCrossoverPanel : UserControl
                 target.Color.A, target.Color.R, target.Color.G, target.Color.B),
             target.StrokeThickness,
             OverlayLineStyles.ToOxy(target.LineStyle));
+    }
+
+    // The same two-entry menu the EQ Wizard's Target button drops, over the same
+    // shared target: the shape is either parametric or a curve imported from a
+    // file. Rebuilt per click, because what it ticks is the target itself.
+    private void ShowTargetMenu()
+    {
+        if (targetCurve is not { } current)
+        {
+            return;
+        }
+
+        if (targetMenu is { Visible: true })
+        {
+            targetMenu.Close();
+            return;
+        }
+
+        targetMenu?.Dispose();
+        targetMenu = TargetCurveMenu.Build(
+            current.Spec.Imported,
+            OpenTargetSettings,
+            ImportTargetCurve);
+        DropDownMenu.ShowUnder(buttonTargetSettings, targetMenu);
+    }
+
+    private void ImportTargetCurve()
+    {
+        if (targetCurve is not { } before ||
+            TargetCurveImport.Prompt(FindForm()) is not { } imported)
+        {
+            return;
+        }
+
+        // An imported shape is a target edit like any other made here: it shows on
+        // this plot, so the plot is put where a dB shape means something, and it
+        // reaches the session and the wizard by the same two calls a saved dialog
+        // uses.
+        radioViewMagnitude.Checked = true;
+        checkBoxShowTarget.Checked = true;
+        var edited = before with
+        {
+            Spec = before.Spec with { Imported = imported }
+        };
+        ApplyTargetLocally(edited);
+        StoreTargetInProject(edited);
+        TargetCurveChanged?.Invoke(edited);
     }
 
     // The same isolated target dialog the EQ Wizard opens (no source picker, no

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -94,6 +94,11 @@ public sealed class VirtualCrossoverTargetSettings
     public double PresenceGainDb { get; set; }
     public double PresenceFrequencyHz { get; set; } = 3_000;
     public double PresenceWidthOctaves { get; set; } = 1.0;
+    // An imported target shape, stored by value for the same reason the rest of
+    // this class is flat: a session has to open aiming at exactly the curve it was
+    // tuned against, and a path to the file it came from is not that promise.
+    public string? ImportedName { get; set; }
+    public double[]? ImportedCurve { get; set; }
     public double ToleranceDb { get; set; } = 3;
     public TargetDeviationMode DeviationMode { get; set; } = TargetDeviationMode.Deviation;
     public int ColorArgb { get; set; } = unchecked((int)0xFF37C8A0);
@@ -116,7 +121,13 @@ public sealed class VirtualCrossoverTargetSettings
             TrebleShelfWidthOctaves,
             PresenceGainDb,
             PresenceFrequencyHz,
-            PresenceWidthOctaves),
+            PresenceWidthOctaves)
+        {
+            // Read back through the importer, which drops what it cannot use: a
+            // curve too damaged to be a shape leaves the parametric terms in
+            // charge rather than failing the session.
+            Imported = ImportedTargetCurve.FromStorage(ImportedName, ImportedCurve)
+        },
         ToleranceDb,
         DeviationMode,
         Color.FromArgb(ColorArgb),
@@ -140,6 +151,8 @@ public sealed class VirtualCrossoverTargetSettings
             PresenceGainDb = curve.Spec.PresenceGainDb,
             PresenceFrequencyHz = curve.Spec.PresenceFrequencyHz,
             PresenceWidthOctaves = curve.Spec.PresenceWidthOctaves,
+            ImportedName = curve.Spec.Imported?.Name,
+            ImportedCurve = curve.Spec.Imported?.ToStorage(),
             ToleranceDb = curve.ToleranceDb,
             DeviationMode = curve.DeviationMode,
             ColorArgb = curve.Color.ToArgb(),

--- a/tests/Resonalyze.App.Tests/EqWizardImportedTargetTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardImportedTargetTests.cs
@@ -1,0 +1,90 @@
+using System.Reflection;
+using OxyPlot;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The house curve inside the wizard itself: the panel has to DRAW the imported
+/// shape (which is the same curve the fit is handed, since Auto Tune reads the
+/// target curve the plot builds), and it has to still be the target after a
+/// restart.
+/// </summary>
+public sealed class EqWizardImportedTargetTests
+{
+    [Fact]
+    public void TheWizardDrawsTheImportedShape()
+    {
+        // Not the preset the target still names underneath it: what the plot
+        // builds is what Auto Tune corrects toward, so this is the whole feature.
+        using var panel = new EqWizardPanel();
+        panel.ApplyTargetCurve(TargetWith(House()));
+
+        EqWizardCurve target = BuildTarget(panel, [100, 1_000, 10_000], offset: -40);
+
+        Assert.Equal(-34, target.Points[0].Y, 9);
+        Assert.Equal(-40, target.Points[1].Y, 9);
+        Assert.Equal(-43, target.Points[2].Y, 9);
+    }
+
+    [Fact]
+    public void ThePresetUnderneathTakesOverWhenTheImportIsDropped()
+    {
+        using var panel = new EqWizardPanel();
+        panel.ApplyTargetCurve(TargetWith(House()));
+
+        panel.ApplyTargetCurve(TargetWith(null));
+
+        EqWizardCurve target = BuildTarget(panel, [100], offset: 0);
+        Assert.Equal(
+            TargetCurveSpec.FromPreset(TargetPreset.Car).Evaluate(100),
+            target.Points[0].Y,
+            9);
+    }
+
+    [Fact]
+    public void TheImportedShapeSurvivesASettingsRoundTrip()
+    {
+        using var saved = new EqWizardPanel();
+        saved.ApplyTargetCurve(TargetWith(House()));
+
+        using var restored = new EqWizardPanel();
+        restored.GetType()
+            .GetMethod("ApplyPersistedSettings", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(restored, [saved.CaptureSettings()]);
+
+        Assert.Equal(House(), restored.TargetCurve.Spec.Imported);
+        // And the parametric shape it was carrying rides back with it, because
+        // picking a preset in the target dialog is what returns to it.
+        Assert.Equal(TargetPreset.Car, restored.TargetCurve.Preset);
+        Assert.Equal(
+            TargetCurveSpec.FromPreset(TargetPreset.Car).BassShelfGainDb,
+            restored.TargetCurve.Spec.BassShelfGainDb);
+    }
+
+    private static ImportedTargetCurve House() =>
+        ImportedTargetCurve.FromPoints(
+            "house.txt",
+            [
+                new OverlayPoint(100, 6),
+                new OverlayPoint(1_000, 0),
+                new OverlayPoint(10_000, -3)
+            ])!;
+
+    private static EqTargetCurve TargetWith(ImportedTargetCurve? imported) => new(
+        TargetPreset.Car,
+        TargetCurveSpec.FromPreset(TargetPreset.Car) with { Imported = imported },
+        ToleranceDb: 3,
+        TargetDeviationMode.Deviation,
+        System.Drawing.Color.FromArgb(255, 55, 200, 160),
+        StrokeThickness: 2,
+        OverlayLineStyle.Dash,
+        SmoothingInverseOctaves: 0);
+
+    private static EqWizardCurve BuildTarget(
+        EqWizardPanel panel,
+        double[] frequencies,
+        double offset) =>
+        (EqWizardCurve)panel.GetType()
+            .GetMethod("BuildTargetCurve", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(panel, [frequencies, offset])!;
+}

--- a/tests/Resonalyze.App.Tests/EqWizardTargetPersistenceTests.cs
+++ b/tests/Resonalyze.App.Tests/EqWizardTargetPersistenceTests.cs
@@ -1,0 +1,74 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The EQ Wizard's target lives in the settings file. A house curve imported into
+/// it is carried there by value — the file is what the next launch opens on, and
+/// a path to wherever the curve was imported from would be a promise the settings
+/// cannot keep.
+/// </summary>
+public sealed class EqWizardTargetPersistenceTests : IDisposable
+{
+    private readonly string directory = Path.Combine(
+        Path.GetTempPath(),
+        $"resonalyze-eq-target-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void AnImportedTargetComesBackAsTheSameCurve()
+    {
+        string path = NewSettingsPath();
+        ImportedTargetCurve imported = ImportedTargetCurve.FromPoints(
+            "house.txt",
+            [
+                new OverlayPoint(30, 9),
+                new OverlayPoint(100, 6),
+                new OverlayPoint(1_000, 0),
+                new OverlayPoint(10_000, -3)
+            ])!;
+        MeasurementSettingsFile settings = MeasurementSettingsFile.LoadOrDefault(path);
+        settings.EqWizard.TargetImportedName = imported.Name;
+        settings.EqWizard.TargetImportedCurve = imported.ToStorage();
+        settings.Save();
+
+        MeasurementSettingsFile reloaded = MeasurementSettingsFile.LoadOrDefault(path);
+
+        Assert.Null(reloaded.LoadWarning);
+        Assert.Equal(
+            imported,
+            ImportedTargetCurve.FromStorage(
+                reloaded.EqWizard.TargetImportedName,
+                reloaded.EqWizard.TargetImportedCurve));
+    }
+
+    [Fact]
+    public void AFileFromBeforeTheImportOpensOnItsParametricShape()
+    {
+        // No imported curve is the ordinary state, and it has to stay readable:
+        // every settings file written before this existed is one of them.
+        string path = NewSettingsPath();
+        MeasurementSettingsFile settings = MeasurementSettingsFile.LoadOrDefault(path);
+        settings.EqWizard.Preset = TargetPreset.Car;
+        settings.Save();
+
+        MeasurementSettingsFile reloaded = MeasurementSettingsFile.LoadOrDefault(path);
+
+        Assert.Null(reloaded.EqWizard.TargetImportedName);
+        Assert.Null(reloaded.EqWizard.TargetImportedCurve);
+        Assert.Null(ImportedTargetCurve.FromStorage(
+            reloaded.EqWizard.TargetImportedName,
+            reloaded.EqWizard.TargetImportedCurve));
+    }
+
+    private string NewSettingsPath()
+    {
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, "settings.json");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/Resonalyze.App.Tests/ImportedTargetCurveTests.cs
+++ b/tests/Resonalyze.App.Tests/ImportedTargetCurveTests.cs
@@ -99,6 +99,26 @@ public sealed class ImportedTargetCurveTests
     }
 
     [Fact]
+    public void LevelsThatOverflowTheAnchoringAreRefused()
+    {
+        // Both levels are finite, so the cleaning above accepts them — their
+        // difference is not, and anchoring is a subtraction. An infinite target
+        // would draw as a broken line, hand Auto Tune an infinite goal, and throw
+        // on the way into the settings file, so there is no curve here at all.
+        Assert.Null(ImportedTargetCurve.FromPoints(
+            "overflow.txt",
+            [new OverlayPoint(100, 1e308), new OverlayPoint(1_000, -1e308)]));
+        Assert.Null(ImportedTargetCurve.FromStorage(
+            "overflow.json",
+            [100, 1e308, 1_000, -1e308]));
+        // Large but survivable levels are still read: the refusal is about the
+        // arithmetic overflowing, not about a number being unusually big.
+        Assert.NotNull(ImportedTargetCurve.FromPoints(
+            "loud.txt",
+            [new OverlayPoint(100, 1e30), new OverlayPoint(1_000, -1e30)]));
+    }
+
+    [Fact]
     public void ADenseFileIsThinnedButStillReadsTheSame()
     {
         // A full-resolution export runs to tens of thousands of lines, and the

--- a/tests/Resonalyze.App.Tests/ImportedTargetCurveTests.cs
+++ b/tests/Resonalyze.App.Tests/ImportedTargetCurveTests.cs
@@ -1,0 +1,231 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// A target imported from a file is an arbitrary text file becoming a shape the
+/// auto-tuner corrects toward, so what the reading does to it matters as much as
+/// that it reads: where it is anchored, what it says between the points, what it
+/// says outside them, and what survives being stored.
+/// </summary>
+public sealed class ImportedTargetCurveTests
+{
+    [Fact]
+    public void TheShapeIsAnchoredAtOneKilohertz()
+    {
+        // A house curve written around 75 dB SPL and the same shape written
+        // around 0 dB are one target: the level a target hangs at belongs to the
+        // plot, and the wizard's Target Level is where the user sets it.
+        ImportedTargetCurve absolute = Build(
+            (100, 81.0), (1_000, 75.0), (10_000, 72.0));
+        ImportedTargetCurve relative = Build(
+            (100, 6.0), (1_000, 0.0), (10_000, -3.0));
+
+        Assert.Equal(0, absolute.Evaluate(1_000), 12);
+        Assert.Equal(6, absolute.Evaluate(100), 12);
+        Assert.Equal(-3, absolute.Evaluate(10_000), 12);
+        for (double frequency = 20; frequency <= 20_000; frequency *= 1.3)
+        {
+            Assert.Equal(relative.Evaluate(frequency), absolute.Evaluate(frequency), 12);
+        }
+    }
+
+    [Fact]
+    public void BetweenPointsTheCurveIsStraightInLogFrequency()
+    {
+        // The midpoint of a decade is its geometric centre, not its arithmetic
+        // one: 316 Hz sits halfway between 100 Hz and 1 kHz on the plot the
+        // target is drawn on, and that is where half the step belongs.
+        ImportedTargetCurve curve = Build((100, 6.0), (1_000, 0.0));
+
+        Assert.Equal(3, curve.Evaluate(Math.Sqrt(100 * 1_000)), 9);
+        Assert.NotEqual(3, curve.Evaluate(550), 1);
+    }
+
+    [Fact]
+    public void OutsideItsRangeTheCurveHoldsItsEnds()
+    {
+        // A file that stops at 200 Hz says nothing about 10 kHz. Continuing its
+        // last slope would invent a target it never stated — and the auto-tuner
+        // would then chase that invention with real filters. A bass-only curve is
+        // therefore flat above its top point, and the anchor lands on that held
+        // value: +8 over +2 at the top becomes +6 over a flat 1 kHz reference.
+        ImportedTargetCurve curve = Build((50, 8.0), (200, 2.0));
+
+        Assert.Equal(6, curve.Evaluate(20), 12);
+        Assert.Equal(6, curve.Evaluate(1), 12);
+        Assert.Equal(0, curve.Evaluate(200), 12);
+        Assert.Equal(0, curve.Evaluate(20_000), 12);
+        Assert.Equal(0, curve.Evaluate(0), 12);
+        Assert.Equal(0, curve.Evaluate(-5), 12);
+    }
+
+    [Fact]
+    public void UnusablePairsAreDroppedAndTheRestIsOrdered()
+    {
+        ImportedTargetCurve curve = Build(
+            (10_000, -3.0),
+            (double.NaN, 1.0),
+            (100, 6.0),
+            (-40, 2.0),
+            (0, 5.0),
+            (1_000, double.PositiveInfinity),
+            (1_000, 0.0));
+
+        Assert.Equal(3, curve.PointCount);
+        Assert.Equal(100, curve.LowFrequencyHz);
+        Assert.Equal(10_000, curve.HighFrequencyHz);
+        Assert.Equal(6, curve.Evaluate(100), 12);
+    }
+
+    [Fact]
+    public void TwoValuesAtOneFrequencyAreAveraged()
+    {
+        // Two levels at one frequency have no order to interpolate along, and
+        // dropping one would let the file's line order decide the target.
+        ImportedTargetCurve curve = Build((100, 4.0), (100, 8.0), (1_000, 0.0));
+
+        Assert.Equal(2, curve.PointCount);
+        Assert.Equal(6, curve.Evaluate(100), 12);
+    }
+
+    [Fact]
+    public void FewerThanTwoUsablePointsIsNotAShape()
+    {
+        // One point is a level, not a shape, and a file of prose is not a curve.
+        Assert.Null(ImportedTargetCurve.FromPoints("one.txt", [new OverlayPoint(1_000, 3)]));
+        Assert.Null(ImportedTargetCurve.FromPoints("none.txt", []));
+        Assert.Null(ImportedTargetCurve.FromPoints(
+            "unusable.txt",
+            [new OverlayPoint(0, 3), new OverlayPoint(double.NaN, 1)]));
+    }
+
+    [Fact]
+    public void ADenseFileIsThinnedButStillReadsTheSame()
+    {
+        // A full-resolution export runs to tens of thousands of lines, and the
+        // curve is carried by value into the settings file and into a session.
+        var points = new List<OverlayPoint>();
+        for (int index = 0; index < 40_000; index++)
+        {
+            double frequency = 20 * Math.Pow(1_000, index / 39_999.0);
+            points.Add(new OverlayPoint(frequency, -2 * Math.Log2(frequency / 1_000)));
+        }
+
+        ImportedTargetCurve curve = ImportedTargetCurve.FromPoints("dense.txt", points)!;
+
+        Assert.Equal(ImportedTargetCurve.MaximumPoints, curve.PointCount);
+        // The band it covers is still the band the file stated, ends included.
+        Assert.Equal(20, curve.LowFrequencyHz, 6);
+        Assert.Equal(20_000, curve.HighFrequencyHz, 6);
+        // And it is still the same curve: thinning a smooth shape onto a log grid
+        // costs far less than the dB the tune is judged in.
+        for (double frequency = 20; frequency <= 20_000; frequency *= 1.1)
+        {
+            Assert.Equal(-2 * Math.Log2(frequency / 1_000), curve.Evaluate(frequency), 3);
+        }
+    }
+
+    [Fact]
+    public void StoredAndReadBackItIsTheSameCurve()
+    {
+        ImportedTargetCurve curve = Build(
+            (30, 9.0), (100, 6.0), (1_000, 0.0), (10_000, -3.0));
+
+        ImportedTargetCurve? restored =
+            ImportedTargetCurve.FromStorage(curve.Name, curve.ToStorage());
+
+        Assert.Equal(curve, restored);
+    }
+
+    [Fact]
+    public void AStoredCurveIsCleanedAgainOnTheWayIn()
+    {
+        // The settings file and a session file are where a NaN or an unordered
+        // pair can enter, so the stored form goes through the same reading as a
+        // freshly imported file rather than being trusted.
+        ImportedTargetCurve? restored = ImportedTargetCurve.FromStorage(
+            "hand-edited.json",
+            [10_000, -3, double.NaN, 4, 100, 6, 1_000, 0, 250]);
+
+        Assert.NotNull(restored);
+        Assert.Equal(3, restored!.PointCount);
+        Assert.Equal(6, restored.Evaluate(100), 12);
+        Assert.Equal(0, restored.Evaluate(1_000), 12);
+    }
+
+    [Fact]
+    public void AnAbsentOrUnusableStoredCurveIsNoCurve()
+    {
+        Assert.Null(ImportedTargetCurve.FromStorage("none", null));
+        Assert.Null(ImportedTargetCurve.FromStorage("half a pair", [1_000]));
+        Assert.Null(ImportedTargetCurve.FromStorage("one point", [1_000, 0]));
+    }
+
+    [Fact]
+    public void CurvesAreComparedByWhatTheyHold()
+    {
+        // The target rides inside a record and a plot cache key is one of the
+        // things that compares it, so equality has to read the points rather
+        // than the reference a fresh import happens to produce.
+        ImportedTargetCurve curve = Build((100, 6.0), (1_000, 0.0));
+        ImportedTargetCurve same = Build((100, 6.0), (1_000, 0.0));
+        ImportedTargetCurve other = Build((100, 5.0), (1_000, 0.0));
+
+        Assert.Equal(curve, same);
+        Assert.Equal(curve.GetHashCode(), same.GetHashCode());
+        Assert.NotEqual(curve, other);
+        Assert.NotEqual(curve, ImportedTargetCurve.FromPoints(
+            "another-name.txt",
+            [new OverlayPoint(100, 6), new OverlayPoint(1_000, 0)])!);
+    }
+
+    [Fact]
+    public void AnImportedShapeReplacesTheParametricTerms()
+    {
+        // The one evaluation every consumer asks — the overlay math, the wizard
+        // plot, the Virtual DSP plot, the dialog's preview and the auto-tuner
+        // behind them — so this is what makes the import reach all of them.
+        TargetCurveSpec car = TargetCurveSpec.FromPreset(TargetPreset.Car);
+        TargetCurveSpec imported = car with
+        {
+            Imported = Build((100, 6.0), (1_000, 0.0), (10_000, -3.0))
+        };
+
+        Assert.Equal(6, imported.Evaluate(100), 12);
+        Assert.Equal(0, imported.Evaluate(1_000), 12);
+        Assert.Equal(-3, imported.Evaluate(10_000), 12);
+        // The parametric numbers are still there, untouched, because picking a
+        // preset in the settings dialog is how the user comes back to them.
+        Assert.Equal(car.BassShelfGainDb, imported.BassShelfGainDb);
+        Assert.Equal(car.Evaluate(100), (imported with { Imported = null }).Evaluate(100));
+    }
+
+    [Fact]
+    public void NormalizingATargetKeepsTheImportedShape()
+    {
+        // Every target that comes off disk is normalized, and normalizing rebuilds
+        // the spec: an imported shape dropped there would turn a user's house
+        // curve back into a preset on the next launch.
+        var curve = new EqTargetCurve(
+            TargetPreset.Custom,
+            TargetCurveSpec.FromPreset(TargetPreset.Custom) with
+            {
+                Imported = Build((100, 6.0), (1_000, 0.0))
+            },
+            ToleranceDb: double.NaN,
+            TargetDeviationMode.Deviation,
+            System.Drawing.Color.FromArgb(255, 55, 200, 160),
+            StrokeThickness: 2,
+            OverlayLineStyle.Dash,
+            SmoothingInverseOctaves: 0);
+
+        EqTargetCurve clean = curve.Normalized();
+
+        Assert.Equal(curve.Spec.Imported, clean.Spec.Imported);
+        Assert.Equal(3, clean.ToleranceDb);
+    }
+
+    private static ImportedTargetCurve Build(params (double Hz, double Db)[] points) =>
+        ImportedTargetCurve.FromPoints(
+            "house.txt",
+            points.Select(point => new OverlayPoint(point.Hz, point.Db)))!;
+}

--- a/tests/Resonalyze.App.Tests/ImportedTargetShapeDialogTests.cs
+++ b/tests/Resonalyze.App.Tests/ImportedTargetShapeDialogTests.cs
@@ -1,0 +1,122 @@
+using System.Drawing;
+using System.Reflection;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The target settings dialog edits the parametric shape, but it is also where
+/// the tolerance, the colour and the line style are edited — and those belong to
+/// a target whichever shape it has. So an imported curve has to survive a visit
+/// to this dialog, and there has to be a way back to a parametric shape that is
+/// not "import a different file".
+/// </summary>
+public sealed class ImportedTargetShapeDialogTests
+{
+    [Fact]
+    public void AnImportedShapeSurvivesAVisitToTheDialog()
+    {
+        // Opened to change a colour, saved, and the house curve is still the
+        // target: the numbers below it describe nothing while it is selected.
+        ImportedTargetCurve imported = House();
+        using OverlayTargetSettingsDialog dialog = Open(imported);
+
+        Assert.Equal(imported, dialog.Spec.Imported);
+        // The preset rides through untouched — it names the parametric shape the
+        // inputs still hold, which is what a preset choice returns to.
+        Assert.Equal(TargetPreset.Car, dialog.Preset);
+        Assert.False(Input(dialog, "tiltInput").Enabled);
+        Assert.False(Input(dialog, "bassGainInput").Enabled);
+    }
+
+    [Fact]
+    public void PickingAPresetDropsTheImportedShape()
+    {
+        ImportedTargetCurve imported = House();
+        using OverlayTargetSettingsDialog dialog = Open(imported);
+
+        SelectPreset(dialog, TargetPreset.XCurve);
+
+        Assert.Null(dialog.Spec.Imported);
+        Assert.Equal(TargetPreset.XCurve, dialog.Preset);
+        Assert.Equal(
+            TargetCurveSpec.FromPreset(TargetPreset.XCurve).TrebleShelfGainDb,
+            dialog.Spec.TrebleShelfGainDb);
+        Assert.True(Input(dialog, "tiltInput").Enabled);
+    }
+
+    [Fact]
+    public void TheImportedShapeStaysInTheListToComeBackTo()
+    {
+        // Trying a preset against your own curve must not cost you the curve:
+        // the imported entry stays in the selector for the dialog's lifetime.
+        ImportedTargetCurve imported = House();
+        using OverlayTargetSettingsDialog dialog = Open(imported);
+
+        SelectPreset(dialog, TargetPreset.Flat);
+        SelectImported(dialog);
+
+        Assert.Equal(imported, dialog.Spec.Imported);
+        Assert.False(Input(dialog, "bassWidthInput").Enabled);
+    }
+
+    [Fact]
+    public void WithoutAnImportedShapeTheListIsPresetsOnly()
+    {
+        using OverlayTargetSettingsDialog dialog = Open(imported: null);
+
+        Assert.Null(dialog.Spec.Imported);
+        Assert.All(
+            Combo(dialog).Items.Cast<object>(),
+            item => Assert.IsType<TargetPreset>(item));
+        Assert.True(Input(dialog, "tiltInput").Enabled);
+    }
+
+    private static ImportedTargetCurve House() =>
+        ImportedTargetCurve.FromPoints(
+            "house.txt",
+            [
+                new OverlayPoint(30, 9),
+                new OverlayPoint(100, 6),
+                new OverlayPoint(1_000, 0),
+                new OverlayPoint(10_000, -3)
+            ])!;
+
+    private static OverlayTargetSettingsDialog Open(ImportedTargetCurve? imported) =>
+        new(
+            Mode.EqWizard,
+            "EQ target",
+            0,
+            TargetPreset.Car,
+            TargetCurveSpec.FromPreset(TargetPreset.Car) with { Imported = imported },
+            toleranceDb: 3,
+            TargetDeviationMode.Deviation,
+            Color.FromArgb(255, 55, 200, 160),
+            strokeThickness: 2,
+            OverlayLineStyle.Dash,
+            100,
+            0,
+            [],
+            null,
+            isolatedTarget: true);
+
+    private static void SelectPreset(OverlayTargetSettingsDialog dialog, TargetPreset preset) =>
+        Combo(dialog).SelectedItem = preset;
+
+    private static void SelectImported(OverlayTargetSettingsDialog dialog)
+    {
+        DarkComboBox combo = Combo(dialog);
+        combo.SelectedItem = combo.Items.Cast<object>()
+            .First(item => item is not TargetPreset);
+    }
+
+    private static DarkComboBox Combo(OverlayTargetSettingsDialog dialog) =>
+        (DarkComboBox)Field(dialog, "presetComboBox");
+
+    private static DarkNumericUpDown Input(OverlayTargetSettingsDialog dialog, string name) =>
+        (DarkNumericUpDown)Field(dialog, name);
+
+    private static object Field(OverlayTargetSettingsDialog dialog, string name) =>
+        dialog.GetType()
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(dialog)!;
+}

--- a/tests/Resonalyze.App.Tests/TargetCurveMenuTests.cs
+++ b/tests/Resonalyze.App.Tests/TargetCurveMenuTests.cs
@@ -1,0 +1,59 @@
+using System.Windows.Forms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The menu behind the Target button in the EQ Wizard and in Virtual DSP. It is
+/// the only place the app states which of the two shapes a target has, so what it
+/// ticks — and that it names the file when there is one — is the whole point of it.
+/// </summary>
+public sealed class TargetCurveMenuTests
+{
+    [Fact]
+    public void WithoutAnImportedCurveTheParametricShapeIsTheOneInForce()
+    {
+        using ContextMenuStrip menu = TargetCurveMenu.Build(null, () => { }, () => { });
+
+        Assert.Equal(2, menu.Items.Count);
+        Assert.True(Item(menu, 0).Checked);
+        Assert.False(Item(menu, 1).Checked);
+        Assert.Equal("Import from file…", Item(menu, 1).Text);
+    }
+
+    [Fact]
+    public void AnImportedCurveIsTickedAndNamed()
+    {
+        ImportedTargetCurve imported = ImportedTargetCurve.FromPoints(
+            "my-house-curve.txt",
+            [new OverlayPoint(100, 6), new OverlayPoint(1_000, 0)])!;
+
+        using ContextMenuStrip menu = TargetCurveMenu.Build(imported, () => { }, () => { });
+
+        Assert.False(Item(menu, 0).Checked);
+        Assert.True(Item(menu, 1).Checked);
+        Assert.Contains("my-house-curve.txt", Item(menu, 1).Text);
+        // The tooltip is what says how much of a curve it is: a file that read as
+        // two points and one that read as four hundred look alike on the button.
+        Assert.Contains("2 points", Item(menu, 1).ToolTipText);
+    }
+
+    [Fact]
+    public void EachEntryCallsItsOwnAction()
+    {
+        int parametric = 0;
+        int import = 0;
+        using ContextMenuStrip menu = TargetCurveMenu.Build(
+            null,
+            () => parametric++,
+            () => import++);
+
+        Item(menu, 0).PerformClick();
+        Item(menu, 1).PerformClick();
+
+        Assert.Equal(1, parametric);
+        Assert.Equal(1, import);
+    }
+
+    private static ToolStripMenuItem Item(ContextMenuStrip menu, int index) =>
+        (ToolStripMenuItem)menu.Items[index];
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -1441,6 +1441,57 @@ public sealed class VirtualCrossoverProjectFileTests
     }
 
     [Fact]
+    public void Save_CarriesAnImportedTargetShapeByValue()
+    {
+        // A house curve is stored the way the rest of the target is — as what it
+        // says, not as a path to the file it came from, which the session cannot
+        // promise is still there (or still holds the same numbers) tomorrow.
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            ImportedTargetCurve imported = ImportedTargetCurve.FromPoints(
+                "house.txt",
+                [
+                    new OverlayPoint(30, 9),
+                    new OverlayPoint(100, 6),
+                    new OverlayPoint(1_000, 0),
+                    new OverlayPoint(10_000, -3)
+                ])!;
+            var curve = new EqTargetCurve(
+                TargetPreset.Car,
+                TargetCurveSpec.FromPreset(TargetPreset.Car) with { Imported = imported },
+                ToleranceDb: 3,
+                TargetDeviationMode.Deviation,
+                System.Drawing.Color.FromArgb(255, 55, 200, 160),
+                StrokeThickness: 2,
+                OverlayLineStyle.Dash,
+                SmoothingInverseOctaves: 0);
+            var saved = new VirtualCrossoverProjectFile
+            {
+                Target = VirtualCrossoverTargetSettings.FromCurve(curve)
+            };
+            saved.Save(root);
+
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.NotNull(loaded.Target);
+            EqTargetCurve restored = loaded.Target!.ToCurve();
+            Assert.Equal(imported, restored.Spec.Imported);
+            Assert.Equal(curve, restored);
+            // The parametric terms travel beside it: they are what picking a
+            // preset in the target dialog goes back to.
+            Assert.Equal(
+                TargetCurveSpec.FromPreset(TargetPreset.Car).BassShelfGainDb,
+                restored.Spec.BassShelfGainDb);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void LoadOrDefault_ProjectWithoutATarget_CarriesNone()
     {
         // Absence is a real state, and it means "no target of its own" rather

--- a/tools/Resonalyze.Screenshots/Shots.cs
+++ b/tools/Resonalyze.Screenshots/Shots.cs
@@ -401,8 +401,12 @@ internal static class Shots
 
         if (wanted("manual/eq-target"))
         {
+            // The button drops a menu (parametric shape / import from file), so the
+            // figure asks for the dialog itself rather than posing the menu — the
+            // shot is of the parametric editor, and a posted drop-down is not a
+            // modal to wait on.
             session.CaptureModal("manual/eq-target",
-                () => Reflect.Field<Button>(panel, "buttonTargetSettings").PerformClick(), 2_000);
+                () => Reflect.Invoke(panel, "OpenTargetSettings"), 2_000);
         }
 
         if (wanted("manual/auto-crossover"))


### PR DESCRIPTION
A user asked for it: he tunes to a house curve of his own and the target could
only be one of the parametric shapes. The Target button in the EQ Wizard and in
Virtual DSP now drops a two-entry menu, ticking the shape in force — the
parametric one the settings dialog builds, or a curve imported from a text file.
Both buttons ask through the same menu and the same importer, because they edit
one shared target.

An imported curve rides inside `TargetCurveSpec` and replaces the parametric
terms in the single `Evaluate` every consumer asks, so it reaches both plots,
the dialog's own preview and Auto Tune without a second path to keep in step.

### How a file is read

- **As relative dB**, anchored by subtracting whatever it reads at 1 kHz — the
  pivot the parametric tilt turns around. A file written around 75 dB SPL and
  the same shape written around 0 dB are one target, hung at the Target Level
  the user sets, which stays the user's knob alone.
- **Straight in log frequency and dB** between its points, and **held flat
  outside its range** rather than continuing the last slope: a curve that stops
  at 200 Hz says nothing about 10 kHz, and Auto Tune would spend real filters
  chasing a target invented there.
- Pairs that cannot be interpolated are cleaned out — non-finite values,
  frequencies at or below zero, duplicates of one frequency averaged — and
  fewer than two survivors is *no shape*, not a broken one.
- **Thinned onto a log grid above 1024 points**, because the curve is stored by
  value and a full-resolution export runs to tens of thousands of lines.
- A **deviation or EQ-correction** file is refused: it is the difference between
  a response and a target, not a target.

### Storage

The curve goes into the wizard's settings and into a Virtual DSP session as its
points, not as a path to where it was imported from, so it survives the file
being moved, renamed or edited. Both are read back through the importer, so a
hand-edited file leaves the parametric terms in charge instead of failing the
session.

### The dialog does not eat it

The imported curve appears as the first entry of the preset list, with the ten
shape inputs disabled while it is selected. So editing the tolerance, the colour
or the line style cannot silently drop it; picking any real preset is the way
back to a parametric shape; and the imported entry stays in the list until the
dialog closes, so trying a preset against your own curve does not cost you the
curve.

### Out of scope, deliberately

The **Target overlay** slot (Frequency Response / Live Spectrum) stays
parametric: it has no target button, it is configured from the slot, and its
file format would need its own fields. REFERENCE says so rather than leaving it
to be discovered.

### Tests

Model (anchoring, log interpolation, held ends, cleaning, thinning, storage
round-trip, equality), the dialog (carries / drops / restores the shape), the
menu (what it ticks and names), the panel end to end (the wizard DRAWS the
imported shape — which is what Auto Tune is handed — and it survives a settings
round-trip), and the Virtual DSP session round-trip. Full suite green:
159 + 1775 + 1355, zero warnings.

### Docs and figures

REFERENCE gains "The target curve" under the EQ Wizard (plus the TOC entry, the
Target-curves section and the Virtual DSP target paragraph); MANUAL and README
follow. TODO listed arbitrary target-curve import as *deliberately out of scope*
on the grounds that the Car / CarMild / XCurve presets cover it — that line is
now the record of the decision being reversed.

`manual/eq-target` clicked the Target button and waited for a modal, which the
menu would have broken silently; the shot now asks for the dialog directly. The
figure itself is unchanged, so **no re-run of the screenshot tool is needed** —
unless you want a new figure of the menu.

### Follow-up recorded, not patched

The review also raised that the import trusts the file to be a magnitude: it
refuses the two roles that are differences and never looks at
`AnalysisCurveKind`, so a phase or group-delay export loads as a target with its
degrees or milliseconds read as dB. Borrowing
`EqWizardSourceResolver.IsEqualizableResponse` would catch only our own labelled
exports — a file from another tool declares no kind, and that `null` is
permitted on purpose, for exactly the foreign files this import exists to read.
Widening it belongs to what the text header can state, so it is a TODO entry
under EQ Wizard rather than a pair of `if`s here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
