### PR TITLE
Group the tuning sheet by zone, and teach the catalog each device's delay ceiling

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1421,7 +1421,12 @@ channel's PEQ. After changing a crossover or a bank — an all-pass band include
 
 When you are satisfied, press **Export...** and generate the final **PDF tuning sheet**.
 It lists the crossover settings, gains, delays, polarities, and PEQ needed to reproduce
-the virtual system in the real DSP.
+the virtual system in the real DSP. On an install that spans several zones the sheet
+prints by group, in the order you would enter it — Sub, then Front, then Rear, then
+Center — each group under its own heading with a graph of its filters, and the front
+group's graph shows the subwoofers' summed filter shape in a pale tone, so the bass
+handover is visible where you dial it in. Blocks keep their panel letters; only the
+order of the sections changes.
 
 If the project names a **Custom** processor, Resonalyze first asks which Q convention
 the PEQ columns should be stated in:

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1423,7 +1423,7 @@ When you are satisfied, press **Export...** and generate the final **PDF tuning 
 It lists the crossover settings, gains, delays, polarities, and PEQ needed to reproduce
 the virtual system in the real DSP. On an install that spans several zones the sheet
 prints by group, in the order you would enter it — Sub, then Front, then Rear, then
-Center — each group under its own heading with a graph of its filters, and the front
+Center — each group on a page of its own, under its heading and a graph of its filters, and the front
 group's graph shows the subwoofers' summed filter shape in a pale tone, so the bass
 handover is visible where you dial it in. Blocks keep their panel letters; only the
 order of the sections changes.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2574,7 +2574,21 @@ The remaining buttons in the column beside the plots:
   sides, not a binaural head simulation.
 - **Export…** writes the whole setup as a tuning sheet (printable PDF or plain
   text): for every side of every pair (a mono pair prints once) the gain, delay in
-  ms and mm, polarity, crossover filters, and PEQ bands down to the all-pass. It
+  ms and mm, polarity, crossover filters, and PEQ bands down to the all-pass.
+  An installation spanning several zones prints **by group**, in the order a
+  tune is typed into a DSP — Sub, then Front, then Rear, then Center — each
+  group led by its name and (on the PDF) a graph of its own DSP chains instead
+  of one combined tangle; blocks keep their panel letters, only the section
+  order changes. A group's graph adds the design sum of its chains per side
+  (left solid, right dashed; one line for a group of mono blocks) where a side
+  has at least two chains to sum — never for the centre, whose derived signal
+  makes any sum involving it a fiction — and the front group's graph carries
+  the subwoofer group's sum in a pale tone, so the bass handover shows both of
+  its sides. These sums are the *filters as designed*, delay and polarity
+  stripped: the acoustic summation already lives on the panel's plot, and
+  folding the cabin's timing compensation into a filter graph would show combs
+  no DSP screen shows. A single-zone project keeps the flat sheet it always
+  had. It
   states the PEQ columns in the [Q convention](#dsp-q-convention) of the project's
   [DSP processor](#dsp-processor): a named model answers for itself and the export
   asks nothing. A **Custom** processor has only what was typed into that dialog, so

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2239,6 +2239,13 @@ Mosconi, ESX, miniDSP and JL Audio — and its **processing rate** and
 [**Q convention**](#dsp-q-convention) come with it, locked. Pick **Custom** and
 state both by hand.
 
+A catalog line may also state the model's **per-channel delay ceiling**, read
+from its manual. Automatic delay proposals are judged against it — a spread the
+device cannot dial refuses with the reason — while a model whose manual has not
+been entered yet, and a Custom profile, keep the engine's long-standing 50 ms
+feasibility gate. The manual delay fields deliberately keep their wider range,
+since the Virtual DSP may model any hardware.
+
 The processing rate is the rate every simulated filter is **built** at, and it is
 deliberately independent of the rate the channels were measured at. A digital
 filter's corner is warped by the rate it was designed for, so designing at the
@@ -2384,7 +2391,14 @@ A group the run cannot measure keeps the delay it had, and says so in the trace.
 Every delay is relative until the last pass, which slides the whole set until
 the earliest channel sits at zero — a rear fill pushed back past the front stage
 asks the front to go negative, and nothing is dialable until that shift. Every
-relation the stages computed survives it.
+relation the stages computed survives it. The finished figure is then judged
+against the processor's own delay ceiling (see
+[DSP processor](#dsp-processor)); a set that does not fit refuses with the
+reason rather than clamping a channel, and when the rear fill is what pushes it
+past the range — the rear often sits *closer* than the front, so the whole gap
+plus the fill lands on the front stage's delays — the refusal also names the
+largest fill that *would* fit, so one rerun with the dialog turned down settles
+it instead of a bisection.
 
 A project with no rear and no centre never enters any of this: it takes the
 single-stage path, which is the same engine call it always took.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2578,8 +2578,8 @@ The remaining buttons in the column beside the plots:
   An installation spanning several zones prints **by group**, in the order a
   tune is typed into a DSP — Sub, then Front, then Rear, then Center — each
   group led by its name and (on the PDF) a graph of its own DSP chains instead
-  of one combined tangle; blocks keep their panel letters, only the section
-  order changes. A group's graph adds the design sum of its chains per side
+  of one combined tangle, every group after the first opening a page of its
+  own; blocks keep their panel letters, only the section order changes. A group's graph adds the design sum of its chains per side
   (left solid, right dashed; one line for a group of mono blocks) where a side
   has at least two chains to sum — never for the centre, whose derived signal
   makes any sum involving it a fiction — and the front group's graph carries

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2584,11 +2584,16 @@ The remaining buttons in the column beside the plots:
   has at least two chains to sum — never for the centre, whose derived signal
   makes any sum involving it a fiction — and the front group's graph carries
   the subwoofer group's sum in a pale tone, so the bass handover shows both of
-  its sides. These sums are the *filters as designed*, delay and polarity
-  stripped: the acoustic summation already lives on the panel's plot, and
-  folding the cabin's timing compensation into a filter graph would show combs
-  no DSP screen shows. A single-zone project keeps the flat sheet it always
-  had. It
+  its sides. These sums are complex, carrying every phase term the chains
+  hold — crossover, PEQ, all-pass and polarity alike, since an LR2-style knit
+  exists only through its deliberate inversion — with just the delays
+  stripped: folding the cabin's timing compensation into a filter graph would
+  bury it in combs no DSP screen shows, and the acoustic summation already
+  lives on the panel's plot. The flip side is stated rather than hidden: a
+  junction inverted to fix the cabin's phase shows an electrical dip here
+  that the car does not have, because that junction knits through timing this
+  graph does not model — the panel's plot is where it is judged. A
+  single-zone project keeps the flat sheet it always had. It
   states the PEQ columns in the [Q convention](#dsp-q-convention) of the project's
   [DSP processor](#dsp-processor): a named model answers for itself and the export
   asks nothing. A **Custom** processor has only what was typed into that dialog, so

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -224,13 +224,19 @@ public static class AutoAlignmentEngine
     /// </summary>
     private const double SeedPartnerMaxReachPeriods = 0.75;
 
-    // The delay ceiling an AUTO DELAY proposal may reach — tighter than the
-    // manual UI range (100 ms, since the Virtual DSP may model any hardware).
-    // Car processors cap per-channel delay in the tens of milliseconds (~17 m
-    // of path here), so a proposal past this could never be transferred to a
-    // device. Real cabin spans run well under 10 ms: this is the feasibility
-    // gate, not an operating region.
-    private const double MaxDelayMs = 50;
+    /// <summary>
+    /// The delay ceiling an AUTO DELAY proposal may reach when the target device's
+    /// own figure is unknown — tighter than the manual UI range (100 ms, since the
+    /// Virtual DSP may model any hardware). Car processors cap per-channel delay
+    /// in the tens of milliseconds (~17 m of path here), so a proposal past this
+    /// could never be transferred to a device. Real cabin spans run well under
+    /// 10 ms: this is the feasibility gate, not an operating region. A catalog
+    /// entry that states its device's real ceiling
+    /// (<see cref="DspProcessorPreset.MaxDelayMs"/>) tightens or widens the gate
+    /// per run through the <c>maxDelayMs</c> parameter of
+    /// <see cref="Compute"/> / <see cref="ComputeStereo"/>.
+    /// </summary>
+    public const double DefaultMaxDelayMs = 50;
 
     // A deliberately wide fine-search window (many periods at a high crossover,
     // ~one at a low one). Its candidates are always logged, surfacing summation
@@ -709,16 +715,23 @@ public static class AutoAlignmentEngine
     /// settings play no part: the caller produces the initial snapshots with
     /// zero overrides and the engine computes an absolute proposal.
     /// </summary>
+    /// <param name="maxDelayMs">
+    /// The target device's per-channel delay ceiling: the feasibility gate and
+    /// every polish pass bound the proposal by it. Defaults to
+    /// <see cref="DefaultMaxDelayMs"/> for a device whose figure is unknown.
+    /// </param>
     public static void Compute(
         IReadOnlyList<AlignmentSnapshot> channelsByBand,
         IReadOnlyList<AlignmentJunction> pairs,
         AlignmentReprocessor reprocess,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         StringBuilder log,
-        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null)
+        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null,
+        double maxDelayMs = DefaultMaxDelayMs)
     {
         ArgumentNullException.ThrowIfNull(channelsByBand);
         ArgumentNullException.ThrowIfNull(alignment);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxDelayMs);
         RequireOneSampleRate(channelsByBand);
         // An absolute proposal, per the contract: stale entries would otherwise
         // leak into the neighbor-base and reprocess reads and skew the result.
@@ -726,7 +739,8 @@ public static class AutoAlignmentEngine
         decisions?.Clear();
         Compute(channelsByBand, pairs, reprocess, alignment, log,
             onsetLocks: null, decisions);
-        NormalizeAndVerifyFeasibility(channelsByBand.ToList(), alignment, log);
+        NormalizeAndVerifyFeasibility(
+            channelsByBand.ToList(), alignment, log, maxDelayMs);
         NormalizePolarityPresentation(channelsByBand, alignment, log);
     }
 
@@ -3084,7 +3098,7 @@ public static class AutoAlignmentEngine
                 newDelay = 0;
             }
 
-            // Unclamped above zero: a value past MaxDelayMs stays honest here —
+            // Unclamped above zero: a value past the delay ceiling stays honest here —
             // relations are what matter mid-run, and the final feasibility
             // check refuses the proposal if the span truly does not fit.
             alignment[channel] = new AlignmentOverride(
@@ -3405,17 +3419,24 @@ public static class AutoAlignmentEngine
     /// zero. Every uniform shift spans BOTH sides, preserving the scene offset
     /// the bridge established.
     /// </summary>
+    /// <param name="maxDelayMs">
+    /// The target device's per-channel delay ceiling: the feasibility gate and
+    /// every polish pass bound the proposal by it. Defaults to
+    /// <see cref="DefaultMaxDelayMs"/> for a device whose figure is unknown.
+    /// </param>
     public static void ComputeStereo(
         StereoAlignmentPlan plan,
         AlignmentReprocessor reprocess,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         StringBuilder log,
-        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null)
+        Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null,
+        double maxDelayMs = DefaultMaxDelayMs)
     {
         ArgumentNullException.ThrowIfNull(plan);
         ArgumentNullException.ThrowIfNull(reprocess);
         ArgumentNullException.ThrowIfNull(alignment);
         ArgumentNullException.ThrowIfNull(log);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxDelayMs);
         List<AlignmentSnapshot> rightByBand = plan.RightChannelsByBand.ToList();
         if (rightByBand.Count == 0 ||
             plan.RightPairs.Count != rightByBand.Count - 1)
@@ -4140,7 +4161,7 @@ public static class AutoAlignmentEngine
         // pair by one shared delta keeps the pair's L-R timing (the scene)
         // untouched while trading junction loss between the sides.
         RebalancePairsKeepingScene(
-            plan, reprocess, alignment, log, onsetLocks, decisions);
+            plan, reprocess, alignment, log, onsetLocks, maxDelayMs, decisions);
 
         // A mono channel's own final polish: its delay (and polarity) is
         // scene-invariant by construction — one shared channel moves both
@@ -4148,15 +4169,17 @@ public static class AutoAlignmentEngine
         // best compromise across its left AND right junctions is searched
         // directly. This is the only pass where the right junction gets a
         // vote on the mono channel at all.
-        ComoveMonoChannels(plan, reprocess, alignment, log, allChannels, decisions);
+        ComoveMonoChannels(
+            plan, reprocess, alignment, log, allChannels, maxDelayMs, decisions);
 
         // The far side's own last word: every far channel may leave its scene
         // position by at most FarSideJunctionPolishMs to buy its own junction
         // summation back — see the method for why the scene can afford it.
         PolishFarSideJunctions(
-            plan, rightByBand, allChannels, reprocess, alignment, log, decisions);
+            plan, rightByBand, allChannels, reprocess, alignment, log,
+            maxDelayMs, decisions);
 
-        NormalizeAndVerifyFeasibility(allChannels, alignment, log);
+        NormalizeAndVerifyFeasibility(allChannels, alignment, log, maxDelayMs);
 
         // The invariant the user requires of automatic delay: no driver is ever
         // inverted on one side of a pair alone.
@@ -4177,7 +4200,8 @@ public static class AutoAlignmentEngine
     internal static void NormalizeAndVerifyFeasibility(
         IReadOnlyList<AlignmentSnapshot> scope,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
-        StringBuilder log)
+        StringBuilder log,
+        double maxDelayMs = DefaultMaxDelayMs)
     {
         // Always rebase (even a sub-hundredth minimum: a tiny negative left in
         // the map would be an unrealizable delay), round onto the DSP's 0.01 ms
@@ -4208,12 +4232,12 @@ public static class AutoAlignmentEngine
         AlignmentSnapshot widest = scope.MaxBy(
             item => alignment.GetValueOrDefault(item.Channel).DelayMs)!;
         double widestDelayMs = alignment.GetValueOrDefault(widest.Channel).DelayMs;
-        if (widestDelayMs > MaxDelayMs + 0.005)
+        if (widestDelayMs > maxDelayMs + 0.005)
         {
             throw new InvalidOperationException(
                 "The proposed alignment does not fit the DSP delay range: " +
                 $"{widest.Channel.Name} needs {widestDelayMs:0.00} ms with the " +
-                $"earliest channel at 0, but the limit is {MaxDelayMs:0} ms. " +
+                $"earliest channel at 0, but the limit is {maxDelayMs:0.##} ms. " +
                 "The measured spread between the earliest and latest channels " +
                 "is wider than the DSP can realize.");
         }
@@ -4528,6 +4552,7 @@ public static class AutoAlignmentEngine
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         StringBuilder log,
         IReadOnlyDictionary<AlignmentJunction, OnsetLockState> onsetLocks,
+        double maxDelayMs,
         Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null)
     {
         if (plan.PairLinks == null)
@@ -4745,9 +4770,9 @@ public static class AutoAlignmentEngine
                 double minOtherMs = fieldOthers.Min(
                     channel => alignment.GetValueOrDefault(channel).DelayMs);
                 minDelta = Math.Max(
-                    minDelta, -pairMinMs - (MaxDelayMs - maxOtherMs));
+                    minDelta, -pairMinMs - (maxDelayMs - maxOtherMs));
                 maxDelta = Math.Min(
-                    maxDelta, MaxDelayMs - pairMaxMs + minOtherMs);
+                    maxDelta, maxDelayMs - pairMaxMs + minOtherMs);
             }
             // The neighbor lobes can, in principle, exclude zero (a settled
             // neighbor a hair over half a period away); never let the window
