### PR TITLE
Reclassify below-noise harmonics: neutral note instead of the amber overlap warning

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -240,7 +240,7 @@ neighbouring order, so the curve is dropped from the plot and from THD and an
 amber warning names the order and the cure: a longer sweep, or a narrower
 analysed range (marginal isolation keeps the curve and just carries the
 caveat). If instead the whole window holds **nothing above the record's own
-noise floor** — plateau and edges alike — there is no harmonic to draw at all:
+noise floor** — anywhere in it — there is no harmonic to draw at all:
 the curve is dropped the same way, but the note is a neutral gray *"below the
 measurement noise floor"*, because distortion too low for the capture to
 resolve is the mark of a clean measurement, not a fault. A longer sweep or more

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -231,6 +231,23 @@ frequency (a second-harmonic hump from a 1 kHz drive appears at 1 kHz, not at
 sweep-deconvolution scale while the primary curve is loopback-normalized, their
 vertical distance is not yet a calibrated distortion percentage.
 
+A ticked HD curve can still be missing from the plot, and the plot says why at
+its top centre rather than leaving the checkbox unexplained. Each order's
+harmonic lives in its own time window of the deconvolved sweep, and two things
+can empty that window of a drawable curve. If the order's packet has **not
+decayed by its window edge** it leaks into — or is polluted by — the
+neighbouring order, so the curve is dropped from the plot and from THD and an
+amber warning names the order and the cure: a longer sweep, or a narrower
+analysed range (marginal isolation keeps the curve and just carries the
+caveat). If instead the whole window holds **nothing above the record's own
+noise floor** — plateau and edges alike — there is no harmonic to draw at all:
+the curve is dropped the same way, but the note is a neutral gray *"below the
+measurement noise floor"*, because distortion too low for the capture to
+resolve is the mark of a clean measurement, not a fault. A longer sweep or more
+drive level lowers that floor if the vanished order still needs to be resolved.
+The two notes can appear together when one order genuinely leaks while another
+sits under the noise.
+
 ### Sweep band and duration
 
 The exponential sweep is described by the band it must cover: a **Low frequency

--- a/dsp/EssHarmonicAnalysis.cs
+++ b/dsp/EssHarmonicAnalysis.cs
@@ -148,13 +148,19 @@ public sealed record HarmonicPacket(
 /// polluted by — the neighbour. <see cref="LeadingEdgeEnergyDb"/> is the edge
 /// toward the higher harmonic (earlier in time), <see cref="TrailingEdgeEnergyDb"/>
 /// toward the lower harmonic (the packet's own decay, later in time).
+/// <see cref="IsBelowNoiseFloor"/> marks the opposite of a leak: the window holds
+/// no packet at all, only the record's own noise floor — the harmonic is too small
+/// to resolve, which is a property of a CLEAN capture, not a fault. Such an order
+/// is still not drawable (its "curve" would be the noise floor), so it stays
+/// unreliable, but it carries no warning.
 /// </summary>
 public sealed record HarmonicPacketValidity(
     int Order,
     double LeadingEdgeEnergyDb,
     double TrailingEdgeEnergyDb,
     bool IsReliable,
-    string? Warning);
+    string? Warning,
+    bool IsBelowNoiseFloor = false);
 
 /// <summary>
 /// Per-order isolation quality for a decomposition, plus the human-readable
@@ -256,6 +262,24 @@ public static class EssHarmonicAnalysis
     // Fraction of the window, at each boundary, treated as the "edge" region whose
     // residual energy signals overlap with the adjacent packet.
     private const double EdgeRegionFraction = 0.15;
+
+    // The edge test above is RELATIVE to the packet's own peak, so on its own it
+    // cannot tell a leaking packet from no packet at all: a harmonic that fell
+    // below the noise floor leaves a windowful of flat noise, whose plateau
+    // maximum (sigma·sqrt(2·ln M) over M plateau samples, ~3–4 sigma for the
+    // lengths in play) reads ~10–12 dB above the edge RMS — squarely inside the
+    // "overlaps its neighbour" verdict. A plateau peak within this margin of the
+    // record's own tail-noise RMS is therefore read as noise, not as a packet:
+    // 16 dB covers the noise crest factor up to M ≈ 10^7 samples, while a genuine
+    // leak — a visible curve — sits far above the floor and is untouched.
+    private const double BelowNoisePlateauDb = 16.0;
+
+    // Tail-noise chunking: the quiet region is split into equal chunks whose RMS
+    // values are combined by a median, so one stray thump in the tail cannot
+    // inflate the noise estimate. Below the minimum chunk length the tail is too
+    // short to trust and the below-noise test is skipped entirely.
+    private const int TailNoiseChunkCount = 8;
+    private const int MinTailNoiseChunkLength = 128;
 
     /// <summary>
     /// The time advance of harmonic <paramref name="harmonicOrder"/> relative to
@@ -625,6 +649,9 @@ public static class EssHarmonicAnalysis
             256,
             options.MaxFftLength);
 
+        double tailNoiseAmplitude =
+            EstimateTailNoiseAmplitude(deconvolvedImpulse, windows[0]);
+
         var packets = new HarmonicPacket[options.MaxHarmonic];
         var validities = new HarmonicPacketValidity[options.MaxHarmonic - 1];
         var warnings = new List<string>();
@@ -643,7 +670,7 @@ public static class EssHarmonicAnalysis
             if (order >= 2)
             {
                 HarmonicPacketValidity validity =
-                    EvaluatePacketOverlap(deconvolvedImpulse, definition);
+                    EvaluatePacketOverlap(deconvolvedImpulse, definition, tailNoiseAmplitude);
                 validities[order - 2] = validity;
                 if (validity.Warning != null)
                 {
@@ -662,12 +689,58 @@ public static class EssHarmonicAnalysis
                 warnings));
     }
 
