### PR TITLE
Let a sub's own front stop vetoing the correlation that reads its band

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2102,12 +2102,17 @@ the two channels' **direct sound alone**: across a whole record a mid/tweeter
 handover's strongest extremum is often a reflection three to five periods from
 the arrival, and cutting to the wavefronts first is what keeps the seed on the
 right lobe. A seeding extremum that lands far from the coarse arrival is
-normally refused as a cycle skip; the exception is an arrival picked deep
-below its own band's energy. A subwoofer's direct front can sit 20-odd dB
-under the cabin build-up arriving behind it — a real front, and the right one
-to time the channel by — while the correlation reads where the energy is. The
-two are then different features, their difference is not a delay, and the
-front does not get to refuse the correlation for disagreeing with it. That
+refused as a cycle skip, and that distance check has one exception: an arrival
+picked deep below its own band's energy. A subwoofer's direct front can sit
+20-odd dB under the cabin build-up arriving behind it — a real front, and the
+right one to time the channel by — while the correlation reads where the energy
+is. The two are then different features and their difference is not a delay, so
+the front is in no position to refuse the correlation. It does not simply stand
+aside: the **direct-sound cut** is asked the same question instead, and the
+extremum is admitted only if the cut puts the pair on that same lobe, within a
+quarter period and in the same polarity. The distance check moves to a better
+witness rather than being dropped — where the cut disagrees, or is too weak or
+too close to its own window edge to speak, the refusal stands. That
 window is the junction's own: it opens on the earliest **front** of the two
 channels being joined, read in their shared band (never later than the peak, and
 falling back to it where the band carries no measurable arrival), and it is

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2107,12 +2107,18 @@ picked deep below its own band's energy. A subwoofer's direct front can sit
 20-odd dB under the cabin build-up arriving behind it — a real front, and the
 right one to time the channel by — while the correlation reads where the energy
 is. The two are then different features and their difference is not a delay, so
-the front is in no position to refuse the correlation. It does not simply stand
-aside: the **direct-sound cut** is asked the same question instead, and the
-extremum is admitted only if the cut puts the pair on that same lobe, within a
-quarter period and in the same polarity. The distance check moves to a better
-witness rather than being dropped — where the cut disagrees, or is too weak or
-too close to its own window edge to speak, the refusal stands. That
+the front is in no position to refuse the correlation. What happens next
+depends on the junction. Above ~1 kHz the **direct-sound cut** is asked the same
+question instead, and the extremum is admitted only if the cut puts the pair on
+that same lobe — the check moves to a better witness rather than being dropped,
+and where the cut disagrees, or is too weak or too close to its own window edge
+to speak, the refusal stands. Below that there is no such witness to move it to:
+the cut's window is measured in crossover periods, so at a bass junction it is
+tens of milliseconds long and holds the very build-up the arrival was picked
+under. There the extremum is admitted on its own strength instead, held to the
+same bar the direct-sound seed must clear rather than the floor a seed needs —
+a deliberately weaker footing, taken because at a low junction the dominant
+whitened extremum is what a hand tune lands on. That
 window is the junction's own: it opens on the earliest **front** of the two
 channels being joined, read in their shared band (never later than the peak, and
 falling back to it where the band carries no measurable arrival), and it is

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2101,7 +2101,13 @@ reflections do not steer it. Above ~1 kHz the seeding correlation is taken on
 the two channels' **direct sound alone**: across a whole record a mid/tweeter
 handover's strongest extremum is often a reflection three to five periods from
 the arrival, and cutting to the wavefronts first is what keeps the seed on the
-right lobe. That
+right lobe. A seeding extremum that lands far from the coarse arrival is
+normally refused as a cycle skip; the exception is an arrival picked deep
+below its own band's energy. A subwoofer's direct front can sit 20-odd dB
+under the cabin build-up arriving behind it — a real front, and the right one
+to time the channel by — while the correlation reads where the energy is. The
+two are then different features, their difference is not a delay, and the
+front does not get to refuse the correlation for disagreeing with it. That
 window is the junction's own: it opens on the earliest **front** of the two
 channels being joined, read in their shared band (never later than the peak, and
 falling back to it where the band carries no measurable arrival), and it is

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -268,8 +268,11 @@ public static class AutoAlignmentEngine
     // How far from the arrival estimate a trusted seed extremum may sit: half a
     // period — the next same-polarity lobe is a full period out, so that is the
     // no-cycle-skip bound — floored at the FIXED ±3 ms span rather than the
-    // grown window. At a low junction the grown window may SEE farther lobes
-    // but must never hand one to the timeline.
+    // grown window. At a low junction the grown window may SEE farther lobes,
+    // and a lobe past this bound reaches the timeline only when the arrival is
+    // in no position to judge it AND the direct-sound cut independently puts
+    // the pair on that same lobe (see SeedVetoMinProminenceDb) — never on the
+    // extremum's own say-so.
     private static double SeedReachMs(double crossoverHz) =>
         Math.Max(DiagnosticCorrelationRangeMs, 500.0 / crossoverHz);
 
@@ -302,15 +305,43 @@ public static class AutoAlignmentEngine
     /// direct-sound cut confirms at r 0.93, for disagreeing with it.
     /// </para>
     /// <para>
-    /// Half the detector's own search depth: a pick in the upper half of the
-    /// range is a shoulder on the band's energy and speaks for it, one in the
-    /// lower half is a separate feature. The gate only ever WITHDRAWS the
-    /// anchor's veto, never moves it — the seed, the window centre, the prior
-    /// and the fallback are untouched, and the extremum still has to pass its
-    /// own trust gates.
+    /// Half the detector's own search depth, derived from it so the two cannot
+    /// drift apart: a pick in the upper half of the range is a shoulder on the
+    /// band's energy and speaks for it, one in the lower half is a separate
+    /// feature.
+    /// </para>
+    /// <para>
+    /// A deep pick alone is NOT enough to withdraw the veto. The reach is the
+    /// last distance constraint the seed has — the correlation window sees a
+    /// period and a quarter to each side precisely so the neighbouring lobes
+    /// are visible, and every other trust gate on the extremum is a quality
+    /// test (|r|, a rival margin, an edge pin), none of which can tell one
+    /// lobe from the next. Withdrawing it on a prominence figure alone would
+    /// leave a whole-period cycle skip legal, and stage 2 cannot undo one: its
+    /// window reaches the opposite-polarity partner half a period out, not the
+    /// same-polarity lobe a full period out. So the deep pick only opens the
+    /// question, and <see cref="DirectSeedMinCoefficient"/>'s witness answers
+    /// it — the direct-sound cut has to land on the SAME lobe, within a
+    /// quarter period and in the same polarity. That witness is what the
+    /// arrival was standing in for: an independent read of where the two
+    /// wavefronts line up, taken on the cuts the reflections never enter.
     /// </para>
     /// </summary>
