### PR TITLE
Unwrap the band-limited arrival read, and survive the honest numbers

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2458,12 +2458,20 @@ refused as a cycle skip. The distance itself is measured honestly first: each
 side's own chain drags its band arrival without moving the wavefront the tune
 aligns (a subwoofer's low-pass alone shifts its band arrival by a dozen
 milliseconds where its partner's chain shifts half that), so the non-common
-part of the two chains' shifts — each measured by running a reference impulse
-through the real chain, with no room in it — sits inside the pair's arrival
-difference as chain, not geometry, and is credited to the check's reach before
-an extremum can be refused for exceeding it. Junctions whose band lies inside
-both passbands see microsecond skews and are untouched. Past that credit the
-check has one exception: an arrival
+part of the two chains' shifts — a signed displacement, each side measured by
+running a reference impulse through the real chain, with no room in it — sits
+inside the pair's arrival difference as chain, not geometry, and is subtracted
+from the anchor before the extremum's distance is measured. The half-period
+bound itself never widens: whatever the skew, an admitted extremum lies within
+half a period of the corrected anchor, so the same-polarity lobe a full period
+out stays refused. A displacement as large as the bound itself instead
+disqualifies the anchor outright — every verdict it could give is smaller than
+its own known error — and the check then stands down the same way it does for
+a deep-picked arrival (below), to the extremum's own strength rather than to
+the disqualification alone. Junctions whose band lies inside both passbands
+see microsecond skews and are untouched, and a pair with one side the
+estimator cannot read gets no correction rather than a guess. Past that
+correction the check has one exception: an arrival
 picked deep below its own band's energy. A subwoofer's direct front can sit
 20-odd dB under the cabin build-up arriving behind it — a real front, and the
 right one to time the channel by — while the correlation reads where the energy

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -901,10 +901,23 @@ precision wherever its own peak is trustworthy.
 
 The first-arrival search rejects **pre-ringing sidelobes** by testing every
 candidate against the analysis kernel's own envelope — an arrival can pre-ring no
-louder than that allows at a given distance, so a candidate above the ceiling is
-a genuine arrival no matter how the surroundings look (which keeps weak direct
-sound alive in reverberant bass), and one at or below it is confirmed as pre-ring
-by its mirror twin.
+louder than that allows at a given distance, so a candidate above the ceiling
+cannot be any single peak's pre-ring (which keeps weak direct sound alive in
+reverberant bass), and one at or below it is confirmed as pre-ring by its mirror
+twin.
+
+Clearing that ceiling is necessary but no longer sufficient: a first arrival
+must also **rise out of its own approach** — stand 3 dB above the quietest
+envelope level within a kernel's core reach behind it. Ahead of the first real
+arrival, a zero-phase analysis kernel lays down the summed backward skirt of
+everything the record plays later: a flat shelf that no single peak's ceiling
+can price (it is a superposition, measured 4.7 dB above the ceiling on a field
+subwoofer band), and whose micro-ripples would otherwise be reported as
+arrivals before the driver made a sound. A genuine front climbs whole decibels
+out of the floor it approaches over; ripple on a shelf climbs by hundredths.
+The approach window is sized by the kernel itself, so it scales with the band's
+rise time, and the strongest peak is exempt — nothing later could have
+manufactured it.
 
 It also refuses to read a **ripple on the foot of a wave packet** as that
 packet's arrival. A cabin's comb interference leaves small bumps a fraction of a
@@ -2441,7 +2454,16 @@ the two channels' **direct sound alone**: across a whole record a mid/tweeter
 handover's strongest extremum is often a reflection three to five periods from
 the arrival, and cutting to the wavefronts first is what keeps the seed on the
 right lobe. A seeding extremum that lands far from the coarse arrival is
-refused as a cycle skip, and that distance check has one exception: an arrival
+refused as a cycle skip. The distance itself is measured honestly first: each
+side's own chain drags its band arrival without moving the wavefront the tune
+aligns (a subwoofer's low-pass alone shifts its band arrival by a dozen
+milliseconds where its partner's chain shifts half that), so the non-common
+part of the two chains' shifts — each measured by running a reference impulse
+through the real chain, with no room in it — sits inside the pair's arrival
+difference as chain, not geometry, and is credited to the check's reach before
+an extremum can be refused for exceeding it. Junctions whose band lies inside
+both passbands see microsecond skews and are untouched. Past that credit the
+check has one exception: an arrival
 picked deep below its own band's energy. A subwoofer's direct front can sit
 20-odd dB under the cabin build-up arriving behind it — a real front, and the
 right one to time the channel by — while the correlation reads where the energy

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -921,14 +921,20 @@ public static class AutoAlignmentEngine
     // how far apart their own chains drag the band arrivals the junction's
     // anchor is a diff of. Measured the way the predictor measures its chain
     // term (a synthetic impulse through the real ApplyChain, so no room enters
-    // it), and available exactly when the predictor is: a side without a
-    // bypassed response or a chain contributes zero rather than a guess.
-    private static double PairChainArrivalSkewMs(AlignmentJunction pair) =>
-        Math.Abs(
-            SideChainArrivalShiftMs(pair.Lower, pair.BandLowHz, pair.BandHighHz) -
-            SideChainArrivalShiftMs(pair.Upper, pair.BandLowHz, pair.BandHighHz));
+    // it), and available exactly when the predictor is on BOTH sides: a skew
+    // is a difference, so one unmeasurable side (no bypassed response, no
+    // chain) withdraws the whole credit — the partner's shift is unknown
+    // there, not zero, and crediting the readable side's full shift against
+    // it would hand the credit exactly the guess it exists to avoid.
+    internal static double PairChainArrivalSkewMs(AlignmentJunction pair) =>
+        SideChainArrivalShiftMs(pair.Lower, pair.BandLowHz, pair.BandHighHz)
+            is { } lower &&
+        SideChainArrivalShiftMs(pair.Upper, pair.BandLowHz, pair.BandHighHz)
+            is { } upper
+            ? Math.Abs(lower - upper)
+            : 0.0;
 
-    private static double SideChainArrivalShiftMs(
+    private static double? SideChainArrivalShiftMs(
         AlignmentSnapshot side,
         double bandLowHz,
         double bandHighHz)
@@ -936,7 +942,7 @@ public static class AutoAlignmentEngine
         if (side.BypassedImpulseResponse is not { } bypassed ||
             side.ProcessingChain is not { } chain)
         {
-            return 0.0;
+            return null;
         }
 
         int contentLength = side.BypassedValidRange.IsKnown

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -396,8 +396,25 @@ public static class AutoAlignmentEngine
     {
         ArgumentNullException.ThrowIfNull(seed);
         ArgumentNullException.ThrowIfNull(directCorroboration);
+        return anchorProminenceDb < SeedVetoMinProminenceDb &&
+            ExtremumMayStandOnItsOwn(
+                anchorIsRawReads, seed, crossoverHz, directCorroboration);
+    }
+
+    // The shared tail of the reach veto's stand-down doors: whatever
+    // disqualified the anchor (a pick deep under the band's energy, or a
+    // chain displacement past the reach itself), the extremum never stands on
+    // the disqualification alone — the anchor must still be the raw measured
+    // reads, the extremum must clear the bar a direct seed clears, and at or
+    // above the direct cut's frequency the cut has the last word on the lobe.
+    // The delegate is taken only after the cheap clauses pass.
+    private static bool ExtremumMayStandOnItsOwn(
+        bool anchorIsRawReads,
+        CorrelationDelayCandidate seed,
+        double crossoverHz,
+        Func<CorrelationDelayCandidate?> directCorroboration)
+    {
         if (!anchorIsRawReads ||
-            anchorProminenceDb >= SeedVetoMinProminenceDb ||
             Math.Abs(seed.Coefficient) < DirectSeedMinCoefficient)
         {
             return false;
@@ -413,6 +430,22 @@ public static class AutoAlignmentEngine
             Math.Abs(corroboration.DelayMs - seed.DelayMs) <=
                 DirectCorroborationPeriods * 1000.0 / crossoverHz;
     }
+
+    // The chain-skew door's OTHER case: the displacement itself reaches the
+    // veto's own bound. A reach veto grades lobe distance by the anchor, and
+    // an anchor the pair's chains displace by the reach or more cannot tell
+    // one lobe from the next any better than the extremum it would refuse —
+    // its every verdict is smaller than its own known error. The anchor is
+    // then disqualified exactly as a deep-under-the-energy pick is, and the
+    // same stand-down policy applies (ExtremumMayStandOnItsOwn): measured on
+    // a field cabin, the woofer/mid junction this door exists for read a
+    // 3.9 ms skew against a 3.0 ms reach, and the dominant extremum it
+    // admitted sat a period from the raw anchor — on the lobe the panel's
+    // metric then measured 0.5 dB better.
+    internal static bool ChainSkewDisqualifiesTheAnchor(
+        double reachMs,
+        double? chainSkewMs) =>
+        chainSkewMs is { } skew && Math.Abs(skew) >= reachMs;
 
     /// <summary>
     /// How close the direct-sound witness must sit to the full-record extremum
@@ -918,21 +951,39 @@ public static class AutoAlignmentEngine
     }
 
     // The NON-COMMON part of the two sides' chain shifts in the pair band —
-    // how far apart their own chains drag the band arrivals the junction's
-    // anchor is a diff of. Measured the way the predictor measures its chain
-    // term (a synthetic impulse through the real ApplyChain, so no room enters
-    // it), and available exactly when the predictor is on BOTH sides: a skew
-    // is a difference, so one unmeasurable side (no bypassed response, no
-    // chain) withdraws the whole credit — the partner's shift is unknown
-    // there, not zero, and crediting the readable side's full shift against
-    // it would hand the credit exactly the guess it exists to avoid.
-    internal static double PairChainArrivalSkewMs(AlignmentJunction pair) =>
+    // how far the two chains drag the band arrivals APART, signed in the
+    // anchor's own convention: the anchor is lowerArrival − upperArrival (the
+    // delay to add to the upper channel), so a positive skew means the
+    // anchor overstates that delay by this much chain. Measured the way the
+    // predictor measures its chain term (a synthetic impulse through the real
+    // ApplyChain, so no room enters it), and available exactly when the
+    // predictor is on BOTH sides: a skew is a difference, so one unmeasurable
+    // side (no bypassed response, no chain) returns null — the partner's
+    // shift is unknown there, not zero, and treating it as zero would hand
+    // the correction exactly the guess it exists to avoid.
+    internal static double? PairChainArrivalSkewMs(AlignmentJunction pair) =>
         SideChainArrivalShiftMs(pair.Lower, pair.BandLowHz, pair.BandHighHz)
             is { } lower &&
         SideChainArrivalShiftMs(pair.Upper, pair.BandLowHz, pair.BandHighHz)
             is { } upper
-            ? Math.Abs(lower - upper)
-            : 0.0;
+            ? lower - upper
+            : null;
+
+    // Whether the pair's own measured chain displacement explains the seed
+    // extremum's distance from the arrival anchor: with the signed skew
+    // subtracted from the anchor (the anchor is lowerArrival − upperArrival
+    // and the offset is extremum − anchor, so the correction ADDS the skew to
+    // the offset), the extremum must sit inside the ORIGINAL reach. The
+    // half-period reach is the no-cycle-skip guarantee, so it is corrected,
+    // never widened: however large the skew, the admitted extremum lies
+    // within half a period of the corrected anchor, and the same-polarity
+    // lobe a full period out stays refused.
+    internal static bool ChainSkewExplainsSeedOffset(
+        double seedOffsetMs,
+        double reachMs,
+        double? chainSkewMs) =>
+        chainSkewMs is { } skew &&
+        Math.Abs(seedOffsetMs + skew) < reachMs;
 
     private static double? SideChainArrivalShiftMs(
         AlignmentSnapshot side,
@@ -2024,27 +2075,57 @@ public static class AutoAlignmentEngine
                     // low-pass alone shifts its band arrival by 12.8 ms on a
                     // field cabin while its woofer partner moves 6.1. The
                     // NON-COMMON part of those shifts sits inside the measured
-                    // diff as chain, not as geometry, so the reach test must
-                    // credit it before it spends it as lobe distance: an
-                    // extremum within reach-plus-skew of the anchor is a
-                    // disagreement the anchor cannot grade, not a cycle skip.
-                    // The skew is measured on the predictor's own synthetic
-                    // impulse (ChainArrivalShiftMs) — no room in it — and is
+                    // diff as chain, not as geometry — a SIGNED, measured
+                    // displacement (the predictor's own synthetic impulse
+                    // through each chain, no room in it), so it is SUBTRACTED
+                    // from the disagreement rather than added to the reach:
+                    // the half-period bound is the no-cycle-skip guarantee and
+                    // is never widened (a symmetric reach-plus-skew allowance
+                    // was reviewed out — at an 80 Hz junction the field's
+                    // 6.7 ms skew would have stretched it past the
+                    // same-polarity lobe a full period out). The skew is
                     // microseconds wherever the pair band sits inside both
                     // passbands, leaving those junctions exactly as before.
-                    double chainSkewMs = PairChainArrivalSkewMs(pair);
-                    if (Math.Abs(seedOffsetMs) < reachMs + chainSkewMs)
+                    double? chainSkewMs = PairChainArrivalSkewMs(pair);
+                    if (ChainSkewExplainsSeedOffset(
+                        seedOffsetMs, reachMs, chainSkewMs))
                     {
                         log.AppendLine(
                             $"  {pair.Lower.Channel.Name}/{pair.Upper.Channel.Name}: " +
                             $"the {seedLabel} sits {Math.Abs(seedOffsetMs):0.000} ms " +
                             $"from the arrival anchor, past its {reachMs:0.000} ms " +
-                            $"reach — but the pair's own chains displace their " +
-                            $"band arrivals by {chainSkewMs:0.000} ms of " +
-                            "non-common shift, so that much of the anchor's diff " +
-                            "is chain, not geometry; the reach is credited and " +
+                            $"reach — but the pair's own chains displace that " +
+                            $"anchor by {chainSkewMs!.Value:+0.000;-0.000} ms of " +
+                            "non-common shift, and against the corrected anchor " +
                             $"the extremum (r {Math.Abs(seed.Coefficient):0.000}) " +
-                            "stands");
+                            $"sits {Math.Abs(seedOffsetMs + chainSkewMs.Value):0.000} ms " +
+                            "off, inside the reach; it stands");
+                        return null;
+                    }
+
+                    // A displacement the size of the reach itself disqualifies
+                    // the anchor outright — every verdict it could give is
+                    // smaller than its own known error — and the veto then
+                    // stands down to the SAME policy the deep-pick door uses,
+                    // never to the disqualification alone: the extremum must
+                    // clear a direct seed's bar, and above the cut's frequency
+                    // the cut has the last word (unreachable there in
+                    // practice: in-band chain skews are microseconds once the
+                    // pair band sits inside both passbands).
+                    if (ChainSkewDisqualifiesTheAnchor(reachMs, chainSkewMs) &&
+                        ExtremumMayStandOnItsOwn(
+                            anchorIsRawReads, seed, pair.CrossoverHz,
+                            DirectCorroboration))
+                    {
+                        log.AppendLine(
+                            $"  {pair.Lower.Channel.Name}/{pair.Upper.Channel.Name}: " +
+                            $"the {seedLabel} sits {Math.Abs(seedOffsetMs):0.000} ms " +
+                            $"from the arrival anchor — but the pair's own " +
+                            $"chains displace that anchor by " +
+                            $"{chainSkewMs!.Value:+0.000;-0.000} ms, the full " +
+                            $"{reachMs:0.000} ms reach and more, so the anchor " +
+                            "cannot grade lobes at all; the extremum stands on " +
+                            $"its own strength (r {Math.Abs(seed.Coefficient):0.000})");
                         return null;
                     }
 

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -2067,6 +2067,22 @@ public static class AutoAlignmentEngine
 
                 // At the boundary itself the two lobes are equidistant, so
                 // the extremum is refused rather than admitted.
+                //
+                // The gate reads the RAW offset deliberately, and the skew
+                // correction below opens only ADMITTANCE doors behind it —
+                // it never re-vetoes an extremum the raw anchor accepts. The
+                // symmetric alternative (gate everything by offset+skew) reads
+                // cleaner and was reviewed twice, but the corrected anchor is
+                // a bounded estimate, not a truth coordinate: the skew is the
+                // chains' full envelope shift where the honest correction is
+                // its group-minus-phase part, and on the archived v2
+                // woofer/mid junction the owner's own lobe sits 1.9 periods
+                // from the corrected anchor while agreeing with the raw one.
+                // Gating by the corrected offset there re-vetoes the tune the
+                // panel's metric measures 0.5 dB better. Raw-offset gating is
+                // also the pre-correction semantics every archived cabin was
+                // calibrated against; narrowing it needs its own field case,
+                // not an arithmetic symmetry.
                 if (!arrivalReanchored && Math.Abs(seedOffsetMs) >= reachMs)
                 {
                     // The anchor is a diff of two band-ENVELOPE arrivals, and
@@ -2099,7 +2115,8 @@ public static class AutoAlignmentEngine
                             "non-common shift, and against the corrected anchor " +
                             $"the extremum (r {Math.Abs(seed.Coefficient):0.000}) " +
                             $"sits {Math.Abs(seedOffsetMs + chainSkewMs.Value):0.000} ms " +
-                            "off, inside the reach; it stands");
+                            "off, inside the reach; the veto is corrected away " +
+                            "and the extremum stands");
                         return null;
                     }
 