+    // A robust time-domain noise amplitude read from the quiet tail after the
+    // linear packet and its reverb guard — the same region EssNoise draws its
+    // spectral estimate from. Returns 0 when the record has no usable tail;
+    // callers then skip the below-noise classification and fall back to the
+    // plain overlap verdict.
+    private static double EstimateTailNoiseAmplitude(
+        ReadOnlySpan<double> impulse,
+        HarmonicWindowDefinition linearWindow)
+    {
+        int linearStart = Math.Max(0, linearWindow.StartSample);
+        int linearEnd = Math.Min(impulse.Length - 1, linearWindow.EndSample);
+        int linearLength = Math.Max(1, linearEnd - linearStart + 1);
+
+        int guard = Math.Max(linearLength, linearLength / 2 + 1);
+        int regionStart = Math.Min(
+            Math.Max(0, linearWindow.EndSample) + guard,
+            impulse.Length);
+        int regionLength = impulse.Length - regionStart;
+
+        int chunkLength = regionLength / TailNoiseChunkCount;
+        if (chunkLength < MinTailNoiseChunkLength)
+        {
+            return 0.0;
+        }
+
+        var chunkRms = new double[TailNoiseChunkCount];
+        for (int chunk = 0; chunk < TailNoiseChunkCount; chunk++)
+        {
+            int start = regionStart + chunk * chunkLength;
+            double sumSquares = 0.0;
+            for (int i = start; i < start + chunkLength; i++)
+            {
+                sumSquares += impulse[i] * impulse[i];
+            }
+            chunkRms[chunk] = Math.Sqrt(sumSquares / chunkLength);
+        }
+
+        Array.Sort(chunkRms);
+        double median = 0.5 * (
+            chunkRms[TailNoiseChunkCount / 2 - 1] + chunkRms[TailNoiseChunkCount / 2]);
+        return double.IsFinite(median) ? median : 0.0;
+    }
+
     // Compares the residual energy at each window edge with the packet peak. A
     // contained (fast-decaying) packet reads far below its peak at both edges; a