@@ -4846,6 +4871,7 @@ public static class AutoAlignmentEngine
         AlignmentReprocessor reprocess,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         StringBuilder log,
+        double maxDelayMs,
         Dictionary<IAlignmentChannel, AlignmentDecision>? decisions)
     {
         foreach (AlignmentSnapshot entry in rightByBand
@@ -4953,7 +4979,7 @@ public static class AutoAlignmentEngine
                 double trialMs = current.DelayMs + delta;
                 if (trialMs < 0 ||
                     Math.Max(othersMaxMs, trialMs) -
-                        Math.Min(othersMinMs, trialMs) > MaxDelayMs)
+                        Math.Min(othersMinMs, trialMs) > maxDelayMs)
                 {
                     // Delays are non-negative and a polish never earns a
                     // uniform shift of the whole field. Nor may it widen the
@@ -5020,6 +5046,7 @@ public static class AutoAlignmentEngine
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
         StringBuilder log,
         IReadOnlyList<AlignmentSnapshot> shiftScope,
+        double maxDelayMs = DefaultMaxDelayMs,
         Dictionary<IAlignmentChannel, AlignmentDecision>? decisions = null)
     {
         foreach (IAlignmentChannel mono in plan.MonoChannels)
@@ -5139,9 +5166,9 @@ public static class AutoAlignmentEngine
             double minOtherMs = others.Min(
                 channel => alignment.GetValueOrDefault(channel).DelayMs);
             double minDelta = Math.Max(
-                -reachMs, -over.DelayMs - (MaxDelayMs - maxOtherMs));
+                -reachMs, -over.DelayMs - (maxDelayMs - maxOtherMs));
             double maxDelta = Math.Min(
-                reachMs, MaxDelayMs - over.DelayMs + minOtherMs);
+                reachMs, maxDelayMs - over.DelayMs + minOtherMs);
 
             double Score(double deltaMs, bool flip)
             {
@@ -5339,11 +5366,11 @@ public static class AutoAlignmentEngine
                     ShiftAllExcept(shiftScope, mono, -newDelayMs, alignment, log);
                     newDelayMs = 0;
                 }
-                else if (newDelayMs > MaxDelayMs)
+                else if (newDelayMs > maxDelayMs)
                 {
                     ShiftAllExcept(
-                        shiftScope, mono, MaxDelayMs - newDelayMs, alignment, log);
-                    newDelayMs = MaxDelayMs;
+                        shiftScope, mono, maxDelayMs - newDelayMs, alignment, log);
+                    newDelayMs = maxDelayMs;
                 }
 
                 alignment[mono] = new AlignmentOverride(

--- a/dsp/DspProcessorProfile.cs
+++ b/dsp/DspProcessorProfile.cs
@@ -24,11 +24,21 @@ namespace Resonalyze.Dsp;
 /// costs something.
 /// </para>
 /// </remarks>
+/// <param name="MaxDelayMs">
+/// The device's per-channel delay ceiling from its maker's manual, or null where it
+/// has not been looked up yet. Null does NOT mean unlimited: an unknown ceiling reads
+/// as <see cref="AutoAlignmentEngine.DefaultMaxDelayMs"/>, the engine's long-standing
+/// feasibility gate, so an unfilled line keeps exactly the behavior it always had.
+/// The catalog is filled from the manuals gradually; a wrong entry here turns a
+/// dialable tune into a refusal (or the reverse), so a line states a number only
+/// when the manual does.
+/// </param>
 public sealed record DspProcessorPreset(
     string Manufacturer,
     string ModelName,
     int SampleRateHz,
-    PeqQConvention QConvention)
+    PeqQConvention QConvention,
+    double? MaxDelayMs = null)
 {
     /// <summary>Stable file identity, e.g. <c>helix-dsp-ultra-s</c>.</summary>
     public string Id { get; } = MakeId(Manufacturer, ModelName);
@@ -106,6 +116,18 @@ public sealed record DspProcessorProfile(
 
     public string DisplayName =>
         DspProcessorCatalog.Preset(ModelId)?.DisplayName ?? "Custom";
+
+    /// <summary>
+    /// The per-channel delay ceiling an automatic proposal must fit for this
+    /// processor. A catalog entry that states its own figure answers with it; a
+    /// Custom profile — and every entry whose manual has not been read yet —
+    /// answers with the engine's <see cref="AutoAlignmentEngine.DefaultMaxDelayMs"/>,
+    /// so an unknown device keeps the behavior every device had before the
+    /// catalog learned this fact.
+    /// </summary>
+    public double MaxDelayMs =>
+        DspProcessorCatalog.Preset(ModelId)?.MaxDelayMs
+            ?? AutoAlignmentEngine.DefaultMaxDelayMs;
 }
 
 /// <summary>

--- a/source/Tools/Sheets/VirtualCrossoverSheet.cs
+++ b/source/Tools/Sheets/VirtualCrossoverSheet.cs
@@ -32,65 +32,95 @@ internal static class VirtualCrossoverSheet
             builder.AppendLine(metricLine);
         }
 
-        for (int i = 0; i < project.Pairs.Count; i++)
+        // One run of sections per zone, in the order a tune is typed into a DSP
+        // (Sub, Front, Rear, Center) — with the zone named above its run. A
+        // single-zone project skips the headings and keeps the flat sheet it
+        // always had: a heading that names the only group there is would be
+        // scaffolding around nothing.
+        IReadOnlyList<(VirtualCrossoverZone Zone, IReadOnlyList<int> PairIndices)>
+            sections = VirtualCrossoverSheetGroups.Sections(project);
+        bool grouped = sections.Count > 1;
+        foreach ((VirtualCrossoverZone zone, IReadOnlyList<int> pairIndices)
+            in sections)
         {
-            foreach ((VirtualCrossoverChannelSettings channel, string sideSuffix)
-                in SideSections(project.Pairs[i]))
+            if (grouped)
             {
-                if (!channel.HasSource)
-                {
-                    continue;
-                }
-
                 builder.AppendLine();
                 builder.AppendLine(
-                    $"Channel {ChannelName(i)}{sideSuffix} — {channel.DisplayName}");
-                // Many DSPs have no separate preamp for their equalizer, so the PEQ preamp
-                // has to be folded into the channel gain when the tune is typed in. The
-                // combined figure rides along on the same line, where it cannot be
-                // mistaken for a second, independent gain to enter.
-                string gainLine = $"  Gain       {Signed(channel.GainDb)} dB";
-                if (channel.PeqPreampDb != 0)
-                {
-                    gainLine +=
-                        $"  (with PEQ preamp: {Signed(channel.GainDb + channel.PeqPreampDb)} dB)";
-                }
+                    $"=== {VirtualCrossoverZones.DisplayName(zone)} ===");
+            }
 
