### PR TITLE
Report a transfer IR that rings before its arrival

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -583,7 +583,10 @@ That reading only means something over a wide excitation. A band-limited record
 cannot hold an event sharper than its own bandwidth allows, so on a narrow band
 even a single arrival smears until it looks like a ring. Below five octaves the
 refusal is therefore withheld and the report speaks instead — the reading is
-still made and still shown, but a band sweep is never refused for it.
+still made and still shown, but a band sweep is never refused for it, and the
+report there names no cause at all: it says the energy is unusual and that this
+band cannot tell a reference fault from a late reflection. Re-measuring the same
+channel full-range is what separates them.
 
 The check stays silent on a sweep whose duration was too short to open a guard
 band around its requested band (under a third of an octave). The estimator's own

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -579,6 +579,12 @@ a single event, the fault is a ring that fills it evenly. A discrete event is
 reported instead of refused, and says so — the reference is probably fine there,
 and what wants checking is where the microphone was pointed.
 
+That reading only means something over a wide excitation. A band-limited record
+cannot hold an event sharper than its own bandwidth allows, so on a narrow band
+even a single arrival smears until it looks like a ring. Below five octaves the
+refusal is therefore withheld and the report speaks instead — the reading is
+still made and still shown, but a band sweep is never refused for it.
+
 The check stays silent on a sweep whose duration was too short to open a guard
 band around its requested band (under a third of an octave). The estimator's own
 band-limiting kernel is symmetric, so it rings both ways too; with the guard the

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -544,6 +544,41 @@ only as far as it takes to leave the input's linear region, since a pad
 attenuates the signal and not the input's own noise and a reference driven toward
 the noise floor pays for it in coherence.
 
+### A reference that is not the excitation
+
+Distortion is not the only way a reference can be wrong while every meter reads
+normally. A loopback routed through an interface's own **direct mixer** — a
+monitor mix, an effects send, a fader — is a plausible-looking signal that is no
+longer a copy of what was played, and the transfer function divides the
+microphone by it. The field case this check was written for ran a whole session
+through such a path: eleven takes, every level normal, coherence 0.9995, and the
+two worst records carrying a 34 Hz resonance of Q≈40 that rang for seconds and
+that all seven array positions reported to within 0.7 dB — where a real cabin
+mode spreads the same positions over 5–9 dB.
+
+What gives that away is **causality**. Nothing arrives before the direct sound,
+and a cabin's own resonances ring forward, so Resonalyze compares the stretch
+from 100 to 600 ms *ahead* of the arrival against the arrival itself. A clean
+record reads −39 dB or less there. Above −18 dB the measurement is refused:
+
+> The transfer function did not form a credible impulse response: it rings almost
+> as loudly BEFORE its arrival as after it. The stretch from 100 to 600 ms ahead
+> of the peak reads −14.1 dB against the arrival itself.
+
+Between −22 dB and that ceiling the measurement is **saved and reported** rather
+than refused, with the same explanation — at that depth the record is still
+usable away from the affected frequencies, and whether the channel is worth
+re-measuring is the tuner's call.
+
+The check stays silent on a sweep whose duration was too short to open a guard
+band around its requested band (under a third of an octave). The estimator's own
+band-limiting kernel is symmetric, so it rings both ways too; with the guard the
+sweep generator aims for it stays far below the ceiling, and without one it
+cannot be told from the fault.
+
+The fix is to take the loopback from the wire: the interface output the sweep is
+played from, straight back into an input, with nothing in between.
+
 ## Live Spectrum
 
 The **Live Spectrum** mode runs in one of two explicitly chosen **Mode**s.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -584,7 +584,7 @@ awkward microphone position does not.
 The check stays silent on a sweep whose duration was too short to open a guard
 band around its requested band (under a third of an octave). The estimator's own
 band-limiting kernel is symmetric, so it rings both ways too; with the guard the
-sweep generator aims for it stays far below the ceiling, and without one it
+sweep generator aims for it stays far below the report line, and without one it
 cannot be told from the fault.
 
 The fix is to take the loopback from the wire: the interface output the sweep is

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -559,34 +559,27 @@ mode spreads the same positions over 5–9 dB.
 What gives that away is **causality**. Nothing arrives before the direct sound,
 and a cabin's own resonances ring forward, so Resonalyze compares the stretch
 from 100 to 600 ms *ahead* of the arrival against the arrival itself. A clean
-record reads −39 dB or less there. Above −18 dB the measurement is refused:
+record reads −39 dB or less there; the two contaminated ones read −14.8 and
+−14.1 dB. Above −22 dB the measurement is **saved and reported**:
 
-> The transfer function did not form a credible impulse response: it rings almost
-> as loudly BEFORE its arrival as after it. The stretch from 100 to 600 ms ahead
-> of the peak reads −14.1 dB against the arrival itself.
+> The measurement was saved, but it carries unusual energy well before its
+> arrival: the stretch from 100 to 600 ms AHEAD of the peak reads −14.1 dB
+> against the arrival itself, where a clean field record reads −39 dB or less.
 
-Between −22 dB and that ceiling the measurement is **saved and reported** rather
-than refused, with the same explanation — at that depth the record is still
-usable away from the affected frequencies, and whether the channel is worth
-re-measuring is the tuner's call.
+The notice offers both shapes that reading comes in and picks neither. One is a
+reference cancelling itself. The other is a record whose strongest sample is not
+its direct sound at all — an obstructed or badly aimed driver, where a later
+reflection outweighs the arrival puts that arrival inside the window. Telling
+them apart needs how *localized* the early energy is, and that separation
+narrows with the record's own bandwidth until it is worth about 2.5 dB on a
+subwoofer-width channel. That is why the reading never refuses a measurement,
+and why the text names no cause: on the evidence available it cannot, and
+guessing would send a tuner to check wiring that was correct all along.
 
-The window is placed against the strongest sample, which is normally the
-arrival. A record whose direct path is obstructed, and whose strongest sample is
-therefore a reflection more than 100 ms later, puts its own direct sound inside
-that window — a reading over the ceiling for a record that is merely awkward.
-Those two are told apart by what fills the window: one arrival with its decay is
-a single event, the fault is a ring that fills it evenly. A discrete event is
-reported instead of refused, and says so — the reference is probably fine there,
-and what wants checking is where the microphone was pointed.
-
-That reading only means something over a wide excitation. A band-limited record
-cannot hold an event sharper than its own bandwidth allows, so on a narrow band
-even a single arrival smears until it looks like a ring. Below five octaves the
-refusal is therefore withheld and the report speaks instead — the reading is
-still made and still shown, but a band sweep is never refused for it, and the
-report there names no cause at all: it says the energy is unusual and that this
-band cannot tell a reference fault from a late reflection. Re-measuring the same
-channel full-range is what separates them.
+So the reading is a prompt to look, not a verdict. If it appears on a channel
+you have no other reason to doubt, the quickest separation is to check the
+loopback path itself and re-measure — a contaminated reference repeats, an
+awkward microphone position does not.
 
 The check stays silent on a sweep whose duration was too short to open a guard
 band around its requested band (under a third of an octave). The estimator's own

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -570,6 +570,15 @@ than refused, with the same explanation — at that depth the record is still
 usable away from the affected frequencies, and whether the channel is worth
 re-measuring is the tuner's call.
 
+The window is placed against the strongest sample, which is normally the
+arrival. A record whose direct path is obstructed, and whose strongest sample is
+therefore a reflection more than 100 ms later, puts its own direct sound inside
+that window — a reading over the ceiling for a record that is merely awkward.
+Those two are told apart by what fills the window: one arrival with its decay is
+a single event, the fault is a ring that fills it evenly. A discrete event is
+reported instead of refused, and says so — the reference is probably fine there,
+and what wants checking is where the microphone was pointed.
+
 The check stays silent on a sweep whose duration was too short to open a guard
 band around its requested band (under a third of an octave). The estimator's own
 band-limiting kernel is symmetric, so it rings both ways too; with the guard the

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -343,6 +343,19 @@ public static class TransferIrDiagnostics
     /// milliseconds in. A share-of-total measure moves with that delay by tens of
     /// dB (an ideal band-limited kernel at zero delay puts half its energy in
     /// wrapped negative time) and cannot be given a threshold at all.
+    /// <para>
+    /// One way a reference earns this reading is worth naming, because it is what
+    /// an interface's own monitor path does when the direct level is pulled down
+    /// and a delayed return is not: once the delayed component EXCEEDS the direct
+    /// one the reference stops being minimum-phase, and its inverse is anticausal.
+    /// The flip is sharp — measured on a reference of one direct plus one 20 ms
+    /// copy, the inverse holds 0 % of its energy in negative time while the direct
+    /// leads by 1.6 dB and 100 % once it trails by 0.9 dB. It is not the only way,
+    /// and the thresholds here are calibrated on field records rather than on that
+    /// model: a dense reverb mixed hot enough to reach the field pair's reading
+    /// also drives compactness to 12-15 dB, where the shape gate refuses it
+    /// already, while the field records cleared that gate at 26.0 and 24.1 dB.
+    /// </para>
     /// </remarks>
     public static double? MeasurePreArrivalDb(
         IReadOnlyList<Complex> impulseResponse,

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -170,23 +170,51 @@ public static class TransferIrDiagnostics
     /// reflection's energy reads -18.0 dB while clearing the compactness floor at
     /// 23.1 dB — a refusal for a record that is merely awkward.
     /// <para>
-    /// The two are told apart by WHAT fills the window. A direct arrival with its
-    /// own decay is one event: measured 20.7-21.9 dB of crest, and 31.0 dB when it
-    /// is a bare band-limited impulse. The fault is a ring that fills the window
-    /// evenly: the two field records read 13.1 and 12.8 dB. 17 dB splits that, 4 dB
-    /// above the fault and 3.7 dB below the awkward record — thinner than the
-    /// margins the refusals here carry, which is exactly why it decides only
-    /// whether to REFUSE or to REPORT. Landing on the wrong side of it costs a
-    /// message, never a measurement.
+    /// The two are told apart by WHAT fills the window. A discrete arrival with its
+    /// own decay concentrates its energy; the fault is a ring that fills the window
+    /// evenly, and the two field records read 13.1 and 12.8 dB of crest. Swept over
+    /// 215 two-arrival records at bands this verdict is allowed for (see
+    /// <see cref="MinimumRefusableSpanOctaves"/>) — first arrival 2-20 % of the
+    /// later one's energy, gaps of 150-400 ms, decays of 0.10 and 0.25 s — the
+    /// LOWEST crest a discrete event produced was 18.3 dB. 16 dB sits 2.9 dB above
+    /// the field fault and 2.3 dB below that worst event.
+    /// </para>
+    /// <para>
+    /// Thinner than the margins the refusals here carry, which is exactly why it
+    /// decides only whether to REFUSE or to REPORT: landing on the wrong side of it
+    /// costs a message, never a measurement.
     /// </para>
     /// <para>
     /// Anchoring on the first credible arrival instead was tried and does not
-    /// work: <see cref="EstimateIrStart"/> answers 500.0 ms on that very record
-    /// (the reflection, not the direct 200 ms ahead of it) and 0.0 ms on both
-    /// field records, where the acausal ring reaches the head of the buffer.
+    /// work: <see cref="EstimateIrStart"/> answers 499.9 ms on such a record (the
+    /// later, stronger arrival, not the direct 200 ms ahead of it) and 0.0 ms on
+    /// both field records, where the acausal ring reaches the head of the buffer.
+    /// Anchoring there also costs the fault 1.7 dB of the level margin.
     /// </para>
     /// </remarks>
-    public const double PreArrivalCrestDb = 17.0;
+    public const double PreArrivalCrestDb = 16.0;
+
+    /// <summary>
+    /// How wide the excitation has to be, in octaves, before a pre-arrival reading
+    /// over <see cref="MaximumPreArrivalDb"/> may be REFUSED rather than reported.
+    /// </summary>
+    /// <remarks>
+    /// Crest is a statement about time, and a band-limited record cannot hold a
+    /// sharper event than its own bandwidth allows: the narrower the excitation,
+    /// the more a single arrival smears until it is indistinguishable from a ring.
+    /// Measured on the same two-arrival sweep, the lowest crest a discrete event
+    /// reached falls with the band — 21.6 dB at 7.6 octaves, 18.3 at 5.9, 17.6 at
+    /// 4.9, 16.1 at 4.3, and by 2.3 octaves it is 13.3 dB, inside the range the
+    /// field fault itself occupies. Five octaves is where the margin appears and
+    /// stays: every band at or above it read 18.3 dB or more. Below it the reading
+    /// is still made and still REPORTED — it is only the refusal that is withheld,
+    /// because there the two shapes genuinely cannot be told apart.
+    /// <para>
+    /// Both field records that provoked this gate were measured over 6.6 and 11
+    /// octaves, so the refusal still reaches them.
+    /// </para>
+    /// </remarks>
+    public const double MinimumRefusableSpanOctaves = 5.0;
 
     /// <summary>
     /// The sharpness floor below which a transfer IR is not a measurement of the
@@ -515,6 +543,31 @@ public static class TransferIrDiagnostics
             gate.LowFullNyquistFraction / gate.LowZeroNyquistFraction);
         return double.IsFinite(guardOctaves) &&
             guardOctaves >= MinimumJudgeableGuardOctaves;
+    }
+
+    /// <summary>
+    /// Whether a pre-arrival reading over <see cref="MaximumPreArrivalDb"/> may be
+    /// refused for a record gated by <paramref name="gate"/>, or only reported —
+    /// see <see cref="MinimumRefusableSpanOctaves"/> for why the excitation's width
+    /// decides that.
+    /// </summary>
+    public static bool CanRefuseOnPreArrival(ExcitationBandGate gate)
+    {
+        if (!CanJudgePreArrival(gate))
+        {
+            return false;
+        }
+
+        // No low edge means the excitation runs to DC: the widest span there is.
+        if (gate.LowZeroNyquistFraction <= 0)
+        {
+            return true;
+        }
+
+        double spanOctaves = Math.Log2(
+            gate.HighZeroNyquistFraction / gate.LowZeroNyquistFraction);
+        return double.IsFinite(spanOctaves) &&
+            spanOctaves >= MinimumRefusableSpanOctaves;
     }
 
     private sealed class RealPartsView(IReadOnlyList<Complex> source)

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -92,6 +92,57 @@ public static class TransferIrDiagnostics
     public const double ArrivalWindowSeconds = 0.002;
 
     /// <summary>
