### PR TITLE
Open a dropped file in the mode it belongs to

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -30,6 +30,7 @@ read-out refuses rather than guesses, what a number was measured against.
 - [Time Alignment](#time-alignment)
 - [Saving and Loading Impulse Responses](#saving-and-loading-impulse-responses)
   - [Importing a sweep recorded elsewhere](#importing-a-sweep-recorded-elsewhere)
+  - [Dropping a file on the window](#dropping-a-file-on-the-window)
 - [Plot Overlays](#plot-overlays)
   - [Target curves](#target-curves)
   - [Import and export](#import-and-export)
@@ -618,7 +619,9 @@ the capture, not on the impulse response the rest of the application carries —
 and either Load button opens either kind of measurement, because which one a file
 holds is the file's business rather than the button's: a capture opened from any
 other mode takes the application to the mode it belongs to, and an impulse
-response opened from MMM takes it to Frequency Response.
+response opened from MMM takes it to Frequency Response. Dragging the file onto
+the window does the same without the dialog (see
+[Dropping a file on the window](#dropping-a-file-on-the-window)).
 
 An **SPL anchor is not required**. Without one the title says `MMM, relative (no
 SPL anchor)` and the levels sit on an arbitrary but internally consistent
@@ -949,6 +952,31 @@ measurement into the saved `.json` and the history, so everything comparing one
 arrival against another refuses it by name: [Time Alignment](#time-alignment)
 declines it as a source and as a Compare partner, and
 [Virtual DSP](#virtual-dsp) will not sum it with another measurement.
+
+### Dropping a file on the window
+
+A file dragged onto the Resonalyze window from Explorer opens exactly as it would
+through the button that owns it, and takes the application to the mode it belongs
+to. An impulse response — or a `.wav` sweep recording, or a REW impulse-response
+`.txt` export — lands in the analysis modes, on Frequency Response when the mode
+in front of you has nowhere to show it. A [moving-mic capture](#live-spectrum)
+goes to Live Spectrum, under its own recipe. A [Virtual DSP](#virtual-dsp) session
+opens the tool and imports it as **Load session...** does, the offer to relink
+missing measurements included.
+
+Which of them a file holds is read from the file, not from its name or its folder:
+each JSON document declares its format at the top, and that marker is all that is
+read — an impulse response is tens of megabytes, and nothing waits for one to be
+parsed to find out where it is going. A file Resonalyze does
+not write says so plainly instead of being mis-opened, and an overlay slot file is
+refused by name: overlays are loaded into a slot you choose, from the overlay
+panel beside the graph.
+
+The whole window takes the drop, wherever the pointer is over it. One file at a
+time — the shell holds one measurement, so a drag carrying several is refused
+while it hovers, the cursor showing that no drop will happen. The same refusal
+covers a drag arriving while a sweep is running, or while a dialog is up: a file
+opened underneath one would replace the very measurement it is asking about.
 
 ## Plot Overlays
 
@@ -2237,7 +2265,9 @@ The remaining buttons in the column beside the plots:
   the convention does to a band's width, and which processors are known to read Q
   that way.
   **Save session... / Load session...** export and import the complete session
-  JSON for sharing or archiving.
+  JSON for sharing or archiving; a session file dragged onto the window opens
+  here too, whichever mode was in front (see
+  [Dropping a file on the window](#dropping-a-file-on-the-window)).
 
 The tool's autosaved state persists in `tools/virtual-crossover.json` and
 survives restarts. Accuracy holds within the usual physics: one microphone

--- a/source/LiveSpectrum/LiveCaptureDocument.cs
+++ b/source/LiveSpectrum/LiveCaptureDocument.cs
@@ -527,8 +527,9 @@ public sealed class LiveCaptureDocument
     /// The question "whose file is this?" is answered by the file, so a capture opened
     /// through the shared Load button can be routed to the mode it belongs to instead
     /// of being refused for not being an impulse response. Only the FORMAT decides
-    /// that: a file that says it is a capture and then fails validation throws, since
-    /// a corrupt capture is a real error and must not be silently offered to the next
+    /// that: false means the file declares another one (or none), and a file that says
+    /// it is a capture and then fails — to parse or to validate — throws, since a
+    /// corrupt capture is a real error and must not be silently offered to the next
     /// reader as something else.
     /// </remarks>
     public static bool TryLoad(string path, out LiveCaptureDocument document)
@@ -551,10 +552,14 @@ public sealed class LiveCaptureDocument
             using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.Read);
             parsed = JsonSerializer.Deserialize<LiveCaptureDocument>(stream, SerializerOptions);
         }
-        catch (JsonException)
+        catch (JsonException exception)
         {
-            // Not JSON we can read at all, so certainly not ours to claim.
-            return false;
+            // The marker above already said this file is ours, so a document that
+            // then fails to parse is a DAMAGED capture, not somebody else's file.
+            // Returning false here would disown it to the impulse-response loader,
+            // which is the very misdiagnosis a failed validation is thrown for below.
+            throw new InvalidDataException(
+                $"The capture file could not be read: {exception.Message}", exception);
         }
 
         if (parsed == null ||

--- a/source/LiveSpectrum/LiveCaptureDocument.cs
+++ b/source/LiveSpectrum/LiveCaptureDocument.cs
@@ -535,6 +535,16 @@ public sealed class LiveCaptureDocument
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
         document = null!;
+        // The marker is read out of the head of the file first, and a file that does
+        // not carry ours is declined without being deserialized: the shared Load path
+        // asks this of EVERY file it opens, and an impulse response is tens of
+        // megabytes that would otherwise be parsed in full — into a capture document
+        // that is thrown away — on its way to the loader it belongs to.
+        if (JsonFormatMarker.Read(path) != CurrentFormat)
+        {
+            return false;
+        }
+
         LiveCaptureDocument? parsed;
         try
         {

--- a/source/Shell/DroppedFile.cs
+++ b/source/Shell/DroppedFile.cs
@@ -1,0 +1,99 @@
+namespace Resonalyze;
+
+/// <summary>
+/// What a file handed to the shell — dragged onto the window — turns out to hold.
+/// </summary>
+internal enum DroppedFileKind
+{
+    /// <summary>Not a document this application opens.</summary>
+    Unknown,
+
+    /// <summary>A Resonalyze impulse response.</summary>
+    ImpulseResponse,
+
+    /// <summary>A stored spatial average (the RTA analyzer's moving-mic capture).</summary>
+    SpatialAverageCapture,
+
+    /// <summary>A Virtual DSP session.</summary>
+    VirtualDspSession,
+
+    /// <summary>A recorded sweep to deconvolve (a WAV).</summary>
+    RecordedSweep,
+
+    /// <summary>A REW impulse response export (a text file).</summary>
+    RewImpulseResponseExport,
+
+    /// <summary>
+    /// An overlay slot file. Recognized only to be refused by name: the overlay panel
+    /// owns those files and addresses them by slot, so there is nothing for a drop to
+    /// open — and "unsupported format" would be a lie about a file this very
+    /// application wrote.
+    /// </summary>
+    OverlaySlot
+}
+
+/// <summary>
+/// Decides which of the application's documents a file holds, so a drop can open it in
+/// the mode it belongs to instead of asking the user which button it was meant for.
+/// </summary>
+/// <remarks>
+/// The four JSON documents share an extension and are told apart by the <c>format</c>
+/// marker each one writes, read out of the head of the file by
+/// <see cref="JsonFormatMarker"/> rather than by deserializing candidate types in turn
+/// to see which one does not throw.
+/// </remarks>
+internal static class DroppedFile
+{
+    /// <summary>
+    /// Whether the extension is one the shell opens at all. This is what answers while
+    /// a drag is still hovering — it decides the cursor, and it must not touch the disk
+    /// for every mouse move over the window. What the file actually IS costs a read and
+    /// is answered once, on the drop.
+    /// </summary>
+    internal static bool HasOpenableExtension(string path)
+    {
+        string extension = Path.GetExtension(path);
+        return string.Equals(extension, ".json", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(extension, ".wav", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(extension, ".txt", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// What <paramref name="path"/> holds, or <see cref="DroppedFileKind.Unknown"/>
+    /// when nothing here recognizes it.
+    /// </summary>
+    /// <remarks>
+    /// A WAV and a text file are taken at their extension, exactly as the Load dialog
+    /// takes them: the sweep importer and the REW importer each read the file properly
+    /// and report what is wrong with it, and a second opinion formed here out of a few
+    /// kilobytes could only be a worse-informed one.
+    /// </remarks>
+    internal static DroppedFileKind Classify(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        string extension = Path.GetExtension(path);
+        if (string.Equals(extension, ".wav", StringComparison.OrdinalIgnoreCase))
+        {
+            return DroppedFileKind.RecordedSweep;
+        }
+
+        if (string.Equals(extension, ".txt", StringComparison.OrdinalIgnoreCase))
+        {
+            return DroppedFileKind.RewImpulseResponseExport;
+        }
+
+        if (!string.Equals(extension, ".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return DroppedFileKind.Unknown;
+        }
+
+        return JsonFormatMarker.Read(path) switch
+        {
+            ImpulseResponseFile.CurrentFormat => DroppedFileKind.ImpulseResponse,
+            LiveCaptureDocument.CurrentFormat => DroppedFileKind.SpatialAverageCapture,
+            VirtualCrossoverProjectFile.CurrentFormat => DroppedFileKind.VirtualDspSession,
+            OverlayFile.CurrentFormat => DroppedFileKind.OverlaySlot,
+            _ => DroppedFileKind.Unknown
+        };
+    }
+}

--- a/source/Shell/Form1.FileDrop.cs
+++ b/source/Shell/Form1.FileDrop.cs
@@ -1,0 +1,93 @@
+namespace Resonalyze;
+
+// Files dragged onto the window from Explorer. The file says which of the
+// application's documents it is, so a drop lands where that document belongs
+// rather than where the user happened to be standing: an impulse response goes to
+// the analyzers, a spatial average to the live analyzer, a session to Virtual DSP.
+// It is the Load button's own routing (see Form1.FileOperations), reached without
+// the dialog.
+public partial class Form1
+{
+    // One at a time. Two files opening at once would each install a measurement,
+    // and the one the user sees would be whichever finished last — while the drag
+    // that started it looked accepted either way.
+    private bool openingDroppedFile;
+
+    private void EnableFileDrop() =>
+        FileDropTarget.Attach(this, CanOpenDroppedFiles, OpenDroppedFiles);
+
+    // Answered on every drag move, so it stops at the extension: what the file
+    // holds is read once, on the drop.
+    private bool CanOpenDroppedFiles(IReadOnlyList<string> files) =>
+        files.Count == 1 &&
+        !openingDroppedFile &&
+        !expSweepMeasurement.InProgress &&
+        DroppedFile.HasOpenableExtension(files[0]);
+
+    private async void OpenDroppedFiles(IReadOnlyList<string> files)
+    {
+        if (!CanOpenDroppedFiles(files))
+        {
+            return;
+        }
+
+        openingDroppedFile = true;
+        try
+        {
+            await OpenDroppedFileAsync(files[0]);
+        }
+        finally
+        {
+            openingDroppedFile = false;
+        }
+    }
+
+    private async Task OpenDroppedFileAsync(string path)
+    {
+        switch (DroppedFile.Classify(path))
+        {
+            case DroppedFileKind.VirtualDspSession:
+                // The tool has to be on screen before it can be given a session:
+                // showing it is what loads its own stored project, and that load
+                // would otherwise land on top of the imported one.
+                await SelectModeAsync(ModeTab.ToolsVirtualCrossover);
+                await virtualCrossoverPanel.ImportSessionFileAsync(path);
+                break;
+
+            // The impulse response, the capture and the two imports all take the
+            // route the Load button takes, which already sends each one to its own
+            // mode and reports its own failures.
+            case DroppedFileKind.ImpulseResponse:
+            case DroppedFileKind.SpatialAverageCapture:
+            case DroppedFileKind.RecordedSweep:
+            case DroppedFileKind.RewImpulseResponseExport:
+                await OpenMeasurementFileAsync(path);
+                break;
+
+            case DroppedFileKind.OverlaySlot:
+                MessageBox.Show(
+                    this,
+                    "That is an overlay slot file — this application's own storage " +
+                    "for one slot of one mode.\r\n\r\nSlots come back with their mode " +
+                    "on their own, so there is nothing here to open. To bring a curve " +
+                    "in from elsewhere, use Import from text… on the slot it belongs " +
+                    "in.",
+                    "Open file",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+                break;
+
+            default:
+                MessageBox.Show(
+                    this,
+                    $"Resonalyze cannot open '{Path.GetFileName(path)}'.\r\n\r\n" +
+                    "Drop an impulse response, a moving-mic capture or a Virtual DSP " +
+                    "session (.json), a recorded sweep (.wav), or a REW impulse " +
+                    "response export (.txt).",
+                    "Open file",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+                break;
+        }
+    }
+}

--- a/source/Shell/Form1.FileOperations.cs
+++ b/source/Shell/Form1.FileOperations.cs
@@ -117,31 +117,50 @@ public partial class Form1
                 return;
             }
 
-            // A stored capture knows which mode it belongs to, so opening one here
-            // takes the application there rather than refusing it for not being an
-            // impulse response. A file that CLAIMS to be a capture and then fails to
-            // parse is reported as the broken capture it is, not handed on to the
-            // impulse-response loader to be misdiagnosed as a bad format.
-            try
+            await OpenMeasurementFileAsync(dialog.FileName);
+        }
+    }
+
+    /// <summary>
+    /// Opens a measurement file: a stored capture goes to the mode it was taken in,
+    /// anything else to the impulse-response side.
+    /// </summary>
+    /// <remarks>
+    /// A stored capture knows which mode it belongs to, so opening one takes the
+    /// application there rather than refusing it for not being an impulse response.
+    /// A file that CLAIMS to be a capture and then fails to parse is reported as the
+    /// broken capture it is, not handed on to the impulse-response loader to be
+    /// misdiagnosed as a bad format.
+    /// <para>
+    /// Shared by both Load buttons and by a file dropped on the window, so all three
+    /// open the same file in the same way.
+    /// </para>
+    /// </remarks>
+    private async Task OpenMeasurementFileAsync(string path)
+    {
+        // Idempotent, and needed by only one of the three callers: the buttons stop
+        // the analyzer before they open their dialog, a drop has stopped nothing.
+        await StopLiveCaptureAsync();
+
+        try
+        {
+            if (await TryOpenLiveCaptureAsync(path))
             {
-                if (await TryOpenLiveCaptureAsync(dialog.FileName))
-                {
-                    return;
-                }
-            }
-            catch (Exception exception)
-            {
-                MessageBox.Show(
-                    this,
-                    $"The capture could not be loaded.\r\n\r\n{exception.Message}",
-                    "Load failed",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
                 return;
             }
-
-            await LoadImpulseResponseLikeAsync(dialog.FileName);
         }
+        catch (Exception exception)
+        {
+            MessageBox.Show(
+                this,
+                $"The capture could not be loaded.\r\n\r\n{exception.Message}",
+                "Load failed",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
+        }
+
+        await LoadImpulseResponseLikeAsync(path);
     }
 
     /// <summary>
@@ -156,10 +175,12 @@ public partial class Form1
     /// </remarks>
     private async Task LoadImpulseResponseLikeAsync(string path)
     {
-        // An impulse response has nowhere to be shown in a live capture mode, so go
-        // where it belongs first — the mirror of a capture taking the application to
-        // Live Spectrum.
-        if (CurrentMode == Mode.LiveSpectrum)
+        // An impulse response has nowhere to be shown in the live analyzer, nor in a
+        // tool that reads sources of its own, so go where it belongs first — the
+        // mirror of a capture taking the application to Live Spectrum. The Load
+        // button is hidden in the tools; a file dropped on the window is not, so the
+        // question is asked of the mode rather than of Live Spectrum by name.
+        if (!GetActiveModeDescriptor().ShowsLoadedMeasurement)
         {
             await SelectModeAsync(ModeTab.Frequency);
         }

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -306,6 +306,11 @@ public partial class Form1
         buttonCompare.Click += (_, _) => ShowCompareMenu();
         FormClosing += Form1_FormClosing;
         Shown += Form1_Shown;
+        // Files dragged in from Explorer, which the window accepts anywhere on it
+        // (see Form1.FileDrop). Last in construction, so the controls the shell has
+        // built are all there to be registered; the ones it builds later register
+        // themselves as they are added.
+        EnableFileDrop();
     }
 
     private void HandleMeasurementCompleted(bool success)

--- a/source/Shell/Form1.LiveCapture.cs
+++ b/source/Shell/Form1.LiveCapture.cs
@@ -173,27 +173,9 @@ public partial class Form1
             return;
         }
 
-        try
-        {
-            if (await TryOpenLiveCaptureAsync(dialog.FileName))
-            {
-                return;
-            }
-        }
-        catch (Exception exception)
-        {
-            MessageBox.Show(
-                this,
-                $"The capture could not be loaded.\r\n\r\n{exception.Message}",
-                "Load failed",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Error);
-            return;
-        }
-
-        // Not a capture, so it belongs to the impulse-response side: that path moves
-        // the application to Frequency Response, the mirror of a capture bringing it
+        // Whichever it is: a capture stays here, an impulse response moves the
+        // application to Frequency Response — the mirror of a capture bringing it
         // here.
-        await LoadImpulseResponseLikeAsync(dialog.FileName);
+        await OpenMeasurementFileAsync(dialog.FileName);
     }
 }

--- a/source/Shell/Form1.ModeCatalog.cs
+++ b/source/Shell/Form1.ModeCatalog.cs
@@ -218,5 +218,17 @@ public partial class Form1
             is not MainContentKind.EqWizard
             and not MainContentKind.SignalGenerator
             and not MainContentKind.VirtualCrossover;
+
+        /// <summary>
+        /// Whether the mode draws the measurement that is loaded — true of every
+        /// analyzer, Time Alignment included, since they all read the same impulse
+        /// response. False of Live Spectrum, which shows what the microphone hears
+        /// right now, and of the Tools modes, which resolve sources of their own. It
+        /// is what decides whether an impulse response arriving from a file has
+        /// anywhere to be shown, or has to take the application to Frequency Response
+        /// first.
+        /// </summary>
+        public bool ShowsLoadedMeasurement =>
+            HasCaptureControls && Tab != ModeTab.LiveSpectrum;
     }
 }

--- a/source/Storage/JsonFormatMarker.cs
+++ b/source/Storage/JsonFormatMarker.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Reads the <c>format</c> marker a Resonalyze JSON document declares, out of the head
+/// of the file, without deserializing the rest of it.
+/// </summary>
+/// <remarks>
+/// Which document a file holds has to be answered before anything can open it, and the
+/// documents are nothing like the same size: a spatial-average capture is a few
+/// hundred kilobytes, an impulse response tens of megabytes. Deserializing one to read
+/// a string its first line already carries means reading and allocating all of it to
+/// answer "not yours" — which is what every load of an impulse response did on its way
+/// past the capture reader.
+/// <para>
+/// The scan is a token walk with the reader's state carried from chunk to chunk, so it
+/// knows as much as a full parse would about WHERE the marker is: only a property of
+/// the root object counts — a nested <c>format</c> belongs to a recipe or a channel,
+/// and naming a file after one of its parts is how a document gets opened as the thing
+/// inside it — and the walk ends with the root object. It is also exactly as strict as
+/// the readers it stands in front of: none of their options ask for case-insensitive
+/// property names, so <c>format</c> matches and <c>Format</c> does not, in the probe
+/// as in the deserializer that follows it.
+/// </para>
+/// </remarks>
+internal static class JsonFormatMarker
+{
+    private const string MarkerProperty = "format";
+
+    /// <summary>
+    /// How much of the file is held at a time. Our own documents declare the marker
+    /// first, so the first read answers; a file that declares one later is walked
+    /// without ever holding more than this.
+    /// </summary>
+    private const int ChunkBytes = 64 * 1024;
+
+    private static ReadOnlySpan<byte> Utf8ByteOrderMark => [0xEF, 0xBB, 0xBF];
+
+    /// <summary>
+    /// The <c>format</c> of the root object in the file at <paramref name="path"/>, or
+    /// null when there is none to read.
+    /// </summary>
+    /// <remarks>
+    /// Null covers every way of not knowing — an unreadable file, one that is not
+    /// JSON, one whose root is not an object, one that declares no format — and they
+    /// are deliberately not told apart. A caller asks this to decide whether a file is
+    /// its own, and every one of those answers that question with "no"; the loader
+    /// that can say more never gets the file.
+    /// </remarks>
+    internal static string? Read(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        try
+        {
+            // Shared read: the file may be one the application is itself writing, and
+            // asking what it is must not fail for holding a lock nobody asked for.
+            using var stream = new FileStream(
+                path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            return Scan(stream);
+        }
+        catch (Exception exception) when (
+            exception is IOException or UnauthorizedAccessException or NotSupportedException
+                or ArgumentException or JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? Scan(FileStream stream)
+    {
+        SkipByteOrderMark(stream);
+
+        var buffer = new byte[ChunkBytes];
+        int filled = 0;
+        bool rootSeen = false;
+        // Set once the marker's property name has been read, so the value can still be
+        // picked up when the two fall either side of a chunk boundary.
+        bool expectingValue = false;
+        JsonReaderState state = default;
+        while (true)
+        {
+            int read = stream.Read(buffer, filled, buffer.Length - filled);
+            filled += read;
+            bool finalBlock = read == 0;
+            var reader = new Utf8JsonReader(buffer.AsSpan(0, filled), finalBlock, state);
+            while (reader.Read())
+            {
+                if (expectingValue)
+                {
+                    return reader.TokenType == JsonTokenType.String ? reader.GetString() : null;
+                }
+
+                if (!rootSeen)
+                {
+                    // A document whose root is not an object declares nothing.
+                    if (reader.TokenType != JsonTokenType.StartObject)
+                    {
+                        return null;
+                    }
+
+                    rootSeen = true;
+                    continue;
+                }
+
+                if (reader.TokenType == JsonTokenType.EndObject && reader.CurrentDepth == 0)
+                {
+                    return null;
+                }
+
+                if (reader.TokenType == JsonTokenType.PropertyName &&
+                    reader.CurrentDepth == 1 &&
+                    reader.ValueTextEquals(MarkerProperty))
+                {
+                    expectingValue = true;
+                }
+            }
+
+            if (finalBlock)
+            {
+                return null;
+            }
+
+            state = reader.CurrentState;
+            int consumed = (int)reader.BytesConsumed;
+            buffer.AsSpan(consumed, filled - consumed).CopyTo(buffer);
+            filled -= consumed;
+            if (filled == buffer.Length)
+            {
+                // One token longer than the whole buffer, which no document of ours
+                // carries near its head. Nothing left to do but decline it.
+                return null;
+            }
+        }
+    }
+
+    private static void SkipByteOrderMark(FileStream stream)
+    {
+        Span<byte> head = stackalloc byte[3];
+        int read = stream.ReadAtLeast(head, head.Length, throwOnEndOfStream: false);
+        if (read != head.Length || !head.SequenceEqual(Utf8ByteOrderMark))
+        {
+            stream.Position = 0;
+        }
+    }
+}

--- a/source/Storage/JsonFormatMarker.cs
+++ b/source/Storage/JsonFormatMarker.cs
@@ -18,10 +18,11 @@ namespace Resonalyze;
 /// knows as much as a full parse would about WHERE the marker is: only a property of
 /// the root object counts — a nested <c>format</c> belongs to a recipe or a channel,
 /// and naming a file after one of its parts is how a document gets opened as the thing
-/// inside it — and the walk ends with the root object. It is also exactly as strict as
-/// the readers it stands in front of: none of their options ask for case-insensitive
-/// property names, so <c>format</c> matches and <c>Format</c> does not, in the probe
-/// as in the deserializer that follows it.
+/// inside it — and the walk ends with the root object. It also reads a document on
+/// exactly the terms the deserializers behind it do, in both directions: their options
+/// accept comments and trailing commas, so the probe does too — a file they would open
+/// must not be turned away at the door — and none of them ask for case-insensitive
+/// property names, so <c>format</c> matches and <c>Format</c> does not, here as there.
 /// </para>
 /// </remarks>
 internal static class JsonFormatMarker
@@ -34,6 +35,17 @@ internal static class JsonFormatMarker
     /// without ever holding more than this.
     /// </summary>
     private const int ChunkBytes = 64 * 1024;
+
+    /// <summary>
+    /// The leniency every one of the document readers is configured with. A capture
+    /// carrying a comment before its marker is a capture they would open, so it must
+    /// not be declined here and sent on to another loader to be misreported.
+    /// </summary>
+    private static readonly JsonReaderOptions ProbeOptions = new()
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip
+    };
 
     private static ReadOnlySpan<byte> Utf8ByteOrderMark => [0xEF, 0xBB, 0xBF];
 
@@ -77,7 +89,7 @@ internal static class JsonFormatMarker
         // Set once the marker's property name has been read, so the value can still be
         // picked up when the two fall either side of a chunk boundary.
         bool expectingValue = false;
-        JsonReaderState state = default;
+        JsonReaderState state = new(ProbeOptions);
         while (true)
         {
             int read = stream.Read(buffer, filled, buffer.Length - filled);

--- a/source/Tools/Eq/EqWizardPanel.Bank.cs
+++ b/source/Tools/Eq/EqWizardPanel.Bank.cs
@@ -696,7 +696,15 @@ public partial class EqWizardPanel
     {
         if (draggedSlot == null)
         {
-            e.Effect = DragDropEffects.None;
+            // Not a strip being moved. It may still be a file dragged in from
+            // Explorer, which the whole window accepts and which is registered on
+            // these same controls: refusing it here would make the bank the one
+            // place a measurement cannot be dropped.
+            if (!FileDropTarget.CarriesFiles(e.Data))
+            {
+                e.Effect = DragDropEffects.None;
+            }
+
             return;
         }
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -155,6 +155,11 @@ public partial class VirtualCrossoverPanel : UserControl
     private VirtualCrossoverAcousticPlot acousticPlot = null!;
     private VirtualCrossoverDspChainPlot dspChainPlot = null!;
     private bool initialized;
+
+    // The stored project's load, so anything that would replace it can wait for it
+    // to finish instead of racing it (see ImportSessionFileAsync). Completed until
+    // the panel is first shown, and never faulted: the load handles its own errors.
+    private Task storedProjectLoad = Task.CompletedTask;
     private bool suppressProjectEvents;
 
     // Single-flight coalescing for the interactive redraw. While a redraw's heavy
@@ -413,14 +418,15 @@ public partial class VirtualCrossoverPanel : UserControl
         }
 
         initialized = true;
-        LoadProjectSafely();
+        storedProjectLoad = LoadProjectSafelyAsync();
     }
 
     // ---------------------------------------------------------------- project
 
-    // Fire-and-forget with a guard: an exception in the async load would
-    // otherwise vanish into an unobserved task.
-    private async void LoadProjectSafely()
+    // Guarded rather than fire-and-forget: an exception in the async load would
+    // otherwise vanish into an unobserved task, and the task is kept so an import
+    // arriving on the panel's heels can wait for it.
+    private async Task LoadProjectSafelyAsync()
     {
         try
         {
@@ -6800,10 +6806,28 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
+        await ImportSessionFileAsync(dialog.FileName);
+    }
+
+    /// <summary>
+    /// Imports the session at <paramref name="path"/>, exactly as the panel's own
+    /// Load does. Reports its own failures.
+    /// </summary>
+    /// <remarks>
+    /// The entry point for a session file dropped on the window, which arrives here
+    /// through a tab switch that has only just told the panel to open. That switch
+    /// starts the stored project loading, and a load still in flight would land on
+    /// top of the import and quietly restore the session the user was replacing —
+    /// so this waits for it rather than racing it.
+    /// </remarks>
+    internal async Task ImportSessionFileAsync(string path)
+    {
+        await storedProjectLoad;
+
         VirtualCrossoverProjectFile imported;
         try
         {
-            imported = VirtualCrossoverProjectFile.LoadFrom(dialog.FileName);
+            imported = VirtualCrossoverProjectFile.LoadFrom(path);
         }
         catch (Exception exception)
         {

--- a/source/Ui/FileDropTarget.cs
+++ b/source/Ui/FileDropTarget.cs
@@ -1,0 +1,151 @@
+using System.Runtime.InteropServices;
+
+namespace Resonalyze.Ui;
+
+/// <summary>
+/// Lets a whole window accept files dragged onto it from Explorer.
+/// </summary>
+/// <remarks>
+/// WinForms drag events do not bubble. Only the control under the pointer is asked,
+/// and one that never registered itself as a drop target refuses the drag outright —
+/// so a window made of panels, plots, labels and buttons has to register every one of
+/// them, which is what this does: the whole tree at the moment it is attached, plus
+/// each control added later (mode settings are docked in on demand, filter strips are
+/// built as they are added).
+/// <para>
+/// It never touches a drag it does not recognize. Controls that carry drop targets of
+/// their own — the EQ wizard's bank reorders its filter strips by dragging — keep
+/// working, because a payload that is not a file drop leaves the effect exactly as the
+/// other handler left it.
+/// </para>
+/// </remarks>
+internal sealed class FileDropTarget
+{
+    // Every control that has been wired, so a control re-added to its parent (or
+    // reached twice through two parents on the way down) does not collect a second
+    // copy of the handlers.
+    private readonly HashSet<Control> registered = [];
+    private readonly Control root;
+    private readonly Func<IReadOnlyList<string>, bool> accepts;
+    private readonly Action<IReadOnlyList<string>> dropped;
+
+    private FileDropTarget(
+        Control root,
+        Func<IReadOnlyList<string>, bool> accepts,
+        Action<IReadOnlyList<string>> dropped)
+    {
+        this.root = root;
+        this.accepts = accepts;
+        this.dropped = dropped;
+    }
+
+    /// <summary>
+    /// Makes <paramref name="root"/> and everything inside it accept dropped files.
+    /// </summary>
+    /// <param name="accepts">
+    /// Whether this set of files can be opened right now. Asked on every drag move, so
+    /// it must be cheap, and asked again on the drop.
+    /// </param>
+    /// <param name="dropped">Opens the files. Called on the UI thread.</param>
+    internal static void Attach(
+        Control root,
+        Func<IReadOnlyList<string>, bool> accepts,
+        Action<IReadOnlyList<string>> dropped)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(accepts);
+        ArgumentNullException.ThrowIfNull(dropped);
+        new FileDropTarget(root, accepts, dropped).Register(root);
+    }
+
+    /// <summary>The files a drag carries, empty when it carries something else.</summary>
+    internal static IReadOnlyList<string> FilesOf(IDataObject? data) =>
+        CarriesFiles(data) && data!.GetData(DataFormats.FileDrop) is string[] files
+            ? files
+            : [];
+
+    /// <summary>
+    /// Whether a drag carries files at all — what another control's own drag handler
+    /// asks before refusing a drag, so that refusing its own kind does not also refuse
+    /// the window's.
+    /// </summary>
+    internal static bool CarriesFiles(IDataObject? data) =>
+        data != null && data.GetDataPresent(DataFormats.FileDrop);
+
+    private void Register(Control control)
+    {
+        if (!registered.Add(control))
+        {
+            return;
+        }
+
+        control.AllowDrop = true;
+        control.DragEnter += HandleDragOver;
+        control.DragOver += HandleDragOver;
+        control.DragDrop += HandleDragDrop;
+        control.ControlAdded += HandleControlAdded;
+        control.Disposed += HandleDisposed;
+        foreach (Control child in control.Controls)
+        {
+            Register(child);
+        }
+    }
+
+    private void HandleControlAdded(object? sender, ControlEventArgs e)
+    {
+        if (e.Control != null)
+        {
+            Register(e.Control);
+        }
+    }
+
+    private void HandleDisposed(object? sender, EventArgs e)
+    {
+        if (sender is Control control)
+        {
+            registered.Remove(control);
+        }
+    }
+
+    private void HandleDragOver(object? sender, DragEventArgs e)
+    {
+        IReadOnlyList<string> files = FilesOf(e.Data);
+        if (files.Count == 0)
+        {
+            // Somebody else's drag — a filter strip being moved within its bank.
+            // Leaving the effect alone is what keeps this from cancelling it.
+            return;
+        }
+
+        e.Effect = CanAccept(files) ? DragDropEffects.Copy : DragDropEffects.None;
+    }
+
+    private void HandleDragDrop(object? sender, DragEventArgs e)
+    {
+        IReadOnlyList<string> files = FilesOf(e.Data);
+        if (files.Count == 0 || !CanAccept(files))
+        {
+            return;
+        }
+
+        e.Effect = DragDropEffects.Copy;
+        dropped(files);
+    }
+
+    private bool CanAccept(IReadOnlyList<string> files) =>
+        IsTakingInput() && accepts(files);
+
+    /// <summary>
+    /// Whether the window is taking input at all. A modal dialog — the application's
+    /// own, or a common one such as Open File — disables its owner at the window level
+    /// while it is up, and the managed <see cref="Control.Enabled"/> flag does not say
+    /// so. Without this a file dropped on the window behind a dialog would be opened
+    /// underneath it, replacing the very measurement the dialog is asking about.
+    /// </summary>
+    private bool IsTakingInput() =>
+        root.IsHandleCreated && IsWindowEnabled(root.Handle);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindowEnabled(IntPtr hWnd);
+}

--- a/tests/Resonalyze.App.Tests/DroppedFileTests.cs
+++ b/tests/Resonalyze.App.Tests/DroppedFileTests.cs
@@ -1,0 +1,217 @@
+using System.Drawing;
+using System.Text;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// A file dragged onto the window is opened by what it IS rather than by whichever
+/// button the user found, so the reading is what decides the mode it lands in. These
+/// pin it against files the application's own writers produce — a marker moved or
+/// renamed on one side of that pairing would otherwise send a measurement to the
+/// wrong loader with nothing to say it had.
+/// </summary>
+public sealed class DroppedFileTests : IDisposable
+{
+    private readonly string directory = Directory.CreateTempSubdirectory(
+        "resonalyze-dropped-").FullName;
+
+    public void Dispose() => Directory.Delete(directory, recursive: true);
+
+    [Fact]
+    public async Task AnImpulseResponseIsReadFromWhatItsOwnWriterWrote()
+    {
+        string path = Path.Combine(directory, "measurement.json");
+        var file = new ImpulseResponseFile
+        {
+            SavedAtUtc = DateTimeOffset.UnixEpoch,
+            SampleRate = 48_000,
+            Bits = 24,
+            Octaves = 10,
+            SweepDurationSeconds = 1.5,
+            SweepDeconvolutionPeakIndex = 1,
+            SweepDeconvolutionRealSamples = [0.125, 1.0, -0.25, 0.0]
+        };
+        await file.SaveAsync(path);
+
+        Assert.Equal(DroppedFileKind.ImpulseResponse, DroppedFile.Classify(path));
+    }
+
+    [Fact]
+    public void ASpatialAverageCaptureIsReadFromWhatItsOwnWriterWrote()
+    {
+        string path = Path.Combine(directory, "capture.json");
+        BuildCapture().Save(path);
+
+        Assert.Equal(DroppedFileKind.SpatialAverageCapture, DroppedFile.Classify(path));
+    }
+
+    [Fact]
+    public void AVirtualDspSessionIsReadFromWhatItsOwnWriterWrote()
+    {
+        string path = Path.Combine(directory, "session.json");
+        new VirtualCrossoverProjectFile().SaveTo(path);
+
+        Assert.Equal(DroppedFileKind.VirtualDspSession, DroppedFile.Classify(path));
+    }
+
+    [Fact]
+    public void AnOverlaySlotIsRecognizedSoItCanBeRefusedByName()
+    {
+        // The overlay panel addresses these by slot, so a drop has nothing to open —
+        // but the file is one this application wrote, and "unsupported format" would
+        // be a lie about it.
+        new OverlayFile
+        {
+            SavedAtUtc = DateTimeOffset.UnixEpoch,
+            Mode = Mode.FrequencyResponse,
+            Slot = 2,
+            Title = "left tweeter",
+            ColorArgb = Color.Orange.ToArgb(),
+            Points = [new OverlayPoint(20, 80), new OverlayPoint(20_000, 70)]
+        }.Save(directory);
+
+        Assert.Equal(
+            DroppedFileKind.OverlaySlot,
+            DroppedFile.Classify(OverlayFile.GetPath(Mode.FrequencyResponse, 2, directory)));
+    }
+
+    [Fact]
+    public void TheMarkerIsSniffedRatherThanTheDocumentParsed()
+    {
+        // An impulse response runs to tens of megabytes, which is why only the head of
+        // the file is read. Truncated in the middle of its samples it is still an
+        // impulse response — and a classifier that deserialized to find out would
+        // refuse this one and hand it to the wrong loader to be misdiagnosed.
+        string path = Path.Combine(directory, "truncated.json");
+        File.WriteAllText(
+            path,
+            "{\r\n  \"format\": \"resonalyze-impulse-response\",\r\n  \"version\": 7,\r\n" +
+            "  \"sweepDeconvolutionRealSamples\": [0.1, 0.2, 0.3");
+
+        Assert.Equal(DroppedFileKind.ImpulseResponse, DroppedFile.Classify(path));
+    }
+
+    [Fact]
+    public void AByteOrderMarkDoesNotHideTheFormat()
+    {
+        string path = Path.Combine(directory, "bom.json");
+        File.WriteAllText(
+            path,
+            "{\"format\": \"resonalyze-virtual-crossover\", \"version\": 8}",
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+        Assert.Equal(DroppedFileKind.VirtualDspSession, DroppedFile.Classify(path));
+    }
+
+    [Fact]
+    public void AFormatNestedInsideTheDocumentDoesNotNameIt()
+    {
+        // A capture's recipe, a session's channel: a nested marker describes a PART of
+        // the document, and answering with it would open the file as one of its own
+        // pieces.
+        string path = Path.Combine(directory, "nested.json");
+        File.WriteAllText(
+            path,
+            "{\"recipe\": {\"format\": \"resonalyze-live-capture\"}, " +
+            "\"format\": \"resonalyze-impulse-response\"}");
+
+        Assert.Equal(DroppedFileKind.ImpulseResponse, DroppedFile.Classify(path));
+    }
+
+    [Theory]
+    [InlineData("declared", "{\"format\": \"something-else\"}")]
+    [InlineData("undeclared", "{\"version\": 7}")]
+    [InlineData("array", "[1, 2, 3]")]
+    [InlineData("prose", "not json at all")]
+    [InlineData("empty", "")]
+    public void JsonThatDeclaresNothingWeWriteIsNotOpened(string name, string content)
+    {
+        string path = Path.Combine(directory, $"foreign-{name}.json");
+        File.WriteAllText(path, content);
+
+        Assert.Equal(DroppedFileKind.Unknown, DroppedFile.Classify(path));
+    }
+
+    [Fact]
+    public void AMissingFileIsSimplyNotOurs()
+    {
+        // A drop can name a file that has gone since the drag began; the answer is the
+        // same "cannot open this" a foreign file gets, not an exception on the UI
+        // thread.
+        Assert.Equal(
+            DroppedFileKind.Unknown,
+            DroppedFile.Classify(Path.Combine(directory, "gone.json")));
+    }
+
+    [Theory]
+    [InlineData("sweep.wav")]
+    [InlineData("SWEEP.WAV")]
+    public void ARecordedSweepIsTakenAtItsExtension(string name)
+    {
+        // The sweep and REW importers read the file properly and report what is wrong
+        // with it; a second opinion formed here out of a few kilobytes could only be a
+        // worse-informed one. The file need not even exist for this answer.
+        Assert.Equal(
+            DroppedFileKind.RecordedSweep,
+            DroppedFile.Classify(Path.Combine(directory, name)));
+    }
+
+    [Fact]
+    public void ATextFileIsTakenAsTheRewExportTheLoadDialogTakesItFor() =>
+        Assert.Equal(
+            DroppedFileKind.RewImpulseResponseExport,
+            DroppedFile.Classify(Path.Combine(directory, "rew-export.txt")));
+
+    [Theory]
+    [InlineData("notes.pdf")]
+    [InlineData("no-extension")]
+    public void AnExtensionTheShellNeverOpensIsNotOurs(string name) =>
+        Assert.Equal(
+            DroppedFileKind.Unknown,
+            DroppedFile.Classify(Path.Combine(directory, name)));
+
+    [Theory]
+    [InlineData("measurement.json", true)]
+    [InlineData("sweep.wav", true)]
+    [InlineData("export.TXT", true)]
+    [InlineData("photo.png", false)]
+    public void TheHoverTestStopsAtTheExtension(string name, bool openable)
+    {
+        // Asked on every mouse move while a drag hovers, so it must not touch the
+        // disk: what the file holds is read once, on the drop.
+        Assert.Equal(openable, DroppedFile.HasOpenableExtension(name));
+    }
+
+    private static LiveCaptureDocument BuildCapture()
+    {
+        const int sampleRate = 48_000;
+        const int sequenceLength = 32_768;
+        var spectrum = new double[sequenceLength / 2 + 1];
+        Array.Fill(spectrum, -60.0);
+        return new LiveCaptureDocument
+        {
+            SavedAtUtc = DateTimeOffset.UnixEpoch,
+            Title = "left tweeter",
+            SpectrumDb = spectrum,
+            CurveDb = new double[LiveCaptureDocument.CurvePointCount],
+            GridStartHz = 20,
+            GridStopHz = 20_000,
+            Recipe = new LiveCaptureRecipe
+            {
+                AnalysisMode = LiveAnalysisMode.Mmm,
+                SampleRateHz = sampleRate,
+                SequenceLength = sequenceLength,
+                FrameMilliseconds = 1000.0 * sequenceLength / sampleRate,
+                WindowType = WindowType.Rectangular,
+                WindowEnbwBins = Windowing.EquivalentNoiseBandwidthBins(
+                    WindowType.Rectangular, sequenceLength),
+                WindowMainLobeBins = Windowing.MainLobeWidthBins(WindowType.Rectangular),
+                AveragedFrameCount = 130,
+                IntegratedSeconds = 130.0 * sequenceLength / sampleRate,
+                SlopeCompensation = true,
+                MagnitudeScale = MagnitudeScale.SoundPressureLevel
+            }
+        };
+    }
+}

--- a/tests/Resonalyze.App.Tests/FileDropTargetTests.cs
+++ b/tests/Resonalyze.App.Tests/FileDropTargetTests.cs
@@ -1,0 +1,244 @@
+using System.Drawing;
+using System.Reflection;
+using System.Windows.Forms;
+using OxyPlot.WindowsForms;
+using Resonalyze.Ui;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The window accepts a dropped file anywhere on itself, which in WinForms means
+/// every control on it has to be registered as a drop target: drag events do not
+/// bubble, and a control that never registered refuses the drag where it stands.
+/// These pin that reach, and the two things it must not do — take a drag that
+/// belongs to somebody else, or open a file while a dialog has the window.
+/// </summary>
+public sealed class FileDropTargetTests
+{
+    [Fact]
+    public void EveryControlOnTheWindowTakesTheDrag() => StaTest.Run(() =>
+    {
+        using Form form = ShownForm();
+        var panel = new Panel { Size = new Size(80, 80) };
+        var button = new Button { Size = new Size(40, 20) };
+        panel.Controls.Add(button);
+        form.Controls.Add(panel);
+
+        FileDropTarget.Attach(form, _ => true, _ => { });
+
+        Assert.True(form.AllowDrop);
+        Assert.True(panel.AllowDrop);
+        Assert.True(button.AllowDrop);
+    });
+
+    [Fact]
+    public void AControlBuiltLaterRegistersItself() => StaTest.Run(() =>
+    {
+        // Mode settings are docked in on demand and filter strips are built as they
+        // are added, so the tree the shell shows is not the tree it started with.
+        using Form form = ShownForm();
+        var panel = new Panel();
+        form.Controls.Add(panel);
+        FileDropTarget.Attach(form, _ => true, _ => { });
+
+        var late = new Label();
+        var laterStill = new Button();
+        late.Controls.Add(laterStill);
+        panel.Controls.Add(late);
+
+        Assert.True(late.AllowDrop);
+        Assert.True(laterStill.AllowDrop);
+    });
+
+    [Fact]
+    public void ARichTextBoxTakesTheDragLikeAnythingElse() => StaTest.Run(() =>
+    {
+        // Time Alignment fills much of its panel with a read-only RichTextBox, and
+        // that is the one control type whose AllowDrop goes down a path of its own —
+        // the native RichEdit drop target rather than the WinForms one. Pinned
+        // because a control that threw here would take the whole shell's wiring with
+        // it at construction, not just its own corner of the window.
+        using Form form = ShownForm();
+        var box = new RichTextBox { Size = new Size(100, 60), ReadOnly = true };
+        form.Controls.Add(box);
+
+        FileDropTarget.Attach(form, _ => true, _ => { });
+        box.CreateControl();
+        DragEventArgs drag = RaiseDragOver(box, Files("measurement.json"));
+
+        Assert.True(box.AllowDrop);
+        Assert.Equal(DragDropEffects.Copy, drag.Effect);
+    });
+
+    [Fact]
+    public void AFileOverADeepChildIsOffered() => StaTest.Run(() =>
+    {
+        using Form form = ShownForm();
+        Button button = DeepChild(form);
+        FileDropTarget.Attach(form, _ => true, _ => { });
+
+        DragEventArgs drag = RaiseDragOver(button, Files("measurement.json"));
+
+        Assert.Equal(DragDropEffects.Copy, drag.Effect);
+    });
+
+    [Fact]
+    public void AFileTheShellCannotOpenIsRefusedWhileItHovers() => StaTest.Run(() =>
+    {
+        using Form form = ShownForm();
+        Button button = DeepChild(form);
+        FileDropTarget.Attach(form, _ => false, _ => Assert.Fail("must not open"));
+
+        DragEventArgs drag = RaiseDragOver(button, Files("photo.png"));
+        RaiseDragDrop(button, Files("photo.png"));
+
+        Assert.Equal(DragDropEffects.None, drag.Effect);
+    });
+
+    [Fact]
+    public void SomebodyElseSDragIsLeftExactlyAsItWas() => StaTest.Run(() =>
+    {
+        // The EQ wizard moves its filter strips by dragging, over the very controls
+        // this is registered on. Its drag carries no files, and clearing the effect
+        // here would cancel a move the bank had already accepted.
+        using Form form = ShownForm();
+        Button button = DeepChild(form);
+        FileDropTarget.Attach(form, _ => true, _ => Assert.Fail("must not open"));
+
+        var payload = new DataObject();
+        payload.SetData("a PEQ strip");
+        DragEventArgs drag = RaiseDragOver(button, payload, effect: DragDropEffects.Move);
+        RaiseDragDrop(button, payload);
+
+        Assert.Equal(DragDropEffects.Move, drag.Effect);
+    });
+
+    [Fact]
+    public void ADroppedFileReachesTheShellByName() => StaTest.Run(() =>
+    {
+        using Form form = ShownForm();
+        Button button = DeepChild(form);
+        List<string>? opened = null;
+        FileDropTarget.Attach(form, _ => true, files => opened = [.. files]);
+
+        RaiseDragDrop(button, Files("capture.json"));
+
+        Assert.Equal(["capture.json"], opened);
+    });
+
+    [Fact]
+    public void AWindowThatIsNotTakingInputTakesNoFileEither() => StaTest.Run(() =>
+    {
+        // What a modal dialog leaves behind: the owner window is disabled while the
+        // dialog is up. A file opened underneath one would replace the very
+        // measurement the dialog is asking about.
+        using Form form = ShownForm();
+        Button button = DeepChild(form);
+        FileDropTarget.Attach(form, _ => true, _ => Assert.Fail("must not open"));
+        form.Enabled = false;
+
+        DragEventArgs drag = RaiseDragOver(button, Files("measurement.json"));
+        RaiseDragDrop(button, Files("measurement.json"));
+
+        Assert.Equal(DragDropEffects.None, drag.Effect);
+    });
+
+    [Fact]
+    public void ADragCarryingNoFilesReadsAsEmptyRatherThanThrowing()
+    {
+        var payload = new DataObject();
+        payload.SetData("a PEQ strip");
+
+        Assert.Empty(FileDropTarget.FilesOf(payload));
+        Assert.Empty(FileDropTarget.FilesOf(null));
+        Assert.False(FileDropTarget.CarriesFiles(payload));
+        Assert.False(FileDropTarget.CarriesFiles(null));
+    }
+
+    [Fact]
+    public void ThePanelsTheShellShowsAllTakeBeingMadeDropTargets() => StaTest.Run(() =>
+    {
+        // Registering means setting AllowDrop on every control the window carries,
+        // and a control type that refused would throw where the shell wires this up:
+        // in its constructor, taking the whole application with it rather than one
+        // corner of one panel. The heavy panels are built and realized here for that
+        // reason — a plot, a rich text box, faders, numeric boxes and combos among
+        // them — and the assert is simply that they are all drop targets afterwards.
+        using Form form = ShownForm();
+        var wizard = new EqWizardPanel();
+        var virtualDsp = new VirtualCrossoverPanel();
+        var timeAlignment = new TimeAlignmentPanel();
+        var plot = new PlotView();
+        form.Controls.AddRange([wizard, virtualDsp, timeAlignment, plot]);
+
+        FileDropTarget.Attach(form, _ => true, _ => { });
+
+        foreach (Control control in Descendants(form))
+        {
+            Assert.True(control.AllowDrop, $"{control.GetType().Name} takes no drop");
+        }
+    });
+
+    private static IEnumerable<Control> Descendants(Control root)
+    {
+        foreach (Control child in root.Controls)
+        {
+            yield return child;
+            foreach (Control descendant in Descendants(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    private static Form ShownForm()
+    {
+        // Off screen: these realize a handle (a drop target is registered with OLE at
+        // that moment) without a window flashing over the test run.
+        var form = new Form
+        {
+            ShowInTaskbar = false,
+            StartPosition = FormStartPosition.Manual,
+            Location = new Point(-4000, -4000),
+            ClientSize = new Size(200, 200)
+        };
+        form.Show();
+        return form;
+    }
+
+    private static Button DeepChild(Form form)
+    {
+        var panel = new Panel { Size = new Size(120, 120) };
+        var button = new Button { Size = new Size(60, 24) };
+        panel.Controls.Add(button);
+        form.Controls.Add(panel);
+        return button;
+    }
+
+    private static DataObject Files(params string[] names)
+    {
+        var payload = new DataObject();
+        payload.SetData(DataFormats.FileDrop, names);
+        return payload;
+    }
+
+    private static DragEventArgs RaiseDragOver(
+        Control control, IDataObject data, DragDropEffects effect = DragDropEffects.None) =>
+        Raise(control, "OnDragOver", data, effect);
+
+    private static DragEventArgs RaiseDragDrop(
+        Control control, IDataObject data, DragDropEffects effect = DragDropEffects.None) =>
+        Raise(control, "OnDragDrop", data, effect);
+
+    // The framework raises these; a test has no drag to make it do so, so the event
+    // is raised the way the framework would and the handlers run as they really do.
+    private static DragEventArgs Raise(
+        Control control, string method, IDataObject data, DragDropEffects effect)
+    {
+        var args = new DragEventArgs(data, 0, 0, 0, DragDropEffects.All, effect);
+        typeof(Control)
+            .GetMethod(method, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(control, [args]);
+        return args;
+    }
+}

--- a/tests/Resonalyze.App.Tests/JsonFormatMarkerTests.cs
+++ b/tests/Resonalyze.App.Tests/JsonFormatMarkerTests.cs
@@ -69,6 +69,24 @@ public sealed class JsonFormatMarkerTests : IDisposable
                 new UTF8Encoding(encoderShouldEmitUTF8Identifier: true)));
 
     [Fact]
+    public void ACommentBeforeTheMarkerIsSkippedTheWayTheReadersSkipIt()
+    {
+        // Every document reader is configured to skip comments and to accept a
+        // trailing comma, so a hand-edited file carrying either is a file they would
+        // open. Turning it away here would send a capture to the impulse-response
+        // loader to be misreported as an unsupported format.
+        string json = string.Join(
+            Environment.NewLine,
+            "{",
+            "  // taken in the back seat",
+            "  \"title\": \"l tw\",",
+            "  \"format\": \"resonalyze-live-capture\",",
+            "}");
+
+        Assert.Equal("resonalyze-live-capture", Marker(json));
+    }
+
+    [Fact]
     public void TheNameIsMatchedAsStrictlyAsTheDeserializerMatchesIt() =>
         // None of the readers' options ask for case-insensitive property names, so a
         // file writing "Format" does not bind there — and must not read as declared

--- a/tests/Resonalyze.App.Tests/JsonFormatMarkerTests.cs
+++ b/tests/Resonalyze.App.Tests/JsonFormatMarkerTests.cs
@@ -1,0 +1,107 @@
+using System.Text;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// Every reader of a Resonalyze JSON document asks this before it opens one, and what
+/// it must be is two things at once: cheap enough to run on a file it is about to
+/// decline — an impulse response is tens of megabytes, and being asked "are you a
+/// capture?" used to parse all of it — and as well informed as the deserializer it
+/// stands in front of, since a wrong answer routes a measurement to the wrong loader.
+/// </summary>
+public sealed class JsonFormatMarkerTests : IDisposable
+{
+    private readonly string directory = Directory.CreateTempSubdirectory(
+        "resonalyze-marker-").FullName;
+
+    public void Dispose() => Directory.Delete(directory, recursive: true);
+
+    [Fact]
+    public void TheFirstPropertyIsWhereOurDocumentsCarryIt() =>
+        Assert.Equal(
+            "resonalyze-impulse-response",
+            Marker("{\"format\": \"resonalyze-impulse-response\", \"version\": 7}"));
+
+    [Fact]
+    public void AMarkerBeyondTheFirstChunkIsStillFound()
+    {
+        // Our writers put it first, but a document that has been through another tool
+        // — re-serialized with its keys sorted, say — can carry it past any fixed
+        // window into the file. The walk therefore continues chunk by chunk rather
+        // than giving up at a cut-off, which is what keeps this exactly as informed
+        // as the full parse it replaces.
+        var json = new StringBuilder("{\"curveDb\": [");
+        json.AppendJoin(", ", Enumerable.Range(0, 40_000));
+        json.Append("], \"format\": \"resonalyze-live-capture\"}");
+
+        Assert.True(json.Length > 128 * 1024, $"only {json.Length} characters");
+        Assert.Equal("resonalyze-live-capture", Marker(json.ToString()));
+    }
+
+    [Fact]
+    public void AMarkerSplitAcrossAChunkBoundaryIsReadWhole()
+    {
+        // The property name can land at the end of one chunk and its value in the
+        // next. The reader's state crosses with it; a walk that started each chunk
+        // fresh would lose the value it was in the middle of.
+        var json = new StringBuilder("{\"pad\": \"");
+        json.Append('x', 64 * 1024 - 16);
+        json.Append("\", \"format\": \"resonalyze-virtual-crossover\"}");
+
+        Assert.Equal("resonalyze-virtual-crossover", Marker(json.ToString()));
+    }
+
+    [Fact]
+    public void OnlyTheRootObjectsOwnPropertyCounts() =>
+        // A nested marker names a PART of the document — a recipe, a channel — and
+        // answering with it would open the file as the thing inside it.
+        Assert.Equal(
+            "resonalyze-overlay",
+            Marker("{\"recipe\": {\"format\": \"resonalyze-live-capture\"}, " +
+                "\"format\": \"resonalyze-overlay\"}"));
+
+    [Fact]
+    public void AByteOrderMarkIsNotPartOfTheDocument() =>
+        Assert.Equal(
+            "resonalyze-live-capture",
+            Marker(
+                "{\"format\": \"resonalyze-live-capture\"}",
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: true)));
+
+    [Fact]
+    public void TheNameIsMatchedAsStrictlyAsTheDeserializerMatchesIt() =>
+        // None of the readers' options ask for case-insensitive property names, so a
+        // file writing "Format" does not bind there — and must not read as declared
+        // here either, or the probe would send a file to a loader that then refuses
+        // it for carrying no format at all.
+        Assert.Null(Marker("{\"Format\": \"resonalyze-impulse-response\"}"));
+
+    [Theory]
+    [InlineData("{\"version\": 7}")]
+    [InlineData("{}")]
+    [InlineData("[{\"format\": \"resonalyze-overlay\"}]")]
+    [InlineData("\"resonalyze-overlay\"")]
+    [InlineData("not json at all")]
+    [InlineData("")]
+    public void ADocumentThatDeclaresNothingReadsAsNothing(string json) =>
+        Assert.Null(Marker(json));
+
+    [Fact]
+    public void ATruncatedDocumentStillDeclaresWhatItGotTo() =>
+        // Where the saving of a large measurement was interrupted: the head is intact
+        // and says what it is, which is all this answers.
+        Assert.Equal(
+            "resonalyze-impulse-response",
+            Marker("{\"format\": \"resonalyze-impulse-response\", \"samples\": [1, 2"));
+
+    [Fact]
+    public void AFileThatIsNotThereReadsAsNothing() =>
+        Assert.Null(JsonFormatMarker.Read(Path.Combine(directory, "gone.json")));
+
+    private string Marker(string json, Encoding? encoding = null)
+    {
+        string path = Path.Combine(directory, $"probe-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, json, encoding ?? new UTF8Encoding(false));
+        return JsonFormatMarker.Read(path)!;
+    }
+}

--- a/tests/Resonalyze.App.Tests/LiveCaptureDocumentTests.cs
+++ b/tests/Resonalyze.App.Tests/LiveCaptureDocumentTests.cs
@@ -176,6 +176,29 @@ public sealed class LiveCaptureDocumentTests
     }
 
     [Fact]
+    public void ADamagedCaptureThrowsRatherThanBeingDisowned()
+    {
+        // The file says what it is in its head and then breaks off — a save
+        // interrupted, a truncated copy. That is a capture that cannot be read, and
+        // reporting it as one is the whole point of claiming by format: handed on as
+        // "not ours" it reaches the impulse-response loader, which tells the user
+        // their capture is an impulse response of an unsupported format.
+        string path = Path.Combine(Path.GetTempPath(), $"damaged-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                path,
+                $"{{\"format\":\"{LiveCaptureDocument.CurrentFormat}\",\"curveDb\":[0.1, 0.2");
+            Assert.Throws<InvalidDataException>(
+                () => LiveCaptureDocument.TryLoad(path, out _));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void ASnapshotCarriesTheFrameCountItsSpectraAverage()
     {
         // The count and the bins must come from one read: a capture that pairs this


### PR DESCRIPTION
A file dragged onto the window from Explorer now opens as if it had been picked
through the button that owns it, and lands in the mode it belongs to. An impulse
response — or a `.wav` sweep recording, or a REW `.txt` export — goes to the
analyzers, on Frequency Response when the mode in front of the user has nowhere to
show it. A moving-mic capture goes to Live Spectrum under its own recipe. A Virtual
DSP session opens the tool and imports it exactly as **Load session...** does, the
offer to relink missing measurements included. An overlay slot file is refused by
name rather than as an unsupported format: this application wrote it, and saying
otherwise about one's own file is a lie the user has no way to check.

Which document a file holds is read from the file. The four JSON documents declare a
`format` marker, and it is read out of the head of the file rather than by
deserializing candidate types in turn to see which one does not throw — a token walk
that carries the reader's state from chunk to chunk, so only a property of the ROOT
object counts (a nested `format` names a recipe or a channel, and answering with it
would open a document as the thing inside it) and the walk still finds a marker that
another tool has re-serialized past any fixed window. The probe reads on exactly the
terms the deserializers behind it do, in both directions: their options accept
comments and trailing commas, so it does too — a file they would open must not be
turned away at the door — and none of them ask for case-insensitive property names,
so `format` matches and `Format` does not.

That probe also fixes something that was already there. `LiveCaptureDocument.TryLoad`
is asked of EVERY file the shared Load path opens, and it answered "not mine" by
deserializing the whole document first: a 49.7 MB impulse response took 122 ms and
the allocations of a full parse to be told apart from a capture, on every single
load. It now reads the marker and declines without parsing — under a millisecond,
same verdict. Claiming by the marker also closes the gap the method's own comment
described: a file whose head says "capture" and whose body then fails to PARSE was
disowned as somebody else's, and reached the impulse-response loader to be reported
as an unsupported format. It throws now, as it already did for a capture that fails
to validate.

Drag events do not bubble in WinForms: only the control under the pointer is asked,
and one that never registered as a drop target refuses the drag where it stands. So
the whole control tree is registered, including the controls the shell builds later
(mode settings dock in on demand, filter strips are built as they are added). A drag
that carries no files is left exactly as it arrived, which is what keeps the EQ
wizard's own strip reordering working over the same controls; its handler now asks
the same question before refusing one, so the bank is not the one place a measurement
cannot be dropped. The window takes one file at a time, and refuses while a sweep is
running or while a dialog has the window — a file opened underneath a modal dialog
would replace the very measurement it is asking about.

Two smaller changes fall out of it. Both Load buttons and the drop now share one
`OpenMeasurementFileAsync`, so all three open a file the same way. And the Virtual DSP
panel's stored-project load became awaitable: a session dropped onto another mode
arrives through a tab switch that has only just told the panel to open, and the
autosave landing behind the import would have restored the session the user was
replacing.

Tests cover the marker probe (first property, past a chunk boundary, split across
one, a comment and a trailing comma, nested markers, byte-order mark, case, truncated
and foreign documents), the classification of files written by the real writers, the
damaged capture that must be reported as one, and the drop plumbing — that every
control takes the registration, that a control built later registers itself, that
somebody else's drag is untouched, and that a disabled window takes no file. The last
of those builds the real EQ Wizard, Virtual DSP and Time Alignment panels and
realizes them: a control type that refused `AllowDrop` would throw where this is
wired up, in the shell's constructor, taking the whole application with it rather
than one corner of one panel.

`REFERENCE.md` gains a "Dropping a file on the window" section, with pointers to it
from Live Spectrum and from the Virtual DSP panel commands.

The end-to-end drag itself is the one thing no test here exercises — an Explorer drag
cannot be raised from a test — so that is worth trying by hand once.
