### PR TITLE
Put Apply back under the report, where the rear fill row pushed everything else

### DIFF
--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.Designer.cs
@@ -216,7 +216,7 @@
             buttonApply.DialogResult = DialogResult.OK;
             buttonApply.FlatStyle = FlatStyle.Popup;
             buttonApply.ForeColor = Color.White;
-            buttonApply.Location = new Point(590, 643);
+            buttonApply.Location = new Point(590, 677);
             buttonApply.Name = "buttonApply";
             buttonApply.Size = new Size(84, 26);
             buttonApply.TabIndex = 11;
@@ -229,7 +229,7 @@
             buttonCancel.DialogResult = DialogResult.Cancel;
             buttonCancel.FlatStyle = FlatStyle.Popup;
             buttonCancel.ForeColor = Color.White;
-            buttonCancel.Location = new Point(680, 643);
+            buttonCancel.Location = new Point(680, 677);
             buttonCancel.Name = "buttonCancel";
             buttonCancel.Size = new Size(84, 26);
             buttonCancel.TabIndex = 12;

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAutoDelayDialogTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAutoDelayDialogTests.cs
@@ -37,15 +37,25 @@ public sealed class VirtualCrossoverAutoDelayDialogTests
         Assert.Contains("Run again", Field<Label>(dialog, "labelStatus").Text);
     });
 
-    [Theory]
-    [InlineData(715)]
-    [InlineData(360)]
-    [InlineData(1100)]
-    public void TheActionButtonsStayVisibleAtEveryHeight(int clientHeight) => StaTest.Run(() =>
+    [Fact]
+    public void TheActionButtonsStayVisibleAtEveryHeight() => StaTest.Run(() =>
     {
         using var dialog = new VirtualCrossoverAutoDelayDialog();
-        dialog.ClientSize = dialog.ClientSize with { Height = clientHeight };
+        AssertNothingCoversTheActionButtons(dialog);
 
+        // The smallest window the dialog can be. Asked for one pixel it clamps
+        // to MinimumSize, which is the form's OUTER size - so the client area
+        // that leaves is a number the test must not repeat, only observe.
+        dialog.Size = dialog.Size with { Height = 1 };
+        Assert.Equal(dialog.MinimumSize.Height, dialog.Height);
+        AssertNothingCoversTheActionButtons(dialog);
+
+        dialog.ClientSize = dialog.ClientSize with { Height = 1_100 };
+        AssertNothingCoversTheActionButtons(dialog);
+    });
+
+    private static void AssertNothingCoversTheActionButtons(Form dialog)
+    {
         foreach (string name in new[] { "buttonApply", "buttonCancel" })
         {
             Button button = Field<Button>(dialog, name);
@@ -74,7 +84,7 @@ public sealed class VirtualCrossoverAutoDelayDialogTests
                     $"{sibling.Name} {sibling.Bounds} covers {name} {button.Bounds}.");
             }
         }
-    });
+    }
 
     private static T Field<T>(object target, string name) where T : class =>
         (T)target.GetType()

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAutoDelayDialogTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAutoDelayDialogTests.cs
@@ -37,6 +37,45 @@ public sealed class VirtualCrossoverAutoDelayDialogTests
         Assert.Contains("Run again", Field<Label>(dialog, "labelStatus").Text);
     });
 