+    /// Where the pre-arrival window starts ahead of the peak: the same 100 ms the
+    /// compactness window reserves for the band-limited kernel's pre-ringing.
+    /// </summary>
+    public const double PreArrivalStartSeconds = 0.100;
+
+    /// <summary>
+    /// Where the pre-arrival window ends. Half a second of it, so a slowly decaying
+    /// ring is read where it is still strong rather than at its own tail.
+    /// </summary>
+    public const double PreArrivalEndSeconds = 0.600;
+
+    /// <summary>
+    /// The pre-arrival reading above which a transfer IR is not a measurement of a
+    /// room but of a reference that cancelled itself.
+    /// <para>
+    /// Calibration, on ideal gated kernels at every supported band plus field
+    /// records from two rigs: an ideal half-octave-guarded kernel reads -26.8 dB at
+    /// the very worst (a 20-25 Hz band sweep) and -34.1 dB at 20-50 Hz, genuine
+    /// field records read -39.0 to -47.3 dB, and the two records taken through a
+    /// loopback that ran through an interface's direct mixer read -14.8 and
+    /// -14.1 dB. -18 dB sits 3.2 dB above the worst of those and 8.8 dB below the
+    /// weakest legitimate shape — the same shape of margin
+    /// <see cref="MinimumCompactnessDb"/> carries, and for the same reason: a real
+    /// capture must not be refused to catch a garbage one.
+    /// </para>
+    /// </summary>
+    public const double MaximumPreArrivalDb = -18.0;
+
+    /// <summary>
+    /// The pre-arrival reading a record has to stay under to be published without a
+    /// word. Between this and <see cref="MaximumPreArrivalDb"/> the record is saved
+    /// and REPORTED rather than refused.
+    /// <para>
+    /// Scaled by imposing a magnitude-only resonance of growing depth at 34.5 Hz,
+    /// Q 40, on a clean field record — an acausal ring of controllable size, not a
+    /// claim about how the field fault arose: 6 dB reads -28.8 dB, 9 dB reads
+    /// -24.5, 12 dB reads -21.0, 16 dB reads -17.1. -22 dB therefore starts
+    /// reporting around 11 dB of it, well before the fault costs a session, and
+    /// still leaves 4.8 dB to the worst legitimate shape there is (the -26.8 dB
+    /// kernel above).
+    /// </para>
+    /// </summary>
+    public const double SuspectPreArrivalDb = -22.0;
+
+    /// <summary>
+    /// The low guard band, in octaves, below which <see cref="CanJudgePreArrival"/>
+    /// withholds the pre-arrival verdict.
+    /// </summary>
+    public const double MinimumJudgeableGuardOctaves = 0.30;
+
+    /// <summary>
     /// The sharpness floor below which a transfer IR is not a measurement of the
     /// sweep it was analyzed against.
     /// <para>
@@ -261,6 +312,144 @@ public static class TransferIrDiagnostics
         // the real parts asked for a second array the size of the response — 34 MB at
         // the transform length a 96 kHz twenty-second take reaches, for nothing.
         return MeasureCompactness(new RealPartsView(impulseResponse), sampleRate);
+    }
+
+    /// <summary>
+    /// How far (dB) the per-sample energy of the stretch WELL BEFORE the arrival
+    /// sits under the arrival's own neighbourhood, measured circularly. Null when
+    /// the record is too short to hold the window, or too degenerate to measure.
+    /// <para>
+    /// This answers a question <see cref="MeasureCompactness"/> cannot: whether the
+    /// ring is CAUSAL. Nothing arrives before the direct sound, so a record that
+    /// rings as loudly ahead of its peak as behind it is not reporting a room. The
+    /// field pair this was written for read -14.8 and -14.1 dB where clean records
+    /// from the same rig read -39.0 and -44.3 dB — and both cleared the compactness
+    /// floor, at 26.0 and 24.1 dB against 22.
+    /// </para>
+    /// <para>
+    /// What separates the two measures is what they are blind to. A resonance
+    /// imposed on a record in MAGNITUDE alone shows up here; a minimum-phase one of
+    /// the same depth does not, because it rings forward only. Compactness reads
+    /// those two as the same record (measured: 24.68 against 24.65 dB). A cabin's
+    /// own resonances are minimum-phase, so this measure ignores them and can carry
+    /// a threshold a reverberant cabin cannot trip — which is what lets it refuse
+    /// where the compactness floor has to stay low enough to keep such a cabin.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// Read against the ARRIVAL rather than the whole record, so it follows the
+    /// peak: a purely electrical measurement peaks at zero, where "before the
+    /// arrival" is the far end of the buffer, and an acoustic one peaks tens of
+    /// milliseconds in. A share-of-total measure moves with that delay by tens of
+    /// dB (an ideal band-limited kernel at zero delay puts half its energy in
+    /// wrapped negative time) and cannot be given a threshold at all.
+    /// </remarks>
+    public static double? MeasurePreArrivalDb(
+        IReadOnlyList<Complex> impulseResponse,
+        int sampleRate)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        return MeasurePreArrivalDb(new RealPartsView(impulseResponse), sampleRate);
+    }
+
+    internal static double? MeasurePreArrivalDb(
+        IReadOnlyList<double> impulseResponse,
+        int sampleRate)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        int length = impulseResponse.Count;
+        if (length < CompactnessMinimumSamples || sampleRate <= 0)
+        {
+            return null;
+        }
+
+        int start = (int)(PreArrivalStartSeconds * sampleRate);
+        // The far edge shrinks on a short record so the two windows cannot meet
+        // around the circle and read each other's content.
+        int end = Math.Min((int)(PreArrivalEndSeconds * sampleRate), length / 4);
+        if (start <= 0 || end < 2 * start)
+        {
+            return null;
+        }
+
+        double peak = 0;
+        int peakIndex = 0;
+        for (int i = 0; i < length; i++)
+        {
+            double sample = impulseResponse[i];
+            if (Math.Abs(sample) > peak)
+            {
+                peak = Math.Abs(sample);
+                peakIndex = i;
+            }
+        }
+
+        double arrival = 0;
+        for (int k = -start; k <= start; k++)
+        {
+            double sample = impulseResponse[((peakIndex + k) % length + length) % length];
+            arrival += sample * sample;
+        }
+
+        double before = 0;
+        for (int k = -end; k < -start; k++)
+        {
+            double sample = impulseResponse[((peakIndex + k) % length + length) % length];
+            before += sample * sample;
+        }
+
+        // Unmeasurable covers "nothing to measure" AND "not a number to measure":
+        // a single NaN/Infinity poisons the sums, and a caller must not read a
+        // poisoned ratio as a pass.
+        if (!double.IsFinite(arrival) || !double.IsFinite(before) || arrival <= 0)
+        {
+            return null;
+        }
+
+        double arrivalPerSample = arrival / (2 * start + 1);
+        double beforePerSample = before / (end - start);
+        // A synthetic record with nothing at all before its arrival would divide by
+        // zero; the floor caps the reading at -120 dB instead.
+        return 10 * Math.Log10(
+            Math.Max(beforePerSample, arrivalPerSample * 1e-12) / arrivalPerSample);
+    }
+
+    /// <summary>
+    /// Whether <see cref="MeasurePreArrivalDb"/> can be given a verdict for a record
+    /// gated by <paramref name="gate"/>, or whether the estimator's own kernel rings
+    /// too much like the fault to tell them apart.
+    /// </summary>
+    /// <remarks>
+    /// The zero-phase excitation gate turns even an ideal H(f)=1 into a symmetric
+    /// band-limited kernel, and how long that kernel rings is set by the width of its
+    /// narrowest transition — the LOW guard band, which is the narrowest in Hz at
+    /// every band, since the same octave guard spans fewer Hz at the bottom. The
+    /// sweep generator aims for half an octave (<c>DesiredGuardOctaves</c>) and only
+    /// falls short when the requested duration cannot open one. Measured on ideal
+    /// gated kernels: with the half-octave guard the worst band the app supports
+    /// (20-25 Hz, a fifth of an octave wide) reads -26.8 dB, and it stays at or
+    /// under -22.7 dB down to a quarter-octave guard — but at 0.05 octaves it reaches
+    /// -14.9 dB, which is where the two broken field records read. Below the floor
+    /// here the check says nothing rather than guessing, in the same spirit as the
+    /// compactness floor sitting on the garbage side of its own gap.
+    /// </remarks>
+    public static bool CanJudgePreArrival(ExcitationBandGate gate)
+    {
+        // No low edge at all (full-band excitation) means no low-edge kernel to
+        // confuse the reading with.
+        if (gate.LowFullNyquistFraction <= 0)
+        {
+            return true;
+        }
+        if (gate.LowZeroNyquistFraction <= 0)
+        {
+            return true;
+        }
+
+        double guardOctaves = Math.Log2(
+            gate.LowFullNyquistFraction / gate.LowZeroNyquistFraction);
+        return double.IsFinite(guardOctaves) &&
+            guardOctaves >= MinimumJudgeableGuardOctaves;
     }
 
     private sealed class RealPartsView(IReadOnlyList<Complex> source)

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -59,19 +59,6 @@ public readonly record struct TransferIrCompactness(
     double PeakDelayMs);
 
 /// <summary>
-/// What sits in a transfer IR's pre-arrival window (see
-/// <see cref="TransferIrDiagnostics.MeasurePreArrivalDb"/>).
-/// <see cref="LevelDb"/> is how far its per-sample energy stands under the
-/// arrival's own neighbourhood — the verdict figure. <see cref="CrestDb"/> is
-/// the window's own crest factor, which says whether that energy is a stationary
-/// ring or one discrete event that the peak-relative window happened to enclose,
-/// and so whether the level is worth refusing over.
-/// </summary>
-public readonly record struct TransferIrPreArrival(
-    double LevelDb,
-    double CrestDb);
-
-/// <summary>
 /// Record-hygiene diagnostics shared by the manual Time Alignment mode and
 /// the auto-delay launcher: where the driver's energy actually lives in
 /// frequency, and whether the record's head carries a playback-crosstalk
@@ -117,34 +104,27 @@ public static class TransferIrDiagnostics
     public const double PreArrivalEndSeconds = 0.600;
 
     /// <summary>
-    /// The pre-arrival reading above which a transfer IR is not a measurement of a
-    /// room but of a reference that cancelled itself.
-    /// <para>
-    /// Calibration, on ideal gated kernels at every supported band plus field
-    /// records from two rigs: an ideal half-octave-guarded kernel reads -26.8 dB at
-    /// the very worst (a 20-25 Hz band sweep) and -34.1 dB at 20-50 Hz, genuine
-    /// field records read -39.0 to -47.3 dB, and the two records taken through a
-    /// loopback that ran through an interface's direct mixer read -14.8 and
-    /// -14.1 dB. -18 dB sits 3.2 dB above the worst of those and 8.8 dB below the
-    /// weakest legitimate shape — the same shape of margin
-    /// <see cref="MinimumCompactnessDb"/> carries, and for the same reason: a real
-    /// capture must not be refused to catch a garbage one.
-    /// </para>
-    /// </summary>
-    public const double MaximumPreArrivalDb = -18.0;
-
-    /// <summary>
     /// The pre-arrival reading a record has to stay under to be published without a
-    /// word. Between this and <see cref="MaximumPreArrivalDb"/> the record is saved
-    /// and REPORTED rather than refused.
+    /// word. Above it the measurement is saved and REPORTED — never refused.
     /// <para>
     /// Scaled by imposing a magnitude-only resonance of growing depth at 34.5 Hz,
     /// Q 40, on a clean field record — an acausal ring of controllable size, not a
     /// claim about how the field fault arose: 6 dB reads -28.8 dB, 9 dB reads
     /// -24.5, 12 dB reads -21.0, 16 dB reads -17.1. -22 dB therefore starts
     /// reporting around 11 dB of it, well before the fault costs a session, and
-    /// still leaves 4.8 dB to the worst legitimate shape there is (the -26.8 dB
-    /// kernel above).
+    /// still leaves 4.8 dB to the worst legitimate shape there is — an ideal
+    /// half-octave-guarded kernel over a 20-25 Hz band sweep, at -26.8 dB. Genuine
+    /// field records read -39.0 to -47.3 dB and the two taken through a
+    /// contaminated reference read -14.8 and -14.1 dB.
+    /// </para>
+    /// <para>
+    /// A report and not a refusal, deliberately. A refusal was built on this
+    /// measure and withdrawn: telling a fault from a record whose strongest sample
+    /// is simply not its arrival needs the pre-arrival window's crest, and the
+    /// separation that offers narrows with the record's own bandwidth — down to
+    /// 2.5 dB at the effective width one of the two field faults has. That is too
+    /// thin to destroy a measurement over, on a calibration set of two records
+    /// from one rig. The reading is reported instead, and the user decides.
     /// </para>
     /// </summary>
     public const double SuspectPreArrivalDb = -22.0;
@@ -154,67 +134,6 @@ public static class TransferIrDiagnostics
     /// withholds the pre-arrival verdict.
     /// </summary>
     public const double MinimumJudgeableGuardOctaves = 0.30;
-
-    /// <summary>
-    /// The crest factor at or above which the pre-arrival window is holding a
-    /// discrete EVENT rather than a stationary ring, and a reading over
-    /// <see cref="MaximumPreArrivalDb"/> is reported instead of refused.
-    /// </summary>
-    /// <remarks>
-    /// The window is placed relative to the strongest sample, which every measure
-    /// in this file treats as the arrival. A record whose direct path is obstructed
-    /// and whose strongest sample is therefore a reflection MORE than
-    /// <see cref="PreArrivalStartSeconds"/> later breaks that assumption: its real
-    /// direct sound then sits inside the pre-arrival window and reads as acausal
-    /// energy. Measured, at 48 kHz with a 200 ms gap, a direct carrying 4 % of the
-    /// reflection's energy reads -18.0 dB while clearing the compactness floor at
-    /// 23.1 dB — a refusal for a record that is merely awkward.
-    /// <para>
-    /// The two are told apart by WHAT fills the window. A discrete arrival with its
-    /// own decay concentrates its energy; the fault is a ring that fills the window
-    /// evenly, and the two field records read 13.1 and 12.8 dB of crest. Swept over
-    /// 215 two-arrival records at bands this verdict is allowed for (see
-    /// <see cref="MinimumRefusableSpanOctaves"/>) — first arrival 2-20 % of the
-    /// later one's energy, gaps of 150-400 ms, decays of 0.10 and 0.25 s — the
-    /// LOWEST crest a discrete event produced was 18.3 dB. 16 dB sits 2.9 dB above
-    /// the field fault and 2.3 dB below that worst event.
-    /// </para>
-    /// <para>
-    /// Thinner than the margins the refusals here carry, which is exactly why it
-    /// decides only whether to REFUSE or to REPORT: landing on the wrong side of it
-    /// costs a message, never a measurement.
-    /// </para>
-    /// <para>
-    /// Anchoring on the first credible arrival instead was tried and does not
-    /// work: <see cref="EstimateIrStart"/> answers 499.9 ms on such a record (the
-    /// later, stronger arrival, not the direct 200 ms ahead of it) and 0.0 ms on
-    /// both field records, where the acausal ring reaches the head of the buffer.
-    /// Anchoring there also costs the fault 1.7 dB of the level margin.
-    /// </para>
-    /// </remarks>
-    public const double PreArrivalCrestDb = 16.0;
-
-    /// <summary>
-    /// How wide the excitation has to be, in octaves, before a pre-arrival reading
-    /// over <see cref="MaximumPreArrivalDb"/> may be REFUSED rather than reported.
-    /// </summary>
-    /// <remarks>
-    /// Crest is a statement about time, and a band-limited record cannot hold a
-    /// sharper event than its own bandwidth allows: the narrower the excitation,
-    /// the more a single arrival smears until it is indistinguishable from a ring.
-    /// Measured on the same two-arrival sweep, the lowest crest a discrete event
-    /// reached falls with the band — 21.6 dB at 7.6 octaves, 18.3 at 5.9, 17.6 at
-    /// 4.9, 16.1 at 4.3, and by 2.3 octaves it is 13.3 dB, inside the range the
-    /// field fault itself occupies. Five octaves is where the margin appears and
-    /// stays: every band at or above it read 18.3 dB or more. Below it the reading
-    /// is still made and still REPORTED — it is only the refusal that is withheld,
-    /// because there the two shapes genuinely cannot be told apart.
-    /// <para>
-    /// Both field records that provoked this gate were measured over 6.6 and 11
-    /// octaves, so the refusal still reaches them.
-    /// </para>
-    /// </remarks>
-    public const double MinimumRefusableSpanOctaves = 5.0;
 
     /// <summary>
     /// The sharpness floor below which a transfer IR is not a measurement of the
