### PR TITLE
Read the Δ L−R levels off the spatial averages while the hybrid is on

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1852,7 +1852,14 @@ decibels of damage that nothing can repair on a system that is correct. Those
 views report the two numbers a tuner does set between groups instead — a **vs
 Front** block giving each group's arrival difference (Δt ms, positive when it
 arrives later) and level difference (ΔdB, negative when it is quieter), measured
-on the groups' summed responses in the band they share. The Groups view exists
+on the groups' summed responses in the band they share. With the
+[hybrid](#hybrid-spatial-averages-under-the-prediction) mode on, the ΔdB is read
+off both groups' spatial averages through their chains instead, each group
+power-summed — an average carries no phase, and over a band spanning octaves the
+junction cross-terms that separates a power sum from a phasor one appear on both
+sides of the comparison; the arrival keeps reading the impulse responses. A group
+with a member that has no capture (an array set may have gaps) keeps its
+point-measured row whole, marked in the tooltip. The Groups view exists
 for exactly that adjustment, which is why it draws the sums rather than the
 drivers: all its lines are gated on one shared anchor, so their relative timing
 is readable off the plot. The target is drawn there too — judging a rear fill's
@@ -2017,13 +2024,15 @@ inaudible there, and takes the point with it when it says the channel is still
 playing.
 
 Everything else keeps reading the impulse responses: timing, polarity, the
-junction analyses, Auto delay, the sum-loss read-out and the phase view. The one
-read-out that follows the hybrid is the **Level Δ L−R** rows of the
-[Δ L−R block](#the-panel-gates-plots-and-read-outs): a level is exactly what the
-captures replace, so while the mode is on those rows compare the sides' spatial
+junction analyses, Auto delay, the sum-loss read-out and the phase view. The
+read-outs that follow the hybrid are the LEVEL rows — a level is exactly what
+the captures replace. The **Level Δ L−R** rows of the
+[Δ L−R block](#the-panel-gates-plots-and-read-outs) compare the sides' spatial
 averages through their chains — under the same one-set condition as the dashed
-opposite-side Sum, and whatever Show view happens to be on screen, because the
-levels a gain trim is judged against do not change with the view. The
+opposite-side Sum — and the **vs Front** ΔdB compares the groups', power-summed
+within each group. Both follow the mode whatever Show view happens to be on
+screen, because the levels a gain trim is judged against do not change with the
+view. The
 toggle needs an average on **every** channel that plays and greys out otherwise,
 since a sum mixing spatially averaged channels with point-measured ones puts two
 references on one axis and still looks like a measurement. The opposite side's

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1855,10 +1855,15 @@ arrives later) and level difference (ΔdB, negative when it is quieter), measure
 on the groups' summed responses in the band they share. With the
 [hybrid](#hybrid-spatial-averages-under-the-prediction) mode on, the ΔdB is read
 off both groups' spatial averages through their chains instead, each group
-power-summed — an average carries no phase, and over a band spanning octaves the
-junction cross-terms that separates a power sum from a phasor one appear on both
-sides of the comparison; the arrival keeps reading the impulse responses. A group
-with a member that has no capture (an array set may have gaps) keeps its
+power-summed — an average carries no phase, so the junction overlaps, where a
+coherent sum can read up to 3 dB above the powers, are approximated; they are a
+fraction of a band spanning octaves, and the more alike the two groups' junction
+layouts are, the more of that approximation cancels out of the difference. The
+arrival keeps reading the impulse responses. Where a member's capture has
+nothing to say inside that member's own band, the group has no honest level
+there and the frequency is left out of both sides of the comparison; a group
+whose captures cannot produce the figure at all — a member without one (an
+array set may have gaps), or no shared data across the band — keeps its
 point-measured row whole, marked in the tooltip. The Groups view exists
 for exactly that adjustment, which is why it draws the sums rather than the
 drivers: all its lines are gated on one shared anchor, so their relative timing

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2017,7 +2017,13 @@ inaudible there, and takes the point with it when it says the channel is still
 playing.
 
 Everything else keeps reading the impulse responses: timing, polarity, the
-junction analyses, Auto delay, the sum-loss read-out and the phase view. The
+junction analyses, Auto delay, the sum-loss read-out and the phase view. The one
+read-out that follows the hybrid is the **Level Δ L−R** rows of the
+[Δ L−R block](#the-panel-gates-plots-and-read-outs): a level is exactly what the
+captures replace, so while the mode is on those rows compare the sides' spatial
+averages through their chains — under the same one-set condition as the dashed
+opposite-side Sum, and whatever Show view happens to be on screen, because the
+levels a gain trim is judged against do not change with the view. The
 toggle needs an average on **every** channel that plays and greys out otherwise,
 since a sum mixing spatially averaged channels with point-measured ones puts two
 references on one axis and still looks like a measurement. The opposite side's
@@ -2199,7 +2205,15 @@ from. A **Δ L−R** block
 below reports each pair's inter-side state — the two sides' band-limited envelope
 arrivals with their difference (positive means the right side leads, the scene
 offset's convention), plus a **Level Δ L−R** row for the by-ear gain trim that
-finishes the centering.
+finishes the centering. Those level rows normally read the gated band level of the
+processed impulse responses; with the
+[hybrid](#hybrid-spatial-averages-under-the-prediction) mode on they compare the
+sides' spatial averages through their chains instead — the levels that mode draws
+and tunes against, free of one microphone position's dips — provided both sides'
+captures form one set (the dashed opposite-side Sum's condition; separate sets
+cannot be levelled against each other without erasing the very imbalance the row
+reports). The tooltip legend says which measurement the rows read, and marks a
+pair that had to stay point-measured — an array set may have gaps.
 
 Editing a chain recomputes the prediction on a background task, so dragging a
 value stays responsive with several channels loaded. The **Mic cal** selector

--- a/source/LiveSpectrum/SpatialAverageHybrid.cs
+++ b/source/LiveSpectrum/SpatialAverageHybrid.cs
@@ -179,6 +179,56 @@ internal static class SpatialAverageHybrid
             : null;
     }
 
+    /// <summary>
+    /// Several channels' hybrid curves on ONE grid combined into a group's level
+    /// curve by adding their POWERS point by point. A point where no member has a
+    /// value is a gap; a member's own gap simply contributes nothing there — its
+    /// crossover has removed it from the group's output anyway.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not the phasor sum the plot's hybrid Sum uses: a spatial
+    /// average carries no phase, so the only sum a set of captures can state by
+    /// themselves is the incoherent one. What this figure feeds — a LEVEL over a
+    /// band spanning octaves — barely tells the two apart: the coherent
+    /// cross-terms live in the junction overlaps, a fraction of the band, and
+    /// they appear on both sides of a group to group comparison. Borrowing the
+    /// point-measured phase to resolve them would put one microphone position's
+    /// interference back into the very numbers the hybrid mode exists to free of
+    /// it, at the price of full-length gated FFTs per group per frame.
+    /// </remarks>
+    public static List<SignalPoint> PowerSum(
+        IReadOnlyList<IReadOnlyList<SignalPoint>> curves)
+    {
+        ArgumentNullException.ThrowIfNull(curves);
+        if (curves.Count == 0)
+        {
+            return [];
+        }
+
+        int count = curves.Min(curve => curve.Count);
+        var points = new List<SignalPoint>(count);
+        for (int i = 0; i < count; i++)
+        {
+            double power = 0;
+            bool any = false;
+            foreach (IReadOnlyList<SignalPoint> curve in curves)
+            {
+                double db = curve[i].Y;
+                if (double.IsFinite(db))
+                {
+                    power += Math.Pow(10.0, db / 10.0);
+                    any = true;
+                }
+            }
+
+            points.Add(new SignalPoint(
+                curves[0][i].X,
+                any ? 10.0 * Math.Log10(power) : double.NaN));
+        }
+
+        return points;
+    }
+
     // The capture back at the level the analyzer measured, before any microphone
     // correction: the pipeline SUBTRACTS the correction, so undoing it adds it back.
     // On the capture's own grid, where each stored value belongs.

--- a/source/LiveSpectrum/SpatialAverageHybrid.cs
+++ b/source/LiveSpectrum/SpatialAverageHybrid.cs
@@ -133,6 +133,52 @@ internal static class SpatialAverageHybrid
         return smoothed;
     }
 
+    /// <summary>
+    /// How much louder the first curve is than the second over the band they share,
+    /// in dB: the mean of the point POWERS on each curve over the indices where BOTH
+    /// are finite, converted back to dB once. Null when no point is finite on both.
+    /// </summary>
+    /// <remarks>
+    /// The energy-mean rule is the one the impulse-response band level uses
+    /// (<c>VirtualCrossoverAnalysis.MeasureBandLevelDb</c>): averaging power lets the
+    /// figure track loudness and shrug off narrow dips, where a dB mean would follow
+    /// them down. That method weights its linear-spaced bins by 1/f; on the
+    /// log-spaced grid these curves are built on, uniform weights say the same thing.
+    /// The two curves must share one grid, and the points are paired on purpose: a
+    /// gap on either side (a protective high-pass, the end of a capture's grid)
+    /// removes that frequency from BOTH, rather than comparing one side's band
+    /// against a different part of the other's.
+    /// </remarks>
+    public static double? BandLevelDeltaDb(
+        IReadOnlyList<SignalPoint> left,
+        IReadOnlyList<SignalPoint> right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+        int count = Math.Min(left.Count, right.Count);
+        double leftPower = 0;
+        double rightPower = 0;
+        for (int i = 0; i < count; i++)
+        {
+            double leftDb = left[i].Y;
+            double rightDb = right[i].Y;
+            if (!double.IsFinite(leftDb) || !double.IsFinite(rightDb))
+            {
+                continue;
+            }
+
+            leftPower += Math.Pow(10.0, leftDb / 10.0);
+            rightPower += Math.Pow(10.0, rightDb / 10.0);
+        }
+
+        // Both sums count the same points, so one ratio is the difference of the
+        // two means; a zero says no shared point (or a level beyond any real dB
+        // scale), and either way there is nothing honest to report.
+        return leftPower > 0 && rightPower > 0
+            ? 10.0 * Math.Log10(leftPower / rightPower)
+            : null;
+    }
+
     // The capture back at the level the analyzer measured, before any microphone
     // correction: the pipeline SUBTRACTS the correction, so undoing it adds it back.
     // On the capture's own grid, where each stored value belongs.

--- a/source/LiveSpectrum/SpatialAverageHybrid.cs
+++ b/source/LiveSpectrum/SpatialAverageHybrid.cs
@@ -181,25 +181,44 @@ internal static class SpatialAverageHybrid
 
     /// <summary>
     /// Several channels' hybrid curves on ONE grid combined into a group's level
-    /// curve by adding their POWERS point by point. A point where no member has a
-    /// value is a gap; a member's own gap simply contributes nothing there — its
-    /// crossover has removed it from the group's output anyway.
+    /// curve by adding their POWERS point by point. Each curve comes with its
+    /// channel's configured band, which separates the two things a member's gap
+    /// can mean. OUTSIDE its band a NaN is an absent contribution — the
+    /// crossover has removed that driver from the group's output, and the rest
+    /// carry on without it. INSIDE its band it means the capture has nothing to
+    /// say about a driver the DSP says is playing — its grid ended, a stretch
+    /// did not survive the protective high-pass — and the whole group point
+    /// becomes a gap: summing the remaining members would quote part of the
+    /// group as all of it, an error that looks exactly like a valid level. A
+    /// band-level read then pairs such a point away from both sides of a
+    /// comparison instead.
     /// </summary>
     /// <remarks>
     /// Deliberately not the phasor sum the plot's hybrid Sum uses: a spatial
     /// average carries no phase, so the only sum a set of captures can state by
-    /// themselves is the incoherent one. What this figure feeds — a LEVEL over a
-    /// band spanning octaves — barely tells the two apart: the coherent
-    /// cross-terms live in the junction overlaps, a fraction of the band, and
-    /// they appear on both sides of a group to group comparison. Borrowing the
-    /// point-measured phase to resolve them would put one microphone position's
-    /// interference back into the very numbers the hybrid mode exists to free of
-    /// it, at the price of full-length gated FFTs per group per frame.
+    /// themselves is the incoherent one. In a junction overlap that is an
+    /// approximation — two coherent in-phase contributions sum up to 3 dB above
+    /// their powers — and how much of it survives a group-to-group DIFFERENCE
+    /// depends on how alike the groups' junction layouts are: much cancels
+    /// between a front and a rear of the same architecture, little is
+    /// guaranteed against a single-driver centre. The overlaps are still a
+    /// fraction of a band spanning octaves, and resolving them would borrow the
+    /// point-measured phase — one microphone position's interference, the very
+    /// thing the hybrid mode distrusts — at the price of full-length gated FFTs
+    /// per group per frame.
     /// </remarks>
     public static List<SignalPoint> PowerSum(
-        IReadOnlyList<IReadOnlyList<SignalPoint>> curves)
+        IReadOnlyList<IReadOnlyList<SignalPoint>> curves,
+        IReadOnlyList<(double LowHz, double HighHz)> bands)
     {
         ArgumentNullException.ThrowIfNull(curves);
+        ArgumentNullException.ThrowIfNull(bands);
+        if (curves.Count != bands.Count)
+        {
+            throw new ArgumentException(
+                "Every curve needs its channel's band.", nameof(bands));
+        }
+
         if (curves.Count == 0)
         {
             return [];
@@ -209,21 +228,31 @@ internal static class SpatialAverageHybrid
         var points = new List<SignalPoint>(count);
         for (int i = 0; i < count; i++)
         {
+            double x = curves[0][i].X;
             double power = 0;
             bool any = false;
-            foreach (IReadOnlyList<SignalPoint> curve in curves)
+            bool missing = false;
+            for (int c = 0; c < curves.Count; c++)
             {
-                double db = curve[i].Y;
+                double db = curves[c][i].Y;
                 if (double.IsFinite(db))
                 {
+                    // A finite value counts wherever it sits — a crossover
+                    // skirt outside the configured band is a real, if quiet,
+                    // contribution.
                     power += Math.Pow(10.0, db / 10.0);
                     any = true;
+                }
+                else if (x >= bands[c].LowHz && x <= bands[c].HighHz)
+                {
+                    missing = true;
+                    break;
                 }
             }
 
             points.Add(new SignalPoint(
-                curves[0][i].X,
-                any ? 10.0 * Math.Log10(power) : double.NaN));
+                x,
+                any && !missing ? 10.0 * Math.Log10(power) : double.NaN));
         }
 
         return points;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
@@ -241,9 +241,10 @@ internal static class VirtualCrossoverMetric
                     "view draws \u2014 so one microphone position's dips " +
                     "have no say in it\r\n(positive: LEFT louder)." +
                     (anyPointLevel
-                        ? " (point mic): that pair has no capture on a side, " +
-                            "so its row\r\nstill reads the gated processed " +
-                            "responses."
+                        ? " (point mic): that pair's captures cannot produce " +
+                            "the figure — a side\r\nwithout one, or no shared " +
+                            "data in this band — so its row still reads " +
+                            "the\r\ngated processed responses."
                         : string.Empty)
                 : "\r\nLevel \u0394 is the gated band level of the processed " +
                     "sides (positive: LEFT louder).") +
@@ -360,8 +361,9 @@ internal static class VirtualCrossoverMetric
                 "chains (each group power-summed — an average carries no " +
                 "phase), so one microphone position's dips have no say in " +
                 "them; the arrivals keep reading the impulse responses. A row " +
-                "marked (point mic) has a member without a capture and still " +
-                "reads the gated processed responses.");
+                "marked (point mic) could not be read from the captures — a " +
+                "member without one, or no shared capture data across the " +
+                "band — and still reads the gated processed responses.");
         }
 
         return builder.ToString();

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
@@ -76,7 +76,10 @@ internal static class VirtualCrossoverMetric
     /// delays included) in the pair's shared band, in ms from the transfer
     /// IR start, plus the sides' gated band-level difference in dB. A side's
     /// arrival is null when it is unmeasurable or unreliable (a silent band,
