### PR TITLE
Read the junction phase through the phase gate, not the steady state

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2250,10 +2250,15 @@ to settle a mid/tweeter lobe the direct-sound correlation can only call by a
 hair (see Auto delay above). It never takes a Δt from it as a move.
 
 A **Junction phase** block reads each adjacent pair's cross-phase through the
-same gate the phase curves are drawn through, at a fixed
-8-cycle frequency-dependent window whatever the gate dialog's FDW selector says —
-so the φ it reports is a figure you can find on the plot beside it, and a shorter
-window chosen for the eye cannot move the numbers. It read a 0.68 s steady-state
+phase gate — its offset and Tukey durations — at a fixed 8-cycle
+frequency-dependent window, whatever the gate dialog's window-mode and FDW
+selectors say. Those selectors shape a curve for the eye; the settings that suit
+one are measurably the wrong instrument for a number, and a fixed window above
+1 kHz cannot score a correctly tuned tweeter junction better than about 0.7 (see
+the ceiling below). In the default frequency-dependent mode the numbers and the
+drawn curves are one window, so the φ reported is a figure you can find on the
+plot beside it; in Fixed mode the plot shows a longer window at high junctions
+than the figures do. It read a 0.68 s steady-state
 window until the two were measured against each other over the archived cabins:
 below 500 Hz they agree (a median 5° and 0.05 ms across twenty junctions in eight
 cars), while above 1 kHz the steady state has nothing left to read — the best

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2249,10 +2249,18 @@ keeps its own guarded estimators, and reads this ladder in exactly one place —
 to settle a mid/tweeter lobe the direct-sound correlation can only call by a
 hair (see Auto delay above). It never takes a Δt from it as a move.
 
-A **Junction phase** block reads each adjacent pair's steady-state cross-phase in
-a time-sized window (~0.68 s of the processed IR) — the regime sustained program
-material actually sums in, deliberately not the direct-sound phase, because the
-room adds several milliseconds of apparent group delay down low. Per junction it
+A **Junction phase** block reads each adjacent pair's cross-phase through the
+same gate the phase curves are drawn through, at a fixed
+8-cycle frequency-dependent window whatever the gate dialog's FDW selector says —
+so the φ it reports is a figure you can find on the plot beside it, and a shorter
+window chosen for the eye cannot move the numbers. It read a 0.68 s steady-state
+window until the two were measured against each other over the archived cabins:
+below 500 Hz they agree (a median 5° and 0.05 ms across twenty junctions in eight
+cars), while above 1 kHz the steady state has nothing left to read — the best
+score ANY delay reaches over the band sits at a median 0.69 there, so a correctly
+tuned tweeter junction could not score better than about 0.7 whatever you did,
+the residue being the room decorrelating the two paths rather than a misalignment.
+Through the gated window that ceiling is 0.93. Per junction the block
 shows **φfc**, the lower channel's phase minus the upper at the crossover (≈0°
 means phase-aligned; ±180° does not by itself call for a flip, since an inverted
 channel and a half-period delay are identical at fc); and **fix ms**, the extra
@@ -2262,7 +2270,12 @@ warning that the overlap band is too narrow to rule out a whole-period hop — s
 the fix is not to be trusted, and the junction's coherence ladder is the better
 read. A fix worth less than 10° of phase at the crossover (0.03 dB in the sum)
 shows as `·`: a settled tune has nothing to apply there, and a number would
-invite a correction that changes nothing. Last comes **score**, where the
+invite a correction that changes nothing. It shows as `—`, polarity mark and all,
+where even the best delay leaves the band out of phase: the two drivers do not
+correlate over their overlap, so the sweep's optimum is the least bad of a set of
+bad alignments rather than a change to make — on the archived cabins the one
+junction this withholds is a 2 kHz handover whose recommendation cost 1.15 dB of summation
+loss when it was applied. Last comes **score**, where the
 junction stands as it is — the band's phase-alignment score (−1…+1) that the
 fix maximizes: 1.00 is aligned across the overlap, 0 a wash, negative means the
 two drivers are subtracting. It moves while a delay is dragged, so it answers

--- a/dsp/JunctionPhaseAlignment.cs
+++ b/dsp/JunctionPhaseAlignment.cs
@@ -8,12 +8,30 @@ namespace Resonalyze.Dsp;
 /// in phase across their overlap band, and what change would improve it.
 /// </summary>
 /// <remarks>
-/// All figures read the steady-state response (a long analysis window over the
-/// full processed IR, room decay included) because that is what sustained
-/// program material sums to at the listening position — the same regime the
-/// sum-loss metric measures. Direct-sound (frequency-dependent-windowed) phase
-/// is deliberately NOT used: it disagrees systematically by several ms at
-/// subwoofer frequencies, which is the room's own group delay.
+/// The figures are read through the caller's own window — for the Virtual DSP
+/// read-out, the panel's phase gate at an 8-cycle frequency-dependent window,
+/// the very window its phase CURVES are drawn through, so a handover the
+/// numbers call inverted is one the eye can find on the plot.
+/// <para>
+/// It was a 0.68 s steady-state window until 2026-09-01, on the grounds that
+/// direct-sound phase disagreed by several milliseconds at subwoofer junctions.
+/// Re-measured over the archived cabins (the battery's window probe, 20
+/// junctions in 8 cars) that ground is gone: below 500 Hz the two windows agree
+/// to a median 5° and 0.046 ms. The old disagreement was the phase gate
+/// anchoring on the IR PEAK, which for a steeply low-passed driver sits tens of
+/// milliseconds after its own front, so the window ate the front it was meant
+/// to isolate; anchoring on the arrival removed it.
+/// </para>
+/// <para>
+/// What the change buys is the top of the range. Above 1 kHz the steady state
+/// has nothing left to read: its CEILING — the best score any delay reaches
+/// over the band — sits at a median 0.690 there, so a correctly tuned tweeter
+/// junction could not score better than about 0.7 whatever the tuner did, and
+/// the residue is the room decorrelating the two paths rather than a
+/// misalignment a delay can repair. Through the gated window the same ceiling
+/// is 0.928. Below 500 Hz the ceiling is unchanged (0.896 against 0.908), which
+/// is the other half of the result: the bass read-out did not move.
+/// </para>
 /// </remarks>
 /// <param name="CurrentScore">
 /// Energy-weighted in-phase score Σw·cos(Δφ)/Σw at the CURRENT settings:
@@ -180,6 +198,29 @@ public static class JunctionPhaseAlignment
     public const double MinimumPhaseConsistency = 0.5;
 
     /// <summary>
+    /// The <see cref="JunctionPhaseResult.BestScore"/> below which the
+    /// RECOMMENDATION — the extra delay and the polarity mark — must not be
+    /// presented: no delay brings this band into phase, so the sweep's optimum
+    /// is the least bad of a set of bad alignments rather than a fix. The φ
+    /// figure has its own gate (<see cref="MinimumPhaseConsistency"/>); this one
+    /// is about the ceiling, and the two answer different questions — a junction
+    /// can hold one clean phase at fc and still be incoherent across its band.
+    /// </summary>
+    /// <remarks>
+    /// Calibrated on the archived cabins by sweeping the threshold and asking
+    /// what suppressing each junction's fix would have cost: from 0.35 to 0.65
+    /// exactly one junction is suppressed — a 2 kHz handover whose two drivers
+    /// do not correlate at all in their direct sound (whitened correlation
+    /// r = 0.07), and whose recommended −0.37 ms took the panel's own summation
+    /// loss down by 1.15 dB and its dip to −10.9 dB when applied. At 0.70 the
+    /// threshold starts catching junctions whose fix changed nothing, and by
+    /// 0.80 one whose fix helped. 0.5 sits in the middle of that plateau, and
+    /// reads as a statement in its own right: at the optimum the band is still
+    /// 60° out of phase on average, so the delay is not what is wrong with it.
+    /// </remarks>
+    public const double MinimumAlignableScore = 0.5;
+
+    /// <summary>
     /// The number of IR samples actually analyzed at a given sample rate:
     /// <see cref="AnalysisDurationSeconds"/> of signal, but never more than the
     /// FFT holds (the cap can trim it at exotic rates). This is the physical
@@ -219,6 +260,12 @@ public static class JunctionPhaseAlignment
     /// the IR is longer), zero-padded to <see cref="AnalysisLengthFor"/> and
     /// transformed. Callers analyzing several junctions reuse one spectrum per
     /// channel.