@@ -2124,8 +2141,9 @@ public static class AutoAlignmentEngine
                             $"chains displace that anchor by " +
                             $"{chainSkewMs!.Value:+0.000;-0.000} ms, the full " +
                             $"{reachMs:0.000} ms reach and more, so the anchor " +
-                            "cannot grade lobes at all; the extremum stands on " +
-                            $"its own strength (r {Math.Abs(seed.Coefficient):0.000})");
+                            "cannot grade lobes and its veto stands down; the " +
+                            "extremum stands on its own strength " +
+                            $"(r {Math.Abs(seed.Coefficient):0.000})");
                         return null;
                     }
 

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -917,6 +917,41 @@ public static class AutoAlignmentEngine
         return filtered - bare;
     }
 
+    // The NON-COMMON part of the two sides' chain shifts in the pair band —
+    // how far apart their own chains drag the band arrivals the junction's
+    // anchor is a diff of. Measured the way the predictor measures its chain
+    // term (a synthetic impulse through the real ApplyChain, so no room enters
+    // it), and available exactly when the predictor is: a side without a
+    // bypassed response or a chain contributes zero rather than a guess.
+    private static double PairChainArrivalSkewMs(AlignmentJunction pair) =>
+        Math.Abs(
+            SideChainArrivalShiftMs(pair.Lower, pair.BandLowHz, pair.BandHighHz) -
+            SideChainArrivalShiftMs(pair.Upper, pair.BandLowHz, pair.BandHighHz));
+
+    private static double SideChainArrivalShiftMs(
+        AlignmentSnapshot side,
+        double bandLowHz,
+        double bandHighHz)
+    {
+        if (side.BypassedImpulseResponse is not { } bypassed ||
+            side.ProcessingChain is not { } chain)
+        {
+            return 0.0;
+        }
+
+        int contentLength = side.BypassedValidRange.IsKnown
+            ? side.BypassedValidRange.EndSample - side.BypassedValidRange.StartSample
+            : bypassed.Length;
+        return ChainArrivalShiftMs(
+            chain,
+            side.Channel.SampleRate,
+            side.Channel.ProcessorSampleRate,
+            bandLowHz,
+            bandHighHz,
+            contentLength,
+            side.PeakIndex);
+    }
+
     /// <summary>
     /// The arrival honesty probe's dispersion allowance for ONE side: how much
     /// later than its own upper-half read the full-band read may sit before
@@ -1977,6 +2012,36 @@ public static class AutoAlignmentEngine
                 // the extremum is refused rather than admitted.
                 if (!arrivalReanchored && Math.Abs(seedOffsetMs) >= reachMs)
                 {
+                    // The anchor is a diff of two band-ENVELOPE arrivals, and
+                    // each side's own chain drags that envelope without moving
+                    // the wavefront the tune actually aligns — a subwoofer
+                    // low-pass alone shifts its band arrival by 12.8 ms on a
+                    // field cabin while its woofer partner moves 6.1. The
+                    // NON-COMMON part of those shifts sits inside the measured
+                    // diff as chain, not as geometry, so the reach test must
+                    // credit it before it spends it as lobe distance: an
+                    // extremum within reach-plus-skew of the anchor is a
+                    // disagreement the anchor cannot grade, not a cycle skip.
+                    // The skew is measured on the predictor's own synthetic
+                    // impulse (ChainArrivalShiftMs) — no room in it — and is
+                    // microseconds wherever the pair band sits inside both
+                    // passbands, leaving those junctions exactly as before.
+                    double chainSkewMs = PairChainArrivalSkewMs(pair);
+                    if (Math.Abs(seedOffsetMs) < reachMs + chainSkewMs)
+                    {
+                        log.AppendLine(
+                            $"  {pair.Lower.Channel.Name}/{pair.Upper.Channel.Name}: " +
+                            $"the {seedLabel} sits {Math.Abs(seedOffsetMs):0.000} ms " +
+                            $"from the arrival anchor, past its {reachMs:0.000} ms " +
+                            $"reach — but the pair's own chains displace their " +
+                            $"band arrivals by {chainSkewMs:0.000} ms of " +
+                            "non-common shift, so that much of the anchor's diff " +
+                            "is chain, not geometry; the reach is credited and " +
+                            $"the extremum (r {Math.Abs(seed.Coefficient):0.000}) " +
+                            "stands");
+                        return null;
+                    }
+
                     // Unless the anchor is not the same kind of read as the
                     // extremum it would be vetoing AND a better witness puts the
                     // pair on that extremum's lobe (see

--- a/dsp/SignalEnvelope.cs
+++ b/dsp/SignalEnvelope.cs
@@ -179,7 +179,7 @@ public static class SignalEnvelope
     }
 
     // A measurement chain with real processing latency (a DSP or amplifier
-    // buffering the playback longer than the search window — a field chain ran
+    // buffering the playback longer than the search window вЂ” a field chain ran
     // ~163 ms) parks the whole IR beyond the start-anchored window's reach, and
     // the "strongest peak" that window can offer is whatever residue leads the
     // buffer: the analysis then reports a confident zero. So the window
@@ -194,7 +194,7 @@ public static class SignalEnvelope
     // the post-peak data the mirror/sidelobe checks read stays available through
     // the rotated view regardless of the window edge.
     //
-    // The re-anchor is deliberately conservative — it fires only when NOTHING in
+    // The re-anchor is deliberately conservative вЂ” it fires only when NOTHING in
     // the start-anchored window sits within the first-arrival search depth of the
     // global peak AND above the noise gate, i.e. when by the tool's own physics
     // the true arrival cannot be inside that window. Depth alone is not enough:
@@ -252,21 +252,21 @@ public static class SignalEnvelope
     // distributed, and the RMS of its lowest quartile is ~0.370 of the full
     // envelope RMS. The quartile floor is deliberately robust (reverb decay
     // must not count as noise), but reported as-is it would flatter the SNR
-    // by ~8.6 dB — so the REPORTED figure compensates the known bias back to
+    // by ~8.6 dB вЂ” so the REPORTED figure compensates the known bias back to
     // the full-envelope noise RMS. The first-arrival threshold keeps the raw
     // robust floor: there under-estimating noise is the safe direction.
     private const double RayleighLowestQuartileRmsRatio = 0.370;
 
     // A transfer IR deconvolved over a long FFT carries a contiguous "tail" of
-    // numerical silence — 100+ dB below the peak, far under any real acoustic or
+    // numerical silence вЂ” 100+ dB below the peak, far under any real acoustic or
     // electronic noise floor. On a clean cabin sweep it can fill a third of the
-    // record near −140 dB; left in, the quietest-quartile estimate lands entirely
+    // record near в€’140 dB; left in, the quietest-quartile estimate lands entirely
     // in it and inflates the reported SNR by tens of dB (an envelope showing ~65
     // dB read 123). So the confidence figure measures noise only over the VALID
-    // region — samples within this many dB of the peak — the same intent as the
+    // region вЂ” samples within this many dB of the peak вЂ” the same intent as the
     // ValidSampleRange the Auto-delay path already crops the FFT tail with (there
     // the envelope arrives pre-cropped, so this bound is a no-op). FindPeak keeps
-    // the raw full-envelope floor: it gates on max(noise, −25 dB-below-peak), so
+    // the raw full-envelope floor: it gates on max(noise, в€’25 dB-below-peak), so
     // the tail never reaches its threshold and the measured arrival is unaffected.
     private const double DeconvolutionFloorDropDb = 100.0;
 
@@ -295,13 +295,13 @@ public static class SignalEnvelope
     // window and the discrete Hilbert transform's own 1/t skirt), so every
     // arrival drags an exactly symmetric train of pre-ringing lobes in front of
     // it. The stronger ones clear the first-arrival threshold and used to read
-    // as earlier "arrivals" milliseconds before the true wavefront — the cleaner
+    // as earlier "arrivals" milliseconds before the true wavefront вЂ” the cleaner
     // the measurement, the more of them survived the noise gate. The kernel that
     // makes the ringing is known, so a candidate is tested against physics, not
     // heuristics: an arrival of height H can produce at offset d a lobe no
     // higher than H times the kernel envelope at d. A candidate above that
     // ceiling (with a 6 dB superposition margin) cannot be pre-ring and is a
-    // genuine arrival; a candidate at or below it is corroborated by symmetry —
+    // genuine arrival; a candidate at or below it is corroborated by symmetry вЂ”
     // an exactly even kernel puts an equal lobe at the mirrored position after
     // the peak, and decay/reflections only add energy on the late side, so the
     // mirror cannot hide a lobe. Level-and-mirror together keep genuine early
@@ -311,17 +311,25 @@ public static class SignalEnvelope
     private const double SidelobeSymmetryRatio = 0.5;
     private const int SidelobeMirrorNeighborhood = 2;
 
+    // The rise a first arrival must show over its approach floor (see
+    // RisesOutOfItsApproach), and the kernel-envelope decay that bounds how far
+    // back that floor is read (see ApproachSpanSamples). The acausal pedestal's
+    // ripples rise by hundredths of a dB; a genuine front climbs by whole ones
+    // - 3 dB separates them with margin on both sides.
+    private const double FrontApproachRiseRatio = 1.41;
+    private const double ApproachWindowKernelLevel = 0.1;
+
     // How long after a candidate a stronger peak still belongs to the SAME wave
-    // packet rather than being a separate arrival — the complement of
+    // packet rather than being a separate arrival вЂ” the complement of
     // <see cref="TimeAlignmentAnalysis"/>'s separate-arrival rule, and the same
     // 1 ms, so the two never disagree about what one arrival is.
     internal const double ArrivalPacketMilliseconds = 1.0;
 
     // The share of its own packet's peak amplitude a candidate must reach to be
     // read as that packet's front rather than a ripple on its foot. A wave
-    // packet's leading edge carries interference structure — a comb null a
+    // packet's leading edge carries interference structure вЂ” a comb null a
     // fraction of a millisecond before the front leaves a small bump above the
-    // search threshold — and taking that bump as "the arrival" reports a time
+    // search threshold вЂ” and taking that bump as "the arrival" reports a time
     // that depends on the record's ripple, not on its path: two identical
     // drivers in opposite doors then read one arrival at its packet peak and the
     // other 20 dB down its own foot, and the level difference enters the
@@ -332,12 +340,12 @@ public static class SignalEnvelope
     // (<see cref="VirtualCrossoverAnalysis.EstimateBroadbandOnset"/>) calls the
     // onset level, and it is deliberately LOCAL: the packet window is one
     // millisecond, so a soft direct arrival buried under a room mode
-    // milliseconds later — what the 25 dB search depth exists to find — is
+    // milliseconds later вЂ” what the 25 dB search depth exists to find вЂ” is
     // nobody's foot ripple and stays selected.
     private const double ArrivalPacketRiseRatio = 0.25;
 
     // How deep the envelope must null between a candidate and a later stronger
