### PR TITLE
Read the Time Alignment band off one transform, and off the UI thread

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -562,6 +562,21 @@ shows it as flat by construction.
 
 ## Time Alignment / unwrap
 
+- [ ] ★ **The panel reads the WHOLE record to answer a question about its first
+  80 ms.** A transfer IR is `NextPow2(2 x capture)` — a 2.2 s sweep at 96 kHz
+  reads a 10.9 s buffer — and every transform is sized by it, so one read costs
+  465 ms where a window around the arrival costs about 90 (measured 2026-08-31
+  on the field records `tw center.json` and `l mid.json`, after the
+  one-transform pass; a 65536-sample cut at 96 kHz places the arrival within
+  0.1 us of the full read). Deliberately NOT taken with that pass: it moves
+  two numbers, and both need a decision rather than a default.
+  - **SNR** is the peak against the record's quietest quarter, and a short
+    cut's quietest quarter is still decay, not noise: 87.0 -> 82.0 dB and
+    80.4 -> 76.7 dB on those two records.
+  - **Coherence** weights the GCC-PHAT refinement and lives on the FULL
+    record's half spectrum; a cut is a different bin grid, so the weight would
+    have to be dropped (losing what #19 added) or resampled onto it.
+  Merge bar is the session battery, as for anything that moves an arrival.
 - [ ] **GCC-PHAT confidence is peak height, not uniqueness**: a single spectral
   line or a narrowband subwoofer reads ~100% while the delay is poorly
   conditioned. Fix: fold RMS bandwidth / peak curvature / peak-to-second-peak

--- a/dsp/SignalEnvelope.cs
+++ b/dsp/SignalEnvelope.cs
@@ -44,7 +44,37 @@ public static class SignalEnvelope
         }
 
         Fourier.Forward(spectrum, FourierOptions.Matlab);
+        return AnalyticMagnitude(spectrum);
+    }
 