-    /// a near-noise record); the level delta is null under the same gate.
+    /// a near-noise record); the level delta is null under the same gate —
+    /// unless it came from the spatial averages (see
+    /// <see cref="LevelFromSpatialAverage"/>), which are measurements of
+    /// their own and stand whatever the impulse responses' noise says.
     /// The timing delta is left minus right, so positive means the RIGHT
     /// side leads — the same sign convention as the Auto delay scene offset,
     /// so after a stereo run every row should read the offset. The level
@@ -95,7 +98,14 @@ internal static class VirtualCrossoverMetric
         // rerun here): its number is real but compares a different feature, so
         // the row's Δ overstates the true skew and renders with a "~".
         bool LeftLatched = false,
-        bool RightLatched = false)
+        bool RightLatched = false,
+        // With the hybrid view on, the level delta compares the sides'
+        // spatial averages through their chains — the levels that view draws
+        // and the tune is judged on — instead of the gated point-measured
+        // responses. Timing stays on the impulse responses either way (a
+        // spatial average carries no phase); only the legend changes with
+        // this flag.
+        bool LevelFromSpatialAverage = false)
     {
         public double? DeltaMs => LeftMs.HasValue && RightMs.HasValue
             ? LeftMs.Value - RightMs.Value
@@ -173,6 +183,14 @@ internal static class VirtualCrossoverMetric
                 ? (latched ? "~" : string.Empty) + $"{value.Value:0.000}"
                 : "\u2014";
 
+        // Which measurement the level rows read, so the legend can say so. A
+        // mixed list is legitimate under the array method (a channel without
+        // an array keeps its point measurement), and there the exception rows
+        // are the point-measured ones, and each is marked in place.
+        bool anySpatialLevel = deltas.Any(delta => delta.LevelFromSpatialAverage);
+        bool anyPointLevel = deltas.Any(delta =>
+            delta.LevelDeltaDb.HasValue && !delta.LevelFromSpatialAverage);
+
         return "Final envelope arrivals of the processed sides (ms from the " +
             "IR start, delays\r\nincluded) and \u0394 L\u2212R (positive: right leads; " +
             "after a stereo Auto delay every\r\nchannel should read the scene " +
@@ -189,7 +207,13 @@ internal static class VirtualCrossoverMetric
                         $"{delta.DeltaMs.Value:+0.000;-0.000;0.000} ms"
                     : "\u2014";
                 string levelText = delta.LevelDeltaDb.HasValue
-                    ? $", level {delta.LevelDeltaDb.Value:+0.0;-0.0;0.0} dB"
+                    ? $", level {delta.LevelDeltaDb.Value:+0.0;-0.0;0.0} dB" +
+                        // The odd one out in a spatial-average list: this pair
+                        // had no capture to read, so its level is still the
+                        // point measurement and must not pass for the rest.
+                        (anySpatialLevel && !delta.LevelFromSpatialAverage
+                            ? " (point mic)"
+                            : string.Empty)
                     : string.Empty;
                 return $"{delta.Channel}: L {Side(delta.LeftMs, delta.LeftLatched)} / " +
                     $"R {Side(delta.RightMs, delta.RightLatched)} ms, " +
@@ -207,8 +231,19 @@ internal static class VirtualCrossoverMetric
                 : string.Empty) +
             "\r\nLow-band envelopes rise slowly, so the lowest rows carry " +
             "extra tolerance (a fraction of a millisecond is noise there)." +