+    /// <para>
+    /// The read-out no longer reads this window (see the class remarks); it is
+    /// the REFERENCE the window comparison is measured against, and what the
+    /// synthetic tests analyze, so a later window change can be judged against
+    /// the same baseline rather than against a rebuilt one.
+    /// </para>
     /// </summary>
     public static Complex[] BuildAnalysisSpectrum(Complex[] impulseResponse, int sampleRate)
     {
@@ -300,6 +347,46 @@ public static class JunctionPhaseAlignment
             throw new ArgumentException(
                 $"Analysis spectra must be {length} bins for {sampleRate} Hz " +
                 "(use BuildAnalysisSpectrum).");
+        }
+
+        return AnalyzeWindowedSpectra(
+            lowerSpectrum, upperSpectrum, sampleRate,
+            crossoverHz, bandLowHz, bandHighHz);
+    }
+
+    /// <summary>
+    /// The same junction arithmetic over spectra built by a DIFFERENT window
+    /// than the steady-state one — a gated or frequency-dependent-windowed
+    /// pair, at whatever FFT length that window uses. Both spectra must share
+    /// that length AND one absolute time origin: the cross-phase is what is
+    /// read, so a per-channel window placement has to be re-referenced to a
+    /// common origin first (<see cref="Resonalyze.Dsp.DataHelper.SumGatedSpectra"/>)
+    /// or the placement difference is read as a delay.
+    /// </summary>
+    /// <remarks>
+    /// This is what the Virtual DSP read-out calls (see the class remarks);
+    /// <see cref="AnalyzeSpectra"/> is the steady-state reference beside it.
+    /// </remarks>
+    public static JunctionPhaseResult? AnalyzeWindowedSpectra(
+        Complex[] lowerSpectrum,
+        Complex[] upperSpectrum,
+        int sampleRate,
+        double crossoverHz,
+        double bandLowHz,
+        double bandHighHz)
+    {
+        ArgumentNullException.ThrowIfNull(lowerSpectrum);
+        ArgumentNullException.ThrowIfNull(upperSpectrum);
+        if (sampleRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        }
+
+        int length = lowerSpectrum.Length;
+        if (upperSpectrum.Length != length || length < 4)
+        {
+            throw new ArgumentException(
+                "Both spectra must share one FFT length of at least 4 bins.");
         }
         if (!(crossoverHz > 0) || !(bandHighHz > bandLowHz) || !(bandLowHz > 0))
         {

--- a/dsp/JunctionPhaseAlignment.cs
+++ b/dsp/JunctionPhaseAlignment.cs
@@ -9,9 +9,10 @@ namespace Resonalyze.Dsp;
 /// </summary>
 /// <remarks>
 /// The figures are read through the caller's own window — for the Virtual DSP
-/// read-out, the panel's phase gate at an 8-cycle frequency-dependent window,
-/// the very window its phase CURVES are drawn through, so a handover the
-/// numbers call inverted is one the eye can find on the plot.
+/// read-out, the panel's phase gate (its offset and Tukey durations) at an
+/// 8-cycle frequency-dependent window, which in that view's default mode is the
+/// very window its phase CURVES are drawn through, so a handover the numbers
+/// call inverted is one the eye can find on the plot.
 /// <para>
 /// It was a 0.68 s steady-state window until 2026-09-01, on the grounds that
 /// direct-sound phase disagreed by several milliseconds at subwoofer junctions.

--- a/source/Tools/VirtualCrossover/JunctionPhaseSpectra.cs
+++ b/source/Tools/VirtualCrossover/JunctionPhaseSpectra.cs
@@ -10,20 +10,43 @@ namespace Resonalyze;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The same window the phase CURVES are drawn through, deliberately: the φ
-/// column and the plot beside it then describe one measurement, and a handover
-/// the numbers call inverted is one the eye can find on the curves. The
-/// read-out used a 0.68 s steady-state window until 2026-09-01 — see the
-/// remarks on <see cref="JunctionPhaseAlignment"/> for what the battery
-/// measured when the two were compared.
+/// The gate the user placed, at the window the MEASUREMENT needs: its offset
+/// (or the arrival it follows unpinned) and its Tukey durations are the
+/// dialog's, its window mode and cycle count are not. The read-out used a
+/// 0.68 s steady-state window until 2026-09-01 — see the remarks on
+/// <see cref="JunctionPhaseAlignment"/> for what the battery measured when the
+/// two were compared.
+/// </para>
+/// <para>
+/// Where that leaves the drawn curves. With the phase view in its default
+/// frequency-dependent mode the two are one window and the φ column can be read
+/// off the plot beside it. In FIXED mode they are not: the curves keep the
+/// dialog's fixed duration while the numbers stay on the 8-cycle window, so at
+/// a high junction the plot shows a far longer window than the figures do. That
+/// is deliberate and it is the same judgement as the cycle count below — the
+/// selector answers "what should this curve look like", and the answer that
+/// suits an eye is measurably the wrong instrument for a number: on the
+/// archived cabins a fixed window's CEILING above 1 kHz (the best score any
+/// delay reaches over the band) is 0.693 against the gated window's 0.928, so
+/// honouring the selector would hand a fixed-mode project a read-out that
+/// cannot score a correctly tuned tweeter junction above about 0.7.
 /// </para>
 /// <para>
 /// Placement is <see cref="PhaseGatePlacement"/>'s, resolved over the channels
 /// handed in and nothing else, so a set the read-out does not cover cannot move
-/// its windows. Each spectrum is then rotated to the record's own origin: a
-/// per-curve placement is a different time reference per channel, and a
-/// junction is read from the CROSS-phase of two of them, which would otherwise
-/// carry the placement difference as a delay.
+/// its windows. That set is the SUMMING channels, which in a grouped view is
+/// not quite the drawn set — a centre is drawn beside the front stage and sums
+/// with neither — so when such a spectator fails the leading-edge guard the
+/// curves fall back to one shared window while these spectra keep their
+/// per-curve placements. The read-out's own channels all passed that guard; a
+/// channel that takes part in none of the junctions being reported has no claim
+/// on the windows they are read through.
+/// </para>
+/// <para>
+/// Each spectrum is then rotated to the record's own origin: a per-curve
+/// placement is a different time reference per channel, and a junction is read
+/// from the CROSS-phase of two of them, which would otherwise carry the
+/// placement difference as a delay.
 /// </para>
 /// </remarks>
 internal static class JunctionPhaseSpectra

--- a/source/Tools/VirtualCrossover/JunctionPhaseSpectra.cs
+++ b/source/Tools/VirtualCrossover/JunctionPhaseSpectra.cs
@@ -1,0 +1,112 @@
+using System.Numerics;
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// The spectra the junction phase read-out is measured from: every channel
+/// through the panel's OWN phase gate, at a frequency-dependent window of
+/// <see cref="FdwCycles"/> cycles, re-referenced to one absolute time origin.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The same window the phase CURVES are drawn through, deliberately: the φ
+/// column and the plot beside it then describe one measurement, and a handover
+/// the numbers call inverted is one the eye can find on the curves. The
+/// read-out used a 0.68 s steady-state window until 2026-09-01 — see the
+/// remarks on <see cref="JunctionPhaseAlignment"/> for what the battery
+/// measured when the two were compared.
+/// </para>
+/// <para>
+/// Placement is <see cref="PhaseGatePlacement"/>'s, resolved over the channels
+/// handed in and nothing else, so a set the read-out does not cover cannot move
+/// its windows. Each spectrum is then rotated to the record's own origin: a
+/// per-curve placement is a different time reference per channel, and a
+/// junction is read from the CROSS-phase of two of them, which would otherwise
+/// carry the placement difference as a delay.
+/// </para>
+/// </remarks>
+internal static class JunctionPhaseSpectra
+{
+    /// <summary>
+    /// The window length, in periods, at every frequency the read-out is taken
+    /// at — fixed here rather than following the gate dialog's 4/6/8 selector.
+    /// </summary>
+    /// <remarks>
+    /// The dialog's setting shapes a curve for the EYE, and 4 cycles is a
+    /// legitimate choice there. It is not a legitimate choice for a number: on
+    /// the archived cabins, 4 cycles moved φ by a median 36° against the
+    /// steady-state reference and flipped the recommended polarity on 5
+    /// junctions of 20, where 8 cycles moved it by 5° and flipped 4 (all of them
+    /// the delay-versus-flip tie the block already marks). 8 is also the longest
+    /// window the selector offers, so it is the one that keeps the read closest
+    /// to the sustained sum the loss column beside it measures.
+    /// </remarks>
+    public const int FdwCycles = 8;
+
+    /// <summary>
+    /// One spectrum per channel, aligned with <paramref name="channels"/>.
+    /// </summary>
+    /// <param name="sampleRate">
+    /// The rate the PLACEMENT arithmetic works in (offsets are milliseconds, so
+    /// it only decides sample rounding). Each spectrum is transformed at its own
+    /// channel's rate.
+    /// </param>
+    /// <param name="pinnedOffsetMs">
+    /// The gate's absolute offset when the user pinned one — then it is one
+    /// shared window for every channel. Null (Auto) gives each channel its own
+    /// estimated arrival, which is what lets the short high-frequency windows
+    /// land on the right channel's first cycles.
+    /// </param>
+    public static List<Complex[]> Build(
+        IReadOnlyList<ProcessedChannel> channels,
+        int sampleRate,
+        double? pinnedOffsetMs,
+        double leftMs,
+        double plateauMs,
+        double rightMs)
+    {
+        ArgumentNullException.ThrowIfNull(channels);
+        IReadOnlyList<PlacementChannel> placement = PlacementChannel.From(channels);
+        double sharedOffsetMs = PhaseGatePlacement.ResolveSharedOffsetMs(
+            placement, sampleRate, pinnedOffsetMs);
+        List<double> offsets = PhaseGatePlacement.ResolvePerCurveOffsets(
+            placement, sharedOffsetMs, sampleRate, pinnedOffsetMs,
+            leftMs, plateauMs, rightMs);
+        var template = new PhaseAnalysisSettings(
+            PhaseWindowMode.FrequencyDependent,
+            FdwCycles,
+            // A detrend is a display convenience — it flattens a curve for the
+            // eye by rotating it against one τ. The cross-phase of two channels
+            // must not be detrended: a shared τ cancels out of it anyway, and
+            // anything per-channel would BE the answer the junction is read for.
+            PhaseDetrendMode.Off,
+            ManualDetrendMilliseconds: 0.0,
+            GateOffsetMs: 0.0,
+            leftMs,
+            plateauMs,
+            rightMs,
+            Unwrap: false,
+            SmoothingInverseOctaves: 0.0);
+
+        var spectra = new List<Complex[]>(channels.Count);
+        for (int i = 0; i < channels.Count; i++)
+        {
+            ProcessedChannel channel = channels[i];
+            // Peak index 0: gate offsets are absolute times from the start of
+            // the record, the same origin GatedPhaseCurves reads the drawn
+            // curves on.
+            Complex[] gated = DataHelper.GetPhaseAnalysisSpectrum(
+                new ImpulseMeasurementView(
+                    channel.ImpulseResponse, 0, channel.SampleRate),
+                template with { GateOffsetMs = offsets[i] },
+                out int extractionStart);
+            // A one-spectrum sum IS the re-reference: the rotation to the
+            // record's origin, without copying the caller's array.
+            spectra.Add(DataHelper.SumGatedSpectra(
+                [(gated, extractionStart)], targetExtractionStart: 0));
+        }
+
+        return spectra;
+    }
+}

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
@@ -453,11 +453,22 @@ internal static class VirtualCrossoverMetric
             // rather than a number nobody should act on. The POLARITY mark
             // still renders beside it — an inversion is not a matter of
             // magnitude, and it stays actionable when the delay does not.
+            //
+            // Both go dark on a junction the sweep cannot align at all: when
+            // even the best delay leaves the band out of phase
+            // (MinimumAlignableScore), the optimum is the least bad of a set of
+            // bad alignments, and printing it invites a change that measurably
+            // makes the sum worse. Dashed like an unreliable φ, and for the
+            // same reason — a figure the measurement does not support.
+            bool alignable =
+                result.BestScore >= JunctionPhaseAlignment.MinimumAlignableScore;
             double significantMs =
                 SignificantFixDegrees / 360.0 * 1_000.0 / entry.CrossoverHz;
-            string fix = Math.Abs(result.BestExtraDelayMs) >= significantMs
-                ? $"{FixText(result.BestExtraDelayMs),6}"
-                : "     ·";
+            string fix = !alignable
+                ? "     —"
+                : Math.Abs(result.BestExtraDelayMs) >= significantMs
+                    ? $"{FixText(result.BestExtraDelayMs),6}"
+                    : "     ·";
             // Polarity slot: "i" recommends flipping the lower channel; "~"
             // keeps the current polarity but flags that flipping nearly ties
             // (an inversion and a half-period delay sum alike here — common at
@@ -465,7 +476,8 @@ internal static class VirtualCrossoverMetric
             // summation; a space means the current polarity is clearly right.
             // This is distinct from the period-hop "!" on the lobe column.
             string polarity =
-                result.BestInvert ? "i"
+                !alignable ? " "
+                : result.BestInvert ? "i"
                 : result.BestScore - result.OppositePolarityScore
                     < JunctionPhaseAlignment.PolarityFlipAdvantage ? "~"
                 : " ";
@@ -475,7 +487,10 @@ internal static class VirtualCrossoverMetric
             // because a negative score that rounds to zero would otherwise
             // render "-0.00" as "-+0.00" (see the fix column).
             string score = $"{result.CurrentScore,5:0.00;-0.00;0.00}";
+            // The period-hop warning is about the fix: with no fix offered it
+            // would be warning about a number that is not on the row.
             string warning =
+                alignable &&
                 result.LobeMargin is { } margin && margin < AmbiguousLobeMargin
                     ? " !"
                     : string.Empty;
@@ -497,7 +512,7 @@ internal static class VirtualCrossoverMetric
             return string.Empty;
         }
 
-        return "Junction phase (steady state — what sustained bass sums to)\r\n" +
+        return "Junction phase (through the phase gate, 8-cycle window)\r\n" +
             string.Join("\r\n", entries.Select(entry =>
             {
                 JunctionPhaseResult result = entry.Result;
@@ -515,12 +530,22 @@ internal static class VirtualCrossoverMetric
                 string flip = result.BestInvert
                     ? $", invert {entry.LowerChannel}"
                     : $" (flip scores {result.OppositePolarityScore:0.00})";
+                // The same gate the column applies, spelled out: the sweep's
+                // best is still reported, because it is the evidence for the
+                // verdict, but it is named as a ceiling rather than offered as
+                // a delay to apply.
+                string advice =
+                    result.BestScore >= JunctionPhaseAlignment.MinimumAlignableScore
+                        ? $"best {result.BestScore:0.00} at " +
+                            $"{FixText(result.BestExtraDelayMs)} ms " +
+                            $"on {entry.LowerChannel}{flip}"
+                        : $"no delay aligns this band (ceiling " +
+                            $"{result.BestScore:0.00}) — the two paths do not " +
+                            "correlate here, so no fix is offered";
                 return $"{entry.Junction} @ {FrequencyText.Format(entry.CrossoverHz)}: " +
                     $"{phaseNote}; " +
                     $"phase score {result.CurrentScore:0.00} now, " +
-                    $"best {result.BestScore:0.00} at " +
-                    $"{FixText(result.BestExtraDelayMs)} ms " +
-                    $"on {entry.LowerChannel}{flip};\r\n   {rival}; " +
+                    $"{advice};\r\n   {rival}; " +
                     $"fit Δτ {result.FitDelayMs:+0.00;-0.00;0.00} ms, " +
                     $"rms {result.FitRmsDeg:0}° " +
                     $"({FrequencyText.Format(entry.LowHz)} – " +
@@ -535,7 +560,10 @@ internal static class VirtualCrossoverMetric
             "negative fix advances the lower channel — apply\r\nit as a +delay " +
             "on the UPPER one when the lower is already at 0. A fix worth less " +
             "than\r\n10° of phase at fc (0.03 dB in the sum) shows as \"·\": " +
-            "there is nothing to apply.\r\nPolarity mark: " +
+            "there is nothing to apply.\r\nA fix shows as \"—\" where even " +
+            "the best delay leaves the band out of phase: the two paths do\r\n" +
+            "not correlate over it, and moving one of them cannot help.\r\n" +
+            "Polarity mark: " +
             "\"i\" (or \"invert\") = flipping the lower channel scores " +
             "clearly better; \"~\" = the\r\ncurrent polarity is kept but a flip " +
             "nearly ties (an inversion and a half-period\r\ndelay sum alike, " +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -241,44 +241,64 @@ internal sealed class VirtualCrossoverMetrics
     }
 
     /// <summary>
-    /// The per-junction phase read-outs: each adjacent pair's steady-state
-    /// cross-phase analysis (the phase score, the phase at the crossover, the
+    /// The per-junction phase read-outs: each adjacent pair's gated cross-phase
+    /// analysis (the phase score, the phase at the crossover, the
     /// score-maximizing extra delay and polarity on the lower channel, and the
     /// lobe margin). Purely informative — nothing here feeds the alignment
-    /// engine. One analysis spectrum is built per channel and shared by the
-    /// junctions it participates in. Empty when there is no junction to read.
+    /// engine. Empty when there is no junction to read.
     /// </summary>
+    /// <param name="buildSpectra">
+    /// The windowed spectra the junctions are read from, one per channel of the
+    /// BAND-ORDERED set it is handed (<see cref="JunctionPhaseSpectra.Build"/>
+    /// under the panel's own gate). Passed in rather than built here because the
+    /// window placement is the panel's state and the whole set decides it
+    /// together — a per-channel factory could not fall back to one shared
+    /// window when a placement fails. Pure by contract: it is invoked off the
+    /// UI thread.
+    /// </param>
     public List<VirtualCrossoverMetric.PhaseEntry> BuildPhaseEntries(
-        List<ProcessedChannel> processed)
+        List<ProcessedChannel> processed,
+        Func<IReadOnlyList<ProcessedChannel>, IReadOnlyList<Complex[]>> buildSpectra)
     {
+        ArgumentNullException.ThrowIfNull(buildSpectra);
         var entries = new List<VirtualCrossoverMetric.PhaseEntry>();
         if (processed.Count < 2)
         {
             return entries;
         }
 
-        var spectra = new Dictionary<ProcessedChannel, Complex[]>();
-        Complex[] SpectrumOf(ProcessedChannel item)
+        List<ProcessedChannel> ordered = ProcessedChannels.OrderByBand(processed);
+        IReadOnlyList<Complex[]> spectra = buildSpectra(ordered);
+        if (spectra.Count != ordered.Count)
         {
-            if (!spectra.TryGetValue(item, out Complex[]? spectrum))
-            {
-                spectrum = JunctionPhaseAlignment.BuildAnalysisSpectrum(
-                    item.ImpulseResponse, item.SampleRate);
-                spectra.Add(item, spectrum);
-            }
-
-            return spectrum;
+            throw new InvalidOperationException(
+                "The spectrum builder must answer one spectrum per channel.");
         }
 
-        foreach (AdjacentPair pair in ProcessedChannels.GetAdjacentPairs(
-            ProcessedChannels.OrderByBand(processed)))
+        // By REFERENCE: a processed channel is a record, so two channels holding
+        // equal values would collide on a value-keyed lookup.
+        Complex[] SpectrumOf(ProcessedChannel item)
+        {
+            for (int i = 0; i < ordered.Count; i++)
+            {
+                if (ReferenceEquals(ordered[i], item))
+                {
+                    return spectra[i];
+                }
+            }
+
+            throw new InvalidOperationException(
+                "The junction names a channel outside the ordered set.");
+        }
+
+        foreach (AdjacentPair pair in ProcessedChannels.GetAdjacentPairs(ordered))
         {
             if (pair.Lower.SampleRate != pair.Upper.SampleRate)
             {
                 continue;
             }
 
-            JunctionPhaseResult? result = JunctionPhaseAlignment.AnalyzeSpectra(
+            JunctionPhaseResult? result = JunctionPhaseAlignment.AnalyzeWindowedSpectra(
                 SpectrumOf(pair.Lower),
                 SpectrumOf(pair.Upper),
                 pair.Lower.SampleRate,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3005,7 +3005,11 @@ public partial class VirtualCrossoverPanel : UserControl
             "to the side you are viewing (L or R): their drivers arrive at\r\n" +
             "different times, so fitting one no longer disturbs the other.\r\n" +
             "The Tukey lengths, window mode, detrend mode and FDW cycles\r\n" +
-            "are shared, so both sides read at one resolution and method.");
+            "are shared, so both sides read at one resolution and method.\r\n" +
+            "The Junction phase read-out is measured through this gate too,\r\n" +
+            "at a fixed 8-cycle window whatever the FDW selector says: the\r\n" +
+            "selector shapes a curve for the eye, and a shorter one moves the\r\n" +
+            "numbers more than it sharpens them.");
         toolTip.SetToolTip(
             buttonSessionExport,
             "Save the whole session (sources, DSP chains, gate, view)\r\n" +
@@ -3275,6 +3279,64 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
+        // A view spanning more than one listening group withholds the loss
+        // entirely — curve and figure alike. Front against rear combs however
+        // well either is tuned (no filter hands one band from one to the other),
+        // so the number would report damage nothing can repair. Those views owe
+        // the reader the cross-group arrival and level instead, which
+        // UpdateMetric appends.
+        //
+        // The same silence falls where the chain holds no junction at all, which
+        // a single-group view can still manage: Rear + Sub on the reference car
+        // is subwoofers up to 110 Hz and a rear fill from 290, with nothing
+        // crossing between them. GetAdjacentPairs already declines to invent that
+        // pair, but the loss curve and its total are computed over the window
+        // regardless — and a total summation loss for a chain with no handover
+        // is a figure about a crossover that is not in the car, which is the
+        // thing this view was supposed to stop printing.
+        //
+        // Resolved HERE rather than beside the loss curve it silences, because
+        // the junction phase block below is withheld under the same condition,
+        // for the same reason: both describe JUNCTIONS, and across groups those
+        // pairs do not exist.
+        bool quotesJunctions =
+            VirtualCrossoverGroupViews.LossChainZone(groupView) != null &&
+            ProcessedChannels.HasJunction(summedChannels);
+
+        // The junction phase read-out. Informative only: it renders alongside
+        // the sum loss and feeds nothing back into the alignment engine.
+        //
+        // Off the UI thread, unlike the sum-loss entries beside it, because it
+        // reads through the phase GATE: an 8-cycle frequency-dependent window is
+        // one transform per distinct window length per channel, which on the
+        // archived cabins measures 50–100 ms for four channels the first time a
+        // set of responses is seen (2 ms afterwards — DataHelper memoizes each
+        // gated spectrum per impulse array, and the phase view's own curves warm
+        // the very same entries). A delay drag makes every frame the first time,
+        // so that cost cannot sit in the frame. The gate is read from the panel's
+        // state HERE, on the UI thread; only plain numbers cross over.
+        List<VirtualCrossoverMetric.PhaseEntry> phaseEntries = [];
+        if (quotesJunctions)
+        {
+            int phaseRate = summedChannels[0].SampleRate;
+            double? pinnedOffsetMs = PinnedGateOffsetMs;
+            double gateLeftMs = gatePreview?.LeftMs ?? project.PhaseGateLeftMs;
+            double gatePlateauMs = gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs;
+            double gateRightMs = gatePreview?.RightMs ?? project.PhaseGateRightMs;
+            phaseEntries = await Task.Run(() =>
+            {
+                // The zone lives INSIDE the task, where it begins and ends on
+                // one thread: Tracy's zones are per-thread LIFO, so one spanning
+                // the await would close on whichever thread resumed it.
+                using var _ = AppProfiler.Zone("VirtualDSP.BuildPhaseEntries");
+                return metrics.BuildPhaseEntries(
+                    summedChannels,
+                    ordered => JunctionPhaseSpectra.Build(
+                        ordered, phaseRate, pinnedOffsetMs,
+                        gateLeftMs, gatePlateauMs, gateRightMs));
+            });
+        }
+
         // The stereo Δ block and the opposite-side sum read BOTH sides'
         // processed responses; their caches make an unchanged configuration
         // free. Same staleness rule as above.
@@ -3342,24 +3404,9 @@ public partial class VirtualCrossoverPanel : UserControl
                 shown, magnitudeGate.SmoothingInverseOctaves, summedChannels);
         }
 
-        // A view spanning more than one listening group withholds the loss
-        // entirely — curve and figure alike. Front against rear combs however
-        // well either is tuned (no filter hands one band from one to the other),
-        // so the number would report damage nothing can repair. Those views owe
-        // the reader the cross-group arrival and level instead, which
-        // UpdateMetric appends.
-        //
-        // The same silence falls where the chain holds no junction at all, which
-        // a single-group view can still manage: Rear + Sub on the reference car
-        // is subwoofers up to 110 Hz and a rear fill from 290, with nothing
-        // crossing between them. GetAdjacentPairs already declines to invent that
-        // pair, but the loss curve and its total are computed over the window
-        // regardless — and a total summation loss for a chain with no handover
-        // is a figure about a crossover that is not in the car, which is the
-        // thing this view was supposed to stop printing.
-        bool quotesJunctions =
-            VirtualCrossoverGroupViews.LossChainZone(groupView) != null &&
-            ProcessedChannels.HasJunction(summedChannels);
+        // Decided before the awaits above, because the junction phase block is
+        // computed there under the same condition; the loss CURVE is what is
+        // withheld here.
         if (!quotesJunctions)
         {
             lossCurve = null;
@@ -3411,8 +3458,8 @@ public partial class VirtualCrossoverPanel : UserControl
             // would invent a crossover between them and label a front-only figure
             // with it.
             UpdateMetric(
-                summedChannels, lossCurve, stereoDeltas, hybrid, groupDeltas,
-                quotesJunctions);
+                summedChannels, lossCurve, phaseEntries, stereoDeltas, hybrid,
+                groupDeltas);
         }
 
         using (AppProfiler.Zone("VirtualDSP.UpdateWarnings"))
@@ -3884,10 +3931,10 @@ public partial class VirtualCrossoverPanel : UserControl
     private void UpdateMetric(
         List<ProcessedChannel> processed,
         List<SignalPoint>? lossCurve,
+        IReadOnlyList<VirtualCrossoverMetric.PhaseEntry> phaseEntries,
         IReadOnlyList<VirtualCrossoverMetric.StereoDelta>? stereoDeltas = null,
         HybridMagnitudes? hybrid = null,
-        IReadOnlyList<VirtualCrossoverMetric.GroupDelta>? crossGroup = null,
-        bool quotesJunctions = true)
+        IReadOnlyList<VirtualCrossoverMetric.GroupDelta>? crossGroup = null)
     {
         IReadOnlyList<VirtualCrossoverMetric.GroupDelta> groupDeltas = crossGroup ?? [];
         // The read-out lives in the host's right-side panel (where overlays sit in
@@ -3902,25 +3949,13 @@ public partial class VirtualCrossoverPanel : UserControl
             entries = metrics.BuildEntries(processed, lossCurve);
         }
 
-        // The junction phase block is informative only: it renders alongside
-        // the sum loss but feeds nothing back into the alignment engine.
-        //
-        // It is withheld under the same condition as the loss, and for the same
-        // reason rather than a related one: both describe JUNCTIONS, and it
-        // builds them by pairing channels that are adjacent along the spectrum.
-        // Across groups those pairs do not exist — on the reference installation
-        // that pairing declares a front midrange handing over to a rear fill at
-        // its own low-pass corner, which no filter does — so every row it
-        // produced there would be about a crossover that is not in the car.
-        List<VirtualCrossoverMetric.PhaseEntry> phaseEntries = [];
-        if (quotesJunctions)
-        {
-            using (AppProfiler.Zone("VirtualDSP.BuildPhaseEntries"))
-            {
-                phaseEntries = metrics.BuildPhaseEntries(processed);
-            }
-        }
-
+        // The junction phase block arrives ready, built off the UI thread by the
+        // caller (see RedrawMainPlotAsync), which also decides whether this view
+        // quotes junctions at all: across listening groups the adjacent pairs it
+        // would read do not exist — on the reference installation that pairing
+        // declares a front midrange handing over to a rear fill at its own
+        // low-pass corner, which no filter does — so it is empty there, for the
+        // same reason the loss is withheld.
         string compact = VirtualCrossoverMetric.FormatCompact(entries);
         string detail = entries.Count > 0 ? VirtualCrossoverMetric.FormatDetail(entries) : string.Empty;
         if (phaseEntries.Count > 0)

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3006,10 +3006,13 @@ public partial class VirtualCrossoverPanel : UserControl
             "different times, so fitting one no longer disturbs the other.\r\n" +
             "The Tukey lengths, window mode, detrend mode and FDW cycles\r\n" +
             "are shared, so both sides read at one resolution and method.\r\n" +
-            "The Junction phase read-out is measured through this gate too,\r\n" +
-            "at a fixed 8-cycle window whatever the FDW selector says: the\r\n" +
-            "selector shapes a curve for the eye, and a shorter one moves the\r\n" +
-            "numbers more than it sharpens them.");
+            "The Junction phase read-out follows this gate's OFFSET and\r\n" +
+            "durations, but always reads an 8-cycle frequency-dependent\r\n" +
+            "window — the mode and FDW selectors shape a curve for the eye,\r\n" +
+            "and the settings that suit one are measurably the wrong\r\n" +
+            "instrument for a number. In the default FDW mode the numbers and\r\n" +
+            "the drawn curves are the same window; in Fixed mode they are not,\r\n" +
+            "and the plot then shows a longer window than the figures do.");
         toolTip.SetToolTip(
             buttonSessionExport,
             "Save the whole session (sources, DSP chains, gate, view)\r\n" +
@@ -3315,6 +3318,14 @@ public partial class VirtualCrossoverPanel : UserControl
         // the very same entries). A delay drag makes every frame the first time,
         // so that cost cannot sit in the frame. The gate is read from the panel's
         // state HERE, on the UI thread; only plain numbers cross over.
+        // The SUMMING channels, like the loss beside it: those are the ones
+        // whose junctions it reports, and the windows are placed over exactly
+        // them. In a grouped view that is not quite the drawn set — a centre is
+        // drawn beside the front stage and sums with neither — so a spectator
+        // failing the leading-edge guard can send the CURVES to one shared
+        // window while these figures keep their per-curve placements. That is
+        // the right way round: a channel taking part in none of the junctions
+        // being reported has no claim on the windows they are read through.
         List<VirtualCrossoverMetric.PhaseEntry> phaseEntries = [];
         if (quotesJunctions)
         {

--- a/tests/Resonalyze.App.Tests/JunctionPhaseWindowHarness.cs
+++ b/tests/Resonalyze.App.Tests/JunctionPhaseWindowHarness.cs
@@ -1,0 +1,659 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Numerics;
+using System.Text;
+using Resonalyze.Dsp;
+using Xunit.Abstractions;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The window probe behind the junction-phase read-out. The same junction
+/// arithmetic (<see cref="JunctionPhaseAlignment"/>) is read through the
+/// steady-state window it ships with AND through the gated / frequency-
+/// dependent windows the phase VIEW draws, over every archived cabin, on the
+/// owner's own saved tuning.
+/// <para>
+/// It exists to re-open a decision: the read-out deliberately ignores FDW
+/// because, when it was written (2026-07-19), direct-sound phase disagreed with
+/// the steady state by several milliseconds at subwoofer junctions. The phase
+/// gates have been re-anchored since — on the arrival rather than the peak
+/// (#78), per-curve with a leading-edge transparency guard, and every magnitude
+/// window on the response start (#107) — so the disagreement is measured again
+/// rather than assumed.
+/// </para>
+/// <para>
+/// A RUNNER, not a pinned expectation, exactly like
+/// <see cref="SessionBatteryHarness"/>: it asserts only that every session was
+/// found and read through every window. What the numbers mean is a reading.
+/// </para>
+/// </summary>
+public sealed class JunctionPhaseWindowHarness(ITestOutputHelper output)
+{
+    /// <summary>Where the report is written.</summary>
+    public const string OutputVariable = "RESONALYZE_JUNCTION_PHASE_WINDOW_OUT";
+
+    /// <summary>
+    /// One window under test. <see cref="Mode"/> null is the production
+    /// steady-state spectrum (the full processed IR, 0.68 s, origin at sample
+    /// 0); everything else is the phase view's own gate, placed by
+    /// <see cref="PhaseGatePlacement"/> the way the panel places it.
+    /// </summary>
+    /// <param name="Shared">
+    /// Forces ONE window for the whole set instead of the panel's per-curve
+    /// placement — the discriminator for whether a disagreement comes from the
+    /// window's LENGTH or from each channel's own arrival estimate, which only
+    /// the per-curve placement depends on.
+    /// </param>
+    private sealed record Window(
+        string Name, PhaseWindowMode? Mode, int Cycles, bool Shared = false);
+
+    private static readonly Window[] Windows =
+    [
+        new("steady", null, 0),
+        new("fixed", PhaseWindowMode.Fixed, 0),
+        new("fdw4", PhaseWindowMode.FrequencyDependent, 4),
+        new("fdw6", PhaseWindowMode.FrequencyDependent, 6),
+        new("fdw8", PhaseWindowMode.FrequencyDependent, 8),
+        new("fdw8s", PhaseWindowMode.FrequencyDependent, 8, Shared: true)
+    ];
+
+    // The two windows whose recommendation is actually APPLIED and judged by the
+    // panel's own summation-loss metric. Judging all five would multiply the run
+    // time for windows nobody is proposing to ship.
+    private static readonly string[] JudgedWindows = ["steady", "fdw8", "fdw8s"];
+
+    /// <summary>One junction read through one window.</summary>
+    private sealed record Reading(string Window, JunctionPhaseResult? Result);
+
+    /// <summary>
+    /// One junction of one cabin: what every window said, and what the metric
+    /// says after each judged window's fix is applied.
+    /// </summary>
+    private sealed record JunctionRow(
+        string Session,
+        string Junction,
+        double CrossoverHz,
+        List<Reading> Readings,
+        double SavedAverageDb,
+        double? SavedDipDb,
+        Dictionary<string, (double AverageDb, double? DipDb)> AfterFix);
+
+    [SessionBatteryFact]
+    public void CompareSteadyStateAgainstGatedWindows()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        var report = new StringBuilder();
+        var rows = new List<JunctionRow>();
+        var seen = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string session in SessionBatteryHarness.ResolveSessions(
+            SessionBatteryHarness.RootDirectory!))
+        {
+            Assert.True(File.Exists(session), $"Session file not found: {session}");
+            rows.AddRange(RunSession(session, report, seen));
+        }
+
+        Assert.NotEmpty(rows);
+        WriteSummary(report, rows);
+        string text = report.ToString();
+        output.WriteLine(text);
+        string path = Environment.GetEnvironmentVariable(OutputVariable)
+            ?? Path.Combine(Path.GetTempPath(), "resonalyze-junction-phase-window.txt");
+        File.WriteAllText(path, text);
+        output.WriteLine($"Report written to {path}");
+    }
+
+    private static List<JunctionRow> RunSession(
+        string sessionPath,
+        StringBuilder report,
+        Dictionary<string, string> seen)
+    {
+        VirtualCrossoverProjectFile project =
+            VirtualCrossoverProjectFile.LoadFrom(sessionPath);
+        List<VirtualCrossoverChannel> channels =
+            SessionBatteryHarness.LoadChannels(project, out string fingerprint);
+        string name = Path.GetFileName(Path.GetDirectoryName(sessionPath)!);
+        report.AppendLine();
+        report.AppendLine($"=== {name}  ({sessionPath})");
+        if (seen.TryGetValue(fingerprint, out string? original))
+        {
+            report.AppendLine(
+                $"  skipped: the same measurements and settings as {original}.");
+            return [];
+        }
+
+        seen.Add(fingerprint, name);
+        List<VirtualCrossoverChannel> participants = channels
+            .Where(channel =>
+                channel.Pair.Enabled &&
+                !channel.Pair.Bypass &&
+                channel.TransferImpulseResponse != null)
+            .ToList();
+        if (participants.Count < 2)
+        {
+            report.AppendLine(
+                $"  skipped: {participants.Count} participating channel(s).");
+            return [];
+        }
+
+        List<ProcessedChannel> saved = SessionBatteryHarness.Process(
+            participants, _ => null);
+        List<ProcessedChannel> ordered = ProcessedChannels.OrderByBand(saved);
+        List<AdjacentPair> pairs = ProcessedChannels.GetAdjacentPairs(ordered);
+        int sampleRate = ordered[0].SampleRate;
+        VirtualCrossoverPhaseGateSettings gate =
+            project.PhaseGateFor(project.ActiveSideRight);
+        report.AppendLine(
+            $"  side {(project.ActiveSideRight ? "R" : "L")}, {participants.Count} " +
+            $"channels, {sampleRate} Hz, gate " +
+            $"{gate.OffsetMs?.ToString("0.00", CultureInfo.InvariantCulture) ?? "auto"} " +
+            $"+ {project.PhaseGateLeftMs:0.#}/{project.PhaseGatePlateauMs:0.#}/" +
+            $"{project.PhaseGateRightMs:0.#} ms, " +
+            $"steady window {JunctionPhaseAlignment.AnalysisSamplesFor(sampleRate) * 1_000.0 / sampleRate:0} ms " +
+            $"/ FFT {JunctionPhaseAlignment.AnalysisLengthFor(sampleRate)}, " +
+            $"gated FFT {DataHelper.GatedFftLength}");
+        if (pairs.Count == 0)
+        {
+            report.AppendLine("  no junction in the set.");
+            return [];
+        }
+
+        // Every window's spectra for the whole set, once. Timed COLD (the first
+        // build of these responses) and WARM (the cache DataHelper keeps per
+        // impulse array), because this runs on the UI thread inside the redraw:
+        // the steady state is one FFT per channel, an FDW spectrum is one per
+        // distinct effective gate.
+        var spectra = new Dictionary<string, List<Complex[]>>(StringComparer.Ordinal);
+        var cold = new Dictionary<string, double>(StringComparer.Ordinal);
+        var warm = new Dictionary<string, double>(StringComparer.Ordinal);
+        foreach (Window window in Windows)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            spectra[window.Name] = BuildSpectra(
+                ordered, project, window, sampleRate, report);
+            cold[window.Name] = stopwatch.Elapsed.TotalMilliseconds;
+            stopwatch.Restart();
+            BuildSpectra(ordered, project, window, sampleRate, null);
+            warm[window.Name] = stopwatch.Elapsed.TotalMilliseconds;
+        }
+
+        report.AppendLine(
+            $"  spectra for {ordered.Count} channels, ms cold/warm: " +
+            string.Join("  ", Windows.Select(window =>
+                $"{window.Name} {cold[window.Name]:0.0}/{warm[window.Name]:0.0}")));
+
+        // The block AS THE PANEL RENDERS IT, through the shipped path end to
+        // end: the read-out is what ships, not the table above it, and the
+        // withheld figures only exist in this rendering.
+        using (var coordinator = new VirtualCrossoverProcessingCoordinator())
+        {
+            var metrics = new VirtualCrossoverMetrics(
+                coordinator,
+                // Never called: the phase entries read spectra, not magnitudes.
+                (_, _, _, _, _) => throw new InvalidOperationException(
+                    "the junction phase block reads no magnitude curve"));
+            List<VirtualCrossoverMetric.PhaseEntry> shipped =
+                metrics.BuildPhaseEntries(
+                    saved,
+                    channels => JunctionPhaseSpectra.Build(
+                        channels,
+                        sampleRate,
+                        gate.OffsetMs,
+                        project.PhaseGateLeftMs,
+                        project.PhaseGatePlateauMs,
+                        project.PhaseGateRightMs));
+            report.AppendLine();
+            foreach (string line in VirtualCrossoverMetric
+                .FormatPhaseCompact(shipped).Split("\r\n"))
+            {
+                report.AppendLine("  | " + line);
+            }
+        }
+
+        List<VirtualCrossoverMetric.Entry> savedEntries =
+            SessionBatteryHarness.Judge(project, saved);
+        var rows = new List<JunctionRow>();
+        foreach (AdjacentPair pair in pairs)
+        {
+            string junction =
+                $"{pair.Lower.Channel.Name}/{pair.Upper.Channel.Name}";
+            // By REFERENCE: a processed channel is a record, so two channels
+            // that happen to hold equal values would collide on value equality.
+            int lower = IndexOf(ordered, pair.Lower);
+            int upper = IndexOf(ordered, pair.Upper);
+            report.AppendLine();
+            report.AppendLine(
+                $"  {junction}  fc {pair.CrossoverHz:0.#} Hz  " +
+                $"band {pair.BandLowHz:0.#}-{pair.BandHighHz:0.#} Hz");
+            // The independent witness: the whitened (PHAT) correlation of the
+            // pair's DIRECT sound. Its readings are corrections to the UPPER
+            // channel, so the junction fix (extra delay on the LOWER one) is
+            // comparable to the NEGATED lag. The owner's tune sits on the
+            // extremum, so on saved settings an on-lobe lag near zero is what a
+            // correct read-out should be recommending nothing against.
+            JunctionCorrelationView correlation =
+                VirtualCrossoverPanel.BuildCorrelationView(pair, ordered);
+            if (correlation.WhitenedDirect.Count > 0)
+            {
+                SignalPoint best = correlation.WhitenedDirect
+                    .MaxBy(point => Math.Abs(point.Y));
+                SignalPoint near = correlation.WhitenedDirect
+                    .Where(point => Math.Abs(point.X) <= 500.0 / pair.CrossoverHz)
+                    .DefaultIfEmpty(best)
+                    .MaxBy(point => Math.Abs(point.Y));
+                report.AppendLine(
+                    $"    direct-PHAT: on-lobe r {near.Y:+0.00;-0.00;0.00} @ " +
+                    $"{near.X:+0.000;-0.000;0.000} ms (fix would be " +
+                    $"{-near.X:+0.000;-0.000;0.000}); best r " +
+                    $"{best.Y:+0.00;-0.00;0.00} @ {best.X:+0.000;-0.000;0.000} ms");
+            }
+
+            report.AppendLine(
+                "    window       φfc    R    fix ms  pol   score    best  " +
+                "opp    fit ms  rms°");
+
+            var readings = new List<Reading>();
+            foreach (Window window in Windows)
+            {
+                List<Complex[]> set = spectra[window.Name];
+                JunctionPhaseResult? result =
+                    JunctionPhaseAlignment.AnalyzeWindowedSpectra(
+                        set[lower], set[upper], sampleRate,
+                        pair.CrossoverHz, pair.BandLowHz, pair.BandHighHz);
+                readings.Add(new Reading(window.Name, result));
+                report.AppendLine("    " + Describe(window.Name, result));
+            }
+
+            VirtualCrossoverMetric.Entry? savedEntry = savedEntries
+                .Cast<VirtualCrossoverMetric.Entry?>()
+                .FirstOrDefault(entry =>
+                    entry!.Value.Junction == junction && !entry.Value.IsTotal);
+            if (savedEntry is not { } baseline)
+            {
+                continue;
+            }
+
+            // The recommendation, applied: the fix goes on the LOWER channel of
+            // this junction (a signed delay — the chain takes a negative one),
+            // together with the polarity the window recommends, and the panel's
+            // own metric re-reads the junction. Nothing else about the session
+            // moves, so the delta is this window's advice and nothing else.
+            var afterFix = new Dictionary<string, (double, double?)>(
+                StringComparer.Ordinal);
+            foreach (string windowName in JudgedWindows)
+            {
+                if (readings.First(item => item.Window == windowName).Result
+                    is not { } advice)
+                {
+                    continue;
+                }
+
+                VirtualCrossoverChannel lowerChannel = pair.Lower.Channel;
+                VirtualCrossoverChannelSettings settings =
+                    lowerChannel.SideSettings(lowerChannel.ActiveRight);
+                List<ProcessedChannel> fixedSet = SessionBatteryHarness.Process(
+                    participants,
+                    channel => ReferenceEquals(channel, lowerChannel)
+                        ? new AlignmentOverride(
+                            settings.DelayMs + advice.BestExtraDelayMs,
+                            settings.InvertPolarity ^ advice.BestInvert)
+                        : (AlignmentOverride?)null);
+                VirtualCrossoverMetric.Entry? entry =
+                    SessionBatteryHarness.Judge(project, fixedSet)
+                        .Cast<VirtualCrossoverMetric.Entry?>()
+                        .FirstOrDefault(item =>
+                            item!.Value.Junction == junction && !item.Value.IsTotal);
+                if (entry is { } judged)
+                {
+                    afterFix[windowName] = (judged.AverageDb, judged.DipDb);
+                }
+            }
+
+            report.AppendLine(
+                $"    sum loss avg/dip: saved {baseline.AverageDb,6:0.00} / " +
+                $"{Format(baseline.DipDb),-6}" +
+                string.Concat(JudgedWindows.Select(windowName =>
+                    afterFix.TryGetValue(windowName, out (double Avg, double? Dip) after)
+                        ? $"   {windowName}-fix {after.Avg,6:0.00} / " +
+                          $"{Format(after.Dip),-6} " +
+                          $"(Δ{after.Avg - baseline.AverageDb:+0.00;-0.00;0.00})"
+                        : $"   {windowName}-fix —")));
+
+            rows.Add(new JunctionRow(
+                name, junction, pair.CrossoverHz, readings,
+                baseline.AverageDb, baseline.DipDb,
+                afterFix.ToDictionary(
+                    item => item.Key, item => item.Value, StringComparer.Ordinal)));
+        }
+
+        return rows;
+    }
+
+    // One window's spectra for the whole set, on ONE absolute time origin.
+    private static List<Complex[]> BuildSpectra(
+        List<ProcessedChannel> ordered,
+        VirtualCrossoverProjectFile project,
+        Window window,
+        int sampleRate,
+        StringBuilder? report)
+    {
+        if (window.Mode is null)
+        {
+            return ordered
+                .Select(item => JunctionPhaseAlignment.BuildAnalysisSpectrum(
+                    item.ImpulseResponse, item.SampleRate))
+                .ToList();
+        }
+
+        // The shipped window goes through the SHIPPED builder, so this row
+        // measures the read-out rather than a second implementation of it. The
+        // remaining rows are the comparison it was chosen against, and they
+        // vary cycles and placement, which the product code does not.
+        if (window is { Mode: PhaseWindowMode.FrequencyDependent, Shared: false } &&
+            window.Cycles == JunctionPhaseSpectra.FdwCycles)
+        {
+            return JunctionPhaseSpectra.Build(
+                ordered,
+                sampleRate,
+                project.PhaseGateFor(project.ActiveSideRight).OffsetMs,
+                project.PhaseGateLeftMs,
+                project.PhaseGatePlateauMs,
+                project.PhaseGateRightMs);
+        }
+
+        // The panel's own placement: the session's pin when it has one, else
+        // each curve on its own estimated arrival start, with the whole set
+        // falling back to one shared window when any placement fails the
+        // leading-edge guard.
+        double? pinned = project.PhaseGateFor(project.ActiveSideRight).OffsetMs;
+        IReadOnlyList<PlacementChannel> placement = PlacementChannel.From(ordered);
+        double sharedOffsetMs = PhaseGatePlacement.ResolveSharedOffsetMs(
+            placement, sampleRate, pinned);
+        List<double> offsets = PhaseGatePlacement.ResolvePerCurveOffsets(
+            placement,
+            sharedOffsetMs,
+            sampleRate,
+            // A non-null pin is what makes the placement one shared window.
+            window.Shared ? sharedOffsetMs : pinned,
+            project.PhaseGateLeftMs,
+            project.PhaseGatePlateauMs,
+            project.PhaseGateRightMs);
+        var template = new PhaseAnalysisSettings(
+            window.Mode.Value,
+            window.Cycles == 0 ? PhaseAnalysisSettings.DefaultFdwCycles : window.Cycles,
+            // The detrend is a display convenience (it flattens a curve for the
+            // eye). The cross-phase between two channels must not be detrended
+            // at all: a common τ cancels, and anything per-channel would BE the
+            // answer this probe is measuring.
+            PhaseDetrendMode.Off,
+            ManualDetrendMilliseconds: 0.0,
+            GateOffsetMs: 0.0,
+            project.PhaseGateLeftMs,
+            project.PhaseGatePlateauMs,
+            project.PhaseGateRightMs,
+            Unwrap: false,
+            SmoothingInverseOctaves: 0.0);
+
+        var spectra = new List<Complex[]>(ordered.Count);
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            Complex[] gated = DataHelper.GetPhaseAnalysisSpectrum(
+                new ImpulseMeasurementView(ordered[i].ImpulseResponse, 0, sampleRate),
+                template with { GateOffsetMs = offsets[i] },
+                out int extractionStart);
+            // Re-referenced to sample 0, the origin the steady-state spectra
+            // already sit on: a window placed per curve otherwise reads its own
+            // placement as the junction's delay.
+            spectra.Add(DataHelper.SumGatedSpectra([(gated, extractionStart)], 0));
+        }
+
+        if (report != null && (window.Name == Windows[1].Name || window.Shared))
+        {
+            report.AppendLine(
+                $"  gate offsets ({window.Name}, ms): " + string.Join(", ", ordered.Select(
+                    (item, index) =>
+                        $"{item.Channel.Name} {offsets[index]:0.00}")) +
+                (offsets.Distinct().Count() == 1
+                    ? "   (one shared window)"
+                    : "   (per curve)"));
+        }
+
+        return spectra;
+    }
+
+    private static string Describe(string window, JunctionPhaseResult? result)
+    {
+        if (result is not { } value)
+        {
+            return $"{window,-9}  (no reading: too few gated bins, or fc out of range)";
+        }
+
+        string phase = value.PhaseConsistency >=
+            JunctionPhaseAlignment.MinimumPhaseConsistency
+            ? $"{value.PhaseAtCrossoverDeg,5:+0;-0;0}°"
+            : $"{value.PhaseAtCrossoverDeg,5:+0;-0;0}?";
+        string polarity = value.BestInvert
+            ? "INV"
+            : value.BestScore - value.OppositePolarityScore <
+                JunctionPhaseAlignment.PolarityFlipAdvantage ? " ~ " : "   ";
+        return
+            $"{window,-9} {phase} {value.PhaseConsistency,5:0.00} " +
+            $"{value.BestExtraDelayMs,8:+0.000;-0.000;0.000} {polarity} " +
+            $"{value.CurrentScore,7:0.000;-0.000;0.000} " +
+            $"{value.BestScore,7:0.000;-0.000;0.000} " +
+            $"{value.OppositePolarityScore,6:0.00;-0.00;0.00} " +
+            $"{value.FitDelayMs,9:+0.000;-0.000;0.000} {value.FitRmsDeg,5:0}";
+    }
+
+    private static string Format(double? value) =>
+        value?.ToString("0.00", CultureInfo.InvariantCulture) ?? "-";
+
+    private static void WriteSummary(StringBuilder report, List<JunctionRow> rows)
+    {
+        report.AppendLine();
+        report.AppendLine("=== per-junction summary (saved tuning)");
+        report.AppendLine(
+            "  session          junction   fc Hz  " +
+            string.Concat(Windows.Select(window => $"{window.Name,8} φ/fix ")) +
+            "   Δsum-loss steady / fdw8");
+        foreach (JunctionRow row in rows)
+        {
+            report.AppendLine(
+                $"  {row.Session,-16} {row.Junction,-10} {row.CrossoverHz,6:0} " +
+                string.Concat(row.Readings.Select(reading =>
+                    reading.Result is { } value
+                        ? $"{value.PhaseAtCrossoverDeg,5:+0;-0;0}/" +
+                          $"{value.BestExtraDelayMs,-8:+0.000;-0.000;0.000}"
+                        : $"{"—",5}/{"—",-8}")) +
+                string.Concat(JudgedWindows.Select(window =>
+                    row.AfterFix.TryGetValue(window, out (double Avg, double? Dip) after)
+                        ? $"  {after.Avg - row.SavedAverageDb,7:+0.00;-0.00;0.00}"
+                        : $"  {"—",7}")));
+        }
+
+        report.AppendLine();
+        report.AppendLine("=== how the windows disagree, across every junction");
+        report.AppendLine(
+            "  window     n   |Δφ vs steady|      |Δfix vs steady| ms      " +
+            "median |fix|   R<0.5   polarity differs");
+        foreach (Window window in Windows)
+        {
+            List<(JunctionPhaseResult Steady, JunctionPhaseResult Other)> paired = rows
+                .Select(row => (
+                    Steady: row.Readings.First(item => item.Window == "steady").Result,
+                    Other: row.Readings.First(item => item.Window == window.Name).Result))
+                .Where(item => item.Steady is not null && item.Other is not null)
+                .Select(item => (item.Steady!, item.Other!))
+                .ToList();
+            if (paired.Count == 0)
+            {
+                report.AppendLine($"  {window.Name,-9}   0");
+                continue;
+            }
+
+            List<double> phaseDeltas = paired
+                .Select(item => Math.Abs(Wrap(
+                    item.Other.PhaseAtCrossoverDeg - item.Steady.PhaseAtCrossoverDeg)))
+                .ToList();
+            List<double> fixDeltas = paired
+                .Select(item => Math.Abs(
+                    item.Other.BestExtraDelayMs - item.Steady.BestExtraDelayMs))
+                .ToList();
+            report.AppendLine(
+                $"  {window.Name,-9} {paired.Count,3}   " +
+                $"med {Median(phaseDeltas),5:0}°  max {phaseDeltas.Max(),5:0}°   " +
+                $"med {Median(fixDeltas),7:0.000}  max {fixDeltas.Max(),7:0.000}   " +
+                $"{Median(paired.Select(item => Math.Abs(item.Other.BestExtraDelayMs)).ToList()),8:0.000}   " +
+                $"{paired.Count(item => item.Other.PhaseConsistency < JunctionPhaseAlignment.MinimumPhaseConsistency),5}   " +
+                $"{paired.Count(item => item.Other.BestInvert != item.Steady.BestInvert),9}");
+        }
+
+        report.AppendLine();
+        report.AppendLine(
+            "=== the ceiling each window allows, split by junction band");
+        report.AppendLine(
+            "  BestScore is the highest in-phase score ANY delay reaches over the " +
+            "band: a ceiling");
+        report.AppendLine(
+            "  well under 1 is the window's own decorrelation, not a misalignment " +
+            "a fix can reach.");
+        report.AppendLine(
+            "  band              n  " +
+            string.Concat(Windows.Select(window => $"{window.Name,8} med ")) +
+            "  fdw8 better/same/worse vs steady");
+        foreach ((string label, Func<double, bool> inBand) in new (string, Func<double, bool>)[]
+        {
+            ("fc < 500 Hz", hz => hz < 500.0),
+            ("fc >= 1000 Hz", hz => hz >= 1_000.0)
+        })
+        {
+            List<JunctionRow> band = rows.Where(row => inBand(row.CrossoverHz)).ToList();
+            if (band.Count == 0)
+            {
+                continue;
+            }
+
+            List<double> steady = Ceilings(band, "steady");
+            List<double> fdw8 = Ceilings(band, "fdw8");
+            int better = 0, same = 0, worse = 0;
+            for (int i = 0; i < Math.Min(steady.Count, fdw8.Count); i++)
+            {
+                if (fdw8[i] > steady[i] + 0.02) better++;
+                else if (fdw8[i] < steady[i] - 0.02) worse++;
+                else same++;
+            }
+
+            report.AppendLine(
+                $"  {label,-16} {band.Count,2}  " +
+                string.Concat(Windows.Select(window =>
+                {
+                    List<double> ceilings = Ceilings(band, window.Name);
+                    return ceilings.Count == 0
+                        ? $"{"—",8}     "
+                        : $"{Median(ceilings),8:0.000}     ";
+                })) +
+                $"  {better} / {same} / {worse}");
+        }
+
+        report.AppendLine();
+        report.AppendLine(
+            "=== calibrating the fix guard: suppress the fix below a BestScore " +
+            "threshold (fdw8)");
+        report.AppendLine(
+            "  A junction whose ceiling is low cannot be brought into phase by ANY " +
+            "delay, so its");
+        report.AppendLine(
+            "  fix is not a recommendation. Judged against what applying that fix " +
+            "did to the");
+        report.AppendLine(
+            "  panel's own sum loss: suppressing a fix that HURT is a catch, " +
+            "suppressing one that");
+        report.AppendLine("  HELPED is a loss.");
+        report.AppendLine(
+            "  threshold   suppressed   of them harmful / neutral / helpful");
+        for (double threshold = 0.30; threshold <= 0.801; threshold += 0.05)
+        {
+            List<JunctionRow> suppressed = rows
+                .Where(row => row.Readings
+                    .First(reading => reading.Window == "fdw8").Result
+                    is { } value && value.BestScore < threshold)
+                .ToList();
+            List<double> deltas = suppressed
+                .Where(row => row.AfterFix.ContainsKey("fdw8"))
+                .Select(row => row.AfterFix["fdw8"].AverageDb - row.SavedAverageDb)
+                .ToList();
+            report.AppendLine(
+                $"  {threshold,9:0.00}   {suppressed.Count,10}   " +
+                $"{deltas.Count(value => value < -0.01),9} / " +
+                $"{deltas.Count(value => Math.Abs(value) <= 0.01),7} / " +
+                $"{deltas.Count(value => value > 0.01),7}" +
+                (suppressed.Count == 0
+                    ? string.Empty
+                    : "   " + string.Join(", ", suppressed.Select(row =>
+                        $"{row.Session} {row.Junction}"))));
+        }
+
+        report.AppendLine();
+        report.AppendLine(
+            "=== what the panel's metric says about each judged window's advice");
+        report.AppendLine(
+            "  window     n   Δsum-loss avg (dB, + = better)      improved / unchanged / worse");
+        foreach (string window in JudgedWindows)
+        {
+            List<double> deltas = rows
+                .Where(row => row.AfterFix.ContainsKey(window))
+                .Select(row => row.AfterFix[window].AverageDb - row.SavedAverageDb)
+                .ToList();
+            if (deltas.Count == 0)
+            {
+                report.AppendLine($"  {window,-9}   0");
+                continue;
+            }
+
+            report.AppendLine(
+                $"  {window,-9} {deltas.Count,3}   " +
+                $"mean {deltas.Average(),6:+0.00;-0.00;0.00}  " +
+                $"med {Median(deltas),6:+0.00;-0.00;0.00}  " +
+                $"best {deltas.Max(),6:+0.00;-0.00;0.00}  " +
+                $"worst {deltas.Min(),6:+0.00;-0.00;0.00}      " +
+                $"{deltas.Count(value => value > 0.01),3} / " +
+                $"{deltas.Count(value => Math.Abs(value) <= 0.01),3} / " +
+                $"{deltas.Count(value => value < -0.01),3}");
+        }
+    }
+
+    private static int IndexOf(List<ProcessedChannel> ordered, ProcessedChannel item)
+    {
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            if (ReferenceEquals(ordered[i], item))
+            {
+                return i;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "The junction names a channel that is not in the ordered set.");
+    }
+
+    // The best in-phase score the sweep reaches over the band, per junction.
+    private static List<double> Ceilings(List<JunctionRow> rows, string window) =>
+        rows
+            .Select(row => row.Readings
+                .First(reading => reading.Window == window).Result?.BestScore)
+            .Where(value => value.HasValue)
+            .Select(value => value!.Value)
+            .ToList();
+
+    private static double Wrap(double degrees) =>
+        degrees - 360.0 * Math.Round(degrees / 360.0);
+
+    private static double Median(List<double> values)
+    {
+        List<double> sorted = values.Order().ToList();
+        int middle = sorted.Count / 2;
+        return sorted.Count % 2 == 1
+            ? sorted[middle]
+            : 0.5 * (sorted[middle - 1] + sorted[middle]);
+    }
+}

