### PR TITLE
Agent Bridge stage 2: engine requests — Auto delay and Auto-tune from an import without their dialogs

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1546,12 +1546,14 @@ use, and answer its questions about the drivers and the car (the **Notes for AI*
 field in the **DSP processor...** dialog saves you retyping them next time). It
 reads the same read-outs you have been reading — sum loss, junction phase, the
 delay lobes, the L/R deltas — and should send you back to **Auto delay** or **Auto
-crossover** with settings rather than to a list of numbers; where it does propose a
-number, **Import AI proposal…** shows every change against the current value and
-applies only what you tick, with **Undo AI import** one click away. What it cannot
-do is hear the car or know your drivers unless you tell it; treat its advice as a
-colleague's, not as a measurement. [REFERENCE.md](REFERENCE.md#ai-assistant-bridge)
-describes the bridge in full.
+crossover** with settings rather than to a list of numbers. **Import AI proposal…**
+shows every change against the current value and applies only what you tick, with
+**Undo AI import** one click away. A reply can also ask to open **Auto crossover**
+for you, or to switch the tune onto its spatial averages with **Hybrid** ticked;
+those arrive as rows you tick like any other, and the engine's own dialog still
+runs in front of you. What it cannot do is hear the car or know your drivers
+unless you tell it; treat its advice as a colleague's, not as a measurement.
+[REFERENCE.md](REFERENCE.md#ai-assistant-bridge) describes the bridge in full.
 
 ### Hear it before you go back to the car
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2842,8 +2842,10 @@ this: the clipboard is the only transport, and you are the one who pastes.
 
   Every proposed change is shown against the value the channel holds *now*, with
   the reason the assistant gave; an engine request is shown against the settings
-  the engine would start from, with what it will write over — and it is still
-  the engine's own dialog that runs and applies it. A change the assistant
+  the engine would start from, with what it will write over. Auto crossover
+  then opens its wizard as the button does; Auto delay runs without its dialog
+  — the button's own checks, search and commit, with the report it would have
+  shown returned in the import's summary and the alignment log. A change the assistant
   reasoned about a value that has since moved is rejected as such; so is one
   outside Virtual DSP's own limits (the channel block's gain and delay ranges and
   steps, the crossover families and slopes, the corner range and the processor's
@@ -2866,10 +2868,12 @@ this: the clipboard is the only transport, and you are the one who pastes.
   rows together and unticking one can leave a state it never showed, which then
   asks before applying — writes them as one set, then runs the engine requests
   in a fixed order (the spatial average first, since it decides which curves the
-  rest are read on, then Auto crossover) and closes with one summary of what was
-  applied and what was skipped. Cancelling an engine's dialog skips that
-  operation and the rest carry on; a failure while writing the settings writes
-  nothing. Validity is not quality: a proposal that passes every check can still
+  rest are read on, then Auto crossover, then Auto delay) and closes with one
+  summary of what was applied and what was skipped. Cancelling the wizard, or
+  a check Auto delay's button would have refused on (fewer than two measured
+  channels, a bypassed participant, a misplaced gate, no crossover anywhere),
+  skips that operation with the reason and the rest carry on; a failure while
+  writing the settings writes nothing. Validity is not quality: a proposal that passes every check can still
   be a worse tune, so listen before you trust it, and re-run **Auto delay** after
   a polarity or crossover change as the guide tells the assistant to advise.
 - **Undo AI import** puts back everything the last import could have moved, not

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2845,7 +2845,12 @@ this: the clipboard is the only transport, and you are the one who pastes.
   the engine would start from, with what it will write over. Auto crossover
   then opens its wizard as the button does; Auto delay runs without its dialog
   — the button's own checks, search and commit, with the report it would have
-  shown returned in the import's summary and the alignment log. A change the assistant
+  shown returned in the import's summary and the alignment log; Auto-tune runs
+  without the EQ Wizard, on the curve the wizard would have opened on for that
+  channel and with the wizard's opening values for whatever the reply leaves
+  out, keeps the bank's all-pass bands, lands the fit the way the wizard's
+  **Return** lands it, and skips itself — with the reason — where the wizard
+  would have asked about the [target level](#eq-wizard). A change the assistant
   reasoned about a value that has since moved is rejected as such; so is one
   outside Virtual DSP's own limits (the channel block's gain and delay ranges and
   steps, the crossover families and slopes, the corner range and the processor's

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2830,33 +2830,52 @@ this: the clipboard is the only transport, and you are the one who pastes.
   responses.
 - **Import AI proposal…** reads the assistant's reply back off the clipboard —
   copy the whole reply, not just the JSON — and opens a review. The reply may
-  address only five things, each on one channel: gain, delay, polarity, the
-  crossover, and the whole PEQ bank; nothing else in a session can be reached
-  from a reply, and an unknown request is listed as rejected. Every proposed
-  change is shown against the value the channel holds *now*, with the reason the
-  assistant gave. A change the assistant reasoned about a value that has since
-  moved is rejected as such; so is one outside Virtual DSP's own limits (the
-  channel block's gain and delay ranges and steps, the crossover families and
-  slopes, the corner range and the processor's Nyquist, the PEQ band count), one
-  that changes nothing, and two that contradict each other. Admissible rows start
-  ticked; rejected rows cannot be ticked; a warning — a delay above the
-  processor's stated ceiling, a PEQ bank whose net response (preamp and every
-  band together) rises above 0 dB somewhere and would clip a full-scale signal
-  there, a bell narrower than Q 2 within an octave of one of the channel's own
-  crossover corners (where it turns the phase the pair's sum is built on), a
-  PEQ bank or crossover the device's own limits were not checked against because
-  the catalog does not know them — is a word in the Status column, not only a
-  colour. **Apply selected** looks at the ticked
-  rows once more against the live settings — and at what the ticked subset
-  leaves behind, since the review judged the rows together and unticking one
-  can leave a state it never showed, which then asks before applying — writes
-  them as one set, saves once and redraws once; a failure anywhere writes
-  nothing. Validity is not quality: a
-  proposal that passes every check can still be a worse tune, so listen before you
-  trust it, and re-run **Auto delay** after a polarity or crossover change as the
-  guide tells the assistant to advise.
-- **Undo AI import** puts every channel the last import touched back exactly as
-  it was. One step; it is gone once a session is loaded.
+  address five things on one channel: gain, delay, polarity, the crossover, and
+  the whole PEQ bank. It may also **ask for an engine to be run**: **Auto
+  crossover**, or the spatial average — the capture family and the **Hybrid**
+  tick together, which is how an assistant that has noticed unused averages puts
+  them to work in one tick. (Auto delay and the EQ Wizard's Auto-tune are part of
+  the protocol and are read and reviewed, but this build refuses them as not
+  available; the package tells the assistant which operations it can run.)
+  Nothing else in a session can be reached from a reply, and an unknown request
+  is listed as rejected.
+
+  Every proposed change is shown against the value the channel holds *now*, with
+  the reason the assistant gave; an engine request is shown against the settings
+  the engine would start from, with what it will write over — and it is still
+  the engine's own dialog that runs and applies it. A change the assistant
+  reasoned about a value that has since moved is rejected as such; so is one
+  outside Virtual DSP's own limits (the channel block's gain and delay ranges and
+  steps, the crossover families and slopes, the corner range and the processor's
+  Nyquist, the PEQ band count, the Auto delay dialog's own fields), one that
+  changes nothing, and two that contradict each other — including a
+  hand-written value an engine in the same reply would write over, which is
+  rejected naming the engine, since the two cannot both be meant and the engine
+  is the one that computes the number.
+
+  Admissible rows start ticked; rejected rows cannot be ticked; a warning — a
+  delay above the processor's stated ceiling, a PEQ bank whose net response
+  (preamp and every band together) rises above 0 dB somewhere and would clip a
+  full-scale signal there, a bell narrower than Q 2 within an octave of one of
+  the channel's own crossover corners (where it turns the phase the pair's sum is
+  built on), a PEQ bank or crossover the device's own limits were not checked
+  against because the catalog does not know them, an engine that will write over
+  more than the rows name — is a word in the Status column, not only a colour.
+  **Apply selected** looks at the ticked rows once more against the live settings
+  — and at what the ticked subset leaves behind, since the review judged the
+  rows together and unticking one can leave a state it never showed, which then
+  asks before applying — writes them as one set, then runs the engine requests
+  in a fixed order (the spatial average first, since it decides which curves the
+  rest are read on, then Auto crossover) and closes with one summary of what was
+  applied and what was skipped. Cancelling an engine's dialog skips that
+  operation and the rest carry on; a failure while writing the settings writes
+  nothing. Validity is not quality: a proposal that passes every check can still
+  be a worse tune, so listen before you trust it, and re-run **Auto delay** after
+  a polarity or crossover change as the guide tells the assistant to advise.
+- **Undo AI import** puts back everything the last import could have moved, not
+  only the channels its rows named: every channel's chain, the spatial average
+  mode and the **Hybrid** tick, and the block order Auto crossover may have
+  changed. One step; it is gone once a session is loaded.
 
 The assistant's side of the protocol — what the package contains, what a reply
 may say, and the method the assistant is asked to follow (measurement

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2847,8 +2847,9 @@ this: the clipboard is the only transport, and you are the one who pastes.
   — the button's own checks, search and commit, with the report it would have
   shown returned in the import's summary and the alignment log; Auto-tune runs
   without the EQ Wizard, on the curve the wizard would have opened on for that
-  channel and with the wizard's opening values for whatever the reply leaves
-  out, keeps the bank's all-pass bands, lands the fit the way the wizard's
+  channel and with the wizard's own Auto Tune settings as they stand (Max
+  Filters, Gain min/max, Max Q, Cuts only, Shelves) for whatever the reply
+  leaves out, keeps the bank's all-pass bands, lands the fit the way the wizard's
   **Return** lands it, and skips itself — with the reason — where the wizard
   would have asked about the [target level](#eq-wizard). A change the assistant
   reasoned about a value that has since moved is rejected as such; so is one

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -147,7 +147,9 @@ Work in this order; each step gates the next.
    PEQ bank on the channels of that junction (the block's PEQ button, Clear —
    the block's Bypass would drop the crossover too and change the junction
    itself), copy a new package, read the junction again, then load the saved
-   session back.
+   session back. You can clear a bank yourself: a `replacePeqBank` with an
+   empty `bands` list and `preampDb: 0` is a valid operation, and *Undo AI
+   import* puts the bank back.
 5. **Crossover corners and slopes.** Judge the acoustic slopes on
    `processedDb`, not the electrical ones: the driver's own roll-off adds to
    the filter. Before proposing a corner, know the driver (model, size,

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -1,6 +1,6 @@
 # Resonalyze Agent Guide
 
-Guide version 1.0 · for protocol v1 · [PROTOCOL.md](PROTOCOL.md) is the schema.
+Guide version 1.1 · for protocol v1 · [PROTOCOL.md](PROTOCOL.md) is the schema.
 
 ## 0. The rules that also travel inside every package
 
@@ -102,8 +102,12 @@ Work in this order; each step gates the next.
      **Array** button's menu) does not read the family the channels hold; a
      playing channel has no capture (`channelsWithCapture` < `channelsShown`
      — name it from `source.spatialAverageCaptures`); or the view is a group
-     comparison, which never draws them. Ask for a new package once the
-     hybrid curves are on; the same manual section explains the switch.
+     comparison, which never draws them. Where the package's
+     `limits.operations` names `useSpatialAverage` you can ask for the mode
+     and the **Hybrid** tick as an operation (§6) rather than describing the
+     clicks; either way, ask for a new package once the hybrid curves are on,
+     since every curve in this one was read the old way. The same manual
+     section explains the switch.
    - `partial`: some measured channels are judged on their average and some
      on a point. Name the ones without (`hybridPreDspDb` absent) and treat
      their PEQ as step 8 says for point measurements.
@@ -226,7 +230,8 @@ Work in this order; each step gates the next.
   while averages sit unused (`analysis.spatialAverage.status` other than
   `active`). Step 2 says what to tell them.
 - Do not pick a delay from one number. Use the lobes, the PHAT peaks and the
-  ladder together, and prefer recommending Auto delay over stating a value.
+  ladder together, and prefer Auto delay — recommended, or requested as an
+  operation where the package offers one — over stating a value.
 - Do not declare a high-pass safe from Fs or cone size. Ask for the driver and
   cite the maker's recommendation; say when you are inferring.
 - Do not invent precision. A 0.01 ms delay or a 0.1 dB trim you cannot justify
@@ -239,20 +244,36 @@ Work in this order; each step gates the next.
 
 ## 6. Engines first, numbers second
 
-Resonalyze has three engines the user can run in one click. Recommend them, with
-settings, before you hand-write what they compute:
+Resonalyze has three engines the user can run in one click. Reach for them
+before you hand-write what they compute:
 
 - **Auto delay** — searches delays and polarities per junction and across the
-  sides. Say: run Auto delay, with the scene offset and steering side, and
-  whether to let it adjust gains. Then copy a new package to check the result.
+  sides. Say, or request: the scene offset, the steering side, and whether to
+  let it adjust gains. Then ask for a new package to check the result.
 - **Auto crossover** — proposes corners and slopes from the drivers' usable
-  bands. Say when to run it and what to confirm afterwards.
+  bands. It takes no settings; say what to confirm in its dialog afterwards.
 - **EQ Wizard Auto-tune** — fits a PEQ bank to the target over a channel's
-  band, optionally on the spatial average. Say which channel, which target
-  level, whether shelves are allowed.
+  band, optionally on the spatial average. Say, or request: which channel,
+  which target level, whether shelves are allowed, cuts only or not.
 
-Write these as `advice`, not as operations. Hand-written operations are for:
-a polarity flip you can justify from the junction read-outs; a crossover
+**You can now ASK for an engine**, as an operation, when the package's
+`limits.operations` names it — `runAutoDelay`, `runAutoCrossover`,
+`autoTunePeq`, and `useSpatialAverage` for the mode and the Hybrid tick. An
+engine request is not a headless run: it opens the engine with your inputs, and
+the user still runs and applies it in the engine's own dialog. What
+`limits.operations` does NOT name, say in `advice` as before — that build
+cannot run it, and asking anyway costs the user a rejected row.
+
+Two rules that follow from it. Do not send an engine request together with a
+hand-written value the engine would write over (Auto delay writes delay and
+polarity, and gains when you ask it to balance them; Auto crossover writes the
+corners and a cut-only gain; Auto-tune replaces one channel's bank) — the
+review rejects the hand-written row. And request each engine once: a repeat is
+refused, naming the first. `autoTunePeq` counts per channel, so ask for it once
+per channel you want fitted.
+
+Hand-written operations are still the right answer for what an engine does not
+decide: a polarity flip you can justify from the junction read-outs; a crossover
 corner or slope you can justify from the driver and the acoustic slope; a gain
 trim from the level deltas; a small, targeted PEQ change with a stated cause
 (for example a door resonance visible in both the point measurement and the
@@ -288,18 +309,23 @@ When a driver or a processor matters to your advice:
 
 Write your analysis in prose. Then, **only if** you have concrete, justified
 changes for the five editable parameters (gain, delay, polarity, crossover,
-PEQ bank of one channel), end with exactly one block between
-`BEGIN_RESONALYZE_AGENT_PROPOSAL_V1` and `END_RESONALYZE_AGENT_PROPOSAL_V1`
-as [PROTOCOL.md](PROTOCOL.md) §2 describes. In it:
+PEQ bank of one channel) or an engine to request, end with exactly one block
+between `BEGIN_RESONALYZE_AGENT_PROPOSAL_V1` and
+`END_RESONALYZE_AGENT_PROPOSAL_V1` as [PROTOCOL.md](PROTOCOL.md) §2 describes.
+In it:
 
 - Copy `packageId`, every `channelId` and every expected current value from
   the package exactly. A changed current value refuses the operation.
 - One operation per channel and parameter. State each `reason` in one or two
   sentences; the user reads it in the review.
-- Put everything else — run Auto delay with these settings, re-measure this
-  channel, switch the view and copy again — into `advice`.
+- Use only the operations `limits.operations` names, and never an engine
+  request beside a hand-written value that engine would write over (§6).
+- Put everything else — re-measure this channel, switch the view and copy
+  again, run an engine this build does not offer as an operation — into
+  `advice`.
 - A reply with no block is a normal reply. A reply that only advises, or only
   asks, is often the right one.
 
-Example of a complete reply: PROTOCOL.md §2 shows one with all five operation
-types; do not include operations you have no evidence for.
+Example of a complete reply: PROTOCOL.md §2 shows one with all five settings
+operations, and §2.2 the engine requests; do not include operations you have no
+evidence for.

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -263,8 +263,16 @@ review is the gate: once the user applies the row, `runAutoDelay` runs at once
 with your inputs (no dialog; the run's report comes back to the user in the
 import's summary, and the same checks the button makes — two measured
 channels, no bypassed participant, the gate in place, a crossover somewhere —
-skip it with the reason when they fail), while `runAutoCrossover` opens the
-wizard for the user to confirm the driver types. Either way, ask for a new
+skip it with the reason when they fail); `autoTunePeq` runs at once as well,
+on the curve the wizard would have opened on for that channel (the spatial
+average while the hybrid view draws it — ask for `useSpatialAverage` first
+where it is not — or the `source` you name), with the wizard's own opening
+values for what you leave out: cuts only, no shelves, Q no narrower than 6,
+the channel's passband as the window. State `targetLevelDb` only when you
+mean to move the project's target level — it is one datum for every channel,
+and the run skips itself when it sits 3 dB or more above the curve or 10 dB
+or more below. `runAutoCrossover` opens the wizard for the user to confirm
+the driver types. Either way, ask for a new
 package afterwards to read the result. What `limits.operations` does NOT name,
 say in `advice` as before — that build cannot run it, and asking anyway costs
 the user a rejected row.

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -268,12 +268,16 @@ channels, no bypassed participant, the gate in place, a crossover somewhere —
 skip it with the reason when they fail); `autoTunePeq` runs at once as well,
 on the curve the wizard would have opened on for that channel (the spatial
 average while the hybrid view draws it — ask for `useSpatialAverage` first
-where it is not — or the `source` you name), with the wizard's own opening
-values for what you leave out: cuts only, no shelves, Q no narrower than 6,
-the channel's passband as the window. State `targetLevelDb` only when you
-mean to move the project's target level — it is one datum for every channel,
-and the run skips itself when it sits 3 dB or more above the curve or 10 dB
-or more below. `runAutoCrossover` opens the wizard for the user to confirm
+where it is not — or the `source` you name), with the EQ Wizard's Auto Tune
+settings as the user left them (Max Filters, gain range, Max Q, Cuts only,
+Shelves) for what you leave out, and the channel's passband as the window;
+a stated edge must lie within 20 Hz–20 kHz and keep the window ordered
+against the passband edge you leave in place. State `targetLevelDb` only when
+you mean to move the project's target level — it is one datum for every
+channel, so every request that states one must state the same value, and
+one import fits every channel to one level; the run skips itself when it sits
+3 dB or more above the curve or 10 dB or more below. `runAutoCrossover`
+opens the wizard for the user to confirm
 the driver types. Either way, ask for a new
 package afterwards to read the result. What `limits.operations` does NOT name,
 say in `advice` as before — that build cannot run it, and asking anyway costs

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -258,11 +258,16 @@ before you hand-write what they compute:
 
 **You can now ASK for an engine**, as an operation, when the package's
 `limits.operations` names it — `runAutoDelay`, `runAutoCrossover`,
-`autoTunePeq`, and `useSpatialAverage` for the mode and the Hybrid tick. An
-engine request is not a headless run: it opens the engine with your inputs, and
-the user still runs and applies it in the engine's own dialog. What
-`limits.operations` does NOT name, say in `advice` as before — that build
-cannot run it, and asking anyway costs the user a rejected row.
+`autoTunePeq`, and `useSpatialAverage` for the mode and the Hybrid tick. The
+review is the gate: once the user applies the row, `runAutoDelay` runs at once
+with your inputs (no dialog; the run's report comes back to the user in the
+import's summary, and the same checks the button makes — two measured
+channels, no bypassed participant, the gate in place, a crossover somewhere —
+skip it with the reason when they fail), while `runAutoCrossover` opens the
+wizard for the user to confirm the driver types. Either way, ask for a new
+package afterwards to read the result. What `limits.operations` does NOT name,
+say in `advice` as before — that build cannot run it, and asking anyway costs
+the user a rejected row.
 
 Two rules that follow from it. Do not send an engine request together with a
 hand-written value the engine would write over (Auto delay writes delay and

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -88,7 +88,8 @@ the catalog does not know it.
               "Bessel": [6,12,18,24,36,48], "Chebyshev": [6,12,18,24,30,36,42,48] },
   "chebyshevRippleDb": [0, 3],
   "operations": ["setGainDb", "setDelayMs", "setPolarity", "setCrossover",
-                 "replacePeqBank", "useSpatialAverage", "runAutoCrossover"] }
+                 "replacePeqBank", "useSpatialAverage", "runAutoCrossover",
+                 "runAutoDelay", "autoTunePeq"] }
 ```
 
 These are Virtual DSP's own limits, not the device's. A reply outside them is
@@ -396,9 +397,10 @@ report, the text the dialog would have shown, comes back in the import's
 summary and the alignment log. `autoTunePeq` runs without the EQ Wizard too:
 it fits the curve the wizard would have opened on for that channel — the
 spatial average while the hybrid view draws it, the point measurement
-otherwise, or whichever `source` names — with the wizard's opening values for
-what the reply leaves out (bells no narrower than Q 6, band gains −15…+6 dB,
-cuts only, no shelves, the channel's passband as the window); all-pass bands
+otherwise, or whichever `source` names — with the EQ Wizard's Auto Tune
+settings as they stand (Max Filters, Gain min/max, Max Q, Cuts only, Shelves —
+the same bank the wizard's button would fit for the same project) for what the
+reply leaves out, and the channel's passband as the window; all-pass bands
 in the bank are kept and the fit tunes around them; a `targetLevelDb` moves the
 project's target level, as the wizard's Return does — it is one datum for the
 whole project, so every request in a reply that states one must state the
@@ -423,7 +425,7 @@ wants only the scene offset changed states only that.
 | --- | --- | --- |
 | `runAutoDelay` | `sceneOffsetMs?`, `rightHandDrive?`, `adjustGains?`, `nearSideCutDb?`, `rearFillOffsetMs?` | the dialog's own fields: scene offset 0–5 ms in steps of 0.01, near-side cut 0–6 dB in steps of 0.1, rear fill offset 0–30 ms in steps of 0.1. `nearSideCutDb` is a magnitude: the LHD/RHD toggle owns the sign. Stereo or single-sided is the panel's decision, as it is for the button |
 | `runAutoCrossover` | none | the wizard has no inputs: the families, the corner window and the chain order are chosen in its own dialog |
-| `autoTunePeq` | `channelId`, `targetLevelDb?`, `minHz?`, `maxHz?`, `allowShelves?`, `cutsOnly?`, `source?` | the channel exists and has a measurement; target level −120…60 dB in whole dB; each stated edge above 0 Hz and below the processor's Nyquist, the lower below the upper; `source` is `point` or `spatialAverage`, and `spatialAverage` needs the channel to carry one |
+| `autoTunePeq` | `channelId`, `targetLevelDb?`, `minHz?`, `maxHz?`, `allowShelves?`, `cutsOnly?`, `source?` | the channel exists, has a measurement and is on the side on screen; target level −120…60 dB in whole dB, the same in every request that states one; each stated edge within the wizard's From/To fields (20 Hz–20 kHz) and below the processor's Nyquist, and the window as the run will use it — a stated edge with the channel's passband edge for the one left out — ordered; `source` is `point` or `spatialAverage`, and `spatialAverage` needs the channel to carry one |
 | `useSpatialAverage` | `mode`, `hybrid` | `mode` is `MovingMic` or `MicArray` and at least one channel carries that family (`channels[].source.spatialAverageCaptures`); `hybrid` must be `true`; a mode already in force with Hybrid already ticked is refused as "no change" |
 
 ```json
@@ -479,8 +481,9 @@ showed (a crossover moved without the bank that went with it).
 4. On *Apply selected*, judges the ticked rows once more against the settings as
    they are at that moment, then writes the settings rows as one set. A failure
    there writes nothing.