-            "\r\nLevel \u0394 is the gated band level of the processed sides " +
-            "(positive: LEFT louder).\r\nTrim the louder side's gain by ear " +
+            (anySpatialLevel
+                ? "\r\nLevel \u0394 compares the sides' spatial averages " +
+                    "through their chains \u2014 the levels\r\nthe hybrid " +
+                    "view draws \u2014 so one microphone position's dips " +
+                    "have no say in it\r\n(positive: LEFT louder)." +
+                    (anyPointLevel
+                        ? " (point mic): that pair has no capture on a side, " +
+                            "so its row\r\nstill reads the gated processed " +
+                            "responses."
+                        : string.Empty)
+                : "\r\nLevel \u0394 is the gated band level of the processed " +
+                    "sides (positive: LEFT louder).") +
+            "\r\nTrim the louder side's gain by ear " +
             "to center the image alongside the timing \u2014\r\na single " +
             "microphone underestimates the binaural difference (no head " +
             "shadow).";

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
@@ -197,15 +197,6 @@ internal static class VirtualCrossoverMetric
             "offset)\r\n" +
             string.Join("\r\n", deltas.Select(delta =>
             {
-                if (!delta.LeftMs.HasValue && !delta.RightMs.HasValue)
-                {
-                    return $"{delta.Channel}: \u2014 (no measurable arrival)";
-                }
-
-                string deltaText = delta.DeltaMs.HasValue
-                    ? (delta.AnyLatched ? "~" : string.Empty) +
-                        $"{delta.DeltaMs.Value:+0.000;-0.000;0.000} ms"
-                    : "\u2014";
                 string levelText = delta.LevelDeltaDb.HasValue
                     ? $", level {delta.LevelDeltaDb.Value:+0.0;-0.0;0.0} dB" +
                         // The odd one out in a spatial-average list: this pair
@@ -215,6 +206,19 @@ internal static class VirtualCrossoverMetric
                             ? " (point mic)"
                             : string.Empty)
                     : string.Empty;
+                if (!delta.LeftMs.HasValue && !delta.RightMs.HasValue)
+                {
+                    // A spatial-average level outlives the arrivals (a capture
+                    // is a measurement of its own), so the row must not drop
+                    // it: the compact block beside this tooltip still shows it.
+                    return $"{delta.Channel}: \u2014 (no measurable arrival)" +
+                        levelText;
+                }
+
+                string deltaText = delta.DeltaMs.HasValue
+                    ? (delta.AnyLatched ? "~" : string.Empty) +
+                        $"{delta.DeltaMs.Value:+0.000;-0.000;0.000} ms"
+                    : "\u2014";
                 return $"{delta.Channel}: L {Side(delta.LeftMs, delta.LeftLatched)} / " +
                     $"R {Side(delta.RightMs, delta.RightLatched)} ms, " +
                     $"\u0394 {deltaText}{levelText} " +
@@ -268,13 +272,20 @@ internal static class VirtualCrossoverMetric
     /// precedence effect keeps the image forward) and what a centre does not.
     /// <see cref="LevelDb"/> is likewise the group minus the front, so negative
     /// means quieter. Either is null when the band holds no reliable arrival.
+    /// <para>
+    /// <see cref="LevelFromSpatialAverage"/> plays the same role as on
+    /// <see cref="StereoDelta"/>: with the hybrid mode on the level compares the
+    /// two groups' spatial averages through their chains, and only the legend
+    /// changes with the flag — the arrival keeps reading the impulse responses.
+    /// </para>
     /// </remarks>
     internal readonly record struct GroupDelta(
         VirtualCrossoverZone Zone,
         double? DelayMs,
         double? LevelDb,
         double LowHz,
-        double HighHz);
+        double HighHz,
+        bool LevelFromSpatialAverage = false);
 
     /// <summary>
     /// The cross-group block for the read-out panel: one row per compared group.
@@ -307,6 +318,10 @@ internal static class VirtualCrossoverMetric
             return string.Empty;
         }
 
+        // The same basis story the stereo block tells (see
+        // FormatStereoDeltasDetail): a spatial list explains itself, and its
+        // point-measured exceptions are marked in place.
+        bool anySpatialLevel = deltas.Any(delta => delta.LevelFromSpatialAverage);
         var builder = new System.Text.StringBuilder(
             "Each group against the front stage, measured on their summed " +
             "responses in the band they share. No summation loss is quoted " +
@@ -328,9 +343,25 @@ internal static class VirtualCrossoverMetric
             {
                 builder.Append($", {Math.Abs(db):0.0} dB ");
                 builder.Append(db < 0 ? "quieter" : "louder");
+                if (anySpatialLevel && !delta.LevelFromSpatialAverage)
+                {
+                    builder.Append(" (point mic)");
+                }
             }
 
             builder.Append('.');
+        }
+
+        if (anySpatialLevel)
+        {
+            builder.AppendLine();
+            builder.Append(
+                "Levels compare the groups' spatial averages through their " +
+                "chains (each group power-summed — an average carries no " +
+                "phase), so one microphone position's dips have no say in " +
+                "them; the arrivals keep reading the impulse responses. A row " +
+                "marked (point mic) has a member without a capture and still " +
+                "reads the gated processed responses.");
         }
 
         return builder.ToString();

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -589,10 +589,21 @@ internal sealed class VirtualCrossoverMetrics
     /// passes the current view's zones: a front view listing the rear pair's L/R
     /// skew is the read-out describing a set the plot does not draw.
     /// </param>
+    /// <param name="hybridLevelDeltaDb">
+    /// A pair's L−R level read off the sides' spatial averages through their
+    /// chains, in the given band, or null where the captures cannot say
+    /// (a side without one, no overlap). Supplied by the panel while the
+    /// hybrid mode is on — the levels the tuner is judging the tune on are
+    /// then the captures', so the read-out follows them; the timing keeps
+    /// reading the impulse responses either way (an average carries no
+    /// phase). Invoked during the synchronous job assembly, so it may read
+    /// UI-thread state.
+    /// </param>
     public async Task<List<VirtualCrossoverMetric.StereoDelta>> ComputeStereoDeltasAsync(
         IReadOnlyList<VirtualCrossoverChannel> channels,
         long revision,
-        Func<VirtualCrossoverChannelPairSettings, bool>? includePair = null)
+        Func<VirtualCrossoverChannelPairSettings, bool>? includePair = null,
+        Func<VirtualCrossoverChannel, double, double, double?>? hybridLevelDeltaDb = null)
     {
         var jobs = new List<StereoDeltaJob>();
         int nextId = 0;
@@ -676,7 +687,11 @@ internal sealed class VirtualCrossoverMetrics
                 highHz,
                 leftJob,
                 rightJob,
-                mono));
+                mono,
+                // Read here, on the calling thread, never in the auxiliary
+                // pass below: the captures and chains are UI-thread state. A
+                // mono channel has no L−R to speak of, so it is never asked.
+                mono ? null : hybridLevelDeltaDb?.Invoke(channel, lowHz, highHz)));
         }
 
         List<SideProcessJob> sides = jobs.SelectMany(job => job.Sides).ToList();
@@ -799,19 +814,26 @@ internal sealed class VirtualCrossoverMetrics
 
                 TimeAlignmentAnalysisResult right = job.Right.Arrival!.Value;
                 bool rightReliable = Reliable(right);
+                // The spatial averages' level, where the panel supplied one,
+                // outranks the point measurement AND its reliability gate: a
+                // capture is a measurement of its own, and a noisy impulse
+                // response says nothing against it.
+                double? levelDelta = job.HybridLevelDeltaDb ??
+                    (leftReliable && rightReliable &&
+                    job.Left.LevelDb is { } leftLevel &&
+                    job.Right.LevelDb is { } rightLevel
+                        ? leftLevel - rightLevel
+                        : null);
                 return new VirtualCrossoverMetric.StereoDelta(
                     job.Channel,
                     leftMs,
                     rightReliable ? right.FirstArrivalDelayMilliseconds : null,
                     job.LowHz,
                     job.HighHz,
-                    leftReliable && rightReliable &&
-                    job.Left.LevelDb is { } leftLevel &&
-                    job.Right.LevelDb is { } rightLevel
-                        ? leftLevel - rightLevel
-                        : null,
+                    levelDelta,
                     LeftLatched: job.Left.Latched,
-                    RightLatched: job.Right.Latched);
+                    RightLatched: job.Right.Latched,
+                    LevelFromSpatialAverage: job.HybridLevelDeltaDb.HasValue);
             })
             .ToList();
     }
@@ -1001,7 +1023,11 @@ internal sealed class VirtualCrossoverMetrics
         double HighHz,
         SideProcessJob Left,
         SideProcessJob Right,
