### PR TITLE
The proposal's prose is wanted, not required

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,4 +1,4 @@
-﻿# Resonalyze Reference
+# Resonalyze Reference
 
 Every mode, panel, setting and graph gesture, with the reasoning behind the ones
 whose behaviour is not obvious — why a window is anchored where it is, why a
@@ -2868,7 +2868,15 @@ this: the clipboard is the only transport, and you are the one who pastes.
 
   Every proposed change is shown against the value the channel holds *now*, with
   the reason the assistant gave; an engine request is shown against the settings
-  the engine would start from, with what it will write over. Auto crossover
+  the engine would start from, with what it will write over. The words are the
+  assistant's to write and not the importer's to demand: a reply that leaves out
+  its summary, or a row's reason, is still read and still offered — refusing it
+  would send you back to the chat for a sentence and lose the rest of the reply
+  on the way. What is missing is said rather than hidden: the warnings above the
+  table count the rows that do not say why, the summary reads *(the reply gave
+  no summary)*, and each such row reads *(no reason given)* in its reason
+  column. A row the importer itself refused shows the refusal instead, which is
+  its explanation. Auto crossover
   then opens its wizard as the button does; Auto delay runs without its dialog
   — the button's own checks, search and commit, with the report it would have
   shown returned in the import's summary and the alignment log; Auto-tune runs

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -155,9 +155,12 @@ The **minimum-phase** part follows its magnitude, so a PEQ that flattens a
 resonance straightens that phase with it — such a band helps the sum. The
 **excess** part does not: the arrival itself and later arrivals — reflections,
 a second path — which no PEQ touches. The **Excess group delay** diagnostic
-separates them: ask for it as a probe (§6), or by its menu path when you would
-rather the user fetched it — *AI assistant… → Copy diagnostics for AI → Excess
-group delay*. Read its SHAPE, not its
+separates them. Two doors, and the cheaper one for the user decides: when the
+curve is all you need, name the menu path — *AI assistant… → Copy diagnostics
+for AI → Excess group delay* — which is a click and a paste, with no proposal
+to import. Ask for it as a probe (§6) when you are asking for junction readings
+anyway: one document, one paste, all of it read off the same session. Read its
+SHAPE, not its
 level: flat means no excess dispersion; two flat curves at different levels
 mean a plain timing offset, Auto delay's work; bending or swinging inside the
 junction band means reflections or a second path, which timing, polarity, an

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -344,7 +344,10 @@ changes or an engine to request, end with exactly one JSON object whose
   requests refused and its settings rows offered unticked — ask for a new
   package when the user reports that.
 - One operation per channel and parameter, each with a `reason` in a sentence
-  or two: the user reads it in the review.
+  or two, and a `summary` over the whole reply: the user reads them in the
+  review, beside the values, to decide. Neither is required — a row that
+  forgets one is still offered, marked "(no reason given)" — so write them
+  because the user is about to act on them, not because the importer insists.
 - Use only what `limits.operations` names; everything else goes in `advice`.
 - A reply with no block is a normal reply. One that only advises, or only asks,
   is often the right one.

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -408,10 +408,10 @@ present must stay within them; the two prose fields may be absent.
 
 Every operation has `id` (unique in the reply) and `op`, and should have
 `reason` — the sentence the review shows the user beside the values. A `reason`
-is wanted rather than required: an operation without one is read and offered
-like any other, marked "(no reason given)" in the review, since refusing a
-sound change over a missing sentence costs the user a round trip and gets them
-no sentence either. There are two families. The five below WRITE one channel's settings:
+is wanted rather than required: an operation without one — or with an empty one,
+which says as much — is read and offered like any other, marked "(no reason
+given)" in the review, since refusing a sound change over a missing sentence
+costs the user a round trip and gets them no sentence either. There are two families. The five below WRITE one channel's settings:
 they add `channelId` (an id from the package) and what they believe the
 **current** value is, copied from the package. A current value that no longer
 matches means the tune moved on since the package was copied, and the operation

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -394,19 +394,24 @@ open door: an `extensions` object, whose content is ignored).
 | `kind` | yes | `"resonalyze.agent-proposal"` |
 | `protocolVersion` | yes | `1` |
 | `packageId` | for engine requests | Echo of the package's id. Required when `operations[]` holds an engine request — one without it is refused; a reply of settings rows alone may leave it out, each row carrying its own expected current value. A package the session cannot vouch for (§2.2) is shown as a warning, refuses the engine requests and offers the settings rows unticked. |
-| `summary` | yes | One paragraph, shown at the top of the review. |
+| `summary` | wanted | One paragraph, shown at the top of the review. A reply without one is still read — the operations are the proposal — and the review says the reply gave none. Write it: it is what the user reads first. |
 | `advice[]` | no | Changes that are not operations — engines to run, things to re-measure. Shown, never applied. |
 | `sources[]` | no | `{ url, title?, factsUsed[] }`; `url` must be `http(s)`. Shown as text, never opened. |
 | `operations[]` | yes | The typed changes, see 2.2. May be empty when the reply is advice only. |
 | `extensions` | no | Ignored. |
 
 Limits: 1 MiB of clipboard text, 64 operations, 32 advice lines / sources /
