### PR TITLE
Agent Bridge: spatial-average status in the package, target level checked before a fit

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1131,7 +1131,12 @@ Psychoacoustic smoothing helps here too, by de-emphasizing narrow, position-depe
 irregularities that are usually not worth correcting — unless you are working in Hybrid
 mode, where smoothing should be **Off** for the reasons given above.
 
-Press **Auto Tune** and let Resonalyze fit the response to the target.
+Press **Auto Tune** and let Resonalyze fit the response to the target. If it asks
+first whether to tune anyway, the target level is the problem, not the curve: it
+sits far enough above the source that the fit would boost the whole band to reach
+it, or far enough below that it would cut the whole band and give the level back to
+the amplifier gain. Answer *No*, move **Target Level** toward the curve, and press
+again.
 
 ![The same channel after Auto Tune: seven bands, RMS error 3.9 → 1.3 dB](assets/images/manual/eq-wizard-tuned.png)
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1589,12 +1589,14 @@ bands where the response simply cannot be corrected.
 Before it runs, the fit reads where **Target Level** sits against the source
 over the From–To window — the median of their difference, so a junction dip or
 a modal null does not move it — and asks first when the datum is the problem
-rather than the shape: a target 3 dB or more **above** the source (with **Cuts
-only** off; under it the auto preamp aligns the curve instead) would be reached
-by boosting the whole window, spending headroom on level; a target 10 dB or more
-**below** the source would be reached by cutting the whole window, handing that
-level to the amplifier gain and its noise. Both are a Target Level typed wrong,
-and the fit would do them faithfully. *Yes* tunes anyway.
+rather than the shape: a target 3 dB or more **above** the source would be
+reached by boosting the whole window, spending headroom on level — or, under
+**Cuts only**, not reached at all: its preamp stops at 0 dB and its bands only
+cut, so the curve stays below the target, and a bump that stays under the
+target line is not a cut the fit will make; a target 10 dB or more **below**
+the source would be reached by cutting the whole window, handing that level to
+the amplifier gain and its noise. All three are a Target Level typed wrong.
+*Yes* tunes anyway.
 
 **Max Q** is the ceiling on how narrow those bands may be — **6.0** by default,
 against the 20 a strip accepts when you type one in by hand. It bounds Auto Tune
@@ -2814,7 +2816,8 @@ this: the clipboard is the only transport, and you are the one who pastes.
   taken, taken but not drawn, drawn for some channels, drawn for all — the
   guide has it press for moving-microphone captures in the first case and
   point out unused ones in the second), and where the target level sits
-  against each side's sum, so a datum typed too high or too low is named
+  against each side's sum — the measured one, and the hybrid one while the
+  hybrid view is drawn — so a datum typed too high or too low is named
   before a PEQ is proposed around it. The numbers are the screen's numbers:
   the package is built from the same computations, for the same **Show** view,
   so what the assistant reads is what you see. Curves are sampled on fixed grids

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1586,6 +1586,16 @@ the band count itself**, up to the **Max Filters** limit (4–32), while a
 cumulative-boost cap and minimum band spacing keep it from stacking maxed-out
 bands where the response simply cannot be corrected.
 
+Before it runs, the fit reads where **Target Level** sits against the source
+over the From–To window — the median of their difference, so a junction dip or
+a modal null does not move it — and asks first when the datum is the problem
+rather than the shape: a target 3 dB or more **above** the source (with **Cuts
+only** off; under it the auto preamp aligns the curve instead) would be reached
+by boosting the whole window, spending headroom on level; a target 10 dB or more
+**below** the source would be reached by cutting the whole window, handing that
+level to the amplifier gain and its noise. Both are a Target Level typed wrong,
+and the fit would do them faithfully. *Yes* tunes anyway.
+
 **Max Q** is the ceiling on how narrow those bands may be — **6.0** by default,
 against the 20 a strip accepts when you type one in by hand. It bounds Auto Tune
 alone; nothing it fitted earlier is touched, and you can still narrow any band
