### PR TITLE
Settle the front chain first, then place the other groups against it

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,4 +1,4 @@
-# Professional Car Audio Tuning with Resonalyze
+﻿# Professional Car Audio Tuning with Resonalyze
 
 **A complete step-by-step guide**
 
@@ -649,8 +649,9 @@ The zone is what the **Show** selector under the plot sorts by, so on a front-on
 you can set every block to Front and Sub and forget it — that is the default view and
 what this chapter's four-way looks like throughout. On a larger install the zone is how
 you look at one part at a time: the front stage with its subwoofers, then the rear fill,
-then the centre. Auto delay does not read the zone yet, so on such a system treat its
-proposal as a starting point for the front stage only.
+then the centre. **Auto delay** reads the zone as well: it settles the front chain first
+and then places the rear fill and the centre against it, so on a larger install the zones
+are what make its proposal mean anything.
 
 So seven RAW measurements become four Virtual DSP channels:
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1694,10 +1694,8 @@ Each channel runs through:
   The zone decides what the main plot is about — see
   [Show](#show-which-part-of-the-installation-the-plot-is-about), which sorts the
   blocks by it and takes the curves, the Sum, the loss and the read-out with it.
-  Auto delay does not read it yet: it still walks every channel as one chain
-  along the spectrum, ordered by band centre, so on an installation with a rear
-  fill or a centre its proposal is not to be trusted until the staged alignment
-  lands. Projects saved
+  [Auto delay](#auto-delay) reads it too: the front chain is settled first and
+  the other groups are placed against it. Projects saved
   before zones existed are given one on load, guessed from what those files do
   record: a stereo pair becomes Front, and a mono block becomes Sub unless it
   high-passes, which no subwoofer does — that one becomes Center. Nothing else
@@ -2299,6 +2297,41 @@ actually achievable after the best per-junction delay.
 
 ### Auto delay
 
+#### Staging: the front chain first, then the groups against it
+
+An installation with a rear fill or a centre is not one crossover chain, so
+**Auto delay** does not walk it as one. It settles the **front chain** — the
+front stage and the subwoofers under it — with the search described below,
+unchanged. Then it places each further group against that result: one reading
+per group, and no re-tuning of anything already settled. Walked as one chain
+those groups produce junctions that do not exist, which on a car with a rear
+fill means a front midrange "handing over" to it at the midrange's own low-pass
+corner.
+
+The later groups are placed rather than searched, because there is nothing
+between them and the front stage to search: no filter hands a band from one to
+the other. A **rear fill** is read against the front stage of its own side (its
+left and right are different drivers at different distances, so each gets its
+own delay) and then pushed back by the **Rear fill** offset in the dialog. A
+**centre** has no side at all, so it is read against BOTH front sums and placed
+at the midpoint; the two readings are each other's witness, since they should
+differ by the scene offset, and a disagreement is reported instead of averaged
+away. Relative polarity comes out of the same correlation as its sign — but it
+is only applied where no fill offset is in play, because past a few
+milliseconds the two groups no longer sum in any way the ear resolves.
+
+A group the run cannot measure keeps the delay it had, and says so in the trace.
+
+Every delay is relative until the last pass, which slides the whole set until
+the earliest channel sits at zero — a rear fill pushed back past the front stage
+asks the front to go negative, and nothing is dialable until that shift. Every
+relation the stages computed survives it.
+
+A project with no rear and no centre never enters any of this: it takes the
+single-stage path, which is the same engine call it always took.
+
+#### The search
+
 **Auto delay** aligns in two stages: band-limited first arrivals, refined by a
 GCC-PHAT cross-correlation whose dominant extremum of either polarity seeds the
 junction (an inverted junction — a subwoofer against its midbass is the classic
@@ -2380,6 +2413,22 @@ sides of a pair by one shared delta to recover what the pin cost. Each far-side
 channel may also leave its own scene position by up to 0.03 ms to buy back its
 junction's summation — below what the scene can resolve, and enough to close the
 skew the arithmetic bridge leaves behind.
+
+**Rear fill** sets how far behind the front stage the rear arrives, and is off
+unless the project has a block in the Rear zone. Ten to twenty milliseconds
+(the default is fifteen) is where the precedence effect keeps the image on the
+dash while the rear adds room; zero co-arrives them, which is what a second row
+of listeners wants and what collapses the image for the front seats. Note that
+rear speakers are often CLOSER to your ears than the front, so some delay is
+needed just to reach zero and this offset sits on top of that. The setting is
+stored with the tune, since a car tuned for its front seats and one tuned for
+its second row want different answers.
+
+The rear's LEVEL is not set here. It usually sits 6-12 dB under the front —
+raise it until you notice it as a separate source, then take 2-3 dB back — and
+the last word belongs to the ear; the read-out's
+[vs Front block](#show-which-part-of-the-installation-the-plot-is-about) gives
+the current figure to adjust against.
 
 A run only proposes: the dialog answers with a report and nothing is written
 until **Apply**. It carries a row per channel — a value the run changes reads

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAlignmentStage.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAlignmentStage.cs
@@ -1,0 +1,103 @@
+namespace Resonalyze;
+
+/// <summary>
+/// The order Auto delay settles a complex installation in. Each stage is
+/// finished before the next begins, and no later stage may re-tune an earlier
+/// one internally — it may only slide it as a rigid body.
+/// </summary>
+/// <remarks>
+/// The alignment engine walks ONE chain along the spectrum, pairing neighbours
+/// and settling each junction against the last. That is the right shape for a
+/// crossover chain and the wrong shape for a car: a rear fill and a centre play
+/// the same band as the front midrange and tweeter from other places, with no
+/// filter handing anything between them. Walked as one chain they produce
+/// junctions that do not exist — on the reference installation, a front
+/// midrange handing over to a rear fill at its own low-pass corner.
+/// <para>
+/// Staging is what replaces that. The front stage and the subwoofers under it
+/// ARE one chain and keep the engine unchanged. What the later groups need is
+/// not a junction search but a single number each: how far behind the front
+/// they should arrive. So they are not searched at all — they are COMPUTED
+/// against a front stage that is already settled, which is also why the stages
+/// cannot fight each other.
+/// </para>
+/// </remarks>
+public enum VirtualCrossoverAlignmentStage
+{
+    /// <summary>
+    /// The front stage with the subwoofers: the crossover chain, settled by the
+    /// existing engine exactly as it always was.
+    /// </summary>
+    FrontChain,
+
+    /// <summary>
+    /// The rear fill: its own L/R pair settled between itself, then the group
+    /// placed as a whole against the front.
+    /// </summary>
+    Rear,
+
+    /// <summary>
+    /// The centre: one driver, placed between the two front sides.
+    /// </summary>
+    Center
+}
+
+/// <summary>
+/// Which zones each alignment stage owns, and what a stage is allowed to do to
+/// the ones before it. Pure and UI-free so the rules are testable without an
+/// engine run.
+/// </summary>
+public static class VirtualCrossoverAlignmentStages
+{
+    /// <summary>The stages in the order they run.</summary>
+    public static readonly IReadOnlyList<VirtualCrossoverAlignmentStage> InOrder =
+    [
+        VirtualCrossoverAlignmentStage.FrontChain,
+        VirtualCrossoverAlignmentStage.Rear,
+        VirtualCrossoverAlignmentStage.Center
+    ];
+
+    /// <summary>
+    /// The stage a block belongs to. The subwoofers join the FRONT chain rather
+    /// than forming one of their own: that is where their junctions are — on the
+    /// reference car the two subs cross each other and the lower one crosses the
+    /// midbass — and it is how they are tuned by hand.
+    /// </summary>
+    public static VirtualCrossoverAlignmentStage StageOf(VirtualCrossoverZone zone) =>
+        zone switch
+        {
+            VirtualCrossoverZone.Rear => VirtualCrossoverAlignmentStage.Rear,
+            VirtualCrossoverZone.Center => VirtualCrossoverAlignmentStage.Center,
+            _ => VirtualCrossoverAlignmentStage.FrontChain
+        };
+
+    /// <summary>
+    /// Whether the stage settles its members by SEARCHING their junctions — the
+    /// chain walk the engine has always done — or by computing one offset for
+    /// the group against a front stage that is already settled.
+    /// </summary>
+    /// <remarks>
+    /// Only the front chain searches. A rear fill has no junction with the front
+    /// to search for, and a centre has no junction with anything: what they need
+    /// is a placement, and a placement computed from a settled reference cannot
+    /// disagree with the thing it was computed from. That is what makes the
+    /// stages one-way — the reason no later stage can pull an earlier one out of
+    /// tune, other than by sliding all of it at once.
+    /// </remarks>
+    public static bool SearchesJunctions(VirtualCrossoverAlignmentStage stage) =>
+        stage == VirtualCrossoverAlignmentStage.FrontChain;
+
+    /// <summary>
+    /// Whether a project needs staging at all: false when every block is in the
+    /// front chain, which is every project written before zones existed and
+    /// every front-only car.
+    /// </summary>
+    /// <remarks>
+    /// The distinction earns its place as the compatibility guarantee. Such a
+    /// project takes the single-stage path, which IS the old code — not a
+    /// staged run that happens to have one stage — so the session battery's
+    /// results are unchanged by construction rather than by measurement.
+    /// </remarks>
+    public static bool NeedsStaging(IEnumerable<VirtualCrossoverZone> zones) =>
+        zones.Any(zone => StageOf(zone) != VirtualCrossoverAlignmentStage.FrontChain);
+}

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
@@ -1,4 +1,4 @@
-namespace Resonalyze
+﻿namespace Resonalyze
 {
     partial class VirtualCrossoverAutoDelayDialog
     {
@@ -34,6 +34,9 @@ namespace Resonalyze
             radioRightHandDrive = new ReleaseClickRadioButton();
             labelSceneOffset = new Label();
             numericSceneOffset = new DarkNumericUpDown();
+            labelRearFill = new Label();
+            numericRearFill = new DarkNumericUpDown();
+            labelRearFillHint = new Label();
             checkBoxGains = new ReleaseClickCheckBox();
             labelNearSideCut = new Label();
             numericNearSideCut = new DarkNumericUpDown();
@@ -43,6 +46,7 @@ namespace Resonalyze
             buttonApply = new ReleaseClickButton();
             buttonCancel = new ReleaseClickButton();
             (numericSceneOffset).BeginInit();
+            (numericRearFill).BeginInit();
             (numericNearSideCut).BeginInit();
             SuspendLayout();
             // 
@@ -133,13 +137,48 @@ namespace Resonalyze
             numericNearSideCut.ThousandsSeparator = false;
             numericNearSideCut.Value = new decimal(new int[] { 1, 0, 0, 0 });
             numericNearSideCut.ValueSuffix = "dB";
+            //
+            // labelRearFill
+            //
+            labelRearFill.AutoSize = true;
+            labelRearFill.ForeColor = Color.FromArgb(210, 214, 222);
+            labelRearFill.Location = new Point(12, 50);
+            labelRearFill.Name = "labelRearFill";
+            labelRearFill.Size = new Size(78, 15);
+            labelRearFill.Text = "Rear fill ms";
+            //
+            // numericRearFill
+            //
+            numericRearFill.BackColor = Color.FromArgb(55, 60, 72);
+            numericRearFill.DecimalPlaces = 1;
+            numericRearFill.ForeColor = Color.White;
+            numericRearFill.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
+            numericRearFill.Location = new Point(100, 46);
+            numericRearFill.Maximum = new decimal(new int[] { 30, 0, 0, 0 });
+            numericRearFill.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
+            numericRearFill.MinimumSize = new Size(36, 19);
+            numericRearFill.Name = "numericRearFill";
+            numericRearFill.Size = new Size(66, 19);
+            numericRearFill.TextAlign = HorizontalAlignment.Right;
+            numericRearFill.ThousandsSeparator = false;
+            numericRearFill.Value = new decimal(new int[] { 15, 0, 0, 0 });
+            //
+            // labelRearFillHint
+            //
+            labelRearFillHint.AutoSize = true;
+            labelRearFillHint.ForeColor = Color.FromArgb(170, 176, 190);
+            labelRearFillHint.Location = new Point(176, 50);
+            labelRearFillHint.Name = "labelRearFillHint";
+            labelRearFillHint.Size = new Size(560, 15);
+            labelRearFillHint.Text =
+                "how far the rear arrives BEHIND the front - 10-20 ms keeps the image on the dash; 0 sums them for a second row";
             // 
             // buttonRun
             // 
             buttonRun.BackColor = Color.FromArgb(46, 51, 67);
             buttonRun.FlatStyle = FlatStyle.Popup;
             buttonRun.ForeColor = Color.White;
-            buttonRun.Location = new Point(12, 44);
+            buttonRun.Location = new Point(12, 78);
             buttonRun.Name = "buttonRun";
             buttonRun.Size = new Size(120, 26);
             buttonRun.TabIndex = 8;
@@ -150,7 +189,7 @@ namespace Resonalyze
             // 
             labelStatus.AutoSize = true;
             labelStatus.ForeColor = Color.FromArgb(185, 190, 200);
-            labelStatus.Location = new Point(144, 50);
+            labelStatus.Location = new Point(144, 84);
             labelStatus.Name = "labelStatus";
             labelStatus.Size = new Size(0, 15);
             labelStatus.TabIndex = 9;
@@ -162,7 +201,7 @@ namespace Resonalyze
             textBoxReport.BorderStyle = BorderStyle.FixedSingle;
             textBoxReport.Font = new Font("Consolas", 9F);
             textBoxReport.ForeColor = Color.FromArgb(210, 214, 222);
-            textBoxReport.Location = new Point(12, 80);
+            textBoxReport.Location = new Point(12, 114);
             textBoxReport.Multiline = true;
             textBoxReport.Name = "textBoxReport";
             textBoxReport.ReadOnly = true;
@@ -202,11 +241,14 @@ namespace Resonalyze
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             BackColor = Color.FromArgb(40, 44, 54);
-            ClientSize = new Size(776, 681);
+            ClientSize = new Size(776, 715);
             Controls.Add(radioLeftHandDrive);
             Controls.Add(radioRightHandDrive);
             Controls.Add(labelSceneOffset);
             Controls.Add(numericSceneOffset);
+            Controls.Add(labelRearFill);
+            Controls.Add(numericRearFill);
+            Controls.Add(labelRearFillHint);
             Controls.Add(checkBoxGains);
             Controls.Add(labelNearSideCut);
             Controls.Add(numericNearSideCut);
@@ -224,6 +266,7 @@ namespace Resonalyze
             StartPosition = FormStartPosition.CenterParent;
             Text = "Auto delay";
             (numericSceneOffset).EndInit();
+            (numericRearFill).EndInit();
             (numericNearSideCut).EndInit();
             ResumeLayout(false);
             PerformLayout();
@@ -235,6 +278,9 @@ namespace Resonalyze
         private ReleaseClickRadioButton radioRightHandDrive;
         private Label labelSceneOffset;
         private DarkNumericUpDown numericSceneOffset;
+        private Label labelRearFill;
+        private DarkNumericUpDown numericRearFill;
+        private Label labelRearFillHint;
         private ReleaseClickCheckBox checkBoxGains;
         private Label labelNearSideCut;
         private DarkNumericUpDown numericNearSideCut;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
@@ -169,9 +169,9 @@
             labelRearFillHint.ForeColor = Color.FromArgb(170, 176, 190);
             labelRearFillHint.Location = new Point(176, 50);
             labelRearFillHint.Name = "labelRearFillHint";
-            labelRearFillHint.Size = new Size(560, 15);
+            labelRearFillHint.Size = new Size(470, 15);
             labelRearFillHint.Text =
-                "how far the rear arrives BEHIND the front - 10-20 ms keeps the image on the dash; 0 sums them for a second row";
+                "how far behind the front the rear arrives - 10-20 ms holds the image; 0 co-arrives";
             // 
             // buttonRun
             // 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
@@ -1,4 +1,4 @@
-namespace Resonalyze;
+﻿namespace Resonalyze;
 
 /// <summary>
 /// The Auto delay dialog: the steering layout (LHD/RHD), the stereo scene
@@ -100,10 +100,17 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
         bool rightHandDrive,
         double nearSideCutDb,
         Func<AutoDelayRunRequest, Task<AutoDelayRunResult>> runner,
-        string? polarityWarning = null)
+        string? polarityWarning = null,
+        bool hasRearFill = false,
+        double rearFillOffsetMs = DefaultRearFillOffsetMs)
     {
         this.stereo = stereo;
         this.runner = runner;
+        numericRearFill.Value = Math.Clamp(
+            (decimal)rearFillOffsetMs,
+            numericRearFill.Minimum,
+            numericRearFill.Maximum);
+        ApplyRearFillAvailability(hasRearFill);
         radioLeftHandDrive.Checked = !rightHandDrive;
         radioRightHandDrive.Checked = rightHandDrive;
         numericSceneOffset.Value = Math.Clamp(
@@ -153,6 +160,45 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
     // checkbox off no gain is written at all, and a single-side run has no L/R
     // relation to tilt. Kept visible-but-disabled either way, so the value the
     // next stereo run would use stays readable.
+    /// <summary>
+    /// The precedence-effect offset a rear fill starts at. Ten to twenty
+    /// milliseconds is where the ear stops placing the sound at the rear
+    /// speakers and starts hearing them as room; fifteen is the middle of it.
+    /// </summary>
+    public const double DefaultRearFillOffsetMs = 15.0;
+
+    // Off entirely without a rear fill: the field would be a setting for a
+    // group the project does not have.
+    private void ApplyRearFillAvailability(bool hasRearFill)
+    {
+        UiStyle.SetTextEnabledLook(labelRearFill, hasRearFill);
+        UiStyle.SetTextEnabledLook(labelRearFillHint, hasRearFill);
+        numericRearFill.Enabled = hasRearFill;
+        numericRearFill.ApplyToolTip(
+            toolTip,
+            hasRearFill
+                ? "How far behind the front stage the rear fill should arrive,\r\n" +
+                    "measured acoustically at the listening position.\r\n" +
+                    "\r\n" +
+                    "10-20 ms (start at 15): the precedence effect keeps the image\r\n" +
+                    "on the dash while the rear adds room. Note the rear speakers\r\n" +
+                    "are often CLOSER to your ears than the front, so some delay\r\n" +
+                    "is needed just to reach zero - this offset is on top of that.\r\n" +
+                    "0 ms: co-arrival, which is what a second row of listeners\r\n" +
+                    "wants and what collapses the image for the front seats.\r\n" +
+                    "\r\n" +
+                    "Level is not set here. Rear fill usually sits 6-12 dB under\r\n" +
+                    "the front (raise it until you notice it as a separate source,\r\n" +
+                    "then take 2-3 dB back); the read-out's vs Front block gives\r\n" +
+                    "you the current figure to adjust against by ear.\r\n" +
+                    "\r\n" +
+                    "Polarity between front and rear is not judged at a Haas\r\n" +
+                    "offset - at that distance the two no longer sum in any way\r\n" +
+                    "the ear resolves."
+                : "This project has no block in the Rear zone, so there is no\r\n" +
+                    "rear fill to place. Set a block's Zone to Rear to use it.");
+    }
+
     private void UpdateNearSideCutEnabled()
     {
         bool enabled = stereo && checkBoxGains.Checked;
@@ -221,7 +267,8 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
                 (double)numericSceneOffset.Value,
                 radioRightHandDrive.Checked,
                 checkBoxGains.Checked,
-                (double)numericNearSideCut.Value));
+                (double)numericNearSideCut.Value,
+                (double)numericRearFill.Value));
             if (IsDisposed)
             {
                 return;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayReport.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayReport.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 using Resonalyze.Dsp;
 
@@ -50,7 +50,12 @@ internal sealed record AutoDelayRunRequest(
     double SceneOffsetMs,
     bool RightHandDrive,
     bool AdjustGains,
-    double NearSideCutDb)
+    double NearSideCutDb,
+    // How far BEHIND the front stage the rear fill should arrive. Zero sums the
+    // two coherently, which is what a second row of listeners wants; the default
+    // is the precedence-effect offset that keeps the image on the dash for the
+    // front seats while the rear adds room. Ignored by a project with no rear.
+    double RearFillOffsetMs = 0)
 {
     /// <summary>
     /// The tilt in the gain engine's LEFT-minus-RIGHT convention: the near

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayReport.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayReport.cs
@@ -114,14 +114,22 @@ internal static class VirtualCrossoverAutoDelayReport
                         $", near-side cut {Math.Abs(GainBalanceEngine.LevelDifferenceDb(request.LevelDifferenceDb)):0.0} dB")
                     : ""));
         }
