### PR TITLE
Give the app's panels rounded corners

### DIFF
--- a/source/Options/MeasurementOptions.Designer.cs
+++ b/source/Options/MeasurementOptions.Designer.cs
@@ -32,7 +32,7 @@
         /// </summary>
         private void InitializeComponent()
         {
-            sweepPanel = new Panel();
+            sweepPanel = new RoundedPanel();
             buttonSaveSweepFile = new ReleaseClickButton();
             labelActualRangeCaption = new Label();
             numericUpDownRequestedDuration = new DarkNumericUpDown();
@@ -51,7 +51,7 @@
             label1 = new Label();
             comboBoxChannel = new DarkComboBox();
             label3 = new Label();
-            audioBackendPanel = new Panel();
+            audioBackendPanel = new RoundedPanel();
             button1 = new ReleaseClickButton();
             labelAudioBackend = new Label();
             comboBoxAudioBackend = new DarkComboBox();
@@ -84,7 +84,6 @@
             // sweepPanel
             // 
             sweepPanel.BackColor = Color.FromArgb(50, 55, 66);
-            sweepPanel.BorderStyle = BorderStyle.FixedSingle;
             sweepPanel.Controls.Add(buttonSaveSweepFile);
             sweepPanel.Controls.Add(comboBoxProtectiveHighPassSlope);
             sweepPanel.Controls.Add(numericUpDownProtectiveHighPassFrequency);
@@ -333,7 +332,6 @@
             // audioBackendPanel
             //
             audioBackendPanel.BackColor = Color.FromArgb(50, 55, 66);
-            audioBackendPanel.BorderStyle = BorderStyle.FixedSingle;
             audioBackendPanel.Controls.Add(button1);
             audioBackendPanel.Controls.Add(asioAudioBackendPanel);
             audioBackendPanel.Controls.Add(waveAudioBackendPanel);
@@ -607,8 +605,8 @@
         }
 
         #endregion
-        private Panel sweepPanel;
-        private Panel audioBackendPanel;
+        private RoundedPanel sweepPanel;
+        private RoundedPanel audioBackendPanel;
         private Label label1;
         private Label label2;
         private DarkComboBox comboBoxChannel;

--- a/source/Overlays/Overlay.cs
+++ b/source/Overlays/Overlay.cs
@@ -186,8 +186,8 @@ public sealed class OverlayCollection
         toolTip.AutoPopDelay = 6_000;
         toolTip.ShowAlways = true;
 
-        Panel templatePanel = container.Controls
-            .OfType<Panel>()
+        RoundedPanel templatePanel = container.Controls
+            .OfType<RoundedPanel>()
             .FirstOrDefault()
             ?? throw new InvalidOperationException(
                 "Overlay template panel is missing.");
@@ -228,7 +228,7 @@ public sealed class OverlayCollection
         var random = new Random(3);
         for (int index = 2; index <= OverlayFile.MaximumSlotCount; index++)
         {
-            Panel panel = CreatePanel(templatePanel, index, random);
+            RoundedPanel panel = CreatePanel(templatePanel, index, random);
             CheckBox checkBox = CreateCheckBox(templateCheckBox, index);
             DarkNumericUpDown offset = CreateOffset(templateOffset, index);
             Button captureButton = CreateCaptureButton(templateCaptureButton, index);
@@ -570,17 +570,19 @@ public sealed class OverlayCollection
         };
     }
 
