### PR TITLE
Hand the stereo engine only the monos its walk tunes

### DIFF
--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -6089,7 +6089,7 @@ public partial class VirtualCrossoverPanel : UserControl
     // Bridges the pair/side model to the stereo engine on a background thread,
     // sharing the same AlignmentReprocessor (run-scoped FFT cache) as the
     // single-side run.
-    private AlignmentReprocessor ComputeStereoAlignment(
+    internal AlignmentReprocessor ComputeStereoAlignment(
         List<VirtualCrossoverSideAlignmentChannel> leftSide,
         List<VirtualCrossoverSideAlignmentChannel> rightSide,
         List<VirtualCrossoverSideAlignmentChannel> union,
@@ -6192,7 +6192,17 @@ public partial class VirtualCrossoverPanel : UserControl
                 Pairs(referenceByBand),
                 farByBand,
                 Pairs(farByBand),
-                union.Where(side => side.Runtime.Pair.Mono)
+                // The engine's mono channels are the ones ITS walk tunes - the
+                // front chain's shared subwoofers, read off the walked left
+                // side. NOT off the union: a staged run keeps a mono centre
+                // (or a mono rear) in the union for the reprocessor while the
+                // walks are narrowed to the chain, and handing those to the
+                // engine trips its own "every mono channel must be part of the
+                // left walk" guard - the refusal the reference car produced.
+                // The guard is right; they belong to stages 2-3. An unstaged
+                // run's left side holds exactly the union's monos, so this
+                // reads the same set it always did there.
+                leftSide.Where(side => side.Runtime.Pair.Mono)
                     .Cast<IAlignmentChannel>()
                     .ToList(),
                 rightHandDrive ? bridgeRight : bridgeLeft,

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverStagedAlignmentTests.cs
@@ -340,4 +340,146 @@ public sealed class VirtualCrossoverStagedAlignmentTests
         Assert.Equal(1.0, alignment[front].DelayMs, 6);
         Assert.Equal(18.0, alignment[rear].DelayMs, 6);
     }
+
+    // A stereo channel pair with a synthetic measurement on each side; a mono
+    // one carries a single (left) side. Deltas at distinct offsets are all the
+    // engine needs: every stage reads band-limited arrivals and correlations,
+    // and a clean impulse has both.
+    private static VirtualCrossoverChannel Measured(
+        string name,
+        VirtualCrossoverZone zone,
+        bool mono,
+        Action<VirtualCrossoverChannelSettings> crossover,
+        int leftDelaySamples,
+        int rightDelaySamples = 0)
+    {
+        var channel = new VirtualCrossoverChannel(name);
+        channel.Pair.Zone = zone;
+        channel.Pair.Mono = mono;
+        crossover(channel.Pair.Left);
+        channel.Pair.Left.SourceFilePath = $"{name}-l.json";
+        channel.SideState(false).TransferImpulseResponse =
+            Impulse(leftDelaySamples);
+        channel.SideState(false).SampleRate = 48_000;
+        if (!mono)
+        {
+            crossover(channel.Pair.Right);
+            channel.Pair.Right.SourceFilePath = $"{name}-r.json";
+            channel.SideState(true).TransferImpulseResponse =
+                Impulse(rightDelaySamples);
+            channel.SideState(true).SampleRate = 48_000;
+        }
+
+        return channel;
+    }
+
+    private static System.Numerics.Complex[] Impulse(int delaySamples)
+    {
+        var ir = new System.Numerics.Complex[16_384];
+        ir[delaySamples] = 1.0;
+        return ir;
+    }
+
+    [Theory]
+    // Both layouts: the engine's guard demands the monos live in its
+    // REFERENCE walk, and a right-hand drive swaps which cabin side that is -
+    // the fix holds on both only because a mono side is ONE instance shared
+    // by both cabin lists.
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ComputeStereoAlignment_WalksTheChain_WithAMonoCentreLeftToItsOwnStage(
+        bool rightHandDrive)
+    {
+        // The reference car's refusal, as a fixture. A staged stereo run
+        // narrows the engine's walks to the front chain but hands it the
+        // UNION's mono channels - and the centre is mono by definition while
+        // belonging to stage 3, so the engine's own validity guard ("every
+        // mono channel must be part of the left walk that tunes it") refused
+        // the plan the panel assembled. The guard is right; the plan was
+        // wrong. The mono channels the engine may be given are the ones its
+        // walk tunes: the front chain's shared subwoofer, not the centre.
+        StaTest.Run(() =>
+        {
+            using var panel = new VirtualCrossoverPanel();
+            VirtualCrossoverChannel sub = Measured(
+                "A", VirtualCrossoverZone.Sub, mono: true,
+                settings =>
+                {
+                    settings.CrossoverKind = CrossoverKind.LowPass;
+                    settings.LowPassEdge = new CrossoverEdge(
+                        CrossoverFilterFamily.LinkwitzRiley, 120, 24);
+                },
+                leftDelaySamples: 520);
+            VirtualCrossoverChannel woofer = Measured(
+                "B", VirtualCrossoverZone.Front, mono: false,
+                settings =>
+                {
+                    settings.CrossoverKind = CrossoverKind.BandPass;
+                    settings.HighPassEdge = new CrossoverEdge(
+                        CrossoverFilterFamily.LinkwitzRiley, 120, 24);
+                    settings.LowPassEdge = new CrossoverEdge(
+                        CrossoverFilterFamily.LinkwitzRiley, 2_000, 24);
+                },
+                leftDelaySamples: 480,
+                rightDelaySamples: 468);
+            VirtualCrossoverChannel tweeter = Measured(
+                "C", VirtualCrossoverZone.Front, mono: false,
+                settings =>
+                {
+                    settings.CrossoverKind = CrossoverKind.HighPass;
+                    settings.HighPassEdge = new CrossoverEdge(
+                        CrossoverFilterFamily.LinkwitzRiley, 2_000, 24);
+                },
+                leftDelaySamples: 500,
+                rightDelaySamples: 462);
+            VirtualCrossoverChannel centre = Measured(
+                "D", VirtualCrossoverZone.Center, mono: true,
+                settings =>
+                {
+                    settings.CrossoverKind = CrossoverKind.HighPass;
+                    settings.HighPassEdge = new CrossoverEdge(
+                        CrossoverFilterFamily.LinkwitzRiley, 290, 24);
+                },
+                leftDelaySamples: 505);
+
+            // The exact shapes RunStereoProposalAsync hands over: the walks
+            // narrowed to the front chain, the union carrying everything for
+            // the reprocessor (stages 2-3 render their snapshots through it).
+            var subSide = new VirtualCrossoverSideAlignmentChannel(sub, false);
+            var woofL = new VirtualCrossoverSideAlignmentChannel(woofer, false);
+            var woofR = new VirtualCrossoverSideAlignmentChannel(woofer, true);
+            var twL = new VirtualCrossoverSideAlignmentChannel(tweeter, false);
+            var twR = new VirtualCrossoverSideAlignmentChannel(tweeter, true);
+            var centreSide = new VirtualCrossoverSideAlignmentChannel(centre, false);
+            List<VirtualCrossoverSideAlignmentChannel> chainLeft =
+                [subSide, woofL, twL];
+            List<VirtualCrossoverSideAlignmentChannel> chainRight =
+                [subSide, woofR, twR];
+            List<VirtualCrossoverSideAlignmentChannel> union =
+                [subSide, woofL, twL, woofR, twR, centreSide];
+
+            var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>();
+            var decisions = new Dictionary<IAlignmentChannel, AlignmentDecision>();
+            var log = new System.Text.StringBuilder();
+            panel.ComputeStereoAlignment(
+                chainLeft, chainRight, union, twL, twR,
+                bridgeBandLowHz: 2_000, bridgeBandHighHz: 20_000,
+                sceneOffsetMs: 0.0, rightHandDrive,
+                alignment, decisions, log);
+
+            // Stage 1 does not touch the centre - it has no junctions and is
+            // placed by its own stage against both settled sides.
+            Assert.DoesNotContain(centreSide, alignment.Keys);
+            // The chain WAS walked: the engine writes an override for every
+            // walked channel except (at most) its own reference - the map is
+            // sparse by contract, so exactly one absence is legitimate.
+            List<IAlignmentChannel> chain = [subSide, woofL, twL, woofR, twR];
+            Assert.True(
+                chain.Count(member => !alignment.ContainsKey(member)) <= 1,
+                "the front chain was not walked: " + string.Join(
+                    ", ",
+                    chain.Where(member => !alignment.ContainsKey(member))
+                        .Select(member => member.Name)));
+        });
+    }
 }