-        if (request.RearFillOffsetMs > 0)
+        if (outcomes.Any(outcome =>
+            outcome.Runtime.Pair.Zone == VirtualCrossoverZone.Rear))
         {
             // The single most consequential number in a rear-fill tune: without
             // it a saved proposal cannot say whether the rear was co-arrived or
             // held back, which is the difference between a front image and a
             // collapsed one.
-            text.AppendLine(FormattableString.Invariant(
-                $"Rear fill {request.RearFillOffsetMs:0.0} ms behind the front stage."));
+            //
+            // Printed whenever there IS a rear, zero included. Zero is a
+            // deliberate choice — the second row wants co-arrival — and hiding
+            // it left the report silent about exactly the case the line was
+            // added to disambiguate.
+            text.AppendLine(request.RearFillOffsetMs > 0
+                ? FormattableString.Invariant(
+                    $"Rear fill {request.RearFillOffsetMs:0.0} ms behind the front stage.")
+                : "Rear fill 0.0 ms: co-arriving with the front stage.");
         }
         if (!request.AdjustGains)
         {

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayReport.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayReport.cs
@@ -114,6 +114,15 @@ internal static class VirtualCrossoverAutoDelayReport
                         $", near-side cut {Math.Abs(GainBalanceEngine.LevelDifferenceDb(request.LevelDifferenceDb)):0.0} dB")
                     : ""));
         }
+        if (request.RearFillOffsetMs > 0)
+        {
+            // The single most consequential number in a rear-fill tune: without
+            // it a saved proposal cannot say whether the rear was co-arrived or
+            // held back, which is the difference between a front image and a
+            // collapsed one.
+            text.AppendLine(FormattableString.Invariant(
+                $"Rear fill {request.RearFillOffsetMs:0.0} ms behind the front stage."));
+        }
         if (!request.AdjustGains)
         {
             text.AppendLine("Gains not adjusted (checkbox off).");

--- a/source/Tools/VirtualCrossover/VirtualCrossoverGroupPlacement.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverGroupPlacement.cs
@@ -1,0 +1,172 @@
+using System.Numerics;
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Where one listening group sits against a settled reference: the delay that
+/// would make the two arrive together, whether the group reads inverted, and
+/// how much the answer can be trusted.
+/// </summary>
+/// <param name="CoArrivalDelayMs">
+/// The delay to ADD to the group so it arrives with the reference. Negative
+/// when the group is already the later of the two — the group normalization
+/// pass is what turns such an answer into something a processor can dial, by
+/// delaying everything else instead.
+/// </param>
+/// <param name="Inverted">
+/// True when the group's phase-whitened correlation against the reference peaks
+/// NEGATIVE, which is a measurement of relative polarity rather than a guess.
+/// </param>
+/// <param name="Coefficient">
+/// The extremum's height, |r| in 0..1. The confidence the caller reports.
+/// </param>
+internal sealed record GroupPlacement(
+    double CoArrivalDelayMs,
+    bool Inverted,
+    double Coefficient);
+
+/// <summary>
+/// Places a whole group (a rear fill, a centre) against a reference that is
+/// already settled — the front stage after the chain walk.
+/// </summary>
+/// <remarks>
+/// Deliberately not a junction search. A rear fill shares no crossover with the
+/// front stage and a centre shares none with anything, so there is no handover
+/// to optimise: what these groups need is one number each, and one number is
+/// what a correlation against a settled reference gives. That is also what makes
+/// the staging one-way — a placement computed from a fixed reference cannot move
+/// the thing it was computed from.
+/// <para>
+/// Two steps, the same shape the alignment engine uses at a junction: a coarse
+/// band-limited ARRIVAL difference says roughly where the answer is, then the
+/// phase-whitened correlation is searched in a short window centred there. The
+/// coarse step matters because a rear fill can sit ten or twenty milliseconds
+/// from the front stage — a correlation searched around zero would find a lobe
+/// rather than the answer, and one searched across the whole range would have
+/// many lobes to choose between.
+/// </para>
+/// </remarks>
+internal static class VirtualCrossoverGroupPlacement
+{
+    /// <summary>
+    /// How far around the coarse arrival estimate the whitened correlation is
+    /// refined. Wide enough to cross the estimate's own error — the arrival read
+    /// is an envelope feature and the correlation peak is a phase feature, and
+    /// they differ by a fraction of a period — and narrow enough that the search
+    /// cannot walk into the neighbouring lobe.
+    /// </summary>
+    public const double RefineRangeMs = 2.0;
+
+    /// <summary>
+    /// Below this |r| the placement is reported but not trusted: the groups play
+    /// the same band from different places, so their correlation is never as
+    /// clean as a crossover's, but a value this low means the band holds no
+    /// common feature to time against at all.
+    /// </summary>
+    public const double MinimumTrustedCoefficient = 0.25;
+
+    /// <summary>
+    /// Places <paramref name="groupIr"/> against <paramref name="referenceIr"/>
+    /// in the band the two share. Null when either side holds no reliable
+    /// arrival there, which is the honest answer for a group that does not
+    /// overlap the reference enough to be timed against it.
+    /// </summary>
+    public static GroupPlacement? Place(
+        Complex[] referenceIr,
+        Complex[] groupIr,
+        int sampleRate,
+        double lowHz,
+        double highHz)
+    {
+        ArgumentNullException.ThrowIfNull(referenceIr);
+        ArgumentNullException.ThrowIfNull(groupIr);
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+        if (!(lowHz > 0) || !(highHz > lowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio))
+        {
+            return null;
+        }
+
+        TimeAlignmentAnalysisResult reference =
+            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                referenceIr, sampleRate, lowHz, highHz);
+        TimeAlignmentAnalysisResult group =
+            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                groupIr, sampleRate, lowHz, highHz);
+        if (!Reliable(reference) || !Reliable(group))
+        {
+            return null;
+        }
+
+        // How much later the group arrives. The correlation's own convention is
+        // the delay to ADD to the second response, so the window it searches is
+        // centred on the negative of that.
+        double lateMs = group.FirstArrivalDelayMilliseconds -
+            reference.FirstArrivalDelayMilliseconds;
+        double centerHz = Math.Sqrt(lowHz * highHz);
+        double octaves = Math.Log2(highHz / lowHz);
+        CorrelationAlignmentResult correlation =
+            VirtualCrossoverAnalysis.FindBandLimitedCorrelationDelay(
+                referenceIr,
+                groupIr,
+                sampleRate,
+                centerHz,
+                octaves,
+                RefineRangeMs,
+                centerLagMs: -lateMs,
+                phaseTransform: true);
+        CorrelationDelayCandidate best = correlation.BestByMagnitude;
+        return new GroupPlacement(
+            best.DelayMs,
+            best.InvertPolarity,
+            Math.Abs(best.Coefficient));
+    }
+
+    /// <summary>
+    /// The centre's placement from its two side readings: the midpoint. A centre
+    /// plays a signal derived from L and R and sits between them, so the delay
+    /// that puts it in the middle is the average of the two that would align it
+    /// with each side alone.
+    /// </summary>
+    /// <remarks>
+    /// The two readings are also each other's witness. They should differ by the
+    /// scene offset — the same figure the stereo run applies and the metric panel
+    /// verifies — because that is how far apart the sides themselves are. A
+    /// larger disagreement means one of the readings landed on the wrong lobe,
+    /// and the caller is told so rather than handed a confident midpoint between
+    /// a right answer and a wrong one.
+    /// <para>
+    /// Polarity is only applied when both sides agree on it. A centre that reads
+    /// inverted against one side and normal against the other is not a centre
+    /// with a wiring fault; it is a measurement that has not settled, and
+    /// flipping on half of it would be a coin toss dressed as a reading.
+    /// </para>
+    /// </remarks>
+    public static (double DelayMs, bool Inverted, bool Confident) Midpoint(
+        GroupPlacement reference,
+        GroupPlacement far,
+        double sceneOffsetMs,
+        double toleranceMs)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+        ArgumentNullException.ThrowIfNull(far);
+        bool agree = reference.Inverted == far.Inverted;
+        bool witnessed =
+            Math.Abs(Math.Abs(reference.CoArrivalDelayMs - far.CoArrivalDelayMs) -
+                Math.Abs(sceneOffsetMs)) <= toleranceMs;
+        return (
+            (reference.CoArrivalDelayMs + far.CoArrivalDelayMs) / 2.0,
+            agree && reference.Inverted,
+            agree &&
+                witnessed &&
+                Math.Min(reference.Coefficient, far.Coefficient) >=
+                    MinimumTrustedCoefficient);
+    }
+
+    private static bool Reliable(TimeAlignmentAnalysisResult arrival) =>
+        arrival.IsValid &&
+        arrival.SignalToNoiseDecibels >= AutoAlignmentEngine.MinimumArrivalSnrDb;
+}

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4686,11 +4686,7 @@ public partial class VirtualCrossoverPanel : UserControl
                 log);
             if (inner.Count > 0)
             {
-                foreach (VirtualCrossoverSideAlignmentChannel member in members)
-                {
-                    alignment[member] = inner[member];
-                }
-
+                ApplyInnerSettlement(members, inner, alignment);
                 settled = reprocessor.Reprocess(alignment);
                 byChannel = settled.ToDictionary(snapshot => snapshot.Channel);
             }
@@ -4777,11 +4773,7 @@ public partial class VirtualCrossoverPanel : UserControl
                 log);
             if (inner.Count > 0)
             {
-                foreach (VirtualCrossoverSideAlignmentChannel member in centreMembers)
-                {
-                    alignment[member] = inner[member];
-                }
-
+                ApplyInnerSettlement(centreMembers, inner, alignment);
                 settled = reprocessor.Reprocess(alignment);
                 byChannel = settled.ToDictionary(snapshot => snapshot.Channel);
             }
