### PR TITLE
Give the stereo delta read-out the whole channel list, so it stops evicting the frame's own responses

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2,7 +2,7 @@
 
 **A complete step-by-step guide**
 
-This guide tracks the repository's `main` branch. Everything in it is in **v0.7.3**.
+This guide tracks the repository's `main` branch. Everything in it is in **v0.7.5**.
 
 > **Author's note.** I wrote Resonalyze. It is free and open-source (MIT) — nothing to
 > buy, nothing to sign up for. If you go through this guide, successfully or not,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverGroupView.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverGroupView.cs
@@ -22,7 +22,7 @@ public enum VirtualCrossoverGroupView
 
     /// <summary>
     /// The front stage beside the centre. Drawn together and compared, never
-    /// summed — see <see cref="VirtualCrossoverGroupViews.ParticipatesInSum"/>.
+    /// summed — see <see cref="VirtualCrossoverGroupViews.ParticipatesInTotalSum"/>.
     /// </summary>
     FrontAndCenter,
 
@@ -144,7 +144,11 @@ public static class VirtualCrossoverGroupViews
             VirtualCrossoverGroupView.FrontAndSub => VirtualCrossoverZone.Front,
             VirtualCrossoverGroupView.RearAndSub => VirtualCrossoverZone.Rear,
             // The centre is not in the sum, so the loss still describes the front
-            // chain alone — the same number this view's Front + Sub sibling shows.
+            // chain alone. Not the same figures its Front + Sub sibling shows,
+            // though: this view does not draw the subwoofers either, so they are
+            // out of the sum as well — the handover between the lowest front
+            // driver and the subs has no row here, and the total is taken over a
+            // chain that stops where that driver's high-pass does.
             VirtualCrossoverGroupView.FrontAndCenter => VirtualCrossoverZone.Front,
             _ => null
         };

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -32,6 +32,25 @@ internal sealed class VirtualCrossoverMetrics
     private readonly Func<IReadOnlyList<ProcessedChannel>, int, GatedMagnitude>?
         buildSumCurve;
 
+    // The last group Δ read-out and the inputs it was computed from. Without it
+    // every frame rebuilds the set from scratch, and a view switch IS a frame:
+    // Front + Center ran its arrival FFTs again on each magnitude/phase/impulse
+    // toggle — hundreds of milliseconds per switch on a full installation, and
+    // the whole redraw waits on them — while Front + Sub, which quotes no group
+    // Δ, switched instantly off the coordinator's processed-response cache. The
+    // stereo block next to it already remembered its arrivals this way; this is
+    // the same bargain for the group ones, and it is written on the UI thread
+    // only, in the continuation after the auxiliary run, exactly as ArrivalCache
+    // is.
+    //
+    // The price is that it holds the processed responses it was measured from
+    // alive: one generation of the front stage and the compared groups, no more,
+    // and only for as long as a view quoting no group Δ stays on screen. The
+    // alternative is dropping the answer the moment the user looks away, which
+    // is the complaint this exists to close.
+    private (GroupDeltaKey Key, IReadOnlyList<VirtualCrossoverMetric.GroupDelta> Deltas)?
+        groupDeltas;
+
     public VirtualCrossoverMetrics(
         VirtualCrossoverProcessingCoordinator coordinator,
         Func<Complex[], int, int, MeasuredBand, CalibrationFile?, GatedMagnitude>
@@ -282,15 +301,6 @@ internal sealed class VirtualCrossoverMetrics
     }
 
     /// <summary>
-    /// The final per-pair L−R timing: both sides' fully processed responses
-    /// (current delays included) get their band-limited envelope arrival read
-    /// in the pair's shared band, and the difference (positive: right leads —
-    /// the scene-offset convention) feeds the metric read-out. A mono channel
-    /// (the shared sub) has one response, so it reports that single arrival in
-    /// its own band with "—" for the right side and the delta; a stereo pair
-    /// needs both sides present and unbypassed.
-    /// </summary>
-    /// <summary>
     /// Each compared group against the front stage, on the ALREADY PROCESSED
     /// responses this frame is drawing: their summed impulse responses give one
     /// arrival and one level per group, and the difference is what the read-out
@@ -300,8 +310,9 @@ internal sealed class VirtualCrossoverMetrics
     /// Cheaper than the stereo block by construction — nothing has to be
     /// re-rendered, because a group's response is the sum of channels this frame
     /// already computed. The arrival analysis still costs FFTs, so it runs on the
-    /// coordinator's auxiliary path and drops silently when superseded, exactly
-    /// as the stereo deltas do.
+    /// coordinator's auxiliary path, drops silently when superseded exactly as
+    /// the stereo deltas do, and is remembered between frames by
+    /// <see cref="groupDeltas"/> exactly as their arrivals are.
     /// </remarks>
     public async Task<IReadOnlyList<VirtualCrossoverMetric.GroupDelta>> ComputeGroupDeltasAsync(
         IReadOnlyList<ProcessedChannel> shown,
@@ -323,13 +334,22 @@ internal sealed class VirtualCrossoverMetrics
             return [];
         }
 