@@ -431,7 +350,7 @@ public static class TransferIrDiagnostics
     /// already, while the field records cleared that gate at 26.0 and 24.1 dB.
     /// </para>
     /// </remarks>
-    public static TransferIrPreArrival? MeasurePreArrivalDb(
+    public static double? MeasurePreArrivalDb(
         IReadOnlyList<Complex> impulseResponse,
         int sampleRate)
     {
@@ -439,7 +358,7 @@ public static class TransferIrDiagnostics
         return MeasurePreArrivalDb(new RealPartsView(impulseResponse), sampleRate);
     }
 
-    internal static TransferIrPreArrival? MeasurePreArrivalDb(
+    internal static double? MeasurePreArrivalDb(
         IReadOnlyList<double> impulseResponse,
         int sampleRate)
     {
@@ -479,12 +398,10 @@ public static class TransferIrDiagnostics
         }
 
         double before = 0;
-        double beforePeak = 0;
         for (int k = -end; k < -start; k++)
         {
             double sample = impulseResponse[((peakIndex + k) % length + length) % length];
             before += sample * sample;
-            beforePeak = Math.Max(beforePeak, Math.Abs(sample));
         }
 
         // Unmeasurable covers "nothing to measure" AND "not a number to measure":
@@ -499,12 +416,8 @@ public static class TransferIrDiagnostics
         double beforePerSample = before / (end - start);
         // A synthetic record with nothing at all before its arrival would divide by
         // zero; the floor caps the reading at -120 dB instead.
-        double levelDb = 10 * Math.Log10(
+        return 10 * Math.Log10(
             Math.Max(beforePerSample, arrivalPerSample * 1e-12) / arrivalPerSample);
-        double crestDb = beforePerSample > 0
-            ? 20 * Math.Log10(beforePeak / Math.Sqrt(beforePerSample))
-            : 0.0;
-        return new TransferIrPreArrival(levelDb, crestDb);
     }
 
     /// <summary>
@@ -543,31 +456,6 @@ public static class TransferIrDiagnostics
             gate.LowFullNyquistFraction / gate.LowZeroNyquistFraction);
         return double.IsFinite(guardOctaves) &&
             guardOctaves >= MinimumJudgeableGuardOctaves;
-    }
-
-    /// <summary>
-    /// Whether a pre-arrival reading over <see cref="MaximumPreArrivalDb"/> may be
-    /// refused for a record gated by <paramref name="gate"/>, or only reported —
-    /// see <see cref="MinimumRefusableSpanOctaves"/> for why the excitation's width
-    /// decides that.
-    /// </summary>
-    public static bool CanRefuseOnPreArrival(ExcitationBandGate gate)
-    {
-        if (!CanJudgePreArrival(gate))
-        {
-            return false;
-        }
-
-        // No low edge means the excitation runs to DC: the widest span there is.
-        if (gate.LowZeroNyquistFraction <= 0)
-        {
-            return true;
-        }
-
-        double spanOctaves = Math.Log2(
-            gate.HighZeroNyquistFraction / gate.LowZeroNyquistFraction);
-        return double.IsFinite(spanOctaves) &&
-            spanOctaves >= MinimumRefusableSpanOctaves;
     }
 
     private sealed class RealPartsView(IReadOnlyList<Complex> source)

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -325,8 +325,8 @@ public static class TransferIrDiagnostics
     /// the same depth does not, because it rings forward only. Compactness reads
     /// those two as the same record (measured: 24.68 against 24.65 dB). A cabin's
     /// own resonances are minimum-phase, so this measure ignores them and can carry
-    /// a threshold a reverberant cabin cannot trip — which is what lets it refuse
-    /// where the compactness floor has to stay low enough to keep such a cabin.
+    /// a threshold a reverberant cabin cannot trip — which is what lets it report a
+    /// fault the compactness floor has to stay low enough to let through.
     /// </para>
     /// </summary>
     /// <remarks>

--- a/dsp/TransferIrDiagnostics.cs
+++ b/dsp/TransferIrDiagnostics.cs
@@ -59,6 +59,19 @@ public readonly record struct TransferIrCompactness(
     double PeakDelayMs);
 
 /// <summary>
+/// What sits in a transfer IR's pre-arrival window (see
+/// <see cref="TransferIrDiagnostics.MeasurePreArrivalDb"/>).
+/// <see cref="LevelDb"/> is how far its per-sample energy stands under the
+/// arrival's own neighbourhood — the verdict figure. <see cref="CrestDb"/> is
+/// the window's own crest factor, which says whether that energy is a stationary
+/// ring or one discrete event that the peak-relative window happened to enclose,
+/// and so whether the level is worth refusing over.
+/// </summary>
+public readonly record struct TransferIrPreArrival(
+    double LevelDb,
+    double CrestDb);
+
+/// <summary>
 /// Record-hygiene diagnostics shared by the manual Time Alignment mode and
 /// the auto-delay launcher: where the driver's energy actually lives in
 /// frequency, and whether the record's head carries a playback-crosstalk
@@ -141,6 +154,39 @@ public static class TransferIrDiagnostics
     /// withholds the pre-arrival verdict.
     /// </summary>
     public const double MinimumJudgeableGuardOctaves = 0.30;
+
+    /// <summary>
+    /// The crest factor at or above which the pre-arrival window is holding a
+    /// discrete EVENT rather than a stationary ring, and a reading over
+    /// <see cref="MaximumPreArrivalDb"/> is reported instead of refused.
+    /// </summary>
+    /// <remarks>
+    /// The window is placed relative to the strongest sample, which every measure
+    /// in this file treats as the arrival. A record whose direct path is obstructed
+    /// and whose strongest sample is therefore a reflection MORE than
+    /// <see cref="PreArrivalStartSeconds"/> later breaks that assumption: its real
+    /// direct sound then sits inside the pre-arrival window and reads as acausal
+    /// energy. Measured, at 48 kHz with a 200 ms gap, a direct carrying 4 % of the
+    /// reflection's energy reads -18.0 dB while clearing the compactness floor at
+    /// 23.1 dB — a refusal for a record that is merely awkward.
+    /// <para>
+    /// The two are told apart by WHAT fills the window. A direct arrival with its
+    /// own decay is one event: measured 20.7-21.9 dB of crest, and 31.0 dB when it
+    /// is a bare band-limited impulse. The fault is a ring that fills the window
+    /// evenly: the two field records read 13.1 and 12.8 dB. 17 dB splits that, 4 dB
+    /// above the fault and 3.7 dB below the awkward record — thinner than the
+    /// margins the refusals here carry, which is exactly why it decides only
+    /// whether to REFUSE or to REPORT. Landing on the wrong side of it costs a
+    /// message, never a measurement.
+    /// </para>
+    /// <para>
+    /// Anchoring on the first credible arrival instead was tried and does not
+    /// work: <see cref="EstimateIrStart"/> answers 500.0 ms on that very record
+    /// (the reflection, not the direct 200 ms ahead of it) and 0.0 ms on both
+    /// field records, where the acausal ring reaches the head of the buffer.
+    /// </para>
+    /// </remarks>
+    public const double PreArrivalCrestDb = 17.0;
 
     /// <summary>
     /// The sharpness floor below which a transfer IR is not a measurement of the
@@ -357,7 +403,7 @@ public static class TransferIrDiagnostics
     /// already, while the field records cleared that gate at 26.0 and 24.1 dB.
     /// </para>
     /// </remarks>
-    public static double? MeasurePreArrivalDb(
+    public static TransferIrPreArrival? MeasurePreArrivalDb(
         IReadOnlyList<Complex> impulseResponse,
         int sampleRate)
     {
@@ -365,7 +411,7 @@ public static class TransferIrDiagnostics
         return MeasurePreArrivalDb(new RealPartsView(impulseResponse), sampleRate);
     }
 
-    internal static double? MeasurePreArrivalDb(
+    internal static TransferIrPreArrival? MeasurePreArrivalDb(
         IReadOnlyList<double> impulseResponse,
         int sampleRate)
     {
@@ -405,10 +451,12 @@ public static class TransferIrDiagnostics
         }
 
         double before = 0;
+        double beforePeak = 0;
         for (int k = -end; k < -start; k++)
         {
             double sample = impulseResponse[((peakIndex + k) % length + length) % length];
             before += sample * sample;
+            beforePeak = Math.Max(beforePeak, Math.Abs(sample));
         }
 
         // Unmeasurable covers "nothing to measure" AND "not a number to measure":
@@ -423,8 +471,12 @@ public static class TransferIrDiagnostics
         double beforePerSample = before / (end - start);
         // A synthetic record with nothing at all before its arrival would divide by
         // zero; the floor caps the reading at -120 dB instead.
-        return 10 * Math.Log10(
+        double levelDb = 10 * Math.Log10(
             Math.Max(beforePerSample, arrivalPerSample * 1e-12) / arrivalPerSample);
+        double crestDb = beforePerSample > 0
+            ? 20 * Math.Log10(beforePeak / Math.Sqrt(beforePerSample))
+            : 0.0;
+        return new TransferIrPreArrival(levelDb, crestDb);
     }
 
     /// <summary>

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -2144,12 +2144,17 @@ namespace Resonalyze
             }
 
             // Everything over the suspect line that the refusal did not take: the
-            // band under the ceiling, and the readings ABOVE it whose window held
-            // one discrete event rather than a ring, which are reported instead of
-            // refused.
+            // band under the ceiling, the readings ABOVE it whose window held one
+            // discrete event rather than a ring, and the ones on a band too narrow
+            // to tell those apart. The notice needs to know which — naming a cause
+            // the band cannot support is how a tuner ends up checking a reference
+            // that was fine.
             return MeasurePreArrival(transfer) is { } preArrival &&
                 preArrival.LevelDb > TransferIrDiagnostics.SuspectPreArrivalDb
-                ? new SweepResultCaution(preArrival.LevelDb, preArrival.CrestDb)
+                ? new SweepResultCaution(
+                    preArrival.LevelDb,
+                    preArrival.CrestDb,
+                    TransferIrDiagnostics.CanRefuseOnPreArrival(ExcitationGate()))
                 : null;
         }
 

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -275,6 +275,11 @@ namespace Resonalyze
         // Per-run acceptance outcome of the last completed measurement; null until
         // a measurement ran (or when the result was restored from a file).
         internal SweepRunQualityReport? QualityReport { get; private set; }
+
+        // What the published result's own shape has to say about itself, or null
+        // when it has nothing. Set alongside QualityReport and cleared with it, so
+        // a restored file never wears the last run's verdict.
+        internal SweepResultCaution? ResultCaution { get; private set; }
         public Exception? LastError { get; private set; }
         internal InputLevelMeterSnapshot CurrentLevels
         {
@@ -367,6 +372,7 @@ namespace Resonalyze
             ProtectiveHighPass = ProtectiveHighPassConfiguration.Normalize(
                 configuration.ProtectiveHighPass);
             QualityReport = null;
+            ResultCaution = null;
             LastError = null;
             CurrentLevels = InputLevelMeterSnapshot.Empty;
 
@@ -431,6 +437,7 @@ namespace Resonalyze
                 MeasurementMode = SweepMeasurementMode.SweepDeconvolution;
                 AcceptedAverageRunCount = 0;
                 QualityReport = null;
+                ResultCaution = null;
                 LastError = null;
                 CurrentLevels = InputLevelMeterSnapshot.Empty;
                 measurementTask = RunCoreAsync(cancellationTokenSource.Token);
@@ -1391,6 +1398,10 @@ namespace Resonalyze
 
                 SweepAverageResult averageResult = accumulator.BuildResult();
                 RequireCredibleTransferIr(averageResult);
+                // After the refusal, never inside it: the other caller of that check
+                // is the total-failure diagnosis, which describes a capture nothing
+                // is going to publish.
+                ResultCaution = DescribeResultCaution(averageResult);
                 ApplyAverageResult(averageResult);
                 success = true;
             }
@@ -2012,6 +2023,7 @@ namespace Resonalyze
                 double.IsFinite(measured.InsideOutsideDb) &&
                 measured.InsideOutsideDb >= TransferIrDiagnostics.MinimumCompactnessDb)
             {
+                RequireCausalTransferIr(result, transfer);
                 return;
             }
 
@@ -2036,6 +2048,90 @@ namespace Resonalyze
                 : " Check the microphone and loopback wiring and levels, then measure again.";
             throw new InvalidOperationException(
                 $"The transfer function did not form a credible impulse response: {shapeDiagnosis}.{levelDiagnosis}{advice}");