-    // sample for the two to be RESOLVED events rather than one packet — the
+    // sample for the two to be RESOLVED events rather than one packet вЂ” the
     // same 20 dB <see cref="TimeAlignmentAnalysis"/> calls a resolved valley,
     // because destructive interference nulls faster than an envelope rises. The
     // packet ends at the first such null: past it the record belongs to another
@@ -350,7 +358,7 @@ public static class SignalEnvelope
 
     // Walks the threshold-passing local maxima from the latest to the earliest,
     // dropping every candidate that reads as a pre-ringing sidelobe of an
-    // already-accepted later peak — a weak first arrival is itself a sidelobe
+    // already-accepted later peak вЂ” a weak first arrival is itself a sidelobe
     // reference, so its own pre-ring cannot masquerade as an even earlier
     // arrival. Returns the earliest surviving candidate that also rises far
     // enough within its own packet, or -1 when none pass. A dwarfed candidate
@@ -366,7 +374,7 @@ public static class SignalEnvelope
     {
         // Beyond this offset not even the strongest peak can ring above the
         // candidate threshold, so no threshold-passing candidate can be anyone's
-        // sidelobe there — it bounds the peak-comparison loop.
+        // sidelobe there вЂ” it bounds the peak-comparison loop.
         int ringReachLimit = 0;
         int reachCap = envelope.Count / 2;
         for (int d = 1; d <= reachCap; d++)
@@ -378,6 +386,8 @@ public static class SignalEnvelope
             }
         }
 
+        int approachSpanSamples = ApproachSpanSamples(
+            kernelEnvelope, packetSpanSamples, reachCap);
         var accepted = new List<int>();
         int firstArrival = -1;
         for (int k = candidates.Count - 1; k >= 0; k--)
@@ -403,7 +413,11 @@ public static class SignalEnvelope
             if (!isSidelobe)
             {
                 accepted.Add(candidate);
-                if (RisesWithinItsPacket(envelope, candidate, packetSpanSamples))
+                // The strongest peak needs no rise witness: it outranks
+                // everything, so nothing later could have manufactured it.
+                if (envelope[candidate] >= strongestPeak ||
+                    (RisesWithinItsPacket(envelope, candidate, packetSpanSamples) &&
+                     RisesOutOfItsApproach(envelope, candidate, approachSpanSamples)))
                 {
                     firstArrival = candidate;
                 }
@@ -413,11 +427,73 @@ public static class SignalEnvelope
         return firstArrival;
     }
 
+    // A genuine front RISES: the driver's energy is added to whatever the
+    // envelope held before it, so the candidate must stand above the floor of
+    // its own approach вЂ” the quietest sample within a kernel's core reach
+    // before it. What fails this test is the texture on the analysis kernel's
+    // own acausal pedestal: a zero-phase kernel spreads the whole later record
+    // backwards, and ahead of the first real arrival that superposition forms
+    // a FLAT shelf (measured on a field subwoofer at 32.5-130 Hz: -20 dB
+    // against a per-peak ring ceiling of -24.7 dB, so the level gate above
+    // reads its micro-ripples - local maxima a few hundredths of a dB proud -
+    // as genuine early arrivals). No single-peak ceiling can price that shelf,
+    // because it is the sum of every later sample's skirt; the rise test reads
+    // the shelf itself instead of predicting it.
+    private static bool RisesOutOfItsApproach(
+        IReadOnlyList<double> envelope,
+        int candidateIndex,
+        int approachSpanSamples)
+    {
+        if (candidateIndex <= 0)
+        {
+            return true;
+        }
+
+        int first = Math.Max(0, candidateIndex - approachSpanSamples);
+        double floor = double.MaxValue;
+        for (int i = first; i < candidateIndex; i++)
+        {
+            floor = Math.Min(floor, envelope[i]);
+        }
+
+        return envelope[candidateIndex] >= floor * FrontApproachRiseRatio;
+    }
+
+    // How far back the approach floor is read: the analysis kernel's own core
+    // - out to where its envelope has decayed by the window level - so the
+    // window scales with the band's rise time (a 32.5-130 Hz front takes
+    // milliseconds to climb; a broadband one is done in a fraction of one).
+    // Never shorter than the arrival packet, which is the no-kernel fallback.
+    private static int ApproachSpanSamples(
+        IReadOnlyList<double>? kernelEnvelope,
+        int packetSpanSamples,
+        int reachCap)
+    {
+        if (kernelEnvelope == null || kernelEnvelope.Count == 0 ||
+            kernelEnvelope[0] <= 0.0)
+        {
+            return packetSpanSamples;
+        }
+
+        double coreLevel = kernelEnvelope[0] * ApproachWindowKernelLevel;
+        int span = packetSpanSamples;
+        int last = Math.Min(kernelEnvelope.Count - 1, reachCap);
+        for (int d = 1; d <= last; d++)
+        {
+            if (kernelEnvelope[d] >= coreLevel)
+            {
+                span = Math.Max(span, d);
+            }
+        }
+
+        return span;
+    }
+
     // Whether the candidate is the front of its own wave packet rather than a
     // ripple on its foot: the strongest envelope sample of THAT PACKET may stand
     // no more than the rise ratio above it. The packet runs one span forward and
     // ends early at a null deep enough to resolve two events, so a genuine
-    // earlier arrival is never dwarfed by whatever rises after the null — the
+    // earlier arrival is never dwarfed by whatever rises after the null вЂ” the
     // separate-arrival case, which keeps its own timing. The strongest peak of
     // the record always passes (nothing outranks it inside its own packet), so
     // the walk can never come back empty because of this test.
@@ -447,7 +523,7 @@ public static class SignalEnvelope
     // The analysis kernel's envelope level at |offset| samples from its centre,
     // relative to the centre peak. With no explicit kernel the only zero-phase
     // ringing left is the discrete Hilbert transform's skirt, whose envelope
-    // pedestal is 2/(pi*n) — the delta worst case; smoother arrivals ring less.
+    // pedestal is 2/(pi*n) вЂ” the delta worst case; smoother arrivals ring less.
     private static double KernelRingLevel(
         IReadOnlyList<double>? kernelEnvelope,
         int offset)
@@ -484,7 +560,7 @@ public static class SignalEnvelope
         }
 
         // The peak's integer index is up to half a sample off the true lobe
-        // centre, so read the mirror as the maximum over a small neighbourhood —
+        // centre, so read the mirror as the maximum over a small neighbourhood вЂ”
         // a deep null one sample off the exact mirror must not disguise a
         // sidelobe as a genuine arrival. Clamp the neighbourhood so it never
         // touches the peak's own lobe.
@@ -529,7 +605,7 @@ public static class SignalEnvelope
         int requestedSamples = (int)Math.Round(
             Math.Max(1, searchWindowMilliseconds) * sampleRate / 1000.0);
         // The floor of 3 exists for the parabolic refinement, but it must never
-        // exceed the envelope itself — a 1–2 sample input would otherwise be
+        // exceed the envelope itself вЂ” a 1вЂ“2 sample input would otherwise be
         // read past its end.
         int cap = Math.Min(envelopeLength, Math.Max(3, envelopeLength / 2));
         return Math.Clamp(requestedSamples, Math.Min(3, cap), cap);
@@ -540,8 +616,8 @@ public static class SignalEnvelope
     private const double NoiseFloorQuantile = 0.25;
 
     // Noise floor as the RMS of the quietest quarter of the envelope. An
-    // acoustic IR's remainder is NOT noise — it is reflections, modal decay and
-    // driver ringing — so a mean over everything-but-the-peak (the previous
+    // acoustic IR's remainder is NOT noise вЂ” it is reflections, modal decay and
+    // driver ringing вЂ” so a mean over everything-but-the-peak (the previous
     // estimate) read reverberation as noise: it misgraded clean reverberant
     // recordings and, worse, inflated the noise-based first-arrival threshold
     // until a genuine weak direct sound was cut out of the candidate list. The
@@ -587,7 +663,7 @@ public sealed class PeakSearchOptions
     /// samples from the kernel centre; entry 0 is the kernel peak and the scale
     /// is arbitrary. The first-arrival search uses it as the exact ceiling of
     /// pre-ringing sidelobe levels at each distance. Null when the signal was
-    /// not filtered — only the Hilbert transform's own skirt is assumed then.
+    /// not filtered вЂ” only the Hilbert transform's own skirt is assumed then.
     /// </summary>
     public IReadOnlyList<double>? AnalysisKernelEnvelope { get; init; }
 }
@@ -598,7 +674,7 @@ public sealed class PeakSearchOptions
 /// maximum (a chain latency beyond the window's reach): the window then covered
 /// [SearchRotation, SearchRotation + window) circularly, and a consumer
 /// measuring distances between the returned indices must measure them in that
-/// window's frame — <c>(index - SearchRotation) mod length</c> — or a pair
+/// window's frame вЂ” <c>(index - SearchRotation) mod length</c> вЂ” or a pair
 /// straddling the buffer seam reads as a buffer-length separation.
 /// </summary>
 public readonly record struct PeakSearchResult(
@@ -607,3 +683,5 @@ public readonly record struct PeakSearchResult(
     double StrongestPeak,
     bool FallbackUsed,
     int SearchRotation = 0);
+
+

--- a/dsp/SignalEnvelope.cs
+++ b/dsp/SignalEnvelope.cs
@@ -179,7 +179,7 @@ public static class SignalEnvelope
     }
 
     // A measurement chain with real processing latency (a DSP or amplifier
-    // buffering the playback longer than the search window вЂ” a field chain ran
+    // buffering the playback longer than the search window — a field chain ran
     // ~163 ms) parks the whole IR beyond the start-anchored window's reach, and
     // the "strongest peak" that window can offer is whatever residue leads the
     // buffer: the analysis then reports a confident zero. So the window
@@ -194,7 +194,7 @@ public static class SignalEnvelope
     // the post-peak data the mirror/sidelobe checks read stays available through
     // the rotated view regardless of the window edge.
     //
-    // The re-anchor is deliberately conservative вЂ” it fires only when NOTHING in
+    // The re-anchor is deliberately conservative — it fires only when NOTHING in
     // the start-anchored window sits within the first-arrival search depth of the
     // global peak AND above the noise gate, i.e. when by the tool's own physics
     // the true arrival cannot be inside that window. Depth alone is not enough:
@@ -252,21 +252,21 @@ public static class SignalEnvelope
     // distributed, and the RMS of its lowest quartile is ~0.370 of the full
     // envelope RMS. The quartile floor is deliberately robust (reverb decay
     // must not count as noise), but reported as-is it would flatter the SNR
-    // by ~8.6 dB вЂ” so the REPORTED figure compensates the known bias back to
+    // by ~8.6 dB — so the REPORTED figure compensates the known bias back to
     // the full-envelope noise RMS. The first-arrival threshold keeps the raw
     // robust floor: there under-estimating noise is the safe direction.
     private const double RayleighLowestQuartileRmsRatio = 0.370;
 
     // A transfer IR deconvolved over a long FFT carries a contiguous "tail" of
-    // numerical silence вЂ” 100+ dB below the peak, far under any real acoustic or
+    // numerical silence — 100+ dB below the peak, far under any real acoustic or
     // electronic noise floor. On a clean cabin sweep it can fill a third of the
-    // record near в€’140 dB; left in, the quietest-quartile estimate lands entirely
+    // record near −140 dB; left in, the quietest-quartile estimate lands entirely
     // in it and inflates the reported SNR by tens of dB (an envelope showing ~65
     // dB read 123). So the confidence figure measures noise only over the VALID
-    // region вЂ” samples within this many dB of the peak вЂ” the same intent as the
+    // region — samples within this many dB of the peak — the same intent as the
     // ValidSampleRange the Auto-delay path already crops the FFT tail with (there
     // the envelope arrives pre-cropped, so this bound is a no-op). FindPeak keeps
-    // the raw full-envelope floor: it gates on max(noise, в€’25 dB-below-peak), so
+    // the raw full-envelope floor: it gates on max(noise, −25 dB-below-peak), so
     // the tail never reaches its threshold and the measured arrival is unaffected.
     private const double DeconvolutionFloorDropDb = 100.0;
 
@@ -295,13 +295,13 @@ public static class SignalEnvelope
     // window and the discrete Hilbert transform's own 1/t skirt), so every
     // arrival drags an exactly symmetric train of pre-ringing lobes in front of
     // it. The stronger ones clear the first-arrival threshold and used to read
-    // as earlier "arrivals" milliseconds before the true wavefront вЂ” the cleaner
+    // as earlier "arrivals" milliseconds before the true wavefront — the cleaner
     // the measurement, the more of them survived the noise gate. The kernel that
     // makes the ringing is known, so a candidate is tested against physics, not
     // heuristics: an arrival of height H can produce at offset d a lobe no
     // higher than H times the kernel envelope at d. A candidate above that
     // ceiling (with a 6 dB superposition margin) cannot be pre-ring and is a
-    // genuine arrival; a candidate at or below it is corroborated by symmetry вЂ”
+    // genuine arrival; a candidate at or below it is corroborated by symmetry —
     // an exactly even kernel puts an equal lobe at the mirrored position after
     // the peak, and decay/reflections only add energy on the late side, so the
     // mirror cannot hide a lobe. Level-and-mirror together keep genuine early
@@ -320,16 +320,16 @@ public static class SignalEnvelope
     private const double ApproachWindowKernelLevel = 0.1;
 
     // How long after a candidate a stronger peak still belongs to the SAME wave
-    // packet rather than being a separate arrival вЂ” the complement of
+    // packet rather than being a separate arrival — the complement of
     // <see cref="TimeAlignmentAnalysis"/>'s separate-arrival rule, and the same
     // 1 ms, so the two never disagree about what one arrival is.
     internal const double ArrivalPacketMilliseconds = 1.0;
 
     // The share of its own packet's peak amplitude a candidate must reach to be
     // read as that packet's front rather than a ripple on its foot. A wave
