### PR TITLE
Agent Bridge: the proposal identifies itself by its kind; guide version in the package; a loaded project forgets the last package

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2834,11 +2834,11 @@ this: the clipboard is the only transport, and you are the one who pastes.
   the whole PEQ bank. It may also **ask for an engine to be run**: **Auto
   crossover**, or the spatial average — the capture family and the **Hybrid**
   tick together, which is how an assistant that has noticed unused averages puts
-  them to work in one tick. (Auto delay and the EQ Wizard's Auto-tune are part of
-  the protocol and are read and reviewed, but this build refuses them as not
-  available; the package tells the assistant which operations it can run.)
-  Nothing else in a session can be reached from a reply, and an unknown request
-  is listed as rejected.
+  them to work in one tick — and **Auto delay** and the EQ Wizard's
+  **Auto-tune**, which run without their dialogs as described below. The
+  package tells the assistant which operations the build can run. Nothing else
+  in a session can be reached from a reply, and an unknown request is listed as
+  rejected.
 
   Every proposed change is shown against the value the channel holds *now*, with
   the reason the assistant gave; an engine request is shown against the settings
@@ -2874,7 +2874,8 @@ this: the clipboard is the only transport, and you are the one who pastes.
   rows together and unticking one can leave a state it never showed, which then
   asks before applying — writes them as one set, then runs the engine requests
   in a fixed order (the spatial average first, since it decides which curves the
-  rest are read on, then Auto crossover, then Auto delay) and closes with one
+  rest are read on, then Auto crossover, then Auto delay, then Auto-tune, which
+  fits to everything the others left behind) and closes with one
   summary of what was applied and what was skipped. Cancelling the wizard, or
   a check Auto delay's button would have refused on (fewer than two measured
   channels, a bypassed participant, a misplaced gate, no crossover anywhere),

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -14,7 +14,7 @@ Rules that apply even without the guide:
 2. Ask for what the notes do not say: driver models and locations, amplifier power, DSP model, listening goals. Ask in small groups.
 3. Prefer Resonalyze's own engines: recommend running Auto delay / Auto crossover / EQ Wizard Auto-tune with stated settings instead of inventing delays and PEQ banks by hand.
 4. Never EQ a cancellation; never claim a crossover is driver-safe from Fs or diameter alone; cite sources for hardware facts.
-5. If and only if you have concrete, justified changes, end with ONE block between BEGIN_RESONALYZE_AGENT_PROPOSAL_V1 and END_RESONALYZE_AGENT_PROPOSAL_V1 following the protocol; copy channel ids and current values from this package exactly.
+5. If and only if you have concrete, justified changes, end with ONE JSON object with "kind": "resonalyze.agent-proposal" following the protocol, in a fenced code block; copy channel ids and current values from this package exactly.
 
 ## 1. Your role
 
@@ -328,10 +328,11 @@ When a driver or a processor matters to your advice:
 
 Write your analysis in prose. Then, **only if** you have concrete, justified
 changes for the five editable parameters (gain, delay, polarity, crossover,
-PEQ bank of one channel) or an engine to request, end with exactly one block
-between `BEGIN_RESONALYZE_AGENT_PROPOSAL_V1` and
-`END_RESONALYZE_AGENT_PROPOSAL_V1` as [PROTOCOL.md](PROTOCOL.md) §2 describes.
-In it:
+PEQ bank of one channel) or an engine to request, end with exactly one JSON
+object whose `"kind"` is `"resonalyze.agent-proposal"`, in a fenced code
+block, as [PROTOCOL.md](PROTOCOL.md) §2 describes — the object identifies
+itself, so nothing outside the block is needed (and text outside the block is
+what a chat leaves behind when the user copies the block alone). In it:
 
 - Copy `packageId`, every `channelId` and every expected current value from
   the package exactly. A changed current value refuses the operation.

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -284,16 +284,20 @@ arrival minus the front's), `levelDb` (the zone's level minus the front's),
 
 ## 2. The reply
 
-The assistant may write anything before and after. Resonalyze reads only the
-JSON between the markers, and there must be **exactly one** such block:
+The assistant may write anything before and after. Resonalyze reads the one
+JSON object in the reply whose `kind` is `resonalyze.agent-proposal` — the
+object identifies itself, and there must be **exactly one** such object:
 