+        }
+
+        /// <summary>
+        /// Refuses a transfer IR that rings as far BEFORE its arrival as after it.
+        /// </summary>
+        /// <remarks>
+        /// The compactness gate above cannot see this class. Its window is ±100/+500
+        /// ms around the peak, and the ring stays inside that window while filling
+        /// the whole record either side of zero: the field pair this was written for
+        /// read 26.0 and 24.1 dB, over a floor of 22, carrying a 34 Hz resonance of
+        /// Q≈40-54 that rang for seconds — and that every one of the seven array
+        /// positions reported to within 0.7 dB, where a real cabin mode spread the
+        /// same positions over 5-9 dB. A feature every position shares to that
+        /// precision belongs to the shared denominator, not to the room.
+        /// <para>
+        /// The verdict is withheld, not guessed, when the excitation could not open a
+        /// guard band wide enough for the estimator's own kernel to be told apart
+        /// from the fault (see <see cref="TransferIrDiagnostics.CanJudgePreArrival"/>).
+        /// </para>
+        /// </remarks>
+        private void RequireCausalTransferIr(SweepAverageResult result, Complex[] transfer)
+        {
+            if (MeasurePreArrival(transfer) is not { } preArrivalDb ||
+                preArrivalDb <= TransferIrDiagnostics.MaximumPreArrivalDb)
+            {
+                return;
+            }
+
+            // A distorting channel produces the same symmetry and has its own,
+            // better diagnosis; it replaces the reference advice rather than
+            // joining it, exactly as it does for the compactness refusal.
+            string distortionDiagnosis = DescribeDistortion(result);
+            string advice = distortionDiagnosis.Length > 0
+                ? distortionDiagnosis
+                : " A cabin cannot do that — its own resonances ring forward — so this is not the room but what the microphone was divided BY, and every channel of the result is divided by that same reference. Check that the loopback carries the excitation itself: a wire from the output, not an interface direct-mixer or monitor path with effects, sends or faders in it. Then measure again.";
+            throw new InvalidOperationException(FormattableString.Invariant(
+                $"The transfer function did not form a credible impulse response: it rings almost as loudly BEFORE its arrival as after it. The stretch from {TransferIrDiagnostics.PreArrivalStartSeconds * 1000:0} to {TransferIrDiagnostics.PreArrivalEndSeconds * 1000:0} ms ahead of the peak reads {preArrivalDb:0.0} dB against the arrival itself, where a real measurement reads -39 dB or less and even an ideal band-limited transfer stays under {TransferIrDiagnostics.MaximumPreArrivalDb:0} dB. Nothing physical arrives half a second before the direct sound.{advice}"));
+        }
+
+        /// <summary>
+        /// The published result's pre-arrival reading, or null when this record
+        /// cannot be given one — the excitation opened no guard band wide enough to
+        /// tell the estimator's own kernel from the fault, or the record is too
+        /// short to hold the window.
+        /// </summary>
+        private double? MeasurePreArrival(Complex[] transfer)
+        {
+            ExcitationBandGate gate = Sweep is { } sweep
+                ? BuildExcitationGate(sweep)
+                : ExcitationBandGate.FullBand;
+            // Not a fail-closed gate: the compactness check has already refused
+            // content that cannot be measured at all, and a record this one cannot
+            // judge must not be refused twice for the same silence.
+            return TransferIrDiagnostics.CanJudgePreArrival(gate)
+                ? TransferIrDiagnostics.MeasurePreArrivalDb(transfer, SampleRate)
+                : null;
+        }
+
+        /// <summary>
+        /// What the published result has to say about itself short of a refusal, or
+        /// null when it has nothing.
+        /// </summary>
+        /// <remarks>
+        /// Measured a second time rather than threaded out of
+        /// <see cref="RequireCausalTransferIr"/>: that method's job is to throw, and
+        /// giving it a return value the throwing path never produces reads worse
+        /// than the two passes cost. Two linear passes over the transfer buffer sit
+        /// against the several transforms of the same length the average already
+        /// paid for.
+        /// </remarks>
+        private SweepResultCaution? DescribeResultCaution(SweepAverageResult result)
+        {
+            if (result.TransferImpulseResponse is not { } transfer)
+            {
+                return null;
+            }
+
+            // The refusal has already run, so anything still here is at or under
+            // MaximumPreArrivalDb; this only picks out the band above the suspect
+            // line.
+            return MeasurePreArrival(transfer) is { } preArrivalDb &&
+                preArrivalDb > TransferIrDiagnostics.SuspectPreArrivalDb
+                ? new SweepResultCaution(preArrivalDb)
+                : null;
         }
 
         /// <summary>

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -2057,9 +2057,9 @@ namespace Resonalyze
         /// </summary>
         private double? MeasurePreArrival(Complex[] transfer)
         {
-            // Not a fail-closed gate: the compactness check has already refused
-            // content that cannot be measured at all, and a record this one cannot
-            // judge must not be refused twice for the same silence.
+            // Null is "no reading", not "bad record": nothing is refused on this
+            // measure, and content that cannot be measured at all was already
+            // turned away by the compactness check above.
             return TransferIrDiagnostics.CanJudgePreArrival(ExcitationGate())
                 ? TransferIrDiagnostics.MeasurePreArrivalDb(transfer, SampleRate)
                 : null;
@@ -2074,8 +2074,8 @@ namespace Resonalyze
             : ExcitationBandGate.FullBand;
 
         /// <summary>
-        /// What the published result has to say about itself short of a refusal, or
-        /// null when it has nothing.
+        /// What the published result has to say about itself, or null when it has
+        /// nothing. Never a refusal — see <see cref="SweepResultCaution"/>.
         /// </summary>
         private SweepResultCaution? DescribeResultCaution(SweepAverageResult result)
         {

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -2070,8 +2070,17 @@ namespace Resonalyze
         /// </remarks>
         private void RequireCausalTransferIr(SweepAverageResult result, Complex[] transfer)
         {
-            if (MeasurePreArrival(transfer) is not { } preArrivalDb ||
-                preArrivalDb <= TransferIrDiagnostics.MaximumPreArrivalDb)
+            if (MeasurePreArrival(transfer) is not { } preArrival ||
+                preArrival.LevelDb <= TransferIrDiagnostics.MaximumPreArrivalDb)
+            {
+                return;
+            }
+
+            // One discrete event in that window is a record whose strongest sample
+            // is not its arrival, not a reference that cancelled itself. It still
+            // gets reported by the caution below — the reading is real either way —
+            // but it must not cost the measurement.
+            if (preArrival.CrestDb >= TransferIrDiagnostics.PreArrivalCrestDb)
             {
                 return;
             }
@@ -2084,7 +2093,7 @@ namespace Resonalyze
                 ? distortionDiagnosis
                 : " A cabin cannot do that — its own resonances ring forward — so this is not the room but what the microphone was divided BY, and every channel of the result is divided by that same reference. Check that the loopback carries the excitation itself: a wire from the output, not an interface direct-mixer or monitor path with effects, sends or faders in it. Then measure again.";
             throw new InvalidOperationException(FormattableString.Invariant(
-                $"The transfer function did not form a credible impulse response: it rings almost as loudly BEFORE its arrival as after it. The stretch from {TransferIrDiagnostics.PreArrivalStartSeconds * 1000:0} to {TransferIrDiagnostics.PreArrivalEndSeconds * 1000:0} ms ahead of the peak reads {preArrivalDb:0.0} dB against the arrival itself, where a real measurement reads -39 dB or less and even an ideal band-limited transfer stays under {TransferIrDiagnostics.MaximumPreArrivalDb:0} dB. Nothing physical arrives half a second before the direct sound.{advice}"));
+                $"The transfer function did not form a credible impulse response: it rings almost as loudly BEFORE its arrival as after it. The stretch from {TransferIrDiagnostics.PreArrivalStartSeconds * 1000:0} to {TransferIrDiagnostics.PreArrivalEndSeconds * 1000:0} ms ahead of the peak reads {preArrival.LevelDb:0.0} dB against the arrival itself, where a real measurement reads -39 dB or less and even an ideal band-limited transfer stays under {TransferIrDiagnostics.MaximumPreArrivalDb:0} dB. Nothing physical arrives half a second before the direct sound.{advice}"));
         }
 
         /// <summary>
@@ -2093,7 +2102,7 @@ namespace Resonalyze
         /// tell the estimator's own kernel from the fault, or the record is too
         /// short to hold the window.
         /// </summary>
-        private double? MeasurePreArrival(Complex[] transfer)
+        private TransferIrPreArrival? MeasurePreArrival(Complex[] transfer)
         {
             ExcitationBandGate gate = Sweep is { } sweep
                 ? BuildExcitationGate(sweep)
@@ -2125,12 +2134,13 @@ namespace Resonalyze
                 return null;
             }
 
-            // The refusal has already run, so anything still here is at or under
-            // MaximumPreArrivalDb; this only picks out the band above the suspect
-            // line.
-            return MeasurePreArrival(transfer) is { } preArrivalDb &&
-                preArrivalDb > TransferIrDiagnostics.SuspectPreArrivalDb
-                ? new SweepResultCaution(preArrivalDb)
+            // Everything over the suspect line that the refusal did not take: the
+            // band under the ceiling, and the readings ABOVE it whose window held
+            // one discrete event rather than a ring, which are reported instead of
+            // refused.
+            return MeasurePreArrival(transfer) is { } preArrival &&
+                preArrival.LevelDb > TransferIrDiagnostics.SuspectPreArrivalDb
+                ? new SweepResultCaution(preArrival.LevelDb, preArrival.CrestDb)
                 : null;
         }
 

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -2023,7 +2023,6 @@ namespace Resonalyze
                 double.IsFinite(measured.InsideOutsideDb) &&
                 measured.InsideOutsideDb >= TransferIrDiagnostics.MinimumCompactnessDb)
             {
-                RequireCausalTransferIr(result, transfer);
                 return;
             }
 
@@ -2051,62 +2050,12 @@ namespace Resonalyze
         }
 
         /// <summary>
-        /// Refuses a transfer IR that rings as far BEFORE its arrival as after it.
-        /// </summary>
-        /// <remarks>
-        /// The compactness gate above cannot see this class. Its window is ±100/+500
-        /// ms around the peak, and the ring stays inside that window while filling
-        /// the whole record either side of zero: the field pair this was written for
-        /// read 26.0 and 24.1 dB, over a floor of 22, carrying a 34 Hz resonance of
-        /// Q≈40-54 that rang for seconds — and that every one of the seven array
-        /// positions reported to within 0.7 dB, where a real cabin mode spread the
-        /// same positions over 5-9 dB. A feature every position shares to that
-        /// precision belongs to the shared denominator, not to the room.
-        /// <para>
-        /// The verdict is withheld, not guessed, when the excitation could not open a
-        /// guard band wide enough for the estimator's own kernel to be told apart
-        /// from the fault (see <see cref="TransferIrDiagnostics.CanJudgePreArrival"/>).
-        /// </para>
-        /// </remarks>
-        private void RequireCausalTransferIr(SweepAverageResult result, Complex[] transfer)
-        {
-            if (MeasurePreArrival(transfer) is not { } preArrival ||
-                preArrival.LevelDb <= TransferIrDiagnostics.MaximumPreArrivalDb)
-            {
-                return;
-            }
-
-            // One discrete event in that window is a record whose strongest sample
-            // is not its arrival, not a reference that cancelled itself. It still
-            // gets reported by the caution below — the reading is real either way —
-            // but it must not cost the measurement. And crest can only say which of
-            // the two it is over a wide enough excitation: on a narrow band even a
-            // single arrival smears until it reads like a ring, so there the
-            // refusal is withheld and the caution speaks instead.
-            if (preArrival.CrestDb >= TransferIrDiagnostics.PreArrivalCrestDb ||
-                !TransferIrDiagnostics.CanRefuseOnPreArrival(ExcitationGate()))
-            {
-                return;
-            }
-
-            // A distorting channel produces the same symmetry and has its own,
-            // better diagnosis; it replaces the reference advice rather than
-            // joining it, exactly as it does for the compactness refusal.
-            string distortionDiagnosis = DescribeDistortion(result);
-            string advice = distortionDiagnosis.Length > 0
-                ? distortionDiagnosis
-                : " A cabin cannot do that — its own resonances ring forward — so this is not the room but what the microphone was divided BY, and every channel of the result is divided by that same reference. Check that the loopback carries the excitation itself: a wire from the output, not an interface direct-mixer or monitor path with effects, sends or faders in it. Then measure again.";
-            throw new InvalidOperationException(FormattableString.Invariant(
-                $"The transfer function did not form a credible impulse response: it rings almost as loudly BEFORE its arrival as after it. The stretch from {TransferIrDiagnostics.PreArrivalStartSeconds * 1000:0} to {TransferIrDiagnostics.PreArrivalEndSeconds * 1000:0} ms ahead of the peak reads {preArrival.LevelDb:0.0} dB against the arrival itself, where a real measurement reads -39 dB or less and even an ideal band-limited transfer stays under {TransferIrDiagnostics.MaximumPreArrivalDb:0} dB. Nothing physical arrives half a second before the direct sound.{advice}"));
-        }
-
-        /// <summary>
         /// The published result's pre-arrival reading, or null when this record
         /// cannot be given one — the excitation opened no guard band wide enough to
         /// tell the estimator's own kernel from the fault, or the record is too
         /// short to hold the window.
         /// </summary>
-        private TransferIrPreArrival? MeasurePreArrival(Complex[] transfer)
+        private double? MeasurePreArrival(Complex[] transfer)
         {
             // Not a fail-closed gate: the compactness check has already refused
             // content that cannot be measured at all, and a record this one cannot
@@ -2128,14 +2077,6 @@ namespace Resonalyze
         /// What the published result has to say about itself short of a refusal, or
         /// null when it has nothing.
         /// </summary>
-        /// <remarks>
-        /// Measured a second time rather than threaded out of
-        /// <see cref="RequireCausalTransferIr"/>: that method's job is to throw, and
-        /// giving it a return value the throwing path never produces reads worse
-        /// than the two passes cost. Two linear passes over the transfer buffer sit
-        /// against the several transforms of the same length the average already
-        /// paid for.
-        /// </remarks>
         private SweepResultCaution? DescribeResultCaution(SweepAverageResult result)
         {
             if (result.TransferImpulseResponse is not { } transfer)
@@ -2143,18 +2084,9 @@ namespace Resonalyze
                 return null;
             }
 
-            // Everything over the suspect line that the refusal did not take: the
-            // band under the ceiling, the readings ABOVE it whose window held one
-            // discrete event rather than a ring, and the ones on a band too narrow
-            // to tell those apart. The notice needs to know which — naming a cause
-            // the band cannot support is how a tuner ends up checking a reference
-            // that was fine.
-            return MeasurePreArrival(transfer) is { } preArrival &&
-                preArrival.LevelDb > TransferIrDiagnostics.SuspectPreArrivalDb
-                ? new SweepResultCaution(
-                    preArrival.LevelDb,
-                    preArrival.CrestDb,
-                    TransferIrDiagnostics.CanRefuseOnPreArrival(ExcitationGate()))
+            return MeasurePreArrival(transfer) is { } preArrivalDb &&
+                preArrivalDb > TransferIrDiagnostics.SuspectPreArrivalDb
+                ? new SweepResultCaution(preArrivalDb)
                 : null;
         }
 

--- a/source/Measurements/ExpSweepMeasurement.cs
+++ b/source/Measurements/ExpSweepMeasurement.cs
@@ -2079,8 +2079,12 @@ namespace Resonalyze
             // One discrete event in that window is a record whose strongest sample
             // is not its arrival, not a reference that cancelled itself. It still
             // gets reported by the caution below — the reading is real either way —
-            // but it must not cost the measurement.
-            if (preArrival.CrestDb >= TransferIrDiagnostics.PreArrivalCrestDb)
+            // but it must not cost the measurement. And crest can only say which of
+            // the two it is over a wide enough excitation: on a narrow band even a
+            // single arrival smears until it reads like a ring, so there the
+            // refusal is withheld and the caution speaks instead.
+            if (preArrival.CrestDb >= TransferIrDiagnostics.PreArrivalCrestDb ||
+                !TransferIrDiagnostics.CanRefuseOnPreArrival(ExcitationGate()))
             {
                 return;
             }
@@ -2104,16 +2108,21 @@ namespace Resonalyze
         /// </summary>
         private TransferIrPreArrival? MeasurePreArrival(Complex[] transfer)
         {
-            ExcitationBandGate gate = Sweep is { } sweep
-                ? BuildExcitationGate(sweep)
-                : ExcitationBandGate.FullBand;
             // Not a fail-closed gate: the compactness check has already refused
             // content that cannot be measured at all, and a record this one cannot
             // judge must not be refused twice for the same silence.
-            return TransferIrDiagnostics.CanJudgePreArrival(gate)
+            return TransferIrDiagnostics.CanJudgePreArrival(ExcitationGate())
                 ? TransferIrDiagnostics.MeasurePreArrivalDb(transfer, SampleRate)
                 : null;
         }
+
+        /// <summary>
+        /// The gate the current sweep excites through, or the full band when there
+        /// is no sweep to read it off.
+        /// </summary>
+        private ExcitationBandGate ExcitationGate() => Sweep is { } sweep
+            ? BuildExcitationGate(sweep)
+            : ExcitationBandGate.FullBand;
 
         /// <summary>
         /// What the published result has to say about itself short of a refusal, or

