### PR TITLE
Measure the delay spread over the chain that is searched, not the groups that are placed

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2471,8 +2471,12 @@ comb can fine-tune only within the physically correct lobe. Candidates are
 scored by in-band average loss *and* the depth of the deepest smoothed notch,
 and weighed against an arrival-based prior, so the search does not add delay or
 flip polarity without a real improvement. If the resulting delays span more
-than ~10 ms — usually one channel's crossover having excessive group delay — a
-banner flags the lagging driver.
+than 15 ms — usually one channel's crossover having excessive group delay — a
+banner flags the lagging driver. The span is read over the **front chain only**,
+the group whose junctions the search settles against each other: a rear fill is
+placed the Rear fill offset behind on purpose, and a centre is placed against a
+front stage already settled, so neither can stretch the chain and neither is
+counted.
 
 Polarity is normally the sum search's to decide, with one exception: where the
 lower channel's low-pass and the upper channel's high-pass share family, corner

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2472,11 +2472,13 @@ scored by in-band average loss *and* the depth of the deepest smoothed notch,
 and weighed against an arrival-based prior, so the search does not add delay or
 flip polarity without a real improvement. If the resulting delays span more
 than 15 ms — usually one channel's crossover having excessive group delay — a
-banner flags the lagging driver. The span is read over the **front chain only**,
-the group whose junctions the search settles against each other: a rear fill is
-placed the Rear fill offset behind on purpose, and a centre is placed against a
-front stage already settled, so neither can stretch the chain and neither is
-counted.
+banner flags the lagging driver. The span is read over **the chain whose
+junctions the search actually settles against each other** — in a staged project
+the front chain, with the rear fill and the centre left out: each of those is
+placed against a front stage already settled (the rear the Rear fill offset
+behind, on purpose), so neither can stretch the chain. Where there is no front
+chain to be placed against — a rear-only project — that project's own chain is
+what the span is read over, exactly as the run walks it.
 
 Polarity is normally the sum search's to decide, with one exception: where the
 lower channel's low-pass and the upper channel's high-pass share family, corner

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4467,34 +4467,65 @@ public partial class VirtualCrossoverPanel : UserControl
     // truth). Bypassed channels carry the raw signal and are excluded.
     private void UpdateCrossoverWarning(List<ProcessedChannel> processed)
     {
-        List<ProcessedChannel> active = processed
-            .Where(item => !item.Channel.Pair.Bypass)
-            .ToList();
-        if (active.Count < 2)
+        if (CrossoverSpreadWarning([.. processed.Select(item => item.Channel)])
+            is not (string name, double spread, bool placedGroups))
         {
             HideWarning();
             return;
         }
 
-        // The latest driver holds the smallest delay (everyone else is delayed
-        // toward it); the spread is how far ahead the earliest driver sits.
-        ProcessedChannel latest = active.MinBy(item => item.Channel.Settings.DelayMs)!;
-        double earliestDelay = active.Max(item => item.Channel.Settings.DelayMs);
-        double spread = earliestDelay - latest.Channel.Settings.DelayMs;
-        if (spread <= CrossoverGroupDelayWarningMs)
-        {
-            HideWarning();
-            return;
-        }
-
-        string name = latest.Channel.Name;
         ShowWarning(
             $"⚠ {name} lags the others by ~{spread:0} ms — check its crossover.",
             $"{name} arrives ~{spread:0} ms after the other drivers, so Auto delay pushes " +
             "them out by that much to match it.\r\n\r\n" +
             "This is usually excessive crossover group delay — a narrow or steep low-frequency " +
-            "band-pass. Reduce its slope or widen its band to bring the alignment delays down.",
+            "band-pass. Reduce its slope or widen its band to bring the alignment delays down." +
+            // Said only where it applies, so a front-only car reads the same
+            // two paragraphs it always did — and where it does apply, it
+            // answers the question the figure raises: the rear block standing
+            // 15 ms out in the delay table is not part of this number.
+            (placedGroups
+                ? "\r\n\r\nThe rear fill and the centre are not counted. They are placed " +
+                    "against the front stage rather than tuned with it, and the rear sits " +
+                    "its fill offset behind by design."
+                : string.Empty),
             CrossoverWarningColor);
+    }
+
+    // The channel the spread names, how wide it is, and whether the project
+    // holds groups the spread had to leave out - or null when there is nothing
+    // to say. Pure so the rule can be read off a set of channels without a
+    // processing run behind it.
+    internal static (string Name, double SpreadMs, bool PlacedGroups)? CrossoverSpreadWarning(
+        IReadOnlyList<VirtualCrossoverChannel> channels)
+    {
+        // Only the front chain. The spread is read as "Auto delay had to push
+        // everyone out to catch this driver up", and that sentence is true of
+        // the chain alone: it is the one stage whose junctions are SEARCHED,
+        // so its members do drag each other. The later stages are PLACED
+        // against a chain already settled and drag nothing — a rear fill
+        // deliberately sits the Rear fill offset behind, which at the default
+        // 15 ms is the warning threshold itself, and a centre carries whatever
+        // its own path costs. Reading either into the spread makes Auto delay's
+        // own output trip the warning, on the very installation the staged run
+        // was built for. The split is the run's own, so a rear-only project —
+        // walked as its own chain, since there is nothing to place it against —
+        // keeps the warning it always had.
+        (List<VirtualCrossoverChannel> active, List<VirtualCrossoverChannel> placed) =
+            SplitAlignmentStages([.. channels.Where(channel => !channel.Pair.Bypass)]);
+        if (active.Count < 2)
+        {
+            return null;
+        }
+
+        // The latest driver holds the smallest delay (everyone else is delayed
+        // toward it); the spread is how far ahead the earliest driver sits.
+        VirtualCrossoverChannel latest = active.MinBy(channel => channel.Settings.DelayMs)!;
+        double earliestDelay = active.Max(channel => channel.Settings.DelayMs);
+        double spread = earliestDelay - latest.Settings.DelayMs;
+        return spread > CrossoverGroupDelayWarningMs
+            ? (latest.Name, spread, placed.Count > 0)
+            : null;
     }
 
     // The two alignment stages, their tuning constants and the selection

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4468,7 +4468,7 @@ public partial class VirtualCrossoverPanel : UserControl
     private void UpdateCrossoverWarning(List<ProcessedChannel> processed)
     {
         if (CrossoverSpreadWarning([.. processed.Select(item => item.Channel)])
-            is not (string name, double spread, bool placedGroups))
+            is not (string name, double spread, IReadOnlyList<VirtualCrossoverZone> placed))
         {
             HideWarning();
             return;
@@ -4483,21 +4483,41 @@ public partial class VirtualCrossoverPanel : UserControl
             // Said only where it applies, so a front-only car reads the same
             // two paragraphs it always did — and where it does apply, it
             // answers the question the figure raises: the rear block standing
-            // 15 ms out in the delay table is not part of this number.
-            (placedGroups
-                ? "\r\n\r\nThe rear fill and the centre are not counted. They are placed " +
-                    "against the front stage rather than tuned with it, and the rear sits " +
-                    "its fill offset behind by design."
-                : string.Empty),
+            // 15 ms out in the delay table is not part of this number. It
+            // names the groups the project actually has, since a car with a
+            // centre and no rear should not be told about a rear fill.
+            ExcludedGroupsNote(placed),
             CrossoverWarningColor);
     }
 