-5. Runs the ticked engine requests, in the fixed order above — each engine
-   through its own dialog, the spatial average straight onto the panel — and
+5. Runs the ticked engine requests, in the fixed order above — the spatial
+   average straight onto the panel, Auto crossover through its wizard, Auto
+   delay and Auto-tune without their dialogs — and
    ends with one summary of what was applied and what was skipped. Undo is armed
    before the first of these writes, so an import that stops part-way is still
    undone in one step.

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -400,7 +400,10 @@ otherwise, or whichever `source` names — with the wizard's opening values for
 what the reply leaves out (bells no narrower than Q 6, band gains −15…+6 dB,
 cuts only, no shelves, the channel's passband as the window); all-pass bands
 in the bank are kept and the fit tunes around them; a `targetLevelDb` moves the
-project's target level, as the wizard's Return does. A channel on the side not
+project's target level, as the wizard's Return does — it is one datum for the
+whole project, so every request in a reply that states one must state the
+same value (the first stated level stands, the others are refused naming it),
+and a run that skips itself leaves the level untouched. A channel on the side not
 on screen is refused at review (the handoff is the shown side's: its gate pin,
 its anchor, its hybrid datum — switch the L/R selector, copy a new package and
 ask again). The run skips itself, with the reason, when `spatialAverage` is

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -86,11 +86,19 @@ the catalog does not know it.
   "peqBands": 32, "peqPreampDb": 60, "crossoverHz": [10, 24000],
   "slopes": { "Butterworth": [6,12,18,24,30,36,42,48], "LinkwitzRiley": [12,24,36,48],
               "Bessel": [6,12,18,24,36,48], "Chebyshev": [6,12,18,24,30,36,42,48] },
-  "chebyshevRippleDb": [0, 3] }
+  "chebyshevRippleDb": [0, 3],
+  "operations": ["setGainDb", "setDelayMs", "setPolarity", "setCrossover",
+                 "replacePeqBank", "useSpatialAverage", "runAutoCrossover"] }
 ```
 
 These are Virtual DSP's own limits, not the device's. A reply outside them is
 rejected; a reply inside them may still exceed what the device can dial.
+
+`operations` is what THIS build can execute. The protocol below describes more
+than any one build runs: an operation missing from the list is still read and
+reviewed — so a reply written for a newer build is understood rather than
+mangled — and then refused with "not available in this version of Resonalyze".
+Use only the operations the package names; everything else goes in `advice`.
 
 ### 1.4 `analysis`
 
@@ -342,13 +350,15 @@ facts per source, 2000 characters per string, JSON depth 8.
 
 ### 2.2 Operations
 
-Every operation has `id` (unique in the reply), `op`, `channelId` (an id from
-the package), `reason` (shown in the review), and what it believes the
+Every operation has `id` (unique in the reply), `op` and `reason` (shown in the
+review). There are two families. The five below WRITE one channel's settings:
+they add `channelId` (an id from the package) and what they believe the
 **current** value is, copied from the package. A current value that no longer
-matches means the tune moved on since the package was copied, and the
-operation is refused rather than applied to a state it was not reasoned about.
-Two operations on one channel's same parameter refuse each other. An operation
-that changes nothing is refused as "no change".
+matches means the tune moved on since the package was copied, and the operation
+is refused rather than applied to a state it was not reasoned about. Two
+operations on one channel's same parameter refuse each other. An operation that
+changes nothing is refused as "no change". The four under *Engine requests*
+below ask for one of the panel's own engines instead.
 
 | `op` | Fields | Checked against |
 | --- | --- | --- |
@@ -368,10 +378,68 @@ All `q` values are RBJ cookbook Q. Resonalyze never converts them on the way in;
 the processor's own convention is applied only where numbers leave for the
 device (the tuning sheets).
 
-Nothing else can be addressed: not the target, the processor, the gates, the
-sources, the calibration, the channel list, mute or bypass. Such changes belong
-in `advice`, as text. An unknown `op` is listed in the review as rejected and
-never applied.
+#### Engine requests
+
+The four operations below carry no value of their own. Three ask for one of the
+panel's engines to be opened with the inputs stated; the fourth,
+`useSpatialAverage`, puts the panel into the state the others should be read in.
+They exist because the engines compute what no reading of a curve can, and
+because a user who has been told to "run Auto delay with a 0.25 ms scene offset"
+otherwise has to find the dialog and retype the numbers.
+
+They carry no `expectedCurrent`: what the engine writes is what the run decides,
+and the engine's own dialog — Auto delay's report, the crossover wizard's rows,
+the EQ Wizard's graph — stays the gate it goes through. Cancelling one skips
+that operation; the rest of the import carries on.
+
+`runAutoDelay`, `runAutoCrossover` and `useSpatialAverage` take **no**
+`channelId`: they address the whole project, and a `channelId` on one is refused
+as a property the protocol does not name. Every other input is optional, and one
+that is left out means the value the panel would open with — so a reply that
+wants only the scene offset changed states only that.
+
+| `op` | Fields | Checked against |
+| --- | --- | --- |
+| `runAutoDelay` | `sceneOffsetMs?`, `rightHandDrive?`, `adjustGains?`, `nearSideCutDb?`, `rearFillOffsetMs?` | the dialog's own fields: scene offset 0–5 ms in steps of 0.01, near-side cut 0–6 dB in steps of 0.1, rear fill offset 0–30 ms in steps of 0.1. `nearSideCutDb` is a magnitude: the LHD/RHD toggle owns the sign. Stereo or single-sided is the panel's decision, as it is for the button |
+| `runAutoCrossover` | none | the wizard has no inputs: the families, the corner window and the chain order are chosen in its own dialog |
+| `autoTunePeq` | `channelId`, `targetLevelDb?`, `minHz?`, `maxHz?`, `allowShelves?`, `cutsOnly?`, `source?` | the channel exists and has a measurement; target level −120…60 dB in whole dB; each stated edge above 0 Hz and below the processor's Nyquist, the lower below the upper; `source` is `point` or `spatialAverage`, and `spatialAverage` needs the channel to carry one |
+| `useSpatialAverage` | `mode`, `hybrid` | `mode` is `MovingMic` or `MicArray` and at least one channel carries that family (`channels[].source.spatialAverageCaptures`); `hybrid` must be `true`; a mode already in force with Hybrid already ticked is refused as "no change" |
+
+```json
+{ "operations": [
+  { "id": "op-6", "op": "useSpatialAverage", "mode": "MovingMic", "hybrid": true,
+    "reason": "Every channel carries an MMM capture and the tune is still read at one point." },
+  { "id": "op-7", "op": "runAutoDelay", "sceneOffsetMs": 0.25, "adjustGains": true,
+    "reason": "Two polarity flips changed the arrivals the current delays were set for." }
+] }
+```
+
+An import runs what it was given in one fixed order, whatever order the reply
+listed: the five settings operations first, then `useSpatialAverage` (it decides
+which curves the rest are read on), then `runAutoCrossover`, then `runAutoDelay`,
+then `autoTunePeq`. One summary at the end says what was applied and what was
+skipped, and *Undo AI import* puts back everything the whole sequence moved.
+
+An engine and a hand-written value the engine would write over cannot both be
+meant, so the hand-written row is **rejected**, naming the engine that would have
+erased it. The engine keeps its row: it is the one that computes the number.
+
+| Requesting | Rejects |
+| --- | --- |
+| `runAutoDelay` | `setDelayMs` and `setPolarity` on any channel; `setGainDb` too when the run balances gains |
+| `runAutoCrossover` | `setCrossover` and `setGainDb` on any channel (the wizard writes a cut-only gain with every corner) |
+| `autoTunePeq` | `replacePeqBank` on the same channel |
+
+An engine this build cannot run erases nothing, so its request is refused and the
+hand-written rows are left to do the work instead. Request each engine once: a
+repeat is refused, naming the first. `autoTunePeq` counts per channel — one fit
+per channel is the point of it — so a second request for the SAME channel is the
+one that is refused.
+
+Beyond the operations of this section, nothing in a session can be addressed:
+not the target, the processor, the gates, the sources, the calibration, the
+channel list, mute or bypass. Such changes belong in `advice`, as text. An
+unknown `op` is listed in the review as rejected and never applied.
 
 The review judges the junction-zone rule on each channel as it would end up
 after **every** applicable row; the commit judges it again on the rows the user
@@ -388,9 +456,16 @@ showed (a crossover moved without the bank that went with it).
 3. Shows the review: every row with its current and proposed value; admissible
    rows ticked, rejected rows greyed with their reason, warnings in words.
 4. On *Apply selected*, judges the ticked rows once more against the settings as
-   they are at that moment, then writes them as one set, saves once, redraws
-   once. A failure anywhere writes nothing.
-5. *Undo AI import* puts every touched channel back exactly as it was.
+   they are at that moment, then writes the settings rows as one set. A failure
+   there writes nothing.
+5. Runs the ticked engine requests, in the fixed order above — each engine
+   through its own dialog, the spatial average straight onto the panel — and
+   ends with one summary of what was applied and what was skipped. Undo is armed
+   before the first of these writes, so an import that stops part-way is still
+   undone in one step.
+6. *Undo AI import* puts back everything the import could have moved: every
+   channel's chain, the spatial average mode and the Hybrid tick, and the block
+   order the crossover wizard may have changed.
 
 ## 3. Privacy
 

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -400,11 +400,13 @@ otherwise, or whichever `source` names — with the wizard's opening values for
 what the reply leaves out (bells no narrower than Q 6, band gains −15…+6 dB,
 cuts only, no shelves, the channel's passband as the window); all-pass bands
 in the bank are kept and the fit tunes around them; a `targetLevelDb` moves the
-project's target level, as the wizard's Return does. It skips itself, with the
-reason, when the channel is on the side not on screen, when `spatialAverage`
-is asked for and the hybrid view is not drawing it, or when the target level
-sits 3 dB or more above the curve (10 dB or more below), which is the question
-the wizard would have asked. `runAutoCrossover` opens the wizard: its rows
+project's target level, as the wizard's Return does. A channel on the side not
+on screen is refused at review (the handoff is the shown side's: its gate pin,
+its anchor, its hybrid datum — switch the L/R selector, copy a new package and
+ask again). The run skips itself, with the reason, when `spatialAverage` is
+asked for and the hybrid view is not drawing it, or when the target level sits
+3 dB or more above the curve (10 dB or more below), which is the question the
+wizard would have asked. `runAutoCrossover` opens the wizard: its rows
 are where the driver types are confirmed, and cancelling it skips that
 operation while the rest of the import carries on.
 

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -387,10 +387,15 @@ They exist because the engines compute what no reading of a curve can, and
 because a user who has been told to "run Auto delay with a 0.25 ms scene offset"
 otherwise has to find the dialog and retype the numbers.
 
-They carry no `expectedCurrent`: what the engine writes is what the run decides,
-and the engine's own dialog — Auto delay's report, the crossover wizard's rows,
-the EQ Wizard's graph — stays the gate it goes through. Cancelling one skips
-that operation; the rest of the import carries on.
+They carry no `expectedCurrent`: what the engine writes is what the run decides.
+The review is the gate. `runAutoDelay` then runs **without its dialog** — the
+same checks the button makes (two measured channels, no bypassed participant,
+the gate in place, a crossover somewhere; a failed check skips the operation
+with the reason in the summary), the same search, the same commit — and its
+report, the text the dialog would have shown, comes back in the import's
+summary and the alignment log. `runAutoCrossover` opens the wizard: its rows
+are where the driver types are confirmed, and cancelling it skips that
+operation while the rest of the import carries on.
 
 `runAutoDelay`, `runAutoCrossover` and `useSpatialAverage` take **no**
 `channelId`: they address the whole project, and a `channelId` on one is refused

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -393,7 +393,18 @@ same checks the button makes (two measured channels, no bypassed participant,
 the gate in place, a crossover somewhere; a failed check skips the operation
 with the reason in the summary), the same search, the same commit — and its
 report, the text the dialog would have shown, comes back in the import's
-summary and the alignment log. `runAutoCrossover` opens the wizard: its rows
+summary and the alignment log. `autoTunePeq` runs without the EQ Wizard too:
+it fits the curve the wizard would have opened on for that channel — the
+spatial average while the hybrid view draws it, the point measurement
+otherwise, or whichever `source` names — with the wizard's opening values for
+what the reply leaves out (bells no narrower than Q 6, band gains −15…+6 dB,
+cuts only, no shelves, the channel's passband as the window); all-pass bands
+in the bank are kept and the fit tunes around them; a `targetLevelDb` moves the
+project's target level, as the wizard's Return does. It skips itself, with the
+reason, when the channel is on the side not on screen, when `spatialAverage`
+is asked for and the hybrid view is not drawing it, or when the target level
+sits 3 dB or more above the curve (10 dB or more below), which is the question
+the wizard would have asked. `runAutoCrossover` opens the wizard: its rows
 are where the driver types are confirmed, and cancelling it skips that
 operation while the rest of the import carries on.
 

--- a/source/Integration/AgentBridge/AgentPackageBuilder.cs
+++ b/source/Integration/AgentBridge/AgentPackageBuilder.cs
@@ -198,7 +198,8 @@ internal static class AgentPackageBuilder
             Enum.GetValues<CrossoverFilterFamily>().ToDictionary(
                 family => family.ToString(),
                 family => CrossoverFilter.SupportedSlopes(family).ToArray()),
-            [0, CrossoverFilter.MaximumChebyshevRippleDb]);
+            [0, CrossoverFilter.MaximumChebyshevRippleDb],
+            AgentProtocol.Operations);
 
     private static AgentPackageAnalysis BuildAnalysis(
         AgentAnalysisInputs analysis,

--- a/source/Integration/AgentBridge/AgentPackageModels.cs
+++ b/source/Integration/AgentBridge/AgentPackageModels.cs
@@ -38,6 +38,11 @@ internal sealed record AgentPackageProcessor(
     string MaxDelaySource,
     int? PeqBandsPerChannel);
 
+/// <param name="Operations">
+/// The `op` names this build can execute. The protocol describes more than a
+/// given build runs, so a reply is written against this list: an operation
+/// missing from it is read and reviewed, then refused.
+/// </param>
 internal sealed record AgentPackageLimits(
     double[] GainDb,
     double GainStepDb,
@@ -47,7 +52,8 @@ internal sealed record AgentPackageLimits(
     double PeqPreampDb,
     double[] CrossoverHz,
     IReadOnlyDictionary<string, int[]> Slopes,
-    double[] ChebyshevRippleDb);
+    double[] ChebyshevRippleDb,
+    IReadOnlyList<string> Operations);
 
 internal sealed record AgentPackageAnalysis(
     string GroupView,

--- a/source/Integration/AgentBridge/AgentProposal.cs
+++ b/source/Integration/AgentBridge/AgentProposal.cs
@@ -4,7 +4,8 @@ namespace Resonalyze.Integration.AgentBridge;
 /// What an assistant proposed, as the parser understood it: the prose that is
 /// shown, and a closed set of typed operations that may be applied. Nothing in
 /// here can address anything but the five editable parameters of one physical
-/// channel — there is no path from a reply to a file, a source or a setting.
+/// channel and the four engines the panel already runs from its own buttons —
+/// there is no path from a reply to a file, a source or a setting.
 /// </summary>
 /// <param name="PackageId">
 /// The id of the package the assistant says it answered, echoed from that
@@ -31,14 +32,20 @@ internal sealed record AgentSource(string Url, string? Title, IReadOnlyList<stri
 internal sealed record AgentRejectedOperation(string? Id, string? Op, string Problem);
 
 /// <summary>
-/// One proposed change to one channel. Every operation carries what the
-/// assistant believes the CURRENT value is, copied from the package it read; a
-/// current value that no longer matches means the tune moved on since the
-/// package was copied, and the operation is refused rather than applied to a
-/// state it was not reasoned about.
+/// One thing a reply asks for. Two families sit under this: an operation that
+/// WRITES one channel's settings, which carries what the assistant believes the
+/// current value is — a current value that no longer matches means the tune
+/// moved on since the package was copied, and the operation is refused rather
+/// than applied to a state it was not reasoned about — and an operation that
+/// asks for one of the panel's own ENGINES to be run, which carries the
+/// engine's inputs instead, because what an engine will write is not knowable
+/// until it has run.
 /// </summary>
-internal abstract record AgentOperation(string Id, string ChannelId, string Reason)
+internal abstract record AgentOperation(string Id, string Reason)
 {
+    /// <summary>The protocol's name for the operation: what its <c>op</c> said.</summary>
+    public abstract string Op { get; }
+
     /// <summary>
     /// The parameter family the operation edits, the unit conflicts are judged in:
     /// two operations on one channel's same family cannot both be right.
@@ -46,31 +53,51 @@ internal abstract record AgentOperation(string Id, string ChannelId, string Reas
     public abstract string Parameter { get; }
 }
 
+/// <summary>An operation addressed at one physical channel, by the package's id for it.</summary>
+internal abstract record AgentChannelOperation(string Id, string ChannelId, string Reason)
+    : AgentOperation(Id, Reason);
+
+/// <summary>
+/// An operation that writes one channel's editable settings directly — the five
+/// the bridge has always had. These are the only operations the importer applies
+/// itself; everything else it asks an engine to do.
+/// </summary>
+internal abstract record AgentSettingsOperation(string Id, string ChannelId, string Reason)
+    : AgentChannelOperation(Id, ChannelId, Reason);
+
 internal sealed record SetGainOperation(
     string Id, string ChannelId, string Reason, double ExpectedCurrentDb, double ProposedDb)
-    : AgentOperation(Id, ChannelId, Reason)
+    : AgentSettingsOperation(Id, ChannelId, Reason)
 {
+    public override string Op => AgentProtocol.SetGainDb;
+
     public override string Parameter => "Gain";
 }
 
 internal sealed record SetDelayOperation(
     string Id, string ChannelId, string Reason, double ExpectedCurrentMs, double ProposedMs)
-    : AgentOperation(Id, ChannelId, Reason)
+    : AgentSettingsOperation(Id, ChannelId, Reason)
 {
+    public override string Op => AgentProtocol.SetDelayMs;
+
     public override string Parameter => "Delay";
 }
 
 internal sealed record SetPolarityOperation(
     string Id, string ChannelId, string Reason, bool ExpectedCurrentInverted, bool ProposedInverted)
-    : AgentOperation(Id, ChannelId, Reason)
+    : AgentSettingsOperation(Id, ChannelId, Reason)
 {
+    public override string Op => AgentProtocol.SetPolarity;
+
     public override string Parameter => "Polarity";
 }
 
 internal sealed record SetCrossoverOperation(
     string Id, string ChannelId, string Reason, AgentCrossover ExpectedCurrent, AgentCrossover Proposed)
-    : AgentOperation(Id, ChannelId, Reason)
+    : AgentSettingsOperation(Id, ChannelId, Reason)
 {
+    public override string Op => AgentProtocol.SetCrossover;
+
     public override string Parameter => "Crossover";
 }
 
@@ -80,9 +107,90 @@ internal sealed record SetCrossoverOperation(
 /// </param>
 internal sealed record ReplacePeqBankOperation(
     string Id, string ChannelId, string Reason, string ExpectedCurrentHash, AgentPeqBank Proposed)
-    : AgentOperation(Id, ChannelId, Reason)
+    : AgentSettingsOperation(Id, ChannelId, Reason)
 {
+    public override string Op => AgentProtocol.ReplacePeqBank;
+
     public override string Parameter => "PEQ bank";
+}
+
+/// <summary>
+/// Run Auto delay. Every input is optional, and a missing one means "what the
+/// project holds now" — which is what the dialog would open with — so a reply
+/// that wants only the scene offset changed states only that. Whether the run is
+/// stereo or single-sided the panel decides exactly as its button does; nothing
+/// in a reply can.
+/// </summary>
+/// <param name="NearSideCutDb">
+/// How much quieter the near side plays, as the dialog edits it. The layout
+/// toggle owns the sign, so this magnitude is never negative.
+/// </param>
+internal sealed record RunAutoDelayOperation(
+    string Id,
+    string Reason,
+    double? SceneOffsetMs,
+    bool? RightHandDrive,
+    bool? AdjustGains,
+    double? NearSideCutDb,
+    double? RearFillOffsetMs) : AgentOperation(Id, Reason)
+{
+    public override string Op => AgentProtocol.RunAutoDelay;
+
+    public override string Parameter => "Auto delay";
+}
+
+/// <summary>
+/// Open the Auto crossover wizard. It takes no inputs: what it proposes comes
+/// from the drivers' own bands, and the choices it does offer are made in its
+/// own dialog, in front of the user.
+/// </summary>
+internal sealed record RunAutoCrossoverOperation(string Id, string Reason)
+    : AgentOperation(Id, Reason)
+{
+    public override string Op => AgentProtocol.RunAutoCrossover;
+
+    public override string Parameter => "Auto crossover";
+}
+
+/// <summary>
+/// Fit a PEQ bank to the target on one channel. A missing input means the
+/// wizard's own answer for it.
+/// </summary>
+/// <param name="Source">
+/// <c>point</c> or <c>spatialAverage</c>: which curve the fit reads. Null leaves
+/// the choice where it is, with the channel and the panel.
+/// </param>
+internal sealed record AutoTunePeqOperation(
+    string Id,
+    string ChannelId,
+    string Reason,
+    double? TargetLevelDb,
+    double? MinHz,
+    double? MaxHz,
+    bool? AllowShelves,
+    bool? CutsOnly,
+    string? Source) : AgentChannelOperation(Id, ChannelId, Reason)
+{
+    public override string Op => AgentProtocol.AutoTunePeq;
+
+    public override string Parameter => "Auto-tune";
+}
+
+/// <summary>
+/// Judge the tune on spatial averages: read the capture family named here and
+/// tick Hybrid. The one operation addressed at the whole project rather than a
+/// channel, because the mode and the tick are the project's.
+/// </summary>
+/// <param name="Hybrid">
+/// Only <c>true</c> is accepted. Turning the hybrid OFF is not something a reply
+/// has a reason to ask for, and refusing it costs nothing.
+/// </param>
+internal sealed record UseSpatialAverageOperation(
+    string Id, string Reason, string Mode, bool Hybrid) : AgentOperation(Id, Reason)
+{
+    public override string Op => AgentProtocol.UseSpatialAverage;
+
+    public override string Parameter => "Spatial average";
 }
 
 /// <summary>

--- a/source/Integration/AgentBridge/AgentProposalApplier.cs
+++ b/source/Integration/AgentBridge/AgentProposalApplier.cs
@@ -9,9 +9,11 @@ internal sealed record AgentUndoEntry(
 
 /// <summary>
 /// The commit half of an import: judges the ticked rows once more against the
-/// session as it is NOW (the dialog may have been open a while), applies them to
-/// the live settings as one set, and hands back what to put back for Undo. No
-/// control and no redraw in here — the panel does those once, after.
+/// session as it is NOW (the dialog may have been open a while), applies the
+/// ones that write settings to the live objects as one set, and hands back what
+/// to put back for Undo. The engine requests among the ticked rows are handed
+/// straight back for the panel to run in its own fixed order — nothing in here
+/// touches a control, opens a dialog or redraws.
 /// </summary>
 internal static class AgentProposalApplier
 {
@@ -93,9 +95,11 @@ internal static class AgentProposalApplier
     }
 
     /// <summary>
-    /// Writes the rows into their channels' live settings. Every channel is
-    /// snapshotted before its first write; should a write throw, what was written
-    /// is put back and the exception surfaces — the settings never hold half a set.
+    /// Writes the settings rows into their channels' live settings. Every channel
+    /// is snapshotted before its first write; should a write throw, what was
+    /// written is put back and the exception surfaces — the settings never hold
+    /// half a set. The engine rows are not touched here: they are asked for, not
+    /// written, and the panel runs them afterwards.
     /// </summary>
     public static List<AgentUndoEntry> Apply(IReadOnlyList<AgentOperationVerdict> toApply)
     {
@@ -105,14 +109,14 @@ internal static class AgentProposalApplier
         try
         {
             foreach (IGrouping<VirtualCrossoverChannelSettings, AgentOperationVerdict> group in toApply
-                .Where(verdict => verdict.Applicable)
+                .Where(verdict => verdict.Applicable && verdict.Operation is AgentSettingsOperation)
                 .GroupBy(verdict => verdict.Channel!.Settings))
             {
                 VirtualCrossoverChannelSettings settings = group.Key;
                 undo.Add(new AgentUndoEntry(settings, AgentOperations.CloneEditable(settings)));
                 foreach (AgentOperationVerdict verdict in group)
                 {
-                    AgentOperations.Apply(verdict.Operation!, settings);
+                    AgentOperations.Apply((AgentSettingsOperation)verdict.Operation!, settings);
                     if (verdict.Operation is ReplacePeqBankOperation)
                     {
                         // The block's PEQ read-out names where a bank came from; this

--- a/source/Integration/AgentBridge/AgentProposalParser.cs
+++ b/source/Integration/AgentBridge/AgentProposalParser.cs
@@ -141,7 +141,7 @@ internal static class AgentProposalParser
             else if (!ids.Add(operation.Id))
             {
                 rejected.Add(new AgentRejectedOperation(
-                    operation.Id, OpNameOf(operation), "Duplicate operation id."));
+                    operation.Id, operation.Op, "Duplicate operation id."));
             }
             else
             {
@@ -239,6 +239,10 @@ internal static class AgentProposalParser
                 AgentProtocol.SetPolarity => Map(element.Deserialize<PolarityWire>(Strict)),
                 AgentProtocol.SetCrossover => Map(element.Deserialize<CrossoverWire>(Strict)),
                 AgentProtocol.ReplacePeqBank => Map(element.Deserialize<PeqWire>(Strict)),
+                AgentProtocol.RunAutoDelay => Map(element.Deserialize<AutoDelayWire>(Strict)),
+                AgentProtocol.RunAutoCrossover => Map(element.Deserialize<AutoCrossoverWire>(Strict)),
+                AgentProtocol.AutoTunePeq => Map(element.Deserialize<AutoTuneWire>(Strict)),
+                AgentProtocol.UseSpatialAverage => Map(element.Deserialize<SpatialAverageWire>(Strict)),
                 _ => null
             };
             if (operation == null)
@@ -265,7 +269,8 @@ internal static class AgentProposalParser
         {
             return "The operation id is missing or too long.";
         }
-        if (string.IsNullOrWhiteSpace(operation.ChannelId) || !WithinLength(operation.ChannelId))
+        if (operation is AgentChannelOperation channel &&
+            (string.IsNullOrWhiteSpace(channel.ChannelId) || !WithinLength(channel.ChannelId)))
         {
             return "The channel id is missing or too long.";
         }
@@ -284,6 +289,11 @@ internal static class AgentProposalParser
                 peq.Proposed?.Bands == null ||
                 peq.Proposed.Bands.Any(band => band == null || band.Type == null) =>
                 "The PEQ bank is incomplete.",
+            AutoTunePeqOperation tune when !WithinLength(tune.Source) =>
+                "The auto-tune source is too long.",
+            UseSpatialAverageOperation spatial when
+                string.IsNullOrWhiteSpace(spatial.Mode) || !WithinLength(spatial.Mode) =>
+                "The spatial average mode is missing or too long.",
             _ => null
         };
     }
@@ -294,15 +304,6 @@ internal static class AgentProposalParser
         crossover.LowPass is { Family: null }
             ? "The crossover spec is incomplete."
             : null;
-
-    private static string OpNameOf(AgentOperation operation) => operation switch
-    {
-        SetGainOperation => AgentProtocol.SetGainDb,
-        SetDelayOperation => AgentProtocol.SetDelayMs,
-        SetPolarityOperation => AgentProtocol.SetPolarity,
-        SetCrossoverOperation => AgentProtocol.SetCrossover,
-        _ => AgentProtocol.ReplacePeqBank
-    };
 
     private static AgentOperation? Map(GainWire? wire) => wire == null
         ? null
@@ -353,6 +354,26 @@ internal static class AgentProposalParser
                     .Select(band => new AgentPeqBand(band.Type, band.FrequencyHz, band.Q, band.GainDb))
                     .ToList()));
     }
+
+    private static AgentOperation? Map(AutoDelayWire? wire) => wire == null
+        ? null
+        : new RunAutoDelayOperation(
+            wire.Id, wire.Reason, wire.SceneOffsetMs, wire.RightHandDrive, wire.AdjustGains,
+            wire.NearSideCutDb, wire.RearFillOffsetMs);
+
+    private static AgentOperation? Map(AutoCrossoverWire? wire) => wire == null
+        ? null
+        : new RunAutoCrossoverOperation(wire.Id, wire.Reason);
+
+    private static AgentOperation? Map(AutoTuneWire? wire) => wire == null
+        ? null
+        : new AutoTunePeqOperation(
+            wire.Id, wire.ChannelId, wire.Reason, wire.TargetLevelDb, wire.MinHz, wire.MaxHz,
+            wire.AllowShelves, wire.CutsOnly, wire.Source);
+
+    private static AgentOperation? Map(SpatialAverageWire? wire) => wire == null
+        ? null
+        : new UseSpatialAverageOperation(wire.Id, wire.Reason, wire.Mode, wire.Hybrid);
 
     private static bool WithinLength(string? value) =>
         value == null || value.Length <= AgentProtocol.MaxStringLength;
@@ -416,30 +437,37 @@ internal static class AgentProposalParser
     {
         public required string Op { get; init; }
         public required string Id { get; init; }
-        public required string ChannelId { get; init; }
         public required string Reason { get; init; }
         public JsonElement? Extensions { get; init; }
     }
 
-    private sealed class GainWire : OperationWire
+    // Everything but the three requests aimed at the whole project: a channel id
+    // is required, and a reply that leaves it out is refused rather than aimed
+    // at a guess.
+    private abstract class ChannelOperationWire : OperationWire
+    {
+        public required string ChannelId { get; init; }
+    }
+
+    private sealed class GainWire : ChannelOperationWire
     {
         public required double ExpectedCurrent { get; init; }
         public required double Proposed { get; init; }
     }
 
-    private sealed class DelayWire : OperationWire
+    private sealed class DelayWire : ChannelOperationWire
     {
         public required double ExpectedCurrent { get; init; }
         public required double Proposed { get; init; }
     }
 
-    private sealed class PolarityWire : OperationWire
+    private sealed class PolarityWire : ChannelOperationWire
     {
         public required bool ExpectedCurrent { get; init; }
         public required bool Proposed { get; init; }
     }
 
-    private sealed class CrossoverWire : OperationWire
+    private sealed class CrossoverWire : ChannelOperationWire
     {
         public required CrossoverSpecWire ExpectedCurrent { get; init; }
         public required CrossoverSpecWire Proposed { get; init; }
@@ -460,7 +488,7 @@ internal static class AgentProposalParser
         public double? RippleDb { get; init; }
     }
 
-    private sealed class PeqWire : OperationWire
+    private sealed class PeqWire : ChannelOperationWire
     {
         public required string ExpectedCurrentHash { get; init; }
         public required PeqBankWire Proposed { get; init; }
@@ -478,6 +506,38 @@ internal static class AgentProposalParser
         public required double FrequencyHz { get; init; }
         public required double Q { get; init; }
         public required double GainDb { get; init; }
+    }
+
+    // The engine requests. An optional input that is absent means "what the panel
+    // would open with", so a `null` and a missing member read the same; what is
+    // `required` here is what the request cannot be understood without.
+    private sealed class AutoDelayWire : OperationWire
+    {
+        public double? SceneOffsetMs { get; init; }
+        public bool? RightHandDrive { get; init; }
+        public bool? AdjustGains { get; init; }
+        public double? NearSideCutDb { get; init; }
+        public double? RearFillOffsetMs { get; init; }
+    }
+
+    private sealed class AutoCrossoverWire : OperationWire
+    {
+    }
+
+    private sealed class AutoTuneWire : ChannelOperationWire
+    {
+        public double? TargetLevelDb { get; init; }
+        public double? MinHz { get; init; }
+        public double? MaxHz { get; init; }
+        public bool? AllowShelves { get; init; }
+        public bool? CutsOnly { get; init; }
+        public string? Source { get; init; }
+    }
+
+    private sealed class SpatialAverageWire : OperationWire
+    {
+        public required string Mode { get; init; }
+        public required bool Hybrid { get; init; }
     }
 }
 

--- a/source/Integration/AgentBridge/AgentProposalValidator.cs
+++ b/source/Integration/AgentBridge/AgentProposalValidator.cs
@@ -516,7 +516,7 @@ internal static class AgentProposalValidator
                         MaximumRearFillOffsetMs, RearFillOffsetStepMs, "The rear fill offset", "ms", 1);
 
             case AutoTunePeqOperation tune:
-                return CheckAutoTune(tune, channel!, session.ProcessorSampleRateHz / 2.0);
+                return CheckAutoTune(tune, channel!, session);
 
             case UseSpatialAverageOperation spatial:
                 return CheckSpatialAverage(spatial, session);
@@ -527,11 +527,20 @@ internal static class AgentProposalValidator
     }
 
     private static string? CheckAutoTune(
-        AutoTunePeqOperation tune, AgentChannelSnapshot channel, double nyquistHz)
+        AutoTunePeqOperation tune, AgentChannelSnapshot channel, AgentSessionSnapshot session)
     {
+        double nyquistHz = session.ProcessorSampleRateHz / 2.0;
         if (!channel.HasMeasurement)
         {
             return $"{channel.Label} has no measurement to fit a bank against.";
+        }
+        // The handoff a fit is built on is the side on screen's — its gate pin,
+        // its render anchor, its hybrid datum — as the PEQ menu builds it.
+        if (channel.Side != AgentChannelSide.Mono &&
+            (channel.Side == AgentChannelSide.Right) != session.ActiveSideRight)
+        {
+            return $"{channel.Label} is on the side not on screen: switch the L/R " +
+                "selector, copy a new package and import again.";
         }
         if (tune.Source != null &&
             tune.Source != PointSource && tune.Source != SpatialAverageSource)

--- a/source/Integration/AgentBridge/AgentProposalValidator.cs
+++ b/source/Integration/AgentBridge/AgentProposalValidator.cs
@@ -484,10 +484,10 @@ internal static class AgentProposalValidator
         AgentOperation operation, AgentSessionSnapshot session) => operation switch
     {
         RunAutoDelayOperation delay => (AgentVerdictStatus.Warning,
-            "Auto delay opens with these inputs and rewrites the delay and polarity of every " +
+            "Auto delay runs with these inputs and rewrites the delay and polarity of every " +
             "channel it aligns" +
             ((delay.AdjustGains ?? session.AutoDelay.AdjustGains) ? ", and their gains" : string.Empty) +
-            ". Its own dialog runs and applies the proposal."),
+            ". It runs without its dialog; its report goes into the import's summary."),
         RunAutoCrossoverOperation => (AgentVerdictStatus.Warning,
             "The Auto crossover wizard rewrites the crossover and the gain of every enabled " +
             "channel that has a measurement, and can reorder the chain. Its own dialog " +

--- a/source/Integration/AgentBridge/AgentProposalValidator.cs
+++ b/source/Integration/AgentBridge/AgentProposalValidator.cs
@@ -493,7 +493,9 @@ internal static class AgentProposalValidator
             "channel that has a measurement, and can reorder the chain. Its own dialog " +
             "confirms the proposal."),
         AutoTunePeqOperation => (AgentVerdictStatus.Warning,
-            "Auto-tune replaces this channel's whole PEQ bank."),
+            "Auto-tune replaces this channel's whole PEQ bank (all-pass bands kept). It runs " +
+            "without the EQ Wizard, on the curve the wizard would have opened on, and skips " +
+            "itself when the target level sits too far from that curve."),
         _ => (AgentVerdictStatus.Valid, "OK")
     };
 

--- a/source/Integration/AgentBridge/AgentProposalValidator.cs
+++ b/source/Integration/AgentBridge/AgentProposalValidator.cs
@@ -29,7 +29,8 @@ internal sealed record AgentOperationVerdict(
     AgentChannelSnapshot? Channel)
 {
     public bool Applicable =>
-        Status != AgentVerdictStatus.Rejected && Operation != null && Channel != null;
+        Status != AgentVerdictStatus.Rejected && Operation != null &&
+        (Operation is not AgentChannelOperation || Channel != null);
 }
 
 /// <summary>A reply judged against a session: the rows, plus reply-level warnings.</summary>
@@ -62,6 +63,30 @@ internal static class AgentProposalValidator
     public const double MinimumDelayMs = 0;
     public const double MaximumDelayMs = 100;
     public const double DelayStepMs = 0.01;
+
+    // The Auto delay dialog's own fields, and the panel's Target Level field,
+    // restated here for the same reason and pinned to their controls by the same
+    // test: an engine request outside them would be clamped on the first touch,
+    // and the run would not be the one that was reviewed.
+    public const double MinimumSceneOffsetMs = 0;
+    public const double MaximumSceneOffsetMs = 5;
+    public const double SceneOffsetStepMs = 0.01;
+    public const double MinimumNearSideCutDb = 0;
+    public const double MaximumNearSideCutDb = 6;
+    public const double NearSideCutStepDb = 0.1;
+    public const double MinimumRearFillOffsetMs = 0;
+    public const double MaximumRearFillOffsetMs = 30;
+    public const double RearFillOffsetStepMs = 0.1;
+    public const double MinimumTargetLevelDb = -120;
+    public const double MaximumTargetLevelDb = 60;
+    public const double TargetLevelStepDb = 1;
+
+    /// <summary>The two curves an auto-tune request may name as its source.</summary>
+    public const string PointSource = "point";
+    public const string SpatialAverageSource = "spatialAverage";
+
+    /// <summary>How the review's Channel column names a row about the whole project.</summary>
+    public const string AllChannels = "all";
 
     public const string DeviceLimitsUnknown =
         "Device limits unknown; only Virtual DSP limits were checked.";
@@ -133,17 +158,10 @@ internal static class AgentProposalValidator
             verdicts.Add(Judge(operation, session));
         }
 
-        // Some warnings are about the channel as it would END UP, not about one
-        // operation: a bell that lands in a junction zone because the crossover
-        // moved, or a bank proposed against a crossover another row moves. Every
-        // channel's applicable rows are applied together to a copy and judged
-        // there; the notes go on the rows that shape that state.
-        AddFinalStateNotes(verdicts);
-
         // Two applicable operations on one channel's same parameter cannot both be
         // meant; neither is picked over the other.
         foreach (IGrouping<(string, string), AgentOperationVerdict> group in verdicts
-            .Where(verdict => verdict.Applicable)
+            .Where(verdict => verdict.Applicable && verdict.Operation is AgentSettingsOperation)
             .GroupBy(verdict => (verdict.Channel!.Id, verdict.Parameter))
             .Where(group => group.Count() > 1))
         {
@@ -160,8 +178,103 @@ internal static class AgentProposalValidator
             }
         }
 
+        RejectRepeatedEngineRequests(verdicts);
+        RejectOverwrittenSettings(verdicts, session);
+
+        // Some warnings are about the channel as it would END UP, not about one
+        // operation: a bell that lands in a junction zone because the crossover
+        // moved, or a bank proposed against a crossover another row moves. Every
+        // channel's applicable rows are applied together to a copy and judged
+        // there; the notes go on the rows that shape that state. LAST, after every
+        // refusal above: a row this pass reads is a row that is going to be
+        // applied, and a note read off one that has just been refused would
+        // describe a state nothing will produce.
+        AddFinalStateNotes(verdicts);
         return new AgentProposalReview(proposal, verdicts, warnings);
     }
+
+    // The panel runs each engine once per import, and a second request for the
+    // same one carries a second set of inputs. The first is kept rather than the
+    // set silently deciding which won — the reply listed them in an order.
+    private static void RejectRepeatedEngineRequests(List<AgentOperationVerdict> verdicts)
+    {
+        var first = new Dictionary<(string Op, string? ChannelId), string>();
+        for (int index = 0; index < verdicts.Count; index++)
+        {
+            AgentOperationVerdict verdict = verdicts[index];
+            if (!verdict.Applicable || verdict.Operation is null or AgentSettingsOperation)
+            {
+                continue;
+            }
+
+            (string, string?) key = (verdict.Operation.Op, ChannelIdOf(verdict.Operation));
+            if (first.TryGetValue(key, out string? owner))
+            {
+                verdicts[index] = verdict with
+                {
+                    Status = AgentVerdictStatus.Rejected,
+                    Message = $"Already requested by {owner}; an engine runs once per import."
+                };
+            }
+            else
+            {
+                first[key] = verdict.Id;
+            }
+        }
+    }
+
+    // An engine and a hand-written value the engine is going to write over cannot
+    // both be meant. The engine keeps its row — it is the one that computes the
+    // number — and the hand-written row is refused, naming what would have erased
+    // it. Only an engine this build can RUN erases anything: a request refused as
+    // unavailable leaves the hand-written rows to do the work instead.
+    private static void RejectOverwrittenSettings(
+        List<AgentOperationVerdict> verdicts, AgentSessionSnapshot session)
+    {
+        foreach (AgentOperationVerdict engine in verdicts
+            .Where(verdict => verdict.Applicable && verdict.Operation is not AgentSettingsOperation)
+            .ToList())
+        {
+            for (int index = 0; index < verdicts.Count; index++)
+            {
+                AgentOperationVerdict verdict = verdicts[index];
+                if (verdict.Applicable &&
+                    verdict.Operation is AgentSettingsOperation written &&
+                    Overwrites(engine.Operation!, written, session))
+                {
+                    verdicts[index] = verdict with
+                    {
+                        Status = AgentVerdictStatus.Rejected,
+                        Message = $"Would be overwritten by {engine.Parameter} ({engine.Id})."
+                    };
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether running <paramref name="engine"/> would write over what
+    /// <paramref name="written"/> asks for. Read off what the panel's own buttons
+    /// do: Auto delay writes delay and polarity, and gains when the balance is
+    /// asked for; the crossover wizard writes both corners and the cut-only gain
+    /// of every channel it proposes for; Auto-tune replaces one channel's bank.
+    /// </summary>
+    public static bool Overwrites(
+        AgentOperation engine, AgentSettingsOperation written, AgentSessionSnapshot session) =>
+        engine switch
+        {
+            RunAutoDelayOperation delay =>
+                written is SetDelayOperation or SetPolarityOperation ||
+                (written is SetGainOperation && (delay.AdjustGains ?? session.AutoDelay.AdjustGains)),
+            RunAutoCrossoverOperation => written is SetCrossoverOperation or SetGainOperation,
+            AutoTunePeqOperation tune =>
+                written is ReplacePeqBankOperation &&
+                string.Equals(tune.ChannelId, written.ChannelId, StringComparison.Ordinal),
+            _ => false
+        };
+
+    private static string? ChannelIdOf(AgentOperation operation) =>
+        operation is AgentChannelOperation channel ? channel.ChannelId : null;
 
     private static void AddFinalStateNotes(List<AgentOperationVerdict> verdicts)
     {
@@ -197,7 +310,7 @@ internal static class AgentProposalValidator
 
         var result = new List<(AgentChannelSnapshot, List<string>)>();
         foreach (IGrouping<AgentChannelSnapshot, AgentOperationVerdict> group in rows
-            .Where(verdict => verdict.Applicable)
+            .Where(verdict => verdict.Applicable && verdict.Operation is AgentSettingsOperation)
             .GroupBy(verdict => verdict.Channel!))
         {
             VirtualCrossoverChannelSettings final = AgentOperations.CloneEditable(group.Key.Settings);
@@ -205,7 +318,7 @@ internal static class AgentProposalValidator
             {
                 foreach (AgentOperationVerdict verdict in group)
                 {
-                    AgentOperations.Apply(verdict.Operation!, final);
+                    AgentOperations.Apply((AgentSettingsOperation)verdict.Operation!, final);
                 }
             }
             catch (InvalidDataException)
@@ -254,7 +367,7 @@ internal static class AgentProposalValidator
         ArgumentNullException.ThrowIfNull(selected);
 
         foreach (IGrouping<AgentChannelSnapshot, AgentOperationVerdict> group in selected
-            .Where(verdict => verdict.Applicable)
+            .Where(verdict => verdict.Applicable && verdict.Operation is AgentSettingsOperation)
             .GroupBy(verdict => verdict.Channel!))
         {
             VirtualCrossoverChannelSettings copy = AgentOperations.CloneEditable(group.Key.Settings);
@@ -262,7 +375,7 @@ internal static class AgentProposalValidator
             {
                 foreach (AgentOperationVerdict verdict in group)
                 {
-                    AgentOperations.Apply(verdict.Operation!, copy);
+                    AgentOperations.Apply((AgentSettingsOperation)verdict.Operation!, copy);
                 }
                 copy.Validate();
             }
@@ -277,17 +390,26 @@ internal static class AgentProposalValidator
 
     private static AgentOperationVerdict Judge(AgentOperation operation, AgentSessionSnapshot session)
     {
-        AgentChannelSnapshot? channel = session.Find(operation.ChannelId);
-        if (channel == null)
+        AgentChannelSnapshot? channel = null;
+        if (operation is AgentChannelOperation addressed)
         {
-            return Rejected(operation, null, string.Empty, string.Empty,
-                $"Unknown channel '{operation.ChannelId}'; the package names the channels this session has.");
+            channel = session.Find(addressed.ChannelId);
+            if (channel == null)
+            {
+                return Rejected(operation, null, string.Empty, string.Empty,
+                    $"Unknown channel '{addressed.ChannelId}'; the package names the channels this session has.");
+            }
         }
 
-        VirtualCrossoverChannelSettings settings = channel.Settings;
-        string current = Describe(operation, settings);
+        if (operation is not AgentSettingsOperation edit)
+        {
+            return JudgeEngineRequest(operation, channel, session);
+        }
 
-        string? stale = CheckExpected(operation, settings);
+        VirtualCrossoverChannelSettings settings = channel!.Settings;
+        string current = Describe(edit, settings);
+
+        string? stale = CheckExpected(edit, settings);
         if (stale != null)
         {
             return Rejected(operation, channel, current, string.Empty,
@@ -296,14 +418,14 @@ internal static class AgentProposalValidator
 
         var notes = new List<string>();
         VirtualCrossoverChannelSettings copy = AgentOperations.CloneEditable(settings);
-        string? problem = CheckValue(operation, session, copy, notes);
+        string? problem = CheckValue(edit, session, copy, notes);
         if (problem != null)
         {
             return Rejected(operation, channel, current, string.Empty, problem);
         }
 
-        string proposed = Describe(operation, copy);
-        if (IsNoChange(operation, settings, copy))
+        string proposed = Describe(edit, copy);
+        if (IsNoChange(edit, settings, copy))
         {
             return Rejected(operation, channel, current, proposed, "No change.");
         }
@@ -318,13 +440,259 @@ internal static class AgentProposalValidator
     private static AgentOperationVerdict Rejected(
         AgentOperation operation, AgentChannelSnapshot? channel, string current, string proposed,
         string message) =>
-        new(operation.Id, channel?.Label ?? string.Empty, operation.Parameter, current, proposed,
+        new(operation.Id, LabelFor(operation, channel), operation.Parameter, current, proposed,
             AgentVerdictStatus.Rejected, message, operation.Reason, operation, channel);
+
+    // A row that is not about one channel says which channels it is about rather
+    // than leaving the column blank: the engines address the whole project.
+    private static string LabelFor(AgentOperation operation, AgentChannelSnapshot? channel) =>
+        channel?.Label ?? (operation is AgentChannelOperation ? string.Empty : AllChannels);
+
+    /// <summary>
+    /// An engine request judged on its INPUTS. There is no current value to
+    /// compare against: what the engine writes is what the run decides, and the
+    /// engine's own dialog is still the gate it goes through. What the review can
+    /// state is where the run would start from, what it was asked for, and what
+    /// it will write over — which is what the row carries.
+    /// </summary>
+    private static AgentOperationVerdict JudgeEngineRequest(
+        AgentOperation operation, AgentChannelSnapshot? channel, AgentSessionSnapshot session)
+    {
+        string current = DescribeEngineStart(operation, channel, session);
+        string proposed = DescribeEngineRequest(operation, session);
+        string? problem = CheckEngineRequest(operation, channel, session);
+        if (problem != null)
+        {
+            return Rejected(operation, channel, current, proposed, problem);
+        }
+        if (!AgentProtocol.Executes(operation.Op))
+        {
+            return Rejected(
+                operation, channel, current, proposed, AgentProtocol.NotAvailable(operation.Op));
+        }
+
+        (AgentVerdictStatus status, string message) = EngineNote(operation, session);
+        return new AgentOperationVerdict(
+            operation.Id, LabelFor(operation, channel), operation.Parameter, current, proposed,
+            status, message, operation.Reason, operation, channel);
+    }
+
+    // What the engine will write over, in the row's own words. A warning rather
+    // than plain OK wherever the run reaches past the channels the reply names:
+    // the reader is ticking a box that hands several channels to a search.
+    private static (AgentVerdictStatus Status, string Message) EngineNote(
+        AgentOperation operation, AgentSessionSnapshot session) => operation switch
+    {
+        RunAutoDelayOperation delay => (AgentVerdictStatus.Warning,
+            "Auto delay opens with these inputs and rewrites the delay and polarity of every " +
+            "channel it aligns" +
+            ((delay.AdjustGains ?? session.AutoDelay.AdjustGains) ? ", and their gains" : string.Empty) +
+            ". Its own dialog runs and applies the proposal."),
+        RunAutoCrossoverOperation => (AgentVerdictStatus.Warning,
+            "The Auto crossover wizard rewrites the crossover and the gain of every enabled " +
+            "channel that has a measurement, and can reorder the chain. Its own dialog " +
+            "confirms the proposal."),
+        AutoTunePeqOperation => (AgentVerdictStatus.Warning,
+            "Auto-tune replaces this channel's whole PEQ bank."),
+        _ => (AgentVerdictStatus.Valid, "OK")
+    };
+
+    // Every input is held to the field a user would type it into, and an input
+    // the reply leaves out is not judged at all — it is the panel's own answer,
+    // which is admissible by construction.
+    private static string? CheckEngineRequest(
+        AgentOperation operation, AgentChannelSnapshot? channel, AgentSessionSnapshot session)
+    {
+        switch (operation)
+        {
+            case RunAutoDelayOperation delay:
+                return Bounded(delay.SceneOffsetMs, MinimumSceneOffsetMs, MaximumSceneOffsetMs,
+                        SceneOffsetStepMs, "The scene offset", "ms", 2)
+                    ?? Bounded(delay.NearSideCutDb, MinimumNearSideCutDb, MaximumNearSideCutDb,
+                        NearSideCutStepDb, "The near-side cut", "dB", 1)
+                    ?? Bounded(delay.RearFillOffsetMs, MinimumRearFillOffsetMs,
+                        MaximumRearFillOffsetMs, RearFillOffsetStepMs, "The rear fill offset", "ms", 1);
+
+            case AutoTunePeqOperation tune:
+                return CheckAutoTune(tune, channel!, session.ProcessorSampleRateHz / 2.0);
+
+            case UseSpatialAverageOperation spatial:
+                return CheckSpatialAverage(spatial, session);
+
+            default:
+                return null;
+        }
+    }
+
+    private static string? CheckAutoTune(
+        AutoTunePeqOperation tune, AgentChannelSnapshot channel, double nyquistHz)
+    {
+        if (!channel.HasMeasurement)
+        {
+            return $"{channel.Label} has no measurement to fit a bank against.";
+        }
+        if (tune.Source != null &&
+            tune.Source != PointSource && tune.Source != SpatialAverageSource)
+        {
+            return $"Unknown auto-tune source '{tune.Source}'; " +
+                $"use '{PointSource}' or '{SpatialAverageSource}'.";
+        }
+        if (tune.Source == SpatialAverageSource && channel.SpatialAverageCaptures.Count == 0)
+        {
+            return $"{channel.Label} carries no spatial average to fit against.";
+        }
+
+        string? problem =
+            Bounded(tune.TargetLevelDb, MinimumTargetLevelDb, MaximumTargetLevelDb,
+                TargetLevelStepDb, "The target level", "dB", 0)
+            ?? Edge(tune.MinHz, nyquistHz, "lower")
+            ?? Edge(tune.MaxHz, nyquistHz, "upper");
+        if (problem != null)
+        {
+            return problem;
+        }
+
+        return tune.MinHz is { } minHz && tune.MaxHz is { } maxHz && minHz >= maxHz
+            ? "The auto-tune window's lower edge must sit below its upper edge."
+            : null;
+    }
+
+    private static string? CheckSpatialAverage(
+        UseSpatialAverageOperation spatial, AgentSessionSnapshot session)
+    {
+        if (!spatial.Hybrid)
+        {
+            return "The hybrid view is what makes a spatial average count, so a request " +
+                "to leave it off has nothing to do.";
+        }
+        if (!AgentOperations.TryParseName(
+                spatial.Mode, out VirtualCrossoverSpatialAverageMode mode) ||
+            mode == VirtualCrossoverSpatialAverageMode.Off)
+        {
+            return $"Unknown spatial average mode '{spatial.Mode}'; use " +
+                $"{VirtualCrossoverSpatialAverageMode.MovingMic} or " +
+                $"{VirtualCrossoverSpatialAverageMode.MicArray}.";
+        }
+        if (!session.HasCapture(mode))
+        {
+            return $"No channel in this session carries a {mode} capture.";
+        }
+
+        return session.SpatialAverageMode == mode && session.HybridTicked ? "No change." : null;
+    }
+
+    // An optional engine input against the field a user would type it into.
+    private static string? Bounded(
+        double? value, double minimum, double maximum, double step,
+        string name, string unit, int decimals)
+    {
+        if (value is not { } number)
+        {
+            return null;
+        }
+        if (!double.IsFinite(number) || number < minimum || number > maximum)
+        {
+            return $"{name} must be between {Fixed(minimum, decimals)} and " +
+                $"{Fixed(maximum, decimals)} {unit}.";
+        }
+
+        return OnStep(number, step)
+            ? null
+            : $"{name} must be a multiple of {Fixed(step, decimals)} {unit}.";
+    }
+
+    private static string? Edge(double? value, double nyquistHz, string name) =>
+        value is not { } frequency ||
+        (double.IsFinite(frequency) && frequency > 0 && frequency < nyquistHz)
+            ? null
+            : $"The auto-tune window's {name} edge must sit above 0 Hz and below the " +
+                $"processor's Nyquist of {Hz(nyquistHz)}.";
+
+    // Where the engine would start from, in the words its own dialog uses.
+    private static string DescribeEngineStart(
+        AgentOperation operation, AgentChannelSnapshot? channel, AgentSessionSnapshot session) =>
+        operation switch
+        {
+            RunAutoDelayOperation => AutoDelayText(
+                session.AutoDelay.SceneOffsetMs,
+                session.AutoDelay.RightHandDrive,
+                session.AutoDelay.AdjustGains,
+                session.AutoDelay.NearSideCutDb,
+                session.AutoDelay.RearFillOffsetMs),
+            RunAutoCrossoverOperation => "the corners, slopes and gains as they stand",
+            AutoTunePeqOperation => channel == null ? string.Empty : BankText(channel.Settings),
+            UseSpatialAverageOperation => SpatialAverageText(
+                session.SpatialAverageMode.ToString(), session.HybridTicked),
+            _ => string.Empty
+        };
+
+    private static string DescribeEngineRequest(
+        AgentOperation operation, AgentSessionSnapshot session) => operation switch
+    {
+        RunAutoDelayOperation delay => AutoDelayText(
+            delay.SceneOffsetMs ?? session.AutoDelay.SceneOffsetMs,
+            delay.RightHandDrive ?? session.AutoDelay.RightHandDrive,
+            delay.AdjustGains ?? session.AutoDelay.AdjustGains,
+            delay.NearSideCutDb ?? session.AutoDelay.NearSideCutDb,
+            delay.RearFillOffsetMs ?? session.AutoDelay.RearFillOffsetMs),
+        RunAutoCrossoverOperation => "the wizard's corners, slopes and cut-only gains",
+        AutoTunePeqOperation tune => AutoTuneText(tune),
+        UseSpatialAverageOperation spatial => SpatialAverageText(spatial.Mode, spatial.Hybrid),
+        _ => string.Empty
+    };
+
+    // The near-side cut only where the gain balance is on: with it off the field
+    // is an input to nothing, and printing it would read as a change.
+    private static string AutoDelayText(
+        double sceneOffsetMs, bool rightHandDrive, bool adjustGains,
+        double nearSideCutDb, double rearFillOffsetMs) =>
+        $"scene {Ms(sceneOffsetMs)} {(rightHandDrive ? "RHD" : "LHD")}, " +
+        $"gains {(adjustGains ? "on" : "off")}" +
+        (adjustGains ? $", near-side cut {Db(nearSideCutDb)}" : string.Empty) +
+        $", rear fill {Ms(rearFillOffsetMs)}";
+
+    // Only what the reply actually states: an input it leaves out is the wizard's
+    // own answer, and printing that would read as a choice the reply made.
+    private static string AutoTuneText(AutoTunePeqOperation tune)
+    {
+        var parts = new List<string>();
+        if (tune.MinHz != null || tune.MaxHz != null)
+        {
+            parts.Add(
+                (tune.MinHz is { } low ? Hz(low) : "the wizard's low edge") + " to " +
+                (tune.MaxHz is { } high ? Hz(high) : "the wizard's high edge"));
+        }
+        if (tune.TargetLevelDb is { } level)
+        {
+            parts.Add("target " + Db(level));
+        }
+        if (tune.AllowShelves is { } shelves)
+        {
+            parts.Add(shelves ? "shelves allowed" : "no shelves");
+        }
+        if (tune.CutsOnly is { } cutsOnly)
+        {
+            parts.Add(cutsOnly ? "cuts only" : "cuts and boosts");
+        }
+        if (tune.Source is { } source)
+        {
+            parts.Add("from the " +
+                (source == SpatialAverageSource ? "spatial average" : "point measurement"));
+        }
+
+        return parts.Count == 0
+            ? "auto-tune with the wizard's own settings"
+            : "auto-tune " + string.Join(", ", parts);
+    }
+
+    private static string SpatialAverageText(string mode, bool hybrid) =>
+        $"{mode}, hybrid {(hybrid ? "on" : "off")}";
 
     // Exact comparison: the package prints every value in round-trip form, so an
     // assistant that copied it hands back the same double. A tolerance here would
     // be a tolerance for a reply that was reasoned about a different value.
-    private static string? CheckExpected(AgentOperation operation, VirtualCrossoverChannelSettings settings)
+    private static string? CheckExpected(
+        AgentSettingsOperation operation, VirtualCrossoverChannelSettings settings)
     {
         switch (operation)
         {
@@ -351,7 +719,7 @@ internal static class AgentProposalValidator
     // Applies the operation to the copy and says what is wrong with the value, if
     // anything; notes collect the warnings that do not refuse it.
     private static string? CheckValue(
-        AgentOperation operation,
+        AgentSettingsOperation operation,
         AgentSessionSnapshot session,
         VirtualCrossoverChannelSettings copy,
         List<string> notes)
@@ -443,7 +811,7 @@ internal static class AgentProposalValidator
     }
 
     private static bool IsNoChange(
-        AgentOperation operation,
+        AgentSettingsOperation operation,
         VirtualCrossoverChannelSettings before,
         VirtualCrossoverChannelSettings after) => operation switch
     {
@@ -461,16 +829,20 @@ internal static class AgentProposalValidator
         return Math.Abs(steps - Math.Round(steps)) < 1e-6;
     }
 
-    private static string Describe(AgentOperation operation, VirtualCrossoverChannelSettings settings) =>
+    private static string Describe(
+        AgentSettingsOperation operation, VirtualCrossoverChannelSettings settings) =>
         operation switch
         {
             SetGainOperation => Db(settings.GainDb),
             SetDelayOperation => Ms(settings.DelayMs),
             SetPolarityOperation => Polarity(settings.InvertPolarity),
             SetCrossoverOperation => Crossover(settings),
-            _ => $"{settings.PeqBands.Count} band{(settings.PeqBands.Count == 1 ? "" : "s")}, " +
-                $"preamp {Db(settings.PeqPreampDb)}"
+            _ => BankText(settings)
         };
+
+    private static string BankText(VirtualCrossoverChannelSettings settings) =>
+        $"{settings.PeqBands.Count} band{(settings.PeqBands.Count == 1 ? "" : "s")}, " +
+        $"preamp {Db(settings.PeqPreampDb)}";
 
     // A crossover in a table cell: the tuning sheet's full wording does not fit
     // one, so the family is abbreviated the way the channel block's own combo
@@ -509,6 +881,10 @@ internal static class AgentProposalValidator
     private static string Hz(double value) =>
         value.ToString("0.###", CultureInfo.InvariantCulture) + " Hz";
 
+    private static string Fixed(double value, int decimals) =>
+        (value + 0).ToString(
+            "F" + decimals.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
+
     private static string Polarity(bool inverted) => inverted ? "Inverted" : "Normal";
 }
 
@@ -544,7 +920,7 @@ internal static class AgentOperations
 
     /// <summary>Writes the operation into the settings; the review has already passed it.</summary>
     /// <exception cref="InvalidDataException">The operation's value cannot be mapped.</exception>
-    public static void Apply(AgentOperation operation, VirtualCrossoverChannelSettings target)
+    public static void Apply(AgentSettingsOperation operation, VirtualCrossoverChannelSettings target)
     {
         ArgumentNullException.ThrowIfNull(operation);
         ArgumentNullException.ThrowIfNull(target);
@@ -750,7 +1126,7 @@ internal static class AgentOperations
 
     // The enum names exactly as the package prints them: no case games, and no
     // numeric strings, which Enum.TryParse would otherwise accept.
-    private static bool TryParseName<TEnum>(string? name, out TEnum value) where TEnum : struct, Enum
+    public static bool TryParseName<TEnum>(string? name, out TEnum value) where TEnum : struct, Enum
     {
         value = default;
         return !string.IsNullOrEmpty(name) &&

--- a/source/Integration/AgentBridge/AgentProposalValidator.cs
+++ b/source/Integration/AgentBridge/AgentProposalValidator.cs
@@ -596,9 +596,17 @@ internal static class AgentProposalValidator
             return problem;
         }
 
-        return tune.MinHz is { } minHz && tune.MaxHz is { } maxHz && minHz >= maxHz
-            ? "The auto-tune window's lower edge must sit below its upper edge."
-            : null;
+        // The window the run will use, with the wizard's own answer for an edge
+        // the reply leaves out (the channel's passband, else the field's end) —
+        // judged as a whole, since a stated lower edge above the passband's
+        // upper is as inverted as two stated edges the wrong way round.
+        (double MinHz, double MaxHz)? passband = VirtualDspEqHandoff.PassbandFor(channel.Settings);
+        double minHz = tune.MinHz ?? passband?.MinHz ?? EqAutoTuneHeadless.WindowMinHz;
+        double maxHz = tune.MaxHz ?? passband?.MaxHz ?? EqAutoTuneHeadless.WindowMaxHz;
+        return EqAutoTuneHeadless.IsUsableWindow(minHz, maxHz)
+            ? null
+            : $"The auto-tune window would be {Hz(minHz)} to {Hz(maxHz)}: its lower edge " +
+                "must sit below its upper edge.";
     }
 
     private static string? CheckSpatialAverage(
@@ -645,12 +653,20 @@ internal static class AgentProposalValidator
             : $"{name} must be a multiple of {Fixed(step, decimals)} {unit}.";
     }
 
+    // The From/To fields' own range, 20 Hz to 20 kHz, and the processor's Nyquist
+    // where that is lower: what the review admits is what the run uses.
     private static string? Edge(double? value, double nyquistHz, string name) =>
         value is not { } frequency ||
-        (double.IsFinite(frequency) && frequency > 0 && frequency < nyquistHz)
+        (double.IsFinite(frequency) &&
+            frequency >= EqAutoTuneHeadless.WindowMinHz &&
+            frequency <= EqAutoTuneHeadless.WindowMaxHz &&
+            frequency < nyquistHz)
             ? null
-            : $"The auto-tune window's {name} edge must sit above 0 Hz and below the " +
-                $"processor's Nyquist of {Hz(nyquistHz)}.";
+            : $"The auto-tune window's {name} edge must sit between " +
+                $"{Hz(EqAutoTuneHeadless.WindowMinHz)} and {Hz(EqAutoTuneHeadless.WindowMaxHz)}" +
+                (nyquistHz < EqAutoTuneHeadless.WindowMaxHz
+                    ? $", below the processor's Nyquist of {Hz(nyquistHz)}."
+                    : ".");
 
     // Where the engine would start from, in the words its own dialog uses.
     private static string DescribeEngineStart(

--- a/source/Integration/AgentBridge/AgentProposalValidator.cs
+++ b/source/Integration/AgentBridge/AgentProposalValidator.cs
@@ -179,6 +179,7 @@ internal static class AgentProposalValidator
         }
 
         RejectRepeatedEngineRequests(verdicts);
+        RejectDisagreeingTargetLevels(verdicts);
         RejectOverwrittenSettings(verdicts, session);
 
         // Some warnings are about the channel as it would END UP, not about one
@@ -219,6 +220,38 @@ internal static class AgentProposalValidator
             else
             {
                 first[key] = verdict.Id;
+            }
+        }
+    }
+
+    // The target level is one datum for the whole project, and an Auto-tune that
+    // states one moves it. Two requests stating different levels would fit one
+    // bank at a level the project no longer holds by the time the other has run,
+    // so only the first stated level stands and the rest are refused naming it.
+    private static void RejectDisagreeingTargetLevels(List<AgentOperationVerdict> verdicts)
+    {
+        (string Id, double LevelDb)? first = null;
+        for (int index = 0; index < verdicts.Count; index++)
+        {
+            AgentOperationVerdict verdict = verdicts[index];
+            if (!verdict.Applicable ||
+                verdict.Operation is not AutoTunePeqOperation { TargetLevelDb: { } level })
+            {
+                continue;
+            }
+
+            if (first is not { } stated)
+            {
+                first = (verdict.Id, level);
+            }
+            else if (!stated.LevelDb.Equals(level))
+            {
+                verdicts[index] = verdict with
+                {
+                    Status = AgentVerdictStatus.Rejected,
+                    Message = $"The target level is one datum for the whole project; " +
+                        $"{stated.Id} already states {Db(stated.LevelDb)}."
+                };
             }
         }
     }

--- a/source/Integration/AgentBridge/AgentProtocol.cs
+++ b/source/Integration/AgentBridge/AgentProtocol.cs
@@ -77,4 +77,38 @@ internal static class AgentProtocol
     public const string SetPolarity = "setPolarity";
     public const string SetCrossover = "setCrossover";
     public const string ReplacePeqBank = "replacePeqBank";
+
+    // The intent operations: "open engine X with these settings" rather than
+    // "write this value". The engine keeps its own confirmation.
+    public const string RunAutoDelay = "runAutoDelay";
+    public const string RunAutoCrossover = "runAutoCrossover";
+    public const string AutoTunePeq = "autoTunePeq";
+    public const string UseSpatialAverage = "useSpatialAverage";
+
+    /// <summary>
+    /// The operations this build EXECUTES, published as <c>limits.operations</c>
+    /// and the list the importer holds a reply to. The protocol describes more
+    /// than a given build can run: the parser and the validator understand every
+    /// operation named above — so a reply written for a later build is read
+    /// rather than mangled — and one that is missing from this list is reviewed
+    /// and then refused with a plain reason. The guide tells the assistant to
+    /// use only what the package lists.
+    /// </summary>
+    public static readonly IReadOnlyList<string> Operations =
+    [
+        SetGainDb,
+        SetDelayMs,
+        SetPolarity,
+        SetCrossover,
+        ReplacePeqBank,
+        UseSpatialAverage,
+        RunAutoCrossover
+    ];
+
+    public static bool Executes(string op) => Operations.Contains(op, StringComparer.Ordinal);
+
+    /// <summary>Why an operation this build does not run was refused.</summary>
+    public static string NotAvailable(string op) =>
+        $"'{op}' is not available in this version of Resonalyze; the package's " +
+        "limits.operations lists the operations it can run.";
 }

--- a/source/Integration/AgentBridge/AgentProtocol.cs
+++ b/source/Integration/AgentBridge/AgentProtocol.cs
@@ -102,7 +102,8 @@ internal static class AgentProtocol
         SetCrossover,
         ReplacePeqBank,
         UseSpatialAverage,
-        RunAutoCrossover
+        RunAutoCrossover,
+        RunAutoDelay
     ];
 
     public static bool Executes(string op) => Operations.Contains(op, StringComparer.Ordinal);

--- a/source/Integration/AgentBridge/AgentProtocol.cs
+++ b/source/Integration/AgentBridge/AgentProtocol.cs
@@ -103,7 +103,8 @@ internal static class AgentProtocol
         ReplacePeqBank,
         UseSpatialAverage,
         RunAutoCrossover,
-        RunAutoDelay
+        RunAutoDelay,
+        AutoTunePeq
     ];
 
     public static bool Executes(string op) => Operations.Contains(op, StringComparer.Ordinal);

--- a/source/Integration/AgentBridge/AgentSessionSnapshot.cs
+++ b/source/Integration/AgentBridge/AgentSessionSnapshot.cs
@@ -94,7 +94,11 @@ internal sealed record AgentSessionSnapshot(
     string? LastPackageId,
     AgentAutoDelaySettings AutoDelay,
     VirtualCrossoverSpatialAverageMode SpatialAverageMode,
-    bool HybridTicked)
+    bool HybridTicked,
+    // The side on screen: an Auto-tune handoff is built for it alone (its gate
+    // pin, its render anchor, its hybrid datum), so a request for the other
+    // side's channel is refused at review rather than skipped at execution.
+    bool ActiveSideRight = false)
 {
     public AgentChannelSnapshot? Find(string channelId) =>
         Channels.FirstOrDefault(channel =>

--- a/source/Integration/AgentBridge/AgentSessionSnapshot.cs
+++ b/source/Integration/AgentBridge/AgentSessionSnapshot.cs
@@ -38,10 +38,21 @@ internal static class AgentChannelIds
 /// against, and what a commit writes to. The validator never mutates it: every
 /// trial edit goes to a copy.
 /// </param>
+/// <param name="HasMeasurement">
+/// Whether the side carries an impulse response. An engine asked to fit this
+/// channel has nothing to fit without one.
+/// </param>
+/// <param name="SpatialAverageCaptures">
+/// Every capture family the side holds, in the mode enum's own names — the same
+/// list the package prints as <c>source.spatialAverageCaptures</c>. What the mode
+/// currently READS is the session's business, not the channel's.
+/// </param>
 internal sealed record AgentChannelSnapshot(
     string Block,
     AgentChannelSide Side,
-    VirtualCrossoverChannelSettings Settings)
+    VirtualCrossoverChannelSettings Settings,
+    bool HasMeasurement,
+    IReadOnlyList<string> SpatialAverageCaptures)
 {
     public string Id => AgentChannelIds.Format(Block, Side);
 
@@ -65,16 +76,48 @@ internal sealed record AgentChannelSnapshot(
 /// The id of the package this session most recently copied, or null when it has
 /// not copied one since it opened. A reply naming another id gets a warning.
 /// </param>
+/// <param name="AutoDelay">
+/// What an Auto delay run would start from: the values the dialog would open
+/// with. An engine request that leaves an input out is judged, and described in
+/// the review, against these.
+/// </param>
+/// <param name="SpatialAverageMode">
+/// The capture family in force — the panel's effective mode, not the raw stored
+/// one, so a project that has not settled its choice yet is judged on what it
+/// actually draws.
+/// </param>
+/// <param name="HybridTicked">Whether the Hybrid box under the plot is ticked.</param>
 internal sealed record AgentSessionSnapshot(
     IReadOnlyList<AgentChannelSnapshot> Channels,
     int ProcessorSampleRateHz,
     double MaxDelayMs,
-    string? LastPackageId)
+    string? LastPackageId,
+    AgentAutoDelaySettings AutoDelay,
+    VirtualCrossoverSpatialAverageMode SpatialAverageMode,
+    bool HybridTicked)
 {
     public AgentChannelSnapshot? Find(string channelId) =>
         Channels.FirstOrDefault(channel =>
             string.Equals(channel.Id, channelId, StringComparison.Ordinal));
+
+    /// <summary>Whether any channel of the session holds a capture of that family.</summary>
+    public bool HasCapture(VirtualCrossoverSpatialAverageMode mode) =>
+        Channels.Any(channel => channel.SpatialAverageCaptures.Contains(
+            mode.ToString(), StringComparer.Ordinal));
 }
+
+/// <summary>
+/// The Auto delay inputs as the dialog would present them: the project's own
+/// figures as layout-neutral magnitudes (the layout toggle owns every sign), and
+/// the gain balance's opt-in, which the dialog opens unticked every time rather
+/// than storing an answer.
+/// </summary>
+internal sealed record AgentAutoDelaySettings(
+    double SceneOffsetMs,
+    bool RightHandDrive,
+    bool AdjustGains,
+    double NearSideCutDb,
+    double RearFillOffsetMs);
 
 /// <summary>
 /// A short fingerprint of one channel's PEQ bank, printed in the package and

--- a/source/Shell/Form1.cs
+++ b/source/Shell/Form1.cs
@@ -207,6 +207,10 @@ namespace Resonalyze
                 eqWizardPanel.BeginVirtualDspHandoff(request);
                 _ = modeController.SelectAsync(ModeTab.ToolsEqWizard);
             };
+            // An AI import that fits a bank without the wizard fits it with the
+            // wizard's own Auto Tune settings, as they stand: the same project
+            // gets the same bank from the button and from the import.
+            virtualCrossoverPanel.AutoTunePolicyProvider = () => eqWizardPanel.CurrentAutoTunePolicy;
             virtualCrossoverPanel.OpenSourceInAnalyzersRequested =
                 (entryId, filePath) =>
                     _ = OpenVirtualDspSourceInAnalyzersAsync(entryId, filePath);

--- a/source/Tools/Eq/EqAutoTuneHeadless.cs
+++ b/source/Tools/Eq/EqAutoTuneHeadless.cs
@@ -216,7 +216,10 @@ internal static class EqAutoTuneHeadless
         {
             double frequency = curve[index].X;
             double error = target[index].Y - curve[index].Y;
-            if (frequency < minHz || frequency > maxHz || !double.IsFinite(error))
+            // Paired by index on one grid; a point whose frequencies disagree is
+            // not a comparison.
+            if (frequency < minHz || frequency > maxHz || !double.IsFinite(error) ||
+                Math.Abs(frequency - target[index].X) > frequency * 1e-6)
             {
                 continue;
             }

--- a/source/Tools/Eq/EqAutoTuneHeadless.cs
+++ b/source/Tools/Eq/EqAutoTuneHeadless.cs
@@ -1,0 +1,247 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// Everything one Auto Tune needs, assembled the way the EQ Wizard assembles
+/// it for a Virtual DSP handoff, but with no wizard on screen: the curve the
+/// fit corrects, the target on the same frequencies, the tuner's options, the
+/// coherence that gates its boosts, and the all-pass bands that are kept out
+/// of the fit and put back afterwards.
+/// </summary>
+internal sealed record EqHeadlessTuneInputs(
+    IReadOnlyList<SignalPoint> Source,
+    IReadOnlyList<SignalPoint> Target,
+    EqAutoTuner.Options Options,
+    IReadOnlyList<SignalPoint>? Coherence,
+    IReadOnlyList<PeqBand> KeptAllPass,
+    double MinHz,
+    double MaxHz,
+    bool CutsOnly);
+
+/// <summary>
+/// Auto Tune without the wizard, for an AI import that asked for it. The
+/// curves and the options are the wizard's own constructions — the same gated
+/// preview or spatial-average curve <c>ComputeSourceCurve</c> draws for a
+/// handoff, the same target on the source's frequencies, the same option
+/// mapping <c>CreateAutoTuneOptions</c> makes — held here where a test can pin
+/// the two against each other, because "almost the same curve" is the failure
+/// that only shows on a live session. The wizard's opening values stand in for
+/// the fields a request leaves out; all-pass bands are always kept, since a
+/// headless run cannot ask.
+/// </summary>
+internal static class EqAutoTuneHeadless
+{
+    /// <summary>The wizard's Gain min/max for a fitted band, as it opens.</summary>
+    public const double BandGainMinDb = -15;
+    public const double BandGainMaxDb = 6;
+
+    /// <summary>The wizard's Max Q as it opens: bells no narrower than this.</summary>
+    public const double MaxQ = 6.0;
+
+    /// <summary>The wizard's preamp field runs ±80 dB; Cuts only lets the auto preamp use it.</summary>
+    public const double PreampRangeDb = 80;
+
+    /// <summary>The wizard's From/To fields: 20 Hz to 20 kHz, at least 1 Hz apart.</summary>
+    public const double WindowMinHz = 20;
+    public const double WindowMaxHz = 20_000;
+    public const double MinWindowGapHz = 1;
+
+    /// <summary>
+    /// The curve the wizard would draw as Source for a Virtual DSP handoff: the
+    /// spatial average through the preview chain when the handoff carries one,
+    /// otherwise the impulse response through the chain and the Virtual DSP
+    /// gate. <paramref name="appliedBank"/> is the bank the preview chain runs
+    /// with (null = none), and the calibration is the one the panel pinned.
+    /// </summary>
+    public static IReadOnlyList<SignalPoint> SourceCurve(
+        EqWizardCurveSource source,
+        int smoothingInverseOctaves,
+        EqualizationCurve? appliedBank)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (source.Kind != EqWizardSourceKind.VirtualDspChannel)
+        {
+            throw new ArgumentException(
+                "Only a Virtual DSP handoff can be tuned without the wizard.", nameof(source));
+        }
+
+        int processorRate = ProcessorRate(source);
+        // The wizard pins the panel's correction whenever the panel pinned any,
+        // and its Off is Off (ChooseCalibration).
+        bool pinned = source.PinsCorrection;
+
+        if (source.SpatialAverage is { } document)
+        {
+            List<double> grid = document.ToCurvePoints().Select(point => point.X).ToList();
+            List<SignalPoint>? curve = SpatialAverageHybrid.BuildChannelCurve(
+                document,
+                (source.PreviewChain ?? DspChannelChain.Identity) with { Peq = appliedBank },
+                processorRate,
+                pinned ? source.SpatialAverageCalibration : SpatialAverageCalibration.Off,
+                grid,
+                smoothingInverseOctaves);
+            if (curve == null)
+            {
+                return Array.Empty<SignalPoint>();
+            }
+
+            double offset = source.SpatialAverageOffsetDb;
+            // An average keeps its gaps: a NaN is a frequency the capture did not
+            // cover, and the fit reads it as such.
+            return curve
+                .Where(point => double.IsFinite(point.X) && point.X > 0)
+                .Select(point => new SignalPoint(point.X, point.Y + offset))
+                .ToList();
+        }
+
+        if (!source.IsGated)
+        {
+            throw new ArgumentException(
+                "A Virtual DSP handoff is gated or carries a spatial average.", nameof(source));
+        }
+
+        IReadOnlyList<SignalPoint> gated = EqWizardGatedPreview.Render(
+            new EqWizardGatedPreviewRequest(
+                source.PreviewImpulseResponse!,
+                source.PreviewChain!,
+                appliedBank,
+                source.Measurement!.PeakIndex,
+                source.Measurement.SampleRate,
+                processorRate,
+                source.GateSettings!,
+                pinned ? source.PinnedCalibration : null,
+                smoothingInverseOctaves,
+                new MeasuredBand(
+                    source.Measurement.LowestMeasuredFrequencyHz,
+                    source.Measurement.HighestMeasuredFrequencyHz)));
+        // A windowed response has no gaps to keep: a hole is a point left out.
+        return gated
+            .Where(point => double.IsFinite(point.X) && point.X > 0 && double.IsFinite(point.Y))
+            .ToList();
+    }
+
+    /// <summary>
+    /// The fit's inputs for a handoff: the source with any all-pass bands of the
+    /// current bank already applied (the fit tunes around what they do, as the
+    /// wizard's "keep them" does), the target on its frequencies, and the
+    /// options — the request's window unless the reply narrows it, the reply's
+    /// shelves and cuts-only choices, the wizard's opening values for the rest.
+    /// </summary>
+    public static EqHeadlessTuneInputs Prepare(
+        VirtualDspEqHandoffRequest request,
+        TargetCurveSpec targetSpec,
+        double? minHz,
+        double? maxHz,
+        bool allowShelves,
+        bool cutsOnly)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(targetSpec);
+
+        EqWizardCurveSource source = request.Source;
+        List<PeqBand> allPass = request.BankSeed.Bands
+            .Where(band => band.Type.IsAllPass())
+            .ToList();
+        // Through a window an all-pass is not flat (filtering and windowing do not
+        // commute), so a gated source is rendered WITH them; an average is not
+        // windowed and an all-pass leaves it alone.
+        IReadOnlyList<SignalPoint> fitSource = SourceCurve(
+            source,
+            request.SmoothingInverseOctaves,
+            allPass.Count > 0 && source.IsGated
+                ? new EqualizationCurve(allPass, preampDb: 0)
+                : null);
+        List<SignalPoint> target = fitSource
+            .Select(point => new SignalPoint(
+                point.X, targetSpec.Evaluate(point.X) + request.TargetLevelDb))
+            .ToList();
+
+        (double windowMinHz, double windowMaxHz) = Window(
+            minHz ?? request.AutoTuneMinHz ?? WindowMinHz,
+            maxHz ?? request.AutoTuneMaxHz ?? WindowMaxHz);
+
+        // Max Filters is a budget for the BANK: the kept bands come off it.
+        int bandLimit = Math.Clamp(
+            EqualizationCurve.MaxBandCount - allPass.Count, 1, EqualizationCurve.MaxBandCount);
+        // The preamp policy the wizard applies (CreateAutoTuneOptions): under Cuts
+        // only the auto preamp may move within the field's range and the 0 dB
+        // ceiling keeps the profile clip-free; otherwise the preamp is the user's
+        // and stays where the bank had it.
+        double seedPreamp = request.BankSeed.PreampDb;
+        var options = new EqAutoTuner.Options
+        {
+            MaxBands = bandLimit,
+            MinFrequencyHz = windowMinHz,
+            MaxFrequencyHz = windowMaxHz,
+            PreampMinDb = cutsOnly ? -PreampRangeDb : seedPreamp,
+            PreampMaxDb = cutsOnly ? PreampRangeDb : seedPreamp,
+            BandGainMinDb = BandGainMinDb,
+            BandGainMaxDb = BandGainMaxDb,
+            TotalGainMaxDb = cutsOnly ? 0 : double.PositiveInfinity,
+            SampleRateHz = ProcessorRate(source),
+            CutsOnlyMode = cutsOnly,
+            QMin = PeqSlotControl.MinimumQ,
+            QMax = MaxQ,
+            AllowShelves = allowShelves
+        };
+
+        return new EqHeadlessTuneInputs(
+            fitSource, target, options, source.Coherence, allPass,
+            windowMinHz, windowMaxHz, cutsOnly);
+    }
+
+    /// <summary>The fit, with the kept all-pass bands put back in front of it.</summary>
+    public static EqualizationCurve Fit(EqHeadlessTuneInputs inputs)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        EqualizationCurve tuned = EqAutoTuner.Tune(
+            inputs.Source, inputs.Target, inputs.Options, inputs.Coherence);
+        return EqWizardPanel.WithAllPassBands(tuned, inputs.KeptAllPass);
+    }
+
+    /// <summary>
+    /// The RMS of target minus curve over the window, the number the wizard's
+    /// scoreboard shows before and after a fit; null with nothing to compare.
+    /// </summary>
+    public static double? RmsErrorDb(
+        IReadOnlyList<SignalPoint> curve, IReadOnlyList<SignalPoint> target, double minHz, double maxHz)
+    {
+        ArgumentNullException.ThrowIfNull(curve);
+        ArgumentNullException.ThrowIfNull(target);
+        double sumSquares = 0;
+        int valid = 0;
+        int count = Math.Min(curve.Count, target.Count);
+        for (int index = 0; index < count; index++)
+        {
+            double frequency = curve[index].X;
+            double error = target[index].Y - curve[index].Y;
+            if (frequency < minHz || frequency > maxHz || !double.IsFinite(error))
+            {
+                continue;
+            }
+
+            sumSquares += error * error;
+            valid++;
+        }
+
+        return valid > 0 ? Math.Sqrt(sumSquares / valid) : null;
+    }
+
+    // The From/To fields' own clamping (SetAutoTuneWindow): ordered, inside
+    // 20 Hz..20 kHz, at least the gap apart.
+    private static (double MinHz, double MaxHz) Window(double lowHz, double highHz)
+    {
+        double from = Math.Clamp(Math.Min(lowHz, highHz), WindowMinHz, WindowMaxHz - MinWindowGapHz);
+        double to = Math.Clamp(Math.Max(lowHz, highHz), from + MinWindowGapHz, WindowMaxHz);
+        return (from, to);
+    }
+
+    // A handoff carries the project's processor, and the bank is realized at
+    // its rate (EqProcessorSampleRate).
+    private static int ProcessorRate(EqWizardCurveSource source) =>
+        source.ProcessorProfile?.SampleRateHz
+            ?? source.SampleRateHz
+            ?? source.Measurement?.SampleRate
+            ?? throw new ArgumentException("The handoff names no sample rate.", nameof(source));
+}

--- a/source/Tools/Eq/EqAutoTuneHeadless.cs
+++ b/source/Tools/Eq/EqAutoTuneHeadless.cs
@@ -193,9 +193,15 @@ internal static class EqAutoTuneHeadless
             minHz ?? request.AutoTuneMinHz ?? WindowMinHz,
             maxHz ?? request.AutoTuneMaxHz ?? WindowMaxHz);
 
-        // Max Filters is a budget for the BANK: the kept bands come off it.
-        int bandLimit = Math.Clamp(
-            policy.MaxBands - allPass.Count, 1, EqualizationCurve.MaxBandCount);
+        // Max Filters is a budget for the BANK: the kept bands come off it, and a
+        // budget they fill leaves the fit nothing to place — the wizard refuses
+        // that run rather than handing back more filters than the limit promises.
+        int bandLimit = RoomUnderMaxFilters(request, policy);
+        if (bandLimit <= 0)
+        {
+            throw new InvalidOperationException(
+                $"Keeping {allPass.Count} all-pass bands leaves no room under Max Filters ({policy.MaxBands}).");
+        }
         // The preamp policy the wizard applies (CreateAutoTuneOptions): under Cuts
         // only the auto preamp may move within the field's range and the 0 dB
         // ceiling keeps the profile clip-free; otherwise the preamp is the user's
@@ -221,6 +227,18 @@ internal static class EqAutoTuneHeadless
         return new EqHeadlessTuneInputs(
             fitSource, target, options, source.Coherence, allPass,
             windowMinHz, windowMaxHz, !boostsAllowed);
+    }
+
+    /// <summary>
+    /// How many bands the fit may place once the bank's all-pass bands are kept:
+    /// Max Filters less those bands. Zero or less is the run the wizard refuses.
+    /// </summary>
+    public static int RoomUnderMaxFilters(VirtualDspEqHandoffRequest request, EqAutoTunePolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(policy);
+        int kept = request.BankSeed.Bands.Count(band => band.Type.IsAllPass());
+        return Math.Min(policy.MaxBands, EqualizationCurve.MaxBandCount) - kept;
     }
 
     /// <summary>The fit, with the kept all-pass bands put back in front of it.</summary>

--- a/source/Tools/Eq/EqAutoTuneHeadless.cs
+++ b/source/Tools/Eq/EqAutoTuneHeadless.cs
@@ -20,15 +20,40 @@ internal sealed record EqHeadlessTuneInputs(
     bool CutsOnly);
 
 /// <summary>
+/// The Auto Tune settings the EQ Wizard holds at the moment — Max Filters, the
+/// band gain range, Max Q, Cuts only, Shelves — as CreateAutoTuneOptions reads
+/// them off its controls. An import's fit takes the wizard's CURRENT policy, so
+/// the button and the import produce the same bank for the same project;
+/// <see cref="Default"/> is what the wizard opens with, for a host that has no
+/// wizard to ask.
+/// </summary>
+internal sealed record EqAutoTunePolicy(
+    int MaxBands,
+    double BandGainMinDb,
+    double BandGainMaxDb,
+    double MaxQ,
+    bool CutsOnly,
+    bool AllowShelves)
+{
+    public static EqAutoTunePolicy Default { get; } = new(
+        EqualizationCurve.MaxBandCount,
+        EqAutoTuneHeadless.BandGainMinDb,
+        EqAutoTuneHeadless.BandGainMaxDb,
+        EqAutoTuneHeadless.MaxQ,
+        CutsOnly: true,
+        AllowShelves: false);
+}
+
+/// <summary>
 /// Auto Tune without the wizard, for an AI import that asked for it. The
 /// curves and the options are the wizard's own constructions — the same gated
 /// preview or spatial-average curve <c>ComputeSourceCurve</c> draws for a
 /// handoff, the same target on the source's frequencies, the same option
 /// mapping <c>CreateAutoTuneOptions</c> makes — held here where a test can pin
 /// the two against each other, because "almost the same curve" is the failure
-/// that only shows on a live session. The wizard's opening values stand in for
-/// the fields a request leaves out; all-pass bands are always kept, since a
-/// headless run cannot ask.
+/// that only shows on a live session. The wizard's current Auto Tune settings
+/// stand in for the fields a request leaves out; all-pass bands are always
+/// kept, since a headless run cannot ask.
 /// </summary>
 internal static class EqAutoTuneHeadless
 {
@@ -126,18 +151,25 @@ internal static class EqAutoTuneHeadless
     /// current bank already applied (the fit tunes around what they do, as the
     /// wizard's "keep them" does), the target on its frequencies, and the
     /// options — the request's window unless the reply narrows it, the reply's
-    /// shelves and cuts-only choices, the wizard's opening values for the rest.
+    /// shelves and cuts-only choices where it states them, the wizard's current
+    /// policy for the rest. The window is taken as stated: the review has already
+    /// held it to the wizard's fields, and a headless run must not reinterpret
+    /// what the user confirmed.
     /// </summary>
     public static EqHeadlessTuneInputs Prepare(
         VirtualDspEqHandoffRequest request,
         TargetCurveSpec targetSpec,
+        EqAutoTunePolicy policy,
         double? minHz,
         double? maxHz,
-        bool allowShelves,
-        bool cutsOnly)
+        bool? allowShelves,
+        bool? cutsOnly)
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(targetSpec);
+        ArgumentNullException.ThrowIfNull(policy);
+        bool boostsAllowed = !(cutsOnly ?? policy.CutsOnly);
+        bool shelves = allowShelves ?? policy.AllowShelves;
 
         EqWizardCurveSource source = request.Source;
         List<PeqBand> allPass = request.BankSeed.Bands
@@ -163,7 +195,7 @@ internal static class EqAutoTuneHeadless
 
         // Max Filters is a budget for the BANK: the kept bands come off it.
         int bandLimit = Math.Clamp(
-            EqualizationCurve.MaxBandCount - allPass.Count, 1, EqualizationCurve.MaxBandCount);
+            policy.MaxBands - allPass.Count, 1, EqualizationCurve.MaxBandCount);
         // The preamp policy the wizard applies (CreateAutoTuneOptions): under Cuts
         // only the auto preamp may move within the field's range and the 0 dB
         // ceiling keeps the profile clip-free; otherwise the preamp is the user's
@@ -174,21 +206,21 @@ internal static class EqAutoTuneHeadless
             MaxBands = bandLimit,
             MinFrequencyHz = windowMinHz,
             MaxFrequencyHz = windowMaxHz,
-            PreampMinDb = cutsOnly ? -PreampRangeDb : seedPreamp,
-            PreampMaxDb = cutsOnly ? PreampRangeDb : seedPreamp,
-            BandGainMinDb = BandGainMinDb,
-            BandGainMaxDb = BandGainMaxDb,
-            TotalGainMaxDb = cutsOnly ? 0 : double.PositiveInfinity,
+            PreampMinDb = boostsAllowed ? seedPreamp : -PreampRangeDb,
+            PreampMaxDb = boostsAllowed ? seedPreamp : PreampRangeDb,
+            BandGainMinDb = policy.BandGainMinDb,
+            BandGainMaxDb = policy.BandGainMaxDb,
+            TotalGainMaxDb = boostsAllowed ? double.PositiveInfinity : 0,
             SampleRateHz = ProcessorRate(source),
-            CutsOnlyMode = cutsOnly,
+            CutsOnlyMode = !boostsAllowed,
             QMin = PeqSlotControl.MinimumQ,
-            QMax = MaxQ,
-            AllowShelves = allowShelves
+            QMax = policy.MaxQ,
+            AllowShelves = shelves
         };
 
         return new EqHeadlessTuneInputs(
             fitSource, target, options, source.Coherence, allPass,
-            windowMinHz, windowMaxHz, cutsOnly);
+            windowMinHz, windowMaxHz, !boostsAllowed);
     }
 
     /// <summary>The fit, with the kept all-pass bands put back in front of it.</summary>
@@ -231,14 +263,16 @@ internal static class EqAutoTuneHeadless
         return valid > 0 ? Math.Sqrt(sumSquares / valid) : null;
     }
 
-    // The From/To fields' own clamping (SetAutoTuneWindow): ordered, inside
-    // 20 Hz..20 kHz, at least the gap apart.
-    private static (double MinHz, double MaxHz) Window(double lowHz, double highHz)
-    {
-        double from = Math.Clamp(Math.Min(lowHz, highHz), WindowMinHz, WindowMaxHz - MinWindowGapHz);
-        double to = Math.Clamp(Math.Max(lowHz, highHz), from + MinWindowGapHz, WindowMaxHz);
-        return (from, to);
-    }
+    // The From/To fields' range, and nothing else: no reordering, no widening
+    // — a lower edge stated above the upper is a window the review would have
+    // refused, and one that slipped through is refused by the run, not read the
+    // other way round.
+    private static (double MinHz, double MaxHz) Window(double lowHz, double highHz) =>
+        (Math.Clamp(lowHz, WindowMinHz, WindowMaxHz), Math.Clamp(highHz, WindowMinHz, WindowMaxHz));
+
+    /// <summary>Whether a window is one the From/To fields could hold: ordered, the gap apart.</summary>
+    public static bool IsUsableWindow(double minHz, double maxHz) =>
+        minHz + MinWindowGapHz <= maxHz;
 
     // A handoff carries the project's processor, and the bank is realized at
     // its rate (EqProcessorSampleRate).

--- a/source/Tools/Eq/EqWizardPanel.cs
+++ b/source/Tools/Eq/EqWizardPanel.cs
@@ -1003,6 +1003,22 @@ public partial class EqWizardPanel : UserControl
     // Mirrors the control limits so the fit only proposes values the controls accept.
     // Bands the caller is holding back (all-pass ones the user chose to keep) come
     // off the fit's budget, so the merged bank still fits the slot count.
+    /// <summary>
+    /// The Auto Tune settings as they stand on the controls — what
+    /// <see cref="CreateAutoTuneOptions"/> reads — for a fit run elsewhere (an
+    /// AI import) that has to produce the bank this button would.
+    /// </summary>
+    [System.ComponentModel.Browsable(false)]
+    [System.ComponentModel.DesignerSerializationVisibility(
+        System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+    internal EqAutoTunePolicy CurrentAutoTunePolicy => new(
+        SelectedBandLimit,
+        (double)numericGainMin.Value,
+        (double)numericGainMax.Value,
+        (double)numericQMax.Value,
+        checkBoxCutsOnly.Checked,
+        checkBoxShelves.Checked);
+
     private EqAutoTuner.Options CreateAutoTuneOptions(int reservedBands)
     {
         // Max Filters is a budget for the BANK, not for the fit alone: a user who set

--- a/source/Tools/VirtualCrossover/AgentProposalDialog.cs
+++ b/source/Tools/VirtualCrossover/AgentProposalDialog.cs
@@ -54,6 +54,12 @@ internal sealed partial class AgentProposalDialog : Form
             }
             row.Cells[ColumnStatus.Index].ToolTipText = verdict.Message;
             row.Cells[ColumnReason.Index].ToolTipText = verdict.Reason;
+            // These two columns are fixed-width and an engine request states its
+            // whole set of inputs in them, well past what the cell can show. The
+            // detail box below repeats them for the selected row; the tooltip is
+            // for reading down the table without moving the selection.
+            row.Cells[ColumnCurrent.Index].ToolTipText = verdict.Current;
+            row.Cells[ColumnProposed.Index].ToolTipText = verdict.Proposed;
         }
 
         // A click on the box is a click on the box: commit it so CellValueChanged
@@ -120,6 +126,14 @@ internal sealed partial class AgentProposalDialog : Form
         {
             lines.Add($"{verdict.Id} — {verdict.ChannelLabel} {verdict.Parameter}: " +
                 $"{StatusWord(verdict.Status)}. {verdict.Message}");
+            if (verdict.Current.Length > 0)
+            {
+                lines.Add("Current: " + verdict.Current);
+            }
+            if (verdict.Proposed.Length > 0)
+            {
+                lines.Add("Proposed: " + verdict.Proposed);
+            }
             if (verdict.Reason.Length > 0)
             {
                 lines.Add("Reason: " + verdict.Reason);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -531,6 +531,19 @@ public partial class VirtualCrossoverPanel
         VirtualCrossoverTargetSettings targetSettings =
             project.Target ?? new VirtualCrossoverTargetSettings();
         TargetCurveSpec spec = (targetCurve ?? targetSettings.ToCurve()).Normalized().Spec;
+        // The wizard's own refusal: kept all-pass bands that fill Max Filters
+        // leave the fit nothing to place, and a bank over the limit is not one
+        // the button would ever hand back.
+        int room = EqAutoTuneHeadless.RoomUnderMaxFilters(request, policy);
+        if (room <= 0)
+        {
+            int kept = request.BankSeed.Bands.Count(band => band.Type.IsAllPass());
+            summary.Add(
+                $"{label}: skipped (keeping {kept} all-pass band{(kept == 1 ? "" : "s")} " +
+                $"leaves no room under Max Filters ({policy.MaxBands})).");
+            return false;
+        }
+
         EqHeadlessTuneInputs inputs = EqAutoTuneHeadless.Prepare(
             request, spec, policy, operation.MinHz, operation.MaxHz,
             operation.AllowShelves, operation.CutsOnly);

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -250,12 +250,16 @@ public partial class VirtualCrossoverPanel
         IReadOnlyList<AgentOperationVerdict> toApply, List<string> summary)
     {
         bool ran = false;
-        foreach (AgentOperation operation in toApply
+        // The verdicts, not the operations alone: a channel operation's target is
+        // the verdict's channel snapshot, held by its settings object, which is
+        // what still names the channel after the crossover wizard has reordered
+        // the blocks and re-lettered them.
+        foreach (AgentOperationVerdict verdict in toApply
             .Where(verdict => verdict.Applicable)
-            .Select(verdict => verdict.Operation!)
-            .Where(operation => operation is not AgentSettingsOperation)
-            .OrderBy(AgentEngineOrder))
+            .Where(verdict => verdict.Operation is not AgentSettingsOperation)
+            .OrderBy(verdict => AgentEngineOrder(verdict.Operation!)))
         {
+            AgentOperation operation = verdict.Operation!;
             switch (operation)
             {
                 case UseSpatialAverageOperation spatial:
@@ -279,7 +283,7 @@ public partial class VirtualCrossoverPanel
                     break;
 
                 case AutoTunePeqOperation tune:
-                    ran |= await RunAgentAutoTuneAsync(tune, summary);
+                    ran |= await RunAgentAutoTuneAsync(tune, verdict.Channel!, summary);
                     break;
 
                 // Every operation the protocol names is executed above; one this
@@ -391,8 +395,11 @@ public partial class VirtualCrossoverPanel
         }
         finally
         {
-            UseWaitCursor = false;
-            Enabled = wasEnabled;
+            if (!IsDisposed)
+            {
+                UseWaitCursor = false;
+                Enabled = wasEnabled;
+            }
         }
         if (IsDisposed)
         {
@@ -408,9 +415,19 @@ public partial class VirtualCrossoverPanel
         {
             summary.Add(launch.PolarityWarning);
         }
-        summary.Add(result.ReportText);
+        // The summary is a message box, which does not scroll: the report's head
+        // (the table is what the dialog showed first) and where the rest went.
+        string[] lines = result.ReportText.Split(
+            ["\r\n", "\n"], StringSplitOptions.None);
+        summary.Add(lines.Length <= AutoDelayReportLinesInSummary
+            ? result.ReportText
+            : string.Join(Environment.NewLine, lines.Take(AutoDelayReportLinesInSummary)) +
+                Environment.NewLine +
+                $"… {lines.Length - AutoDelayReportLinesInSummary} more lines in the alignment log.");
         return true;
     }
+
+    private const int AutoDelayReportLinesInSummary = 16;
 
     // Auto-tune without the wizard: the same handoff the PEQ menu would build
     // for the channel, the same curves and options the wizard would fit
@@ -420,24 +437,25 @@ public partial class VirtualCrossoverPanel
     // The review was the gate; the target-level check the wizard would have
     // asked about is a refusal here, with the phrase in the summary.
     private async Task<bool> RunAgentAutoTuneAsync(
-        AutoTunePeqOperation operation, List<string> summary)
+        AutoTunePeqOperation operation, AgentChannelSnapshot target, List<string> summary)
     {
         string label = $"Auto-tune {operation.ChannelId}";
+        // By the settings object the review judged, not by the id: the crossover
+        // wizard, run earlier in the same import, may have reordered the blocks,
+        // and the letter the reply used then names another channel.
         (VirtualCrossoverChannel Channel, bool RightSide)? slot = AgentChannelSlots()
-            .Where(item => string.Equals(
-                AgentChannelIds.Format(item.Block, item.Side), operation.ChannelId,
-                StringComparison.Ordinal))
+            .Where(item => ReferenceEquals(item.Channel.SideSettings(item.RightSide), target.Settings))
             .Select(item => ((VirtualCrossoverChannel, bool)?)(item.Channel, item.RightSide))
             .FirstOrDefault();
         if (slot is not { } found)
         {
-            summary.Add($"{label}: skipped (no such channel).");
+            summary.Add($"{label}: skipped (the channel is no longer in the project).");
             return false;
         }
 
         (VirtualCrossoverChannel channel, bool rightSide) = found;
-        // The handoff is built for the side on screen, as the PEQ menu builds it:
-        // the gate pin, the render anchor and the hybrid datum are that side's.
+        // The review refused the other side already; this guards a snapshot the
+        // side selector moved under.
         if (!channel.Pair.Mono && rightSide != channel.ActiveRight)
         {
             summary.Add(
@@ -485,6 +503,14 @@ public partial class VirtualCrossoverPanel
         EqHeadlessTuneInputs inputs = EqAutoTuneHeadless.Prepare(
             request, spec, operation.MinHz, operation.MaxHz,
             operation.AllowShelves ?? false, cutsOnly);
+        // The wizard beeps at a source it cannot draw; the tuner must not be
+        // handed one.
+        if (inputs.Source.Count < 2)
+        {
+            summary.Add($"{label}: skipped (the measurement gives no usable curve).");
+            return false;
+        }
+
         string? levelWarning = EqTargetLevelCheck.Warning(
             EqTargetLevelCheck.TargetAboveSourceDb(
                 inputs.Source, inputs.Target, inputs.MinHz, inputs.MaxHz),
@@ -517,8 +543,11 @@ public partial class VirtualCrossoverPanel
         }
         finally
         {
-            UseWaitCursor = false;
-            Enabled = wasEnabled;
+            if (!IsDisposed)
+            {
+                UseWaitCursor = false;
+                Enabled = wasEnabled;
+            }
         }
         if (IsDisposed)
         {
@@ -755,7 +784,8 @@ public partial class VirtualCrossoverPanel
             lastAgentPackageId,
             AgentAutoDelayDefaults(),
             SpatialAverageMode,
-            checkBoxHybrid.Checked);
+            checkBoxHybrid.Checked,
+            project.ActiveSideRight);
 
     // Every physical channel in block order: a stereo block yields its left and
     // right slots, a mono block its single one (routed to the left slot, as the

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -27,6 +27,16 @@ public partial class VirtualCrossoverPanel
 
     private ContextMenuStrip? agentMenu;
 
+    /// <summary>
+    /// The EQ Wizard's Auto Tune settings at the moment an import fits a bank
+    /// without it — wired by the host so the import produces the bank the
+    /// wizard's button would; the wizard's opening values when nothing is wired.
+    /// </summary>
+    [System.ComponentModel.Browsable(false)]
+    [System.ComponentModel.DesignerSerializationVisibility(
+        System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+    internal Func<EqAutoTunePolicy>? AutoTunePolicyProvider { get; set; }
+
     /// <summary>Records the package this session just copied, for the review's correlation warning.</summary>
     internal void RememberAgentPackage(string packageId) => lastAgentPackageId = packageId;
 
@@ -250,6 +260,12 @@ public partial class VirtualCrossoverPanel
         IReadOnlyList<AgentOperationVerdict> toApply, List<string> summary)
     {
         bool ran = false;
+        // One target level for every fit of this import, decided before the first
+        // runs: the level the reply states (the review made the stated ones
+        // agree), else the project's as it stands now. Read per operation, a row
+        // that states none would fit at the old datum and the next row move it.
+        double importTargetLevelDb = ImportTargetLevelDb(toApply, (double)numericTargetLevel.Value);
+        EqAutoTunePolicy policy = AutoTunePolicyProvider?.Invoke() ?? EqAutoTunePolicy.Default;
         // The verdicts, not the operations alone: a channel operation's target is
         // the verdict's channel snapshot, held by its settings object, which is
         // what still names the channel after the crossover wizard has reordered
@@ -283,7 +299,8 @@ public partial class VirtualCrossoverPanel
                     break;
 
                 case AutoTunePeqOperation tune:
-                    ran |= await RunAgentAutoTuneAsync(tune, verdict.Channel!, summary);
+                    ran |= await RunAgentAutoTuneAsync(
+                        tune, verdict.Channel!, importTargetLevelDb, policy, summary);
                     break;
 
                 // Every operation the protocol names is executed above; one this
@@ -436,8 +453,26 @@ public partial class VirtualCrossoverPanel
     // channel that moved while the fit ran is refused rather than written.
     // The review was the gate; the target-level check the wizard would have
     // asked about is a refusal here, with the phrase in the summary.
+    /// <summary>
+    /// The target level every Auto-tune of one import fits to: the first level a
+    /// ticked request states, else the project's own. UI-free so it can be pinned.
+    /// </summary>
+    internal static double ImportTargetLevelDb(
+        IReadOnlyList<AgentOperationVerdict> toApply, double currentTargetLevelDb) =>
+        toApply
+            .Where(verdict => verdict.Status != AgentVerdictStatus.Rejected)
+            .Select(verdict => verdict.Operation)
+            .OfType<AutoTunePeqOperation>()
+            .Select(tune => tune.TargetLevelDb)
+            .FirstOrDefault(level => level != null)
+            ?? currentTargetLevelDb;
+
     private async Task<bool> RunAgentAutoTuneAsync(
-        AutoTunePeqOperation operation, AgentChannelSnapshot target, List<string> summary)
+        AutoTunePeqOperation operation,
+        AgentChannelSnapshot target,
+        double targetLevelDb,
+        EqAutoTunePolicy policy,
+        List<string> summary)
     {
         string label = $"Auto-tune {operation.ChannelId}";
         // By the settings object the review judged, not by the id: the crossover
@@ -486,7 +521,7 @@ public partial class VirtualCrossoverPanel
         // itself must leave nothing behind, since the import's undo is dropped
         // when nothing ran.
         VirtualDspEqHandoffRequest? request = BuildPeqHandoffRequest(
-            channel, withChain: true, average, operation.TargetLevelDb);
+            channel, withChain: true, average, targetLevelDb);
         if (request == null)
         {
             summary.Add($"{label}: skipped (no measurement to fit against).");
@@ -496,15 +531,24 @@ public partial class VirtualCrossoverPanel
         VirtualCrossoverTargetSettings targetSettings =
             project.Target ?? new VirtualCrossoverTargetSettings();
         TargetCurveSpec spec = (targetCurve ?? targetSettings.ToCurve()).Normalized().Spec;
-        bool cutsOnly = operation.CutsOnly ?? true;
         EqHeadlessTuneInputs inputs = EqAutoTuneHeadless.Prepare(
-            request, spec, operation.MinHz, operation.MaxHz,
-            operation.AllowShelves ?? false, cutsOnly);
+            request, spec, policy, operation.MinHz, operation.MaxHz,
+            operation.AllowShelves, operation.CutsOnly);
+        bool cutsOnly = inputs.CutsOnly;
         // The wizard beeps at a source it cannot draw; the tuner must not be
         // handed one.
         if (inputs.Source.Count < 2)
         {
             summary.Add($"{label}: skipped (the measurement gives no usable curve).");
+            return false;
+        }
+        // The review held the window to the wizard's fields; a snapshot the
+        // crossover moved under can still leave a stated edge past the other.
+        if (!EqAutoTuneHeadless.IsUsableWindow(inputs.MinHz, inputs.MaxHz))
+        {
+            summary.Add(
+                $"{label}: skipped (the window {inputs.MinHz:0}–{inputs.MaxHz:0} Hz " +
+                "has its lower edge above its upper).");
             return false;
         }
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -88,11 +88,18 @@ public partial class VirtualCrossoverPanel
     /// chain is taken, not only the ones a row names: an engine writes channels no
     /// row mentions, and the crossover wizard can reorder the blocks as well.
     /// </summary>
+    // The stereo scene, the level tilt and the rear-fill offset are what an Auto
+    // delay run commits beside the channels (CommitAutoDelayResult), so an undo
+    // of an import that ran one has to carry them too.
     private sealed record AgentImportUndo(
         IReadOnlyList<AgentUndoEntry> Channels,
         VirtualCrossoverSpatialAverageMode? SpatialAverageMode,
         bool HybridTicked,
-        IReadOnlyList<VirtualCrossoverChannel> Order);
+        IReadOnlyList<VirtualCrossoverChannel> Order,
+        double SceneOffsetMagnitudeMs,
+        bool RightHandDrive,
+        double StereoLevelDifferenceDb,
+        double RearFillOffsetMs);
 
     /// <summary>
     /// Import AI proposal: clipboard → strict parse → review against the live
@@ -102,7 +109,10 @@ public partial class VirtualCrossoverPanel
     /// before anything is written, so a failure part-way through still leaves the
     /// whole import undoable.
     /// </summary>
-    private void ImportAiProposal()
+    // async void as the button handlers are: the engines that run without their
+    // dialogs await their compute, and the try/finally below is what keeps the
+    // busy flag honest across those awaits.
+    private async void ImportAiProposal()
     {
         if (agentBusy)
         {
@@ -185,7 +195,7 @@ public partial class VirtualCrossoverPanel
                     $"Applied {rows} of {proposed} proposed change{(proposed == 1 ? "" : "s")}.");
             }
 
-            bool ran = RunAgentEngineRequests(toApply, summary);
+            bool ran = await RunAgentEngineRequests(toApply, summary);
             if (written.Count == 0 && !ran)
             {
                 agentUndo = previousUndo;
@@ -234,7 +244,7 @@ public partial class VirtualCrossoverPanel
     /// operation and the import carries on with the next.
     /// </summary>
     /// <returns>Whether any of them changed the project.</returns>
-    private bool RunAgentEngineRequests(
+    private async Task<bool> RunAgentEngineRequests(
         IReadOnlyList<AgentOperationVerdict> toApply, List<string> summary)
     {
         bool ran = false;
@@ -262,10 +272,14 @@ public partial class VirtualCrossoverPanel
                     ran |= refused == null;
                     break;
 
-                // Auto delay and Auto-tune are not in AgentProtocol.Operations
-                // yet, so the review refuses them and no row reaches here. When
-                // they are wired up they take a case of their own, in the order
-                // AgentEngineOrder already gives them.
+                case RunAutoDelayOperation delay:
+                    ran |= await RunAgentAutoDelayAsync(delay, summary);
+                    break;
+
+                // Auto-tune is not in AgentProtocol.Operations yet, so the review
+                // refuses it and no row reaches here. When it is wired up it
+                // takes a case of its own, in the order AgentEngineOrder already
+                // gives it.
                 default:
                     summary.Add(
                         $"{operation.Parameter}: skipped " +
@@ -319,6 +333,81 @@ public partial class VirtualCrossoverPanel
         return true;
     }
 
+    // The Auto delay inputs as the dialog would open with them: the project's
+    // figures as layout-neutral magnitudes (the layout toggle owns every sign),
+    // and the gain balance unticked — the project stores the tilt it would
+    // apply, never the opt-in. Printed in the package's "Current" column and
+    // filled in for every input a request leaves out, so the two agree.
+    private AgentAutoDelaySettings AgentAutoDelayDefaults() =>
+        new(
+            project.StereoSceneOffsetMagnitudeMs,
+            project.StereoRightHandDrive,
+            AdjustGains: false,
+            Math.Abs(project.StereoLevelDifferenceDb),
+            project.RearFillOffsetMs);
+
+    /// <summary>
+    /// The run inputs a request asks for: what it states, and the dialog's own
+    /// answer for what it leaves out. UI-free so the rule can be pinned.
+    /// </summary>
+    internal static AutoDelayRunRequest BuildAutoDelayRequest(
+        RunAutoDelayOperation operation, AgentAutoDelaySettings defaults) =>
+        new(
+            operation.SceneOffsetMs ?? defaults.SceneOffsetMs,
+            operation.RightHandDrive ?? defaults.RightHandDrive,
+            operation.AdjustGains ?? defaults.AdjustGains,
+            operation.NearSideCutDb ?? defaults.NearSideCutDb,
+            operation.RearFillOffsetMs ?? defaults.RearFillOffsetMs);
+
+    // Auto delay without its dialog: the button's own checks (headless, so a
+    // refusal is a phrase for the summary rather than a box), the same compute
+    // delegate the dialog's Run would call, and the same commit its Apply would
+    // make — report, log and outcome metric included. The review was the gate.
+    // The panel is disabled for the compute's span: the dialog's modality is
+    // what kept the channel configuration still under the button's run, and an
+    // edit landing mid-search would be aligned against a chain that is gone.
+    private async Task<bool> RunAgentAutoDelayAsync(
+        RunAutoDelayOperation operation, List<string> summary)
+    {
+        (AutoDelayLaunch? launch, string? refusal) = PrepareAutoDelay(interactive: false);
+        if (launch == null)
+        {
+            summary.Add($"Auto delay: skipped ({refusal}).");
+            return false;
+        }
+
+        AutoDelayRunRequest request = BuildAutoDelayRequest(operation, AgentAutoDelayDefaults());
+        AutoDelayRunResult result;
+        bool wasEnabled = Enabled;
+        Enabled = false;
+        UseWaitCursor = true;
+        try
+        {
+            result = await launch.Runner(request);
+        }
+        finally
+        {
+            UseWaitCursor = false;
+            Enabled = wasEnabled;
+        }
+        if (IsDisposed)
+        {
+            return false;
+        }
+
+        await ApplyConfirmedAutoDelayAsync(result);
+        summary.Add(
+            $"Auto delay: applied ({(launch.Stereo ? "stereo" : "single side")}, " +
+            $"scene {request.SceneOffsetMs:0.00} ms {(request.RightHandDrive ? "RHD" : "LHD")}, " +
+            $"gains {(request.AdjustGains ? "balanced" : "kept")}).");
+        if (launch.PolarityWarning != null)
+        {
+            summary.Add(launch.PolarityWarning);
+        }
+        summary.Add(result.ReportText);
+        return true;
+    }
+
     // Everything the import could move, before it moves any of it.
     private AgentImportUndo CaptureAgentUndo() =>
         new(
@@ -329,7 +418,11 @@ public partial class VirtualCrossoverPanel
                 .ToList(),
             project.SpatialAverageMode,
             checkBoxHybrid.Checked,
-            channels.ToList());
+            channels.ToList(),
+            project.StereoSceneOffsetMagnitudeMs,
+            project.StereoRightHandDrive,
+            project.StereoLevelDifferenceDb,
+            project.RearFillOffsetMs);
 
     private void UndoAiImport()
     {
@@ -357,6 +450,9 @@ public partial class VirtualCrossoverPanel
             project.SpatialAverageMode = undo.SpatialAverageMode;
             checkBoxHybrid.Checked = undo.HybridTicked;
             project.ShowHybridCurves = undo.HybridTicked;
+            project.SetStereoScene(undo.SceneOffsetMagnitudeMs, undo.RightHandDrive);
+            project.StereoLevelDifferenceDb = undo.StereoLevelDifferenceDb;
+            project.RearFillOffsetMs = undo.RearFillOffsetMs;
         }
         finally
         {
@@ -501,14 +597,7 @@ public partial class VirtualCrossoverPanel
             ProcessorSampleRateHz,
             ProcessorProfile.MaxDelayMs,
             lastAgentPackageId,
-            new AgentAutoDelaySettings(
-                project.StereoSceneOffsetMagnitudeMs,
-                project.StereoRightHandDrive,
-                // The dialog's gain balance opens unticked every time: the project
-                // stores the tilt it would apply, never the opt-in itself.
-                AdjustGains: false,
-                Math.Abs(project.StereoLevelDifferenceDb),
-                project.RearFillOffsetMs),
+            AgentAutoDelayDefaults(),
             SpatialAverageMode,
             checkBoxHybrid.Checked);
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -481,15 +481,12 @@ public partial class VirtualCrossoverPanel
             return false;
         }
 
-        // The datum is the project's, moved before the handoff is built so the
-        // token carries it — as the wizard's Return moves it on the way back.
-        if (operation.TargetLevelDb is { } level &&
-            !((double)numericTargetLevel.Value).Equals(level))
-        {
-            numericTargetLevel.Value = numericTargetLevel.ClampValue(level);
-        }
-
-        VirtualDspEqHandoffRequest? request = BuildPeqHandoffRequest(channel, withChain: true, average);
+        // A stated target level is built into the request (the token carries it)
+        // and reaches the panel only once the fit has landed — a run that skips
+        // itself must leave nothing behind, since the import's undo is dropped
+        // when nothing ran.
+        VirtualDspEqHandoffRequest? request = BuildPeqHandoffRequest(
+            channel, withChain: true, average, operation.TargetLevelDb);
         if (request == null)
         {
             summary.Add($"{label}: skipped (no measurement to fit against).");
@@ -557,6 +554,15 @@ public partial class VirtualCrossoverPanel
         // Landed the way the wizard's Return lands, against the capture the
         // request was built with — the reply may have asked for the point
         // measurement under a hybrid view, and the token says which it was.
+        // The datum the fit was built against becomes the project's now, as the
+        // wizard's Return moves it on the way back; the token carries the same
+        // value, which is what the landing checks.
+        decimal previousTargetLevel = numericTargetLevel.Value;
+        if (!((double)numericTargetLevel.Value).Equals(request.TargetLevelDb))
+        {
+            numericTargetLevel.Value = numericTargetLevel.ClampValue(request.TargetLevelDb);
+        }
+
         VirtualCrossoverChannelState state = channel.SideState(channel.ActiveRight);
         MagnitudeGateSnapshot snapshot = magnitudeGate;
         if (!VirtualDspEqHandoff.TryApplyReturn(
@@ -572,6 +578,8 @@ public partial class VirtualCrossoverPanel
                 average.Capture,
                 ProcessorSampleRateHz))
         {
+            // Nothing landed, so nothing of the request stays — the datum included.
+            numericTargetLevel.Value = previousTargetLevel;
             summary.Add($"{label}: skipped (the channel changed while the fit ran).");
             return false;
         }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -99,7 +99,9 @@ public partial class VirtualCrossoverPanel
         double SceneOffsetMagnitudeMs,
         bool RightHandDrive,
         double StereoLevelDifferenceDb,
-        double RearFillOffsetMs);
+        double RearFillOffsetMs,
+        // The datum an Auto-tune request may move, as the wizard's return does.
+        double TargetLevelDb);
 
     /// <summary>
     /// Import AI proposal: clipboard → strict parse → review against the live
@@ -276,10 +278,12 @@ public partial class VirtualCrossoverPanel
                     ran |= await RunAgentAutoDelayAsync(delay, summary);
                     break;
 
-                // Auto-tune is not in AgentProtocol.Operations yet, so the review
-                // refuses it and no row reaches here. When it is wired up it
-                // takes a case of its own, in the order AgentEngineOrder already
-                // gives it.
+                case AutoTunePeqOperation tune:
+                    ran |= await RunAgentAutoTuneAsync(tune, summary);
+                    break;
+
+                // Every operation the protocol names is executed above; one this
+                // build does not run never reaches here, the review refuses it.
                 default:
                     summary.Add(
                         $"{operation.Parameter}: skipped " +
@@ -408,6 +412,156 @@ public partial class VirtualCrossoverPanel
         return true;
     }
 
+    // Auto-tune without the wizard: the same handoff the PEQ menu would build
+    // for the channel, the same curves and options the wizard would fit
+    // (EqAutoTuneHeadless, pinned against the wizard's own render), and the
+    // same landing the wizard's Return takes — every guard included, so a
+    // channel that moved while the fit ran is refused rather than written.
+    // The review was the gate; the target-level check the wizard would have
+    // asked about is a refusal here, with the phrase in the summary.
+    private async Task<bool> RunAgentAutoTuneAsync(
+        AutoTunePeqOperation operation, List<string> summary)
+    {
+        string label = $"Auto-tune {operation.ChannelId}";
+        (VirtualCrossoverChannel Channel, bool RightSide)? slot = AgentChannelSlots()
+            .Where(item => string.Equals(
+                AgentChannelIds.Format(item.Block, item.Side), operation.ChannelId,
+                StringComparison.Ordinal))
+            .Select(item => ((VirtualCrossoverChannel, bool)?)(item.Channel, item.RightSide))
+            .FirstOrDefault();
+        if (slot is not { } found)
+        {
+            summary.Add($"{label}: skipped (no such channel).");
+            return false;
+        }
+
+        (VirtualCrossoverChannel channel, bool rightSide) = found;
+        // The handoff is built for the side on screen, as the PEQ menu builds it:
+        // the gate pin, the render anchor and the hybrid datum are that side's.
+        if (!channel.Pair.Mono && rightSide != channel.ActiveRight)
+        {
+            summary.Add(
+                $"{label}: skipped (the other side is on screen; switch the L/R " +
+                "selector and import again).");
+            return false;
+        }
+
+        // What the wizard would open on: the average while the hybrid view draws
+        // it, the point measurement otherwise — unless the reply chose.
+        (LiveCaptureDocument? Capture, double OffsetDb) average =
+            HandoffSpatialAverage(channel, channel.ActiveRight);
+        if (operation.Source == AgentProposalValidator.PointSource)
+        {
+            average = (null, 0.0);
+        }
+        else if (operation.Source == AgentProposalValidator.SpatialAverageSource &&
+            average.Capture == null)
+        {
+            summary.Add(
+                $"{label}: skipped (the hybrid view is not drawing this channel's " +
+                "spatial average; ask for useSpatialAverage first).");
+            return false;
+        }
+
+        // The datum is the project's, moved before the handoff is built so the
+        // token carries it — as the wizard's Return moves it on the way back.
+        if (operation.TargetLevelDb is { } level &&
+            !((double)numericTargetLevel.Value).Equals(level))
+        {
+            numericTargetLevel.Value = numericTargetLevel.ClampValue(level);
+        }
+
+        VirtualDspEqHandoffRequest? request = BuildPeqHandoffRequest(channel, withChain: true, average);
+        if (request == null)
+        {
+            summary.Add($"{label}: skipped (no measurement to fit against).");
+            return false;
+        }
+
+        VirtualCrossoverTargetSettings targetSettings =
+            project.Target ?? new VirtualCrossoverTargetSettings();
+        TargetCurveSpec spec = (targetCurve ?? targetSettings.ToCurve()).Normalized().Spec;
+        bool cutsOnly = operation.CutsOnly ?? true;
+        EqHeadlessTuneInputs inputs = EqAutoTuneHeadless.Prepare(
+            request, spec, operation.MinHz, operation.MaxHz,
+            operation.AllowShelves ?? false, cutsOnly);
+        string? levelWarning = EqTargetLevelCheck.Warning(
+            EqTargetLevelCheck.TargetAboveSourceDb(
+                inputs.Source, inputs.Target, inputs.MinHz, inputs.MaxHz),
+            cutsOnly, inputs.MinHz, inputs.MaxHz);
+        if (levelWarning != null)
+        {
+            summary.Add($"{label}: skipped ({levelWarning.Split('.')[0]}).");
+            return false;
+        }
+
+        double? before = EqAutoTuneHeadless.RmsErrorDb(
+            inputs.Source, inputs.Target, inputs.MinHz, inputs.MaxHz);
+        EqualizationCurve fitted;
+        double? after;
+        bool wasEnabled = Enabled;
+        Enabled = false;
+        UseWaitCursor = true;
+        try
+        {
+            (fitted, after) = await Task.Run(() =>
+            {
+                EqualizationCurve curve = EqAutoTuneHeadless.Fit(inputs);
+                // The corrected curve as the wizard's Source + EQ draws it: the
+                // bank in the chain, through the window or over the average.
+                IReadOnlyList<SignalPoint> corrected = EqAutoTuneHeadless.SourceCurve(
+                    request.Source, request.SmoothingInverseOctaves, curve);
+                return (curve, EqAutoTuneHeadless.RmsErrorDb(
+                    corrected, inputs.Target, inputs.MinHz, inputs.MaxHz));
+            });
+        }
+        finally
+        {
+            UseWaitCursor = false;
+            Enabled = wasEnabled;
+        }
+        if (IsDisposed)
+        {
+            return false;
+        }
+
+        // Landed the way the wizard's Return lands, against the capture the
+        // request was built with — the reply may have asked for the point
+        // measurement under a hybrid view, and the token says which it was.
+        VirtualCrossoverChannelState state = channel.SideState(channel.ActiveRight);
+        MagnitudeGateSnapshot snapshot = magnitudeGate;
+        if (!VirtualDspEqHandoff.TryApplyReturn(
+                channels,
+                request.Token,
+                fitted,
+                projectGeneration,
+                CalibrationFor(state),
+                SpatialAverageCalibrationFor(state),
+                snapshot.Template,
+                snapshot.PinnedOffsetMs,
+                (double)numericTargetLevel.Value,
+                average.Capture,
+                ProcessorSampleRateHz))
+        {
+            summary.Add($"{label}: skipped (the channel changed while the fit ran).");
+            return false;
+        }
+
+        channel.SideSettings(channel.ActiveRight).PeqSourceName = "Auto-tune (AI import)";
+        UpdatePeqReadouts(channel);
+        int fittedBands = fitted.Bands.Count(band => !band.Type.IsAllPass());
+        summary.Add(
+            $"{label}: applied — {fittedBands} band{(fittedBands == 1 ? "" : "s")}" +
+            (inputs.KeptAllPass.Count > 0 ? $" + {inputs.KeptAllPass.Count} all-pass kept" : string.Empty) +
+            $", preamp {fitted.PreampDb:0.0} dB, {inputs.MinHz:0}–{inputs.MaxHz:0} Hz, " +
+            $"{(cutsOnly ? "cuts only" : "cuts and boosts")}, on the " +
+            $"{(average.Capture != null ? "spatial average" : "point measurement")}; " +
+            $"RMS error {Rms(before)} -> {Rms(after)}.");
+        return true;
+
+        static string Rms(double? value) => value is { } rms ? $"{rms:0.0} dB" : "n/a";
+    }
+
     // Everything the import could move, before it moves any of it.
     private AgentImportUndo CaptureAgentUndo() =>
         new(
@@ -422,7 +576,8 @@ public partial class VirtualCrossoverPanel
             project.StereoSceneOffsetMagnitudeMs,
             project.StereoRightHandDrive,
             project.StereoLevelDifferenceDb,
-            project.RearFillOffsetMs);
+            project.RearFillOffsetMs,
+            (double)numericTargetLevel.Value);
 
     private void UndoAiImport()
     {
@@ -453,6 +608,7 @@ public partial class VirtualCrossoverPanel
             project.SetStereoScene(undo.SceneOffsetMagnitudeMs, undo.RightHandDrive);
             project.StereoLevelDifferenceDb = undo.StereoLevelDifferenceDb;
             project.RearFillOffsetMs = undo.RearFillOffsetMs;
+            numericTargetLevel.Value = numericTargetLevel.ClampValue(undo.TargetLevelDb);
         }
         finally
         {

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -77,16 +77,30 @@ public partial class VirtualCrossoverPanel
         DropDownMenu.ShowUnder(buttonAi, agentMenu);
     }
 
-    // What the last import wrote, for Undo, and the project generation it was
+    // What the last import moved, for Undo, and the project generation it was
     // written into: a session loaded since has different settings objects, and
     // the entries would restore into ones nobody displays.
-    private List<AgentUndoEntry>? agentUndo;
+    private AgentImportUndo? agentUndo;
     private long agentUndoGeneration;
+
+    /// <summary>
+    /// Everything one import can move, as it stood before it ran. Every channel's
+    /// chain is taken, not only the ones a row names: an engine writes channels no
+    /// row mentions, and the crossover wizard can reorder the blocks as well.
+    /// </summary>
+    private sealed record AgentImportUndo(
+        IReadOnlyList<AgentUndoEntry> Channels,
+        VirtualCrossoverSpatialAverageMode? SpatialAverageMode,
+        bool HybridTicked,
+        IReadOnlyList<VirtualCrossoverChannel> Order);
 
     /// <summary>
     /// Import AI proposal: clipboard → strict parse → review against the live
     /// settings → the dialog → a second review of the ticked rows against the
-    /// settings as they are at commit → one write, one save, one redraw.
+    /// settings as they are at commit → one write of the settings rows, then the
+    /// engine requests in their fixed order, then one summary. Undo is armed
+    /// before anything is written, so a failure part-way through still leaves the
+    /// whole import undoable.
     /// </summary>
     private void ImportAiProposal()
     {
@@ -97,6 +111,7 @@ public partial class VirtualCrossoverPanel
 
         agentBusy = true;
         RefreshAutoActionsEnabled();
+        var summary = new List<string>();
         try
         {
             if (!AgentClipboard.TryRead(out string? text, out string? error))
@@ -150,25 +165,57 @@ public partial class VirtualCrossoverPanel
                 return;
             }
 
-            List<AgentUndoEntry> undo = AgentProposalApplier.Apply(toApply);
-            RefreshChannelsAfterAgentWrite(undo);
+            // Armed BEFORE the first write, not after the last one: an engine can
+            // throw with the settings rows already in the tune, and an import the
+            // user cannot undo is the worst thing this menu could leave behind.
+            // The previous import's undo is put back only if nothing moved at all.
+            AgentImportUndo undo = CaptureAgentUndo();
+            AgentImportUndo? previousUndo = agentUndo;
+            long previousUndoGeneration = agentUndoGeneration;
             agentUndo = undo;
             agentUndoGeneration = projectGeneration;
+
+            List<AgentUndoEntry> written = AgentProposalApplier.Apply(toApply);
+            if (written.Count > 0)
+            {
+                RefreshChannelsAfterAgentWrite(written);
+                int proposed = review.Verdicts.Count;
+                int rows = toApply.Count(verdict => verdict.Operation is AgentSettingsOperation);
+                summary.Add(
+                    $"Applied {rows} of {proposed} proposed change{(proposed == 1 ? "" : "s")}.");
+            }
+
+            bool ran = RunAgentEngineRequests(toApply, summary);
+            if (written.Count == 0 && !ran)
+            {
+                agentUndo = previousUndo;
+                agentUndoGeneration = previousUndoGeneration;
+            }
+
             ScheduleSave();
             RedrawAll();
-
-            int proposed = review.Verdicts.Count;
             MessageBox.Show(
                 FindForm(),
-                $"Applied {toApply.Count} of {proposed} proposed change{(proposed == 1 ? "" : "s")}. " +
-                "Undo AI import is in the same menu.",
+                string.Join(Environment.NewLine, summary) + Environment.NewLine +
+                Environment.NewLine + "Undo AI import is in the same menu.",
                 "Import AI proposal",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Information);
         }
         catch (Exception exception) when (exception is not OutOfMemoryException)
         {
-            ShowError("The AI proposal was not imported.", exception.Message);
+            // What the summary already holds DID happen; saying "not imported"
+            // over it would send the reader looking for changes that are there.
+            ShowError(
+                summary.Count == 0
+                    ? "The AI proposal was not imported."
+                    : "The AI proposal was imported only in part.",
+                summary.Count == 0
+                    ? exception.Message
+                    : string.Join(Environment.NewLine, summary) + Environment.NewLine +
+                        Environment.NewLine + "Then it stopped: " + exception.Message +
+                        Environment.NewLine + Environment.NewLine +
+                        "Undo AI import puts the whole import back.");
         }
         finally
         {
@@ -176,6 +223,113 @@ public partial class VirtualCrossoverPanel
             RefreshAutoActionsEnabled();
         }
     }
+
+    /// <summary>
+    /// The engine requests of one import, in the fixed order an import runs them,
+    /// whatever order the reply listed: the spatial average first (it decides
+    /// which curves the rest read), then Auto crossover, then Auto delay, then
+    /// Auto-tune, which is last because it fits the bank to everything the others
+    /// left behind. The settings rows are already written by the time this runs.
+    /// Each engine keeps its own confirmation: cancelling one skips that
+    /// operation and the import carries on with the next.
+    /// </summary>
+    /// <returns>Whether any of them changed the project.</returns>
+    private bool RunAgentEngineRequests(
+        IReadOnlyList<AgentOperationVerdict> toApply, List<string> summary)
+    {
+        bool ran = false;
+        foreach (AgentOperation operation in toApply
+            .Where(verdict => verdict.Applicable)
+            .Select(verdict => verdict.Operation!)
+            .Where(operation => operation is not AgentSettingsOperation)
+            .OrderBy(AgentEngineOrder))
+        {
+            switch (operation)
+            {
+                case UseSpatialAverageOperation spatial:
+                    bool applied = ApplyAgentSpatialAverage(spatial);
+                    summary.Add(applied
+                        ? $"Spatial average: {spatial.Mode}, hybrid on."
+                        : $"Spatial average: skipped ('{spatial.Mode}' names no capture family).");
+                    ran |= applied;
+                    break;
+
+                case RunAutoCrossoverOperation:
+                    string? refused = OpenAutoSetupWizard();
+                    summary.Add(refused == null
+                        ? "Auto crossover: applied."
+                        : $"Auto crossover: skipped ({refused}).");
+                    ran |= refused == null;
+                    break;
+
+                // Auto delay and Auto-tune are not in AgentProtocol.Operations
+                // yet, so the review refuses them and no row reaches here. When
+                // they are wired up they take a case of their own, in the order
+                // AgentEngineOrder already gives them.
+                default:
+                    summary.Add(
+                        $"{operation.Parameter}: skipped " +
+                        "(not available in this version of Resonalyze).");
+                    break;
+            }
+        }
+
+        return ran;
+    }
+
+    private static int AgentEngineOrder(AgentOperation operation) => operation switch
+    {
+        UseSpatialAverageOperation => 0,
+        RunAutoCrossoverOperation => 1,
+        RunAutoDelayOperation => 2,
+        _ => 3
+    };
+
+    // The mode and the tick together: either one alone leaves the point
+    // measurement in charge, which is the thing the operation exists to fix. The
+    // panel's own project events are suppressed around the pair so the import
+    // saves and redraws once, at the end, rather than after each step.
+    /// <returns>Whether the mode named by the request is one the panel has.</returns>
+    private bool ApplyAgentSpatialAverage(UseSpatialAverageOperation operation)
+    {
+        // The review has already refused an unknown mode, so this is a guard, not
+        // a path — but the summary is written from the answer, so it must be one.
+        if (!AgentOperations.TryParseName(
+            operation.Mode, out VirtualCrossoverSpatialAverageMode mode))
+        {
+            return false;
+        }
+
+        bool suppressed = suppressProjectEvents;
+        suppressProjectEvents = true;
+        try
+        {
+            SetSpatialAverageMode(mode);
+            checkBoxHybrid.Checked = true;
+            project.ShowHybridCurves = true;
+        }
+        finally
+        {
+            suppressProjectEvents = suppressed;
+        }
+
+        // SetSpatialAverageMode returns early when the mode is already the one
+        // asked for, and the tick alone still changes what can be drawn.
+        RefreshHybridAvailability();
+        return true;
+    }
+
+    // Everything the import could move, before it moves any of it.
+    private AgentImportUndo CaptureAgentUndo() =>
+        new(
+            AgentChannelSlots()
+                .Select(slot => slot.Channel.SideSettings(slot.RightSide))
+                .Select(settings => new AgentUndoEntry(
+                    settings, AgentOperations.CloneEditable(settings)))
+                .ToList(),
+            project.SpatialAverageMode,
+            checkBoxHybrid.Checked,
+            channels.ToList());
 
     private void UndoAiImport()
     {
@@ -190,12 +344,50 @@ public partial class VirtualCrossoverPanel
             return;
         }
 
-        List<AgentUndoEntry> undo = agentUndo;
+        AgentImportUndo undo = agentUndo;
         agentUndo = null;
-        AgentProposalApplier.Restore(undo);
-        RefreshChannelsAfterAgentWrite(undo);
+        AgentProposalApplier.Restore(undo.Channels);
+        RefreshChannelsAfterAgentWrite(undo.Channels);
+        RestoreAgentChannelOrder(undo.Order);
+
+        bool suppressed = suppressProjectEvents;
+        suppressProjectEvents = true;
+        try
+        {
+            project.SpatialAverageMode = undo.SpatialAverageMode;
+            checkBoxHybrid.Checked = undo.HybridTicked;
+            project.ShowHybridCurves = undo.HybridTicked;
+        }
+        finally
+        {
+            suppressProjectEvents = suppressed;
+        }
+
+        foreach (VirtualCrossoverChannel channel in channels)
+        {
+            RefreshSpatialAverageStatus(channel);
+        }
+
+        RefreshHybridAvailability();
         ScheduleSave();
         RedrawAll();
+    }
+
+    // The Auto crossover wizard can reorder the blocks, and the block letters a
+    // reply used are that order. Restored by identity rather than by index: the
+    // list holds the same objects, in another arrangement.
+    private void RestoreAgentChannelOrder(IReadOnlyList<VirtualCrossoverChannel> order)
+    {
+        if (order.Count != channels.Count || order.SequenceEqual(channels))
+        {
+            return;
+        }
+
+        List<int> indices = order.Select(channel => channels.IndexOf(channel)).ToList();
+        if (indices.All(index => index >= 0))
+        {
+            ApplyChannelOrder(indices);
+        }
     }
 
     // The blocks whose settings an import (or its undo) wrote, refreshed the way
@@ -291,16 +483,34 @@ public partial class VirtualCrossoverPanel
         }
     }
 
-    /// <summary>The channels as the bridge names them, with their live settings.</summary>
+    /// <summary>
+    /// The channels as the bridge names them, with their live settings and what
+    /// each side carries, plus the project figures an engine request is judged
+    /// and described against.
+    /// </summary>
     internal AgentSessionSnapshot BuildAgentSessionSnapshot() =>
         new(
             AgentChannelSlots()
                 .Select(slot => new AgentChannelSnapshot(
-                    slot.Block, slot.Side, slot.Channel.SideSettings(slot.RightSide)))
+                    slot.Block,
+                    slot.Side,
+                    slot.Channel.SideSettings(slot.RightSide),
+                    slot.Channel.SideState(slot.RightSide).TransferImpulseResponse != null,
+                    AgentSpatialAverageCaptures(slot.Channel.SideState(slot.RightSide))))
                 .ToList(),
             ProcessorSampleRateHz,
             ProcessorProfile.MaxDelayMs,
-            lastAgentPackageId);
+            lastAgentPackageId,
+            new AgentAutoDelaySettings(
+                project.StereoSceneOffsetMagnitudeMs,
+                project.StereoRightHandDrive,
+                // The dialog's gain balance opens unticked every time: the project
+                // stores the tilt it would apply, never the opt-in itself.
+                AdjustGains: false,
+                Math.Abs(project.StereoLevelDifferenceDb),
+                project.RearFillOffsetMs),
+            SpatialAverageMode,
+            checkBoxHybrid.Checked);
 
     // Every physical channel in block order: a stereo block yields its left and
     // right slots, a mono block its single one (routed to the left slot, as the

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -2406,6 +2406,23 @@ public partial class VirtualCrossoverPanel : UserControl
             return;
         }
 
+        VirtualDspEqHandoffRequest? request = BuildPeqHandoffRequest(
+            channel, withChain, HandoffSpatialAverage(channel, channel.ActiveRight));
+        if (request != null)
+        {
+            requested(request);
+        }
+    }
+
+    // The handoff as the PEQ menu builds it, for the wizard or for an import
+    // that tunes without one: the ACTIVE side, the gate snapshot, the shared
+    // anchor of the current render, the target level the panel shows. Null when
+    // the channel side has no measurement to hand over.
+    private VirtualDspEqHandoffRequest? BuildPeqHandoffRequest(
+        VirtualCrossoverChannel channel,
+        bool withChain,
+        (LiveCaptureDocument? Capture, double OffsetDb) spatialAverage)
+    {
         MagnitudeGateSnapshot snapshot = magnitudeGate;
         // Only a render that still describes the CURRENT settings may place the
         // window: a delay or crossover edit invalidates the coordinator and queues a
@@ -2417,8 +2434,6 @@ public partial class VirtualCrossoverPanel : UserControl
             processingCoordinator.IsCurrent(render.Revision)
                 ? ProcessedChannels.SharedStartAnchorIndex(render.Channels)
                 : null;
-        (LiveCaptureDocument? Capture, double OffsetDb) spatialAverage =
-            HandoffSpatialAverage(channel, channel.ActiveRight);
         VirtualDspEqHandoffRequest request;
         try
         {
@@ -2457,10 +2472,10 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             // The measurement vanished between opening the menu and choosing — a
             // silent no-op, like a deleted history entry in the source picker.
-            return;
+            return null;
         }
 
-        requested(request);
+        return request;
     }
 
     /// <summary>

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -2421,7 +2421,10 @@ public partial class VirtualCrossoverPanel : UserControl
     private VirtualDspEqHandoffRequest? BuildPeqHandoffRequest(
         VirtualCrossoverChannel channel,
         bool withChain,
-        (LiveCaptureDocument? Capture, double OffsetDb) spatialAverage)
+        (LiveCaptureDocument? Capture, double OffsetDb) spatialAverage,
+        // An import may ask for another target level; it is built INTO the
+        // request, and written to the panel only once the fit has landed.
+        double? targetLevelDb = null)
     {
         MagnitudeGateSnapshot snapshot = magnitudeGate;
         // Only a render that still describes the CURRENT settings may place the
@@ -2446,7 +2449,7 @@ public partial class VirtualCrossoverPanel : UserControl
                 snapshot.PinnedOffsetMs,
                 renderAnchor,
                 CapturePhaseContext(channel),
-                (double)numericTargetLevel.Value,
+                targetLevelDb ?? (double)numericTargetLevel.Value,
                 (double)numericTargetLevel.Minimum,
                 (double)numericTargetLevel.Maximum,
                 snapshot.SmoothingInverseOctaves,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -4640,6 +4640,57 @@ public partial class VirtualCrossoverPanel : UserControl
     // every time.
     private async void AutoAlignDelay()
     {
+        (AutoDelayLaunch? launch, _) = PrepareAutoDelay(interactive: true);
+        if (launch == null)
+        {
+            return;
+        }
+
+        using var dialog = new VirtualCrossoverAutoDelayDialog();
+        // The dialog edits both tuning figures as layout-neutral magnitudes;
+        // the project stores each with the layout in its sign (the scene
+        // offset's wire format, the gain engine's L-R convention), so older
+        // builds read the same file — hence the magnitudes here and the
+        // layout-signed write-back in CommitAutoDelayResult.
+        dialog.Init(
+            launch.Stereo,
+            project.StereoSceneOffsetMagnitudeMs,
+            project.StereoRightHandDrive,
+            Math.Abs(project.StereoLevelDifferenceDb),
+            launch.Runner,
+            launch.PolarityWarning,
+            launch.HasRearFill,
+            project.RearFillOffsetMs);
+        if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
+            dialog.Result is not { } result ||
+            IsDisposed)
+        {
+            return;
+        }
+
+        await ApplyConfirmedAutoDelayAsync(result);
+    }
+
+    /// <summary>
+    /// An Auto delay run made ready but not started: which kind it is, the
+    /// compute delegate (run inputs -> proposal) over the participants the
+    /// checks admitted, and the two things the dialog shows beside the inputs.
+    /// The button hands it to the dialog; an AI import runs it straight away.
+    /// </summary>
+    private sealed record AutoDelayLaunch(
+        bool Stereo,
+        Func<AutoDelayRunRequest, Task<AutoDelayRunResult>> Runner,
+        string? PolarityWarning,
+        bool HasRearFill);
+
+    // Every check the button makes before its dialog opens, answered as a
+    // launch or a refusal. Interactive, the refusals speak on screen as they
+    // always did and the broad-window question is asked; headless (an AI
+    // import), nothing is shown and that question is a refusal too — the
+    // import's summary quotes the phrase, and the user sets the crossovers
+    // first, which is the answer the question was steering them to anyway.
+    private (AutoDelayLaunch? Launch, string? Refusal) PrepareAutoDelay(bool interactive)
+    {
         // Stereo whenever the data allows it: some non-mono pair has BOTH
         // sides resolved (the highest such pair becomes the L/R bridge) and
         // the left side can hold its own walk. Otherwise the classic
@@ -4658,20 +4709,19 @@ public partial class VirtualCrossoverPanel : UserControl
             .LastOrDefault();
         if (bridgeRight != null && leftSide.Count(InFrontChain) >= 2)
         {
-            await AutoAlignStereoAsync(leftSide, rightSide, bridgeRight);
-            return;
+            return PrepareStereoAutoDelay(leftSide, rightSide, bridgeRight, interactive);
         }
 
-        await AutoAlignSingleSideAsync();
+        return PrepareSingleSideAutoDelay(interactive);
     }
 
-    // The single-side Auto delay command: participant validation up front,
-    // then the modal Auto delay dialog. The proposal (delays, polarities and
+    // The single-side Auto delay run: participant validation up front, then
+    // the launch. From the button the proposal (delays, polarities and
     // optionally gains) is computed by the dialog's Run and written only on
-    // its Apply — Discard leaves every channel setting as it was. The
-    // dialog's modality is also what keeps the channel configuration stable
-    // under the background compute.
-    private async Task AutoAlignSingleSideAsync()
+    // its Apply — Discard leaves every channel setting as it was — and the
+    // dialog's modality is what keeps the channel configuration stable under
+    // the background compute; an import disables the panel for the same span.
+    private (AutoDelayLaunch? Launch, string? Refusal) PrepareSingleSideAutoDelay(bool interactive)
     {
         // Cheap participant snapshot: enabled channels with a resolved
         // measurement. No DSP runs here — the shared crop and every ApplyChain
@@ -4683,8 +4733,12 @@ public partial class VirtualCrossoverPanel : UserControl
             .ToList();
         if (participants.Count < 2)
         {
-            System.Media.SystemSounds.Beep.Play();
-            return;
+            if (interactive)
+            {
+                System.Media.SystemSounds.Beep.Play();
+            }
+
+            return (null, "fewer than two enabled channels have a measurement");
         }
 
         // A bypassed channel processes through the identity chain, so the
@@ -4698,19 +4752,24 @@ public partial class VirtualCrossoverPanel : UserControl
             .ToList();
         if (bypassed.Count > 0)
         {
-            ShowError(
-                "Auto delay cannot run with bypassed channels.",
-                "Bypass feeds the raw measured signal, so the computed delays " +
-                "and polarities would not apply to: " +
-                string.Join(", ", bypassed.Select(channel => channel.Name)) +
-                ".\r\n\r\nDisable Bypass on every participating channel " +
-                "(or mute the channel to exclude it) and run Auto delay again.");
-            return;
+            if (interactive)
+            {
+                ShowError(
+                    "Auto delay cannot run with bypassed channels.",
+                    "Bypass feeds the raw measured signal, so the computed delays " +
+                    "and polarities would not apply to: " +
+                    string.Join(", ", bypassed.Select(channel => channel.Name)) +
+                    ".\r\n\r\nDisable Bypass on every participating channel " +
+                    "(or mute the channel to exclude it) and run Auto delay again.");
+            }
+
+            return (null, "a participating channel is bypassed: " +
+                string.Join(", ", bypassed.Select(channel => channel.Name)));
         }
 
-        if (RefuseOnMisplacedGate("Auto delay"))
+        if (interactive ? RefuseOnMisplacedGate("Auto delay") : GateIsMisplaced)
         {
-            return;
+            return (null, "the phase gate is misplaced");
         }
 
         // Without crossovers the search falls back to a broad midband window and
@@ -4718,6 +4777,10 @@ public partial class VirtualCrossoverPanel : UserControl
         // only matters (and is only well-defined) in the overlap region.
         bool anyCrossover = participants.Any(
             channel => channel.Settings.CrossoverKind != CrossoverKind.Off);
+        if (!anyCrossover && !interactive)
+        {
+            return (null, "no channel has a crossover configured; set the crossovers first");
+        }
         if (!anyCrossover)
         {
             DialogResult answer = MessageBox.Show(
@@ -4735,33 +4798,21 @@ public partial class VirtualCrossoverPanel : UserControl
                 MessageBoxIcon.Warning);
             if (answer != DialogResult.Yes)
             {
-                return;
+                return (null, "cancelled");
             }
         }
 
         (double minHz, double maxHz) = VirtualCrossoverJunctions.GetCrossoverWindow(
             participants.Select(channel => channel.Settings));
 
-        using var dialog = new VirtualCrossoverAutoDelayDialog();
-        dialog.Init(
-            stereo: false,
-            project.StereoSceneOffsetMagnitudeMs,
-            project.StereoRightHandDrive,
-            Math.Abs(project.StereoLevelDifferenceDb),
-            request => RunSingleSideProposalAsync(
-                participants, minHz, maxHz, request),
-            polarityWarning: null,
-            hasRearFill: participants.Any(channel =>
-                channel.Pair.Zone == VirtualCrossoverZone.Rear),
-            project.RearFillOffsetMs);
-        if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
-            dialog.Result is not { } result ||
-            IsDisposed)
-        {
-            return;
-        }
-
-        await ApplyConfirmedAutoDelayAsync(result);
+        return (
+            new AutoDelayLaunch(
+                Stereo: false,
+                request => RunSingleSideProposalAsync(participants, minHz, maxHz, request),
+                PolarityWarning: null,
+                HasRearFill: participants.Any(channel =>
+                    channel.Pair.Zone == VirtualCrossoverZone.Rear)),
+            null);
     }
 
     // Compute errors surface inside the dialog; here the confirmed proposal
@@ -5925,10 +5976,11 @@ public partial class VirtualCrossoverPanel : UserControl
     // then the far side's descent — the cascade itself lives in
     // AutoAlignmentEngine.ComputeStereo (dsp, unit-tested on synthetic
     // systems and real car measurements), fed a mirrored plan for RHD.
-    private async Task AutoAlignStereoAsync(
+    private (AutoDelayLaunch? Launch, string? Refusal) PrepareStereoAutoDelay(
         List<VirtualCrossoverSideAlignmentChannel> leftSide,
         List<VirtualCrossoverSideAlignmentChannel> rightSide,
-        VirtualCrossoverSideAlignmentChannel bridgeRight)
+        VirtualCrossoverSideAlignmentChannel bridgeRight,
+        bool interactive)
     {
         List<VirtualCrossoverSideAlignmentChannel> union = leftSide.Concat(rightSide)
             .Distinct()
@@ -5943,26 +5995,35 @@ public partial class VirtualCrossoverPanel : UserControl
             .ToList();
         if (bypassed.Count > 0)
         {
-            ShowError(
-                "Auto delay cannot run with bypassed channels.",
-                "Bypass feeds the raw measured signal, so the computed delays " +
-                "and polarities would not apply to: " +
-                string.Join(", ", bypassed.Select(item => item.Name)) +
-                ".\r\n\r\nDisable Bypass on every participating channel " +
-                "(or mute the channel to exclude it) and run Auto delay again.");
-            return;
+            if (interactive)
+            {
+                ShowError(
+                    "Auto delay cannot run with bypassed channels.",
+                    "Bypass feeds the raw measured signal, so the computed delays " +
+                    "and polarities would not apply to: " +
+                    string.Join(", ", bypassed.Select(item => item.Name)) +
+                    ".\r\n\r\nDisable Bypass on every participating channel " +
+                    "(or mute the channel to exclude it) and run Auto delay again.");
+            }
+
+            return (null, "a participating channel is bypassed: " +
+                string.Join(", ", bypassed.Select(item => item.Name)));
         }
 
         // The verdict describes the side on screen; the detail text says so and
         // asks for the other one to be checked after switching, because only
         // the shown side's channels have been processed to judge it against.
-        if (RefuseOnMisplacedGate("Auto delay"))
+        if (interactive ? RefuseOnMisplacedGate("Auto delay") : GateIsMisplaced)
         {
-            return;
+            return (null, "the phase gate is misplaced");
         }
 
         bool anyCrossover = union.Any(
             item => item.Settings.CrossoverKind != CrossoverKind.Off);
+        if (!anyCrossover && !interactive)
+        {
+            return (null, "no channel has a crossover configured; set the crossovers first");
+        }
         if (!anyCrossover)
         {
             DialogResult answer = MessageBox.Show(
@@ -5980,7 +6041,7 @@ public partial class VirtualCrossoverPanel : UserControl
                 MessageBoxIcon.Warning);
             if (answer != DialogResult.Yes)
             {
-                return;
+                return (null, "cancelled");
             }
         }
 
@@ -6000,41 +6061,29 @@ public partial class VirtualCrossoverPanel : UserControl
         if (bridgeBandHighHz <
             bridgeBandLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
         {
-            ShowError(
-                "The stereo bridge has no usable shared band.",
-                $"The top pair's crossover bands barely overlap: " +
-                $"{bridgeLeft.Name} plays {leftBandLowHz:0}-{leftBandHighHz:0} Hz, " +
-                $"{bridgeRight.Name} plays {rightBandLowHz:0}-{rightBandHighHz:0} Hz. " +
-                "Align the pair's crossover settings so the sides share at " +
-                "least a third of an octave and run Auto delay again.");
-            return;
+            if (interactive)
+            {
+                ShowError(
+                    "The stereo bridge has no usable shared band.",
+                    $"The top pair's crossover bands barely overlap: " +
+                    $"{bridgeLeft.Name} plays {leftBandLowHz:0}-{leftBandHighHz:0} Hz, " +
+                    $"{bridgeRight.Name} plays {rightBandLowHz:0}-{rightBandHighHz:0} Hz. " +
+                    "Align the pair's crossover settings so the sides share at " +
+                    "least a third of an octave and run Auto delay again.");
+            }
+
+            return (null, "the stereo bridge has no usable shared band");
         }
 
-        using var dialog = new VirtualCrossoverAutoDelayDialog();
-        // The dialog edits both tuning figures as layout-neutral magnitudes;
-        // the project stores each with the layout in its sign (the scene
-        // offset's wire format, the gain engine's L-R convention), so older
-        // builds read the same file — hence the magnitudes here and the
-        // layout-signed write-back in CommitAutoDelayResult.
-        dialog.Init(
-            stereo: true,
-            project.StereoSceneOffsetMagnitudeMs,
-            project.StereoRightHandDrive,
-            Math.Abs(project.StereoLevelDifferenceDb),
-            request => RunStereoProposalAsync(
-                leftSide, rightSide, union, bridgeLeft, bridgeRight,
-                bridgeBandLowHz, bridgeBandHighHz, request),
-            DescribeLeftRightPolarityMismatch(leftSide, rightSide),
-            union.Any(side => side.Runtime.Pair.Zone == VirtualCrossoverZone.Rear),
-            project.RearFillOffsetMs);
-        if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
-            dialog.Result is not { } result ||
-            IsDisposed)
-        {
-            return;
-        }
-
-        await ApplyConfirmedAutoDelayAsync(result);
+        return (
+            new AutoDelayLaunch(
+                Stereo: true,
+                request => RunStereoProposalAsync(
+                    leftSide, rightSide, union, bridgeLeft, bridgeRight,
+                    bridgeBandLowHz, bridgeBandHighHz, request),
+                DescribeLeftRightPolarityMismatch(leftSide, rightSide),
+                union.Any(side => side.Runtime.Pair.Zone == VirtualCrossoverZone.Rear)),
+            null);
     }
 
     // A launch-time red heads-up for the Auto delay dialog when a driver's LEFT
@@ -7193,6 +7242,10 @@ public partial class VirtualCrossoverPanel : UserControl
     // sum-loss read-out and (for Auto delay) the outcome metric written into
     // the alignment log — so a run started here can only be verified against a
     // view of the reverberant tail.
+    // The verdict a refusal is built on, readable without showing anything —
+    // an AI import quotes the phrase in its summary instead of a dialog.
+    private bool GateIsMisplaced => gatePlacement is { CutsChannels: true };
+
     private bool RefuseOnMisplacedGate(string command)
     {
         if (gatePlacement is not { CutsChannels: true } verdict)

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -7948,12 +7948,19 @@ public partial class VirtualCrossoverPanel : UserControl
 
     // ----------------------------------------------------------------- wizard
 
-    // The crossover wizard: detects each channel's usable band and driver type
-    // from the raw magnitude, lets the user confirm the types, and writes the
-    // analytic proposal (LR24 splits, cut-only gains) into the channels. Delay
-    // and polarity stay untouched — that is Auto delay's job, done against the
-    // complex sum afterward.
-    private void OpenAutoSetupWizard()
+    /// <summary>
+    /// The crossover wizard: detects each channel's usable band and driver type
+    /// from the raw magnitude, lets the user confirm the types, and writes the
+    /// analytic proposal (LR24 splits, cut-only gains) into the channels. Delay
+    /// and polarity stay untouched — that is Auto delay's job, done against the
+    /// complex sum afterward.
+    /// </summary>
+    /// <returns>
+    /// Null when the proposal was written; otherwise why it was not, in a phrase
+    /// an import's summary can quote. The button ignores it: every refusal has
+    /// already said its piece on screen.
+    /// </returns>
+    private string? OpenAutoSetupWizard()
     {
         var participating = channels
             .Where(channel => channel.Pair.Enabled &&
@@ -7962,7 +7969,7 @@ public partial class VirtualCrossoverPanel : UserControl
         if (participating.Count < 2)
         {
             System.Media.SystemSounds.Beep.Play();
-            return;
+            return "fewer than two enabled channels have a measurement";
         }
 
         // The band read below is gate-independent (it windows each raw response
@@ -7971,7 +7978,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // misplaced window still has to be dealt with before the wizard runs.
         if (RefuseOnMisplacedGate("Auto crossover"))
         {
-            return;
+            return "the phase gate is misplaced";
         }
 
         // Band/type detection reads the raw (unprocessed) responses with a fixed
@@ -8035,7 +8042,7 @@ public partial class VirtualCrossoverPanel : UserControl
         catch (ArgumentException exception)
         {
             ShowError("A channel's response has no usable band.", exception.Message);
-            return;
+            return "a channel's response has no usable band";
         }
 
         using var dialog = new VirtualCrossoverAutoSetupDialog();
@@ -8046,7 +8053,7 @@ public partial class VirtualCrossoverPanel : UserControl
         if (dialog.ShowDialog(FindForm()) != DialogResult.OK ||
             dialog.Result is not { } proposals)
         {
-            return;
+            return "cancelled in the wizard";
         }
 
         for (int i = 0; i < participating.Count; i++)
@@ -8091,6 +8098,7 @@ public partial class VirtualCrossoverPanel : UserControl
 
         ScheduleSave();
         RedrawAll();
+        return null;
     }
 
     /// <summary>

--- a/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
@@ -371,8 +371,7 @@ public sealed class AgentPackageBuilderTests
         Assert.Contains("useSpatialAverage", operations);
         Assert.Contains("runAutoCrossover", operations);
         Assert.Contains("runAutoDelay", operations);
-        // The protocol describes this one; this build reviews it and refuses.
-        Assert.DoesNotContain("autoTunePeq", operations);
+        Assert.Contains("autoTunePeq", operations);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
@@ -370,8 +370,8 @@ public sealed class AgentPackageBuilderTests
         Assert.Equal(AgentProtocol.Operations, operations);
         Assert.Contains("useSpatialAverage", operations);
         Assert.Contains("runAutoCrossover", operations);
-        // The protocol describes these two; this build reviews them and refuses.
-        Assert.DoesNotContain("runAutoDelay", operations);
+        Assert.Contains("runAutoDelay", operations);
+        // The protocol describes this one; this build reviews it and refuses.
         Assert.DoesNotContain("autoTunePeq", operations);
     }
 

--- a/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
@@ -360,6 +360,22 @@ public sealed class AgentPackageBuilderTests
     }
 
     [Fact]
+    public void Limits_NameTheOperationsThisBuildCanRun()
+    {
+        JsonElement limits = Json(AgentPackageBuilder.Build(Inputs(), Id, Clock).Text!).GetProperty("limits");
+
+        string[] operations = limits.GetProperty("operations")
+            .EnumerateArray().Select(operation => operation.GetString()!).ToArray();
+
+        Assert.Equal(AgentProtocol.Operations, operations);
+        Assert.Contains("useSpatialAverage", operations);
+        Assert.Contains("runAutoCrossover", operations);
+        // The protocol describes these two; this build reviews them and refuses.
+        Assert.DoesNotContain("runAutoDelay", operations);
+        Assert.DoesNotContain("autoTunePeq", operations);
+    }
+
+    [Fact]
     public void Limits_RestateWhatTheProjectValidatorEnforces()
     {
         JsonElement limits = Json(AgentPackageBuilder.Build(Inputs(), Id, Clock).Text!).GetProperty("limits");

--- a/tests/Resonalyze.App.Tests/AgentProposalApplierTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalApplierTests.cs
@@ -161,11 +161,14 @@ public sealed class AgentProposalApplierTests
         };
         var session = new AgentSessionSnapshot(
             [
-                new AgentChannelSnapshot("A", AgentChannelSide.Left, aLeft),
-                new AgentChannelSnapshot("A", AgentChannelSide.Right, aRight),
-                new AgentChannelSnapshot("B", AgentChannelSide.Left, bLeft)
+                new AgentChannelSnapshot("A", AgentChannelSide.Left, aLeft, true, []),
+                new AgentChannelSnapshot("A", AgentChannelSide.Right, aRight, true, []),
+                new AgentChannelSnapshot("B", AgentChannelSide.Left, bLeft, true, [])
             ],
-            96_000, 50, null);
+            96_000, 50, null,
+            new AgentAutoDelaySettings(0.25, RightHandDrive: false, AdjustGains: false, 1.0, 15.0),
+            VirtualCrossoverSpatialAverageMode.MovingMic,
+            HybridTicked: false);
         var proposal = new AgentProposal(null, "summary", [], [],
             [
                 new SetGainOperation("op-1", "A:right", "level", -2.0, -3.0),

--- a/tests/Resonalyze.App.Tests/AgentProposalDialogTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalDialogTests.cs
@@ -86,7 +86,72 @@ public sealed class AgentProposalDialogTests
         });
     }
 
+    [Fact]
+    public void AnEngineRow_NamesTheWholeProject_AndCarriesWhatTheEngineWouldWriteOver()
+    {
+        StaTest.Run(() =>
+        {
+            using var dialog = new AgentProposalDialog(EngineReview());
+            DataGridView grid = Grid(dialog);
+
+            Assert.Equal(AgentProposalValidator.AllChannels, grid.Rows[0].Cells[1].Value);
+            Assert.Equal("Auto crossover", grid.Rows[0].Cells[2].Value);
+            Assert.Equal("Warning", grid.Rows[0].Cells[5].Value);
+            Assert.Equal(true, grid.Rows[0].Cells[0].Value);
+            Assert.Contains("can reorder the chain", grid.Rows[0].Cells[5].ToolTipText);
+
+            // Current and Proposed are 170 px wide and an engine states its whole
+            // set of inputs there, so both have to be readable off the row and
+            // off the detail box rather than only clipped into the cell.
+            Assert.Equal(
+                "the corners, slopes and gains as they stand", grid.Rows[0].Cells[3].ToolTipText);
+            Assert.Equal(
+                "the wizard's corners, slopes and cut-only gains",
+                grid.Rows[0].Cells[4].ToolTipText);
+            grid.ClearSelection();
+            grid.Rows[0].Selected = true;
+            string detail = ((TextBox)dialog.Controls["textBoxDetail"]!).Text;
+            Assert.Contains("Current: the corners, slopes and gains as they stand", detail);
+            Assert.Contains("Proposed: the wizard's corners", detail);
+
+            // The hand-written corner the wizard would erase is listed, greyed.
+            Assert.Equal(false, grid.Rows[1].Cells[0].Value);
+            Assert.Equal("Rejected", grid.Rows[1].Cells[5].Value);
+            Assert.Equal(["op-1"], dialog.Selected.Select(verdict => verdict.Id));
+        });
+    }
+
     private static DataGridView Grid(Form dialog) => (DataGridView)dialog.Controls["gridView"]!;
+
+    private static AgentProposalReview EngineReview()
+    {
+        var bLeft = new VirtualCrossoverChannelSettings
+        {
+            CrossoverKind = CrossoverKind.BandPass,
+            HighPassEdge = new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 250, 24),
+            LowPassEdge = new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 2800, 24)
+        };
+        var session = new AgentSessionSnapshot(
+            [new AgentChannelSnapshot("B", AgentChannelSide.Left, bLeft, true, [])],
+            96_000, 10, null,
+            new AgentAutoDelaySettings(0.25, RightHandDrive: false, AdjustGains: false, 1.0, 15.0),
+            VirtualCrossoverSpatialAverageMode.MovingMic,
+            HybridTicked: false);
+        var proposal = new AgentProposal(
+            null, "The corners are guesses.", [], [],
+            [
+                new RunAutoCrossoverOperation("op-1", "let the wizard split them"),
+                new SetCrossoverOperation("op-2", "B:left", "lower the top",
+                    new AgentCrossover("BandPass",
+                        new AgentCrossoverEdge("LinkwitzRiley", 250, 24, null),
+                        new AgentCrossoverEdge("LinkwitzRiley", 2800, 24, null)),
+                    new AgentCrossover("BandPass",
+                        new AgentCrossoverEdge("LinkwitzRiley", 250, 24, null),
+                        new AgentCrossoverEdge("LinkwitzRiley", 2600, 24, null)))
+            ],
+            []);
+        return AgentProposalValidator.Review(proposal, session);
+    }
 
     private static AgentProposalReview Review()
     {
@@ -99,10 +164,13 @@ public sealed class AgentProposalDialogTests
         };
         var session = new AgentSessionSnapshot(
             [
-                new AgentChannelSnapshot("A", AgentChannelSide.Right, aRight),
-                new AgentChannelSnapshot("B", AgentChannelSide.Left, bLeft)
+                new AgentChannelSnapshot("A", AgentChannelSide.Right, aRight, true, []),
+                new AgentChannelSnapshot("B", AgentChannelSide.Left, bLeft, true, [])
             ],
-            96_000, 10, "11111111-1111-1111-1111-111111111111");
+            96_000, 10, "11111111-1111-1111-1111-111111111111",
+            new AgentAutoDelaySettings(0.25, RightHandDrive: false, AdjustGains: false, 1.0, 15.0),
+            VirtualCrossoverSpatialAverageMode.MovingMic,
+            HybridTicked: false);
         var proposal = new AgentProposal(
             "22222222-2222-2222-2222-222222222222",
             "The left mid/tweeter junction cancels near 3.1 kHz.",

--- a/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
@@ -40,6 +40,106 @@ public sealed class AgentProposalParserTests
         }
         """;
 
+
+    private const string FourEngines = """
+        {
+          "kind": "resonalyze.agent-proposal",
+          "protocolVersion": 1,
+          "summary": "Let the engines do the arithmetic.",
+          "operations": [
+            { "id": "op-1", "op": "useSpatialAverage", "mode": "MicArray", "hybrid": true, "reason": "Arrays are attached but unused." },
+            { "id": "op-2", "op": "runAutoCrossover", "reason": "The corners are guesses." },
+            { "id": "op-3", "op": "runAutoDelay", "sceneOffsetMs": 0.25, "rightHandDrive": false, "adjustGains": true, "nearSideCutDb": 1.5, "reason": "Realign after the flip." },
+            { "id": "op-4", "op": "autoTunePeq", "channelId": "B:left", "targetLevelDb": -6, "minHz": 100, "maxHz": 8000, "allowShelves": true, "cutsOnly": false, "source": "spatialAverage", "reason": "Fit the door." }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void Parse_ReadsTheFourEngineRequests_AndLeavesTheirOmittedInputsNull()
+    {
+        AgentProposalParseResult result = AgentProposalParser.Parse(Begin + FourEngines + End);
+
+        Assert.True(result.Succeeded, result.Error);
+        AgentProposal proposal = result.Proposal!;
+        Assert.Empty(proposal.Rejected);
+        Assert.Collection(proposal.Operations,
+            operation =>
+            {
+                var spatial = Assert.IsType<UseSpatialAverageOperation>(operation);
+                Assert.Equal("useSpatialAverage", spatial.Op);
+                Assert.Equal("Spatial average", spatial.Parameter);
+                Assert.Equal("MicArray", spatial.Mode);
+                Assert.True(spatial.Hybrid);
+            },
+            operation =>
+            {
+                var crossover = Assert.IsType<RunAutoCrossoverOperation>(operation);
+                Assert.Equal("runAutoCrossover", crossover.Op);
+                Assert.Equal("The corners are guesses.", crossover.Reason);
+            },
+            operation =>
+            {
+                var delay = Assert.IsType<RunAutoDelayOperation>(operation);
+                Assert.Equal(0.25, delay.SceneOffsetMs);
+                Assert.False(delay.RightHandDrive);
+                Assert.True(delay.AdjustGains);
+                Assert.Equal(1.5, delay.NearSideCutDb);
+                // Not stated is not zero: the panel's own value stands.
+                Assert.Null(delay.RearFillOffsetMs);
+            },
+            operation =>
+            {
+                var tune = Assert.IsType<AutoTunePeqOperation>(operation);
+                Assert.Equal("B:left", tune.ChannelId);
+                Assert.Equal(-6, tune.TargetLevelDb);
+                Assert.Equal(100, tune.MinHz);
+                Assert.Equal(8000, tune.MaxHz);
+                Assert.True(tune.AllowShelves);
+                Assert.False(tune.CutsOnly);
+                Assert.Equal("spatialAverage", tune.Source);
+            });
+
+        // The two whole-project engines carry no channel at all, by their type.
+        Assert.Equal(
+            ["B:left"],
+            proposal.Operations.OfType<AgentChannelOperation>().Select(operation => operation.ChannelId));
+    }
+
+    [Theory]
+    [InlineData("\"op\": \"runAutoCrossover\"", "\"op\": \"runAutoCrossover\", \"channelId\": \"B:left\"", "op-2")]
+    [InlineData("\"op\": \"autoTunePeq\", \"channelId\": \"B:left\"", "\"op\": \"autoTunePeq\"", "op-4")]
+    [InlineData("\"mode\": \"MicArray\", ", "", "op-1")]
+    [InlineData("\"hybrid\": true", "\"hybrid\": \"true\"", "op-1")]
+    [InlineData("\"sceneOffsetMs\": 0.25", "\"sceneOffsetMs\": \"0.25\"", "op-3")]
+    // `required` only demands the member be PRESENT; a null passes the reader.
+    [InlineData("\"channelId\": \"B:left\"", "\"channelId\": null", "op-4")]
+    [InlineData("\"mode\": \"MicArray\"", "\"mode\": null", "op-1")]
+    [InlineData("\"hybrid\": true", "\"hybrid\": null", "op-1")]
+    public void Parse_RefusesAnEngineRequestThatIsNotTheShapeTheProtocolDescribes(
+        string from, string to, string id)
+    {
+        string json = FourEngines.Replace(from, to);
+
+        AgentProposal proposal = AgentProposalParser.Parse(Begin + json + End).Proposal!;
+
+        Assert.Equal(id, Assert.Single(proposal.Rejected).Id);
+        Assert.Equal(3, proposal.Operations.Count);
+    }
+
+    [Fact]
+    public void Parse_RefusesAnEngineRequestWhoseModeIsBlank()
+    {
+        // Length and emptiness are the parser's business; whether the mode NAMES
+        // a capture family the session has is the validator's.
+        string json = FourEngines.Replace("\"mode\": \"MicArray\"", "\"mode\": \"   \"");
+
+        AgentProposal proposal = AgentProposalParser.Parse(Begin + json + End).Proposal!;
+
+        Assert.Equal("op-1", Assert.Single(proposal.Rejected).Id);
+        Assert.Contains("spatial average mode is missing", proposal.Rejected[0].Problem);
+    }
+
     [Fact]
     public void Parse_ReadsAllFiveOperationsOutOfAReplyWithProseAroundTheBlock()
     {

--- a/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
@@ -569,7 +569,7 @@ public sealed class AgentProposalValidatorTests
     [InlineData("D:mono", null, null, null, null, "has no measurement")]
     [InlineData("B:left", 90.0, null, null, null, "The target level must be between -120 and 60 dB")]
     [InlineData("B:left", null, 8000.0, 100.0, null, "lower edge must sit below its upper edge")]
-    [InlineData("B:left", null, 100.0, 60_000.0, null, "upper edge must sit above 0 Hz and below")]
+    [InlineData("B:left", null, 100.0, 60_000.0, null, "upper edge must sit between 20 Hz and 20000 Hz")]
     [InlineData("B:left", null, null, null, "hybrid", "Unknown auto-tune source 'hybrid'")]
     [InlineData("B:left", null, null, null, "spatialAverage", "carries no spatial average")]
     public void Review_HoldsAnAutoTuneRequestToTheChannelAndTheWizardsFields(
@@ -701,6 +701,38 @@ public sealed class AgentProposalValidatorTests
 
         Assert.True(verdict.Applicable);
         Assert.Equal("0 bands, preamp 0.0 dB", verdict.Proposed);
+    }
+
+    [Fact]
+    public void Review_HoldsTheAutoTuneWindowToTheWizardsFields_AsTheRunWillUseIt()
+    {
+        // B:left plays 250..2800 Hz. A lower edge stated above the passband's
+        // upper would be a window the run cannot fit; an edge past the From/To
+        // fields' 20 Hz..20 kHz is one the wizard could never hold; a window
+        // inside both is fine, with either edge left to the passband.
+        AgentProposal proposal = Proposal(
+            new AutoTunePeqOperation("op-1", "B:left", "", null, 3_000, null, null, null, null),
+            new AutoTunePeqOperation("op-2", "A:left", "", null, 5, null, null, null, null),
+            new AutoTunePeqOperation("op-3", "C:mono", "", null, null, 40_000, null, null, null),
+            new AutoTunePeqOperation("op-4", "B:right", "", null, 400, null, null, null, null));
+
+        AgentProposalReview review = AgentProposalValidator.Review(
+            proposal, Session() with { ActiveSideRight = false });
+
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[0].Status);
+        Assert.Contains("would be 3000 Hz to 2800 Hz", review.Verdicts[0].Message);
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[1].Status);
+        Assert.Contains("between 20 Hz and 20000 Hz", review.Verdicts[1].Message);
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[2].Status);
+        Assert.Contains("between 20 Hz and 20000 Hz", review.Verdicts[2].Message);
+        // The other side is refused before its window is read.
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[3].Status);
+        Assert.Contains("side not on screen", review.Verdicts[3].Message);
+
+        AgentProposalReview inside = AgentProposalValidator.Review(
+            Proposal(new AutoTunePeqOperation("op-1", "B:left", "", null, 400, null, null, null, null)),
+            Session());
+        Assert.True(inside.Verdicts[0].Applicable);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
@@ -501,8 +501,10 @@ public sealed class AgentProposalValidatorTests
             },
             v =>
             {
-                Assert.Equal(AgentVerdictStatus.Rejected, v.Status);
-                Assert.Contains("not available in this version of Resonalyze", v.Message);
+                Assert.Equal(AgentVerdictStatus.Warning, v.Status);
+                Assert.True(v.Applicable);
+                Assert.Contains("rewrites the delay and polarity", v.Message);
+                Assert.Contains("without its dialog", v.Message);
                 Assert.Equal("scene 0.25 ms LHD, gains off, rear fill 15.00 ms", v.Current);
                 Assert.Equal("scene 0.35 ms LHD, gains off, rear fill 15.00 ms", v.Proposed);
             },
@@ -520,7 +522,7 @@ public sealed class AgentProposalValidatorTests
         // The list the package publishes is the list the review holds a reply to.
         Assert.Equal(
             ["setGainDb", "setDelayMs", "setPolarity", "setCrossover", "replacePeqBank",
-                "useSpatialAverage", "runAutoCrossover"],
+                "useSpatialAverage", "runAutoCrossover", "runAutoDelay"],
             AgentProtocol.Operations);
     }
 
@@ -648,16 +650,21 @@ public sealed class AgentProposalValidatorTests
     [Fact]
     public void Review_LeavesHandWrittenRowsAloneWhenTheEngineThatWouldEraseThemCannotRun()
     {
+        // Auto-tune is the engine this build does not run yet: its request is
+        // refused, so the bank it would have replaced stays a live row.
+        AgentSessionSnapshot session = Session();
+        AgentChannelSnapshot bLeft = session.Find("B:left")!;
+        string hash = AgentPeqHash.Compute(bLeft.Settings.PeqPreampDb, bLeft.Settings.PeqBands);
         AgentProposal proposal = Proposal(
-            new RunAutoDelayOperation("op-1", "", null, null, null, null, null),
-            new SetDelayOperation("op-2", "A:right", "", 1.42, 1.37),
-            new SetPolarityOperation("op-3", "B:left", "", false, true));
+            new AutoTunePeqOperation("op-1", "B:left", "", null, null, null, null, null, null),
+            new ReplacePeqBankOperation("op-2", "B:left", "", hash,
+                new AgentPeqBank(0, [new AgentPeqBand("Peaking", 820, 2.1, -2.4)])));
 
-        AgentProposalReview review = AgentProposalValidator.Review(proposal, Session());
+        AgentProposalReview review = AgentProposalValidator.Review(proposal, session);
 
         Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[0].Status);
+        Assert.Contains("not available in this version of Resonalyze", review.Verdicts[0].Message);
         Assert.True(review.Verdicts[1].Applicable);
-        Assert.True(review.Verdicts[2].Applicable);
     }
 
     [Theory]

--- a/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
@@ -510,8 +510,10 @@ public sealed class AgentProposalValidatorTests
             },
             v =>
             {
-                Assert.Equal(AgentVerdictStatus.Rejected, v.Status);
-                Assert.Contains("not available in this version of Resonalyze", v.Message);
+                Assert.Equal(AgentVerdictStatus.Warning, v.Status);
+                Assert.True(v.Applicable);
+                Assert.Contains("replaces this channel's whole PEQ bank", v.Message);
+                Assert.Contains("without the EQ Wizard", v.Message);
                 Assert.Equal("B left", v.ChannelLabel);
                 Assert.Equal("2 bands, preamp 0.0 dB", v.Current);
                 Assert.Equal(
@@ -522,7 +524,7 @@ public sealed class AgentProposalValidatorTests
         // The list the package publishes is the list the review holds a reply to.
         Assert.Equal(
             ["setGainDb", "setDelayMs", "setPolarity", "setCrossover", "replacePeqBank",
-                "useSpatialAverage", "runAutoCrossover", "runAutoDelay"],
+                "useSpatialAverage", "runAutoCrossover", "runAutoDelay", "autoTunePeq"],
             AgentProtocol.Operations);
     }
 
@@ -648,10 +650,8 @@ public sealed class AgentProposalValidatorTests
     }
 
     [Fact]
-    public void Review_LeavesHandWrittenRowsAloneWhenTheEngineThatWouldEraseThemCannotRun()
+    public void Review_RejectsTheBankAnAutoTuneOnTheSameChannelWouldReplace()
     {
-        // Auto-tune is the engine this build does not run yet: its request is
-        // refused, so the bank it would have replaced stays a live row.
         AgentSessionSnapshot session = Session();
         AgentChannelSnapshot bLeft = session.Find("B:left")!;
         string hash = AgentPeqHash.Compute(bLeft.Settings.PeqPreampDb, bLeft.Settings.PeqBands);
@@ -662,9 +662,9 @@ public sealed class AgentProposalValidatorTests
 
         AgentProposalReview review = AgentProposalValidator.Review(proposal, session);
 
-        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[0].Status);
-        Assert.Contains("not available in this version of Resonalyze", review.Verdicts[0].Message);
-        Assert.True(review.Verdicts[1].Applicable);
+        Assert.True(review.Verdicts[0].Applicable);
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[1].Status);
+        Assert.Equal("Would be overwritten by Auto-tune (op-1).", review.Verdicts[1].Message);
     }
 
     [Theory]

--- a/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
@@ -667,6 +667,42 @@ public sealed class AgentProposalValidatorTests
         Assert.Equal("Would be overwritten by Auto-tune (op-1).", review.Verdicts[1].Message);
     }
 
+    [Fact]
+    public void Review_RefusesAnAutoTuneForTheSideNotOnScreen()
+    {
+        // The fit is built on the handoff the PEQ menu would build, and that is
+        // the side on screen's: its gate pin, its anchor, its hybrid datum.
+        AgentProposal proposal = Proposal(
+            new AutoTunePeqOperation("op-1", "B:left", "", null, null, null, null, null, null),
+            new AutoTunePeqOperation("op-2", "A:right", "", null, null, null, null, null, null));
+
+        AgentProposalReview left = AgentProposalValidator.Review(proposal, Session());
+        Assert.True(left.Verdicts[0].Applicable);
+        Assert.Equal(AgentVerdictStatus.Rejected, left.Verdicts[1].Status);
+        Assert.Contains("side not on screen", left.Verdicts[1].Message);
+
+        AgentProposalReview right = AgentProposalValidator.Review(
+            proposal, Session() with { ActiveSideRight = true });
+        Assert.Equal(AgentVerdictStatus.Rejected, right.Verdicts[0].Status);
+        Assert.True(right.Verdicts[1].Applicable);
+    }
+
+    [Fact]
+    public void Review_TakesAnEmptyBank_AsTheWayToClearAChannelsPeq()
+    {
+        AgentSessionSnapshot session = Session();
+        AgentChannelSnapshot bLeft = session.Find("B:left")!;
+        string hash = AgentPeqHash.Compute(bLeft.Settings.PeqPreampDb, bLeft.Settings.PeqBands);
+        AgentProposal proposal = Proposal(
+            new ReplacePeqBankOperation("op-1", "B:left", "", hash, new AgentPeqBank(0, [])));
+
+        AgentOperationVerdict verdict = Assert.Single(
+            AgentProposalValidator.Review(proposal, session).Verdicts);
+
+        Assert.True(verdict.Applicable);
+        Assert.Equal("0 bands, preamp 0.0 dB", verdict.Proposed);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
@@ -703,6 +703,30 @@ public sealed class AgentProposalValidatorTests
         Assert.Equal("0 bands, preamp 0.0 dB", verdict.Proposed);
     }
 
+    [Fact]
+    public void Review_RefusesAutoTunesThatDisagreeAboutTheProjectsTargetLevel()
+    {
+        // The target level is one datum for the project: two fits at two levels
+        // would leave the first bank tuned against a level the project no
+        // longer holds. The first stated level stands; a request that states
+        // none, or the same, is fine.
+        AgentProposal proposal = Proposal(
+            new AutoTunePeqOperation("op-1", "B:left", "", -6, null, null, null, null, null),
+            new AutoTunePeqOperation("op-2", "A:left", "", -8, null, null, null, null, null),
+            new AutoTunePeqOperation("op-3", "C:mono", "", -6, null, null, null, null, null),
+            new AutoTunePeqOperation("op-4", "A:left", "", null, null, null, null, null, null));
+
+        AgentProposalReview review = AgentProposalValidator.Review(proposal, Session());
+
+        Assert.True(review.Verdicts[0].Applicable);
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[1].Status);
+        Assert.Contains("op-1 already states -6.0 dB", review.Verdicts[1].Message);
+        Assert.True(review.Verdicts[2].Applicable);
+        // op-4 repeats op-2's channel: refused as a repeat, not for its level.
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[3].Status);
+        Assert.Contains("Already requested by op-2", review.Verdicts[3].Message);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Windows.Forms;
 using Resonalyze.Dsp;
 using Resonalyze.Integration.AgentBridge;
 
@@ -204,7 +206,7 @@ public sealed class AgentProposalValidatorTests
         Assert.Contains("needs its lowPass edge", review.Verdicts[1].Message);
 
         var copy = AgentOperations.CloneEditable(session.Find("B:left")!.Settings);
-        AgentOperations.Apply(review.Verdicts[0].Operation!, copy);
+        AgentOperations.Apply((AgentSettingsOperation)review.Verdicts[0].Operation!, copy);
         Assert.Equal(CrossoverKind.HighPass, copy.CrossoverKind);
         Assert.Equal(new CrossoverEdge(CrossoverFilterFamily.Bessel, 300, 18, 1.0), copy.HighPassEdge);
         Assert.Equal(new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 2800, 24), copy.LowPassEdge);
@@ -260,7 +262,7 @@ public sealed class AgentProposalValidatorTests
         Assert.Contains("PEQ preamp is invalid", review.Verdicts[5].Message);
 
         var copy = AgentOperations.CloneEditable(bLeft.Settings);
-        AgentOperations.Apply(review.Verdicts[4].Operation!, copy);
+        AgentOperations.Apply((AgentSettingsOperation)review.Verdicts[4].Operation!, copy);
         Assert.Equal(0.8, copy.PeqBands[1].Q);
         Assert.Equal(PeqBandType.AllPassSecondOrder, copy.PeqBands[1].Type);
     }
@@ -468,8 +470,328 @@ public sealed class AgentProposalValidatorTests
         Assert.Equal(-2.0, session.Find("A:right")!.Settings.GainDb);
     }
 
+
+    [Fact]
+    public void Review_TakesTheEngineRequestsThisBuildRuns_AndRefusesTheOnesItDoesNot()
+    {
+        AgentProposal proposal = Proposal(
+            new UseSpatialAverageOperation("op-1", "the averages are attached", "MicArray", true),
+            new RunAutoCrossoverOperation("op-2", "the corners are guesses"),
+            new RunAutoDelayOperation("op-3", "realign after the flip", 0.35, null, null, null, null),
+            new AutoTunePeqOperation("op-4", "B:left", "fit the door", -6, 100, 8000, true, false, "point"));
+
+        AgentProposalReview review = AgentProposalValidator.Review(
+            proposal, Session(captures: ["MicArray"]));
+
+        Assert.Collection(review.Verdicts,
+            v =>
+            {
+                Assert.Equal(AgentVerdictStatus.Valid, v.Status);
+                Assert.Equal(AgentProposalValidator.AllChannels, v.ChannelLabel);
+                Assert.Equal("Spatial average", v.Parameter);
+                Assert.Equal("Off, hybrid off", v.Current);
+                Assert.Equal("MicArray, hybrid on", v.Proposed);
+            },
+            v =>
+            {
+                Assert.Equal(AgentVerdictStatus.Warning, v.Status);
+                Assert.Equal(AgentProposalValidator.AllChannels, v.ChannelLabel);
+                Assert.Contains("rewrites the crossover and the gain", v.Message);
+                Assert.True(v.Applicable);
+            },
+            v =>
+            {
+                Assert.Equal(AgentVerdictStatus.Rejected, v.Status);
+                Assert.Contains("not available in this version of Resonalyze", v.Message);
+                Assert.Equal("scene 0.25 ms LHD, gains off, rear fill 15.00 ms", v.Current);
+                Assert.Equal("scene 0.35 ms LHD, gains off, rear fill 15.00 ms", v.Proposed);
+            },
+            v =>
+            {
+                Assert.Equal(AgentVerdictStatus.Rejected, v.Status);
+                Assert.Contains("not available in this version of Resonalyze", v.Message);
+                Assert.Equal("B left", v.ChannelLabel);
+                Assert.Equal("2 bands, preamp 0.0 dB", v.Current);
+                Assert.Equal(
+                    "auto-tune 100 Hz to 8000 Hz, target -6.0 dB, shelves allowed, " +
+                    "cuts and boosts, from the point measurement", v.Proposed);
+            });
+
+        // The list the package publishes is the list the review holds a reply to.
+        Assert.Equal(
+            ["setGainDb", "setDelayMs", "setPolarity", "setCrossover", "replacePeqBank",
+                "useSpatialAverage", "runAutoCrossover"],
+            AgentProtocol.Operations);
+    }
+
+    [Fact]
+    public void Review_DescribesAnAutoDelayRunAgainstTheProjectsOwnFigures()
+    {
+        AgentProposal proposal = Proposal(
+            new RunAutoDelayOperation("op-1", "", null, true, true, 2.0, 12.5));
+
+        AgentOperationVerdict verdict = AgentProposalValidator.Review(
+            proposal, Session(adjustGains: false)).Verdicts[0];
+
+        // What it leaves out is what the dialog would open with; the near-side
+        // cut appears only on the side of the line where the balance is on.
+        Assert.Equal("scene 0.25 ms LHD, gains off, rear fill 15.00 ms", verdict.Current);
+        Assert.Equal(
+            "scene 0.25 ms RHD, gains on, near-side cut 2.0 dB, rear fill 12.50 ms",
+            verdict.Proposed);
+    }
+
+    [Theory]
+    [InlineData(6.0, null, null, "The scene offset must be between 0.00 and 5.00 ms")]
+    [InlineData(0.255, null, null, "The scene offset must be a multiple of 0.01 ms")]
+    [InlineData(null, 7.0, null, "The near-side cut must be between 0.0 and 6.0 dB")]
+    [InlineData(null, 1.25, null, "The near-side cut must be a multiple of 0.1 dB")]
+    [InlineData(null, null, 45.0, "The rear fill offset must be between 0.0 and 30.0 ms")]
+    public void Review_HoldsAnAutoDelayRequestToTheDialogsOwnFields(
+        double? sceneOffsetMs, double? nearSideCutDb, double? rearFillOffsetMs, string words)
+    {
+        AgentProposal proposal = Proposal(new RunAutoDelayOperation(
+            "op-1", "", sceneOffsetMs, null, null, nearSideCutDb, rearFillOffsetMs));
+
+        AgentOperationVerdict verdict = AgentProposalValidator.Review(proposal, Session()).Verdicts[0];
+
+        Assert.Equal(AgentVerdictStatus.Rejected, verdict.Status);
+        // The value is wrong on its own terms, so that is what the row says —
+        // not that the engine happens to be unavailable in this build.
+        Assert.Contains(words, verdict.Message);
+    }
+
+    [Theory]
+    [InlineData("D:mono", null, null, null, null, "has no measurement")]
+    [InlineData("B:left", 90.0, null, null, null, "The target level must be between -120 and 60 dB")]
+    [InlineData("B:left", null, 8000.0, 100.0, null, "lower edge must sit below its upper edge")]
+    [InlineData("B:left", null, 100.0, 60_000.0, null, "upper edge must sit above 0 Hz and below")]
+    [InlineData("B:left", null, null, null, "hybrid", "Unknown auto-tune source 'hybrid'")]
+    [InlineData("B:left", null, null, null, "spatialAverage", "carries no spatial average")]
+    public void Review_HoldsAnAutoTuneRequestToTheChannelAndTheWizardsFields(
+        string channelId, double? targetLevelDb, double? minHz, double? maxHz, string? source, string words)
+    {
+        AgentProposal proposal = Proposal(new AutoTunePeqOperation(
+            "op-1", channelId, "", targetLevelDb, minHz, maxHz, null, null, source));
+
+        AgentOperationVerdict verdict = AgentProposalValidator.Review(proposal, Session()).Verdicts[0];
+
+        Assert.Equal(AgentVerdictStatus.Rejected, verdict.Status);
+        Assert.Contains(words, verdict.Message);
+    }
+
+    [Theory]
+    [InlineData("MicArray", true, VirtualCrossoverSpatialAverageMode.Off, false, "MovingMic", "No channel in this session carries a MicArray capture")]
+    [InlineData("MovingMic", false, VirtualCrossoverSpatialAverageMode.Off, false, "MovingMic", "nothing to do")]
+    [InlineData("Off", true, VirtualCrossoverSpatialAverageMode.Off, false, "MovingMic", "Unknown spatial average mode 'Off'")]
+    [InlineData("movingmic", true, VirtualCrossoverSpatialAverageMode.Off, false, "MovingMic", "Unknown spatial average mode 'movingmic'")]
+    [InlineData("MovingMic", true, VirtualCrossoverSpatialAverageMode.MovingMic, true, "MovingMic", "No change.")]
+    public void Review_HoldsASpatialAverageRequestToWhatTheSessionCarries(
+        string mode,
+        bool hybrid,
+        VirtualCrossoverSpatialAverageMode current,
+        bool hybridTicked,
+        string capture,
+        string words)
+    {
+        AgentProposal proposal = Proposal(new UseSpatialAverageOperation("op-1", "", mode, hybrid));
+
+        AgentOperationVerdict verdict = AgentProposalValidator.Review(
+            proposal,
+            Session(spatialAverageMode: current, hybridTicked: hybridTicked, captures: [capture]))
+            .Verdicts[0];
+
+        Assert.Equal(AgentVerdictStatus.Rejected, verdict.Status);
+        Assert.Contains(words, verdict.Message);
+    }
+
+    [Fact]
+    public void Review_AcceptsTheHybridTickAloneWhenTheModeIsAlreadyTheOneAsked()
+    {
+        AgentProposal proposal = Proposal(
+            new UseSpatialAverageOperation("op-1", "", "MovingMic", true));
+
+        AgentOperationVerdict verdict = AgentProposalValidator.Review(
+            proposal,
+            Session(
+                spatialAverageMode: VirtualCrossoverSpatialAverageMode.MovingMic,
+                hybridTicked: false,
+                captures: ["MovingMic"]))
+            .Verdicts[0];
+
+        Assert.True(verdict.Applicable);
+        Assert.Equal("MovingMic, hybrid off", verdict.Current);
+        Assert.Equal("MovingMic, hybrid on", verdict.Proposed);
+    }
+
+    [Fact]
+    public void Review_RefusesAHandWrittenValueTheRequestedEngineWouldWriteOver()
+    {
+        AgentProposal proposal = Proposal(
+            new RunAutoCrossoverOperation("op-1", "let the wizard split them"),
+            new SetCrossoverOperation("op-2", "B:left", "",
+                Crossover("BandPass", Edge("LinkwitzRiley", 250, 24), Edge("LinkwitzRiley", 2800, 24)),
+                Crossover("BandPass", Edge("LinkwitzRiley", 250, 24), Edge("LinkwitzRiley", 2600, 24))),
+            new SetGainOperation("op-3", "A:right", "", -2.0, -2.6),
+            new SetDelayOperation("op-4", "A:right", "", 1.42, 1.37));
+
+        AgentProposalReview review = AgentProposalValidator.Review(proposal, Session());
+
+        Assert.True(review.Verdicts[0].Applicable);
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[1].Status);
+        Assert.Equal("Would be overwritten by Auto crossover (op-1).", review.Verdicts[1].Message);
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[2].Status);
+        // The wizard leaves delay and polarity alone; that is Auto delay's work.
+        Assert.True(review.Verdicts[3].Applicable);
+    }
+
+    [Fact]
+    public void Review_LeavesHandWrittenRowsAloneWhenTheEngineThatWouldEraseThemCannotRun()
+    {
+        AgentProposal proposal = Proposal(
+            new RunAutoDelayOperation("op-1", "", null, null, null, null, null),
+            new SetDelayOperation("op-2", "A:right", "", 1.42, 1.37),
+            new SetPolarityOperation("op-3", "B:left", "", false, true));
+
+        AgentProposalReview review = AgentProposalValidator.Review(proposal, Session());
+
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[0].Status);
+        Assert.True(review.Verdicts[1].Applicable);
+        Assert.True(review.Verdicts[2].Applicable);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Overwrites_ReadsWhatEachEngineActuallyWrites(bool projectAdjustsGains)
+    {
+        AgentSessionSnapshot session = Session(adjustGains: projectAdjustsGains);
+        var autoDelay = new RunAutoDelayOperation("op-1", "", null, null, null, null, null);
+        var autoCrossover = new RunAutoCrossoverOperation("op-2", "");
+        var autoTune = new AutoTunePeqOperation("op-3", "B:left", "", null, null, null, null, null, null);
+        var gain = new SetGainOperation("op-4", "A:right", "", -2.0, -2.6);
+        var delay = new SetDelayOperation("op-5", "A:right", "", 1.42, 1.37);
+        var polarity = new SetPolarityOperation("op-6", "B:left", "", false, true);
+        var crossover = new SetCrossoverOperation("op-7", "B:left", "",
+            Crossover("BandPass", Edge("LinkwitzRiley", 250, 24), Edge("LinkwitzRiley", 2800, 24)),
+            Crossover("BandPass", Edge("LinkwitzRiley", 250, 24), Edge("LinkwitzRiley", 2600, 24)));
+        var bank = new ReplacePeqBankOperation("op-8", "B:left", "", "hash",
+            new AgentPeqBank(0, [new AgentPeqBand("Peaking", 820, 2.1, -2.4)]));
+        var otherBank = new ReplacePeqBankOperation("op-9", "A:right", "", "hash",
+            new AgentPeqBank(0, [new AgentPeqBand("Peaking", 820, 2.1, -2.4)]));
+
+        Assert.True(AgentProposalValidator.Overwrites(autoDelay, delay, session));
+        Assert.True(AgentProposalValidator.Overwrites(autoDelay, polarity, session));
+        Assert.False(AgentProposalValidator.Overwrites(autoDelay, crossover, session));
+        // The gain balance is an opt-in, and a run that does not ask for it
+        // leaves a hand-written trim standing.
+        Assert.Equal(projectAdjustsGains, AgentProposalValidator.Overwrites(autoDelay, gain, session));
+        Assert.True(AgentProposalValidator.Overwrites(
+            autoDelay with { AdjustGains = true }, gain, session));
+        Assert.False(AgentProposalValidator.Overwrites(
+            autoDelay with { AdjustGains = false }, gain, session));
+
+        Assert.True(AgentProposalValidator.Overwrites(autoCrossover, crossover, session));
+        Assert.True(AgentProposalValidator.Overwrites(autoCrossover, gain, session));
+        Assert.False(AgentProposalValidator.Overwrites(autoCrossover, delay, session));
+
+        // Auto-tune reaches one channel's bank, and only that one.
+        Assert.True(AgentProposalValidator.Overwrites(autoTune, bank, session));
+        Assert.False(AgentProposalValidator.Overwrites(autoTune, otherBank, session));
+        Assert.False(AgentProposalValidator.Overwrites(autoTune, crossover, session));
+    }
+
+    [Fact]
+    public void Review_ReadsTheFinalStateOffTheRowsThatSurvive_NotTheOnesItRefused()
+    {
+        AgentSessionSnapshot session = Session();
+        AgentChannelSnapshot bLeft = session.Find("B:left")!;
+        // B left runs LR24 250-2800. The bell at 1350 Hz sits in the junction zone
+        // of the PROPOSED 2600 Hz corner (an octave below it) and outside the zone
+        // of the 2800 Hz corner the channel actually keeps.
+        AgentProposal proposal = Proposal(
+            new RunAutoCrossoverOperation("op-1", "let the wizard split them"),
+            new SetCrossoverOperation("op-2", "B:left", "",
+                Crossover("BandPass", Edge("LinkwitzRiley", 250, 24), Edge("LinkwitzRiley", 2800, 24)),
+                Crossover("BandPass", Edge("LinkwitzRiley", 250, 24), Edge("LinkwitzRiley", 2600, 24))),
+            new ReplacePeqBankOperation("op-3", "B:left", "door",
+                AgentPeqHash.Compute(bLeft.Settings.PeqPreampDb, bLeft.Settings.PeqBands),
+                new AgentPeqBank(0, [new AgentPeqBand("Peaking", 1350, 3, -3)])));
+
+        AgentProposalReview review = AgentProposalValidator.Review(proposal, session);
+
+        // The crossover row is refused, so it moves no corner — and the bank must
+        // not be judged against a corner that is not going to be there.
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[1].Status);
+        Assert.True(review.Verdicts[2].Applicable);
+        Assert.DoesNotContain("junction zone", review.Verdicts[2].Message);
+        Assert.Equal(AgentProposalValidator.DeviceLimitsUnknown, review.Verdicts[2].Message);
+    }
+
+    [Fact]
+    public void Review_RefusesASecondRequestForTheSameEngine_KeepingTheFirst()
+    {
+        AgentProposal proposal = Proposal(
+            new RunAutoCrossoverOperation("op-1", "split them"),
+            new RunAutoCrossoverOperation("op-2", "split them again"));
+
+        AgentProposalReview review = AgentProposalValidator.Review(proposal, Session());
+
+        Assert.True(review.Verdicts[0].Applicable);
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[1].Status);
+        Assert.Contains("Already requested by op-1", review.Verdicts[1].Message);
+    }
+
+    [Fact]
+    public void EngineInputLimits_MatchTheFieldsTheyWouldBeTypedInto()
+    {
+        // Same reason as the gain and delay pin above: the validator restates
+        // these ranges rather than reading them off a control it cannot see.
+        StaTest.Run(() =>
+        {
+            using var dialog = new VirtualCrossoverAutoDelayDialog();
+            AssertField(dialog, "numericSceneOffset",
+                AgentProposalValidator.MinimumSceneOffsetMs,
+                AgentProposalValidator.MaximumSceneOffsetMs,
+                AgentProposalValidator.SceneOffsetStepMs);
+            AssertField(dialog, "numericNearSideCut",
+                AgentProposalValidator.MinimumNearSideCutDb,
+                AgentProposalValidator.MaximumNearSideCutDb,
+                AgentProposalValidator.NearSideCutStepDb);
+            AssertField(dialog, "numericRearFill",
+                AgentProposalValidator.MinimumRearFillOffsetMs,
+                AgentProposalValidator.MaximumRearFillOffsetMs,
+                AgentProposalValidator.RearFillOffsetStepMs);
+
+            using var panel = new VirtualCrossoverPanel();
+            AssertField(panel, "numericTargetLevel",
+                AgentProposalValidator.MinimumTargetLevelDb,
+                AgentProposalValidator.MaximumTargetLevelDb,
+                AgentProposalValidator.TargetLevelStepDb);
+        });
+    }
+
+    // A field's step is its decimal places: the arrows' Increment is a
+    // convenience, the places are what a typed value is rounded to.
+    private static void AssertField(
+        Control owner, string name, double minimum, double maximum, double step)
+    {
+        var field = (DarkNumericUpDown)owner.GetType()
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(owner)!;
+        Assert.Equal((decimal)minimum, field.Minimum);
+        Assert.Equal((decimal)maximum, field.Maximum);
+        Assert.Equal(step, Math.Pow(10, -field.DecimalPlaces), 12);
+    }
+
     private static AgentSessionSnapshot Session(
-        int processorRateHz = 96_000, double maxDelayMs = 50, string? lastPackageId = Package)
+        int processorRateHz = 96_000,
+        double maxDelayMs = 50,
+        string? lastPackageId = Package,
+        VirtualCrossoverSpatialAverageMode spatialAverageMode = VirtualCrossoverSpatialAverageMode.Off,
+        bool hybridTicked = false,
+        bool adjustGains = false,
+        IReadOnlyList<string>? captures = null)
     {
         var aLeft = new VirtualCrossoverChannelSettings { GainDb = 0, DelayMs = 0 };
         var aRight = new VirtualCrossoverChannelSettings { GainDb = -2.0, DelayMs = 1.42 };
@@ -482,17 +804,24 @@ public sealed class AgentProposalValidatorTests
         };
         var bRight = new VirtualCrossoverChannelSettings();
         var cMono = new VirtualCrossoverChannelSettings { CrossoverKind = CrossoverKind.LowPass };
+        var dMono = new VirtualCrossoverChannelSettings();
         return new AgentSessionSnapshot(
             [
-                new AgentChannelSnapshot("A", AgentChannelSide.Left, aLeft),
-                new AgentChannelSnapshot("A", AgentChannelSide.Right, aRight),
-                new AgentChannelSnapshot("B", AgentChannelSide.Left, bLeft),
-                new AgentChannelSnapshot("B", AgentChannelSide.Right, bRight),
-                new AgentChannelSnapshot("C", AgentChannelSide.Mono, cMono)
+                new AgentChannelSnapshot("A", AgentChannelSide.Left, aLeft, true, captures ?? []),
+                new AgentChannelSnapshot("A", AgentChannelSide.Right, aRight, true, captures ?? []),
+                new AgentChannelSnapshot("B", AgentChannelSide.Left, bLeft, true, captures ?? []),
+                new AgentChannelSnapshot("B", AgentChannelSide.Right, bRight, true, captures ?? []),
+                new AgentChannelSnapshot("C", AgentChannelSide.Mono, cMono, true, captures ?? []),
+                // The block a source was never resolved for: an engine asked to
+                // fit it has nothing to read.
+                new AgentChannelSnapshot("D", AgentChannelSide.Mono, dMono, false, [])
             ],
             processorRateHz,
             maxDelayMs,
-            lastPackageId);
+            lastPackageId,
+            new AgentAutoDelaySettings(0.25, RightHandDrive: false, adjustGains, 1.0, 15.0),
+            spatialAverageMode,
+            hybridTicked);
     }
 
     private static AgentProposal Proposal(params AgentOperation[] operations) =>

--- a/tests/Resonalyze.App.Tests/EqAutoTuneHeadlessTests.cs
+++ b/tests/Resonalyze.App.Tests/EqAutoTuneHeadlessTests.cs
@@ -67,7 +67,7 @@ public sealed class EqAutoTuneHeadlessTests
         VirtualDspEqHandoffRequest request = Build(channel);
 
         EqHeadlessTuneInputs inputs = EqAutoTuneHeadless.Prepare(
-            request, TargetCurveSpec.FromPreset(TargetPreset.Flat), null, null,
+            request, TargetCurveSpec.FromPreset(TargetPreset.Flat), EqAutoTunePolicy.Default, null, null,
             allowShelves: false, cutsOnly: true);
 
         PeqBand kept = Assert.Single(inputs.KeptAllPass);
@@ -100,7 +100,7 @@ public sealed class EqAutoTuneHeadlessTests
         // Cuts only: the auto preamp may use the field's whole range, the net
         // gain is capped at 0 dB.
         EqAutoTuner.Options cuts = EqAutoTuneHeadless.Prepare(
-            request, target, null, null, allowShelves: false, cutsOnly: true).Options;
+            request, target, EqAutoTunePolicy.Default, null, null, allowShelves: false, cutsOnly: true).Options;
         Assert.True(cuts.CutsOnlyMode);
         Assert.Equal(-EqAutoTuneHeadless.PreampRangeDb, cuts.PreampMinDb);
         Assert.Equal(EqAutoTuneHeadless.PreampRangeDb, cuts.PreampMaxDb);
@@ -119,7 +119,7 @@ public sealed class EqAutoTuneHeadlessTests
         // Boosts allowed: the preamp is the user's and stays where the bank had
         // it; the reply's window and shelves are honoured.
         EqAutoTuner.Options boosts = EqAutoTuneHeadless.Prepare(
-            request, target, 100, 3_000, allowShelves: true, cutsOnly: false).Options;
+            request, target, EqAutoTunePolicy.Default, 100, 3_000, allowShelves: true, cutsOnly: false).Options;
         Assert.False(boosts.CutsOnlyMode);
         Assert.Equal(-2.5, boosts.PreampMinDb);
         Assert.Equal(-2.5, boosts.PreampMaxDb);
@@ -130,21 +130,59 @@ public sealed class EqAutoTuneHeadlessTests
     }
 
     [Fact]
-    public void Prepare_ClampsTheWindowLikeTheFromToFields()
+    public void Prepare_TakesTheWindowAsStated_AndOnlyHoldsItToTheFieldsRange()
     {
         VirtualDspEqHandoffRequest request = Build(BuildChannel());
         TargetCurveSpec target = TargetCurveSpec.FromPreset(TargetPreset.Flat);
 
-        // Inverted edges are ordered; edges past the fields' range are clamped.
-        EqHeadlessTuneInputs swapped = EqAutoTuneHeadless.Prepare(
-            request, target, 5_000, 300, allowShelves: false, cutsOnly: true);
-        Assert.Equal(300, swapped.MinHz);
-        Assert.Equal(5_000, swapped.MaxHz);
+        // Inverted edges are NOT reordered: the review confirmed a lower and an
+        // upper edge, and a run that swapped them would fit a window nobody
+        // ticked. The pair reads as unusable instead.
+        EqHeadlessTuneInputs inverted = EqAutoTuneHeadless.Prepare(
+            request, target, EqAutoTunePolicy.Default, 5_000, 300, allowShelves: false, cutsOnly: true);
+        Assert.Equal(5_000, inverted.MinHz);
+        Assert.Equal(300, inverted.MaxHz);
+        Assert.False(EqAutoTuneHeadless.IsUsableWindow(inverted.MinHz, inverted.MaxHz));
+        Assert.True(EqAutoTuneHeadless.IsUsableWindow(300, 5_000));
+        Assert.False(EqAutoTuneHeadless.IsUsableWindow(300, 300.5));
 
         EqHeadlessTuneInputs wide = EqAutoTuneHeadless.Prepare(
-            request, target, 5, 40_000, allowShelves: false, cutsOnly: true);
+            request, target, EqAutoTunePolicy.Default, 5, 40_000, allowShelves: false, cutsOnly: true);
         Assert.Equal(EqAutoTuneHeadless.WindowMinHz, wide.MinHz);
         Assert.Equal(EqAutoTuneHeadless.WindowMaxHz, wide.MaxHz);
+    }
+
+    [Fact]
+    public void Prepare_FitsWithTheWizardsCurrentSettings_UnlessTheReplyStatesItsOwn()
+    {
+        // The wizard's controls as the user left them — Max Filters 8, Max Q 3.5,
+        // cuts down to -10 dB, boosts allowed, shelves on — reach the tuner the
+        // way CreateAutoTuneOptions would hand them; the reply overrides only
+        // what it states.
+        VirtualDspEqHandoffRequest request = Build(BuildChannel());
+        TargetCurveSpec target = TargetCurveSpec.FromPreset(TargetPreset.Flat);
+        var policy = new EqAutoTunePolicy(8, -10, 4, 3.5, CutsOnly: false, AllowShelves: true);
+
+        EqAutoTuner.Options asWizard = EqAutoTuneHeadless.Prepare(
+            request, target, policy, null, null, allowShelves: null, cutsOnly: null).Options;
+        Assert.Equal(8, asWizard.MaxBands);
+        Assert.Equal(-10, asWizard.BandGainMinDb);
+        Assert.Equal(4, asWizard.BandGainMaxDb);
+        Assert.Equal(3.5, asWizard.QMax);
+        Assert.False(asWizard.CutsOnlyMode);
+        Assert.True(asWizard.AllowShelves);
+
+        EqAutoTuner.Options overridden = EqAutoTuneHeadless.Prepare(
+            request, target, policy, null, null, allowShelves: false, cutsOnly: true).Options;
+        Assert.True(overridden.CutsOnlyMode);
+        Assert.False(overridden.AllowShelves);
+        Assert.Equal(8, overridden.MaxBands);
+        Assert.Equal(3.5, overridden.QMax);
+
+        // The opening values, for a host with no wizard to ask.
+        Assert.Equal(EqualizationCurve.MaxBandCount, EqAutoTunePolicy.Default.MaxBands);
+        Assert.True(EqAutoTunePolicy.Default.CutsOnly);
+        Assert.False(EqAutoTunePolicy.Default.AllowShelves);
     }
 
     [Fact]
@@ -154,7 +192,7 @@ public sealed class EqAutoTuneHeadlessTests
         channel.Settings.PeqBands = [new PeqBand(400, 0.7, 0, PeqBandType.AllPassSecondOrder)];
         VirtualDspEqHandoffRequest request = Build(channel);
         EqHeadlessTuneInputs inputs = EqAutoTuneHeadless.Prepare(
-            request, TargetCurveSpec.FromPreset(TargetPreset.Flat), null, null,
+            request, TargetCurveSpec.FromPreset(TargetPreset.Flat), EqAutoTunePolicy.Default, null, null,
             allowShelves: false, cutsOnly: true);
 
         EqualizationCurve fitted = EqAutoTuneHeadless.Fit(inputs);

--- a/tests/Resonalyze.App.Tests/EqAutoTuneHeadlessTests.cs
+++ b/tests/Resonalyze.App.Tests/EqAutoTuneHeadlessTests.cs
@@ -186,6 +186,37 @@ public sealed class EqAutoTuneHeadlessTests
     }
 
     [Fact]
+    public void Prepare_RefusesWhenTheKeptAllPassBandsFillMaxFilters_AsTheWizardDoes()
+    {
+        // Max Filters 4 and four all-pass bands kept: the wizard says "no room"
+        // and does not run; a fit that placed one band anyway would hand back
+        // five filters under a limit of four.
+        VirtualCrossoverChannel channel = BuildChannel();
+        channel.Settings.PeqBands =
+        [
+            new PeqBand(200, 0.7, 0, PeqBandType.AllPassSecondOrder),
+            new PeqBand(300, 0.7, 0, PeqBandType.AllPassSecondOrder),
+            new PeqBand(400, 0.7, 0, PeqBandType.AllPassFirstOrder),
+            new PeqBand(500, 0.7, 0, PeqBandType.AllPassSecondOrder)
+        ];
+        VirtualDspEqHandoffRequest request = Build(channel);
+        var four = new EqAutoTunePolicy(4, -15, 6, 6, CutsOnly: true, AllowShelves: false);
+        var five = four with { MaxBands = 5 };
+        TargetCurveSpec target = TargetCurveSpec.FromPreset(TargetPreset.Flat);
+
+        Assert.Equal(0, EqAutoTuneHeadless.RoomUnderMaxFilters(request, four));
+        Assert.Throws<InvalidOperationException>(() =>
+            EqAutoTuneHeadless.Prepare(request, target, four, null, null, null, null));
+
+        Assert.Equal(1, EqAutoTuneHeadless.RoomUnderMaxFilters(request, five));
+        EqHeadlessTuneInputs inputs = EqAutoTuneHeadless.Prepare(request, target, five, null, null, null, null);
+        Assert.Equal(1, inputs.Options.MaxBands);
+        EqualizationCurve fitted = EqAutoTuneHeadless.Fit(inputs);
+        Assert.True(fitted.Bands.Count <= 5);
+        Assert.Equal(4, fitted.Bands.Count(band => band.Type.IsAllPass()));
+    }
+
+    [Fact]
     public void Fit_ReturnsTheKeptAllPassBandsWithTheFittedOnes()
     {
         VirtualCrossoverChannel channel = BuildChannel();

--- a/tests/Resonalyze.App.Tests/EqAutoTuneHeadlessTests.cs
+++ b/tests/Resonalyze.App.Tests/EqAutoTuneHeadlessTests.cs
@@ -1,0 +1,259 @@
+using System.Numerics;
+using System.Reflection;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// Auto Tune from an AI import runs with no wizard on screen, so what it fits
+/// has to be exactly what the wizard would have fitted for the same handoff:
+/// the curves are compared point for point against the wizard's own render,
+/// for a gated impulse response and for a spatial average alike. The option
+/// mapping and the window clamp are pinned beside them.
+/// </summary>
+public sealed class EqAutoTuneHeadlessTests
+{
+    private const int SampleRate = 48_000;
+
+    private static readonly PhaseAnalysisSettings GateTemplate = new(
+        PhaseWindowMode.Fixed,
+        PhaseAnalysisSettings.DefaultFdwCycles,
+        PhaseDetrendMode.Off,
+        ManualDetrendMilliseconds: 0.0,
+        GateOffsetMs: 0.0,
+        LeftMs: 2.0,
+        PlateauMs: 12.0,
+        RightMs: 5.0,
+        Unwrap: false,
+        SmoothingInverseOctaves: 0.0);
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(6)]
+    public void TheGatedSource_IsTheWizardsOwnCurve(int smoothing)
+    {
+        VirtualDspEqHandoffRequest request = Build(BuildChannel(), smoothing: smoothing);
+
+        IReadOnlyList<SignalPoint> headless =
+            EqAutoTuneHeadless.SourceCurve(request.Source, smoothing, appliedBank: null);
+        IReadOnlyList<SignalPoint> wizard = WizardSourceCurve(request);
+
+        AssertSameCurve(wizard, headless);
+    }
+
+    [Fact]
+    public void TheSpatialAverageSource_IsTheWizardsOwnCurve_OffsetIncluded()
+    {
+        VirtualDspEqHandoffRequest request = Build(
+            BuildChannel(), spatialAverage: Capture(), spatialAverageOffsetDb: -73.5);
+
+        IReadOnlyList<SignalPoint> headless =
+            EqAutoTuneHeadless.SourceCurve(request.Source, 0, appliedBank: null);
+        IReadOnlyList<SignalPoint> wizard = WizardSourceCurve(request);
+
+        Assert.NotEmpty(headless);
+        AssertSameCurve(wizard, headless);
+    }
+
+    [Fact]
+    public void Prepare_KeepsTheAllPassBands_AndFitsAroundWhatTheyDoThroughTheWindow()
+    {
+        VirtualCrossoverChannel channel = BuildChannel();
+        channel.Settings.PeqBands =
+        [
+            new PeqBand(200, 1.0, -3),
+            new PeqBand(400, 0.7, 0, PeqBandType.AllPassSecondOrder)
+        ];
+        VirtualDspEqHandoffRequest request = Build(channel);
+
+        EqHeadlessTuneInputs inputs = EqAutoTuneHeadless.Prepare(
+            request, TargetCurveSpec.FromPreset(TargetPreset.Flat), null, null,
+            allowShelves: false, cutsOnly: true);
+
+        PeqBand kept = Assert.Single(inputs.KeptAllPass);
+        Assert.Equal(400, kept.FrequencyHz);
+        // The bank's budget is the processor's slot count less the kept band.
+        Assert.Equal(EqualizationCurve.MaxBandCount - 1, inputs.Options.MaxBands);
+        // The source the fit corrects is the response WITH the all-pass in the
+        // chain — through a window that is not the same curve.
+        IReadOnlyList<SignalPoint> withoutAllPass =
+            EqAutoTuneHeadless.SourceCurve(request.Source, 0, appliedBank: null);
+        IReadOnlyList<SignalPoint> withAllPass = EqAutoTuneHeadless.SourceCurve(
+            request.Source, 0, new EqualizationCurve(inputs.KeptAllPass, preampDb: 0));
+        AssertSameCurve(withAllPass, inputs.Source);
+        Assert.NotEqual(
+            withoutAllPass.Select(point => point.Y), withAllPass.Select(point => point.Y));
+        // Target on the source's frequencies, at the handoff's level.
+        Assert.Equal(inputs.Source.Select(point => point.X), inputs.Target.Select(point => point.X));
+        Assert.All(inputs.Target, point => Assert.Equal(-41, point.Y, 9));
+    }
+
+    [Fact]
+    public void Prepare_MapsTheOptionsAsTheWizardDoes()
+    {
+        VirtualCrossoverChannel channel = BuildChannel();
+        channel.Settings.PeqPreampDb = -2.5;
+        VirtualDspEqHandoffRequest request = Build(
+            channel, processorProfile: DspProcessorCatalog.Preset("helix-dsp-ultra-s")!.ToProfile());
+        TargetCurveSpec target = TargetCurveSpec.FromPreset(TargetPreset.Flat);
+
+        // Cuts only: the auto preamp may use the field's whole range, the net
+        // gain is capped at 0 dB.
+        EqAutoTuner.Options cuts = EqAutoTuneHeadless.Prepare(
+            request, target, null, null, allowShelves: false, cutsOnly: true).Options;
+        Assert.True(cuts.CutsOnlyMode);
+        Assert.Equal(-EqAutoTuneHeadless.PreampRangeDb, cuts.PreampMinDb);
+        Assert.Equal(EqAutoTuneHeadless.PreampRangeDb, cuts.PreampMaxDb);
+        Assert.Equal(0, cuts.TotalGainMaxDb);
+        Assert.False(cuts.AllowShelves);
+        // The window is the channel's passband, as the handoff set the wizard's
+        // From/To; the rate is the processor's.
+        Assert.Equal(80, cuts.MinFrequencyHz);
+        Assert.Equal(500, cuts.MaxFrequencyHz);
+        Assert.Equal(96_000, cuts.SampleRateHz);
+        Assert.Equal(EqAutoTuneHeadless.BandGainMinDb, cuts.BandGainMinDb);
+        Assert.Equal(EqAutoTuneHeadless.BandGainMaxDb, cuts.BandGainMaxDb);
+        Assert.Equal(PeqSlotControl.MinimumQ, cuts.QMin);
+        Assert.Equal(EqAutoTuneHeadless.MaxQ, cuts.QMax);
+
+        // Boosts allowed: the preamp is the user's and stays where the bank had
+        // it; the reply's window and shelves are honoured.
+        EqAutoTuner.Options boosts = EqAutoTuneHeadless.Prepare(
+            request, target, 100, 3_000, allowShelves: true, cutsOnly: false).Options;
+        Assert.False(boosts.CutsOnlyMode);
+        Assert.Equal(-2.5, boosts.PreampMinDb);
+        Assert.Equal(-2.5, boosts.PreampMaxDb);
+        Assert.Equal(double.PositiveInfinity, boosts.TotalGainMaxDb);
+        Assert.True(boosts.AllowShelves);
+        Assert.Equal(100, boosts.MinFrequencyHz);
+        Assert.Equal(3_000, boosts.MaxFrequencyHz);
+    }
+
+    [Fact]
+    public void Prepare_ClampsTheWindowLikeTheFromToFields()
+    {
+        VirtualDspEqHandoffRequest request = Build(BuildChannel());
+        TargetCurveSpec target = TargetCurveSpec.FromPreset(TargetPreset.Flat);
+
+        // Inverted edges are ordered; edges past the fields' range are clamped.
+        EqHeadlessTuneInputs swapped = EqAutoTuneHeadless.Prepare(
+            request, target, 5_000, 300, allowShelves: false, cutsOnly: true);
+        Assert.Equal(300, swapped.MinHz);
+        Assert.Equal(5_000, swapped.MaxHz);
+
+        EqHeadlessTuneInputs wide = EqAutoTuneHeadless.Prepare(
+            request, target, 5, 40_000, allowShelves: false, cutsOnly: true);
+        Assert.Equal(EqAutoTuneHeadless.WindowMinHz, wide.MinHz);
+        Assert.Equal(EqAutoTuneHeadless.WindowMaxHz, wide.MaxHz);
+    }
+
+    [Fact]
+    public void Fit_ReturnsTheKeptAllPassBandsWithTheFittedOnes()
+    {
+        VirtualCrossoverChannel channel = BuildChannel();
+        channel.Settings.PeqBands = [new PeqBand(400, 0.7, 0, PeqBandType.AllPassSecondOrder)];
+        VirtualDspEqHandoffRequest request = Build(channel);
+        EqHeadlessTuneInputs inputs = EqAutoTuneHeadless.Prepare(
+            request, TargetCurveSpec.FromPreset(TargetPreset.Flat), null, null,
+            allowShelves: false, cutsOnly: true);
+
+        EqualizationCurve fitted = EqAutoTuneHeadless.Fit(inputs);
+
+        Assert.Contains(fitted.Bands, band => band.Type.IsAllPass() && band.FrequencyHz == 400);
+        Assert.True(fitted.Bands.Count <= EqualizationCurve.MaxBandCount);
+        Assert.All(fitted.Bands.Where(band => !band.Type.IsAllPass()), band => Assert.True(band.GainDb <= 0));
+    }
+
+    // The wizard, handed the same request, asked for the Source curve it draws.
+    private static IReadOnlyList<SignalPoint> WizardSourceCurve(VirtualDspEqHandoffRequest request)
+    {
+        using var panel = new EqWizardPanel();
+        panel.BeginVirtualDspHandoff(request);
+        object curve = typeof(EqWizardPanel)
+            .GetMethod("ComputeSourceCurve", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(panel, [])!;
+        var points = (IReadOnlyList<OxyPlot.DataPoint>)curve.GetType().GetProperty("Points")!.GetValue(curve)!;
+        return points.Select(point => new SignalPoint(point.X, point.Y)).ToList();
+    }
+
+    private static void AssertSameCurve(IReadOnlyList<SignalPoint> expected, IReadOnlyList<SignalPoint> actual)
+    {
+        Assert.Equal(expected.Count, actual.Count);
+        for (int index = 0; index < expected.Count; index++)
+        {
+            Assert.Equal(expected[index].X, actual[index].X, 9);
+            if (double.IsNaN(expected[index].Y))
+            {
+                Assert.True(double.IsNaN(actual[index].Y), $"point {index} at {expected[index].X} Hz");
+            }
+            else
+            {
+                Assert.Equal(expected[index].Y, actual[index].Y, 9);
+            }
+        }
+    }
+
+    private static VirtualDspEqHandoffRequest Build(
+        VirtualCrossoverChannel channel,
+        int smoothing = 0,
+        LiveCaptureDocument? spatialAverage = null,
+        double spatialAverageOffsetDb = 0,
+        DspProcessorProfile? processorProfile = null) =>
+        VirtualDspEqHandoff.Build(
+            channel,
+            channel.ActiveRight,
+            withChain: true,
+            processorProfile ?? DspProcessorProfile.Custom(SampleRate, PeqQConvention.Rbj),
+            GateTemplate,
+            pinnedGateOffsetMs: null,
+            renderAnchorIndex: 480,
+            phaseContext: null,
+            targetLevelDb: -41,
+            targetLevelMinDb: -120,
+            targetLevelMaxDb: 60,
+            smoothingInverseOctaves: smoothing,
+            calibration: null,
+            calibrationName: null,
+            SpatialAverageCalibration.Own,
+            projectGeneration: 1,
+            spatialAverage,
+            spatialAverageOffsetDb);
+
+    private static LiveCaptureDocument Capture() => new()
+    {
+        SavedAtUtc = DateTimeOffset.UnixEpoch,
+        Title = "l tw mmm",
+        CurveDb = Enumerable.Range(0, 1_024)
+            .Select(index => -20.0 + 3 * Math.Sin(index / 40.0))
+            .ToArray(),
+        GridStartHz = 20,
+        GridStopHz = 20_000,
+        Recipe = new LiveCaptureRecipe
+        {
+            AnalysisMode = LiveAnalysisMode.Mmm,
+            SampleRateHz = SampleRate
+        }
+    };
+
+    // The handoff tests' channel: a decaying wavelet at 10 ms through a full chain.
+    private static VirtualCrossoverChannel BuildChannel()
+    {
+        var impulseResponse = new Complex[4_096];
+        for (int i = 0; i < 64; i++)
+        {
+            impulseResponse[480 + i] =
+                Math.Exp(-i / 12.0) * Math.Cos(2 * Math.PI * i / 16.0);
+        }
+
+        var channel = new VirtualCrossoverChannel("A");
+        channel.SampleRate = SampleRate;
+        channel.TransferImpulseResponse = impulseResponse;
+        channel.TransferPeakIndex = 480;
+        channel.Settings.GainDb = -3;
+        channel.Settings.DelayMs = 1.25;
+        channel.Settings.CrossoverKind = CrossoverKind.BandPass;
+        channel.Settings.HighPassEdge = channel.Settings.HighPassEdge with { FrequencyHz = 80 };
+        channel.Settings.LowPassEdge = channel.Settings.LowPassEdge with { FrequencyHz = 500 };
+        return channel;
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
@@ -82,14 +82,13 @@ public sealed class VirtualCrossoverAgentEngineTests
             // Listed the other way round on purpose: the import runs the spatial
             // average first whatever order the reply gave, because it decides
             // which curves the engines after it are read on.
-            bool ran = (bool)Invoke(panel, "RunAgentEngineRequests",
-                new List<AgentOperationVerdict>
-                {
+            bool ran = RunEngines(panel,
+                [
                     Row(new RunAutoCrossoverOperation("op-1", "split them"), "Auto crossover"),
                     Row(new UseSpatialAverageOperation("op-2", "unused arrays", "MicArray", true),
                         "Spatial average")
-                },
-                summary)!;
+                ],
+                summary);
 
             Assert.Equal(
                 [
@@ -114,12 +113,9 @@ public sealed class VirtualCrossoverAgentEngineTests
             using VirtualCrossoverPanel panel = Loaded();
             var summary = new List<string>();
 
-            bool ran = (bool)Invoke(panel, "RunAgentEngineRequests",
-                new List<AgentOperationVerdict>
-                {
-                    Row(new RunAutoCrossoverOperation("op-1", ""), "Auto crossover")
-                },
-                summary)!;
+            bool ran = RunEngines(panel,
+                [Row(new RunAutoCrossoverOperation("op-1", ""), "Auto crossover")],
+                summary);
 
             // The import reads this answer to decide whether Undo stays armed: a
             // refused wizard moved nothing, and arming it would offer to put back
@@ -129,6 +125,92 @@ public sealed class VirtualCrossoverAgentEngineTests
             Assert.Contains("skipped", summary[0]);
         });
     }
+
+    [Fact]
+    public void AutoDelayRequest_TakesWhatTheReplyStates_AndTheDialogsAnswerForTheRest()
+    {
+        var defaults = new AgentAutoDelaySettings(0.25, false, false, 1.0, 15.0);
+
+        // Only the scene offset stated: everything else is what the dialog would
+        // have opened with, the gain balance unticked included.
+        AutoDelayRunRequest partial = VirtualCrossoverPanel.BuildAutoDelayRequest(
+            new RunAutoDelayOperation("op-1", "", 0.35, null, null, null, null), defaults);
+        Assert.Equal(0.35, partial.SceneOffsetMs);
+        Assert.False(partial.RightHandDrive);
+        Assert.False(partial.AdjustGains);
+        Assert.Equal(1.0, partial.NearSideCutDb);
+        Assert.Equal(15.0, partial.RearFillOffsetMs);
+
+        AutoDelayRunRequest full = VirtualCrossoverPanel.BuildAutoDelayRequest(
+            new RunAutoDelayOperation("op-1", "", null, true, true, 2.0, 12.5), defaults);
+        Assert.Equal(0.25, full.SceneOffsetMs);
+        Assert.True(full.RightHandDrive);
+        Assert.True(full.AdjustGains);
+        Assert.Equal(2.0, full.NearSideCutDb);
+        Assert.Equal(12.5, full.RearFillOffsetMs);
+        // The tilt in the gain engine's convention follows the layout, as the
+        // dialog's would.
+        Assert.Equal(2.0, full.LevelDifferenceDb);
+    }
+
+    [Fact]
+    public void AutoDelay_RunHeadless_IsRefusedWithThePhraseTheSummaryQuotes()
+    {
+        StaTest.Run(() =>
+        {
+            using VirtualCrossoverPanel panel = Loaded();
+            var summary = new List<string>();
+
+            // The button's own first check, answered as a phrase instead of a
+            // beep: no block here carries a measurement.
+            bool ran = RunEngines(panel,
+                [Row(new RunAutoDelayOperation("op-1", "", 0.35, null, null, null, null), "Auto delay")],
+                summary);
+
+            Assert.False(ran);
+            Assert.Equal(
+                ["Auto delay: skipped (fewer than two enabled channels have a measurement)."],
+                summary);
+        });
+    }
+
+    [Fact]
+    public void UndoAiImport_PutsBackTheStereoSceneTheTiltAndTheRearFill()
+    {
+        StaTest.Run(() =>
+        {
+            // What an Auto delay run commits beside the channels
+            // (CommitAutoDelayResult): the scene offset with its layout, the
+            // level tilt, the rear-fill offset.
+            using VirtualCrossoverPanel panel = Loaded();
+            VirtualCrossoverProjectFile project = Project(panel);
+            project.SetStereoScene(0.25, rightHandDrive: false);
+            project.StereoLevelDifferenceDb = -1.0;
+            project.RearFillOffsetMs = 15.0;
+
+            object undo = Invoke(panel, "CaptureAgentUndo")!;
+            project.SetStereoScene(0.6, rightHandDrive: true);
+            project.StereoLevelDifferenceDb = 2.5;
+            project.RearFillOffsetMs = 9.0;
+
+            Set(panel, "agentUndo", undo);
+            Set(panel, "agentUndoGeneration", Field(panel, "projectGeneration"));
+            Invoke(panel, "UndoAiImport");
+
+            Assert.Equal(0.25, project.StereoSceneOffsetMagnitudeMs);
+            Assert.False(project.StereoRightHandDrive);
+            Assert.Equal(-1.0, project.StereoLevelDifferenceDb);
+            Assert.Equal(15.0, project.RearFillOffsetMs);
+        });
+    }
+
+    // The engines run as the import runs them — awaited; on a panel with no
+    // measurement every engine answers before it would await anything, so the
+    // task is complete by the time it is handed back.
+    private static bool RunEngines(
+        VirtualCrossoverPanel panel, List<AgentOperationVerdict> rows, List<string> summary) =>
+        ((Task<bool>)Invoke(panel, "RunAgentEngineRequests", rows, summary)!)
+            .GetAwaiter().GetResult();
 
     private static AgentOperationVerdict Row(AgentOperation operation, string parameter) =>
         new(operation.Id, AgentProposalValidator.AllChannels, parameter,

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
@@ -154,6 +154,25 @@ public sealed class VirtualCrossoverAgentEngineTests
     }
 
     [Fact]
+    public void ImportTargetLevel_IsTheFirstStatedOne_ElseTheProjectsOwn_ForEveryFit()
+    {
+        // Decided once for the whole import: a row that states no level must not
+        // fit at the old datum while the next row moves it.
+        AgentOperationVerdict stated = Row(
+            new AutoTunePeqOperation("op-1", "B:left", "", -6, null, null, null, null, null), "Auto-tune");
+        AgentOperationVerdict omitted = Row(
+            new AutoTunePeqOperation("op-2", "A:left", "", null, null, null, null, null, null), "Auto-tune");
+        AgentOperationVerdict rejected = Row(
+            new AutoTunePeqOperation("op-3", "C:mono", "", -9, null, null, null, null, null), "Auto-tune")
+            with { Status = AgentVerdictStatus.Rejected };
+
+        Assert.Equal(-6, VirtualCrossoverPanel.ImportTargetLevelDb([omitted, stated], -4));
+        Assert.Equal(-4, VirtualCrossoverPanel.ImportTargetLevelDb([omitted], -4));
+        Assert.Equal(-4, VirtualCrossoverPanel.ImportTargetLevelDb([rejected, omitted], -4));
+        Assert.Equal(-4, VirtualCrossoverPanel.ImportTargetLevelDb([], -4));
+    }
+
+    [Fact]
     public void AutoDelay_RunHeadless_IsRefusedWithThePhraseTheSummaryQuotes()
     {
         StaTest.Run(() =>

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
@@ -1,0 +1,170 @@
+using System.Reflection;
+using System.Windows.Forms;
+using Resonalyze.Integration.AgentBridge;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The panel's half of an engine request: an operation the review passed is
+/// carried out by the same code a button click runs, and Undo AI import puts
+/// back everything the import could have moved — not only the channels a row
+/// named. An engine writes channels no row mentions, and the crossover wizard
+/// can reorder the blocks, so the undo snapshot is the whole project's chain,
+/// the spatial average mode, the Hybrid tick and the block order.
+/// </summary>
+public sealed class VirtualCrossoverAgentEngineTests
+{
+    private const BindingFlags Hidden = BindingFlags.NonPublic | BindingFlags.Instance;
+
+    [Fact]
+    public void UseSpatialAverage_SetsTheModeAndTicksHybridTogether()
+    {
+        StaTest.Run(() =>
+        {
+            using VirtualCrossoverPanel panel = Loaded();
+            Project(panel).SpatialAverageMode = VirtualCrossoverSpatialAverageMode.Off;
+            Hybrid(panel).Checked = false;
+
+            Invoke(panel, "ApplyAgentSpatialAverage",
+                new UseSpatialAverageOperation("op-1", "arrays are attached", "MicArray", true));
+
+            // Either half alone leaves the point measurement in charge, which is
+            // the state the operation exists to get out of.
+            Assert.Equal(
+                VirtualCrossoverSpatialAverageMode.MicArray, Project(panel).SpatialAverageMode);
+            Assert.True(Hybrid(panel).Checked);
+            Assert.True(Project(panel).ShowHybridCurves);
+        });
+    }
+
+    [Fact]
+    public void UndoAiImport_PutsBackTheChainTheModeTheTickAndTheBlockOrder()
+    {
+        StaTest.Run(() =>
+        {
+            using VirtualCrossoverPanel panel = Loaded();
+            Project(panel).SpatialAverageMode = VirtualCrossoverSpatialAverageMode.Off;
+            Hybrid(panel).Checked = false;
+            List<VirtualCrossoverChannel> order = Channels(panel).ToList();
+            double gain = Channels(panel)[0].SideSettings(rightSide: false).GainDb;
+
+            object undo = Invoke(panel, "CaptureAgentUndo")!;
+            Invoke(panel, "ApplyAgentSpatialAverage",
+                new UseSpatialAverageOperation("op-1", "", "MicArray", true));
+            // A channel no row named, and the reordering the wizard can do.
+            Channels(panel)[0].SideSettings(rightSide: false).GainDb = gain - 6;
+            Invoke(panel, "MoveChannel", Channels(panel)[0], 1);
+            Assert.NotEqual(order, Channels(panel));
+
+            Set(panel, "agentUndo", undo);
+            Set(panel, "agentUndoGeneration", Field(panel, "projectGeneration"));
+            Invoke(panel, "UndoAiImport");
+
+            Assert.Equal(VirtualCrossoverSpatialAverageMode.Off, Project(panel).SpatialAverageMode);
+            Assert.False(Hybrid(panel).Checked);
+            Assert.False(Project(panel).ShowHybridCurves);
+            Assert.Equal(order, Channels(panel));
+            Assert.Equal(gain, Channels(panel)[0].SideSettings(rightSide: false).GainDb);
+            Assert.Null(Field(panel, "agentUndo"));
+        });
+    }
+
+    [Fact]
+    public void EngineRequests_RunInTheImportsOwnOrder_AndSayWhatWasSkipped()
+    {
+        StaTest.Run(() =>
+        {
+            using VirtualCrossoverPanel panel = Loaded();
+            Project(panel).SpatialAverageMode = VirtualCrossoverSpatialAverageMode.Off;
+            Hybrid(panel).Checked = false;
+            var summary = new List<string>();
+
+            // Listed the other way round on purpose: the import runs the spatial
+            // average first whatever order the reply gave, because it decides
+            // which curves the engines after it are read on.
+            bool ran = (bool)Invoke(panel, "RunAgentEngineRequests",
+                new List<AgentOperationVerdict>
+                {
+                    Row(new RunAutoCrossoverOperation("op-1", "split them"), "Auto crossover"),
+                    Row(new UseSpatialAverageOperation("op-2", "unused arrays", "MicArray", true),
+                        "Spatial average")
+                },
+                summary)!;
+
+            Assert.Equal(
+                [
+                    "Spatial average: MicArray, hybrid on.",
+                    // No block here carries a measurement, so the wizard refuses
+                    // before it opens — and the summary says which one did not run.
+                    "Auto crossover: skipped (fewer than two enabled channels have a measurement)."
+                ],
+                summary);
+            Assert.True(ran);
+            Assert.Equal(
+                VirtualCrossoverSpatialAverageMode.MicArray, Project(panel).SpatialAverageMode);
+            Assert.True(Hybrid(panel).Checked);
+        });
+    }
+
+    [Fact]
+    public void AnEngineRequestThatChangesNothing_LeavesRanFalse()
+    {
+        StaTest.Run(() =>
+        {
+            using VirtualCrossoverPanel panel = Loaded();
+            var summary = new List<string>();
+
+            bool ran = (bool)Invoke(panel, "RunAgentEngineRequests",
+                new List<AgentOperationVerdict>
+                {
+                    Row(new RunAutoCrossoverOperation("op-1", ""), "Auto crossover")
+                },
+                summary)!;
+
+            // The import reads this answer to decide whether Undo stays armed: a
+            // refused wizard moved nothing, and arming it would offer to put back
+            // a tune nobody touched.
+            Assert.False(ran);
+            Assert.Single(summary);
+            Assert.Contains("skipped", summary[0]);
+        });
+    }
+
+    private static AgentOperationVerdict Row(AgentOperation operation, string parameter) =>
+        new(operation.Id, AgentProposalValidator.AllChannels, parameter,
+            string.Empty, string.Empty, AgentVerdictStatus.Warning, string.Empty,
+            operation.Reason, operation, null);
+
+    // A panel bound to its project's pairs, the way applying a project binds
+    // them: without that the two lists are unrelated objects and a reorder has
+    // nothing to permute.
+    private static VirtualCrossoverPanel Loaded()
+    {
+        var panel = new VirtualCrossoverPanel();
+        List<VirtualCrossoverChannel> channels = Channels(panel);
+        for (int index = 0; index < channels.Count; index++)
+        {
+            channels[index].Pair = Project(panel).Pairs[index];
+        }
+
+        return panel;
+    }
+
+    private static object Field(object target, string name) =>
+        target.GetType().GetField(name, Hidden)!.GetValue(target)!;
+
+    private static void Set(object target, string name, object? value) =>
+        target.GetType().GetField(name, Hidden)!.SetValue(target, value);
+
+    private static object? Invoke(object target, string name, params object?[] arguments) =>
+        target.GetType().GetMethod(name, Hidden)!.Invoke(target, arguments);
+
+    private static List<VirtualCrossoverChannel> Channels(VirtualCrossoverPanel panel) =>
+        (List<VirtualCrossoverChannel>)Field(panel, "channels");
+
+    private static VirtualCrossoverProjectFile Project(VirtualCrossoverPanel panel) =>
+        (VirtualCrossoverProjectFile)Field(panel, "project");
+
+    private static CheckBox Hybrid(VirtualCrossoverPanel panel) =>
+        (CheckBox)Field(panel, "checkBoxHybrid");
+}


### PR DESCRIPTION
Agent Bridge, stage 2: a reply may ask for the panel's engines instead of hand-writing what they compute. One PR for the whole stage, one commit per step, in the order of the accepted plan.

## Protocol (commit 1)

Four operations join the five settings ones — `runAutoDelay`, `runAutoCrossover`, `autoTunePeq`, `useSpatialAverage` — as a family of their own (`AgentOperation` → `AgentChannelOperation` → `AgentSettingsOperation`, mirrored in the parser's wire classes, so a `channelId` on `runAutoCrossover` is refused as a member the protocol does not name rather than ignored). `limits.operations` says what the build executes; an operation it does not name is still parsed and reviewed in full, then refused with "not available in this version of Resonalyze", so a reply for a newer build is understood, not mangled.

An engine and a hand-written value it would write over cannot both be meant: the hand-written row is **rejected** naming the engine (`AgentProposalValidator.Overwrites`, one predicate) — Auto delay against `setDelayMs`/`setPolarity` and `setGainDb` when it balances gains; Auto crossover against `setCrossover` and `setGainDb` (the wizard writes a cut-only gain with every corner); Auto-tune against `replacePeqBank` on its channel. Imports run in one fixed order whatever the reply listed — settings rows, the spatial average, Auto crossover, Auto delay, Auto-tune — with one summary at the end. **Undo AI import** is a full snapshot now: every channel's settings, the spatial-average mode, the Hybrid tick, the block order, the stereo scene, the level tilt, the rear-fill offset and the target level.

`useSpatialAverage` sets the mode and ticks Hybrid together (either alone leaves the point measurement in charge); `runAutoCrossover` opens the existing wizard, which now reports why it did not write — "cancelled in the wizard" included — for the summary.

## Auto delay without its dialog (commit 2)

`PrepareAutoDelay(interactive)` answers with a launch (stereo or single, the runner, the dialog's two extras) or a refusal; the button keeps its beeps, error boxes and the broad-window question, an import gets a phrase for the summary and the question is a refusal (set the crossovers first). The run is the button's own compute delegate and commit, report, alignment log and outcome metric included; the report comes back in the import's summary. The panel is disabled for the compute's span, since the dialog's modality was what kept the chain still under the search. Inputs a request leaves out are the dialog's own answers (`BuildAutoDelayRequest`, pinned), the figures the package prints as *Current*.

## Auto-tune without the EQ Wizard (commit 3)

`EqAutoTuneHeadless` builds the curve `ComputeSourceCurve` would draw for the channel's handoff (the spatial average through the preview chain while the hybrid view draws it, the gated impulse response otherwise, or the `source` the reply names), the target on the same frequencies, and the options `CreateAutoTuneOptions` would hand the tuner, with the wizard's opening values for what the reply leaves out. All-pass bands are kept and the fit tunes around what they do through the window. The two renders are pinned against the wizard's own, point for point, for a gated source and for a spatial average. The landing is `VirtualDspEqHandoff.TryApplyReturn` with every guard; a `targetLevelDb` moves the project's datum as the wizard's Return does. The run skips itself with the reason where the wizard would have refused or asked: the channel on the side not on screen, a spatial average asked for while the hybrid view is not drawing it, a target level 3 dB or more above the curve or 10 dB or more below.

## Verification

- Battery in Debug on the final commit: App 2192 passed, 0 failed (Dsp and Audio untouched; CI runs them).
- New tests: parser/validator/applier for the four operations and the conflict predicate, the dialog rows, the engine order and the full undo on a live panel, `BuildAutoDelayRequest`, the headless Auto delay refusal, and `EqAutoTuneHeadless` against the wizard's own render (gated and spatial-average sources), its option mapping, window clamp and all-pass handling.
- Live, through a reflection harness on the panel: Passat v2 — `runAutoDelay` ran stereo in 25 s, wrote delays and polarities, Undo restored them exactly; `autoTunePeq` on the point measurement, 5 bands, RMS 5.4 → 2.6 dB, undone. v6 with MMM on every channel — `useSpatialAverage` applied and undone, `autoTunePeq` on the spatial average, 4 bands, RMS 4.9 → 2.4 dB, undone. The crossover wizard is modal and was not driven from the harness; its refusal paths and order are tested, the run itself is the button's code.

## Not done here

- A rejected hand-written row cannot be revived by unticking the engine's row in the review; that is the cost of "Rejected, not Warning". A re-judge on untick is a possible follow-up.
- `runAutoCrossover` rejects `setGainDb`/`setCrossover` on every channel, including muted ones the wizard would not touch: the snapshot knows `HasMeasurement` but not `Enabled`, and refusing is the safe side.
- Documentation figures: the review dialog with engine rows, the import summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