--- a/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
+++ b/tests/Resonalyze.App.Tests/SessionBatteryHarness.cs
@@ -159,7 +159,7 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
         output.WriteLine($"Report written to {reportPath}");
     }
 
-    private static IEnumerable<string> ResolveSessions(string root)
+    internal static IEnumerable<string> ResolveSessions(string root)
     {
         string? configured = Environment.GetEnvironmentVariable(SessionsVariable);
         IEnumerable<string> names = string.IsNullOrWhiteSpace(configured)
@@ -447,7 +447,7 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
     // source run through its chain (the session's, or the session's with the
     // proposal's delay and polarity on top) by the same snapshot the tool
     // processes through, so the head crop and the FFT are the tool's.
-    private static List<ProcessedChannel> Process(
+    internal static List<ProcessedChannel> Process(
         List<VirtualCrossoverChannel> participants,
         Func<VirtualCrossoverChannel, AlignmentOverride?> overrideFor)
     {
@@ -488,7 +488,7 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
     // its own smoothing code) — never a default invented here. Calibration is
     // null: it belongs to the machine that measured, not to the session, and
     // it applies identically to both sides of the comparison anyway.
-    private static List<VirtualCrossoverMetric.Entry> Judge(
+    internal static List<VirtualCrossoverMetric.Entry> Judge(
         VirtualCrossoverProjectFile project,
         List<ProcessedChannel> processed)
     {
@@ -547,7 +547,7 @@ public sealed class SessionBatteryHarness(ITestOutputHelper output)
     // session: the stored path first, then the same measurement beside the
     // session file (VirtualCrossoverSourceLocator), which is what makes an
     // archived cabin load on a machine that never measured it.
-    private static List<VirtualCrossoverChannel> LoadChannels(
+    internal static List<VirtualCrossoverChannel> LoadChannels(
         VirtualCrossoverProjectFile project,
         out string fingerprint)
     {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -397,6 +397,62 @@ public sealed class VirtualCrossoverMetricTests
     }
 
     [Fact]
+    public void FormatPhaseCompact_WithholdsTheFixWhereNoDelayAlignsTheBand()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            // A junction whose two drivers do not correlate over the overlap:
+            // the sweep's best is still far out of phase, so its optimum is the
+            // least bad of a set of bad alignments and not a delay to apply.
+            // Field case behind the threshold: a 2 kHz handover whose −0.37 ms
+            // "fix" cost 1.15 dB of summation loss when applied.
+            VirtualCrossoverMetric.PhaseEntry incoherent = PhaseJunction() with
+            {
+                Result = PhaseJunction().Result with
+                {
+                    BestScore = 0.34,
+                    CurrentScore = 0.29,
+                    OppositePolarityScore = 0.31
+                }
+            };
+
+            string text = VirtualCrossoverMetric.FormatPhaseCompact([incoherent]);
+
+            Assert.Contains("A/B     -3°      —   0.29", text);
+            Assert.DoesNotContain("-1.30", text);
+            // The polarity mark goes with it: it is read off the same two
+            // scores, and a flip is the more disruptive of the two changes.
+            Assert.DoesNotContain("~", text);
+            // And the period-hop warning, which is about the withheld fix.
+            Assert.DoesNotContain("!", text);
+
+            // Above the threshold the same junction recommends normally.
+            Assert.Contains(
+                "-1.30",
+                VirtualCrossoverMetric.FormatPhaseCompact([PhaseJunction()]));
+        });
+    }
+
+    [Fact]
+    public void FormatPhaseDetail_SaysWhyTheFixIsWithheld()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            VirtualCrossoverMetric.PhaseEntry incoherent = PhaseJunction() with
+            {
+                Result = PhaseJunction().Result with { BestScore = 0.34 }
+            };
+
+            string text = VirtualCrossoverMetric.FormatPhaseDetail([incoherent]);
+
+            // The ceiling is still reported — it is the evidence for the
+            // verdict — but named as a ceiling rather than offered as a delay.
+            Assert.Contains("no delay aligns this band (ceiling 0.34)", text);
+            Assert.DoesNotContain("best 0.34 at", text);
+        });
+    }
+
+    [Fact]
     public void FormatPhaseCompact_KeepsThePolarityMarkOnAMutedFix()
     {
         RunWithInvariantCulture(() =>

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -187,6 +187,53 @@ public sealed class VirtualCrossoverMetricsTests
             [Processed("A", Impulse(), 5, 48_000)], lossCurve: null));
     }
 