-        bool Mono = false)
+        bool Mono = false,
+        // The pair's L−R level off the sides' spatial averages, resolved at
+        // assembly time (see ComputeStereoDeltasAsync); null when the hybrid
+        // is off or the captures cannot produce one.
+        double? HybridLevelDeltaDb = null)
     {
         // A mono job's Left and Right are the same instance; iterate the left
         // slot alone so the shared response is processed once.

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -314,10 +314,21 @@ internal sealed class VirtualCrossoverMetrics
     /// the stereo deltas do, and is remembered between frames by
     /// <see cref="groupDeltas"/> exactly as their arrivals are.
     /// </remarks>
+    /// <param name="hybridGroupLevelDeltaDb">
+    /// A compared group's level against the front, read off both groups'
+    /// spatial averages through their chains in the shared band, or null where
+    /// the captures cannot say (a member without one). Supplied by the panel
+    /// while the hybrid mode is on, the same contract as the stereo block's
+    /// reader: invoked during the synchronous assembly, so it may read
+    /// UI-thread state, and its answer joins the cache key — a toggle of the
+    /// hybrid must not be served a remembered point-measured set.
+    /// </param>
     public async Task<IReadOnlyList<VirtualCrossoverMetric.GroupDelta>> ComputeGroupDeltasAsync(
         IReadOnlyList<ProcessedChannel> shown,
         VirtualCrossoverGroupView view,
-        long revision)
+        long revision,
+        Func<IReadOnlyList<ProcessedChannel>, IReadOnlyList<ProcessedChannel>,
+            double, double, double?>? hybridGroupLevelDeltaDb = null)
     {
         IReadOnlyList<VirtualCrossoverZone> compared =
             VirtualCrossoverGroupViews.ComparedAgainstFront(view);
@@ -345,11 +356,20 @@ internal sealed class VirtualCrossoverMetrics
                 // cache key below can carry it: two groups timed over different
                 // spans are two different answers even from the same responses.
                 (double zoneLow, double zoneHigh) = GroupBand(members);
+                double lowHz = Math.Max(frontLow, zoneLow);
+                double highHz = Math.Min(frontHigh, zoneHigh);
                 jobs.Add(new GroupDeltaJob(
                     zone,
                     members,
-                    Math.Max(frontLow, zoneLow),
-                    Math.Min(frontHigh, zoneHigh)));
+                    lowHz,
+                    highHz,
+                    // Read here, on the calling thread — captures, chains and
+                    // calibration are UI-thread state. A band the worker will
+                    // refuse to time is not asked either: that row stays the
+                    // all-null refusal it always was.
+                    highHz >= lowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio
+                        ? hybridGroupLevelDeltaDb?.Invoke(members, front, lowHz, highHz)
+                        : null));
             }
         }
 
@@ -426,10 +446,15 @@ internal sealed class VirtualCrossoverMetrics
                             ? zoneArrival.FirstArrivalDelayMilliseconds -
                                 frontRead.Arrival.FirstArrivalDelayMilliseconds
                             : null,
-                        VirtualCrossoverAnalysis.MeasureBandLevelDb(
-                            zoneIr, sampleRate, lowHz, highHz) - frontRead.LevelDb,
+                        // The spatial averages' level, where the panel supplied
+                        // one, outranks the point measurement — the same rule
+                        // as the stereo block's rows.
+                        job.HybridLevelDeltaDb ??
+                            VirtualCrossoverAnalysis.MeasureBandLevelDb(
+                                zoneIr, sampleRate, lowHz, highHz) - frontRead.LevelDb,
                         lowHz,
-                        highHz));
+                        highHz,
+                        LevelFromSpatialAverage: job.HybridLevelDeltaDb.HasValue));
                 }
 
                 return results;
@@ -456,7 +481,11 @@ internal sealed class VirtualCrossoverMetrics
         VirtualCrossoverZone Zone,
         List<ProcessedChannel> Members,
         double LowHz,
-        double HighHz);
+        double HighHz,
+        // The group's level against the front off the spatial averages,
+        // resolved at assembly time (see ComputeGroupDeltasAsync); null when
+        // the hybrid is off or the captures cannot produce one.
+        double? HybridLevelDeltaDb = null);
 
     /// <summary>
     /// What a set of group Δs is a function of: which processed responses each
@@ -485,7 +514,8 @@ internal sealed class VirtualCrossoverMetrics
             this.jobs =
             [
                 .. jobs.Select(job => new JobKey(
-                    job.Zone, Responses(job.Members), job.LowHz, job.HighHz))
+                    job.Zone, Responses(job.Members), job.LowHz, job.HighHz,
+                    job.HybridLevelDeltaDb))
             ];
             this.sampleRate = sampleRate;
         }
@@ -501,9 +531,19 @@ internal sealed class VirtualCrossoverMetrics
 
             for (int i = 0; i < jobs.Length; i++)
             {
+                // The hybrid level is part of the answer, not only of the
+                // inputs: the responses stand still while the hybrid is
+                // toggled (or a capture, chain or calibration moves its
+                // figure), and a remembered point-measured set must not
+                // answer for the capture-based one or vice versa. Nullable
+                // equality is exact here — the same inputs reproduce the
+                // same bits.
                 if (jobs[i].Zone != other.jobs[i].Zone ||
                     jobs[i].LowHz != other.jobs[i].LowHz ||
                     jobs[i].HighHz != other.jobs[i].HighHz ||
+                    !Nullable.Equals(
+                        jobs[i].HybridLevelDeltaDb,
+                        other.jobs[i].HybridLevelDeltaDb) ||
                     !SameResponses(jobs[i].Members, other.jobs[i].Members))
                 {
                     return false;
@@ -517,7 +557,8 @@ internal sealed class VirtualCrossoverMetrics
             VirtualCrossoverZone Zone,
             Complex[][] Members,
             double LowHz,
-            double HighHz);
+            double HighHz,
+            double? HybridLevelDeltaDb);
 
         private static Complex[][] Responses(IReadOnlyList<ProcessedChannel> members) =>
             [.. members.Select(item => item.ImpulseResponse)];

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.SpatialAverage.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.SpatialAverage.cs
@@ -535,6 +535,86 @@ public partial class VirtualCrossoverPanel
             smoothingCode: 0);
     }
 
+    /// <summary>
+    /// The "vs Front" read-out's level source while the hybrid mode is on, or
+    /// null to leave those rows on their gated point-measured levels: a compared
+    /// group's ΔdB against the front is then read off both groups' spatial
+    /// averages through their chains, each group power-summed (see
+    /// <see cref="SpatialAverageHybrid.PowerSum"/> for why not phasors).
+    /// </summary>
+    /// <remarks>
+    /// Follows the mode rather than the view for the reason
+    /// <see cref="HybridStereoLevelReader"/> does. The condition is the ACTIVE
+    /// side's coverage alone — both groups sit on the same side, so the set
+    /// offset is one figure and cancels out of the difference; nothing here
+    /// compares across the sides, and the stereo reader's one-set-of-both-sides
+    /// check would refuse comparisons it has no stake in.
+    /// </remarks>
+    private Func<IReadOnlyList<ProcessedChannel>, IReadOnlyList<ProcessedChannel>,
+        double, double, double?>? HybridGroupLevelReader() =>
+        checkBoxHybrid.Checked && hybridAvailable
+            ? HybridGroupLevelDeltaDb
+            : null;
+
+    // One compared group's level against the front, both groups' member curves
+    // built on ONE grid so the band-level rule can pair their points. Null when
+    // any member of either group has no capture (an array set may have gaps):
+    // power-summing the rest would understate that group by a playing member,
+    // so the row falls back to its point-measured level whole and says so.
+    private double? HybridGroupLevelDeltaDb(
+        IReadOnlyList<ProcessedChannel> members,
+        IReadOnlyList<ProcessedChannel> front,
+        double lowHz,
+        double highHz)
+    {
+        List<double> grid = HybridLevelGrid(lowHz, highHz);
+        List<SignalPoint>? zoneCurve = BuildHybridGroupPowerCurve(members, grid);
+        List<SignalPoint>? frontCurve = BuildHybridGroupPowerCurve(front, grid);
+        return zoneCurve == null || frontCurve == null
+            ? null
+            : SpatialAverageHybrid.BandLevelDeltaDb(zoneCurve, frontCurve);
+    }
+
+    private List<SignalPoint>? BuildHybridGroupPowerCurve(
+        IReadOnlyList<ProcessedChannel> members, List<double> grid)
+    {
+        // The shown set is the ACTIVE side's processed responses, so the
+        // captures are that side's too; SideState routes a mono member (a mono
+        // centre is legitimate) to its single slot the way the plot does.
+        bool rightSide = project.ActiveSideRight;
+        var curves = new List<IReadOnlyList<SignalPoint>>(members.Count);
+        foreach (ProcessedChannel member in members)
+        {
+            VirtualCrossoverChannelState state =
+                member.Channel.SideState(rightSide);
+            if (state.SpatialAverageFor(SpatialAverageMode) is not { } document)
+            {
+                return null;
+            }
+
+            IReadOnlyList<SignalPoint>? curve = SpatialAverageHybrid.BuildChannelCurve(
+                document,
+                // Bypassed members DO reach the grouped read-outs (unlike the
+                // stereo block, which skips the pair), contributing their raw
+                // measured signal — the same rule the plot applies.
+                member.Channel.Pair.Bypass
+                    ? DspChannelChain.Identity
+                    : member.Channel.SideSettings(rightSide).ToChain(),
+                member.Channel.ProcessorSampleRateFor(rightSide),
+                SpatialAverageCalibrationFor(state),
+                grid,
+                smoothingCode: 0);
+            if (curve == null)
+            {
+                return null;
+            }
+
+            curves.Add(curve);
+        }
+
+        return SpatialAverageHybrid.PowerSum(curves);
+    }
+
     // Log-spaced through the band at a resolution comfortably past the captures'
     // own (~1/48 octave): the figure is an energy mean of a smooth curve, and a
     // log grid with uniform weights is what reproduces the impulse-response band
@@ -717,9 +797,10 @@ public partial class VirtualCrossoverPanel
                     "measured at one point. Both sums follow, adding the channels as " +
                     "phasors with the phase the impulse responses measure — the other " +
                     "side needs its own captures too, and its dashed sum is dropped " +