-```text
-BEGIN_RESONALYZE_AGENT_PROPOSAL_V1
-{ … }
-END_RESONALYZE_AGENT_PROPOSAL_V1
+```json
+{ "kind": "resonalyze.agent-proposal", "protocolVersion": 1, … }
 ```
 
-A Markdown fence around the JSON is tolerated. Everything else is strict: no
+A Markdown fence around the JSON is expected and tolerated; braces inside
+strings do not confuse the reader. The earlier envelope — the object between a
+`BEGIN_RESONALYZE_AGENT_PROPOSAL_V1` and an `END_RESONALYZE_AGENT_PROPOSAL_V1`
+line — is still read when a reply carries it, but it is no longer asked for:
+a chat that sets such markers outside the block it offers to copy leaves the
+user pasting a block the importer could not find. Everything else is strict: no
 comments, no trailing commas, no `NaN`/`Infinity`, property names exactly as
 written here (case matters), no properties the protocol does not name (one
 open door: an `extensions` object, whose content is ignored).

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -47,6 +47,7 @@ to the 100 KB ceiling, and beyond that nothing is copied:
 | --- | --- |
 | `kind` | `"resonalyze.agent-package"` |
 | `protocolVersion` | `1` |
+| `guideVersion` | The version of [AGENT_GUIDE.md](AGENT_GUIDE.md) this build was written against (its first line). The guide at the URL may be newer; read it, and know which methodology the package's author expected. |
 | `packageId` | A new GUID per copy. Echo it in the reply; a mismatch is a warning, not a refusal. |
 | `createdAtUtc` | ISO 8601, UTC. |
 | `application` | `{ name, version }` |

--- a/source/Integration/AgentBridge/AgentPackageBuilder.cs
+++ b/source/Integration/AgentBridge/AgentPackageBuilder.cs
@@ -153,6 +153,7 @@ internal static class AgentPackageBuilder
         return new AgentPackage(
             AgentProtocol.PackageKind,
             AgentProtocol.Version,
+            AgentProtocol.GuideVersion,
             packageId.ToString("D"),
             createdAtUtc.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", System.Globalization.CultureInfo.InvariantCulture),
             new AgentPackageApplication("Resonalyze", inputs.ApplicationVersion),

--- a/source/Integration/AgentBridge/AgentPackageModels.cs
+++ b/source/Integration/AgentBridge/AgentPackageModels.cs
@@ -9,6 +9,7 @@ namespace Resonalyze.Integration.AgentBridge;
 internal sealed record AgentPackage(
     string Kind,
     int ProtocolVersion,
+    string GuideVersion,
     string PackageId,
     string CreatedAtUtc,
     AgentPackageApplication Application,

--- a/source/Integration/AgentBridge/AgentProposalParser.cs
+++ b/source/Integration/AgentBridge/AgentProposalParser.cs
@@ -161,17 +161,45 @@ internal static class AgentProposalParser
     // Exactly one begin and one end, in that order, with something between them.
     // Two blocks are not "take the last one": an assistant that wrote two was
     // asked for one, and guessing which it meant is how the wrong tune gets applied.
+    // The proposal is the one JSON object in the reply whose "kind" names it. A
+    // chat pastes the object inside a Markdown fence and puts anything around it;
+    // the earlier envelope of BEGIN/END markers is still read when a reply
+    // carries it, since assistants keep copying what they saw work — but a chat
+    // that set the markers OUTSIDE the block it offers to copy is why the object
+    // now identifies itself.
     private static bool TryExtractBlock(string text, out string json, out string? problem)
     {
         json = string.Empty;
         int begins = Count(text, AgentProtocol.ProposalBegin);
         int ends = Count(text, AgentProtocol.ProposalEnd);
-        if (begins == 0 && ends == 0)
+        if (begins > 0 || ends > 0)
         {
-            problem = $"No proposal block found: the reply must contain a JSON block " +
-                $"between {AgentProtocol.ProposalBegin} and {AgentProtocol.ProposalEnd}.";
+            return TryExtractMarkedBlock(text, begins, ends, out json, out problem);
+        }
+
+        List<string> candidates = ProposalObjects(text);
+        if (candidates.Count == 0)
+        {
+            problem = "No proposal found: the reply must contain one JSON object with " +
+                $"\"kind\": \"{AgentProtocol.ProposalKind}\" (a fenced code block is fine).";
             return false;
         }
+        if (candidates.Count > 1)
+        {
+            problem = $"The reply must contain exactly one proposal; found {candidates.Count} " +
+                $"JSON objects with \"kind\": \"{AgentProtocol.ProposalKind}\".";
+            return false;
+        }
+
+        json = candidates[0];
+        problem = null;
+        return true;
+    }
+
+    private static bool TryExtractMarkedBlock(
+        string text, int begins, int ends, out string json, out string? problem)
+    {
+        json = string.Empty;
         if (begins != 1 || ends != 1)
         {
             problem = $"The reply must contain exactly one proposal block; found " +
@@ -188,8 +216,21 @@ internal static class AgentProposalParser
             return false;
         }
 
-        json = text[start..end].Trim();
-        // A fenced block is what most chat UIs copy; the fence is not part of the JSON.
+        json = Unfenced(text[start..end]);
+        if (json.Length == 0)
+        {
+            problem = "The proposal block is empty.";
+            return false;
+        }
+
+        problem = null;
+        return true;
+    }
+
+    // A fenced block is what most chat UIs copy; the fence is not part of the JSON.
+    private static string Unfenced(string text)
+    {
+        string json = text.Trim();
         if (json.StartsWith("```", StringComparison.Ordinal))
         {
             int newline = json.IndexOf('\n');
@@ -201,14 +242,83 @@ internal static class AgentProposalParser
             json = json.Trim();
         }
 