+    /// <summary>
+    /// The same envelope for a caller that ALREADY holds the signal's forward
+    /// spectrum on the length it wants the envelope at. A complete record's
+    /// band-limited read transforms once and then wants the envelope, the
+    /// whitened correlation and the band mask's own ringing off that one
+    /// spectrum; going back through <see cref="Envelope"/> would pay an inverse
+    /// and a forward transform of the full record length to arrive at the array
+    /// it was handed. The argument is left untouched.
+    /// </summary>
+    internal static double[] EnvelopeFromSpectrum(Complex[] spectrum)
+    {
+        ArgumentNullException.ThrowIfNull(spectrum);
+        if (spectrum.Length == 0)
+        {
+            throw new ArgumentException(
+                "Spectrum must not be empty.",
+                nameof(spectrum));
+        }
+
+        return AnalyticMagnitude((Complex[])spectrum.Clone());
+    }
+
+    // The analytic signal's magnitude: keep DC (and Nyquist), double the
+    // positive frequencies, drop the negative ones, transform back. Consumes
+    // the array it is given.
+    private static double[] AnalyticMagnitude(Complex[] spectrum)
+    {
+        int length = spectrum.Length;
         if ((length & 1) == 0)
         {
             for (int bin = 1; bin < length / 2; bin++)

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -130,77 +130,74 @@ public static class TimeAlignmentAnalysis
             throw new ArgumentOutOfRangeException(nameof(sampleRate));
         }
 
-        double[] analysisSignal;
+        // The whitened correlation below reads the analysis SPECTRUM on the
+        // complete-record path, where every stage runs at the record's own
+        // length, and the filtered SIGNAL on the cut path, whose stages run at
+        // three lengths of their own with a trim back to the caller's frame
+        // between them.
+        Complex[]? recordSpectrum = null;
+        double[]? cutSignal = null;
+        double[] envelope;
         double[]? kernelEnvelope = null;
-        if (options.UseBandpassWindow)
+        if (options.WrapPeakPositions)
         {
-            // Filtered on a ZERO-PADDED buffer, then trimmed back, so every
-            // index below is in the caller's own frame. BandpassWindow.Apply
-            // says why in its own words: the transform is circular, and this
-            // signal is normally a CUT of a longer record (a channel's valid
-            // range), so an unpadded filter wraps the tail onto the head. Not a
-            // rounding artifact — a lone impulse 64 samples from the end of a
-            // 32768-sample buffer puts 93 % of its own peak into the first
-            // 40 ms, which the arrival search then reads as a front (see
-            // BandpassWrapTests).
+            // A COMPLETE record (see the flag's doc) is the one signal that must
+            // NOT be padded: it is circular by construction, so the unpadded
+            // transform is exact for it and the padding's seam transient is what
+            // reads as a fabricated arrival.
             //
-            // The padding is sized by the KERNEL, never by rounding alone: a
-            // guard first, and only then the rise to a power of two. Rounding
-            // alone would leave a length that is already a power of two — what
-            // ChainValidRange hands out whenever the chain delay is a whole
-            // number of samples, zero included — with no guard at all, and a
-            // length one short of one with a single sample of it.
-            //
-            // Landing on a power of two is worth doing anyway: MathNet is quick
-            // only there and falls back to Bluestein otherwise, measured 20 ms
-            // at 262144 samples against 317 ms at 262145.
-            //
-            // A COMPLETE record (WrapPeakPositions — see its doc) is the one
-            // signal that must NOT be padded: it is circular by construction,
-            // the unpadded transform is exact for it, and the padding's seam
-            // transient is what reads as a fabricated arrival.
-            int transformLength = options.WrapPeakPositions
-                ? impulseResponse.Count
-                : DspMath.NextPowerOfTwo(
-                    impulseResponse.Count +
-                        BandpassGuardSamples(sampleRate, options));
-            var padded = new double[transformLength];
-            for (int i = 0; i < impulseResponse.Count; i++)
+            // At that one length a SINGLE forward transform serves the whole
+            // read: the band mask multiplies the spectrum in place, and the
+            // envelope, the whitened correlation and the mask's own ringing all
+            // come off it. The band-limited SIGNAL is never materialized —
+            // building it and transforming it back twice (once for the
+            // envelope, once for the correlation) was five transforms of the
+            // full record length that returned the spectrum already in hand.
+            // The Time Alignment panel is this caller, and a megabyte of
+            // transfer IR is where it shows: 741 ms a read against 477.
+            recordSpectrum = new Complex[impulseResponse.Count];
+            for (int i = 0; i < recordSpectrum.Length; i++)
             {
-                padded[i] = impulseResponse[i];
+                recordSpectrum[i] = new Complex(impulseResponse[i], 0.0);
             }
 
-            double[] window = BandpassWindow.Create(
-                transformLength,
-                sampleRate,
-                options.BandpassCenterHz,
-                options.BandpassPassOctaves,
-                options.BandpassFadeOctaves);
-            double[] filtered = BandpassWindow.Apply(padded, window);
-            analysisSignal = filtered.Length == impulseResponse.Count
-                ? filtered
-                : filtered[..impulseResponse.Count];
-            // Indexed by DISTANCE from the kernel's centre, so the padded window's
-            // longer, finer curve answers the same question the short one did.
-            kernelEnvelope = BuildKernelEnvelope(window);
+            Fourier.Forward(recordSpectrum, FourierOptions.Matlab);
+            if (options.UseBandpassWindow)
+            {
+                double[] window = BandpassWindow.Create(
+                    recordSpectrum.Length,
+                    sampleRate,
+                    options.BandpassCenterHz,
+                    options.BandpassPassOctaves,
+                    options.BandpassFadeOctaves);
+                for (int bin = 0; bin < recordSpectrum.Length; bin++)
+                {
+                    recordSpectrum[bin] *= window[bin];
+                }
+
+                kernelEnvelope = BuildKernelEnvelope(window);
+            }
+
+            envelope = SignalEnvelope.EnvelopeFromSpectrum(recordSpectrum);
         }
         else
         {
-            analysisSignal = impulseResponse.ToArray();
+            cutSignal = options.UseBandpassWindow
+                ? FilterCut(impulseResponse, sampleRate, options, out kernelEnvelope)
+                : impulseResponse.ToArray();
+            // The analytic signal is a spectral operation too, and just as
+            // circular: an unpadded Hilbert transform folds the crop's tail onto
+            // its own head exactly as the bandpass does, and it is the ENVELOPE
+            // the first-arrival search walks. Padded here rather than inside
+            // SignalEnvelope.Envelope, which has a real contract for a signal
+            // periodic in its window (a bin-centred cosine must come back with a
+            // flat envelope, and padding would break that correctly) — this
+            // caller is the one that knows whether it holds a CUT or a complete
+            // circular record, which keeps its envelope exactly as circular as
+            // the record is.
+            envelope = EnvelopeOfCrop(cutSignal);
         }
 
-        // The analytic signal is a spectral operation too, and just as circular:
-        // an unpadded Hilbert transform folds the crop's tail onto its own head
-        // exactly as the bandpass does, and it is the ENVELOPE the first-arrival
-        // search walks. Padded here rather than inside SignalEnvelope.Envelope,
-        // which has a real contract for a signal periodic in its window (a
-        // bin-centred cosine must come back with a flat envelope, and padding
-        // would break that correctly) — this caller is the one that knows
-        // whether it holds a CUT or a complete circular record, which keeps
-        // its envelope exactly as circular as the record is.
-        double[] envelope = options.WrapPeakPositions
-            ? SignalEnvelope.Envelope(analysisSignal)
-            : EnvelopeOfCrop(analysisSignal);
         PeakSearchResult peakSearchResult = SignalEnvelope.FindPeak(
             envelope,
             sampleRate,
@@ -234,9 +231,10 @@ public static class TimeAlignmentAnalysis
         // cross-phase). The envelope peak stays the robust coarse anchor; the
         // whitened correlation sharpens its position, independent of the driver's
         // magnitude shape, and falls back to the envelope parabola when weak.
-        PhaseTransformCorrelation phaseTransform =
-            TransferFunction.ComputePhaseTransformFromResponse(
-                analysisSignal, coherence: coherence);
+        PhaseTransformCorrelation phaseTransform = recordSpectrum is { } spectrum
+            ? ComputePhaseTransform(spectrum, coherence)
+            : TransferFunction.ComputePhaseTransformFromResponse(
+                cutSignal!, coherence: coherence);
         int refineRadius = ComputePhatSearchRadius(sampleRate);
         RefinedArrival firstArrival = RefineArrivalSample(
             phaseTransform, envelope, envelopePeakIndex, refineRadius);
@@ -482,6 +480,90 @@ public static class TimeAlignmentAnalysis
     }
 
 
+    // The band-limited signal of a CUT, in the caller's own frame.
+    //
+    // Filtered on a ZERO-PADDED buffer, then trimmed back, so every index the
+    // read produces is in that frame. BandpassWindow.Apply says why in its own
+    // words: the transform is circular, and this signal is a CUT of a longer
+    // record (a channel's valid range), so an unpadded filter wraps the tail
+    // onto the head. Not a rounding artifact — a lone impulse 64 samples from
+    // the end of a 32768-sample buffer puts 93 % of its own peak into the first
+    // 40 ms, which the arrival search then reads as a front (see
+    // BandpassWrapTests).
+    //
+    // The padding is sized by the KERNEL, never by rounding alone: a guard
+    // first, and only then the rise to a power of two. Rounding alone would
+    // leave a length that is already a power of two — what ChainValidRange
+    // hands out whenever the chain delay is a whole number of samples, zero
+    // included — with no guard at all, and a length one short of one with a
+    // single sample of it.
+    //
+    // Landing on a power of two is worth doing anyway: MathNet is quick only
+    // there and falls back to Bluestein otherwise, measured 20 ms at 262144
+    // samples against 317 ms at 262145.
+    //
+    // Three lengths live in this path on purpose — the mask's, the envelope's
+    // (EnvelopeOfCrop) and the correlation's — with a trim back to the caller's
+    // frame between them, which is why a cut cannot share one spectrum the way
+    // a complete record does.
+    private static double[] FilterCut(
+        IReadOnlyList<double> impulseResponse,
+        int sampleRate,
+        TimeAlignmentAnalysisOptions options,
+        out double[] kernelEnvelope)
+    {
+        int transformLength = DspMath.NextPowerOfTwo(
+            impulseResponse.Count + BandpassGuardSamples(sampleRate, options));
+        var padded = new double[transformLength];
+        for (int i = 0; i < impulseResponse.Count; i++)
+        {
+            padded[i] = impulseResponse[i];
+        }
+
+        double[] window = BandpassWindow.Create(
+            transformLength,
+            sampleRate,
+            options.BandpassCenterHz,
+            options.BandpassPassOctaves,
+            options.BandpassFadeOctaves);
+        double[] filtered = BandpassWindow.Apply(padded, window);
+        // Indexed by DISTANCE from the kernel's centre, so the padded window's
+        // longer, finer curve answers the same question the short one did.
+        kernelEnvelope = BuildKernelEnvelope(window);
+        return filtered.Length == impulseResponse.Count
+            ? filtered
+            : filtered[..impulseResponse.Count];
+    }
+
+    // The whitened correlation the arrivals are refined against. On the
+    // complete-record path it shares the forward transform the read already
+    // made, whenever the record's length is the one the correlation runs at; a
+    // length that is not a power of two makes the correlation pad to the next
+    // one — a DIFFERENT bin grid — so that case reconstructs the band-limited
+    // signal and takes the padded route it always did.
+    private static PhaseTransformCorrelation ComputePhaseTransform(
+        Complex[] recordSpectrum,
+        IReadOnlyList<double>? coherence)
+    {
+        int length = recordSpectrum.Length;
+        if (DspMath.NextPowerOfTwo(length) == length)
+        {
+            return TransferFunction.ComputePhaseTransformFromSpectrum(
+                recordSpectrum, coherence: coherence);
+        }
+
+        var filtered = (Complex[])recordSpectrum.Clone();
+        Fourier.Inverse(filtered, FourierOptions.Matlab);
+        var signal = new double[length];
+        for (int i = 0; i < length; i++)
+        {
+            signal[i] = filtered[i].Real;
+        }
+
+        return TransferFunction.ComputePhaseTransformFromResponse(
+            signal, coherence: coherence);
+    }
+
     // The magnitude envelope of a CUT: computed on a zero-padded copy and
     // trimmed back, so the Hilbert transform's own circularity cannot carry the
     // tail round to the head. Half a buffer of silence is ample — the analytic
@@ -553,21 +635,16 @@ public static class TimeAlignmentAnalysis
     // earlier arrival.
     private static double[] BuildKernelEnvelope(double[] window)
     {
+        // The kernel's forward spectrum IS the mask — it is real and even — so
+        // the envelope reads straight off it, instead of transforming the mask
+        // into a kernel only to transform that kernel back.
         var spectrum = new Complex[window.Length];
         for (int i = 0; i < window.Length; i++)
         {
             spectrum[i] = new Complex(window[i], 0.0);
         }
 
-        Fourier.Inverse(spectrum, FourierOptions.Matlab);
-
-        var kernel = new double[window.Length];
-        for (int i = 0; i < kernel.Length; i++)
-        {
-            kernel[i] = spectrum[i].Real;
-        }
-
-        return SignalEnvelope.Envelope(kernel);
+        return SignalEnvelope.EnvelopeFromSpectrum(spectrum);
     }
 
     private static double FindFractionalPeakOffset(

--- a/dsp/TransferFunction.cs
+++ b/dsp/TransferFunction.cs
@@ -566,9 +566,29 @@ public static class TransferFunction
         // power-of-two, and zero-padding does not move the correlation peak: the
         // lag axis stays index-aligned with the impulse response.
         int fftLength = DspMath.NextPowerOfTwo(impulseResponse.Count);
-        Complex[] spectrum = RealForwardSpectrum(impulseResponse, fftLength);
-        var gateReference = new double[fftLength];
-        for (int bin = 0; bin < fftLength; bin++)
+        return ComputePhaseTransformFromSpectrum(
+            RealForwardSpectrum(impulseResponse, fftLength), referenceGate, coherence);
+    }
+
+    /// <summary>
+    /// The same correlation for a caller that ALREADY holds the response's
+    /// forward spectrum on the correlation's own grid — a band-limited analysis
+    /// that transformed the record once and band-limited it in place. The
+    /// spectrum is read, never written.
+    /// </summary>
+    internal static PhaseTransformCorrelation ComputePhaseTransformFromSpectrum(
+        Complex[] spectrum,
+        double referenceGate = 0.02,
+        IReadOnlyList<double>? coherence = null)
+    {
+        ArgumentNullException.ThrowIfNull(spectrum);
+        if (spectrum.Length == 0)
+        {
+            throw new ArgumentException("Spectrum must not be empty.");
+        }
+
+        var gateReference = new double[spectrum.Length];
+        for (int bin = 0; bin < spectrum.Length; bin++)
         {
             gateReference[bin] = spectrum[bin].Magnitude;
         }

--- a/source/TimeAlignment/AnalysisReadSchedule.cs
+++ b/source/TimeAlignment/AnalysisReadSchedule.cs
@@ -1,0 +1,128 @@
+namespace Resonalyze;
+
+/// <summary>
+/// Which read is drawn, which is running and which is waiting, for a panel
+/// whose analysis is too slow to run inside the click that asks for it.
+/// <para>
+/// A request describes a whole read — the records and every setting it is taken
+/// under — so two equal requests have one answer. That is what lets the panel
+/// recognize the read already on screen (it is refreshed from more places than
+/// there are changes to draw) and coalesce a held-down spinner into one read
+/// instead of a queue of them.
+/// </para>
+/// <para>
+/// The version is the whole point of the type: a read carries the one it was
+/// started with, and only a read whose version is still current may be drawn.
+/// Anything else describes a state the controls have left — including a read
+/// still in flight when the user returns to what is ALREADY on screen, which is
+/// otherwise the one path where a stale answer lands on top of a correct one.
+/// </para>
+/// </summary>
+internal sealed class AnalysisReadSchedule<TRequest>
+    where TRequest : struct
+{
+    private TRequest? drawn;
+    private TRequest? running;
+    private TRequest? queued;
+    private int version;
+
+    /// <summary>
+    /// The version to run <paramref name="request"/> under, or null when there
+    /// is nothing to run: it is already drawn, it is already running, or it has
+    /// been queued behind the read in flight. Any read that no longer describes
+    /// the request being submitted is retired here — dropped from the queue, or
+    /// left to land on a version that has moved on.
+    /// </summary>
+    public int? Submit(TRequest request)
+    {
+        // Already on screen. Whatever is in flight or queued was asked for a
+        // state of the controls that has since been left, so it must not be
+        // allowed to land: retire it and keep the answer already drawn.
+        if (drawn is { } current && Equals(current, request))
+        {
+            Retire();
+            return null;
+        }
+
+        // Already on its way. Anything queued behind it is older than this
+        // request by construction, so it goes.
+        if (running is { } inFlight && Equals(inFlight, request))
+        {
+            queued = null;
+            return null;
+        }
+
+        // One read at a time: a held spinner fires a request per click, and
+        // starting each of them puts analyses on the pool to have all but the
+        // last thrown away.
+        if (running != null)
+        {
+            queued = request;
+            return null;
+        }
+
+        version++;
+        running = request;
+        return version;
+    }
+
+    /// <summary>
+    /// Whether a finished read may be drawn, given the version it started
+    /// under. A read that may be drawn becomes the drawn one.
+    /// </summary>
+    public bool Accept(TRequest request, int readVersion)
+    {
+        if (readVersion != version)
+        {
+            return false;
+        }
+
+        running = null;
+        drawn = request;
+        return true;
+    }
+
+    /// <summary>
+    /// The read that was asked for while the last one was running, and the
+    /// version to run it under — or null when nothing waits, or when what waits
+    /// is what has just been drawn.
+    /// </summary>
+    public int? TakeQueued(out TRequest request)
+    {
+        if (queued is not { } next)
+        {
+            request = default;
+            return null;
+        }
+
+        queued = null;
+        request = next;
+        return Submit(next);
+    }
+
+    /// <summary>
+    /// Forgets everything: nothing is drawn, and no read in flight may be. For
+    /// the panel losing its record, where the answer to every request there was
+    /// stops existing.
+    /// </summary>
+    public void Clear()
+    {
+        Retire();
+        drawn = null;
+    }
+
+    private void Retire()
+    {
+        if (running != null)
+        {
+            // The version moves, so the read in flight fails its own Accept.
+            version++;
+            running = null;
+        }
+
+        queued = null;
+    }
+
+    private static bool Equals(TRequest left, TRequest right) =>
+        EqualityComparer<TRequest>.Default.Equals(left, right);
+}

--- a/source/TimeAlignment/AnalysisReadSchedule.cs
+++ b/source/TimeAlignment/AnalysisReadSchedule.cs
@@ -1,126 +1,140 @@
 namespace Resonalyze;
 
 /// <summary>
-/// Which read is drawn, which is running and which is waiting, for a panel
-/// whose analysis is too slow to run inside the click that asks for it.
+/// Which read is on screen, which is on the pool, and which one the controls
+/// are actually asking for, for a panel whose analysis is far too slow to run
+/// inside the click that asks for it.
 /// <para>
 /// A request describes a whole read — the records and every setting it is taken
 /// under — so two equal requests have one answer. That is what lets the panel
 /// recognize the read already on screen (it is refreshed from more places than
-/// there are changes to draw) and coalesce a held-down spinner into one read
+/// there are changes to draw) and fold a held-down spinner into one read
 /// instead of a queue of them.
 /// </para>
 /// <para>
-/// The version is the whole point of the type: a read carries the one it was
-/// started with, and only a read whose version is still current may be drawn.
-/// Anything else describes a state the controls have left — including a read
-/// still in flight when the user returns to what is ALREADY on screen, which is
-/// otherwise the one path where a stale answer lands on top of a correct one.
+/// The rule the rest of it follows: <b>the newest request is authoritative</b>.
+/// A read whose request is no longer what the controls ask for is retired the
+/// moment that becomes true — the version moves, so the read fails its own
+/// <see cref="Complete"/> and is never drawn. Not merely "eventually corrected
+/// by the next read": a result that does not answer the controls in front of
+/// the user is a panel lying about its own state, and the window in which it
+/// could be read is exactly the window this whole background pass opened.
+/// </para>
+/// <para>
+/// One read runs at a time. A retired read still holds the pool until it
+/// finishes — it cannot be cancelled — so the desired one starts when it lands,
+/// which is why <see cref="Complete"/> must be called for every finished read
+/// and <see cref="TakeDesired"/> after it, drawn or not.
 /// </para>
 /// </summary>
 internal sealed class AnalysisReadSchedule<TRequest>
     where TRequest : struct
 {
     private TRequest? drawn;
-    private TRequest? running;
-    private TRequest? queued;
+    private TRequest? flight;
+    private TRequest? desired;
+    private int flightVersion;
     private int version;
 
     /// <summary>
-    /// The version to run <paramref name="request"/> under, or null when there
-    /// is nothing to run: it is already drawn, it is already running, or it has
-    /// been queued behind the read in flight. Any read that no longer describes
-    /// the request being submitted is retired here — dropped from the queue, or
-    /// left to land on a version that has moved on.
+    /// The version to run <paramref name="request"/> under, or null when it is
+    /// not this call's job to run it: it is already drawn, it is already the
+    /// read in flight, or it has to wait for the pool. Every read this request
+    /// supersedes is retired here.
     /// </summary>
     public int? Submit(TRequest request)
     {
-        // Already on screen. Whatever is in flight or queued was asked for a
-        // state of the controls that has since been left, so it must not be
-        // allowed to land: retire it and keep the answer already drawn.
+        // Already on screen: whatever else is happening was asked for a state
+        // of the controls that has since been left.
         if (drawn is { } current && Equals(current, request))
         {
+            desired = null;
             Retire();
             return null;
         }
 
-        // Already on its way. Anything queued behind it is older than this
-        // request by construction, so it goes.
-        if (running is { } inFlight && Equals(inFlight, request))
+        // Back to the read already on the pool. If it was retired a moment ago
+        // it is revived rather than recomputed — it answers exactly what is
+        // being asked for again, and one read runs at a time, so no other
+        // version is live to collide with its own.
+        if (flight is { } inFlight && Equals(inFlight, request))
         {
-            queued = null;
+            version = flightVersion;
+            desired = null;
             return null;
         }
 
-        // One read at a time: a held spinner fires a request per click, and
-        // starting each of them puts analyses on the pool to have all but the
-        // last thrown away.
-        if (running != null)
+        // Something else holds the pool. It cannot be cancelled, but it can be
+        // retired, and this request waits for the slot rather than doubling up
+        // on it — a held spinner fires a request per click.
+        if (flight != null)
         {
-            queued = request;
+            desired = request;
+            Retire();
             return null;
         }
 
+        desired = null;
         version++;
-        running = request;
+        flight = request;
+        flightVersion = version;
         return version;
     }
 
     /// <summary>
-    /// Whether a finished read may be drawn, given the version it started
-    /// under. A read that may be drawn becomes the drawn one.
+    /// Hands the pool slot back and says whether the finished read may be
+    /// drawn — only a read still running under the current version may. A read
+    /// that may be drawn becomes the drawn one.
     /// </summary>
-    public bool Accept(TRequest request, int readVersion)
+    public bool Complete(TRequest request, int readVersion)
     {
+        flight = null;
         if (readVersion != version)
         {
             return false;
         }
 
-        running = null;
         drawn = request;
+        desired = null;
         return true;
     }
 
     /// <summary>
-    /// The read that was asked for while the last one was running, and the
-    /// version to run it under — or null when nothing waits, or when what waits
-    /// is what has just been drawn.
+    /// The read the controls are still waiting for, and the version to run it
+    /// under — or null when what is drawn is what they ask for. Call after
+    /// every <see cref="Complete"/>, including one that refused to draw: that
+    /// is the moment the pool frees.
     /// </summary>
-    public int? TakeQueued(out TRequest request)
+    public int? TakeDesired(out TRequest request)
     {
-        if (queued is not { } next)
+        if (desired is not { } next)
         {
             request = default;
             return null;
         }
 
-        queued = null;
         request = next;
         return Submit(next);
     }
 
     /// <summary>
-    /// Forgets everything: nothing is drawn, and no read in flight may be. For
-    /// the panel losing its record, where the answer to every request there was
-    /// stops existing.
+    /// Forgets everything: nothing is drawn, nothing is wanted, and no read in
+    /// flight may be drawn. For the panel losing its record, where the answer
+    /// to every request there was stops existing.
     /// </summary>
     public void Clear()
     {
-        Retire();
+        desired = null;
         drawn = null;
+        Retire();
     }
 
     private void Retire()
     {
-        if (running != null)
+        if (flight != null && flightVersion == version)
         {
-            // The version moves, so the read in flight fails its own Accept.
             version++;
-            running = null;
         }
-
-        queued = null;
     }
 
     private static bool Equals(TRequest left, TRequest right) =>

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -286,8 +286,18 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         AnalysisOutcome outcome,
         int version)
     {
-        if (disposed || !reads.Accept(request, version))
+        if (disposed)
         {
+            return;
+        }
+
+        // A read the controls have left is not drawn at all — the panel would
+        // otherwise stand there stating an alignment for a band nobody is
+        // looking at — but its slot on the pool frees here, so what IS wanted
+        // starts either way.
+        if (!reads.Complete(request, version))
+        {
+            StartDesiredAnalysis();
             return;
         }
 
@@ -299,7 +309,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         {
             SetStatusText(message);
             ClearEnvelopePreview();
-            StartQueuedAnalysis();
+            StartDesiredAnalysis();
             return;
         }
 
@@ -317,16 +327,15 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             outcome.MainResult,
             outcome.MainSource.SampleRate,
             outcome.Compare?.Result);
-        StartQueuedAnalysis();
+        StartDesiredAnalysis();
     }
 
-    // The read asked for while this one was running, if it still asks for
-    // something this one did not answer.
-    private void StartQueuedAnalysis()
+    // What the controls are still waiting for, now that the pool is free.
+    private void StartDesiredAnalysis()
     {
-        if (reads.TakeQueued(out AnalysisRequest queued) is { } version)
+        if (reads.TakeDesired(out AnalysisRequest desired) is { } version)
         {
-            StartAnalysis(queued, version);
+            StartAnalysis(desired, version);
         }
     }
 
@@ -1378,8 +1387,8 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     {
         AppendSignalQuality(title, result);
         AppendAlignmentConfidence(result);
-        AppendArrivalHonesty(result, honestyProbe);
-        AppendCrosstalkFlag(crosstalk);
+        AppendArrivalHonesty(bandMode, result, honestyProbe);
+        AppendCrosstalkFlag(bandMode, crosstalk);
         AppendLevelsLine(levels);
         AppendSeparator();
         AppendDelayTable(result, reference);
@@ -1409,14 +1418,21 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // a fixed early sample in every record of a session; on band-limited
     // drivers it sits within the first-peak threshold and the FULL-BAND
     // First Arrival confidently times it instead of the sound.
-    private void AppendCrosstalkFlag(CrosstalkHeadGate? crosstalk)
+    private void AppendCrosstalkFlag(
+        TimeAlignmentBandMode bandMode,
+        CrosstalkHeadGate? crosstalk)
     {
         if (crosstalk is not { } gate)
         {
             return;
         }
 
-        if (options.BandMode == TimeAlignmentBandMode.FullBand)
+        // The mode the READ was taken in, never the one the controls have
+        // reached since: "removed from this analysis" is a statement about
+        // which record these very figures came off, and a bypass read whose
+        // panel has moved to Auto would otherwise claim a cleaning it never
+        // had.
+        if (bandMode == TimeAlignmentBandMode.FullBand)
         {
             // Bypass shows the record as-is, so the figures above may time
             // the click; the banded modes analyze it removed.
@@ -1443,10 +1459,11 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // produces a confident wrong number exactly where this tool is used most
     // (subwoofer and midbass bands).
     private void AppendArrivalHonesty(
+        TimeAlignmentBandMode bandMode,
         TimeAlignmentAnalysisResult result,
         TimeAlignmentArrivalProbe? probe)
     {
-        if (options.BandMode == TimeAlignmentBandMode.FullBand)
+        if (bandMode == TimeAlignmentBandMode.FullBand)
         {
             return;
         }

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -44,22 +44,13 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // questions ("where this driver plays" against "where these two meet").
     private bool lastAutoBandIsShared;
     private bool disposed;
-    // The read that is drawn, and the one being computed. This panel is
-    // refreshed from more places than there are changes to draw: a mode switch
-    // asks twice (the tab shows the panel, then the redraw that follows asks
-    // again), and a compare change, a loaded file and a restored history entry
-    // each arrive through two paths of their own. Every one of those used to
-    // re-run the whole band-limited analysis of a record that had not moved.
-    private AnalysisRequest? renderedRequest;
-    private AnalysisRequest? pendingRequest;
-    // The read asked for while another was still running. One read at a time:
-    // holding the band's up arrow fires a request per click, and starting each
-    // of them puts four analyses of the same record on the thread pool to have
-    // three of them thrown away.
-    private AnalysisRequest? queuedRequest;
-    // Bumped by every refresh: an analysis whose version has moved on has been
-    // superseded, and its result is dropped rather than drawn over the newer one.
-    private int analysisVersion;
+    // What is drawn, what is running, what waits. This panel is refreshed from
+    // more places than there are changes to draw: a mode switch asks twice (the
+    // tab shows the panel, then the redraw that follows asks again), and a
+    // compare change, a loaded file and a restored history entry each arrive
+    // through two paths of their own. Every one of those used to re-run the
+    // whole band-limited analysis of a record that had not moved.
+    private readonly AnalysisReadSchedule<AnalysisRequest> reads = new();
     // Per-record derivations, kept so that a band edit — which changes neither
     // the record nor its hygiene — stops paying for them again. One slot per
     // role; the entry is swapped as a whole, so a reader never sees a verdict
@@ -216,10 +207,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
         if (!TryGetMainSource(out TimeAlignmentAnalysisSource mainSource, out string noDataMessage))
         {
-            analysisVersion++;
-            pendingRequest = null;
-            queuedRequest = null;
-            renderedRequest = null;
+            reads.Clear();
             lastAutoBand = null;
             UpdateAutoBandLabel();
             UpdateBandpassPreview();
@@ -248,14 +236,10 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             options.FirstPeakThresholdBelowMaxDb,
             options.FirstPeakMinimumSnrDb,
             options.PeakSearchWindowMilliseconds);
-        if ((renderedRequest is { } drawn && drawn == request) ||
-            (pendingRequest is { } running && running == request))
+        if (reads.Submit(request) is { } version)
         {
-            // Already drawn, or already on its way: the answer cannot differ.
-            return;
+            StartAnalysis(request, version);
         }
-
-        StartAnalysis(request);
     }
 
     // Starts the read, off the UI thread wherever there is a message loop to
@@ -263,16 +247,8 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // milliseconds, and it used to be spent inside the click that asked for it:
     // that is what made a nudge of the band boxes feel like a hang, and what
     // held the shell still for a moment after every sweep.
-    private void StartAnalysis(AnalysisRequest request)
+    private void StartAnalysis(AnalysisRequest request, int version)
     {
-        if (pendingRequest != null)
-        {
-            queuedRequest = request;
-            return;
-        }
-
-        int version = ++analysisVersion;
-        pendingRequest = request;
         if (!owner.IsHandleCreated || owner.IsDisposed || owner.InvokeRequired)
         {
             // Nothing to come back to: the controllers are built and refreshed
@@ -310,13 +286,11 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         AnalysisOutcome outcome,
         int version)
     {
-        if (disposed || version != analysisVersion)
+        if (disposed || !reads.Accept(request, version))
         {
             return;
         }
 
-        pendingRequest = null;
-        renderedRequest = request;
         lastAutoBand = outcome.AutoBand;
         lastAutoBandIsShared = outcome.AutoBandShared;
         UpdateAutoBandLabel();
@@ -325,7 +299,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         {
             SetStatusText(message);
             ClearEnvelopePreview();
-            StartQueuedAnalysis(request);
+            StartQueuedAnalysis();
             return;
         }
 
@@ -343,22 +317,16 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             outcome.MainResult,
             outcome.MainSource.SampleRate,
             outcome.Compare?.Result);
-        StartQueuedAnalysis(request);
+        StartQueuedAnalysis();
     }
 
-    // The last request made while this one was running, if it asks for anything
-    // this read did not answer.
-    private void StartQueuedAnalysis(AnalysisRequest rendered)
+    // The read asked for while this one was running, if it still asks for
+    // something this one did not answer.
+    private void StartQueuedAnalysis()
     {
-        if (queuedRequest is not { } queued)
+        if (reads.TakeQueued(out AnalysisRequest queued) is { } version)
         {
-            return;
-        }
-
-        queuedRequest = null;
-        if (queued != rendered)
-        {
-            StartAnalysis(queued);
+            StartAnalysis(queued, version);
         }
     }
 

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -44,6 +44,33 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // questions ("where this driver plays" against "where these two meet").
     private bool lastAutoBandIsShared;
     private bool disposed;
+    // The read that is drawn, and the one being computed. This panel is
+    // refreshed from more places than there are changes to draw: a mode switch
+    // asks twice (the tab shows the panel, then the redraw that follows asks
+    // again), and a compare change, a loaded file and a restored history entry
+    // each arrive through two paths of their own. Every one of those used to
+    // re-run the whole band-limited analysis of a record that had not moved.
+    private AnalysisRequest? renderedRequest;
+    private AnalysisRequest? pendingRequest;
+    // The read asked for while another was still running. One read at a time:
+    // holding the band's up arrow fires a request per click, and starting each
+    // of them puts four analyses of the same record on the thread pool to have
+    // three of them thrown away.
+    private AnalysisRequest? queuedRequest;
+    // Bumped by every refresh: an analysis whose version has moved on has been
+    // superseded, and its result is dropped rather than drawn over the newer one.
+    private int analysisVersion;
+    // Per-record derivations, kept so that a band edit — which changes neither
+    // the record nor its hygiene — stops paying for them again. One slot per
+    // role; the entry is swapped as a whole, so a reader never sees a verdict
+    // paired with another record's samples.
+    private ProjectionEntry? mainProjection;
+    private ProjectionEntry? compareProjection;
+    private HygieneEntry? mainHygiene;
+    private HygieneEntry? compareHygiene;
+    // Guards those four slots: a superseded read can still be running on its own
+    // thread when the next one starts, and both reach for them.
+    private readonly object recordDerivations = new();
 
     // The fade the Auto mode puts around the detected pass band.
     private const double AutoBandFadeOctaves = 0.5;
@@ -189,6 +216,10 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
         if (!TryGetMainSource(out TimeAlignmentAnalysisSource mainSource, out string noDataMessage))
         {
+            analysisVersion++;
+            pendingRequest = null;
+            queuedRequest = null;
+            renderedRequest = null;
             lastAutoBand = null;
             UpdateAutoBandLabel();
             UpdateBandpassPreview();
@@ -197,8 +228,149 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             return;
         }
 
+        // The window preview and its caption follow the CONTROLS, so an edit
+        // moves them at once instead of at the end of the read behind it. In the
+        // Auto mode the caption still names the band of the last finished read
+        // until the new one lands, which is what "detected" has always meant.
+        UpdateAutoBandLabel();
+        UpdateBandpassPreview();
+
+        // The band is FROZEN into the request here. The read runs off the UI
+        // thread, where the shared options object can be edited under it, and a
+        // number on screen has to state the band it was actually taken in.
+        var request = new AnalysisRequest(
+            mainSource,
+            getCompareMeasurement(),
+            options.BandMode,
+            options.BandpassCenterHz,
+            options.BandpassPassOctaves,
+            options.BandpassFadeOctaves,
+            options.FirstPeakThresholdBelowMaxDb,
+            options.FirstPeakMinimumSnrDb,
+            options.PeakSearchWindowMilliseconds);
+        if ((renderedRequest is { } drawn && drawn == request) ||
+            (pendingRequest is { } running && running == request))
+        {
+            // Already drawn, or already on its way: the answer cannot differ.
+            return;
+        }
+
+        StartAnalysis(request);
+    }
+
+    // Starts the read, off the UI thread wherever there is a message loop to
+    // come back to. At a megabyte of transfer IR one read is a few hundred
+    // milliseconds, and it used to be spent inside the click that asked for it:
+    // that is what made a nudge of the band boxes feel like a hang, and what
+    // held the shell still for a moment after every sweep.
+    private void StartAnalysis(AnalysisRequest request)
+    {
+        if (pendingRequest != null)
+        {
+            queuedRequest = request;
+            return;
+        }
+
+        int version = ++analysisVersion;
+        pendingRequest = request;
+        if (!owner.IsHandleCreated || owner.IsDisposed || owner.InvokeRequired)
+        {
+            // Nothing to come back to: the controllers are built and refreshed
+            // before the shell has a window, and the panel tests never open one.
+            CompleteAnalysis(request, RunAnalysis(request), version);
+            return;
+        }
+
+        _ = RunAnalysisAsync(request, version);
+    }
+
+    private async Task RunAnalysisAsync(AnalysisRequest request, int version)
+    {
+        AnalysisOutcome outcome;
         try
         {
+            outcome = await Task.Run(() => RunAnalysis(request));
+        }
+        catch (Exception exception)
+        {
+            outcome = AnalysisOutcome.Failed(exception.Message);
+        }
+
+        if (!disposed && !owner.IsDisposed)
+        {
+            CompleteAnalysis(request, outcome, version);
+        }
+    }
+
+    // Draws a finished read — unless a newer one has been asked for since, in
+    // which case this one is stale and drawing it would put the previous band's
+    // numbers under the band the user is now looking at.
+    private void CompleteAnalysis(
+        AnalysisRequest request,
+        AnalysisOutcome outcome,
+        int version)
+    {
+        if (disposed || version != analysisVersion)
+        {
+            return;
+        }
+
+        pendingRequest = null;
+        renderedRequest = request;
+        lastAutoBand = outcome.AutoBand;
+        lastAutoBandIsShared = outcome.AutoBandShared;
+        UpdateAutoBandLabel();
+        UpdateBandpassPreview();
+        if (outcome.Message is { } message)
+        {
+            SetStatusText(message);
+            ClearEnvelopePreview();
+            StartQueuedAnalysis(request);
+            return;
+        }
+
+        SetMeasurementResultStatus(
+            request.BandMode,
+            outcome.MainSource,
+            outcome.MainResult,
+            outcome.MainProbe,
+            outcome.MainCrosstalk,
+            outcome.Compare,
+            outcome.CompareProbe,
+            outcome.CompareCrosstalk,
+            outcome.CompareWarning);
+        UpdateEnvelopePreview(
+            outcome.MainResult,
+            outcome.MainSource.SampleRate,
+            outcome.Compare?.Result);
+        StartQueuedAnalysis(request);
+    }
+
+    // The last request made while this one was running, if it asks for anything
+    // this read did not answer.
+    private void StartQueuedAnalysis(AnalysisRequest rendered)
+    {
+        if (queuedRequest is not { } queued)
+        {
+            return;
+        }
+
+        queuedRequest = null;
+        if (queued != rendered)
+        {
+            StartAnalysis(queued);
+        }
+    }
+
+    // The read itself. Nothing here touches a control or the shared options
+    // object: it works from the request alone, so it is safe on a worker thread
+    // and it states the band it was given rather than the band the boxes have
+    // reached by the time it lands.
+    private AnalysisOutcome RunAnalysis(AnalysisRequest request)
+    {
+        try
+        {
+            TimeAlignmentAnalysisSource mainSource = request.MainSource;
             // Crosstalk hygiene first: detection always runs on the RAW
             // record, then the banded modes analyze the CLEANED record —
             // the same order the Auto delay engine uses. A broadband click
@@ -206,10 +378,9 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             // alike, so analyzing the raw record could green-light
             // ("verified") an arrival that times the click. The bypass mode
             // keeps the raw record and flags the contamination instead.
-            CrosstalkHeadGate? mainCrosstalk = TransferIrDiagnostics.DetectCrosstalkHead(
-                mainSource.TransferImpulseResponse, mainSource.SampleRate);
-            TimeAlignmentAnalysisSource mainAnalysisSource =
-                CleanForAnalysis(mainSource, mainCrosstalk);
+            HygieneEntry mainHygieneEntry = Hygiene(ref mainHygiene, mainSource);
+            TimeAlignmentAnalysisSource mainAnalysisSource = CleanForAnalysis(
+                mainSource, mainHygieneEntry, request.BandMode);
 
             // The Compare record is resolved and cleaned BEFORE the band is
             // chosen: in the Auto mode the band is the one both records share,
@@ -217,17 +388,20 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             // which of the two was loaded as Main (a field mid pair: 32.7-7671
             // Hz one way, 75.5-4695 Hz the other, and 0.3 ms of delta with it).
             TimeAlignmentAnalysisSource? compareSource = TryGetCompareSource(
+                request,
                 mainSource,
                 out string? compareWarning,
                 out CrosstalkHeadGate? compareCrosstalk);
 
-            // One options object per refresh, and the Compare measurement is
+            // One options object per read, and the Compare measurement is
             // analyzed in the same band, so the delta column compares like with
             // like.
             TimeAlignmentAnalysisOptions analysisOptions = CreateAnalysisOptions(
-                mainAnalysisSource, compareSource, wrapPeakPositions: true);
-            UpdateAutoBandLabel();
-            UpdateBandpassPreview();
+                request,
+                mainAnalysisSource,
+                compareSource,
+                out DominantBand? autoBand,
+                out bool autoBandShared);
 
             TimeAlignmentAnalysisResult mainResult = TimeAlignmentAnalysis.Analyze(
                 mainAnalysisSource.TransferImpulseResponse,
@@ -236,13 +410,13 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 mainAnalysisSource.TransferCoherence);
             if (!mainResult.IsValid)
             {
-                SetStatusText(
+                return AnalysisOutcome.Failed(
                     "No signal in the analysis band.\r\n" +
                     "The transfer IR carries no energy inside the current " +
                     "band-pass window — widen or move the band, or check " +
-                    "that the measurement actually captured the driver.");
-                ClearEnvelopePreview();
-                return;
+                    "that the measurement actually captured the driver.",
+                    autoBand,
+                    autoBandShared);
             }
 
             TimeAlignmentArrivalProbe? mainProbe = TimeAlignmentAnalysis.ProbeArrivalHonesty(
@@ -261,39 +435,141 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                     analysisOptions,
                     compareAnalysis.Value.Result,
                     compareAnalysis.Value.Source.TransferCoherence);
-            SetMeasurementResultStatus(
+            return new AnalysisOutcome(
                 mainSource,
+                autoBand,
+                autoBandShared,
                 mainResult,
                 mainProbe,
-                mainCrosstalk,
+                mainHygieneEntry.Crosstalk,
                 compareAnalysis,
                 compareProbe,
                 compareCrosstalk,
-                compareWarning);
-            UpdateEnvelopePreview(
-                mainResult,
-                mainSource.SampleRate,
-                compareAnalysis?.Result);
+                compareWarning,
+                Message: null);
         }
         catch (Exception exception)
         {
-            SetStatusText(exception.Message);
-            ClearEnvelopePreview();
+            return AnalysisOutcome.Failed(exception.Message);
         }
+    }
+
+    // Everything one read needs, taken on the UI thread before it starts. Two
+    // requests that compare equal describe the same read of the same records,
+    // which is what lets a repeated refresh recognize the answer already drawn.
+    private readonly record struct AnalysisRequest(
+        TimeAlignmentAnalysisSource MainSource,
+        TimeAlignmentCompareMeasurement? Compare,
+        TimeAlignmentBandMode BandMode,
+        double BandpassCenterHz,
+        double BandpassPassOctaves,
+        double BandpassFadeOctaves,
+        double FirstPeakThresholdBelowMaxDb,
+        double FirstPeakMinimumSnrDb,
+        double PeakSearchWindowMilliseconds);
+
+    // What one read produced. A Message instead of a result is the read saying
+    // why it has nothing to show — a band with no energy in it, or a record the
+    // analysis threw on — and the panel prints that in place of the tables.
+    private sealed record AnalysisOutcome(
+        TimeAlignmentAnalysisSource MainSource,
+        DominantBand? AutoBand,
+        bool AutoBandShared,
+        TimeAlignmentAnalysisResult MainResult,
+        TimeAlignmentArrivalProbe? MainProbe,
+        CrosstalkHeadGate? MainCrosstalk,
+        TimeAlignmentCompareAnalysis? Compare,
+        TimeAlignmentArrivalProbe? CompareProbe,
+        CrosstalkHeadGate? CompareCrosstalk,
+        string? CompareWarning,
+        string? Message)
+    {
+        public static AnalysisOutcome Failed(
+            string message,
+            DominantBand? autoBand = null,
+            bool autoBandShared = false) =>
+            new(
+                default,
+                autoBand,
+                autoBandShared,
+                default,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                message);
+    }
+
+    // A transfer IR's real projection, remembered per record. The analysis reads
+    // doubles while the measurement holds Complex, and converting a megabyte of
+    // samples on every refresh costs both the copy and a NEW array — and a new
+    // array would make every request look like a different one.
+    private sealed record ProjectionEntry(Complex[] Source, double[] Samples);
+
+    // The crosstalk verdict and the cleaned copy that follows from it,
+    // remembered for the same reason: neither depends on the band, so a spin of
+    // a numeric box should not pay for a detection pass and a full copy of the
+    // samples before the analysis it asked for even starts.
+    private sealed record HygieneEntry(
+        double[] Samples,
+        CrosstalkHeadGate? Crosstalk,
+        double[] Cleaned);
+
+    private double[] RealSamples(ref ProjectionEntry? slot, Complex[] transfer)
+    {
+        lock (recordDerivations)
+        {
+            if (slot is { } entry && ReferenceEquals(entry.Source, transfer))
+            {
+                return entry.Samples;
+            }
+
+            var projected = new ProjectionEntry(
+                transfer,
+                Array.ConvertAll(transfer, sample => sample.Real));
+            slot = projected;
+            return projected.Samples;
+        }
+    }
+
+    private HygieneEntry Hygiene(ref HygieneEntry? slot, TimeAlignmentAnalysisSource source)
+    {
+        double[] samples = source.TransferImpulseResponse;
+        lock (recordDerivations)
+        {
+            if (slot is { } cached && ReferenceEquals(cached.Samples, samples))
+            {
+                return cached;
+            }
+        }
+
+        CrosstalkHeadGate? crosstalk = TransferIrDiagnostics.DetectCrosstalkHead(
+            samples, source.SampleRate);
+        var entry = new HygieneEntry(
+            samples,
+            crosstalk,
+            crosstalk is { } gate
+                ? TransferIrDiagnostics.CleanCrosstalkHead(samples, source.SampleRate, gate)
+                : samples);
+        lock (recordDerivations)
+        {
+            slot = entry;
+        }
+
+        return entry;
     }
 
     // The banded modes analyze the record with the convicted click removed
     // (band detection included); the bypass mode shows the record as-is and
     // relies on the red flag instead.
-    private TimeAlignmentAnalysisSource CleanForAnalysis(
+    private static TimeAlignmentAnalysisSource CleanForAnalysis(
         TimeAlignmentAnalysisSource source,
-        CrosstalkHeadGate? crosstalk) =>
-        options.BandMode != TimeAlignmentBandMode.FullBand && crosstalk is { } gate
-            ? source with
-            {
-                TransferImpulseResponse = TransferIrDiagnostics.CleanCrosstalkHead(
-                    source.TransferImpulseResponse, source.SampleRate, gate)
-            }
+        HygieneEntry hygiene,
+        TimeAlignmentBandMode bandMode) =>
+        bandMode != TimeAlignmentBandMode.FullBand && hygiene.Crosstalk != null
+            ? source with { TransferImpulseResponse = hygiene.Cleaned }
             : source;
 
     private bool TryGetMainSource(
@@ -326,7 +602,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 measurement.Sweep?.ComputedDuration ?? 0.0,
                 measurement.PlaybackChannel,
                 measurement.MeasurementMode,
-                Array.ConvertAll(transferImpulseResponse, sample => sample.Real),
+                RealSamples(ref mainProjection, transferImpulseResponse),
                 measurement.TransferCoherence,
                 measurement.CurrentLevels);
             message = string.Empty;
@@ -380,7 +656,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         return $"Compare: {compare.Value.DisplayName}, {snapshot.SampleRate} Hz, {snapshot.Bits} bit.";
     }
 
-    private static TimeAlignmentAnalysisSource CreateCompareSource(
+    private TimeAlignmentAnalysisSource CreateCompareSource(
         TimeAlignmentCompareMeasurement compare,
         MeasurementHistorySnapshot snapshot) =>
         new(
@@ -391,32 +667,32 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             snapshot.SweepDurationSeconds,
             snapshot.PlayChannel,
             snapshot.MeasurementMode,
-            Array.ConvertAll(
-                snapshot.TransferImpulseResponse!,
-                sample => sample.Real),
+            RealSamples(ref compareProjection, snapshot.TransferImpulseResponse!),
             snapshot.TransferCoherence,
             snapshot.MeterSnapshot);
 
-    private TimeAlignmentAnalysisOptions CreateAnalysisOptions(
+    private static TimeAlignmentAnalysisOptions CreateAnalysisOptions(
+        AnalysisRequest request,
         TimeAlignmentAnalysisSource source,
         TimeAlignmentAnalysisSource? compareSource,
-        bool wrapPeakPositions)
+        out DominantBand? autoBand,
+        out bool autoBandShared)
     {
-        double centerHz = options.BandpassCenterHz;
-        double passOctaves = options.BandpassPassOctaves;
-        double fadeOctaves = options.BandpassFadeOctaves;
-        lastAutoBand = null;
-        lastAutoBandIsShared = false;
-        if (options.BandMode == TimeAlignmentBandMode.AutoBand)
+        double centerHz = request.BandpassCenterHz;
+        double passOctaves = request.BandpassPassOctaves;
+        double fadeOctaves = request.BandpassFadeOctaves;
+        autoBand = null;
+        autoBandShared = false;
+        if (request.BandMode == TimeAlignmentBandMode.AutoBand)
         {
             DominantBand band = DetectDominantBand(source);
             if (compareSource is { } compare &&
                 TryDetectDominantBand(compare, out DominantBand compareBand))
             {
-                (band, lastAutoBandIsShared) = SharedBand(band, compareBand);
+                (band, autoBandShared) = SharedBand(band, compareBand);
             }
 
-            lastAutoBand = band;
+            autoBand = band;
             centerHz = Math.Sqrt(band.LowHz * band.HighHz);
             passOctaves = Math.Log2(band.HighHz / band.LowHz);
             fadeOctaves = AutoBandFadeOctaves;
@@ -424,14 +700,17 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
         return new TimeAlignmentAnalysisOptions
         {
-            UseBandpassWindow = options.BandMode != TimeAlignmentBandMode.FullBand,
+            UseBandpassWindow = request.BandMode != TimeAlignmentBandMode.FullBand,
             BandpassCenterHz = centerHz,
             BandpassPassOctaves = passOctaves,
             BandpassFadeOctaves = fadeOctaves,
-            FirstPeakThresholdBelowMaxDb = options.FirstPeakThresholdBelowMaxDb,
-            FirstPeakMinimumSnrDb = options.FirstPeakMinimumSnrDb,
-            PeakSearchWindowMilliseconds = options.PeakSearchWindowMilliseconds,
-            WrapPeakPositions = wrapPeakPositions
+            FirstPeakThresholdBelowMaxDb = request.FirstPeakThresholdBelowMaxDb,
+            FirstPeakMinimumSnrDb = request.FirstPeakMinimumSnrDb,
+            PeakSearchWindowMilliseconds = request.PeakSearchWindowMilliseconds,
+            // Every position this panel prints is a delay against another
+            // arrival, so a peak past the halfway mark is read as the negative
+            // lead it is rather than as a buffer-length delay.
+            WrapPeakPositions = true
         };
     }
 
@@ -615,13 +894,14 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // analysis in the banded modes), and no analysis yet — the band still has
     // to be agreed between the two records.
     private TimeAlignmentAnalysisSource? TryGetCompareSource(
+        AnalysisRequest request,
         TimeAlignmentAnalysisSource mainSource,
         out string? warning,
         out CrosstalkHeadGate? crosstalk)
     {
         warning = null;
         crosstalk = null;
-        TimeAlignmentCompareMeasurement? compare = getCompareMeasurement();
+        TimeAlignmentCompareMeasurement? compare = request.Compare;
         if (compare == null)
         {
             return null;
@@ -647,9 +927,9 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         {
             TimeAlignmentAnalysisSource compareSource =
                 CreateCompareSource(compareValue, snapshot);
-            crosstalk = TransferIrDiagnostics.DetectCrosstalkHead(
-                compareSource.TransferImpulseResponse, compareSource.SampleRate);
-            return CleanForAnalysis(compareSource, crosstalk);
+            HygieneEntry hygiene = Hygiene(ref compareHygiene, compareSource);
+            crosstalk = hygiene.Crosstalk;
+            return CleanForAnalysis(compareSource, hygiene, request.BandMode);
         }
         catch (Exception exception)
         {
@@ -1054,6 +1334,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     }
 
     private void SetMeasurementResultStatus(
+        TimeAlignmentBandMode bandMode,
         TimeAlignmentAnalysisSource mainSource,
         TimeAlignmentAnalysisResult mainResult,
         TimeAlignmentArrivalProbe? mainProbe,
@@ -1068,9 +1349,14 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         {
             statusTextBox.Clear();
             AppendMeasurementResult(
-                "Main", mainSource.Levels, mainResult, mainProbe, mainCrosstalk);
+                bandMode, "Main", mainSource.Levels, mainResult, mainProbe, mainCrosstalk);
             AppendCompareResult(
-                mainResult, compareAnalysis, compareProbe, compareCrosstalk, compareWarning);
+                bandMode,
+                mainResult,
+                compareAnalysis,
+                compareProbe,
+                compareCrosstalk,
+                compareWarning);
             statusTextBox.SelectionStart = 0;
             statusTextBox.SelectionLength = 0;
         }
@@ -1081,6 +1367,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     }
 
     private void AppendCompareResult(
+        TimeAlignmentBandMode bandMode,
         TimeAlignmentAnalysisResult mainResult,
         TimeAlignmentCompareAnalysis? compareAnalysis,
         TimeAlignmentArrivalProbe? compareProbe,
@@ -1103,6 +1390,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         // Passing the Main result makes the Compare delay table show each value's delta
         // against Source in parentheses.
         AppendMeasurementResult(
+            bandMode,
             "Compare",
             compareAnalysis!.Value.Source.Levels,
             compareAnalysis.Value.Result,
@@ -1112,6 +1400,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     }
 
     private void AppendMeasurementResult(
+        TimeAlignmentBandMode bandMode,
         string title,
         InputLevelMeterSnapshot levels,
         TimeAlignmentAnalysisResult result,
@@ -1126,7 +1415,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         AppendLevelsLine(levels);
         AppendSeparator();
         AppendDelayTable(result, reference);
-        if (IsArrivalRecommendable(result, honestyProbe, options.BandMode, crosstalk != null))
+        if (IsArrivalRecommendable(result, honestyProbe, bandMode, crosstalk != null))
         {
             AppendStrongestPeakHint(result);
         }

--- a/tests/Resonalyze.App.Tests/AnalysisReadScheduleTests.cs
+++ b/tests/Resonalyze.App.Tests/AnalysisReadScheduleTests.cs
@@ -1,0 +1,129 @@
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The Time Alignment panel's read scheduler. Its whole job is that what is on
+/// screen answers the controls as they stand now: a read is slow enough that
+/// the user can move on twice while it runs, and every one of those moves has
+/// to leave a finished read either drawable or retired.
+/// </summary>
+public sealed class AnalysisReadScheduleTests
+{
+    private readonly AnalysisReadSchedule<int> schedule = new();
+
+    [Fact]
+    public void AFreshRequestRuns()
+    {
+        Assert.NotNull(schedule.Submit(1));
+    }
+
+    [Fact]
+    public void ARequestAlreadyDrawnDoesNotRunAgain()
+    {
+        int version = schedule.Submit(1)!.Value;
+        Assert.True(schedule.Accept(1, version));
+
+        // The refresh a mode switch fires behind the one that drew this.
+        Assert.Null(schedule.Submit(1));
+    }
+
+    [Fact]
+    public void ARequestAlreadyRunningDoesNotStartTwice()
+    {
+        schedule.Submit(1);
+
+        Assert.Null(schedule.Submit(1));
+    }
+
+    [Fact]
+    public void OnlyOneReadRunsAndOnlyTheLastOneWaits()
+    {
+        int version = schedule.Submit(1)!.Value;
+
+        // A held-down spinner: a request per click while the first read runs.
+        Assert.Null(schedule.Submit(2));
+        Assert.Null(schedule.Submit(3));
+        Assert.Null(schedule.Submit(4));
+
+        Assert.True(schedule.Accept(1, version));
+        Assert.NotNull(schedule.TakeQueued(out int queued));
+        Assert.Equal(4, queued);
+        Assert.Null(schedule.TakeQueued(out _));
+    }
+
+    // The failure this scheduler exists for. Selecting a Compare record and
+    // clearing it again before the read finishes leaves the panel asking for
+    // exactly what it already shows — and the read for the record that is no
+    // longer selected must not land on top of it with its Compare deltas.
+    [Fact]
+    public void AReadIsRetiredWhenTheControlsReturnToWhatIsDrawn()
+    {
+        int drawn = schedule.Submit(1)!.Value;
+        schedule.Accept(1, drawn);
+        int abandoned = schedule.Submit(2)!.Value;
+
+        Assert.Null(schedule.Submit(1));
+
+        Assert.False(schedule.Accept(2, abandoned));
+    }
+
+    [Fact]
+    public void ReturningToWhatIsDrawnAlsoDropsWhatWasWaiting()
+    {
+        int drawn = schedule.Submit(1)!.Value;
+        schedule.Accept(1, drawn);
+        int abandoned = schedule.Submit(2)!.Value;
+        schedule.Submit(3);
+
+        Assert.Null(schedule.Submit(1));
+
+        Assert.False(schedule.Accept(2, abandoned));
+        Assert.Null(schedule.TakeQueued(out _));
+    }
+
+    // The same trap one step in: the queued read is older than the request that
+    // returns to the one already running, so it describes a state that has been
+    // left twice over.
+    [Fact]
+    public void ReturningToWhatIsRunningDropsWhatWasWaiting()
+    {
+        int version = schedule.Submit(1)!.Value;
+        schedule.Submit(2);
+
+        Assert.Null(schedule.Submit(1));
+
+        Assert.True(schedule.Accept(1, version));
+        Assert.Null(schedule.TakeQueued(out _));
+    }
+
+    // What waited runs when the read ahead of it lands, and is then the drawn
+    // read like any other — the refresh that follows it draws nothing again.
+    [Fact]
+    public void AQueuedReadRunsAndThenCountsAsDrawn()
+    {
+        int first = schedule.Submit(1)!.Value;
+        schedule.Submit(2);
+        Assert.True(schedule.Accept(1, first));
+        int queuedVersion = schedule.TakeQueued(out int queued)!.Value;
+        Assert.Equal(2, queued);
+
+        Assert.True(schedule.Accept(2, queuedVersion));
+        Assert.Null(schedule.Submit(2));
+    }
+
+    // Losing the record: nothing is drawn any more, and the read that was
+    // running for it cannot be drawn either — the panel is showing the
+    // "no data" message instead.
+    [Fact]
+    public void ClearingRetiresTheRunningReadAndForgetsTheDrawnOne()
+    {
+        int drawn = schedule.Submit(1)!.Value;
+        schedule.Accept(1, drawn);
+        int abandoned = schedule.Submit(2)!.Value;
+
+        schedule.Clear();
+
+        Assert.False(schedule.Accept(2, abandoned));
+        // The same request is new again: what it used to answer is gone.
+        Assert.NotNull(schedule.Submit(1));
+    }
+}

--- a/tests/Resonalyze.App.Tests/AnalysisReadScheduleTests.cs
+++ b/tests/Resonalyze.App.Tests/AnalysisReadScheduleTests.cs
@@ -2,10 +2,19 @@ namespace Resonalyze.App.Tests;
 
 /// <summary>
 /// The Time Alignment panel's read scheduler. Its whole job is that what is on
-/// screen answers the controls as they stand now: a read is slow enough that
-/// the user can move on twice while it runs, and every one of those moves has
-/// to leave a finished read either drawable or retired.
+/// screen answers the controls as they stand NOW: a read is slow enough that
+/// the user moves on twice while it runs, and a finished read that no longer
+/// describes the controls must not be drawn at all — a panel stating an
+/// alignment for a band nobody is looking at is worse than a panel that has not
+/// caught up yet.
 /// </summary>
+/// <remarks>
+/// Driven with plain integers because the state machine is the subject: through
+/// the panel these paths need a real message loop (with none, the read runs
+/// inline and nothing is ever in flight), which is exactly why they went
+/// untested — and one of them unnoticed — while the scheduling lived in four
+/// fields of the controller.
+/// </remarks>
 public sealed class AnalysisReadScheduleTests
 {
     private readonly AnalysisReadSchedule<int> schedule = new();
@@ -20,7 +29,7 @@ public sealed class AnalysisReadScheduleTests
     public void ARequestAlreadyDrawnDoesNotRunAgain()
     {
         int version = schedule.Submit(1)!.Value;
-        Assert.True(schedule.Accept(1, version));
+        Assert.True(schedule.Complete(1, version));
 
         // The refresh a mode switch fires behind the one that drew this.
         Assert.Null(schedule.Submit(1));
@@ -34,79 +43,94 @@ public sealed class AnalysisReadScheduleTests
         Assert.Null(schedule.Submit(1));
     }
 
+    // The rule, stated on its own: a read the controls have moved off is not
+    // drawn when it lands — not "drawn, then corrected by the next one".
     [Fact]
-    public void OnlyOneReadRunsAndOnlyTheLastOneWaits()
+    public void ASupersededReadIsNotDrawnAndTheWantedOneRunsInstead()
     {
-        int version = schedule.Submit(1)!.Value;
+        int drawn = schedule.Submit(1)!.Value;
+        schedule.Complete(1, drawn);
+        int superseded = schedule.Submit(2)!.Value;
 
-        // A held-down spinner: a request per click while the first read runs.
+        Assert.Null(schedule.Submit(3));
+
+        Assert.False(schedule.Complete(2, superseded));
+        int next = schedule.TakeDesired(out int wanted)!.Value;
+        Assert.Equal(3, wanted);
+        Assert.True(schedule.Complete(3, next));
+    }
+
+    [Fact]
+    public void OnlyTheLastOfAHeldSpinnerEverRuns()
+    {
+        int first = schedule.Submit(1)!.Value;
+
+        // A request per click while the first read runs.
         Assert.Null(schedule.Submit(2));
         Assert.Null(schedule.Submit(3));
         Assert.Null(schedule.Submit(4));
 
-        Assert.True(schedule.Accept(1, version));
-        Assert.NotNull(schedule.TakeQueued(out int queued));
-        Assert.Equal(4, queued);
-        Assert.Null(schedule.TakeQueued(out _));
+        Assert.False(schedule.Complete(1, first));
+        Assert.NotNull(schedule.TakeDesired(out int wanted));
+        Assert.Equal(4, wanted);
+        Assert.Null(schedule.TakeDesired(out _));
     }
 
-    // The failure this scheduler exists for. Selecting a Compare record and
-    // clearing it again before the read finishes leaves the panel asking for
-    // exactly what it already shows — and the read for the record that is no
-    // longer selected must not land on top of it with its Compare deltas.
+    // Regression, first order: render A, start B, return to A before B lands.
+    // B must not be drawn, and nothing else may run — A is already the answer.
     [Fact]
-    public void AReadIsRetiredWhenTheControlsReturnToWhatIsDrawn()
+    public void ReturningToWhatIsDrawnRetiresTheReadInFlight()
     {
         int drawn = schedule.Submit(1)!.Value;
-        schedule.Accept(1, drawn);
+        schedule.Complete(1, drawn);
         int abandoned = schedule.Submit(2)!.Value;
 
         Assert.Null(schedule.Submit(1));
 
-        Assert.False(schedule.Accept(2, abandoned));
+        Assert.False(schedule.Complete(2, abandoned));
+        Assert.Null(schedule.TakeDesired(out _));
     }
 
+    // Regression, second order: start A, want B, return to A. A is drawn when
+    // it lands and B never runs — it describes a state left twice over.
     [Fact]
-    public void ReturningToWhatIsDrawnAlsoDropsWhatWasWaiting()
-    {
-        int drawn = schedule.Submit(1)!.Value;
-        schedule.Accept(1, drawn);
-        int abandoned = schedule.Submit(2)!.Value;
-        schedule.Submit(3);
-
-        Assert.Null(schedule.Submit(1));
-
-        Assert.False(schedule.Accept(2, abandoned));
-        Assert.Null(schedule.TakeQueued(out _));
-    }
-
-    // The same trap one step in: the queued read is older than the request that
-    // returns to the one already running, so it describes a state that has been
-    // left twice over.
-    [Fact]
-    public void ReturningToWhatIsRunningDropsWhatWasWaiting()
+    public void ReturningToWhatIsRunningDropsWhatWasWanted()
     {
         int version = schedule.Submit(1)!.Value;
         schedule.Submit(2);
 
         Assert.Null(schedule.Submit(1));
 
-        Assert.True(schedule.Accept(1, version));
-        Assert.Null(schedule.TakeQueued(out _));
+        Assert.True(schedule.Complete(1, version));
+        Assert.Null(schedule.TakeDesired(out _));
     }
 
-    // What waited runs when the read ahead of it lands, and is then the drawn
-    // read like any other — the refresh that follows it draws nothing again.
+    // The read the controls come back to is revived, not recomputed: it answers
+    // exactly what is being asked for again, and one read runs at a time, so no
+    // other version is live to collide with its own.
     [Fact]
-    public void AQueuedReadRunsAndThenCountsAsDrawn()
+    public void ReturningToARetiredReadInFlightRevivesIt()
+    {
+        int version = schedule.Submit(1)!.Value;
+        schedule.Submit(2);
+        schedule.Submit(1);
+
+        Assert.True(schedule.Complete(1, version));
+        Assert.Null(schedule.TakeDesired(out _));
+    }
+
+    // What waited runs when the pool frees, and is then the drawn read like any
+    // other — the refresh that follows it draws nothing again.
+    [Fact]
+    public void AWantedReadRunsAndThenCountsAsDrawn()
     {
         int first = schedule.Submit(1)!.Value;
         schedule.Submit(2);
-        Assert.True(schedule.Accept(1, first));
-        int queuedVersion = schedule.TakeQueued(out int queued)!.Value;
-        Assert.Equal(2, queued);
+        Assert.False(schedule.Complete(1, first));
+        int version = schedule.TakeDesired(out int wanted)!.Value;
+        Assert.Equal(2, wanted);
 
-        Assert.True(schedule.Accept(2, queuedVersion));
+        Assert.True(schedule.Complete(2, version));
         Assert.Null(schedule.Submit(2));
     }
 
@@ -117,12 +141,13 @@ public sealed class AnalysisReadScheduleTests
     public void ClearingRetiresTheRunningReadAndForgetsTheDrawnOne()
     {
         int drawn = schedule.Submit(1)!.Value;
-        schedule.Accept(1, drawn);
+        schedule.Complete(1, drawn);
         int abandoned = schedule.Submit(2)!.Value;
 
         schedule.Clear();
 
-        Assert.False(schedule.Accept(2, abandoned));
+        Assert.False(schedule.Complete(2, abandoned));
+        Assert.Null(schedule.TakeDesired(out _));
         // The same request is new again: what it used to answer is gone.
         Assert.NotNull(schedule.Submit(1));
     }

--- a/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/SignalEnvelopeTests.cs
@@ -1,3 +1,6 @@
+using System.Numerics;
+using MathNet.Numerics.IntegralTransforms;
+
 namespace Resonalyze.Dsp.Tests;
 
 public sealed class SignalEnvelopeTests
@@ -570,6 +573,66 @@ public sealed class SignalEnvelopeTests
         // The −60 dB floor minus the Rayleigh compensation (≈ 8.64 dB), the same
         // as the reverb-tail case — NOT the ~131 dB the raw quartile would read.
         Assert.InRange(confidence, 51.2, 51.5);
+    }
+
+    // The premise of the band-limited read's single transform: a caller that
+    // already holds the forward spectrum gets exactly the envelope it would have
+    // got by transforming back and asking for it, and its spectrum survives the
+    // call (the analysis reads that same array again for the correlation).
+    [Fact]
+    public void EnvelopeFromSpectrum_MatchesTheEnvelopeOfTheSignalItCameFrom()
+    {
+        const int length = 512;
+        double[] signal = CreateSine(length, 11, 0.8);
+        for (int i = 0; i < length; i++)
+        {
+            signal[i] += 0.3 * Math.Cos(2.0 * Math.PI * 37 * i / length);
+        }
+
+        var spectrum = new Complex[length];
+        for (int i = 0; i < length; i++)
+        {
+            spectrum[i] = new Complex(signal[i], 0.0);
+        }
+
+        Fourier.Forward(spectrum, FourierOptions.Matlab);
+        Complex[] untouched = (Complex[])spectrum.Clone();
+
+        double[] expected = SignalEnvelope.Envelope(signal);
+        double[] actual = SignalEnvelope.EnvelopeFromSpectrum(spectrum);
+
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.Equal(expected[i], actual[i], precision: 12);
+        }
+
+        Assert.Equal(untouched, spectrum);
+    }
+
+    // An odd length takes the other half of the analytic mask, so it is pinned
+    // on both sides of that branch.
+    [Fact]
+    public void EnvelopeFromSpectrum_MatchesForAnOddLength()
+    {
+        const int length = 255;
+        double[] signal = CreateSine(length, 9, 1.1);
+
+        var spectrum = new Complex[length];
+        for (int i = 0; i < length; i++)
+        {
+            spectrum[i] = new Complex(signal[i], 0.0);
+        }
+
+        Fourier.Forward(spectrum, FourierOptions.Matlab);
+
+        double[] expected = SignalEnvelope.Envelope(signal);
+        double[] actual = SignalEnvelope.EnvelopeFromSpectrum(spectrum);
+
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.Equal(expected[i], actual[i], precision: 12);
+        }
     }
 
     private static double[] CreateSine(int length, int bin, double amplitude)

--- a/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TimeAlignmentAnalysisTests.cs
@@ -21,6 +21,43 @@ public sealed class TimeAlignmentAnalysisTests
         Assert.InRange(result.StrongestPeakSeparationMilliseconds, 8.0, 8.7);
     }
 
+    // A COMPLETE record whose length is not a power of two. Its transforms run
+    // at that length — circular is exact for it — but the whitened correlation
+    // pads to the next power of two, a grid the record's own spectrum is not
+    // on, so the read reconstructs the band-limited signal for it instead of
+    // sharing that spectrum. Both routes have to place the same arrival.
+    [Fact]
+    public void Analyze_PlacesTheSameArrivalWhenTheLengthIsNotAPowerOfTwo()
+    {
+        var options = new TimeAlignmentAnalysisOptions
+        {
+            UseBandpassWindow = true,
+            BandpassCenterHz = 1_000,
+            BandpassPassOctaves = 2,
+            BandpassFadeOctaves = 0.5,
+            WrapPeakPositions = true
+        };
+        var padded = new double[8_192];
+        padded[300] = 1.0;
+        var odd = new double[8_193];
+        odd[300] = 1.0;
+
+        TimeAlignmentAnalysisResult power = TimeAlignmentAnalysis.Analyze(
+            padded, SampleRate, options);
+        TimeAlignmentAnalysisResult notPower = TimeAlignmentAnalysis.Analyze(
+            odd, SampleRate, options);
+
+        Assert.True(power.IsValid);
+        Assert.True(notPower.IsValid);
+        // Not bit for bit: the two lengths put the zero-phase mask on different
+        // bin grids, which is worth about a twentieth of a microsecond here —
+        // a four-hundredth of a sample at this rate.
+        Assert.Equal(
+            power.FirstArrivalDelayMilliseconds,
+            notPower.FirstArrivalDelayMilliseconds,
+            precision: 3);
+    }
+
     [Fact]
     public void Analyze_DoesNotFlagACleanSingleArrival()
     {

--- a/tests/Resonalyze.Dsp.Tests/TimeAlignmentCircularRecordTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TimeAlignmentCircularRecordTests.cs
@@ -102,9 +102,15 @@ public sealed class TimeAlignmentCircularRecordTests
             options.BandpassFadeOctaves);
         double[] circular = SignalEnvelope.Envelope(
             BandpassWindow.Apply(record, window));
+        // To a tolerance rather than to the bit: the reference filters and
+        // transforms back before taking its envelope, while the read masks the
+        // record's own spectrum and reads the envelope off it — the same
+        // arithmetic with one round trip fewer, so the two agree to sixteen
+        // significant digits and not always to the seventeenth. What this test
+        // falsifies is padding, which moves these samples by tens of percent.
         for (int i = 0; i < circular.Length; i++)
         {
-            Assert.Equal(circular[i], result.EnvelopeSamples[i], precision: 12);
+            Assert.Equal(circular[i], result.EnvelopeSamples[i], tolerance: 1e-12);
         }
     }
 

--- a/tests/Resonalyze.Dsp.Tests/TransferFunctionTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/TransferFunctionTests.cs
@@ -684,6 +684,44 @@ public sealed class TransferFunctionTests
         return impulse;
     }
 