+    [Fact]
+    public void JunctionSpectra_KeepEachCurveOnItsOwnWindowAndStillCarryTheDelay()
+    {
+        // The window placement and the cross-phase pull against each other: an
+        // unpinned gate puts each curve on its OWN arrival, which is what keeps
+        // a late channel inside the short high-frequency windows, and that is a
+        // different time reference per channel. A junction is read from the
+        // CROSS-phase of two of them, so unless every spectrum is rotated back
+        // to the record's origin the placement difference reads as a delay —
+        // and here it would cancel the very misalignment under test.
+        List<ProcessedChannel> ordered =
+        [
+            ProcessedThroughChain("A", CrossoverKind.LowPass, 200),
+            ProcessedThroughChain("B", CrossoverKind.HighPass, 200, delayMs: 2.0)
+        ];
+
+        // The placement really is per curve here — otherwise this test would
+        // pass on a bug, both curves sharing one window and nothing to rotate.
+        List<double> offsets = PhaseGatePlacement.ResolvePerCurveOffsets(
+            PlacementChannel.From(ordered),
+            PhaseGatePlacement.EarliestStartMs(
+                PlacementChannel.From(ordered), 48_000),
+            48_000,
+            pinnedOffsetMs: null,
+            leftMs: 0.5,
+            plateauMs: 4.0,
+            rightMs: 1.5);
+        // Well over one period of the 200 Hz junction (5 ms), so a spectrum left
+        // on its own placement could not read as this pair at all.
+        Assert.True(
+            offsets[1] - offsets[0] > 1.0,
+            $"the placements have to differ: {offsets[0]} and {offsets[1]} ms");
+
+        JunctionPhaseResult? result = JunctionPhaseAlignment.AnalyzeWindowedSpectra(
+            JunctionSpectra(ordered)[0],
+            JunctionSpectra(ordered)[1],
+            48_000,
+            crossoverHz: 200,
+            bandLowHz: 100,
+            bandHighHz: 400);
+
+        // B is 2 ms late, so the lower channel needs the same 2 ms — the whole
+        // of it, not the fraction a lost re-reference would leave.
+        Assert.NotNull(result);
+        Assert.InRange(result!.BestExtraDelayMs, 1.9, 2.1);
+    }
+
     // A channel processed through a real crossover chain, for the junction
     // phase read-out: the settings carry the crossover (so the junction and its
     // overlap band resolve) and the IR is the chain-applied impulse.