-                builder.AppendLine(gainLine);
-                builder.AppendLine(
-                    $"  Delay      {Number(channel.DelayMs, "0.00")} ms" +
-                    $"  (= {Number(channel.DelayMs * Acoustics.SpeedOfSoundAt20CMetersPerSecond, "0.#")} mm)");
-                builder.AppendLine(
-                    $"  Polarity   {(channel.InvertPolarity ? "Inverted" : "Normal")}");
-                builder.AppendLine($"  Crossover  {DescribeCrossover(channel)}");
-                if (channel.PeqBands.Count > 0 || channel.PeqPreampDb != 0)
-                {
-                    builder.AppendLine(
-                        $"  PEQ        {channel.PeqSourceName ?? "custom"}, " +
-                        $"preamp {Signed(channel.PeqPreampDb)} dB");
-                    for (int band = 0; band < channel.PeqBands.Count; band++)
-                    {
-                        PeqBand peq = PeqQConventions.ToConvention(
-                            channel.PeqBands[band], qConvention);
-                        // The keyword comes from the profile writer rather than being
-                        // spelled here: a shelf printed as PK is an instruction to
-                        // dial in the wrong filter. An all-pass line carries no gain
-                        // (the filter has none) and drops the Q on a first order,
-                        // which has no Q to dial in.
-                        string tail = peq.Type.IsAllPass()
-                            ? peq.Type == PeqBandType.AllPassFirstOrder
-                                ? string.Empty
-                                : $" Q {Number(peq.Q, "0.0#")}"
-                            : $" Gain {Signed(peq.GainDb)} dB Q {Number(peq.Q, "0.0#")}";
-                        builder.AppendLine(
-                            $"    Filter {band + 1}: ON {PeqTextFile.TypeToken(peq.Type)} " +
-                            $"Fc {Number(peq.FrequencyHz, "0.###")} Hz{tail}");
-                    }
-                }
+            foreach (int i in pairIndices)
+            {
+                AppendPairSections(builder, project, i, qConvention);
             }
         }
 
         return builder.ToString();
+    }
+
+    // The body of one pair's printed sections, shared by the grouped and flat
+    // layouts above so the two cannot come to print a channel differently.
+    private static void AppendPairSections(
+        StringBuilder builder,
+        VirtualCrossoverProjectFile project,
+        int i,
+        PeqQConvention qConvention)
+    {
+        foreach ((VirtualCrossoverChannelSettings channel, string sideSuffix)
+            in SideSections(project.Pairs[i]))
+        {
+            if (!channel.HasSource)
+            {
+                continue;
+            }
+
+            builder.AppendLine();
+            builder.AppendLine(
+                $"Channel {ChannelName(i)}{sideSuffix} — {channel.DisplayName}");
+            // Many DSPs have no separate preamp for their equalizer, so the PEQ preamp
+            // has to be folded into the channel gain when the tune is typed in. The
+            // combined figure rides along on the same line, where it cannot be
+            // mistaken for a second, independent gain to enter.
+            string gainLine = $"  Gain       {Signed(channel.GainDb)} dB";
+            if (channel.PeqPreampDb != 0)
+            {
+                gainLine +=
+                    $"  (with PEQ preamp: {Signed(channel.GainDb + channel.PeqPreampDb)} dB)";
+            }
+
+            builder.AppendLine(gainLine);
+            builder.AppendLine(
+                $"  Delay      {Number(channel.DelayMs, "0.00")} ms" +
+                $"  (= {Number(channel.DelayMs * Acoustics.SpeedOfSoundAt20CMetersPerSecond, "0.#")} mm)");
+            builder.AppendLine(
+                $"  Polarity   {(channel.InvertPolarity ? "Inverted" : "Normal")}");
+            builder.AppendLine($"  Crossover  {DescribeCrossover(channel)}");
+            if (channel.PeqBands.Count > 0 || channel.PeqPreampDb != 0)
+            {
+                builder.AppendLine(
+                    $"  PEQ        {channel.PeqSourceName ?? "custom"}, " +
+                    $"preamp {Signed(channel.PeqPreampDb)} dB");
+                for (int band = 0; band < channel.PeqBands.Count; band++)
+                {
+                    PeqBand peq = PeqQConventions.ToConvention(
+                        channel.PeqBands[band], qConvention);
+                    // The keyword comes from the profile writer rather than being
+                    // spelled here: a shelf printed as PK is an instruction to
+                    // dial in the wrong filter. An all-pass line carries no gain
+                    // (the filter has none) and drops the Q on a first order,
+                    // which has no Q to dial in.
+                    string tail = peq.Type.IsAllPass()
+                        ? peq.Type == PeqBandType.AllPassFirstOrder
+                            ? string.Empty
+                            : $" Q {Number(peq.Q, "0.0#")}"
+                        : $" Gain {Signed(peq.GainDb)} dB Q {Number(peq.Q, "0.0#")}";
+                    builder.AppendLine(
+                        $"    Filter {band + 1}: ON {PeqTextFile.TypeToken(peq.Type)} " +
+                        $"Fc {Number(peq.FrequencyHz, "0.###")} Hz{tail}");
+                }
+            }
+        }
     }
 
     public static string ChannelName(int index) => ((char)('A' + index)).ToString();

--- a/source/Tools/Sheets/VirtualCrossoverSheetGroups.cs
+++ b/source/Tools/Sheets/VirtualCrossoverSheetGroups.cs
@@ -1,0 +1,63 @@
+namespace Resonalyze;
+
+/// <summary>
+/// How the tuning sheet groups a project's channels: one section run per zone,
+/// in the order a tune is typed into a DSP. Pure rules with no rendering, so
+/// the text and PDF sheets cannot come to group the same project differently,
+/// and a test can read the grouping without building either.
+/// </summary>
+internal static class VirtualCrossoverSheetGroups
+{
+    /// <summary>
+    /// The zone order the sheet's sections follow — the order a tune is entered:
+    /// the bass foundation first, then the front stage it hands to, then the
+    /// groups placed against that stage. Deliberately NOT
+    /// <see cref="VirtualCrossoverZones.All"/>, which is the zone SELECTOR's
+    /// order (up the spectrum, then outward from the front stage).
+    /// </summary>
+    public static readonly IReadOnlyList<VirtualCrossoverZone> SectionOrder =
+    [
+        VirtualCrossoverZone.Sub,
+        VirtualCrossoverZone.Front,
+        VirtualCrossoverZone.Rear,
+        VirtualCrossoverZone.Center
+    ];
+
+    /// <summary>
+    /// The participating pairs, grouped by zone and ordered for the sheet.
+    /// Inside a group the pairs keep their panel order, so the block letters
+    /// still read A before B. A pair participates when any side it would print
+    /// has a source — the same rule the sheets apply per channel — and a zone
+    /// with no participants gets no group. A single-zone project comes back as
+    /// its one group, and the sheets print it without any group scaffolding:
+    /// the sheet such a project always had.
+    /// </summary>
+    public static IReadOnlyList<(VirtualCrossoverZone Zone, IReadOnlyList<int> PairIndices)>
+        Sections(VirtualCrossoverProjectFile project)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+
+        var byZone = new Dictionary<VirtualCrossoverZone, List<int>>();
+        for (int i = 0; i < project.Pairs.Count; i++)
+        {
+            if (VirtualCrossoverSheet.SideSections(project.Pairs[i])
+                .Any(section => section.Settings.HasSource))
+            {
+                VirtualCrossoverZone zone = project.Pairs[i].Zone;
+                if (!byZone.TryGetValue(zone, out List<int>? indices))
+                {
+                    indices = [];
+                    byZone[zone] = indices;
+                }
+
+                indices.Add(i);
+            }
+        }
+
+        return SectionOrder
+            .Where(byZone.ContainsKey)
+            .Select(zone =>
+                (zone, (IReadOnlyList<int>)byZone[zone]))
+            .ToList();
+    }
+}

--- a/source/Tools/Sheets/VirtualCrossoverSheetPdf.cs
+++ b/source/Tools/Sheets/VirtualCrossoverSheetPdf.cs
@@ -447,12 +447,10 @@ internal static class VirtualCrossoverSheetPdf
     }
 
     /// <summary>