-        if (json.Length == 0)
+        return json;
+    }
+
+    // Every top-level JSON object in the text that names the proposal kind. A
+    // brace scanner that knows JSON strings (so a brace inside a reason does not
+    // end an object) walks each candidate from its opening brace; an object
+    // that never closes, or does not name the kind, is prose and skipped, and
+    // the walk resumes after the candidate so nested objects are not counted
+    // twice.
+    private static List<string> ProposalObjects(string text)
+    {
+        var found = new List<string>();
+        string kindMarker = "\"" + AgentProtocol.ProposalKind + "\"";
+        int index = 0;
+        while ((index = text.IndexOf('{', index)) >= 0)
         {
-            problem = "The proposal block is empty.";
-            return false;
+            int close = MatchingBrace(text, index);
+            if (close < 0)
+            {
+                index++;
+                continue;
+            }
+
+            string candidate = text[index..(close + 1)];
+            if (candidate.Contains(kindMarker, StringComparison.Ordinal))
+            {
+                found.Add(candidate);
+                index = close + 1;
+            }
+            else
+            {
+                index++;
+            }
         }
 
-        problem = null;
-        return true;
+        return found;
+    }
+
+    private static int MatchingBrace(string text, int open)
+    {
+        int depth = 0;
+        bool inString = false;
+        for (int index = open; index < text.Length; index++)
+        {
+            char c = text[index];
+            if (inString)
+            {
+                if (c == '\\')
+                {
+                    index++;
+                }
+                else if (c == '"')
+                {
+                    inString = false;
+                }
+                continue;
+            }
+
+            switch (c)
+            {
+                case '"':
+                    inString = true;
+                    break;
+                case '{':
+                    depth++;
+                    break;
+                case '}':
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return index;
+                    }
+                    break;
+            }
+        }
+
+        return -1;
     }
 
     private static (AgentOperation? Operation, AgentRejectedOperation? Rejection) ReadOperation(

--- a/source/Integration/AgentBridge/AgentProposalParser.cs
+++ b/source/Integration/AgentBridge/AgentProposalParser.cs
@@ -255,10 +255,26 @@ internal static class AgentProposalParser
     {
         var found = new List<string>();
         string kindMarker = "\"" + AgentProtocol.ProposalKind + "\"";
-        int index = 0;
-        while ((index = text.IndexOf('{', index)) >= 0)
+        // No object opened after the last mention of the kind can contain it.
+        int lastMarker = text.LastIndexOf(kindMarker, StringComparison.Ordinal);
+        if (lastMarker < 0)
         {
-            int close = MatchingBrace(text, index);
+            return found;
+        }
+
+        // Each brace that never closes is walked to the end of the text, and a
+        // paste full of them (a minified script, say) would be quadratic. The
+        // walk gets a budget generous for any reply and small for such a paste;
+        // past it the reply reads as holding whatever was found by then.
+        long budget = 8L * text.Length + (1L << 20);
+        int index = 0;
+        while (index <= lastMarker && (index = text.IndexOf('{', index)) >= 0 && index <= lastMarker)
+        {
+            int close = MatchingBrace(text, index, ref budget);
+            if (budget <= 0)
+            {
+                break;
+            }
             if (close < 0)
             {
                 index++;
@@ -280,11 +296,11 @@ internal static class AgentProposalParser
         return found;
     }
 
-    private static int MatchingBrace(string text, int open)
+    private static int MatchingBrace(string text, int open, ref long budget)
     {
         int depth = 0;
         bool inString = false;
-        for (int index = open; index < text.Length; index++)
+        for (int index = open; index < text.Length && budget-- > 0; index++)
         {
             char c = text[index];
             if (inString)

--- a/source/Integration/AgentBridge/AgentProposalValidator.cs
+++ b/source/Integration/AgentBridge/AgentProposalValidator.cs
@@ -138,7 +138,17 @@ internal static class AgentProposalValidator
         ArgumentNullException.ThrowIfNull(session);
 
         var warnings = new List<string>();
-        if (proposal.PackageId != null && session.LastPackageId != null &&
+        if (proposal.PackageId != null && session.LastPackageId == null)
+        {
+            // The panel forgets its package when the project is loaded, the blocks
+            // are reordered or a source is replaced: the ids the reply uses were
+            // read off a project this one no longer is.
+            warnings.Add(
+                "The reply names a package this project has not copied — a project was " +
+                "loaded, the blocks were reordered or a measurement was replaced since, or the " +
+                "package came from elsewhere. The current values below decide.");
+        }
+        else if (proposal.PackageId != null && session.LastPackageId != null &&
             !string.Equals(proposal.PackageId, session.LastPackageId, StringComparison.OrdinalIgnoreCase))
         {
             warnings.Add(

--- a/source/Integration/AgentBridge/AgentProtocol.cs
+++ b/source/Integration/AgentBridge/AgentProtocol.cs
@@ -59,9 +59,16 @@ internal static class AgentProtocol
         "EQ Wizard Auto-tune with stated settings instead of inventing delays and PEQ banks by hand.\r\n" +
         "4. Never EQ a cancellation; never claim a crossover is driver-safe from Fs or diameter " +
         "alone; cite sources for hardware facts.\r\n" +
-        "5. If and only if you have concrete, justified changes, end with ONE block between " +
-        ProposalBegin + " and " + ProposalEnd + " following the protocol; copy channel ids and " +
-        "current values from this package exactly.";
+        "5. If and only if you have concrete, justified changes, end with ONE JSON object with " +
+        "\"kind\": \"" + ProposalKind + "\" following the protocol, in a fenced code block; " +
+        "copy channel ids and current values from this package exactly.";
+
+    /// <summary>
+    /// The version of the guide this build was written against, printed in the
+    /// package so an assistant reading a newer guide at the URL knows which
+    /// methodology the package's author expected.
+    /// </summary>
+    public const string GuideVersion = "1.1";
 
     /// <summary>The whole clipboard text, UTF-8 bytes, before any parsing.</summary>
     public const int MaxProposalBytes = 1024 * 1024;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -40,6 +40,13 @@ public partial class VirtualCrossoverPanel
     /// <summary>Records the package this session just copied, for the review's correlation warning.</summary>
     internal void RememberAgentPackage(string packageId) => lastAgentPackageId = packageId;
 
+    // The one place the package is forgotten. A package vouches for a project of
+    // one composition: these channels, in this order, with these measurements.
+    // Any change to that — a project loaded, a block added, removed or reordered,
+    // a source resolved or cleared — makes a reply's ids and current values
+    // describe a project this one no longer is, and the review then says so.
+    private void ForgetAgentPackage() => lastAgentPackageId = null;
+
     // The same two-state toggle the Target button's menu uses: a click while the
     // menu is open closes it; the menu is rebuilt per click so its enabled states
     // are current.

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -558,6 +558,11 @@ public partial class VirtualCrossoverPanel : UserControl
         VirtualCrossoverSessionCalibration? previousSession = sessionCalibration;
         project = newProject;
         relinkDirectory = null;
+        // A package copied from the previous project vouches for nothing here: a
+        // reply naming it gets the review's "different package" warning, and the
+        // previous import's undo would restore into settings nobody displays.
+        lastAgentPackageId = null;
+        agentUndo = null;
         // A new project on the same blocks. The channel OBJECTS are reused when the
         // count matches (see the rebind below), so nothing about a channel reference
         // says which session it now describes — this counter does, and an EQ Wizard

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -561,7 +561,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // A package copied from the previous project vouches for nothing here: a
         // reply naming it gets the review's "different package" warning, and the
         // previous import's undo would restore into settings nobody displays.
-        lastAgentPackageId = null;
+        ForgetAgentPackage();
         agentUndo = null;
         // A new project on the same blocks. The channel OBJECTS are reused when the
         // count matches (see the rebind below), so nothing about a channel reference
@@ -1314,7 +1314,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // The block letters are the channel ids a package used; after a reorder
         // they name other channels, so the package is forgotten and a reply
         // naming it gets the review's warning.
-        lastAgentPackageId = null;
+        ForgetAgentPackage();
         List<VirtualCrossoverChannel> reordered =
             order.Select(index => channels[index]).ToList();
         channels.Clear();
@@ -1476,6 +1476,8 @@ public partial class VirtualCrossoverPanel : UserControl
     private void SetChannelCount(int count)
     {
         count = Math.Clamp(count, MinChannelCount, MaxChannelCount);
+        // A block added or removed: the composition a copied package described.
+        ForgetAgentPackage();
 
         while (channels.Count > count)
         {
@@ -2169,6 +2171,9 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private void ClearSourceCore(VirtualCrossoverChannel channel, bool rightSide)
     {
+        // The package described a measurement under this channel's id that is
+        // about to be gone.
+        ForgetAgentPackage();
         channel.SideState(rightSide).Clear();
         VirtualCrossoverChannelSettings settings = channel.SideSettings(rightSide);
         settings.DisplayName = string.Empty;
@@ -2194,7 +2199,7 @@ public partial class VirtualCrossoverPanel : UserControl
         // A measurement resolved here replaces what a copied package described
         // under this channel's id; the package is forgotten and a reply naming it
         // gets the review's warning. (A project load has forgotten it already.)
-        lastAgentPackageId = null;
+        ForgetAgentPackage();
         VirtualCrossoverChannelSettings settings = channel.SideSettings(rightSide);
         VirtualCrossoverChannelState state = channel.SideState(rightSide);
         // The side's OTHER persisted reference, resolved on the same pass and ahead

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -1614,6 +1614,9 @@ public partial class VirtualCrossoverPanel : UserControl
 
         if (wasMono != monoNow)
         {
+            // A:left and A:right become A:mono, or the other way round: the ids a
+            // copied package used no longer name these channels.
+            ForgetAgentPackage();
             if (monoNow)
             {
                 // The right slot becomes unreachable behind the mono routing;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -1311,6 +1311,10 @@ public partial class VirtualCrossoverPanel : UserControl
     /// </remarks>
     private void ApplyChannelOrder(IReadOnlyList<int> order)
     {
+        // The block letters are the channel ids a package used; after a reorder
+        // they name other channels, so the package is forgotten and a reply
+        // naming it gets the review's warning.
+        lastAgentPackageId = null;
         List<VirtualCrossoverChannel> reordered =
             order.Select(index => channels[index]).ToList();
         channels.Clear();
@@ -2187,6 +2191,10 @@ public partial class VirtualCrossoverPanel : UserControl
     private async Task ResolveSourceAsync(
         VirtualCrossoverChannel channel, bool rightSide, bool showErrors)
     {
+        // A measurement resolved here replaces what a copied package described
+        // under this channel's id; the package is forgotten and a reply naming it
+        // gets the review's warning. (A project load has forgotten it already.)
+        lastAgentPackageId = null;
         VirtualCrossoverChannelSettings settings = channel.SideSettings(rightSide);
         VirtualCrossoverChannelState state = channel.SideState(rightSide);
         // The side's OTHER persisted reference, resolved on the same pass and ahead

--- a/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
@@ -31,6 +31,9 @@ public sealed class AgentPackageBuilderTests
         JsonElement root = Json(text);
         Assert.Equal(AgentProtocol.PackageKind, root.GetProperty("kind").GetString());
         Assert.Equal(1, root.GetProperty("protocolVersion").GetInt32());
+        // The methodology the package's author wrote against, since the guide at
+        // the URL moves on without the program.
+        Assert.Equal(AgentProtocol.GuideVersion, root.GetProperty("guideVersion").GetString());
         Assert.Equal(Id.ToString(), root.GetProperty("packageId").GetString());
         Assert.Equal("2026-09-02T07:00:00Z", root.GetProperty("createdAtUtc").GetString());
         Assert.Equal("Passat B8, LHD.", root.GetProperty("notes").GetString());

--- a/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
@@ -55,6 +55,47 @@ public sealed class AgentProposalParserTests
         }
         """;
 
+    [Theory]
+    [InlineData("bare")]
+    [InlineData("fenced")]
+    [InlineData("prose")]
+    public void Parse_FindsTheProposalByItsKind_WithNoEnvelopeAroundIt(string shape)
+    {
+        // The object identifies itself: bare, in a fence, or buried in prose that
+        // has braces of its own — including a brace inside a JSON string.
+        string reply = shape switch
+        {
+            "bare" => FiveOperations,
+            "fenced" => "Here is what I would change.\n```json\n" + FiveOperations + "\n```\nDone.",
+            _ => "Notes {not JSON} first. { \"kind\": \"something else\" }\n```json\n" +
+                FiveOperations.Replace("\"Level.\"", "\"Level {see the deltas}.\"") +
+                "\n```\nAnd a stray } at the end.",
+        };
+
+        AgentProposalParseResult result = AgentProposalParser.Parse(reply);
+
+        Assert.True(result.Succeeded, result.Error);
+        Assert.Equal(5, result.Proposal!.Operations.Count);
+        if (shape == "prose")
+        {
+            Assert.Equal("Level {see the deltas}.", result.Proposal.Operations[1].Reason);
+        }
+    }
+
+    [Fact]
+    public void Parse_RefusesAReplyWithTwoProposals_OrNone()
+    {
+        AgentProposalParseResult two = AgentProposalParser.Parse(
+            FiveOperations + "\n\nOr alternatively:\n" + FourEngines);
+        Assert.False(two.Succeeded);
+        Assert.Contains("exactly one proposal; found 2", two.Error);
+
+        AgentProposalParseResult none = AgentProposalParser.Parse(
+            "I would not change anything. { \"kind\": \"resonalyze.agent-package\" }");
+        Assert.False(none.Succeeded);
+        Assert.Contains("No proposal found", none.Error);
+    }
+
     [Fact]
     public void Parse_ReadsTheFourEngineRequests_AndLeavesTheirOmittedInputsNull()
     {
@@ -188,7 +229,7 @@ public sealed class AgentProposalParserTests
 
     [Theory]
     [InlineData("", "no text")]
-    [InlineData("Just prose, no block at all.", "No proposal block")]
+    [InlineData("Just prose, no block at all.", "No proposal found")]
     [InlineData("BEGIN_RESONALYZE_AGENT_PROPOSAL_V1 {} END_RESONALYZE_AGENT_PROPOSAL_V1 BEGIN_RESONALYZE_AGENT_PROPOSAL_V1 {} END_RESONALYZE_AGENT_PROPOSAL_V1", "exactly one")]
     [InlineData("END_RESONALYZE_AGENT_PROPOSAL_V1 {} BEGIN_RESONALYZE_AGENT_PROPOSAL_V1", "before its begin")]
     [InlineData("BEGIN_RESONALYZE_AGENT_PROPOSAL_V1   END_RESONALYZE_AGENT_PROPOSAL_V1", "empty")]

--- a/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
@@ -83,6 +83,25 @@ public sealed class AgentProposalParserTests
     }
 
     [Fact]
+    public void Parse_IsNotThrownByProseQuotesOrByAPasteFullOfBraces()
+    {
+        // A lone quote in the prose before the object must not swallow it: each
+        // candidate is walked from its own opening brace, where no string is open.
+        AgentProposalParseResult quoted = AgentProposalParser.Parse(
+            "As the maker's sheet says, \"Fs 65 Hz. The rest is my reading.\n```json\n" +
+            FiveOperations + "\n```");
+        Assert.True(quoted.Succeeded, quoted.Error);
+
+        // Twenty thousand braces that never close, then the proposal: the walk is
+        // budgeted, so the reply is answered in well under a second either way.
+        string braces = string.Concat(Enumerable.Repeat("{ ", 20_000));
+        var clock = System.Diagnostics.Stopwatch.StartNew();
+        _ = AgentProposalParser.Parse(braces + "\n" + FiveOperations);
+        clock.Stop();
+        Assert.True(clock.ElapsedMilliseconds < 2_000, $"{clock.ElapsedMilliseconds} ms");
+    }
+
+    [Fact]
     public void Parse_RefusesAReplyWithTwoProposals_OrNone()
     {
         AgentProposalParseResult two = AgentProposalParser.Parse(

--- a/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
@@ -411,7 +411,7 @@ public sealed class AgentProposalValidatorTests
     }
 
     [Fact]
-    public void Review_WarnsWhenTheReplyAnswersAnotherPackage_AndNotWhenItNamesNone()
+    public void Review_WarnsWhenTheReplyAnswersAnotherPackage_OrOneThisProjectNeverCopied()
     {
         AgentProposal other = Proposal(new SetGainOperation("op-1", "A:right", "", -2.0, -3.0)) with
         {
@@ -421,7 +421,10 @@ public sealed class AgentProposalValidatorTests
 
         Assert.Single(AgentProposalValidator.Review(other, Session()).Warnings);
         Assert.Empty(AgentProposalValidator.Review(none, Session()).Warnings);
-        Assert.Empty(AgentProposalValidator.Review(other, Session(lastPackageId: null)).Warnings);
+        // The panel forgets its package on a project load, a block reorder or a
+        // source replacement: a reply naming one then gets its warning too.
+        string forgotten = Assert.Single(AgentProposalValidator.Review(other, Session(lastPackageId: null)).Warnings);
+        Assert.Contains("has not copied", forgotten);
         // A warning is only a warning: the row itself still applies.
         Assert.True(AgentProposalValidator.Review(other, Session()).Verdicts[0].Applicable);
     }


### PR DESCRIPTION
Follow-ups from the first field run of the Agent Bridge and from the GPT review of `main` at 05efa87.

## The proposal identifies itself

The field run showed the chat placing `BEGIN_RESONALYZE_AGENT_PROPOSAL_V1` / `END_…` *outside* the block it offers to copy, so the user pasted a block the importer could not find. The proposal is now the one JSON object in the reply whose `kind` is `resonalyze.agent-proposal` — bare, fenced, or buried in prose with braces of its own (a brace scanner that knows JSON strings walks the candidates; exactly one must name the kind; two are refused, none is refused). The marker envelope is still read when a reply carries it. The inline rules, the guide (§0, §9) and PROTOCOL §2 ask for the object, not the markers.

## Guide version in the package

`guideVersion` sits beside `protocolVersion` (`AgentProtocol.GuideVersion`, currently `1.1`): the guide at the URL moves on without the program, and an assistant reading a newer one should know which methodology the package's author wrote against.

## A loaded project forgets the last package

`lastAgentPackageId` and the previous import's undo are cleared in `BindProjectAsync`: a reply from the previous project got no "different package" warning after loading another one, and the undo would have restored into settings nobody displays.

## REFERENCE

The sentence saying this build refuses Auto delay and Auto-tune was left over from before they ran; the execution order names Auto-tune.

## Not taken: a state fingerprint

The review asked for a mandatory state fingerprint (channels, DSP, sources, processor, target, gates, analysis, spatial-average state) with exact-match refusal. That reverses the owner's stage-1 decision — `expectedCurrent` per operation is the stale guard, `packageId` is a warning — and is left for the owner to decide; the two cheap parts that fit the existing design (forgetting the package on project load, warning on a mismatch) are in.

## Verification

- Battery in Debug: App 2203 passed, 0 failed.
- New tests: the proposal found bare, fenced and in prose with braces in strings; two proposals or none refused; the marker tests kept; `guideVersion` in the package.
- Smoke on the Passat v2 session with a marker-less, fenced reply surrounded by prose with stray braces: parsed and reviewed as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