-    private static Panel CreatePanel(
-        Panel template,
+    private static RoundedPanel CreatePanel(
+        RoundedPanel template,
         int index,
         Random random)
     {
-        return new Panel
+        return new RoundedPanel
         {
             BackColor = Color.FromArgb(
                 random.Next(255),
                 random.Next(255),
                 random.Next(255)),
+            BorderColor = template.BorderColor,
+            CornerRadius = template.CornerRadius,
             Location = new Point(
                 template.Location.X,
                 template.Location.Y +

--- a/source/Overlays/OverlayOperationSettingsDialog.Designer.cs
+++ b/source/Overlays/OverlayOperationSettingsDialog.Designer.cs
@@ -53,7 +53,7 @@
             numericTimeOffset = new DarkNumericUpDown();
             labelTimeOffset = new Label();
             checkBoxInvPhase = new ReleaseClickCheckBox();
-            panel1 = new Panel();
+            panel1 = new RoundedPanel();
             (thicknessInput).BeginInit();
             (blendFrequencyInput).BeginInit();
             (tiltPivotInput).BeginInit();
@@ -458,7 +458,6 @@
             // 
             // panel1
             // 
-            panel1.BorderStyle = BorderStyle.FixedSingle;
             panel1.Controls.Add(curveBLabel);
             panel1.Controls.Add(checkBoxInvPhase);
             panel1.Controls.Add(sourceBComboBox);
@@ -565,6 +564,6 @@
         private DarkNumericUpDown numericTimeOffset;
         private Label labelTimeOffset;
         private ReleaseClickCheckBox checkBoxInvPhase;
-        private Panel panel1;
+        private RoundedPanel panel1;
     }
 }

--- a/source/Shell/Form1.Designer.cs
+++ b/source/Shell/Form1.Designer.cs
@@ -33,8 +33,8 @@
             var resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
             buttonRecord = new ReleaseClickButton();
             plotView1 = new OxyPlot.WindowsForms.PlotView();
-            overlays = new Panel();
-            overlayPanel1 = new Panel();
+            overlays = new RoundedPanel();
+            overlayPanel1 = new RoundedPanel();
             buttonSaveOverlay = new ReleaseClickButton();
             labelOverlay1 = new Label();
             numericUpDown1 = new DarkNumericUpDown();
@@ -46,7 +46,7 @@
             buttonOverlayShowAll = new ReleaseClickButton();
             buttonOverlayHideAll = new ReleaseClickButton();
             buttonCurrentModeSettings = new ReleaseClickButton();
-            panel1 = new Panel();
+            panel1 = new RoundedPanel();
             buttonCompare = new ReleaseClickButton();
             inputLevelMeterPanel = new InputLevelMeterPanel();
             buttonHistory = new ReleaseClickButton();
@@ -96,7 +96,6 @@
             // overlays
             // 
             overlays.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            overlays.BorderStyle = BorderStyle.FixedSingle;
             overlays.Controls.Add(overlayPanel1);
             overlays.Location = new Point(1264, 479);
             overlays.Name = "overlays";
@@ -106,10 +105,12 @@
             // overlayPanel1
             // 
             overlayPanel1.BackColor = Color.OrangeRed;
+            overlayPanel1.BorderColor = Color.Transparent;
             overlayPanel1.Controls.Add(buttonSaveOverlay);
             overlayPanel1.Controls.Add(labelOverlay1);
             overlayPanel1.Controls.Add(numericUpDown1);
             overlayPanel1.Controls.Add(checkBox1);
+            overlayPanel1.CornerRadius = 3;
             overlayPanel1.Location = new Point(3, 3);
             overlayPanel1.Name = "overlayPanel1";
             overlayPanel1.Size = new Size(206, 25);
@@ -273,7 +274,6 @@
             // panel1
             // 
             panel1.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            panel1.BorderStyle = BorderStyle.FixedSingle;
             panel1.Controls.Add(buttonCompare);
             panel1.Controls.Add(buttonRecord);
             panel1.Controls.Add(buttonRecordOpt);
@@ -483,11 +483,11 @@
 
         private ReleaseClickButton buttonRecord;
         private OxyPlot.WindowsForms.PlotView plotView1;
-        private Panel overlays;
+        private RoundedPanel overlays;
         private ReleaseClickButton buttonSaveOverlay;
         private Label labelOverlay1;
         private ReleaseClickCheckBox checkBox1;
-        private Panel overlayPanel1;
+        private RoundedPanel overlayPanel1;
         private ReleaseClickButton buttonRecordOpt;
         private ReleaseClickButton buttonSave;
         private ReleaseClickButton buttonLoad;
@@ -495,7 +495,7 @@
         private ReleaseClickButton buttonOverlayShowAll;
         private ReleaseClickButton buttonCurrentModeSettings;
         private ReleaseClickButton buttonOverlayHideAll;
-        private Panel panel1;
+        private RoundedPanel panel1;
         private InputLevelMeterPanel inputLevelMeterPanel;
         private DarkNumericUpDown numericUpDown1;
         private ReleaseClickButton buttonHistory;

--- a/source/Tools/Eq/EqWizardPanel.Designer.cs
+++ b/source/Tools/Eq/EqWizardPanel.Designer.cs
@@ -67,7 +67,7 @@
             checkBoxEqCurve = new ReleaseClickCheckBox();
             checkBoxCutsOnly = new ReleaseClickCheckBox();
             checkBoxShelves = new ReleaseClickCheckBox();
-            panelAutoTune = new Panel();
+            panelAutoTune = new RoundedPanel();
             buttonOverlaySettings = new ReleaseClickButton();
             comboBoxCalibration = new DarkComboBox();
             labelCalibration = new Label();
@@ -468,7 +468,6 @@
             // panelAutoTune
             // 
             panelAutoTune.BackColor = Color.FromArgb(46, 51, 62);
-            panelAutoTune.BorderStyle = BorderStyle.FixedSingle;
             panelAutoTune.Controls.Add(labelGainMin);
             panelAutoTune.Controls.Add(numericGainMin);
             panelAutoTune.Controls.Add(labelGainMax);
@@ -765,7 +764,7 @@
         private ReleaseClickCheckBox checkBoxEqCurve;
         private ReleaseClickCheckBox checkBoxCutsOnly;
         private ReleaseClickCheckBox checkBoxShelves;
-        private Panel panelAutoTune;
+        private RoundedPanel panelAutoTune;
         private ReleaseClickButton buttonOverlaySettings;
         private DarkComboBox comboBoxCalibration;
         private Label labelCalibration;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.Designer.cs
@@ -352,11 +352,11 @@
             // 
             // labelPeqInfo
             // 
-            labelPeqInfo.AutoSize = true;
+            labelPeqInfo.AutoEllipsis = true;
             labelPeqInfo.ForeColor = Color.FromArgb(170, 176, 190);
             labelPeqInfo.Location = new Point(152, 183);
             labelPeqInfo.Name = "labelPeqInfo";
-            labelPeqInfo.Size = new Size(48, 15);
+            labelPeqInfo.Size = new Size(167, 15);
             labelPeqInfo.TabIndex = 21;
             labelPeqInfo.Text = "No PEQ";
             // 
@@ -485,7 +485,6 @@
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             BackColor = Color.FromArgb(46, 51, 62);
-            BorderStyle = BorderStyle.FixedSingle;
             Controls.Add(labelTotalGain);
             Controls.Add(numericLowPassRipple);
             Controls.Add(numericHighPassRipple);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
@@ -22,6 +22,16 @@ public partial class VirtualCrossoverChannelControl : UserControl
 
     public VirtualCrossoverChannelControl()
     {
+        // The block is one of the app's cards, and the flow list stacks a dozen of
+        // them: it paints its own rounded surface and outline in place of the
+        // framework's square border. ResizeRedraw because collapsing resizes it.
+        SetStyle(
+            ControlStyles.AllPaintingInWmPaint |
+            ControlStyles.OptimizedDoubleBuffer |
+            ControlStyles.ResizeRedraw |
+            ControlStyles.UserPaint,
+            true);
+
         InitializeComponent();
         // The designer pins the block to one size (MinimumSize == MaximumSize) so the
         // flow list cannot stretch it; collapsing moves that pin, so the expanded
@@ -283,6 +293,20 @@ public partial class VirtualCrossoverChannelControl : UserControl
     // current DPI (AutoScaleMode.Dpi) and a pixel literal would cut the wrong one.
     private int FoldLine => comboBoxCrossoverKind.Top;
 
+    // The gap the expanded block leaves under its lowest row. Measured rather than
+    // stated for the same reason as the fold line, and off ALL the children: the ones
+    // below the fold are hidden while folded, but they never move.
+    private int BottomMargin()
+    {
+        int content = 0;
+        foreach (Control child in Controls)
+        {
+            content = Math.Max(content, child.Bottom);
+        }
+
+        return Math.Max(0, expandedHeight - content);
+    }
+
     private void ApplyCollapsedState()
     {
         buttonCollapse.Text = collapsed ? "+" : "−";
@@ -302,9 +326,12 @@ public partial class VirtualCrossoverChannelControl : UserControl
         }
 
         ResumeLayout(false);
-        // The border sits outside the client area, hence the Height/ClientSize term.
+        // The block paints its own border INSIDE its client area, so a folded height
+        // measured to the last kept row draws that border ON the fold button. The
+        // expanded block leaves a margin under its lowest row; a folded one leaves
+        // the same, which is also what keeps the bottom corners round.
         int height = collapsed
-            ? keptBottom + (Height - ClientSize.Height)
+            ? keptBottom + BottomMargin()
             : expandedHeight;
         // The whole move runs inside one suspended parent layout: each size assignment
         // below asks the flow list to reflow, and a list laid out against a half-moved
@@ -350,6 +377,17 @@ public partial class VirtualCrossoverChannelControl : UserControl
         {
             expandedHeight = (int)Math.Round(expandedHeight * factor.Height);
         }
+    }
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        RoundedSurface.Paint(
+            this,
+            e.Graphics,
+            RoundedSurface.DefaultCornerRadius,
+            UiPalette.DialogBorder);
+
+        base.OnPaint(e);
     }
 
     /// <summary>

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
@@ -1,4 +1,4 @@
-namespace Resonalyze
+﻿namespace Resonalyze
 {
     partial class VirtualCrossoverPanel
     {
@@ -67,7 +67,7 @@ namespace Resonalyze
             buttonSessionImport = new ReleaseClickButton();
             buttonSessionExport = new ReleaseClickButton();
             buttonAudition = new ReleaseClickButton();
-            dspModePanel = new Panel();
+            dspModePanel = new RoundedPanel();
             labelDspMode = new Label();
             radioDspMagnitude = new ReleaseClickRadioButton();
             radioDspPhase = new ReleaseClickRadioButton();
@@ -75,8 +75,8 @@ namespace Resonalyze
             radioDspCorrelation = new ReleaseClickRadioButton();
             radioDspCoherence = new ReleaseClickRadioButton();
             comboBoxCorrelationPair = new DarkComboBox();
-            panel1 = new Panel();
-            panel2 = new Panel();
+            panel1 = new RoundedPanel();
+            panel2 = new RoundedPanel();
             (numericTargetLevel).BeginInit();
             sideSelectorPanel.SuspendLayout();
             dspModePanel.SuspendLayout();
@@ -503,11 +503,11 @@ namespace Resonalyze
             // 
             dspModePanel.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
             dspModePanel.BackColor = Color.FromArgb(40, 44, 54);
-            dspModePanel.BorderStyle = BorderStyle.FixedSingle;
             dspModePanel.Controls.Add(labelDspMode);
             dspModePanel.Controls.Add(radioDspMagnitude);
             dspModePanel.Controls.Add(radioDspPhase);
             dspModePanel.Controls.Add(radioDspGroupDelay);
+            dspModePanel.CornerRadius = 4;
             dspModePanel.Location = new Point(490, 733);
             dspModePanel.Name = "dspModePanel";
             dspModePanel.Size = new Size(302, 23);
@@ -599,10 +599,10 @@ namespace Resonalyze
             // 
             // panel1
             // 
-            panel1.BorderStyle = BorderStyle.FixedSingle;
             panel1.Controls.Add(radioViewMagnitude);
             panel1.Controls.Add(radioViewImpulse);
             panel1.Controls.Add(radioViewPhase);
+            panel1.CornerRadius = 4;
             panel1.Location = new Point(399, 437);
             panel1.Name = "panel1";
             panel1.Size = new Size(233, 23);
@@ -611,10 +611,10 @@ namespace Resonalyze
             // panel2
             // 
             panel2.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
-            panel2.BorderStyle = BorderStyle.FixedSingle;
             panel2.Controls.Add(radioDspCorrelation);
             panel2.Controls.Add(radioDspCoherence);
             panel2.Controls.Add(comboBoxCorrelationPair);
+            panel2.CornerRadius = 4;
             panel2.Location = new Point(798, 733);
             panel2.Name = "panel2";
             panel2.Size = new Size(255, 23);
@@ -710,7 +710,7 @@ namespace Resonalyze
         private ReleaseClickButton buttonSessionImport;
         private ReleaseClickButton buttonSessionExport;
         private ReleaseClickButton buttonAudition;
-        private Panel dspModePanel;
+        private RoundedPanel dspModePanel;
         private Label labelDspMode;
         private ReleaseClickRadioButton radioDspMagnitude;
         private ReleaseClickRadioButton radioDspPhase;
@@ -718,7 +718,7 @@ namespace Resonalyze
         private ReleaseClickRadioButton radioDspCorrelation;
         private ReleaseClickRadioButton radioDspCoherence;
         private DarkComboBox comboBoxCorrelationPair;
-        private Panel panel1;
-        private Panel panel2;
+        private RoundedPanel panel1;
+        private RoundedPanel panel2;
     }
 }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Resonalyze
+namespace Resonalyze
 {
     partial class VirtualCrossoverPanel
     {

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -1201,7 +1201,6 @@ public partial class VirtualCrossoverPanel : UserControl
         var control = new VirtualCrossoverChannelControl
         {
             BackColor = Color.FromArgb(46, 51, 62),
-            BorderStyle = BorderStyle.FixedSingle,
             Font = new Font("Segoe UI", 9F),
             ForeColor = Color.White,
             Margin = new Padding(0, 0, 0, 6),

--- a/source/Ui/Controls/InputLevelMeterPanel.cs
+++ b/source/Ui/Controls/InputLevelMeterPanel.cs
@@ -80,11 +80,15 @@ internal sealed class InputLevelMeterPanel : Control
         base.OnPaint(args);
 
         Graphics graphics = args.Graphics;
-        graphics.SmoothingMode = SmoothingMode.AntiAlias;
-        graphics.Clear(SurfaceColor);
 
-        using var borderPen = new Pen(BorderColor);
-        graphics.DrawRectangle(borderPen, 0, 0, Width - 1, Height - 1);
+        // The meter is one of the sidebar's cards, so it is cornered like them.
+        RoundedSurface.Paint(
+            this,
+            graphics,
+            RoundedSurface.DefaultCornerRadius,
+            BorderColor);
+
+        graphics.SmoothingMode = SmoothingMode.AntiAlias;
 
         (Rectangle micRow, Rectangle loopRow) = GetRowRectangles();
         DrawRow(

--- a/source/Ui/Controls/RoundedPanel.cs
+++ b/source/Ui/Controls/RoundedPanel.cs
@@ -1,0 +1,154 @@
+using System.ComponentModel;
+
+namespace Resonalyze;
+
+/// <summary>
+/// The app's card: a <see cref="Panel"/> that paints itself with rounded corners
+/// and its own one-pixel outline, in place of the framework's square
+/// <see cref="BorderStyle.FixedSingle"/> one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The corners are painted, not cut — see <see cref="RoundedSurface"/> for why,
+/// and for the one thing that assumes: the parent behind the panel has to be a
+/// flat colour. <see cref="Control.BackColor"/> is the surface as it always was,
+/// so a panel converted from a stock one keeps the colour its designer gave it.
+/// </para>
+/// <para>
+/// Children are NOT clipped to the rounded shape (no region is set), so a child
+/// laid flush into a corner paints its own background over the arc. At the radii
+/// used here that is a pixel or two, and every panel in the app leaves its
+/// content a margin; a child that genuinely has to sit in the corner wants a
+/// smaller <see cref="CornerRadius"/> rather than a region.
+/// </para>
+/// <para>
+/// The same rule decides where this panel does NOT belong: a container whose
+/// child is docked over the whole of it has no surface left to round, and the
+/// outline would be painted under that child instead of around it. The EQ
+/// wizard's PEQ well is filled edge to edge by its slot table and keeps the
+/// framework's non-client border for exactly that reason.
+/// </para>
+/// <para>
+/// <see cref="ScrollableControl.AutoScroll"/> is not supported: scrolling shifts
+/// the painted pixels and only invalidates what the shift uncovered, which
+/// smears the outline. Nothing in the app scrolls a card.
+/// </para>
+/// </remarks>
+internal sealed class RoundedPanel : Panel
+{
+    private int cornerRadius = RoundedSurface.DefaultCornerRadius;
+    private Color borderColor = UiPalette.DialogBorder;
+
+    public RoundedPanel()
+    {
+        SetStyle(
+            ControlStyles.AllPaintingInWmPaint |
+            ControlStyles.OptimizedDoubleBuffer |
+            ControlStyles.ResizeRedraw |
+            ControlStyles.UserPaint,
+            true);
+    }
+
+    /// <summary>
+    /// Corner radius in 96-DPI pixels, scaled to the display when painted. Zero
+    /// gives square corners and leaves the outline, which is the stock panel's
+    /// look drawn in the palette's colour.
+    /// </summary>
+    [Category("Appearance")]
+    [DefaultValue(RoundedSurface.DefaultCornerRadius)]
+    [Description("Corner radius in 96-DPI pixels, scaled to the display when painted.")]
+    public int CornerRadius
+    {
+        get => cornerRadius;
+        set
+        {
+            int radius = Math.Max(0, value);
+            if (radius == cornerRadius)
+            {
+                return;
+            }
+
+            cornerRadius = radius;
+            Invalidate();
+        }
+    }
+
+    /// <summary>
+    /// Colour of the one-pixel outline. <see cref="Color.Transparent"/> — or any
+    /// fully transparent colour — draws none, for a panel that is only a tinted
+    /// surface.
+    /// </summary>
+    [Category("Appearance")]
+    [Description("Colour of the one-pixel outline; transparent draws none.")]
+    public Color BorderColor
+    {
+        get => borderColor;
+        set
+        {
+            if (value == borderColor)
+            {
+                return;
+            }
+
+            borderColor = value;
+            Invalidate();
+        }
+    }
+
+    // The default is a palette colour rather than a constant, so the designer
+    // cannot be told it with [DefaultValue]; this is the pair it asks for
+    // instead, and it keeps the theme's own border out of the .Designer.cs.
+    private bool ShouldSerializeBorderColor() => borderColor != UiPalette.DialogBorder;
+
+    private void ResetBorderColor() => BorderColor = UiPalette.DialogBorder;
+
+    /// <summary>
+    /// Hidden: the panel draws its own outline, and the framework's square one
+    /// would be drawn around the rounded shape rather than instead of it.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public new BorderStyle BorderStyle
+    {
+        get => base.BorderStyle;
+
+        // Whatever is asked for, the answer is none — including a designer session
+        // that re-opens the form and offers the property in its grid.
+        set => base.BorderStyle = BorderStyle.None;
+    }
+
+    // The surface is painted whole in OnPaint, corners included, so the stock
+    // background fill would only be overdrawn a moment later.
+    protected override void OnPaintBackground(PaintEventArgs e)
+    {
+    }
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        RoundedSurface.Paint(this, e.Graphics, cornerRadius, borderColor);
+        base.OnPaint(e);
+    }
+
+    // The corners are the parent's colour, so they are only right for as long as
+    // the parent's colour is what it was — including the move to a new parent.
+    protected override void OnParentBackColorChanged(EventArgs e)
+    {
+        base.OnParentBackColorChanged(e);
+        Invalidate();
+    }
+
+    protected override void OnParentChanged(EventArgs e)
+    {
+        base.OnParentChanged(e);
+        Invalidate();
+    }
+
+    // The radius is in logical pixels, so it means a different number of device
+    // pixels on the new display.
+    protected override void OnDpiChangedAfterParent(EventArgs e)
+    {
+        base.OnDpiChangedAfterParent(e);
+        Invalidate();
+    }
+}

--- a/source/Ui/Controls/RoundedSurface.cs
+++ b/source/Ui/Controls/RoundedSurface.cs
@@ -1,0 +1,196 @@
+using System.Drawing.Drawing2D;
+
+namespace Resonalyze;
+
+/// <summary>
+/// The rounded rectangle the app's cards are drawn as, and the painting a
+/// WinForms control has to do to show one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A control's window stays a rectangle whatever it paints inside itself, and
+/// WinForms has no per-pixel alpha to composite a cut corner with. A window
+/// region (<see cref="Control.Region"/>) does cut one, but a region is not
+/// anti-aliased, so the arc comes out as a staircase. So nothing is cut here:
+/// the corners are PAINTED with the colour behind the control
+/// (<see cref="ColorBehind"/>) and the rounded shape is drawn on top of them,
+/// anti-aliased. The one assumption that costs is that whatever is behind the
+/// control is a flat colour — every surface in this app is, and a control over
+/// a gradient or an image would show a square patch of the wrong colour in each
+/// corner.
+/// </para>
+/// <para>
+/// The radius is stated in 96-DPI pixels and scaled at paint time, like every
+/// other hand-drawn dimension in this folder: a radius fixed in device pixels
+/// visibly shrinks against the text beside it at 150%. Paint time, not
+/// construction time, because <see cref="Control.DeviceDpi"/> is only final once
+/// the handle exists in its monitor's context.
+/// </para>
+/// </remarks>
+internal static class RoundedSurface
+{
+    /// <summary>Corner radius of a card, in 96-DPI pixels.</summary>
+    internal const int DefaultCornerRadius = 6;
+
+    /// <summary>
+    /// The logical radius in device pixels, clamped so the arcs can never
+    /// overrun the shape: at more than half the shorter side the four corners
+    /// would meet and the path would fold on itself.
+    /// </summary>
+    internal static int ScaleRadius(int logicalRadius, int deviceDpi, Size size)
+    {
+        if (logicalRadius <= 0)
+        {
+            return 0;
+        }
+
+        int dpi = deviceDpi > 0 ? deviceDpi : 96;
+        int radius = (int)Math.Round(logicalRadius * dpi / 96.0);
+        int limit = Math.Min(size.Width, size.Height) / 2;
+        return Math.Clamp(radius, 0, Math.Max(0, limit));
+    }
+
+    /// <summary>
+    /// The rounded rectangle as a path. A radius of zero gives the plain
+    /// rectangle, so a caller does not have to branch on it.
+    /// </summary>
+    internal static GraphicsPath CreatePath(RectangleF bounds, float radius)
+    {
+        var path = new GraphicsPath();
+        if (bounds.Width <= 0 || bounds.Height <= 0)
+        {
+            return path;
+        }
+
+        float diameter = Math.Min(radius * 2f, Math.Min(bounds.Width, bounds.Height));
+        if (diameter <= 0)
+        {
+            path.AddRectangle(bounds);
+            return path;
+        }
+
+        path.AddArc(bounds.X, bounds.Y, diameter, diameter, 180, 90);
+        path.AddArc(bounds.Right - diameter, bounds.Y, diameter, diameter, 270, 90);
+        path.AddArc(
+            bounds.Right - diameter,
+            bounds.Bottom - diameter,
+            diameter,
+            diameter,
+            0,
+            90);
+        path.AddArc(bounds.X, bounds.Bottom - diameter, diameter, diameter, 90, 90);
+        path.CloseFigure();
+        return path;
+    }
+
+    /// <summary>
+    /// Paints <paramref name="control"/> as a rounded surface of its own
+    /// <see cref="Control.BackColor"/>, outlined in <paramref name="border"/>,
+    /// with <paramref name="logicalRadius"/> corners scaled to its display. The
+    /// control has to have asked for <see cref="ControlStyles.UserPaint"/> and
+    /// must not also carry a framework border.
+    /// </summary>
+    internal static void Paint(
+        Control control,
+        Graphics graphics,
+        int logicalRadius,
+        Color border)
+    {
+        Paint(
+            graphics,
+            control.ClientRectangle,
+            ScaleRadius(logicalRadius, control.DeviceDpi, control.ClientSize),
+            ColorBehind(control),
+            control.BackColor,
+            border);
+    }
+
+    /// <summary>
+    /// Fills <paramref name="client"/> with the rounded surface: the corners
+    /// take <paramref name="outside"/>, the shape takes <paramref name="fill"/>,
+    /// and a one-pixel <paramref name="border"/> outlines it. A fully
+    /// transparent fill or border is simply not drawn.
+    /// </summary>
+    internal static void Paint(
+        Graphics graphics,
+        Rectangle client,
+        int radius,
+        Color outside,
+        Color fill,
+        Color border)
+    {
+        if (client.Width <= 0 || client.Height <= 0)
+        {
+            return;
+        }
+
+        // The caller may have more to draw on this surface afterwards, and the
+        // two modes below are not what it asked for.
+        GraphicsState state = graphics.Save();
+
+        graphics.SmoothingMode = SmoothingMode.AntiAlias;
+        // Anti-aliased GDI+ puts a pixel's CENTRE on its integer coordinate by
+        // default, so a one-pixel line laid on a half-pixel straddles two rows
+        // and each gets part of the colour — the outline came out washed out and
+        // two pixels thick. Half puts the centre at x+0.5, which is the offset
+        // the inset below is written against.
+        graphics.PixelOffsetMode = PixelOffsetMode.Half;
+
+        // What makes the corners read as cut away: the colour behind the control
+        // painted into them before anything else. Clear honours the clip, so a
+        // partial invalidation still only costs its own rectangle.
+        graphics.Clear(outside);
+
+        bool bordered = border.A > 0;
+
+        // A one-pixel pen strokes half in and half out of the path, so an outline
+        // laid on the client edge would spill half of itself outside the control
+        // and come out grey. Inset by half a pixel and it lands ON the outermost
+        // pixel, exactly where the framework's own FixedSingle border was.
+        RectangleF bounds = bordered
+            ? new RectangleF(
+                client.X + 0.5f,
+                client.Y + 0.5f,
+                client.Width - 1f,
+                client.Height - 1f)
+            : client;
+
+        using GraphicsPath path = CreatePath(bounds, radius);
+        if (fill.A > 0)
+        {
+            // Filled first and stroked over: the stroke covers the fill's own
+            // anti-aliased edge, which would otherwise show as a pale fringe
+            // between the surface and its outline.
+            using var brush = new SolidBrush(fill);
+            graphics.FillPath(brush, path);
+        }
+
+        if (bordered)
+        {
+            using var pen = new Pen(border);
+            graphics.DrawPath(pen, path);
+        }
+
+        graphics.Restore(state);
+    }
+
+    /// <summary>
+    /// The colour behind <paramref name="control"/> — what its cut corners show.
+    /// Transparent parents are walked past the way <see cref="Control"/> walks
+    /// them for its own simulated transparency; a control with no opaque parent
+    /// at all keeps its own colour, which draws square corners rather than a
+    /// guess.
+    /// </summary>
+    internal static Color ColorBehind(Control control)
+    {
+        for (Control? parent = control.Parent; parent != null; parent = parent.Parent)
+        {
+            if (parent.BackColor.A == 255)
+            {
+                return parent.BackColor;
+            }
+        }
+
+        return control.BackColor;
+    }
+}

--- a/tests/Resonalyze.App.Tests/RoundedSurfaceTests.cs
+++ b/tests/Resonalyze.App.Tests/RoundedSurfaceTests.cs
@@ -1,0 +1,160 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The rounded card the app draws its panels as. Nothing cuts the corners away —
+/// they are painted with the colour behind the control — so what the tests below
+/// look at is the three colours a card is made of and where each one lands:
+/// the colour behind in the corner, the outline on the edge, the surface inside.
+/// </summary>
+public sealed class RoundedSurfaceTests
+{
+    private static readonly Color Outside = Color.FromArgb(10, 20, 30);
+    private static readonly Color Fill = Color.FromArgb(200, 100, 50);
+    private static readonly Color Border = Color.FromArgb(0, 200, 120);
+
+    // A radius stated in 96-DPI pixels has to grow with the display, or it shrinks
+    // against the text beside it. 6 logical pixels at 125% is 7.5, which rounds to 8.
+    [Theory]
+    [InlineData(96, 6)]
+    [InlineData(120, 8)]
+    [InlineData(144, 9)]
+    [InlineData(192, 12)]
+    public void ScaleRadius_FollowsTheDisplay(int dpi, int expected) =>
+        Assert.Equal(expected, RoundedSurface.ScaleRadius(6, dpi, new Size(400, 300)));
+
+    // Past half the shorter side the four arcs would meet and the path would fold
+    // on itself, so a strip only a few pixels tall clamps rather than folds.
+    [Fact]
+    public void ScaleRadius_StopsAtHalfTheShorterSide() =>
+        Assert.Equal(5, RoundedSurface.ScaleRadius(20, 96, new Size(40, 10)));
+
+    [Fact]
+    public void ScaleRadius_ZeroStaysSquare() =>
+        Assert.Equal(0, RoundedSurface.ScaleRadius(0, 192, new Size(40, 30)));
+
+    [Fact]
+    public void Paint_ShowsTheColourBehindInTheCorners()
+    {
+        using Bitmap surface = PaintSurface(radius: 6);
+
+        Assert.Equal(Outside.ToArgb(), surface.GetPixel(0, 0).ToArgb());
+        Assert.Equal(Outside.ToArgb(), surface.GetPixel(39, 0).ToArgb());
+        Assert.Equal(Outside.ToArgb(), surface.GetPixel(0, 29).ToArgb());
+        Assert.Equal(Outside.ToArgb(), surface.GetPixel(39, 29).ToArgb());
+    }
+
+    // One pixel of the outline colour exactly, on the outermost row and column.
+    // Anti-aliased GDI+ places a line's colour by coverage, and a half-pixel error
+    // in either direction spreads it over two rows at a fraction of its strength —
+    // which is what the outline looked like before the pixel offset was set.
+    [Fact]
+    public void Paint_DrawsTheOutlineOnTheEdgeItself()
+    {
+        using Bitmap surface = PaintSurface(radius: 6);
+
+        Assert.Equal(Border.ToArgb(), surface.GetPixel(20, 0).ToArgb());
+        Assert.Equal(Border.ToArgb(), surface.GetPixel(20, 29).ToArgb());
+        Assert.Equal(Border.ToArgb(), surface.GetPixel(0, 15).ToArgb());
+        Assert.Equal(Border.ToArgb(), surface.GetPixel(39, 15).ToArgb());
+        Assert.Equal(Fill.ToArgb(), surface.GetPixel(20, 1).ToArgb());
+        Assert.Equal(Fill.ToArgb(), surface.GetPixel(20, 15).ToArgb());
+    }
+
+    // No radius is a square card, not a cut-away one: nothing of the colour behind
+    // is left in the corners. Read on the unbordered surface, where the corner is
+    // one flat colour rather than whatever coverage the outline's mitre gives it.
+    [Fact]
+    public void Paint_WithoutARadiusFillsTheCornersToo()
+    {
+        using Bitmap plain = PaintSurface(radius: 0, border: Color.Transparent);
+        using Bitmap outlined = PaintSurface(radius: 0);
+
+        Assert.Equal(Fill.ToArgb(), plain.GetPixel(0, 0).ToArgb());
+        Assert.Equal(Fill.ToArgb(), plain.GetPixel(39, 29).ToArgb());
+        Assert.NotEqual(Outside.ToArgb(), outlined.GetPixel(0, 0).ToArgb());
+    }
+
+    [Fact]
+    public void Paint_WithoutABorderLeavesTheSurfaceToTheEdge()
+    {
+        using Bitmap surface = PaintSurface(radius: 6, border: Color.Transparent);
+
+        Assert.Equal(Fill.ToArgb(), surface.GetPixel(20, 0).ToArgb());
+        Assert.Equal(Outside.ToArgb(), surface.GetPixel(0, 0).ToArgb());
+    }
+
+    // The corners show what is BEHIND the control, which a transparent parent is
+    // not: the walk has to carry on to the first parent that paints something.
+    [Fact]
+    public void ColorBehind_LooksPastTransparentParents()
+    {
+        using var form = new Form { BackColor = Outside };
+        using var host = new Panel { BackColor = Color.Transparent };
+        using var panel = new RoundedPanel { BackColor = Fill };
+        form.Controls.Add(host);
+        host.Controls.Add(panel);
+
+        Assert.Equal(Outside.ToArgb(), RoundedSurface.ColorBehind(panel).ToArgb());
+    }
+
+    // With nothing behind it there is no honest answer, and the surface's own
+    // colour is the one that draws square corners rather than a guessed frame.
+    [Fact]
+    public void ColorBehind_WithoutAParentIsTheControlsOwnColour()
+    {
+        using var panel = new RoundedPanel { BackColor = Fill };
+
+        Assert.Equal(Fill.ToArgb(), RoundedSurface.ColorBehind(panel).ToArgb());
+    }
+
+    // The control end of it: a panel realised in a form paints the form's colour
+    // into its corners and its own inside them.
+    [Fact]
+    public void RoundedPanel_PaintsItsParentsColourIntoTheCorners() =>
+        StaTest.Run(() =>
+        {
+            using var form = new Form
+            {
+                BackColor = Outside,
+                ClientSize = new Size(120, 90),
+                FormBorderStyle = FormBorderStyle.None,
+                StartPosition = FormStartPosition.Manual,
+                Location = new Point(-4000, -4000)
+            };
+            using var panel = new RoundedPanel
+            {
+                BackColor = Fill,
+                BorderColor = Border,
+                Bounds = new Rectangle(10, 10, 60, 40)
+            };
+            form.Controls.Add(panel);
+            form.Show();
+
+            using var surface = new Bitmap(panel.Width, panel.Height);
+            panel.DrawToBitmap(surface, new Rectangle(Point.Empty, panel.Size));
+
+            Assert.Equal(Outside.ToArgb(), surface.GetPixel(0, 0).ToArgb());
+            Assert.Equal(Border.ToArgb(), surface.GetPixel(30, 0).ToArgb());
+            Assert.Equal(Fill.ToArgb(), surface.GetPixel(30, 20).ToArgb());
+        });
+
+    private static Bitmap PaintSurface(int radius, Color? border = null)
+    {
+        var surface = new Bitmap(40, 30);
+        using (Graphics graphics = Graphics.FromImage(surface))
+        {
+            RoundedSurface.Paint(
+                graphics,
+                new Rectangle(0, 0, 40, 30),
+                radius,
+                Outside,
+                Fill,
+                border ?? Border);
+        }
+
+        return surface;
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverChannelControlBorderTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverChannelControlBorderTests.cs
@@ -1,0 +1,60 @@
+using System.Windows.Forms;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The channel block draws its own rounded outline, which puts that outline on the
+/// last row and column of its CLIENT area — where the framework's old
+/// <see cref="BorderStyle.FixedSingle"/> sat outside it, and clipped whatever
+/// reached it. Nothing clips now, so the block has to keep its own content off its
+/// edge; both ways it failed in the field are below.
+/// </summary>
+public sealed class VirtualCrossoverChannelControlBorderTests
+{
+    // The fold measured the block to the last kept row, which the border was then
+    // drawn on: the fold button came out with the outline through its bottom edge
+    // and the corners cut off. Folded, the block leaves the gap it leaves expanded.
+    [Fact]
+    public void Folding_LeavesTheSameGapUnderTheLastRowAsTheExpandedBlock()
+    {
+        using var control = new VirtualCrossoverChannelControl();
+        int expanded = BottomGap(control);
+
+        control.Collapsed = true;
+
+        Assert.True(expanded > 0);
+        Assert.Equal(expanded, BottomGap(control));
+        Assert.True(control.CollapseButton.Bottom < control.ClientSize.Height);
+    }
+
+    // The PEQ summary is written at run time and is longer than its row: it used to
+    // be cut mid-glyph by the non-client border, and with that gone it painted its
+    // own background over the outline instead. It is bounded and ellipsised now —
+    // the full text was already in its tooltip.
+    [Fact]
+    public void ThePeqSummary_StaysInsideTheBlockHoweverLongItGets()
+    {
+        using var control = new VirtualCrossoverChannelControl();
+
+        control.PeqInfoLabel.Text =
+            "A very long EQ profile name: 14 bands, preamp -3,5 dB";
+
+        Assert.False(control.PeqInfoLabel.AutoSize);
+        Assert.True(control.PeqInfoLabel.AutoEllipsis);
+        Assert.True(control.PeqInfoLabel.Right < control.ClientSize.Width);
+    }
+
+    private static int BottomGap(VirtualCrossoverChannelControl control)
+    {
+        int content = 0;
+        foreach (Control child in control.Controls)
+        {
+            if (child.Visible)
+            {
+                content = Math.Max(content, child.Bottom);
+            }
+        }
+
+        return control.ClientSize.Height - content;
+    }
+}


### PR DESCRIPTION
A custom `RoundedPanel` replaces the framework's square `FixedSingle` border
wherever a panel is a card: the sidebar blocks holding the level meter, the
record buttons and the overlay list, the two Record Settings cards, the EQ
wizard's Auto Tune card, the Virtual DSP channel blocks and its radio strips,
and the overlay slots themselves.

Nothing is clipped to the rounded shape. A window region does cut a corner, but
a region is not anti-aliased and the arc comes out a staircase; instead the
corners are painted with the colour behind the control and the rounded shape is
drawn over them. That assumes whatever is behind the control is a flat colour,
which every surface in this app is. `RoundedSurface` holds the painting, so the
two controls that are not panels — the input level meter and the Virtual DSP
channel block — draw the same card.

A one-pixel outline lands on the edge itself only under `PixelOffsetMode.Half`
with the path inset half a pixel; the three other combinations were measured and
either miss two of the four edges or spread the colour over two rows at part of
its strength. The radius is stated in 96-DPI pixels and scaled at paint time,
because `DeviceDpi` is only final once the handle exists in its monitor's
context.

Where it does not belong, the framework border stays: a container whose child is
docked over the whole of it has no surface left to round (the EQ wizard's PEQ
well), a panel that scrolls smears its outline (every mode panel), and a panel
whose colour matches its parent has no box to see in the first place.

Moving the border into the client area also moves what used to clip the block's
own content, which is how two things in the Virtual DSP channel block reached
the outline. The run-time PEQ summary is bounded and ellipsised rather than
overflowing — its full text was already in its tooltip — and a folded block
leaves the gap under its last row that an expanded one leaves, rather than
ending flush with the fold button.

The figures in `assets/images/` still show the square panels and want re-taking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