-    /// One line on a chains graph: the magnitude of the SUM of its chains — a
-    /// channel's own curve is a sum of one. Every chain is taken as its
-    /// DESIGN: delay and polarity stripped (neither moves a single chain's
-    /// magnitude, and folded into a sum they would mix the cabin's timing
-    /// compensation into what this graph shows, which is the filters as typed
-    /// into the DSP — the acoustic summation lives in the app's plot).
+    /// One line on a chains graph: the magnitude of the complex SUM of its
+    /// chains — a channel's own curve is a sum of one. The chains carry
+    /// everything the DSP is told except the delay (see
+    /// <see cref="DesignChain"/>).
     /// </summary>
     internal sealed record ChainCurve(
         string Title,
@@ -470,9 +468,20 @@ internal static class VirtualCrossoverSheetPdf
     private const double CurveThickness = 2;
     private const double SumThickness = 2.5;
 
+    // The chain as the DSP realizes it, less the time compensation. Only the
+    // delay is stripped: it exists to mirror the cabin's path differences, and
+    // folded into a sum it would bury the filter graph in combing. Polarity
+    // STAYS — it is a design term like any filter phase (an LR2 crossover
+    // knits flat only through its deliberate inversion), and the complex sum
+    // already carries every other phase term the chain has (crossover, PEQ,
+    // all-pass), so dropping this one 180° would make the sum neither the
+    // electrical answer nor an envelope. A junction inverted for ACOUSTIC
+    // reasons therefore shows an electrical notch here — honestly: that
+    // junction knits through timing this graph does not model, and the
+    // acoustic summation lives on the panel's plot.
     private static DspChannelChain DesignChain(
         VirtualCrossoverChannelSettings channel) =>
-        channel.ToChain() with { DelayMs = 0, InvertPolarity = false };
+        channel.ToChain() with { DelayMs = 0 };
 
     private static ChainCurve ChannelCurve(SheetEntry entry) =>
         new(

--- a/source/Tools/Sheets/VirtualCrossoverSheetPdf.cs
+++ b/source/Tools/Sheets/VirtualCrossoverSheetPdf.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Numerics;
 using MigraDoc.DocumentObjectModel;
 using MigraDoc.DocumentObjectModel.Tables;
 using OxyPlot;
@@ -8,6 +9,9 @@ using OxyPlot.WindowsForms;
 using Resonalyze.Dsp;
 // Disambiguates against System.Drawing.Color, which the WinForms implicit usings pull in.
 using Color = MigraDoc.DocumentObjectModel.Color;
+// One printed side of a channel pair, as the graphs consume it.
+using SheetEntry = (int Index, string SideSuffix, bool Dashed,
+    Resonalyze.VirtualCrossoverChannelSettings Channel);
 
 namespace Resonalyze;
 
@@ -67,56 +71,120 @@ internal static class VirtualCrossoverSheetPdf
 
         var sheet = new PdfSheet("Virtual DSP", subtitleText, qConvention);
 
-        // Both sides of every pair print in one sheet; a mono pair prints
-        // once. On the graph the right side reuses the pair's hue dashed.
-        var participating =
-            new List<(int Index, string SideSuffix, bool Dashed,
-                VirtualCrossoverChannelSettings Channel)>();
-        for (int i = 0; i < project.Pairs.Count; i++)
+        // One run of sections per zone, in the order a tune is typed into a DSP
+        // (Sub, Front, Rear, Center), each run led by the zone's name and a
+        // graph of ITS chains — a system of a dozen channels on one graph is a
+        // tangle, and a group's is readable. A single-zone project keeps the
+        // flat sheet it always had: one combined graph, no group scaffolding.
+        IReadOnlyList<(VirtualCrossoverZone Zone, IReadOnlyList<int> PairIndices)>
+            sections = VirtualCrossoverSheetGroups.Sections(project);
+        if (sections.Count <= 1)
+        {
+            List<SheetEntry> participating = Participants(
+                project,
+                [.. sections.SelectMany(section => section.PairIndices)]);
+            if (participating.Count > 0)
+            {
+                sheet.AddImage(
+                    RenderPng(BuildChainsModel(
+                        [.. participating.Select(ChannelCurve)], sampleRate)),
+                    Unit.FromCentimeter(17));
+            }
+
+            foreach (int i in sections.SelectMany(section => section.PairIndices))
+            {
+                AddPairOrChannelSections(sheet, project, i);
+            }
+
+            return sheet;
+        }
+
+        // The subwoofer group's chains reappear pale on the FRONT group's graph:
+        // the front chain hands its bass over to those subs, and the handover
+        // cannot be judged on a graph that shows only one side of it.
+        List<SheetEntry> subwooferMembers = [.. sections
+            .Where(section => section.Zone == VirtualCrossoverZone.Sub)
+            .SelectMany(section => Participants(project, section.PairIndices))];
+        foreach ((VirtualCrossoverZone zone, IReadOnlyList<int> pairIndices)
+            in sections)
+        {
+            AddGroupHeading(sheet.Section, VirtualCrossoverZones.DisplayName(zone));
+            sheet.AddImage(
+                RenderPng(BuildChainsModel(
+                    GroupCurves(
+                        zone, Participants(project, pairIndices), subwooferMembers),
+                    sampleRate)),
+                Unit.FromCentimeter(17));
+            foreach (int i in pairIndices)
+            {
+                AddPairOrChannelSections(sheet, project, i);
+            }
+        }
+
+        return sheet;
+    }
+
+    // Both sides of every pair print in one sheet; a mono pair prints once. On
+    // the graphs the right side reuses the pair's hue dashed.
+    private static List<SheetEntry> Participants(
+        VirtualCrossoverProjectFile project,
+        IReadOnlyList<int> pairIndices)
+    {
+        var participants = new List<SheetEntry>();
+        foreach (int i in pairIndices)
         {
             foreach ((VirtualCrossoverChannelSettings channel, string sideSuffix)
                 in VirtualCrossoverSheet.SideSections(project.Pairs[i]))
             {
                 if (channel.HasSource)
                 {
-                    participating.Add(
+                    participants.Add(
                         (i, sideSuffix,
                          sideSuffix == VirtualCrossoverSheet.RightSuffix, channel));
                 }
             }
         }
 
-        if (participating.Count > 0)
+        return participants;
+    }
+
+    // A stereo pair with both sides loaded prints as ONE section with an
+    // L/R value table — the two sides of a pair are dialed in together,
+    // so their numbers belong side by side. A mono pair (or a pair with
+    // one loaded side) keeps the single-channel layout.
+    private static void AddPairOrChannelSections(
+        PdfSheet sheet,
+        VirtualCrossoverProjectFile project,
+        int i)
+    {
+        VirtualCrossoverChannelPairSettings pair = project.Pairs[i];
+        if (!pair.Mono && pair.Left.HasSource && pair.Right.HasSource)
         {
-            sheet.AddImage(
-                RenderChainsGraph(participating, sampleRate),
-                Unit.FromCentimeter(17));
+            AddPairSection(sheet, i, pair.Left, pair.Right);
+            return;
         }
 
-        // A stereo pair with both sides loaded prints as ONE section with an
-        // L/R value table — the two sides of a pair are dialed in together,
-        // so their numbers belong side by side. A mono pair (or a pair with
-        // one loaded side) keeps the single-channel layout.
-        for (int i = 0; i < project.Pairs.Count; i++)
+        foreach ((VirtualCrossoverChannelSettings channel, string sideSuffix)
+            in VirtualCrossoverSheet.SideSections(pair))
         {
-            VirtualCrossoverChannelPairSettings pair = project.Pairs[i];
-            if (!pair.Mono && pair.Left.HasSource && pair.Right.HasSource)
+            if (channel.HasSource)
             {
-                AddPairSection(sheet, i, pair.Left, pair.Right);
-                continue;
-            }
-
-            foreach ((VirtualCrossoverChannelSettings channel, string sideSuffix)
-                in VirtualCrossoverSheet.SideSections(pair))
-            {
-                if (channel.HasSource)
-                {
-                    AddChannelSection(sheet, i, sideSuffix, channel);
-                }
+                AddChannelSection(sheet, i, sideSuffix, channel);
             }
         }
+    }
 
-        return sheet;
+    // The zone's name above its run of channel sections — a tier above the
+    // channel headings (15 pt), so the sheet's two levels read at a glance.
+    private static void AddGroupHeading(Section section, string title)
+    {
+        Paragraph heading = section.AddParagraph(title);
+        heading.Format.Font.Bold = true;
+        heading.Format.Font.Size = 19;
+        heading.Format.SpaceBefore = Unit.FromMillimeter(7);
+        heading.Format.SpaceAfter = Unit.FromMillimeter(1);
+        // Never break between the group's name and the graph it introduces.
+        heading.Format.KeepWithNext = true;
     }
 
     private static void AddPairSection(
@@ -359,12 +427,119 @@ internal static class VirtualCrossoverSheetPdf
         WriteValue(row.Cells[1], value, valueColor);
     }
 
-    // A compact white graph of every participating channel side's DSP chain
-    // magnitude (gain + crossover + PEQ; the delay has no magnitude effect).
+    /// <summary>
+    /// One line on a chains graph: the magnitude of the SUM of its chains — a
+    /// channel's own curve is a sum of one. Every chain is taken as its
+    /// DESIGN: delay and polarity stripped (neither moves a single chain's
+    /// magnitude, and folded into a sum they would mix the cabin's timing
+    /// compensation into what this graph shows, which is the filters as typed
+    /// into the DSP — the acoustic summation lives in the app's plot).
+    /// </summary>
+    internal sealed record ChainCurve(
+        string Title,
+        OxyColor Color,
+        LineStyle Style,
+        double Thickness,
+        IReadOnlyList<DspChannelChain> Chains);
+
+    // The neutral tones of the sum curves: dark for the group's own sum, pale
+    // for the subwoofer context on the front graph — context must never compete
+    // with the channels the graph is about.
+    private static readonly OxyColor SumColor = OxyColor.FromRgb(0x38, 0x38, 0x38);
+    private static readonly OxyColor SubContextColor =
+        OxyColor.FromRgb(0xB4, 0xB4, 0xB4);
+    private const double CurveThickness = 2;
+    private const double SumThickness = 2.5;
+
+    private static DspChannelChain DesignChain(
+        VirtualCrossoverChannelSettings channel) =>
+        channel.ToChain() with { DelayMs = 0, InvertPolarity = false };
+
+    private static ChainCurve ChannelCurve(SheetEntry entry) =>
+        new(
+            $"Channel {VirtualCrossoverSheet.ChannelName(entry.Index)}{entry.SideSuffix}",
+            ChainColors[entry.Index % ChainColors.Length],
+            entry.Dashed ? LineStyle.Dash : LineStyle.Solid,
+            CurveThickness,
+            [DesignChain(entry.Channel)]);
+
+    /// <summary>
+    /// The curves of ONE group's graph: every member's own chain; the group's
+    /// design sum per side — drawn only where a side has at least two chains
+    /// to sum (a sum of one would retrace the channel), and never for the
+    /// centre, whose signal is derived from L and R so no sum involving it is
+    /// honest; and, on the front group, the subwoofer group's sum in a pale
+    /// tone as context for the bass handover.
+    /// </summary>
+    internal static IReadOnlyList<ChainCurve> GroupCurves(
+        VirtualCrossoverZone zone,
+        IReadOnlyList<SheetEntry> members,
+        IReadOnlyList<SheetEntry> subwooferMembers)
+    {
+        var curves = new List<ChainCurve>(members.Select(ChannelCurve));
+        if (zone != VirtualCrossoverZone.Center)
+        {
+            AddSumCurves(curves, members, "Sum", SumColor, requireTwo: true);
+        }
+
+        if (zone == VirtualCrossoverZone.Front)
+        {
+            AddSumCurves(
+                curves, subwooferMembers, "Sub sum", SubContextColor,
+                requireTwo: false);
+        }
+
+        return curves;
+    }
+
+    // A sum is per SIDE — left and right carry different programs, so one line
+    // through both would be the comb-filter fiction this tool refuses
+    // everywhere. Mono members feed both sides identically; a group of nothing
+    // but mono members has one sum, not two copies of it.
+    private static void AddSumCurves(
+        List<ChainCurve> curves,
+        IReadOnlyList<SheetEntry> members,
+        string title,
+        OxyColor color,
+        bool requireTwo)
+    {
+        List<DspChannelChain> SideChains(string excludedSuffix) =>
+            [.. members
+                .Where(member => member.SideSuffix != excludedSuffix)
+                .Select(member => DesignChain(member.Channel))];
+
+        List<DspChannelChain> left = SideChains(VirtualCrossoverSheet.RightSuffix);
+        List<DspChannelChain> right = SideChains(VirtualCrossoverSheet.LeftSuffix);
+        int floor = requireTwo ? 2 : 1;
+        if (members.All(member =>
+            member.SideSuffix == VirtualCrossoverSheet.MonoSuffix))
+        {
+            if (left.Count >= floor)
+            {
+                curves.Add(new ChainCurve(
+                    title, color, LineStyle.Solid, SumThickness, left));
+            }
+
+            return;
+        }
+
+        if (left.Count >= floor)
+        {
+            curves.Add(new ChainCurve(
+                $"{title} L", color, LineStyle.Solid, SumThickness, left));
+        }
+
+        if (right.Count >= floor)
+        {
+            curves.Add(new ChainCurve(
+                $"{title} R", color, LineStyle.Dash, SumThickness, right));
+        }
+    }
+
+    // A compact white graph of DSP chain magnitudes (gain + crossover + PEQ).
     // Left and right sides of one pair share a hue; the right side is dashed.
-    private static byte[] RenderChainsGraph(
-        IReadOnlyList<(int Index, string SideSuffix, bool Dashed,
-            VirtualCrossoverChannelSettings Channel)> channels,
+    internal static PlotModel BuildChainsModel(
+        IReadOnlyList<ChainCurve> curves,
         int sampleRate)
     {
         IReadOnlyList<double> grid = EqualizationCurve.LogFrequencyGrid(20, 20_000, 200);
@@ -378,9 +553,15 @@ internal static class VirtualCrossoverSheetPdf
         };
         // OxyPlot 2.x renders no legend unless one is explicitly added; the
         // per-series channel titles were invisible in the exported sheet.
+        // The legend lives OUTSIDE the plot area, laid out in rows below it:
+        // inside it is an opaque box, and on a real car's front group it sat
+        // exactly where the tweeters and the sums run (~0 dB, upper right),
+        // hiding everything above the last crossover corner.
         model.Legends.Add(new OxyPlot.Legends.Legend
         {
-            LegendPosition = OxyPlot.Legends.LegendPosition.TopRight,
+            LegendPlacement = OxyPlot.Legends.LegendPlacement.Outside,
+            LegendPosition = OxyPlot.Legends.LegendPosition.BottomCenter,
+            LegendOrientation = OxyPlot.Legends.LegendOrientation.Horizontal,
             LegendTextColor = OxyColors.Black,
             LegendBorder = OxyColors.Gray,
             LegendBackground = OxyColors.White
@@ -388,21 +569,24 @@ internal static class VirtualCrossoverSheetPdf
 
         double minDb = -6;
         double maxDb = 6;
-        foreach ((int index, string sideSuffix, bool dashed,
-            VirtualCrossoverChannelSettings channel) in channels)
+        foreach (ChainCurve curve in curves)
         {
-            DspChannelChain chain = channel.ToChain() with { DelayMs = 0 };
             var series = new LineSeries
             {
-                Color = ChainColors[index % ChainColors.Length],
-                StrokeThickness = 2,
-                LineStyle = dashed ? LineStyle.Dash : LineStyle.Solid,
-                Title = $"Channel {VirtualCrossoverSheet.ChannelName(index)}{sideSuffix}"
+                Color = curve.Color,
+                StrokeThickness = curve.Thickness,
+                LineStyle = curve.Style,
+                Title = curve.Title
             };
             foreach (double frequency in grid)
             {
-                double db = DataHelper.AmplitudeToDecibels(
-                    chain.Response(frequency, sampleRate).Magnitude);
+                Complex response = Complex.Zero;
+                foreach (DspChannelChain chain in curve.Chains)
+                {
+                    response += chain.Response(frequency, sampleRate);
+                }
+
+                double db = DataHelper.AmplitudeToDecibels(response.Magnitude);
                 series.Points.Add(new DataPoint(frequency, db));
                 if (db > -70)
                 {
@@ -437,7 +621,14 @@ internal static class VirtualCrossoverSheetPdf
             Unit = "dB"
         });
 
-        var exporter = new PngExporter { Width = 900, Height = 280 };
+        return model;
+    }
+
+    private static byte[] RenderPng(PlotModel model)
+    {
+        // A little taller than the old 280: the legend now takes rows under
+        // the plot area rather than a box inside it.
+        var exporter = new PngExporter { Width = 900, Height = 330 };
         using var stream = new MemoryStream();
         exporter.Export(model, stream);
         return stream.ToArray();

--- a/source/Tools/Sheets/VirtualCrossoverSheetPdf.cs
+++ b/source/Tools/Sheets/VirtualCrossoverSheetPdf.cs
@@ -105,10 +105,21 @@ internal static class VirtualCrossoverSheetPdf
         List<SheetEntry> subwooferMembers = [.. sections
             .Where(section => section.Zone == VirtualCrossoverZone.Sub)
             .SelectMany(section => Participants(project, section.PairIndices))];
+        bool firstGroup = true;
         foreach ((VirtualCrossoverZone zone, IReadOnlyList<int> pairIndices)
             in sections)
         {
-            AddGroupHeading(sheet.Section, VirtualCrossoverZones.DisplayName(zone));
+            // Every group after the first starts a page of its own: the sheet
+            // is read standing at the DSP one group at a time, and a page that
+            // begins with the group's name and graph needs no scrolling back to
+            // see which zone the values belong to. The first group stays on the
+            // title page — breaking before it would leave that page holding
+            // nothing but the banner.
+            AddGroupHeading(
+                sheet.Section,
+                VirtualCrossoverZones.DisplayName(zone),
+                newPage: !firstGroup);
+            firstGroup = false;
             sheet.AddImage(
                 RenderPng(BuildChainsModel(
                     GroupCurves(
@@ -174,13 +185,21 @@ internal static class VirtualCrossoverSheetPdf
         }
     }
 
+    // The size of a group heading: well above the channel headings (15 pt) and
+    // just under the document title (24 pt), so a page's first glance says
+    // which zone it belongs to. A named constant because the tests find the
+    // group headings BY this size — a literal changed in one place would make
+    // them silently find nothing.
+    internal const int GroupHeadingPointSize = 22;
+
     // The zone's name above its run of channel sections — a tier above the
-    // channel headings (15 pt), so the sheet's two levels read at a glance.
-    private static void AddGroupHeading(Section section, string title)
+    // channel headings, so the sheet's two levels read at a glance.
+    private static void AddGroupHeading(Section section, string title, bool newPage)
     {
         Paragraph heading = section.AddParagraph(title);
         heading.Format.Font.Bold = true;
-        heading.Format.Font.Size = 19;
+        heading.Format.Font.Size = GroupHeadingPointSize;
+        heading.Format.PageBreakBefore = newPage;
         heading.Format.SpaceBefore = Unit.FromMillimeter(7);
         heading.Format.SpaceAfter = Unit.FromMillimeter(1);
         // Never break between the group's name and the graph it introduces.

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -1397,6 +1397,15 @@ public partial class VirtualCrossoverPanel : UserControl
     /// </summary>
     private int ProcessorSampleRateHz => ProcessorProfile.SampleRateHz;
 
+    /// <summary>
+    /// The per-channel delay ceiling of the processor being designed for: a catalog
+    /// entry that states its manual's figure answers with it, everything else with
+    /// the engine's long-standing default. Read wherever an automatic proposal
+    /// judges whether it can be dialed in; the MANUAL delay fields deliberately
+    /// keep their wider range, since the Virtual DSP may model any hardware.
+    /// </summary>
+    private double ProcessorMaxDelayMs => ProcessorProfile.MaxDelayMs;
+
     private bool ProcessorRateFollowsMeasurements =>
         project.DspProcessorRateFollowsMeasurements;
 
@@ -4681,7 +4690,10 @@ public partial class VirtualCrossoverPanel : UserControl
     // timed against its own side's front stage, so the rear inherits the front's
     // L/R relation rather than being forced to one delay. The centre has no side
     // and is placed between both.
-    private void PlaceLaterStagesStereo(
+    // Returns the channels that CARRY the rear-fill offset — the placed members
+    // of the rear stage — so the normalization pass can work out how much fill
+    // would fit when the finished figure does not.
+    private IReadOnlyCollection<IAlignmentChannel> PlaceLaterStagesStereo(
         IReadOnlyList<VirtualCrossoverSideAlignmentChannel> chainReference,
         IReadOnlyList<VirtualCrossoverSideAlignmentChannel> chainFar,
         IReadOnlyList<VirtualCrossoverSideAlignmentChannel> later,
@@ -4693,6 +4705,7 @@ public partial class VirtualCrossoverPanel : UserControl
         bool rightHandDrive,
         System.Text.StringBuilder log)
     {
+        var fillCarriers = new List<IAlignmentChannel>();
         IReadOnlyList<AlignmentSnapshot> settled = reprocessor.Reprocess(alignment);
         Dictionary<IAlignmentChannel, AlignmentSnapshot> byChannel =
             settled.ToDictionary(snapshot => snapshot.Channel);
@@ -4791,6 +4804,7 @@ public partial class VirtualCrossoverPanel : UserControl
                 continue;
             }
 
+            fillCarriers.AddRange(members);
             double delayMs = placement.CoArrivalDelayMs + rearFillOffsetMs;
             bool invert = rearFillOffsetMs < HaasPolarityIrrelevantMs &&
                 placement.Inverted;
@@ -4881,7 +4895,7 @@ public partial class VirtualCrossoverPanel : UserControl
                         "against both front stages, so the current delay stands");
                 }
 
-                return;
+                return fillCarriers;
             }
 
             (double delayMs, bool inverted, bool confident) =
@@ -4919,6 +4933,8 @@ public partial class VirtualCrossoverPanel : UserControl
                             "so this placement is a best guess"));
             }
         }
+
+        return fillCarriers;
     }
 
     /// <summary>
@@ -5089,7 +5105,10 @@ public partial class VirtualCrossoverPanel : UserControl
     // Each later group gets ONE delay for all its members: the placement is a
     // property of where the group sits in the car, and it is applied to the group
     // as a rigid body so nothing inside it is re-tuned by this pass.
-    private void PlaceLaterStages(
+    // Returns the channels that CARRY the rear-fill offset — the placed members
+    // of the rear stage — so the normalization pass can work out how much fill
+    // would fit when the finished figure does not.
+    private IReadOnlyCollection<IAlignmentChannel> PlaceLaterStages(
         IReadOnlyList<VirtualCrossoverChannel> chain,
         IReadOnlyList<VirtualCrossoverChannel> later,
         AlignmentReprocessor reprocessor,
@@ -5098,6 +5117,7 @@ public partial class VirtualCrossoverPanel : UserControl
         double rearFillOffsetMs,
         System.Text.StringBuilder log)
     {
+        var fillCarriers = new List<IAlignmentChannel>();
         IReadOnlyList<AlignmentSnapshot> settled = reprocessor.Reprocess(alignment);
         Dictionary<IAlignmentChannel, AlignmentSnapshot> byChannel =
             settled.ToDictionary(snapshot => snapshot.Channel);
@@ -5172,6 +5192,11 @@ public partial class VirtualCrossoverPanel : UserControl
             double offsetMs = stage == VirtualCrossoverAlignmentStage.Rear
                 ? rearFillOffsetMs
                 : 0.0;
+            if (stage == VirtualCrossoverAlignmentStage.Rear)
+            {
+                fillCarriers.AddRange(members);
+            }
+
             double delayMs = placement.CoArrivalDelayMs + offsetMs;
             bool invert = offsetMs < HaasPolarityIrrelevantMs && placement.Inverted;
             log.AppendLine(
@@ -5203,6 +5228,8 @@ public partial class VirtualCrossoverPanel : UserControl
                     (offsetMs != 0 ? $", held back {offsetMs:0.##} ms" : string.Empty));
             }
         }
+
+        return fillCarriers;
     }
 
     // Every channel slid together until the earliest sits at zero. The stages
@@ -5219,31 +5246,110 @@ public partial class VirtualCrossoverPanel : UserControl
     // around it - a rigid-body shift that is not rigid, and the one relation in
     // the whole run that must not change. So every participant is read here, an
     // absent one as zero, and every participant is written back.
+    //
+    // The ceiling verdict after the shift is unconditional — a rear fill can push
+    // the LATEST channel past the processor's range without any channel having
+    // gone negative, so it cannot ride on whether a shift happened. And because
+    // the fill is the one number in the whole proposal that is preference rather
+    // than physics, a refusal works out the largest fill that WOULD fit and says
+    // so, instead of leaving the user to bisect it by rerunning.
     internal static void NormalizeStagedDelays(
         IReadOnlyList<IAlignmentChannel> scope,
         Dictionary<IAlignmentChannel, AlignmentOverride> alignment,
-        System.Text.StringBuilder log)
+        System.Text.StringBuilder log,
+        double maxDelayMs = AutoAlignmentEngine.DefaultMaxDelayMs,
+        double rearFillOffsetMs = 0,
+        IReadOnlyCollection<IAlignmentChannel>? rearFillCarriers = null)
     {
         if (scope.Count == 0)
         {
             return;
         }
 
-        double minimum = scope.Min(
+        // The raw placements, kept from before the shift: the fill scan below
+        // judges each trial span with min(0, minimum) folded in, which a uniform
+        // shift already applied to the map would double-count.
+        Dictionary<IAlignmentChannel, double> raw = scope.Distinct().ToDictionary(
+            channel => channel,
             channel => alignment.GetValueOrDefault(channel).DelayMs);
-        if (minimum >= 0)
+
+        double minimum = raw.Values.Min();
+        if (minimum < 0)
+        {
+            log.AppendLine(
+                $"  normalization: every channel shifted +{-minimum:0.00} ms so the " +
+                "earliest sits at zero.");
+            foreach (IAlignmentChannel channel in raw.Keys)
+            {
+                AlignmentOverride over = alignment.GetValueOrDefault(channel);
+                alignment[channel] = over with { DelayMs = over.DelayMs - minimum };
+            }
+        }
+
+        IAlignmentChannel widest = raw.Keys.MaxBy(
+            channel => alignment.GetValueOrDefault(channel).DelayMs)!;
+        double widestDelayMs = alignment.GetValueOrDefault(widest).DelayMs;
+        if (widestDelayMs <= maxDelayMs + 0.005)
         {
             return;
         }
 
-        log.AppendLine(
-            $"  normalization: every channel shifted +{-minimum:0.00} ms so the " +
-            "earliest sits at zero.");
-        foreach (IAlignmentChannel channel in scope)
+        string message =
+            "The staged alignment does not fit the DSP delay range: " +
+            $"{widest.Name} needs {widestDelayMs:0.00} ms with the earliest " +
+            $"channel at 0, but the limit is {maxDelayMs:0.##} ms.";
+        message += LargestFittingRearFill(
+                raw, rearFillCarriers, rearFillOffsetMs, maxDelayMs)
+            is double fittingMs
+            ? $" The {rearFillOffsetMs:0.##} ms rear fill is what pushes it past " +
+                $"the range: up to {fittingMs:0.##} ms of fill fits — lower " +
+                "Rear fill in the dialog and rerun."
+            : " The spread between the earliest and latest channels is wider " +
+                "than the DSP can realize.";
+        throw new InvalidOperationException(message);
+    }
+
+    // The largest rear fill the processor's delay range can hold, on the DSP's
+    // own 0.01 ms grid. Found by walking DOWN from the requested fill rather
+    // than solved in closed form, because the dialable span is not monotone in
+    // the fill: a rear group whose co-arrival placement came out negative first
+    // CLOSES the span as the fill grows (the fill lifts it toward zero) and only
+    // then widens it. Null when no fill was in play, or when even a fill of zero
+    // leaves the spread past the ceiling — then the fill is not the story and
+    // the refusal must not pretend lowering it would help.
+    private static double? LargestFittingRearFill(
+        IReadOnlyDictionary<IAlignmentChannel, double> raw,
+        IReadOnlyCollection<IAlignmentChannel>? carriers,
+        double requestedFillMs,
+        double maxDelayMs)
+    {
+        if (carriers == null || carriers.Count == 0 || requestedFillMs <= 0)
         {
-            AlignmentOverride over = alignment.GetValueOrDefault(channel);
-            alignment[channel] = over with { DelayMs = over.DelayMs - minimum };
+            return null;
         }
+
+        for (double fillMs = Math.Floor(requestedFillMs * 100) / 100;
+            fillMs >= 0;
+            fillMs = Math.Round(fillMs - 0.01, 2))
+        {
+            double minMs = double.MaxValue;
+            double maxMs = double.MinValue;
+            foreach ((IAlignmentChannel channel, double delayMs) in raw)
+            {
+                double trialMs = carriers.Contains(channel)
+                    ? delayMs - requestedFillMs + fillMs
+                    : delayMs;
+                minMs = Math.Min(minMs, trialMs);
+                maxMs = Math.Max(maxMs, trialMs);
+            }
+
+            if (maxMs - Math.Min(0, minMs) <= maxDelayMs + 0.005)
+            {
+                return fillMs;
+            }
+        }
+
+        return null;
     }
 
     private async Task<AutoDelayRunResult> RunSingleSideProposalAsync(
@@ -5278,12 +5384,15 @@ public partial class VirtualCrossoverPanel : UserControl
                 walkSet: later.Count > 0 ? chain : null);
             if (later.Count > 0)
             {
-                // Stages 2 and 3, then the shift that makes the lot dialable.
-                PlaceLaterStages(
-                    chain, later, reprocessor, alignment, decisions,
-                    request.RearFillOffsetMs, log);
+                // Stages 2 and 3, then the shift that makes the lot dialable —
+                // judged against the processor's own delay ceiling.
+                IReadOnlyCollection<IAlignmentChannel> fillCarriers =
+                    PlaceLaterStages(
+                        chain, later, reprocessor, alignment, decisions,
+                        request.RearFillOffsetMs, log);
                 NormalizeStagedDelays(
-                    [.. participants.Cast<IAlignmentChannel>()], alignment, log);
+                    [.. participants.Cast<IAlignmentChannel>()], alignment, log,
+                    ProcessorMaxDelayMs, request.RearFillOffsetMs, fillCarriers);
             }
 
             // The "before" snapshots carry the CURRENT delays and polarities —
@@ -5638,7 +5747,8 @@ public partial class VirtualCrossoverPanel : UserControl
             reprocessor.Reprocess,
             alignment,
             log,
-            decisions);
+            decisions,
+            maxDelayMs: ProcessorMaxDelayMs);
         return reprocessor;
     }
 