-                    "rather than drawn by the other method. The read-out's Level " +
-                    "Δ L−R rows follow too, comparing the sides' captures under the " +
-                    "same condition. Timing, polarity and the " +
+                    "rather than drawn by the other method. The read-out's level " +
+                    "rows follow too: Level Δ L−R compares the sides' captures " +
+                    "under the same condition, and the vs Front ΔdB compares the " +
+                    "groups'. Timing, polarity and the " +
                     "sum-loss read-out are " +
                     "unaffected: they keep reading the impulse responses.\r\n\r\n" +
                     "The channel curves are exact — a filter does not depend on " +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.SpatialAverage.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.SpatialAverage.cs
@@ -558,9 +558,11 @@ public partial class VirtualCrossoverPanel
 
     // One compared group's level against the front, both groups' member curves
     // built on ONE grid so the band-level rule can pair their points. Null when
-    // any member of either group has no capture (an array set may have gaps):
-    // power-summing the rest would understate that group by a playing member,
-    // so the row falls back to its point-measured level whole and says so.
+    // any member of either group has no capture at all (an array set may have
+    // gaps) — power-summing the rest would understate that group by a playing
+    // member — and when the captures leave no point in the band where both
+    // groups have a value; either way the row falls back to its point-measured
+    // level whole and says so.
     private double? HybridGroupLevelDeltaDb(
         IReadOnlyList<ProcessedChannel> members,
         IReadOnlyList<ProcessedChannel> front,
@@ -583,6 +585,7 @@ public partial class VirtualCrossoverPanel
         // centre is legitimate) to its single slot the way the plot does.
         bool rightSide = project.ActiveSideRight;
         var curves = new List<IReadOnlyList<SignalPoint>>(members.Count);
+        var bands = new List<(double LowHz, double HighHz)>(members.Count);
         foreach (ProcessedChannel member in members)
         {
             VirtualCrossoverChannelState state =
@@ -610,9 +613,15 @@ public partial class VirtualCrossoverPanel
             }
 
             curves.Add(curve);
+            // The member's configured band, for the sum's two readings of a
+            // gap (see PowerSum): inside it a capture with nothing to say
+            // breaks the GROUP's point, outside it the member is simply
+            // absent. The same band rule GroupBand keyed the comparison on.
+            bands.Add(VirtualCrossoverJunctions.GetChannelBand(
+                member.Channel.SideSettings(rightSide)));
         }
 
-        return SpatialAverageHybrid.PowerSum(curves);
+        return SpatialAverageHybrid.PowerSum(curves, bands);
     }
 
     // Log-spaced through the band at a resolution comfortably past the captures'

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.SpatialAverage.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.SpatialAverage.cs
@@ -613,16 +613,35 @@ public partial class VirtualCrossoverPanel
             }
 
             curves.Add(curve);
-            // The member's configured band, for the sum's two readings of a
-            // gap (see PowerSum): inside it a capture with nothing to say
-            // breaks the GROUP's point, outside it the member is simply
-            // absent. The same band rule GroupBand keyed the comparison on.
-            bands.Add(VirtualCrossoverJunctions.GetChannelBand(
-                member.Channel.SideSettings(rightSide)));
+            bands.Add(HybridGroupMemberBand(member.Channel, rightSide));
         }
 
         return SpatialAverageHybrid.PowerSum(curves, bands);
     }
+
+    /// <summary>
+    /// The band a group member is expected to PLAY in — what separates a
+    /// capture's silence from an absent driver in the group power sum (see
+    /// <see cref="SpatialAverageHybrid.PowerSum"/>): inside it a capture with
+    /// nothing to say breaks the group's point, outside it the member is simply
+    /// absent.
+    /// </summary>
+    /// <remarks>
+    /// Normally the configured crossover band, the same rule the comparison's
+    /// own span is keyed on. A BYPASSED member is the exception the review
+    /// caught: its chain is Identity, so it plays its raw full-range response
+    /// wherever its measurement reaches — the configured corners it is not
+    /// running say nothing about where it is present, and reading them here
+    /// turned "the capture does not know" below an idle high-pass back into
+    /// "the driver is absent", the very confusion the band exists to prevent.
+    /// Static and pure so the rule can be pinned without a panel.
+    /// </remarks>
+    internal static (double LowHz, double HighHz) HybridGroupMemberBand(
+        VirtualCrossoverChannel channel, bool rightSide) =>
+        channel.Pair.Bypass
+            ? (20.0, 20_000.0)
+            : VirtualCrossoverJunctions.GetChannelBand(
+                channel.SideSettings(rightSide));
 
     // Log-spaced through the band at a resolution comfortably past the captures'
     // own (~1/48 octave): the figure is an energy mean of a smooth curve, and a

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.SpatialAverage.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.SpatialAverage.cs
@@ -464,6 +464,96 @@ public partial class VirtualCrossoverPanel
     }
 
     /// <summary>
+    /// The Δ L−R read-out's level source while the hybrid mode is on, or null to
+    /// leave that read-out on its gated point-measured levels: a pair's L−R level
+    /// is then read off the two sides' spatial averages through their chains, in
+    /// the pair's shared band — the levels the hybrid view draws and the levels a
+    /// gain trim is being judged against.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately the hybrid INTENT plus coverage rather than
+    /// <see cref="HybridRequested"/>: that flag follows the current Show view, and
+    /// a level that flipped basis when the user glanced at the phase view would
+    /// read as two different imbalances in one tune. The captures do not stop
+    /// being the authoritative levels because the plot is momentarily drawing
+    /// something else.
+    /// <para>
+    /// Comparing levels ACROSS the sides assumes one recipe at one input gain
+    /// held both sides' captures — exactly the condition the dashed opposite-side
+    /// sum borrows the active side's offset under, so it is the same check. The
+    /// set offset is common to both sides by that construction and cancels out of
+    /// every difference, which is why none is applied here.
+    /// </para>
+    /// </remarks>
+    private Func<VirtualCrossoverChannel, double, double, double?>?
+        HybridStereoLevelReader() =>
+        checkBoxHybrid.Checked && hybridAvailable &&
+        CanDrawOppositeHybridSum(!project.ActiveSideRight)
+            ? HybridStereoLevelDeltaDb
+            : null;
+
+    // One pair's L−R spatial-average level difference, both sides built on ONE
+    // grid so the band-level rule can pair their points (see
+    // SpatialAverageHybrid.BandLevelDeltaDb). Null when a side has no capture —
+    // an array set may have gaps — or the captures never overlap in this band;
+    // the read-out then keeps that pair's point-measured level and says so.
+    private double? HybridStereoLevelDeltaDb(
+        VirtualCrossoverChannel channel, double lowHz, double highHz)
+    {
+        List<double> grid = HybridLevelGrid(lowHz, highHz);
+        IReadOnlyList<SignalPoint>? left =
+            BuildHybridSideLevelCurve(channel, rightSide: false, grid);
+        IReadOnlyList<SignalPoint>? right =
+            BuildHybridSideLevelCurve(channel, rightSide: true, grid);
+        return left == null || right == null
+            ? null
+            : SpatialAverageHybrid.BandLevelDeltaDb(left, right);
+    }
+
+    // One side's capture through that side's own chain, calibration and processor
+    // rate — the same reading BuildHybridChannelCurve makes for the plot, on the
+    // caller's grid and with no display smoothing (an energy mean needs none).
+    private IReadOnlyList<SignalPoint>? BuildHybridSideLevelCurve(
+        VirtualCrossoverChannel channel, bool rightSide, List<double> grid)
+    {
+        VirtualCrossoverChannelState state = channel.PhysicalSideState(rightSide);
+        if (state.SpatialAverageFor(SpatialAverageMode) is not { } document)
+        {
+            return null;
+        }
+
+        return SpatialAverageHybrid.BuildChannelCurve(
+            document,
+            // A bypassed pair never reaches the Δ block, but the rule stays the
+            // plot's: bypass contributes the raw measured signal.
+            channel.Pair.Bypass
+                ? DspChannelChain.Identity
+                : channel.SideSettings(rightSide).ToChain(),
+            channel.ProcessorSampleRateFor(rightSide),
+            SpatialAverageCalibrationFor(state),
+            grid,
+            smoothingCode: 0);
+    }
+
+    // Log-spaced through the band at a resolution comfortably past the captures'
+    // own (~1/48 octave): the figure is an energy mean of a smooth curve, and a
+    // log grid with uniform weights is what reproduces the impulse-response band
+    // level's 1/f weighting.
+    private static List<double> HybridLevelGrid(double lowHz, double highHz)
+    {
+        const double PointsPerOctave = 48.0;
+        int steps = Math.Max(
+            1, (int)Math.Ceiling(Math.Log2(highHz / lowHz) * PointsPerOctave));
+        var grid = new List<double>(steps + 1);
+        for (int i = 0; i <= steps; i++)
+        {
+            grid.Add(lowHz * Math.Pow(highHz / lowHz, (double)i / steps));
+        }
+
+        return grid;
+    }
+
+    /// <summary>
     /// Whether one offset may level both sides' captures — the condition the dashed
     /// opposite sum is drawn under. Static and pure so it can be pinned directly.
     /// </summary>
@@ -627,7 +717,9 @@ public partial class VirtualCrossoverPanel
                     "measured at one point. Both sums follow, adding the channels as " +
                     "phasors with the phase the impulse responses measure — the other " +
                     "side needs its own captures too, and its dashed sum is dropped " +
-                    "rather than drawn by the other method. Timing, polarity and the " +
+                    "rather than drawn by the other method. The read-out's Level " +
+                    "Δ L−R rows follow too, comparing the sides' captures under the " +
+                    "same condition. Timing, polarity and the " +
                     "sum-loss read-out are " +
                     "unaffected: they keep reading the impulse responses.\r\n\r\n" +
                     "The channel curves are exact — a filter does not depend on " +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3289,7 +3289,12 @@ public partial class VirtualCrossoverPanel : UserControl
                 channels,
                 revision,
                 includePair: pair =>