-        var jobs = new List<(VirtualCrossoverZone Zone, List<ProcessedChannel> Members)>();
+        (double frontLow, double frontHigh) = GroupBand(front);
+        var jobs = new List<GroupDeltaJob>();
         foreach (VirtualCrossoverZone zone in compared)
         {
             List<ProcessedChannel> members = ZoneMembers(shown, zone);
             if (members.Count > 0)
             {
-                jobs.Add((zone, members));
+                // The band is settled here rather than inside the worker so the
+                // cache key below can carry it: two groups timed over different
+                // spans are two different answers even from the same responses.
+                (double zoneLow, double zoneHigh) = GroupBand(members);
+                jobs.Add(new GroupDeltaJob(
+                    zone,
+                    members,
+                    Math.Max(frontLow, zoneLow),
+                    Math.Min(frontHigh, zoneHigh)));
             }
         }
 
@@ -338,24 +358,39 @@ internal sealed class VirtualCrossoverMetrics
             return [];
         }
 
-        (double frontLow, double frontHigh) = GroupBand(front);
         int sampleRate = front[0].SampleRate;
+        var key = new GroupDeltaKey(front, jobs, sampleRate);
+        if (groupDeltas is { } cached && cached.Key.Matches(key))
+        {
+            // A superseded frame is answered exactly as it was before the set was
+            // remembered — with nothing. The cache changes what a CURRENT frame
+            // costs, not which frames get an answer, and the auxiliary path this
+            // replaces made the same refusal one line further in.
+            return coordinator.IsCurrent(revision) ? cached.Deltas : [];
+        }
+
         List<VirtualCrossoverMetric.GroupDelta>? deltas =
             await coordinator.RunAuxiliaryAsync(revision, cancellationToken =>
             {
                 Complex[] frontIr = VirtualCrossoverAnalysis.SumImpulseResponses(
                     [.. front.Select(item => item.ImpulseResponse)]);
+                // The front stage is the reference for every compared group, and
+                // the views that compare two of them (Groups, Everything) usually
+                // time both over the same span — so its arrival and level are read
+                // once per BAND rather than once per group.
+                var frontByBand =
+                    new Dictionary<(double LowHz, double HighHz),
+                        (TimeAlignmentAnalysisResult Arrival, double? LevelDb)>();
                 var results = new List<VirtualCrossoverMetric.GroupDelta>();
-                foreach ((VirtualCrossoverZone zone, List<ProcessedChannel> members) in jobs)
+                foreach (GroupDeltaJob job in jobs)
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {
                         return null;
                     }
 
-                    (double zoneLow, double zoneHigh) = GroupBand(members);
-                    double lowHz = Math.Max(frontLow, zoneLow);
-                    double highHz = Math.Min(frontHigh, zoneHigh);
+                    double lowHz = job.LowHz;
+                    double highHz = job.HighHz;
                     if (highHz < lowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
                     {
                         // Too little overlap to time anything — a rear pair crossed
@@ -363,40 +398,147 @@ internal sealed class VirtualCrossoverMetrics
                         // an unmeasurable row rather than dropped, so the group does
                         // not silently vanish from the read-out.
                         results.Add(new VirtualCrossoverMetric.GroupDelta(
-                            zone, null, null, lowHz, highHz));
+                            job.Zone, null, null, lowHz, highHz));
                         continue;
                     }
 
+                    if (!frontByBand.TryGetValue(
+                            (lowHz, highHz),
+                            out (TimeAlignmentAnalysisResult Arrival, double? LevelDb) frontRead))
+                    {
+                        frontRead = (
+                            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                                frontIr, sampleRate, lowHz, highHz),
+                            VirtualCrossoverAnalysis.MeasureBandLevelDb(
+                                frontIr, sampleRate, lowHz, highHz));
+                        frontByBand[(lowHz, highHz)] = frontRead;
+                    }
+
                     Complex[] zoneIr = VirtualCrossoverAnalysis.SumImpulseResponses(
-                        [.. members.Select(item => item.ImpulseResponse)]);
-                    TimeAlignmentAnalysisResult frontArrival =
-                        VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
-                            frontIr, sampleRate, lowHz, highHz);
+                        [.. job.Members.Select(item => item.ImpulseResponse)]);
                     TimeAlignmentAnalysisResult zoneArrival =
                         VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
                             zoneIr, sampleRate, lowHz, highHz);