@@ -5894,19 +6004,21 @@ public partial class VirtualCrossoverPanel : UserControl
                 // Stages 2 and 3 read the sides in the engine's own ROLES, so a
                 // right-hand-drive run places its groups against the same
                 // reference the walk settled rather than against the mirror.
-                PlaceLaterStagesStereo(
-                    request.RightHandDrive ? chainRight : chainLeft,
-                    request.RightHandDrive ? chainLeft : chainRight,
-                    later,
-                    reprocessor,
-                    engineAlignment,
-                    decisions,
-                    request.SceneOffsetMs,
-                    request.RearFillOffsetMs,
-                    request.RightHandDrive,
-                    log);
+                IReadOnlyCollection<IAlignmentChannel> fillCarriers =
+                    PlaceLaterStagesStereo(
+                        request.RightHandDrive ? chainRight : chainLeft,
+                        request.RightHandDrive ? chainLeft : chainRight,
+                        later,
+                        reprocessor,
+                        engineAlignment,
+                        decisions,
+                        request.SceneOffsetMs,
+                        request.RearFillOffsetMs,
+                        request.RightHandDrive,
+                        log);
                 NormalizeStagedDelays(
-                    [.. union.Cast<IAlignmentChannel>()], engineAlignment, log);
+                    [.. union.Cast<IAlignmentChannel>()], engineAlignment, log,
+                    ProcessorMaxDelayMs, request.RearFillOffsetMs, fillCarriers);
             }
 
             // The "before" snapshots carry the CURRENT delays and polarities —