-    private const double SeedVetoMinProminenceDb = -12.5;
+    private const double SeedVetoMinProminenceDb =
+        -TimeAlignmentAnalysisOptions.DefaultFirstPeakThresholdBelowMaxDb / 2.0;
+
+    /// <summary>
+    /// How close the direct-sound witness must sit to the full-record extremum
+    /// to be corroborating it rather than contradicting it: a quarter period,
+    /// the same "on this lobe" tolerance the joint-support adjudication uses.
+    /// Half a period away is the opposite-polarity partner and a full period
+    /// away is the cycle skip the reach veto exists to refuse — neither is
+    /// corroboration. Measured on the field cabin: at the three junctions whose
+    /// anchor is a deep pick the two extrema agree to 0.00-0.02 of a period,
+    /// while at every junction whose anchor is honest they disagree by 0.54 to
+    /// 3.88 periods.
+    /// </summary>
+    private const double DirectCorroborationPeriods = 0.25;
 
     /// <summary>
     /// The margin by which the seed extremum must beat the SAME-POLARITY rival
@@ -1722,6 +1753,57 @@ public static class AutoAlignmentEngine
             bool anchorIsRawReads =
                 !lowerLatchedByPrediction && !upperLatchedByPrediction &&
                 !unreplacedLatch;
+
+            // The witness that replaces the deep arrival as the seed's distance
+            // constraint: the same whitened correlation on the two channels'
+            // DIRECT-SOUND cuts, held to the trust gates the direct seed itself
+            // must pass above (no edge pin, DirectSeedMinCoefficient, and a
+            // margin over its own same-sign rival). Computed on demand and only
+            // where the exception is live, so a junction that never asks pays
+            // nothing — and reused where the cut has already been taken for the
+            // seed path. Deliberately NOT a seed of its own below
+            // DirectSeedMinCrossoverHz: it only ever answers "is the pair on
+            // this lobe", which is the one question the arrival could not.
+            CorrelationDelayCandidate? DirectCorroboration()
+            {
+                CorrelationAlignmentResult? witness = directPhat;
+                if (witness == null)
+                {
+                    (Complex[] lowerCut, Complex[] upperCut) =
+                        VirtualCrossoverAnalysis.CutDirectSoundPair(
+                            pair.Lower.ImpulseResponse,
+                            pair.Upper.ImpulseResponse,
+                            pair.Lower.Channel.SampleRate,
+                            pair.BandLowHz,
+                            pair.BandHighHz,
+                            pair.CrossoverHz,
+                            SeedCorrelationRangeMs(pair.CrossoverHz),
+                            pair.Lower.ValidRange,
+                            pair.Upper.ValidRange);
+                    witness = VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
+                        lowerCut,
+                        upperCut,
+                        pair.Lower.Channel.SampleRate,
+                        pair.CrossoverHz,
+                        passOctaves,
+                        SeedCorrelationRangeMs(pair.CrossoverHz),
+                        centerLagMs,
+                        phaseTransform: true);
+                }
+
+                CorrelationDelayCandidate best = witness.BestByMagnitude;
+                CorrelationDelayCandidate? rival = best.InvertPolarity
+                    ? witness.NegativeRival
+                    : witness.PositiveRival;
+                return !witness.PositivePeak.EdgePinned &&
+                    !witness.NegativeTrough.EdgePinned &&
+                    Math.Abs(best.Coefficient) >= DirectSeedMinCoefficient &&
+                    (rival == null ||
+                        Math.Abs(best.Coefficient) - Math.Abs(rival.Coefficient) >=
+                            PhatSeedMinRivalDominance)
+                    ? best
+                    : null;
+            }
             Complex[] lowerDirectCut = [];
             Complex[] upperDirectCut = [];
 
@@ -1747,13 +1829,18 @@ public static class AutoAlignmentEngine
                     return "same-polarity rival near-tie";
                 }
                 // The reach veto grades the extremum against the arrival, so it
-                // is lifted only once the pair is RE-ANCHORED on honest
-                // half-band reads: against a convicted-and-replaced anchor it
-                // would enforce the very cycle skip it exists to prevent. A
-                // conviction without a replacement anchor keeps the veto — the
-                // window is still centered on the corrupted diff, and a strong
-                // distant modal peak found there is exactly the skip candidate
-                // the veto guards.
+                // stands down in two cases, and only two. The pair may have been
+                // RE-ANCHORED on honest half-band reads: against a
+                // convicted-and-replaced anchor the veto would enforce the very
+                // cycle skip it exists to prevent. Or the arrival that would
+                // enforce it may be a pick deep under its own band's energy, in
+                // which case the direct-sound cut is asked to put the pair on
+                // the extremum's lobe itself (see SeedVetoMinProminenceDb) — the
+                // veto is transferred to a better witness, not dropped. A
+                // conviction WITHOUT a replacement anchor keeps it either way —
+                // the window is still centered on the corrupted diff, and a
+                // strong distant modal peak found there is exactly the skip
+                // candidate the veto guards.
                 //
                 // A pair whose anchor could not place it inside a lobe has
                 // already been convicted and re-anchored above, which clears
@@ -1800,12 +1887,22 @@ public static class AutoAlignmentEngine
                 if (!arrivalReanchored && Math.Abs(seedOffsetMs) >= reachMs)
                 {
                     // Unless the anchor is not the same kind of read as the
-                    // extremum it would be vetoing (see
+                    // extremum it would be vetoing AND a better witness puts the
+                    // pair on that extremum's lobe (see
                     // SeedVetoMinProminenceDb). One side picked deep under its
                     // own band's energy and the other on top of it: their
-                    // difference is not a delay the reach can grade.
+                    // difference is not a delay the reach can grade. The
+                    // constraint is transferred, not dropped — the direct-sound
+                    // cut has to agree within a quarter period and in the same
+                    // polarity, which is a lobe test the arrival could not
+                    // perform and the extremum's own quality gates do not
+                    // attempt.
                     if (!anchorIsRawReads ||
-                        anchorProminenceDb >= SeedVetoMinProminenceDb)
+                        anchorProminenceDb >= SeedVetoMinProminenceDb ||
+                        DirectCorroboration() is not { } corroboration ||
+                        corroboration.InvertPolarity != seed.InvertPolarity ||
+                        Math.Abs(corroboration.DelayMs - seed.DelayMs) >
+                            DirectCorroborationPeriods * 1000.0 / pair.CrossoverHz)
                     {
                         return $"{seedLabel} beyond the arrival's reach";
                     }
@@ -1816,8 +1913,10 @@ public static class AutoAlignmentEngine
                         $"from the arrival anchor, past its {reachMs:0.000} ms " +
                         $"reach — but that anchor was picked " +
                         $"{-anchorProminenceDb:0.0} dB under its own band's " +