@@ -219,6 +266,18 @@ public sealed class VirtualCrossoverMetricsTests
             OxyColors.White);
     }
 
+    // The panel's own window, unpinned (each curve on its own arrival) with the
+    // project's default Tukey shoulders — the placement the read-out ships with.
+    private static IReadOnlyList<Complex[]> JunctionSpectra(
+        IReadOnlyList<ProcessedChannel> ordered) =>
+        JunctionPhaseSpectra.Build(
+            ordered,
+            ordered[0].SampleRate,
+            pinnedOffsetMs: null,
+            leftMs: 0.5,
+            plateauMs: 4.0,
+            rightMs: 1.5);
+
     [Fact]
     public void BuildPhaseEntries_IsEmptyForFewerThanTwoChannels()
     {
@@ -226,7 +285,8 @@ public sealed class VirtualCrossoverMetricsTests
         var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _, _, _) => EmptyMagnitude);
 
         Assert.Empty(metrics.BuildPhaseEntries(
-            [ProcessedThroughChain("A", CrossoverKind.LowPass, 200)]));
+            [ProcessedThroughChain("A", CrossoverKind.LowPass, 200)],
+            JunctionSpectra));
     }
 
     [Fact]
@@ -237,12 +297,15 @@ public sealed class VirtualCrossoverMetricsTests
 
         // Passed upper-first on purpose: the entries must order by band, not by
         // argument order. The upper channel runs 2 ms late, so the read-out