--- a/source/Measurements/SweepRunQuality.cs
+++ b/source/Measurements/SweepRunQuality.cs
@@ -128,81 +128,49 @@ internal sealed record SweepRunRejection(
     IReadOnlyList<string> Issues);
 
 /// <summary>
-/// A published measurement that cleared the refusals and should not have been left
-/// to speak for itself.
+/// A published measurement whose own shape says something the user would
+/// otherwise only find by wondering why a tune fought back.
 /// </summary>
 /// <remarks>
-/// The pre-arrival refusal is calibrated on the garbage side of its gap, so a real
-/// capture is never thrown away for it. That leaves the band between
-/// <see cref="TransferIrDiagnostics.SuspectPreArrivalDb"/> and
-/// <see cref="TransferIrDiagnostics.MaximumPreArrivalDb"/>, where a reference is
-/// starting to cancel itself but the result is not yet garbage — and where a
-/// measurement used to be saved without a word. The field session behind this one
-/// spent an evening on eleven takes whose reference ran through an interface's
-/// direct mixer; the two worst read -14.8 and -14.1 dB and are refused outright,
-/// but the milder ones from the same rig are exactly what this band is for.
+/// The field session behind this spent an evening on eleven takes whose reference
+/// ran through an interface's direct mixer instead of the wire. Every level
+/// normal, coherence 0.9995, four of four runs accepted, and the two worst records
+/// carried a 34 Hz resonance of Q 38-54 that rang for seconds and put half their
+/// energy before their own arrival. They cleared the compactness floor at 26.0 and
+/// 24.1 dB against 22 and were published without a word. This notice is what was
+/// missing.
 /// <para>
-/// A notice rather than a refusal, because the cost is asymmetric: at this depth
-/// the record is still usable outside the affected band, and the user is the one
-/// who knows whether the channel is worth re-measuring. It also catches the
-/// readings the refusal deliberately hands back — a window holding one discrete
-/// event rather than a ring (see
-/// <see cref="TransferIrDiagnostics.PreArrivalCrestDb"/>), which is a different
-/// fault and gets a different sentence.
+/// A notice and never a refusal. A refusal was built on this reading and
+/// withdrawn: what separates a contaminated reference from a record whose
+/// strongest sample is simply not its arrival is how localized the pre-arrival
+/// energy is, and that separation narrows with the record's own bandwidth until it
+/// is 2.5 dB at the effective width one of the two field faults has. Too thin to
+/// destroy a measurement over, on a calibration set of two records from one rig.
+/// </para>
+/// <para>
+/// So the text names no cause. Both shapes are given, the reference first because
+/// everything is divided by it, and the reader is left to look. Naming one is how
+/// a tuner ends up checking wiring that was correct all along — the failure the
+/// distortion diagnosis was written to end.
 /// </para>
 /// </remarks>
-/// <param name="CanDiagnoseCause">
-/// Whether the excitation was wide enough for <paramref name="CrestDb"/> to say
-/// WHICH of the two shapes the energy is (see
-/// <see cref="TransferIrDiagnostics.MinimumRefusableSpanOctaves"/>). False on a
-/// narrow band, where a single arrival smears until it reads like a ring — and
-/// where naming a cause would send a tuner to fix a reference that is fine.
-/// </param>
-internal sealed record SweepResultCaution(
-    double PreArrivalDb,
-    double CrestDb,
-    bool CanDiagnoseCause)
+internal sealed record SweepResultCaution(double PreArrivalDb)
 {
     /// <summary>User-facing summary for the end-of-measurement notice.</summary>
     public string Describe() =>
         FormattableString.Invariant(
-            $"The measurement was saved, but it carries energy well before its arrival: the stretch from {TransferIrDiagnostics.PreArrivalStartSeconds * 1000:0} to {TransferIrDiagnostics.PreArrivalEndSeconds * 1000:0} ms AHEAD of the peak reads {PreArrivalDb:0.0} dB against the arrival itself, where a clean field record reads -39 dB or less.\r\n\r\n") +
-        // Three readings, three sentences. Naming a cause the measurement cannot
-        // support is the failure the distortion diagnosis was written to end — a
-        // field session spent checking wiring that was correct all along — and the
-        // narrow-band case would repeat it exactly.
-        DescribeCause();
-
-    private string DescribeCause()
-    {
-        if (!CanDiagnoseCause)
-        {
-            return "What that energy IS cannot be told from this measurement: the " +
-                "sweep is too narrow a band for a single arrival to look any " +
-                "sharper than a ring, so a reference that is cancelling itself " +
-                "and a driver whose direct sound is outweighed by a later " +
-                "reflection read alike here. Nothing is being blamed. A " +
-                "full-range sweep of the same channel would separate the two, " +
-                "and comparing this curve against one that measures cleanly is " +
-                "worth doing before you tune on it.";
-        }
-
-        return CrestDb >= TransferIrDiagnostics.PreArrivalCrestDb
-            ? "That energy is one discrete event rather than a ring, which is what " +
-                "a record whose strongest sample is NOT its direct sound looks " +
-                "like: an obstructed or badly aimed driver, where a later " +
-                "reflection outweighs the arrival. The reference is probably fine. " +
-                "Check what the microphone was pointed at, and read the arrival " +
-                "time on this record with that in mind."
-            : "Nothing physical arrives before the direct sound, and a room cannot " +
-                "ring backwards, so this is not the cabin — it is what the " +
-                "microphone was divided BY. Check that the loopback carries the " +
-                "excitation itself: a wire from the output, not an interface " +
-                "direct-mixer or monitor path with effects, sends or faders in it. " +
-                "The result is still usable away from the affected frequencies, " +
-                "but compare it against a channel that measures cleanly before you " +
-                "tune on this one.";
-    }
+            $"The measurement was saved, but it carries unusual energy well before its arrival: the stretch from {TransferIrDiagnostics.PreArrivalStartSeconds * 1000:0} to {TransferIrDiagnostics.PreArrivalEndSeconds * 1000:0} ms AHEAD of the peak reads {PreArrivalDb:0.0} dB against the arrival itself, where a clean field record reads -39 dB or less.\r\n\r\n") +
+        "Nothing physical arrives before the direct sound, so this is either the " +
+        "reference — a loopback that is not a clean copy of the excitation cancels " +
+        "itself and divides into a resonance the microphone never heard — or a " +
+        "record whose strongest sample is not its direct sound at all, where a " +
+        "later reflection outweighs an obstructed arrival. This measurement cannot " +
+        "tell which.\r\n\r\n" +
+        "Worth checking that the loopback carries the excitation itself: a wire " +
+        "from the output, not an interface direct-mixer or monitor path with " +
+        "effects, sends or faders in it. The result is still usable away from the " +
+        "affected frequencies, but compare it against a channel that measures " +
+        "cleanly before you tune on this one.";
 }
 
 /// <summary>

--- a/source/Measurements/SweepRunQuality.cs
+++ b/source/Measurements/SweepRunQuality.cs
@@ -151,16 +151,43 @@ internal sealed record SweepRunRejection(
 /// fault and gets a different sentence.
 /// </para>
 /// </remarks>
-internal sealed record SweepResultCaution(double PreArrivalDb, double CrestDb)
+/// <param name="CanDiagnoseCause">
+/// Whether the excitation was wide enough for <paramref name="CrestDb"/> to say
+/// WHICH of the two shapes the energy is (see
+/// <see cref="TransferIrDiagnostics.MinimumRefusableSpanOctaves"/>). False on a
+/// narrow band, where a single arrival smears until it reads like a ring — and
+/// where naming a cause would send a tuner to fix a reference that is fine.
+/// </param>
+internal sealed record SweepResultCaution(
+    double PreArrivalDb,
+    double CrestDb,
+    bool CanDiagnoseCause)
 {
     /// <summary>User-facing summary for the end-of-measurement notice.</summary>
     public string Describe() =>
         FormattableString.Invariant(
             $"The measurement was saved, but it carries energy well before its arrival: the stretch from {TransferIrDiagnostics.PreArrivalStartSeconds * 1000:0} to {TransferIrDiagnostics.PreArrivalEndSeconds * 1000:0} ms AHEAD of the peak reads {PreArrivalDb:0.0} dB against the arrival itself, where a clean field record reads -39 dB or less.\r\n\r\n") +
-        // The two shapes that reading comes in need different sentences: sending a
-        // user to check wiring that is correct is the failure the distortion
-        // diagnosis was written to end, and it would be repeated here.
-        (CrestDb >= TransferIrDiagnostics.PreArrivalCrestDb
+        // Three readings, three sentences. Naming a cause the measurement cannot
+        // support is the failure the distortion diagnosis was written to end — a
+        // field session spent checking wiring that was correct all along — and the
+        // narrow-band case would repeat it exactly.
+        DescribeCause();
+
+    private string DescribeCause()
+    {
+        if (!CanDiagnoseCause)
+        {
+            return "What that energy IS cannot be told from this measurement: the " +
+                "sweep is too narrow a band for a single arrival to look any " +
+                "sharper than a ring, so a reference that is cancelling itself " +
+                "and a driver whose direct sound is outweighed by a later " +
+                "reflection read alike here. Nothing is being blamed. A " +
+                "full-range sweep of the same channel would separate the two, " +
+                "and comparing this curve against one that measures cleanly is " +
+                "worth doing before you tune on it.";
+        }
+
+        return CrestDb >= TransferIrDiagnostics.PreArrivalCrestDb
             ? "That energy is one discrete event rather than a ring, which is what " +
                 "a record whose strongest sample is NOT its direct sound looks " +
                 "like: an obstructed or badly aimed driver, where a later " +
@@ -174,7 +201,8 @@ internal sealed record SweepResultCaution(double PreArrivalDb, double CrestDb)
                 "direct-mixer or monitor path with effects, sends or faders in it. " +
                 "The result is still usable away from the affected frequencies, " +
                 "but compare it against a channel that measures cleanly before you " +
-                "tune on this one.");
+                "tune on this one.";
+    }
 }
 
 /// <summary>

--- a/source/Measurements/SweepRunQuality.cs
+++ b/source/Measurements/SweepRunQuality.cs
@@ -144,22 +144,37 @@ internal sealed record SweepRunRejection(
 /// <para>
 /// A notice rather than a refusal, because the cost is asymmetric: at this depth
 /// the record is still usable outside the affected band, and the user is the one
-/// who knows whether the channel is worth re-measuring.
+/// who knows whether the channel is worth re-measuring. It also catches the
+/// readings the refusal deliberately hands back — a window holding one discrete
+/// event rather than a ring (see
+/// <see cref="TransferIrDiagnostics.PreArrivalCrestDb"/>), which is a different
+/// fault and gets a different sentence.
 /// </para>
 /// </remarks>
-internal sealed record SweepResultCaution(double PreArrivalDb)
+internal sealed record SweepResultCaution(double PreArrivalDb, double CrestDb)
 {
     /// <summary>User-facing summary for the end-of-measurement notice.</summary>
     public string Describe() =>
         FormattableString.Invariant(
-            $"The measurement was saved, but it rings before its arrival more than a clean one does: the stretch from {TransferIrDiagnostics.PreArrivalStartSeconds * 1000:0} to {TransferIrDiagnostics.PreArrivalEndSeconds * 1000:0} ms AHEAD of the peak reads {PreArrivalDb:0.0} dB against the arrival itself, where a clean field record reads -39 dB or less.\r\n\r\n") +
-        "Nothing physical arrives before the direct sound, and a room cannot ring " +
-        "backwards, so this is not the cabin — it is what the microphone was " +
-        "divided BY. Check that the loopback carries the excitation itself: a wire " +
-        "from the output, not an interface direct-mixer or monitor path with " +
-        "effects, sends or faders in it. The result is still usable away from the " +
-        "affected frequencies, but compare it against a channel that measures " +
-        "cleanly before you tune on this one.";
+            $"The measurement was saved, but it carries energy well before its arrival: the stretch from {TransferIrDiagnostics.PreArrivalStartSeconds * 1000:0} to {TransferIrDiagnostics.PreArrivalEndSeconds * 1000:0} ms AHEAD of the peak reads {PreArrivalDb:0.0} dB against the arrival itself, where a clean field record reads -39 dB or less.\r\n\r\n") +
+        // The two shapes that reading comes in need different sentences: sending a
+        // user to check wiring that is correct is the failure the distortion
+        // diagnosis was written to end, and it would be repeated here.
+        (CrestDb >= TransferIrDiagnostics.PreArrivalCrestDb
+            ? "That energy is one discrete event rather than a ring, which is what " +
+                "a record whose strongest sample is NOT its direct sound looks " +
+                "like: an obstructed or badly aimed driver, where a later " +
+                "reflection outweighs the arrival. The reference is probably fine. " +
+                "Check what the microphone was pointed at, and read the arrival " +
+                "time on this record with that in mind."
+            : "Nothing physical arrives before the direct sound, and a room cannot " +
+                "ring backwards, so this is not the cabin — it is what the " +
+                "microphone was divided BY. Check that the loopback carries the " +
+                "excitation itself: a wire from the output, not an interface " +
+                "direct-mixer or monitor path with effects, sends or faders in it. " +
+                "The result is still usable away from the affected frequencies, " +
+                "but compare it against a channel that measures cleanly before you " +
+                "tune on this one.");
 }
 
 /// <summary>

--- a/source/Measurements/SweepRunQuality.cs
+++ b/source/Measurements/SweepRunQuality.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using Resonalyze.Dsp;
 
 namespace Resonalyze;
 
@@ -125,6 +126,41 @@ internal static class SweepRunQualityCheck
 internal sealed record SweepRunRejection(
     int Run,
     IReadOnlyList<string> Issues);
+
+/// <summary>
+/// A published measurement that cleared the refusals and should not have been left
+/// to speak for itself.
+/// </summary>
+/// <remarks>
+/// The pre-arrival refusal is calibrated on the garbage side of its gap, so a real
+/// capture is never thrown away for it. That leaves the band between
+/// <see cref="TransferIrDiagnostics.SuspectPreArrivalDb"/> and
+/// <see cref="TransferIrDiagnostics.MaximumPreArrivalDb"/>, where a reference is
+/// starting to cancel itself but the result is not yet garbage — and where a
+/// measurement used to be saved without a word. The field session behind this one
+/// spent an evening on eleven takes whose reference ran through an interface's
+/// direct mixer; the two worst read -14.8 and -14.1 dB and are refused outright,
+/// but the milder ones from the same rig are exactly what this band is for.
+/// <para>
+/// A notice rather than a refusal, because the cost is asymmetric: at this depth
+/// the record is still usable outside the affected band, and the user is the one
+/// who knows whether the channel is worth re-measuring.
+/// </para>
+/// </remarks>
+internal sealed record SweepResultCaution(double PreArrivalDb)
+{
+    /// <summary>User-facing summary for the end-of-measurement notice.</summary>
+    public string Describe() =>
+        FormattableString.Invariant(
+            $"The measurement was saved, but it rings before its arrival more than a clean one does: the stretch from {TransferIrDiagnostics.PreArrivalStartSeconds * 1000:0} to {TransferIrDiagnostics.PreArrivalEndSeconds * 1000:0} ms AHEAD of the peak reads {PreArrivalDb:0.0} dB against the arrival itself, where a clean field record reads -39 dB or less.\r\n\r\n") +
+        "Nothing physical arrives before the direct sound, and a room cannot ring " +
+        "backwards, so this is not the cabin — it is what the microphone was " +
+        "divided BY. Check that the loopback carries the excitation itself: a wire " +
+        "from the output, not an interface direct-mixer or monitor path with " +
+        "effects, sends or faders in it. The result is still usable away from the " +
+        "affected frequencies, but compare it against a channel that measures " +
+        "cleanly before you tune on this one.";
+}
 
 /// <summary>
 /// Outcome of the per-run acceptance over a whole averaged measurement.

--- a/source/Shell/Form1.Initialization.cs
+++ b/source/Shell/Form1.Initialization.cs
@@ -366,6 +366,7 @@ public partial class Form1
             if (success)
             {
                 NotifyDegradedSweepAverage();
+                NotifyResultCaution();
             }
         });
     }