-    // packet that has not decayed by the edge is leaking into its neighbour.
+    // packet that has not decayed by the edge is leaking into its neighbour — but
+    // a packet whose plateau never rises above the record's tail noise holds no
+    // harmonic at all and is classified below-noise instead of overlapping.
     private static HarmonicPacketValidity EvaluatePacketOverlap(
         ReadOnlySpan<double> impulse,
-        HarmonicWindowDefinition window)
+        HarmonicWindowDefinition window,
+        double tailNoiseAmplitude)
     {
         int start = Math.Max(0, window.StartSample);
         int end = Math.Min(impulse.Length - 1, window.EndSample);
@@ -696,6 +769,18 @@ public static class EssHarmonicAnalysis
         int edgeLength = Math.Max(1, (int)Math.Round(EdgeRegionFraction * length));
         double leadingDb = EdgeEnergyDb(impulse, start, edgeLength, peakEnergy);
         double trailingDb = EdgeEnergyDb(impulse, end - edgeLength + 1, edgeLength, peakEnergy);
+
+        // No packet stands above the record's own noise here: whatever the edges
+        // read, there is nothing to leak and nothing to draw. Dropped like an
+        // overlap, but without a warning — an unresolvably small harmonic is the
+        // mark of a clean capture, not a measurement fault.
+        if (tailNoiseAmplitude > 0.0 &&
+            peakEnergy <= tailNoiseAmplitude * Math.Pow(10.0, BelowNoisePlateauDb / 20.0))
+        {
+            return new HarmonicPacketValidity(
+                window.Order, leadingDb, trailingDb,
+                IsReliable: false, Warning: null, IsBelowNoiseFloor: true);
+        }
 
         double worst = Math.Max(leadingDb, trailingDb);
         bool reliable = worst <= InvalidEdgeDb;

--- a/dsp/EssHarmonicAnalysis.cs
+++ b/dsp/EssHarmonicAnalysis.cs
@@ -274,6 +274,14 @@ public static class EssHarmonicAnalysis
     // leak — a visible curve — sits far above the floor and is untouched.
     private const double BelowNoisePlateauDb = 16.0;
 
+    // A below-noise verdict must hold for the WHOLE window, edges included: a
+    // neighbour's undecayed tail (or the linear packet's skirt) can sit in an
+    // edge region while the plateau reads pure noise, and that contamination is
+    // exactly what the edge test exists to catch — it must stay a warned overlap,
+    // not a blessed clean capture. An edge RMS is averaged over hundreds of
+    // samples and sits tight on the true noise RMS, so a modest margin suffices.
+    private const double BelowNoiseEdgeMarginDb = 6.0;
+
     // Tail-noise chunking: the quiet region is split into equal chunks whose RMS
     // values are combined by a median, so one stray thump in the tail cannot
     // inflate the noise estimate. Below the minimum chunk length the tail is too
@@ -770,16 +778,27 @@ public static class EssHarmonicAnalysis
         double leadingDb = EdgeEnergyDb(impulse, start, edgeLength, peakEnergy);
         double trailingDb = EdgeEnergyDb(impulse, end - edgeLength + 1, edgeLength, peakEnergy);
 
-        // No packet stands above the record's own noise here: whatever the edges
-        // read, there is nothing to leak and nothing to draw. Dropped like an
-        // overlap, but without a warning — an unresolvably small harmonic is the
-        // mark of a clean capture, not a measurement fault.
+        // No packet stands above the record's own noise here — and the edges are
+        // themselves at the noise floor, so nothing foreign is intruding either:
+        // there is nothing to leak and nothing to draw. Dropped like an overlap,
+        // but without a warning — an unresolvably small harmonic is the mark of a
+        // clean capture, not a measurement fault. A hot edge over a noise-level
+        // plateau (a neighbour's tail reaching in) falls through to the overlap
+        // verdict below instead of being blessed as clean.
         if (tailNoiseAmplitude > 0.0 &&
             peakEnergy <= tailNoiseAmplitude * Math.Pow(10.0, BelowNoisePlateauDb / 20.0))
         {
-            return new HarmonicPacketValidity(
-                window.Order, leadingDb, trailingDb,
-                IsReliable: false, Warning: null, IsBelowNoiseFloor: true);
+            double edgeCeiling =
+                tailNoiseAmplitude * Math.Pow(10.0, BelowNoiseEdgeMarginDb / 20.0);
+            bool edgesAtNoise =
+                peakEnergy * Math.Pow(10.0, leadingDb / 20.0) <= edgeCeiling &&
+                peakEnergy * Math.Pow(10.0, trailingDb / 20.0) <= edgeCeiling;
+            if (edgesAtNoise)
+            {
+                return new HarmonicPacketValidity(
+                    window.Order, leadingDb, trailingDb,
+                    IsReliable: false, Warning: null, IsBelowNoiseFloor: true);
+            }
         }
 
         double worst = Math.Max(leadingDb, trailingDb);

--- a/dsp/EssHarmonicAnalysis.cs
+++ b/dsp/EssHarmonicAnalysis.cs
@@ -268,18 +268,20 @@ public static class EssHarmonicAnalysis
     // below the noise floor leaves a windowful of flat noise, whose plateau
     // maximum (sigma·sqrt(2·ln M) over M plateau samples, ~3–4 sigma for the
     // lengths in play) reads ~10–12 dB above the edge RMS — squarely inside the
-    // "overlaps its neighbour" verdict. A plateau peak within this margin of the
-    // record's own tail-noise RMS is therefore read as noise, not as a packet:
-    // 16 dB covers the noise crest factor up to M ≈ 10^7 samples, while a genuine
-    // leak — a visible curve — sits far above the floor and is untouched.
-    private const double BelowNoisePlateauDb = 16.0;
+    // "overlaps its neighbour" verdict. A window whose maximum — over the WHOLE
+    // window, so a packet hiding between the plateau and an edge counts too —
+    // stays within this margin of the record's own tail-noise RMS is therefore
+    // read as noise, not as a packet: 16 dB covers the noise crest factor up to
+    // M ≈ 10^7 samples, while a genuine leak — a visible curve — sits far above
+    // the floor and is untouched.
+    private const double BelowNoiseWindowPeakDb = 16.0;
 
-    // A below-noise verdict must hold for the WHOLE window, edges included: a
-    // neighbour's undecayed tail (or the linear packet's skirt) can sit in an
-    // edge region while the plateau reads pure noise, and that contamination is
-    // exactly what the edge test exists to catch — it must stay a warned overlap,
-    // not a blessed clean capture. An edge RMS is averaged over hundreds of
-    // samples and sits tight on the true noise RMS, so a modest margin suffices.
+    // The edge regions get a second, tighter bound of their own: an edge RMS is
+    // averaged over hundreds of samples and sits tight on the true noise RMS, so
+    // a modest margin suffices — and it catches low-crest coherent contamination
+    // (a neighbour's tail, the linear packet's skirt) whose maximum stays under
+    // the window-peak ceiling above. Either failure keeps the warned overlap
+    // verdict instead of blessing the capture as clean.
     private const double BelowNoiseEdgeMarginDb = 6.0;
 
     // Tail-noise chunking: the quiet region is split into equal chunks whose RMS
@@ -778,22 +780,33 @@ public static class EssHarmonicAnalysis
         double leadingDb = EdgeEnergyDb(impulse, start, edgeLength, peakEnergy);
         double trailingDb = EdgeEnergyDb(impulse, end - edgeLength + 1, edgeLength, peakEnergy);
 
-        // No packet stands above the record's own noise here — and the edges are
-        // themselves at the noise floor, so nothing foreign is intruding either:
-        // there is nothing to leak and nothing to draw. Dropped like an overlap,
-        // but without a warning — an unresolvably small harmonic is the mark of a
-        // clean capture, not a measurement fault. A hot edge over a noise-level
-        // plateau (a neighbour's tail reaching in) falls through to the overlap
-        // verdict below instead of being blessed as clean.
-        if (tailNoiseAmplitude > 0.0 &&
-            peakEnergy <= tailNoiseAmplitude * Math.Pow(10.0, BelowNoisePlateauDb / 20.0))
+        // Nothing anywhere in the window stands above the record's own noise —
+        // the maximum is taken over the WHOLE window, not just the plateau the
+        // overlap heuristic peaks at, so a packet hiding in a shoulder between
+        // the plateau and an edge disqualifies the verdict too — and the edge
+        // RMS values are themselves at the noise floor, which additionally
+        // catches low-crest coherent contamination the maximum could miss.
+        // Then there is nothing to leak and nothing to draw: dropped like an
+        // overlap, but without a warning — an unresolvably small harmonic is
+        // the mark of a clean capture, not a measurement fault. Anything hot
+        // over a noise-level plateau falls through to the overlap verdict below
+        // instead of being blessed as clean.
+        if (tailNoiseAmplitude > 0.0)
         {
+            double windowPeakEnergy = 0.0;
+            for (int i = start; i <= end; i++)
+            {
+                windowPeakEnergy = Math.Max(windowPeakEnergy, Math.Abs(impulse[i]));
+            }
+
             double edgeCeiling =
                 tailNoiseAmplitude * Math.Pow(10.0, BelowNoiseEdgeMarginDb / 20.0);
-            bool edgesAtNoise =
+            bool belowNoise =
+                windowPeakEnergy <=
+                    tailNoiseAmplitude * Math.Pow(10.0, BelowNoiseWindowPeakDb / 20.0) &&
                 peakEnergy * Math.Pow(10.0, leadingDb / 20.0) <= edgeCeiling &&
                 peakEnergy * Math.Pow(10.0, trailingDb / 20.0) <= edgeCeiling;
-            if (edgesAtNoise)
+            if (belowNoise)
             {
                 return new HarmonicPacketValidity(
                     window.Order, leadingDb, trailingDb,

--- a/source/Plotting/MeasurementPlotContext.cs
+++ b/source/Plotting/MeasurementPlotContext.cs
@@ -155,6 +155,14 @@ internal sealed class MeasurementPlotContext
     /// </summary>
     public IReadOnlyList<string> DistortionWarnings { get; private set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// Per-order packet validity from the last frequency-response build. The plot
+    /// layer uses it to tell a genuinely problematic drop (overlap — amber warning)
+    /// from a benign one (harmonic below the noise floor — neutral note).
+    /// </summary>
+    public IReadOnlyList<HarmonicPacketValidity> DistortionPacketValidity
+    { get; private set; } = Array.Empty<HarmonicPacketValidity>();
+
     public IReadOnlyList<AnalysisCurve> CreateFrequencyResponseCurves(
         FrequencyResponseOptions options,
         CalibrationFile? calibration,
@@ -177,6 +185,7 @@ internal sealed class MeasurementPlotContext
         SpectrumCurves curves)
     {
         DistortionWarnings = Array.Empty<string>();
+        DistortionPacketValidity = Array.Empty<HarmonicPacketValidity>();
         // The geometry of the sweep behind THIS result: for a restored measurement
         // that is what the file recorded, not what the sweep rebuilt on load spans
         // (its generation is length-capped, and legacy edges are unreachable).
@@ -225,6 +234,7 @@ internal sealed class MeasurementPlotContext
                 options.UseCalibration ? calibration : null,
                 curves & SpectrumCurves.Distortion);
         DistortionWarnings = distortion.Warnings;
+        DistortionPacketValidity = distortion.PacketValidity;
         return distortion.Curves;
     }
 }

--- a/source/Plotting/OverlayTextAnnotation.cs
+++ b/source/Plotting/OverlayTextAnnotation.cs
@@ -12,6 +12,15 @@ namespace Resonalyze
         BottomUp
     }
 
+    /// <summary>
+    /// Plot-area overlay text. <c>TextPosition.X</c> is the 0..1 fraction across the
+    /// plot area; <c>TextPosition.Y</c> is the line slot counted from the flowing
+    /// edge (top for <see cref="TextFlowDirection.TopDown"/>, bottom for
+    /// <see cref="TextFlowDirection.BottomUp"/>). The FIRST line of the text sits in
+    /// that slot and a multi-line block grows with the flow — into the plot, never
+    /// past its edge. (The block used to be centred on the slot instead, which
+    /// pushed the first line of any multi-line note half out of the plot area.)
+    /// </summary>
     public class OverlayTextAnnotation : TextualAnnotation
     {
         public bool IsPlotLabelOverlay { get; init; }
@@ -28,7 +37,7 @@ namespace Resonalyze
             var axisRect = PlotElementUtilities.GetClippingRect(this);
             var textHeight = rc.MeasureText("X", this.ActualFont, this.ActualFontSize, this.ActualFontWeight).Height;
             double x = TextPosition.X;
-            double y = textHeight * (0.5 + 1.0 * TextPosition.Y);
+            double y = textHeight * TextPosition.Y;
             double screenY = TextFlowDirection == TextFlowDirection.TopDown
                 ? axisRect.Top + y
                 : axisRect.Bottom - y;
@@ -36,7 +45,13 @@ namespace Resonalyze
                 (1.0 - x) * axisRect.BottomLeft.X + x * axisRect.TopRight.X,
                 screenY);
 
-            this.GetActualTextAlignment(out var ha, out var va);
+            // Anchor the block's flowing edge at the slot: a single line renders
+            // exactly where the old centre-on-slot math put it, while extra lines
+            // extend into the plot instead of being clipped by its border.
+            this.GetActualTextAlignment(out var ha, out _);
+            var va = TextFlowDirection == TextFlowDirection.TopDown
+                ? VerticalAlignment.Top
+                : VerticalAlignment.Bottom;
             rc.DrawMathText(
                 position,
                 this.Text,

--- a/source/Plotting/PlotModelFactory.cs
+++ b/source/Plotting/PlotModelFactory.cs
@@ -2865,10 +2865,13 @@ internal sealed class PlotModelFactory
     }
 
     // A harmonic order the user asked for can be missing from the plot: its packet
-    // overlapped a neighbour and was dropped (so it is also left out of THD), or the
-    // measurement carries no sweep to derive harmonics from. Silently dropping the
-    // curve leaves the ticked checkbox unexplained, so a short note at the top names
-    // the missing curves and — where the DSP said why — the reason.
+    // overlapped a neighbour and was dropped (so it is also left out of THD), the
+    // harmonic sits below the measurement noise floor, or the measurement carries
+    // no sweep to derive harmonics from. Silently dropping the curve leaves the
+    // ticked checkbox unexplained, so a short note at the top names the missing
+    // curves and — where the DSP said why — the reason. A below-noise order is the
+    // mark of a clean capture, so it gets a neutral gray note, never the amber
+    // warning that used to scold users for their quietest measurements.
     private void AddHiddenHarmonicAnnotation(
         PlotModel model, IReadOnlyList<AnalysisCurve> curves)
     {
@@ -2878,38 +2881,73 @@ internal sealed class PlotModelFactory
             present.Add(curve.Kind);
         }
 
-        var missing = new List<string>();
-        void Check(bool requested, AnalysisCurveKind kind, string label)
+        var missing = new List<(int Order, string Label)>();
+        void Check(bool requested, AnalysisCurveKind kind, int order, string label)
         {
             if (requested && !present.Contains(kind))
             {
-                missing.Add(label);
+                missing.Add((order, label));
             }
         }
 
-        Check(frequencyResponseVisibility.ShowHd2, AnalysisCurveKind.SecondHarmonic, "HD2");
-        Check(frequencyResponseVisibility.ShowHd3, AnalysisCurveKind.ThirdHarmonic, "HD3");
-        Check(frequencyResponseVisibility.ShowHd4, AnalysisCurveKind.FourthHarmonic, "HD4");
+        Check(frequencyResponseVisibility.ShowHd2, AnalysisCurveKind.SecondHarmonic, 2, "HD2");
+        Check(frequencyResponseVisibility.ShowHd3, AnalysisCurveKind.ThirdHarmonic, 3, "HD3");
+        Check(frequencyResponseVisibility.ShowHd4, AnalysisCurveKind.FourthHarmonic, 4, "HD4");
         if (missing.Count == 0)
         {
             return;
         }
 
-        IReadOnlyList<string> warnings = measurementContext.DistortionWarnings;
-        string reason = warnings.Count > 0
-            ? string.Join("\n", warnings)
-            : "no sweep distortion data — record a sweep, or use a longer one so the "
-                + "harmonic packet clears its neighbour";
-        string plural = missing.Count > 1 ? "curves" : "curve";
-        model.Annotations.Add(new OverlayTextAnnotation
+        var belowNoiseOrders = new HashSet<int>(
+            measurementContext.DistortionPacketValidity
+                .Where(packet => packet.IsBelowNoiseFloor)
+                .Select(packet => packet.Order));
+        List<string> problem = missing
+            .Where(m => !belowNoiseOrders.Contains(m.Order))
+            .Select(m => m.Label)
+            .ToList();
+        List<string> belowNoise = missing
+            .Where(m => belowNoiseOrders.Contains(m.Order))
+            .Select(m => m.Label)
+            .ToList();
+
+        int nextLine = 0;
+        if (problem.Count > 0)
         {
-            Text = $"{string.Join(", ", missing)} {plural} not shown\n{reason}",
-            TextPosition = new DataPoint(0.5, 0),
-            TextFlowDirection = TextFlowDirection.TopDown,
-            FontSize = 12,
-            TextColor = OxyColors.Goldenrod,
-            TextHorizontalAlignment = OxyPlot.HorizontalAlignment.Center
-        });
+            // The advice clause goes to its own line so the widest line stays
+            // readable in a narrow window instead of running past the plot edge.
+            IReadOnlyList<string> warnings = measurementContext.DistortionWarnings;
+            string reason = warnings.Count > 0
+                ? string.Join("\n", warnings.Select(w => w.Replace("; ", ";\n")))
+                : "no sweep distortion data — record a sweep,\n"
+                    + "or use a longer one so the harmonic packet clears its neighbour";
+            string plural = problem.Count > 1 ? "curves" : "curve";
+            string text = $"{string.Join(", ", problem)} {plural} not shown\n{reason}";
+            model.Annotations.Add(new OverlayTextAnnotation
+            {
+                Text = text,
+                TextPosition = new DataPoint(0.5, 0),
+                TextFlowDirection = TextFlowDirection.TopDown,
+                FontSize = 12,
+                TextColor = OxyColors.Goldenrod,
+                TextHorizontalAlignment = OxyPlot.HorizontalAlignment.Center
+            });
+            nextLine = text.Split('\n').Length;
+        }
+
+        if (belowNoise.Count > 0)
+        {
+            model.Annotations.Add(new OverlayTextAnnotation
+            {
+                Text = $"{string.Join(", ", belowNoise)} below the measurement noise floor\n"
+                    + "distortion too low to resolve — a clean capture, not a fault",
+                TextPosition = new DataPoint(0.5, nextLine),
+                TextFlowDirection = TextFlowDirection.TopDown,
+                FontSize = 12,
+                TextColor = OxyColors.Gray,
+                TextHorizontalAlignment = OxyPlot.HorizontalAlignment.Center
+            });
+        }
     }
 
     // Phase and group delay need loopback timing; without a transfer IR the plot would