-                    bool timed = Reliable(frontArrival) && Reliable(zoneArrival);
+                    bool timed = Reliable(frontRead.Arrival) && Reliable(zoneArrival);
                     results.Add(new VirtualCrossoverMetric.GroupDelta(
-                        zone,
+                        job.Zone,
                         timed
                             ? zoneArrival.FirstArrivalDelayMilliseconds -
-                                frontArrival.FirstArrivalDelayMilliseconds
+                                frontRead.Arrival.FirstArrivalDelayMilliseconds
                             : null,
                         VirtualCrossoverAnalysis.MeasureBandLevelDb(
-                            zoneIr, sampleRate, lowHz, highHz) -
-                            VirtualCrossoverAnalysis.MeasureBandLevelDb(
-                                frontIr, sampleRate, lowHz, highHz),
+                            zoneIr, sampleRate, lowHz, highHz) - frontRead.LevelDb,
                         lowHz,
                         highHz));
                 }
 
                 return results;
             });
-        return deltas ?? [];
+        if (deltas == null)
+        {
+            // Superseded: remember nothing, or the next frame would answer with
+            // a set that was never finished against inputs it never saw.
+            return [];
+        }
+
+        // Read-only from here on: the same instance now answers many frames, and
+        // a caller that cast it back to its List would be editing the cache.
+        IReadOnlyList<VirtualCrossoverMetric.GroupDelta> remembered = deltas.AsReadOnly();
+        groupDeltas = (key, remembered);
+        return remembered;
 
         static bool Reliable(TimeAlignmentAnalysisResult arrival) =>
             arrival.IsValid &&
             arrival.SignalToNoiseDecibels >= AutoAlignmentEngine.MinimumArrivalSnrDb;