+    [Theory]
+    [InlineData(715)]
+    [InlineData(360)]
+    [InlineData(1100)]
+    public void TheActionButtonsStayVisibleAtEveryHeight(int clientHeight) => StaTest.Run(() =>
+    {
+        using var dialog = new VirtualCrossoverAutoDelayDialog();
+        dialog.ClientSize = dialog.ClientSize with { Height = clientHeight };
+
+        foreach (string name in new[] { "buttonApply", "buttonCancel" })
+        {
+            Button button = Field<Button>(dialog, name);
+
+            Assert.True(
+                button.Top >= 0 && button.Bottom <= dialog.ClientSize.Height,
+                $"{name} is outside the client area: {button.Bounds} in {dialog.ClientSize}.");
+
+            // Controls.Add appends, so a LOWER index paints in front: any
+            // earlier sibling overlapping the button hides it, however
+            // correct the button's own coordinates are. That is what the
+            // rear fill row did to Apply - the report box moved down with
+            // the row, the buttons did not, and a dialog that reported a
+            // proposal had no way to accept it.
+            int index = dialog.Controls.GetChildIndex(button);
+            foreach (Control sibling in dialog.Controls)
+            {
+                if (ReferenceEquals(sibling, button)
+                    || dialog.Controls.GetChildIndex(sibling) > index)
+                {
+                    continue;
+                }
+
+                Assert.False(
+                    sibling.Bounds.IntersectsWith(button.Bounds),
+                    $"{sibling.Name} {sibling.Bounds} covers {name} {button.Bounds}.");
+            }
+        }
+    });
+
     private static T Field<T>(object target, string name) where T : class =>
         (T)target.GetType()
             .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!


### PR DESCRIPTION
## The defect

Reported from the field, on the run that was meant to validate the reference car: the dialog printed a full proposal, said `Proposal ready — Apply writes it, Discard keeps the current settings`, and there was nothing to press.

The buttons were never gone. #150 added the Rear fill row and moved the run button, the status line and the report box down by 34 px, growing the form by the same 34. `buttonApply` and `buttonCancel` stayed at their old `y = 643`, which after the shift falls **inside** the report box (`114 .. 667`). `Controls.Add` appends, so the box — added first — paints in front of them. Two pixels of button showed below its lower edge; that sliver is visible at the bottom of the reporter's screenshot.

Everything about the buttons other than their coordinates was fine: enabled, focusable, reachable by <kbd>Tab</kbd>, and <kbd>Enter</kbd> still accepted the proposal. That is why nothing in the app noticed.

## The fix

Both buttons move down by the same 34 px (`643 → 677`). That restores the 10 px gap under the report box and the 12 px margin above the form's edge, exactly the relations the layout had before #150. The anchors (`Bottom | Right` on the buttons, `Top | Bottom | Left | Right` on the box) already carried those relations to every window size, so no other geometry needs touching — and equally, resizing was never a workaround.

## Why the existing test passed

`ChangingRearFillInvalidatesTheCompletedProposal` already asserted `apply.Enabled` after a run. It was enabled. A `Button` knows nothing about a sibling drawn over it, so the assertion that looked like it covered Apply covered only half of it.

The new test reads the z-order instead: for each action button, no sibling with a **lower** child index may intersect its bounds, checked at the design height and at both ends of the range the anchors must cover: a tall window, and the smallest one the dialog can actually be — the test asks for a one-pixel form, lets WinForms clamp it to `MinimumSize`, and asserts the clamp landed, so it observes the client height that leaves rather than repeating a number. (`MinimumSize` is the form's OUTER size, so a *client* height of 360 is not the minimum at all; the first revision of this test said it was and checked a middling height twice.). It fails on the parent commit with

```
textBoxReport {X=12,Y=114,Width=752,Height=553} covers buttonApply {X=590,Y=643,Width=84,Height=26}
```

which is the reported symptom stated as geometry.

## Is there a second one

Two sweeps, both clean:

- **Runtime**, over every `Form` in the assembly with a default constructor: no button intersects an earlier sibling.
- **Static**, over all 33 designer files with top-level `Controls.Add` (this catches the dialogs whose constructors take arguments): two hits, both false. `Form1`'s Virtual DSP metric label and `VirtualCrossoverAutoSetupDialog`'s preview label overlap buttons at *design* coordinates only — both dialogs recompute that column at runtime (the auto setup dialog literally sets its own `ClientSize` from `labelPreview.Bottom + margin + buttonApply.Height + margin`), which is why the runtime sweep is silent on them.

The dialog was also rendered to a bitmap with handles created, showing Apply and Discard in place under the report.

## Tests

Full solution, Release: **3548 passed, 12 skipped, 0 failed** (159 audio + 1971 app + 1418 dsp). The session battery is untouched by a two-literal designer change and was not re-run.

