### PR TITLE
Agent Bridge: a session fingerprint replaces the forget-the-package list; the hybrid curves travel at the grid's width

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2872,10 +2872,12 @@ this: the clipboard is the only transport, and you are the one who pastes.
   measurement and captures, every chain, the gates, the scene and the target —
   and the reply is checked against the session as it stands: a reply answering
   a package this session did not copy, or copied before something changed (a
-  measurement replaced by hand, a capture attached, a gate moved, an import
-  undone), is shown with a warning and its engine requests are refused, since
-  an engine reads the session as it is now, which the assistant has not seen;
-  the hand-written rows stand on their own expected current values. A change
+  measurement replaced by hand, a capture attached, a gate moved, the side or
+  the view switched, an import undone), is shown with a warning and its engine
+  requests are refused, since an engine reads the session as it is now, which
+  the assistant has not seen — as is an engine request in a reply that names
+  no package at all; the hand-written rows stand on their own expected current
+  values but come unticked, for you to tick what the change does not bear on. A change
   the assistant reasoned about a value that has since moved is rejected as
   such; so is one
   outside Virtual DSP's own limits (the channel block's gain and delay ranges and

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2824,7 +2824,11 @@ this: the clipboard is the only transport, and you are the one who pastes.
   smoothing whatever the panel's smoothing selector shows — a Sum loss read at
   1/48 octave and one read at 1/6 are different numbers, and packages have to
   compare across sessions and across users, so the panel's own read-out at
-  another smoothing may differ from the package's. Beyond that, what the
+  another smoothing may differ from the package's. The hybrid curves and their
+  sum are the exception to the exception: an average is read with the
+  smoothing off, as the [Hybrid](#hybrid-spatial-averages-under-the-prediction)
+  section says, and off cannot travel on the package's 12-point-per-octave
+  grid, so they go at 1/12 octave — one grid step. Beyond that, what the
   assistant reads is what you see. Curves are sampled on fixed grids
   rather than taken off the plot, so the package does not depend on the window's
   size or zoom. Before the JSON the text carries a short set of rules for the
@@ -2863,8 +2867,17 @@ this: the clipboard is the only transport, and you are the one who pastes.
   Filters, Gain min/max, Max Q, Cuts only, Shelves) for whatever the reply
   leaves out, keeps the bank's all-pass bands, lands the fit the way the wizard's
   **Return** lands it, and skips itself — with the reason — where the wizard
-  would have asked about the [target level](#eq-wizard). A change the assistant
-  reasoned about a value that has since moved is rejected as such; so is one
+  would have asked about the [target level](#eq-wizard). The package is
+  fingerprinted when it is copied — the blocks and their order, each side's
+  measurement and captures, every chain, the gates, the scene and the target —
+  and the reply is checked against the session as it stands: a reply answering
+  a package this session did not copy, or copied before something changed (a
+  measurement replaced by hand, a capture attached, a gate moved, an import
+  undone), is shown with a warning and its engine requests are refused, since
+  an engine reads the session as it is now, which the assistant has not seen;
+  the hand-written rows stand on their own expected current values. A change
+  the assistant reasoned about a value that has since moved is rejected as
+  such; so is one
   outside Virtual DSP's own limits (the channel block's gain and delay ranges and
   steps, the crossover families and slopes, the corner range and the processor's
   Nyquist, the PEQ band count, the Auto delay dialog's own fields), one that
@@ -2902,7 +2915,11 @@ this: the clipboard is the only transport, and you are the one who pastes.
 - **Undo AI import** puts back everything the last import could have moved, not
   only the channels its rows named: every channel's chain, the spatial average
   mode and the **Hybrid** tick, and the block order Auto crossover may have
-  changed. One step; it is gone once a session is loaded.
+  changed. One step; it is gone once a session is loaded. The fingerprint
+  check reads the undone session as what it is: a package copied before the
+  import describes it again, one copied after the import (the diagnostic pass
+  the guide asks for) no longer does, and a reply answering that one has its
+  engine requests refused until a new package is copied.
 
 The assistant's side of the protocol — what the package contains, what a reply
 may say, and the method the assistant is asked to follow (measurement

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -14,7 +14,7 @@ Rules that apply even without the guide:
 2. Ask for what the notes do not say: driver models and locations, amplifier power, DSP model, listening goals. Ask in small groups.
 3. Prefer Resonalyze's own engines: recommend running Auto delay / Auto crossover / EQ Wizard Auto-tune with stated settings instead of inventing delays and PEQ banks by hand.
 4. Never EQ a cancellation; never claim a crossover is driver-safe from Fs or diameter alone; cite sources for hardware facts.
-5. If and only if you have concrete, justified changes, end with ONE JSON object with "kind": "resonalyze.agent-proposal" following the protocol, in a fenced code block; copy channel ids and current values from this package exactly.
+5. If and only if you have concrete, justified changes, end with ONE JSON object with "kind": "resonalyze.agent-proposal" following the protocol, in a fenced code block; copy packageId, channel ids and current values from this package exactly.
 
 ## 1. Your role
 
@@ -433,9 +433,11 @@ what a chat leaves behind when the user copies the block alone). In it:
 
 - Copy `packageId`, every `channelId` and every expected current value from
   the package exactly. A changed current value refuses the operation. A
-  package the session cannot vouch for — another one, or this one after the
-  user changed something or undid an import — refuses every engine request;
-  when the user reports that, ask for a new package.
+  reply that names no package, or a package the session cannot vouch for —
+  another one, or this one after the user changed something, switched the
+  side or the view, or undid an import — refuses every engine request and
+  offers the settings rows unticked; when the user reports that, ask for a
+  new package.
 - One operation per channel and parameter. State each `reason` in one or two
   sentences; the user reads it in the review.
 - Use only the operations `limits.operations` names, and never an engine

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -1,6 +1,6 @@
 # Resonalyze Agent Guide
 
-Guide version 1.2 · for protocol v1 · [PROTOCOL.md](PROTOCOL.md) is the schema.
+Guide version 1.3 · for protocol v1 · [PROTOCOL.md](PROTOCOL.md) is the schema.
 
 ## 0. The rules that also travel inside every package
 
@@ -40,7 +40,14 @@ what you are sure of, what you are inferring, and what you would need to know.
   is computed at psychoacoustic smoothing (1/3 octave below 100 Hz, 1/6 above
   1 kHz) whatever the user's panel shows, so two packages compare and a dip's
   depth means the same in each. The user's own read-out at another smoothing
-  may differ from the package's; the package's is the one to reason from.
+  may differ from the package's; the package's is the one to reason from. The
+  one exception is the hybrid columns and sums (`hybridPreDspDb`,
+  `hybridProcessedDb`, the hybrid sum): a spatial average is read with the
+  smoothing off, since the average has already removed what smoothing exists
+  to hide, and those travel at the grid's own 1/12 octave
+  (`analysis.spatialAverage.smoothingInverseOctaves`). Compare a hybrid column
+  with the measured one beside it by shape; a narrow feature's depth is not
+  the same reading at the two widths.
 - **Two sample rates.** `channels[].source.sampleRateHz` is what the measurement
   was taken at; `processor.sampleRateHz` is what the device builds its filters
   at. Every corner and PEQ band you propose must sit below half the processor's
@@ -185,7 +192,11 @@ Work in this order; each step gates the next.
    empty `bands` list and `preampDb: 0` is a valid operation; the block's
    Bypass would drop the crossover too and change the junction itself), copy
    a new package, read the junction again, then *Undo AI import* to put the
-   banks back. Read the pass on the PHASE read-outs, not on Sum loss alone:
+   banks back — and ask for one more package before you propose anything:
+   after the undo the session is the one before the pass, not the one the
+   diagnostic package described, and a proposal answering that package has
+   its engine requests refused. Read the pass on the PHASE read-outs, not on
+   Sum loss alone:
    Sum loss is the coherent sum against the magnitude sum, so it moves with
    the two channels' level ratio as much as with their phase — at a fixed
    120° between them, two equal levels lose 6.0 dB and the same pair with
@@ -194,7 +205,7 @@ Work in this order; each step gates the next.
    by that route, and clearing it (its preamp too) changes the ratio back.
    So compare, before and after, the junction's `phase` block —
    `phaseAtCrossoverDeg`, `currentScore` (a phase-alignment score by
-   construction, not a level one), `fitRmsDeg`, `phaseConsistency` — and the
+   construction, not a level one), `fitRmsDeg`, `consistency` — and the
    excess group delay, alongside the two channels' levels in `bandHz`. The
    bands were straightening the minimum-phase part only when the phase
    metrics are WORSE without them and the excess curve is unchanged; then
@@ -421,7 +432,10 @@ itself, so nothing outside the block is needed (and text outside the block is
 what a chat leaves behind when the user copies the block alone). In it:
 
 - Copy `packageId`, every `channelId` and every expected current value from
-  the package exactly. A changed current value refuses the operation.
+  the package exactly. A changed current value refuses the operation. A
+  package the session cannot vouch for — another one, or this one after the
+  user changed something or undid an import — refuses every engine request;
+  when the user reports that, ask for a new package.
 - One operation per channel and parameter. State each `reason` in one or two
   sentences; the user reads it in the review.
 - Use only the operations `limits.operations` names, and never an engine

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -543,9 +543,11 @@ showed (a crossover moved without the bank that went with it).
    session must pass.
 3. Shows the review: every row with its current and proposed value; admissible
    rows ticked, rejected rows greyed with their reason, warnings in words.
-4. On *Apply selected*, judges the ticked rows once more against the settings as
-   they are at that moment, then writes the settings rows as one set. A failure
-   there writes nothing.
+4. On *Apply selected*, judges the ticked rows once more against the settings
+   and the session fingerprint as they are at that moment — a row the fresh
+   review would refuse, or would no longer offer ticked, stops the whole
+   import with a request to review again — then writes the settings rows as
+   one set. A failure there writes nothing.
 5. Runs the ticked engine requests, in the fixed order above — the spatial
    average straight onto the panel, Auto crossover through its wizard, Auto
    delay and Auto-tune without their dialogs — and

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -48,7 +48,7 @@ to the 100 KB ceiling, and beyond that nothing is copied:
 | `kind` | `"resonalyze.agent-package"` |
 | `protocolVersion` | `1` |
 | `guideVersion` | The version of [AGENT_GUIDE.md](AGENT_GUIDE.md) this build was written against (its first line). The guide at the URL may be newer; read it, and know which methodology the package's author expected. |
-| `packageId` | A new GUID per copy. Echo it in the reply; a mismatch is a warning, not a refusal. |
+| `packageId` | A new GUID per copy. Echo it in the reply: it is how the importer knows which session the reply describes. A reply naming a package the session cannot vouch for — none copied, another one, or this one after the session changed — is shown with a warning; its settings rows are judged on their expected current values, its engine requests refused (§2.2). |
 | `createdAtUtc` | ISO 8601, UTC. |
 | `application` | `{ name, version }` |
 | `conventions` | Units and sign conventions, as text, for readers without the guide. |
@@ -111,7 +111,8 @@ package's OWN smoothing, not the display's: every magnitude curve, sum and Sum
 loss in a package is computed at psychoacoustic smoothing — 1/3 octave below
 100 Hz narrowing to 1/6 above 1 kHz — whatever the panel's combo box shows, so
 two packages compare and a dip's depth means the same thing in each; the