-    // The channel the spread names, how wide it is, and whether the project
-    // holds groups the spread had to leave out - or null when there is nothing
-    // to say. Pure so the rule can be read off a set of channels without a
-    // processing run behind it.
-    internal static (string Name, double SpreadMs, bool PlacedGroups)? CrossoverSpreadWarning(
-        IReadOnlyList<VirtualCrossoverChannel> channels)
+    // The sentence naming the groups the spread left out, empty when it left
+    // out none.
+    internal static string ExcludedGroupsNote(IReadOnlyList<VirtualCrossoverZone> placed)
+    {
+        bool rear = placed.Contains(VirtualCrossoverZone.Rear);
+        bool centre = placed.Contains(VirtualCrossoverZone.Center);
+        return (rear, centre) switch
+        {
+            (true, true) =>
+                "\r\n\r\nThe rear fill and the centre are not counted. They are placed " +
+                    "against the front stage rather than tuned with it, and the rear sits " +
+                    "its fill offset behind by design.",
+            (true, false) =>
+                "\r\n\r\nThe rear fill is not counted. It is placed against the front stage " +
+                    "rather than tuned with it, and sits its fill offset behind by design.",
+            (false, true) =>
+                "\r\n\r\nThe centre is not counted. It is placed against the front stage " +
+                    "rather than tuned with it.",
+            _ => string.Empty
+        };
+    }
+
+    // The channel the spread names, how wide it is, and the zones of the groups
+    // the spread had to leave out - or null when there is nothing to say. Pure
+    // so the rule can be read off a set of channels without a processing run
+    // behind it.
+    internal static (string Name, double SpreadMs, IReadOnlyList<VirtualCrossoverZone> Placed)?
+        CrossoverSpreadWarning(IReadOnlyList<VirtualCrossoverChannel> channels)
     {
         // Only the front chain. The spread is read as "Auto delay had to push
         // everyone out to catch this driver up", and that sentence is true of
@@ -4524,7 +4544,7 @@ public partial class VirtualCrossoverPanel : UserControl
         double earliestDelay = active.Max(channel => channel.Settings.DelayMs);
         double spread = earliestDelay - latest.Settings.DelayMs;
         return spread > CrossoverGroupDelayWarningMs
-            ? (latest.Name, spread, placed.Count > 0)
+            ? (latest.Name, spread, [.. placed.Select(channel => channel.Pair.Zone).Distinct()])
             : null;
     }
 

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverDelaySpreadWarningTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverDelaySpreadWarningTests.cs
@@ -1,0 +1,118 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The live "one driver lags the others" warning. Its whole premise is that the
+/// delays it reads are the ones Auto delay had to spend making drivers
+/// co-arrive — so it may only be measured over the drivers Auto delay actually
+/// aligns to each other.
+/// </summary>
+public sealed class VirtualCrossoverDelaySpreadWarningTests
+{
+    private static VirtualCrossoverChannel Block(
+        string name, VirtualCrossoverZone zone, double delayMs)
+    {
+        var channel = new VirtualCrossoverChannel(name) { SampleRate = 48_000 };
+        channel.Pair.Zone = zone;
+        channel.Pair.Left.DelayMs = delayMs;
+        channel.Pair.Right.DelayMs = delayMs;
+        return channel;
+    }
+
+    [Fact]
+    public void ARearFillHeldBackOnPurposeIsNotADriverThatLags()
+    {
+        // The reference car's own figures, from the run that raised this: the
+        // front chain settles inside five milliseconds and the rear fill sits
+        // fifteen behind it because that is what was asked for. Read across the
+        // whole set, the two look like one driver arriving 17 ms late.
+        VirtualCrossoverChannel[] channels =
+        [
+            Block("A", VirtualCrossoverZone.Sub, 1.25),
+            Block("B", VirtualCrossoverZone.Sub, 0.59),
+            Block("C", VirtualCrossoverZone.Front, 1.46),
+            Block("D", VirtualCrossoverZone.Front, 4.41),
+            Block("E", VirtualCrossoverZone.Front, 4.63),
+            Block("F", VirtualCrossoverZone.Rear, 18.01),
+            Block("G", VirtualCrossoverZone.Center, 4.19)
+        ];
+
+        Assert.Null(VirtualCrossoverPanel.CrossoverSpreadWarning(channels));
+    }
+
+    [Fact]
+    public void AFrontChainThatReallyIsStretchedStillWarns()
+    {
+        // The case the warning exists for, with a rear fill in the project so
+        // the fix cannot pass by silencing everything: the spread is inside the
+        // chain, and the chain is what Auto delay stretches.
+        VirtualCrossoverChannel[] channels =
+        [
+            Block("A", VirtualCrossoverZone.Sub, 0.0),
+            Block("B", VirtualCrossoverZone.Front, 18.0),
+            Block("C", VirtualCrossoverZone.Front, 17.5),
+            Block("D", VirtualCrossoverZone.Rear, 30.0)
+        ];
+
+        (string Name, double SpreadMs, bool PlacedGroups)? warning =
+            VirtualCrossoverPanel.CrossoverSpreadWarning(channels);
+
+        Assert.NotNull(warning);
+        Assert.Equal("A", warning!.Value.Name);
+        // 18.0, not the 30.0 the rear block would make of it.
+        Assert.Equal(18.0, warning.Value.SpreadMs, 3);
+        // ...and the detail says so, because the delay table shows that 30.
+        Assert.True(warning.Value.PlacedGroups);
+    }
+
+    [Fact]
+    public void ARearOnlyProjectIsItsOwnChainAndKeepsTheWarning()
+    {
+        // Nothing to be placed against, so Auto delay walks the rear blocks as
+        // the chain - and a spread between them is the same symptom it always
+        // was. The warning has to follow the same split the run does rather
+        // than the zone name.
+        VirtualCrossoverChannel[] channels =
+        [
+            Block("A", VirtualCrossoverZone.Rear, 0.0),
+            Block("B", VirtualCrossoverZone.Rear, 20.0)
+        ];
+
+        (string Name, double SpreadMs, bool PlacedGroups)? warning =
+            VirtualCrossoverPanel.CrossoverSpreadWarning(channels);
+
+        Assert.NotNull(warning);
+        Assert.Equal("A", warning!.Value.Name);
+        // Nothing was left out, so the detail keeps the wording it always had.
+        Assert.False(warning.Value.PlacedGroups);
+    }
+
+    [Fact]
+    public void ACentreIsPlacedAgainstTheFrontAndCannotStretchIt()
+    {
+        // A centre is computed against a settled front stage, so however late
+        // it arrives it moves nothing but itself. Reading it as part of the
+        // spread would blame the front chain for the centre's own crossover.
+        VirtualCrossoverChannel[] channels =
+        [
+            Block("A", VirtualCrossoverZone.Front, 0.5),
+            Block("B", VirtualCrossoverZone.Front, 1.0),
+            Block("C", VirtualCrossoverZone.Center, 25.0)
+        ];
+
+        Assert.Null(VirtualCrossoverPanel.CrossoverSpreadWarning(channels));
+    }
+
+    [Fact]
+    public void BypassedChannelsStayOutOfTheSpread()
+    {
+        VirtualCrossoverChannel[] channels =
+        [
+            Block("A", VirtualCrossoverZone.Front, 0.0),
+            Block("B", VirtualCrossoverZone.Front, 1.0),
+            Block("C", VirtualCrossoverZone.Front, 40.0)
+        ];
+        channels[2].Pair.Bypass = true;
+
+        Assert.Null(VirtualCrossoverPanel.CrossoverSpreadWarning(channels));
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverDelaySpreadWarningTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverDelaySpreadWarningTests.cs
@@ -53,15 +53,41 @@ public sealed class VirtualCrossoverDelaySpreadWarningTests
             Block("D", VirtualCrossoverZone.Rear, 30.0)
         ];
 
-        (string Name, double SpreadMs, bool PlacedGroups)? warning =
+        (string Name, double SpreadMs, IReadOnlyList<VirtualCrossoverZone> Placed)? warning =
             VirtualCrossoverPanel.CrossoverSpreadWarning(channels);
 
         Assert.NotNull(warning);
-        Assert.Equal("A", warning!.Value.Name);
+        string note = VirtualCrossoverPanel.ExcludedGroupsNote(warning!.Value.Placed);
+        Assert.Equal("A", warning.Value.Name);
         // 18.0, not the 30.0 the rear block would make of it.
         Assert.Equal(18.0, warning.Value.SpreadMs, 3);
         // ...and the detail says so, because the delay table shows that 30.
-        Assert.True(warning.Value.PlacedGroups);
+        Assert.Equal([VirtualCrossoverZone.Rear], warning.Value.Placed);
+        Assert.Contains("The rear fill is not counted", note);
+        Assert.DoesNotContain("centre", note);
+    }
+
+    [Fact]
+    public void TheNoteNamesOnlyTheGroupsTheProjectHas()
+    {
+        // A car with a centre and no rear should not be told about a rear fill
+        // it does not own - and the sentence about a fill offset belongs to the
+        // rear alone, so it goes with it.
+        VirtualCrossoverChannel[] channels =
+        [
+            Block("A", VirtualCrossoverZone.Front, 0.0),
+            Block("B", VirtualCrossoverZone.Front, 18.0),
+            Block("C", VirtualCrossoverZone.Center, 4.0)
+        ];
+
+        (string Name, double SpreadMs, IReadOnlyList<VirtualCrossoverZone> Placed)? warning =
+            VirtualCrossoverPanel.CrossoverSpreadWarning(channels);
+
+        Assert.NotNull(warning);
+        string note = VirtualCrossoverPanel.ExcludedGroupsNote(warning!.Value.Placed);
+        Assert.Contains("The centre is not counted", note);
+        Assert.DoesNotContain("rear", note);
+        Assert.DoesNotContain("fill offset", note);
     }
 
     [Fact]