-        // recommends the same extra delay on the lower one.
+        // recommends the same extra delay on the lower one — a misalignment the
+        // gated window has to recover through the panel's own placement, which
+        // is what makes this a test of the read-out and not of the dsp maths.
         List<VirtualCrossoverMetric.PhaseEntry> entries = metrics.BuildPhaseEntries(
         [
             ProcessedThroughChain("B", CrossoverKind.HighPass, 200, delayMs: 2.0),
             ProcessedThroughChain("A", CrossoverKind.LowPass, 200)
-        ]);
+        ],
+            JunctionSpectra);
 
         VirtualCrossoverMetric.PhaseEntry entry = Assert.Single(entries);
         Assert.Equal("A/B", entry.Junction);
@@ -251,7 +314,12 @@ public sealed class VirtualCrossoverMetricsTests
         Assert.Equal(100, entry.LowHz);
         Assert.Equal(400, entry.HighHz);
         Assert.InRange(entry.Result.BestExtraDelayMs, 1.9, 2.1);
-        Assert.InRange(entry.Result.BestScore, 0.95, 1.0);
+        // Not ~1.00: the read goes through the panel's gate, and the project's
+        // default 0.5/4/1.5 ms window holds barely more than one period of a
+        // 200 Hz junction, so the band's own skirts cost it a few hundredths.
+        // The figure under test is the recovered delay above; this bound only
+        // asserts the band still reads as aligned.
+        Assert.InRange(entry.Result.BestScore, 0.90, 1.0);
     }
 
     [Fact]