@@ -4929,7 +4921,12 @@ public partial class VirtualCrossoverPanel : UserControl
     //
     // Returns the delay each member ended on relative to the group's own
     // earliest, which the caller adds its group offset to.
-    private static Dictionary<IAlignmentChannel, AlignmentOverride> SettleWithinGroup(
+    /// <returns>
+    /// The engine's own SPARSE map: the member it chose as the group's reference
+    /// has no entry. Compose it with <see cref="ApplyInnerSettlement"/> rather
+    /// than by indexing.
+    /// </returns>
+    internal static Dictionary<IAlignmentChannel, AlignmentOverride> SettleWithinGroup(
         IReadOnlyList<IAlignmentChannel> members,
         Func<IAlignmentChannel, VirtualCrossoverChannelSettings> settingsOf,
         IReadOnlyDictionary<IAlignmentChannel, AlignmentSnapshot> snapshots,
@@ -4969,6 +4966,29 @@ public partial class VirtualCrossoverPanel : UserControl
             inner,
             log);
         return inner;
+    }
+
+    /// <summary>
+    /// Copies a group's internally settled delays onto the run's override map.
+    /// </summary>
+    /// <remarks>
+    /// One line, and it earns a name because of what it must NOT be: an indexer
+    /// lookup. The engine's map is sparse by contract — its reference channel
+    /// gets no entry at all, since absence means "nothing proposed" — so the
+    /// obvious <c>inner[member]</c> throws the moment a later group is a two-way
+    /// and the walk inside it picks one of the two as its reference. That is the
+    /// same convention the normalization pass respects, one function away, and
+    /// writing it out three times is how the two came to disagree.
+    /// </remarks>
+    internal static void ApplyInnerSettlement(
+        IEnumerable<IAlignmentChannel> members,
+        IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> inner,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment)
+    {
+        foreach (IAlignmentChannel member in members)
+        {
+            alignment[member] = inner.GetValueOrDefault(member);
+        }
     }
 
     // What the REPORT is told about a placement. The diagnostic log gets the
@@ -5042,11 +5062,7 @@ public partial class VirtualCrossoverPanel : UserControl
                 log);
             if (inner.Count > 0)
             {
-                foreach (VirtualCrossoverChannel member in members)
-                {
-                    alignment[member] = inner[member];
-                }
-
+                ApplyInnerSettlement(members, inner, alignment);
                 settled = reprocessor.Reprocess(alignment);
                 byChannel = settled.ToDictionary(snapshot => snapshot.Channel);
             }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4588,6 +4588,160 @@ public partial class VirtualCrossoverPanel : UserControl
     // final snapshots. Board levelling only — a single side has no L/R
     // relation, so neither the scene offset nor the level difference plays a
     // part here.
+    // ------------------------------------------------------ staged alignment
+
+    // Beyond this much intended offset a polarity flip stops describing anything
+    // audible: the two groups are no longer summing in a way an ear resolves, so
+    // the sign of a correlation between them is a fact about the measurement
+    // rather than about what the listener hears.
+    private const double HaasPolarityIrrelevantMs = 5.0;
+
+    // The front chain and the groups placed against it afterwards. A project with
+    // no rear fill and no centre - every project written before zones existed -
+    // comes back with everything in the chain and nothing after it, and then takes
+    // the unstaged path, which is the engine call it always took.
+    private static (List<VirtualCrossoverChannel> Chain, List<VirtualCrossoverChannel> Later)
+        SplitAlignmentStages(IReadOnlyList<VirtualCrossoverChannel> participants)
+    {
+        List<VirtualCrossoverChannel> chain = [.. participants.Where(channel =>
+            VirtualCrossoverAlignmentStages.StageOf(channel.Pair.Zone) ==
+                VirtualCrossoverAlignmentStage.FrontChain)];
+        List<VirtualCrossoverChannel> later = [.. participants.Except(chain)];
+        // Nothing to be placed AGAINST. A rear-only project is a legitimate thing
+        // to align - it is simply its own chain, so it is walked as one rather
+        // than left waiting for a front stage that does not exist.
+        return chain.Count == 0 || later.Count == 0
+            ? ([.. participants], [])
+            : (chain, later);
+    }
+
+    // The union of a group's members' playing bands.
+    private static (double LowHz, double HighHz) GroupBandOf(
+        IEnumerable<VirtualCrossoverChannel> members)
+    {
+        double low = double.MaxValue;
+        double high = double.MinValue;
+        foreach (VirtualCrossoverChannel member in members)
+        {
+            (double memberLow, double memberHigh) =
+                VirtualCrossoverJunctions.GetChannelBand(member.Settings);
+            low = Math.Min(low, memberLow);
+            high = Math.Max(high, memberHigh);
+        }
+
+        return (low, high);
+    }
+
+    // Stages 2 and 3, on the responses the front-chain walk has already settled.
+    // Each later group gets ONE delay for all its members: the placement is a
+    // property of where the group sits in the car, and it is applied to the group
+    // as a rigid body so nothing inside it is re-tuned by this pass.
+    private void PlaceLaterStages(
+        IReadOnlyList<VirtualCrossoverChannel> chain,
+        IReadOnlyList<VirtualCrossoverChannel> later,
+        AlignmentReprocessor reprocessor,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        double rearFillOffsetMs,
+        System.Text.StringBuilder log)
+    {
+        IReadOnlyList<AlignmentSnapshot> settled = reprocessor.Reprocess(alignment);
+        Dictionary<IAlignmentChannel, AlignmentSnapshot> byChannel =
+            settled.ToDictionary(snapshot => snapshot.Channel);
+        Complex[] SumOf(IEnumerable<VirtualCrossoverChannel> group) =>
+            VirtualCrossoverAnalysis.SumImpulseResponses(
+                [.. group.Select(channel => byChannel[channel].ImpulseResponse)]);
+
+        Complex[] reference = SumOf(chain);
+        int sampleRate = chain[0].SampleRate;
+        (double chainLow, double chainHigh) = GroupBandOf(chain);
+        foreach (VirtualCrossoverAlignmentStage stage in
+            VirtualCrossoverAlignmentStages.InOrder.Where(
+                item => item != VirtualCrossoverAlignmentStage.FrontChain))
+        {
+            List<VirtualCrossoverChannel> members = [.. later.Where(channel =>
+                VirtualCrossoverAlignmentStages.StageOf(channel.Pair.Zone) == stage)];
+            if (members.Count == 0)
+            {
+                continue;
+            }
+
+            (double groupLow, double groupHigh) = GroupBandOf(members);
+            double lowHz = Math.Max(chainLow, groupLow);
+            double highHz = Math.Min(chainHigh, groupHigh);
+            GroupPlacement? placement = VirtualCrossoverGroupPlacement.Place(
+                reference, SumOf(members), sampleRate, lowHz, highHz);
+            if (placement == null)
+            {
+                // Its CURRENT delay stands, written explicitly rather than left
+                // absent: an absent override means zero to the reprocessor, which
+                // would silently move a group this run could not measure.
+                log.AppendLine(
+                    $"  {stage}: not placed - the band it shares with the front " +
+                    $"stage ({lowHz:0}-{highHz:0} Hz) holds no reliable arrival. " +
+                    "Its current delay stands.");
+                foreach (VirtualCrossoverChannel member in members)
+                {
+                    alignment[member] = new AlignmentOverride(
+                        member.Settings.DelayMs, member.Settings.InvertPolarity);
+                }
+
+                continue;
+            }
+
+            // A rear fill is WANTED behind the front stage: the precedence effect
+            // keeps the image on the dash while the rear adds room. A centre
+            // belongs with the front stage, so it takes no offset.
+            double offsetMs = stage == VirtualCrossoverAlignmentStage.Rear
+                ? rearFillOffsetMs
+                : 0.0;
+            double delayMs = placement.CoArrivalDelayMs + offsetMs;
+            bool invert = offsetMs < HaasPolarityIrrelevantMs && placement.Inverted;
+            log.AppendLine(
+                $"  {stage}: {delayMs:+0.00;-0.00;0.00} ms (co-arrival " +
+                $"{placement.CoArrivalDelayMs:+0.00;-0.00;0.00}" +
+                (offsetMs != 0 ? $" plus {offsetMs:0.##} ms fill" : string.Empty) +
+                $"), r {placement.Coefficient:0.00}" +
+                (invert ? ", inverted" : string.Empty) +
+                (placement.Coefficient < VirtualCrossoverGroupPlacement.MinimumTrustedCoefficient
+                    ? " - LOW CONFIDENCE"
+                    : string.Empty));
+            foreach (VirtualCrossoverChannel member in members)
+            {
+                alignment[member] = new AlignmentOverride(delayMs, invert);
+            }
+        }
+    }
+
+    // Every channel slid together until the earliest sits at zero. The stages
+    // compute their offsets against a settled front stage without regard for what
+    // a processor can dial - a rear fill pushed back past the front asks the front
+    // to go negative - so nothing is dialable until this pass, and after it every
+    // relation is preserved with the whole set made dialable.
+    private static void NormalizeStagedDelays(
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        System.Text.StringBuilder log)
+    {
+        if (alignment.Count == 0)
+        {
+            return;
+        }
+
+        double minimum = alignment.Values.Min(over => over.DelayMs);
+        if (minimum >= 0)
+        {
+            return;
+        }
+
+        log.AppendLine(
+            $"  normalization: every channel shifted +{-minimum:0.00} ms so the " +
+            "earliest sits at zero.");
+        foreach (IAlignmentChannel channel in alignment.Keys.ToList())
+        {
+            AlignmentOverride over = alignment[channel];
+            alignment[channel] = over with { DelayMs = over.DelayMs - minimum };
+        }
+    }
+
     private async Task<AutoDelayRunResult> RunSingleSideProposalAsync(
         List<VirtualCrossoverChannel> participants,
         double windowMinHz,
@@ -4606,8 +4760,26 @@ public partial class VirtualCrossoverPanel : UserControl
         AutoDelaySumLossForecast? sumLoss = null;
         await Task.Run(() =>
         {
-            AlignmentReprocessor reprocessor =
-                ComputeAutoAlignment(participants, alignment, decisions, log);
+            // Stage 1: the front chain, walked by the engine exactly as it
+            // always was. An unstaged project has every participant in that
+            // chain, so this IS the old call for it — not a staged run with one
+            // stage — and its result cannot drift from what the battery pinned.
+            (List<VirtualCrossoverChannel> chain, List<VirtualCrossoverChannel> later) =
+                SplitAlignmentStages(participants);
+            AlignmentReprocessor reprocessor = ComputeAutoAlignment(
+                participants,
+                alignment,
+                decisions,
+                log,
+                walkSet: later.Count > 0 ? chain : null);
+            if (later.Count > 0)
+            {
+                // Stages 2 and 3, then the shift that makes the lot dialable.
+                PlaceLaterStages(
+                    chain, later, reprocessor, alignment, request.RearFillOffsetMs, log);
+                NormalizeStagedDelays(alignment, log);
+            }
+
             // The "before" snapshots carry the CURRENT delays and polarities —
             // the alignment itself deliberately ignores them, so they exist
             // only for the report's before/after sum-loss forecast.
@@ -4891,11 +5063,19 @@ public partial class VirtualCrossoverPanel : UserControl
     // channels that changed their overrides are re-FFT'd, and the shared
     // UI-thread coordinator cache is never touched. Returned so the gain stage
     // can reuse the same cache for the final snapshots.
+    /// <param name="walkSet">
+    /// The channels the engine's chain WALK covers, when that is narrower than
+    /// the participants. The reprocessor is still built over all of them — the
+    /// later stages place their groups against snapshots it renders — but only
+    /// these form junctions. Null walks everything, which is every project
+    /// without a rear fill or a centre.
+    /// </param>
     private AlignmentReprocessor ComputeAutoAlignment(
         List<VirtualCrossoverChannel> participants,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         Dictionary<IAlignmentChannel, AlignmentDecision> decisions,
-        System.Text.StringBuilder log)
+        System.Text.StringBuilder log,
+        IReadOnlyList<VirtualCrossoverChannel>? walkSet = null)
     {
         // Order along the spectrum by band center; adjacent drivers form the
         // junctions the search walks (the same ordering and pair bands the metric
@@ -4923,20 +5103,27 @@ public partial class VirtualCrossoverPanel : UserControl
         var snapshots = ordered
             .Select((channel, i) => (channel, snapshot: initial[i]))
             .ToDictionary(item => item.channel, item => item.snapshot);
+        // The walk covers the front chain when the project is staged; every
+        // participant otherwise. Its members keep the band ordering they had
+        // among the whole set, so a narrowed walk is the same walk with members
+        // removed rather than a differently ordered one.
+        List<VirtualCrossoverChannel> walked = walkSet == null
+            ? ordered
+            : [.. ordered.Where(walkSet.Contains)];
         var junctions = new List<AlignmentJunction>();
-        for (int i = 0; i < ordered.Count - 1; i++)
+        for (int i = 0; i < walked.Count - 1; i++)
         {
             double pairHz = VirtualCrossoverJunctions.GetPairCrossoverHz(
-                ordered[i].Settings, ordered[i + 1].Settings);
+                walked[i].Settings, walked[i + 1].Settings);
             (double bandLowHz, double bandHighHz) =
                 VirtualCrossoverJunctions.OverlapBand(pairHz);
             junctions.Add(new AlignmentJunction(
-                snapshots[ordered[i]], snapshots[ordered[i + 1]],
+                snapshots[walked[i]], snapshots[walked[i + 1]],
                 pairHz, bandLowHz, bandHighHz));
         }
 
         AutoAlignmentEngine.Compute(
-            ordered.Select(channel => snapshots[channel]).ToList(),
+            walked.Select(channel => snapshots[channel]).ToList(),
             junctions,
             reprocessor.Reprocess,
             alignment,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4616,6 +4616,7 @@ public partial class VirtualCrossoverPanel : UserControl
         IReadOnlyList<VirtualCrossoverSideAlignmentChannel> later,
         AlignmentReprocessor reprocessor,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        Dictionary<IAlignmentChannel, AlignmentDecision> decisions,
         double sceneOffsetMs,
         double rearFillOffsetMs,
         bool rightHandDrive,
@@ -4647,7 +4648,13 @@ public partial class VirtualCrossoverPanel : UserControl
         // settled reads the responses as they now stand.
         Complex[] referenceSum = SumOf(chainReference);
         Complex[] farSum = SumOf(chainFar);
-        (double chainLow, double chainHigh) = BandOf(chainReference);
+        // Each side's OWN band. The two sides can carry different crossover
+        // corners - the tool has always allowed it, and the stereo bridge
+        // already intersects them rather than assuming they match - so timing a
+        // far-side group inside the reference side's band would measure it over
+        // frequencies it may not play.
+        (double referenceLow, double referenceHigh) = BandOf(chainReference);
+        (double farLow, double farHigh) = BandOf(chainFar);
         int sampleRate = chainReference[0].SampleRate;
 
         // The rear fill, one side at a time against the front stage of the SAME
@@ -4690,8 +4697,8 @@ public partial class VirtualCrossoverPanel : UserControl
 
             string name = string.Join("+", members.Select(item => item.Name));
             (double sideLow, double sideHigh) = BandOf(members);
-            double lowHz = Math.Max(chainLow, sideLow);
-            double highHz = Math.Min(chainHigh, sideHigh);
+            double lowHz = Math.Max(far ? farLow : referenceLow, sideLow);
+            double highHz = Math.Min(far ? farHigh : referenceHigh, sideHigh);
             GroupPlacement? placement = VirtualCrossoverGroupPlacement.Place(
                 far ? farSum : referenceSum,
                 SumOf(members),
@@ -4707,6 +4714,11 @@ public partial class VirtualCrossoverPanel : UserControl
                 {
                     alignment[member] = new AlignmentOverride(
                         member.Settings.DelayMs, member.Settings.InvertPolarity);
+                    decisions[member] = new AlignmentDecision(
+                        AlignmentDecisionKind.Locked,
+                        null,
+                        $"not placed: no reliable arrival in {lowHz:0}-{highHz:0} Hz " +
+                        "against this side's front stage, so the current delay stands");
                 }
 
                 continue;
@@ -4733,6 +4745,14 @@ public partial class VirtualCrossoverPanel : UserControl
                     flip.InvertPolarity;
                 alignment[member] = new AlignmentOverride(
                     innerMs + delayMs, innerInvert ^ invert);
+                decisions[member] = PlacementDecision(
+                    placement.Coefficient,
+                    corroborated: true,
+                    "placed as a rear group against this side's front stage in " +
+                    $"{lowHz:0}-{highHz:0} Hz, r {placement.Coefficient:0.00}" +
+                    (rearFillOffsetMs != 0
+                        ? $", held back {rearFillOffsetMs:0.##} ms"
+                        : string.Empty));
             }
         }
 
@@ -4768,9 +4788,13 @@ public partial class VirtualCrossoverPanel : UserControl
 
             string centreName =
                 string.Join("+", centreMembers.Select(item => item.Name));
+            // The centre is read against BOTH sides and the two readings are
+            // averaged and compared, so they have to be taken over the SAME band:
+            // the intersection of what both front stages play, narrowed to what
+            // the centre plays.
             (double centreLow, double centreHigh) = BandOf(centreMembers);
-            double lowHz = Math.Max(chainLow, centreLow);
-            double highHz = Math.Min(chainHigh, centreHigh);
+            double lowHz = Math.Max(Math.Max(referenceLow, farLow), centreLow);
+            double highHz = Math.Min(Math.Min(referenceHigh, farHigh), centreHigh);
             Complex[] centreIr = SumOf(centreMembers);
             GroupPlacement? againstReference = VirtualCrossoverGroupPlacement.Place(
                 referenceSum, centreIr, sampleRate, lowHz, highHz);
@@ -4787,6 +4811,11 @@ public partial class VirtualCrossoverPanel : UserControl
                 {
                     alignment[member] = new AlignmentOverride(
                         member.Settings.DelayMs, member.Settings.InvertPolarity);
+                    decisions[member] = new AlignmentDecision(
+                        AlignmentDecisionKind.Locked,
+                        null,
+                        $"not placed: no reliable arrival in {lowHz:0}-{highHz:0} Hz " +
+                        "against both front stages, so the current delay stands");
                 }
 
                 return;
@@ -4816,6 +4845,15 @@ public partial class VirtualCrossoverPanel : UserControl
                     flip.InvertPolarity;
                 alignment[member] = new AlignmentOverride(
                     innerMs + delayMs, innerInvert ^ inverted);
+                decisions[member] = PlacementDecision(
+                    Math.Min(againstReference.Coefficient, againstFar.Coefficient),
+                    confident,
+                    "placed midway between the two front stages in " +
+                    $"{lowHz:0}-{highHz:0} Hz" +
+                    (confident
+                        ? " - the two sides corroborate each other"
+                        : " - the two sides DISAGREE by more than the scene offset, " +
+                            "so this placement is a best guess"));
             }
         }
     }