@@ -6092,7 +6204,8 @@ public partial class VirtualCrossoverPanel : UserControl
             reprocessor.Reprocess,
             alignment,
             log,
-            decisions);
+            decisions,
+            maxDelayMs: ProcessorMaxDelayMs);
         return reprocessor;
     }
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverZone.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverZone.cs
@@ -54,8 +54,10 @@ public enum VirtualCrossoverZone
 public static class VirtualCrossoverZones
 {
     /// <summary>
-    /// The zones in the order the UI lists them and the tuning sheet sections
-    /// follow — up the spectrum, then outward from the front stage.
+    /// The zones in the order the UI lists them — up the spectrum, then outward
+    /// from the front stage. The tuning sheet deliberately does NOT follow this:
+    /// its sections run in the order a tune is typed into a DSP
+    /// (<see cref="VirtualCrossoverSheetGroups.SectionOrder"/>).
     /// </summary>
     public static readonly IReadOnlyList<VirtualCrossoverZone> All =
     [

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
@@ -423,6 +423,195 @@ public sealed class VirtualCrossoverSheetPdfTests
         return builder.ToString();
     }
 
+    [Fact]
+    public void Build_GroupedProject_LeadsEachZoneWithItsNameAndItsOwnGraph()
+    {
+        using PdfSheet sheet = VirtualCrossoverSheetPdf.Build(
+            VirtualCrossoverSheetTests.GroupedProject(), null, 48_000);
+
+        // The walk of the document in order: every group heading (the only
+        // 19 pt paragraphs on the sheet) and every graph image. Each zone's
+        // name must be followed by its graph — Sub first, the order a tune is
+        // typed into a DSP — regardless of whether the banner image loaded.
+        List<string> walk = HeadingsAndImages(sheet.Document);
+        int start = walk.IndexOf("Sub");
+        Assert.True(start >= 0, "the Sub group heading is missing");
+        Assert.Equal(
+            ["Sub", "image", "Front", "image", "Rear", "image", "Center", "image"],
+            walk.Skip(start));
+    }
+
+    [Fact]
+    public void Build_SingleZoneProject_KeepsTheFlatSheetItAlwaysHad()
+    {
+        var project = new VirtualCrossoverProjectFile();
+        project.Pairs[0].Left.SourceFilePath = "l.json";
+        project.Pairs[0].Left.DisplayName = "L";
+        project.Pairs[0].Right.SourceFilePath = "r.json";
+        project.Pairs[0].Right.DisplayName = "R";
+
+        using PdfSheet sheet = VirtualCrossoverSheetPdf.Build(project, null, 48_000);
+
+        List<string> walk = HeadingsAndImages(sheet.Document);
+        // No group headings, and one combined graph (any image before it is
+        // the product banner, which renders only when its asset is present).
+        Assert.DoesNotContain("Sub", walk);
+        Assert.DoesNotContain("Front", walk);
+        Assert.InRange(walk.Count(item => item == "image"), 1, 2);
+    }
+
+    private static VirtualCrossoverChannelSettings Loaded(
+        string name, double gainDb = 0)
+        => new() { SourceFilePath = name, DisplayName = name, GainDb = gainDb };
+
+    [Fact]
+    public void GroupCurves_SumsPerSide_AndPutsTheSubContextOnTheFrontGraph()
+    {
+        // Two stereo front pairs: each side has two chains to sum, so the
+        // group gets a solid left sum and a dashed right sum — and, being the
+        // front group, the subwoofer group's sum rides along in a pale tone.
+        (int, string, bool, VirtualCrossoverChannelSettings)[] front =
+        [
+            (0, VirtualCrossoverSheet.LeftSuffix, false, Loaded("mid L")),
+            (0, VirtualCrossoverSheet.RightSuffix, true, Loaded("mid R")),
+            (1, VirtualCrossoverSheet.LeftSuffix, false, Loaded("tw L")),
+            (1, VirtualCrossoverSheet.RightSuffix, true, Loaded("tw R"))
+        ];
+        (int, string, bool, VirtualCrossoverChannelSettings)[] subs =
+        [
+            (3, VirtualCrossoverSheet.MonoSuffix, false, Loaded("sub"))
+        ];
+
+        IReadOnlyList<VirtualCrossoverSheetPdf.ChainCurve> curves =
+            VirtualCrossoverSheetPdf.GroupCurves(
+                VirtualCrossoverZone.Front, front, subs);
+
+        Assert.Equal(4, curves.Count(curve => curve.Title.StartsWith("Channel")));
+        VirtualCrossoverSheetPdf.ChainCurve sumLeft =
+            Assert.Single(curves, curve => curve.Title == "Sum L");
+        VirtualCrossoverSheetPdf.ChainCurve sumRight =
+            Assert.Single(curves, curve => curve.Title == "Sum R");
+        Assert.Equal(2, sumLeft.Chains.Count);
+        Assert.Equal(2, sumRight.Chains.Count);
+        Assert.Equal(OxyPlot.LineStyle.Solid, sumLeft.Style);
+        Assert.Equal(OxyPlot.LineStyle.Dash, sumRight.Style);
+
+        // The lone mono sub still shows on the front graph — it is context for
+        // the bass handover, not a member — visibly paler than the group's own
+        // sum so it cannot compete with the channels the graph is about.
+        VirtualCrossoverSheetPdf.ChainCurve subContext =
+            Assert.Single(curves, curve => curve.Title == "Sub sum");
+        Assert.Single(subContext.Chains);
+        Assert.True(subContext.Color.R > sumLeft.Color.R,
+            "the sub context must be paler than the group sum");
+    }
+
+    [Fact]
+    public void GroupCurves_DrawsNoSum_ForTheCentreOrForASumOfOne()
+    {
+        // The centre's signal is derived from L and R, so no sum involving it
+        // is honest — even a two-way centre's graph shows chains only.
+        (int, string, bool, VirtualCrossoverChannelSettings)[] centre =
+        [
+            (2, VirtualCrossoverSheet.MonoSuffix, false, Loaded("centre lo")),
+            (3, VirtualCrossoverSheet.MonoSuffix, false, Loaded("centre hi"))
+        ];
+        Assert.DoesNotContain(
+            VirtualCrossoverSheetPdf.GroupCurves(
+                VirtualCrossoverZone.Center, centre, []),
+            curve => curve.Title.Contains("Sum"));
+
+        // And a rear of one stereo pair has one chain per side: its "sum"
+        // would retrace the channel, so none is drawn.
+        (int, string, bool, VirtualCrossoverChannelSettings)[] rear =
+        [
+            (1, VirtualCrossoverSheet.LeftSuffix, false, Loaded("rear L")),
+            (1, VirtualCrossoverSheet.RightSuffix, true, Loaded("rear R"))
+        ];
+        Assert.DoesNotContain(
+            VirtualCrossoverSheetPdf.GroupCurves(
+                VirtualCrossoverZone.Rear, rear, []),
+            curve => curve.Title.Contains("Sum"));
+    }
+
+    [Fact]
+    public void GroupCurves_AGroupOfMonoMembers_GetsOneSumRatherThanTwoCopies()
+    {
+        // Two mono subs dividing the bottom: both feed both sides identically,
+        // so the left and right "sums" would be the same line twice.
+        (int, string, bool, VirtualCrossoverChannelSettings)[] subs =
+        [
+            (3, VirtualCrossoverSheet.MonoSuffix, false, Loaded("rear sub")),
+            (4, VirtualCrossoverSheet.MonoSuffix, false, Loaded("front sub"))
+        ];
+
+        IReadOnlyList<VirtualCrossoverSheetPdf.ChainCurve> curves =
+            VirtualCrossoverSheetPdf.GroupCurves(
+                VirtualCrossoverZone.Sub, subs, subs);
+
+        VirtualCrossoverSheetPdf.ChainCurve sum =
+            Assert.Single(curves, curve => curve.Title == "Sum");
+        Assert.Equal(2, sum.Chains.Count);
+    }
+
+    [Fact]
+    public void BuildChainsModel_ASumCurve_IsTheComplexSumOfItsChains()
+    {
+        // Two identical flat chains sum to double the pressure: +6.02 dB, not
+        // the +3 dB a power sum would claim. Pinned numerically so the sum
+        // stays a COMPLEX sum of the chain responses.
+        var chain = new VirtualCrossoverChannelSettings().ToChain()
+            with { DelayMs = 0 };
+        var curve = new VirtualCrossoverSheetPdf.ChainCurve(
+            "Sum", OxyPlot.OxyColors.Black, OxyPlot.LineStyle.Solid, 2,
+            [chain, chain]);
+
+        OxyPlot.PlotModel model =
+            VirtualCrossoverSheetPdf.BuildChainsModel([curve], 48_000);
+
+        var series = (OxyPlot.Series.LineSeries)Assert.Single(model.Series);
+        Assert.All(series.Points, point => Assert.Equal(6.0206, point.Y, 3));
+    }
+
+    // The document in reading order, reduced to what the grouped layout is
+    // about: each group heading (the only 19 pt paragraphs on the sheet) as its
+    // text, and each image as "image".
+    private static List<string> HeadingsAndImages(Document document)
+    {
+        var walk = new List<string>();
+        DocumentElements elements = document.LastSection.Elements;
+        for (int i = 0; i < elements.Count; i++)
+        {
+            if (elements[i] is not Paragraph paragraph)
+            {
+                continue;
+            }
+
+            bool holdsImage = false;
+            for (int j = 0; j < paragraph.Elements.Count; j++)
+            {
+                if (paragraph.Elements[j]
+                    is MigraDoc.DocumentObjectModel.Shapes.Image)
+                {
+                    holdsImage = true;
+                }
+            }
+
+            if (holdsImage)
+            {
+                walk.Add("image");
+            }
+            else if (paragraph.Format.Font.Size == Unit.FromPoint(19))
+            {
+                var builder = new StringBuilder();
+                AppendParagraphText(paragraph, builder);
+                walk.Add(builder.ToString());
+            }
+        }
+
+        return walk;
+    }
+
     private static IEnumerable<Table> PairTables(Document document)
     {
         DocumentElements elements = document.LastSection.Elements;

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
@@ -430,7 +430,7 @@ public sealed class VirtualCrossoverSheetPdfTests
             VirtualCrossoverSheetTests.GroupedProject(), null, 48_000);
 
         // The walk of the document in order: every group heading (the only
-        // 19 pt paragraphs on the sheet) and every graph image. Each zone's
+        // group-heading-sized paragraphs on the sheet) and every graph image. Each zone's
         // name must be followed by its graph — Sub first, the order a tune is
         // typed into a DSP — regardless of whether the banner image loaded.
         List<string> walk = HeadingsAndImages(sheet.Document);
@@ -439,6 +439,39 @@ public sealed class VirtualCrossoverSheetPdfTests
         Assert.Equal(
             ["Sub", "image", "Front", "image", "Rear", "image", "Center", "image"],
             walk.Skip(start));
+    }
+
+    [Fact]
+    public void Build_GroupedProject_StartsEveryGroupAfterTheFirstOnItsOwnPage()
+    {
+        // The sheet is read standing at the DSP one group at a time, so each
+        // group opens a page of its own — except the first, which stays on the
+        // title page rather than leaving it holding nothing but the banner.
+        using PdfSheet sheet = VirtualCrossoverSheetPdf.Build(
+            VirtualCrossoverSheetTests.GroupedProject(), null, 48_000);
+
+        List<Paragraph> headings = GroupHeadings(sheet.Document);
+        Assert.Equal(4, headings.Count);
+        Assert.False(headings[0].Format.PageBreakBefore);
+        Assert.All(headings.Skip(1), heading =>
+            Assert.True(heading.Format.PageBreakBefore));
+    }
+
+    // The group headings in reading order — the only group-heading-sized paragraphs on the sheet.
+    private static List<Paragraph> GroupHeadings(Document document)
+    {
+        var headings = new List<Paragraph>();
+        DocumentElements elements = document.LastSection.Elements;
+        for (int i = 0; i < elements.Count; i++)
+        {
+            if (elements[i] is Paragraph paragraph &&
+                paragraph.Format.Font.Size == Unit.FromPoint(VirtualCrossoverSheetPdf.GroupHeadingPointSize))
+            {
+                headings.Add(paragraph);
+            }
+        }
+
+        return headings;
     }
 
     [Fact]