--- a/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotModelFactoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using OxyPlot;
 using OxyPlot.Series;
 using Resonalyze.Dsp;
 using Resonalyze.Options;
@@ -1763,6 +1764,71 @@ public sealed class PlotModelFactoryTests
         Assert.True(anyFinite, "the synthetic HD2 packet produced no usable points");
     }
 
+    // The amber "packet overlaps its neighbour" warning used to fire on the
+    // CLEANEST captures: a harmonic below the noise floor leaves a windowful of
+    // flat noise, which the peak-relative edge test misreads as a leak. Such
+    // orders get a neutral gray note now — never the amber warning.
+    [Fact]
+    public void CreateFrequencyResponse_HarmonicsBelowTheNoiseFloor_GetANeutralNote()
+    {
+        using ExpSweepMeasurement measurement = CreateSweepWithNoiseFloorOnly();
+        using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+
+        OxyPlot.PlotModel model = CreateFactory(measurement, noise)
+            .CreateFrequencyResponse(includeCurves: true);
+
+        Assert.DoesNotContain(
+            model.Series.OfType<LineSeries>(),
+            item => item.Tag is CurveTag
+            {
+                Kind: AnalysisCurveKind.SecondHarmonic
+                    or AnalysisCurveKind.ThirdHarmonic
+                    or AnalysisCurveKind.FourthHarmonic
+            });
+        OverlayTextAnnotation note =
+            Assert.Single(model.Annotations.OfType<OverlayTextAnnotation>());
+        Assert.Contains("below the measurement noise floor", note.Text);
+        Assert.DoesNotContain("overlaps", note.Text);
+        Assert.Equal(OxyColors.Gray, note.TextColor);
+    }
+
+    // The counterpart: a packet that genuinely leaks into its neighbour — a
+    // visible curve, far above the noise floor — keeps the amber warning, while
+    // the orders that really are buried in the same record's noise get the gray
+    // note beside it, each bucket naming only its own curves.
+    [Fact]
+    public void CreateFrequencyResponse_AGenuineOverlap_KeepsTheAmberWarning()
+    {
+        EssSweepMetadata sweep = NoiseFixtureSweep();
+        HarmonicWindowDefinition h2 = EssHarmonicAnalysis.BuildWindow(sweep, 2, 0.5);
+
+        Complex[] deconvolution = NoisyCleanDeconvolution(sweep);
+        // HD2 content persisting at full level to its window edge: the real leak.
+        for (int i = h2.PeakSample; i <= h2.EndSample && i < deconvolution.Length; i++)
+        {
+            deconvolution[i] = new Complex(0.3 * Math.Cos(0.3 * (i - h2.PeakSample)), 0.0);
+        }
+
+        using ExpSweepMeasurement measurement = CreateSweepMeasurement(deconvolution, sweep);
+        using var noise = new NoiseMeasurement(new FakeAudioSessionFactory());
+
+        OxyPlot.PlotModel model = CreateFactory(measurement, noise)
+            .CreateFrequencyResponse(includeCurves: true);
+
+        List<OverlayTextAnnotation> notes =
+            model.Annotations.OfType<OverlayTextAnnotation>().ToList();
+        Assert.Equal(2, notes.Count);
+        OverlayTextAnnotation amber =
+            Assert.Single(notes, n => n.TextColor == OxyColors.Goldenrod);
+        Assert.Contains("HD2", amber.Text);
+        Assert.Contains("overlaps its neighbour", amber.Text);
+        Assert.DoesNotContain("HD3", amber.Text);
+        OverlayTextAnnotation gray = Assert.Single(notes, n => n.TextColor == OxyColors.Gray);
+        Assert.Contains("HD3", gray.Text);
+        Assert.Contains("HD4", gray.Text);
+        Assert.Contains("below the measurement noise floor", gray.Text);
+    }
+
     [Fact]
     public void CreateFrequencyResponse_InRelativeMode_LeavesRoomForAPaddedLoopback()
     {
@@ -1975,6 +2041,62 @@ public sealed class PlotModelFactoryTests
         measurement.RestoreLevelSnapshot(new InputLevelMeterSnapshot(
             new InputLevelMeterEntry(true, -3, -6, false, false),
             new InputLevelMeterEntry(true, -6, -9, false, false)));
+        return measurement;
+    }
+
+    private static EssSweepMetadata NoiseFixtureSweep() =>
+        EssSweepMetadata.FromExponentialSweep(
+            sampleRate: 48_000, octaves: 10, sweepSampleCount: 200_000,
+            deconvolutionPeakIndex: 150_000);
+
+    // The deconvolution every clean capture approximates: a linear delta over a
+    // deterministic broadband noise floor, with no harmonic content at all.
+    private static Complex[] NoisyCleanDeconvolution(EssSweepMetadata sweep)
+    {
+        var random = new Random(9241);
+        var deconvolution = new Complex[sweep.SweepSampleCount];
+        for (int i = 0; i < deconvolution.Length; i++)
+        {
+            // Sum of 12 uniforms minus 6: zero-mean, unit-variance, deterministic.
+            double gaussian = -6.0;
+            for (int k = 0; k < 12; k++)
+            {
+                gaussian += random.NextDouble();
+            }
+            deconvolution[i] = new Complex(1e-4 * gaussian, 0.0);
+        }
+
+        deconvolution[sweep.DeconvolutionPeakIndex] = Complex.One;
+        return deconvolution;
+    }
+
+    private static ExpSweepMeasurement CreateSweepWithNoiseFloorOnly()
+    {
+        EssSweepMetadata sweep = NoiseFixtureSweep();
+        return CreateSweepMeasurement(NoisyCleanDeconvolution(sweep), sweep);
+    }
+
+    private static ExpSweepMeasurement CreateSweepMeasurement(
+        Complex[] deconvolution, EssSweepMetadata sweep)
+    {
+        var transferImpulse = new Complex[2048];
+        transferImpulse[64] = Complex.One;
+
+        var measurement = new ExpSweepMeasurement(new FakeAudioSessionFactory());
+        measurement.RestoreImpulseResponse(
+            lowFrequencyHz: sweep.StartFrequencyHz,
+            highFrequencyHz: sweep.EndFrequencyHz,
+            sampleRate: (int)sweep.SampleRateHz,
+            bits: 24,
+            sweepDurationSeconds: sweep.DurationSeconds,
+            playChannel: PlaybackChannel.Mono,
+            sweepDeconvolutionImpulseResponse: deconvolution,
+            sweepDeconvolutionPeakIndex: sweep.DeconvolutionPeakIndex,
+            measurementMode: SweepMeasurementMode.LoopbackTransfer,
+            transferImpulseResponse: transferImpulse,
+            transferPeakIndex: 64,
+            achievedLowFrequencyHz: sweep.StartFrequencyHz,
+            achievedHighFrequencyHz: sweep.EndFrequencyHz);
         return measurement;
     }
 