### PR DESCRIPTION
The reference car's first staged stereo Auto delay refused with the engine's own validity guard: **"Every mono channel must be part of the left walk that tunes it."** The guard is correct — the plan it was handed was not.

## The defect

PR #150 narrowed stage 1's walks to the front chain and taught the **bridge picker** the same lesson (`InFrontChain`, with a comment saying why). The plan's **mono-channel list** was the straggler: still built from the *union* —

```csharp
union.Where(side => side.Runtime.Pair.Mono)
```

— while a centre is mono **by definition** (and a mono rear is legal) yet belongs to stages 2–3, which deliberately bypass the junction machinery. Stage 1's plan then declared a shared mono channel the walk does not contain. Had the guard not fired, `ComoveMonoChannels` would have hunted junctions the centre does not have.

It needed *stereo + staging + a mono block outside the chain* to trigger — the battery is front-only, PR #150's tests drove `PlaceLaterStagesStereo` below this call boundary, and the single-side path assembles no such plan. The reference car is the first thing to walk this path.

## The fix

One line: the mono list reads off the **walked left side** — the chain's shared subwoofers exactly. It holds on both drive layouts because a mono side is ONE instance shared by both cabin lists (the engine's guard checks membership in its *reference* walk, which RHD swaps). An unstaged run's left side holds exactly the union's monos, so nothing changes there.

`ComputeStereoAlignment` goes `private → internal` for the falsifier; no other code change.

## Verification

- **Falsifier first, red first**: a synthetic staged system (mono sub in-chain, stereo woofer/tweeter, mono centre in the union only) drives the real `ComputeStereoAlignment` and failed on the unfixed code with the user's exact exception — then green after the fix, asserting the centre stays untouched and the chain was walked (sparse-map contract honoured: at most one absent reference). Parametrised over LHD/RHD.
- **Field discriminator**: the fix was run end to end on the reference car itself (a throwaway in-assembly probe, deleted before commit): stage 1 settles the five-channel chain both sides, the rear pair lands per side at co-arrival + 15 ms Haas, the centre sits midway between the two front sums with an honest LOW CONFIDENCE (its two side readings disagree beyond the probe's scene offset), normalization dials everything in under the ceiling.
- 3,547 tests, 0 failing; **7-cabin battery line-for-line identical** (single-side path untouched, and the unstaged stereo equivalence is by construction).

## Reviewed adversarially before posting

Every consumer of `plan.MonoChannels` in the engine was read against the new set (bridge guard, right-walk skip, junction filter, co-move, polarity symmetry — all operate on walked channels); `new StereoAlignmentPlan` has exactly one construction site; the union keeps feeding the reprocessor, which stages 2–3 require.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