@@ -4933,6 +4971,29 @@ public partial class VirtualCrossoverPanel : UserControl
         return inner;
     }
 
+    // What the REPORT is told about a placement. The diagnostic log gets the
+    // whole story, but the dialog shows the report, and a placement the run does
+    // not trust has to arrive there marked - otherwise a doubtful centre reads as
+    // an ordinary proposal and gets applied on the strength of looking like one.
+    private static AlignmentDecision PlacementDecision(
+        double coefficient,
+        bool corroborated,
+        string detail)
+    {
+        AlignmentConfidence confidence =
+            !corroborated || coefficient < VirtualCrossoverGroupPlacement.MinimumTrustedCoefficient
+                ? AlignmentConfidence.Low
+                : coefficient >= StrongPlacementCoefficient
+                    ? AlignmentConfidence.High
+                    : AlignmentConfidence.Medium;
+        return new AlignmentDecision(AlignmentDecisionKind.Search, confidence, detail);
+    }
+
+    // Above this the groups share a feature clean enough to time against with
+    // confidence. Two groups playing one band from different places never
+    // correlate like a crossover, so the bar is well below a junction's.
+    private const double StrongPlacementCoefficient = 0.6;
+
     // Stages 2 and 3, on the responses the front-chain walk has already settled.
     // Each later group gets ONE delay for all its members: the placement is a
     // property of where the group sits in the car, and it is applied to the group
@@ -4942,6 +5003,7 @@ public partial class VirtualCrossoverPanel : UserControl
         IReadOnlyList<VirtualCrossoverChannel> later,
         AlignmentReprocessor reprocessor,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        Dictionary<IAlignmentChannel, AlignmentDecision> decisions,
         double rearFillOffsetMs,
         System.Text.StringBuilder log)
     {
@@ -5007,6 +5069,11 @@ public partial class VirtualCrossoverPanel : UserControl
                 {
                     alignment[member] = new AlignmentOverride(
                         member.Settings.DelayMs, member.Settings.InvertPolarity);
+                    decisions[member] = new AlignmentDecision(
+                        AlignmentDecisionKind.Locked,
+                        null,
+                        $"not placed: no reliable arrival in {lowHz:0}-{highHz:0} Hz " +
+                        "against the front stage, so the current delay stands");
                 }
 
                 continue;
@@ -5041,6 +5108,12 @@ public partial class VirtualCrossoverPanel : UserControl
                     flip.InvertPolarity;
                 alignment[member] = new AlignmentOverride(
                     innerMs + delayMs, innerInvert ^ invert);
+                decisions[member] = PlacementDecision(
+                    placement.Coefficient,
+                    corroborated: true,
+                    $"placed as a {stage} group against the front stage in " +
+                    $"{lowHz:0}-{highHz:0} Hz, r {placement.Coefficient:0.00}" +
+                    (offsetMs != 0 ? $", held back {offsetMs:0.##} ms" : string.Empty));
             }
         }
     }
@@ -5050,16 +5123,27 @@ public partial class VirtualCrossoverPanel : UserControl
     // a processor can dial - a rear fill pushed back past the front asks the front
     // to go negative - so nothing is dialable until this pass, and after it every
     // relation is preserved with the whole set made dialable.
+    //
+    // It takes the SCOPE rather than working off the map's keys, because the map
+    // is sparse by design: the engine documents absence as "nothing proposed"
+    // and deliberately leaves its reference channel out (see
+    // AutoAlignmentEngine.NormalizeAndVerifyFeasibility). Shifting only the keys
+    // would leave that reference standing at zero while its own siblings moved
+    // around it - a rigid-body shift that is not rigid, and the one relation in
+    // the whole run that must not change. So every participant is read here, an
+    // absent one as zero, and every participant is written back.
     internal static void NormalizeStagedDelays(
+        IReadOnlyList<IAlignmentChannel> scope,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         System.Text.StringBuilder log)
     {
-        if (alignment.Count == 0)
+        if (scope.Count == 0)
         {
             return;
         }
 
-        double minimum = alignment.Values.Min(over => over.DelayMs);
+        double minimum = scope.Min(
+            channel => alignment.GetValueOrDefault(channel).DelayMs);
         if (minimum >= 0)
         {
             return;
@@ -5068,9 +5152,9 @@ public partial class VirtualCrossoverPanel : UserControl
         log.AppendLine(
             $"  normalization: every channel shifted +{-minimum:0.00} ms so the " +
             "earliest sits at zero.");
-        foreach (IAlignmentChannel channel in alignment.Keys.ToList())
+        foreach (IAlignmentChannel channel in scope)
         {
-            AlignmentOverride over = alignment[channel];
+            AlignmentOverride over = alignment.GetValueOrDefault(channel);
             alignment[channel] = over with { DelayMs = over.DelayMs - minimum };
         }
     }
@@ -5109,8 +5193,10 @@ public partial class VirtualCrossoverPanel : UserControl
             {
                 // Stages 2 and 3, then the shift that makes the lot dialable.
                 PlaceLaterStages(
-                    chain, later, reprocessor, alignment, request.RearFillOffsetMs, log);
-                NormalizeStagedDelays(alignment, log);
+                    chain, later, reprocessor, alignment, decisions,
+                    request.RearFillOffsetMs, log);
+                NormalizeStagedDelays(
+                    [.. participants.Cast<IAlignmentChannel>()], alignment, log);
             }
 
             // The "before" snapshots carry the CURRENT delays and polarities —
@@ -5727,11 +5813,13 @@ public partial class VirtualCrossoverPanel : UserControl
                     later,
                     reprocessor,
                     engineAlignment,
+                    decisions,
                     request.SceneOffsetMs,
                     request.RearFillOffsetMs,
                     request.RightHandDrive,
                     log);
-                NormalizeStagedDelays(engineAlignment, log);
+                NormalizeStagedDelays(
+                    [.. union.Cast<IAlignmentChannel>()], engineAlignment, log);
             }
 
             // The "before" snapshots carry the CURRENT delays and polarities —

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4431,13 +4431,17 @@ public partial class VirtualCrossoverPanel : UserControl
         // single-side run on whatever side is displayed.
         (List<VirtualCrossoverSideAlignmentChannel> leftSide, List<VirtualCrossoverSideAlignmentChannel> rightSide) =
             CollectStereoSides();
+        // The bridge ties the two sides together, so it has to be a FRONT-CHAIN
+        // pair: tied at a rear pair the whole scene would be anchored to the
+        // fill instead of to the stage it is supposed to sit behind.
         VirtualCrossoverSideAlignmentChannel? bridgeRight = rightSide
             .Where(item => item.RightSide &&
+                InFrontChain(item) &&
                 leftSide.Any(left =>
                     left.Runtime == item.Runtime && !left.RightSide))
             .OrderBy(item => VirtualCrossoverJunctions.BandCenterHz(item.Settings))
             .LastOrDefault();
-        if (bridgeRight != null && leftSide.Count >= 2)
+        if (bridgeRight != null && leftSide.Count(InFrontChain) >= 2)
         {
             await AutoAlignStereoAsync(leftSide, rightSide, bridgeRight);
             return;
@@ -4530,7 +4534,11 @@ public partial class VirtualCrossoverPanel : UserControl
             project.StereoRightHandDrive,
             Math.Abs(project.StereoLevelDifferenceDb),
             request => RunSingleSideProposalAsync(
-                participants, minHz, maxHz, request));
+                participants, minHz, maxHz, request),
+            polarityWarning: null,
+            hasRearFill: participants.Any(channel =>
+                channel.Pair.Zone == VirtualCrossoverZone.Rear),
+            project.RearFillOffsetMs);
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
             dialog.Result is not { } result ||
             IsDisposed)
@@ -4588,6 +4596,151 @@ public partial class VirtualCrossoverPanel : UserControl
     // final snapshots. Board levelling only — a single side has no L/R
     // relation, so neither the scene offset nor the level difference plays a
     // part here.