+    }
+
+    private sealed record GroupDeltaJob(
+        VirtualCrossoverZone Zone,
+        List<ProcessedChannel> Members,
+        double LowHz,
+        double HighHz);
+
+    /// <summary>
+    /// What a set of group Δs is a function of: which processed responses each
+    /// group holds, in order, the band each comparison is timed over, and the
+    /// rate they were processed at. Nothing else in a frame can move the answer.
+    /// </summary>
+    /// <remarks>
+    /// Responses are compared by REFERENCE, the way the stereo block's
+    /// <c>ArrivalCache</c> compares its own: the coordinator hands back the very
+    /// same array while nothing feeding a channel has changed, and manufactures a
+    /// new one as soon as anything has. So reference equality is not an
+    /// optimization over a value comparison here — it is the exact question.
+    /// </remarks>
+    private sealed class GroupDeltaKey
+    {
+        private readonly Complex[][] front;
+        private readonly JobKey[] jobs;
+        private readonly int sampleRate;
+
+        public GroupDeltaKey(
+            IReadOnlyList<ProcessedChannel> front,
+            IReadOnlyList<GroupDeltaJob> jobs,
+            int sampleRate)
+        {
+            this.front = Responses(front);
+            this.jobs =
+            [
+                .. jobs.Select(job => new JobKey(
+                    job.Zone, Responses(job.Members), job.LowHz, job.HighHz))
+            ];
+            this.sampleRate = sampleRate;
+        }
+
+        public bool Matches(GroupDeltaKey other)
+        {
+            if (sampleRate != other.sampleRate ||
+                jobs.Length != other.jobs.Length ||
+                !SameResponses(front, other.front))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < jobs.Length; i++)
+            {
+                if (jobs[i].Zone != other.jobs[i].Zone ||
+                    jobs[i].LowHz != other.jobs[i].LowHz ||
+                    jobs[i].HighHz != other.jobs[i].HighHz ||
+                    !SameResponses(jobs[i].Members, other.jobs[i].Members))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private sealed record JobKey(
+            VirtualCrossoverZone Zone,
+            Complex[][] Members,
+            double LowHz,
+            double HighHz);
+
+        private static Complex[][] Responses(IReadOnlyList<ProcessedChannel> members) =>
+            [.. members.Select(item => item.ImpulseResponse)];
+
+        private static bool SameResponses(Complex[][] left, Complex[][] right)
+        {
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                if (!ReferenceEquals(left[i], right[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 
     private static List<ProcessedChannel> ZoneMembers(
@@ -424,6 +566,15 @@ internal sealed class VirtualCrossoverMetrics
         return (low, high);
     }
 
+    /// <summary>
+    /// The final per-pair L−R timing: both sides' fully processed responses
+    /// (current delays included) get their band-limited envelope arrival read
+    /// in the pair's shared band, and the difference (positive: right leads —
+    /// the scene-offset convention) feeds the metric read-out. A mono channel
+    /// (the shared sub) has one response, so it reports that single arrival in
+    /// its own band with "—" for the right side and the delta; a stereo pair
+    /// needs both sides present and unbypassed.
+    /// </summary>
     public async Task<List<VirtualCrossoverMetric.StereoDelta>> ComputeStereoDeltasAsync(
         IReadOnlyList<VirtualCrossoverChannel> channels,
         long revision)

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -575,9 +575,24 @@ internal sealed class VirtualCrossoverMetrics
     /// its own band with "—" for the right side and the delta; a stereo pair
     /// needs both sides present and unbypassed.
     /// </summary>
+    /// <param name="channels">
+    /// EVERY channel of the project, never a pre-filtered subset. A block's
+    /// position in this list is its identity in the processing coordinator's
+    /// cache, and a filtered list renumbers the blocks after the first one it
+    /// drops — so the read-out would claim slots belonging to other channels and
+    /// evict the responses the frame had just processed, on every frame. Narrow
+    /// the set with <paramref name="includePair"/> instead, the way
+    /// <see cref="ComputeSideSumAsync"/> does.
+    /// </param>
+    /// <param name="includePair">
+    /// Which blocks the read-out covers, or null for all of them. The panel
+    /// passes the current view's zones: a front view listing the rear pair's L/R
+    /// skew is the read-out describing a set the plot does not draw.
+    /// </param>
     public async Task<List<VirtualCrossoverMetric.StereoDelta>> ComputeStereoDeltasAsync(
         IReadOnlyList<VirtualCrossoverChannel> channels,
-        long revision)
+        long revision,
+        Func<VirtualCrossoverChannelPairSettings, bool>? includePair = null)
     {
         var jobs = new List<StereoDeltaJob>();
         int nextId = 0;
@@ -588,7 +603,8 @@ internal sealed class VirtualCrossoverMetrics
 
             // Mute and Bypass belong to the block, so they answer for both sides at
             // once; only the measurements are per side.
-            if (!channel.Pair.Enabled || channel.Pair.Bypass)
+            if (!channel.Pair.Enabled || channel.Pair.Bypass ||
+                includePair?.Invoke(channel.Pair) == false)
             {
                 continue;
             }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3281,12 +3281,15 @@ public partial class VirtualCrossoverPanel : UserControl
         // The Δ block follows the Show selector like everything else in the
         // frame: a front view listing the rear pair's L/R skew is the read-out
         // describing a set the plot does not draw, which is the whole class of
-        // mismatch this selector exists to close.
-        List<VirtualCrossoverChannel> shownBlocks =
-            [.. channels.Where(channel =>
-                VirtualCrossoverGroupViews.IsShown(groupView, channel.Pair.Zone))];
+        // mismatch this selector exists to close. It is narrowed by a FILTER and
+        // never by handing over a shortened list — a block's position in that
+        // list is its identity in the coordinator's cache.
         List<VirtualCrossoverMetric.StereoDelta> stereoDeltas =
-            await metrics.ComputeStereoDeltasAsync(shownBlocks, revision);
+            await metrics.ComputeStereoDeltasAsync(
+                channels,
+                revision,
+                includePair: pair =>
+                    VirtualCrossoverGroupViews.IsShown(groupView, pair.Zone));
         // What the cross-group views quote instead of a summation loss. Reads the
         // responses this frame already processed, so it adds no render — only the
         // arrival FFTs, on the coordinator's auxiliary path.

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3308,7 +3308,7 @@ public partial class VirtualCrossoverPanel : UserControl
                 // to be the same part of the system this side is showing.
                 includePair: pair =>
                     VirtualCrossoverGroupViews.ParticipatesInTotalSum(
-                        SelectedGroupView, pair.Zone));
+                        groupView, pair.Zone));
         }
         if (mainPlotView.IsDisposed || !processingCoordinator.IsCurrent(revision))
         {
@@ -3416,7 +3416,7 @@ public partial class VirtualCrossoverPanel : UserControl
         using (AppProfiler.Zone("VirtualDSP.BuildAcousticRender"))
         {
             acousticRender = BuildAcousticRender(
-                shown, summedChannels, magnitudes, sumCurve, lossCurve,
+                shown, summedChannels, groupView, magnitudes, sumCurve, lossCurve,
                 oppositeSum, hybrid);
         }
 
@@ -3460,6 +3460,7 @@ public partial class VirtualCrossoverPanel : UserControl
     private AcousticRender BuildAcousticRender(
         List<ProcessedChannel> processed,
         IReadOnlyList<ProcessedChannel> summed,
+        VirtualCrossoverGroupView view,
         List<AnalysisCurve>? magnitudes,
         AnalysisCurve? sumCurve,
         List<SignalPoint>? lossCurve,
@@ -3486,7 +3487,7 @@ public partial class VirtualCrossoverPanel : UserControl
             return new AcousticRender(hint, [], BuildImpulseRender(processed));
         }
 
-        if (VirtualCrossoverGroupViews.DrawsGroupSums(SelectedGroupView))
+        if (VirtualCrossoverGroupViews.DrawsGroupSums(view))
         {
             return new AcousticRender(hint, BuildGroupSumCurves(processed), null);
         }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -648,4 +648,135 @@ public sealed class VirtualCrossoverMetricsTests
 
         Assert.Null(rearOnly);
     }
+
+    // A channel whose processed response is a lone impulse at a known sample,
+    // long enough for the band-limited arrival analysis to have something to
+    // work with, tagged with the zone the grouped views sort it by.
+    private static ProcessedChannel Zoned(
+        string name,
+        VirtualCrossoverZone zone,
+        int peak,
+        Complex[]? ir = null)
+    {
+        var channel = new VirtualCrossoverChannel(name) { SampleRate = 48_000 };
+        channel.Pair.Zone = zone;
+        ir ??= LongImpulse(peak);
+        return new ProcessedChannel(channel, ir, peak, 48_000, OxyColors.White);
+    }
+
+    private static Complex[] LongImpulse(int peak)
+    {
+        var ir = new Complex[4096];
+        ir[peak] = Complex.One;
+        return ir;
+    }
+
+    [Fact]
+    public async Task ComputeGroupDeltas_ReusesTheReadOutWhileTheResponsesStand()
+    {
+        // The group Δ read-out costs arrival FFTs over the summed groups, and the
+        // whole redraw waits on them. A view switch rebuilds the frame without
+        // touching a single response, so it must be answered from memory the way
+        // the coordinator answers for the responses themselves — otherwise
+        // Front + Center pays for those FFTs again on every magnitude/phase/
+        // impulse toggle while Front + Sub, which quotes no group Δ, is instant.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(
+            coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        List<ProcessedChannel> shown =
+        [
+            Zoned("Front", VirtualCrossoverZone.Front, 100),
+            Zoned("Centre", VirtualCrossoverZone.Center, 150)
+        ];
+
+        IReadOnlyList<VirtualCrossoverMetric.GroupDelta> first =
+            await metrics.ComputeGroupDeltasAsync(
+                shown, VirtualCrossoverGroupView.FrontAndCenter, coordinator.CurrentRevision);
+        IReadOnlyList<VirtualCrossoverMetric.GroupDelta> second =
+            await metrics.ComputeGroupDeltasAsync(
+                shown, VirtualCrossoverGroupView.FrontAndCenter, coordinator.CurrentRevision);
+
+        Assert.Single(first);
+        Assert.Equal(VirtualCrossoverZone.Center, first[0].Zone);
+        // The same instance: a recompute builds a new list, so identity is what
+        // says the arrival analysis did not run a second time.
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public async Task ComputeGroupDeltas_RecomputesWhenAResponseIsReplaced()
+    {
+        // The other half of the bargain. The coordinator manufactures a NEW array
+        // for a channel the moment anything feeding it moves, so a remembered
+        // read-out must be answered for by the very arrays it was measured from.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(
+            coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        ProcessedChannel front = Zoned("Front", VirtualCrossoverZone.Front, 100);
+        IReadOnlyList<VirtualCrossoverMetric.GroupDelta> first =
+            await metrics.ComputeGroupDeltasAsync(
+                [front, Zoned("Centre", VirtualCrossoverZone.Center, 150)],
+                VirtualCrossoverGroupView.FrontAndCenter,
+                coordinator.CurrentRevision);
+
+        IReadOnlyList<VirtualCrossoverMetric.GroupDelta> second =
+            await metrics.ComputeGroupDeltasAsync(
+                [front, Zoned("Centre", VirtualCrossoverZone.Center, 260)],
+                VirtualCrossoverGroupView.FrontAndCenter,
+                coordinator.CurrentRevision);
+
+        Assert.NotSame(first, second);
+        Assert.Single(second);
+        // And the answer moved with the response: the centre now arrives later.
+        Assert.NotNull(first[0].DelayMs);
+        Assert.NotNull(second[0].DelayMs);
+        Assert.True(second[0].DelayMs > first[0].DelayMs);
+    }
+
+    [Fact]
+    public async Task ComputeGroupDeltas_StaySilentInASingleGroupView()
+    {
+        // Front + Sub spans one listening group, so it quotes a summation loss
+        // and no group Δ at all — which is why it was the fast view to begin with.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(
+            coordinator, (_, _, _, _, _) => EmptyMagnitude);
+
+        Assert.Empty(await metrics.ComputeGroupDeltasAsync(
+            [
+                Zoned("Front", VirtualCrossoverZone.Front, 100),
+                Zoned("Sub", VirtualCrossoverZone.Sub, 150)
+            ],
+            VirtualCrossoverGroupView.FrontAndSub,
+            coordinator.CurrentRevision));
+    }
+
+    [Fact]
+    public async Task ComputeGroupDeltas_ReportOneRowPerComparedGroup()
+    {
+        // Everything compares two groups against the front, and both are timed
+        // over the same span here — the path where the front stage's own arrival
+        // is read once for the band rather than once per group. The rows must
+        // still be the two the view promises, each against the same reference.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(
+            coordinator, (_, _, _, _, _) => EmptyMagnitude);
+
+        IReadOnlyList<VirtualCrossoverMetric.GroupDelta> deltas =
+            await metrics.ComputeGroupDeltasAsync(
+                [
+                    Zoned("Front", VirtualCrossoverZone.Front, 100),
+                    Zoned("Rear", VirtualCrossoverZone.Rear, 200),
+                    Zoned("Centre", VirtualCrossoverZone.Center, 150)
+                ],
+                VirtualCrossoverGroupView.Everything,
+                coordinator.CurrentRevision);
+
+        Assert.Equal(2, deltas.Count);
+        Assert.Equal(VirtualCrossoverZone.Rear, deltas[0].Zone);
+        Assert.Equal(VirtualCrossoverZone.Center, deltas[1].Zone);
+        // 100 samples at 48 kHz is 2.083 ms behind the front, 50 is 1.042 ms.
+        Assert.Equal(100.0 / 48.0, deltas[0].DelayMs!.Value, 2);
+        Assert.Equal(50.0 / 48.0, deltas[1].DelayMs!.Value, 2);
+    }
 }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -691,16 +691,46 @@ public sealed class VirtualCrossoverMetricsTests
 
         IReadOnlyList<VirtualCrossoverMetric.GroupDelta> first =
             await metrics.ComputeGroupDeltasAsync(
-                shown, VirtualCrossoverGroupView.FrontAndCenter, coordinator.CurrentRevision);
+                shown, VirtualCrossoverGroupView.FrontAndCenter, coordinator.Invalidate());
+        // The second frame is asked the way a real toggle asks: RequestRedraw
+        // invalidates first and the frame then carries the NEW revision, so a
+        // repeat call at the old one would prove nothing about the path the user
+        // takes.
         IReadOnlyList<VirtualCrossoverMetric.GroupDelta> second =
             await metrics.ComputeGroupDeltasAsync(
-                shown, VirtualCrossoverGroupView.FrontAndCenter, coordinator.CurrentRevision);
+                shown, VirtualCrossoverGroupView.FrontAndCenter, coordinator.Invalidate());
 
         Assert.Single(first);
         Assert.Equal(VirtualCrossoverZone.Center, first[0].Zone);
         // The same instance: a recompute builds a new list, so identity is what
         // says the arrival analysis did not run a second time.
         Assert.Same(first, second);