-facts per source, 2000 characters per string, JSON depth 8.
+facts per source, 2000 characters per string, JSON depth 8. A string that is
+present must stay within them; the two prose fields may be absent.
 
 ### 2.2 Operations
 
-Every operation has `id` (unique in the reply), `op` and `reason` (shown in the
-review). There are two families. The five below WRITE one channel's settings:
+Every operation has `id` (unique in the reply) and `op`, and should have
+`reason` — the sentence the review shows the user beside the values. A `reason`
+is wanted rather than required: an operation without one is read and offered
+like any other, marked "(no reason given)" in the review, since refusing a
+sound change over a missing sentence costs the user a round trip and gets them
+no sentence either. There are two families. The five below WRITE one channel's settings:
 they add `channelId` (an id from the package) and what they believe the
 **current** value is, copied from the package. A current value that no longer
 matches means the tune moved on since the package was copied, and the operation

--- a/source/Integration/AgentBridge/AgentProposal.cs
+++ b/source/Integration/AgentBridge/AgentProposal.cs
@@ -19,7 +19,7 @@ namespace Resonalyze.Integration.AgentBridge;
 /// </param>
 internal sealed record AgentProposal(
     string? PackageId,
-    string Summary,
+    string? Summary,
     IReadOnlyList<string> Advice,
     IReadOnlyList<AgentSource> Sources,
     IReadOnlyList<AgentOperation> Operations,
@@ -41,7 +41,7 @@ internal sealed record AgentRejectedOperation(string? Id, string? Op, string Pro
 /// engine's inputs instead, because what an engine will write is not knowable
 /// until it has run.
 /// </summary>
-internal abstract record AgentOperation(string Id, string Reason)
+internal abstract record AgentOperation(string Id, string? Reason)
 {
     /// <summary>The protocol's name for the operation: what its <c>op</c> said.</summary>
     public abstract string Op { get; }
@@ -54,7 +54,7 @@ internal abstract record AgentOperation(string Id, string Reason)
 }
 
 /// <summary>An operation addressed at one physical channel, by the package's id for it.</summary>
-internal abstract record AgentChannelOperation(string Id, string ChannelId, string Reason)
+internal abstract record AgentChannelOperation(string Id, string ChannelId, string? Reason)
     : AgentOperation(Id, Reason);
 
 /// <summary>
@@ -62,11 +62,11 @@ internal abstract record AgentChannelOperation(string Id, string ChannelId, stri
 /// the bridge has always had. These are the only operations the importer applies
 /// itself; everything else it asks an engine to do.
 /// </summary>
-internal abstract record AgentSettingsOperation(string Id, string ChannelId, string Reason)
+internal abstract record AgentSettingsOperation(string Id, string ChannelId, string? Reason)
     : AgentChannelOperation(Id, ChannelId, Reason);
 
 internal sealed record SetGainOperation(
-    string Id, string ChannelId, string Reason, double ExpectedCurrentDb, double ProposedDb)
+    string Id, string ChannelId, string? Reason, double ExpectedCurrentDb, double ProposedDb)
     : AgentSettingsOperation(Id, ChannelId, Reason)
 {
     public override string Op => AgentProtocol.SetGainDb;
@@ -75,7 +75,7 @@ internal sealed record SetGainOperation(
 }
 
 internal sealed record SetDelayOperation(
-    string Id, string ChannelId, string Reason, double ExpectedCurrentMs, double ProposedMs)
+    string Id, string ChannelId, string? Reason, double ExpectedCurrentMs, double ProposedMs)
     : AgentSettingsOperation(Id, ChannelId, Reason)
 {
     public override string Op => AgentProtocol.SetDelayMs;
@@ -84,7 +84,7 @@ internal sealed record SetDelayOperation(
 }
 
 internal sealed record SetPolarityOperation(
-    string Id, string ChannelId, string Reason, bool ExpectedCurrentInverted, bool ProposedInverted)
+    string Id, string ChannelId, string? Reason, bool ExpectedCurrentInverted, bool ProposedInverted)
     : AgentSettingsOperation(Id, ChannelId, Reason)
 {
     public override string Op => AgentProtocol.SetPolarity;
@@ -93,7 +93,7 @@ internal sealed record SetPolarityOperation(
 }
 
 internal sealed record SetCrossoverOperation(
-    string Id, string ChannelId, string Reason, AgentCrossover ExpectedCurrent, AgentCrossover Proposed)
+    string Id, string ChannelId, string? Reason, AgentCrossover ExpectedCurrent, AgentCrossover Proposed)
     : AgentSettingsOperation(Id, ChannelId, Reason)
 {
     public override string Op => AgentProtocol.SetCrossover;
@@ -106,7 +106,7 @@ internal sealed record SetCrossoverOperation(
 /// standing in for the whole current bank so the reply need not repeat it.
 /// </param>
 internal sealed record ReplacePeqBankOperation(
-    string Id, string ChannelId, string Reason, string ExpectedCurrentHash, AgentPeqBank Proposed)
+    string Id, string ChannelId, string? Reason, string ExpectedCurrentHash, AgentPeqBank Proposed)
     : AgentSettingsOperation(Id, ChannelId, Reason)
 {
     public override string Op => AgentProtocol.ReplacePeqBank;
@@ -127,7 +127,7 @@ internal sealed record ReplacePeqBankOperation(
 /// </param>
 internal sealed record RunAutoDelayOperation(
     string Id,
-    string Reason,
+    string? Reason,
     double? SceneOffsetMs,
     bool? RightHandDrive,
     bool? AdjustGains,
@@ -144,7 +144,7 @@ internal sealed record RunAutoDelayOperation(
 /// from the drivers' own bands, and the choices it does offer are made in its
 /// own dialog, in front of the user.
 /// </summary>
-internal sealed record RunAutoCrossoverOperation(string Id, string Reason)
+internal sealed record RunAutoCrossoverOperation(string Id, string? Reason)
     : AgentOperation(Id, Reason)
 {
     public override string Op => AgentProtocol.RunAutoCrossover;
@@ -174,7 +174,7 @@ internal sealed record RunAutoCrossoverOperation(string Id, string Reason)
 /// </param>
 internal sealed record ProbeOperation(
     string Id,
-    string Reason,
+    string? Reason,
     string Probe,
     string? JunctionId,
     IReadOnlyList<AgentProbeVariant>? Variants) : AgentOperation(Id, Reason)
@@ -221,7 +221,7 @@ internal sealed record AgentProbeChange(
 /// </summary>
 internal sealed record TuneJunctionOperation(
     string Id,
-    string Reason,
+    string? Reason,
     string JunctionId,
     double? MinHz,
     double? MaxHz,
@@ -245,7 +245,7 @@ internal sealed record TuneJunctionOperation(
 internal sealed record AutoTunePeqOperation(
     string Id,
     string ChannelId,
-    string Reason,
+    string? Reason,
     double? TargetLevelDb,
     double? MinHz,
     double? MaxHz,
@@ -268,7 +268,7 @@ internal sealed record AutoTunePeqOperation(
 /// has a reason to ask for, and refusing it costs nothing.
 /// </param>
 internal sealed record UseSpatialAverageOperation(
-    string Id, string Reason, string Mode, bool Hybrid) : AgentOperation(Id, Reason)
+    string Id, string? Reason, string Mode, bool Hybrid) : AgentOperation(Id, Reason)
 {
     public override string Op => AgentProtocol.UseSpatialAverage;
 

--- a/source/Integration/AgentBridge/AgentProposalParser.cs
+++ b/source/Integration/AgentBridge/AgentProposalParser.cs
@@ -147,7 +147,7 @@ internal static class AgentProposalParser
 
         return AgentProposalParseResult.Success(new AgentProposal(
             string.IsNullOrWhiteSpace(wire.PackageId) ? null : wire.PackageId,
-            string.IsNullOrWhiteSpace(wire.Summary) ? null : wire.Summary,
+            Prose(wire.Summary),
             advice,
             sources,
             operations,
@@ -387,6 +387,15 @@ internal static class AgentProposalParser
         }
     }
 
+    // Blank is missing. A reply that writes "reason": "" has said as much as one
+    // that left the field out, and the review can only mark what it can tell
+    // apart — so the two arrive as the same thing, exactly as a blank summary
+    // does. (An operation the PARSER refused carries an empty reason on its
+    // verdict, set by the validator, and keeps its blank: its problem is the
+    // explanation.)
+    private static string? Prose(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+
     private static string? CheckStrings(AgentOperation operation)
     {
         if (string.IsNullOrWhiteSpace(operation.Id) || !WithinLength(operation.Id))
@@ -458,20 +467,20 @@ internal static class AgentProposalParser
 
     private static AgentOperation? Map(GainWire? wire) => wire == null
         ? null
-        : new SetGainOperation(wire.Id, wire.ChannelId, wire.Reason, wire.ExpectedCurrent, wire.Proposed);
+        : new SetGainOperation(wire.Id, wire.ChannelId, Prose(wire.Reason), wire.ExpectedCurrent, wire.Proposed);
 
     private static AgentOperation? Map(DelayWire? wire) => wire == null
         ? null
-        : new SetDelayOperation(wire.Id, wire.ChannelId, wire.Reason, wire.ExpectedCurrent, wire.Proposed);
+        : new SetDelayOperation(wire.Id, wire.ChannelId, Prose(wire.Reason), wire.ExpectedCurrent, wire.Proposed);
 
     private static AgentOperation? Map(PolarityWire? wire) => wire == null
         ? null
-        : new SetPolarityOperation(wire.Id, wire.ChannelId, wire.Reason, wire.ExpectedCurrent, wire.Proposed);
+        : new SetPolarityOperation(wire.Id, wire.ChannelId, Prose(wire.Reason), wire.ExpectedCurrent, wire.Proposed);
 
     private static AgentOperation? Map(CrossoverWire? wire) => wire == null
         ? null
         : new SetCrossoverOperation(
-            wire.Id, wire.ChannelId, wire.Reason,
+            wire.Id, wire.ChannelId, Prose(wire.Reason),
             Map(NotNull(wire.ExpectedCurrent, "expectedCurrent")),
             Map(NotNull(wire.Proposed, "proposed")));
 
@@ -497,7 +506,7 @@ internal static class AgentProposalParser
         PeqBankWire bank = NotNull(wire.Proposed, "proposed");
         List<PeqBandWire> bands = NotNull(bank.Bands, "proposed.bands");
         return new ReplacePeqBankOperation(
-            wire.Id, wire.ChannelId, wire.Reason, wire.ExpectedCurrentHash,
+            wire.Id, wire.ChannelId, Prose(wire.Reason), wire.ExpectedCurrentHash,
             new AgentPeqBank(
                 bank.PreampDb,
                 bands
@@ -509,17 +518,17 @@ internal static class AgentProposalParser
     private static AgentOperation? Map(AutoDelayWire? wire) => wire == null
         ? null
         : new RunAutoDelayOperation(
-            wire.Id, wire.Reason, wire.SceneOffsetMs, wire.RightHandDrive, wire.AdjustGains,
+            wire.Id, Prose(wire.Reason), wire.SceneOffsetMs, wire.RightHandDrive, wire.AdjustGains,
             wire.NearSideCutDb, wire.RearFillOffsetMs);
 
     private static AgentOperation? Map(AutoCrossoverWire? wire) => wire == null
         ? null
-        : new RunAutoCrossoverOperation(wire.Id, wire.Reason);
+        : new RunAutoCrossoverOperation(wire.Id, Prose(wire.Reason));
 
     private static AgentOperation? Map(TuneJunctionWire? wire) => wire == null
         ? null
         : new TuneJunctionOperation(
-            wire.Id, wire.Reason, wire.JunctionId, wire.MinHz, wire.MaxHz,
+            wire.Id, Prose(wire.Reason), wire.JunctionId, wire.MinHz, wire.MaxHz,
             wire.Families, wire.Slopes, wire.IndependentSlopes);
 
     // Every nested element goes through NotNull: `"variants": [null]` and
@@ -530,7 +539,7 @@ internal static class AgentProposalParser
         ? null
         : new ProbeOperation(
             wire.Id,
-            wire.Reason,
+            Prose(wire.Reason),
             wire.Probe,
             wire.JunctionId,
             wire.Variants?.Select(item =>
@@ -563,12 +572,12 @@ internal static class AgentProposalParser
     private static AgentOperation? Map(AutoTuneWire? wire) => wire == null
         ? null
         : new AutoTunePeqOperation(
-            wire.Id, wire.ChannelId, wire.Reason, wire.TargetLevelDb, wire.MinHz, wire.MaxHz,
+            wire.Id, wire.ChannelId, Prose(wire.Reason), wire.TargetLevelDb, wire.MinHz, wire.MaxHz,
             wire.AllowShelves, wire.CutsOnly, wire.Source);
 
     private static AgentOperation? Map(SpatialAverageWire? wire) => wire == null
         ? null
-        : new UseSpatialAverageOperation(wire.Id, wire.Reason, wire.Mode, wire.Hybrid);
+        : new UseSpatialAverageOperation(wire.Id, Prose(wire.Reason), wire.Mode, wire.Hybrid);
 
     private static bool WithinLength(string? value) =>
         value == null || value.Length <= AgentProtocol.MaxStringLength;

--- a/source/Integration/AgentBridge/AgentProposalParser.cs
+++ b/source/Integration/AgentBridge/AgentProposalParser.cs
@@ -76,10 +76,6 @@ internal static class AgentProposalParser
                 $"The proposal uses protocol version {wire.ProtocolVersion}; this build " +
                 $"reads version {AgentProtocol.Version}.");
         }
-        if (string.IsNullOrWhiteSpace(wire.Summary))
-        {
-            return AgentProposalParseResult.Fail("The proposal has no summary.");
-        }
         // `required` only requires the member to be PRESENT; a JSON null passes it.
         if (wire.Operations == null)
         {
@@ -151,7 +147,7 @@ internal static class AgentProposalParser
 
         return AgentProposalParseResult.Success(new AgentProposal(
             string.IsNullOrWhiteSpace(wire.PackageId) ? null : wire.PackageId,
-            wire.Summary,
+            string.IsNullOrWhiteSpace(wire.Summary) ? null : wire.Summary,
             advice,
             sources,
             operations,
@@ -402,9 +398,9 @@ internal static class AgentProposalParser
         {
             return "The channel id is missing or too long.";
         }
-        if (operation.Reason == null || !WithinLength(operation.Reason))
+        if (!WithinLength(operation.Reason))
         {
-            return "The reason is missing or too long.";
+            return "The reason is too long.";
         }
 
         return operation switch
@@ -618,7 +614,12 @@ internal static class AgentProposalParser
         public required string Kind { get; init; }
         public required int ProtocolVersion { get; init; }
         public string? PackageId { get; init; }
-        public required string Summary { get; init; }
+        // Wanted, not required. An assistant that leaves the prose out has still
+        // said what it wants done in the operations, and refusing the whole
+        // reply over a missing sentence costs the user a round trip through the
+        // chat to get back a sentence they were about to read anyway. The
+        // review says the reply gave none.
+        public string? Summary { get; init; }
         public List<string>? Advice { get; init; }
         public List<SourceWire>? Sources { get; init; }
         public required List<JsonElement> Operations { get; init; }
@@ -636,7 +637,8 @@ internal static class AgentProposalParser
     {
         public required string Op { get; init; }
         public required string Id { get; init; }
-        public required string Reason { get; init; }
+        /// <summary>Wanted, not required — see <c>ProposalWire.Summary</c>.</summary>
+        public string? Reason { get; init; }
         public JsonElement? Extensions { get; init; }
     }
 

--- a/source/Integration/AgentBridge/AgentProposalParser.cs
+++ b/source/Integration/AgentBridge/AgentProposalParser.cs
@@ -393,8 +393,12 @@ internal static class AgentProposalParser
     // does. (An operation the PARSER refused carries an empty reason on its
     // verdict, set by the validator, and keeps its blank: its problem is the
     // explanation.)
+    // A blank that is too long is still too long: only what the limits already
+    // allow is collapsed, so CheckStrings still sees an over-limit string and
+    // refuses it. (The summary is length-checked on the wire value above, before
+    // it ever reaches here.)
     private static string? Prose(string? value) =>
-        string.IsNullOrWhiteSpace(value) ? null : value;
+        string.IsNullOrWhiteSpace(value) && WithinLength(value) ? null : value;
 
     private static string? CheckStrings(AgentOperation operation)
     {

--- a/source/Integration/AgentBridge/AgentProposalValidator.cs
+++ b/source/Integration/AgentBridge/AgentProposalValidator.cs
@@ -165,8 +165,8 @@ internal static class AgentProposalValidator
             warnings.Add(unexplained == proposal.Operations.Count
                 ? $"No operation says why: judge the {unexplained} row" +
                     $"{(unexplained == 1 ? "" : "s")} below by the values alone."
-                : $"{unexplained} of {proposal.Operations.Count} operations say why they are " +
-                    "proposed; the rest are marked in the reason column.");
+                : $"{unexplained} of {proposal.Operations.Count} operations do not say why; " +
+                    "they are marked in the reason column.");
         }
 
         var verdicts = new List<AgentOperationVerdict>();

--- a/source/Integration/AgentBridge/AgentProposalValidator.cs
+++ b/source/Integration/AgentBridge/AgentProposalValidator.cs
@@ -24,7 +24,7 @@ internal sealed record AgentOperationVerdict(
     string Proposed,
     AgentVerdictStatus Status,
     string Message,
-    string Reason,
+    string? Reason,
     AgentOperation? Operation,
     AgentChannelSnapshot? Channel)
 {
@@ -149,6 +149,24 @@ internal static class AgentProposalValidator
         if (stale != null)
         {
             warnings.Add(stale);
+        }
+
+        // The prose is wanted and not required, so its absence is reported
+        // rather than refused: the user reads the summary and the reasons to
+        // decide, and a reply that left them out is exactly the reply they
+        // should be told about before they tick anything.
+        if (proposal.Summary == null)
+        {
+            warnings.Add("The reply gave no summary of what it is proposing.");
+        }
+        int unexplained = proposal.Operations.Count(operation => operation.Reason == null);
+        if (unexplained > 0)
+        {
+            warnings.Add(unexplained == proposal.Operations.Count
+                ? $"No operation says why: judge the {unexplained} row" +
+                    $"{(unexplained == 1 ? "" : "s")} below by the values alone."
+                : $"{unexplained} of {proposal.Operations.Count} operations say why they are " +
+                    "proposed; the rest are marked in the reason column.");
         }
 
         var verdicts = new List<AgentOperationVerdict>();

--- a/source/Tools/VirtualCrossover/AgentProposalDialog.cs
+++ b/source/Tools/VirtualCrossover/AgentProposalDialog.cs
@@ -13,6 +13,15 @@ namespace Resonalyze;
 internal sealed partial class AgentProposalDialog : Form
 {
     private static readonly Color RejectedText = Color.FromArgb(140, 146, 158);
+
+    /// <summary>
+    /// What stands where the reply's own prose would have been. The fields are
+    /// wanted and not required — a reply that leaves them out is still read —
+    /// so the review has to say the words are missing rather than show a blank
+    /// that reads like there was nothing to say.
+    /// </summary>
+    private const string NoSummaryText = "(the reply gave no summary)";
+    private const string NoReasonText = "(no reason given)";
     private static readonly Color WarningText = Color.FromArgb(230, 184, 0);
 
     private readonly AgentProposalReview review;
@@ -24,7 +33,7 @@ internal sealed partial class AgentProposalDialog : Form
         this.review = review;
 
         StyleGrid();
-        labelSummary.Text = review.Proposal.Summary;
+        labelSummary.Text = review.Proposal.Summary ?? NoSummaryText;
         labelWarnings.Text = review.Warnings.Count > 0
             ? string.Join(Environment.NewLine, review.Warnings)
             : string.Empty;
@@ -38,7 +47,11 @@ internal sealed partial class AgentProposalDialog : Form
                 verdict.Current,
                 verdict.Proposed,
                 StatusWord(verdict.Status),
-                verdict.Reason);
+                // A row the assistant explained shows its sentence; one it did
+                // not is marked, so the blank cannot be read as "no reason to
+                // give". A row the parser refused carries an empty reason and
+                // is left blank: its message IS the explanation.
+                verdict.Reason ?? NoReasonText);
             DataGridViewRow row = gridView.Rows[index];
             row.Tag = verdict;
             if (!verdict.Applicable)
@@ -134,9 +147,13 @@ internal sealed partial class AgentProposalDialog : Form
             {
                 lines.Add("Proposed: " + verdict.Proposed);
             }
-            if (verdict.Reason.Length > 0)
+            if (verdict.Reason is { Length: > 0 })
             {
                 lines.Add("Reason: " + verdict.Reason);
+            }
+            else if (verdict.Reason == null)
+            {
+                lines.Add("Reason: " + NoReasonText);
             }
         }
 

--- a/source/Tools/VirtualCrossover/AgentProposalDialog.cs
+++ b/source/Tools/VirtualCrossover/AgentProposalDialog.cs
@@ -40,6 +40,11 @@ internal sealed partial class AgentProposalDialog : Form
 
         foreach (AgentOperationVerdict verdict in review.Verdicts)
         {
+            // A row the assistant explained shows its sentence; one it did not
+            // is marked, so the blank cannot be read as "no reason to give". A
+            // row the parser refused carries an empty reason and is left blank:
+            // its message IS the explanation.
+            string reasonText = verdict.Reason ?? NoReasonText;
             int index = gridView.Rows.Add(
                 verdict.Applicable && verdict.Ticked,
                 verdict.ChannelLabel,
@@ -47,11 +52,7 @@ internal sealed partial class AgentProposalDialog : Form
                 verdict.Current,
                 verdict.Proposed,
                 StatusWord(verdict.Status),
-                // A row the assistant explained shows its sentence; one it did
-                // not is marked, so the blank cannot be read as "no reason to
-                // give". A row the parser refused carries an empty reason and
-                // is left blank: its message IS the explanation.
-                verdict.Reason ?? NoReasonText);
+                reasonText);
             DataGridViewRow row = gridView.Rows[index];
             row.Tag = verdict;
             if (!verdict.Applicable)
@@ -66,7 +67,7 @@ internal sealed partial class AgentProposalDialog : Form
                 row.Cells[ColumnStatus.Index].Style.SelectionForeColor = WarningText;
             }
             row.Cells[ColumnStatus.Index].ToolTipText = verdict.Message;
-            row.Cells[ColumnReason.Index].ToolTipText = verdict.Reason;
+            row.Cells[ColumnReason.Index].ToolTipText = reasonText;
             // These two columns are fixed-width and an engine request states its
             // whole set of inputs in them, well past what the cell can show. The
             // detail box below repeats them for the selected row; the tooltip is

--- a/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
@@ -460,6 +460,21 @@ public sealed class AgentProposalParserTests
     }
 
     [Fact]
+    public void Parse_ReadsABlankReasonAsNoReason()
+    {
+        // "reason": "" says exactly as much as no field at all, and the review
+        // can only mark what it can tell apart.
+        string json = FiveOperations.Replace("\"reason\": \"Arrival.\"", "\"reason\": \"  \"");
+
+        AgentProposal proposal = AgentProposalParser.Parse(Begin + json + End).Proposal!;
+
+        Assert.Null(proposal.Operations.Single(op => op.Id == "op-3").Reason);
+        Assert.All(
+            proposal.Operations.Where(op => op.Id != "op-3"),
+            op => Assert.False(string.IsNullOrWhiteSpace(op.Reason)));
+    }
+
+    [Fact]
     public void Parse_KeepsAReplyThatLeftTheSummaryOut()
     {
         // The words are for the user, and losing the whole reply over them

--- a/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
@@ -400,7 +400,6 @@ public sealed class AgentProposalParserTests
     [Theory]
     [InlineData("\"kind\": \"resonalyze.agent-proposal\"", "\"kind\": \"something-else\"", "not a Resonalyze proposal")]
     [InlineData("\"protocolVersion\": 1", "\"protocolVersion\": 2", "protocol version 2")]
-    [InlineData("\"summary\": \"The left mid/tweeter junction cancels near 3.1 kHz.\"", "\"summary\": \"\"", "no summary")]
     [InlineData("\"advice\": [\"Run Auto delay afterwards.\"]", "\"advice\": [\"Run Auto delay afterwards.\"],", "not the JSON")]
     [InlineData("\"packageId\":", "// a comment\n \"packageId\":", "not the JSON")]
     [InlineData("\"proposed\": -2.6", "\"proposed\": NaN", "not the JSON")]
@@ -435,7 +434,8 @@ public sealed class AgentProposalParserTests
         string json = FiveOperations
             // An operation nobody supports, a path-like target.
             .Replace("\"op\": \"setGainDb\"", "\"op\": \"setProjectProperty\"")
-            // A delay without its reason.
+            // A delay without its reason: kept, because the prose is wanted and
+            // not required — the shapes around it are what a reply is refused for.
             .Replace(", \"reason\": \"Arrival.\"", "")
             // A crossover with a stray field.
             .Replace("\"reason\": \"Lower the top.\"", "\"reason\": \"Lower the top.\", \"path\": \"pairs[0]\"");
@@ -444,7 +444,8 @@ public sealed class AgentProposalParserTests
 
         Assert.True(result.Succeeded, result.Error);
         AgentProposal proposal = result.Proposal!;
-        Assert.Equal(["op-1", "op-5"], proposal.Operations.Select(op => op.Id));
+        Assert.Equal(["op-1", "op-3", "op-5"], proposal.Operations.Select(op => op.Id));
+        Assert.Null(proposal.Operations.Single(op => op.Id == "op-3").Reason);
         Assert.Collection(proposal.Rejected,
             rejected =>
             {
@@ -453,14 +454,31 @@ public sealed class AgentProposalParserTests
             },
             rejected =>
             {
-                Assert.Equal("op-3", rejected.Id);
-                Assert.Contains("shape", rejected.Problem);
-            },
-            rejected =>
-            {
                 Assert.Equal("op-4", rejected.Id);
                 Assert.Contains("shape", rejected.Problem);
             });
+    }
+
+    [Fact]
+    public void Parse_KeepsAReplyThatLeftTheSummaryOut()
+    {
+        // The words are for the user, and losing the whole reply over them
+        // sends the user back to the chat for a sentence — with the operations
+        // they were about to read thrown away on the way.
+        foreach (string json in new[]
+        {
+            FiveOperations.Replace(
+                "\"summary\": \"The left mid/tweeter junction cancels near 3.1 kHz.\",", ""),
+            FiveOperations.Replace(
+                "\"The left mid/tweeter junction cancels near 3.1 kHz.\"", "\"   \"")
+        })
+        {
+            AgentProposalParseResult result = AgentProposalParser.Parse(Begin + json + End);
+
+            Assert.True(result.Succeeded, result.Error);
+            Assert.Null(result.Proposal!.Summary);
+            Assert.Equal(5, result.Proposal.Operations.Count);
+        }
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalParserTests.cs
@@ -475,6 +475,24 @@ public sealed class AgentProposalParserTests
     }
 
     [Fact]
+    public void Parse_RefusesABlankReasonThatIsOverTheLengthLimit()
+    {
+        // Blank counts as missing, but the limits are what stop a reply from
+        // being any size it likes: collapsing an over-limit string to "missing"
+        // would let it through the very check it fails.
+        string json = FiveOperations.Replace(
+            "\"reason\": \"Arrival.\"",
+            "\"reason\": \"" + new string(' ', AgentProtocol.MaxStringLength + 1) + "\"");
+
+        AgentProposal proposal = AgentProposalParser.Parse(Begin + json + End).Proposal!;
+
+        Assert.DoesNotContain(proposal.Operations, op => op.Id == "op-3");
+        AgentRejectedOperation rejected = Assert.Single(proposal.Rejected);
+        Assert.Equal("op-3", rejected.Id);
+        Assert.Contains("too long", rejected.Problem);
+    }
+
+    [Fact]
     public void Parse_KeepsAReplyThatLeftTheSummaryOut()
     {
         // The words are for the user, and losing the whole reply over them

--- a/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
@@ -1009,6 +1009,45 @@ public sealed class AgentProposalValidatorTests
             Fingerprint: fingerprint);
     }
 
+    [Fact]
+    public void Review_SaysWhenTheReplyLeftItsProseOut()
+    {
+        // Not a refusal: the operations are the proposal, and the user reads
+        // the values either way. But the missing words are exactly what they
+        // would have read to decide, so the review names their absence.
+        AgentProposal proposal = new(
+            Package, null, [], [],
+            [
+                new SetGainOperation("op-1", "A:right", null, -2.0, -2.6),
+                new SetDelayOperation("op-2", "A:right", "arrival", 1.42, 1.37)
+            ],
+            []);
+
+        AgentProposalReview review = AgentProposalValidator.Review(proposal, Session());
+
+        Assert.Equal(2, review.Warnings.Count);
+        Assert.Contains("no summary", review.Warnings[0]);
+        Assert.Contains("1 of 2 operations say why", review.Warnings[1]);
+        Assert.All(review.Verdicts, verdict => Assert.True(verdict.Applicable, verdict.Message));
+        Assert.Null(review.Verdicts[0].Reason);
+        Assert.Equal("arrival", review.Verdicts[1].Reason);
+    }
+
+    [Fact]
+    public void Review_SaysWhenNoOperationSaysWhy()
+    {
+        AgentProposal proposal = new(
+            Package, "the words that go on top", [], [],
+            [new SetGainOperation("op-1", "A:right", null, -2.0, -2.6)],
+            []);
+
+        AgentProposalReview review = AgentProposalValidator.Review(proposal, Session());
+
+        string warning = Assert.Single(review.Warnings);
+        Assert.Contains("No operation says why", warning);
+        Assert.Contains("1 row", warning);
+    }
+
     private static AgentProposal Proposal(params AgentOperation[] operations) =>
         new(Package, "summary", [], [], operations, []);
 

--- a/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
+++ b/tests/Resonalyze.App.Tests/AgentProposalValidatorTests.cs
@@ -1015,11 +1015,15 @@ public sealed class AgentProposalValidatorTests
         // Not a refusal: the operations are the proposal, and the user reads
         // the values either way. But the missing words are exactly what they
         // would have read to decide, so the review names their absence.
+        // Three operations, ONE of them unexplained: with two the count of the
+        // explained and of the unexplained are the same number, and a sentence
+        // that named the wrong one would read true.
         AgentProposal proposal = new(
             Package, null, [], [],
             [
                 new SetGainOperation("op-1", "A:right", null, -2.0, -2.6),
-                new SetDelayOperation("op-2", "A:right", "arrival", 1.42, 1.37)
+                new SetDelayOperation("op-2", "A:right", "arrival", 1.42, 1.37),
+                new SetPolarityOperation("op-3", "B:left", "phase", false, true)
             ],
             []);
 
@@ -1027,7 +1031,7 @@ public sealed class AgentProposalValidatorTests
 
         Assert.Equal(2, review.Warnings.Count);
         Assert.Contains("no summary", review.Warnings[0]);
-        Assert.Contains("1 of 2 operations say why", review.Warnings[1]);
+        Assert.Contains("1 of 3 operations do not say why", review.Warnings[1]);
         Assert.All(review.Verdicts, verdict => Assert.True(verdict.Applicable, verdict.Message));
         Assert.Null(review.Verdicts[0].Reason);
         Assert.Equal("arrival", review.Verdicts[1].Reason);


### PR DESCRIPTION
Field report from the owner: assistants periodically forget `summary` and an
operation's `reason`.

Both fields exist for the person reading the review, and the importer was
treating them as protocol:

- no `summary` — the **whole reply** was refused (`The proposal has no
  summary.`), so the user went back to the chat for one sentence and every
  operation went with it;
- no `reason` — the field was `required` for the deserializer, so the operation
  was rejected with `Not the shape the protocol describes: … missing required
  properties`.

Refusing gives the user no sentence either. It gives them a round trip.

## What changed

Both are optional, and their absence is **shown** rather than punished — an
empty cell would otherwise read as "there was nothing to say":

- review warnings: `The reply gave no summary of what it is proposing.` and
  `1 of 2 operations say why they are proposed; the rest are marked in the
  reason column.` (or `No operation says why: judge the 3 rows below by the
  values alone.`);
- the dialog marks the rows: `(no reason given)`, `(the reply gave no summary)`.

An operation the parser refused carries an empty reason rather than a missing
one and stays blank — its own message is the explanation — so the mark means
what it says.

`AGENT_GUIDE.md` and `PROTOCOL.md` now say "wanted" instead of "required":
write them because the user is about to act on them, not because the importer
insists. Length limits still apply to a string that IS present.

## Tests

- `Parse_KeepsAReplyThatLeftTheSummaryOut` — the field absent, and present but
  blank.
- `Parse_RejectsOneBadOperationAndKeepsTheOthers` now shows the contrast: the
  operation with no `reason` is kept with `Reason == null`, the malformed
  shapes beside it are still refused.
- `Review_SaysWhenTheReplyLeftItsProseOut`, `Review_SaysWhenNoOperationSaysWhy`.

App suite: 2275 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