-    // packet's leading edge carries interference structure вЂ” a comb null a
+    // packet's leading edge carries interference structure — a comb null a
     // fraction of a millisecond before the front leaves a small bump above the
-    // search threshold вЂ” and taking that bump as "the arrival" reports a time
+    // search threshold — and taking that bump as "the arrival" reports a time
     // that depends on the record's ripple, not on its path: two identical
     // drivers in opposite doors then read one arrival at its packet peak and the
     // other 20 dB down its own foot, and the level difference enters the
@@ -340,12 +340,12 @@ public static class SignalEnvelope
     // (<see cref="VirtualCrossoverAnalysis.EstimateBroadbandOnset"/>) calls the
     // onset level, and it is deliberately LOCAL: the packet window is one
     // millisecond, so a soft direct arrival buried under a room mode
-    // milliseconds later вЂ” what the 25 dB search depth exists to find вЂ” is
+    // milliseconds later — what the 25 dB search depth exists to find — is
     // nobody's foot ripple and stays selected.
     private const double ArrivalPacketRiseRatio = 0.25;
 
     // How deep the envelope must null between a candidate and a later stronger
-    // sample for the two to be RESOLVED events rather than one packet вЂ” the
+    // sample for the two to be RESOLVED events rather than one packet — the
     // same 20 dB <see cref="TimeAlignmentAnalysis"/> calls a resolved valley,
     // because destructive interference nulls faster than an envelope rises. The
     // packet ends at the first such null: past it the record belongs to another
@@ -358,7 +358,7 @@ public static class SignalEnvelope
 
     // Walks the threshold-passing local maxima from the latest to the earliest,
     // dropping every candidate that reads as a pre-ringing sidelobe of an
-    // already-accepted later peak вЂ” a weak first arrival is itself a sidelobe
+    // already-accepted later peak — a weak first arrival is itself a sidelobe
     // reference, so its own pre-ring cannot masquerade as an even earlier
     // arrival. Returns the earliest surviving candidate that also rises far
     // enough within its own packet, or -1 when none pass. A dwarfed candidate
@@ -374,7 +374,7 @@ public static class SignalEnvelope
     {
         // Beyond this offset not even the strongest peak can ring above the
         // candidate threshold, so no threshold-passing candidate can be anyone's
-        // sidelobe there вЂ” it bounds the peak-comparison loop.
+        // sidelobe there — it bounds the peak-comparison loop.
         int ringReachLimit = 0;
         int reachCap = envelope.Count / 2;
         for (int d = 1; d <= reachCap; d++)
@@ -429,7 +429,7 @@ public static class SignalEnvelope
 
     // A genuine front RISES: the driver's energy is added to whatever the
     // envelope held before it, so the candidate must stand above the floor of
-    // its own approach вЂ” the quietest sample within a kernel's core reach
+    // its own approach — the quietest sample within a kernel's core reach
     // before it. What fails this test is the texture on the analysis kernel's
     // own acausal pedestal: a zero-phase kernel spreads the whole later record
     // backwards, and ahead of the first real arrival that superposition forms
@@ -493,7 +493,7 @@ public static class SignalEnvelope
     // ripple on its foot: the strongest envelope sample of THAT PACKET may stand
     // no more than the rise ratio above it. The packet runs one span forward and
     // ends early at a null deep enough to resolve two events, so a genuine
-    // earlier arrival is never dwarfed by whatever rises after the null вЂ” the
+    // earlier arrival is never dwarfed by whatever rises after the null — the
     // separate-arrival case, which keeps its own timing. The strongest peak of
     // the record always passes (nothing outranks it inside its own packet), so
     // the walk can never come back empty because of this test.
@@ -523,7 +523,7 @@ public static class SignalEnvelope
     // The analysis kernel's envelope level at |offset| samples from its centre,
     // relative to the centre peak. With no explicit kernel the only zero-phase
     // ringing left is the discrete Hilbert transform's skirt, whose envelope
-    // pedestal is 2/(pi*n) вЂ” the delta worst case; smoother arrivals ring less.
+    // pedestal is 2/(pi*n) — the delta worst case; smoother arrivals ring less.
     private static double KernelRingLevel(
         IReadOnlyList<double>? kernelEnvelope,
         int offset)
@@ -560,7 +560,7 @@ public static class SignalEnvelope
         }
 
         // The peak's integer index is up to half a sample off the true lobe
-        // centre, so read the mirror as the maximum over a small neighbourhood вЂ”
+        // centre, so read the mirror as the maximum over a small neighbourhood —
         // a deep null one sample off the exact mirror must not disguise a
         // sidelobe as a genuine arrival. Clamp the neighbourhood so it never
         // touches the peak's own lobe.
@@ -605,7 +605,7 @@ public static class SignalEnvelope
         int requestedSamples = (int)Math.Round(
             Math.Max(1, searchWindowMilliseconds) * sampleRate / 1000.0);
         // The floor of 3 exists for the parabolic refinement, but it must never
-        // exceed the envelope itself вЂ” a 1вЂ“2 sample input would otherwise be
+        // exceed the envelope itself — a 1–2 sample input would otherwise be
         // read past its end.
         int cap = Math.Min(envelopeLength, Math.Max(3, envelopeLength / 2));
         return Math.Clamp(requestedSamples, Math.Min(3, cap), cap);
@@ -616,8 +616,8 @@ public static class SignalEnvelope
     private const double NoiseFloorQuantile = 0.25;
 
     // Noise floor as the RMS of the quietest quarter of the envelope. An
-    // acoustic IR's remainder is NOT noise вЂ” it is reflections, modal decay and
-    // driver ringing вЂ” so a mean over everything-but-the-peak (the previous
+    // acoustic IR's remainder is NOT noise — it is reflections, modal decay and
+    // driver ringing — so a mean over everything-but-the-peak (the previous
     // estimate) read reverberation as noise: it misgraded clean reverberant
     // recordings and, worse, inflated the noise-based first-arrival threshold
     // until a genuine weak direct sound was cut out of the candidate list. The
@@ -663,7 +663,7 @@ public sealed class PeakSearchOptions
     /// samples from the kernel centre; entry 0 is the kernel peak and the scale
     /// is arbitrary. The first-arrival search uses it as the exact ceiling of
     /// pre-ringing sidelobe levels at each distance. Null when the signal was
-    /// not filtered вЂ” only the Hilbert transform's own skirt is assumed then.
+    /// not filtered — only the Hilbert transform's own skirt is assumed then.
     /// </summary>
     public IReadOnlyList<double>? AnalysisKernelEnvelope { get; init; }
 }
@@ -674,7 +674,7 @@ public sealed class PeakSearchOptions
 /// maximum (a chain latency beyond the window's reach): the window then covered
 /// [SearchRotation, SearchRotation + window) circularly, and a consumer
 /// measuring distances between the returned indices must measure them in that
-/// window's frame вЂ” <c>(index - SearchRotation) mod length</c> вЂ” or a pair
+/// window's frame — <c>(index - SearchRotation) mod length</c> — or a pair
 /// straddling the buffer seam reads as a buffer-length separation.
 /// </summary>
 public readonly record struct PeakSearchResult(

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -23,6 +23,23 @@ public sealed class TimeAlignmentAnalysisOptions
         DefaultFirstPeakThresholdBelowMaxDb;
     public double FirstPeakMinimumSnrDb { get; init; } = 12;
     public double PeakSearchWindowMilliseconds { get; init; } = 80;
+
+    /// <summary>
+    /// The caller's statement that the signal is a COMPLETE deconvolved record
+    /// — circular by construction, its tail continuous with its head — rather
+    /// than a CUT of a longer one. It does two things that must stay together:
+    /// peak positions may wrap around the buffer, and the spectral transforms
+    /// (the bandpass, the Hilbert envelope) run at the record's own length,
+    /// because circular convolution is EXACT for a circular signal. Zero
+    /// padding such a record would manufacture a discontinuity at the seam
+    /// and its edge transient reads as structure: on a field subwoofer whose
+    /// transfer IR carries a DC shelf, the padded envelope dipped 9 dB at the
+    /// record start and "rose" back — a climb the first-arrival search rightly
+    /// accepted as a front, at 0.2 ms on a record whose driver first played at
+    /// 13 ms. A cut (the default) is the opposite case: its tail is NOT its
+    /// head's past, and filtering it unpadded wraps the tail onto the head —
+    /// see the padding note in <see cref="TimeAlignmentAnalysis.Analyze"/>.
+    /// </summary>
     public bool WrapPeakPositions { get; init; }
 }
 
@@ -137,9 +154,16 @@ public static class TimeAlignmentAnalysis
             // Landing on a power of two is worth doing anyway: MathNet is quick
             // only there and falls back to Bluestein otherwise, measured 20 ms
             // at 262144 samples against 317 ms at 262145.