-                        $"energy, so it is not the read the extremum disagrees " +
-                        $"with and cannot veto it");
+                        $"energy, and the direct-sound cut puts the pair on the " +
+                        $"same lobe ({corroboration.DelayMs:+0.000;-0.000} ms, " +
+                        $"r {corroboration.Coefficient:+0.000;-0.000}) — the veto " +
+                        $"passes to the cut, which admits this lobe");
                 }
                 return null;
             }

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -284,6 +284,35 @@ public static class AutoAlignmentEngine
     private const double PhatSeedMinCoefficient = 0.15;
 
     /// <summary>
+    /// How far below its own band's energy a first arrival may be picked and
+    /// still be allowed to VETO a whitened extremum for disagreeing with it
+    /// (<see cref="TimeAlignmentAnalysisResult.FirstArrivalProminenceDecibels"/>,
+    /// which is 0 dB when the arrival IS the band's strongest peak).
+    /// <para>
+    /// The arrival detector searches 25 dB below the band maximum on purpose:
+    /// a soft direct rise sitting under a strong in-room modal build-up is a
+    /// real front, and reading the mode instead would time the channel whole
+    /// periods late. But a pick that deep is not the same KIND of feature the
+    /// whitened correlation reads. The correlation is driven by where the
+    /// band's ENERGY is; an arrival 23.5 dB down sits 14.5 ms ahead of it (a
+    /// field 50-110 Hz subwoofer, its front at 8.7 ms against a body at
+    /// 23.2 ms). Comparing that front against a neighbour whose own arrival IS
+    /// its band peak measures the difference between two questions, not a
+    /// delay — and the reach veto then refuses an extremum at r 0.95, which the
+    /// direct-sound cut confirms at r 0.93, for disagreeing with it.
+    /// </para>
+    /// <para>
+    /// Half the detector's own search depth: a pick in the upper half of the
+    /// range is a shoulder on the band's energy and speaks for it, one in the
+    /// lower half is a separate feature. The gate only ever WITHDRAWS the
+    /// anchor's veto, never moves it — the seed, the window centre, the prior
+    /// and the fallback are untouched, and the extremum still has to pass its
+    /// own trust gates.
+    /// </para>
+    /// </summary>
+    private const double SeedVetoMinProminenceDb = -12.5;
+
+    /// <summary>
     /// The margin by which the seed extremum must beat the SAME-POLARITY rival
     /// one period over before its position is trusted. This is the whole-period
     /// cycle skip — the error the fine window cannot undo, since its reach is
@@ -1670,6 +1699,12 @@ public static class AutoAlignmentEngine
             // (a local function cannot capture a variable declared after it).
             CorrelationAlignmentResult? directPhat = null;
             CorrelationDelayCandidate? directSeed = null;
+            // The weaker of the two sides' picks: the anchor is their
+            // DIFFERENCE, so one side reading a feature the other does not is
+            // enough to make it one.
+            double anchorProminenceDb = Math.Min(
+                lowerRead.FirstArrivalProminenceDecibels,
+                upperRead.FirstArrivalProminenceDecibels);
             Complex[] lowerDirectCut = [];
             Complex[] upperDirectCut = [];
 
@@ -1747,7 +1782,24 @@ public static class AutoAlignmentEngine
                 // the extremum is refused rather than admitted.
                 if (!arrivalReanchored && Math.Abs(seedOffsetMs) >= reachMs)
                 {
-                    return $"{seedLabel} beyond the arrival's reach";
+                    // Unless the anchor is not the same kind of read as the
+                    // extremum it would be vetoing (see
+                    // SeedVetoMinProminenceDb). One side picked deep under its
+                    // own band's energy and the other on top of it: their
+                    // difference is not a delay the reach can grade.
+                    if (anchorProminenceDb >= SeedVetoMinProminenceDb)
+                    {
+                        return $"{seedLabel} beyond the arrival's reach";
+                    }
+
+                    log.AppendLine(
+                        $"  {pair.Lower.Channel.Name}/{pair.Upper.Channel.Name}: " +
+                        $"the {seedLabel} sits {Math.Abs(seedOffsetMs):0.000} ms " +
+                        $"from the arrival anchor, past its {reachMs:0.000} ms " +
+                        $"reach — but that anchor was picked " +
+                        $"{-anchorProminenceDb:0.0} dB under its own band's " +
+                        $"energy, so it is not the read the extremum disagrees " +
+                        $"with and cannot veto it");
                 }
                 return null;
             }

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -350,15 +350,63 @@ public static class AutoAlignmentEngine
     /// (<see cref="DirectSeedMinCoefficient"/>) rather than the floor a seed
     /// needs (<see cref="PhatSeedMinCoefficient"/>, which a coincidence
     /// clears). That is a weaker footing than the high junctions get, and it is
-    /// taken because at a LOW junction the dominant full-record |PHAT| extremum
-    /// is the owner's own ground truth — his hand tunes land on it, and an Auto
-    /// delay that does not is the defect. The field junction reads r 0.950 with
-    /// its same-sign rival 0.418 behind; what this gate refuses is a lobe that
-    /// wins by a hair.
+    /// taken because the intended target at a LOW junction is the dominant
+    /// full-record extremum: across the archived cabins the hand tunes land on
+    /// it, and an Auto delay that does not is the defect. The field junction
+    /// reads r 0.950 with its same-sign rival 0.418 behind; what this gate
+    /// refuses is a lobe that wins by a hair.
     /// </para>
     /// </summary>
     private const double SeedVetoMinProminenceDb =
         -TimeAlignmentAnalysisOptions.DefaultFirstPeakThresholdBelowMaxDb / 2.0;