-                    VirtualCrossoverGroupViews.IsShown(groupView, pair.Zone));
+                    VirtualCrossoverGroupViews.IsShown(groupView, pair.Zone),
+                // While the hybrid mode is on, the block's Level Δ rows read
+                // the sides' spatial averages — the levels that mode declares
+                // authoritative — whatever this frame's view draws; see
+                // HybridStereoLevelReader for why it is not HybridRequested.
+                hybridLevelDeltaDb: HybridStereoLevelReader());
         // What the cross-group views quote instead of a summation loss. Reads the
         // responses this frame already processed, so it adds no render — only the
         // arrival FFTs, on the coordinator's auxiliary path.

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3297,9 +3297,12 @@ public partial class VirtualCrossoverPanel : UserControl
                 hybridLevelDeltaDb: HybridStereoLevelReader());
         // What the cross-group views quote instead of a summation loss. Reads the
         // responses this frame already processed, so it adds no render — only the
-        // arrival FFTs, on the coordinator's auxiliary path.
+        // arrival FFTs, on the coordinator's auxiliary path. Its ΔdB rows follow
+        // the hybrid mode exactly as the stereo block's level rows do.
         IReadOnlyList<VirtualCrossoverMetric.GroupDelta> groupDeltas =
-            await metrics.ComputeGroupDeltasAsync(shown, groupView, revision);
+            await metrics.ComputeGroupDeltasAsync(
+                shown, groupView, revision,
+                hybridGroupLevelDeltaDb: HybridGroupLevelReader());
         // The side sum comes from metrics (shared coordinator cache); the CURVE
         // is built here so it windows through the OPPOSITE side's gate
         // placement — the active side's pin must not gate the other side.

--- a/tests/Resonalyze.App.Tests/SpatialAverageHybridTests.cs
+++ b/tests/Resonalyze.App.Tests/SpatialAverageHybridTests.cs
@@ -223,6 +223,70 @@ public sealed class SpatialAverageHybridTests
         Assert.All(curve!, point => Assert.Equal(-30.0, point.Y, 6));
     }
 
+    /// <summary>
+    /// The Δ L−R level rule on hybrid curves: an energy mean per side over one
+    /// shared grid, differenced once. Two flat curves read exactly their offset,
+    /// whichever way it points.
+    /// </summary>
+    [Fact]
+    public void BandLevelDeltaDb_ReadsTheOffsetBetweenFlatCurves()
+    {
+        List<SignalPoint> left = Flat(-20, count: 97);
+        List<SignalPoint> right = Flat(-23, count: 97);
+
+        Assert.Equal(3.0, SpatialAverageHybrid.BandLevelDeltaDb(left, right)!.Value, 9);
+        Assert.Equal(-3.0, SpatialAverageHybrid.BandLevelDeltaDb(right, left)!.Value, 9);
+    }
+
+    /// <summary>
+    /// A gap on EITHER side removes that frequency from both: the comparison must
+    /// stay symmetric, not weigh one side's band against a different part of the
+    /// other's. Here the halves differ by 12 dB, and a one-sided exclusion would
+    /// drag the figure by several dB.
+    /// </summary>
+    [Fact]
+    public void BandLevelDeltaDb_PairsThePointsSoAGapRemovesTheFrequencyFromBothSides()
+    {
+        // Both sides: −20 dB in the lower half, −8 dB in the upper. The left loses
+        // its upper half to a gap; honest pairing leaves two identical −20 dB
+        // halves, so the delta is zero.
+        List<SignalPoint> left = Flat(-20, count: 96);
+        List<SignalPoint> right = Flat(-20, count: 96);
+        for (int i = 48; i < 96; i++)
+        {
+            left[i] = new SignalPoint(left[i].X, double.NaN);
+            right[i] = new SignalPoint(right[i].X, -8);
+        }
+
+        Assert.Equal(0.0, SpatialAverageHybrid.BandLevelDeltaDb(left, right)!.Value, 9);
+    }
+
+    /// <summary>With no point finite on both sides there is nothing to compare.</summary>
+    [Fact]
+    public void BandLevelDeltaDb_NullWhenTheCurvesNeverOverlap()
+    {
+        List<SignalPoint> left = Flat(-20, count: 8);
+        List<SignalPoint> right = Flat(-20, count: 8);
+        for (int i = 0; i < 8; i++)
+        {
+            if (i < 4)
+            {
+                left[i] = new SignalPoint(left[i].X, double.NaN);
+            }
+            else
+            {
+                right[i] = new SignalPoint(right[i].X, double.NaN);
+            }
+        }
+
+        Assert.Null(SpatialAverageHybrid.BandLevelDeltaDb(left, right));
+    }
+
+    private static List<SignalPoint> Flat(double db, int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new SignalPoint(100 * Math.Pow(2, i / 48.0), db))
+            .ToList();
+
     private static LiveCaptureDocument Capture(double db) => new()
     {
         SavedAtUtc = DateTimeOffset.UnixEpoch,

--- a/tests/Resonalyze.App.Tests/SpatialAverageHybridTests.cs
+++ b/tests/Resonalyze.App.Tests/SpatialAverageHybridTests.cs
@@ -282,6 +282,31 @@ public sealed class SpatialAverageHybridTests
         Assert.Null(SpatialAverageHybrid.BandLevelDeltaDb(left, right));
     }
 
+    /// <summary>
+    /// The group rule under the "vs Front" ΔdB: powers add, so two equal members
+    /// read 3 dB over one, a member's own gap contributes nothing (its crossover
+    /// has removed it from the group's output anyway), and only a point where NO
+    /// member has a value is a gap of the group's.
+    /// </summary>
+    [Fact]
+    public void PowerSum_AddsPowersAndPassesOnlyAWholeGap()
+    {
+        List<SignalPoint> first = Flat(-20, count: 8);
+        List<SignalPoint> second = Flat(-20, count: 8);
+        second[5] = new SignalPoint(second[5].X, double.NaN);
+        first[6] = new SignalPoint(first[6].X, double.NaN);
+        second[6] = new SignalPoint(second[6].X, double.NaN);
+
+        List<SignalPoint> sum = SpatialAverageHybrid.PowerSum([first, second]);
+
+        Assert.Equal(8, sum.Count);
+        Assert.Equal(-20 + 10 * Math.Log10(2), sum[0].Y, 9);
+        // One member gone: the other's level stands alone.
+        Assert.Equal(-20, sum[5].Y, 9);
+        // Both gone: the group has nothing to say there.
+        Assert.True(double.IsNaN(sum[6].Y));
+    }
+
     private static List<SignalPoint> Flat(double db, int count) =>
         Enumerable.Range(0, count)
             .Select(i => new SignalPoint(100 * Math.Pow(2, i / 48.0), db))

--- a/tests/Resonalyze.App.Tests/SpatialAverageHybridTests.cs
+++ b/tests/Resonalyze.App.Tests/SpatialAverageHybridTests.cs
@@ -332,6 +332,52 @@ public sealed class SpatialAverageHybridTests
         Assert.Equal(-20 + 10 * Math.Log10(2), sum[6].Y, 9);
     }
 
+    /// <summary>
+    /// A bypassed member's chain is Identity, so it plays its raw full-range
+    /// response — its configured crossover corners are idle and say nothing
+    /// about where it is present. Reading them as its band turned a capture's
+    /// silence below the idle high-pass back into "the driver is absent" (the
+    /// review's edge case): the gap must break the group point instead.
+    /// </summary>
+    [Fact]
+    public void PowerSum_ABypassedMembersIdleCrossoverDoesNotExcuseItsCaptureGap()
+    {
+        var tweeter = new VirtualCrossoverChannel("Tweeter");
+        VirtualCrossoverChannelSettings settings = tweeter.SideSettings(false);
+        settings.CrossoverKind = CrossoverKind.BandPass;
+        settings.HighPassEdge = new CrossoverEdge(
+            CrossoverFilterFamily.LinkwitzRiley, 2_000, 24);
+        settings.LowPassEdge = new CrossoverEdge(
+            CrossoverFilterFamily.LinkwitzRiley, 8_000, 24);
+        tweeter.Pair.Bypass = true;
+
+        (double LowHz, double HighHz) band =
+            VirtualCrossoverPanel.HybridGroupMemberBand(tweeter, rightSide: false);
+
+        // Bypassed, the member plays full range; with the crossover running it
+        // is the configured band, the same rule the comparison spans.
+        Assert.Equal((20.0, 20_000.0), band);
+        tweeter.Pair.Bypass = false;
+        Assert.Equal(
+            (2_000.0, 8_000.0),
+            VirtualCrossoverPanel.HybridGroupMemberBand(tweeter, rightSide: false));
+
+        // The gap sits at ~107 Hz — far below the idle 2 kHz corner. Through
+        // the full-range band it breaks the group point; through the configured
+        // corners it would have read as an absent driver and summed the mid
+        // alone, the very error the in-band rule exists to stop.
+        List<SignalPoint> mid = Flat(-20, count: 8);
+        List<SignalPoint> bypassed = Flat(-20, count: 8);
+        bypassed[5] = new SignalPoint(bypassed[5].X, double.NaN);
+
+        List<SignalPoint> sum = SpatialAverageHybrid.PowerSum(
+            [mid, bypassed],
+            [(20, 20_000), (20.0, 20_000.0)]);
+
+        Assert.True(double.IsNaN(sum[5].Y));
+        Assert.Equal(-20 + 10 * Math.Log10(2), sum[4].Y, 9);
+    }
+
     private static List<SignalPoint> Flat(double db, int count) =>
         Enumerable.Range(0, count)
             .Select(i => new SignalPoint(100 * Math.Pow(2, i / 48.0), db))