-            int transformLength = DspMath.NextPowerOfTwo(
-                impulseResponse.Count +
-                    BandpassGuardSamples(sampleRate, options));
+            //
+            // A COMPLETE record (WrapPeakPositions — see its doc) is the one
+            // signal that must NOT be padded: it is circular by construction,
+            // the unpadded transform is exact for it, and the padding's seam
+            // transient is what reads as a fabricated arrival.
+            int transformLength = options.WrapPeakPositions
+                ? impulseResponse.Count
+                : DspMath.NextPowerOfTwo(
+                    impulseResponse.Count +
+                        BandpassGuardSamples(sampleRate, options));
             var padded = new double[transformLength];
             for (int i = 0; i < impulseResponse.Count; i++)
             {
@@ -171,9 +195,12 @@ public static class TimeAlignmentAnalysis
         // search walks. Padded here rather than inside SignalEnvelope.Envelope,
         // which has a real contract for a signal periodic in its window (a
         // bin-centred cosine must come back with a flat envelope, and padding
-        // would break that correctly) — this caller is the one that knows it
-        // holds a CUT.
-        double[] envelope = EnvelopeOfCrop(analysisSignal);
+        // would break that correctly) — this caller is the one that knows
+        // whether it holds a CUT or a complete circular record, which keeps
+        // its envelope exactly as circular as the record is.
+        double[] envelope = options.WrapPeakPositions
+            ? SignalEnvelope.Envelope(analysisSignal)
+            : EnvelopeOfCrop(analysisSignal);
         PeakSearchResult peakSearchResult = SignalEnvelope.FindPeak(
             envelope,
             sampleRate,

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -82,9 +82,17 @@ public readonly record struct TimeAlignmentArrivalProbe(
 public static class TimeAlignmentAnalysis
 {
     // Periods of the kernel's lowest frequency to keep clear beside the
-    // signal (see BandpassGuardSamples), and the ceiling on that guard.
+    // signal (see BandpassGuardSamples), and the ceiling on that guard — in
+    // SECONDS, so a higher record rate cannot silently shrink the guard below
+    // its own stated need. A fixed sample count looked equivalent at 48 kHz
+    // and starved the same band at 384 kHz, where 262,144 samples buys only
+    // 9.4 of the ~15 cycles the 27.5-110 Hz kernel needs. Two seconds is the
+    // full twenty cycles at 10 Hz — the lowest fade start a band-limited read
+    // can produce (its low edge clamps at 20 Hz, and the octave fade halves
+    // it) — so only a caller asking directly for a band below that meets the
+    // cap, which is what keeps a pathological transform bounded.
     private const double BandpassGuardCycles = 20.0;
-    private const int MaxBandpassGuardSamples = 262_144;
+    private const double MaxBandpassGuardSeconds = 2.0;
 
     public static TimeAlignmentAnalysisResult Analyze(
         IReadOnlyList<double> impulseResponse,
@@ -479,14 +487,17 @@ public static class TimeAlignmentAnalysis
     /// window, the kernel needs 13 to 18 of those periods to decay past −120 dB
     /// (20 Hz–110 Hz: 13.2, 27.5–110: 14.9, 110–290: 17.2, 3.5 k–20 k: 17.9), so
     /// twenty of them carries margin at every band the analysis is asked for.
-    /// The floor and the cap mirror <see cref="VirtualCrossoverAnalysis"/>'s own
-    /// filter-tail padding, for the same reason: a pathological band may not
-    /// size the transform without bound.
+    /// The cap exists for the same reason <see cref="VirtualCrossoverAnalysis"/>
+    /// caps its own filter-tail padding — a pathological band may not size the
+    /// transform without bound — and it is stated in seconds so it can never
+    /// undercut the cycle count at a high record rate (see
+    /// <see cref="MaxBandpassGuardSeconds"/>).
     /// </remarks>
     private static int BandpassGuardSamples(
         int sampleRate,
         TimeAlignmentAnalysisOptions options)
     {
+        int maxSamples = (int)(MaxBandpassGuardSeconds * sampleRate);
         (double fadeStartHz, double passStartHz, _, _) = BandpassWindow.BandAround(
             options.BandpassCenterHz,
             options.BandpassPassOctaves,
@@ -497,12 +508,12 @@ public static class TimeAlignmentAnalysis
         double lowestHz = fadeStartHz > 0 ? fadeStartHz : passStartHz;
         if (!double.IsFinite(lowestHz) || lowestHz <= 0)
         {
-            return MaxBandpassGuardSamples;
+            return maxSamples;
         }
 
         double samples = BandpassGuardCycles * sampleRate / lowestHz;
-        return samples >= MaxBandpassGuardSamples
-            ? MaxBandpassGuardSamples
+        return samples >= maxSamples
+            ? maxSamples
             : (int)Math.Ceiling(samples);
     }
 

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -81,6 +81,11 @@ public readonly record struct TimeAlignmentArrivalProbe(
 
 public static class TimeAlignmentAnalysis
 {
+    // Periods of the kernel's lowest frequency to keep clear beside the
+    // signal (see BandpassGuardSamples), and the ceiling on that guard.
+    private const double BandpassGuardCycles = 20.0;
+    private const int MaxBandpassGuardSamples = 262_144;
+
     public static TimeAlignmentAnalysisResult Analyze(
         IReadOnlyList<double> impulseResponse,
         int sampleRate,
@@ -104,18 +109,29 @@ public static class TimeAlignmentAnalysis
         double[]? kernelEnvelope = null;
         if (options.UseBandpassWindow)
         {
-            // Filtered on a ZERO-PADDED buffer of the next power of two, then
-            // trimmed back, so every index below is in the caller's own frame.
-            // BandpassWindow.Apply says why in its own words: the transform is
-            // circular, and this signal is normally a CUT of a longer record (a
-            // channel's valid range), so an unpadded filter wraps the tail onto
-            // the head — worst exactly where the kernel is longest, a narrow low
-            // band. Padding also buys the fast transform: MathNet is quick only
-            // on an exact power of two, and a crop lands one sample past one by
-            // construction (ChainValidRange rounds outward) — measured 20 ms at
-            // 262144 samples against 317 ms at 262145. A signal already a power
-            // of two long is filtered exactly as it was before, to the bit.
-            int transformLength = DspMath.NextPowerOfTwo(impulseResponse.Count);
+            // Filtered on a ZERO-PADDED buffer, then trimmed back, so every
+            // index below is in the caller's own frame. BandpassWindow.Apply
+            // says why in its own words: the transform is circular, and this
+            // signal is normally a CUT of a longer record (a channel's valid
+            // range), so an unpadded filter wraps the tail onto the head. Not a
+            // rounding artifact — a lone impulse 64 samples from the end of a
+            // 32768-sample buffer puts 93 % of its own peak into the first
+            // 40 ms, which the arrival search then reads as a front (see
+            // BandpassWrapTests).
+            //
+            // The padding is sized by the KERNEL, never by rounding alone: a
+            // guard first, and only then the rise to a power of two. Rounding
+            // alone would leave a length that is already a power of two — what
+            // ChainValidRange hands out whenever the chain delay is a whole
+            // number of samples, zero included — with no guard at all, and a
+            // length one short of one with a single sample of it.
+            //
+            // Landing on a power of two is worth doing anyway: MathNet is quick
+            // only there and falls back to Bluestein otherwise, measured 20 ms
+            // at 262144 samples against 317 ms at 262145.
+            int transformLength = DspMath.NextPowerOfTwo(
+                impulseResponse.Count +
+                    BandpassGuardSamples(sampleRate, options));
             var padded = new double[transformLength];
             for (int i = 0; i < impulseResponse.Count; i++)
             {
@@ -141,7 +157,15 @@ public static class TimeAlignmentAnalysis
             analysisSignal = impulseResponse.ToArray();
         }
 
-        double[] envelope = SignalEnvelope.Envelope(analysisSignal);
+        // The analytic signal is a spectral operation too, and just as circular:
+        // an unpadded Hilbert transform folds the crop's tail onto its own head
+        // exactly as the bandpass does, and it is the ENVELOPE the first-arrival
+        // search walks. Padded here rather than inside SignalEnvelope.Envelope,
+        // which has a real contract for a signal periodic in its window (a
+        // bin-centred cosine must come back with a flat envelope, and padding
+        // would break that correctly) — this caller is the one that knows it
+        // holds a CUT.
+        double[] envelope = EnvelopeOfCrop(analysisSignal);
         PeakSearchResult peakSearchResult = SignalEnvelope.FindPeak(
             envelope,
             sampleRate,
@@ -422,6 +446,65 @@ public static class TimeAlignmentAnalysis
             refinedByPhat);
     }
 
+
+    // The magnitude envelope of a CUT: computed on a zero-padded copy and
+    // trimmed back, so the Hilbert transform's own circularity cannot carry the
+    // tail round to the head. Half a buffer of silence is ample — the analytic
+    // signal's kernel is 1/(pi*n), decayed to -80 dB within a few thousand
+    // samples, unlike the bandpass mask above whose reach is set by its lowest
+    // frequency.
+    private static double[] EnvelopeOfCrop(double[] signal)
+    {
+        int transformLength = DspMath.NextPowerOfTwo(signal.Length + signal.Length / 2);
+        if (transformLength == signal.Length)
+        {
+            return SignalEnvelope.Envelope(signal);
+        }
+
+        var padded = new double[transformLength];
+        Array.Copy(signal, padded, signal.Length);
+        double[] envelope = SignalEnvelope.Envelope(padded);
+        return envelope[..signal.Length];
+    }
+
+    /// <summary>
+    /// How much silence the bandpass kernel needs beside the signal so its own
+    /// skirt decays inside the transform instead of around it.
+    /// </summary>
+    /// <remarks>
+    /// The kernel reaches out by periods of the frequency its lower fade STARTS
+    /// at — an octave under the passband when a fade is asked for — so the guard
+    /// is counted in those periods rather than in samples: the same crop wraps
+    /// harmlessly at 3.5 kHz and catastrophically at 27.5 Hz. Measured on this
+    /// window, the kernel needs 13 to 18 of those periods to decay past −120 dB
+    /// (20 Hz–110 Hz: 13.2, 27.5–110: 14.9, 110–290: 17.2, 3.5 k–20 k: 17.9), so
+    /// twenty of them carries margin at every band the analysis is asked for.
+    /// The floor and the cap mirror <see cref="VirtualCrossoverAnalysis"/>'s own
+    /// filter-tail padding, for the same reason: a pathological band may not
+    /// size the transform without bound.
+    /// </remarks>
+    private static int BandpassGuardSamples(
+        int sampleRate,
+        TimeAlignmentAnalysisOptions options)
+    {
+        (double fadeStartHz, double passStartHz, _, _) = BandpassWindow.BandAround(
+            options.BandpassCenterHz,
+            options.BandpassPassOctaves,
+            options.BandpassFadeOctaves);
+        // With no fade the mask starts at the passband edge, and a brick wall
+        // rings longer than a faded one rather than shorter — so the guard is
+        // taken from whichever edge is lower, never from a zero.
+        double lowestHz = fadeStartHz > 0 ? fadeStartHz : passStartHz;
+        if (!double.IsFinite(lowestHz) || lowestHz <= 0)
+        {
+            return MaxBandpassGuardSamples;
+        }
+
+        double samples = BandpassGuardCycles * sampleRate / lowestHz;
+        return samples >= MaxBandpassGuardSamples
+            ? MaxBandpassGuardSamples
+            : (int)Math.Ceiling(samples);
+    }
 
     // The time response of the zero-phase bandpass mask, as an analytic
     // envelope indexed by |offset| from the kernel centre. The kernel is real

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -104,13 +104,36 @@ public static class TimeAlignmentAnalysis
         double[]? kernelEnvelope = null;
         if (options.UseBandpassWindow)
         {
+            // Filtered on a ZERO-PADDED buffer of the next power of two, then
+            // trimmed back, so every index below is in the caller's own frame.
+            // BandpassWindow.Apply says why in its own words: the transform is
+            // circular, and this signal is normally a CUT of a longer record (a
+            // channel's valid range), so an unpadded filter wraps the tail onto
+            // the head — worst exactly where the kernel is longest, a narrow low
+            // band. Padding also buys the fast transform: MathNet is quick only
+            // on an exact power of two, and a crop lands one sample past one by
+            // construction (ChainValidRange rounds outward) — measured 20 ms at
+            // 262144 samples against 317 ms at 262145. A signal already a power
+            // of two long is filtered exactly as it was before, to the bit.
+            int transformLength = DspMath.NextPowerOfTwo(impulseResponse.Count);
+            var padded = new double[transformLength];
+            for (int i = 0; i < impulseResponse.Count; i++)
+            {
+                padded[i] = impulseResponse[i];
+            }
+
             double[] window = BandpassWindow.Create(
-                impulseResponse.Count,
+                transformLength,
                 sampleRate,
                 options.BandpassCenterHz,
                 options.BandpassPassOctaves,
                 options.BandpassFadeOctaves);
-            analysisSignal = BandpassWindow.Apply(impulseResponse, window);
+            double[] filtered = BandpassWindow.Apply(padded, window);
+            analysisSignal = filtered.Length == impulseResponse.Count
+                ? filtered
+                : filtered[..impulseResponse.Count];
+            // Indexed by DISTANCE from the kernel's centre, so the padded window's
+            // longer, finer curve answers the same question the short one did.
             kernelEnvelope = BuildKernelEnvelope(window);
         }
         else

--- a/tests/Resonalyze.Dsp.Tests/AcausalPedestalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AcausalPedestalTests.cs
@@ -1,0 +1,89 @@
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The front-rise contract of the first-arrival search: texture on a flat
+/// shelf ahead of the arrival must not be read as a front, however that shelf
+/// got there.
+/// </summary>
+/// <remarks>
+/// The shelf is what a zero-phase bandpass builds ahead of a reverberant
+/// record: every later sample's backward skirt, superposed. Measured on a
+/// field subwoofer at 32.5-130 Hz it sat at -20 dB under the peak — 4.7 dB
+/// ABOVE the per-peak ring ceiling (kernel ring -30.7 dB at that distance,
+/// doubled by the superposition margin), because no single-peak ceiling can
+/// price a whole tail's superposition. Its micro-ripples are local maxima, and
+/// exactly one of them survives the sidelobe walk: the one whose only in-reach
+/// accepted peak is the main arrival itself, whose ceiling it beats. The
+/// search then reported 0.02 ms on a record whose driver first played at
+/// 27 ms, and the alignment predictor built impossible negative arrivals from
+/// reads like it.
+/// <para>
+/// The rise gate (RisesOutOfItsApproach) reads the shelf instead of
+/// predicting it: a front must climb out of the floor of its own approach —
+/// a kernel core's reach behind it — and ripple on a flat shelf climbs by
+/// hundredths of a dB where a genuine front climbs by whole ones. This pins
+/// the failing geometry at the search's own level, with the field case's
+/// proportions.
+/// </para>
+/// </remarks>
+public sealed class AcausalPedestalTests
+{
+    private const int SampleRate = 96_000;
+
+    [Fact]
+    public void RippleOnAFlatShelf_IsNotReadAsAnArrival()
+    {
+        const int length = 8_192;
+        const int shelfEnd = 600;
+        const int peakIndex = 1_000;
+        const double shelfLevel = 0.1;
+
+        var envelope = new double[length];
+        for (int i = 0; i < shelfEnd; i++)
+        {
+            // The flat shelf, textured: a local maximum every 15 samples, one
+            // percent proud — far more relief than the field's micro-ripples
+            // had, so the gate is exercised above its own margin of luck.
+            envelope[i] = shelfLevel * (i % 15 == 7 ? 1.01 : 1.0);
+        }
+        for (int i = shelfEnd; i <= peakIndex; i++)
+        {
+            // A monotone climb out of the shelf into the arrival.
+            envelope[i] = shelfLevel +
+                (1.0 - shelfLevel) * (i - shelfEnd) / (peakIndex - shelfEnd);
+        }
+        for (int i = peakIndex + 1; i < length; i++)
+        {
+            // The decay, dropping under the shelf quickly and staying quiet, so
+            // the noise-floor quantile reads the tail rather than the shelf.
+            envelope[i] = Math.Max(1e-6, Math.Exp(-(i - peakIndex) / 150.0));
+        }
+
+        // A kernel whose ring at the shelf's distance from the peak is far
+        // below the shelf — the field geometry: ring(2568) was -30.7 dB there
+        // against a -20 dB shelf, so the per-peak ceiling (ring doubled) could
+        // not name the ripple a sidelobe, and it reached the packet tests as a
+        // "genuine" early arrival.
+        var kernelEnvelope = new double[length];
+        for (int d = 0; d < length; d++)
+        {
+            kernelEnvelope[d] = Math.Exp(-d / 60.0);
+        }
+
+        PeakSearchResult result = SignalEnvelope.FindPeak(
+            envelope,
+            SampleRate,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                AnalysisKernelEnvelope = kernelEnvelope
+            });
+
+        // Nothing arrives on the shelf: the first arrival is the climb's peak.
+        Assert.True(
+            result.SelectedIndex >= shelfEnd,
+            $"the search selected index {result.SelectedIndex} — a ripple on " +
+            "the flat shelf ahead of the arrival, not a front that rises");
+        Assert.Equal(peakIndex, result.StrongestIndex);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/AcausalPedestalTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AcausalPedestalTests.cs
@@ -86,4 +86,64 @@ public sealed class AcausalPedestalTests
             "the flat shelf ahead of the arrival, not a front that rises");
         Assert.Equal(peakIndex, result.StrongestIndex);
     }
+
+    // The gate's other edge, held so it cannot creep: a SOFT genuine front
+    // standing 6 dB proud of the same shelf must still be read — finding a
+    // weak direct rise under a strong later build-up is the very reason the
+    // search runs 25 dB deep, and a rise threshold tightened past ~6 dB would
+    // start eating the fronts the depth exists for. The bump rises 6 dB out
+    // of the shelf where the ripple rises hundredths; the gate must tell
+    // them apart in the same record.
+    [Fact]
+    public void SoftFrontProudOfTheShelf_IsStillRead()
+    {
+        const int length = 8_192;
+        const int shelfEnd = 900;
+        const int frontIndex = 700;
+        const int peakIndex = 1_500;
+        const double shelfLevel = 0.1;
+        const double frontLevel = 0.2;
+
+        var envelope = new double[length];
+        for (int i = 0; i < shelfEnd; i++)
+        {
+            envelope[i] = shelfLevel * (i % 15 == 7 ? 1.01 : 1.0);
+        }
+        // The soft arrival: a smooth lobe over the shelf, peaking 6 dB proud,
+        // resolved from the later build-up by its own descent.
+        for (int i = frontIndex - 120; i <= frontIndex + 120; i++)
+        {
+            double x = (i - frontIndex) / 120.0;
+            envelope[i] = Math.Max(
+                envelope[i], shelfLevel + (frontLevel - shelfLevel) *
+                    0.5 * (1 + Math.Cos(Math.PI * x)));
+        }
+        for (int i = shelfEnd; i <= peakIndex; i++)
+        {
+            envelope[i] = shelfLevel +
+                (1.0 - shelfLevel) * (i - shelfEnd) / (peakIndex - shelfEnd);
+        }
+        for (int i = peakIndex + 1; i < length; i++)
+        {
+            envelope[i] = Math.Max(1e-6, Math.Exp(-(i - peakIndex) / 150.0));
+        }
+
+        var kernelEnvelope = new double[length];
+        for (int d = 0; d < length; d++)
+        {
+            kernelEnvelope[d] = Math.Exp(-d / 60.0);
+        }
+
+        PeakSearchResult result = SignalEnvelope.FindPeak(
+            envelope,
+            SampleRate,
+            new PeakSearchOptions
+            {
+                Mode = PeakSearchMode.FirstArrival,
+                AnalysisKernelEnvelope = kernelEnvelope
+            });
+
+        Assert.Equal(frontIndex, result.SelectedIndex);
+        Assert.Equal(peakIndex, result.StrongestIndex);
+    }
 }

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -901,6 +901,70 @@ public sealed class AutoAlignmentEngineTests
         }
     }
 
+    // The reach credit's instrument, pinned where it can be asked directly:
+    // the NON-COMMON part of the pair's chain shifts is a property of the
+    // CHAINS alone (a synthetic impulse through the real ApplyChain — no room
+    // in it), so a bass pair whose lower side carries a steep low-pass reads
+    // a lobe-scale skew, identical chains cancel to zero exactly, a pair
+    // whose band sits inside both passbands reads microseconds, and one side
+    // the predictor could not read (no bypassed response, no chain) withdraws
+    // the WHOLE credit — the partner's shift is unknown there, not zero, and
+    // this cell is what caught an earlier draft crediting the readable
+    // side's full 20 ms against an unmeasured partner.
+    [Fact]
+    public void PairChainArrivalSkew_ReadsTheChainsAlone()
+    {
+        const int Length = 32_768;
+        var subChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.LowPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 48)));
+        var wooferChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.BandPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 300, 24),
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 24)));
+        AlignmentSnapshot sub = PredictableSnapshot(
+            "SUB", SingleImpulse(Length, BasePosition), subChain);
+        AlignmentSnapshot woofer = PredictableSnapshot(
+            "W", SingleImpulse(Length, BasePosition), wooferChain);
+
+        // Lobe-scale: a period at 55 Hz is 18.2 ms, and the steep low-pass
+        // alone drags the sub's band arrival most of one.
+        double skew = AutoAlignmentEngine.PairChainArrivalSkewMs(
+            new AlignmentJunction(sub, woofer, 55, 27.5, 110));
+        Assert.InRange(skew, 10.0, 20.0);
+
+        AlignmentSnapshot subTwin = PredictableSnapshot(
+            "SUB2", SingleImpulse(Length, BasePosition), subChain);
+        Assert.Equal(
+            0.0,
+            AutoAlignmentEngine.PairChainArrivalSkewMs(
+                new AlignmentJunction(sub, subTwin, 55, 27.5, 110)));
+
+        var midChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.LowPass,
+            new CrossoverEdge(CrossoverFilterFamily.Butterworth, 2_000, 24)));
+        var tweeterChain = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.HighPass,
+            HighPassEdge: new CrossoverEdge(
+                CrossoverFilterFamily.Butterworth, 2_000, 24)));
+        double highSkew = AutoAlignmentEngine.PairChainArrivalSkewMs(
+            new AlignmentJunction(
+                PredictableSnapshot(
+                    "M", SingleImpulse(Length, BasePosition), midChain),
+                PredictableSnapshot(
+                    "T", SingleImpulse(Length, BasePosition), tweeterChain),
+                2_000, 1_000, 4_000));
+        Assert.InRange(highSkew, 0.0, 0.3);
+
+        Complex[] bareIr = SingleImpulse(Length, BasePosition);
+        var bare = new AlignmentSnapshot(
+            new TestChannel("X", bareIr), bareIr, BasePosition);
+        Assert.Equal(
+            0.0,
+            AutoAlignmentEngine.PairChainArrivalSkewMs(
+                new AlignmentJunction(bare, sub, 55, 27.5, 110)));
+    }
+
     // The reach veto's stand-down policy, asserted as a policy. An acoustic
     // fixture can only reach these cells by luck of the numbers a synthetic IR
     // happens to produce; the predicate can be asked directly.

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -1726,12 +1726,14 @@ public sealed class AutoAlignmentEngineTests
             CrossoverKind.BandPass,
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 180, 36),
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 36)));
-        Complex[] subBypassed = LowFrontUnderCabinBuildUp(Length, 2.0, 0.02);
+        Complex[] subBypassed = LowFrontUnderCabinBuildUp(Length, 4.0, 0.02);
         // The woofer fires 23 ms after the sub's front, which only re-centres
         // the correlation window (a pure delay moves a channel's read and its