+    // The other half of that premise: the whitened correlation off a spectrum
+    // the caller already holds is the one it would have got from the signal.
+    [Fact]
+    public void ComputePhaseTransformFromSpectrum_MatchesTheResponseOverload()
+    {
+        const int length = 1_024;
+        var response = new double[length];
+        var random = new Random(4711);
+        for (int i = 0; i < 64; i++)
+        {
+            response[200 + i] = Math.Exp(-i / 12.0) * Math.Sin(2.0 * Math.PI * i / 9.0);
+        }
+
+        for (int i = 0; i < length; i++)
+        {
+            response[i] += (random.NextDouble() - 0.5) * 1e-3;
+        }
+
+        var spectrum = new Complex[length];
+        for (int i = 0; i < length; i++)
+        {
+            spectrum[i] = new Complex(response[i], 0.0);
+        }
+
+        Fourier.Forward(spectrum, FourierOptions.Matlab);
+
+        PhaseTransformDelay expected = TransferFunction
+            .ComputePhaseTransformFromResponse(response)
+            .RefineAround(200, 8);
+        PhaseTransformDelay actual = TransferFunction
+            .ComputePhaseTransformFromSpectrum(spectrum)
+            .RefineAround(200, 8);
+
+        Assert.Equal(expected.Refined, actual.Refined);
+        Assert.Equal(expected.LagSamples, actual.LagSamples, precision: 10);
+        Assert.Equal(expected.PeakCorrelation, actual.PeakCorrelation, precision: 10);
+    }
+
     private static double[] Delay(double[] input, int delay)
     {
         var output = new double[input.Length];


### PR DESCRIPTION
## What this is

The Time Alignment panel froze the shell for most of a second on every band edit, twice on every entry into the mode, and once more after every sweep. Nothing about the read changes: this is the same arithmetic, taken once instead of twice, off the click that asked for it, and with the transforms it never needed removed.

Measured on the owner's own records at 96 kHz (`tw center.json`, 524288 samples; `l mid.json`, 1048576 — a transfer IR is `NextPow2(2 × capture)`, so a 2.2 s sweep reads a 10.9 s buffer):

| one panel read | main (#160) | this PR |
|---|---|---|
| 524288 samples | 392 ms | **309 ms** |
| 1048576 samples | 789 ms | **465 ms** |

...and each of those reads used to happen twice per event, inside the UI thread.

## 1. One transform where the record is circular (`TimeAlignmentAnalysis.Analyze`)

A band-limited read spent **nine** transforms of the full record length: `BandpassWindow.Apply` (forward + inverse), the kernel envelope (inverse, then a forward and an inverse to take its envelope), the signal's own envelope (forward + inverse), and GCC-PHAT (forward + inverse). Every one of those forwards recomputed a spectrum the read already held: `Apply` produces the filtered signal by inverse-transforming `FFT(x)·W`, and both consumers immediately transform it back.

So the record is transformed **once**, the mask multiplies that spectrum in place, and the envelope, the whitened correlation and the mask's own ringing all read off it. The band-limited SIGNAL is never materialized. Four transforms, and the two new entry points state the contract they rest on:

- `SignalEnvelope.EnvelopeFromSpectrum` — the analytic magnitude of a spectrum the caller already holds, leaving the argument untouched (the correlation reads it next).
- `TransferFunction.ComputePhaseTransformFromSpectrum` — the same split for the whitened correlation; `ComputePhaseTransformFromResponse` is now its forward transform plus a call.
- `BuildKernelEnvelope` reads the mask directly: the kernel's forward spectrum IS the mask, real and even, so transforming the mask into a kernel to transform that kernel straight back was never necessary. This one applies to **both** paths, which is why the engine gets faster too.

**This applies exactly where #160 says the transforms run at the record's own length** — a COMPLETE record (`WrapPeakPositions`), which is circular by construction. That is the panel. A CUT deliberately runs its three stages at three different lengths (the kernel-sized guard for the mask, `EnvelopeOfCrop`'s own padding, the correlation's rise to a power of two) with a trim back to the caller's frame between them, so there is no one spectrum to share: that path is untouched, its body lifted verbatim into `FilterCut` along with #160's comments. A complete record whose length is *not* a power of two (nothing in the app produces one today) reconstructs the filtered signal for the correlation and takes the padded route it always did — pinned by `Analyze_PlacesTheSameArrivalWhenTheLengthIsNotAPowerOfTwo`.

## 2. The panel reads off the UI thread (`TimeAlignmentPanelController`)

Every other mode builds its model through `Task.Run` (`RefreshCurrentModePlotAsync`); this one did not. The read now runs on the pool, and falls back to running inline where there is no message loop to return to (the controllers are built and refreshed before the shell has a window, and the panel tests never open one).

Which needs a scheduler, because a read is slow enough that the user moves on twice while it runs. `AnalysisReadSchedule` owns that, on one rule: **the newest request is authoritative**. A read whose request is no longer what the controls ask for is retired the moment that becomes true — the version moves, so the read fails its own `Complete` and is never drawn. Not "drawn, then corrected by the next one": a result that does not answer the controls in front of the user is the panel lying about its own state, and the window in which it can be read is exactly the window this background pass opened. One read runs at a time; a retired read still holds the pool until it finishes, so the wanted one starts when it lands, and a read the controls come back to is revived rather than recomputed.

Two more things fall out of the same structure:

- **A request is comparable.** `AnalysisRequest` freezes the records (by reference) and the band settings, so a refresh that asks for what is already drawn — or already running — returns without computing. That is what absorbs the duplicate refreshes: a mode switch asks twice (`SetVisible`, then the redraw behind it, since Time Alignment has no plot model of its own), and a compare change and a file load each arrive through two paths. Re-entering the mode on an unchanged record is free. Call sites were left alone deliberately — the panel recognizing its own answer covers the paths that exist today and the ones added tomorrow.
- **The report belongs to the frozen request**, not to the live controls: the band mode travels into the status writer, `AppendArrivalHonesty` and `AppendCrosstalkFlag` included, so a full-band read landing after the panel has moved to Auto cannot print "crosstalk removed from this analysis" over figures taken off the raw record.

The crosstalk verdict, the cleaned copy it produces and the `Complex`→`double` projection are remembered per record — none of them depends on the band, and a spin of a numeric box was paying for a detection pass and a full copy of a megabyte of samples before the analysis it asked for even started. The window preview and its caption now follow the controls immediately instead of waiting behind the read.

## Verification

- **Numbers do not move.** On both field records the read agrees to twelve decimal places: 5.339163394316 ms and 5.633817442385 ms, with SNR (80.432456490, 86.960270896 dB) and prominence to the same places.
- **Seven-cabin battery** (`RESONALYZE_SESSION_BATTERY=D:\hobby\AMP`): 178 report rows **identical**, main against this branch. Its own wall clock 40.6 → 34.8 s, from the kernel envelope alone.
- Suites green: dsp 1444, app 2001, audio 159.
- New tests pin the premise each half rests on. DSP: `EnvelopeFromSpectrum` and `ComputePhaseTransformFromSpectrum` each equal the overload that transforms first (even length and odd), and the non-power-of-two complete record places the same arrival through the fallback. Panel: the schedule is driven directly, including both orders of the failure two reviews found — render A, start B, return to A, finish B (B is not drawn, nothing else runs); start A, want B, return to A (A is drawn, B never runs) — plus supersession end to end, the held spinner, revival, and losing the record. Integers rather than the panel, since through the panel these paths need a real message loop, which is exactly why the app suite could not see them.

## One test of #160 relaxed

`TimeAlignmentCircularRecordTests.CompleteRecord_BandedEnvelopeIsTheCircularOne` compares the read's envelope to `Envelope(Apply(record, window))` at `precision: 12`. The reference transforms back and forth once more than the read now does, so the two agree to **sixteen** significant digits — and on this fixture both land on the midpoint of the twelfth decimal, where `Math.Round` sends them to different values (0.25699488108250007 against 0.25699488108250002). Changed to `tolerance: 1e-12`, which is ten orders of magnitude tighter than the artifact the test exists to catch: padding creeping back into this branch moves those samples by tens of percent.

## Not in this PR

Reading a WINDOW of the record instead of all of it would take the 465 ms to about 90, and the arrival agrees to 0.1 µs — but it moves two numbers, so it is filed in TODO.md with both prices rather than taken here: the SNR is the peak against the quietest quarter of the record, and a short cut's quietest quarter is still decay, not noise (87.0 → 82.0 dB, 80.4 → 76.7 dB on the two records); and the γ² that weights the correlation lives on the full record's half spectrum, so a cut would have to drop or resample it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