+    // ------------------------------------------------- staged alignment (stereo)
+
+    // The stereo split, per side. A mono block appears once (as its left
+    // instance) and belongs to whichever stage its zone names, so a centre is
+    // found here exactly once however many sides are walked.
+    private static bool InFrontChain(VirtualCrossoverSideAlignmentChannel side) =>
+        VirtualCrossoverAlignmentStages.StageOf(side.Runtime.Pair.Zone) ==
+            VirtualCrossoverAlignmentStage.FrontChain;
+
+    // Stages 2 and 3 of a stereo run. The rear fill is placed PER SIDE — its
+    // left and right are different drivers at different distances, and each is
+    // timed against its own side's front stage, so the rear inherits the front's
+    // L/R relation rather than being forced to one delay. The centre has no side
+    // and is placed between both.
+    private void PlaceLaterStagesStereo(
+        IReadOnlyList<VirtualCrossoverSideAlignmentChannel> chainReference,
+        IReadOnlyList<VirtualCrossoverSideAlignmentChannel> chainFar,
+        IReadOnlyList<VirtualCrossoverSideAlignmentChannel> later,
+        AlignmentReprocessor reprocessor,
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
+        double sceneOffsetMs,
+        double rearFillOffsetMs,
+        System.Text.StringBuilder log)
+    {
+        IReadOnlyList<AlignmentSnapshot> settled = reprocessor.Reprocess(alignment);
+        Dictionary<IAlignmentChannel, AlignmentSnapshot> byChannel =
+            settled.ToDictionary(snapshot => snapshot.Channel);
+        Complex[] SumOf(IEnumerable<VirtualCrossoverSideAlignmentChannel> group) =>
+            VirtualCrossoverAnalysis.SumImpulseResponses(
+                [.. group.Select(side => byChannel[side].ImpulseResponse)]);
+        (double LowHz, double HighHz) BandOf(
+            IEnumerable<VirtualCrossoverSideAlignmentChannel> group)
+        {
+            double low = double.MaxValue;
+            double high = double.MinValue;
+            foreach (VirtualCrossoverSideAlignmentChannel side in group)
+            {
+                (double sideLow, double sideHigh) =
+                    VirtualCrossoverJunctions.GetChannelBand(side.Settings);
+                low = Math.Min(low, sideLow);
+                high = Math.Max(high, sideHigh);
+            }
+
+            return (low, high);
+        }
+
+        Complex[] referenceSum = SumOf(chainReference);
+        Complex[] farSum = SumOf(chainFar);
+        (double chainLow, double chainHigh) = BandOf(chainReference);
+        int sampleRate = chainReference[0].SampleRate;
+
+        // The rear fill, one side at a time against the front stage of the SAME
+        // side: that is the comparison a listener in that seat makes, and it
+        // leaves the rear's own L/R relation following the front's.
+        foreach (VirtualCrossoverSideAlignmentChannel side in later.Where(item =>
+            VirtualCrossoverAlignmentStages.StageOf(item.Runtime.Pair.Zone) ==
+                VirtualCrossoverAlignmentStage.Rear))
+        {
+            bool far = side.RightSide;
+            (double sideLow, double sideHigh) = BandOf([side]);
+            double lowHz = Math.Max(chainLow, sideLow);
+            double highHz = Math.Min(chainHigh, sideHigh);
+            GroupPlacement? placement = VirtualCrossoverGroupPlacement.Place(
+                far ? farSum : referenceSum,
+                byChannel[side].ImpulseResponse,
+                sampleRate,
+                lowHz,
+                highHz);
+            if (placement == null)
+            {
+                log.AppendLine(
+                    $"  rear {side.Name}: not placed - no reliable arrival in " +
+                    $"{lowHz:0}-{highHz:0} Hz. Its current delay stands.");
+                alignment[side] = new AlignmentOverride(
+                    side.Settings.DelayMs, side.Settings.InvertPolarity);
+                continue;
+            }
+
+            double delayMs = placement.CoArrivalDelayMs + rearFillOffsetMs;
+            bool invert = rearFillOffsetMs < HaasPolarityIrrelevantMs &&
+                placement.Inverted;
+            log.AppendLine(
+                $"  rear {side.Name}: {delayMs:+0.00;-0.00;0.00} ms (co-arrival " +
+                $"{placement.CoArrivalDelayMs:+0.00;-0.00;0.00}" +
+                (rearFillOffsetMs != 0
+                    ? $" plus {rearFillOffsetMs:0.##} ms fill"
+                    : string.Empty) +
+                $"), r {placement.Coefficient:0.00}" +
+                (invert ? ", inverted" : string.Empty));
+            alignment[side] = new AlignmentOverride(delayMs, invert);
+        }
+
+        // The centre: one driver with no side, so it is read against BOTH front
+        // sums and placed at the midpoint. The two readings are each other's
+        // witness - they should differ by the scene offset, because that is how
+        // far apart the sides themselves are - so a disagreement is reported
+        // rather than averaged away.
+        foreach (VirtualCrossoverSideAlignmentChannel centre in later.Where(item =>
+            VirtualCrossoverAlignmentStages.StageOf(item.Runtime.Pair.Zone) ==
+                VirtualCrossoverAlignmentStage.Center))
+        {
+            (double centreLow, double centreHigh) = BandOf([centre]);
+            double lowHz = Math.Max(chainLow, centreLow);
+            double highHz = Math.Min(chainHigh, centreHigh);
+            Complex[] centreIr = byChannel[centre].ImpulseResponse;
+            GroupPlacement? againstReference = VirtualCrossoverGroupPlacement.Place(
+                referenceSum, centreIr, sampleRate, lowHz, highHz);
+            GroupPlacement? againstFar = VirtualCrossoverGroupPlacement.Place(
+                farSum, centreIr, sampleRate, lowHz, highHz);
+            if (againstReference == null || againstFar == null)
+            {
+                log.AppendLine(
+                    $"  centre {centre.Name}: not placed - no reliable arrival " +
+                    $"in {lowHz:0}-{highHz:0} Hz against " +
+                    (againstReference == null ? "the reference side" : "the far side") +
+                    ". Its current delay stands.");
+                alignment[centre] = new AlignmentOverride(
+                    centre.Settings.DelayMs, centre.Settings.InvertPolarity);
+                continue;
+            }
+
+            (double delayMs, bool inverted, bool confident) =
+                VirtualCrossoverGroupPlacement.Midpoint(
+                    againstReference,
+                    againstFar,
+                    sceneOffsetMs,
+                    CentreWitnessToleranceMs);
+            log.AppendLine(
+                $"  centre {centre.Name}: {delayMs:+0.00;-0.00;0.00} ms - midway " +
+                $"between {againstReference.CoArrivalDelayMs:+0.00;-0.00;0.00} " +
+                $"(reference side, r {againstReference.Coefficient:0.00}) and " +
+                $"{againstFar.CoArrivalDelayMs:+0.00;-0.00;0.00} " +
+                $"(far side, r {againstFar.Coefficient:0.00})" +
+                (inverted ? ", inverted" : string.Empty) +
+                (confident ? string.Empty : " - LOW CONFIDENCE"));
+            alignment[centre] = new AlignmentOverride(delayMs, inverted);
+        }
+    }
+
+    // How far the centre's two side readings may disagree beyond the scene
+    // offset before the placement stops being corroborated. Wide enough for the
+    // difference between an envelope arrival and a phase extremum on two
+    // different paths, narrow enough that a whole lobe cannot hide inside it.
+    private const double CentreWitnessToleranceMs = 0.35;
+
     // ------------------------------------------------------ staged alignment
 
     // Beyond this much intended offset a polarity flip stops describing anything
@@ -4600,7 +4753,7 @@ public partial class VirtualCrossoverPanel : UserControl
     // no rear fill and no centre - every project written before zones existed -
     // comes back with everything in the chain and nothing after it, and then takes
     // the unstaged path, which is the engine call it always took.
-    private static (List<VirtualCrossoverChannel> Chain, List<VirtualCrossoverChannel> Later)
+    internal static (List<VirtualCrossoverChannel> Chain, List<VirtualCrossoverChannel> Later)
         SplitAlignmentStages(IReadOnlyList<VirtualCrossoverChannel> participants)
     {
         List<VirtualCrossoverChannel> chain = [.. participants.Where(channel =>
@@ -4717,7 +4870,7 @@ public partial class VirtualCrossoverPanel : UserControl
     // a processor can dial - a rear fill pushed back past the front asks the front
     // to go negative - so nothing is dialable until this pass, and after it every
     // relation is preserved with the whole set made dialable.
-    private static void NormalizeStagedDelays(
+    internal static void NormalizeStagedDelays(
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         System.Text.StringBuilder log)
     {
@@ -4960,6 +5113,10 @@ public partial class VirtualCrossoverPanel : UserControl
     // not lose them.
     private void CommitAutoDelayResult(AutoDelayRunResult result)
     {
+        // The rear fill offset is part of the tune the run just committed, so it
+        // is stored with it: the next run on this car should start from the
+        // answer this car settled on rather than from the dialog's default.
+        project.RearFillOffsetMs = result.Request.RearFillOffsetMs;
         foreach (AutoDelayChannelOutcome outcome in result.Outcomes)
         {
             outcome.Settings.DelayMs = outcome.AfterDelayMs;
@@ -5269,7 +5426,9 @@ public partial class VirtualCrossoverPanel : UserControl
             request => RunStereoProposalAsync(
                 leftSide, rightSide, union, bridgeLeft, bridgeRight,
                 bridgeBandLowHz, bridgeBandHighHz, request),
-            DescribeLeftRightPolarityMismatch(leftSide, rightSide));
+            DescribeLeftRightPolarityMismatch(leftSide, rightSide),
+            union.Any(side => side.Runtime.Pair.Zone == VirtualCrossoverZone.Rear),
+            project.RearFillOffsetMs);
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
             dialog.Result is not { } result ||
             IsDisposed)
@@ -5364,10 +5523,36 @@ public partial class VirtualCrossoverPanel : UserControl
         AutoDelaySumLossForecast? rightSumLoss = null;
         await Task.Run(() =>
         {
+            // Stage 1: the front chain on both sides. The reprocessor still
+            // covers the whole union — the later stages place their groups
+            // against snapshots it renders — but only the chain is walked.
+            List<VirtualCrossoverSideAlignmentChannel> chainLeft =
+                [.. leftSide.Where(InFrontChain)];
+            List<VirtualCrossoverSideAlignmentChannel> chainRight =
+                [.. rightSide.Where(InFrontChain)];
+            List<VirtualCrossoverSideAlignmentChannel> later =
+                [.. union.Where(side => !InFrontChain(side))];
             AlignmentReprocessor reprocessor = ComputeStereoAlignment(
-                leftSide, rightSide, union, bridgeLeft, bridgeRight,
+                chainLeft, chainRight, union, bridgeLeft, bridgeRight,
                 bridgeBandLowHz, bridgeBandHighHz, request.SceneOffsetMs,
                 request.RightHandDrive, engineAlignment, decisions, log);
+            if (later.Count > 0)
+            {
+                // Stages 2 and 3 read the sides in the engine's own ROLES, so a
+                // right-hand-drive run places its groups against the same
+                // reference the walk settled rather than against the mirror.
+                PlaceLaterStagesStereo(
+                    request.RightHandDrive ? chainRight : chainLeft,
+                    request.RightHandDrive ? chainLeft : chainRight,
+                    later,
+                    reprocessor,
+                    engineAlignment,
+                    request.SceneOffsetMs,
+                    request.RearFillOffsetMs,
+                    log);
+                NormalizeStagedDelays(engineAlignment, log);
+            }
+
             // The "before" snapshots carry the CURRENT delays and polarities —
             // the alignment itself deliberately ignores them, so they exist
             // only for the report's before/after sum-loss forecast.

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4618,6 +4618,7 @@ public partial class VirtualCrossoverPanel : UserControl
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         double sceneOffsetMs,
         double rearFillOffsetMs,
+        bool rightHandDrive,
         System.Text.StringBuilder log)
     {
         IReadOnlyList<AlignmentSnapshot> settled = reprocessor.Reprocess(alignment);
@@ -4642,6 +4643,8 @@ public partial class VirtualCrossoverPanel : UserControl
             return (low, high);
         }
 
+        // Rebound by the inner walks below, so a group placed after another has
+        // settled reads the responses as they now stand.
         Complex[] referenceSum = SumOf(chainReference);
         Complex[] farSum = SumOf(chainFar);
         (double chainLow, double chainHigh) = BandOf(chainReference);
@@ -4650,27 +4653,62 @@ public partial class VirtualCrossoverPanel : UserControl
         // The rear fill, one side at a time against the front stage of the SAME
         // side: that is the comparison a listener in that seat makes, and it
         // leaves the rear's own L/R relation following the front's.
-        foreach (VirtualCrossoverSideAlignmentChannel side in later.Where(item =>
-            VirtualCrossoverAlignmentStages.StageOf(item.Runtime.Pair.Zone) ==
-                VirtualCrossoverAlignmentStage.Rear))
+        // Grouped by CABIN SIDE, because a rear fill can be a two-way of its own:
+        // its drivers cross each other, and that junction is the engine's
+        // business. Placed one driver at a time they each landed near their own
+        // right answer while their MUTUAL alignment — quite possibly tuned by
+        // hand — was overwritten by two unrelated numbers.
+        foreach (IGrouping<bool, VirtualCrossoverSideAlignmentChannel> sideGroup in
+            later
+                .Where(item =>
+                    VirtualCrossoverAlignmentStages.StageOf(item.Runtime.Pair.Zone) ==
+                        VirtualCrossoverAlignmentStage.Rear)
+                .GroupBy(item => item.RightSide))
         {
-            bool far = side.RightSide;
-            (double sideLow, double sideHigh) = BandOf([side]);
+            List<VirtualCrossoverSideAlignmentChannel> members = [.. sideGroup];
+            // The sums arrive in the engine's ROLES, not in cabin sides: on a
+            // right-hand-drive run the reference IS the right side. Reading the
+            // cabin side here would have timed every rear driver against the
+            // front stage of the opposite side.
+            bool far = IsFarSide(sideGroup.Key, rightHandDrive);
+            Dictionary<IAlignmentChannel, AlignmentOverride> inner = SettleWithinGroup(
+                [.. members.Cast<IAlignmentChannel>()],
+                member => ((VirtualCrossoverSideAlignmentChannel)member).Settings,
+                byChannel,
+                reprocessor,
+                log);
+            if (inner.Count > 0)
+            {
+                foreach (VirtualCrossoverSideAlignmentChannel member in members)
+                {
+                    alignment[member] = inner[member];
+                }
+
+                settled = reprocessor.Reprocess(alignment);
+                byChannel = settled.ToDictionary(snapshot => snapshot.Channel);
+            }
+
+            string name = string.Join("+", members.Select(item => item.Name));
+            (double sideLow, double sideHigh) = BandOf(members);
             double lowHz = Math.Max(chainLow, sideLow);
             double highHz = Math.Min(chainHigh, sideHigh);
             GroupPlacement? placement = VirtualCrossoverGroupPlacement.Place(
                 far ? farSum : referenceSum,
-                byChannel[side].ImpulseResponse,
+                SumOf(members),
                 sampleRate,
                 lowHz,
                 highHz);
             if (placement == null)
             {
                 log.AppendLine(
-                    $"  rear {side.Name}: not placed - no reliable arrival in " +
+                    $"  rear {name}: not placed - no reliable arrival in " +
                     $"{lowHz:0}-{highHz:0} Hz. Its current delay stands.");
-                alignment[side] = new AlignmentOverride(
-                    side.Settings.DelayMs, side.Settings.InvertPolarity);
+                foreach (VirtualCrossoverSideAlignmentChannel member in members)
+                {
+                    alignment[member] = new AlignmentOverride(
+                        member.Settings.DelayMs, member.Settings.InvertPolarity);
+                }
+
                 continue;
             }
 
@@ -4678,14 +4716,24 @@ public partial class VirtualCrossoverPanel : UserControl
             bool invert = rearFillOffsetMs < HaasPolarityIrrelevantMs &&
                 placement.Inverted;
             log.AppendLine(
-                $"  rear {side.Name}: {delayMs:+0.00;-0.00;0.00} ms (co-arrival " +
+                $"  rear {name}: {delayMs:+0.00;-0.00;0.00} ms (co-arrival " +
                 $"{placement.CoArrivalDelayMs:+0.00;-0.00;0.00}" +
                 (rearFillOffsetMs != 0
                     ? $" plus {rearFillOffsetMs:0.##} ms fill"
                     : string.Empty) +
                 $"), r {placement.Coefficient:0.00}" +
                 (invert ? ", inverted" : string.Empty));
-            alignment[side] = new AlignmentOverride(delayMs, invert);
+            foreach (VirtualCrossoverSideAlignmentChannel member in members)
+            {
+                double innerMs = inner.TryGetValue(member, out AlignmentOverride own)
+                    ? own.DelayMs
+                    : 0.0;
+                bool innerInvert =
+                    inner.TryGetValue(member, out AlignmentOverride flip) &&
+                    flip.InvertPolarity;
+                alignment[member] = new AlignmentOverride(
+                    innerMs + delayMs, innerInvert ^ invert);
+            }
         }
 
         // The centre: one driver with no side, so it is read against BOTH front
@@ -4693,14 +4741,37 @@ public partial class VirtualCrossoverPanel : UserControl
         // witness - they should differ by the scene offset, because that is how
         // far apart the sides themselves are - so a disagreement is reported
         // rather than averaged away.
-        foreach (VirtualCrossoverSideAlignmentChannel centre in later.Where(item =>
+        List<VirtualCrossoverSideAlignmentChannel> centreMembers = [.. later.Where(item =>
             VirtualCrossoverAlignmentStages.StageOf(item.Runtime.Pair.Zone) ==
-                VirtualCrossoverAlignmentStage.Center))
+                VirtualCrossoverAlignmentStage.Center)];
+        if (centreMembers.Count > 0)
         {
-            (double centreLow, double centreHigh) = BandOf([centre]);
+            // A two-way centre is two mono blocks that cross each other, so it
+            // gets the same treatment as a two-way rear: its own junction first,
+            // then one placement for the pair.
+            Dictionary<IAlignmentChannel, AlignmentOverride> inner = SettleWithinGroup(
+                [.. centreMembers.Cast<IAlignmentChannel>()],
+                member => ((VirtualCrossoverSideAlignmentChannel)member).Settings,
+                byChannel,
+                reprocessor,
+                log);
+            if (inner.Count > 0)
+            {
+                foreach (VirtualCrossoverSideAlignmentChannel member in centreMembers)
+                {
+                    alignment[member] = inner[member];
+                }
+
+                settled = reprocessor.Reprocess(alignment);
+                byChannel = settled.ToDictionary(snapshot => snapshot.Channel);
+            }
+
+            string centreName =
+                string.Join("+", centreMembers.Select(item => item.Name));
+            (double centreLow, double centreHigh) = BandOf(centreMembers);
             double lowHz = Math.Max(chainLow, centreLow);
             double highHz = Math.Min(chainHigh, centreHigh);
-            Complex[] centreIr = byChannel[centre].ImpulseResponse;
+            Complex[] centreIr = SumOf(centreMembers);
             GroupPlacement? againstReference = VirtualCrossoverGroupPlacement.Place(
                 referenceSum, centreIr, sampleRate, lowHz, highHz);
             GroupPlacement? againstFar = VirtualCrossoverGroupPlacement.Place(
@@ -4708,13 +4779,17 @@ public partial class VirtualCrossoverPanel : UserControl
             if (againstReference == null || againstFar == null)
             {
                 log.AppendLine(
-                    $"  centre {centre.Name}: not placed - no reliable arrival " +
+                    $"  centre {centreName}: not placed - no reliable arrival " +
                     $"in {lowHz:0}-{highHz:0} Hz against " +
                     (againstReference == null ? "the reference side" : "the far side") +
                     ". Its current delay stands.");
-                alignment[centre] = new AlignmentOverride(
-                    centre.Settings.DelayMs, centre.Settings.InvertPolarity);
-                continue;
+                foreach (VirtualCrossoverSideAlignmentChannel member in centreMembers)
+                {
+                    alignment[member] = new AlignmentOverride(
+                        member.Settings.DelayMs, member.Settings.InvertPolarity);
+                }
+
+                return;
             }
 
             (double delayMs, bool inverted, bool confident) =
@@ -4724,16 +4799,34 @@ public partial class VirtualCrossoverPanel : UserControl
                     sceneOffsetMs,
                     CentreWitnessToleranceMs);
             log.AppendLine(
-                $"  centre {centre.Name}: {delayMs:+0.00;-0.00;0.00} ms - midway " +
+                $"  centre {centreName}: {delayMs:+0.00;-0.00;0.00} ms - midway " +
                 $"between {againstReference.CoArrivalDelayMs:+0.00;-0.00;0.00} " +
                 $"(reference side, r {againstReference.Coefficient:0.00}) and " +
                 $"{againstFar.CoArrivalDelayMs:+0.00;-0.00;0.00} " +
                 $"(far side, r {againstFar.Coefficient:0.00})" +
                 (inverted ? ", inverted" : string.Empty) +
                 (confident ? string.Empty : " - LOW CONFIDENCE"));
-            alignment[centre] = new AlignmentOverride(delayMs, inverted);
+            foreach (VirtualCrossoverSideAlignmentChannel member in centreMembers)
+            {
+                double innerMs = inner.TryGetValue(member, out AlignmentOverride own)
+                    ? own.DelayMs
+                    : 0.0;
+                bool innerInvert =
+                    inner.TryGetValue(member, out AlignmentOverride flip) &&
+                    flip.InvertPolarity;
+                alignment[member] = new AlignmentOverride(
+                    innerMs + delayMs, innerInvert ^ inverted);
+            }
         }
     }
+
+    /// <summary>
+    /// Whether a cabin side is the engine's FAR side under this layout. The
+    /// driver's side is the reference — left on left-hand drive, right on right —
+    /// so the far one is simply the other.
+    /// </summary>
+    internal static bool IsFarSide(bool rightSide, bool rightHandDrive) =>
+        rightSide != rightHandDrive;
 
     // How far the centre's two side readings may disagree beyond the scene
     // offset before the placement stops being corroborated. Wide enough for the
@@ -4785,6 +4878,61 @@ public partial class VirtualCrossoverPanel : UserControl
         return (low, high);
     }
 
+    // A later group that is itself a chain — a two-way rear, a two-way centre —
+    // has junctions of its own, and they are the engine's business. Walked here
+    // FIRST, so the group arrives at its placement already internally settled and
+    // the placement then moves it as one.
+    //
+    // Without this the two drivers of such a group were each placed against the
+    // front stage independently. Each landed near its own right answer and their
+    // MUTUAL alignment — the junction between them, quite possibly tuned by hand —
+    // was overwritten by two unrelated numbers. That is worse than not tuning
+    // them: an untouched junction is at least still the one the user set.
+    //
+    // Returns the delay each member ended on relative to the group's own
+    // earliest, which the caller adds its group offset to.
+    private static Dictionary<IAlignmentChannel, AlignmentOverride> SettleWithinGroup(
+        IReadOnlyList<IAlignmentChannel> members,
+        Func<IAlignmentChannel, VirtualCrossoverChannelSettings> settingsOf,
+        IReadOnlyDictionary<IAlignmentChannel, AlignmentSnapshot> snapshots,
+        AlignmentReprocessor reprocessor,
+        System.Text.StringBuilder log)
+    {
+        var inner = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        if (members.Count < 2)
+        {
+            return inner;
+        }
+
+        List<IAlignmentChannel> byBand = [.. members.OrderBy(member =>
+            VirtualCrossoverJunctions.BandCenterHz(settingsOf(member)))];
+        var junctions = new List<AlignmentJunction>();
+        for (int i = 0; i < byBand.Count - 1; i++)
+        {
+            double pairHz = VirtualCrossoverJunctions.GetPairCrossoverHz(
+                settingsOf(byBand[i]), settingsOf(byBand[i + 1]));
+            (double lowHz, double highHz) = VirtualCrossoverJunctions.OverlapBand(pairHz);
+            junctions.Add(new AlignmentJunction(
+                snapshots[byBand[i]], snapshots[byBand[i + 1]], pairHz, lowHz, highHz));
+        }
+
+        if (junctions.Count == 0)
+        {
+            return inner;
+        }
+
+        log.AppendLine(
+            $"  settling {byBand.Count} drivers within the group " +
+            $"({junctions.Count} junction(s)) before placing it:");
+        AutoAlignmentEngine.Compute(
+            [.. byBand.Select(member => snapshots[member])],
+            junctions,
+            reprocessor.Reprocess,
+            inner,
+            log);
+        return inner;
+    }
+
     // Stages 2 and 3, on the responses the front-chain walk has already settled.
     // Each later group gets ONE delay for all its members: the placement is a
     // property of where the group sits in the car, and it is applied to the group
@@ -4803,6 +4951,10 @@ public partial class VirtualCrossoverPanel : UserControl
         Complex[] SumOf(IEnumerable<VirtualCrossoverChannel> group) =>
             VirtualCrossoverAnalysis.SumImpulseResponses(
                 [.. group.Select(channel => byChannel[channel].ImpulseResponse)]);
+        // Captured by the local functions above, so the inner walks below rebind
+        // it rather than shadowing it: a group placed after another group settled
+        // must read the responses as they now stand.
+
 
         Complex[] reference = SumOf(chain);
         int sampleRate = chain[0].SampleRate;
@@ -4816,6 +4968,25 @@ public partial class VirtualCrossoverPanel : UserControl
             if (members.Count == 0)
             {
                 continue;
+            }
+
+            // The group's own junctions first, so what gets placed is a settled
+            // group rather than a set of drivers about to be scattered.
+            Dictionary<IAlignmentChannel, AlignmentOverride> inner = SettleWithinGroup(
+                [.. members.Cast<IAlignmentChannel>()],
+                member => ((VirtualCrossoverChannel)member).Settings,
+                byChannel,
+                reprocessor,
+                log);
+            if (inner.Count > 0)
+            {
+                foreach (VirtualCrossoverChannel member in members)
+                {
+                    alignment[member] = inner[member];
+                }
+
+                settled = reprocessor.Reprocess(alignment);
+                byChannel = settled.ToDictionary(snapshot => snapshot.Channel);
             }
 
             (double groupLow, double groupHigh) = GroupBandOf(members);
@@ -4860,7 +5031,16 @@ public partial class VirtualCrossoverPanel : UserControl
                     : string.Empty));
             foreach (VirtualCrossoverChannel member in members)
             {
-                alignment[member] = new AlignmentOverride(delayMs, invert);
+                // The group offset is added to what the inner walk left the
+                // member on, so the group moves as one and its own junctions
+                // survive the move.
+                double innerMs = inner.TryGetValue(member, out AlignmentOverride own)
+                    ? own.DelayMs
+                    : 0.0;
+                bool innerInvert = inner.TryGetValue(member, out AlignmentOverride flip) &&
+                    flip.InvertPolarity;
+                alignment[member] = new AlignmentOverride(
+                    innerMs + delayMs, innerInvert ^ invert);
             }
         }
     }