-screen's read-outs at another smoothing may differ),
+screen's read-outs at another smoothing may differ — the hybrid curves and
+sums are the one exception, at `spatialAverage.smoothingInverseOctaves`, below),
 `spatialAverage` (below), `phaseWindowMode`, `fdwCycles`, `phaseDetrendMode`, `gateShapeMs`
 (`left`, `plateau`, `right`), `gateLeft` / `gateRight` (`offsetMs`, `detrendMs`
 where pinned), `calibration` (the microphone calibration's name, no path),
@@ -123,7 +124,7 @@ the channels that have a measurement:
 
 ```json
 "spatialAverage": { "mode": "MovingMic", "hybridTicked": true, "hybridDrawn": false,
-                    "status": "capturedNotShown",
+                    "smoothingInverseOctaves": 12, "status": "capturedNotShown",
                     "channelsShown": 7, "channelsWithCapture": 5, "channelsDrawn": 0 }
 ```
 
@@ -132,6 +133,17 @@ the channels that have a measurement:
   `hybridDrawn` whether the hybrid curves are actually on the plot — that also
   needs every playing channel to carry a capture of the selected family and a
   view that shows them (not a group comparison).
+- `smoothingInverseOctaves` is the width the hybrid curves and sums are read at
+  — `hybridPreDspDb`, `hybridProcessedDb`, the sides' hybrid sum and
+  `hybridSumVsTargetDb`: 1/12 octave, the grid's own width, not the package's
+  psychoacoustic one. The manual reads a spatial average with the smoothing
+  off — the average has already removed the position-dependent wiggles
+  smoothing exists to hide, and a fractional-octave window straddling a
+  crossover's skirt pulls the level toward the passband right where the
+  acoustic slopes are judged — and off cannot travel on a 12-point-per-octave
+  grid; one grid step is the nearest. A hybrid column and the measured column
+  beside it are therefore not at one width: compare the two by shape, not by
+  the depth of a narrow feature.
 - The counts run over the channels the current view **shows** — the union of
   `sides[].channels`, the channels the diagnostics are built from. A channel the
   view leaves out has its own curves but never hybrid ones, whatever it holds;
@@ -208,7 +220,7 @@ The parametric terms (`levelDb`, `preset`, `tiltDbPerOctave`, `bassShelf`,
   window), `chainDb` (the chain alone, built at the processor's rate), `peqDb`
   (the PEQ alone), `hybridPreDspDb` and `hybridProcessedDb` (the spatial average
   before and through the chain, present when the hybrid view is on and the
-  channel has a capture), `coherence` (γ², when the source carried it). The two
+  channel has a capture, at the hybrid's own smoothing, §1.4), `coherence` (γ², when the source carried it). The two
   hybrid columns are placed on the **same level axis** as the impulse-response
   columns — the datum the panel draws them with is applied — so every column of
   a channel compares directly with every other. A `null` cell is a frequency the
@@ -299,7 +311,7 @@ same chat as a second text:
 RESONALYZE_AGENT_DIAGNOSTIC_V1
 …
 BEGIN_RESONALYZE_AGENT_DIAGNOSTIC_JSON
-{ "kind": "resonalyze.agent-diagnostic", "protocolVersion": 1, "guideVersion": "1.2",
+{ "kind": "resonalyze.agent-diagnostic", "protocolVersion": 1, "guideVersion": "1.3",
   "diagnostic": "excessGroupDelay", "packageId": "…", "createdAtUtc": "…",
   "conventions": { … },
   "channels": [ { "id": "B:left", "series": { "columns": ["frequencyHz","excessGdMs"], "rows": [ … ] } }, … ] }
@@ -307,7 +319,9 @@ END_RESONALYZE_AGENT_DIAGNOSTIC_JSON
 ```
 
 `packageId` names the package the diagnostic was copied beside (absent when
-none was copied since the project was loaded); the channel ids and the
+none was copied since the session opened, or when the session has changed
+since that copy — the same check the reply's review makes, §2.2 — so an id
+that is present vouches that the curves belong beside it); the channel ids and the
 broadband grid are the package's, so the two lay side by side. A row is left
 out where the reading could not be made.
 
@@ -376,7 +390,7 @@ open door: an `extensions` object, whose content is ignored).
 | --- | --- | --- |
 | `kind` | yes | `"resonalyze.agent-proposal"` |
 | `protocolVersion` | yes | `1` |
-| `packageId` | no | Echo of the package's id. A different id is shown as a warning. |
+| `packageId` | no | Echo of the package's id. A package the session cannot vouch for (§2.2) is shown as a warning and refuses the engine requests. |
 | `summary` | yes | One paragraph, shown at the top of the review. |
 | `advice[]` | no | Changes that are not operations — engines to run, things to re-measure. Shown, never applied. |
 | `sources[]` | no | `{ url, title?, factsUsed[] }`; `url` must be `http(s)`. Shown as text, never opened. |
@@ -480,6 +494,17 @@ which curves the rest are read on), then `runAutoCrossover`, then `runAutoDelay`
 then `autoTunePeq`. One summary at the end says what was applied and what was
 skipped, and *Undo AI import* puts back everything the whole sequence moved.
 
+An engine request is refused — the reply's other rows left to their own checks
+— when the session cannot vouch for the package the reply names: no package
+copied since the session opened, another package than the last one copied, or
+that package copied from a session that has since changed (a measurement or
+capture replaced, a block added, removed or reordered, a chain, gate or datum
+moved, an import undone). Resonalyze fingerprints the session at every copy
+and compares at every review. A settings row still stands on its expected
+current value; an engine reads the session as it is *now*, which the assistant
+has not seen. Ask for a new package. A reply that names no package is taken at
+its word.
+
 An engine and a hand-written value the engine would write over cannot both be
 meant, so the hand-written row is **rejected**, naming the engine that would have
 erased it. The engine keeps its row: it is the one that computes the number.
@@ -526,7 +551,12 @@ showed (a crossover moved without the bank that went with it).
    undone in one step.
 6. *Undo AI import* puts back everything the import could have moved: every
    channel's chain, the spatial average mode and the Hybrid tick, and the block
-   order the crossover wizard may have changed.
+   order the crossover wizard may have changed. The fingerprint check reads
+   the undone session as what it is: a package copied *before* the import
+   describes it again, and a reply answering that package is taken in full; a
+   package copied *after* the import — the guide's diagnostic pass — no longer
+   does, and a reply answering it has its engine requests refused until a new
+   package is copied.
 
 ## 3. Privacy
 

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -543,11 +543,12 @@ showed (a crossover moved without the bank that went with it).
    session must pass.
 3. Shows the review: every row with its current and proposed value; admissible
    rows ticked, rejected rows greyed with their reason, warnings in words.
-4. On *Apply selected*, judges the ticked rows once more against the settings
-   and the session fingerprint as they are at that moment — a row the fresh
-   review would refuse, or would no longer offer ticked, stops the whole
-   import with a request to review again — then writes the settings rows as
-   one set. A failure there writes nothing.
+4. On *Apply selected*, first compares the current session fingerprint with the
+   one the review showed; a difference stops the whole import with a request to
+   review again. If it is unchanged, the ticked rows are judged once more
+   against the live settings and written as one set. A stale-package warning
+   already shown in the review does not block a settings row the user deliberately
+   ticked; a row that is no longer applicable does. A failure writes nothing.
 5. Runs the ticked engine requests, in the fixed order above — the spatial
    average straight onto the panel, Auto crossover through its wizard, Auto
    delay and Auto-tune without their dialogs — and

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -48,7 +48,7 @@ to the 100 KB ceiling, and beyond that nothing is copied:
 | `kind` | `"resonalyze.agent-package"` |
 | `protocolVersion` | `1` |
 | `guideVersion` | The version of [AGENT_GUIDE.md](AGENT_GUIDE.md) this build was written against (its first line). The guide at the URL may be newer; read it, and know which methodology the package's author expected. |
-| `packageId` | A new GUID per copy. Echo it in the reply: it is how the importer knows which session the reply describes. A reply naming a package the session cannot vouch for — none copied, another one, or this one after the session changed — is shown with a warning; its settings rows are judged on their expected current values, its engine requests refused (§2.2). |
+| `packageId` | A new GUID per copy. Echo it in the reply: it is how the importer knows which session the reply describes, and an engine request without it is refused. A reply naming a package the session cannot vouch for — none copied, another one, or this one after the session changed — is shown with a warning; its settings rows are judged on their expected current values but offered unticked, its engine requests refused (§2.2). |
 | `createdAtUtc` | ISO 8601, UTC. |
 | `application` | `{ name, version }` |
 | `conventions` | Units and sign conventions, as text, for readers without the guide. |
@@ -390,7 +390,7 @@ open door: an `extensions` object, whose content is ignored).
 | --- | --- | --- |
 | `kind` | yes | `"resonalyze.agent-proposal"` |
 | `protocolVersion` | yes | `1` |
-| `packageId` | no | Echo of the package's id. A package the session cannot vouch for (§2.2) is shown as a warning and refuses the engine requests. |
+| `packageId` | for engine requests | Echo of the package's id. Required when `operations[]` holds an engine request — one without it is refused; a reply of settings rows alone may leave it out, each row carrying its own expected current value. A package the session cannot vouch for (§2.2) is shown as a warning, refuses the engine requests and offers the settings rows unticked. |
 | `summary` | yes | One paragraph, shown at the top of the review. |
 | `advice[]` | no | Changes that are not operations — engines to run, things to re-measure. Shown, never applied. |
 | `sources[]` | no | `{ url, title?, factsUsed[] }`; `url` must be `http(s)`. Shown as text, never opened. |
@@ -494,15 +494,18 @@ which curves the rest are read on), then `runAutoCrossover`, then `runAutoDelay`
 then `autoTunePeq`. One summary at the end says what was applied and what was
 skipped, and *Undo AI import* puts back everything the whole sequence moved.
 
-An engine request is refused — the reply's other rows left to their own checks
-— when the session cannot vouch for the package the reply names: no package
-copied since the session opened, another package than the last one copied, or
-that package copied from a session that has since changed (a measurement or
-capture replaced, a block added, removed or reordered, a chain, gate or datum
-moved, an import undone). Resonalyze fingerprints the session at every copy
-and compares at every review. A settings row still stands on its expected
-current value; an engine reads the session as it is *now*, which the assistant
-has not seen. Ask for a new package. A reply that names no package is taken at
+An engine request is refused when the reply names no package, or names one the
+session cannot vouch for: no package copied since the session opened, another
+package than the last one copied, or that package copied from a session that
+has since changed (a measurement, capture or calibration replaced, a block
+added, removed or reordered, a chain, gate or datum moved, the side on screen
+or the view switched, an import undone). Resonalyze fingerprints the session
+at every copy and compares at every review. An engine reads the session as it
+is *now*, which the assistant has not seen. The settings rows stay — each is
+still judged on its expected current value — but are offered **unticked** and
+marked, since a current value can match after the measurement the row was
+reasoned from has been replaced; the user ticks what still applies. Ask for a
+new package. A reply of settings rows alone that names no package is taken at
 its word.
 
 An engine and a hand-written value the engine would write over cannot both be

--- a/source/Integration/AgentBridge/AgentPackageBuilder.cs
+++ b/source/Integration/AgentBridge/AgentPackageBuilder.cs
@@ -253,6 +253,7 @@ internal static class AgentPackageBuilder
             analysis.SpatialAverageMode?.ToString(),
             analysis.HybridTicked,
             analysis.HybridDrawn,
+            analysis.HybridSmoothingInverseOctaves,
             status,
             shown.Count,
             withCapture,

--- a/source/Integration/AgentBridge/AgentPackageInputs.cs
+++ b/source/Integration/AgentBridge/AgentPackageInputs.cs
@@ -47,6 +47,10 @@ internal sealed record AgentAnalysisInputs(
     // to fix than "not ticked".
     bool HybridTicked,
     bool HybridDrawn,
+    // The hybrid curves' and sums' own smoothing — the grid's width, not the
+    // package's psychoacoustic one — printed so a reader knows the two families
+    // of curves were not read at one width (see the capture's note).
+    int HybridSmoothingInverseOctaves,
     PhaseWindowMode PhaseWindowMode,
     int FdwCycles,
     PhaseDetrendMode DetrendMode,

--- a/source/Integration/AgentBridge/AgentPackageModels.cs
+++ b/source/Integration/AgentBridge/AgentPackageModels.cs
@@ -83,11 +83,16 @@ internal sealed record AgentPackageAnalysis(
 /// all). Counted over the channels the current view shows — the ones whose
 /// curves the package's diagnostics are built from — and "drawn" is read off
 /// the hybrid curves actually present, not off what is attached.
+/// <see cref="SmoothingInverseOctaves"/> is the hybrid curves' and sums' own
+/// smoothing: the package's grid width rather than its psychoacoustic one,
+/// because the manual reads an average with the smoothing off, and off cannot
+/// travel on a grid.
 /// </summary>
 internal sealed record AgentPackageSpatialAverage(
     string? Mode,
     bool HybridTicked,
     bool HybridDrawn,
+    int SmoothingInverseOctaves,
     string Status,
     int ChannelsShown,
     int ChannelsWithCapture,

--- a/source/Integration/AgentBridge/AgentProposalApplier.cs
+++ b/source/Integration/AgentBridge/AgentProposalApplier.cs
@@ -54,7 +54,11 @@ internal static class AgentProposalApplier
             return "No applicable change was selected.";
         }
 
-        AgentOperationVerdict? stale = toApply.FirstOrDefault(verdict => !verdict.Applicable);
+        // A row the fresh review would no longer offer ticked is one the user
+        // ticked without seeing why it should not be: a measurement, a gate or
+        // the view moved under the dialog, and the row's expected current value
+        // still matches. The same answer as a row that stopped applying.
+        AgentOperationVerdict? stale = toApply.FirstOrDefault(verdict => !verdict.Applicable || !verdict.Ticked);
         if (stale != null)
         {
             toApply.Clear();

--- a/source/Integration/AgentBridge/AgentProposalApplier.cs
+++ b/source/Integration/AgentBridge/AgentProposalApplier.cs
@@ -30,9 +30,16 @@ internal static class AgentProposalApplier
     /// unticked row can take a compensating change with it. The panel asks before
     /// applying over them; they never refuse on their own.
     /// </param>
+    /// <param name="reviewedFingerprint">
+    /// The session fingerprint shown in the review dialog. A different current
+    /// fingerprint means the session moved while the dialog was open; an already
+    /// stale row that the user deliberately ticked is allowed while it stays the
+    /// same.
+    /// </param>
     public static string? Prepare(
         AgentProposal proposal,
         IReadOnlySet<string> selectedIds,
+        string? reviewedFingerprint,
         AgentSessionSnapshot session,
         out List<AgentOperationVerdict> toApply,
         out List<string> unseenWarnings)
@@ -54,11 +61,20 @@ internal static class AgentProposalApplier
             return "No applicable change was selected.";
         }
 
-        // A row the fresh review would no longer offer ticked is one the user
-        // ticked without seeing why it should not be: a measurement, a gate or
-        // the view moved under the dialog, and the row's expected current value
-        // still matches. The same answer as a row that stopped applying.
-        AgentOperationVerdict? stale = toApply.FirstOrDefault(verdict => !verdict.Applicable || !verdict.Ticked);
+        // Ticked is the review's DEFAULT, not an admissibility gate: a stale
+        // settings row is deliberately offered unticked for the user to opt in.
+        // What matters at commit is whether the session moved AFTER that warning
+        // was shown. The dialog's fingerprint is the only state that can answer
+        // that; comparing the fresh verdict's Ticked flag would reject the exact
+        // manual override the review offers.
+        if (!string.Equals(reviewedFingerprint, session.Fingerprint, StringComparison.Ordinal))
+        {
+            toApply.Clear();
+            return "The session changed while the review was open. " +
+                "Import the reply again to review it against the current settings.";
+        }
+
+        AgentOperationVerdict? stale = toApply.FirstOrDefault(verdict => !verdict.Applicable);
         if (stale != null)
         {
             toApply.Clear();

--- a/source/Integration/AgentBridge/AgentProposalValidator.cs
+++ b/source/Integration/AgentBridge/AgentProposalValidator.cs
@@ -28,6 +28,13 @@ internal sealed record AgentOperationVerdict(
     AgentOperation? Operation,
     AgentChannelSnapshot? Channel)
 {
+    /// <summary>
+    /// Whether the review offers the row ticked. An applicable row is, unless the
+    /// session can no longer vouch for the package it was written against: then
+    /// it is offered unticked, for the user to tick knowingly.
+    /// </summary>
+    public bool Ticked { get; init; } = true;
+
     public bool Applicable =>
         Status != AgentVerdictStatus.Rejected && Operation != null &&
         (Operation is not AgentChannelOperation || Channel != null);
@@ -190,28 +197,37 @@ internal static class AgentProposalValidator
         // applied, and a note read off one that has just been refused would
         // describe a state nothing will produce.
         AddFinalStateNotes(verdicts);
+        // After every note: the stale mark is the last word on a row, and a note
+        // added after it would read as if it were part of the same sentence.
+        MarkSettingsRowsOnAStaleSession(verdicts, stale);
         return new AgentProposalReview(proposal, verdicts, warnings);
     }
 
     // Whether the session can vouch for the package the reply answers, and if
-    // not, why: no package copied since the session opened (or the reply's came
-    // from elsewhere), another package than the one last copied, or the session
-    // changed since that copy — its fingerprint (AgentSessionFingerprint) no
-    // longer matches, whichever way it changed. A reply that names no package
-    // is taken at its word. The settings rows survive all three, judged on their
-    // expected current values as always; the engine requests do not, since an
-    // engine reads the session as it is now, which the assistant has not seen.
+    // not, why: the reply names none while asking for an engine, no package was
+    // copied since the session opened (or the reply's came from elsewhere), it
+    // is another package than the one last copied, or the session changed since
+    // that copy — its fingerprint (AgentSessionFingerprint) no longer matches,
+    // whichever way it changed. A reply of settings rows alone that names no
+    // package is taken at its word: each row carries its own expected current
+    // value. Under any of the four the settings rows stay, judged on those
+    // values but offered unticked (MarkSettingsRowsOnAStaleSession), and the
+    // engine requests are refused, since an engine reads the session as it is
+    // now, which the assistant has not seen.
     private static string? StaleSessionReason(AgentProposal proposal, AgentSessionSnapshot session)
     {
+        const string Decide =
+            " The settings rows are judged on the current values below and left " +
+            "unticked; the engine requests are refused, since they would run on a " +
+            "session the assistant has not seen — copy a new package and ask again.";
         if (proposal.PackageId == null)
         {
-            return null;
+            return proposal.Operations.Any(operation => operation is not AgentSettingsOperation)
+                ? "The reply names no package, so nothing says which session its engine " +
+                    "requests were written for." + Decide
+                : null;
         }
 
-        const string Decide =
-            " The settings rows are judged on the current values below; the engine " +
-            "requests are refused, since they would run on a session the assistant has " +
-            "not seen — copy a new package and ask again.";
         if (session.LastPackageId == null)
         {
             return "The reply names a package this session has not copied since it opened, " +
@@ -251,6 +267,39 @@ internal static class AgentProposalValidator
                     Status = AgentVerdictStatus.Rejected,
                     Message = "The session is not the one the package described; " +
                         "copy a new package and ask again."
+                };
+            }
+        }
+    }
+
+    // A settings row from a package the session cannot vouch for is judged on
+    // its expected current value as always, and that value can still match after
+    // the MEASUREMENT the row was reasoned from has been replaced. The row stays
+    // — the user may know the change does not bear on it — but is offered
+    // unticked and marked, rather than ticked by default among rows that are.
+    private static void MarkSettingsRowsOnAStaleSession(
+        List<AgentOperationVerdict> verdicts, string? staleReason)
+    {
+        if (staleReason == null)
+        {
+            return;
+        }
+
+        const string Note =
+            "Written against a package this session cannot vouch for (see the warning " +
+            "above); tick it only if what changed does not bear on this row.";
+        for (int index = 0; index < verdicts.Count; index++)
+        {
+            AgentOperationVerdict verdict = verdicts[index];
+            if (verdict.Applicable && verdict.Operation is AgentSettingsOperation)
+            {
+                verdicts[index] = verdict with
+                {
+                    Status = AgentVerdictStatus.Warning,
+                    Message = verdict.Status == AgentVerdictStatus.Warning
+                        ? verdict.Message + " " + Note
+                        : Note,
+                    Ticked = false
                 };
             }
         }

--- a/source/Integration/AgentBridge/AgentProposalValidator.cs
+++ b/source/Integration/AgentBridge/AgentProposalValidator.cs
@@ -138,22 +138,10 @@ internal static class AgentProposalValidator
         ArgumentNullException.ThrowIfNull(session);
 
         var warnings = new List<string>();
-        if (proposal.PackageId != null && session.LastPackageId == null)
+        string? stale = StaleSessionReason(proposal, session);
+        if (stale != null)
         {
-            // The panel forgets its package when the project is loaded, the blocks
-            // are reordered or a source is replaced: the ids the reply uses were
-            // read off a project this one no longer is.
-            warnings.Add(
-                "The reply names a package this project has not copied — a project was " +
-                "loaded, the blocks were reordered or a measurement was replaced since, or the " +
-                "package came from elsewhere. The current values below decide.");
-        }
-        else if (proposal.PackageId != null && session.LastPackageId != null &&
-            !string.Equals(proposal.PackageId, session.LastPackageId, StringComparison.OrdinalIgnoreCase))
-        {
-            warnings.Add(
-                "The reply answers a different package than the one last copied from this " +
-                "session (or the session was reopened since). The current values below decide.");
+            warnings.Add(stale);
         }
 
         var verdicts = new List<AgentOperationVerdict>();
@@ -188,6 +176,7 @@ internal static class AgentProposalValidator
             }
         }
 
+        RejectEngineRequestsOnAStaleSession(verdicts, stale);
         RejectRepeatedEngineRequests(verdicts);
         RejectDisagreeingTargetLevels(verdicts);
         RejectOverwrittenSettings(verdicts, session);
@@ -202,6 +191,69 @@ internal static class AgentProposalValidator
         // describe a state nothing will produce.
         AddFinalStateNotes(verdicts);
         return new AgentProposalReview(proposal, verdicts, warnings);
+    }
+
+    // Whether the session can vouch for the package the reply answers, and if
+    // not, why: no package copied since the session opened (or the reply's came
+    // from elsewhere), another package than the one last copied, or the session
+    // changed since that copy — its fingerprint (AgentSessionFingerprint) no
+    // longer matches, whichever way it changed. A reply that names no package
+    // is taken at its word. The settings rows survive all three, judged on their
+    // expected current values as always; the engine requests do not, since an
+    // engine reads the session as it is now, which the assistant has not seen.
+    private static string? StaleSessionReason(AgentProposal proposal, AgentSessionSnapshot session)
+    {
+        if (proposal.PackageId == null)
+        {
+            return null;
+        }
+
+        const string Decide =
+            " The settings rows are judged on the current values below; the engine " +
+            "requests are refused, since they would run on a session the assistant has " +
+            "not seen — copy a new package and ask again.";
+        if (session.LastPackageId == null)
+        {
+            return "The reply names a package this session has not copied since it opened, " +
+                "or one that came from elsewhere." + Decide;
+        }
+        if (!string.Equals(proposal.PackageId, session.LastPackageId, StringComparison.OrdinalIgnoreCase))
+        {
+            return "The reply answers a different package than the one last copied from this " +
+                "session." + Decide;
+        }
+        if (session.LastPackageFingerprint != null && session.Fingerprint != null &&
+            !string.Equals(session.LastPackageFingerprint, session.Fingerprint, StringComparison.Ordinal))
+        {
+            return "The session has changed since that package was copied — a measurement or " +
+                "capture replaced, a block added, removed or reordered, a chain, gate or datum " +
+                "moved, or an import undone." + Decide;
+        }
+
+        return null;
+    }
+
+    private static void RejectEngineRequestsOnAStaleSession(
+        List<AgentOperationVerdict> verdicts, string? staleReason)
+    {
+        if (staleReason == null)
+        {
+            return;
+        }
+
+        for (int index = 0; index < verdicts.Count; index++)
+        {
+            AgentOperationVerdict verdict = verdicts[index];
+            if (verdict.Applicable && verdict.Operation is not AgentSettingsOperation)
+            {
+                verdicts[index] = verdict with
+                {
+                    Status = AgentVerdictStatus.Rejected,
+                    Message = "The session is not the one the package described; " +
+                        "copy a new package and ask again."
+                };
+            }
+        }
     }
 
     // The panel runs each engine once per import, and a second request for the

--- a/source/Integration/AgentBridge/AgentProtocol.cs
+++ b/source/Integration/AgentBridge/AgentProtocol.cs
@@ -73,7 +73,7 @@ internal static class AgentProtocol
         "alone; cite sources for hardware facts.\r\n" +
         "5. If and only if you have concrete, justified changes, end with ONE JSON object with " +
         "\"kind\": \"" + ProposalKind + "\" following the protocol, in a fenced code block; " +
-        "copy channel ids and current values from this package exactly.";
+        "copy packageId, channel ids and current values from this package exactly.";
 
     /// <summary>
     /// The version of the guide this build was written against, printed in the

--- a/source/Integration/AgentBridge/AgentProtocol.cs
+++ b/source/Integration/AgentBridge/AgentProtocol.cs
@@ -80,7 +80,7 @@ internal static class AgentProtocol
     /// package so an assistant reading a newer guide at the URL knows which
     /// methodology the package's author expected.
     /// </summary>
-    public const string GuideVersion = "1.2";
+    public const string GuideVersion = "1.3";
 
     /// <summary>The whole clipboard text, UTF-8 bytes, before any parsing.</summary>
     public const int MaxProposalBytes = 1024 * 1024;

--- a/source/Integration/AgentBridge/AgentSessionFingerprint.cs
+++ b/source/Integration/AgentBridge/AgentSessionFingerprint.cs
@@ -57,5 +57,17 @@ internal static class AgentSessionFingerprint
             ? string.Empty
             : Digests.GetValue(values, array => Hex(SHA256.HashData(MemoryMarshal.AsBytes<T>((T[])array))));
 
+    /// <summary>
+    /// The content of a short curve — a calibration's points — as sixteen hex
+    /// digits, hashed on every call: the points are read off a list the caller
+    /// flattens, so there is no array instance to cache by.
+    /// </summary>
+    public static string ContentDigest(IEnumerable<double> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        double[] flat = values.ToArray();
+        return Hex(SHA256.HashData(MemoryMarshal.AsBytes<double>(flat)));
+    }
+
     private static string Hex(byte[] hash) => Convert.ToHexStringLower(hash)[..16];
 }

--- a/source/Integration/AgentBridge/AgentSessionFingerprint.cs
+++ b/source/Integration/AgentBridge/AgentSessionFingerprint.cs
@@ -1,0 +1,61 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Resonalyze.Integration.AgentBridge;
+
+/// <summary>
+/// A short hash of everything a package vouches for: the blocks and their
+/// order, each side's measurement and captures, every chain, and the project
+/// figures the diagnostics were computed under. Taken when a package is copied
+/// and again when a reply is reviewed; a difference means the reply describes
+/// a session this one no longer is, whichever way it changed — a measurement
+/// replaced, an import undone, a gate moved — and the review says so without
+/// anyone having to remember to forget the package on every such path.
+/// </summary>
+/// <remarks>
+/// The lines are written by the panel, which is the one thing that knows the
+/// whole session; this class only fixes the hashing so a test can pin that two
+/// manifests differing in one field differ in the hash. Order-sensitive: the
+/// block order is part of what the channel ids mean.
+/// </remarks>
+internal static class AgentSessionFingerprint
+{
+    // One digest per array INSTANCE, kept as long as the array is: a measurement
+    // is hashed once when first fingerprinted, not on every review. The arrays
+    // this is asked about — a loaded impulse response, its coherence, an
+    // imported target curve — are replaced, never edited in place, which is
+    // what makes the cache honest.
+    private static readonly ConditionalWeakTable<Array, string> Digests = new();
+
+    /// <summary>Sixteen hex digits of SHA-256 over the lines, newline-joined.</summary>
+    public static string Compute(IEnumerable<string> lines)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+        return Hex(SHA256.HashData(Encoding.UTF8.GetBytes(string.Join('\n', lines))));
+    }
+
+    /// <summary>
+    /// A number in round-trip invariant form; <c>null</c> as the empty string.
+    /// Negative zero reads as zero: a gain typed as 0 and one arrived at by
+    /// arithmetic are the same setting.
+    /// </summary>
+    public static string Number(double? value) =>
+        value is { } number
+            ? (number == 0 ? 0.0 : number).ToString("R", CultureInfo.InvariantCulture)
+            : string.Empty;
+
+    /// <summary>
+    /// The CONTENT of an array, as sixteen hex digits — so a measurement saved
+    /// over its own file, same name, same length, same rate, still reads as the
+    /// different measurement it is. <c>null</c> as the empty string.
+    /// </summary>
+    public static string ContentDigest<T>(T[]? values) where T : unmanaged =>
+        values == null
+            ? string.Empty
+            : Digests.GetValue(values, array => Hex(SHA256.HashData(MemoryMarshal.AsBytes<T>((T[])array))));
+
+    private static string Hex(byte[] hash) => Convert.ToHexStringLower(hash)[..16];
+}

--- a/source/Integration/AgentBridge/AgentSessionSnapshot.cs
+++ b/source/Integration/AgentBridge/AgentSessionSnapshot.cs
@@ -74,7 +74,8 @@ internal sealed record AgentChannelSnapshot(
 /// </param>
 /// <param name="LastPackageId">
 /// The id of the package this session most recently copied, or null when it has
-/// not copied one since it opened. A reply naming another id gets a warning.
+/// not copied one since it opened. A reply naming another id gets a warning,
+/// and its engine requests are refused.
 /// </param>
 /// <param name="AutoDelay">
 /// What an Auto delay run would start from: the values the dialog would open
@@ -98,7 +99,13 @@ internal sealed record AgentSessionSnapshot(
     // The side on screen: an Auto-tune handoff is built for it alone (its gate
     // pin, its render anchor, its hybrid datum), so a request for the other
     // side's channel is refused at review rather than skipped at execution.
-    bool ActiveSideRight = false)
+    bool ActiveSideRight = false,
+    // The fingerprint the last copied package was taken at, and the session's
+    // own now (AgentSessionFingerprint): unequal, the session has changed since
+    // the copy, whichever way. Null when the panel took none — a test session —
+    // and then the two are not compared.
+    string? LastPackageFingerprint = null,
+    string? Fingerprint = null)
 {
     public AgentChannelSnapshot? Find(string channelId) =>
         Channels.FirstOrDefault(channel =>

--- a/source/Tools/VirtualCrossover/AgentProposalDialog.cs
+++ b/source/Tools/VirtualCrossover/AgentProposalDialog.cs
@@ -32,7 +32,7 @@ internal sealed partial class AgentProposalDialog : Form
         foreach (AgentOperationVerdict verdict in review.Verdicts)
         {
             int index = gridView.Rows.Add(
-                verdict.Applicable,
+                verdict.Applicable && verdict.Ticked,
                 verdict.ChannelLabel,
                 verdict.Parameter,
                 verdict.Current,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -85,7 +85,10 @@ public partial class VirtualCrossoverPanel
                 $"{Number(project.PhaseGateRight.OffsetMs)};{Number(project.PhaseGateRight.DetrendMs)}",
             $"stereo;{Number(project.StereoSceneOffsetMagnitudeMs)};{project.StereoRightHandDrive};" +
                 $"{Number(project.StereoLevelDifferenceDb)};{Number(project.RearFillOffsetMs)}",
-            $"calibration;{project.CalibrationId}",
+            // The selected correction by id AND by its points: a curve re-read or
+            // edited under the same id (ReconcileCalibrationSelection) is another
+            // correction on every measurement the package reads.
+            $"calibration;{project.CalibrationId};{ownCalibrationSelected};{Curve(Calibration)}",
             $"target;{Number((double)numericTargetLevel.Value)};{TargetShape(project.Target)}",
             // The assistant reasons from the notes as much as from the curves.
             $"notes;{project.AiNotes}"
@@ -107,8 +110,10 @@ public partial class VirtualCrossoverPanel
                 Digest(state.TransferImpulseResponse), state.SampleRate, state.TransferPeakIndex,
                 Number(state.MeasuredBand.LowestHz), Number(state.MeasuredBand.HighestHz),
                 Digest(state.TransferCoherence),
-                state.MicrophoneCalibration?.Name, state.MicrophoneCalibration?.FileName,
-                state.MicrophoneCalibration?.Points.Count,
+                // The correction this side's curves are actually read through —
+                // its own under "Own (as measured)", the selected one otherwise —
+                // by its points.
+                Curve(CalibrationFor(state)),
                 // The captures by session: a pass re-recorded over the same file is
                 // a new capture session with a new id.
                 settings.SpatialAveragePath, Capture(state.SpatialAverage), Capture(state.ArrayCapture),
@@ -123,6 +128,12 @@ public partial class VirtualCrossoverPanel
 
         static string Digest<T>(T[]? values) where T : unmanaged =>
             AgentSessionFingerprint.ContentDigest(values);
+
+        static string Curve(CalibrationFile? calibration) =>
+            calibration == null
+                ? string.Empty
+                : AgentSessionFingerprint.ContentDigest(
+                    calibration.Points.SelectMany(point => new[] { point.FrequencyHz, point.Decibels }));
 
         static string Capture(LiveCaptureDocument? document) =>
             document == null

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -290,8 +290,9 @@ public partial class VirtualCrossoverPanel
             }
 
             AgentProposal proposal = parsed.Proposal!;
+            AgentSessionSnapshot reviewedSession = BuildAgentSessionSnapshot();
             AgentProposalReview review =
-                AgentProposalValidator.Review(proposal, BuildAgentSessionSnapshot());
+                AgentProposalValidator.Review(proposal, reviewedSession);
             HashSet<string> selected;
             using (var dialog = new AgentProposalDialog(review))
             {
@@ -304,7 +305,7 @@ public partial class VirtualCrossoverPanel
             }
 
             string? problem = AgentProposalApplier.Prepare(
-                proposal, selected, BuildAgentSessionSnapshot(),
+                proposal, selected, reviewedSession.Fingerprint, BuildAgentSessionSnapshot(),
                 out List<AgentOperationVerdict> toApply, out List<string> unseenWarnings);
             if (problem != null)
             {

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -61,9 +61,10 @@ public partial class VirtualCrossoverPanel
     /// The blocks in order (their letters are the channel ids), what each side is
     /// measured and averaged with, every chain — an import undone puts the chains
     /// back under a package that was copied without them — and the project figures
-    /// the diagnostics were computed under. Not the display: the view, the side on
-    /// screen, the zoom and the smoothing selector change what is shown, not what
-    /// was measured, and the package has its own smoothing anyway.
+    /// the diagnostics were computed under, the side on screen and the view among
+    /// them, since the engines read those. Not the zoom or the smoothing selector:
+    /// they change what is shown, not what was measured, and the package has its
+    /// own smoothing anyway.
     /// </summary>
     /// <remarks>
     /// Taken at Copy and again at every review, so no path that changes the session
@@ -78,6 +79,11 @@ public partial class VirtualCrossoverPanel
         {
             $"processor;{ProcessorProfile.ModelId};{ProcessorSampleRateHz}",
             $"average;{SpatialAverageMode};{checkBoxHybrid.Checked}",
+            // The side on screen and the view are what the package was computed
+            // for, and what the engines read: Auto crossover proposes from the
+            // shown side's measurements, a single-sided Auto delay aligns it, and
+            // whether Auto-tune's default source is the hybrid follows the view.
+            $"view;{project.ActiveSideRight};{SelectedGroupView}",
             $"phase;{project.PhaseWindowMode};{project.PhaseFdwCycles};{project.PhaseDetrendMode};" +
                 $"{Number(project.PhaseGateLeftMs)};{Number(project.PhaseGatePlateauMs)};" +
                 $"{Number(project.PhaseGateRightMs)};" +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -14,11 +14,14 @@ namespace Resonalyze;
 /// </summary>
 public partial class VirtualCrossoverPanel
 {
-    // The id of the package this session most recently copied; a reply naming
-    // another one gets a warning in the review. Not persisted — a reopened
+    // The id of the package this session most recently copied and the session
+    // fingerprint it was copied at (ComputeAgentFingerprint); a reply naming
+    // another package, or this one after the session has changed, gets a warning
+    // in the review and its engine requests refused. Not persisted — a reopened
     // session cannot vouch for what an earlier one copied, and the expected
-    // current values are the guard that matters.
+    // current values are the guard that matters for the settings rows.
     private string? lastAgentPackageId;
+    private string? lastAgentPackageFingerprint;
 
     // One bridge operation at a time: a second Copy while the first gathers
     // would race the coordinator, and an import while a copy gathers would move
@@ -26,6 +29,11 @@ public partial class VirtualCrossoverPanel
     private bool agentBusy;
 
     private ContextMenuStrip? agentMenu;
+
+    // The smoothing the package's hybrid curves and sums travel at: the width of
+    // the package's own 12-point-per-octave grid, the nearest a grid can come to
+    // the Off the manual reads the hybrid view at (see CaptureAgentPackageInputsAsync).
+    private const int AgentHybridSmoothingInverseOctaves = 12;
 
     /// <summary>
     /// The EQ Wizard's Auto Tune settings at the moment an import fits a bank
@@ -37,15 +45,106 @@ public partial class VirtualCrossoverPanel
         System.ComponentModel.DesignerSerializationVisibility.Hidden)]
     internal Func<EqAutoTunePolicy>? AutoTunePolicyProvider { get; set; }
 
-    /// <summary>Records the package this session just copied, for the review's correlation warning.</summary>
-    internal void RememberAgentPackage(string packageId) => lastAgentPackageId = packageId;
+    /// <summary>
+    /// Records the package this session just copied and the session it was copied
+    /// from, for the review's staleness check.
+    /// </summary>
+    internal void RememberAgentPackage(string packageId, string fingerprint)
+    {
+        lastAgentPackageId = packageId;
+        lastAgentPackageFingerprint = fingerprint;
+    }
 
-    // The one place the package is forgotten. A package vouches for a project of
-    // one composition: these channels, in this order, with these measurements.
-    // Any change to that — a project loaded, a block added, removed or reordered,
-    // a source resolved or cleared — makes a reply's ids and current values
-    // describe a project this one no longer is, and the review then says so.
-    private void ForgetAgentPackage() => lastAgentPackageId = null;
+    /// <summary>
+    /// The session as one hash (<see cref="AgentSessionFingerprint"/>): everything a
+    /// package vouches for that an expected current value does not already guard.
+    /// The blocks in order (their letters are the channel ids), what each side is
+    /// measured and averaged with, every chain — an import undone puts the chains
+    /// back under a package that was copied without them — and the project figures
+    /// the diagnostics were computed under. Not the display: the view, the side on
+    /// screen, the zoom and the smoothing selector change what is shown, not what
+    /// was measured, and the package has its own smoothing anyway.
+    /// </summary>
+    /// <remarks>
+    /// Taken at Copy and again at every review, so no path that changes the session
+    /// has to remember to forget the package: a source picked by hand, a capture
+    /// attached, a gate moved, a project loaded all change the hash and the review
+    /// reads the difference. The same session loaded again hashes the same, and a
+    /// package copied from it stays good — which forgetting could never say.
+    /// </remarks>
+    internal string ComputeAgentFingerprint()
+    {
+        var lines = new List<string>
+        {
+            $"processor;{ProcessorProfile.ModelId};{ProcessorSampleRateHz}",
+            $"average;{SpatialAverageMode};{checkBoxHybrid.Checked}",
+            $"phase;{project.PhaseWindowMode};{project.PhaseFdwCycles};{project.PhaseDetrendMode};" +
+                $"{Number(project.PhaseGateLeftMs)};{Number(project.PhaseGatePlateauMs)};" +
+                $"{Number(project.PhaseGateRightMs)};" +
+                $"{Number(project.PhaseGateLeft.OffsetMs)};{Number(project.PhaseGateLeft.DetrendMs)};" +
+                $"{Number(project.PhaseGateRight.OffsetMs)};{Number(project.PhaseGateRight.DetrendMs)}",
+            $"stereo;{Number(project.StereoSceneOffsetMagnitudeMs)};{project.StereoRightHandDrive};" +
+                $"{Number(project.StereoLevelDifferenceDb)};{Number(project.RearFillOffsetMs)}",
+            $"calibration;{project.CalibrationId}",
+            $"target;{Number((double)numericTargetLevel.Value)};{TargetShape(project.Target)}",
+            // The assistant reasons from the notes as much as from the curves.
+            $"notes;{project.AiNotes}"
+        };
+        foreach ((string block, AgentChannelSide side, VirtualCrossoverChannel channel, bool rightSide)
+            in AgentChannelSlots())
+        {
+            VirtualCrossoverChannelSettings settings = channel.SideSettings(rightSide);
+            VirtualCrossoverChannelState state = channel.SideState(rightSide);
+            lines.Add(string.Join(';',
+                block, AgentChannelIds.SideName(side), channel.Pair.Zone,
+                channel.Pair.Enabled, channel.Pair.Bypass,
+                // The measurement: its reference, and the CONTENT actually loaded
+                // behind it — a file re-measured and saved over its own name is a
+                // different impulse response with the same reference, length and
+                // rate — with what the package reads off it: the peak, the measured
+                // band, the coherence, the calibration it was read through.
+                settings.HistoryEntryId, settings.SourceFilePath, settings.DisplayName,
+                Digest(state.TransferImpulseResponse), state.SampleRate, state.TransferPeakIndex,
+                Number(state.MeasuredBand.LowestHz), Number(state.MeasuredBand.HighestHz),
+                Digest(state.TransferCoherence),
+                state.MicrophoneCalibration?.Name, state.MicrophoneCalibration?.FileName,
+                state.MicrophoneCalibration?.Points.Count,
+                // The captures by session: a pass re-recorded over the same file is
+                // a new capture session with a new id.
+                settings.SpatialAveragePath, Capture(state.SpatialAverage), Capture(state.ArrayCapture),
+                Number(settings.GainDb), Number(settings.DelayMs), settings.InvertPolarity,
+                settings.CrossoverKind, Edge(settings.HighPassEdge), Edge(settings.LowPassEdge),
+                AgentPeqHash.Compute(settings.PeqPreampDb, settings.PeqBands)));
+        }
+
+        return AgentSessionFingerprint.Compute(lines);
+
+        static string Number(double? value) => AgentSessionFingerprint.Number(value);
+
+        static string Digest<T>(T[]? values) where T : unmanaged =>
+            AgentSessionFingerprint.ContentDigest(values);
+
+        static string Capture(LiveCaptureDocument? document) =>
+            document == null
+                ? string.Empty
+                : $"{document.CaptureSessionId:D}/{document.SavedAtUtc.UtcTicks}/{document.Method}";
+
+        static string Edge(CrossoverEdge edge) =>
+            $"{edge.Family}/{Number(edge.FrequencyHz)}/{edge.SlopeDbPerOctave}/{Number(edge.RippleDb)}";
+
+        static string TargetShape(VirtualCrossoverTargetSettings? target) =>
+            target == null
+                ? string.Empty
+                : string.Join('/',
+                    target.Preset, Number(target.TiltDbPerOctave),
+                    Number(target.BassShelfGainDb), Number(target.BassShelfFrequencyHz),
+                    Number(target.BassShelfWidthOctaves),
+                    Number(target.TrebleShelfGainDb), Number(target.TrebleShelfFrequencyHz),
+                    Number(target.TrebleShelfWidthOctaves),
+                    Number(target.PresenceGainDb), Number(target.PresenceFrequencyHz),
+                    Number(target.PresenceWidthOctaves),
+                    Number(target.ToleranceDb), target.ImportedName, Digest(target.ImportedCurve));
+    }
 
     // The same two-state toggle the Target button's menu uses: a click while the
     // menu is open closes it; the menu is rebuilt per click so its enabled states
@@ -727,6 +826,11 @@ public partial class VirtualCrossoverPanel
             project.StereoLevelDifferenceDb = undo.StereoLevelDifferenceDb;
             project.RearFillOffsetMs = undo.RearFillOffsetMs;
             numericTargetLevel.Value = numericTargetLevel.ClampValue(undo.TargetLevelDb);
+            // The field's ValueChanged writes the project through OnViewChanged,
+            // which is what the suppression above silences — so the project's
+            // datum, the one the package and the saved session read, is written
+            // here by hand, as the Hybrid tick's is.
+            project.TargetLevelDb = (double)numericTargetLevel.Value;
         }
         finally
         {
@@ -825,7 +929,12 @@ public partial class VirtualCrossoverPanel
 
             (double, double, double) gate =
                 (project.PhaseGateLeftMs, project.PhaseGatePlateauMs, project.PhaseGateRightMs);
-            string? packageId = lastAgentPackageId;
+            // The package the curves belong beside — while this is still the
+            // session it was copied from. Changed, the id would tie the curves to
+            // channel ids and gates that no longer mean what they meant there.
+            string? packageId = lastAgentPackageFingerprint == ComputeAgentFingerprint()
+                ? lastAgentPackageId
+                : null;
             DateTimeOffset now = DateTimeOffset.UtcNow;
             (AgentDiagnosticBuildResult result, int count) = await Task.Run(() =>
             {
@@ -883,13 +992,13 @@ public partial class VirtualCrossoverPanel
         RefreshAutoActionsEnabled();
         try
         {
-            AgentPackageInputs? inputs = await CaptureAgentPackageInputsAsync() ??
-                await CaptureAgentPackageInputsAsync();
+            (AgentPackageInputs Inputs, string Fingerprint)? gathered =
+                await GatherAgentPackageAsync() ?? await GatherAgentPackageAsync();
             if (IsDisposed)
             {
                 return;
             }
-            if (inputs == null)
+            if (gathered is not { } package)
             {
                 ShowError(
                     "The AI package was not copied.",
@@ -897,6 +1006,7 @@ public partial class VirtualCrossoverPanel
                 return;
             }
 
+            (AgentPackageInputs inputs, string fingerprint) = package;
             Guid packageId = Guid.NewGuid();
             DateTimeOffset now = DateTimeOffset.UtcNow;
             AgentPackageBuildResult result = await Task.Run(
@@ -916,7 +1026,7 @@ public partial class VirtualCrossoverPanel
                 return;
             }
 
-            RememberAgentPackage(packageId.ToString("D"));
+            RememberAgentPackage(packageId.ToString("D"), fingerprint);
             string omitted = result.Omitted.Count > 0
                 ? Environment.NewLine + "Left out to fit the size limit: " +
                     string.Join(", ", result.Omitted) + "."
@@ -940,6 +1050,24 @@ public partial class VirtualCrossoverPanel
         }
     }
 
+    // The inputs and the fingerprint of ONE session state. The capture vouches
+    // that the coordinator's revision held while it gathered, but the fingerprint
+    // reads things the revision does not cover — the target level, the Hybrid
+    // tick, a gate pin — so it is taken on both sides of the gather and the pair
+    // is kept only when the two agree. Null otherwise; the caller retries once,
+    // as it does for the capture's own refusal.
+    private async Task<(AgentPackageInputs Inputs, string Fingerprint)?> GatherAgentPackageAsync()
+    {
+        string before = ComputeAgentFingerprint();
+        AgentPackageInputs? inputs = await CaptureAgentPackageInputsAsync();
+        if (inputs == null || IsDisposed || ComputeAgentFingerprint() != before)
+        {
+            return null;
+        }
+
+        return (inputs, before);
+    }
+
     /// <summary>
     /// The channels as the bridge names them, with their live settings and what
     /// each side carries, plus the project figures an engine request is judged
@@ -961,7 +1089,9 @@ public partial class VirtualCrossoverPanel
             AgentAutoDelayDefaults(),
             SpatialAverageMode,
             checkBoxHybrid.Checked,
-            project.ActiveSideRight);
+            project.ActiveSideRight,
+            lastAgentPackageFingerprint,
+            ComputeAgentFingerprint());
 
     // Every physical channel in block order: a stereo block yields its left and
     // right slots, a mono block its single one (routed to the left slot, as the
@@ -1004,6 +1134,14 @@ public partial class VirtualCrossoverPanel
         // the one the manual reads a tune at, so it is the one the package uses.
         int smoothing = SpectrumSmoothing.PsychoacousticCode;
         MagnitudeGateSnapshot packageGate = magnitudeGate with { SmoothingInverseOctaves = smoothing };
+        // Except the hybrid curves and their sum, which the manual reads with the
+        // smoothing OFF: the average has already averaged the position-dependent
+        // wiggles down, and a fractional-octave window straddling a crossover's
+        // skirt pulls the level up toward the passband, right where the acoustic
+        // slopes are judged. Off cannot travel on a 12-point-per-octave grid, so
+        // they go at the grid's own width, 1/12 octave — one step, no more.
+        MagnitudeGateSnapshot hybridGate =
+            magnitudeGate with { SmoothingInverseOctaves = AgentHybridSmoothingInverseOctaves };
 
         var sides = new List<AgentSideInputs>();
         var curves = new Dictionary<
@@ -1048,32 +1186,45 @@ public partial class VirtualCrossoverPanel
             // gate placement, never the active side's pin — the same rule the
             // on-screen opposite sum follows.
             bool oppositeSide = rightSide != activeRight;
-            var sideMetrics = new VirtualCrossoverMetrics(
-                processingCoordinator,
-                (impulseResponse, anchorIndex, sampleRate, band, calibration) =>
-                    BuildGatedMagnitudeCurve(
-                        packageGate,
-                        impulseResponse,
-                        anchorIndex,
-                        sampleRate,
-                        packageGate.ResolveGateOffsetMs(oppositeSide, anchorIndex, sampleRate),
-                        band,
-                        calibration),
-                CalibrationFor,
-                (members, anchorIndex) =>
-                    BuildMeasuredSumCurve(
-                        packageGate,
-                        members,
-                        anchorIndex,
-                        packageGate.ResolveGateOffsetMs(
-                            oppositeSide, anchorIndex, members.Count > 0 ? members[0].SampleRate : 0)));
+            VirtualCrossoverMetrics MetricsThrough(MagnitudeGateSnapshot gate) =>
+                new(
+                    processingCoordinator,
+                    (impulseResponse, anchorIndex, sampleRate, band, calibration) =>
+                        BuildGatedMagnitudeCurve(
+                            gate,
+                            impulseResponse,
+                            anchorIndex,
+                            sampleRate,
+                            gate.ResolveGateOffsetMs(oppositeSide, anchorIndex, sampleRate),
+                            band,
+                            calibration),
+                    CalibrationFor,
+                    (members, anchorIndex) =>
+                        BuildMeasuredSumCurve(
+                            gate,
+                            members,
+                            anchorIndex,
+                            gate.ResolveGateOffsetMs(
+                                oppositeSide, anchorIndex, members.Count > 0 ? members[0].SampleRate : 0)));
+            VirtualCrossoverMetrics sideMetrics = MetricsThrough(packageGate);
 
             List<AnalysisCurve>? magnitudes = null;
             AnalysisCurve? sumCurve = null;
             List<SignalPoint>? loss = null;
+            // The hybrid set's references at the hybrid's own width: a channel the
+            // array mode falls back to its point measurement for enters the hybrid
+            // sum through these, and one smoothed psychoacoustically first would be
+            // smoothed twice, at two widths, in a sum that claims one. Built only
+            // when the hybrid is asked for — it is a second gated pass.
+            List<AnalysisCurve>? hybridReferences = null;
             if (shown.Count > 0)
             {
                 (magnitudes, sumCurve, loss) = sideMetrics.BuildCurves(shown, smoothing, summed);
+                if (HybridRequested)
+                {
+                    (hybridReferences, _, _) = MetricsThrough(hybridGate)
+                        .BuildCurves(shown, AgentHybridSmoothingInverseOctaves, summed);
+                }
             }
 
             bool quotesJunctions =
@@ -1102,19 +1253,19 @@ public partial class VirtualCrossoverPanel
                         ordered, phaseRate, pinnedOffsetMs,
                         gateLeftMs, gatePlateauMs, gateRightMs)));
             }
-            HybridMagnitudes? hybrid = HybridRequested && magnitudes != null
-                ? BuildHybridMagnitudes(shown, magnitudes, rightSide, smoothing)
+            HybridMagnitudes? hybrid = hybridReferences != null
+                ? BuildHybridMagnitudes(shown, hybridReferences, rightSide, AgentHybridSmoothingInverseOctaves)
                 : null;
             // The sum the hybrid view draws beside the measured one: the same two
             // constructions the plot uses (see RedrawMainPlotAsync), the active
             // side's from the shown set, the opposite side's under its own gate
             // placement — and null, as on screen, when the sides cannot be held
             // to one offset.
-            IReadOnlyList<SignalPoint>? hybridSum = hybrid == null || magnitudes == null
+            IReadOnlyList<SignalPoint>? hybridSum = hybrid == null || hybridReferences == null
                 ? null
                 : rightSide == activeRight
-                    ? BuildActiveHybridSumCurve(shown, magnitudes, hybrid, packageGate)
-                    : BuildOppositeHybridSumCurve(sideSum, hybrid.OffsetDb, packageGate)?.Points;
+                    ? BuildActiveHybridSumCurve(shown, hybridReferences, hybrid, hybridGate)
+                    : BuildOppositeHybridSumCurve(sideSum, hybrid.OffsetDb, hybridGate)?.Points;
 
             for (int index = 0; index < shown.Count; index++)
             {
@@ -1125,12 +1276,12 @@ public partial class VirtualCrossoverPanel
                 // twin is the same capture through no chain, on the same axis.
                 IReadOnlyList<SignalPoint>? hybridProcessed = null;
                 IReadOnlyList<SignalPoint>? hybridPreDsp = null;
-                if (hybrid != null && magnitudes != null && !hybrid.PointMeasuredChannels[index])
+                if (hybrid != null && hybridReferences != null && !hybrid.PointMeasuredChannels[index])
                 {
                     hybridProcessed = ShiftedBy(hybrid.Channels[index], hybrid.OffsetDb);
                     hybridPreDsp = BuildHybridPreDspCurve(
-                        shown[index].Channel, rightSide, magnitudes[index].Points,
-                        smoothing, hybrid.OffsetDb);
+                        shown[index].Channel, rightSide, hybridReferences[index].Points,
+                        AgentHybridSmoothingInverseOctaves, hybrid.OffsetDb);
                 }
 
                 curves[(shown[index].Channel, rightSide)] = (
@@ -1294,6 +1445,7 @@ public partial class VirtualCrossoverPanel
             project.SpatialAverageMode,
             checkBoxHybrid.Checked,
             HybridRequested,
+            AgentHybridSmoothingInverseOctaves,
             project.PhaseWindowMode,
             project.PhaseFdwCycles,
             project.PhaseDetrendMode,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -558,10 +558,10 @@ public partial class VirtualCrossoverPanel : UserControl
         VirtualCrossoverSessionCalibration? previousSession = sessionCalibration;
         project = newProject;
         relinkDirectory = null;
-        // A package copied from the previous project vouches for nothing here: a
-        // reply naming it gets the review's "different package" warning, and the
-        // previous import's undo would restore into settings nobody displays.
-        ForgetAgentPackage();
+        // The previous import's undo would restore into settings nobody displays.
+        // (A package copied from the previous project needs no forgetting: the
+        // review's session fingerprint tells the two projects apart — and finds
+        // the same project loaded again to be the same.)
         agentUndo = null;
         // A new project on the same blocks. The channel OBJECTS are reused when the
         // count matches (see the rebind below), so nothing about a channel reference
@@ -1311,10 +1311,6 @@ public partial class VirtualCrossoverPanel : UserControl
     /// </remarks>
     private void ApplyChannelOrder(IReadOnlyList<int> order)
     {
-        // The block letters are the channel ids a package used; after a reorder
-        // they name other channels, so the package is forgotten and a reply
-        // naming it gets the review's warning.
-        ForgetAgentPackage();
         List<VirtualCrossoverChannel> reordered =
             order.Select(index => channels[index]).ToList();
         channels.Clear();
@@ -1476,8 +1472,6 @@ public partial class VirtualCrossoverPanel : UserControl
     private void SetChannelCount(int count)
     {
         count = Math.Clamp(count, MinChannelCount, MaxChannelCount);
-        // A block added or removed: the composition a copied package described.
-        ForgetAgentPackage();
 
         while (channels.Count > count)
         {
@@ -1614,9 +1608,6 @@ public partial class VirtualCrossoverPanel : UserControl
 
         if (wasMono != monoNow)
         {
-            // A:left and A:right become A:mono, or the other way round: the ids a
-            // copied package used no longer name these channels.
-            ForgetAgentPackage();
             if (monoNow)
             {
                 // The right slot becomes unreachable behind the mono routing;
@@ -2174,9 +2165,6 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private void ClearSourceCore(VirtualCrossoverChannel channel, bool rightSide)
     {
-        // The package described a measurement under this channel's id that is
-        // about to be gone.
-        ForgetAgentPackage();
         channel.SideState(rightSide).Clear();
         VirtualCrossoverChannelSettings settings = channel.SideSettings(rightSide);
         settings.DisplayName = string.Empty;
@@ -2199,10 +2187,6 @@ public partial class VirtualCrossoverPanel : UserControl
     private async Task ResolveSourceAsync(
         VirtualCrossoverChannel channel, bool rightSide, bool showErrors)
     {
-        // A measurement resolved here replaces what a copied package described
-        // under this channel's id; the package is forgotten and a reply naming it
-        // gets the review's warning. (A project load has forgotten it already.)
-        ForgetAgentPackage();
         VirtualCrossoverChannelSettings settings = channel.SideSettings(rightSide);
         VirtualCrossoverChannelState state = channel.SideState(rightSide);
         // The side's OTHER persisted reference, resolved on the same pass and ahead
@@ -7397,10 +7381,6 @@ public partial class VirtualCrossoverPanel : UserControl
                 // lengths and the analysis modes are project-wide, so both sides keep
                 // reading the phase at the same resolution and by the same method.
                 VirtualCrossoverPhaseGateSettings gate = ActiveGate;
-                // The gate is what a copied package's phase read-outs — and a
-                // diagnostic copied beside it — were computed through; changed,
-                // the package no longer describes what a new copy would say.
-                ForgetAgentPackage();
                 // Auto pressed = unpinned: store null so this side's gate
                 // keeps following the earliest estimated channel IR start.
                 gate.OffsetMs = dialog.AutoOffset ? null : dialog.GateOffsetMs;

--- a/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentPackageBuilderTests.cs
@@ -232,6 +232,8 @@ public sealed class AgentPackageBuilderTests
         Assert.Equal("MovingMic", status.GetProperty("mode").GetString());
         Assert.True(status.GetProperty("hybridTicked").GetBoolean());
         Assert.True(status.GetProperty("hybridDrawn").GetBoolean());
+        // The hybrid curves' own width, beside the package's psychoacoustic one.
+        Assert.Equal(12, status.GetProperty("smoothingInverseOctaves").GetInt32());
         Assert.Equal("partial", status.GetProperty("status").GetString());
         Assert.Equal(2, status.GetProperty("channelsShown").GetInt32());
         Assert.Equal(1, status.GetProperty("channelsWithCapture").GetInt32());
@@ -561,6 +563,7 @@ public sealed class AgentPackageBuilderTests
             new AgentAnalysisInputs(
                 VirtualCrossoverGroupView.FrontAndSub, false, 6, true,
                 VirtualCrossoverSpatialAverageMode.MovingMic, HybridTicked: true, HybridDrawn: true,
+                HybridSmoothingInverseOctaves: 12,
                 PhaseWindowMode.FrequencyDependent, 6, PhaseDetrendMode.Auto,
                 5, 100, 20, null, null, null, 8.66, "ECM8000_90deg.txt", 0.25, false, -1, 0),
             new AgentTargetInputs(-4, TargetPreset.Flat, TargetCurveSpec.FromPreset(TargetPreset.Flat), 3, null),

--- a/tests/Resonalyze.App.Tests/AgentProposalApplierTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalApplierTests.cs
@@ -5,8 +5,8 @@ namespace Resonalyze.App.Tests;
 
 /// <summary>
 /// The commit half of an import: a second look at the ticked rows against the
-/// live settings, one write for the whole set, and an exact way back. Pinned
-/// on settings objects alone — the panel adds only the control refresh.
+/// live settings and the fingerprint the review showed, one write for the whole
+/// set, and an exact way back. The panel adds only the control refresh.
 /// </summary>
 public sealed class AgentProposalApplierTests
 {
@@ -16,47 +16,109 @@ public sealed class AgentProposalApplierTests
         (AgentSessionSnapshot session, AgentProposal proposal) = Scene();
         var ticked = new HashSet<string>(["op-1", "op-3"]);
 
-        string? problem = AgentProposalApplier.Prepare(proposal, ticked, session, out List<AgentOperationVerdict> toApply, out _);
+        string? problem = AgentProposalApplier.Prepare(
+            proposal, ticked, session.Fingerprint, session,
+            out List<AgentOperationVerdict> toApply, out _);
         Assert.Null(problem);
         Assert.Equal(["op-1", "op-3"], toApply.Select(verdict => verdict.Id));
 
         // The user turned the gain knob while the dialog was open.
         session.Find("A:right")!.Settings.GainDb = -2.5;
-        problem = AgentProposalApplier.Prepare(proposal, ticked, session, out toApply, out _);
+        problem = AgentProposalApplier.Prepare(
+            proposal, ticked, session.Fingerprint, session, out toApply, out _);
         Assert.NotNull(problem);
         Assert.Contains("op-1", problem);
         Assert.Contains("changed while the review was open", problem);
         Assert.Empty(toApply);
 
-        Assert.Contains("No applicable change", AgentProposalApplier.Prepare(proposal, new HashSet<string>(), session, out _, out _));
+        Assert.Contains("No applicable change", AgentProposalApplier.Prepare(
+            proposal, new HashSet<string>(), session.Fingerprint, session, out _, out _));
     }
 
     [Fact]
-    public void Prepare_RefusesARowTheFreshReviewWouldNoLongerOfferTicked()
+    public void Prepare_Refuses_WhenFingerprintMovesFromValidFToG()
     {
         (AgentSessionSnapshot scene, AgentProposal proposal) = Scene();
         const string Package = "11111111-1111-1111-1111-111111111111";
+        const string F = "aaaaaaaaaaaaaaaa";
+        const string G = "bbbbbbbbbbbbbbbb";
         proposal = proposal with { PackageId = Package };
-        AgentSessionSnapshot session = scene with
+        AgentSessionSnapshot reviewed = scene with
         {
             LastPackageId = Package,
-            LastPackageFingerprint = "aaaaaaaaaaaaaaaa",
-            Fingerprint = "aaaaaaaaaaaaaaaa"
+            LastPackageFingerprint = F,
+            Fingerprint = F
         };
         var ticked = new HashSet<string>(["op-1"]);
 
-        Assert.Null(AgentProposalApplier.Prepare(proposal, ticked, session, out List<AgentOperationVerdict> toApply, out _));
-        Assert.Single(toApply);
+        Assert.True(AgentProposalValidator.Review(proposal, reviewed)
+            .Verdicts.Single(verdict => verdict.Id == "op-1").Ticked);
 
-        // Nothing the row's expected current value guards has moved — a
-        // measurement, a gate or the view did, under the dialog — so the fresh
-        // review still finds the row applicable but no longer offers it ticked.
-        // The user ticked it without seeing that warning: not applied.
         string? problem = AgentProposalApplier.Prepare(
-            proposal, ticked, session with { Fingerprint = "bbbbbbbbbbbbbbbb" }, out toApply, out _);
+            proposal, ticked, F, reviewed with { Fingerprint = G },
+            out List<AgentOperationVerdict> toApply, out _);
         Assert.NotNull(problem);
-        Assert.Contains("op-1", problem);
-        Assert.Contains("cannot vouch for", problem);
+        Assert.Contains("changed while the review was open", problem);
+        Assert.Empty(toApply);
+    }
+
+    [Fact]
+    public void Prepare_AppliesManuallyTickedStaleRow_WhenReviewAndApplyBothUseG()
+    {
+        (AgentSessionSnapshot scene, AgentProposal proposal) = Scene();
+        const string Package = "11111111-1111-1111-1111-111111111111";
+        const string F = "aaaaaaaaaaaaaaaa";
+        const string G = "bbbbbbbbbbbbbbbb";
+        proposal = proposal with { PackageId = Package };
+        AgentSessionSnapshot staleAtReview = scene with
+        {
+            LastPackageId = Package,
+            LastPackageFingerprint = F,
+            Fingerprint = G
+        };
+        var ticked = new HashSet<string>(["op-1"]);
+
+        AgentOperationVerdict row = AgentProposalValidator.Review(proposal, staleAtReview)
+            .Verdicts.Single(verdict => verdict.Id == "op-1");
+        Assert.True(row.Applicable);
+        Assert.False(row.Ticked);
+
+        string? problem = AgentProposalApplier.Prepare(
+            proposal, ticked, G, staleAtReview,
+            out List<AgentOperationVerdict> toApply, out _);
+
+        Assert.Null(problem);
+        Assert.Equal("op-1", Assert.Single(toApply).Id);
+        List<AgentUndoEntry> undo = AgentProposalApplier.Apply(toApply);
+        Assert.Equal(-3.0, staleAtReview.Find("A:right")!.Settings.GainDb);
+        Assert.Single(undo);
+    }
+
+    [Fact]
+    public void Prepare_RefusesManuallyTickedStaleRow_WhenFingerprintMovesFromGToH()
+    {
+        (AgentSessionSnapshot scene, AgentProposal proposal) = Scene();
+        const string Package = "11111111-1111-1111-1111-111111111111";
+        const string F = "aaaaaaaaaaaaaaaa";
+        const string G = "bbbbbbbbbbbbbbbb";
+        const string H = "cccccccccccccccc";
+        proposal = proposal with { PackageId = Package };
+        AgentSessionSnapshot staleAtReview = scene with
+        {
+            LastPackageId = Package,
+            LastPackageFingerprint = F,
+            Fingerprint = G
+        };
+        var ticked = new HashSet<string>(["op-1"]);
+
+        Assert.False(AgentProposalValidator.Review(proposal, staleAtReview)
+            .Verdicts.Single(verdict => verdict.Id == "op-1").Ticked);
+
+        string? problem = AgentProposalApplier.Prepare(
+            proposal, ticked, G, staleAtReview with { Fingerprint = H },
+            out List<AgentOperationVerdict> toApply, out _);
+
+        Assert.NotNull(problem);
         Assert.Contains("changed while the review was open", problem);
         Assert.Empty(toApply);
     }
@@ -70,7 +132,9 @@ public sealed class AgentProposalApplierTests
             Rejected = [new AgentRejectedOperation("op-1", "garbage", "Unsupported operation 'garbage'.")]
         };
 
-        string? problem = AgentProposalApplier.Prepare(proposal, new HashSet<string>(["op-1"]), session, out List<AgentOperationVerdict> toApply, out _);
+        string? problem = AgentProposalApplier.Prepare(
+            proposal, new HashSet<string>(["op-1"]), session.Fingerprint, session,
+            out List<AgentOperationVerdict> toApply, out _);
 
         Assert.Null(problem);
         AgentOperationVerdict only = Assert.Single(toApply);
@@ -101,10 +165,14 @@ public sealed class AgentProposalApplierTests
         AgentProposalReview review = AgentProposalValidator.Review(proposal, session);
         Assert.All(review.Verdicts, verdict => Assert.DoesNotContain("junction zone", verdict.Message));
 
-        Assert.Null(AgentProposalApplier.Prepare(proposal, new HashSet<string>(["op-1", "op-2"]), session, out _, out List<string> both));
+        Assert.Null(AgentProposalApplier.Prepare(
+            proposal, new HashSet<string>(["op-1", "op-2"]), session.Fingerprint, session,
+            out _, out List<string> both));
         Assert.Empty(both);
 
-        Assert.Null(AgentProposalApplier.Prepare(proposal, new HashSet<string>(["op-1"]), session, out List<AgentOperationVerdict> toApply, out List<string> crossoverOnly));
+        Assert.Null(AgentProposalApplier.Prepare(
+            proposal, new HashSet<string>(["op-1"]), session.Fingerprint, session,
+            out List<AgentOperationVerdict> toApply, out List<string> crossoverOnly));
         Assert.Single(toApply);
         string warning = Assert.Single(crossoverOnly);
         Assert.StartsWith("B left:", warning);
@@ -116,7 +184,9 @@ public sealed class AgentProposalApplierTests
         bLeft.LowPassEdge = new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 1200, 24);
         var gainOnly = new AgentProposal(null, "summary", [], [],
             [new SetGainOperation("op-3", "B:left", "", 0, -1)], []);
-        Assert.Null(AgentProposalApplier.Prepare(gainOnly, new HashSet<string>(["op-3"]), session, out _, out List<string> untouched));
+        Assert.Null(AgentProposalApplier.Prepare(
+            gainOnly, new HashSet<string>(["op-3"]), session.Fingerprint, session,
+            out _, out List<string> untouched));
         Assert.Empty(untouched);
     }
 
@@ -128,7 +198,8 @@ public sealed class AgentProposalApplierTests
         VirtualCrossoverChannelSettings bLeft = session.Find("B:left")!.Settings;
         VirtualCrossoverChannelSettings before = AgentOperations.CloneEditable(bLeft);
         Assert.Null(AgentProposalApplier.Prepare(
-            proposal, new HashSet<string>(["op-1", "op-3", "op-4"]), session, out List<AgentOperationVerdict> toApply, out _));
+            proposal, new HashSet<string>(["op-1", "op-3", "op-4"]),
+            session.Fingerprint, session, out List<AgentOperationVerdict> toApply, out _));
 
         List<AgentUndoEntry> undo = AgentProposalApplier.Apply(toApply);
 

--- a/tests/Resonalyze.App.Tests/AgentProposalApplierTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalApplierTests.cs
@@ -32,6 +32,36 @@ public sealed class AgentProposalApplierTests
     }
 
     [Fact]
+    public void Prepare_RefusesARowTheFreshReviewWouldNoLongerOfferTicked()
+    {
+        (AgentSessionSnapshot scene, AgentProposal proposal) = Scene();
+        const string Package = "11111111-1111-1111-1111-111111111111";
+        proposal = proposal with { PackageId = Package };
+        AgentSessionSnapshot session = scene with
+        {
+            LastPackageId = Package,
+            LastPackageFingerprint = "aaaaaaaaaaaaaaaa",
+            Fingerprint = "aaaaaaaaaaaaaaaa"
+        };
+        var ticked = new HashSet<string>(["op-1"]);
+
+        Assert.Null(AgentProposalApplier.Prepare(proposal, ticked, session, out List<AgentOperationVerdict> toApply, out _));
+        Assert.Single(toApply);
+
+        // Nothing the row's expected current value guards has moved — a
+        // measurement, a gate or the view did, under the dialog — so the fresh
+        // review still finds the row applicable but no longer offers it ticked.
+        // The user ticked it without seeing that warning: not applied.
+        string? problem = AgentProposalApplier.Prepare(
+            proposal, ticked, session with { Fingerprint = "bbbbbbbbbbbbbbbb" }, out toApply, out _);
+        Assert.NotNull(problem);
+        Assert.Contains("op-1", problem);
+        Assert.Contains("cannot vouch for", problem);
+        Assert.Contains("changed while the review was open", problem);
+        Assert.Empty(toApply);
+    }
+
+    [Fact]
     public void Prepare_IgnoresARefusedRowThatSharesTheTickedRowsId()
     {
         (AgentSessionSnapshot session, AgentProposal proposal) = Scene();

--- a/tests/Resonalyze.App.Tests/AgentProposalDialogTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalDialogTests.cs
@@ -66,7 +66,34 @@ public sealed class AgentProposalDialogTests
             Assert.Contains("changed since the package was copied", detail.Text);
             Assert.Contains("Run Auto delay afterwards.", detail.Text);
             Assert.Contains("https://example.com/datasheet.pdf", detail.Text);
+            Assert.Equal(string.Empty, dialog.Controls["labelWarnings"]!.Text);
+        });
+    }
+
+    [Fact]
+    public void AReplyToAPackageTheSessionCannotVouchFor_ComesUnticked_WithTheWarningShown()
+    {
+        StaTest.Run(() =>
+        {
+            using var dialog = new AgentProposalDialog(
+                Review(packageId: "22222222-2222-2222-2222-222222222222"));
+            DataGridView grid = Grid(dialog);
+            Button apply = dialog.Controls.OfType<Button>().Single(button => button.Text == "Apply selected");
+
             Assert.Contains("different package", dialog.Controls["labelWarnings"]!.Text);
+            // The settings rows stay, marked and unticked: an expected current
+            // value can still match after the measurement the row was reasoned
+            // from was replaced, so the user ticks what still applies.
+            Assert.Equal(false, grid.Rows[1].Cells[0].Value);
+            Assert.False(grid.Rows[1].Cells[0].ReadOnly);
+            Assert.Equal("Warning", grid.Rows[1].Cells[5].Value);
+            Assert.Contains("cannot vouch for", grid.Rows[1].Cells[5].ToolTipText);
+            Assert.Equal(false, grid.Rows[2].Cells[0].Value);
+            Assert.Empty(dialog.Selected);
+            Assert.False(apply.Enabled);
+
+            grid.Rows[1].Cells[0].Value = true;
+            Assert.Equal(["op-1"], dialog.Selected.Select(verdict => verdict.Id));
         });
     }
 
@@ -133,12 +160,13 @@ public sealed class AgentProposalDialogTests
         };
         var session = new AgentSessionSnapshot(
             [new AgentChannelSnapshot("B", AgentChannelSide.Left, bLeft, true, [])],
-            96_000, 10, null,
+            96_000, 10, "11111111-1111-1111-1111-111111111111",
             new AgentAutoDelaySettings(0.25, RightHandDrive: false, AdjustGains: false, 1.0, 15.0),
             VirtualCrossoverSpatialAverageMode.MovingMic,
             HybridTicked: false);
+        // An engine request needs the package it was written for named.
         var proposal = new AgentProposal(
-            null, "The corners are guesses.", [], [],
+            "11111111-1111-1111-1111-111111111111", "The corners are guesses.", [], [],
             [
                 new RunAutoCrossoverOperation("op-1", "let the wizard split them"),
                 new SetCrossoverOperation("op-2", "B:left", "lower the top",
@@ -153,7 +181,7 @@ public sealed class AgentProposalDialogTests
         return AgentProposalValidator.Review(proposal, session);
     }
 
-    private static AgentProposalReview Review()
+    private static AgentProposalReview Review(string packageId = "11111111-1111-1111-1111-111111111111")
     {
         var aRight = new VirtualCrossoverChannelSettings { GainDb = -2.0, DelayMs = 1.42 };
         var bLeft = new VirtualCrossoverChannelSettings
@@ -172,7 +200,7 @@ public sealed class AgentProposalDialogTests
             VirtualCrossoverSpatialAverageMode.MovingMic,
             HybridTicked: false);
         var proposal = new AgentProposal(
-            "22222222-2222-2222-2222-222222222222",
+            packageId,
             "The left mid/tweeter junction cancels near 3.1 kHz.",
             ["Run Auto delay afterwards."],
             [new AgentSource("https://example.com/datasheet.pdf", "Datasheet", ["Fs 65 Hz"])],

--- a/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
@@ -425,9 +425,45 @@ public sealed class AgentProposalValidatorTests
         // package: a reply naming one gets its warning too.
         string forgotten = Assert.Single(AgentProposalValidator.Review(other, Session(lastPackageId: null)).Warnings);
         Assert.Contains("has not copied", forgotten);
-        // A warning is only a warning for a settings row: it still applies, on
-        // its expected current value.
-        Assert.True(AgentProposalValidator.Review(other, Session()).Verdicts[0].Applicable);
+        // A settings row still applies, on its expected current value — but is
+        // offered unticked and marked: the value can match after the measurement
+        // the row was reasoned from has been replaced.
+        AgentOperationVerdict row = AgentProposalValidator.Review(other, Session()).Verdicts[0];
+        Assert.True(row.Applicable);
+        Assert.False(row.Ticked);
+        Assert.Equal(AgentVerdictStatus.Warning, row.Status);
+        Assert.Contains("cannot vouch for", row.Message);
+        AgentOperationVerdict good = AgentProposalValidator.Review(none, Session()).Verdicts[0];
+        Assert.True(good.Ticked);
+        Assert.Equal(AgentVerdictStatus.Valid, good.Status);
+    }
+
+    [Fact]
+    public void Review_RefusesEngineRequests_InAReplyThatNamesNoPackage()
+    {
+        // No expected current value guards an engine request, so without a
+        // package id nothing says which session it was written for.
+        AgentProposal proposal = Proposal(
+            new SetGainOperation("op-1", "A:right", "", -2.0, -3.0),
+            new RunAutoDelayOperation("op-2", "", null, null, null, null, null)) with
+        {
+            PackageId = null
+        };
+
+        AgentProposalReview review = AgentProposalValidator.Review(proposal, Session());
+
+        string warning = Assert.Single(review.Warnings);
+        Assert.Contains("names no package", warning);
+        Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[1].Status);
+        Assert.True(review.Verdicts[0].Applicable);
+        Assert.False(review.Verdicts[0].Ticked);
+
+        // Settings rows alone need no package: each carries its own guard.
+        AgentProposalReview settingsOnly = AgentProposalValidator.Review(
+            Proposal(new SetGainOperation("op-1", "A:right", "", -2.0, -3.0)) with { PackageId = null },
+            Session());
+        Assert.Empty(settingsOnly.Warnings);
+        Assert.True(settingsOnly.Verdicts[0].Ticked);
     }
 
     [Fact]
@@ -451,10 +487,12 @@ public sealed class AgentProposalValidatorTests
             AgentProposalReview review = AgentProposalValidator.Review(proposal, session);
             string warning = Assert.Single(review.Warnings);
             Assert.Contains("copy a new package", warning);
-            // The settings row is judged on its expected current value, as always;
-            // an engine reads the session as it is NOW, which the assistant has
-            // not seen, so the requests are refused rather than run blind.
+            // The settings row is judged on its expected current value, as always,
+            // and offered unticked; an engine reads the session as it is NOW,
+            // which the assistant has not seen, so the requests are refused
+            // rather than run blind.
             Assert.True(review.Verdicts[0].Applicable);
+            Assert.False(review.Verdicts[0].Ticked);
             Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[1].Status);
             Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[2].Status);
             Assert.Contains("copy a new package", review.Verdicts[1].Message);
@@ -466,6 +504,7 @@ public sealed class AgentProposalValidatorTests
             proposal, Session(lastFingerprint: "aaaaaaaaaaaaaaaa", fingerprint: "aaaaaaaaaaaaaaaa")).Warnings);
         Assert.Empty(AgentProposalValidator.Review(proposal, Session()).Warnings);
         Assert.True(AgentProposalValidator.Review(proposal, Session()).Verdicts[1].Applicable);
+        Assert.True(AgentProposalValidator.Review(proposal, Session()).Verdicts[0].Ticked);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
@@ -421,12 +421,51 @@ public sealed class AgentProposalValidatorTests
 
         Assert.Single(AgentProposalValidator.Review(other, Session()).Warnings);
         Assert.Empty(AgentProposalValidator.Review(none, Session()).Warnings);
-        // The panel forgets its package on a project load, a block reorder or a
-        // source replacement: a reply naming one then gets its warning too.
+        // A session that has copied nothing since it opened cannot vouch for any
+        // package: a reply naming one gets its warning too.
         string forgotten = Assert.Single(AgentProposalValidator.Review(other, Session(lastPackageId: null)).Warnings);
         Assert.Contains("has not copied", forgotten);
-        // A warning is only a warning: the row itself still applies.
+        // A warning is only a warning for a settings row: it still applies, on
+        // its expected current value.
         Assert.True(AgentProposalValidator.Review(other, Session()).Verdicts[0].Applicable);
+    }
+
+    [Fact]
+    public void Review_RefusesEngineRequests_WhenTheSessionCannotVouchForThePackage()
+    {
+        AgentProposal proposal = Proposal(
+            new SetGainOperation("op-1", "A:right", "", -2.0, -3.0),
+            new RunAutoDelayOperation("op-2", "", null, null, null, null, null),
+            new AutoTunePeqOperation("op-3", "B:left", "", null, null, null, null, null, null));
+
+        // Three ways the session cannot vouch for the package the reply answers:
+        // it copied none, it copied another, or it has changed since the copy —
+        // its fingerprint no longer matches the one the package was taken at.
+        foreach (AgentSessionSnapshot session in new[]
+        {
+            Session(lastPackageId: null),
+            Session(lastPackageId: "11111111-2222-3333-4444-555555555555"),
+            Session(lastFingerprint: "aaaaaaaaaaaaaaaa", fingerprint: "bbbbbbbbbbbbbbbb")
+        })
+        {
+            AgentProposalReview review = AgentProposalValidator.Review(proposal, session);
+            string warning = Assert.Single(review.Warnings);
+            Assert.Contains("copy a new package", warning);
+            // The settings row is judged on its expected current value, as always;
+            // an engine reads the session as it is NOW, which the assistant has
+            // not seen, so the requests are refused rather than run blind.
+            Assert.True(review.Verdicts[0].Applicable);
+            Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[1].Status);
+            Assert.Equal(AgentVerdictStatus.Rejected, review.Verdicts[2].Status);
+            Assert.Contains("copy a new package", review.Verdicts[1].Message);
+        }
+
+        // The same fingerprint at the copy and now: the package is still good, and
+        // a session that took no fingerprint at all is not compared.
+        Assert.Empty(AgentProposalValidator.Review(
+            proposal, Session(lastFingerprint: "aaaaaaaaaaaaaaaa", fingerprint: "aaaaaaaaaaaaaaaa")).Warnings);
+        Assert.Empty(AgentProposalValidator.Review(proposal, Session()).Warnings);
+        Assert.True(AgentProposalValidator.Review(proposal, Session()).Verdicts[1].Applicable);
     }
 
     [Fact]
@@ -893,7 +932,9 @@ public sealed class AgentProposalValidatorTests
         VirtualCrossoverSpatialAverageMode spatialAverageMode = VirtualCrossoverSpatialAverageMode.Off,
         bool hybridTicked = false,
         bool adjustGains = false,
-        IReadOnlyList<string>? captures = null)
+        IReadOnlyList<string>? captures = null,
+        string? lastFingerprint = null,
+        string? fingerprint = null)
     {
         var aLeft = new VirtualCrossoverChannelSettings { GainDb = 0, DelayMs = 0 };
         var aRight = new VirtualCrossoverChannelSettings { GainDb = -2.0, DelayMs = 1.42 };
@@ -923,7 +964,9 @@ public sealed class AgentProposalValidatorTests
             lastPackageId,
             new AgentAutoDelaySettings(0.25, RightHandDrive: false, adjustGains, 1.0, 15.0),
             spatialAverageMode,
-            hybridTicked);
+            hybridTicked,
+            LastPackageFingerprint: lastFingerprint,
+            Fingerprint: fingerprint);
     }
 
     private static AgentProposal Proposal(params AgentOperation[] operations) =>

--- a/tests/Resonalyze.App.Tests/AgentSessionFingerprintTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentSessionFingerprintTests.cs
@@ -34,6 +34,9 @@ public sealed class AgentSessionFingerprintTests
         Assert.NotEqual(digest, AgentSessionFingerprint.ContentDigest(other));
         Assert.NotEqual(digest, AgentSessionFingerprint.ContentDigest(a[..2]));
         Assert.Equal(string.Empty, AgentSessionFingerprint.ContentDigest<double>(null));
+        // The uncached twin, for a curve flattened on the way: same reading.
+        Assert.Equal(digest, AgentSessionFingerprint.ContentDigest(a.AsEnumerable()));
+        Assert.NotEqual(digest, AgentSessionFingerprint.ContentDigest(other.AsEnumerable()));
         // A complex array hashes its real and imaginary parts alike.
         Assert.NotEqual(
             AgentSessionFingerprint.ContentDigest([new System.Numerics.Complex(1, 0)]),

--- a/tests/Resonalyze.App.Tests/AgentSessionFingerprintTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentSessionFingerprintTests.cs
@@ -1,0 +1,64 @@
+using System.Globalization;
+using Resonalyze.Integration.AgentBridge;
+
+namespace Resonalyze.App.Tests;
+
+public sealed class AgentSessionFingerprintTests
+{
+    [Fact]
+    public void Compute_IsStable_AndReadsEveryLineInOrder()
+    {
+        string[] lines = ["processor;x;96000", "A;left;Front;True;False;;a.json"];
+        string baseline = AgentSessionFingerprint.Compute(lines);
+
+        Assert.Equal(16, baseline.Length);
+        Assert.Matches("^[0-9a-f]{16}$", baseline);
+        Assert.Equal(baseline, AgentSessionFingerprint.Compute(lines));
+        // The block order is part of what the channel ids mean.
+        Assert.NotEqual(baseline, AgentSessionFingerprint.Compute(lines.Reverse()));
+        Assert.NotEqual(baseline, AgentSessionFingerprint.Compute([lines[0], lines[1] + ";1"]));
+        Assert.NotEqual(baseline, AgentSessionFingerprint.Compute([lines[0]]));
+    }
+
+    [Fact]
+    public void ContentDigest_ReadsTheSamples_NotTheArray()
+    {
+        double[] a = [0.1, 0.2, 0.3];
+        double[] same = [0.1, 0.2, 0.3];
+        double[] other = [0.1, 0.2, 0.30000001];
+        string digest = AgentSessionFingerprint.ContentDigest(a);
+
+        Assert.Equal(16, digest.Length);
+        Assert.Equal(digest, AgentSessionFingerprint.ContentDigest(a));
+        Assert.Equal(digest, AgentSessionFingerprint.ContentDigest(same));
+        Assert.NotEqual(digest, AgentSessionFingerprint.ContentDigest(other));
+        Assert.NotEqual(digest, AgentSessionFingerprint.ContentDigest(a[..2]));
+        Assert.Equal(string.Empty, AgentSessionFingerprint.ContentDigest<double>(null));
+        // A complex array hashes its real and imaginary parts alike.
+        Assert.NotEqual(
+            AgentSessionFingerprint.ContentDigest([new System.Numerics.Complex(1, 0)]),
+            AgentSessionFingerprint.ContentDigest([new System.Numerics.Complex(1, 1)]));
+    }
+
+    [Fact]
+    public void Number_IsCultureInvariant_AndRoundTrips()
+    {
+        CultureInfo previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            Assert.Equal("1.42", AgentSessionFingerprint.Number(1.42));
+            Assert.Equal("0.1", AgentSessionFingerprint.Number(0.1));
+            Assert.Equal(string.Empty, AgentSessionFingerprint.Number(null));
+            Assert.Equal("0", AgentSessionFingerprint.Number(-0.0));
+            // Two values a display would print alike must not hash alike.
+            Assert.NotEqual(
+                AgentSessionFingerprint.Number(0.30000000000000004),
+                AgentSessionFingerprint.Number(0.3));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+}

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
@@ -297,6 +297,11 @@ public sealed class VirtualCrossoverAgentEngineTests
             Moves(() => Project(panel).PhaseGateLeft.OffsetMs = 3.25);
             Moves(() => Project(panel).StereoLevelDifferenceDb = -2.0);
             Moves(() => Project(panel).Pairs[0].Mono = true);
+            // The side on screen and the view: what Auto crossover and a
+            // single-sided Auto delay read, and what decides Auto-tune's source.
+            Moves(() => Project(panel).ActiveSideRight = true);
+            dynamic groupView = Field(panel, "comboBoxGroupView");
+            Moves(() => groupView.SelectedItem = VirtualCrossoverGroupView.Everything);
             Moves(() => ((DarkNumericUpDown)Field(panel, "numericTargetLevel")).Value += 1);
         });
     }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
@@ -276,6 +276,13 @@ public sealed class VirtualCrossoverAgentEngineTests
             Moves(() => leftState.TransferCoherence = [0.9, 0.8]);
             Moves(() => leftState.MeasuredBand = new MeasuredBand(40, 8000));
             Moves(() => leftState.TransferPeakIndex += 1);
+            // The correction the side is read through, by its points: the same
+            // file re-read with one value edited is another correction.
+            Set(panel, "ownCalibrationSelected", true);
+            Moves(() => leftState.MicrophoneCalibration =
+                new VirtualCrossoverCalibrationSettings { Name = "mic", Points = [[1000, 0.5], [2000, 1.0]] });
+            Moves(() => leftState.MicrophoneCalibration =
+                new VirtualCrossoverCalibrationSettings { Name = "mic", Points = [[1000, 0.5], [2000, 1.5]] });
             Moves(() => Project(panel).AiNotes = "Front: 6.5\" mids in the doors.");
             Moves(() => Project(panel).Target = new VirtualCrossoverTargetSettings { ImportedCurve = [1, 2, 3] });
             Moves(() => Project(panel).Target!.ImportedCurve = [1, 2, 4]);

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAgentEngineTests.cs
@@ -47,6 +47,9 @@ public sealed class VirtualCrossoverAgentEngineTests
             Hybrid(panel).Checked = false;
             List<VirtualCrossoverChannel> order = Channels(panel).ToList();
             double gain = Channels(panel)[0].SideSettings(rightSide: false).GainDb;
+            var targetLevel = (DarkNumericUpDown)Field(panel, "numericTargetLevel");
+            double level = Project(panel).TargetLevelDb;
+            Assert.Equal(level, (double)targetLevel.Value);
 
             object undo = Invoke(panel, "CaptureAgentUndo")!;
             Invoke(panel, "ApplyAgentSpatialAverage",
@@ -55,6 +58,10 @@ public sealed class VirtualCrossoverAgentEngineTests
             Channels(panel)[0].SideSettings(rightSide: false).GainDb = gain - 6;
             Invoke(panel, "MoveChannel", Channels(panel)[0], 1);
             Assert.NotEqual(order, Channels(panel));
+            // The datum an Auto-tune landing moves: the field, and through its
+            // ValueChanged, the project.
+            targetLevel.Value += 3;
+            Assert.Equal(level + 3, Project(panel).TargetLevelDb);
 
             Set(panel, "agentUndo", undo);
             Set(panel, "agentUndoGeneration", Field(panel, "projectGeneration"));
@@ -65,6 +72,11 @@ public sealed class VirtualCrossoverAgentEngineTests
             Assert.False(Project(panel).ShowHybridCurves);
             Assert.Equal(order, Channels(panel));
             Assert.Equal(gain, Channels(panel)[0].SideSettings(rightSide: false).GainDb);
+            // Both halves of the datum: the undo sets the field with the project
+            // events suppressed, so the project's copy — what the package and the
+            // saved session read — has to be written by hand, and once was not.
+            Assert.Equal(level, (double)targetLevel.Value);
+            Assert.Equal(level, Project(panel).TargetLevelDb);
             Assert.Null(Field(panel, "agentUndo"));
         });
     }
@@ -226,6 +238,93 @@ public sealed class VirtualCrossoverAgentEngineTests
     // The engines run as the import runs them — awaited; on a panel with no
     // measurement every engine answers before it would await anything, so the
     // task is complete by the time it is handed back.
+    [Fact]
+    public void Fingerprint_MovesWithWhatAPackageVouchesFor_AndComesBackWithUndo()
+    {
+        StaTest.Run(() =>
+        {
+            using VirtualCrossoverPanel panel = Loaded();
+            Project(panel).SpatialAverageMode = VirtualCrossoverSpatialAverageMode.Off;
+            Hybrid(panel).Checked = false;
+            string baseline = Fingerprint(panel);
+            Assert.Equal(baseline, Fingerprint(panel));
+
+            // Each of these was once a path that had to remember to forget the
+            // package, and the two the review found missing — a source picked by
+            // hand, a capture attached — are the reason it is a hash now.
+            VirtualCrossoverChannelSettings left = Channels(panel)[0].SideSettings(rightSide: false);
+            var seen = new HashSet<string>(StringComparer.Ordinal) { baseline };
+            void Moves(Action change)
+            {
+                change();
+                Assert.True(seen.Add(Fingerprint(panel)), "the fingerprint did not move");
+            }
+
+            Moves(() => left.SourceFilePath = @"D:\measurements\left mid (retaken).json");
+            // A measurement saved over its own file: same reference, same length,
+            // same rate, other samples — the CONTENT is what the hash reads.
+            VirtualCrossoverChannelState leftState = Channels(panel)[0].SideState(rightSide: false);
+            var samples = new System.Numerics.Complex[64];
+            samples[3] = new System.Numerics.Complex(0.5, 0);
+            Moves(() => leftState.TransferImpulseResponse = samples);
+            var retaken = new System.Numerics.Complex[64];
+            retaken[3] = new System.Numerics.Complex(0.4, 0);
+            Moves(() => leftState.TransferImpulseResponse = retaken);
+            // The same samples in another array are the same measurement.
+            leftState.TransferImpulseResponse = (System.Numerics.Complex[])retaken.Clone();
+            Assert.Contains(Fingerprint(panel), seen);
+            Moves(() => leftState.TransferCoherence = [0.9, 0.8]);
+            Moves(() => leftState.MeasuredBand = new MeasuredBand(40, 8000));
+            Moves(() => leftState.TransferPeakIndex += 1);
+            Moves(() => Project(panel).AiNotes = "Front: 6.5\" mids in the doors.");
+            Moves(() => Project(panel).Target = new VirtualCrossoverTargetSettings { ImportedCurve = [1, 2, 3] });
+            Moves(() => Project(panel).Target!.ImportedCurve = [1, 2, 4]);
+            Moves(() => left.SpatialAveragePath = @"D:\measurements\left mid mmm.json");
+            Moves(() => leftState.SpatialAverage = new LiveCaptureDocument { CaptureSessionId = Guid.NewGuid() });
+            Moves(() => leftState.SpatialAverage = new LiveCaptureDocument { CaptureSessionId = Guid.NewGuid() });
+            Moves(() => left.GainDb -= 1.5);
+            Moves(() => left.PeqBands = [new Resonalyze.Dsp.PeqBand(820, 2.1, -2.4)]);
+            Moves(() => Invoke(panel, "MoveChannel", Channels(panel)[0], 1));
+            Moves(() => Hybrid(panel).Checked = true);
+            Moves(() => Project(panel).SpatialAverageMode = VirtualCrossoverSpatialAverageMode.MovingMic);
+            Moves(() => Project(panel).PhaseGateLeft.OffsetMs = 3.25);
+            Moves(() => Project(panel).StereoLevelDifferenceDb = -2.0);
+            Moves(() => Project(panel).Pairs[0].Mono = true);
+            Moves(() => ((DarkNumericUpDown)Field(panel, "numericTargetLevel")).Value += 1);
+        });
+    }
+
+    [Fact]
+    public void Fingerprint_IsBackWhereItWas_AfterUndoAiImport()
+    {
+        StaTest.Run(() =>
+        {
+            using VirtualCrossoverPanel panel = Loaded();
+            Project(panel).SpatialAverageMode = VirtualCrossoverSpatialAverageMode.Off;
+            Hybrid(panel).Checked = false;
+            string before = Fingerprint(panel);
+
+            object undo = Invoke(panel, "CaptureAgentUndo")!;
+            Invoke(panel, "ApplyAgentSpatialAverage",
+                new UseSpatialAverageOperation("op-1", "", "MicArray", true));
+            Channels(panel)[0].SideSettings(rightSide: false).GainDb -= 6;
+            Invoke(panel, "MoveChannel", Channels(panel)[0], 1);
+            Assert.NotEqual(before, Fingerprint(panel));
+
+            Set(panel, "agentUndo", undo);
+            Set(panel, "agentUndoGeneration", Field(panel, "projectGeneration"));
+            Invoke(panel, "UndoAiImport");
+
+            // The guide's diagnostic pass: clear the banks, copy a package, undo.
+            // The session is then the one BEFORE the import again — not the one
+            // that package described — and the review reads it off the hash.
+            Assert.Equal(before, Fingerprint(panel));
+        });
+    }
+
+    private static string Fingerprint(VirtualCrossoverPanel panel) =>
+        (string)Invoke(panel, "ComputeAgentFingerprint")!;
+
     private static bool RunEngines(
         VirtualCrossoverPanel panel, List<AgentOperationVerdict> rows, List<string> summary) =>
         ((Task<bool>)Invoke(panel, "RunAgentEngineRequests", rows, summary)!)


### PR DESCRIPTION
Follow-up to #168/#170 from the review of `main` at 6225e05.

## Session fingerprint instead of the forget-the-package list

The panel kept a hand-written list of paths that invalidate a copied package (project load, block count, reorder, source resolved or cleared, mono toggle, gate dialog), each calling `ForgetAgentPackage`. The review found paths the list missed: a measurement picked by hand through **Choose file…** or **History** (`OnSourceAssigned`), **Undo AI import** (the guide's own diagnostic pass puts the banks back under a package copied without them), and a spatial average attached, detached or switched.

The list is gone. `AgentSessionFingerprint` hashes the session — blocks in order, each side's measurement by reference **and by content** (a digest of the samples, cached per array), its peak, band, coherence and calibration, captures by capture session, every chain, the phase gates, the scene, the target shape and imported curve, the notes — on both sides of a Copy's gather (kept only when they agree, since the coordinator's revision does not cover the target level or a gate pin) and again at every review.

A reply naming a package the session cannot vouch for (none copied, another one, or this one after the hash moved) is shown with a warning as before; **new: its engine requests are refused**, since an engine reads the session as it is now, which the assistant has not seen. Settings rows still stand on their expected current values. The same session loaded again hashes the same. The excess-group-delay diagnostic names the package only while the hash still matches.

Found beside it: Undo set the target-level field with project events suppressed, and `project.TargetLevelDb` — what the package and the saved session read — is written only through those events, so it kept the imported level. Written by hand now, pinned by a test that fails without the line.

## Hybrid curves at the grid's width

The package smoothed its hybrid curves and sums psychoacoustically, against the manual's "smoothing **Off** in Hybrid mode". Off cannot travel on a 12-point-per-octave grid, so the hybrid columns and sums now go at 1/12 octave (`analysis.spatialAverage.smoothingInverseOctaves`); Sum loss and the measured curves keep the fixed psychoacoustic width. The hybrid set's references are a second gated pass at that width, so a channel the array mode falls back to its point measurement for is not smoothed twice at two widths.

## Guide 1.3

The diagnostic pass ends with a fresh package after the undo; the junction phase field is named as the protocol spells it (`consistency`); the smoothing exception is stated. PROTOCOL and REFERENCE describe the fingerprint check, the engine refusal and the conditional effect of Undo (a package copied before the import describes the undone session again; one copied after it does not).

## Checks

- App tests: 2212 passed, 11 skipped (Debug).
- Harness on the v6 session (MMM 7/7): package byte-identical at 1/48 and 1/3 display smoothing; `smoothingInverseOctaves: 12`, `guideVersion: 1.3`; capture 1.65 → 1.73 s with the second hybrid pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