@@ -77,13 +103,16 @@ public sealed class VirtualCrossoverDelaySpreadWarningTests
             Block("B", VirtualCrossoverZone.Rear, 20.0)
         ];
 
-        (string Name, double SpreadMs, bool PlacedGroups)? warning =
+        (string Name, double SpreadMs, IReadOnlyList<VirtualCrossoverZone> Placed)? warning =
             VirtualCrossoverPanel.CrossoverSpreadWarning(channels);
 
         Assert.NotNull(warning);
         Assert.Equal("A", warning!.Value.Name);
         // Nothing was left out, so the detail keeps the wording it always had.
-        Assert.False(warning.Value.PlacedGroups);
+        Assert.Empty(warning.Value.Placed);
+        Assert.Equal(
+            string.Empty,
+            VirtualCrossoverPanel.ExcludedGroupsNote(warning.Value.Placed));
     }
 
     [Fact]


### PR DESCRIPTION
## The contradiction

Reported from the field, on the same run as #157: Auto delay places the rear fill 15 ms behind the front stage — which is what the Rear fill row asks it to do — and the panel then warns that a driver lags.

> ⚠ B lags the others by ~17 ms — check its crossover.

Both halves are the program's own doing. `B` is a subwoofer sitting at 0.59 ms; the 17 is the distance to the rear block at 18.01. The banner names the channel with the *smallest* delay because the rule behind it is "everyone else was delayed to catch this one up", and it measures the spread across every non-bypassed channel.