-        // prediction together, so the pair's disagreement is untouched) — far
-        // enough from the window edge that the seed's neighbouring lobe is
-        // measured rather than edge-pinned.
+        // prediction together, so the pair's disagreement is untouched). The
+        // offset is not what poses this case: every value swept from 8 to 35 ms
+        // keeps the conservative path. What poses it is the build-up's LENGTH —
+        // it is what leaves the seed without an interior neighbour to measure a
+        // lobe spacing from.
         Complex[] wooferBypassed = SingleImpulse(
             Length, BasePosition + 23 * SampleRate / 1000);
 
@@ -1833,6 +1835,8 @@ public sealed class AutoAlignmentEngineTests
         return ir;
     }
 
+
+
     private static (string Trace, AlignmentOverride Woofer) RunDeadZonePair(
         AlignmentSnapshot sub, Complex[] subBypassed, DspChannelChain subChain,
         AlignmentSnapshot woofer, Complex[] wooferBypassed,
@@ -1882,12 +1886,17 @@ public sealed class AutoAlignmentEngineTests
     }
 
     // The archived Passat v2 defect: the sub's band read latched onto a mode
-    // 1.7 allowances past its prediction — inside the conviction dead zone,
+    // 1.9 allowances past its prediction — inside the conviction dead zone,
     // where the predictor may not convict alone (its own shaping error can
     // reach 1.2 allowances) — and the silently withdrawn pair anchored the
     // junction a period late. The whitened comb is the second witness: the
     // pair's shared content sits with the prediction, so the read is
     // convicted and the junction lands on the true front family.
+    //
+    // What conviction buys is measured, not assumed: this very sub, paired with
+    // a woofer that denies the comb its witness (the stand-down case below),
+    // ends at 30.0 ms INVERTED — the late family. Convicted, it ends at 18.0 ms
+    // upright. The two answers are what the arbitration decides between.
     [Fact]
     public void Compute_DeadZoneLatch_IsConvictedByTheWhitenedCombArbitration()
     {
@@ -1899,7 +1908,7 @@ public sealed class AutoAlignmentEngineTests
             CrossoverKind.BandPass,
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 300, 48),
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 48)));
-        Complex[] subBypassed = FrontUnderShortMode(Length, 40.0, 4.0, 0.10);
+        Complex[] subBypassed = FrontUnderShortMode(Length, 30.0, 14.0, 0.03);
         Complex[] wooferBypassed = SingleImpulse(Length, BasePosition);
         AlignmentSnapshot sub = PredictableSnapshot("SUB", subBypassed, subChain);
         AlignmentSnapshot woofer = PredictableSnapshot(
@@ -1932,18 +1941,24 @@ public sealed class AutoAlignmentEngineTests
         Assert.Contains("convicted by arbitration", trace);
         Assert.Contains("modal latch behind the crossover", trace);
         Assert.Contains("seed phat", trace);
-        // The junction lands on the true front family (the clean-sum optimum
-        // sits at ~8 ms, the latched family a lobe later at ~14+ ms inv).
+        // The junction lands on the true front family: upright, and far ahead of
+        // the 30.0 ms inverted answer the same sub gets when the arbitration is
+        // denied its witness.
         Assert.False(over.InvertPolarity);
-        Assert.InRange(over.DelayMs, 6.0, 10.0);
+        Assert.InRange(over.DelayMs, 16.0, 20.0);
     }
 
-    // The arbitration's other verdict, and the fleet's common one: when the
-    // woofer carries its own late build-up, the comb reads as strongly at the
-    // measured family as at the predicted one — the two are indistinguishable,
-    // so there is no second witness and the conviction-strength discrepancy
-    // may not be acted on. The pair withdraws from the predictor exactly as
-    // it did before the arbitration existed.
+    // The arbitration's other verdict, and the fleet's common one. The witness
+    // is the pair's SHARED content, so what denies it is content only one of
+    // them carries: here the woofer rings at 90 Hz, where the sub is 48 dB/oct
+    // down and cannot answer. The comb then finds nothing at the predicted
+    // family worth trusting — it reads r ≈ 0.3 against the 0.6 floor, not a
+    // photo finish with the measured family — and a conviction-strength
+    // discrepancy may not be acted on with no second witness. The pair
+    // withdraws from the predictor exactly as it did before the arbitration
+    // existed, and the woofer's own read still verifies: only one side is in
+    // dispute, which is what keeps this the arbitration's case and not a
+    // two-sided mess.
     [Fact]
     public void Compute_DeadZoneLatch_ArbitrationStandsDownWithoutASecondWitness()
     {
@@ -1955,8 +1970,8 @@ public sealed class AutoAlignmentEngineTests
             CrossoverKind.BandPass,
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 300, 24),
             new CrossoverEdge(CrossoverFilterFamily.Butterworth, 55, 24)));
-        Complex[] subBypassed = FrontUnderShortMode(Length, 40.0, 4.0, 0.06);
-        Complex[] wooferBypassed = FrontUnderShortMode(Length, 70.0, 4.0, 0.35);
+        Complex[] subBypassed = FrontUnderShortMode(Length, 30.0, 14.0, 0.03);
+        Complex[] wooferBypassed = FrontUnderShortMode(Length, 90.0, 14.0, 0.40);
         AlignmentSnapshot sub = PredictableSnapshot("SUB", subBypassed, subChain);
         AlignmentSnapshot woofer = PredictableSnapshot(
             "W", wooferBypassed, wooferChain);

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -901,16 +901,18 @@ public sealed class AutoAlignmentEngineTests
         }
     }
 
-    // The reach credit's instrument, pinned where it can be asked directly:
-    // the NON-COMMON part of the pair's chain shifts is a property of the
-    // CHAINS alone (a synthetic impulse through the real ApplyChain — no room
-    // in it), so a bass pair whose lower side carries a steep low-pass reads
-    // a lobe-scale skew, identical chains cancel to zero exactly, a pair
-    // whose band sits inside both passbands reads microseconds, and one side
-    // the predictor could not read (no bypassed response, no chain) withdraws
-    // the WHOLE credit — the partner's shift is unknown there, not zero, and
-    // this cell is what caught an earlier draft crediting the readable
-    // side's full 20 ms against an unmeasured partner.
+    // The anchor correction's instrument, pinned where it can be asked
+    // directly: the NON-COMMON part of the pair's chain shifts is a property
+    // of the CHAINS alone (a synthetic impulse through the real ApplyChain —
+    // no room in it), SIGNED in the anchor's own convention — so a bass pair
+    // whose LOWER side carries the steep low-pass reads a lobe-scale POSITIVE
+    // skew (the anchor overstates the delay to add to the upper channel),
+    // identical chains cancel to zero exactly, a pair whose band sits inside
+    // both passbands reads microseconds, and one side the predictor could not
+    // read (no bypassed response, no chain) returns null — the partner's
+    // shift is unknown there, not zero, and this cell is what caught an
+    // earlier draft crediting the readable side's full 20 ms against an
+    // unmeasured partner.
     [Fact]
     public void PairChainArrivalSkew_ReadsTheChainsAlone()
     {
@@ -927,11 +929,12 @@ public sealed class AutoAlignmentEngineTests
         AlignmentSnapshot woofer = PredictableSnapshot(
             "W", SingleImpulse(Length, BasePosition), wooferChain);
 
-        // Lobe-scale: a period at 55 Hz is 18.2 ms, and the steep low-pass
-        // alone drags the sub's band arrival most of one.
-        double skew = AutoAlignmentEngine.PairChainArrivalSkewMs(
+        // Lobe-scale and positive: a period at 55 Hz is 18.2 ms, and the
+        // steep low-pass drags the LOWER side's band arrival most of one.
+        double? skew = AutoAlignmentEngine.PairChainArrivalSkewMs(
             new AlignmentJunction(sub, woofer, 55, 27.5, 110));
-        Assert.InRange(skew, 10.0, 20.0);
+        Assert.NotNull(skew);
+        Assert.InRange(skew.Value, 10.0, 20.0);
 
         AlignmentSnapshot subTwin = PredictableSnapshot(
             "SUB2", SingleImpulse(Length, BasePosition), subChain);
@@ -947,22 +950,84 @@ public sealed class AutoAlignmentEngineTests
             CrossoverKind.HighPass,
             HighPassEdge: new CrossoverEdge(
                 CrossoverFilterFamily.Butterworth, 2_000, 24)));