@@ -5549,6 +5729,7 @@ public partial class VirtualCrossoverPanel : UserControl
                     engineAlignment,
                     request.SceneOffsetMs,
                     request.RearFillOffsetMs,
+                    request.RightHandDrive,
                     log);
                 NormalizeStagedDelays(engineAlignment, log);
             }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -746,6 +746,15 @@ public sealed class VirtualCrossoverProjectFile
         VirtualCrossoverGroupView.FrontAndSub;
 
     /// <summary>
+    /// How far behind the front stage Auto delay places the rear fill, in ms.
+    /// Part of the tune rather than a dialog default: a car tuned for its front
+    /// seats and one tuned for its second row want different answers, and the
+    /// next run should start from the one this car settled on.
+    /// </summary>
+    public double RearFillOffsetMs { get; set; } =
+        VirtualCrossoverAutoDelayDialog.DefaultRearFillOffsetMs;
+
+    /// <summary>
     /// Whether the magnitude view draws the hybrid — each channel from its spatial
     /// average — rather than the impulse responses alone.
     /// </summary>
@@ -1458,6 +1467,11 @@ public sealed class VirtualCrossoverProjectFile
         {
             throw new InvalidDataException(
                 "The virtual crossover group view is invalid.");
+        }
+        if (!double.IsFinite(RearFillOffsetMs) || RearFillOffsetMs is < 0 or > 30)
+        {
+            throw new InvalidDataException(
+                "The virtual crossover rear fill offset is invalid.");
         }
         if (CorrelationPairIndex is < 0 or >= MaximumChannelCount)
         {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAlignmentStageTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAlignmentStageTests.cs
@@ -1,0 +1,73 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The order Auto delay settles a complex installation in, and the property
+/// that makes the order safe: only the front chain searches, so no later stage
+/// can pull an earlier one out of tune.
+/// </summary>
+public sealed class VirtualCrossoverAlignmentStageTests
+{
+    [Theory]
+    [InlineData(VirtualCrossoverZone.Front, VirtualCrossoverAlignmentStage.FrontChain)]
+    // The subwoofers join the FRONT chain rather than forming one of their own:
+    // that is where their junctions are, and how they are tuned by hand.
+    [InlineData(VirtualCrossoverZone.Sub, VirtualCrossoverAlignmentStage.FrontChain)]
+    [InlineData(VirtualCrossoverZone.Rear, VirtualCrossoverAlignmentStage.Rear)]
+    [InlineData(VirtualCrossoverZone.Center, VirtualCrossoverAlignmentStage.Center)]
+    public void EachZoneBelongsToOneStage(
+        VirtualCrossoverZone zone,
+        VirtualCrossoverAlignmentStage stage) =>
+        Assert.Equal(stage, VirtualCrossoverAlignmentStages.StageOf(zone));
+
+    [Fact]
+    public void OnlyTheFrontChainSearchesItsJunctions()
+    {
+        // This is the whole reason the staging is safe rather than merely
+        // ordered. A stage that searched would be free to move what it was
+        // measured against; one that computes a placement from a settled
+        // reference cannot disagree with it, so the stages are one-way and no
+        // later group can pull the front stage out of tune.
+        Assert.True(VirtualCrossoverAlignmentStages.SearchesJunctions(
+            VirtualCrossoverAlignmentStage.FrontChain));
+        Assert.False(VirtualCrossoverAlignmentStages.SearchesJunctions(
+            VirtualCrossoverAlignmentStage.Rear));
+        Assert.False(VirtualCrossoverAlignmentStages.SearchesJunctions(
+            VirtualCrossoverAlignmentStage.Center));
+    }
+
+    [Fact]
+    public void TheFrontChainRunsFirstBecauseTheOthersAreMeasuredAgainstIt()
+    {
+        Assert.Equal(
+            VirtualCrossoverAlignmentStage.FrontChain,
+            VirtualCrossoverAlignmentStages.InOrder[0]);
+        Assert.Equal(
+            VirtualCrossoverAlignmentStages.InOrder.Distinct().Count(),
+            VirtualCrossoverAlignmentStages.InOrder.Count);
+        // Every stage a zone can name is one the run actually performs.
+        foreach (VirtualCrossoverZone zone in VirtualCrossoverZones.All)
+        {
+            Assert.Contains(
+                VirtualCrossoverAlignmentStages.StageOf(zone),
+                VirtualCrossoverAlignmentStages.InOrder);
+        }
+    }
+
+    [Fact]
+    public void AProjectWithoutARearOrACentreNeedsNoStagingAtAll()
+    {
+        // The compatibility guarantee, stated as code rather than as a hope:
+        // every project written before zones existed migrates into Front and Sub
+        // only, so it takes the single-stage path — which IS the old engine call,
+        // not a staged run that happens to have one stage. The session battery is
+        // therefore unchanged by construction.
+        Assert.False(VirtualCrossoverAlignmentStages.NeedsStaging(
+            [VirtualCrossoverZone.Sub, VirtualCrossoverZone.Front, VirtualCrossoverZone.Front]));
+        Assert.False(VirtualCrossoverAlignmentStages.NeedsStaging([]));
+
+        Assert.True(VirtualCrossoverAlignmentStages.NeedsStaging(
+            [VirtualCrossoverZone.Front, VirtualCrossoverZone.Rear]));
+        Assert.True(VirtualCrossoverAlignmentStages.NeedsStaging(
+            [VirtualCrossoverZone.Front, VirtualCrossoverZone.Center]));
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAutoDelayReportTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAutoDelayReportTests.cs
@@ -1,4 +1,4 @@
-using Resonalyze.Dsp;
+﻿using Resonalyze.Dsp;
 
 namespace Resonalyze.App.Tests;
 
@@ -33,9 +33,67 @@ public sealed class VirtualCrossoverAutoDelayReportTests
             delayKind, delayConfidence, delayDetail, gainConfidence, gainDetail);
     }
 
+    private static AutoDelayChannelOutcome RearOutcome(string name)
+    {
+        AutoDelayChannelOutcome outcome = Outcome(name, 0.0, 15.0);
+        outcome.Runtime.Pair.Zone = VirtualCrossoverZone.Rear;
+        return outcome;
+    }
+
     private static string Row(string report, string name) =>
         report.Split('\n')
             .First(line => line.StartsWith(name, StringComparison.Ordinal));
+
+    [Fact]
+    public void Format_StatesTheRearFillOffsetIncludingADeliberateZero()
+    {
+        // Zero is a CHOICE — the second row wants the rear co-arriving — and it
+        // is the one the reader most needs told, because a report silent about
+        // the offset reads the same whether the rear was co-arrived or held
+        // back fifteen milliseconds. Printing it only when non-zero left the
+        // line unable to disambiguate the very case it was added for.
+        var request = new AutoDelayRunRequest(0.25, false, false, 0.0, 0.0);
+
+        string report = VirtualCrossoverAutoDelayReport.Format(
+            [Outcome("A L", 0.0, 1.0), RearOutcome("C L")],
+            stereo: true,
+            request,
+            null);
+
+        Assert.Contains("Rear fill 0.0 ms", report);
+        Assert.Contains("co-arriving", report);
+    }
+
+    [Fact]
+    public void Format_SaysHowFarBackARearFillWasHeld()
+    {
+        var request = new AutoDelayRunRequest(0.25, false, false, 0.0, 15.0);
+
+        string report = VirtualCrossoverAutoDelayReport.Format(
+            [Outcome("A L", 0.0, 1.0), RearOutcome("C L")],
+            stereo: true,
+            request,
+            null);
+
+        Assert.Contains("Rear fill 15.0 ms behind", report);
+    }
+
+    [Fact]
+    public void Format_SaysNothingAboutARearFillAProjectDoesNotHave()
+    {
+        // The offset is stored per project, so it carries a value even for a
+        // front-only car. Printing it there would describe a group that is not
+        // in the run.
+        var request = new AutoDelayRunRequest(0.25, false, false, 0.0, 15.0);
+
+        string report = VirtualCrossoverAutoDelayReport.Format(
+            [Outcome("A L", 0.0, 1.0), Outcome("B L", 0.0, 2.0)],
+            stereo: true,
+            request,
+            null);
+
+        Assert.DoesNotContain("Rear fill", report);
+    }
 
     [Fact]
     public void Format_ShowsBeforeAfterAndConfidence()

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverGroupPlacementTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverGroupPlacementTests.cs
@@ -1,0 +1,147 @@
+using System.Numerics;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// Placing a whole group against a settled reference: the delay that makes the
+/// two arrive together, and the relative polarity that falls out of the same
+/// measurement.
+/// </summary>
+public sealed class VirtualCrossoverGroupPlacementTests
+{
+    private const int Rate = 48_000;
+
+    // A band-limited click: enough of a packet for an arrival read and a
+    // correlation peak, with nothing periodic to offer a rival lobe.
+    private static Complex[] Packet(double delayMs, double scale = 1.0)
+    {
+        var ir = new Complex[16_384];
+        int center = 2_048 + (int)Math.Round(delayMs * Rate / 1_000.0);
+        // A short raised-cosine burst around 1 kHz: real enough to time, cheap
+        // enough to keep the test fast.
+        const double ToneHz = 1_000.0;
+        const int HalfWidth = 96;
+        for (int i = -HalfWidth; i <= HalfWidth; i++)
+        {
+            int index = center + i;
+            if (index < 0 || index >= ir.Length)
+            {
+                continue;
+            }
+
+            double window = 0.5 * (1.0 + Math.Cos(Math.PI * i / HalfWidth));
+            ir[index] += scale * window * Math.Sin(2.0 * Math.PI * ToneHz * i / Rate);
+        }
+
+        return ir;
+    }
+
+    [Fact]
+    public void Place_ReadsBackADelayItWasGiven()
+    {
+        // The group sits 6 ms behind the reference, so aligning it means taking
+        // 6 ms OFF — the delay to add is negative, and the normalization pass is
+        // what later turns that into something a processor can dial.
+        Complex[] reference = Packet(0);
+        Complex[] group = Packet(6.0);
+
+        GroupPlacement? placement = VirtualCrossoverGroupPlacement.Place(
+            reference, group, Rate, 500, 2_000);
+
+        Assert.NotNull(placement);
+        Assert.InRange(placement.CoArrivalDelayMs, -6.15, -5.85);
+        Assert.False(placement.Inverted);
+        Assert.InRange(placement.Coefficient, 0.5, 1.0);
+    }
+
+    [Fact]
+    public void Place_ReadsPolarityFromTheSameMeasurement()
+    {
+        // Inverting the group must not change WHERE it is, only how it reads.
+        // Polarity is a measurement here rather than a guess, which is why the
+        // caller may apply it rather than merely suggest it.
+        Complex[] reference = Packet(0);
+        Complex[] inverted = Packet(4.0, scale: -1.0);
+
+        GroupPlacement? placement = VirtualCrossoverGroupPlacement.Place(
+            reference, inverted, Rate, 500, 2_000);
+
+        Assert.NotNull(placement);
+        Assert.True(placement.Inverted);
+        Assert.InRange(placement.CoArrivalDelayMs, -4.15, -3.85);
+    }
+
+    [Fact]
+    public void Place_RefusesABandTooNarrowToTimeAnythingIn()
+    {
+        Complex[] reference = Packet(0);
+        Complex[] group = Packet(3.0);
+
+        Assert.Null(VirtualCrossoverGroupPlacement.Place(
+            reference, group, Rate, 1_000, 1_050));
+    }
+
+    [Fact]
+    public void Midpoint_PutsTheCentreBetweenTheTwoSides()
+    {
+        // The centre reads 5.00 ms against one side and 5.50 against the other,
+        // which is exactly the 0.5 ms the sides themselves are apart. It belongs
+        // in the middle, and the two readings corroborate each other.
+        var near = new GroupPlacement(-5.00, false, 0.8);
+        var far = new GroupPlacement(-5.50, false, 0.8);
+
+        (double delayMs, bool inverted, bool confident) =
+            VirtualCrossoverGroupPlacement.Midpoint(near, far, 0.5, 0.25);
+
+        Assert.Equal(-5.25, delayMs, 3);
+        Assert.False(inverted);
+        Assert.True(confident);
+    }
+
+    [Fact]
+    public void Midpoint_StillPlacesTheCentreWhenTheSidesDisagreeButSaysSoInstead()
+    {
+        // The sides are 3 ms apart where the scene offset says 0.5: one of the
+        // two readings landed on the wrong lobe. The midpoint is still the best
+        // available answer, so it is returned — but the run must not present it
+        // with the confidence of one the sides corroborated.
+        var near = new GroupPlacement(-5.0, false, 0.8);
+        var far = new GroupPlacement(-8.0, false, 0.8);
+
+        (double delayMs, _, bool confident) =
+            VirtualCrossoverGroupPlacement.Midpoint(near, far, 0.5, 0.25);
+
+        Assert.Equal(-6.5, delayMs, 3);
+        Assert.False(confident);
+    }
+
+    [Fact]
+    public void Midpoint_WillNotFlipPolarityOnHalfAMeasurement()
+    {
+        // A centre reading inverted against one side and normal against the
+        // other is not a centre wired backwards; it is a measurement that has
+        // not settled. Flipping on that would be a coin toss dressed as a
+        // reading, so the polarity stays and the confidence goes.
+        var near = new GroupPlacement(-5.0, true, 0.8);
+        var far = new GroupPlacement(-5.5, false, 0.8);
+
+        (_, bool inverted, bool confident) =
+            VirtualCrossoverGroupPlacement.Midpoint(near, far, 0.5, 0.25);
+
+        Assert.False(inverted);
+        Assert.False(confident);
+    }
+
+    [Fact]
+    public void Midpoint_WithholdsConfidenceFromAWeakReading()
+    {
+        var near = new GroupPlacement(-5.0, false, 0.8);
+        var far = new GroupPlacement(-5.5, false, 0.05);
+
+        (_, _, bool confident) =
+            VirtualCrossoverGroupPlacement.Midpoint(near, far, 0.5, 0.25);
+
+        Assert.False(confident);
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
@@ -111,6 +111,21 @@ public sealed class VirtualCrossoverStagedAlignmentTests
                 .Select(item => item.Name));
     }
 
+    [Theory]
+    // Left-hand drive: the driver's side is the left, so the right is the far one.
+    [InlineData(false, false, false)]
+    [InlineData(true, false, true)]
+    // Right-hand drive mirrors it, and this is the case that was wrong: the
+    // group sums reach the placement in the engine's ROLES, so reading the cabin
+    // side there timed every rear driver against the opposite side's front stage.
+    [InlineData(true, true, false)]
+    [InlineData(false, true, true)]
+    public void IsFarSide_FollowsTheLayoutRatherThanTheCabinSide(
+        bool rightSide,
+        bool rightHandDrive,
+        bool far) =>
+        Assert.Equal(far, VirtualCrossoverPanel.IsFarSide(rightSide, rightHandDrive));
+
     [Fact]
     public void NormalizeStagedDelays_SlidesEveryChannelAndKeepsEveryRelation()
     {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
@@ -67,6 +67,51 @@ public sealed class VirtualCrossoverStagedAlignmentTests
     }
 
     [Fact]
+    public void TheWalkNeverPairsAFrontDriverWithTheRearFill()
+    {
+        // The defect this whole change exists to remove, written as the thing
+        // that used to happen. The reference car's rear pair is high-passed at
+        // 290 Hz, so by band centre it lands between the midrange and the
+        // tweeter — and the walk, which pairs neighbours, declared a midrange
+        // handing over to a rear fill at the midrange's own low-pass corner. No
+        // filter does that.
+        //
+        // Staging is what stops it: the walk set is the front chain, so the rear
+        // is not a neighbour of anything. Run against the unstaged list the same
+        // assertion fails, which is what makes this a falsifier rather than a
+        // restatement.
+        var mid = Block("A", VirtualCrossoverZone.Front);
+        mid.Settings.CrossoverKind = CrossoverKind.BandPass;
+        mid.Settings.HighPassEdge =
+            new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 290, 24);
+        mid.Settings.LowPassEdge =
+            new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 3_500, 24);
+        var tweeter = Block("B", VirtualCrossoverZone.Front);
+        tweeter.Settings.CrossoverKind = CrossoverKind.HighPass;
+        tweeter.Settings.HighPassEdge =
+            new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 3_500, 24);
+        var rear = Block("C", VirtualCrossoverZone.Rear);
+        rear.Settings.CrossoverKind = CrossoverKind.HighPass;
+        rear.Settings.HighPassEdge =
+            new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 290, 24);
+
+        (List<VirtualCrossoverChannel> chain, List<VirtualCrossoverChannel> later) =
+            VirtualCrossoverPanel.SplitAlignmentStages([mid, tweeter, rear]);
+
+        Assert.Equal(["A", "B"], chain.Select(item => item.Name));
+        Assert.Equal(["C"], later.Select(item => item.Name));
+
+        // Ordered by band centre the rear sits BETWEEN the two front drivers, so
+        // an unstaged walk would have paired it with both. Pinned here so the
+        // ordering that caused the defect is on record rather than assumed.
+        Assert.Equal(
+            ["A", "C", "B"],
+            new[] { mid, tweeter, rear }
+                .OrderBy(item => VirtualCrossoverJunctions.BandCenterHz(item.Settings))
+                .Select(item => item.Name));
+    }
+
+    [Fact]
     public void NormalizeStagedDelays_SlidesEveryChannelAndKeepsEveryRelation()
     {
         // The rear fill was pushed behind the front stage, which asked the front

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
@@ -1,0 +1,120 @@
+﻿using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The two decisions the staged Auto delay run turns on: which channels the
+/// engine walks, and the rigid shift that makes the finished set dialable.
+/// </summary>
+public sealed class VirtualCrossoverStagedAlignmentTests
+{
+    private static VirtualCrossoverChannel Block(string name, VirtualCrossoverZone zone)
+    {
+        var channel = new VirtualCrossoverChannel(name) { SampleRate = 48_000 };
+        channel.Pair.Zone = zone;
+        return channel;
+    }
+
+    [Fact]
+    public void SplitAlignmentStages_LeavesAFrontOnlyProjectUnstaged()
+    {
+        // The compatibility guarantee where it is acted on. Everything lands in
+        // the chain and nothing after it, so the caller passes a null walk set —
+        // the old engine call — and skips both later passes. This is why the
+        // session battery cannot drift: not because the staged path happens to
+        // agree, but because such a project never enters it.
+        VirtualCrossoverChannel sub = Block("A", VirtualCrossoverZone.Sub);
+        VirtualCrossoverChannel mid = Block("B", VirtualCrossoverZone.Front);
+        VirtualCrossoverChannel tweeter = Block("C", VirtualCrossoverZone.Front);
+
+        (List<VirtualCrossoverChannel> chain, List<VirtualCrossoverChannel> later) =
+            VirtualCrossoverPanel.SplitAlignmentStages([sub, mid, tweeter]);
+
+        Assert.Equal(3, chain.Count);
+        Assert.Empty(later);
+    }
+
+    [Fact]
+    public void SplitAlignmentStages_HoldsTheRearAndCentreBackForTheirOwnStages()
+    {
+        VirtualCrossoverChannel sub = Block("A", VirtualCrossoverZone.Sub);
+        VirtualCrossoverChannel front = Block("B", VirtualCrossoverZone.Front);
+        VirtualCrossoverChannel rear = Block("C", VirtualCrossoverZone.Rear);
+        VirtualCrossoverChannel centre = Block("D", VirtualCrossoverZone.Center);
+
+        (List<VirtualCrossoverChannel> chain, List<VirtualCrossoverChannel> later) =
+            VirtualCrossoverPanel.SplitAlignmentStages([sub, front, rear, centre]);
+
+        Assert.Equal(["A", "B"], chain.Select(item => item.Name));
+        Assert.Equal(["C", "D"], later.Select(item => item.Name));
+    }
+
+    [Fact]
+    public void SplitAlignmentStages_WalksARearOnlyProjectAsItsOwnChain()
+    {
+        // Nothing to be placed against. A rear-only project is a legitimate
+        // thing to align — it is simply its own chain — and holding it back
+        // would leave every one of its channels waiting for a front stage that
+        // does not exist.
+        VirtualCrossoverChannel low = Block("A", VirtualCrossoverZone.Rear);
+        VirtualCrossoverChannel high = Block("B", VirtualCrossoverZone.Rear);
+
+        (List<VirtualCrossoverChannel> chain, List<VirtualCrossoverChannel> later) =
+            VirtualCrossoverPanel.SplitAlignmentStages([low, high]);
+
+        Assert.Equal(2, chain.Count);
+        Assert.Empty(later);
+    }
+
+    [Fact]
+    public void NormalizeStagedDelays_SlidesEveryChannelAndKeepsEveryRelation()
+    {
+        // The rear fill was pushed behind the front stage, which asked the front
+        // stage to go negative. Nothing is dialable until this pass; afterwards
+        // the earliest sits at zero and every gap between channels is the one
+        // the stages computed.
+        var front = Block("A", VirtualCrossoverZone.Front);
+        var sub = Block("B", VirtualCrossoverZone.Sub);
+        var rear = Block("C", VirtualCrossoverZone.Rear);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [front] = new AlignmentOverride(-4.0, false),
+            [sub] = new AlignmentOverride(-1.5, true),
+            [rear] = new AlignmentOverride(11.0, false)
+        };
+        var log = new System.Text.StringBuilder();
+
+        VirtualCrossoverPanel.NormalizeStagedDelays(alignment, log);
+
+        Assert.Equal(0.0, alignment[front].DelayMs, 6);
+        Assert.Equal(2.5, alignment[sub].DelayMs, 6);
+        Assert.Equal(15.0, alignment[rear].DelayMs, 6);
+        // Polarity is a property of the channel, not of where the set sits.
+        Assert.True(alignment[sub].InvertPolarity);
+        // The shift is reported, so a reader of the trace can tell a staged run's
+        // absolute delays from the relative ones the stages computed. Matched on
+        // the word rather than the number: the log is written in the machine's
+        // own culture, where the decimal separator may be a comma.
+        Assert.Contains("normalization", log.ToString());
+        Assert.Contains("shifted", log.ToString());
+    }
+
+    [Fact]
+    public void NormalizeStagedDelays_LeavesADialableSetAlone()
+    {
+        // No shift where none is needed: moving a set that already starts at a
+        // positive delay would add latency the tune did not ask for.
+        var front = Block("A", VirtualCrossoverZone.Front);
+        var rear = Block("B", VirtualCrossoverZone.Rear);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [front] = new AlignmentOverride(1.0, false),
+            [rear] = new AlignmentOverride(16.0, false)
+        };
+
+        VirtualCrossoverPanel.NormalizeStagedDelays(alignment, new System.Text.StringBuilder());
+
+        Assert.Equal(1.0, alignment[front].DelayMs, 6);
+        Assert.Equal(16.0, alignment[rear].DelayMs, 6);
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
@@ -144,7 +144,7 @@ public sealed class VirtualCrossoverStagedAlignmentTests
         };
         var log = new System.Text.StringBuilder();
 