--- a/tests/Resonalyze.App.Tests/SpatialAverageHybridTests.cs
+++ b/tests/Resonalyze.App.Tests/SpatialAverageHybridTests.cs
@@ -283,28 +283,53 @@ public sealed class SpatialAverageHybridTests
     }
 
     /// <summary>
-    /// The group rule under the "vs Front" ΔdB: powers add, so two equal members
-    /// read 3 dB over one, a member's own gap contributes nothing (its crossover
-    /// has removed it from the group's output anyway), and only a point where NO
-    /// member has a value is a gap of the group's.
+    /// The group rule under the "vs Front" ΔdB: powers add (two equal members
+    /// read 3 dB over one), and a member's gap OUTSIDE its configured band is an
+    /// absence — the crossover removed that driver, and the rest carry on.
     /// </summary>
     [Fact]
-    public void PowerSum_AddsPowersAndPassesOnlyAWholeGap()
+    public void PowerSum_AddsPowersAndTreatsAGapOutsideTheMembersBandAsAbsence()
     {
-        List<SignalPoint> first = Flat(-20, count: 8);
-        List<SignalPoint> second = Flat(-20, count: 8);
-        second[5] = new SignalPoint(second[5].X, double.NaN);
-        first[6] = new SignalPoint(first[6].X, double.NaN);
-        second[6] = new SignalPoint(second[6].X, double.NaN);
+        List<SignalPoint> mid = Flat(-20, count: 8);
+        List<SignalPoint> tweeter = Flat(-20, count: 8);
+        tweeter[5] = new SignalPoint(tweeter[5].X, double.NaN);
 
-        List<SignalPoint> sum = SpatialAverageHybrid.PowerSum([first, second]);
+        // The tweeter's band starts above the gap, so the gap sits in its
+        // stopband; the mid covers the whole grid.
+        List<SignalPoint> sum = SpatialAverageHybrid.PowerSum(
+            [mid, tweeter],
+            [(20, 20_000), (tweeter[6].X, 20_000)]);
 
         Assert.Equal(8, sum.Count);
         Assert.Equal(-20 + 10 * Math.Log10(2), sum[0].Y, 9);
-        // One member gone: the other's level stands alone.
+        // The out-of-band member is absent there: the mid's level stands alone.
         Assert.Equal(-20, sum[5].Y, 9);
-        // Both gone: the group has nothing to say there.
-        Assert.True(double.IsNaN(sum[6].Y));
+        Assert.Equal(-20 + 10 * Math.Log10(2), sum[7].Y, 9);
+    }
+
+    /// <summary>
+    /// The other meaning of a gap, and the one that must NOT read as a level: a
+    /// capture with nothing to say INSIDE its member's configured band describes
+    /// a driver the DSP says is playing. Summing the remaining members there
+    /// quoted part of the group as all of it — a systematic error that looked
+    /// exactly like a valid figure — so the group point is a gap, which the
+    /// band-level rule then pairs away from both sides of the comparison.
+    /// </summary>
+    [Fact]
+    public void PowerSum_BreaksTheGroupWhereACaptureIsSilentInsideItsMembersBand()
+    {
+        List<SignalPoint> mid = Flat(-20, count: 8);
+        List<SignalPoint> tweeter = Flat(-20, count: 8);
+        tweeter[5] = new SignalPoint(tweeter[5].X, double.NaN);
+
+        List<SignalPoint> sum = SpatialAverageHybrid.PowerSum(
+            [mid, tweeter],
+            [(20, 20_000), (20, 20_000)]);
+
+        Assert.True(double.IsNaN(sum[5].Y));
+        // The break is the point's alone: its neighbours still sum both members.
+        Assert.Equal(-20 + 10 * Math.Log10(2), sum[4].Y, 9);
+        Assert.Equal(-20 + 10 * Math.Log10(2), sum[6].Y, 9);
     }
 
     private static List<SignalPoint> Flat(double db, int count) =>

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -243,7 +243,7 @@ public sealed class VirtualCrossoverMetricTests
 
             Assert.Contains("level +1.6 dB (175 Hz", text);
             Assert.Contains("level -0.6 dB (point mic)", text);
-            Assert.Contains("(point mic): that pair has no capture", text);
+            Assert.Contains("(point mic): that pair's captures cannot produce", text);
         });
     }
 
@@ -287,7 +287,7 @@ public sealed class VirtualCrossoverMetricTests
             Assert.Contains("6.3 dB quieter.", text);
             Assert.Contains("2.1 dB quieter (point mic).", text);
             Assert.Contains("spatial averages", text);
-            Assert.Contains("member without a capture", text);
+            Assert.Contains("could not be read from the captures", text);
         });
     }
 

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -247,6 +247,66 @@ public sealed class VirtualCrossoverMetricTests
         });
     }
 
+    [Fact]
+    public void FormatStereoDeltasDetail_KeepsTheSpatialLevelWhenNoArrivalIsMeasurable()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            // A capture is a measurement of its own, so its level outlives the
+            // arrivals — and the compact block shows it, so the tooltip must
+            // not swallow it behind the "no measurable arrival" early row.
+            string text = VirtualCrossoverMetric.FormatStereoDeltasDetail(
+            [
+                new VirtualCrossoverMetric.StereoDelta(
+                    "B", null, null, 175, 1_300, LevelDeltaDb: -2.5,
+                    LevelFromSpatialAverage: true)
+            ]);
+
+            Assert.Contains(
+                "B: — (no measurable arrival), level -2.5 dB", text);
+        });
+    }
+
+    [Fact]
+    public void FormatGroupDeltasDetail_ExplainsSpatialLevelsAndMarksThePointMeasuredException()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            // With the hybrid on the ΔdB rows read the groups' spatial
+            // averages; a group with a member that has no capture keeps its
+            // point-measured figure and is the marked exception.
+            string text = VirtualCrossoverMetric.FormatGroupDeltasDetail(
+            [
+                new VirtualCrossoverMetric.GroupDelta(
+                    VirtualCrossoverZone.Rear, 8.12, -6.3, 290, 20_000,
+                    LevelFromSpatialAverage: true),
+                new VirtualCrossoverMetric.GroupDelta(
+                    VirtualCrossoverZone.Center, -0.35, -2.1, 290, 20_000)
+            ]);
+
+            Assert.Contains("6.3 dB quieter.", text);
+            Assert.Contains("2.1 dB quieter (point mic).", text);
+            Assert.Contains("spatial averages", text);
+            Assert.Contains("member without a capture", text);
+        });
+    }
+
+    [Fact]
+    public void FormatGroupDeltasDetail_SaysNothingAboutAveragesForAPointMeasuredList()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            string text = VirtualCrossoverMetric.FormatGroupDeltasDetail(
+            [
+                new VirtualCrossoverMetric.GroupDelta(
+                    VirtualCrossoverZone.Rear, 8.12, -6.3, 290, 20_000)
+            ]);
+
+            Assert.DoesNotContain("spatial", text);
+            Assert.DoesNotContain("(point mic)", text);
+        });
+    }
+
     private static VirtualCrossoverMetric.PhaseEntry PhaseJunction(
         double? lobeMargin = 0.19,
         double? rivalExtraMs = -12.20,

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -202,6 +202,51 @@ public sealed class VirtualCrossoverMetricTests
         });
     }
 
+    [Fact]
+    public void FormatStereoDeltasDetail_SwapsTheLevelLegendWhenTheLevelsComeFromSpatialAverages()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            // With the hybrid mode on the level rows compare the sides' spatial
+            // averages, and the legend must say so instead of claiming the gated
+            // point measurement. A uniform list carries no per-row marks.
+            string text = VirtualCrossoverMetric.FormatStereoDeltasDetail(
+            [
+                new VirtualCrossoverMetric.StereoDelta(
+                    "B", 25.977, 25.724, 175, 1_300, LevelDeltaDb: 1.63,
+                    LevelFromSpatialAverage: true)
+            ]);
+
+            Assert.Contains("spatial averages", text);
+            Assert.Contains("positive: LEFT louder", text);
+            Assert.DoesNotContain("gated band level", text);
+            Assert.DoesNotContain("(point mic)", text);
+        });
+    }
+
+    [Fact]
+    public void FormatStereoDeltasDetail_MarksThePointMeasuredExceptionInASpatialList()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            // An array set may have gaps: a pair the captures cannot speak for
+            // keeps its point-measured level, and in a spatial list that row is
+            // the exception — marked in place, explained in the legend.
+            string text = VirtualCrossoverMetric.FormatStereoDeltasDetail(
+            [
+                new VirtualCrossoverMetric.StereoDelta(
+                    "B", 25.977, 25.724, 175, 1_300, LevelDeltaDb: 1.63,
+                    LevelFromSpatialAverage: true),
+                new VirtualCrossoverMetric.StereoDelta(
+                    "C", 15.341, 15.412, 1_800, 20_000, LevelDeltaDb: -0.62)
+            ]);
+
+            Assert.Contains("level +1.6 dB (175 Hz", text);
+            Assert.Contains("level -0.6 dB (point mic)", text);
+            Assert.Contains("(point mic): that pair has no capture", text);
+        });
+    }
+
     private static VirtualCrossoverMetric.PhaseEntry PhaseJunction(
         double? lobeMargin = 0.19,
         double? rivalExtraMs = -12.20,

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -785,6 +785,49 @@ public sealed class VirtualCrossoverMetricsTests
     }
 
     [Fact]