-        double highSkew = AutoAlignmentEngine.PairChainArrivalSkewMs(
+        double? highSkew = AutoAlignmentEngine.PairChainArrivalSkewMs(
             new AlignmentJunction(
                 PredictableSnapshot(
                     "M", SingleImpulse(Length, BasePosition), midChain),
                 PredictableSnapshot(
                     "T", SingleImpulse(Length, BasePosition), tweeterChain),
                 2_000, 1_000, 4_000));
-        Assert.InRange(highSkew, 0.0, 0.3);
+        Assert.NotNull(highSkew);
+        Assert.InRange(Math.Abs(highSkew.Value), 0.0, 0.3);
 
         Complex[] bareIr = SingleImpulse(Length, BasePosition);
         var bare = new AlignmentSnapshot(
             new TestChannel("X", bareIr), bareIr, BasePosition);
-        Assert.Equal(
-            0.0,
+        Assert.Null(
             AutoAlignmentEngine.PairChainArrivalSkewMs(
                 new AlignmentJunction(bare, sub, 55, 27.5, 110)));
+    }
+
+    // The correction's no-cycle-skip guarantee, asserted as a policy. The
+    // reach is half a period — the bound past which the next same-polarity
+    // lobe lives — and the skew must CORRECT the anchor inside it, never
+    // widen it: the review's counterexample was an 80 Hz junction (reach
+    // 6.25 ms) with the field's 6.7 ms skew, where a symmetric
+    // reach-plus-skew allowance reached 12.95 ms and admitted the lobe a
+    // full period out. Rows are (offset, reach, skew, verdict); the field
+    // cell is the Passat v2 junction that motivated the correction.
+    [Theory]
+    // Passat v2: offset −11.19, skew +6.74, reach 9.09 → corrected −4.45.
+    [InlineData(-11.193, 9.09, 6.74, true)]
+    // The same disagreement with the OPPOSITE skew is not explained — a
+    // symmetric allowance cannot tell these two rows apart.
+    [InlineData(-11.193, 9.09, -6.74, false)]
+    // The review's 80 Hz counterexample: the extremum a full period
+    // (12.5 ms) from the corrected anchor stays refused however the skew
+    // stacks with it...
+    [InlineData(-19.2, 6.25, 6.7, false)]
+    // ...while the extremum ON the corrected anchor's own lobe is admitted.
+    [InlineData(-8.5, 6.25, 6.7, true)]
+    // The boundary belongs to the veto, as everywhere else in the search.
+    [InlineData(-12.9, 6.25, 6.74, true)]
+    [InlineData(-13.0, 6.25, 6.75, false)]
+    // No measured skew, no correction — never a guess.
+    [InlineData(-11.193, 9.09, double.NaN, false)]
+    public void ChainSkewExplainsSeedOffset_CorrectsTheAnchor_NeverWidensTheReach(
+        double seedOffsetMs, double reachMs, double skewMs, bool expected)
+    {
+        Assert.Equal(
+            expected,
+            AutoAlignmentEngine.ChainSkewExplainsSeedOffset(
+                seedOffsetMs,
+                reachMs,
+                double.IsNaN(skewMs) ? null : skewMs));
+    }
+
+    // The skew door's second case: a displacement the size of the reach
+    // itself disqualifies the anchor — its every verdict is smaller than its
+    // own known error — and the veto stands down to the deep-pick door's own
+    // policy (raw anchor, a direct seed's r bar, the cut's last word above
+    // its frequency), never to the disqualification alone. Rows are
+    // (reach, skew, verdict); the first is the field woofer/mid cell whose
+    // admitted extremum sat a period from the raw anchor and measured 0.5 dB
+    // better, the fifth is the Passat v2 sub cell where the anchor is still
+    // capable and the signed correction is the door that opens.
+    [Theory]
+    [InlineData(3.0, 3.864, true)]
+    [InlineData(3.0, -3.864, true)]
+    [InlineData(3.0, 2.99, false)]
+    [InlineData(3.0, 3.0, true)]
+    [InlineData(7.692, 6.739, false)]
+    [InlineData(3.0, double.NaN, false)]
+    public void ChainSkewDisqualifiesTheAnchor_AtTheReachItself(
+        double reachMs, double skewMs, bool expected)
+    {
+        Assert.Equal(
+            expected,
+            AutoAlignmentEngine.ChainSkewDisqualifiesTheAnchor(
+                reachMs,
+                double.IsNaN(skewMs) ? null : skewMs));
     }
 
     // The reach veto's stand-down policy, asserted as a policy. An acoustic

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -1949,16 +1949,23 @@ public sealed class AutoAlignmentEngineTests
     }
 
     // The arbitration's other verdict, and the fleet's common one. The witness
-    // is the pair's SHARED content, so what denies it is content only one of
-    // them carries: here the woofer rings at 90 Hz, where the sub is 48 dB/oct
-    // down and cannot answer. The comb then finds nothing at the predicted
-    // family worth trusting — it reads r ≈ 0.3 against the 0.6 floor, not a
-    // photo finish with the measured family — and a conviction-strength
-    // discrepancy may not be acted on with no second witness. The pair
-    // withdraws from the predictor exactly as it did before the arbitration
-    // existed, and the woofer's own read still verifies: only one side is in
-    // dispute, which is what keeps this the arbitration's case and not a
-    // two-sided mess.
+    // is the pair's SHARED content, so it is denied by content that pulls that
+    // agreement AWAY from the prediction: here the woofer rings at 90 Hz, where
+    // the sub is 48 dB/oct down and answers only with its own front. The comb
+    // reads r 0.85 at the predicted family against 0.98 at the MEASURED one —
+    // the prediction is not merely un-corroborated, it is out-voted, and a
+    // conviction-strength discrepancy may not be acted on against a witness
+    // pointing the other way.
+    //
+    // Note WHICH bar refuses it: 0.85 clears the 0.6 floor comfortably, so this
+    // case is held by the advantage arm alone. Lowering the floor leaves the
+    // test green; only removing the advantage flips it, which is the falsifier
+    // this fixture was checked against.
+    //
+    // The pair withdraws from the predictor exactly as it did before the
+    // arbitration existed, and the woofer's own read still verifies: only one
+    // side is in dispute, which is what keeps this the arbitration's case and
+    // not a two-sided mess.
     [Fact]
     public void Compute_DeadZoneLatch_ArbitrationStandsDownWithoutASecondWitness()
     {
@@ -1999,6 +2006,27 @@ public sealed class AutoAlignmentEngineTests
             sub, subBypassed, subChain, woofer, wooferBypassed, wooferChain);
 
         Assert.Contains("latch arbitration stood down for SUB/W", trace);
+        // Which ARM refuses it, not merely that it refused: a fixture that
+        // failed the FLOOR instead would satisfy every other assertion here
+        // while encoding a different case, and re-posing this test is exactly
+        // when that substitution happens. Read off the trace rather than
+        // matched as text — the engine formats in the machine's culture, so the
+        // separator is a comma on some of them (the session battery pins
+        // InvariantCulture for the same reason).
+        Match combReading = Regex.Match(
+            trace,
+            @"comb r ([-0-9]+[.,][0-9]+) at the predicted family vs ([-0-9]+[.,][0-9]+)");
+        Assert.True(combReading.Success, trace);
+        static double Reading(Group group) => double.Parse(
+            group.Value.Replace(',', '.'), CultureInfo.InvariantCulture);
+        double atPredicted = Reading(combReading.Groups[1]);
+        double atMeasured = Reading(combReading.Groups[2]);
+        // Clears LatchArbitrationMinR (0.6) — so the floor is not what refuses
+        // it — and loses to the measured family, which is what does.
+        Assert.True(atPredicted >= 0.6, $"{atPredicted} should clear the floor");
+        Assert.True(
+            atPredicted < atMeasured,
+            $"{atPredicted} should lose to {atMeasured}");
         Assert.DoesNotContain("convicted by arbitration", trace);
         Assert.DoesNotContain("modal latch behind the crossover", trace);
     }

--- a/tests/Resonalyze.Dsp.Tests/BandpassWrapTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/BandpassWrapTests.cs
@@ -1,0 +1,63 @@
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The zero-padding contract of the band-limited read: filtering a CUT of a
+/// longer record must not wrap that cut's tail onto its own head.
+/// </summary>
+/// <remarks>
+/// <see cref="BandpassWindow.Apply"/> states the requirement in its own doc, and
+/// the arrival search is its most exposed caller: it walks the head of the
+/// record looking for the FIRST arrival, so a skirt folded back from the tail is
+/// read as an arrival before the driver played. The failure is not subtle —
+/// unpadded, a lone impulse 64 samples from the end of a 32768-sample buffer
+/// puts 65 % of its own peak into the first 40 ms, where nothing was played.
+/// <para>
+/// A length that is already a power of two is the case worth pinning: it needs
+/// the padding exactly as much as any other, and it is the one an
+/// implementation keyed on <c>NextPowerOfTwo(count)</c> alone silently skips —
+/// <see cref="VirtualCrossoverAnalysis.ChainValidRange"/> hands out a crop of
+/// exactly the record length whenever the chain delay is a whole number of
+/// samples, zero included.
+/// </para>
+/// </remarks>
+public sealed class BandpassWrapTests
+{
+    private const int SampleRate = 48_000;
+
+    // Narrow and low: the kernel is longest where the band is lowest, so this is
+    // where a short transform wraps hardest.
+    private const double LowHz = 27.5;
+    private const double HighHz = 110.0;
+
+    [Theory]
+    [InlineData(32_768)]
+    [InlineData(65_536)]
+    public void BandLimitedRead_DoesNotWrapTheTailOntoTheHead(int length)
+    {
+        var impulseResponse = new System.Numerics.Complex[length];
+        // Near the very end, so anything appearing at the start can only have
+        // come around the buffer.
+        impulseResponse[length - 64] = 1.0;
+
+        TimeAlignmentAnalysisResult result =
+            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+                impulseResponse,
+                SampleRate,
+                LowHz,
+                HighHz,
+                new ValidSampleRange(0, length));
+
+        double[] envelope = result.EnvelopeSamples;
+        Assert.NotEmpty(envelope);
+        double peak = envelope.Max();
+        Assert.True(peak > 0, "the band carried no energy at all");
+        // The first 40 ms is entirely before the impulse: the kernel's own
+        // skirt reaches backwards from the tail, not forwards to here.
+        int head = 40 * SampleRate / 1000;
+        double headPeak = envelope.Take(head).Max();
+        Assert.True(
+            headPeak < peak * 0.01,
+            $"the head holds {headPeak / peak * 100:0.0}% of the peak — the tail " +
+            "wrapped around the transform");
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/ShapedFrontProbe.cs
+++ b/tests/Resonalyze.Dsp.Tests/ShapedFrontProbe.cs
@@ -129,14 +129,17 @@ public sealed class ShapedFrontProbe
     // transfer, and the prediction can be several milliseconds out. That is a
     // real limit of the estimator, so what has to hold is the safety
     // property: such a shortfall may never be mistaken for a modal latch.
-    // (This row is the review's own counterexample, which lands ~5 ms out.)
+    // (The BW24 row is the review's own counterexample, which lands ~5 ms
+    // out; the BW48 row doubles the source's steepness so the property is
+    // held by two poses rather than standing on one.)
     [Theory]
-    [InlineData("BW24 LP 80 over 40-160", 40, 160)]
+    [InlineData("BW24 LP 80 over 40-160", 24, 40, 160)]
+    [InlineData("BW48 LP 80 over 40-160", 48, 40, 160)]
     public void PredictedArrival_NeverConvictsForSourceShapingAlone(
-        string caseName, double lowHz, double highHz)
+        string caseName, int sourceSlope, double lowHz, double highHz)
     {
         (AlignmentSnapshot snapshot, double measuredMs) = Shaped(
-            LowPass(80, 24),
+            LowPass(80, sourceSlope),
             HighPass(80, 48, CrossoverFilterFamily.LinkwitzRiley),
             lowHz, highHz);
 

--- a/tests/Resonalyze.Dsp.Tests/ShapedFrontProbe.cs
+++ b/tests/Resonalyze.Dsp.Tests/ShapedFrontProbe.cs
@@ -129,11 +129,9 @@ public sealed class ShapedFrontProbe
     // transfer, and the prediction can be several milliseconds out. That is a
     // real limit of the estimator, so what has to hold is the safety
     // property: such a shortfall may never be mistaken for a modal latch.
-    // (The first row is the review's own counterexample, which lands ~5 ms
-    // out.)
+    // (This row is the review's own counterexample, which lands ~5 ms out.)
     [Theory]
     [InlineData("BW24 LP 80 over 40-160", 40, 160)]
-    [InlineData("BW24 LP 80 over 100-400", 100, 400)]
     public void PredictedArrival_NeverConvictsForSourceShapingAlone(
         string caseName, double lowHz, double highHz)
     {
@@ -150,6 +148,42 @@ public sealed class ShapedFrontProbe
             state != AutoAlignmentEngine.PredictionState.Latched,
             $"{caseName}: source shaping alone convicted the read " +
             $"(measured {measuredMs:0.000}, predicted {predictedMs:0.000} ms)");
+    }
+
+    // The same source graded a band higher used to sit in the theory above,
+    // and it passed on an artifact: the arrival detector read the processed
+    // front at 169.91 ms — 0.76 ms BEFORE the source impulse at 170.67 — off
+    // a ripple of the analysis kernel's acausal pedestal (see
+    // AcausalPedestalTests), and the acausal read graded Inconsistent by
+    // luck. With the front-rise gate the measured read is the honest band
+    // envelope peak, and for a channel this deep under its own roll-off
+    // (an LP 80 graded at 100-400 is tens of dB down across the band) the
+    // estimator's shortfall honestly passes the conviction factor.
+    //
+    // What holds instead is that the conviction is CORRECTIVE: the prediction
+    // the pair would re-anchor to sits at the bypassed front, ahead of the
+    // measured envelope peak — so acting on it moves the anchor toward the
+    // wavefront, never away from it.
+    [Fact]
+    public void PredictedArrival_ExtremeShapingConviction_PullsTowardTheFront()
+    {
+        (AlignmentSnapshot snapshot, double measuredMs) = Shaped(
+            LowPass(80, 24),
+            HighPass(80, 48, CrossoverFilterFamily.LinkwitzRiley),
+            100, 400);
+        double bareMs = VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+            snapshot.BypassedImpulseResponse!, SampleRate, 100, 400,
+            snapshot.BypassedValidRange).FirstArrivalDelayMilliseconds;
+
+        AutoAlignmentEngine.PredictionState state =
+            AutoAlignmentEngine.GradeAgainstPrediction(
+                snapshot, measuredMs, 100, 400, out double predictedMs);
+
+        Assert.Equal(AutoAlignmentEngine.PredictionState.Latched, state);
+        Assert.True(
+            predictedMs < measuredMs && Math.Abs(predictedMs - bareMs) < 2.5,
+            $"the conviction must pull toward the front: bare {bareMs:0.000}, " +
+            $"predicted {predictedMs:0.000}, measured {measuredMs:0.000} ms");
     }
 
     [Fact]