### PR DESCRIPTION
The Junction phase block read a 0.68 s steady-state window over the whole processed IR, on the grounds — written into `JunctionPhaseAlignment` in July — that direct-sound phase disagreed with it "by several ms at subwoofer frequencies, which is the room's own group delay". After the gate work of #78 (anchor the automatic phase gates on the arrival) and #107 (anchor every magnitude window on the response start), that claim was worth re-measuring rather than inheriting.

## What the battery says

`JunctionPhaseWindowHarness` reads the eight archived cabins the way the app does, on each session's **saved tuning**, and runs the same `JunctionPhaseAlignment` arithmetic through six windows: the steady state, the session's fixed gate, FDW at 4/6/8 cycles, and FDW-8 forced onto one shared window. Twenty junctions.

```bash
RESONALYZE_SESSION_BATTERY="D:\hobby\AMP" dotnet test tests/Resonalyze.App.Tests/Resonalyze.App.Tests.csproj -c Release --filter "FullyQualifiedName~JunctionPhaseWindowHarness"
```

**The stated reason for excluding FDW no longer reproduces.** FDW-8 against the steady state: median |Δφ| 5°, median |Δfix| 0.046 ms. The old disagreement was the gate anchoring on the IR *peak*, which for a steeply low-passed driver sits tens of milliseconds after its own front — the window ate the front it existed to isolate.