+    }
+
+    [Fact]
+    public async Task ComputeGroupDeltas_AnswerNothingForASupersededFrame()
+    {
+        // The other half of remembering the set: a frame the user has already
+        // overtaken is answered as it was before the cache existed — with
+        // nothing. Cheap to get wrong, because a cache hit is tempting to serve
+        // unconditionally, and then a stale frame carries a read-out the caller
+        // was supposed to drop.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(
+            coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        List<ProcessedChannel> shown =
+        [
+            Zoned("Front", VirtualCrossoverZone.Front, 100),
+            Zoned("Centre", VirtualCrossoverZone.Center, 150)
+        ];
+
+        long superseded = coordinator.Invalidate();
+        Assert.Single(await metrics.ComputeGroupDeltasAsync(
+            shown, VirtualCrossoverGroupView.FrontAndCenter, superseded));
+        coordinator.Invalidate();
+
+        Assert.Empty(await metrics.ComputeGroupDeltasAsync(
+            shown, VirtualCrossoverGroupView.FrontAndCenter, superseded));
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -779,4 +779,60 @@ public sealed class VirtualCrossoverMetricsTests
         Assert.Equal(100.0 / 48.0, deltas[0].DelayMs!.Value, 2);
         Assert.Equal(50.0 / 48.0, deltas[1].DelayMs!.Value, 2);
     }