-        VirtualCrossoverPanel.NormalizeStagedDelays(alignment, log);
+        VirtualCrossoverPanel.NormalizeStagedDelays([front, sub, rear], alignment, log);
 
         Assert.Equal(0.0, alignment[front].DelayMs, 6);
         Assert.Equal(2.5, alignment[sub].DelayMs, 6);
@@ -160,6 +160,67 @@ public sealed class VirtualCrossoverStagedAlignmentTests
     }
 
     [Fact]
+    public void NormalizeStagedDelays_MovesTheANCHOR_ThoughItHasNoEntryOfItsOwn()
+    {
+        // The map is SPARSE by design: the alignment engine documents absence as
+        // "nothing proposed" and deliberately leaves its reference channel out
+        // rather than manufacture a zero-delay proposal for it
+        // (AutoAlignmentEngine.NormalizeAndVerifyFeasibility says so in as many
+        // words). A shift driven off the map's KEYS therefore skipped exactly
+        // that channel: the anchor stayed at zero while its own siblings moved
+        // around it, so the "rigid-body" shift silently rewrote the one relation
+        // in the whole run that must not change — the front chain's internal
+        // alignment the engine had just settled.
+        //
+        // The earlier version of this test put the anchor in the dictionary by
+        // hand and so could never have caught it.
+        var anchor = Block("A", VirtualCrossoverZone.Front);
+        var sibling = Block("B", VirtualCrossoverZone.Front);
+        var rear = Block("C", VirtualCrossoverZone.Rear);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            // No entry for the anchor at all — it sits at an implied zero.
+            [sibling] = new AlignmentOverride(2.5, false),
+            [rear] = new AlignmentOverride(-3.0, false)
+        };
+
+        VirtualCrossoverPanel.NormalizeStagedDelays(
+            [anchor, sibling, rear], alignment, new System.Text.StringBuilder());
+
+        // Everything moved by the same +3, the anchor included, so the front
+        // chain's 2.5 ms gap is still 2.5 ms.
+        Assert.Equal(3.0, alignment[anchor].DelayMs, 6);
+        Assert.Equal(5.5, alignment[sibling].DelayMs, 6);
+        Assert.Equal(0.0, alignment[rear].DelayMs, 6);
+        Assert.Equal(
+            2.5,
+            alignment[sibling].DelayMs - alignment[anchor].DelayMs,
+            6);
+    }
+
+    [Fact]
+    public void NormalizeStagedDelays_ReadsAnAbsentAnchorAsTheEarliestChannel()
+    {
+        // And the minimum has to see it too. With every proposed delay positive
+        // but the implied-zero anchor below them all, there is nothing to shift:
+        // the set already starts at zero.
+        var anchor = Block("A", VirtualCrossoverZone.Front);
+        var rear = Block("B", VirtualCrossoverZone.Rear);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [rear] = new AlignmentOverride(12.0, false)
+        };
+
+        VirtualCrossoverPanel.NormalizeStagedDelays(
+            [anchor, rear], alignment, new System.Text.StringBuilder());
+
+        Assert.Equal(12.0, alignment[rear].DelayMs, 6);
+        // Untouched: materializing a zero for it would be harmless here, but the
+        // pass must not invent proposals it was not asked for.
+        Assert.False(alignment.ContainsKey(anchor));
+    }
+
+    [Fact]
     public void NormalizeStagedDelays_LeavesADialableSetAlone()
     {
         // No shift where none is needed: moving a set that already starts at a
@@ -172,7 +233,8 @@ public sealed class VirtualCrossoverStagedAlignmentTests
             [rear] = new AlignmentOverride(16.0, false)
         };
 