+
+    /// <summary>
+    /// Whether the seed reach veto may stand down for this junction — the whole
+    /// policy of <see cref="SeedVetoMinProminenceDb"/> in one place, so it can
+    /// be read and tested as a policy rather than inferred from an acoustic
+    /// fixture that happens to produce the right numbers.
+    /// <para>
+    /// Called ONLY where the veto would otherwise fire, and false is the
+    /// default: every clause has to say yes. The anchor must still be the raw
+    /// measured reads, its pick must sit in the lower half of the detector's
+    /// search depth, and the extremum must clear the bar a direct seed clears
+    /// rather than the floor a seed needs. Above
+    /// <see cref="DirectSeedMinCrossoverHz"/> the direct-sound cut then has the
+    /// last word on the lobe; below it there is no wavefront witness to ask, and
+    /// the three clauses above are the whole of it.
+    /// </para>
+    /// <para>
+    /// <paramref name="directCorroboration"/> is a delegate rather than a value
+    /// so the cut is taken only when the cheap clauses have already passed — and
+    /// so a test can assert it is never taken when they have not.
+    /// </para>
+    /// </summary>
+    internal static bool MayWithdrawSeedReachVeto(
+        double anchorProminenceDb,
+        bool anchorIsRawReads,
+        CorrelationDelayCandidate seed,
+        double crossoverHz,
+        Func<CorrelationDelayCandidate?> directCorroboration)
+    {
+        ArgumentNullException.ThrowIfNull(seed);
+        ArgumentNullException.ThrowIfNull(directCorroboration);
+        if (!anchorIsRawReads ||
+            anchorProminenceDb >= SeedVetoMinProminenceDb ||
+            Math.Abs(seed.Coefficient) < DirectSeedMinCoefficient)
+        {
+            return false;
+        }
+
+        if (crossoverHz < DirectSeedMinCrossoverHz)
+        {
+            return true;
+        }
+
+        return directCorroboration() is { } corroboration &&
+            corroboration.InvertPolarity == seed.InvertPolarity &&
+            Math.Abs(corroboration.DelayMs - seed.DelayMs) <=
+                DirectCorroborationPeriods * 1000.0 / crossoverHz;
+    }
 
     /// <summary>
     /// How close the direct-sound witness must sit to the full-record extremum
@@ -1926,21 +1974,12 @@ public static class AutoAlignmentEngine
                     // polarity, which is a lobe test the arrival could not
                     // perform and the extremum's own quality gates do not
                     // attempt.
-                    if (!anchorIsRawReads ||
-                        anchorProminenceDb >= SeedVetoMinProminenceDb ||
-                        Math.Abs(seed.Coefficient) < DirectSeedMinCoefficient)
-                    {
-                        return $"{seedLabel} beyond the arrival's reach";
-                    }
-
-                    // And where the cut is a wavefront read, it has the last
-                    // word on the lobe.
-                    if (pair.CrossoverHz >= DirectSeedMinCrossoverHz &&
-                        (DirectCorroboration() is not { } corroboration ||
-                            corroboration.InvertPolarity != seed.InvertPolarity ||
-                            Math.Abs(corroboration.DelayMs - seed.DelayMs) >
-                                DirectCorroborationPeriods * 1000.0 /
-                                    pair.CrossoverHz))
+                    if (!MayWithdrawSeedReachVeto(
+                        anchorProminenceDb,
+                        anchorIsRawReads,
+                        seed,
+                        pair.CrossoverHz,
+                        DirectCorroboration))
                     {
                         return $"{seedLabel} beyond the arrival's reach";
                     }

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1510,6 +1510,11 @@ public static class AutoAlignmentEngine
 
             double probeLowHz = Math.Sqrt(pair.BandLowHz * pair.BandHighHz);
             bool arrivalReanchored = false;
+            // A latch the upper-half probe convicted but could NOT replace (the
+            // other side's probe read different physics). The pair keeps the
+            // corrupted diff on purpose — see the re-anchor condition below —
+            // and the prominence exception must not undo that.
+            bool unreplacedLatch = false;
             if (!lowerLatchedByPrediction && !upperLatchedByPrediction &&
                 pair.BandHighHz >=
                 probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
@@ -1576,6 +1581,10 @@ public static class AutoAlignmentEngine
                         lowerArrival = lowerProbe.FirstArrivalDelayMilliseconds;
                         upperArrival = upperProbe.FirstArrivalDelayMilliseconds;
                         arrivalReanchored = true;
+                    }
+                    else
+                    {
+                        unreplacedLatch = true;
                     }
                 }
             }
@@ -1701,10 +1710,18 @@ public static class AutoAlignmentEngine
             CorrelationDelayCandidate? directSeed = null;
             // The weaker of the two sides' picks: the anchor is their
             // DIFFERENCE, so one side reading a feature the other does not is
-            // enough to make it one.
+            // enough to make it one. It describes the anchor only while the
+            // anchor is still those raw reads — a predicted front has replaced
+            // both of them, and a latch convicted without a comparable
+            // replacement is the one case where the corrupted diff is kept
+            // DELIBERATELY, with the reach veto as what stands between it and
+            // the modal extremum measured around it. Both keep the veto.
             double anchorProminenceDb = Math.Min(
                 lowerRead.FirstArrivalProminenceDecibels,
                 upperRead.FirstArrivalProminenceDecibels);
+            bool anchorIsRawReads =
+                !lowerLatchedByPrediction && !upperLatchedByPrediction &&
+                !unreplacedLatch;
             Complex[] lowerDirectCut = [];
             Complex[] upperDirectCut = [];
 
@@ -1787,7 +1804,8 @@ public static class AutoAlignmentEngine
                     // SeedVetoMinProminenceDb). One side picked deep under its
                     // own band's energy and the other on top of it: their
                     // difference is not a delay the reach can grade.
-                    if (anchorProminenceDb >= SeedVetoMinProminenceDb)
+                    if (!anchorIsRawReads ||
+                        anchorProminenceDb >= SeedVetoMinProminenceDb)
                     {
                         return $"{seedLabel} beyond the arrival's reach";
                     }

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -320,11 +320,41 @@ public static class AutoAlignmentEngine
     /// leave a whole-period cycle skip legal, and stage 2 cannot undo one: its
     /// window reaches the opposite-polarity partner half a period out, not the
     /// same-polarity lobe a full period out. So the deep pick only opens the
-    /// question, and <see cref="DirectSeedMinCoefficient"/>'s witness answers
-    /// it — the direct-sound cut has to land on the SAME lobe, within a
-    /// quarter period and in the same polarity. That witness is what the
-    /// arrival was standing in for: an independent read of where the two
-    /// wavefronts line up, taken on the cuts the reflections never enter.
+    /// question, and what answers it depends on the junction.
+    /// </para>
+    /// <para>
+    /// AT AND ABOVE <see cref="DirectSeedMinCrossoverHz"/> the direct-sound cut
+    /// answers it: it has to land on the same lobe, within
+    /// <see cref="DirectCorroborationPeriods"/> and in the same polarity — an
+    /// independent read of where the two wavefronts line up, taken where the
+    /// reflections never enter.
+    /// </para>
+    /// <para>
+    /// BELOW it that witness does not exist, and this says so rather than
+    /// faking one. The cut's window is sized in PERIODS — half a period of
+    /// fade, two periods of plateau — so at a 110 Hz junction it runs 27 ms and
+    /// the very build-up the arrival was picked under sits inside its plateau.
+    /// Measured on the field cabin: 96 % of that "direct" cut's energy lies
+    /// more than a period behind the front, and shortening the plateau to 1.5,
+    /// 1.0, 0.75 and 0.5 periods walks its extremum to +4.95, +4.16, -0.24 and
+    /// -0.38 ms. It is not a wavefront read (the same physics
+    /// <see cref="DirectSeedMinCrossoverHz"/> already states). A sub-band
+    /// consistency test fares no better: at a crossover the lower half of the
+    /// pair band is the lower channel alone and the upper half the upper
+    /// channel alone, so the halves do not measure one relation — they read
+    /// +6.37 and +4.61 against the whole band's +1.32.
+    /// </para>
+    /// <para>
+    /// So below that frequency the exception rests on the EXTREMUM's own
+    /// strength, held to the bar a direct seed must clear
+    /// (<see cref="DirectSeedMinCoefficient"/>) rather than the floor a seed
+    /// needs (<see cref="PhatSeedMinCoefficient"/>, which a coincidence
+    /// clears). That is a weaker footing than the high junctions get, and it is
+    /// taken because at a LOW junction the dominant full-record |PHAT| extremum
+    /// is the owner's own ground truth — his hand tunes land on it, and an Auto
+    /// delay that does not is the defect. The field junction reads r 0.950 with
+    /// its same-sign rival 0.418 behind; what this gate refuses is a lobe that
+    /// wins by a hair.
     /// </para>
     /// </summary>
     private const double SeedVetoMinProminenceDb =