**What the change actually buys is the top of the range.** `BestScore` is the highest in-phase score *any* delay reaches over the band — a property of the window, with no phase unwrapping in it:

| band | n | steady | fdw8 | better / same / worse |
|---|---|---|---|---|
| fc < 500 Hz | 13 | 0.896 | 0.908 | 3 / 8 / 2 |
| fc ≥ 1000 Hz | 7 | **0.690** | **0.928** | 6 / 0 / 1 |

Under the steady window a correctly tuned tweeter junction could not score better than about 0.7 whatever the tuner did: the residue is the room decorrelating the two paths, not a misalignment a delay can repair. The weighted fit rms falls from 95–427° to 13–58° over the same bands. Below 500 Hz nothing moves, which is the other half of the result — the bass read-out is unchanged.

## What ships

- **`JunctionPhaseSpectra`** builds the read-out's spectra through the panel's own gate — the same window the phase *curves* are drawn through, so φ is a figure you can find on the plot beside it — and rotates each one back to the record's origin. Without that rotation a per-curve placement reads as a delay; the new test proves it (removing the re-reference turns a known +2.0 ms misalignment into −0.86 ms).
- **8 cycles, fixed**, whatever the gate dialog's FDW selector says. The selector shapes a curve for the eye and 4 cycles is a legitimate choice there; it is not a legitimate choice for a number — on these cabins it moved φ by a median 36° and flipped the recommended polarity on 5 junctions of 20.
- **A guard on the recommendation.** The gated window brings one new failure: a junction whose drivers do not correlate at all still gets a confident-looking fix. Below `MinimumAlignableScore` the fix, the polarity mark and the period-hop `!` are withheld as `—`, and the tooltip says why. The threshold was swept against what applying each fix did to the panel's own summation loss:

```
  threshold   suppressed   of them harmful / neutral / helpful
       0.35            1           1 /       0 /       0   Passat C/D
       0.50            1           1 /       0 /       0   Passat C/D
       0.65            1           1 /       0 /       0   Passat C/D
       0.70            2           1 /       1 /       0   3RC A/B, Passat C/D
       0.80            3           1 /       1 /       1   3RC A/B, Passat C/D, v5_exp B/C
```

  0.5 sits mid-plateau, and reads as a statement in its own right: at the optimum the band is still 60° out of phase on average, so the delay is not what is wrong with it. The one junction it withholds is a 2 kHz handover (whitened direct correlation r = 0.07) whose −0.37 ms cost 1.15 dB of average summation loss and took its dip to −10.9 dB when applied.
- **Off the UI thread.** A frequency-dependent window is one transform per distinct window length per channel: 50–100 ms for four channels the first time a set of responses is seen, 2 ms afterwards (it shares `DataHelper`'s per-IR cache with the phase view's own curves). A delay drag makes every frame the first time, so it cannot sit in the redraw.

## How the block reads now

```
v5_exp (the owner's own tune)     Passat
       φfc  fix ms  score                φfc  fix ms  score
A/B    -3°      ·   0.95         A/B    +28°  +1.19~  0.71
B/C   -15°  -0.38~  0.74         B/C    +18°      ·   0.93
C/D    +6°      ·~  0.97         C/D    +53°      —   0.29
```

A settled tune now reads as settled at the top (0.97 where the steady window said 0.79), and the incoherent junction says nothing instead of recommending half a period.

## Verification

- `JunctionPhaseSpectra.Build` reproduces the probe's own fdw8 rows **byte for byte** — the shipped path is the measured one, not a second implementation of it.
- The re-reference test fails when the rotation is removed (verified by deliberately breaking it).
- The Auto delay battery is unmoved: **+0.097 dB (12 better / 5 worse)**. Nothing here feeds the alignment engine.
- Full solution green: 1444 + 2047 + 159.
- `BuildPhaseEntries_ReadsTheJunctionAndRecoversAMisalignment` was recalibrated: `BestScore` is 0.947 rather than ≥0.95, because the read now goes through the project's default 0.5/4/1.5 ms window, which holds barely more than one period of a 200 Hz junction. The recovered delay — the figure under test — is unchanged.

## Known limit

Above ~1 kHz the gated read inherits each channel's own arrival estimate, which the steady state did not (one origin, no estimate). On the Passat C/D junction, forcing one shared window instead of per-curve placement moved the fix by 0.4 ms. The `MinimumAlignableScore` guard covers that case because the junction is also incoherent; a junction with a high ceiling and a bad arrival estimate would not be caught.

`JunctionPhaseWindowHarness` stays in the tree beside the Auto delay battery so the next window change is judged by the same ruler rather than a rebuilt one, and the steady-state entry points on `JunctionPhaseAlignment` stay as that comparison's baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