@@ -2798,7 +2808,14 @@ this: the clipboard is the only transport, and you are the one who pastes.
   each channel's Raw and Processed curves at 12 points per octave, the side sums,
   the [Sum loss](#the-panel-gates-plots-and-read-outs) and Junction phase rows,
   the delay-search lobes and the PHAT read of every junction, the coherence
-  ladder, and the Δ L−R and group blocks. The numbers are the screen's numbers:
+  ladder, and the Δ L−R and group blocks — plus two readings the assistant is
+  asked to act on before anything else: where the tune stands with
+  [spatial averages](#hybrid-spatial-averages-under-the-prediction) (none
+  taken, taken but not drawn, drawn for some channels, drawn for all — the
+  guide has it press for moving-microphone captures in the first case and
+  point out unused ones in the second), and where the target level sits
+  against each side's sum, so a datum typed too high or too low is named
+  before a PEQ is proposed around it. The numbers are the screen's numbers:
   the package is built from the same computations, for the same **Show** view,
   so what the assistant reads is what you see. Curves are sampled on fixed grids
   rather than taken off the plot, so the package does not depend on the window's

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -91,17 +91,19 @@ Work in this order; each step gates the next.
      [https://github.com/DIMOSUS/Resonalyze/blob/main/MANUAL.md#optional-equalize-the-spatial-average](https://github.com/DIMOSUS/Resonalyze/blob/main/MANUAL.md#optional-equalize-the-spatial-average)
      (how to attach the captures and turn the hybrid view on). Until then,
      keep any PEQ advice to broad, minimum-phase trends and say why.
-   - `capturedNotShown`: the user has averages and is not using them — the
-     hybrid curves are not on the plot, so every level and PEQ read-out in
-     this package still comes from the point measurements and the averaging
-     is doing nothing. Say so plainly, first. Read `mode`, `hybridTicked`,
-     `hybridDrawn` and the counts to say which: the **Hybrid** box under the
-     plot is unticked; the mode (the **MMM** / **Array** button's menu) does
-     not read the family the channels hold; a playing channel has no capture
-     (`channelsWithCapture` < `channelsMeasured` — name it from
-     `source.spatialAverageCaptures`); or the view is a group comparison,
-     which never draws them. Ask for a new package once the hybrid curves are
-     on; the same manual section explains the switch.
+   - `capturedNotShown`: the user has averages and the channel curves are not
+     using them — no `hybridPreDspDb` / `hybridProcessedDb` is in the package,
+     so every per-channel magnitude and every PEQ judgement here still rests
+     on the point measurements. Say so plainly, first. (The `stereo[]` and
+     `groups[]` level rows choose their basis on their own: read each row's
+     `levelFromSpatialAverage` before calling them point-measured.) Read
+     `mode`, `hybridTicked`, `hybridDrawn` and the counts to say which: the
+     **Hybrid** box under the plot is unticked; the mode (the **MMM** /
+     **Array** button's menu) does not read the family the channels hold; a
+     playing channel has no capture (`channelsWithCapture` < `channelsShown`
+     — name it from `source.spatialAverageCaptures`); or the view is a group
+     comparison, which never draws them. Ask for a new package once the
+     hybrid curves are on; the same manual section explains the switch.
    - `partial`: some measured channels are judged on their average and some
      on a point. Name the ones without (`hybridPreDspDb` absent) and treat
      their PEQ as step 8 says for point measurements.
@@ -153,16 +155,25 @@ Work in this order; each step gates the next.
    A `latched` flag means the arrival timed the room's modal build-up, not the
    direct rise — the number is real but overstates the skew.
 7. **Target and tonal balance.** First the datum: `sides[].sumVsTargetDb` is
-   the median of the side's sum against the target curve. The target level is
-   a number the user typed, and a fit obeys it literally — a target 3 dB or
-   more above the sum makes Auto-tune boost every channel across its band and
-   spend headroom on level; 10 dB or more below makes it cut everything and
-   hand the level back to the amplifier gain, with its noise. Say so before
-   any PEQ advice and have the user move the **Target Level** (the panel's
-   field next to *Target*) rather than let the bands carry it. Then
-   `sides[].sumDb` against `target.curve`: judge broad trends over half an
-   octave or more; a narrow dip at a junction is interference, not tonal
-   balance, and belongs to step 4.
+   the median of the side's measured sum against the target curve, and
+   `sides[].hybridSumVsTargetDb` the same off the sum the hybrid view draws.
+   While `analysis.spatialAverage.status` is `active`, read the hybrid one —
+   the target the user is about to fit to is judged against the averages,
+   and `sumDb` is still the single-position sum; where `partial`, say which
+   channels the two datums disagree about. The target level is a number the
+   user typed, and a fit obeys it literally — a target 3 dB or more above the
+   sum makes Auto-tune boost every channel across its band and spend
+   headroom on level (or, under *Cuts only*, leave the curve short of the
+   target and pass over a bump that stays under it); 10 dB or more below
+   makes it cut everything and hand the level back to the amplifier gain,
+   with its noise. Say so before any PEQ advice and have the user move the
+   **Target Level** (the panel's field next to *Target*) rather than let the
+   bands carry it. Then the tonal balance: `sides[].sumDb` against
+   `target.curve` on a point-measured tune, the channels' `hybridProcessedDb`
+   on an averaged one (the hybrid sum is an estimate of one position's
+   interference and is not for judging a junction's depth). Judge broad
+   trends over half an octave or more; a narrow dip at a junction is
+   interference, not tonal balance, and belongs to step 4.
 8. **PEQ, last.** Only after timing and crossovers are settled. Prefer cuts.
    Prefer the spatial average (`hybridPreDspDb` for what the driver does,
    `hybridProcessedDb` for what the tune does to it) over the point measurement

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -60,6 +60,10 @@ what you are sure of, what you are inferring, and what you would need to know.
   junction diagnostics were computed for. Channels outside that view still have
   their own curves, but no junction read-outs. If you need the rear or the
   centre judged, ask the user to switch the *Show* selector and copy again.
+- **`analysis.spatialAverage`** says whether the tune is being judged on
+  spatial averages: `status` is `none`, `capturedNotShown`, `partial` or
+  `active`, with the counts behind it; `channels[].source.spatialAverageCaptures`
+  lists what each channel holds. Step 2 of the analysis reads it.
 
 ## 3. The order of analysis
 
@@ -71,12 +75,43 @@ Work in this order; each step gates the next.
    stops at 40 Hz has nothing to say about 25 Hz. A junction whose
    `phase` is absent "not consistent enough" is a junction the measurement
    cannot judge — say so rather than guessing.
-2. **Topology and roles.** Blocks are lettered A, B, C… in the panel's order;
+2. **What the measurement can support: the spatial average.** Read
+   `analysis.spatialAverage.status` before anything about levels or PEQ.
+   - `none`: every channel is a single microphone position. Timing and phase
+     need that fixed point; equalization does not want it — the narrow dips
+     at one position move when the head moves, and a PEQ that fills them
+     corrects a spot in the car, not a driver. **Recommend, firmly, that the
+     user takes moving-microphone captures (MMM) before the tune is
+     equalized.** It needs no equipment beyond the microphone they already
+     measured with — a slow sweep of the microphone through the listening
+     volume while the channel plays noise — and it is what moves a tune from
+     "right at one point" to competition-grade. Point them at the manual:
+     [https://github.com/DIMOSUS/Resonalyze/blob/main/MANUAL.md#optional-a-spatial-average-for-the-eq](https://github.com/DIMOSUS/Resonalyze/blob/main/MANUAL.md#optional-a-spatial-average-for-the-eq)
+     (what it is and how to take one) and
+     [https://github.com/DIMOSUS/Resonalyze/blob/main/MANUAL.md#optional-equalize-the-spatial-average](https://github.com/DIMOSUS/Resonalyze/blob/main/MANUAL.md#optional-equalize-the-spatial-average)
+     (how to attach the captures and turn the hybrid view on). Until then,
+     keep any PEQ advice to broad, minimum-phase trends and say why.
+   - `capturedNotShown`: the user has averages and is not using them — the
+     hybrid curves are not on the plot, so every level and PEQ read-out in
+     this package still comes from the point measurements and the averaging
+     is doing nothing. Say so plainly, first. Read `mode`, `hybridTicked`,
+     `hybridDrawn` and the counts to say which: the **Hybrid** box under the
+     plot is unticked; the mode (the **MMM** / **Array** button's menu) does
+     not read the family the channels hold; a playing channel has no capture
+     (`channelsWithCapture` < `channelsMeasured` — name it from
+     `source.spatialAverageCaptures`); or the view is a group comparison,
+     which never draws them. Ask for a new package once the hybrid curves are
+     on; the same manual section explains the switch.
+   - `partial`: some measured channels are judged on their average and some
+     on a point. Name the ones without (`hybridPreDspDb` absent) and treat
+     their PEQ as step 8 says for point measurements.
+   - `active`: judge levels and PEQ on `hybridPreDspDb` / `hybridProcessedDb`.
+3. **Topology and roles.** Blocks are lettered A, B, C… in the panel's order;
    `zone` says front / rear / centre / sub; `mono` marks a shared channel. Read
    the chain each block runs and check it makes sense for what the notes say
    the driver is. If the notes do not name the drivers, ask before judging
    crossovers.
-3. **Polarity and timing at each junction.** For every `junctions[]` entry:
+4. **Polarity and timing at each junction.** For every `junctions[]` entry:
    - `sumLoss.averageDb` and `dipDb`: how much the pair loses to interference
      over its overlap. Near 0 is good; a dip of several dB at the crossover is
      the classic sign of a phase mismatch.
@@ -107,20 +142,28 @@ Work in this order; each step gates the next.
    the block's Bypass would drop the crossover too and change the junction
    itself), copy a new package, read the junction again, then load the saved
    session back.
-4. **Crossover corners and slopes.** Judge the acoustic slopes on
+5. **Crossover corners and slopes.** Judge the acoustic slopes on
    `processedDb`, not the electrical ones: the driver's own roll-off adds to
    the filter. Before proposing a corner, know the driver (model, size,
    enclosure or location, amplifier power) and where it stops being safe and
    linear. Fs and diameter alone do not prove a high-pass is safe.
-5. **Between the sides and the groups.** `stereo[]` per block: `deltaMs` is
+6. **Between the sides and the groups.** `stereo[]` per block: `deltaMs` is
    left − right arrival (positive: the right side leads), `levelDeltaDb` is
    left − right. `groups[]`: each zone's arrival and level against the front.
    A `latched` flag means the arrival timed the room's modal build-up, not the
    direct rise — the number is real but overstates the skew.
-6. **Target and tonal balance.** `sides[].sumDb` against `target.curve`. Judge
-   broad trends over half an octave or more; a narrow dip at a junction is
-   interference, not tonal balance, and belongs to step 3.
-7. **PEQ, last.** Only after timing and crossovers are settled. Prefer cuts.
+7. **Target and tonal balance.** First the datum: `sides[].sumVsTargetDb` is
+   the median of the side's sum against the target curve. The target level is
+   a number the user typed, and a fit obeys it literally — a target 3 dB or
+   more above the sum makes Auto-tune boost every channel across its band and
+   spend headroom on level; 10 dB or more below makes it cut everything and
+   hand the level back to the amplifier gain, with its noise. Say so before
+   any PEQ advice and have the user move the **Target Level** (the panel's
+   field next to *Target*) rather than let the bands carry it. Then
+   `sides[].sumDb` against `target.curve`: judge broad trends over half an
+   octave or more; a narrow dip at a junction is interference, not tonal
+   balance, and belongs to step 4.
+8. **PEQ, last.** Only after timing and crossovers are settled. Prefer cuts.
    Prefer the spatial average (`hybridPreDspDb` for what the driver does,
    `hybridProcessedDb` for what the tune does to it) over the point measurement
    for anything above the modal region. Never fill a cancellation with boost.
@@ -167,6 +210,10 @@ Work in this order; each step gates the next.
   and moves with the listener.
 - Do not conclude from a region the measurement does not trust (low
   coherence, outside the measured band, `unavailableReason`).
+- Do not equalize a single-point measurement above the modal region when the
+  user could be averaging — and do not read a point measurement as the tune
+  while averages sit unused (`analysis.spatialAverage.status` other than
+  `active`). Step 2 says what to tell them.
 - Do not pick a delay from one number. Use the lobes, the PHAT peaks and the
   ladder together, and prefer recommending Auto delay over stating a value.
 - Do not declare a high-pass safe from Fs or cone size. Ask for the driver and

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -97,12 +97,32 @@ rejected; a reply inside them may still exceed what the device can dial.
 `groupView` (which part of the installation the diagnostics were computed for:
 `FrontAndSub`, `RearAndSub`, `FrontAndCenter`, `GroupsCompared`, `Everything`),
 `activeSide`, `smoothingInverseOctaves`, `psychoacousticSmoothing`,
-`spatialAverageMode`, `hybrid` (whether the spatial averages were drawn under the
-prediction), `phaseWindowMode`, `fdwCycles`, `phaseDetrendMode`, `gateShapeMs`
+`spatialAverage` (below), `phaseWindowMode`, `fdwCycles`, `phaseDetrendMode`, `gateShapeMs`
 (`left`, `plateau`, `right`), `gateLeft` / `gateRight` (`offsetMs`, `detrendMs`
 where pinned), `calibration` (the microphone calibration's name, no path),
 `stereoSceneOffsetMs`, `rightHandDrive`, `stereoLevelDifferenceDb`,
 `rearFillOffsetMs`.
+
+`spatialAverage` says where the tune stands with spatial averages, counted over
+the channels that have a measurement:
+
+```json
+"spatialAverage": { "mode": "MovingMic", "hybridTicked": true, "hybridDrawn": false,
+                    "status": "capturedNotShown",
+                    "channelsMeasured": 7, "channelsWithCapture": 5, "channelsDrawn": 0 }
+```
+
+- `mode` is the family the project reads (`MovingMic`, `MicArray`, `Off`; absent
+  when the project has never chosen). `hybridTicked` is the Hybrid box;
+  `hybridDrawn` whether the hybrid curves are actually on the plot — that also
+  needs every playing channel to carry a capture of the selected family and a
+  view that shows them (not a group comparison).
+- `status`: `none` — no channel carries a capture of any family, the tune rests
+  on single-point measurements; `capturedNotShown` — captures exist, but the
+  hybrid curves are not drawn (the box is off, the mode does not read them, the
+  view cannot show them, or a playing channel lacks one); `partial` — drawn for
+  some measured channels; `active` — every measured channel is judged on its
+  average. `channelsDrawn` counts channels whose hybrid curves are in the package.
 
 ### 1.5 `target`
 
@@ -138,6 +158,9 @@ The parametric terms (`levelDb`, `preset`, `tiltDbPerOctave`, `bassShelf`,
   `source.spatialAverage` names the capture family the hybrid curves are built
   from — the selected mode (`MovingMic` or `MicArray`) when the channel holds a
   capture of it; absent otherwise, whatever other captures the channel has.
+  `source.spatialAverageCaptures` lists every family the channel holds, read or
+  not; absent when it holds none. The two differ exactly when the user has an
+  average they are not using — see `analysis.spatialAverage`.
 - Both crossover edges are always stored; `kind` says which act (`LowPass` uses
   `lowPass`, `HighPass` uses `highPass`, `BandPass` both, `Off` none). `rippleDb`
   matters only for `Chebyshev`.
@@ -171,7 +194,9 @@ The parametric terms (`levelDb`, `preset`, `tiltDbPerOctave`, `bassShelf`,
 `side`, `channels` (the ids that played on this side in the current view),
 `sumDb` (the coherent sum on the broadband grid), `totalSumLoss`
 (`averageDb`, `dipDb` — only where the chain is continuous and the view is one
-listening group), `unavailableReason`.
+listening group), `sumVsTargetDb` (the median of `sumDb` minus `target.curve`
+over the grid: positive = the side plays above the target level; where the
+target datum sits, unmoved by a junction dip or a band edge), `unavailableReason`.
 
 ### 1.8 `junctions[]`
 

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -109,7 +109,7 @@ the channels that have a measurement:
 ```json
 "spatialAverage": { "mode": "MovingMic", "hybridTicked": true, "hybridDrawn": false,
                     "status": "capturedNotShown",
-                    "channelsMeasured": 7, "channelsWithCapture": 5, "channelsDrawn": 0 }
+                    "channelsShown": 7, "channelsWithCapture": 5, "channelsDrawn": 0 }
 ```
 
 - `mode` is the family the project reads (`MovingMic`, `MicArray`, `Off`; absent
@@ -117,12 +117,22 @@ the channels that have a measurement:
   `hybridDrawn` whether the hybrid curves are actually on the plot — that also
   needs every playing channel to carry a capture of the selected family and a
   view that shows them (not a group comparison).
-- `status`: `none` — no channel carries a capture of any family, the tune rests
-  on single-point measurements; `capturedNotShown` — captures exist, but the
-  hybrid curves are not drawn (the box is off, the mode does not read them, the
-  view cannot show them, or a playing channel lacks one); `partial` — drawn for
-  some measured channels; `active` — every measured channel is judged on its
-  average. `channelsDrawn` counts channels whose hybrid curves are in the package.
+- The counts run over the channels the current view **shows** — the union of
+  `sides[].channels`, the channels the diagnostics are built from. A channel the
+  view leaves out has its own curves but never hybrid ones, whatever it holds;
+  a muted channel has no curves at all; neither is counted. `channelsDrawn` is
+  read off the hybrid curves actually present in the package, not off what is
+  attached.
+- `status`: `none` — no shown channel carries a capture of any family, the tune
+  rests on single-point measurements; `capturedNotShown` — captures exist, but
+  no hybrid curve is in the package (the box is off, the mode does not read
+  them, the view cannot show them, or a playing channel lacks one); `partial` —
+  hybrid curves for some shown channels; `active` — every shown channel is
+  judged on its average.
+- The status is about the channel curves. The `stereo[]` and `groups[]` level
+  rows choose their basis on their own — they read the averages whenever the
+  box is ticked and the captures cover both sides, whatever the view — and say
+  so per row in `levelFromSpatialAverage`.
 
 ### 1.5 `target`
 
@@ -196,7 +206,13 @@ The parametric terms (`levelDb`, `preset`, `tiltDbPerOctave`, `bassShelf`,
 (`averageDb`, `dipDb` — only where the chain is continuous and the view is one
 listening group), `sumVsTargetDb` (the median of `sumDb` minus `target.curve`
 over the grid: positive = the side plays above the target level; where the
-target datum sits, unmoved by a junction dip or a band edge), `unavailableReason`.
+target datum sits, unmoved by a junction dip or a band edge),
+`hybridSumVsTargetDb` (the same reading off the sum the hybrid view draws —
+the spatial averages' levels held together by the point measurement's phase;
+present only while the hybrid curves are drawn, and an estimate of one
+position's interference rather than a measurement, so it carries the datum but
+not a junction's depth), `unavailableReason`. `sumDb` itself is always the
+measured, single-position sum.
 
 ### 1.8 `junctions[]`
 

--- a/source/Integration/AgentBridge/AgentPackageBuilder.cs
+++ b/source/Integration/AgentBridge/AgentPackageBuilder.cs
@@ -160,7 +160,7 @@ internal static class AgentPackageBuilder
             inputs.Notes,
             BuildProcessor(inputs.Processor),
             BuildLimits(),
-            BuildAnalysis(inputs.Analysis),
+            BuildAnalysis(inputs.Analysis, inputs.Channels),
             BuildTarget(inputs.Target),
             inputs.Channels.Select(channel => BuildChannel(channel, inputs, keepCoherence)).ToList(),
             sides,
@@ -200,14 +200,15 @@ internal static class AgentPackageBuilder
                 family => CrossoverFilter.SupportedSlopes(family).ToArray()),
             [0, CrossoverFilter.MaximumChebyshevRippleDb]);
 
-    private static AgentPackageAnalysis BuildAnalysis(AgentAnalysisInputs analysis) =>
+    private static AgentPackageAnalysis BuildAnalysis(
+        AgentAnalysisInputs analysis,
+        IReadOnlyList<AgentChannelInputs> channels) =>
         new(
             analysis.GroupView.ToString(),
             analysis.ActiveSideRight ? "right" : "left",
             analysis.SmoothingInverseOctaves,
             analysis.PsychoacousticSmoothing,
-            analysis.SpatialAverageMode?.ToString(),
-            analysis.HybridOn,
+            BuildSpatialAverage(analysis, channels),
             analysis.PhaseWindowMode.ToString(),
             analysis.FdwCycles,
             analysis.DetrendMode.ToString(),
@@ -219,6 +220,38 @@ internal static class AgentPackageBuilder
             analysis.RightHandDrive,
             analysis.StereoLevelDifferenceDb,
             analysis.RearFillOffsetMs);
+
+    // One word for where the tune stands with spatial averages, counted over the
+    // channels that have a measurement at all. "Drawn" is the selected mode's
+    // capture under a hybrid view that is actually showing — a capture the mode
+    // does not read, or a tick the view cannot honour, leaves the point
+    // measurement in charge, and that is what the assistant has to tell the user.
+    private static AgentPackageSpatialAverage BuildSpatialAverage(
+        AgentAnalysisInputs analysis,
+        IReadOnlyList<AgentChannelInputs> channels)
+    {
+        List<AgentSourceInputs> measured = channels
+            .Where(channel => channel.Source != null)
+            .Select(channel => channel.Source!)
+            .ToList();
+        int withCapture = measured.Count(source => source.SpatialAverageCaptures.Count > 0);
+        int drawn = analysis.HybridDrawn
+            ? measured.Count(source => source.SpatialAverage != null)
+            : 0;
+        string status =
+            withCapture == 0 ? "none"
+            : drawn == 0 ? "capturedNotShown"
+            : drawn < measured.Count ? "partial"
+            : "active";
+        return new AgentPackageSpatialAverage(
+            analysis.SpatialAverageMode?.ToString(),
+            analysis.HybridTicked,
+            analysis.HybridDrawn,
+            status,
+            measured.Count,
+            withCapture,
+            drawn);
+    }
 
     private static AgentPackageTarget BuildTarget(AgentTargetInputs target)
     {
@@ -275,6 +308,7 @@ internal static class AgentPackageBuilder
             source?.SampleRateHz,
             source == null ? null : [source.MeasuredBand.LowEdgeHz, source.MeasuredBand.HighEdgeHz],
             source?.SpatialAverage,
+            source is { SpatialAverageCaptures.Count: > 0 } ? source.SpatialAverageCaptures : null,
             source?.UnavailableReason ?? (source == null ? "no measurement loaded" : null));
 
         return new AgentPackageChannel(
@@ -369,6 +403,7 @@ internal static class AgentPackageBuilder
         List<string> channels = side.ChannelIds.ToList();
 
         AgentSeries? sum = null;
+        double? sumVsTarget = null;
         if (side.Sum != null)
         {
             List<double> grid = AgentCurveSampling.LogGrid(
@@ -383,6 +418,23 @@ internal static class AgentPackageBuilder
                 .Where(row => row[1] != null)
                 .ToList();
             sum = new AgentSeries(["frequencyHz", "sumDb"], rows);
+
+            // The median, not the mean: a junction dip or the sub's roll-off is
+            // interference or a band edge, not a level, and must not pull the datum.
+            TargetCurveSpec spec = inputs.Target.Spec;
+            List<double> excess = grid
+                .Select(frequency => AgentCurveSampling.Sample(side.Sum, frequency) is { } level
+                    ? level - (inputs.Target.LevelDb + spec.Evaluate(frequency))
+                    : double.NaN)
+                .Where(double.IsFinite)
+                .Order()
+                .ToList();
+            if (excess.Count > 0)
+            {
+                sumVsTarget = Round1(excess.Count % 2 == 1
+                    ? excess[excess.Count / 2]
+                    : (excess[excess.Count / 2 - 1] + excess[excess.Count / 2]) / 2);
+            }
         }
 
         VirtualCrossoverMetric.Entry? total = side.Entries
@@ -394,6 +446,7 @@ internal static class AgentPackageBuilder
             channels,
             sum,
             total is { } t ? new AgentPackageLoss(Round1(t.AverageDb), AgentCurveSampling.Round(t.DipDb, 1)) : null,
+            sumVsTarget,
             side.UnavailableReason ??
                 (total == null && side.Sum != null
                     ? "no total: the chain is not continuous, or the view spans more than one listening group"

--- a/source/Integration/AgentBridge/AgentPackageBuilder.cs
+++ b/source/Integration/AgentBridge/AgentPackageBuilder.cs
@@ -160,7 +160,7 @@ internal static class AgentPackageBuilder
             inputs.Notes,
             BuildProcessor(inputs.Processor),
             BuildLimits(),
-            BuildAnalysis(inputs.Analysis, inputs.Channels),
+            BuildAnalysis(inputs.Analysis, inputs.Channels, inputs.Sides),
             BuildTarget(inputs.Target),
             inputs.Channels.Select(channel => BuildChannel(channel, inputs, keepCoherence)).ToList(),
             sides,
@@ -202,13 +202,14 @@ internal static class AgentPackageBuilder
 
     private static AgentPackageAnalysis BuildAnalysis(
         AgentAnalysisInputs analysis,
-        IReadOnlyList<AgentChannelInputs> channels) =>
+        IReadOnlyList<AgentChannelInputs> channels,
+        IReadOnlyList<AgentSideInputs> sides) =>
         new(
             analysis.GroupView.ToString(),
             analysis.ActiveSideRight ? "right" : "left",
             analysis.SmoothingInverseOctaves,
             analysis.PsychoacousticSmoothing,
-            BuildSpatialAverage(analysis, channels),
+            BuildSpatialAverage(analysis, channels, sides),
             analysis.PhaseWindowMode.ToString(),
             analysis.FdwCycles,
             analysis.DetrendMode.ToString(),
@@ -222,33 +223,36 @@ internal static class AgentPackageBuilder
             analysis.RearFillOffsetMs);
 
     // One word for where the tune stands with spatial averages, counted over the
-    // channels that have a measurement at all. "Drawn" is the selected mode's
-    // capture under a hybrid view that is actually showing — a capture the mode
-    // does not read, or a tick the view cannot honour, leaves the point
-    // measurement in charge, and that is what the assistant has to tell the user.
+    // channels the current view SHOWS — the sides' channel lists — since those
+    // are the channels the package's diagnostics are built from; a channel the
+    // view left out has its own curves but no hybrid ones, whatever it holds, and
+    // a muted one has no curves at all. "Drawn" is read off the hybrid curves
+    // actually present, not off the attachment: a capture the mode does not read,
+    // or a tick the view cannot honour, leaves the point measurement in charge,
+    // and that is what the assistant has to tell the user.
     private static AgentPackageSpatialAverage BuildSpatialAverage(
         AgentAnalysisInputs analysis,
-        IReadOnlyList<AgentChannelInputs> channels)
+        IReadOnlyList<AgentChannelInputs> channels,
+        IReadOnlyList<AgentSideInputs> sides)
     {
-        List<AgentSourceInputs> measured = channels
-            .Where(channel => channel.Source != null)
+        var shownIds = sides.SelectMany(side => side.ChannelIds).ToHashSet(StringComparer.Ordinal);
+        List<AgentSourceInputs> shown = channels
+            .Where(channel => shownIds.Contains(channel.Id) && channel.Source != null)
             .Select(channel => channel.Source!)
             .ToList();
-        int withCapture = measured.Count(source => source.SpatialAverageCaptures.Count > 0);
-        int drawn = analysis.HybridDrawn
-            ? measured.Count(source => source.SpatialAverage != null)
-            : 0;
+        int withCapture = shown.Count(source => source.SpatialAverageCaptures.Count > 0);
+        int drawn = shown.Count(source => source.HybridPreDsp != null || source.HybridProcessed != null);
         string status =
             withCapture == 0 ? "none"
             : drawn == 0 ? "capturedNotShown"
-            : drawn < measured.Count ? "partial"
+            : drawn < shown.Count ? "partial"
             : "active";
         return new AgentPackageSpatialAverage(
             analysis.SpatialAverageMode?.ToString(),
             analysis.HybridTicked,
             analysis.HybridDrawn,
             status,
-            measured.Count,
+            shown.Count,
             withCapture,
             drawn);
     }
@@ -418,24 +422,17 @@ internal static class AgentPackageBuilder
                 .Where(row => row[1] != null)
                 .ToList();
             sum = new AgentSeries(["frequencyHz", "sumDb"], rows);
-
-            // The median, not the mean: a junction dip or the sub's roll-off is
-            // interference or a band edge, not a level, and must not pull the datum.
-            TargetCurveSpec spec = inputs.Target.Spec;
-            List<double> excess = grid
-                .Select(frequency => AgentCurveSampling.Sample(side.Sum, frequency) is { } level
-                    ? level - (inputs.Target.LevelDb + spec.Evaluate(frequency))
-                    : double.NaN)
-                .Where(double.IsFinite)
-                .Order()
-                .ToList();
-            if (excess.Count > 0)
-            {
-                sumVsTarget = Round1(excess.Count % 2 == 1
-                    ? excess[excess.Count / 2]
-                    : (excess[excess.Count / 2 - 1] + excess[excess.Count / 2]) / 2);
-            }
+            sumVsTarget = MedianAboveTarget(side.Sum, grid, inputs.Target);
         }
+
+        double? hybridSumVsTarget = side.HybridSum == null
+            ? null
+            : MedianAboveTarget(
+                side.HybridSum,
+                AgentCurveSampling.LogGrid(
+                    AgentCurveSampling.BroadbandLowHz, AgentCurveSampling.BroadbandHighHz,
+                    AgentCurveSampling.BroadbandPointsPerOctave),
+                inputs.Target);
 
         VirtualCrossoverMetric.Entry? total = side.Entries
             .Where(entry => entry.IsTotal)
@@ -447,6 +444,7 @@ internal static class AgentPackageBuilder
             sum,
             total is { } t ? new AgentPackageLoss(Round1(t.AverageDb), AgentCurveSampling.Round(t.DipDb, 1)) : null,
             sumVsTarget,
+            hybridSumVsTarget,
             side.UnavailableReason ??
                 (total == null && side.Sum != null
                     ? "no total: the chain is not continuous, or the view spans more than one listening group"
@@ -662,6 +660,30 @@ internal static class AgentPackageBuilder
         curve == null ? null : AgentCurveSampling.Round(AgentCurveSampling.Sample(curve, frequency), 1);
 
     private static double Round1(double value) => Math.Round(value, 1);
+
+    // The median, not the mean: a junction dip or the sub's roll-off is
+    // interference or a band edge, not a level, and must not pull the datum.
+    private static double? MedianAboveTarget(
+        IReadOnlyList<SignalPoint> curve,
+        IReadOnlyList<double> grid,
+        AgentTargetInputs target)
+    {
+        List<double> excess = grid
+            .Select(frequency => AgentCurveSampling.Sample(curve, frequency) is { } level
+                ? level - (target.LevelDb + target.Spec.Evaluate(frequency))
+                : double.NaN)
+            .Where(double.IsFinite)
+            .Order()
+            .ToList();
+        if (excess.Count == 0)
+        {
+            return null;
+        }
+
+        return Round1(excess.Count % 2 == 1
+            ? excess[excess.Count / 2]
+            : (excess[excess.Count / 2 - 1] + excess[excess.Count / 2]) / 2);
+    }
 
     private static double Round2(double value) => Math.Round(value, 2);
 }

--- a/source/Integration/AgentBridge/AgentPackageInputs.cs
+++ b/source/Integration/AgentBridge/AgentPackageInputs.cs
@@ -41,7 +41,12 @@ internal sealed record AgentAnalysisInputs(
     int SmoothingInverseOctaves,
     bool PsychoacousticSmoothing,
     VirtualCrossoverSpatialAverageMode? SpatialAverageMode,
-    bool HybridOn,
+    // The tick is intent; whether the hybrid curves are actually drawn also needs
+    // every playing channel to carry a capture and a view that shows them. Both
+    // travel, because "ticked but not drawn" is a different thing for the user
+    // to fix than "not ticked".
+    bool HybridTicked,
+    bool HybridDrawn,
     PhaseWindowMode PhaseWindowMode,
     int FdwCycles,
     PhaseDetrendMode DetrendMode,
@@ -90,11 +95,14 @@ internal sealed record AgentChannelInputs(
 /// <param name="Processed">After the chain — the Processed curve, shared window with the side's sum.</param>
 /// <param name="HybridPreDsp">The spatial average before the chain, on the impulse responses' level axis (the hybrid datum applied), when the hybrid mode is on.</param>
 /// <param name="HybridProcessed">The spatial average through the chain, on the same axis — the curve the hybrid view draws.</param>
+/// <param name="SpatialAverage">The capture family the hybrid curves are built from — the selected mode's, when the channel holds one.</param>
+/// <param name="SpatialAverageCaptures">Every capture family the channel holds, whether or not the mode reads it — what an assistant needs to say "you have averages you are not using".</param>
 /// <param name="Coherence">The measurement's γ² per frequency, when the source carried it.</param>
 internal sealed record AgentSourceInputs(
     int SampleRateHz,
     MeasuredBand MeasuredBand,
     string? SpatialAverage,
+    IReadOnlyList<string> SpatialAverageCaptures,
     IReadOnlyList<SignalPoint>? PreDsp,
     IReadOnlyList<SignalPoint>? Processed,
     IReadOnlyList<SignalPoint>? HybridPreDsp,

--- a/source/Integration/AgentBridge/AgentPackageInputs.cs
+++ b/source/Integration/AgentBridge/AgentPackageInputs.cs
@@ -115,12 +115,15 @@ internal sealed record AgentSourceInputs(
 /// and the junction read-outs exactly as the panel's metric block quotes them.
 /// </summary>
 /// <param name="ChannelIds">The channels the view drew on this side — the set the sum, the loss and the junctions were computed from.</param>
+/// <param name="Sum">The measured sum — the impulse responses through their chains, coherently added.</param>
+/// <param name="HybridSum">The sum the hybrid view draws: the spatial averages' levels held together by the point measurement's phase, on the same axis as <paramref name="Sum"/>. An estimate of a point's interference, present only while the hybrid curves are drawn.</param>
 /// <param name="Entries">The Sum loss rows, per junction plus the total where the chain is continuous.</param>
 /// <param name="PhaseEntries">The Junction phase rows.</param>
 internal sealed record AgentSideInputs(
     AgentChannelSide Side,
     IReadOnlyList<string> ChannelIds,
     IReadOnlyList<SignalPoint>? Sum,
+    IReadOnlyList<SignalPoint>? HybridSum,
     IReadOnlyList<SignalPoint>? Loss,
     IReadOnlyList<VirtualCrossoverMetric.Entry> Entries,
     IReadOnlyList<VirtualCrossoverMetric.PhaseEntry> PhaseEntries,

--- a/source/Integration/AgentBridge/AgentPackageModels.cs
+++ b/source/Integration/AgentBridge/AgentPackageModels.cs
@@ -54,8 +54,7 @@ internal sealed record AgentPackageAnalysis(
     string ActiveSide,
     int SmoothingInverseOctaves,
     bool PsychoacousticSmoothing,
-    string? SpatialAverageMode,
-    bool Hybrid,
+    AgentPackageSpatialAverage SpatialAverage,
     string PhaseWindowMode,
     int FdwCycles,
     string PhaseDetrendMode,
@@ -67,6 +66,22 @@ internal sealed record AgentPackageAnalysis(
     bool RightHandDrive,
     double StereoLevelDifferenceDb,
     double RearFillOffsetMs);
+
+/// <summary>
+/// Whether the tune is being judged on spatial averages, and if not, why not —
+/// stated as one word so the assistant does not have to count captures across
+/// the channels: <c>none</c> (no channel carries one), <c>capturedNotShown</c>
+/// (captures exist, the hybrid view is not drawn), <c>partial</c> (drawn for
+/// some measured channels), <c>active</c>.
+/// </summary>
+internal sealed record AgentPackageSpatialAverage(
+    string? Mode,
+    bool HybridTicked,
+    bool HybridDrawn,
+    string Status,
+    int ChannelsMeasured,
+    int ChannelsWithCapture,
+    int ChannelsDrawn);
 
 internal sealed record AgentPackageGateShape(double Left, double Plateau, double Right);
 
@@ -103,6 +118,7 @@ internal sealed record AgentPackageSource(
     int? SampleRateHz,
     double[]? MeasuredBandHz,
     string? SpatialAverage,
+    IReadOnlyList<string>? SpatialAverageCaptures,
     string? UnavailableReason);
 
 internal sealed record AgentPackageDsp(
@@ -140,6 +156,10 @@ internal sealed record AgentPackageSide(
     IReadOnlyList<string> Channels,
     AgentSeries? SumDb,
     AgentPackageLoss? TotalSumLoss,
+    // The median of sum minus target over the broadband grid: where the target
+    // level datum sits against what the side actually plays. Sign: positive =
+    // the side plays above the target.
+    double? SumVsTargetDb,
     string? UnavailableReason);
 
 internal sealed record AgentPackageLoss(double AverageDb, double? DipDb);

--- a/source/Integration/AgentBridge/AgentPackageModels.cs
+++ b/source/Integration/AgentBridge/AgentPackageModels.cs
@@ -70,16 +70,19 @@ internal sealed record AgentPackageAnalysis(
 /// <summary>
 /// Whether the tune is being judged on spatial averages, and if not, why not —
 /// stated as one word so the assistant does not have to count captures across
-/// the channels: <c>none</c> (no channel carries one), <c>capturedNotShown</c>
-/// (captures exist, the hybrid view is not drawn), <c>partial</c> (drawn for
-/// some measured channels), <c>active</c>.
+/// the channels: <c>none</c> (no shown channel carries one),
+/// <c>capturedNotShown</c> (captures exist, no hybrid curve is in the package),
+/// <c>partial</c> (hybrid curves for some shown channels), <c>active</c> (for
+/// all). Counted over the channels the current view shows — the ones whose
+/// curves the package's diagnostics are built from — and "drawn" is read off
+/// the hybrid curves actually present, not off what is attached.
 /// </summary>
 internal sealed record AgentPackageSpatialAverage(
     string? Mode,
     bool HybridTicked,
     bool HybridDrawn,
     string Status,
-    int ChannelsMeasured,
+    int ChannelsShown,
     int ChannelsWithCapture,
     int ChannelsDrawn);
 
@@ -158,8 +161,10 @@ internal sealed record AgentPackageSide(
     AgentPackageLoss? TotalSumLoss,
     // The median of sum minus target over the broadband grid: where the target
     // level datum sits against what the side actually plays. Sign: positive =
-    // the side plays above the target.
+    // the side plays above the target. The hybrid twin reads the same off the
+    // sum the hybrid view draws, while it is drawn.
     double? SumVsTargetDb,
+    double? HybridSumVsTargetDb,
     string? UnavailableReason);
 
 internal sealed record AgentPackageLoss(double AverageDb, double? DipDb);

--- a/source/Tools/Eq/EqTargetLevelCheck.cs
+++ b/source/Tools/Eq/EqTargetLevelCheck.cs
@@ -1,0 +1,115 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Where the target level datum sits against the curve about to be fitted. A
+/// target far above the source makes the fit boost across the whole window and
+/// spend headroom on level, not on shape; a target far below makes it cut the
+/// whole window and hand the level to the amplifier gain, with its noise. Both
+/// are a datum set wrong, and the fit will do them faithfully — so the wizard
+/// asks first. UI-free so the reading is the same wherever a fit starts.
+/// </summary>
+internal static class EqTargetLevelCheck
+{
+    /// <summary>
+    /// A target this far above the source (dB, median over the window) needs
+    /// broadband boost. Only a fit that may boost is warned: under Cuts only the
+    /// auto preamp aligns the curve to the target instead and no level is lost.
+    /// </summary>
+    public const double BoostWarningDb = 3;
+
+    /// <summary>
+    /// A target this far below the source (dB, median over the window) is a
+    /// broadband cut, in either mode.
+    /// </summary>
+    public const double CutWarningDb = 10;
+
+    /// <summary>
+    /// The median of target minus source over the window: positive = the target
+    /// sits above the source. Null when the window holds no comparable point.
+    /// The two curves are expected on one frequency grid, as the wizard builds
+    /// its target on the source's own frequencies; a point whose frequencies
+    /// disagree is skipped rather than compared.
+    /// </summary>
+    public static double? TargetAboveSourceDb(
+        IReadOnlyList<SignalPoint> source,
+        IReadOnlyList<SignalPoint> target,
+        double minHz,
+        double maxHz)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(target);
+
+        var differences = new List<double>();
+        int count = Math.Min(source.Count, target.Count);
+        for (int index = 0; index < count; index++)
+        {
+            SignalPoint measured = source[index];
+            SignalPoint wanted = target[index];
+            if (measured.X < minHz || measured.X > maxHz ||
+                Math.Abs(measured.X - wanted.X) > measured.X * 1e-6)
+            {
+                continue;
+            }
+
+            double difference = wanted.Y - measured.Y;
+            if (double.IsFinite(difference))
+            {
+                differences.Add(difference);
+            }
+        }
+
+        if (differences.Count == 0)
+        {
+            return null;
+        }
+
+        // The median: a junction dip or a modal null in the window is a feature
+        // the fit will look at on its own, not a level, and must not move the datum.
+        differences.Sort();
+        int middle = differences.Count / 2;
+        return differences.Count % 2 == 1
+            ? differences[middle]
+            : (differences[middle - 1] + differences[middle]) / 2;
+    }
+
+    /// <summary>
+    /// The question to put to the user before the fit, or null when the datum
+    /// is close enough that the fit is about shape.
+    /// </summary>
+    public static string? Warning(
+        double? targetAboveSourceDb,
+        bool cutsOnly,
+        double minHz,
+        double maxHz)
+    {
+        if (targetAboveSourceDb is not { } offset)
+        {
+            return null;
+        }
+
+        string window = $"{minHz:0}–{maxHz:0} Hz";
+        if (offset >= BoostWarningDb && !cutsOnly)
+        {
+            return
+                $"The target sits {offset:0.0} dB above the source over {window} " +
+                "(median). The fit will boost across the whole window and spend " +
+                "headroom on level rather than on shape." + Environment.NewLine +
+                Environment.NewLine +
+                "Lower the Target Level, or tick Cuts only. Tune anyway?";
+        }
+
+        if (-offset >= CutWarningDb)
+        {
+            return
+                $"The target sits {-offset:0.0} dB below the source over {window} " +
+                "(median). The fit will cut the whole window, and that level has " +
+                "to come back from the amplifier gain, with its noise." +
+                Environment.NewLine + Environment.NewLine +
+                "Raise the Target Level. Tune anyway?";
+        }
+
+        return null;
+    }
+}

--- a/source/Tools/Eq/EqTargetLevelCheck.cs
+++ b/source/Tools/Eq/EqTargetLevelCheck.cs
@@ -14,8 +14,10 @@ internal static class EqTargetLevelCheck
 {
     /// <summary>
     /// A target this far above the source (dB, median over the window) needs
-    /// broadband boost. Only a fit that may boost is warned: under Cuts only the
-    /// auto preamp aligns the curve to the target instead and no level is lost.
+    /// broadband boost. A fit that may boost spends headroom to get there; a
+    /// Cuts-only fit cannot get there at all — its preamp is capped at 0 dB and
+    /// its bands only cut — so the curve stays below the target, and a bump
+    /// that stays under the target line is not a cut the fit will make.
     /// </summary>
     public const double BoostWarningDb = 3;
 
@@ -90,14 +92,20 @@ internal static class EqTargetLevelCheck
         }
 
         string window = $"{minHz:0}–{maxHz:0} Hz";
-        if (offset >= BoostWarningDb && !cutsOnly)
+        if (offset >= BoostWarningDb)
         {
-            return
-                $"The target sits {offset:0.0} dB above the source over {window} " +
-                "(median). The fit will boost across the whole window and spend " +
-                "headroom on level rather than on shape." + Environment.NewLine +
-                Environment.NewLine +
-                "Lower the Target Level, or tick Cuts only. Tune anyway?";
+            return cutsOnly
+                ? $"The target sits {offset:0.0} dB above the source over {window} " +
+                  "(median). Cuts only cannot raise the curve: the fit will leave " +
+                  "it below the target, and a bump that stays under the target line " +
+                  "is not a cut it will make." + Environment.NewLine +
+                  Environment.NewLine +
+                  "Lower the Target Level to the curve. Tune anyway?"
+                : $"The target sits {offset:0.0} dB above the source over {window} " +
+                  "(median). The fit will boost across the whole window and spend " +
+                  "headroom on level rather than on shape." + Environment.NewLine +
+                  Environment.NewLine +
+                  "Lower the Target Level. Tune anyway?";
         }
 
         if (-offset >= CutWarningDb)

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -889,10 +889,36 @@ public partial class EqWizardPanel : UserControl
             return;
         }
 
+        List<SignalPoint> fitSource = FitSource(render.Source, keepAllPass ? allPass : [])
+            .Select(point => new SignalPoint(point.X, point.Y))
+            .ToList();
+        List<SignalPoint> fitTarget = render.Target.Points
+            .Select(point => new SignalPoint(point.X, point.Y))
+            .ToList();
+
+        // A datum set wrong is something the fit does faithfully — boosting or
+        // cutting the whole window to reach it — so it is asked about before,
+        // not discovered in the headroom read-out after.
+        (double windowMinHz, double windowMaxHz) = GetFrequencyWindow();
+        string? levelWarning = EqTargetLevelCheck.Warning(
+            EqTargetLevelCheck.TargetAboveSourceDb(fitSource, fitTarget, windowMinHz, windowMaxHz),
+            checkBoxCutsOnly.Checked,
+            windowMinHz,
+            windowMaxHz);
+        if (levelWarning != null &&
+            MessageBox.Show(
+                FindForm(),
+                levelWarning,
+                "EQ Wizard",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning) != DialogResult.Yes)
+        {
+            return;
+        }
+
         var request = new EqWizardAutoTuneRequest(
-            FitSource(render.Source, keepAllPass ? allPass : [])
-                .Select(point => new SignalPoint(point.X, point.Y)),
-            render.Target.Points.Select(point => new SignalPoint(point.X, point.Y)),
+            fitSource,
+            fitTarget,
             CreateAutoTuneOptions(reserved),
             // Only a loopback-transfer impulse response carries coherence; an imported
             // curve has none, so boosts fall back to null-detection alone.

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -549,6 +549,9 @@ public partial class VirtualCrossoverPanel
                     // The family the hybrid curves are built from — the selected
                     // mode's capture — not whichever capture the side happens to hold.
                     state.SpatialAverageFor(SpatialAverageMode) != null ? SpatialAverageMode.ToString() : null,
+                    // And every family it holds, read or not: the difference between
+                    // "has no average" and "has one the view is not using".
+                    AgentSpatialAverageCaptures(state),
                     raw,
                     processed ? found.Processed : null,
                     processed ? found.HybridPreDsp : null,
@@ -591,6 +594,7 @@ public partial class VirtualCrossoverPanel
             project.SmoothingInverseOctaves,
             project.PsychoacousticSmoothing,
             project.SpatialAverageMode,
+            checkBoxHybrid.Checked,
             HybridRequested,
             project.PhaseWindowMode,
             project.PhaseFdwCycles,
@@ -628,6 +632,24 @@ public partial class VirtualCrossoverPanel
             sides,
             stereo,
             groups);
+    }
+
+    // Every capture family the side holds, in the mode enum's own names so the
+    // package's per-channel list and its analysis.spatialAverage.mode agree.
+    private static IReadOnlyList<string> AgentSpatialAverageCaptures(VirtualCrossoverChannelState state)
+    {
+        var captures = new List<string>(2);
+        if (state.SpatialAverage != null)
+        {
+            captures.Add(VirtualCrossoverSpatialAverageMode.MovingMic.ToString());
+        }
+
+        if (state.ArrayCapture != null)
+        {
+            captures.Add(VirtualCrossoverSpatialAverageMode.MicArray.ToString());
+        }
+
+        return captures;
     }
 
     // The channel's spatial average through NO chain, on the impulse responses'

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -356,7 +356,7 @@ public partial class VirtualCrossoverPanel
             if (sideSum == null)
             {
                 sides.Add(new AgentSideInputs(
-                    sideName, [], null, null, [], [], [], "no channel with a source on this side"));
+                    sideName, [], null, null, null, [], [], [], "no channel with a source on this side"));
                 continue;
             }
 
@@ -419,6 +419,16 @@ public partial class VirtualCrossoverPanel
             HybridMagnitudes? hybrid = HybridRequested && magnitudes != null
                 ? BuildHybridMagnitudes(shown, magnitudes, rightSide, smoothing)
                 : null;
+            // The sum the hybrid view draws beside the measured one: the same two
+            // constructions the plot uses (see RedrawMainPlotAsync), the active
+            // side's from the shown set, the opposite side's under its own gate
+            // placement — and null, as on screen, when the sides cannot be held
+            // to one offset.
+            IReadOnlyList<SignalPoint>? hybridSum = hybrid == null || magnitudes == null
+                ? null
+                : rightSide == activeRight
+                    ? BuildActiveHybridSumCurve(shown, magnitudes, hybrid)
+                    : BuildOppositeHybridSumCurve(sideSum, hybrid.OffsetDb)?.Points;
 
             for (int index = 0; index < shown.Count; index++)
             {
@@ -483,6 +493,7 @@ public partial class VirtualCrossoverPanel
                     item.Channel.Name,
                     item.Channel.Pair.Mono ? AgentChannelSide.Mono : sideName)).ToList(),
                 sumCurve?.Points,
+                hybridSum,
                 loss,
                 entries,
                 phaseEntries,

--- a/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
@@ -218,6 +218,85 @@ public sealed class AgentPackageBuilderTests
     }
 
     [Fact]
+    public void Build_SaysWhereTheTuneStandsWithSpatialAverages()
+    {
+        // The fixture: A:left measured with no capture, B:mono holds a
+        // moving-microphone capture, the hybrid box is ticked but the view is not
+        // drawing it. Captured, not shown.
+        AgentPackageInputs inputs = Inputs();
+        JsonElement status = Json(AgentPackageBuilder.Build(inputs, Id, Clock).Text!)
+            .GetProperty("analysis").GetProperty("spatialAverage");
+        Assert.Equal("MovingMic", status.GetProperty("mode").GetString());
+        Assert.True(status.GetProperty("hybridTicked").GetBoolean());
+        Assert.False(status.GetProperty("hybridDrawn").GetBoolean());
+        Assert.Equal("capturedNotShown", status.GetProperty("status").GetString());
+        Assert.Equal(2, status.GetProperty("channelsMeasured").GetInt32());
+        Assert.Equal(1, status.GetProperty("channelsWithCapture").GetInt32());
+        Assert.Equal(0, status.GetProperty("channelsDrawn").GetInt32());
+
+        // Each channel lists what it holds, and only when it holds something.
+        JsonElement channels = Json(AgentPackageBuilder.Build(inputs, Id, Clock).Text!).GetProperty("channels");
+        Assert.False(channels[0].GetProperty("source").TryGetProperty("spatialAverageCaptures", out _));
+        Assert.Equal(["MovingMic"], channels[2].GetProperty("source").GetProperty("spatialAverageCaptures").EnumerateArray().Select(c => c.GetString()));
+
+        // Drawn: the capture the mode reads, under a view that shows it — for one
+        // of the two measured channels.
+        AgentPackageInputs drawn = inputs with { Analysis = inputs.Analysis with { HybridDrawn = true } };
+        Assert.Equal("partial", Status(drawn));
+
+        // Every measured channel drawn from its average.
+        AgentPackageInputs everywhere = drawn with
+        {
+            Channels = drawn.Channels
+                .Select(channel => channel.Source == null
+                    ? channel
+                    : channel with { Source = channel.Source with { SpatialAverage = "MovingMic", SpatialAverageCaptures = ["MovingMic", "MicArray"] } })
+                .ToList()
+        };
+        Assert.Equal("active", Status(everywhere));
+
+        // A capture the selected mode does not read is captured, not shown —
+        // whatever the box says.
+        AgentPackageInputs wrongMode = everywhere with
+        {
+            Channels = everywhere.Channels
+                .Select(channel => channel.Source == null
+                    ? channel
+                    : channel with { Source = channel.Source with { SpatialAverage = null } })
+                .ToList()
+        };
+        Assert.Equal("capturedNotShown", Status(wrongMode));
+
+        // Nothing to draw from at all: the case the assistant is told to press.
+        AgentPackageInputs none = inputs with
+        {
+            Channels = inputs.Channels
+                .Select(channel => channel.Source == null
+                    ? channel
+                    : channel with { Source = channel.Source with { SpatialAverage = null, SpatialAverageCaptures = [] } })
+                .ToList()
+        };
+        Assert.Equal("none", Status(none));
+
+        static string Status(AgentPackageInputs inputs) =>
+            Json(AgentPackageBuilder.Build(inputs, Id, Clock).Text!)
+                .GetProperty("analysis").GetProperty("spatialAverage").GetProperty("status").GetString()!;
+    }
+
+    [Fact]
+    public void Build_ReadsTheSidesLevelAgainstTheTarget()
+    {
+        // The left sum is Ramp(2): 2 dB at 40 Hz falling half a dB per octave,
+        // against a flat target at -4 dB. On the 20 Hz..20 kHz grid the sum has
+        // points from 40 Hz to 10 kHz; the median of sum - target lands in the
+        // middle of that span, near 640 Hz: 2 - 0.5 * log2(16) + 4 = 4 dB.
+        JsonElement root = Json(AgentPackageBuilder.Build(Inputs(), Id, Clock).Text!);
+
+        Assert.Equal(4.0, root.GetProperty("sides")[0].GetProperty("sumVsTargetDb").GetDouble(), 1);
+        Assert.False(root.GetProperty("sides")[1].TryGetProperty("sumVsTargetDb", out _));
+    }
+
+    [Fact]
     public void Build_IsDeterministic()
     {
         string first = AgentPackageBuilder.Build(Inputs(), Id, Clock).Text!;
@@ -387,7 +466,7 @@ public sealed class AgentPackageBuilderTests
         List<SignalPoint> bProcessed = Ramp(-3);
         var aLeft = new AgentChannelInputs("A", AgentChannelSide.Left, VirtualCrossoverZone.Front,
             "left mid.json", true, false, aLeftSettings, 96_000,
-            new AgentSourceInputs(48_000, new MeasuredBand(40, 20_000), null, Ramp(0), aLeftProcessed, null, null, null, null));
+            new AgentSourceInputs(48_000, new MeasuredBand(40, 20_000), null, [], Ramp(0), aLeftProcessed, null, null, null, null));
         var aRight = new AgentChannelInputs("A", AgentChannelSide.Right, VirtualCrossoverZone.Front,
             "right mid.json", true, false, aRightSettings, 96_000, null);
         var b = new AgentChannelInputs("B", AgentChannelSide.Mono, VirtualCrossoverZone.Sub,
@@ -396,7 +475,7 @@ public sealed class AgentPackageBuilderTests
         // listed: the side's channel list is what says it played.
         var bWithCurves = b with
         {
-            Source = new AgentSourceInputs(48_000, new MeasuredBand(20, 200), "MovingMic", Ramp(-3), bProcessed, Ramp(-2), Ramp(-4), null, null)
+            Source = new AgentSourceInputs(48_000, new MeasuredBand(20, 200), "MovingMic", ["MovingMic"], Ramp(-3), bProcessed, Ramp(-2), Ramp(-4), null, null)
         };
 
         var correlation = new JunctionCorrelationView(
@@ -439,7 +518,7 @@ public sealed class AgentPackageBuilderTests
                 PeqQConvention.Symmetric, 10, MaxDelayFromCatalog: true),
             new AgentAnalysisInputs(
                 VirtualCrossoverGroupView.FrontAndSub, false, 6, true,
-                VirtualCrossoverSpatialAverageMode.MovingMic, false,
+                VirtualCrossoverSpatialAverageMode.MovingMic, HybridTicked: true, HybridDrawn: false,
                 PhaseWindowMode.FrequencyDependent, 6, PhaseDetrendMode.Auto,
                 5, 100, 20, null, null, null, 8.66, "ECM8000_90deg.txt", 0.25, false, -1, 0),
             new AgentTargetInputs(-4, TargetPreset.Flat, TargetCurveSpec.FromPreset(TargetPreset.Flat), 3, null),

--- a/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
@@ -220,57 +220,75 @@ public sealed class AgentPackageBuilderTests
     [Fact]
     public void Build_SaysWhereTheTuneStandsWithSpatialAverages()
     {
-        // The fixture: A:left measured with no capture, B:mono holds a
-        // moving-microphone capture, the hybrid box is ticked but the view is not
-        // drawing it. Captured, not shown.
+        // The fixture: the left view shows A:left (measured, no capture) and
+        // B:mono (a moving-microphone capture, hybrid curves in the package). One
+        // of two shown channels drawn from its average: partial.
         AgentPackageInputs inputs = Inputs();
         JsonElement status = Json(AgentPackageBuilder.Build(inputs, Id, Clock).Text!)
             .GetProperty("analysis").GetProperty("spatialAverage");
         Assert.Equal("MovingMic", status.GetProperty("mode").GetString());
         Assert.True(status.GetProperty("hybridTicked").GetBoolean());
-        Assert.False(status.GetProperty("hybridDrawn").GetBoolean());
-        Assert.Equal("capturedNotShown", status.GetProperty("status").GetString());
-        Assert.Equal(2, status.GetProperty("channelsMeasured").GetInt32());
+        Assert.True(status.GetProperty("hybridDrawn").GetBoolean());
+        Assert.Equal("partial", status.GetProperty("status").GetString());
+        Assert.Equal(2, status.GetProperty("channelsShown").GetInt32());
         Assert.Equal(1, status.GetProperty("channelsWithCapture").GetInt32());
-        Assert.Equal(0, status.GetProperty("channelsDrawn").GetInt32());
+        Assert.Equal(1, status.GetProperty("channelsDrawn").GetInt32());
 
         // Each channel lists what it holds, and only when it holds something.
         JsonElement channels = Json(AgentPackageBuilder.Build(inputs, Id, Clock).Text!).GetProperty("channels");
         Assert.False(channels[0].GetProperty("source").TryGetProperty("spatialAverageCaptures", out _));
         Assert.Equal(["MovingMic"], channels[2].GetProperty("source").GetProperty("spatialAverageCaptures").EnumerateArray().Select(c => c.GetString()));
 
-        // Drawn: the capture the mode reads, under a view that shows it — for one
-        // of the two measured channels.
-        AgentPackageInputs drawn = inputs with { Analysis = inputs.Analysis with { HybridDrawn = true } };
-        Assert.Equal("partial", Status(drawn));
-
-        // Every measured channel drawn from its average.
-        AgentPackageInputs everywhere = drawn with
+        // Every shown channel drawn from its average.
+        AgentPackageInputs everywhere = inputs with
         {
-            Channels = drawn.Channels
+            Channels = inputs.Channels
                 .Select(channel => channel.Source == null
                     ? channel
-                    : channel with { Source = channel.Source with { SpatialAverage = "MovingMic", SpatialAverageCaptures = ["MovingMic", "MicArray"] } })
+                    : channel with { Source = channel.Source with { SpatialAverage = "MovingMic", SpatialAverageCaptures = ["MovingMic", "MicArray"], HybridPreDsp = Ramp(-2), HybridProcessed = Ramp(-4) } })
                 .ToList()
         };
         Assert.Equal("active", Status(everywhere));
 
-        // A capture the selected mode does not read is captured, not shown —
-        // whatever the box says.
-        AgentPackageInputs wrongMode = everywhere with
+        // "Drawn" is the hybrid curves actually in the package, not the
+        // attachment: captures the view did not turn into curves — the box off,
+        // the mode reading another family, a group view — are captured, not shown.
+        AgentPackageInputs notDrawn = everywhere with
         {
+            Analysis = everywhere.Analysis with { HybridDrawn = false },
             Channels = everywhere.Channels
                 .Select(channel => channel.Source == null
                     ? channel
-                    : channel with { Source = channel.Source with { SpatialAverage = null } })
+                    : channel with { Source = channel.Source with { HybridPreDsp = null, HybridProcessed = null } })
                 .ToList()
         };
-        Assert.Equal("capturedNotShown", Status(wrongMode));
+        Assert.Equal("capturedNotShown", Status(notDrawn));
+
+        // A channel the view leaves out has curves of its own but no hybrid ones,
+        // whatever it holds; a muted one has no curves at all. Neither is counted:
+        // the status describes the channels the diagnostics are built from.
+        AgentPackageInputs outsideTheView = everywhere with
+        {
+            Channels =
+            [
+                .. everywhere.Channels,
+                new AgentChannelInputs("E", AgentChannelSide.Left, VirtualCrossoverZone.Rear,
+                    "rear left.json", true, false, new VirtualCrossoverChannelSettings(), 96_000,
+                    new AgentSourceInputs(48_000, new MeasuredBand(60, 20_000), "MovingMic", ["MovingMic"], Ramp(0), Ramp(-1), null, null, null, null)),
+                new AgentChannelInputs("F", AgentChannelSide.Left, VirtualCrossoverZone.Front,
+                    "muted.json", false, false, new VirtualCrossoverChannelSettings(), 96_000,
+                    new AgentSourceInputs(48_000, new MeasuredBand(60, 20_000), null, [], null, null, null, null, null, "channel muted"))
+            ]
+        };
+        JsonElement outside = Json(AgentPackageBuilder.Build(outsideTheView, Id, Clock).Text!)
+            .GetProperty("analysis").GetProperty("spatialAverage");
+        Assert.Equal("active", outside.GetProperty("status").GetString());
+        Assert.Equal(2, outside.GetProperty("channelsShown").GetInt32());
 
         // Nothing to draw from at all: the case the assistant is told to press.
-        AgentPackageInputs none = inputs with
+        AgentPackageInputs none = notDrawn with
         {
-            Channels = inputs.Channels
+            Channels = notDrawn.Channels
                 .Select(channel => channel.Source == null
                     ? channel
                     : channel with { Source = channel.Source with { SpatialAverage = null, SpatialAverageCaptures = [] } })
@@ -293,7 +311,12 @@ public sealed class AgentPackageBuilderTests
         JsonElement root = Json(AgentPackageBuilder.Build(Inputs(), Id, Clock).Text!);
 
         Assert.Equal(4.0, root.GetProperty("sides")[0].GetProperty("sumVsTargetDb").GetDouble(), 1);
+        // The hybrid sum, Ramp(3), reads one dB higher — its own datum, so the
+        // assistant is not sent to move the target by a point measurement while
+        // the tune is judged on averages.
+        Assert.Equal(5.0, root.GetProperty("sides")[0].GetProperty("hybridSumVsTargetDb").GetDouble(), 1);
         Assert.False(root.GetProperty("sides")[1].TryGetProperty("sumVsTargetDb", out _));
+        Assert.False(root.GetProperty("sides")[1].TryGetProperty("hybridSumVsTargetDb", out _));
     }
 
     [Fact]
@@ -500,6 +523,7 @@ public sealed class AgentPackageBuilderTests
             AgentChannelSide.Left,
             ["A:left", "B:mono"],
             Ramp(2),
+            Ramp(3),
             Ramp(-1).Select(point => new SignalPoint(point.X, double.IsNaN(point.Y) ? point.Y : -Math.Abs(point.Y) / 4)).ToList(),
             [
                 new VirtualCrossoverMetric.Entry("B/A", -1.3, -4.8, 40, 160, IsTotal: false),
@@ -509,7 +533,7 @@ public sealed class AgentPackageBuilderTests
             [new AgentJunctionInputs("B", "A", 80, 40, 160, bProcessed, aLeftProcessed, correlation, coherence)],
             null);
         var rightSide = new AgentSideInputs(
-            AgentChannelSide.Right, [], null, null, [], [], [], "no channel with a source on this side");
+            AgentChannelSide.Right, [], null, null, null, [], [], [], "no channel with a source on this side");
 
         return new AgentPackageInputs(
             "1.2.3",
@@ -518,7 +542,7 @@ public sealed class AgentPackageBuilderTests
                 PeqQConvention.Symmetric, 10, MaxDelayFromCatalog: true),
             new AgentAnalysisInputs(
                 VirtualCrossoverGroupView.FrontAndSub, false, 6, true,
-                VirtualCrossoverSpatialAverageMode.MovingMic, HybridTicked: true, HybridDrawn: false,
+                VirtualCrossoverSpatialAverageMode.MovingMic, HybridTicked: true, HybridDrawn: true,
                 PhaseWindowMode.FrequencyDependent, 6, PhaseDetrendMode.Auto,
                 5, 100, 20, null, null, null, 8.66, "ECM8000_90deg.txt", 0.25, false, -1, 0),
             new AgentTargetInputs(-4, TargetPreset.Flat, TargetCurveSpec.FromPreset(TargetPreset.Flat), 3, null),

--- a/tests/Resonalyze.App.Tests/EqTargetLevelCheckTests.cs
+++ b/tests/Resonalyze.App.Tests/EqTargetLevelCheckTests.cs
@@ -53,11 +53,12 @@ public sealed class EqTargetLevelCheckTests
     [Theory]
     [InlineData(2.9, false, null)]
     [InlineData(3.0, false, "above")]
-    [InlineData(3.0, true, null)]
+    [InlineData(2.9, true, null)]
+    [InlineData(3.0, true, "above")]
     [InlineData(-9.9, false, null)]
     [InlineData(-10.0, false, "below")]
     [InlineData(-10.0, true, "below")]
-    public void TheWarningFollowsTheThresholds_AndCutsOnlyIsOnlyWarnedBelow(
+    public void TheWarningFollowsTheThresholds_InBothModes(
         double targetAboveSourceDb, bool cutsOnly, string? expected)
     {
         string? warning = EqTargetLevelCheck.Warning(targetAboveSourceDb, cutsOnly, 80, 3_000);
@@ -73,6 +74,22 @@ public sealed class EqTargetLevelCheckTests
         }
 
         Assert.Null(EqTargetLevelCheck.Warning(null, cutsOnly, 80, 3_000));
+    }
+
+    [Fact]
+    public void ATargetAboveTheSource_IsExplainedDifferentlyUnderCutsOnly()
+    {
+        // The tuner's Cuts-only preamp is capped at 0 dB and its bands only cut,
+        // so it cannot reach a target above the source at all — the fit is not
+        // "boosts and headroom" there, it is "nothing happens, and a bump under
+        // the target line stays".
+        string boosting = EqTargetLevelCheck.Warning(4, cutsOnly: false, 80, 3_000)!;
+        string cutting = EqTargetLevelCheck.Warning(4, cutsOnly: true, 80, 3_000)!;
+
+        Assert.Contains("boost across the whole window", boosting);
+        Assert.Contains("Cuts only cannot raise the curve", cutting);
+        Assert.Contains("Lower the Target Level to the curve", cutting);
+        Assert.DoesNotContain("tick Cuts only", boosting);
     }
 
     private static List<SignalPoint> Grid(Func<double, double> level)

--- a/tests/Resonalyze.App.Tests/EqTargetLevelCheckTests.cs
+++ b/tests/Resonalyze.App.Tests/EqTargetLevelCheckTests.cs
@@ -5,9 +5,9 @@ namespace Resonalyze.App.Tests;
 /// <summary>
 /// The question Auto Tune asks when the target level datum sits far from the
 /// curve it is about to fit. Pinned: the reading is a median over the window
-/// (a dip does not move it), the thresholds, and that Cuts only is warned about
-/// a target below the source but not above it — there the auto preamp aligns
-/// the curve and nothing is lost.
+/// (a dip does not move it), the thresholds in both modes, and that a target
+/// above the source is explained differently under Cuts only — there the fit
+/// cannot raise the curve at all, rather than raising it at the cost of headroom.
 /// </summary>
 public sealed class EqTargetLevelCheckTests
 {

--- a/tests/Resonalyze.App.Tests/EqTargetLevelCheckTests.cs
+++ b/tests/Resonalyze.App.Tests/EqTargetLevelCheckTests.cs
@@ -1,0 +1,88 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The question Auto Tune asks when the target level datum sits far from the
+/// curve it is about to fit. Pinned: the reading is a median over the window
+/// (a dip does not move it), the thresholds, and that Cuts only is warned about
+/// a target below the source but not above it — there the auto preamp aligns
+/// the curve and nothing is lost.
+/// </summary>
+public sealed class EqTargetLevelCheckTests
+{
+    [Fact]
+    public void TheReadingIsTheMedianOverTheWindow_AndADipDoesNotMoveIt()
+    {
+        List<SignalPoint> source = Grid(frequency => -80);
+        // A 12 dB notch at 1 kHz, the kind a junction leaves: three grid points.
+        source = source
+            .Select(point => Math.Abs(point.X - 1_000) < 60 ? point with { Y = -92 } : point)
+            .ToList();
+        List<SignalPoint> target = Grid(frequency => -76);
+
+        double? offset = EqTargetLevelCheck.TargetAboveSourceDb(source, target, 100, 10_000);
+
+        Assert.Equal(4, offset!.Value, 6);
+    }
+
+    [Fact]
+    public void OnlyTheWindowCounts_AndAnEmptyWindowReadsAsNothing()
+    {
+        List<SignalPoint> source = Grid(frequency => frequency < 500 ? -60 : -90);
+        List<SignalPoint> target = Grid(frequency => -80);
+
+        Assert.Equal(-20, EqTargetLevelCheck.TargetAboveSourceDb(source, target, 20, 400)!.Value, 6);
+        Assert.Equal(10, EqTargetLevelCheck.TargetAboveSourceDb(source, target, 600, 20_000)!.Value, 6);
+        Assert.Null(EqTargetLevelCheck.TargetAboveSourceDb(source, target, 30_000, 40_000));
+        Assert.Null(EqTargetLevelCheck.TargetAboveSourceDb([], [], 20, 20_000));
+    }
+
+    [Fact]
+    public void HolesAndMismatchedFrequenciesAreSkipped()
+    {
+        List<SignalPoint> source = Grid(frequency => -80);
+        List<SignalPoint> target = Grid(frequency => -78);
+        source[10] = source[10] with { Y = double.NaN };
+        // A target built on another grid is not compared point for point.
+        target[11] = new SignalPoint(target[11].X * 1.5, 0);
+
+        Assert.Equal(2, EqTargetLevelCheck.TargetAboveSourceDb(source, target, 20, 20_000)!.Value, 6);
+    }
+
+    [Theory]
+    [InlineData(2.9, false, null)]
+    [InlineData(3.0, false, "above")]
+    [InlineData(3.0, true, null)]
+    [InlineData(-9.9, false, null)]
+    [InlineData(-10.0, false, "below")]
+    [InlineData(-10.0, true, "below")]
+    public void TheWarningFollowsTheThresholds_AndCutsOnlyIsOnlyWarnedBelow(
+        double targetAboveSourceDb, bool cutsOnly, string? expected)
+    {
+        string? warning = EqTargetLevelCheck.Warning(targetAboveSourceDb, cutsOnly, 80, 3_000);
+
+        if (expected == null)
+        {
+            Assert.Null(warning);
+        }
+        else
+        {
+            Assert.Contains($"dB {expected} the source over 80–3000 Hz", warning);
+            Assert.EndsWith("Tune anyway?", warning);
+        }
+
+        Assert.Null(EqTargetLevelCheck.Warning(null, cutsOnly, 80, 3_000));
+    }
+
+    private static List<SignalPoint> Grid(Func<double, double> level)
+    {
+        var points = new List<SignalPoint>();
+        for (double frequency = 20; frequency <= 20_000; frequency *= Math.Pow(2, 1.0 / 24))
+        {
+            points.Add(new SignalPoint(frequency, level(frequency)));
+        }
+
+        return points;
+    }
+}


### PR DESCRIPTION
Agent Bridge, stage 2, step 1 of the accepted plan: the assistant is told where the tune stands with spatial averages, and a fit checks its target level before it runs.

## Package

- `analysis.spatialAverage` — one word for the tune, counted by the builder over the channels the current view shows (the union of `sides[].channels`): `none` (no shown channel carries a capture of any family), `capturedNotShown` (captures exist, no hybrid curve is in the package), `partial`, `active`; with `mode`, `hybridTicked`, `hybridDrawn` and the three counts behind it, so the assistant can say *which* thing to fix. `channelsDrawn` is read off the hybrid curves actually present, not off what is attached — a rear channel outside the Show view or a muted one does not count.
- `channels[].source.spatialAverageCaptures` — every family the channel holds, read or not. Differs from the existing `source.spatialAverage` exactly when an average is attached and unused.
- `sides[].sumVsTargetDb` — the median of the side's measured sum against the target curve — and `sides[].hybridSumVsTargetDb`, the same off the sum the hybrid view draws (the plot's own construction, both sides), present while the hybrid curves are drawn and named an estimate. A median, so a junction dip or the sub's roll-off does not move the datum.
- Nothing added to the inline rules; the wording lives in the guide.

## Guide

- New step 2 in the order of analysis. `none` → recommend moving-microphone captures firmly, with links to the manual's *Optional: a spatial average for the EQ* and *Optional: equalize the spatial average*. `capturedNotShown` → say the channel curves and PEQ judgements still rest on the point measurements, and read the flags to name the cause (Hybrid unticked, the mode does not read the family the channels hold, a playing channel without a capture, a group view); the `stereo[]` / `groups[]` rows carry their own basis in `levelFromSpatialAverage`.
- Step 7 (target and tonal balance) opens with the datum check, on the hybrid datum while the status is `active`; §5 gets a "do not" for equalizing a point measurement while averages could be had.

## EQ Wizard

`EqTargetLevelCheck` (UI-free): the median of target minus source over the From–To window. Auto Tune asks Yes/No before it runs when the target sits 3 dB or more above the source — the fit would boost the whole window; under **Cuts only** it cannot raise the curve at all (the tuner's preamp is capped at 0 dB) and a bump under the target line goes uncorrected, which the question says in that mode — or 10 dB or more below it (the whole window cut, the level handed to the amplifier gain).

## Docs

PROTOCOL §1.4 / §1.6 / §1.7, REFERENCE (the bridge section, the Auto Tune paragraph), MANUAL (the Auto Tune step).

## Verification

- Battery in Debug (the Release output was in use): App 2138, Audio 159, Dsp 1444 passed, 0 failed.
- New tests: the four statuses, the out-of-view and muted channels, the per-channel list, both datums, the median/holes/window behaviour and the thresholds and wording of the target check in both modes.
- Smoke on the Passat v2 session: status `none` over 7 channels, `sumVsTargetDb` −0.8 / −0.5 dB against a −4 dB target; on the v6 session with MMM on every channel: `active` 7/7, left datums −0.9 measured / −2.7 hybrid. The package parses and reviews as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