@@ -574,7 +607,7 @@ public sealed class VirtualCrossoverSheetPdfTests
     }
 
     // The document in reading order, reduced to what the grouped layout is
-    // about: each group heading (the only 19 pt paragraphs on the sheet) as its
+    // about: each group heading (the only group-heading-sized paragraphs on the sheet) as its
     // text, and each image as "image".
     private static List<string> HeadingsAndImages(Document document)
     {
@@ -601,7 +634,7 @@ public sealed class VirtualCrossoverSheetPdfTests
             {
                 walk.Add("image");
             }
-            else if (paragraph.Format.Font.Size == Unit.FromPoint(19))
+            else if (paragraph.Format.Font.Size == Unit.FromPoint(VirtualCrossoverSheetPdf.GroupHeadingPointSize))
             {
                 var builder = new StringBuilder();
                 AppendParagraphText(paragraph, builder);

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetPdfTests.cs
@@ -571,10 +571,16 @@ public sealed class VirtualCrossoverSheetPdfTests
     public void GroupCurves_AGroupOfMonoMembers_GetsOneSumRatherThanTwoCopies()
     {
         // Two mono subs dividing the bottom: both feed both sides identically,
-        // so the left and right "sums" would be the same line twice.
+        // so the left and right "sums" would be the same line twice. One of
+        // them is inverted — a design fact the sum's chains must carry: the
+        // first cut of this graph quietly un-inverted every chain, and two
+        // subs knitting THROUGH an inversion summed as if they fought it.
+        VirtualCrossoverChannelSettings rearSub = Loaded("rear sub");
+        rearSub.InvertPolarity = true;
+        rearSub.DelayMs = 5.73;
         (int, string, bool, VirtualCrossoverChannelSettings)[] subs =
         [
-            (3, VirtualCrossoverSheet.MonoSuffix, false, Loaded("rear sub")),
+            (3, VirtualCrossoverSheet.MonoSuffix, false, rearSub),
             (4, VirtualCrossoverSheet.MonoSuffix, false, Loaded("front sub"))
         ];
 
@@ -585,6 +591,10 @@ public sealed class VirtualCrossoverSheetPdfTests
         VirtualCrossoverSheetPdf.ChainCurve sum =
             Assert.Single(curves, curve => curve.Title == "Sum");
         Assert.Equal(2, sum.Chains.Count);
+        Assert.Single(sum.Chains, chain => chain.InvertPolarity);
+        // The delay, by contrast, IS stripped: it mirrors the cabin's path
+        // differences, which this graph deliberately does not model.
+        Assert.All(sum.Chains, chain => Assert.Equal(0, chain.DelayMs));
     }
 
     [Fact]
@@ -604,6 +614,32 @@ public sealed class VirtualCrossoverSheetPdfTests
 
         var series = (OxyPlot.Series.LineSeries)Assert.Single(model.Series);
         Assert.All(series.Points, point => Assert.Equal(6.0206, point.Y, 3));
+    }
+
+    [Fact]
+    public void BuildChainsModel_ASumCurve_HonorsAnInvertedChain()
+    {
+        // Polarity is a design term like any filter phase — an LR2 crossover
+        // knits flat only through its deliberate inversion — so the sum must
+        // carry it. A flat chain plus an inverted one at -6 dB is 1 - 0.5:
+        // -6.02 dB, where a sum that quietly un-inverted the chain would
+        // report 1 + 0.5 = +3.52 dB.
+        var flat = new VirtualCrossoverChannelSettings().ToChain()
+            with { DelayMs = 0 };
+        var inverted = new VirtualCrossoverChannelSettings
+        {
+            GainDb = -6.0206,
+            InvertPolarity = true
+        }.ToChain() with { DelayMs = 0 };
+        var curve = new VirtualCrossoverSheetPdf.ChainCurve(
+            "Sum", OxyPlot.OxyColors.Black, OxyPlot.LineStyle.Solid, 2,
+            [flat, inverted]);
+
+        OxyPlot.PlotModel model =
+            VirtualCrossoverSheetPdf.BuildChainsModel([curve], 48_000);
+
+        var series = (OxyPlot.Series.LineSeries)Assert.Single(model.Series);
+        Assert.All(series.Points, point => Assert.Equal(-6.0206, point.Y, 3));
     }
 
     // The document in reading order, reduced to what the grouped layout is

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSheetTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSheetTests.cs
@@ -199,4 +199,83 @@ public sealed class VirtualCrossoverSheetTests
             "Low-pass Butterworth 6 dB/oct @ 3000 Hz",
             VirtualCrossoverSheet.DescribeCrossover(channel));
     }
+
+    // A project spanning several zones, laid out like the reference car: a
+    // front stereo pair, a rear stereo pair, a mono centre and a mono sub —
+    // deliberately in PANEL order (front first, sub last), so a sheet that
+    // groups correctly must visibly reorder the sections.
+    internal static VirtualCrossoverProjectFile GroupedProject()
+    {
+        var project = new VirtualCrossoverProjectFile();
+        while (project.Pairs.Count < 4)
+        {
+            project.Pairs.Add(new VirtualCrossoverChannelPairSettings());
+        }
+
+        project.Pairs[0].Zone = VirtualCrossoverZone.Front;
+        project.Pairs[0].Left.SourceFilePath = "front-l.json";
+        project.Pairs[0].Left.DisplayName = "front L";
+        project.Pairs[0].Right.SourceFilePath = "front-r.json";
+        project.Pairs[0].Right.DisplayName = "front R";
+        project.Pairs[1].Zone = VirtualCrossoverZone.Rear;
+        project.Pairs[1].Left.SourceFilePath = "rear-l.json";
+        project.Pairs[1].Left.DisplayName = "rear L";
+        project.Pairs[1].Right.SourceFilePath = "rear-r.json";
+        project.Pairs[1].Right.DisplayName = "rear R";
+        project.Pairs[2].Zone = VirtualCrossoverZone.Center;
+        project.Pairs[2].Mono = true;
+        project.Pairs[2].Left.SourceFilePath = "centre.json";
+        project.Pairs[2].Left.DisplayName = "centre";
+        project.Pairs[3].Zone = VirtualCrossoverZone.Sub;
+        project.Pairs[3].Mono = true;
+        project.Pairs[3].Left.SourceFilePath = "sub.json";
+        project.Pairs[3].Left.DisplayName = "sub";
+        return project;
+    }
+
+    [Fact]
+    public void FormatText_GroupsSectionsByZone_InTheOrderATuneIsTyped()
+    {
+        string text = VirtualCrossoverSheet.FormatText(GroupedProject(), null);
+
+        // Sub first, then the front stage, then the groups placed against it —
+        // the order the values are entered into a DSP, not the panel's order.
+        int sub = text.IndexOf("=== Sub ===", StringComparison.Ordinal);
+        int front = text.IndexOf("=== Front ===", StringComparison.Ordinal);
+        int rear = text.IndexOf("=== Rear ===", StringComparison.Ordinal);
+        int centre = text.IndexOf("=== Center ===", StringComparison.Ordinal);
+        Assert.True(sub >= 0, "the Sub heading is missing");
+        Assert.True(front > sub, "Front must follow Sub");
+        Assert.True(rear > front, "Rear must follow Front");
+        Assert.True(centre > rear, "Center must follow Rear");
+
+        // Grouping moves SECTIONS, never names: the sub is the panel's block D
+        // and its section — printed first — still says so.
+        int subChannel = text.IndexOf(
+            "Channel D (mono) — sub", StringComparison.Ordinal);
+        Assert.InRange(subChannel, sub, front);
+    }
+
+    [Fact]
+    public void SheetSectionOrder_CoversEveryZone()
+    {
+        // The grouping walks SectionOrder and keeps only zones it names, so a
+        // zone added to the enum but forgotten here would silently DROP its
+        // channels from the sheet — the worst possible failure for a document
+        // whose whole job is completeness.
+        Assert.Equal(
+            VirtualCrossoverZones.All.Order(),
+            VirtualCrossoverSheetGroups.SectionOrder.Order());
+    }
+
+    [Fact]
+    public void FormatText_SingleZoneProject_KeepsTheFlatSheetItAlwaysHad()
+    {
+        // One zone means one group, and a heading naming the only group there
+        // is would be scaffolding around nothing — the classic project's sheet
+        // must not change shape because zones now exist.
+        string text = VirtualCrossoverSheet.FormatText(CreateProject(), null);
+
+        Assert.DoesNotContain("===", text);
+    }
 }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
@@ -239,4 +239,105 @@ public sealed class VirtualCrossoverStagedAlignmentTests
         Assert.Equal(1.0, alignment[front].DelayMs, 6);
         Assert.Equal(16.0, alignment[rear].DelayMs, 6);
     }