--- a/tests/Resonalyze.Dsp.Tests/TimeAlignmentCircularRecordTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TimeAlignmentCircularRecordTests.cs
@@ -1,0 +1,129 @@
+namespace Resonalyze.Dsp.Tests;
+
+/// <summary>
+/// The circular-record contract of <see cref="TimeAlignmentAnalysis.Analyze"/>:
+/// a COMPLETE deconvolved record (<c>WrapPeakPositions</c>) is circular by
+/// construction — its tail is continuous with its head — so its transforms run
+/// unpadded, at the record's own length, where circular convolution is exact.
+/// Zero padding such a record manufactures a seam where the tail no longer
+/// meets the head, and the Hilbert envelope's edge transient at that seam
+/// reads as structure.
+/// </summary>
+/// <remarks>
+/// The field case (v5_exp subwoofer): a transfer IR carrying a DC shelf
+/// (out-of-band deconvolution residue, −17 dB under the peak). Circularly the
+/// shelf is a featureless constant the first-arrival search walks straight
+/// past — the read is the 13.28 ms front. Padded, the envelope dipped 9 dB at
+/// the record start and climbed back over the first millisecond, and the
+/// search rightly accepted that climb as a front: 0.2 ms, before the driver
+/// made a sound. The same padding turned the mid channel's smooth wrapped
+/// skirt into a 25 dB step at the record seam on the panel's envelope view.
+/// </remarks>
+public sealed class TimeAlignmentCircularRecordTests
+{
+    private const int SampleRate = 96_000;
+    private const int Length = 65_536;
+
+    // A sub-like complete record: a DC shelf across the whole circular
+    // buffer (the field record's out-of-band residue), a band-limited front
+    // at 13 ms, measurement noise, and a distortion-products block near the
+    // record end — where sweep deconvolution parks it.
+    private static double[] CompleteRecord()
+    {
+        var record = new double[Length];
+        int front = (int)(0.013 * SampleRate);
+        var noise = new Random(20260831);
+        for (int i = 0; i < Length; i++)
+        {
+            record[i] = -0.14 + 0.004 * (noise.NextDouble() * 2 - 1);
+        }
+        for (int i = front; i < Length; i++)
+        {
+            double t = (i - front) / (double)SampleRate;
+            record[i] += (1 - Math.Exp(-t / 0.004)) * Math.Exp(-t / 0.08) *
+                Math.Sin(2 * Math.PI * 60.0 * t);
+        }
+        int harmonics = Length - 2_000;
+        for (int i = harmonics; i < Length; i++)
+        {
+            double t = (i - harmonics) / (double)SampleRate;
+            record[i] += 0.1 * Math.Exp(-t / 0.004) *
+                Math.Sin(2 * Math.PI * 200.0 * t);
+        }
+        return record;
+    }
+
+    // The falsifier: the envelope of a complete record must BE the record's
+    // own circular envelope — the same samples the public primitive returns,
+    // whose own contract (a bin-centred cosine comes back flat) is what
+    // defines circular. The padded path differs by tens of percent near the
+    // seam, so any padding creeping back into this branch turns this red.
+    [Fact]
+    public void CompleteRecord_EnvelopeIsTheCircularEnvelope()
+    {
+        double[] record = CompleteRecord();
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            record,
+            SampleRate,
+            new TimeAlignmentAnalysisOptions { WrapPeakPositions = true });
+
+        double[] circular = SignalEnvelope.Envelope(record);
+        Assert.Equal(circular.Length, result.EnvelopeSamples.Length);
+        for (int i = 0; i < circular.Length; i++)
+        {
+            Assert.Equal(circular[i], result.EnvelopeSamples[i], precision: 12);
+        }
+    }
+
+    // And the banded read of the same record: filtered at the record's own
+    // length — exact for a circular signal — never on a padded copy.
+    [Fact]
+    public void CompleteRecord_BandedEnvelopeIsTheCircularOne()
+    {
+        double[] record = CompleteRecord();
+        var options = new TimeAlignmentAnalysisOptions
+        {
+            WrapPeakPositions = true,
+            UseBandpassWindow = true,
+            BandpassCenterHz = 80,
+            BandpassPassOctaves = 2,
+            BandpassFadeOctaves = 0.5
+        };
+
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            record, SampleRate, options);
+
+        double[] window = BandpassWindow.Create(
+            Length,
+            SampleRate,
+            options.BandpassCenterHz,
+            options.BandpassPassOctaves,
+            options.BandpassFadeOctaves);
+        double[] circular = SignalEnvelope.Envelope(
+            BandpassWindow.Apply(record, window));
+        for (int i = 0; i < circular.Length; i++)
+        {
+            Assert.Equal(circular[i], result.EnvelopeSamples[i], precision: 12);
+        }
+    }
+
+    // The outcome the contract exists for, stated on the fixture: nothing
+    // plays before 13 ms, so nothing before it may be called an arrival. The
+    // field verification is the v5_exp subwoofer itself, whose full-band read
+    // moved from 0.198 ms (padded) to 13.277 ms with the circular contract.
+    [Fact]
+    public void CompleteRecord_DcShelfIsNotReadAsAnArrival()
+    {
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            CompleteRecord(),
+            SampleRate,
+            new TimeAlignmentAnalysisOptions { WrapPeakPositions = true });
+
+        Assert.True(result.IsValid);
+        Assert.True(
+            result.FirstArrivalDelayMilliseconds > 10.0,
+            $"the search read {result.FirstArrivalDelayMilliseconds:0.000} ms — " +
+            "ahead of everything the driver played");
+    }
+}


### PR DESCRIPTION
## What this is

Three changes that stand or fall together: the band-limited read stops wrapping, the first-arrival search stops reading the artifact the wrap had been hiding, and the seed reach veto stops spending chain group delay as if it were lobe distance. Separately each of the first two moves the field the wrong way; together the battery ends **better than the wrapped engine ever measured**.

## 1. Padding, sized by the kernel (`TimeAlignmentAnalysis.Analyze`)

`BandpassWindow.Apply` is circular, and the arrival read filters a CUT of a longer record - unpadded, the tail wraps onto the head. Not a rounding artifact: a lone impulse 64 samples from the end of a 32768 buffer puts **93 % of its peak into the first 40 ms** (`BandpassWrapTests`). The padding is a guard of 20 periods of the kernel's lowest frequency, then the rise to a power of two - rounding alone would leave an exactly-pow2 crop (what `ChainValidRange` hands out at zero delay, i.e. every bypassed read the predictor makes) with no guard at all. The guard's cap is stated in **seconds** (2.0 s = twenty cycles at the lowest fade start a band-limited read can produce), so a 384 kHz record cannot silently shrink it below the kernel's stated need. The envelope's Hilbert transform is just as circular and gets the same treatment (`EnvelopeOfCrop`).

**Speed nets out to noise** (+0.9 % on the battery, re-measured): the guard buys back the Bluestein cliff on odd-length crops but lifts already-pow2 crops one transform size up, and the two cancel. The earlier 27 % headline belonged to the rounding-only variant and does not survive the guard - the correctness is what this buys, at roughly zero cost, not a speedup.

## 2. A front must rise out of its own approach (`SignalEnvelope`)

Unwrapped, the reads got worse, not better: battery 12/5 -> 8/11. Isolated by padding pow2 and non-pow2 crops independently, the mover was the whole-record (predictor) reads - ahead of the first real arrival a zero-phase kernel builds a flat acausal shelf out of the whole record's backward skirts, measured at **-20 dB** under the peak on the Passat v2 subwoofer against a **-25 dB** search depth and a **-24.7 dB** per-peak ring ceiling. No single-peak ceiling can price a superposition, so the shelf's micro-ripples read as genuine early arrivals: bare reads collapsed to ~0 ms and the predictor built a **-22.3 ms** "arrival" on v5_exp, convicting an honest sub read and dragging it 44 ms away. The wrap used to flood the head into a monotone ramp with no local maxima - the only reason the engine had never met the shelf.

The new witness: a first-arrival candidate must climb **3 dB out of the quietest envelope sample within its approach** - the kernel core's reach behind it (the kernel envelope's -20 dB point, so the window scales with the band's rise time). Shelf ripple climbs hundredths of a dB; genuine fronts climb whole ones; the strongest peak is exempt. The gate lives in `SignalEnvelope.FindPeak`, so its radius is every first-arrival consumer - the band-limited reads, the broadband onset, the excess-delay read - where the no-kernel approach window is the 1 ms arrival packet, and the full suite holds under it. Pinned both ways in `AcausalPedestalTests`: the shelf's ripple must be refused (fails pre-gate at index 9), and a soft front standing 6 dB proud of the same shelf must still be read - the threshold cannot creep past the fronts the 25 dB search depth exists for.

## 3. Chain skew is not lobe distance (`AutoAlignmentEngine`)

With honest reads, one regression remained: Passat v2. Its old proposal was right **by accident** - two wrap artifacts cancelled into a false modal-latch conviction whose re-anchor landed on the owner's lobe. Honest reads dissolve the conviction (prediction 26.4 vs measured 26.8: the sub's low-pass genuinely delays its band arrival by 12.8 ms), and the reach veto then refused the dominant PHAT extremum - r 0.91, the owner's own tune to 0.4 ms - for disagreeing with an anchor whose diff was mostly chain: 12.8 ms of sub-chain shift vs 6.1 ms of woofer-chain shift.

The skew is measured on the predictor's own synthetic impulse (room-free) and SIGNED in the anchor's own convention, and it opens two doors, neither of which widens the half-period no-cycle-skip bound (a symmetric reach-plus-skew allowance was reviewed out: at an 80 Hz junction the field's 6.7 ms skew would have stretched it past the same-polarity lobe a full period out). Door one **corrects the anchor**: with the signed skew subtracted, the extremum must sit inside the ORIGINAL reach - on Passat v2 the corrected disagreement is 4.45 ms against a 7.69 ms reach. Door two handles the regime where the displacement is as large as the reach itself (the v2 woofer/mid junction: skew 3.86 ms against a 3.0 ms reach): such an anchor is disqualified outright - every verdict it could give is smaller than its own known error - and the veto stands down to the SAME policy the deep-pick exception uses (raw anchor, a direct seed's r bar, the cut's last word above its frequency), never to the disqualification alone. Junctions whose band sits inside both passbands see microsecond skews and keep their behavior to the bit, and a pair with one unmeasurable side gets no correction at all - the partner's shift is unknown there, not zero. The reach gate itself stays on the RAW offset, deliberately: the corrected anchor is a bounded estimate, not a truth coordinate (the skew is the chains' full envelope shift where the honest correction is its group-minus-phase part), and on the archived v2 woofer/mid junction the owner's own lobe sits 1.9 periods from the corrected anchor while agreeing with the raw one - gating by the corrected offset re-vetoes the tune the panel's metric measures 0.5 dB better, and raw gating is the pre-correction semantics every archived cabin was calibrated against. The doors only ADMIT behind the veto, never re-veto. Precisely: through the correction door the full-period lobe stays refused however the skew stacks; past the disqualification bound the decision passes to the dominant extremum under the deep-pick door's own policy (shared predicate, same r bar, same below-1-kHz limits - there is no wavefront witness to ask there, and the engine's own docs take that trade for the deep pick already). Both doors are pure predicates with policy tests, `PairChainArrivalSkew_ReadsTheChainsAlone` pins the instrument, and the door log lines now carry the word `veto`, so the battery's diffable report prints every field firing - the current run shows all four (three correction-door cells with corrected offsets 4.45/0.63/4.44 ms inside their reaches at r 0.914/0.917/0.968, and v2 B/C through the disqualification door at r 0.806). A synthetic end-to-end junction remains a follow-up: clean band-limited impulses read their own analysis skirt, and a usable fixture needs the trace-swept posing the dead-zone guards took a session each.

## 1b. A complete record stays circular

The padding fixed cuts and quietly broke the one signal that is not one. A deconvolved record is circular by construction - its tail IS its head's past - and the unpadded transform is exact for it. Padding it manufactured a seam: the Time Alignment panel's envelope grew a 25 dB step at the record boundary, and on the v5_exp subwoofer the Hilbert edge transient at that seam (a 9 dB dip climbing back out of a -17 dB DC shelf) read as a 0.198 ms `arrival` on a record whose driver first plays at 13 ms - both caught by the owner against v0.7.2 side by side. `WrapPeakPositions` (the panel's statement that the signal is a complete record) now scopes both spectral operations: complete records transform at their own length, cuts keep the guard. The panel's envelope returns to pre-branch to the bit - and the read comes out BETTER than pre-branch: v0.7.2 read that subwoofer's full-band arrival at 0.018 ms (the first ripple of the same shelf, no rise witness); circular processing plus this PR's rise gate reads 13.277 ms. Pinned in `TimeAlignmentCircularRecordTests` by envelope equality with the circular primitive, which the padded path fails at the seam by construction. Engine reads never set the flag; the battery is unchanged to the digit.

## The numbers (7-cabin battery, panel's own metric)

| | junctions avg | score | dip |
|---|---|---|---|
| main (wrapped) | +0.069 dB | 12 / 5 | +0.087 |
| padded, no witnesses | -0.197 dB | 8 / 11 | -0.559 |
| **this PR** | **+0.097 dB** | **12 / 5** | **+0.177** |

Passat v2's proposal now reproduces the owner's tune to 0.01 ms including polarity - through PHAT and the skew credit, not through cancelling artifacts. Against the wrapped baseline, honestly counted per junction: no average lower by more than 0.006 dB, and one dip that gains less than the baseline gained (v3 B/C +1.27 against +1.47 - both far above the saved tune); v2 B/C gains +0.48 avg over baseline. Report identical to the digit across re-runs.

## Re-pinned with the instrument

`ShapedFrontProbe`'s "LP 80 over 100-400" row passed on the artifact: its measured read sat **0.76 ms before the source impulse**. With honest reads that extreme shaping honestly convicts - and the conviction is corrective (the prediction it re-anchors to sits at the bypassed front, ahead of the measured envelope peak), which is what the replacement test asserts. The never-convicts safety property itself stands on two source poses again (BW24 and BW48 at 40-160). Suites: dsp 1440/1440, app 1982/1982 green; REFERENCE.md describes both new rules and the circular-record contract.

## Follow-up candidates (not in this PR)

- A synthetic end-to-end junction driving the skew doors (the instrument and both policies are pinned; the wiring is held by the battery and the trace lines).
- The rise threshold (3 dB) and approach-window level (-20 dB) tie in the battery against 6 dB / -12 dB variants; field data may later prefer one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)