@@ -387,6 +388,26 @@ public partial class Form1
             "Measurement",
             MessageBoxButtons.OK,
             MessageBoxIcon.Information);
+    }
+
+    // The result published, and its own shape says something the user would
+    // otherwise only find by wondering why a tune fought back. A warning rather
+    // than the information icon the run report uses: nothing is wrong with the
+    // capture, but the reference it was divided by is suspect.
+    private void NotifyResultCaution()
+    {
+        SweepResultCaution? caution = expSweepMeasurement.ResultCaution;
+        if (caution == null || closingInProgress)
+        {
+            return;
+        }
+
+        MessageBox.Show(
+            this,
+            caution.Describe(),
+            "Measurement",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Warning);
     }
 
     private void HandleAverageProgressChanged(SweepAverageProgress progress)

--- a/tests/Resonalyze.App.Tests/SweepRunQualityCheckTests.cs
+++ b/tests/Resonalyze.App.Tests/SweepRunQualityCheckTests.cs
@@ -149,6 +149,56 @@ public sealed class SweepRunQualityCheckTests
         Assert.DoesNotContain("retry", text);
     }
 
+    // A ring on a band wide enough to recognise one: the reference is the thing to
+    // check, and the notice says so.
+    [Fact]
+    public void ResultCautionBlamesTheReferenceOnlyWhenTheBandCanShowIt()
+    {
+        string text = new SweepResultCaution(
+            PreArrivalDb: -19.0,
+            CrestDb: 12.8,
+            CanDiagnoseCause: true).Describe();
+
+        Assert.Contains("-19.0 dB", text);
+        Assert.Contains("divided BY", text);
+        Assert.Contains("loopback carries the excitation itself", text);
+    }
+
+    // The same reading on a band too narrow to tell a ring from one arrival. The
+    // measurement is kept and reported, but nothing is blamed: at this width a
+    // single arrival smears until it reads like a ring, and sending the tuner to
+    // check a reference that is fine is the failure the distortion diagnosis
+    // exists to avoid.
+    [Fact]
+    public void ResultCautionNamesNoCauseWhenTheBandCannotSeparateThem()
+    {
+        string text = new SweepResultCaution(
+            PreArrivalDb: -19.0,
+            CrestDb: 12.8,
+            CanDiagnoseCause: false).Describe();
+
+        Assert.Contains("-19.0 dB", text);
+        Assert.Contains("cannot be told from this measurement", text);
+        Assert.Contains("Nothing is being blamed", text);
+        Assert.DoesNotContain("loopback carries the excitation itself", text);
+        Assert.DoesNotContain("divided BY", text);
+    }
+
+    // A discrete event on a band that can show it: the reference is exonerated
+    // instead, and the reader is sent to the microphone.
+    [Fact]
+    public void ResultCautionNamesTheArrivalWhenTheWindowHoldsOneEvent()
+    {
+        string text = new SweepResultCaution(
+            PreArrivalDb: -17.0,
+            CrestDb: 21.0,
+            CanDiagnoseCause: true).Describe();
+
+        Assert.Contains("one discrete event", text);
+        Assert.Contains("The reference is probably fine", text);
+        Assert.DoesNotContain("loopback carries the excitation itself", text);
+    }
+
     private static float[] Tone(int length, float amplitude)
     {
         var samples = new float[length];

--- a/tests/Resonalyze.App.Tests/SweepRunQualityCheckTests.cs
+++ b/tests/Resonalyze.App.Tests/SweepRunQualityCheckTests.cs
@@ -149,54 +149,22 @@ public sealed class SweepRunQualityCheckTests
         Assert.DoesNotContain("retry", text);
     }
 
-    // A ring on a band wide enough to recognise one: the reference is the thing to
-    // check, and the notice says so.
+    // The notice quotes the reading, offers BOTH shapes it can come in, and picks
+    // neither: what separates them cannot be measured reliably enough to say, and
+    // naming one would send a tuner to check wiring that was correct all along.
     [Fact]
-    public void ResultCautionBlamesTheReferenceOnlyWhenTheBandCanShowIt()
+    public void ResultCautionQuotesTheReadingAndNamesNoSingleCause()
     {
-        string text = new SweepResultCaution(
-            PreArrivalDb: -19.0,
-            CrestDb: 12.8,
-            CanDiagnoseCause: true).Describe();
+        string text = new SweepResultCaution(PreArrivalDb: -19.0).Describe();
 
         Assert.Contains("-19.0 dB", text);
-        Assert.Contains("divided BY", text);
+        Assert.Contains("100 to 600 ms AHEAD of the peak", text);
+        // Both candidates present, neither asserted.
+        Assert.Contains("either the reference", text);
+        Assert.Contains("strongest sample is not its direct sound", text);
+        Assert.Contains("cannot tell which", text);
         Assert.Contains("loopback carries the excitation itself", text);
-    }
-
-    // The same reading on a band too narrow to tell a ring from one arrival. The
-    // measurement is kept and reported, but nothing is blamed: at this width a
-    // single arrival smears until it reads like a ring, and sending the tuner to
-    // check a reference that is fine is the failure the distortion diagnosis
-    // exists to avoid.
-    [Fact]
-    public void ResultCautionNamesNoCauseWhenTheBandCannotSeparateThem()
-    {
-        string text = new SweepResultCaution(
-            PreArrivalDb: -19.0,
-            CrestDb: 12.8,
-            CanDiagnoseCause: false).Describe();
-
-        Assert.Contains("-19.0 dB", text);
-        Assert.Contains("cannot be told from this measurement", text);
-        Assert.Contains("Nothing is being blamed", text);
-        Assert.DoesNotContain("loopback carries the excitation itself", text);
-        Assert.DoesNotContain("divided BY", text);
-    }
-
-    // A discrete event on a band that can show it: the reference is exonerated
-    // instead, and the reader is sent to the microphone.
-    [Fact]
-    public void ResultCautionNamesTheArrivalWhenTheWindowHoldsOneEvent()
-    {
-        string text = new SweepResultCaution(
-            PreArrivalDb: -17.0,
-            CrestDb: 21.0,
-            CanDiagnoseCause: true).Describe();
-
-        Assert.Contains("one discrete event", text);
-        Assert.Contains("The reference is probably fine", text);
-        Assert.DoesNotContain("loopback carries the excitation itself", text);
+        Assert.Contains("still usable away from the affected frequencies", text);
     }
 
     private static float[] Tone(int length, float amplitude)

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using MathNet.Numerics.IntegralTransforms;
 
 namespace Resonalyze.Dsp.Tests;
 
@@ -780,5 +781,262 @@ public sealed class TransferIrDiagnosticsTests
             [new Complex(double.NaN, 0), new Complex(1, 0)], SampleRate));
         Assert.Null(TransferIrDiagnostics.MeasureArrivalSharpnessDb(
             [new Complex(1, 0)], sampleRate: 0));
+    }
+
+    // The excitation gate at the narrowest supported bands, built the way the
+    // measurement builds it (half-octave guard bands), through the PRODUCTION
+    // estimator. The kernel it turns an ideal H(f)=1 into is symmetric, so it is
+    // the one legitimate shape that can look acausal — and it must stay clear of
+    // the ceiling at every band, or a band sweep would be refused for being one.
+    [Theory]
+    [InlineData(20.0, 25.0)]
+    [InlineData(20.0, 50.0)]
+    [InlineData(20.0, 1000.0)]
+    [InlineData(50.0, 100.0)]
+    [InlineData(0.0, 0.0)] // full range
+    public void MeasurePreArrivalDb_IdealGatedTransfersStayUnderTheCeiling(
+        double lowFullHz, double highFullHz)
+    {
+        const int FrameLength = 262_144;
+        ExcitationBandGate gate = ProductionGate(lowFullHz, highFullHz);
+        double[] reference = StationaryNoise(FrameLength, seed: 7);
+
+        double[] ideal = TransferFunction.ComputeAveragedRelativeIr(
+            [new TransferFunctionFrame(reference, reference)],
+            gate).ImpulseResponse;
+
+        Assert.True(
+            TransferIrDiagnostics.CanJudgePreArrival(gate),
+            $"a half-octave guard at {lowFullHz}-{highFullHz} Hz must be judgeable");
+        double? preArrival = TransferIrDiagnostics.MeasurePreArrivalDb(ideal, SampleRate);
+        Assert.NotNull(preArrival);
+        Assert.True(
+            preArrival.Value < TransferIrDiagnostics.MaximumPreArrivalDb - 5,
+            $"ideal {lowFullHz}-{highFullHz} Hz read {preArrival.Value:0.0} dB");
+    }
+
+    // The measure's whole reason to exist, and the reason it is not a second
+    // spelling of compactness. The same resonance imposed two ways: once in
+    // magnitude alone, which rings both directions, and once as the minimum-phase
+    // filter a cabin would be, which rings forward only. Compactness reads one
+    // number for both — so its floor has to sit low enough to keep a genuinely
+    // resonant cabin, and a fault hiding above that floor cannot be refused on
+    // shape. This measure sees only the first, which is what lets it carry a
+    // threshold at all.
+    [Fact]
+    public void MeasurePreArrivalDb_SeparatesADenominatorDipFromACabinResonance()
+    {
+        const int FrameLength = 262_144;
+        // The depth the field pair's reference actually lost, on a sub-band record
+        // like the one it was measured on: the fault is driven by whatever the
+        // record carries at the cancelled frequency, so a 20-200 Hz take is the
+        // honest base for it and a full-range one would understate it.
+        const double DepthDb = 18.0;
+        double[] clean = SyntheticCabinTransfer(
+            FrameLength, delayMs: 12.0, decaySeconds: 0.25, highFullHz: 200.0);
+        var band = new PeqBand(34.5, 40.0, DepthDb);
+        BiquadCoefficients biquad = PeakingBiquad.Compute(band, SampleRate);
+
+        // The same peak at 34.5 Hz either way; only the phase differs.
+        double[] denominatorDip = ApplySpectrum(
+            clean, z => Complex.Abs(BiquadResponse(biquad, z)));
+        double[] cabinResonance = ApplySpectrum(
+            clean, z => BiquadResponse(biquad, z));
+
+        double cleanPreArrival = TransferIrDiagnostics
+            .MeasurePreArrivalDb(clean, SampleRate)!.Value;
+        double dipPreArrival = TransferIrDiagnostics
+            .MeasurePreArrivalDb(denominatorDip, SampleRate)!.Value;
+        double cabinPreArrival = TransferIrDiagnostics
+            .MeasurePreArrivalDb(cabinResonance, SampleRate)!.Value;
+
+        // The absolute ceiling is calibrated on field records (see
+        // MaximumPreArrivalDb); what a synthetic can prove is the CONTRAST, and
+        // that a fault of this depth is at least reported rather than passed in
+        // silence. The end-to-end refusal is pinned where the reference can be
+        // spoiled for real, in the measurement's own tests.
+        Assert.True(
+            dipPreArrival > cabinPreArrival + 10,
+            $"a zero-phase denominator dip read {dipPreArrival:0.0} dB against " +
+            $"{cabinPreArrival:0.0} dB for the same depth minimum-phase");
+        Assert.True(
+            dipPreArrival > TransferIrDiagnostics.SuspectPreArrivalDb,
+            $"a zero-phase denominator dip must be reported; read {dipPreArrival:0.0} dB");
+        Assert.True(
+            cabinPreArrival < cleanPreArrival + 1.0,
+            $"a minimum-phase cabin resonance must leave the reading where it was " +
+            $"({cleanPreArrival:0.0} dB); it read {cabinPreArrival:0.0} dB");
+        Assert.True(
+            cabinPreArrival < TransferIrDiagnostics.SuspectPreArrivalDb,
+            "a minimum-phase cabin resonance must not even be reported; " +
+            $"read {cabinPreArrival:0.0} dB");
+
+        // And the reason a second measure was needed at all: compactness reads the
+        // two as the same record.
+        double dipCompactness = TransferIrDiagnostics
+            .MeasureCompactness(denominatorDip, SampleRate)!.Value.InsideOutsideDb;
+        double cabinCompactness = TransferIrDiagnostics
+            .MeasureCompactness(cabinResonance, SampleRate)!.Value.InsideOutsideDb;
+        Assert.True(
+            Math.Abs(dipCompactness - cabinCompactness) < 2.0,
+            "compactness is supposed to be blind to the difference, but read " +
+            $"{dipCompactness:0.0} dB against {cabinCompactness:0.0} dB");
+    }
+
+    // A sweep too short to open a guard band leaves the gate a near-hard edge, and
+    // its kernel then rings as long as the fault does. The verdict is withheld
+    // rather than guessed.
+    [Theory]
+    [InlineData(0.50, true)]
+    [InlineData(0.30, true)]
+    [InlineData(0.10, false)]
+    [InlineData(0.02, false)]
+    public void CanJudgePreArrival_FollowsTheGuardBandWidth(
+        double guardOctaves, bool judgeable)
+    {
+        double nyquist = SampleRate / 2.0;
+        double lowFull = 20.0 / nyquist;
+        var gate = new ExcitationBandGate(
+            lowFull / Math.Pow(2.0, guardOctaves),
+            lowFull,
+            50.0 / nyquist,
+            50.0 * 1.414 / nyquist);
+
+        Assert.Equal(judgeable, TransferIrDiagnostics.CanJudgePreArrival(gate));
+    }
+
+    [Fact]
+    public void CanJudgePreArrival_AcceptsAGateWithNoLowEdge()
+    {
+        Assert.True(TransferIrDiagnostics.CanJudgePreArrival(ExcitationBandGate.FullBand));
+    }
+
+    [Fact]
+    public void MeasurePreArrivalDb_IsNullWhenThereIsNothingToMeasure()
+    {
+        // Too short to hold the window: half a second of buffer cannot carry one
+        // that reaches 100 ms out and 600 ms back.
+        Assert.Null(TransferIrDiagnostics.MeasurePreArrivalDb(
+            new Complex[SampleRate / 2], SampleRate));
+        Assert.Null(TransferIrDiagnostics.MeasurePreArrivalDb(
+            new Complex[1 << 12], sampleRate: 0));
+        var poisoned = new Complex[1 << 18];
+        poisoned[100] = double.NaN;
+        Assert.Null(TransferIrDiagnostics.MeasurePreArrivalDb(poisoned, SampleRate));
+        // Silent: no arrival to read the tail against.
+        Assert.Null(TransferIrDiagnostics.MeasurePreArrivalDb(
+            new Complex[1 << 18], SampleRate));
+    }
+
+    [Fact]
+    public void MeasurePreArrivalDb_ComplexTwinMatchesTheRealPath()
+    {
+        double[] impulseResponse = SyntheticCabinTransfer(262_144, delayMs: 12.0, decaySeconds: 0.25);
+        var complexIr = Array.ConvertAll(impulseResponse, v => new Complex(v, 0.0));
+
+        Assert.Equal(
+            TransferIrDiagnostics.MeasurePreArrivalDb(impulseResponse, SampleRate),
+            TransferIrDiagnostics.MeasurePreArrivalDb(complexIr, SampleRate));
+    }
+
+    // The gate the measurement builds for a requested band: half-octave guards on
+    // each side, which is what ExponentialSineSweep aims for.
+    private static ExcitationBandGate ProductionGate(double lowFullHz, double highFullHz)
+    {
+        if (lowFullHz <= 0)
+        {
+            return ExcitationBandGate.FullBand;
+        }
+
+        double nyquist = SampleRate / 2.0;
+        double guard = Math.Sqrt(2.0);
+        return new ExcitationBandGate(
+            lowFullHz / guard / nyquist,
+            lowFullHz / nyquist,
+            highFullHz / nyquist,
+            Math.Min(1.0, highFullHz * guard / nyquist));
+    }
+
+    // A record shaped like a measurement rather than like a delta: a direct
+    // arrival some milliseconds in, a decaying cabin behind it, and the whole
+    // thing read through the PRODUCTION estimator at 20-1000 Hz. The shape
+    // matters — a bare kernel concentrates all its energy in a few samples, which
+    // flatters every ratio measured against the arrival.
+    private static double[] SyntheticCabinTransfer(
+        int length,
+        double delayMs,
+        double decaySeconds,
+        double highFullHz = 1000.0)
+    {
+        double[] reference = StationaryNoise(length, seed: 7);
+        double[] tail = StationaryNoise(length, seed: 99);
+        int arrival = (int)Math.Round(delayMs * SampleRate / 1000.0);
+        int decay = (int)Math.Round(decaySeconds * SampleRate);
+
+        var room = new double[length];
+        room[arrival] = 1.0;
+        for (int i = 1; i < decay; i++)
+        {
+            // -60 dB over the decay length, which is a car cabin at low frequency.
+            room[(arrival + i) % length] +=
+                0.5 * tail[i] * Math.Exp(-6.908 * i / decay);
+        }
+
+        return TransferFunction.ComputeAveragedRelativeIr(
+            [new TransferFunctionFrame(reference, CircularConvolve(reference, room))],
+            ProductionGate(20.0, highFullHz)).ImpulseResponse;
+    }
+
+    private static double[] CircularConvolve(double[] left, double[] right)
+    {
+        int length = left.Length;
+        var a = new Complex[length];
+        var b = new Complex[length];
+        for (int i = 0; i < length; i++)
+        {
+            a[i] = left[i];
+            b[i] = right[i];
+        }
+
+        Fourier.Forward(a, FourierOptions.Matlab);
+        Fourier.Forward(b, FourierOptions.Matlab);
+        for (int bin = 0; bin < length; bin++)
+        {
+            a[bin] *= b[bin] * length;
+        }
+
+        Fourier.Inverse(a, FourierOptions.Matlab);
+        return Array.ConvertAll(a, value => value.Real);
+    }
+
+    private static Complex BiquadResponse(BiquadCoefficients biquad, Complex z)
+    {
+        // The stored a1/a2 are negated for miniDSP's additive feedback form.
+        Complex inverse = 1.0 / z;
+        Complex inverseSquared = inverse * inverse;
+        return (biquad.B0 + biquad.B1 * inverse + biquad.B2 * inverseSquared) /
+            (1.0 - biquad.A1 * inverse - biquad.A2 * inverseSquared);
+    }
+
+    private static double[] ApplySpectrum(
+        double[] impulseResponse,
+        Func<Complex, Complex> response)
+    {
+        int length = impulseResponse.Length;
+        var spectrum = new Complex[length];
+        for (int i = 0; i < length; i++)
+        {
+            spectrum[i] = impulseResponse[i];
+        }
+
+        Fourier.Forward(spectrum, FourierOptions.Matlab);
+        for (int bin = 0; bin < length; bin++)
+        {
+            spectrum[bin] *= response(
+                Complex.FromPolarCoordinates(1.0, Math.Tau * bin / length));
+        }
+
+        Fourier.Inverse(spectrum, FourierOptions.Matlab);
+        return Array.ConvertAll(spectrum, value => value.Real);
     }
 }

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -808,12 +808,11 @@ public sealed class TransferIrDiagnosticsTests
         Assert.True(
             TransferIrDiagnostics.CanJudgePreArrival(gate),
             $"a half-octave guard at {lowFullHz}-{highFullHz} Hz must be judgeable");