+
+    [Fact]
+    public void NormalizeStagedDelays_RefusesACeilingBreach_EvenWithoutAShift()
+    {
+        // The ceiling verdict must not ride on whether a shift happened: a rear
+        // fill pushes the LATEST channel out while every delay stays positive,
+        // so a check placed inside the shift branch would wave exactly the case
+        // it exists for straight through to a device that cannot dial it.
+        var front = Block("A", VirtualCrossoverZone.Front);
+        var rear = Block("B", VirtualCrossoverZone.Rear);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [front] = new AlignmentOverride(0.0, false),
+            [rear] = new AlignmentOverride(23.0, false)
+        };
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => VirtualCrossoverPanel.NormalizeStagedDelays(
+                [front, rear], alignment, new System.Text.StringBuilder(),
+                maxDelayMs: 20.0, rearFillOffsetMs: 15.0, rearFillCarriers: [rear]));
+
+        // The refusal names the culprit and the answer: the rear delay is
+        // 8 ms of physics plus 15 ms of preference, and a 20 ms device holds
+        // exactly 12 ms of that preference.
+        Assert.Contains("does not fit", error.Message);
+        Assert.Contains("20 ms", error.Message);
+        Assert.Contains("15 ms rear fill", error.Message);
+        Assert.Contains("up to 12 ms of fill fits", error.Message);
+    }
+
+    [Fact]
+    public void NormalizeStagedDelays_FillSuggestion_SurvivesANonMonotoneSpan()
+    {
+        // The span is NOT monotone in the fill. Here the rear's co-arrival
+        // placement came out at -4 ms (the rear physically farther), so the
+        // fill first lifts it toward zero — CLOSING the dialable span — and
+        // only past +4 starts widening it. A closed-form "subtract the excess"
+        // would land on 11 ms and still not fit; the walk down the DSP's own
+        // grid finds the true largest fill.
+        var front = Block("A", VirtualCrossoverZone.Front);
+        var rear = Block("B", VirtualCrossoverZone.Rear);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [front] = new AlignmentOverride(0.0, false),
+            // -4 ms co-arrival + 15 ms requested fill.
+            [rear] = new AlignmentOverride(11.0, false)
+        };
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => VirtualCrossoverPanel.NormalizeStagedDelays(
+                [front, rear], alignment, new System.Text.StringBuilder(),
+                maxDelayMs: 10.0, rearFillOffsetMs: 15.0, rearFillCarriers: [rear]));
+
+        // At 14 ms of fill the rear needs -4 + 14 = 10 ms — exactly the ceiling.
+        Assert.Contains("up to 14 ms of fill fits", error.Message);
+    }
+
+    [Fact]
+    public void NormalizeStagedDelays_WithoutAFillInPlay_RefusesWithoutBlamingIt()
+    {
+        // A spread the device cannot realize with no rear fill involved — the
+        // honest message is the engine's own, not a suggestion to lower a knob
+        // that is already at zero.
+        var front = Block("A", VirtualCrossoverZone.Front);
+        var centre = Block("B", VirtualCrossoverZone.Center);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [front] = new AlignmentOverride(0.0, false),
+            [centre] = new AlignmentOverride(26.0, false)
+        };
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => VirtualCrossoverPanel.NormalizeStagedDelays(
+                [front, centre], alignment, new System.Text.StringBuilder(),
+                maxDelayMs: 20.0));
+
+        Assert.Contains("does not fit", error.Message);
+        Assert.DoesNotContain("rear fill", error.Message);
+        Assert.Contains("wider than the DSP can realize", error.Message);
+    }
+
+    [Fact]
+    public void NormalizeStagedDelays_KeepsAFittingSetUnderATightCeiling()
+    {
+        // The device ceiling is a gate, not a scaler: a set that fits a tight
+        // ceiling passes through untouched, fill and all.
+        var front = Block("A", VirtualCrossoverZone.Front);
+        var rear = Block("B", VirtualCrossoverZone.Rear);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [front] = new AlignmentOverride(1.0, false),
+            [rear] = new AlignmentOverride(18.0, false)
+        };
+
+        VirtualCrossoverPanel.NormalizeStagedDelays(
+            [front, rear], alignment, new System.Text.StringBuilder(),
+            maxDelayMs: 18.0, rearFillOffsetMs: 15.0, rearFillCarriers: [rear]);
+
+        Assert.Equal(1.0, alignment[front].DelayMs, 6);
+        Assert.Equal(18.0, alignment[rear].DelayMs, 6);
+    }
 }

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -2120,4 +2120,34 @@ public sealed class AutoAlignmentEngineTests
                 [earlySnapshot, lateSnapshot], alignment, new StringBuilder()));
         Assert.Contains("does not fit", error.Message);
     }
+
+    [Fact]
+    public void NormalizeAndVerifyFeasibility_JudgesAgainstTheDeviceOwnCeiling()
+    {
+        // The 50 ms gate is the DEFAULT, standing in for a device whose manual
+        // has not been read: a catalog entry that states its real ceiling
+        // tightens the same check, and the refusal quotes the figure it was
+        // judged against so the user knows which limit refused them.
+        var early = new TestChannel("E", DelayedImpulse(0.0));
+        var late = new TestChannel("L", DelayedImpulse(1.0));
+        var earlySnapshot = new AlignmentSnapshot(early, early.InitialIr, BasePosition);
+        var lateSnapshot = new AlignmentSnapshot(late, late.InitialIr, BasePosition);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [early] = new AlignmentOverride(0.0, false),
+            [late] = new AlignmentOverride(12.0, false)
+        };
+
+        // Fits the default gate…
+        AutoAlignmentEngine.NormalizeAndVerifyFeasibility(
+            [earlySnapshot, lateSnapshot], alignment, new StringBuilder());
+
+        // …and the same span refuses on a device that holds only 10 ms.
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => AutoAlignmentEngine.NormalizeAndVerifyFeasibility(
+                [earlySnapshot, lateSnapshot], alignment, new StringBuilder(),
+                maxDelayMs: 10.0));
+        Assert.Contains("does not fit", error.Message);
+        Assert.Contains("10 ms", error.Message);
+    }
 }

--- a/tests/Resonalyze.Dsp.Tests/DspProcessorCatalogTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/DspProcessorCatalogTests.cs
@@ -70,4 +70,38 @@ public sealed class DspProcessorCatalogTests
         Assert.Equal(192_000, DspProcessorCatalog.Resolve(custom).SampleRateHz);
         Assert.Equal("Custom", custom.DisplayName);
     }
+
+    [Fact]
+    public void AnUnknownDelayCeilingReadsAsTheEnginesDefault()
+    {
+        // The catalog learns each device's per-channel delay ceiling from its
+        // manual, gradually. Until a line states one, the profile answers with
+        // the engine's long-standing 50 ms feasibility gate — the exact behavior
+        // every device had before the catalog knew this fact — and so does a
+        // Custom profile, which has nobody's manual to read.
+        DspProcessorProfile named = DspProcessorCatalog.Presets[0].ToProfile();
+        DspProcessorProfile custom =
+            DspProcessorProfile.Custom(96_000, PeqQConvention.Rbj);
+
+        Assert.Equal(AutoAlignmentEngine.DefaultMaxDelayMs, custom.MaxDelayMs);
+        // Presets[0] is AMP Panacea, whose manual figure has not been entered
+        // yet; if a number lands in its line this assertion is WRONG to keep —
+        // replace it with the manual's figure.
+        Assert.Equal(AutoAlignmentEngine.DefaultMaxDelayMs, named.MaxDelayMs);
+    }
+
+    [Fact]
+    public void EveryStatedDelayCeilingIsAPositiveDialableNumber()
+    {
+        // A zero or negative ceiling would make every proposal infeasible, and
+        // one past 100 ms would let the engine propose a delay the manual
+        // fields (whose range is 100 ms) cannot hold — a data typo in one
+        // catalog line must fail here, not in a user's refusal or a silently
+        // clamped Apply.
+        Assert.All(
+            DspProcessorCatalog.Presets,
+            preset => Assert.True(
+                preset.MaxDelayMs is null or (> 0 and <= 100),
+                $"{preset.Id} states a delay ceiling outside (0, 100] ms"));
+    }
 }

--- a/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/StereoAlignmentTests.cs
@@ -1023,7 +1023,7 @@ public sealed class StereoAlignmentTests
         var log = new StringBuilder();
 
         AutoAlignmentEngine.ComoveMonoChannels(
-            plan, Reprocess, alignment, log, snapshots, decisions);
+            plan, Reprocess, alignment, log, snapshots, decisions: decisions);
 
         Assert.Contains("Co-move sub:", log.ToString());
         AlignmentDecision decision = decisions[sub];
@@ -1226,7 +1226,7 @@ public sealed class StereoAlignmentTests
         var log = new StringBuilder();
         AutoAlignmentEngine.PolishFarSideJunctions(
             plan, snapshots, snapshots, Reprocess, alignment, log,
-            decisions: null);
+            AutoAlignmentEngine.DefaultMaxDelayMs, decisions: null);
         return (alignment[farMid].DelayMs, alignment[farTwr].DelayMs, log.ToString());
     }
 


### PR DESCRIPTION
PR 5 of the complex-installations series (after #147 zones, #148 grouped views, #150 staged auto delay, #151 per-group auto crossover): the tuning sheet learns the same grouping the rest of the tool now speaks, and the DSP catalog learns each device's delay ceiling.

## The sheet prints by group

Sections run **Sub → Front → Rear → Center** — the order a tune is typed into a DSP, deliberately not the zone selector's order (whose stale doc claim to govern the sheet is corrected). Each zone gets its own heading (22 pt — the sheet is read at the DSP one group at a time, so a page's first glance names its zone), every group after the first **opens a page of its own**, and on the PDF each group leads with a graph of **its own** chains instead of one combined tangle — the reference car put eleven curves on that single graph. Letters never move: grouping reorders sections, not names. A **single-zone project keeps the flat sheet it always had** (no headings, one combined graph), so every classic project's sheet is untouched — pinned by tests.

A group's graph carries the **design sum** of its chains per side (left solid, right dashed; one line for a group of mono blocks), only where a side has at least two chains to sum — a sum of one would retrace the channel — and **never for the centre**, whose derived signal makes any sum involving it a fiction. The **front group's graph adds the subwoofer group's sum in a pale tone**: the front chain hands its bass to those subs at ~110 Hz, and the handover cannot be judged on a graph showing only one side of it. The sums are complex and carry every phase term the chains hold — polarity included (review caught the first cut un-inverting chains: an LR2-style knit exists only *through* its deliberate inversion, and dropping one 180° from a sum that keeps crossover/PEQ/all-pass phase made it neither the electrical answer nor an envelope). Only the **delays** are stripped: they mirror the cabin's paths and would bury a filter graph in combing — the acoustic summation lives on the panel's plot, and a junction inverted to fix the cabin's phase honestly shows an electrical dip here that the plot, not this graph, resolves.

Shot off the real reference session (rear pair re-pointed to Rear):

| group | what the graph shows |
|---|---|
| Sub | the two mono subs' LP 50 / BP 50–110 shapes and their single dark sum knitting at 50 Hz |
| Front | three pairs, Sum L/R across the whole band, the pale sub sum rolling off through the 110 Hz handover |
| Rear | one pair, no sum (it would retrace) |
| Center | one chain, no sum, by rule |

**A standing defect fell out of shooting those graphs:** the legend was an opaque white box *inside* the plot area, top right — exactly where the tweeters and the sums run (~0 dB). On the reference car's front group it hid everything above the last crossover corner; the flat sheet's combined graph has been paying the same price all along. The legend now lays out in rows **below** the plot area.

## The catalog states a device's delay ceiling

`DspProcessorPreset` grows an optional `MaxDelayMs` — the growth path its own docs promised. **No line states a figure yet**: the numbers get entered as manuals are read, and an unread line (or a Custom profile) keeps the engine's long-standing 50 ms gate bit for bit, which is what keeps the battery identical. The whole proposal is judged against the device's number: the feasibility refusal, and every polish pass that bounds itself by the range (scene rebalance, far-side polish, mono co-move — using 50 there while the device holds 10 would let a polish widen a fitting spread into a refusal). A catalog test pins every stated ceiling to (0, 100] ms — past 100 the manual delay fields could not hold the proposal.

## The staged shift refuses honestly

`NormalizeStagedDelays` now verifies the finished figure **unconditionally** — a rear fill pushes the *latest* channel out with nothing going negative, so a check living inside the shift branch would wave through exactly the case it exists for (rear closer + Haas 15 ≈ 16–18 ms is the classic field overrun; a tight device refuses it). Because the fill is the one number in the proposal that is preference rather than physics, the refusal computes **the largest fill that fits** and says so:

> The staged alignment does not fit the DSP delay range: D Left needs 23.00 ms with the earliest channel at 0, but the limit is 20 ms. The 15 ms rear fill is what pushes it past the range: up to 12 ms of fill fits — lower Rear fill in the dialog and rerun.

Found by walking the DSP's own 0.01 ms grid down from the requested fill, not in closed form: the span is **not monotone** in the fill (a rear placed at a negative co-arrival first *closes* the span as the fill grows), so subtract-the-excess can name a fill that still does not fit — there is a test whose closed-form answer would be wrong by 3 ms. When no fill is in play, or when even zero fill does not fit, the message does not pretend lowering it would help.

## Deliberate choices

- The within-group settle (`SettleWithinGroup`) still runs its inner walk at the default gate; the composed result is what the staged verdict judges. An inner spread near any real ceiling is orders of magnitude away.
- The DSP processor dialog does not display the ceiling — it is engine data, not a setting; the REFERENCE section explains where the limit comes from.
- The sheet still prints every pair with a source, enabled or not — the rule it always had, untouched.

## Verification

- 3,534 tests, 0 failing (12 skipped by design; 18 new: ceiling gate and its message, fill suggestion incl. the non-monotone case, grouping order for both sheet formats, the per-group page breaks, sum rules per zone, the complex-sum pins at +6.02 dB and — with an inverted chain — at −6.02 dB, a guard that a zone missing from `SectionOrder` cannot silently drop channels from the sheet).
- **Session battery: 7 cabins, twice, line for line identical** to the PR #151 run.
- Text and PDF sheets rendered off the real reference session and read by eye; the group graphs above are from that render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