-        VirtualCrossoverPanel.NormalizeStagedDelays(alignment, new System.Text.StringBuilder());
+        VirtualCrossoverPanel.NormalizeStagedDelays(
+            [front, rear], alignment, new System.Text.StringBuilder());
 
         Assert.Equal(1.0, alignment[front].DelayMs, 6);
         Assert.Equal(16.0, alignment[rear].DelayMs, 6);

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverTwoWayGroupTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverTwoWayGroupTests.cs
@@ -1,0 +1,126 @@
+using System.Numerics;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// A later stage whose group is a two-way of its own — a two-way rear fill, a
+/// two-way centre. Its drivers cross each other, so the engine walks that
+/// junction before the group is placed, and the result it hands back follows
+/// the engine's own sparse-map contract.
+/// </summary>
+public sealed class VirtualCrossoverTwoWayGroupTests
+{
+    private const int Rate = 48_000;
+
+    private static VirtualCrossoverChannel Driver(
+        string name,
+        CrossoverKind kind,
+        double cornerHz,
+        double arrivalMs)
+    {
+        var channel = new VirtualCrossoverChannel(name) { SampleRate = Rate };
+        channel.Pair.Zone = VirtualCrossoverZone.Rear;
+        channel.Settings.CrossoverKind = kind;
+        var edge = new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, cornerHz, 24);
+        if (kind == CrossoverKind.LowPass)
+        {
+            channel.Settings.LowPassEdge = edge;
+        }
+        else
+        {
+            channel.Settings.HighPassEdge = edge;
+        }
+
+        var impulse = new Complex[16_384];
+        impulse[2_048 + (int)Math.Round(arrivalMs * Rate / 1_000.0)] = Complex.One;
+        channel.TransferImpulseResponse = impulse;
+        return channel;
+    }
+
+    [Fact]
+    public void SettleWithinGroup_HandsBackTheEnginesSparseMapAndComposesWithoutThrowing()
+    {
+        // The crash this pins: the engine's override map has NO entry for the
+        // channel it chose as the group's reference, because absence means
+        // "nothing proposed". Copying the map onto the run with an indexer threw
+        // the moment a later group had two drivers — which is exactly the case
+        // the multi-way fix had just introduced, one function away from the
+        // normalization pass that respects the same contract.
+        VirtualCrossoverChannel woofer =
+            Driver("R1", CrossoverKind.LowPass, 300, arrivalMs: 0.0);
+        VirtualCrossoverChannel tweeter =
+            Driver("R2", CrossoverKind.HighPass, 300, arrivalMs: 0.6);
+        List<VirtualCrossoverChannel> members = [woofer, tweeter];
+
+        var reprocessor = new AlignmentReprocessor(
+            [.. members.Select(member => new AlignmentReprocessInput(
+                member,
+                member.TransferImpulseResponse!,
+                Rate,
+                Rate,
+                member.Settings.ToChain()))]);
+        IReadOnlyList<AlignmentSnapshot> initial = reprocessor.Reprocess(
+            new Dictionary<IAlignmentChannel, AlignmentOverride>());
+        Dictionary<IAlignmentChannel, AlignmentSnapshot> snapshots = members
+            .Select((member, index) => (member, snapshot: initial[index]))
+            .ToDictionary(item => (IAlignmentChannel)item.member, item => item.snapshot);
+
+        Dictionary<IAlignmentChannel, AlignmentOverride> inner =
+            VirtualCrossoverPanel.SettleWithinGroup(
+                [.. members.Cast<IAlignmentChannel>()],
+                member => ((VirtualCrossoverChannel)member).Settings,
+                snapshots,
+                reprocessor,
+                new System.Text.StringBuilder());
+
+        // The map is sparse: the engine settled the pair and named one of them
+        // its reference, which carries no entry. If that ever stops being true
+        // the composition below is still right, but the reason for it is gone.
+        Assert.NotEmpty(inner);
+        Assert.True(
+            inner.Count < members.Count,
+            "the engine's map is expected to omit the group's own reference");
+
+        // The composition the crash was in. Every member must come out with an
+        // override, the absent one reading as an untouched zero.
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+        VirtualCrossoverPanel.ApplyInnerSettlement(members, inner, alignment);
+
+        Assert.Equal(2, alignment.Count);
+        Assert.All(members, member => Assert.True(alignment.ContainsKey(member)));
+
+        // And the junction the engine just settled survives the copy: the two
+        // drivers are still the same distance apart as the walk left them.
+        double settledGap =
+            alignment[tweeter].DelayMs - alignment[woofer].DelayMs;
+        double engineGap =
+            inner.GetValueOrDefault(tweeter).DelayMs -
+            inner.GetValueOrDefault(woofer).DelayMs;
+        Assert.Equal(engineGap, settledGap, 6);
+        // The later driver needs the shorter delay, so the gap is negative and
+        // of the order of the 0.6 ms head start it was given.
+        Assert.InRange(settledGap, -1.2, -0.1);
+    }
+
+    [Fact]
+    public void ApplyInnerSettlement_ReadsAnAbsentReferenceAsAnUntouchedZero()
+    {
+        // The same rule stated without an engine run, so the reason survives even
+        // if the engine's own behaviour changes.
+        var reference = new VirtualCrossoverChannel("A") { SampleRate = Rate };
+        var other = new VirtualCrossoverChannel("B") { SampleRate = Rate };
+        var inner = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [other] = new AlignmentOverride(1.37, true)
+        };
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+
+        VirtualCrossoverPanel.ApplyInnerSettlement([reference, other], inner, alignment);
+
+        Assert.Equal(0.0, alignment[reference].DelayMs, 6);
+        Assert.False(alignment[reference].InvertPolarity);
+        Assert.Equal(1.37, alignment[other].DelayMs, 6);
+        Assert.True(alignment[other].InvertPolarity);
+    }
+}


### PR DESCRIPTION
Third of the "complex installations" series, on top of #147 (zones) and #148
(grouped views). Those two gave the tool the fact and the eyes; this one gives
Auto delay the staging.

## Why

The alignment engine walks ONE chain along the spectrum, pairing neighbours and
settling each junction against the last. That is the right shape for a crossover
chain and the wrong shape for a car. On the reference installation the rear pair
is high-passed at 290 Hz, so **by band centre it lands between the midrange and
the tweeter** — and the walk declared a midrange handing over to a rear fill at
the midrange's own low-pass corner. No filter does that. Auto delay was not
solving the problem badly; it was solving one nobody has.

## What

**Stage 1 — the front chain.** The front stage and the subwoofers under it,
walked by the existing engine, unchanged. The subwoofers belong here because
this is where their junctions are: on the reference car the two subs cross each
other and the lower one crosses the midbass.

**Stages 2 and 3 — placement, not search.** There is nothing between a rear fill
and the front stage to search: no filter hands a band from one to the other, and
a centre has no junction with anything. What those groups need is one number
each, and one number is what a correlation against a settled reference gives.
Two steps, the same shape the engine uses at a junction: a coarse band-limited
arrival difference says roughly where the answer is, then the phase-whitened
correlation is refined in a short window centred there. The coarse step is what
makes it work — a rear fill can sit twenty milliseconds from the front stage,
where a correlation searched around zero finds a lobe and one searched across
the whole range has many to choose between.

- A **rear fill** is read per side against its own side's front stage: left and
  right are different drivers at different distances, so forcing one delay on
  both would be the opposite of a tune. Then it is pushed back by the Rear fill
  offset.
- A **centre** has no side, so it is read against BOTH front sums and placed at
  the midpoint. The two readings are each other's witness — they should differ
  by the scene offset, since that is how far apart the sides are — and a
  disagreement is reported rather than averaged away.
- Polarity comes out of the same correlation as the sign of its extremum, so it
  is measured rather than guessed. It is applied only where no fill offset is in
  play: past a few milliseconds the two groups no longer sum in any way the ear
  resolves, and flipping there is cosmetics on a measurement that has stopped
  describing what is heard.
- A group the run cannot measure keeps its current delay, written EXPLICITLY
  into the override map. An absent override means zero to the reprocessor, so
  silence would have moved the very group the run just admitted it could not
  read.

**Stage 4 — normalization.** Every delay is relative until this pass, and freely
negative: a rear fill pushed back past the front asks the front to go negative.
The pass slides everything at once until the earliest sits at zero, preserving
every relation the stages computed. It does nothing to a set that is already
dialable, so no tune gains latency it did not ask for.

**The L/R bridge is now required to be a front-chain pair.** It is where the two
sides are tied together, and tied at a rear pair the whole scene would be
anchored to the fill instead of to the stage it is supposed to sit behind.

## Why the staging is safe rather than merely ordered

Only the front chain searches. A stage that searched would be free to move what
it was measured against; one that computes a placement from a settled reference
cannot disagree with it. So the stages are one-way by construction — no later
group can pull the front stage out of tune, other than by sliding all of it at
once in the normalization. That property is asserted directly in
`VirtualCrossoverAlignmentStageTests`.

## The dialog

A **Rear fill** row: how far behind the front stage the rear should arrive,
defaulting to the precedence-effect 15 ms, off entirely when the project has no
Rear block. Its tooltip carries the working numbers — the 10–20 ms range, that 0
co-arrives them for a second row of listeners, and the warning that rear
speakers often sit CLOSER to the ears than the front, so some delay is needed
just to reach zero and this offset is on top of that. The setting is stored with
the tune: a car tuned for its front seats and one tuned for its second row want
different answers.

**The rear's LEVEL is deliberately not here.** It sits 6–12 dB under the front
and the last word is the ear's; #148's `vs Front` block already reports the
current figure to adjust against, and teaching the gain engine about groups is a
change to a validated component that this PR does not need. Both the tooltip and
`REFERENCE.md` say so, so the absence is something a reader can act on rather
than discover.

## Merge bar

**The seven-cabin session battery is identical line for line** — the only diff
being the two wall-clock timings it prints. Run twice, once on this branch and
once on a stashed baseline, on both the single-side and the stereo path.

That is by construction rather than by luck: a project with no rear and no
centre reports that it needs no staging, and the caller then passes a null walk
set, which is literally the old engine call, and skips both later passes. Such a
project never enters the staged path at all.

The falsifier is `TheWalkNeverPairsAFrontDriverWithTheRearFill`, which records
the band ordering that caused the defect (`A, C, B` — the rear between the two
front drivers) and asserts the walk set now holds the front chain alone.

Full suite green: 3438 passed, 0 failed.

## Still ahead

The per-group crossover wizard (#4 of the plan) and the grouped tuning sheet
plus a per-device delay ceiling (#5). Field validation on the reference car is
the owner's, and its rear pair will need re-pointing from Front to Rear first —
the v9 migration cannot tell a rear pair from a front one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