-        TransferIrPreArrival? preArrival =
-            TransferIrDiagnostics.MeasurePreArrivalDb(ideal, SampleRate);
+        double? preArrival = TransferIrDiagnostics.MeasurePreArrivalDb(ideal, SampleRate);
         Assert.NotNull(preArrival);
         Assert.True(
-            preArrival.Value.LevelDb < TransferIrDiagnostics.MaximumPreArrivalDb - 5,
-            $"ideal {lowFullHz}-{highFullHz} Hz read {preArrival.Value.LevelDb:0.0} dB");
+            preArrival.Value < TransferIrDiagnostics.SuspectPreArrivalDb - 4,
+            $"ideal {lowFullHz}-{highFullHz} Hz read {preArrival.Value:0.0} dB");
     }
 
     // The measure's whole reason to exist, and the reason it is not a second
@@ -845,17 +844,15 @@ public sealed class TransferIrDiagnosticsTests
             clean, z => BiquadResponse(biquad, z));
 
         double cleanPreArrival = TransferIrDiagnostics
-            .MeasurePreArrivalDb(clean, SampleRate)!.Value.LevelDb;
+            .MeasurePreArrivalDb(clean, SampleRate)!.Value;
         double dipPreArrival = TransferIrDiagnostics
-            .MeasurePreArrivalDb(denominatorDip, SampleRate)!.Value.LevelDb;
+            .MeasurePreArrivalDb(denominatorDip, SampleRate)!.Value;
         double cabinPreArrival = TransferIrDiagnostics
-            .MeasurePreArrivalDb(cabinResonance, SampleRate)!.Value.LevelDb;
+            .MeasurePreArrivalDb(cabinResonance, SampleRate)!.Value;
 
-        // The absolute ceiling is calibrated on field records (see
-        // MaximumPreArrivalDb); what a synthetic can prove is the CONTRAST, and
-        // that a fault of this depth is at least reported rather than passed in
-        // silence. The end-to-end refusal is pinned where the reference can be
-        // spoiled for real, in the measurement's own tests.
+        // What a synthetic can prove is the CONTRAST, and that a fault of this
+        // depth is reported rather than passed in silence. The absolute line is
+        // calibrated on field records, not on this.
         Assert.True(
             dipPreArrival > cabinPreArrival + 10,
             $"a zero-phase denominator dip read {dipPreArrival:0.0} dB against " +
@@ -912,85 +909,36 @@ public sealed class TransferIrDiagnosticsTests
         Assert.True(TransferIrDiagnostics.CanJudgePreArrival(ExcitationBandGate.FullBand));
     }
 
-    // The window is placed against the strongest sample, so a record whose direct
-    // path is obstructed and whose strongest sample is a LATER reflection puts its
-    // real direct sound inside that window and reads as acausal. The level alone
-    // cannot tell that from the fault — both are over the ceiling — but what fills
-    // the window can: one arrival with its own decay is a discrete event, the fault
-    // is a ring that fills it evenly.
-    // Two fully causal arrivals, the weaker one first: a record whose strongest
-    // sample is not its direct sound. The level alone reads it as acausal at every
-    // band, and it must never be REFUSED for that — either because the window is
-    // seen to hold one discrete event, or, where the excitation is too narrow for
-    // that reading to mean anything, because the refusal is withheld there.
+    // The measure's known blind spot, pinned so nobody builds a refusal on it
+    // again. The window is placed against the strongest sample, which is normally
+    // the arrival; a record whose direct path is obstructed and whose strongest
+    // sample is a LATER reflection puts its own direct sound inside that window,
+    // and the reading calls it acausal at every band. These records are fully
+    // causal, which is why the verdict here is a report and not a refusal.
     [Theory]
     [InlineData(20.0, 25.0, 0.20)]
     [InlineData(20.0, 50.0, 0.20)]
     [InlineData(20.0, 200.0, 0.20)]
     [InlineData(20.0, 1000.0, 0.20)]
-    [InlineData(20.0, 1000.0, 0.30)]
     [InlineData(20.0, 1000.0, 0.45)]
     [InlineData(20.0, 20000.0, 0.20)]
-    public void MeasurePreArrivalDb_NeverRefusesAnObstructedArrival(
+    public void MeasurePreArrivalDb_IsFooledByAnObstructedArrival(
         double lowFullHz, double highFullHz, double directAmplitude)
     {
         const int FrameLength = 262_144;
         var record = new double[FrameLength];
         AddDecayingArrival(record, atMs: 300.0, amplitude: directAmplitude, decaySeconds: 0.25);
         AddDecayingArrival(record, atMs: 500.0, amplitude: 1.0, decaySeconds: 0.25);
-        ExcitationBandGate gate = ProductionGate(lowFullHz, highFullHz);
-        double[] banded = BandLimit(record, gate);
+        double[] banded = BandLimit(record, ProductionGate(lowFullHz, highFullHz));
 
-        TransferIrPreArrival reading =
-            TransferIrDiagnostics.MeasurePreArrivalDb(banded, SampleRate)!.Value;
-
-        // Whichever way the record is spared, it must be spared: crest says it is
-        // one event, or the band is too narrow for the refusal to be offered.
-        bool refused =
-            reading.LevelDb > TransferIrDiagnostics.MaximumPreArrivalDb &&
-            reading.CrestDb < TransferIrDiagnostics.PreArrivalCrestDb &&
-            TransferIrDiagnostics.CanRefuseOnPreArrival(gate);
-        Assert.False(
-            refused,
-            $"{lowFullHz}-{highFullHz} Hz at {100 * directAmplitude * directAmplitude:0} % " +
-            $"read {reading.LevelDb:0.0} dB with {reading.CrestDb:0.0} dB of crest");
-    }
-
-    // The band rule the case above leans on, stated on its own: crest can only
-    // separate an event from a ring over a wide excitation.
-    [Theory]
-    [InlineData(20.0, 50.0, false)]
-    [InlineData(20.0, 200.0, false)]
-    [InlineData(20.0, 400.0, true)]
-    [InlineData(20.0, 1000.0, true)]
-    [InlineData(0.0, 0.0, true)] // full range
-    public void CanRefuseOnPreArrival_FollowsTheExcitationSpan(
-        double lowFullHz, double highFullHz, bool refusable)
-    {
-        Assert.Equal(
-            refusable,
-            TransferIrDiagnostics.CanRefuseOnPreArrival(
-                ProductionGate(lowFullHz, highFullHz)));
-    }
-
-    // The counterpart, on the shape the refusal exists for: a ring fills the window
-    // evenly and must NOT be excused as a discrete event.
-    [Fact]
-    public void MeasurePreArrivalDb_ARingIsNotADiscreteEvent()
-    {
-        const int FrameLength = 262_144;
-        double[] clean = SyntheticCabinTransfer(
-            FrameLength, delayMs: 12.0, decaySeconds: 0.25, highFullHz: 200.0);
-        BiquadCoefficients biquad = PeakingBiquad.Compute(
-            new PeqBand(34.5, 40.0, 18.0), SampleRate);
-        double[] ringing = ApplySpectrum(clean, z => Complex.Abs(BiquadResponse(biquad, z)));
-
-        TransferIrPreArrival reading =
-            TransferIrDiagnostics.MeasurePreArrivalDb(ringing, SampleRate)!.Value;
+        double reading = TransferIrDiagnostics
+            .MeasurePreArrivalDb(banded, SampleRate)!.Value;
 
         Assert.True(
-            reading.CrestDb < TransferIrDiagnostics.PreArrivalCrestDb,
-            $"a ring must not read as a discrete event; crest was {reading.CrestDb:0.0} dB");
+            reading > TransferIrDiagnostics.SuspectPreArrivalDb,
+            $"{lowFullHz}-{highFullHz} Hz at " +
+            $"{100 * directAmplitude * directAmplitude:0} % read {reading:0.0} dB, " +
+            "so this fixture no longer demonstrates the blind spot");
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -787,7 +787,8 @@ public sealed class TransferIrDiagnosticsTests
     // measurement builds it (half-octave guard bands), through the PRODUCTION
     // estimator. The kernel it turns an ideal H(f)=1 into is symmetric, so it is
     // the one legitimate shape that can look acausal — and it must stay clear of
-    // the ceiling at every band, or a band sweep would be refused for being one.
+    // the report line at every band, or a band sweep would be reported for
+    // being one.
     [Theory]
     [InlineData(20.0, 25.0)]
     [InlineData(20.0, 50.0)]
@@ -820,9 +821,9 @@ public sealed class TransferIrDiagnosticsTests
     // magnitude alone, which rings both directions, and once as the minimum-phase
     // filter a cabin would be, which rings forward only. Compactness reads one
     // number for both — so its floor has to sit low enough to keep a genuinely
-    // resonant cabin, and a fault hiding above that floor cannot be refused on
-    // shape. This measure sees only the first, which is what lets it carry a
-    // threshold at all.
+    // resonant cabin, and a fault hiding above that floor goes unremarked. This
+    // measure sees only the first, which is what lets it carry a threshold at
+    // all.
     [Fact]
     public void MeasurePreArrivalDb_SeparatesADenominatorDipFromACabinResonance()
     {

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -918,28 +918,59 @@ public sealed class TransferIrDiagnosticsTests
     // cannot tell that from the fault — both are over the ceiling — but what fills
     // the window can: one arrival with its own decay is a discrete event, the fault
     // is a ring that fills it evenly.
+    // Two fully causal arrivals, the weaker one first: a record whose strongest
+    // sample is not its direct sound. The level alone reads it as acausal at every
+    // band, and it must never be REFUSED for that — either because the window is
+    // seen to hold one discrete event, or, where the excitation is too narrow for
+    // that reading to mean anything, because the refusal is withheld there.
     [Theory]
-    [InlineData(0.20)] // the direct at 4 % of the reflection's energy: -18.0 dB
-    [InlineData(0.30)]
-    [InlineData(0.45)]
-    public void MeasurePreArrivalDb_MarksAnObstructedArrivalAsADiscreteEvent(
-        double directAmplitude)
+    [InlineData(20.0, 25.0, 0.20)]
+    [InlineData(20.0, 50.0, 0.20)]
+    [InlineData(20.0, 200.0, 0.20)]
+    [InlineData(20.0, 1000.0, 0.20)]
+    [InlineData(20.0, 1000.0, 0.30)]
+    [InlineData(20.0, 1000.0, 0.45)]
+    [InlineData(20.0, 20000.0, 0.20)]
+    public void MeasurePreArrivalDb_NeverRefusesAnObstructedArrival(
+        double lowFullHz, double highFullHz, double directAmplitude)
     {
         const int FrameLength = 262_144;
         var record = new double[FrameLength];
         AddDecayingArrival(record, atMs: 300.0, amplitude: directAmplitude, decaySeconds: 0.25);
         AddDecayingArrival(record, atMs: 500.0, amplitude: 1.0, decaySeconds: 0.25);
-        double[] banded = BandLimit(record, 20.0, 1000.0);
+        ExcitationBandGate gate = ProductionGate(lowFullHz, highFullHz);
+        double[] banded = BandLimit(record, gate);
 
         TransferIrPreArrival reading =
             TransferIrDiagnostics.MeasurePreArrivalDb(banded, SampleRate)!.Value;
 
-        Assert.True(
-            reading.LevelDb > TransferIrDiagnostics.MaximumPreArrivalDb,
-            $"the level alone is supposed to be fooled; it read {reading.LevelDb:0.0} dB");
-        Assert.True(
-            reading.CrestDb >= TransferIrDiagnostics.PreArrivalCrestDb,
-            $"a discrete arrival must read as one; crest was {reading.CrestDb:0.0} dB");
+        // Whichever way the record is spared, it must be spared: crest says it is
+        // one event, or the band is too narrow for the refusal to be offered.
+        bool refused =
+            reading.LevelDb > TransferIrDiagnostics.MaximumPreArrivalDb &&
+            reading.CrestDb < TransferIrDiagnostics.PreArrivalCrestDb &&
+            TransferIrDiagnostics.CanRefuseOnPreArrival(gate);
+        Assert.False(
+            refused,
+            $"{lowFullHz}-{highFullHz} Hz at {100 * directAmplitude * directAmplitude:0} % " +
+            $"read {reading.LevelDb:0.0} dB with {reading.CrestDb:0.0} dB of crest");
+    }
+
+    // The band rule the case above leans on, stated on its own: crest can only
+    // separate an event from a ring over a wide excitation.
+    [Theory]
+    [InlineData(20.0, 50.0, false)]
+    [InlineData(20.0, 200.0, false)]
+    [InlineData(20.0, 400.0, true)]
+    [InlineData(20.0, 1000.0, true)]
+    [InlineData(0.0, 0.0, true)] // full range
+    public void CanRefuseOnPreArrival_FollowsTheExcitationSpan(
+        double lowFullHz, double highFullHz, bool refusable)
+    {
+        Assert.Equal(
+            refusable,
+            TransferIrDiagnostics.CanRefuseOnPreArrival(
+                ProductionGate(lowFullHz, highFullHz)));
     }
 
     // The counterpart, on the shape the refusal exists for: a ring fills the window
@@ -1056,14 +1087,8 @@ public sealed class TransferIrDiagnosticsTests
         }
     }
 