+
+    [Fact]
+    public async Task ComputeStereoDeltas_DoesNotEvictTheFramesProcessedResponses()
+    {
+        // A block's POSITION in the list handed to the stereo Δ read-out is its
+        // identity in the coordinator's cache. Hand over a filtered list and every
+        // block after the first omission is renumbered onto a slot belonging to
+        // another channel: the read-out overwrites responses the frame had just
+        // processed, the next frame misses on them, reprocesses, overwrites the
+        // read-out's in turn — and the two thrash each other for as long as the
+        // view stays open. On the reference car that is every view except the one
+        // whose blocks happen to sit at the head of the list.
+        int processCount = 0;
+        using var coordinator = new VirtualCrossoverProcessingCoordinator(
+            (source, chain, sampleRate, _, _) =>
+            {
+                Interlocked.Increment(ref processCount);
+                return source.Apply(chain, sampleRate, sampleRate);
+            });
+        var metrics = new VirtualCrossoverMetrics(
+            coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        // Three mono blocks: the read-out below covers the LAST one only, so with
+        // a shortened list it would take slot 0 — the first block's.
+        List<VirtualCrossoverChannel> channels =
+            [ResolvedMono("A"), ResolvedMono("B"), ResolvedMono("C")];
+        long revision = coordinator.Invalidate();
+        VirtualCrossoverProcessingSnapshot frame = new(
+            revision,
+            channels.Select((channel, index) => new VirtualCrossoverChannelSnapshot(
+                index,
+                new ProcessingSlotId(index, false),
+                channel.SideState(false).ProcessingSource!,
+                48_000,
+                48_000,
+                channel.Settings.ToChain())));
+
+        Assert.NotNull(await coordinator.ProcessAsync(frame));
+        int afterFirstFrame = processCount;
+
+        await metrics.ComputeStereoDeltasAsync(
+            channels, revision, includePair: pair => ReferenceEquals(pair, channels[2].Pair));
+        // The frame runs again with nothing changed, exactly as a view or mode
+        // toggle makes it: every response must still be in the cache.
+        Assert.NotNull(await coordinator.ProcessAsync(frame));
+
+        Assert.Equal(3, afterFirstFrame);
+        Assert.Equal(3, processCount);
+    }
+
+    // A mono block with a resolved source on the side the panel draws.
+    private static VirtualCrossoverChannel ResolvedMono(string name)
+    {
+        VirtualCrossoverChannel channel = ResolvedChannel(name, 48_000);
+        channel.Pair.Mono = true;
+        return channel;
+    }
 }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProcessingCoordinatorTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProcessingCoordinatorTests.cs