@@ -1758,12 +1788,11 @@ public static class AutoAlignmentEngine
             // constraint: the same whitened correlation on the two channels'
             // DIRECT-SOUND cuts, held to the trust gates the direct seed itself
             // must pass above (no edge pin, DirectSeedMinCoefficient, and a
-            // margin over its own same-sign rival). Computed on demand and only
-            // where the exception is live, so a junction that never asks pays
-            // nothing — and reused where the cut has already been taken for the
-            // seed path. Deliberately NOT a seed of its own below
-            // DirectSeedMinCrossoverHz: it only ever answers "is the pair on
-            // this lobe", which is the one question the arrival could not.
+            // margin over its own same-sign rival). Asked only at or
+            // above DirectSeedMinCrossoverHz, where the cut is a wavefront read;
+            // the seed path there has usually taken it already and this reuses
+            // it. It answers only "is the pair on this lobe", which is the one
+            // question the arrival could not.
             CorrelationDelayCandidate? DirectCorroboration()
             {
                 CorrelationAlignmentResult? witness = directPhat;
@@ -1899,10 +1928,19 @@ public static class AutoAlignmentEngine
                     // attempt.
                     if (!anchorIsRawReads ||
                         anchorProminenceDb >= SeedVetoMinProminenceDb ||
-                        DirectCorroboration() is not { } corroboration ||
-                        corroboration.InvertPolarity != seed.InvertPolarity ||
-                        Math.Abs(corroboration.DelayMs - seed.DelayMs) >
-                            DirectCorroborationPeriods * 1000.0 / pair.CrossoverHz)
+                        Math.Abs(seed.Coefficient) < DirectSeedMinCoefficient)
+                    {
+                        return $"{seedLabel} beyond the arrival's reach";
+                    }
+
+                    // And where the cut is a wavefront read, it has the last
+                    // word on the lobe.
+                    if (pair.CrossoverHz >= DirectSeedMinCrossoverHz &&
+                        (DirectCorroboration() is not { } corroboration ||
+                            corroboration.InvertPolarity != seed.InvertPolarity ||
+                            Math.Abs(corroboration.DelayMs - seed.DelayMs) >
+                                DirectCorroborationPeriods * 1000.0 /
+                                    pair.CrossoverHz))
                     {
                         return $"{seedLabel} beyond the arrival's reach";
                     }
@@ -1913,10 +1951,14 @@ public static class AutoAlignmentEngine
                         $"from the arrival anchor, past its {reachMs:0.000} ms " +
                         $"reach — but that anchor was picked " +
                         $"{-anchorProminenceDb:0.0} dB under its own band's " +
-                        $"energy, and the direct-sound cut puts the pair on the " +
-                        $"same lobe ({corroboration.DelayMs:+0.000;-0.000} ms, " +
-                        $"r {corroboration.Coefficient:+0.000;-0.000}) — the veto " +
-                        $"passes to the cut, which admits this lobe");
+                        $"energy, and the extremum stands at " +
+                        $"r {Math.Abs(seed.Coefficient):0.000} — " +
+                        (pair.CrossoverHz >= DirectSeedMinCrossoverHz
+                            ? "the veto passes to the direct-sound cut, which puts " +
+                              "the pair on this same lobe"
+                            : "below the cut's own frequency there is no wavefront " +
+                              "witness to pass it to, and the dominant extremum " +
+                              "stands on its own strength"));
                 }
                 return null;
             }

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -9,7 +9,18 @@ public sealed class TimeAlignmentAnalysisOptions
     public double BandpassCenterHz { get; init; } = 1000;
     public double BandpassPassOctaves { get; init; } = 1;
     public double BandpassFadeOctaves { get; init; } = 0.5;
-    public double FirstPeakThresholdBelowMaxDb { get; init; } = 25;
+    /// <summary>
+    /// How far below the band maximum the first-arrival search looks. A soft
+    /// direct rise under a strong in-room build-up is a real front, and this
+    /// depth is what finds it. Exposed as a constant because
+    /// <see cref="AutoAlignmentEngine"/> derives a threshold from it: a pick
+    /// in the lower half of this range is a different feature from the band's
+    /// energy, and the two must move together if this ever changes.
+    /// </summary>
+    public const double DefaultFirstPeakThresholdBelowMaxDb = 25;
+
+    public double FirstPeakThresholdBelowMaxDb { get; init; } =
+        DefaultFirstPeakThresholdBelowMaxDb;
     public double FirstPeakMinimumSnrDb { get; init; } = 12;
     public double PeakSearchWindowMilliseconds { get; init; } = 80;
     public bool WrapPeakPositions { get; init; }

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -947,6 +947,14 @@ public sealed class AutoAlignmentEngineTests
         // The latched side's full-band anchor (~37 ms) stands — no re-anchor
         // onto the probes' mismatched wavefronts.
         Assert.Contains("arrivals 37", pairLine);
+        // And the veto that anchor cannot be talked out of. This pair also
+        // trips the low-prominence exception (the unverified side's front is
+        // picked 17 dB under its own band's energy), and that exception is
+        // exactly what must NOT reach here: a conviction with no comparable
+        // replacement keeps its corrupted diff deliberately, so lifting the
+        // veto would seed from the modal extremum measured around it.
+        Assert.Contains("beyond the arrival's reach", pairLine);
+        Assert.DoesNotContain("cannot veto it", text);
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -901,6 +901,90 @@ public sealed class AutoAlignmentEngineTests
         }
     }
 