## Why the rule stopped holding

That rule describes a **crossover chain**: members whose junctions are searched against each other genuinely drag each other, so a driver with pathological group delay does force every other delay out. Since #150 that is no longer the whole set:

- a **rear fill** is not delayed to catch anything. It is *placed* the Rear fill offset behind the front stage, and the default offset is 15.0 ms — which is `CrossoverGroupDelayWarningMs` exactly. Any car with a rear and the default offset trips the banner as soon as Auto delay succeeds.
- a **centre** is placed against a front stage that is already settled, so however late it arrives it moves nothing but itself.

Neither can stretch the chain, which is precisely the property that makes the staging one-way.

## The fix

`CrossoverSpreadWarning` measures the spread over the front chain, taking the split from `SplitAlignmentStages` — the run's own — rather than from the zone name. That matters at the edge: a **rear-only project has nothing to be placed against**, so the split walks it as its own chain and it keeps the warning it always had. A project written before zones existed puts everything in the chain, so it is unchanged by construction.

Where blocks were left out, the detail text adds one line saying so. Without it the banner contradicts the delay table the user is reading — the rear block standing 15 ms out is right there on screen, and the number does not include it.

This does not lose a check. A rear whose own delay is impossible is caught by the ceiling verdict from #152, which is where an unreachable figure belongs; what is gone is only the claim that the rear stretched the front.