@@ -727,4 +727,35 @@ public sealed class VirtualCrossoverProcessingCoordinatorTests
             Peq: new EqualizationCurve(
                 [new PeqBand(1_000, 1.4, bandGainDb)],
                 preampDb));
+
+    [Fact]
+    public async Task ProcessAsync_HandsBackTheVerySameArrayFromItsCache()
+    {
+        // Two caches upstream — the stereo block's arrival cache and the group Δ
+        // read-out — recognise "nothing that feeds this moved" by comparing the
+        // processed array BY REFERENCE, because that is the exact question: a
+        // changed chain makes ApplyChain allocate a new one. Copying a cached
+        // response on the way out would be a reasonable-looking defensive change
+        // that silently turns both of those into permanent misses, and nothing
+        // else in the suite would notice.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator(
+            (source, chain, sampleRate, _, _) => source.Apply(chain, sampleRate, sampleRate));
+        var snapshot = new VirtualCrossoverProcessingSnapshot(
+            coordinator.Invalidate(),
+            [
+                new VirtualCrossoverChannelSnapshot(
+                    1,
+                    new VirtualCrossoverSourceSnapshot(CreateImpulse(32, 3, 1.0)),
+                    48_000,
+                    48_000,
+                    DspChannelChain.Identity)
+            ]);
+
+        VirtualCrossoverRenderResult? first = await coordinator.ProcessAsync(snapshot);
+        VirtualCrossoverRenderResult? second = await coordinator.ProcessAsync(snapshot);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Same(first.Channels[0].ImpulseResponse, second.Channels[0].ImpulseResponse);
+    }
 }


### PR DESCRIPTION
## The symptom

Reported from the field on the Monster run: switching the main plot between magnitude / phase / impulse takes a couple of seconds in **Front + Center** and **Rear + Sub** — the old curves stay on screen the whole time, which is what the redraw deliberately does while it computes — while **Front + Sub** is instant after its first frame.

## The cause

A block's **position in the list handed to `ComputeStereoDeltasAsync` is its identity in the processing coordinator's cache** (`ProcessingSlotId(channelIndex, rightSide)`). Before #148 that call got the whole channel list, so the position was the block's real index. #148 started passing the *shown* blocks so the read-out would follow the view selector — and every block after the first omitted one was silently renumbered onto a slot belonging to somebody else.

From there it is a loop, once per frame:

1. the frame processes every enabled channel into its own slots;
2. the read-out looks up its renumbered slots, finds another channel's entry, misses, processes, and **overwrites** them;
3. the next frame looks up those slots for their real owners, misses, processes, overwrites back;
4. every response handed out is therefore a **new array**, so the stereo block's `ArrivalCache` — keyed by the array's identity, which is the exact question — misses too, and the band-limited arrival analysis it guards runs again for every side.

That analysis is what costs the seconds. Measured on the reference session: **cold 1358–1666 ms, warm 0–1 ms.** Reprocessing the channels themselves is only ~37 ms; the cache it destroys is worth forty times what it costs.

**Front + Sub escapes by coincidence** — its blocks happen to sit at the head of the pair list, so the filtered indices equal the real ones. So do Groups and Everything, which show every block. Exactly the three views that were never reported slow.

### Measured, three consecutive frames on the reference car