+    // The reach veto's stand-down policy, asserted as a policy. An acoustic
+    // fixture can only reach these cells by luck of the numbers a synthetic IR
+    // happens to produce; the predicate can be asked directly.
+    private static CorrelationDelayCandidate Seed(
+        double coefficient, double delayMs = 0.0, bool invert = false) =>
+        new(delayMs, coefficient, invert);
+
+    [Theory]
+    // Below the direct cut's own frequency the extremum's strength is the whole
+    // of it — and 0.15, the floor a SEED needs, is not enough to move a lobe.
+    [InlineData(110.0, -20.0, true, 0.21, false)]
+    [InlineData(110.0, -20.0, true, 0.49, false)]
+    [InlineData(110.0, -20.0, true, 0.50, true)]
+    [InlineData(110.0, -20.0, true, 0.95, true)]
+    // A trough carries the same weight as a peak; the seed uses position only.
+    [InlineData(110.0, -20.0, true, -0.95, true)]
+    // A pick in the upper half of the detector's search depth speaks for the
+    // band's energy and keeps its veto however strong the extremum is.
+    [InlineData(110.0, -12.4, true, 0.95, false)]
+    [InlineData(110.0, 0.0, true, 0.95, false)]
+    // The boundary itself belongs to the veto, as every other gate here reads it.
+    [InlineData(110.0, -12.5, true, 0.95, false)]
+    [InlineData(110.0, -12.51, true, 0.95, true)]
+    // An anchor that is no longer the raw reads — a predicted front replaced
+    // it, or a latch was convicted with no comparable replacement.
+    [InlineData(110.0, -20.0, false, 0.95, false)]
+    public void MayWithdrawSeedReachVeto_BelowTheDirectCutsFrequency(
+        double crossoverHz,
+        double anchorProminenceDb,
+        bool anchorIsRawReads,
+        double seedCoefficient,
+        bool expected)
+    {
+        bool asked = false;
+        bool withdraw = AutoAlignmentEngine.MayWithdrawSeedReachVeto(
+            anchorProminenceDb,
+            anchorIsRawReads,
+            Seed(seedCoefficient),
+            crossoverHz,
+            () =>
+            {
+                asked = true;
+                return null;
+            });
+
+        Assert.Equal(expected, withdraw);
+        // The cut costs an FFT pair; below its frequency it is never taken.
+        Assert.False(asked, "the direct cut was taken below its own frequency");
+    }
+
+    [Theory]
+    // At and above it the cut has the last word: same lobe, same polarity.
+    [InlineData(0.0, false, true)]
+    [InlineData(0.124, false, true)]   // a quarter period at 2 kHz is 0.125 ms
+    [InlineData(0.126, false, false)]
+    [InlineData(-0.124, false, true)]
+    [InlineData(0.0, true, false)]     // the same position, opposite polarity
+    public void MayWithdrawSeedReachVeto_AtTheDirectCutsFrequency(
+        double corroborationDelayMs, bool corroborationInverted, bool expected)
+    {
+        Assert.Equal(
+            expected,
+            AutoAlignmentEngine.MayWithdrawSeedReachVeto(
+                anchorProminenceDb: -20.0,
+                anchorIsRawReads: true,
+                Seed(0.95),
+                crossoverHz: 2_000.0,
+                () => Seed(0.9, corroborationDelayMs, corroborationInverted)));
+    }
+
+    [Fact]
+    public void MayWithdrawSeedReachVeto_WithNoUsableDirectCut_KeepsTheVeto()
+    {
+        // The cut ran and failed its own trust gates (edge-pinned, too weak, or
+        // tied against its own rival): there is nothing to pass the veto to.
+        Assert.False(
+            AutoAlignmentEngine.MayWithdrawSeedReachVeto(
+                anchorProminenceDb: -20.0,
+                anchorIsRawReads: true,
+                Seed(0.95),
+                crossoverHz: 2_000.0,
+                () => null));
+    }
+
     [Fact]
     public void Compute_DeepArrivalPickWithAContradictingDirectCut_KeepsTheReachVeto()
     {

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -887,13 +887,14 @@ public sealed class AutoAlignmentEngineTests
             // near-zero relation the extremum reads — not the ~7 ms the two
             // fronts differ by.
             Assert.InRange(relative, -1.5, 1.5);
-            Assert.Contains("the veto passes to the cut", text);
+            Assert.Contains("under its own band's energy", text);
+            Assert.Contains("stands on its own strength", text);
             Assert.Contains("-> seed phat", text);
         }
         else
         {
             Assert.Contains("beyond the arrival's reach", text);
-            Assert.DoesNotContain("the veto passes to the cut", text);
+            Assert.DoesNotContain("under its own band's energy", text);
             Assert.True(
                 Math.Abs(relative) > 2.5,
                 $"the vetoed run should keep the arrival's answer, got {relative:0.00} ms");
@@ -925,7 +926,7 @@ public sealed class AutoAlignmentEngineTests
             Run([woofer, tweeter], [2_000], log, bands: [(700, 5_600)]);
 
         string text = log.ToString();
-        Assert.DoesNotContain("the veto passes to the cut", text);
+        Assert.DoesNotContain("under its own band's energy", text);
         Assert.Contains(
             "seed direct-cut (phat: peak beyond the arrival's reach)", text);
         // The fronts' own relation, not the reflection pair's phantom at

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -841,42 +841,96 @@ public sealed class AutoAlignmentEngineTests
         Assert.InRange(alignment[mid].DelayMs, 3.0, 9.0);
     }
 