--- a/tests/Resonalyze.Dsp.Tests/EssHarmonicBelowNoiseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EssHarmonicBelowNoiseTests.cs
@@ -121,19 +121,23 @@ public sealed class EssHarmonicBelowNoiseTests
         Assert.True(h2Validity.IsReliable);
     }
 
-    [Fact]
-    public void AContaminatedEdgeOverANoisePlateau_IsNotBlessedAsBelowNoise()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AContaminatedEdgeOverANoisePlateau_IsNotBlessedAsBelowNoise(bool leading)
     {
-        // A neighbour's undecayed tail sits in the LEADING edge region of HD2's
-        // window while the plateau itself holds nothing above the noise floor.
-        // The below-noise verdict must not swallow that: the window is polluted,
-        // which is exactly what the edge-based overlap warning exists to say.
+        // A neighbour's undecayed tail sits in ONE edge region of HD2's window
+        // while the plateau itself holds nothing above the noise floor. The
+        // below-noise verdict must not swallow that on either side: the window
+        // is polluted, which is exactly what the edge-based overlap warning
+        // exists to say.
         var sweep = Sweep();
         HarmonicWindowDefinition h2 = EssHarmonicAnalysis.BuildWindow(sweep, 2, 0.5);
         double[] impulse = NoisyCleanImpulse();
         int windowLength = h2.EndSample - h2.StartSample + 1;
-        int edgeEnd = h2.StartSample + (int)(0.15 * windowLength);
-        for (int i = h2.StartSample; i < edgeEnd; i++)
+        int edgeLength = (int)(0.15 * windowLength);
+        int edgeStart = leading ? h2.StartSample : h2.EndSample - edgeLength + 1;
+        for (int i = edgeStart; i < edgeStart + edgeLength; i++)
         {
             impulse[i] = 0.01;
         }

--- a/tests/Resonalyze.Dsp.Tests/EssHarmonicBelowNoiseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EssHarmonicBelowNoiseTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Linq;
+using Resonalyze.Dsp;
+using Xunit;
+
+namespace Resonalyze.Dsp.Tests;
+
+// Pins the below-noise classification of harmonic packets. The overlap check reads
+// the window edges RELATIVE to the packet's own peak, so a harmonic that fell below
+// the measurement noise floor — a windowful of flat noise, edges roughly at the
+// plateau peak — used to be misread as "packet overlaps its neighbour" and scolded
+// the user's cleanest captures with an amber warning. Such an order must instead be
+// classified below-noise: still dropped (its "curve" would be the noise floor), but
+// with no warning, because an unresolvably small harmonic is good news.
+public sealed class EssHarmonicBelowNoiseTests
+{
+    private const int SampleRate = 48_000;
+    private const int Octaves = 10;
+    private const int SweepSamples = 200_000;
+    private const int PeakIndex = 150_000;
+    private const int ImpulseLength = 200_000;
+    private const double NoiseSigma = 1e-4;
+
+    private static EssSweepMetadata Sweep() =>
+        EssSweepMetadata.FromExponentialSweep(SampleRate, Octaves, SweepSamples, PeakIndex);
+
+    // A linear delta over a deterministic white-noise floor, with no harmonic
+    // content at all — the record every clean electrical capture approximates.
+    private static double[] NoisyCleanImpulse(int seed = 12345)
+    {
+        var random = new Random(seed);
+        double[] impulse = new double[ImpulseLength];
+        for (int i = 0; i < ImpulseLength; i++)
+        {
+            // Sum of 12 uniforms minus 6: zero-mean, unit-variance, deterministic.
+            double gaussian = -6.0;
+            for (int k = 0; k < 12; k++)
+            {
+                gaussian += random.NextDouble();
+            }
+            impulse[i] = NoiseSigma * gaussian;
+        }
+
+        impulse[PeakIndex] = 1.0;
+        return impulse;
+    }
+
+    [Fact]
+    public void HarmonicsBelowTheNoiseFloor_AreClassifiedBelowNoise_WithNoWarnings()
+    {
+        EssHarmonicDecomposition decomposition = EssHarmonicAnalysis.AnalyzeEssHarmonics(
+            NoisyCleanImpulse(), Sweep(), new HarmonicAnalysisOptions(MaxHarmonic: 4));
+
+        Assert.All(decomposition.Validity.Packets, packet =>
+        {
+            Assert.True(packet.IsBelowNoiseFloor);
+            Assert.False(packet.IsReliable);
+            Assert.Null(packet.Warning);
+        });
+        // No warnings: nothing here is a fault, so IsValid stays true.
+        Assert.Empty(decomposition.Validity.Warnings);
+        Assert.True(decomposition.Validity.IsValid);
+    }
+
+    [Fact]
+    public void HarmonicsBelowTheNoiseFloor_AreDroppedFromCurves_WithoutAWarning()
+    {
+        EssDistortion.DistortionCurveResult result = EssDistortion.ComputeDistortionCurvesResult(
+            NoisyCleanImpulse(),
+            Sweep(),
+            new DistortionOptions(MaxHarmonic: 4),
+            calibration: null,
+            SpectrumCurves.Harmonics);
+
+        Assert.DoesNotContain(result.Curves, c => c.Kind == AnalysisCurveKind.SecondHarmonic);
+        Assert.DoesNotContain(result.Curves, c => c.Kind == AnalysisCurveKind.ThirdHarmonic);
+        Assert.DoesNotContain(result.Curves, c => c.Kind == AnalysisCurveKind.FourthHarmonic);
+        Assert.Empty(result.Warnings);
+        Assert.All(result.PacketValidity, packet => Assert.True(packet.IsBelowNoiseFloor));
+    }
+
+    [Fact]
+    public void AGenuineOverlap_StaysFlaggedAsOverlap_WhenANoiseFloorIsPresent()
+    {
+        var sweep = Sweep();
+        HarmonicWindowDefinition h2 = EssHarmonicAnalysis.BuildWindow(sweep, 2, 0.5);
+
+        double[] impulse = NoisyCleanImpulse();
+        // HD2 content far above the noise that persists to the window edge — the
+        // real leak the overlap warning exists for.
+        for (int i = h2.PeakSample; i <= h2.EndSample && i < ImpulseLength; i++)
+        {
+            impulse[i] = 0.3 * Math.Cos(0.3 * (i - h2.PeakSample));
+        }
+
+        EssHarmonicDecomposition decomposition = EssHarmonicAnalysis.AnalyzeEssHarmonics(
+            impulse, sweep, new HarmonicAnalysisOptions(MaxHarmonic: 4));
+
+        HarmonicPacketValidity h2Validity =
+            decomposition.Validity.Packets.Single(p => p.Order == 2);
+        Assert.False(h2Validity.IsBelowNoiseFloor);
+        Assert.False(h2Validity.IsReliable);
+        Assert.NotNull(h2Validity.Warning);
+        Assert.Contains(decomposition.Validity.Warnings, w => w.Contains("HD2"));
+    }
+
+    [Fact]
+    public void AHarmonicWellAboveTheNoiseFloor_IsNotReclassified()
+    {
+        var sweep = Sweep();
+        double[] impulse = NoisyCleanImpulse();
+        // A contained HD2 delta far above the noise floor stays a reliable packet.
+        impulse[PeakIndex - EssHarmonicAnalysis.HarmonicOffsetSamples(sweep, 2)] = 0.02;
+
+        EssHarmonicDecomposition decomposition = EssHarmonicAnalysis.AnalyzeEssHarmonics(
+            impulse, sweep, new HarmonicAnalysisOptions(MaxHarmonic: 4));
+
+        HarmonicPacketValidity h2Validity =
+            decomposition.Validity.Packets.Single(p => p.Order == 2);
+        Assert.False(h2Validity.IsBelowNoiseFloor);
+        Assert.True(h2Validity.IsReliable);
+    }
+
+    [Fact]
+    public void WithoutAUsableTail_TheOldOverlapVerdictIsKept()
+    {
+        // The noise stops right after the linear window, leaving a silent tail
+        // whose RMS is zero — no usable floor estimate, so the below-noise test
+        // must stand down and the noise-filled harmonic windows fall back to the
+        // edge-based isolation verdict.
+        var sweep = Sweep();
+        HarmonicWindowDefinition linear = EssHarmonicAnalysis.BuildWindow(sweep, 1, 0.5);
+        double[] impulse = NoisyCleanImpulse();
+        for (int i = Math.Max(0, linear.EndSample); i < ImpulseLength; i++)
+        {
+            impulse[i] = 0.0;
+        }
+        impulse[PeakIndex] = 1.0;
+
+        EssHarmonicDecomposition decomposition = EssHarmonicAnalysis.AnalyzeEssHarmonics(
+            impulse, sweep, new HarmonicAnalysisOptions(MaxHarmonic: 4));
+
+        // Whether each noise-filled window lands on the marginal or the invalid
+        // side of the edge margin, it must be warned about the OLD way — never
+        // silently blessed as below-noise without a floor to judge against.
+        Assert.All(decomposition.Validity.Packets, packet =>
+        {
+            Assert.False(packet.IsBelowNoiseFloor);
+            Assert.NotNull(packet.Warning);
+        });
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/EssHarmonicBelowNoiseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EssHarmonicBelowNoiseTests.cs
@@ -154,6 +154,41 @@ public sealed class EssHarmonicBelowNoiseTests
     }
 
     [Fact]
+    public void ASignalInTheShoulder_BetweenPlateauAndEdge_IsNotBlessedAsBelowNoise()
+    {
+        // The below-noise verdict must survey the WHOLE window. A burst in the
+        // shoulder between the central plateau and the trailing edge leaves both
+        // the plateau maximum and the edge RMS values at the noise floor — the
+        // only regions the verdict used to consult — yet the window plainly
+        // holds a packet, so blessing it as a clean capture would be a lie.
+        var sweep = Sweep();
+        HarmonicWindowDefinition h2 = EssHarmonicAnalysis.BuildWindow(sweep, 2, 0.5);
+        double[] impulse = NoisyCleanImpulse();
+        int length = h2.EndSample - h2.StartSample + 1;
+        int plateauTo = Math.Min(h2.EndSample, h2.PeakSample + length / 8);
+        int trailingEdgeStart =
+            h2.EndSample - Math.Max(1, (int)Math.Round(0.15 * length)) + 1;
+        const int burstLength = 500;
+        int burstStart = plateauTo + (trailingEdgeStart - plateauTo - burstLength) / 2;
+        // The burst must sit strictly between the plateau and the edge region,
+        // or this test would degenerate into one of the already-covered cases.
+        Assert.True(burstStart > plateauTo);
+        Assert.True(burstStart + burstLength < trailingEdgeStart);
+        for (int i = burstStart; i < burstStart + burstLength; i++)
+        {
+            impulse[i] = 0.01;
+        }
+
+        EssHarmonicDecomposition decomposition = EssHarmonicAnalysis.AnalyzeEssHarmonics(
+            impulse, sweep, new HarmonicAnalysisOptions(MaxHarmonic: 4));
+
+        HarmonicPacketValidity h2Validity =
+            decomposition.Validity.Packets.Single(p => p.Order == 2);
+        Assert.False(h2Validity.IsBelowNoiseFloor);
+        Assert.NotNull(h2Validity.Warning);
+    }
+
+    [Fact]
     public void WithoutAUsableTail_TheOldOverlapVerdictIsKept()
     {
         // The noise stops right after the linear window, leaving a silent tail

--- a/tests/Resonalyze.Dsp.Tests/EssHarmonicBelowNoiseTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EssHarmonicBelowNoiseTests.cs
@@ -122,6 +122,34 @@ public sealed class EssHarmonicBelowNoiseTests
     }
 
     [Fact]
+    public void AContaminatedEdgeOverANoisePlateau_IsNotBlessedAsBelowNoise()
+    {
+        // A neighbour's undecayed tail sits in the LEADING edge region of HD2's
+        // window while the plateau itself holds nothing above the noise floor.
+        // The below-noise verdict must not swallow that: the window is polluted,
+        // which is exactly what the edge-based overlap warning exists to say.
+        var sweep = Sweep();
+        HarmonicWindowDefinition h2 = EssHarmonicAnalysis.BuildWindow(sweep, 2, 0.5);
+        double[] impulse = NoisyCleanImpulse();
+        int windowLength = h2.EndSample - h2.StartSample + 1;
+        int edgeEnd = h2.StartSample + (int)(0.15 * windowLength);
+        for (int i = h2.StartSample; i < edgeEnd; i++)
+        {
+            impulse[i] = 0.01;
+        }
+
+        EssHarmonicDecomposition decomposition = EssHarmonicAnalysis.AnalyzeEssHarmonics(
+            impulse, sweep, new HarmonicAnalysisOptions(MaxHarmonic: 4));
+
+        HarmonicPacketValidity h2Validity =
+            decomposition.Validity.Packets.Single(p => p.Order == 2);
+        Assert.False(h2Validity.IsBelowNoiseFloor);
+        Assert.False(h2Validity.IsReliable);
+        Assert.NotNull(h2Validity.Warning);
+        Assert.Contains(decomposition.Validity.Warnings, w => w.Contains("HD2"));
+    }
+
+    [Fact]
     public void WithoutAUsableTail_TheOldOverlapVerdictIsKept()
     {
         // The noise stops right after the linear window, leaving a silent tail


### PR DESCRIPTION
## Problem

In FR mode, a harmonic that fell **below the measurement noise floor** triggered the threatening amber warning "HDn packet overlaps its neighbour — increase the sweep duration", scolding users for their **cleanest** captures. The overlap check reads window edges relative to the packet's own peak, so it cannot tell a leaking packet from no packet at all: a noise-only window has edges ~10–12 dB below its plateau maximum (sigma·sqrt(2·ln M) crest factor), squarely inside the "overlap" verdict.

## Fix

**DSP** (`EssHarmonicAnalysis`)
- A robust time-domain tail-noise amplitude (same quiet region `EssNoise` draws from; median of 8 chunk RMS values, so a stray thump cannot inflate it).
- A packet whose plateau peak is within 16 dB of that floor (covers the noise crest factor up to M ~ 10^7 with margin) holds no harmonic: new `IsBelowNoiseFloor` classification — still dropped from curves/THD (its "curve" would be the noise floor), but **no warning**, and `IsValid` stays true.
- No usable tail (short or silent record) → the below-noise test stands down and the old verdict applies unchanged. Genuine leaks sit far above the floor and keep the amber warning.

**UI** (`PlotModelFactory`, `MeasurementPlotContext`)
- Missing HD curves split into two buckets: real problems keep the amber annotation; below-noise orders get a neutral gray note — *"below the measurement noise floor / distortion too low to resolve — a clean capture, not a fault"*. Mixed cases stack both, each naming only its own curves.

**Rendering** (`OverlayTextAnnotation`)
- Long-standing bug: multi-line overlay text was vertically centred on its anchor line, pushing the first line half out of the plot area (visible on the old amber warning too). The block is now anchored by its flowing edge — single-line notes (legend labels, SPL/transfer notices, live overlays) render pixel-identical, multi-line blocks grow into the plot and can no longer clip.
- The long overlap-warning line wraps at "; " so narrow windows fit it.

## Tests

- 5 new DSP tests (`EssHarmonicBelowNoiseTests`): below-noise classification with no warnings, drop-without-warning through the curve pipeline, genuine overlap NOT reclassified when noise is present, a harmonic well above the floor untouched, fallback to the old verdict without a usable tail.
- 2 new UI tests (`PlotModelFactoryTests`): gray-note-only for a clean capture; mixed case renders amber (HD2) + gray (HD3, HD4) with correct colors and bucketing.
- Full suites green: DSP 1415, App 1955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)