| view | shortened list (#148) | full list + filter |
|---|---|---|
| Front + Sub | 3392, **0, 0** ms | 3279, **0, 0** ms |
| Rear + Sub | 1900, **479, 496** ms — 2 channels reprocessed *every* frame | 1860, **0, 0** ms |
| Front + Center | 2865, **1446, 1389** ms — 6–7 reprocessed every frame | 2804, **0, 0** ms |
| Groups | 4619, 0, 0 ms | 4643, 0, 0 ms |
| Everything | 4667, 0, 0 ms | 4636, 0, 0 ms |

The first frame is the genuinely cold arrival analysis and is untouched by this PR — see *Not in this PR*.

## The fix

`ComputeStereoDeltasAsync` takes the **whole** channel list plus an `includePair` filter, exactly the shape `ComputeSideSumAsync` already uses for the same reason. The read-out still follows the view selector; it just no longer renames the blocks to do it. The parameter now carries a doc comment saying why a shortened list is not an option.

Pinned by `ComputeStereoDeltas_DoesNotEvictTheFramesProcessedResponses`: a frame is processed, the read-out is asked for the last block only, and the frame is processed again — the count of channels that had to be recomputed must be zero. Falsified against #148's shape (hand it the shortened list and the assertion fails).

## Also in this PR

**The group Δ read-out is remembered between frames.** Independent of the above, and found first while chasing it: `ComputeGroupDeltasAsync` (#148) cached nothing, so `Front + Center`, `Groups` and `Everything` re-ran their arrival FFTs on every frame — 350–490 ms and 706–884 ms respectively on the reference car, with the whole redraw waiting on them. It is now keyed on the processed responses it was measured from, by reference, the way the stereo block's `ArrivalCache` is; and the front stage's own arrival is read once per **band** instead of once per compared group (706 → 560 ms on a cold frame). A cache hit is still gated on `IsCurrent(revision)`, so a superseded frame is answered exactly as before — with nothing.

*This was not the reported lag.* It is real repeated work and worth removing, but `Rear + Sub` quotes no group Δ at all and was slow anyway, which is what sent the search back to the coordinator.

**Three things found in the same pass over the area:**

- **A dangling doc cref.** `VirtualCrossoverGroupView` pointed at `ParticipatesInSum`; the method is `ParticipatesInTotalSum`. The compiler cannot see this — `GenerateDocumentationFile` is not set on any project, so CS1574 is never raised. A sweep of every `cref` in `source/`, `dsp/`, `audio/` and `tools/` (450 files) found this one and no other.
- **A comment promising a figure that is not shown.** `LossChainZone(FrontAndCenter)` claimed the loss there is "the same number this view's Front + Sub sibling shows". It is not: `IsShown(FrontAndCenter, Sub)` is false, so the subwoofers are out of the *sum* as well as off the plot — the handover between the lowest front driver and the subs has no row here. `REFERENCE.md` was already right ("the front stage only"); only the comment lied.
- **A frame reading the view from two places.** `RedrawMainPlotAsync` captures `groupView` under a comment explaining why one place must decide, then two sites read the live combo anyway. One is the `includePair` lambda, which runs *across an await*: a combo change in flight gave the opposite side's sum one view and the rest of the frame another, kept off screen only by the `IsCurrent` guard downstream. Both now use the captured value.

Three suspicions were checked and dismissed rather than "fixed": `front[0].SampleRate` without a guard (a project is locked to one rate by `VirtualCrossoverSourceRules`), ragged processed lengths in `SumImpulseResponses` (zero-extends to the longest, and arrival positions are absolute), and the empty summed set in `Groups` (`BuildCurves` bails below two channels and the loss is withheld).

## Tests

The group deltas had no tests at all. Six new ones:

- the read-out is the same instance across two calls with unchanged responses — a recompute allocates a new list, so identity is what says the FFTs did not run again;
- a replaced response recomputes, and the answer moves with it;
- a single-group view stays silent;
- `Everything` reports one row per compared group, both against the same reference, with the arrival differences the sample offsets predict;
- **the stereo Δ read-out does not evict the frame's own processed responses** — the fix above;
- **`ProcessAsync_HandsBackTheVerySameArrayFromItsCache`**, on the coordinator. Both caches rest on that array identity and nothing pinned it. Copying a cached response on the way out is a reasonable-looking defensive change that would turn both into permanent misses — reintroducing exactly this bug — with no test failing.

Every discriminating test was falsified against the behaviour it guards.

Full solution, Release: 0 warnings, all tests green. No documentation change — behaviour is identical, only latency moves.

## Not in this PR

The **first** frame in a view is still 1.9–4.6 s on this car, and that is a separate defect: `AnalysisWindow` hands the analyser the length of a `ValidSampleRange`, and `ChainValidRange` always yields `inputLength + 1`. MathNet is fast only on an exact power of two, so that one extra sample costs **7×**:

```
262144: 157 ms    262145: 1113 ms    262400: 1101 ms    524288: 179 ms
```

It reaches the stereo deltas and a dozen call sites in `AutoAlignmentEngine`. The cure — padding the analysis window up to a power of two — changes the frequency grid and therefore the zero-phase bandpass being applied, so auto-delay numbers can move: it needs the session battery as its merge bar and belongs in its own PR after v0.7.5.

## Release note

`MANUAL.md` now says **v0.7.5**. The line still read v0.7.3 — it was never bumped for v0.7.4. It is the only version literal in the repository; the app's and the installer's come from the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