-    [Fact]
-    public void Compute_ArrivalPickedFarUnderItsBandEnergy_CannotVetoTheExtremum()
+    // A front amplitude either side of half the arrival detector's search
+    // depth, against a body that is the band's own energy 8 ms behind it.
+    // 0.20 reads -14.8 dB of prominence, 0.30 reads -11.6 dB; nothing else
+    // about the pair changes.
+    [Theory]
+    [InlineData(0.20, true)]
+    [InlineData(0.30, false)]
+    public void Compute_ArrivalPickedFarUnderItsBandEnergy_CannotVetoTheExtremum(
+        double frontAmplitude, bool deepEnoughToStandDown)
     {
         // The field failure this pins (a 110 Hz sub/midbass junction): the
         // subwoofer's own direct front is a real arrival, and the detector
-        // finds it 23 dB below the band's energy — the cabin's build-up
-        // arrives 12 ms behind it and dwarfs it. Its neighbour's arrival IS
-        // its band peak, so the pair anchor subtracts a front from an energy
-        // centre and lands a whole lobe away from the whitened extremum, which
-        // reads the energy on both sides. The reach veto then refused that
-        // extremum (r 0.95, the direct-sound cut concurring at 0.93) for
-        // disagreeing with the anchor, and the run parked the midbass half a
-        // period early with its polarity flipped to match.
+        // finds it well below the band's energy — the cabin's build-up arrives
+        // behind it and dwarfs it. Its neighbour's arrival IS its band peak, so
+        // the pair anchor subtracts a front from an energy centre and lands a
+        // whole lobe away from the whitened extremum, which reads the energy on
+        // both sides. The reach veto then refused that extremum (r 0.95, the
+        // direct-sound cut concurring at 0.93) for disagreeing with the anchor,
+        // and the run parked the midbass half a period early with its polarity
+        // flipped to match.
         //
         // Nothing here re-anchors: the pair band's upper half carries the same
         // two copies as the full band, so the honesty probe agrees with the
         // read and the arrival stands. The anchor is honest — it is simply not
-        // the read the extremum disagrees with, and that is what withdraws its
-        // veto.
-        var sub = new TestChannel("W", ImpulseWithEcho(0.0, 0.07, 12.0, 1.0));
-        var midbass = new TestChannel("B", DelayedImpulse(12.0));
+        // the read the extremum disagrees with, and only THAT withdraws its
+        // veto, and only to the direct-sound cut, which agrees with the
+        // extremum here. A shallower pick keeps the veto and the 6.9 ms
+        // anchor with it.
+        var sub = new TestChannel(
+            "W", ImpulseWithEcho(0.0, frontAmplitude, 8.0, 1.0));
+        var midbass = new TestChannel("B", DelayedImpulse(8.0));
         var log = new StringBuilder();
 
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
             Run([sub, midbass], [110], log);
 
-        // Both channels' energy already coincides, so the proposal is the
-        // near-zero relation the extremum reads — not the 12 ms the two
-        // fronts differ by.
         double relative = alignment.GetValueOrDefault(midbass).DelayMs -
             alignment.GetValueOrDefault(sub).DelayMs;
-        Assert.InRange(relative, -1.5, 1.5);
         string text = log.ToString();
-        Assert.Contains("cannot veto it", text);
-        Assert.Contains("-> seed phat", text);
         Assert.DoesNotContain("(modal latch)", text);
+        if (deepEnoughToStandDown)
+        {
+            // Both channels' energy already coincides, so the proposal is the
+            // near-zero relation the extremum reads — not the ~7 ms the two
+            // fronts differ by.
+            Assert.InRange(relative, -1.5, 1.5);
+            Assert.Contains("the veto passes to the cut", text);
+            Assert.Contains("-> seed phat", text);
+        }
+        else
+        {
+            Assert.Contains("beyond the arrival's reach", text);
+            Assert.DoesNotContain("the veto passes to the cut", text);
+            Assert.True(
+                Math.Abs(relative) > 2.5,
+                $"the vetoed run should keep the arrival's answer, got {relative:0.00} ms");
+        }
+    }
+
+    [Fact]
+    public void Compute_DeepArrivalPickWithAContradictingDirectCut_KeepsTheReachVeto()
+    {
+        // The blanket version of the exception would have been a cycle skip
+        // waiting to happen: withdrawing the reach leaves the extremum with
+        // quality gates only (|r|, a rival margin, an edge pin), and not one of
+        // them can tell a lobe from the next one over. This is that shape.
+        //
+        // Both channels carry one strong LATE reflection off shared geometry,
+        // five periods behind the fronts, and it is loud enough (x5) that the
+        // arrival is picked 13.9 dB under the band's energy — deep enough to
+        // open the exception. The reflection pair's whitened lobe dominates the
+        // full record at r 0.980, separated and past the reach. The direct-sound
+        // cut never sees those reflections and puts the pair 2.5 ms away, so it
+        // refuses to corroborate and the veto stands — which is also what keeps
+        // the tightened direct-seed reach at a mid/tweeter junction from being
+        // bypassed by a deep pick.
+        var woofer = new TestChannel("W", ReflectedFront(1.0, 3.0, 5.0));
+        var tweeter = new TestChannel("T", ReflectedFront(0.0, 5.5, 5.0));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([woofer, tweeter], [2_000], log, bands: [(700, 5_600)]);
+
+        string text = log.ToString();
+        Assert.DoesNotContain("the veto passes to the cut", text);
+        Assert.Contains(
+            "seed direct-cut (phat: peak beyond the arrival's reach)", text);
+        // The fronts' own relation, not the reflection pair's phantom at
+        // -1.5 ms.
+        Assert.InRange(alignment[tweeter].DelayMs, 0.9, 1.1);
     }
 
     // The upper channel of the incomparable-probe case: its full band reads

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -841,6 +841,44 @@ public sealed class AutoAlignmentEngineTests
         Assert.InRange(alignment[mid].DelayMs, 3.0, 9.0);
     }
 
+    [Fact]
+    public void Compute_ArrivalPickedFarUnderItsBandEnergy_CannotVetoTheExtremum()
+    {
+        // The field failure this pins (a 110 Hz sub/midbass junction): the
+        // subwoofer's own direct front is a real arrival, and the detector
+        // finds it 23 dB below the band's energy — the cabin's build-up
+        // arrives 12 ms behind it and dwarfs it. Its neighbour's arrival IS
+        // its band peak, so the pair anchor subtracts a front from an energy
+        // centre and lands a whole lobe away from the whitened extremum, which
+        // reads the energy on both sides. The reach veto then refused that
+        // extremum (r 0.95, the direct-sound cut concurring at 0.93) for
+        // disagreeing with the anchor, and the run parked the midbass half a
+        // period early with its polarity flipped to match.
+        //
+        // Nothing here re-anchors: the pair band's upper half carries the same
+        // two copies as the full band, so the honesty probe agrees with the
+        // read and the arrival stands. The anchor is honest — it is simply not
+        // the read the extremum disagrees with, and that is what withdraws its
+        // veto.
+        var sub = new TestChannel("W", ImpulseWithEcho(0.0, 0.07, 12.0, 1.0));
+        var midbass = new TestChannel("B", DelayedImpulse(12.0));
+        var log = new StringBuilder();
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            Run([sub, midbass], [110], log);
+
+        // Both channels' energy already coincides, so the proposal is the
+        // near-zero relation the extremum reads — not the 12 ms the two
+        // fronts differ by.
+        double relative = alignment.GetValueOrDefault(midbass).DelayMs -
+            alignment.GetValueOrDefault(sub).DelayMs;
+        Assert.InRange(relative, -1.5, 1.5);
+        string text = log.ToString();
+        Assert.Contains("cannot veto it", text);
+        Assert.Contains("-> seed phat", text);
+        Assert.DoesNotContain("(modal latch)", text);
+    }
+
     // The upper channel of the incomparable-probe case: its full band reads
     // the (low-passed) direct front, but its upper half is owned by a strong
     // high-passed late reflection — the half-band probe times a feature far