## Tests

The decision moved into a pure `internal static` helper first (no behaviour change), so the rule can be read off a set of channels without a processing run. Six new tests; three of them fail on the parent commit:

- the reference car's own figures — front chain inside 5 ms, rear at 18.01, centre at 4.19 — must produce **no warning** (this is the reported symptom, and it failed with the 17 ms banner);
- a front chain that really is stretched, **with a rear block in the project**, still warns, names the right driver, and reports 18.0 ms rather than the 30.0 the rear would make of it — so the fix cannot pass by silencing everything;
- a centre 25 ms out cannot raise the banner on a front stage that spans half a millisecond;
- a rear-only project keeps the warning;
- bypassed channels stay out, as before;
- the detail names only the groups the project actually has — a car with a centre and no rear is not told about a rear fill, and the clause about sitting a fill offset behind goes with the rear alone.

Full solution, Release: **3551 passed, 12 skipped, 0 failed**. The session battery is front-only and cannot reach this code — the banner is drawn from applied delays, not computed by the engine — so it was not re-run.

`REFERENCE.md` also described the threshold as ~10 ms; it has been 15 since the delay limits were raised. Corrected while documenting the scope — and the scope is stated as *the chain whose junctions the search settles*, with the front chain as the usual case rather than the definition, so the text does not contradict the rear-only project it deliberately keeps working.