+    public async Task ComputeGroupDeltas_TakesTheLevelFromTheHybridReaderAndKeysTheCacheOnIt()
+    {
+        // The panel supplies the reader while the hybrid mode is on: the ΔdB
+        // then reports what the groups' spatial averages say. The answer joins
+        // the cache key — toggling the hybrid leaves every response standing,
+        // and the remembered point-measured set must not answer for the
+        // capture-based one.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(
+            coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        List<ProcessedChannel> shown =
+        [
+            Zoned("Front", VirtualCrossoverZone.Front, 100),
+            Zoned("Centre", VirtualCrossoverZone.Center, 150)
+        ];
+        var asked = new List<(int Members, int Front, double LowHz, double HighHz)>();
+
+        IReadOnlyList<VirtualCrossoverMetric.GroupDelta> hybrid =
+            await metrics.ComputeGroupDeltasAsync(
+                shown, VirtualCrossoverGroupView.FrontAndCenter, coordinator.Invalidate(),
+                hybridGroupLevelDeltaDb: (members, front, lowHz, highHz) =>
+                {
+                    asked.Add((members.Count, front.Count, lowHz, highHz));
+                    return -5.5;
+                });
+
+        VirtualCrossoverMetric.GroupDelta delta = Assert.Single(hybrid);
+        Assert.Equal(-5.5, delta.LevelDb);
+        Assert.True(delta.LevelFromSpatialAverage);
+        // Asked once, with the compared group, the front and their shared band.
+        Assert.Equal((1, 1, 20.0, 20_000.0), Assert.Single(asked));
+
+        // The hybrid off again: the same responses must be re-read rather than
+        // answered from the capture-based memory.
+        IReadOnlyList<VirtualCrossoverMetric.GroupDelta> point =
+            await metrics.ComputeGroupDeltasAsync(
+                shown, VirtualCrossoverGroupView.FrontAndCenter, coordinator.Invalidate());
+
+        Assert.NotSame(hybrid, point);
+        Assert.False(Assert.Single(point).LevelFromSpatialAverage);
+    }
+
+    [Fact]
     public async Task ComputeGroupDeltas_AnswerNothingForASupersededFrame()
     {
         // The other half of remembering the set: a frame the user has already

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -429,6 +429,83 @@ public sealed class VirtualCrossoverMetricsTests
         Assert.NotNull(channel.PhysicalSideState(false).ArrivalCache);
     }
 
+    [Fact]
+    public async Task ComputeStereoDeltasAsync_TakesTheLevelFromTheHybridReaderWhenSupplied()
+    {
+        // The panel supplies the reader while the hybrid mode is on: the level
+        // row then reports what the spatial averages say — asked once, in the
+        // pair's shared band — and the row says which measurement it read.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        long revision = coordinator.Invalidate();
+        var channel = new VirtualCrossoverChannel("A");
+        Resolve(channel, rightSide: false);
+        Resolve(channel, rightSide: true);
+        var asked = new List<(double LowHz, double HighHz)>();
+
+        List<VirtualCrossoverMetric.StereoDelta> deltas =
+            await metrics.ComputeStereoDeltasAsync(
+                [channel],
+                revision,
+                hybridLevelDeltaDb: (_, lowHz, highHz) =>
+                {
+                    asked.Add((lowHz, highHz));
+                    return -2.5;
+                });
+
+        VirtualCrossoverMetric.StereoDelta delta = Assert.Single(deltas);
+        Assert.Equal(-2.5, delta.LevelDeltaDb);
+        Assert.True(delta.LevelFromSpatialAverage);
+        Assert.Equal((20.0, 20_000.0), Assert.Single(asked));
+    }
+
+    [Fact]
+    public async Task ComputeStereoDeltasAsync_AReaderWithNothingToSayLeavesThePointMeasuredLevel()
+    {
+        // An array set may have gaps: a pair the captures cannot speak for keeps
+        // its gated point-measured level, unmarked as spatial.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        long revision = coordinator.Invalidate();
+        var channel = new VirtualCrossoverChannel("A");
+        Resolve(channel, rightSide: false);
+        Resolve(channel, rightSide: true);
+
+        List<VirtualCrossoverMetric.StereoDelta> deltas =
+            await metrics.ComputeStereoDeltasAsync(
+                [channel], revision, hybridLevelDeltaDb: (_, _, _) => null);
+
+        VirtualCrossoverMetric.StereoDelta delta = Assert.Single(deltas);
+        // The two sides are byte-identical impulses, so the point level says 0.
+        Assert.Equal(0.0, delta.LevelDeltaDb!.Value, 6);
+        Assert.False(delta.LevelFromSpatialAverage);
+    }
+
+    [Fact]
+    public async Task ComputeStereoDeltasAsync_NeverAsksTheHybridReaderForAMonoChannel()
+    {
+        // One physical driver serving both sides has no L−R to compare, so the
+        // reader must not be consulted for it — a capture could answer, and the
+        // row would then invent an imbalance for a channel that cannot have one.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        long revision = coordinator.Invalidate();
+        var channel = new VirtualCrossoverChannel("Sub") { Pair = { Mono = true } };
+        Resolve(channel, rightSide: false);
+
+        List<VirtualCrossoverMetric.StereoDelta> deltas =
+            await metrics.ComputeStereoDeltasAsync(
+                [channel],
+                revision,
+                hybridLevelDeltaDb: (_, _, _) =>
+                    throw new InvalidOperationException(
+                        "A mono channel must not reach the hybrid level reader."));
+
+        VirtualCrossoverMetric.StereoDelta delta = Assert.Single(deltas);
+        Assert.Null(delta.LevelDeltaDb);
+        Assert.False(delta.LevelFromSpatialAverage);
+    }
+
     // A Hann-windowed tone burst: toneHz for cycles periods, scaled by
     // amplitude, placed at startMs.
     private static void AddBurst(


### PR DESCRIPTION
## What

The Virtual DSP read-out's **Level Δ L−R** rows reported the gated band level of the point-measured impulse responses even while the hybrid view was drawing — and being tuned against — the spatial averages, so the report and the plot disagreed by exactly the point position's dips.

While the hybrid mode is on, each pair's level is now read off the two sides' spatial averages through their chains — the levels that mode draws and a gain trim is judged against. Timing, polarity and the sum-loss read-out keep reading the impulse responses (an average carries no phase).

## Decisions

- **Condition**: hybrid tick + coverage, and both sides' captures form **one set** — the same `CanDrawOppositeHybridSum` check the dashed opposite-side sum is drawn under. The common set offset then cancels out of every difference, which is why none is applied; separate per-side sets cannot be levelled against each other without erasing the very imbalance the row reports, so there the rows stay point-measured.
- **View-independent**: deliberately the mode's intent + coverage rather than `HybridRequested` — a level that flipped basis when the user glanced at the phase view would read as two different imbalances in one tune.
- **Math**: `SpatialAverageHybrid.BandLevelDeltaDb` — an energy mean per side over one shared log grid, differenced once. Uniform weights on a log grid reproduce `MeasureBandLevelDb`'s 1/f weighting on linear bins. The points are **paired**: a gap on either side (a protective high-pass, the end of a capture's grid) removes that frequency from both sides.
- **Fallbacks**: a pair without a capture on a side (an array set may have gaps) keeps its point-measured level and is marked `(point mic)` in the tooltip legend; mono channels are never asked. The hybrid level is not gated on arrival reliability — a capture is a measurement of its own.
- The compact column is visually unchanged; the tooltip legend says which measurement the rows read. The non-hybrid path is **byte-for-byte unchanged**.

## Docs

- Hybrid checkbox tooltip: names the Level Δ L−R rows as the one read-out that follows the hybrid.
- `REFERENCE.md`: the Hybrid section's "everything else keeps reading the impulse responses" paragraph and the Δ L−R block description.

## Tests

- `BandLevelDeltaDb`: flat-offset delta, pairwise gap exclusion (asymmetric halves would drag a one-sided mean by ~9 dB), null with no overlap.
- `ComputeStereoDeltasAsync`: reader's value + `LevelFromSpatialAverage` flag flow through (asked once, in the pair's shared band); a null reader answer keeps the point level unmarked; a mono channel never reaches the reader.
- Formatting: the legend swaps for a spatial list; a mixed list marks the point-measured exception row.

Full suite green: 159 + 2000 + 1444, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up (5fb8158)

- **Codex P2 fixed**: a pair whose arrivals are both unmeasurable no longer drops its spatial-average level from the tooltip's "no measurable arrival" row — the compact block was already showing it.
- **"vs Front" ΔdB follows the hybrid too**: each compared group and the front are read off their members' captures through their chains and **power-summed** — an average carries no phase, the junction cross-terms a phasor sum would add live in a fraction of the shared band and appear on both sides of the comparison, and borrowing the point-measured phase would cost full-length gated FFTs per group per frame. Both groups sit on the active side, so the set offset cancels and no cross-side one-set condition applies. A group with a member lacking a capture keeps its point-measured row whole, marked `(point mic)` in the tooltip. The hybrid answer joins the group-delta cache key, so toggling the hybrid is never served the remembered point-measured set. Arrivals keep reading the impulse responses.


---

## Review fix (6f1070e)

Owner's P2 on the group code: `PowerSum` conflated "the crossover removed this driver" with "the capture has no data". A member's NaN **inside its configured band** now breaks the whole group point (the driver plays there and the captures cannot say what it produces), and `BandLevelDeltaDb` pairs that frequency away from both sides; **outside the band** a gap stays an absence and the rest carry on. The old test pinned the wrong assumption and is replaced; a regression test covers the in-band gap. The `(point mic)` legends now also name the no-shared-data fallback, and the power-vs-phasor remark no longer overstates the cross-term cancellation (like-architecture groups yes, single-driver centre not guaranteed).


**+ 391fc8b**: the bypass edge case from the follow-up review — a bypassed member runs Identity and plays full range, so its band for the gap rule is now (20, 20 000) rather than its idle crossover corners (`HybridGroupMemberBand`, static and pinned with the idle-corner gap regression).