### PR DESCRIPTION
On the Monster cabin, Auto delay pulled channel C (the 110-290 Hz midbass) forward: it became the run's reference at delay 0 while everything else was delayed 3-4.3 ms behind it. Both correlations put it 4.8 ms ahead of the front sub and 1.6 ms ahead of the mid — the "half a period early plus inversion" alias at the 110 Hz junction.

## The defect

Not channel C, whose reads are all clean (prominence 0.0 dB in every band). The F/C junction failed on the SUBWOOFER's side. In 55-220 Hz the arrival detector picked **8.715 ms at prominence -23.5 dB**, while the band's own energy arrives at **23.2 ms**:

```
  F envelope in 55-220 Hz (dB below the band's peak)
   7.0: -24.0   8.5: -23.5   9.0: -23.5   11.5: -25.8    <- the pick
  17.0:  -4.3  20.0:  -0.9   23.0:  -0.0                 <- the band's body
```

That pick is a real front — the detector's 25 dB search depth exists to find exactly this, a soft direct rise under a strong in-room build-up. But it is not the same kind of feature the neighbour's arrival is: the midbass's arrival IS its band peak. Subtracting one from the other gives +4.372 ms, which is not a delay, and the coarse stage did two things with it — seeded the stage-2 window, and armed the reach veto that refused the whitened extremum at **+1.322 ms, r 0.950**.

The margin was 1.5 dB against a fixed threshold: the same shoulder reads -29.6 dB in the 25-100 Hz band, where it is correctly discarded.

## The rule

A single predicate, `MayWithdrawSeedReachVeto`, called only where the veto would otherwise fire. Every clause has to say yes:

1. the anchor is still the **raw measured reads** — not a predicted front that replaced them, and not a latch convicted with no comparable replacement (that path keeps its corrupted diff deliberately, and the veto is what stands between it and the modal extremum measured around it);
2. the anchoring pick sits in the **lower half of the detector's own search depth** (`-DefaultFirstPeakThresholdBelowMaxDb / 2`, so the two cannot drift apart);
3. the extremum clears `DirectSeedMinCoefficient` — the bar a direct seed clears, not `PhatSeedMinCoefficient`, the floor a seed needs;
4. **at and above `DirectSeedMinCrossoverHz`**, the direct-sound cut must put the pair on the same lobe, within a quarter period and in the same polarity.

Nothing else moves: the seed, the window centre, the prior and the arrival fallback are untouched.

### Why clause 4 stops at 1 kHz

Because below it the cut is not a wavefront read, and the PR says so rather than pretending otherwise. `CutDirectSoundPair` sizes its window in crossover PERIODS, so at 110 Hz it runs 4.2 to 31.4 ms and the build-up the arrival was picked under sits inside its plateau:

```
plateau   F window (ms)     body in?   extremum          r
 2.00      4.17.. 31.44     YES         +1.362       +0.932
 1.50      4.17.. 26.90     YES         +4.945 inv   -0.958
 1.00      4.17.. 22.33     no          +4.157 inv   -0.977
 0.75      4.17.. 20.06     no          -0.239       +0.974
 0.50      4.17.. 17.79     no          -0.384       +0.987

96.1 % of that cut's energy sits more than one period behind the front
```

So below 1 kHz the exception rests on clauses 1-3 alone. That is a **deliberately weaker footing** than the high junctions get, and the doc comment says so. It is taken because the intended target at a low junction is the dominant full-record extremum: across the archived cabins the hand tunes land on it, and an Auto delay that does not is the defect. The field junction reads r 0.950 with its same-sign rival 0.418 behind.

### Witnesses measured and rejected

- **The chains' own front-vs-corner skew.** Not a well-defined quantity: across 55-220 Hz this pair's relative group delay swings from +15 to -3 ms, so the band average reads 0.7 / 1.6 / 3.5 / 9.2 ms as the weighting sharpens, and a Q-10 PEQ on the corner inflates the value at fc (a synthetic pair measured 20.7 ms against a true optimum of 6.9).
- **The strongest-peak (energy) reference.** Does not fix the case: the sub's strongest peak in 55-220 Hz is its modal body at 23.192 ms while the midbass's is its band peak at 13.087 ms, so that anchor sits 8.8 ms from the extremum against a 4.5 ms reach. Seven of the eight junctions stay vetoed.
- **Sub-band consistency.** At a crossover the pair band's lower half is the lower channel alone and its upper half the upper channel alone, so the halves do not measure one relation — they read +6.37 and +4.61 against the whole band's +1.32.
- **The summation metric.** The gap between the two lobes is 0.79 dB, inside the ~1.4 dB comb-noise ceiling `WideWindowPromotionMarginDb` is calibrated against.

## Verification

**Seven archived cabins** (3RC, Passat, Passat v2, v2, v2/head_90_grad, v3, v4, v5_exp): the battery's ROW lines are **byte-identical** to baseline. Nothing in the fleet moves.

**The field cabin**, judged by the panel's own metric against the settings the bad run left behind:

| junction | before Δavg / Δdip | after Δavg / Δdip |
| --- | --- | --- |
| G/F | +0.18 / +0.53 | **+0.47 / +1.33** |
| F/C | +0.16 / -0.57 | **+1.45 / +2.02** |
| C/B | -0.05 / -0.57 | **+0.58 / +2.02** |
| B/A | +0.74 / +1.39 | +0.74 / +1.39 |
| total | +0.17 / +1.39 | **+0.51 / +1.39** |

Every junction now sits on its own direct-PHAT extremum. Before: `F/C on-lobe r -0.61 with best -0.86 elsewhere`, `C/B -0.52 with best +0.89 elsewhere`.

The stereo proposal moves the subs rather than the midbass (F 4.87 -> 0.59 ms, G 5.73 -> 1.25 ms, C L 1.43 -> 1.46 ms, polarity flip gone from C), and the "consider a compromise mono delay by hand" warning disappears.

## Tests

- **The policy matrix, asserted directly** on `MayWithdrawSeedReachVeto`: r 0.21 and 0.49 keep the veto, 0.50 stands it down, a trough counts as a peak, a pick at or above half the search depth keeps it however strong the extremum, a non-raw anchor keeps it, the boundary itself (-12.5 dB) keeps it. Above 1 kHz the cut decides by lobe and polarity, and a test asserts the cut is never taken below its own frequency.
- **End to end, both sides of the threshold**: a front at 0.20 of the body reads -14.8 dB and lands the pair within 1.5 ms; at 0.30 it reads -11.6 dB, keeps the veto, and the pair sits 3.7 ms apart on the arrival's answer.
- **A reflection phantom at 2 kHz**, r 0.980, five periods out, arrival picked 13.9 dB down: the cut contradicts it, the veto stands, the fronts' relation is kept.
- **The incomparable-probe case**: a latch convicted with no comparable replacement keeps its veto, which the repository's own fixture reaches (its unverified side's front is picked 17.2 dB under its band's energy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