-    private static double[] BandLimit(double[] record, double lowHz, double highHz)
+    private static double[] BandLimit(double[] record, ExcitationBandGate gate)
     {
-        double nyquist = SampleRate / 2.0;
-        ExcitationBandGate gate = new(
-            lowHz / 1.414 / nyquist,
-            lowHz / nyquist,
-            highHz / nyquist,
-            Math.Min(1.0, highHz * 1.414 / nyquist));
         double[] reference = StationaryNoise(record.Length, seed: 7);
         return TransferFunction.ComputeAveragedRelativeIr(
             [new TransferFunctionFrame(reference, CircularConvolve(reference, record))],

--- a/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferIrDiagnosticsTests.cs
@@ -808,11 +808,12 @@ public sealed class TransferIrDiagnosticsTests
         Assert.True(
             TransferIrDiagnostics.CanJudgePreArrival(gate),
             $"a half-octave guard at {lowFullHz}-{highFullHz} Hz must be judgeable");
-        double? preArrival = TransferIrDiagnostics.MeasurePreArrivalDb(ideal, SampleRate);
+        TransferIrPreArrival? preArrival =
+            TransferIrDiagnostics.MeasurePreArrivalDb(ideal, SampleRate);
         Assert.NotNull(preArrival);
         Assert.True(
-            preArrival.Value < TransferIrDiagnostics.MaximumPreArrivalDb - 5,
-            $"ideal {lowFullHz}-{highFullHz} Hz read {preArrival.Value:0.0} dB");
+            preArrival.Value.LevelDb < TransferIrDiagnostics.MaximumPreArrivalDb - 5,
+            $"ideal {lowFullHz}-{highFullHz} Hz read {preArrival.Value.LevelDb:0.0} dB");
     }
 
     // The measure's whole reason to exist, and the reason it is not a second
@@ -844,11 +845,11 @@ public sealed class TransferIrDiagnosticsTests
             clean, z => BiquadResponse(biquad, z));
 
         double cleanPreArrival = TransferIrDiagnostics
-            .MeasurePreArrivalDb(clean, SampleRate)!.Value;
+            .MeasurePreArrivalDb(clean, SampleRate)!.Value.LevelDb;
         double dipPreArrival = TransferIrDiagnostics
-            .MeasurePreArrivalDb(denominatorDip, SampleRate)!.Value;
+            .MeasurePreArrivalDb(denominatorDip, SampleRate)!.Value.LevelDb;
         double cabinPreArrival = TransferIrDiagnostics
-            .MeasurePreArrivalDb(cabinResonance, SampleRate)!.Value;
+            .MeasurePreArrivalDb(cabinResonance, SampleRate)!.Value.LevelDb;
 
         // The absolute ceiling is calibrated on field records (see
         // MaximumPreArrivalDb); what a synthetic can prove is the CONTRAST, and
@@ -909,6 +910,56 @@ public sealed class TransferIrDiagnosticsTests
     public void CanJudgePreArrival_AcceptsAGateWithNoLowEdge()
     {
         Assert.True(TransferIrDiagnostics.CanJudgePreArrival(ExcitationBandGate.FullBand));
+    }
+
+    // The window is placed against the strongest sample, so a record whose direct
+    // path is obstructed and whose strongest sample is a LATER reflection puts its
+    // real direct sound inside that window and reads as acausal. The level alone
+    // cannot tell that from the fault — both are over the ceiling — but what fills
+    // the window can: one arrival with its own decay is a discrete event, the fault
+    // is a ring that fills it evenly.
+    [Theory]
+    [InlineData(0.20)] // the direct at 4 % of the reflection's energy: -18.0 dB
+    [InlineData(0.30)]
+    [InlineData(0.45)]
+    public void MeasurePreArrivalDb_MarksAnObstructedArrivalAsADiscreteEvent(
+        double directAmplitude)
+    {
+        const int FrameLength = 262_144;
+        var record = new double[FrameLength];
+        AddDecayingArrival(record, atMs: 300.0, amplitude: directAmplitude, decaySeconds: 0.25);
+        AddDecayingArrival(record, atMs: 500.0, amplitude: 1.0, decaySeconds: 0.25);
+        double[] banded = BandLimit(record, 20.0, 1000.0);
+
+        TransferIrPreArrival reading =
+            TransferIrDiagnostics.MeasurePreArrivalDb(banded, SampleRate)!.Value;
+
+        Assert.True(
+            reading.LevelDb > TransferIrDiagnostics.MaximumPreArrivalDb,
+            $"the level alone is supposed to be fooled; it read {reading.LevelDb:0.0} dB");
+        Assert.True(
+            reading.CrestDb >= TransferIrDiagnostics.PreArrivalCrestDb,
+            $"a discrete arrival must read as one; crest was {reading.CrestDb:0.0} dB");
+    }
+
+    // The counterpart, on the shape the refusal exists for: a ring fills the window
+    // evenly and must NOT be excused as a discrete event.
+    [Fact]
+    public void MeasurePreArrivalDb_ARingIsNotADiscreteEvent()
+    {
+        const int FrameLength = 262_144;
+        double[] clean = SyntheticCabinTransfer(
+            FrameLength, delayMs: 12.0, decaySeconds: 0.25, highFullHz: 200.0);
+        BiquadCoefficients biquad = PeakingBiquad.Compute(
+            new PeqBand(34.5, 40.0, 18.0), SampleRate);
+        double[] ringing = ApplySpectrum(clean, z => Complex.Abs(BiquadResponse(biquad, z)));
+
+        TransferIrPreArrival reading =
+            TransferIrDiagnostics.MeasurePreArrivalDb(ringing, SampleRate)!.Value;
+
+        Assert.True(
+            reading.CrestDb < TransferIrDiagnostics.PreArrivalCrestDb,
+            $"a ring must not read as a discrete event; crest was {reading.CrestDb:0.0} dB");
     }
 
     [Fact]
@@ -985,6 +1036,38 @@ public sealed class TransferIrDiagnosticsTests
         return TransferFunction.ComputeAveragedRelativeIr(
             [new TransferFunctionFrame(reference, CircularConvolve(reference, room))],
             ProductionGate(20.0, highFullHz)).ImpulseResponse;
+    }
+
+    // One arrival with a decay behind it, which is what a real one looks like and
+    // what makes the crest reading honest — a bare impulse would flatter it.
+    private static void AddDecayingArrival(
+        double[] record,
+        double atMs,
+        double amplitude,
+        double decaySeconds)
+    {
+        int at = (int)Math.Round(atMs * SampleRate / 1000.0);
+        int decay = (int)Math.Round(decaySeconds * SampleRate);
+        double[] tail = StationaryNoise(decay, seed: (uint)(at + 17));
+        record[at] += amplitude;
+        for (int i = 1; i < decay && at + i < record.Length; i++)
+        {
+            record[at + i] += amplitude * 1.2 * tail[i] * Math.Exp(-6.908 * i / decay);
+        }
+    }
+
+    private static double[] BandLimit(double[] record, double lowHz, double highHz)
+    {
+        double nyquist = SampleRate / 2.0;
+        ExcitationBandGate gate = new(
+            lowHz / 1.414 / nyquist,
+            lowHz / nyquist,
+            highHz / nyquist,
+            Math.Min(1.0, highHz * 1.414 / nyquist));
+        double[] reference = StationaryNoise(record.Length, seed: 7);
+        return TransferFunction.ComputeAveragedRelativeIr(
+            [new TransferFunctionFrame(reference, CircularConvolve(reference, record))],
+            gate).ImpulseResponse;
     }
 
     private static double[] CircularConvolve(double[] left, double[] right)


### PR DESCRIPTION
A field session arrived with eleven takes whose loopback ran through the
interface's own direct mixer instead of the wire. Every level normal, coherence
0.9995, four of four runs accepted, and the two worst records carried a 34 Hz
resonance of Q≈38-54 that rang for 2.8-4.1 s and put half their energy before
their own arrival. All seven array positions reported it to within 0.7 dB, where
a real cabin mode spreads the same positions over 5-9 dB, so it belonged to the
shared denominator rather than to the room. They read 26.0 and 24.1 dB of
compactness against a floor of 22 and were published without a word. The owner
found out by asking why one file looked wrong.

This adds the missing word. It does not add a refusal — one was built here and
withdrawn, and the reasoning is below.

## What the existing gate cannot see

Raising the compactness floor is the obvious move and it is the wrong one.
Compactness cannot tell a contaminated reference from a genuinely long-decaying
cabin: the same resonance imposed on one record in magnitude alone and as the
minimum-phase filter a room would be reads 24.68 and 24.65 dB. Its floor has to
stay low enough to keep the cabin, which leaves this fault above it by
construction.

## The measure

`MeasurePreArrivalDb` reads the per-sample energy from 100 to 600 ms AHEAD of
the arrival against the arrival's own ±100 ms, circularly. Nothing arrives
before the direct sound, and a cabin's resonances ring forward:

| | pre-arrival | compactness |
|---|---|---|
| field records, clean | -39.0 to -47.3 dB | 43.7-52.2 dB |
| field pair, broken | **-14.8 / -14.1 dB** | 26.0 / 24.1 dB |
| minimum-phase resonance (a cabin) | -39.5 dB | 24.65 dB |
| same resonance, magnitude only | -21.0 dB | 24.68 dB |

Above **-22 dB** the measurement is saved and reported. Ideal gated kernels
through the production estimator put the worst legitimate shape at -26.8 dB (a
20-25 Hz band sweep), so the line clears it by 4.8 dB.

Read against the arrival rather than the whole record, so it follows the peak: a
purely electrical measurement legitimately peaks at zero, and a share-of-total
measure swings by tens of dB with that delay — an ideal band-limited kernel at
zero delay puts half its energy in wrapped negative time, exactly like the fault.
`CanJudgePreArrival` withholds the reading entirely where the sweep opened no
guard band wider than a third of an octave, because there the estimator's own
symmetric kernel rings like the fault.

## Why there is no refusal

A refusal was built on this measure and taken out again over three review rounds,
each of which found the same false positive in different clothes. The window is
placed against the strongest sample; a record whose direct path is obstructed and
whose strongest sample is a later reflection puts its own direct sound inside the
window and reads as acausal while being perfectly causal.

Anchoring on the first credible arrival does not fix it. `EstimateIrStart`
answers 499.9 ms on exactly that record — the later, stronger arrival — and
0.0 ms on both field faults, where the acausal ring reaches the head of the
buffer.

How *localized* the early energy is does separate them, but only over a wide
excitation, because a band-limited record cannot hold an event sharper than its
bandwidth allows. Measured across 215 two-arrival records, the lowest crest a
discrete event produced falls with the band: 21.6 dB at 7.6 octaves, 18.3 at 5.9,
16.1 at 4.3, 13.3 at 2.3 — and the field faults sit at 13.1 and 12.8. Keeping
both of them refusable forces the width floor down to the 90 Hz effective width
one of them has, where the gap is 2.5 dB. That is not a basis for destroying a
measurement, on a calibration set of two records from one rig.

Two things also failed to reproduce and are worth recording. An ordinary
narrow-band take never approaches the reading — a single arrival through a
20-40 Hz channel reads -86 dB, some 60 dB clear of the report line. And the
narrowest constructed counterexamples fail the existing compactness floor on
their own, at 19.4 and 16.8 dB, so they were never this gate's to refuse.

The notice therefore states both shapes the reading comes in, leads with the
reference because everything is divided by it, and asserts neither. Naming one is
how a tuner ends up checking wiring that was correct all along — the failure the
distortion diagnosis exists to prevent.

## Tests

`TransferIrDiagnosticsTests`, all through the production estimator with
production gate shapes: ideal gated transfers stay clear of the line at every
band; the guard-band withholding follows its threshold; the complex twin matches
the real path; a magnitude-only resonance is reported while a minimum-phase one
of the same depth is not, with compactness reading the two within 2 dB of each
other. The blind spot is pinned too — six bands of obstructed-arrival records
asserting that the measure IS fooled by them — so nobody rebuilds a refusal on it
without meeting that first. One app test pins the notice: it quotes the reading,
offers both causes and names neither.

Full suite green: 1374 dsp, 1825 app, 159 audio.

`REFERENCE.md` gains "A reference that is not the excitation" under the input
meter section.

## Known gap

The notice is transient: it is shown when the measurement completes and is not
carried into the saved file, so a record reopened later, or handed to someone
else, arrives without it. Closing that means either a field in the file format or
recomputing the reading on load plus somewhere to show it, and it is left out of
this change deliberately rather than overlooked.
