### PR TITLE
The zoom box measures before it zooms, and F1 says what the mouse does

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -110,7 +110,10 @@ spans the whole ±180° a wrapped phase can occupy — the box is still the
 rectangle you dragged and still reads `1.30 kHz × 150°`, and a click then
 moves the frequency axis alone. Frequencies pass to kHz from 1 kHz up. The box
 is pinned to the data rather than to the screen, so panning or zooming while
-it waits leaves it around the same part of the curve.
+it waits leaves it around the same part of the curve, and it goes away when
+the graph stops showing what it framed: switching the Virtual DSP view between
+magnitude, phase and impulse re-arms an axis to another quantity, and numbers
+in units the graph no longer uses are not worth keeping.
 
 The **graph limits** dialog types the same ranges exactly — top, bottom, left and
 right as numbers, plus **Fit to data**, **Fit Y to data** and **Defaults**, which

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -77,13 +77,40 @@ preview, the history list — are fixed-scale by design and take none of this.)
 | `x` / **Shift**+`X` | Zooms the horizontal axis out / in by about two, around the pointer |
 | `y` / **Shift**+`Y` | The same for the vertical axis |
 | Middle-button drag | Variable zoom: right and left work the horizontal axis, up and down the vertical one |
-| **Ctrl** + right-button drag | Draws a zoom rectangle |
+| **Ctrl** + right-button drag | Draws a zoom box, labelled with the size of the area it frames in axis units; it stays on the graph until you click inside it to zoom there |
 | Right-button drag | Pans |
 | The **+** / **&minus;** buttons on the graph | Zoom the axis they sit against by about two, click after click; they appear while the pointer is over the plot, and hovering one names the axis it moves |
 | Double click | Opens the graph limits dialog |
 | **Ctrl+Z** | Steps back through the zoom-to-area, variable-zoom, zoom-button and fit-to-data moves (a wheel notch is its own undo — scroll it back) |
 | **Ctrl+Alt+F** / **Ctrl+Alt+Y** | Fit to data / fit the vertical axis to data |
 | **Home** or `A` | Back to the view's own default scale (also the **Defaults** button in the limits dialog) |
+| **F1** | Opens **Graph controls**, the card listing every gesture in this table |
+
+None of this is written anywhere on the graph itself, so **F1** over any graph
+opens **Graph controls** — the same list, on a card. It is a window, not a
+dialog: it stays open beside the graph while you try what it says, F1 brings
+it back to the front rather than opening a second one, and **Esc** or
+**Close** sends it away. The graph has to have been clicked once for the key
+to reach it, as with every other key in the table.
+
+The zoom box works the way REW's does, in two steps rather than one, and it is
+a ruler before it is a selection. The drag draws it, and a label beside it
+says how wide and how tall the framed area is in the units of the axes it is
+drawn over — `1.90 kHz × 20.0 dB`. Letting go of the button does not move the
+scale: the box stays on the graph, so the width of a suckout or the depth of a
+dip can be read and left at that. Clicking inside the box is what zooms there;
+a click anywhere else on the graph, or **Esc**, lets it go, and **Ctrl+Z**
+steps back a zoom the box did apply. If the box is too thin to zoom to, the
+click says which side is too small and leaves the box where it is rather than
+doing nothing at all.
+
+Both sides are measured whatever the axes allow, and only the zoom is
+conditional: over a scale that is locked — the Virtual DSP **Phase** view
+spans the whole ±180° a wrapped phase can occupy — the box is still the
+rectangle you dragged and still reads `1.30 kHz × 150°`, and a click then
+moves the frequency axis alone. Frequencies pass to kHz from 1 kHz up. The box
+is pinned to the data rather than to the screen, so panning or zooming while
+it waits leaves it around the same part of the curve.
 
 The **graph limits** dialog types the same ranges exactly — top, bottom, left and
 right as numbers, plus **Fit to data**, **Fit Y to data** and **Defaults**, which

--- a/source/Plotting/PlotAxisIdentity.cs
+++ b/source/Plotting/PlotAxisIdentity.cs
@@ -1,0 +1,59 @@
+using OxyPlot;
+using OxyPlot.Axes;
+
+namespace Resonalyze;
+
+/// <summary>
+/// What an axis MEANS, as far as a stored range is concerned: what it is called and
+/// the hard limits it is armed with. Re-arming those is how the app says "this axis
+/// now shows something else".
+/// </summary>
+internal readonly record struct PlotAxisIdentity(
+    string? Key,
+    string? Title,
+    Type AxisType,
+    double AbsoluteMinimum,
+    double AbsoluteMaximum);
+
+/// <summary>
+/// Whether a plot is still showing what a remembered range was taken from.
+///
+/// The model reference alone does not answer it. The Virtual DSP acoustic view
+/// re-arms ONE axis object between dB, degrees and a unitless impulse scale without
+/// replacing the model, and swaps the bottom axis between frequency and time in
+/// place; the EQ wizard re-arms its dB axis for a new source. A range, an undo entry
+/// or a zoom box held across such a change would be numbers in the units of a scale
+/// that is no longer on screen — dB read as a normalized impulse — so anything that
+/// remembers a range remembers this alongside it and drops what it holds when the
+/// two stop matching.
+/// </summary>
+internal static class PlotAxisIdentities
+{
+    public static IReadOnlyList<PlotAxisIdentity> Describe(PlotModel? model) =>
+        model == null
+            ? Array.Empty<PlotAxisIdentity>()
+            : model.Axes
+                .Select(axis => new PlotAxisIdentity(
+                    axis.Key,
+                    axis.Title,
+                    axis.GetType(),
+                    axis.AbsoluteMinimum,
+                    axis.AbsoluteMaximum))
+                .ToList();
+
+    /// <summary>
+    /// True when <paramref name="model"/> is the same plot, showing the same
+    /// quantities, that <paramref name="identities"/> was taken from.
+    /// </summary>
+    public static bool Match(
+        PlotModel? model,
+        PlotModel? rememberedModel,
+        IReadOnlyList<PlotAxisIdentity> identities)
+    {
+        ArgumentNullException.ThrowIfNull(identities);
+
+        return model != null &&
+            ReferenceEquals(model, rememberedModel) &&
+            Describe(model).SequenceEqual(identities);
+    }
+}

--- a/source/Plotting/PlotGestureController.cs
+++ b/source/Plotting/PlotGestureController.cs
@@ -382,6 +382,7 @@ internal sealed class PlotGestureController : PlotController
         }
 
         zoomBox.Box = box;
+        zoomBox.Axes = zoomBoxAxes;
         zoomBox.AnchorRight = current.X >= start.X;
         zoomBox.AnchorBottom = current.Y >= start.Y;
         zoomBox.Text = box?.Describe() ?? string.Empty;
@@ -404,6 +405,7 @@ internal sealed class PlotGestureController : PlotController
         zoomBoxModel.Annotations.Remove(zoomBox);
         zoomBoxModel = null;
         zoomBoxAxes = Array.Empty<PlotAxisIdentity>();
+        zoomBox.Axes = zoomBoxAxes;
         zoomBox.Box = null;
         zoomBox.Text = string.Empty;
         zoomBox.Hint = string.Empty;

--- a/source/Plotting/PlotGestureController.cs
+++ b/source/Plotting/PlotGestureController.cs
@@ -1,6 +1,7 @@
 using OxyPlot;
 using OxyPlot.Axes;
 using OxyPlot.WindowsForms;
+using Resonalyze.Ui.Dialogs;
 
 namespace Resonalyze;
 
@@ -20,11 +21,18 @@ namespace Resonalyze;
 /// opposite end where it is.</item>
 /// <item>x / Shift+X and y / Shift+Y — zoom one axis out / in by about two.</item>
 /// <item>middle drag — variable zoom (<see cref="PlotVariableZoomManipulator"/>);
-/// Ctrl + right drag — zoom to area. Both are undoable with Ctrl+Z.</item>
+/// Ctrl + right drag — a zoom box (<see cref="PlotZoomRectangleManipulator"/>), which
+/// like REW's is drawn first and applied second: the box stays on the graph with the
+/// size of the area it frames written beside it, a click inside it zooms there, any
+/// other click lets it go. It is a ruler before it is a selection, so it is drawn and
+/// measured over locked scales too — only the zoom is conditional. Both are undoable
+/// with Ctrl+Z.</item>
 /// <item>right drag — pan. Ctrl+Alt+F / Ctrl+Alt+Y — fit to data / fit Y to
 /// data. Double click — the graph limits dialog.</item>
 /// <item>the plus/minus buttons drawn against each axis while the pointer is over
 /// the plot (<see cref="PlotZoomButtons"/>).</item>
+/// <item>F1 — the whole map on a card (<see cref="GraphHelpDialog"/>). Every gesture
+/// here is one nobody is told about anywhere else in the window.</item>
 /// </list>
 /// Two bindings have no REW counterpart and are kept because they are what this app
 /// did before: Ctrl + wheel zooms the vertical axis only (the plain wheel used to,
@@ -40,17 +48,26 @@ internal sealed class PlotGestureController : PlotController
     /// </summary>
     private const int UndoDepth = 32;
 
-    /// <summary>How long the zoom buttons' hint stays up once shown, in milliseconds.</summary>
-    private const int ZoomButtonTipDurationMs = 4000;
+    /// <summary>How long a hint over the graph stays up once shown, in milliseconds.</summary>
+    private const int TipDurationMs = 4000;
 
     private readonly PlotView view;
     private readonly LinkedList<IReadOnlyList<PlotAxisViewport>> zoomUndo = new();
     private readonly PlotZoomButtonsAnnotation zoomButtons = new();
 
     // A plus and a minus against an axis do not say WHICH axis, or that they zoom
-    // at all, so the hovered one names itself. OxyPlot's own element tooltips are
-    // not wired up in its WinForms view, hence a plain ToolTip on the control.
-    private readonly ToolTip zoomButtonTip = new() { ShowAlways = true };
+    // at all, so the hovered one names itself, and a box too small to zoom to says so
+    // rather than being ignored. OxyPlot's own element tooltips are not wired up in
+    // its WinForms view, hence a plain ToolTip on the control.
+    private readonly ToolTip graphTip = new() { ShowAlways = true };
+
+    // REW's zoom box outlives the drag that draws it, so the controller owns it
+    // rather than the manipulator: the box waits on the graph, and the click that
+    // zooms to it (or lets it go) arrives long after that manipulator is gone.
+    private readonly PlotZoomRectangleAnnotation zoomBox = new();
+    private PlotModel? zoomBoxModel;
+    private bool zoomBoxPending;
+    private bool zoomBoxHovered;
 
     // Where the pointer last was, in the view's coordinates. The keyboard zoom
     // commands need it: OxyPlot's key events carry no position, and REW zooms the
@@ -75,7 +92,7 @@ internal sealed class PlotGestureController : PlotController
         this.view = view;
         view.MouseMove += (_, e) => TrackPointer(new ScreenPoint(e.X, e.Y));
         view.MouseLeave += (_, _) => HideZoomButtons();
-        view.Disposed += (_, _) => zoomButtonTip.Dispose();
+        view.Disposed += (_, _) => graphTip.Dispose();
 
         BindWheelGestures();
         BindMouseGestures();
@@ -109,19 +126,18 @@ internal sealed class PlotGestureController : PlotController
                     args);
             }));
 
-        // Same manipulator OxyPlot binds here; rebound only so the gesture records an
-        // undo step first.
+        // Replaces OxyPlot's zoom rectangle, which zooms the moment the button comes
+        // up. REW draws the box first and zooms on a click inside it, and the undo
+        // step is therefore recorded by that click rather than here — a box that is
+        // only read must not leave anything on the undo stack.
         this.BindMouseDown(
             OxyMouseButton.Right,
             OxyModifierKeys.Control,
             new DelegatePlotCommand<OxyMouseDownEventArgs>((target, controller, args) =>
-            {
-                PushZoomUndo();
                 controller.AddMouseManipulator(
                     target,
-                    new ZoomRectangleManipulator(target),
-                    args);
-            }));
+                    new PlotZoomRectangleManipulator(target, this),
+                    args)));
 
         // A second click on a zoom button arrives here as a DOUBLE click, so this
         // binding has to answer it as another zoom step: clicking a button twice is
@@ -140,13 +156,14 @@ internal sealed class PlotGestureController : PlotController
                 GraphLimitsDialog.ShowFor(view);
             }));
 
-        // A plain left press either hits an on-graph zoom button or does what
-        // OxyPlot binds it to — the snapping tracker.
+        // A plain left press answers a waiting zoom box first, then an on-graph zoom
+        // button, and otherwise does what OxyPlot binds it to — the snapping tracker.
         this.BindMouseDown(
             OxyMouseButton.Left,
             new DelegatePlotCommand<OxyMouseDownEventArgs>((target, controller, args) =>
             {
-                if (TryClickZoomButton(target, args.Position))
+                if (TryClickZoomBox(target, args.Position) ||
+                    TryClickZoomButton(target, args.Position))
                 {
                     return;
                 }
@@ -195,6 +212,7 @@ internal sealed class PlotGestureController : PlotController
         }
 
         AttachZoomButtons(model);
+        TrackZoomBoxHover(model, position);
         ScreenPoint? shown = model.PlotArea.Contains(position.X, position.Y)
             ? position
             : null;
@@ -222,7 +240,7 @@ internal sealed class PlotGestureController : PlotController
     {
         if (hovered is not PlotZoomButton button)
         {
-            zoomButtonTip.Hide(view);
+            graphTip.Hide(view);
             return;
         }
 
@@ -230,18 +248,16 @@ internal sealed class PlotGestureController : PlotController
         string name = axis == null
             ? (button.Horizontal ? "horizontal axis" : "vertical axis")
             : PlotAxisZoom.DescribeAxis(axis);
-        zoomButtonTip.Show(
-            $"{(button.ZoomIn ? "Zoom in" : "Zoom out")} — {name}",
-            view,
-            (int)position.X + 16,
-            (int)position.Y + 20,
-            ZoomButtonTipDurationMs);
+        ShowTip($"{(button.ZoomIn ? "Zoom in" : "Zoom out")} — {name}", position);
     }
+
+    private void ShowTip(string text, ScreenPoint position) =>
+        graphTip.Show(text, view, (int)position.X + 16, (int)position.Y + 20, TipDurationMs);
 
     private void HideZoomButtons()
     {
         hoveredButton = null;
-        zoomButtonTip.Hide(view);
+        graphTip.Hide(view);
         if (zoomButtons.Pointer == null)
         {
             return;
@@ -249,6 +265,141 @@ internal sealed class PlotGestureController : PlotController
 
         zoomButtons.Pointer = null;
         view.InvalidatePlot(false);
+    }
+
+    /// <summary>
+    /// Starts a box, dropping whatever was waiting: one box at a time, like one
+    /// selection at a time.
+    /// </summary>
+    public void BeginZoomBox()
+    {
+        DismissZoomBox();
+        if (view.ActualModel is not PlotModel model)
+        {
+            return;
+        }
+
+        zoomBoxModel = model;
+        model.Annotations.Add(zoomBox);
+    }
+
+    /// <summary>Redraws the box as the drag grows; <c>null</c> while it is still a dot.</summary>
+    public void UpdateZoomBox(PlotZoomBox? box, ScreenPoint start, ScreenPoint current) =>
+        ShowZoomBox(box, start, current, pending: false);
+
+    /// <summary>
+    /// Leaves the finished box on the graph, waiting to be read and perhaps clicked.
+    /// Every box that was actually drawn is kept, however thin: a box a millimetre
+    /// tall still measures a fraction of a decibel, and whether it can also be zoomed
+    /// to is a question for the click, not for the release. A Ctrl + right CLICK that
+    /// drew no box at all is simply forgotten.
+    /// </summary>
+    public void FinishZoomBox(PlotZoomBox box, ScreenPoint start, ScreenPoint end)
+    {
+        if (PlotZoomRectangleReadout.WasDrawn(start, end))
+        {
+            ShowZoomBox(box, start, end, pending: true);
+            return;
+        }
+
+        DismissZoomBox();
+    }
+
+    /// <summary>
+    /// The click REW zooms on. Inside the waiting box it takes the view there — and
+    /// only here is an undo step recorded, because only here does anything move. A
+    /// box too thin to zoom to keeps its place and says which side is too small, so
+    /// the reading survives the misfire. A click anywhere else lets the box go and
+    /// then goes on to do whatever it would have done: the box is an overlay, not a
+    /// state the graph is stuck in.
+    /// </summary>
+    private bool TryClickZoomBox(IPlotView target, ScreenPoint position)
+    {
+        if (!zoomBoxPending || zoomBox.Box is not PlotZoomBox box)
+        {
+            return false;
+        }
+
+        if (zoomBoxModel is not PlotModel model ||
+            !ReferenceEquals(model, target.ActualModel) ||
+            !box.CanZoom ||
+            !box.Contains(model.PlotArea, position))
+        {
+            DismissZoomBox();
+            return false;
+        }
+
+        if (PlotZoomRectangleReadout.RefusalFor(box, box.Screen(model.PlotArea)) is string refusal)
+        {
+            ShowTip(refusal, position);
+            return true;
+        }
+
+        PushZoomUndo();
+        box.Zoom();
+        DismissZoomBox();
+        target.InvalidatePlot(false);
+        return true;
+    }
+
+    private void ShowZoomBox(
+        PlotZoomBox? box,
+        ScreenPoint start,
+        ScreenPoint current,
+        bool pending)
+    {
+        if (zoomBoxModel == null)
+        {
+            return;
+        }
+
+        zoomBox.Box = box;
+        zoomBox.AnchorRight = current.X >= start.X;
+        zoomBox.AnchorBottom = current.Y >= start.Y;
+        zoomBox.Text = box?.Describe() ?? string.Empty;
+        zoomBox.Hint = box is PlotZoomBox drawn
+            ? PlotZoomRectangleReadout.HintFor(drawn, pending)
+            : string.Empty;
+        zoomBoxPending = pending && box != null;
+        view.InvalidatePlot(false);
+    }
+
+    private void DismissZoomBox()
+    {
+        zoomBoxPending = false;
+        SetZoomBoxHovered(false);
+        if (zoomBoxModel == null)
+        {
+            return;
+        }
+
+        zoomBoxModel.Annotations.Remove(zoomBox);
+        zoomBoxModel = null;
+        zoomBox.Box = null;
+        zoomBox.Text = string.Empty;
+        zoomBox.Hint = string.Empty;
+        view.InvalidatePlot(false);
+    }
+
+    // A box that is waiting to be clicked has to look clickable, or the instruction
+    // beside it is the only thing saying so.
+    private void TrackZoomBoxHover(PlotModel model, ScreenPoint position) =>
+        SetZoomBoxHovered(
+            zoomBoxPending &&
+            ReferenceEquals(zoomBoxModel, model) &&
+            zoomBox.Box is PlotZoomBox box &&
+            box.CanZoom &&
+            box.Contains(model.PlotArea, position));
+
+    private void SetZoomBoxHovered(bool hovered)
+    {
+        if (hovered == zoomBoxHovered)
+        {
+            return;
+        }
+
+        zoomBoxHovered = hovered;
+        view.Cursor = hovered ? Cursors.Hand : Cursors.Default;
     }
 
     // The models are rebuilt constantly and the annotation belongs to whichever one
@@ -259,6 +410,16 @@ internal sealed class PlotGestureController : PlotController
         if (ReferenceEquals(buttonsModel, model))
         {
             return;
+        }
+
+        // The box belongs to the model it was drawn over: a rebuild takes it away, so
+        // the waiting state goes with it rather than surviving onto another graph.
+        // Guarded on the box's OWN model, not on this one having changed: the first
+        // pointer event of all can arrive during the drag that draws the box, and
+        // that must not drop the box being drawn.
+        if (!ReferenceEquals(zoomBoxModel, model))
+        {
+            DismissZoomBox();
         }
 
         buttonsModel?.Annotations.Remove(zoomButtons);
@@ -282,6 +443,20 @@ internal sealed class PlotGestureController : PlotController
             OxyModifierKeys.Shift,
             KeyZoomCommand(horizontal: false, PlotAxisZoom.StepZoomInScale));
 
+        this.BindKeyDown(
+            OxyKey.Escape,
+            new DelegatePlotCommand<OxyKeyEventArgs>((_, _, _) => DismissZoomBox()));
+
+        // Handled here rather than left to Windows: answering the key ourselves is
+        // also what stops it reaching DefWindowProc, which would turn it into a
+        // second, empty help request.
+        this.BindKeyDown(
+            OxyKey.F1,
+            new DelegatePlotCommand<OxyKeyEventArgs>((_, _, args) =>
+            {
+                GraphHelpDialog.ShowFor(view.FindForm());
+                args.Handled = true;
+            }));
         this.BindKeyDown(
             OxyKey.Z,
             OxyModifierKeys.Control,

--- a/source/Plotting/PlotGestureController.cs
+++ b/source/Plotting/PlotGestureController.cs
@@ -69,6 +69,16 @@ internal sealed class PlotGestureController : PlotController
     private bool zoomBoxPending;
     private bool zoomBoxHovered;
 
+    // What the box was drawn against. The model reference is not enough: the
+    // Virtual DSP acoustic view re-arms its value axis between dB, degrees and a
+    // unitless impulse scale and swaps its bottom axis in place, all inside ONE
+    // model, and a box held across that would apply decibels to an impulse.
+    private IReadOnlyList<PlotAxisIdentity> zoomBoxAxes = Array.Empty<PlotAxisIdentity>();
+
+    // Set by the click that zooms to a box, so the DOUBLE click the second press of
+    // a quick double tap arrives as does not also open the limits dialog.
+    private bool zoomBoxJustClicked;
+
     // Where the pointer last was, in the view's coordinates. The keyboard zoom
     // commands need it: OxyPlot's key events carry no position, and REW zooms the
     // axis around the pointer rather than around the centre of the plot.
@@ -84,7 +94,7 @@ internal sealed class PlotGestureController : PlotController
     // re-arms ONE axis object between dB, degrees and milliseconds without
     // replacing the model, and the EQ wizard re-arms its dB axis for a new source.
     private PlotModel? undoModel;
-    private IReadOnlyList<AxisIdentity> undoAxes = Array.Empty<AxisIdentity>();
+    private IReadOnlyList<PlotAxisIdentity> undoAxes = Array.Empty<PlotAxisIdentity>();
 
     public PlotGestureController(PlotView view)
     {
@@ -148,6 +158,15 @@ internal sealed class PlotGestureController : PlotController
             clickCount: 2,
             new DelegatePlotCommand<OxyMouseDownEventArgs>((target, _, args) =>
             {
+                // The second press of a double tap inside a zoom box: the first
+                // press already zoomed there, and opening the limits dialog on top
+                // of that is not what the hand asked for.
+                if (zoomBoxJustClicked)
+                {
+                    zoomBoxJustClicked = false;
+                    return;
+                }
+
                 if (TryClickZoomButton(target, args.Position))
                 {
                     return;
@@ -162,6 +181,7 @@ internal sealed class PlotGestureController : PlotController
             OxyMouseButton.Left,
             new DelegatePlotCommand<OxyMouseDownEventArgs>((target, controller, args) =>
             {
+                zoomBoxJustClicked = false;
                 if (TryClickZoomBox(target, args.Position) ||
                     TryClickZoomButton(target, args.Position))
                 {
@@ -211,6 +231,9 @@ internal sealed class PlotGestureController : PlotController
             return;
         }
 
+        // Before the buttons: their own attach returns early while the model is
+        // unchanged, and a re-armed axis is exactly the case that keeps the model.
+        DropZoomBoxOfAnotherView(model);
         AttachZoomButtons(model);
         TrackZoomBoxHover(model, position);
         ScreenPoint? shown = model.PlotArea.Contains(position.X, position.Y)
@@ -280,6 +303,7 @@ internal sealed class PlotGestureController : PlotController
         }
 
         zoomBoxModel = model;
+        zoomBoxAxes = PlotAxisIdentities.Describe(model);
         model.Annotations.Add(zoomBox);
     }
 
@@ -320,8 +344,11 @@ internal sealed class PlotGestureController : PlotController
             return false;
         }
 
+        // Checked here as well as on every pointer move: a view can be re-armed
+        // without the mouse having gone anywhere, and this is the click that would
+        // otherwise act on it.
         if (zoomBoxModel is not PlotModel model ||
-            !ReferenceEquals(model, target.ActualModel) ||
+            !PlotAxisIdentities.Match(target.ActualModel, model, zoomBoxAxes) ||
             !box.CanZoom ||
             !box.Contains(model.PlotArea, position))
         {
@@ -338,6 +365,7 @@ internal sealed class PlotGestureController : PlotController
         PushZoomUndo();
         box.Zoom();
         DismissZoomBox();
+        zoomBoxJustClicked = true;
         target.InvalidatePlot(false);
         return true;
     }
@@ -375,6 +403,7 @@ internal sealed class PlotGestureController : PlotController
 
         zoomBoxModel.Annotations.Remove(zoomBox);
         zoomBoxModel = null;
+        zoomBoxAxes = Array.Empty<PlotAxisIdentity>();
         zoomBox.Box = null;
         zoomBox.Text = string.Empty;
         zoomBox.Hint = string.Empty;
@@ -386,10 +415,25 @@ internal sealed class PlotGestureController : PlotController
     private void TrackZoomBoxHover(PlotModel model, ScreenPoint position) =>
         SetZoomBoxHovered(
             zoomBoxPending &&
-            ReferenceEquals(zoomBoxModel, model) &&
             zoomBox.Box is PlotZoomBox box &&
             box.CanZoom &&
             box.Contains(model.PlotArea, position));
+
+    /// <summary>
+    /// Drops a box the plot has stopped agreeing with: another model, or the same
+    /// model with an axis re-armed to a different quantity under it. The box holds
+    /// AXIS VALUES, which is what lets it ride out a pan or a wheel notch — and
+    /// exactly what makes it nonsense once the axis means something else.
+    /// </summary>
+    private void DropZoomBoxOfAnotherView(PlotModel model)
+    {
+        if (zoomBoxModel == null || PlotAxisIdentities.Match(model, zoomBoxModel, zoomBoxAxes))
+        {
+            return;
+        }
+
+        DismissZoomBox();
+    }
 
     private void SetZoomBoxHovered(bool hovered)
     {
@@ -410,16 +454,6 @@ internal sealed class PlotGestureController : PlotController
         if (ReferenceEquals(buttonsModel, model))
         {
             return;
-        }
-
-        // The box belongs to the model it was drawn over: a rebuild takes it away, so
-        // the waiting state goes with it rather than surviving onto another graph.
-        // Guarded on the box's OWN model, not on this one having changed: the first
-        // pointer event of all can arrive during the drag that draws the box, and
-        // that must not drop the box being drawn.
-        if (!ReferenceEquals(zoomBoxModel, model))
-        {
-            DismissZoomBox();
         }
 
         buttonsModel?.Annotations.Remove(zoomButtons);
@@ -570,38 +604,13 @@ internal sealed class PlotGestureController : PlotController
     /// </summary>
     private void DropUndoOfAnotherModel()
     {
-        IReadOnlyList<AxisIdentity> axes = DescribeAxes(view.ActualModel);
-        if (ReferenceEquals(undoModel, view.ActualModel) && axes.SequenceEqual(undoAxes))
+        if (PlotAxisIdentities.Match(view.ActualModel, undoModel, undoAxes))
         {
             return;
         }
 
         zoomUndo.Clear();
         undoModel = view.ActualModel;
-        undoAxes = axes;
+        undoAxes = PlotAxisIdentities.Describe(view.ActualModel);
     }
-
-    private static IReadOnlyList<AxisIdentity> DescribeAxes(PlotModel? model) =>
-        model == null
-            ? Array.Empty<AxisIdentity>()
-            : model.Axes
-                .Select(axis => new AxisIdentity(
-                    axis.Key,
-                    axis.Title,
-                    axis.GetType(),
-                    axis.AbsoluteMinimum,
-                    axis.AbsoluteMaximum))
-                .ToList();
-
-    /// <summary>
-    /// What an axis MEANS, as far as a stored range is concerned: what it is called
-    /// and the hard limits it is armed with. Re-arming those is how the app says
-    /// "this axis now shows something else".
-    /// </summary>
-    private readonly record struct AxisIdentity(
-        string? Key,
-        string? Title,
-        Type AxisType,
-        double AbsoluteMinimum,
-        double AbsoluteMaximum);
 }

--- a/source/Plotting/PlotGestureHelp.cs
+++ b/source/Plotting/PlotGestureHelp.cs
@@ -1,0 +1,82 @@
+namespace Resonalyze;
+
+/// <summary>One line of the graph help: a gesture, and what it does.</summary>
+internal readonly record struct PlotGestureHelpEntry(string Gesture, string Effect);
+
+/// <summary>A group of gestures under one heading.</summary>
+internal sealed record PlotGestureHelpSection(
+    string Title,
+    IReadOnlyList<PlotGestureHelpEntry> Entries);
+
+/// <summary>
+/// The graph controls in the words the user reads them in — what F1 puts on screen.
+///
+/// It is a list rather than a hand-laid dialog because it is the SAME map twice
+/// over: <see cref="PlotGestureController"/> binds it, and the "Graph Zoom and
+/// Limits" table in REFERENCE.md tabulates it. A gesture that changes has three
+/// places to change, and keeping this one in a form nobody has to lay out again is
+/// what makes the third cheap enough to actually do.
+///
+/// The wording is deliberately shorter than the reference's: this is a card to
+/// glance at with one hand on the mouse, not the place a behaviour is explained.
+/// </summary>
+internal static class PlotGestureHelp
+{
+    /// <summary>What the window is called, and the line under its title.</summary>
+    public const string Title = "Graph controls";
+
+    public const string Introduction =
+        "The analysis plot, the Time Alignment previews, the EQ Wizard and the " +
+        "Virtual DSP graphs all take these. Small previews inside settings panels " +
+        "are fixed-scale by design and take none of them.";
+
+    public static IReadOnlyList<PlotGestureHelpSection> Sections { get; } =
+    [
+        new PlotGestureHelpSection("Zoom",
+        [
+            new PlotGestureHelpEntry("Wheel", "Both axes, around the pointer"),
+            new PlotGestureHelpEntry("Alt + wheel", "The same, in fine steps"),
+            new PlotGestureHelpEntry("Shift + wheel", "The horizontal axis only"),
+            new PlotGestureHelpEntry("Ctrl + wheel", "The vertical axis only"),
+            new PlotGestureHelpEntry("Wheel over an axis", "That axis alone"),
+            new PlotGestureHelpEntry(
+                "Wheel over the end of an axis",
+                "Moves that one limit, leaving the other end"),
+            new PlotGestureHelpEntry(
+                "Middle-button drag",
+                "Variable zoom: sideways works the horizontal axis, up and down the vertical one"),
+            new PlotGestureHelpEntry("X / Shift + X", "The horizontal axis out / in by about two"),
+            new PlotGestureHelpEntry("Y / Shift + Y", "The vertical axis out / in by about two"),
+            new PlotGestureHelpEntry(
+                "The + / − buttons on the graph",
+                "Zoom the axis they sit against, click after click"),
+        ]),
+        new PlotGestureHelpSection("Zoom box",
+        [
+            new PlotGestureHelpEntry(
+                "Ctrl + right-button drag",
+                "Draws a box and measures it in the units of the axes"),
+            new PlotGestureHelpEntry(
+                "Click inside the box",
+                "Zooms to it — only the axes that allow zoom move"),
+            new PlotGestureHelpEntry(
+                "Click elsewhere, or Esc",
+                "Lets the box go, leaving the scale where it is"),
+        ]),
+        new PlotGestureHelpSection("Pan, fit and limits",
+        [
+            new PlotGestureHelpEntry("Right-button drag", "Pans"),
+            new PlotGestureHelpEntry("Ctrl + Alt + F", "Fits the view to the data"),
+            new PlotGestureHelpEntry("Ctrl + Alt + Y", "Fits the vertical axis to the data"),
+            new PlotGestureHelpEntry("Home, or A", "Back to the view's own default scale"),
+            new PlotGestureHelpEntry("Double click", "Opens the graph limits dialog"),
+        ]),
+        new PlotGestureHelpSection("Undo and help",
+        [
+            new PlotGestureHelpEntry(
+                "Ctrl + Z",
+                "Steps back through the zoom moves (a wheel notch is its own undo — scroll it back)"),
+            new PlotGestureHelpEntry("F1", "This window"),
+        ]),
+    ];
+}

--- a/source/Plotting/PlotZoomRectangleManipulator.cs
+++ b/source/Plotting/PlotZoomRectangleManipulator.cs
@@ -1,0 +1,62 @@
+using OxyPlot;
+
+namespace Resonalyze;
+
+/// <summary>
+/// REW's zoom box, the drawing half: Ctrl + right drag frames an area on the graph
+/// and reads its size out as it goes. What it does NOT do is zoom — in REW the box
+/// stays on the graph when the button comes up and the scale only moves when the box
+/// is clicked, which is what lets it be used as a measuring tape. The waiting, the
+/// click and the zoom itself belong to <see cref="PlotGestureController"/>, which is
+/// where the box outlives this manipulator.
+/// </summary>
+internal sealed class PlotZoomRectangleManipulator : MouseManipulator
+{
+    private readonly PlotGestureController owner;
+
+    public PlotZoomRectangleManipulator(IPlotView plotView, PlotGestureController owner)
+        : base(plotView)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        this.owner = owner;
+    }
+
+    public override void Started(OxyMouseEventArgs e)
+    {
+        // The base assigns the axes the drag is over, which is what the box is
+        // measured in, so it goes first.
+        base.Started(e);
+        PlotView.SetCursorType(CursorType.ZoomRectangle);
+        owner.BeginZoomBox();
+        Draw(e.Position);
+    }
+
+    public override void Delta(OxyMouseEventArgs e)
+    {
+        base.Delta(e);
+        Draw(e.Position);
+    }
+
+    public override void Completed(OxyMouseEventArgs e)
+    {
+        base.Completed(e);
+        PlotView.SetCursorType(CursorType.Default);
+        owner.FinishZoomBox(
+            PlotZoomBox.Frame(XAxis, YAxis, StartPosition, e.Position),
+            StartPosition,
+            e.Position);
+    }
+
+    private void Draw(ScreenPoint position)
+    {
+        // Below a few pixels there is nothing to draw and nothing to read: the box is
+        // still a dot, and a "0.000 Hz" flashing under the cursor at every press is
+        // noise.
+        owner.UpdateZoomBox(
+            PlotZoomRectangleReadout.WasDrawn(StartPosition, position)
+                ? PlotZoomBox.Frame(XAxis, YAxis, StartPosition, position)
+                : null,
+            StartPosition,
+            position);
+    }
+}

--- a/source/Plotting/PlotZoomRectangleReadout.cs
+++ b/source/Plotting/PlotZoomRectangleReadout.cs
@@ -1,0 +1,488 @@
+using System.Globalization;
+using OxyPlot;
+using OxyPlot.Annotations;
+using OxyPlot.Axes;
+
+namespace Resonalyze;
+
+/// <summary>
+/// The area a zoom box frames, held in AXIS VALUES rather than in pixels.
+///
+/// REW's box outlives the drag that drew it: the graph is zoomed by a click INSIDE
+/// the box, not by the button coming up, so between the two the plot can be panned,
+/// wheeled or redrawn. A box remembered in pixels would then frame a different piece
+/// of the curve than the one somebody drew around; values do not move.
+///
+/// The box frames BOTH directions whatever the axes allow, because measuring is what
+/// it is mostly for and an axis that cannot be zoomed can still be read: the Virtual
+/// DSP phase view has its height locked at ±180°, and a phase difference across a
+/// crossover is exactly the kind of thing worth measuring there. Zooming is the
+/// second act, and it moves only the axes that allow it. A direction with no axis to
+/// read against is left null and drawn across the whole plot area.
+/// </summary>
+internal readonly record struct PlotZoomBox(
+    Axis? HorizontalAxis,
+    double HorizontalFrom,
+    double HorizontalTo,
+    Axis? VerticalAxis,
+    double VerticalFrom,
+    double VerticalTo)
+{
+    /// <summary>Nothing framed at all: neither axis can be zoomed.</summary>
+    public bool IsEmpty => HorizontalAxis == null && VerticalAxis == null;
+
+    /// <summary>
+    /// The box a drag from <paramref name="start"/> to <paramref name="current"/>
+    /// frames, read through the axes it was drawn over.
+    /// </summary>
+    public static PlotZoomBox Frame(
+        Axis? xAxis,
+        Axis? yAxis,
+        ScreenPoint start,
+        ScreenPoint current)
+    {
+        Axis? x = Measurable(xAxis);
+        Axis? y = Measurable(yAxis);
+        (double left, double right) = Values(x, start.X, current.X);
+        (double low, double high) = Values(y, start.Y, current.Y);
+        return new PlotZoomBox(x, left, right, y, low, high);
+    }
+
+    /// <summary>Where the box sits on screen NOW, whatever the axes have done since.</summary>
+    public OxyRect Screen(OxyRect plotArea)
+    {
+        (double left, double right) =
+            Pixels(HorizontalAxis, HorizontalFrom, HorizontalTo, plotArea.Left, plotArea.Right);
+        (double top, double bottom) =
+            Pixels(VerticalAxis, VerticalFrom, VerticalTo, plotArea.Top, plotArea.Bottom);
+        return new OxyRect(left, top, right - left, bottom - top);
+    }
+
+    /// <summary>True when the point is inside the box — the click REW zooms on.</summary>
+    public bool Contains(OxyRect plotArea, ScreenPoint point) =>
+        !IsEmpty && Screen(plotArea).Contains(point.X, point.Y);
+
+    /// <summary>
+    /// True when clicking the box would move anything. A box over a locked scale is
+    /// still worth drawing — it measures — but it is not worth offering a zoom for.
+    /// </summary>
+    public bool CanZoom =>
+        HorizontalAxis is { IsZoomEnabled: true } || VerticalAxis is { IsZoomEnabled: true };
+
+    /// <summary>
+    /// Zooms to what the box frames — but only along the axes that allow it. A box
+    /// drawn over the Virtual DSP phase view moves the frequency axis and leaves the
+    /// locked ±180° height where it is, having measured it all the same.
+    /// </summary>
+    public void Zoom()
+    {
+        if (HorizontalAxis is { IsZoomEnabled: true } horizontal)
+        {
+            horizontal.Zoom(HorizontalFrom, HorizontalTo);
+        }
+
+        if (VerticalAxis is { IsZoomEnabled: true } vertical)
+        {
+            vertical.Zoom(VerticalFrom, VerticalTo);
+        }
+    }
+
+    /// <summary>
+    /// The size of the framed area as text — "1.53 kHz × 12.4 dB". Both directions
+    /// are stated whenever there is an axis to state them in, zoomable or not: the
+    /// number is the point of the box, and a locked scale is no less measurable for
+    /// being locked.
+    /// </summary>
+    public string Describe(CultureInfo? culture = null)
+    {
+        culture ??= CultureInfo.CurrentCulture;
+        string? width = HorizontalAxis == null
+            ? null
+            : PlotZoomRectangleReadout.FormatSpan(
+                HorizontalAxis,
+                HorizontalTo - HorizontalFrom,
+                culture);
+        string? height = VerticalAxis == null
+            ? null
+            : PlotZoomRectangleReadout.FormatSpan(
+                VerticalAxis,
+                VerticalTo - VerticalFrom,
+                culture);
+
+        if (width != null && height != null)
+        {
+            return $"{width} \u00D7 {height}";
+        }
+
+        return width ?? height ?? string.Empty;
+    }
+
+    /// <summary>
+    /// An axis a span can be READ against: one the plot actually shows. The
+    /// waterfall's hidden ±1 placeholder and the colour scales are not scales anybody
+    /// reads a difference off, so a box over them measures the other direction alone.
+    /// </summary>
+    private static Axis? Measurable(Axis? axis) =>
+        axis is { IsAxisVisible: true } and not IColorAxis ? axis : null;
+
+    private static (double From, double To) Values(Axis? axis, double first, double second)
+    {
+        if (axis == null)
+        {
+            return (double.NaN, double.NaN);
+        }
+
+        double a = axis.InverseTransform(first);
+        double b = axis.InverseTransform(second);
+        return (Math.Min(a, b), Math.Max(a, b));
+    }
+
+    private static (double Low, double High) Pixels(
+        Axis? axis,
+        double from,
+        double to,
+        double areaLow,
+        double areaHigh)
+    {
+        if (axis == null)
+        {
+            return (areaLow, areaHigh);
+        }
+
+        double a = axis.Transform(from);
+        double b = axis.Transform(to);
+        return (Math.Min(a, b), Math.Max(a, b));
+    }
+}
+
+/// <summary>
+/// What REW writes beside its zoom box: how wide and how tall the framed area is IN
+/// THE UNITS OF THE AXES it is drawn over — "1.53 kHz × 12.4 dB". Together with the
+/// box outliving the drag, that is what makes the gesture a measuring tape as well
+/// as a selection: the width of a suckout or the depth of a dip gets read without
+/// counting gridlines, and without the scale moving unless the click that moves it
+/// is given.
+///
+/// The arithmetic lives here rather than in the manipulator so it can be tested
+/// without a view: everything below takes axes, values and screen coordinates and
+/// returns numbers, text and rectangles.
+/// </summary>
+internal static class PlotZoomRectangleReadout
+{
+    /// <summary>Frequencies pass to kHz at and above this span, as REW writes them.</summary>
+    private const double KilohertzThreshold = 1000;
+
+    /// <summary>
+    /// Longest title that still reads as a UNIT rather than as the name of the
+    /// quantity: "samples" fits, "Coherence γ²" does not, and repeating the name of
+    /// the axis after the number reads worse than leaving the number bare.
+    /// </summary>
+    private const int MaxUnitLength = 7;
+
+    private const string Hertz = "Hz";
+    private const string Kilohertz = "kHz";
+    private const string Degrees = "\u00B0";
+
+    /// <summary>Gap between the box's corner and the label, in pixels.</summary>
+    private const double Gap = 10;
+
+    /// <summary>Padding between the label's text and its backdrop, in pixels.</summary>
+    public const double PaddingX = 6;
+    public const double PaddingY = 3;
+
+    /// <summary>
+    /// Shortest side, in pixels, that can be zoomed to. Below it the box is a slip of
+    /// the hand rather than a selection, and REW answers such a box by saying which
+    /// side is too small instead of zooming to it.
+    /// </summary>
+    private const double MinimumZoomSize = 10;
+
+    /// <summary>
+    /// Pointer travel below which nothing was drawn at all — a Ctrl + right CLICK
+    /// rather than a box. It is not refused and not reported: there is nothing to
+    /// refuse, and a message at every stray click would be worse than silence.
+    /// </summary>
+    private const double MinimumDragSize = 3;
+
+    /// <summary>True once the pointer has moved far enough to have drawn a box.</summary>
+    public static bool WasDrawn(ScreenPoint start, ScreenPoint current) =>
+        Math.Abs(current.X - start.X) >= MinimumDragSize ||
+        Math.Abs(current.Y - start.Y) >= MinimumDragSize;
+
+    /// <summary>
+    /// The second line of the label, under the size: what the waiting box is waiting
+    /// for. It is a line of its own rather than a tail on the number, which keeps the
+    /// label narrow enough to sit beside the box instead of stretching across the
+    /// graph. There is none during the drag, none when there is nothing to measure,
+    /// and none over a locked scale — where the box is a ruler and nothing else, and
+    /// inviting a click that would do nothing is worse than saying nothing.
+    /// </summary>
+    public static string HintFor(PlotZoomBox box, bool pending) =>
+        pending && box.CanZoom && !box.IsEmpty ? "click inside to zoom" : string.Empty;
+
+    /// <summary>
+    /// Why the box cannot be zoomed to, or null when it can. Judged at the click, and
+    /// against the box as it stands on screen by then — it may have been panned or
+    /// wheeled since it was drawn — along the sides a zoom would actually move. REW
+    /// names the side that is too small rather than silently doing nothing, which is
+    /// the difference between "the program ignored me" and "that box is too thin".
+    /// </summary>
+    public static string? RefusalFor(PlotZoomBox box, OxyRect screen)
+    {
+        bool tooNarrow = box.HorizontalAxis is { IsZoomEnabled: true } &&
+                         screen.Width < MinimumZoomSize;
+        bool tooShort = box.VerticalAxis is { IsZoomEnabled: true } &&
+                        screen.Height < MinimumZoomSize;
+
+        if (tooNarrow && tooShort)
+        {
+            return "That box is too small to zoom in to";
+        }
+
+        if (tooNarrow)
+        {
+            return "That box is too narrow to zoom in to";
+        }
+
+        return tooShort ? "That box is too short to zoom in to" : null;
+    }
+
+    /// <summary>
+    /// A span in one axis's units, with the unit the axis says it is in. Frequencies
+    /// pass to kHz where REW passes them, so a two-octave box over the midrange reads
+    /// "1.53 kHz" rather than a four-digit number of hertz.
+    /// </summary>
+    public static string FormatSpan(Axis axis, double span, CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(axis);
+        ArgumentNullException.ThrowIfNull(culture);
+
+        string unit = UnitOf(axis);
+        if (unit == Hertz && Math.Abs(span) >= KilohertzThreshold)
+        {
+            span /= KilohertzThreshold;
+            unit = Kilohertz;
+        }
+
+        string number = FormatNumber(span, culture);
+        if (unit.Length == 0)
+        {
+            return number;
+        }
+
+        // A degree sign is set against its number; a word unit is set apart from it.
+        return unit == Degrees ? number + unit : $"{number} {unit}";
+    }
+
+    /// <summary>
+    /// Three significant figures, which is as much as any of these axes is read to:
+    /// a box is framed by eye, and a fourth digit only makes the label longer.
+    /// </summary>
+    private static string FormatNumber(double value, CultureInfo culture) =>
+        value.ToString(
+            Math.Abs(value) switch
+            {
+                >= 100 => "0",
+                >= 10 => "0.0",
+                >= 1 => "0.00",
+                _ => "0.000",
+            },
+            culture);
+
+    /// <summary>
+    /// What the axis says it is measured in. Most axes are titled with the unit
+    /// itself ("dB", "ms", "deg"), some carry it in parentheses ("Sum loss (dB)")
+    /// and some lead with it ("ms from peak"); a title longer than a unit is the
+    /// NAME of the quantity, and names are left out. The two axes the app titles
+    /// with nothing at all — frequency and phase — are known by their key instead,
+    /// because they are the two the zoom box is drawn over most.
+    /// </summary>
+    private static string UnitOf(Axis axis)
+    {
+        string? title = axis.Title;
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return axis.Key switch
+            {
+                PlotModelFactory.FrequencyAxisKey => Hertz,
+                PlotModelFactory.PhaseAxisKey => Degrees,
+                // A bottom log axis with no key is a frequency axis all the same —
+                // the Time Alignment previews build theirs by hand.
+                _ => axis is LogarithmicAxis && axis.IsHorizontal() ? Hertz : string.Empty,
+            };
+        }
+
+        title = title.Trim();
+        int opening = title.LastIndexOf('(');
+        string candidate = opening >= 0 && title.EndsWith(')')
+            ? title[(opening + 1)..^1].Trim()
+            : title.Split(' ', '\t')[0];
+
+        return candidate.Length is > 0 and <= MaxUnitLength ? candidate : string.Empty;
+    }
+
+    /// <summary>
+    /// Where the label goes: OUTSIDE the box, beside the corner the drag ended at.
+    /// The area being framed is what the user is looking at, and the number
+    /// describing it must not sit on top of it. Clamped into the plot area, so a box
+    /// drawn against an edge keeps its label on the graph instead of over the axis.
+    /// </summary>
+    public static OxyRect PlaceLabel(
+        OxyRect plotArea,
+        OxyRect rectangle,
+        ScreenPoint corner,
+        OxySize text)
+    {
+        double width = text.Width + (2 * PaddingX);
+        double height = text.Height + (2 * PaddingY);
+        double left = corner.X >= rectangle.Left + (rectangle.Width / 2)
+            ? corner.X + Gap
+            : corner.X - Gap - width;
+        double top = corner.Y >= rectangle.Top + (rectangle.Height / 2)
+            ? corner.Y + Gap
+            : corner.Y - Gap - height;
+
+        return new OxyRect(
+            Math.Clamp(left, plotArea.Left, Math.Max(plotArea.Left, plotArea.Right - width)),
+            Math.Clamp(top, plotArea.Top, Math.Max(plotArea.Top, plotArea.Bottom - height)),
+            width,
+            height);
+    }
+}
+
+/// <summary>
+/// Draws the zoom box and its read-out: the shaded rectangle while it is dragged and
+/// for as long as it then waits to be clicked. The annotation belongs to the model it
+/// was drawn over, so a rebuild — a new measurement, a mode switch — takes the box
+/// with it rather than leaving it floating over a different graph.
+/// </summary>
+internal sealed class PlotZoomRectangleAnnotation : Annotation
+{
+    private static readonly OxyColor Fill = OxyColor.FromAColor(60, OxyColors.Gold);
+    private static readonly OxyColor Stroke = OxyColor.FromAColor(220, OxyColors.Gold);
+    private static readonly OxyColor LabelFill = OxyColor.FromAColor(220, OxyColors.Black);
+    private static readonly OxyColor LabelStroke = OxyColor.FromAColor(140, OxyColors.White);
+
+    /// <summary>Space between the size and the instruction under it, in pixels.</summary>
+    private const double LineGap = 2;
+
+    /// <summary>How much the instruction is set down from the size it explains.</summary>
+    private const double HintFontStep = 1;
+
+    private static readonly byte HintOpacity = 170;
+
+    public PlotZoomRectangleAnnotation()
+    {
+        Layer = AnnotationLayer.AboveSeries;
+    }
+
+    /// <summary>What is framed, or null while no box is drawn.</summary>
+    public PlotZoomBox? Box { get; set; }
+
+    /// <summary>The size of the framed area; empty when there is nothing to read yet.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>The instruction under it, or empty when the box is only a ruler.</summary>
+    public string Hint { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Which corner the drag ended at, so the label stays on the side the pointer
+    /// left it on even after the box has travelled with a pan.
+    /// </summary>
+    public bool AnchorRight { get; set; }
+
+    public bool AnchorBottom { get; set; }
+
+    public override void Render(IRenderContext rc)
+    {
+        if (Box is not PlotZoomBox box || box.IsEmpty || PlotModel == null)
+        {
+            return;
+        }
+
+        OxyRect plotArea = PlotModel.PlotArea;
+        OxyRect rectangle = box.Screen(plotArea);
+        if (!TryIntersect(rectangle, plotArea, out OxyRect drawn))
+        {
+            // Panned or zoomed clean off the graph. The box is still remembered — it
+            // is anchored to the data, and comes back with it.
+            return;
+        }
+
+        rc.DrawRectangle(drawn, Fill, OxyColors.Undefined, 0, EdgeRenderingMode.PreferSpeed);
+        rc.DrawLine(
+            [
+                new ScreenPoint(drawn.Left, drawn.Top),
+                new ScreenPoint(drawn.Right, drawn.Top),
+                new ScreenPoint(drawn.Right, drawn.Bottom),
+                new ScreenPoint(drawn.Left, drawn.Bottom),
+                new ScreenPoint(drawn.Left, drawn.Top)
+            ],
+            Stroke,
+            1,
+            EdgeRenderingMode.PreferGeometricAccuracy,
+            LineStyle.Dash.GetDashArray(),
+            LineJoin.Miter);
+
+        if (Text.Length == 0)
+        {
+            return;
+        }
+
+        double hintFontSize = ActualFontSize - HintFontStep;
+        OxySize size = rc.MeasureText(Text, ActualFont, ActualFontSize, ActualFontWeight);
+        OxySize hint = Hint.Length == 0
+            ? new OxySize(0, 0)
+            : rc.MeasureText(Hint, ActualFont, hintFontSize, ActualFontWeight);
+        var block = new OxySize(
+            Math.Max(size.Width, hint.Width),
+            size.Height + (Hint.Length == 0 ? 0 : hint.Height + LineGap));
+
+        var corner = new ScreenPoint(
+            AnchorRight ? rectangle.Right : rectangle.Left,
+            AnchorBottom ? rectangle.Bottom : rectangle.Top);
+        OxyRect label = PlotZoomRectangleReadout.PlaceLabel(plotArea, rectangle, corner, block);
+        rc.DrawRectangle(label, LabelFill, LabelStroke, 1, EdgeRenderingMode.PreferGeometricAccuracy);
+
+        double left = label.Left + PlotZoomRectangleReadout.PaddingX;
+        rc.DrawText(
+            new ScreenPoint(left, label.Top + PlotZoomRectangleReadout.PaddingY),
+            Text,
+            ActualTextColor,
+            ActualFont,
+            ActualFontSize,
+            ActualFontWeight);
+        if (Hint.Length == 0)
+        {
+            return;
+        }
+
+        // Set down from the number it explains: the size is what is being read, the
+        // instruction is only there until it has been read once.
+        rc.DrawText(
+            new ScreenPoint(
+                left,
+                label.Top + PlotZoomRectangleReadout.PaddingY + size.Height + LineGap),
+            Hint,
+            OxyColor.FromAColor(HintOpacity, ActualTextColor),
+            ActualFont,
+            hintFontSize,
+            ActualFontWeight);
+    }
+
+    private static bool TryIntersect(OxyRect rectangle, OxyRect area, out OxyRect intersection)
+    {
+        double left = Math.Max(rectangle.Left, area.Left);
+        double top = Math.Max(rectangle.Top, area.Top);
+        double width = Math.Min(rectangle.Right, area.Right) - left;
+        double height = Math.Min(rectangle.Bottom, area.Bottom) - top;
+        if (width <= 0 || height <= 0)
+        {
+            intersection = default;
+            return false;
+        }
+
+        intersection = new OxyRect(left, top, width, height);
+        return true;
+    }
+}

--- a/source/Plotting/PlotZoomRectangleReadout.cs
+++ b/source/Plotting/PlotZoomRectangleReadout.cs
@@ -173,11 +173,14 @@ internal static class PlotZoomRectangleReadout
     private const double KilohertzThreshold = 1000;
 
     /// <summary>
-    /// Longest title that still reads as a UNIT rather than as the name of the
-    /// quantity: "samples" fits, "Coherence γ²" does not, and repeating the name of
-    /// the axis after the number reads worse than leaving the number bare.
+    /// The units these plots are actually measured in. A list rather than a rule
+    /// about short words, because a short word is just as often the NAME of a
+    /// dimensionless quantity — the impulse view's "step" axis, the correlation
+    /// views' "r" — and "0.420 step" reads as a unit that does not exist. A title
+    /// that is not one of these says nothing after the number.
     /// </summary>
-    private const int MaxUnitLength = 7;
+    private static readonly string[] KnownUnits =
+        ["dB", "ms", "s", "Hz", "kHz", "deg", "\u00B0", "%", "samples"];
 
     private const string Hertz = "Hz";
     private const string Kilohertz = "kHz";
@@ -314,11 +317,19 @@ internal static class PlotZoomRectangleReadout
 
         title = title.Trim();
         int opening = title.LastIndexOf('(');
-        string candidate = opening >= 0 && title.EndsWith(')')
-            ? title[(opening + 1)..^1].Trim()
-            : title.Split(' ', '\t')[0];
+        if (opening >= 0 && title.EndsWith(')'))
+        {
+            // Parentheses at the end of a title are the unit by convention, whatever
+            // is in them: "Sum loss (dB)", "delay added to the upper channel (ms)".
+            return title[(opening + 1)..^1].Trim();
+        }
 
-        return candidate.Length is > 0 and <= MaxUnitLength ? candidate : string.Empty;
+        // Otherwise the title has to BE a unit, whole or as its first word:
+        // "dB", "samples", "ms from peak".
+        string candidate = title.Split(' ', '\t')[0];
+        return KnownUnits.Contains(candidate, StringComparer.OrdinalIgnoreCase)
+            ? candidate
+            : string.Empty;
     }
 
     /// <summary>

--- a/source/Plotting/PlotZoomRectangleReadout.cs
+++ b/source/Plotting/PlotZoomRectangleReadout.cs
@@ -366,6 +366,12 @@ internal static class PlotZoomRectangleReadout
 /// for as long as it then waits to be clicked. The annotation belongs to the model it
 /// was drawn over, so a rebuild — a new measurement, a mode switch — takes the box
 /// with it rather than leaving it floating over a different graph.
+///
+/// It also stops drawing itself the moment the axes under it stop meaning what they
+/// meant. The Virtual DSP view switch re-arms them and repaints in the same breath,
+/// and the controller does not hear about it until the next mouse event — so the box
+/// checks for itself rather than waiting to be told, and a reading in dB is never
+/// left on screen over a scale that has become degrees.
 /// </summary>
 internal sealed class PlotZoomRectangleAnnotation : Annotation
 {
@@ -390,6 +396,12 @@ internal sealed class PlotZoomRectangleAnnotation : Annotation
     /// <summary>What is framed, or null while no box is drawn.</summary>
     public PlotZoomBox? Box { get; set; }
 
+    /// <summary>
+    /// What the axes meant when the box was drawn. The box is only drawn while they
+    /// still mean it.
+    /// </summary>
+    public IReadOnlyList<PlotAxisIdentity> Axes { get; set; } = Array.Empty<PlotAxisIdentity>();
+
     /// <summary>The size of the framed area; empty when there is nothing to read yet.</summary>
     public string Text { get; set; } = string.Empty;
 
@@ -406,7 +418,7 @@ internal sealed class PlotZoomRectangleAnnotation : Annotation
 
     public override void Render(IRenderContext rc)
     {
-        if (Box is not PlotZoomBox box || box.IsEmpty || PlotModel == null)
+        if (Box is not PlotZoomBox box || box.IsEmpty || !StillDescribesItsPlot())
         {
             return;
         }
@@ -480,6 +492,13 @@ internal sealed class PlotZoomRectangleAnnotation : Annotation
             hintFontSize,
             ActualFontWeight);
     }
+
+    /// <summary>
+    /// Whether the plot still shows what the box was drawn against. Checked at every
+    /// paint because a re-arm is a repaint, and the pointer need never move again.
+    /// </summary>
+    internal bool StillDescribesItsPlot() =>
+        PlotModel != null && PlotAxisIdentities.Describe(PlotModel).SequenceEqual(Axes);
 
     private static bool TryIntersect(OxyRect rectangle, OxyRect area, out OxyRect intersection)
     {

--- a/source/Ui/Dialogs/GraphHelpDialog.Designer.cs
+++ b/source/Ui/Dialogs/GraphHelpDialog.Designer.cs
@@ -1,0 +1,113 @@
+namespace Resonalyze.Ui.Dialogs
+{
+    partial class GraphHelpDialog
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                components?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            tableRows = new TableLayoutPanel();
+            panelButtons = new Panel();
+            buttonClose = new ReleaseClickButton();
+            labelIntroduction = new Label();
+            panelButtons.SuspendLayout();
+            SuspendLayout();
+            //
+            // tableRows
+            //
+            tableRows.AutoScroll = true;
+            tableRows.ColumnCount = 2;
+            tableRows.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            tableRows.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            tableRows.Dock = DockStyle.Fill;
+            tableRows.GrowStyle = TableLayoutPanelGrowStyle.AddRows;
+            tableRows.Location = new Point(16, 66);
+            tableRows.Name = "tableRows";
+            tableRows.RowCount = 0;
+            tableRows.Size = new Size(628, 536);
+            tableRows.TabIndex = 1;
+            //
+            // panelButtons
+            //
+            panelButtons.Controls.Add(buttonClose);
+            panelButtons.Dock = DockStyle.Bottom;
+            panelButtons.Location = new Point(16, 602);
+            panelButtons.Name = "panelButtons";
+            panelButtons.Size = new Size(628, 42);
+            panelButtons.TabIndex = 2;
+            //
+            // buttonClose
+            //
+            buttonClose.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            buttonClose.FlatStyle = FlatStyle.Popup;
+            buttonClose.ForeColor = Color.White;
+            buttonClose.Location = new Point(532, 10);
+            buttonClose.Name = "buttonClose";
+            buttonClose.Size = new Size(96, 26);
+            buttonClose.TabIndex = 0;
+            buttonClose.Text = "Close";
+            buttonClose.UseVisualStyleBackColor = true;
+            //
+            // labelIntroduction
+            //
+            labelIntroduction.AutoSize = true;
+            labelIntroduction.Dock = DockStyle.Top;
+            labelIntroduction.ForeColor = Color.FromArgb(185, 190, 200);
+            labelIntroduction.Location = new Point(16, 16);
+            labelIntroduction.MaximumSize = new Size(620, 0);
+            labelIntroduction.Name = "labelIntroduction";
+            labelIntroduction.Padding = new Padding(0, 0, 0, 12);
+            labelIntroduction.Size = new Size(620, 50);
+            labelIntroduction.TabIndex = 0;
+            //
+            // GraphHelpDialog
+            //
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
+            BackColor = Color.FromArgb(40, 44, 54);
+            ClientSize = new Size(660, 660);
+            // Docked in the reverse of the order they are added: WinForms lays out the
+            // LAST child first, so the note and the buttons claim their bands and the
+            // card fills what is left of the client area.
+            Controls.Add(tableRows);
+            Controls.Add(panelButtons);
+            Controls.Add(labelIntroduction);
+            Font = new Font("Segoe UI", 9F);
+            ForeColor = Color.White;
+            FormBorderStyle = FormBorderStyle.Sizable;
+            MinimizeBox = false;
+            Name = "GraphHelpDialog";
+            Padding = new Padding(16);
+            ShowIcon = false;
+            ShowInTaskbar = false;
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "Graph controls";
+            panelButtons.ResumeLayout(false);
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private TableLayoutPanel tableRows;
+        private Panel panelButtons;
+        private ReleaseClickButton buttonClose;
+        private Label labelIntroduction;
+    }
+}

--- a/source/Ui/Dialogs/GraphHelpDialog.cs
+++ b/source/Ui/Dialogs/GraphHelpDialog.cs
@@ -1,0 +1,163 @@
+using Resonalyze.Ui;
+
+namespace Resonalyze.Ui.Dialogs;
+
+/// <summary>
+/// The graph controls on one card, opened with F1 over any graph
+/// (<see cref="PlotGestureHelp"/> is what it lists). Modeless and single-instance
+/// on purpose: a cheat sheet is read WHILE the other hand tries the gesture, so it
+/// must not hold the app, and F1 pressed again brings the one window forward rather
+/// than stacking another.
+/// </summary>
+/// <remarks>
+/// The window and its three parts are built in the designer, so the form gets the
+/// one scaling pass <c>AutoScaleMode.Dpi</c> owes it and every size stated there is
+/// in the designer's 96 DPI. The ROWS are added here because they come from a list,
+/// but only into the designer's <c>TableLayoutPanel</c> and only in logical units:
+/// each label auto-sizes to the already-scaled font, and the margins and the wrap
+/// width are scaled by the same pass. Nothing multiplies a size by the DPI itself —
+/// that pass and this one would square the factor.
+/// </remarks>
+internal sealed partial class GraphHelpDialog : Form
+{
+    // One window at a time, kept across F1 presses. Static because the window is
+    // the app's, not any one plot's: the same card describes every graph.
+    private static GraphHelpDialog? openWindow;
+
+    private GraphHelpDialog()
+    {
+        InitializeComponent();
+        Text = PlotGestureHelp.Title;
+        labelIntroduction.Text = PlotGestureHelp.Introduction;
+        buttonClose.Click += (_, _) => Close();
+        BuildRows();
+    }
+
+    /// <summary>
+    /// Shows the card, or brings the open one forward. <paramref name="owner"/> is
+    /// the window it belongs to, so it stays above it and closes with it.
+    /// </summary>
+    public static void ShowFor(IWin32Window? owner)
+    {
+        if (openWindow is { IsDisposed: false } already)
+        {
+            already.Activate();
+            return;
+        }
+
+        var window = new GraphHelpDialog();
+        openWindow = window;
+        window.FormClosed += (_, _) =>
+        {
+            if (ReferenceEquals(openWindow, window))
+            {
+                openWindow = null;
+            }
+        };
+
+        if (owner == null)
+        {
+            window.Show();
+        }
+        else
+        {
+            window.Show(owner);
+        }
+    }
+
+    protected override void OnShown(EventArgs e)
+    {
+        base.OnShown(e);
+
+        // The card is as tall as it needs to be at 96 DPI, and a display that scales
+        // it further is not asked to make room: it is trimmed to the desktop rather
+        // than hanging off the bottom of it, and what does not fit scrolls. Device
+        // pixels on both sides of this line, which is why it converts.
+        Rectangle desktop = Screen.FromControl(this).WorkingArea;
+        Height = Math.Min(Height, desktop.Height - LogicalToDeviceUnits(40));
+
+        // CenterParent is a MODAL setting; a modeless window has to place itself,
+        // and it is placed once it knows its own scaled size.
+        if (Owner is not Form parent)
+        {
+            return;
+        }
+
+        StartPosition = FormStartPosition.Manual;
+        Location = new Point(
+            parent.Left + ((parent.Width - Width) / 2),
+            parent.Top + ((parent.Height - Height) / 2));
+    }
+
+    protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+    {
+        // Esc closes a modeless window too, but only because it is asked to:
+        // DialogResult does nothing outside ShowDialog.
+        if (keyData == Keys.Escape)
+        {
+            Close();
+            return true;
+        }
+
+        return base.ProcessCmdKey(ref msg, keyData);
+    }
+
+    private void BuildRows()
+    {
+        tableRows.SuspendLayout();
+        foreach (PlotGestureHelpSection section in PlotGestureHelp.Sections)
+        {
+            AddHeading(section.Title, first: tableRows.RowCount == 0);
+            foreach (PlotGestureHelpEntry entry in section.Entries)
+            {
+                AddEntry(entry);
+            }
+        }
+
+        tableRows.ResumeLayout(performLayout: false);
+    }
+
+    private void AddHeading(string title, bool first)
+    {
+        var heading = new Label
+        {
+            AutoSize = true,
+            Font = new Font(Font, FontStyle.Bold),
+            ForeColor = UiPalette.AccentBlueSoft,
+            Margin = new Padding(0, first ? 0 : 14, 0, 4),
+            Text = title,
+        };
+        int row = NextRow();
+        tableRows.Controls.Add(heading, 0, row);
+        tableRows.SetColumnSpan(heading, 2);
+    }
+
+    private void AddEntry(PlotGestureHelpEntry entry)
+    {
+        var gesture = new Label
+        {
+            AutoSize = true,
+            ForeColor = UiPalette.TextPrimary,
+            Margin = new Padding(0, 2, 18, 2),
+            Text = entry.Gesture,
+        };
+        var effect = new Label
+        {
+            AutoSize = true,
+            ForeColor = UiPalette.TextSecondary,
+            Margin = new Padding(0, 2, 0, 2),
+            MaximumSize = new Size(380, 0),
+            Text = entry.Effect,
+        };
+
+        int row = NextRow();
+        tableRows.Controls.Add(gesture, 0, row);
+        tableRows.Controls.Add(effect, 1, row);
+    }
+
+    private int NextRow()
+    {
+        tableRows.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        return tableRows.RowCount++;
+    }
+}

--- a/tests/Resonalyze.App.Tests/PlotAxisIdentitiesTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotAxisIdentitiesTests.cs
@@ -68,6 +68,30 @@ public sealed class PlotAxisIdentitiesTests
         Assert.False(PlotAxisIdentities.Match(model, model, taken));
     }
 
+    [Fact]
+    public void ADrawnBoxStopsDrawingItselfTheMomentTheAxesAreRearmed()
+    {
+        PlotModel model = AcousticModel(out LogarithmicAxis frequency, out LinearAxis value);
+        var box = new PlotZoomRectangleAnnotation
+        {
+            Box = new PlotZoomBox(frequency, 500, 2_000, value, -40, -20),
+            Text = "1.50 kHz",
+            Axes = PlotAxisIdentities.Describe(model),
+        };
+        model.Annotations.Add(box);
+
+        Assert.True(box.StillDescribesItsPlot());
+
+        // The Virtual DSP view switch re-arms the axes and repaints in the same
+        // breath; the controller hears about it only on the next mouse event, which
+        // may never come. So the box answers for itself, at the paint.
+        value.Title = "deg";
+        value.AbsoluteMinimum = -180;
+        value.AbsoluteMaximum = 180;
+
+        Assert.False(box.StillDescribesItsPlot());
+    }
+
     // The shape of the Virtual DSP acoustic plot: a frequency axis and one value axis
     // that gets re-armed rather than replaced.
     private static PlotModel AcousticModel(out LogarithmicAxis frequency, out LinearAxis value)

--- a/tests/Resonalyze.App.Tests/PlotAxisIdentitiesTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotAxisIdentitiesTests.cs
@@ -1,0 +1,95 @@
+using OxyPlot;
+using OxyPlot.Axes;
+
+namespace Resonalyze.App.Tests;
+
+// What tells a remembered range that the plot has stopped showing what it was taken
+// from. The model reference alone does not: the Virtual DSP acoustic view re-arms one
+// axis object between dB, degrees and a unitless impulse scale, and swaps its bottom
+// axis between frequency and time, all inside ONE model.
+public sealed class PlotAxisIdentitiesTests
+{
+    [Fact]
+    public void AnUntouchedModelStillMatchesWhatWasTakenFromIt()
+    {
+        PlotModel model = AcousticModel(out _, out _);
+        IReadOnlyList<PlotAxisIdentity> taken = PlotAxisIdentities.Describe(model);
+
+        Assert.True(PlotAxisIdentities.Match(model, model, taken));
+
+        // A range or a pan is not a change of meaning: what the axis IS stays what
+        // it was, so a box drawn before a wheel notch survives it.
+        model.Axes[0].Zoom(100, 2_000);
+        Assert.True(PlotAxisIdentities.Match(model, model, taken));
+    }
+
+    [Fact]
+    public void ADifferentModelNeverMatches()
+    {
+        PlotModel model = AcousticModel(out _, out _);
+        IReadOnlyList<PlotAxisIdentity> taken = PlotAxisIdentities.Describe(model);
+
+        Assert.False(PlotAxisIdentities.Match(AcousticModel(out _, out _), model, taken));
+        Assert.False(PlotAxisIdentities.Match(null, model, taken));
+    }
+
+    [Fact]
+    public void AValueAxisRearmedToAnotherQuantityStopsMatching()
+    {
+        PlotModel model = AcousticModel(out _, out LinearAxis value);
+        IReadOnlyList<PlotAxisIdentity> takenOnMagnitude = PlotAxisIdentities.Describe(model);
+
+        // Virtual DSP's Magnitude → Phase: the same axis OBJECT, now degrees.
+        value.Title = "deg";
+        value.AbsoluteMinimum = -180;
+        value.AbsoluteMaximum = 180;
+
+        Assert.False(PlotAxisIdentities.Match(model, model, takenOnMagnitude));
+
+        // And → Impulse, where it carries no title at all and a unitless range.
+        IReadOnlyList<PlotAxisIdentity> takenOnPhase = PlotAxisIdentities.Describe(model);
+        value.Title = string.Empty;
+        value.AbsoluteMinimum = -1.05;
+        value.AbsoluteMaximum = 1.05;
+
+        Assert.False(PlotAxisIdentities.Match(model, model, takenOnPhase));
+    }
+
+    [Fact]
+    public void SwappingTheBottomAxisInPlaceStopsMatching()
+    {
+        PlotModel model = AcousticModel(out LogarithmicAxis frequency, out _);
+        IReadOnlyList<PlotAxisIdentity> taken = PlotAxisIdentities.Describe(model);
+
+        // Virtual DSP's impulse view: frequency out, milliseconds in, same model.
+        model.Axes.Remove(frequency);
+        model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "ms" });
+
+        Assert.False(PlotAxisIdentities.Match(model, model, taken));
+    }
+
+    // The shape of the Virtual DSP acoustic plot: a frequency axis and one value axis
+    // that gets re-armed rather than replaced.
+    private static PlotModel AcousticModel(out LogarithmicAxis frequency, out LinearAxis value)
+    {
+        var model = new PlotModel();
+        frequency = new LogarithmicAxis
+        {
+            Position = AxisPosition.Bottom,
+            AbsoluteMinimum = 20,
+            AbsoluteMaximum = 20_000,
+            Minimum = 20,
+            Maximum = 20_000,
+        };
+        value = new LinearAxis
+        {
+            Position = AxisPosition.Left,
+            Title = "dB",
+            AbsoluteMinimum = -90,
+            AbsoluteMaximum = 60,
+        };
+        model.Axes.Add(frequency);
+        model.Axes.Add(value);
+        return model;
+    }
+}

--- a/tests/Resonalyze.App.Tests/PlotGestureHelpTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotGestureHelpTests.cs
@@ -1,0 +1,66 @@
+namespace Resonalyze.App.Tests;
+
+// The card F1 puts on screen. It is prose rather than behaviour, so what is worth
+// pinning is that it stays a complete, non-repeating list: a gesture nobody can find
+// here is a gesture nobody is told about anywhere in the window.
+public sealed class PlotGestureHelpTests
+{
+    [Fact]
+    public void EverySectionCarriesEntriesAndEveryEntrySaysBothHalves()
+    {
+        Assert.NotEmpty(PlotGestureHelp.Sections);
+
+        foreach (PlotGestureHelpSection section in PlotGestureHelp.Sections)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(section.Title));
+            Assert.NotEmpty(section.Entries);
+            foreach (PlotGestureHelpEntry entry in section.Entries)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(entry.Gesture), section.Title);
+                Assert.False(string.IsNullOrWhiteSpace(entry.Effect), entry.Gesture);
+            }
+        }
+    }
+
+    [Fact]
+    public void NoGestureIsListedTwice()
+    {
+        string[] gestures = Entries().Select(entry => entry.Gesture).ToArray();
+
+        Assert.Equal(gestures.Length, gestures.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.Equal(
+            PlotGestureHelp.Sections.Count,
+            PlotGestureHelp.Sections
+                .Select(section => section.Title)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count());
+    }
+
+    [Theory]
+    // The card has to explain the key that opened it, or a reader has no way to get
+    // back to it.
+    [InlineData("F1")]
+    // The gestures with no other signpost in the window: nothing on screen says the
+    // wheel zooms, that a box can be drawn, or that a zoom can be walked back.
+    [InlineData("Wheel")]
+    [InlineData("Ctrl + right-button drag")]
+    [InlineData("Click inside the box")]
+    [InlineData("Ctrl + Z")]
+    [InlineData("Double click")]
+    [InlineData("Home, or A")]
+    public void TheGesturesWithNoOtherSignpostAreListed(string gesture)
+    {
+        Assert.Contains(Entries(), entry => entry.Gesture == gesture);
+    }
+
+    [Fact]
+    public void TheCardNamesItselfAndSaysWhichGraphsItIsAbout()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(PlotGestureHelp.Title));
+        Assert.Contains("Virtual DSP", PlotGestureHelp.Introduction);
+        Assert.Contains("EQ Wizard", PlotGestureHelp.Introduction);
+    }
+
+    private static IEnumerable<PlotGestureHelpEntry> Entries() =>
+        PlotGestureHelp.Sections.SelectMany(section => section.Entries);
+}

--- a/tests/Resonalyze.App.Tests/PlotZoomRectangleReadoutTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotZoomRectangleReadoutTests.cs
@@ -287,9 +287,15 @@ public sealed class PlotZoomRectangleReadoutTests
     // A title that LEADS with the unit and then qualifies it.
     [InlineData("ms from peak", "12.4 ms")]
     [InlineData("dB re Main peak", "12.4 dB")]
-    // A title that is the name of the quantity rather than a unit: the number stands
-    // on its own rather than being followed by the axis's own name.
+    // A title that NAMES the quantity rather than stating a unit: the number stands
+    // on its own rather than being followed by the axis's own name. Short names are
+    // the trap here -- "step" and "r" are dimensionless quantities, not units, and
+    // "0.420 step" states one that does not exist.
     [InlineData("Coherence \u03B3\u00B2", "12.4")]
+    [InlineData("step", "12.4")]
+    [InlineData("r", "12.4")]
+    [InlineData("envelope r", "12.4")]
+    [InlineData("junction score (dB)", "12.4 dB")]
     public void FormatSpan_TakesItsUnitFromTheAxisTitle(string title, string expected)
     {
         var axis = new LinearAxis { Position = AxisPosition.Left, Title = title };

--- a/tests/Resonalyze.App.Tests/PlotZoomRectangleReadoutTests.cs
+++ b/tests/Resonalyze.App.Tests/PlotZoomRectangleReadoutTests.cs
@@ -1,0 +1,436 @@
+using System.Globalization;
+using OxyPlot;
+using OxyPlot.Axes;
+using OxyPlot.Series;
+using OxyPlot.WindowsForms;
+
+namespace Resonalyze.App.Tests;
+
+// REW's zoom box, which is a ruler first and a selection second: what it frames, what
+// it says the framed area measures — including over a scale that cannot be zoomed —
+// what it does to the axes when it is finally clicked, and what it answers to a box
+// too small to zoom to.
+public sealed class PlotZoomRectangleReadoutTests
+{
+    private const int PlotWidth = 800;
+    private const int PlotHeight = 600;
+
+    private static readonly CultureInfo Culture = CultureInfo.InvariantCulture;
+
+    [Fact]
+    public void Describe_ReportsTheFramedAreaInTheUnitsOfBothAxes()
+    {
+        PlotModel model = RenderedModel();
+        PlotZoomBox box = Frame(model, 100, 2_000, -40, -20);
+
+        // 100 Hz to 2 kHz is 1900 Hz of width; -40 to -20 dBr is 20 dB of height.
+        Assert.Equal("1.90 kHz \u00D7 20.0 dB", box.Describe(Culture));
+    }
+
+    [Fact]
+    public void Describe_KeepsNarrowFrequencySpansInHertz()
+    {
+        PlotModel model = RenderedModel();
+        PlotZoomBox box = Frame(model, 100, 340, -40, -39);
+
+        Assert.Equal("240 Hz \u00D7 1.00 dB", box.Describe(Culture));
+    }
+
+    [Fact]
+    public void Describe_MeasuresAnAxisThatCannotBeZoomed()
+    {
+        PlotModel model = RenderedModel();
+        YAxis(model).IsZoomEnabled = false;
+        PlotZoomBox box = Frame(model, 100, 2_000, -40, -20);
+
+        // A locked scale is no less readable for being locked, and reading it is what
+        // the box is mostly for.
+        Assert.Equal("1.90 kHz \u00D7 20.0 dB", box.Describe(Culture));
+    }
+
+    [Fact]
+    public void Frame_DrawsTheDraggedRectangleEvenWhereAnAxisRefusesZoom()
+    {
+        PlotModel model = RenderedModel();
+        YAxis(model).IsZoomEnabled = false;
+
+        PlotZoomBox box = PlotZoomBox.Frame(
+            XAxis(model),
+            YAxis(model),
+            new ScreenPoint(300, 200),
+            new ScreenPoint(200, 400));
+        OxyRect screen = box.Screen(model.PlotArea);
+
+        // Dragged right to left, so the box is normalized — and it is a rectangle, not
+        // a full-height band: the height is what was dragged, because it is measured.
+        Assert.Equal(200, screen.Left, 6);
+        Assert.Equal(100, screen.Width, 6);
+        Assert.Equal(200, screen.Top, 6);
+        Assert.Equal(200, screen.Height, 6);
+    }
+
+    [Fact]
+    public void Frame_SpansThePlotAreaWhereThereIsNoAxisToMeasureAgainst()
+    {
+        PlotModel model = RenderedModel();
+        // The waterfall's placeholder axis: present, but not a scale anybody reads a
+        // difference off.
+        YAxis(model).IsAxisVisible = false;
+
+        PlotZoomBox box = PlotZoomBox.Frame(
+            XAxis(model),
+            YAxis(model),
+            new ScreenPoint(300, 200),
+            new ScreenPoint(200, 400));
+        OxyRect screen = box.Screen(model.PlotArea);
+
+        Assert.Equal(100, screen.Width, 6);
+        Assert.Equal(model.PlotArea.Top, screen.Top, 6);
+        Assert.Equal(model.PlotArea.Height, screen.Height, 6);
+        Assert.Equal("1.90 kHz", Frame(model, 100, 2_000, -40, -20).Describe(Culture));
+    }
+
+    [Fact]
+    public void Frame_KeepsFramingTheSameDataWhenTheViewMovesUnderIt()
+    {
+        PlotModel model = RenderedModel();
+        PlotZoomBox box = Frame(model, 100, 2_000, -40, -20);
+        OxyRect before = box.Screen(model.PlotArea);
+
+        // The box waits for a click, and the wheel can turn in the meantime. Held in
+        // pixels it would then frame a different piece of the curve.
+        XAxis(model).Zoom(50, 5_000);
+        Render(model);
+        OxyRect after = box.Screen(model.PlotArea);
+
+        Assert.NotEqual(before.Left, after.Left, 3);
+        Assert.Equal(100, XAxis(model).InverseTransform(after.Left), 6);
+        Assert.Equal(2_000, XAxis(model).InverseTransform(after.Right), 6);
+        Assert.Equal("1.90 kHz \u00D7 20.0 dB", box.Describe(Culture));
+    }
+
+    [Fact]
+    public void Zoom_TakesTheAxesToWhatTheBoxFrames()
+    {
+        PlotModel model = RenderedModel();
+        PlotZoomBox box = Frame(model, 100, 2_000, -40, -20);
+
+        box.Zoom();
+        Render(model);
+
+        Assert.Equal(100, XAxis(model).ActualMinimum, 6);
+        Assert.Equal(2_000, XAxis(model).ActualMaximum, 6);
+        Assert.Equal(-40, YAxis(model).ActualMinimum, 6);
+        Assert.Equal(-20, YAxis(model).ActualMaximum, 6);
+    }
+
+    [Fact]
+    public void Zoom_MovesOnlyTheAxesThatAllowIt()
+    {
+        PlotModel model = RenderedModel();
+        YAxis(model).IsZoomEnabled = false;
+        double top = YAxis(model).ActualMaximum;
+        double bottom = YAxis(model).ActualMinimum;
+        PlotZoomBox box = Frame(model, 100, 2_000, -40, -20);
+
+        Assert.True(box.CanZoom);
+        box.Zoom();
+        Render(model);
+
+        // The frequency axis goes where the box says; the locked scale it measured
+        // stays exactly where it was.
+        Assert.Equal(100, XAxis(model).ActualMinimum, 6);
+        Assert.Equal(bottom, YAxis(model).ActualMinimum, 6);
+        Assert.Equal(top, YAxis(model).ActualMaximum, 6);
+    }
+
+    [Fact]
+    public void CanZoom_IsFalseWhereEveryScaleIsLocked()
+    {
+        PlotModel model = RenderedModel();
+        XAxis(model).IsZoomEnabled = false;
+        YAxis(model).IsZoomEnabled = false;
+        PlotZoomBox box = Frame(model, 100, 2_000, -40, -20);
+
+        Assert.False(box.CanZoom);
+        Assert.False(box.IsEmpty);
+        box.Zoom();
+        Render(model);
+
+        Assert.Equal(20, XAxis(model).ActualMinimum, 6);
+        Assert.Equal(20_000, XAxis(model).ActualMaximum, 6);
+    }
+
+    [Fact]
+    public void Contains_AnswersTheClickThatZoomsAndTheOneThatDoesNot()
+    {
+        PlotModel model = RenderedModel();
+        PlotZoomBox box = Frame(model, 100, 2_000, -40, -20);
+        OxyRect screen = box.Screen(model.PlotArea);
+
+        Assert.True(box.Contains(
+            model.PlotArea,
+            new ScreenPoint(screen.Left + (screen.Width / 2), screen.Top + (screen.Height / 2))));
+        Assert.False(box.Contains(
+            model.PlotArea,
+            new ScreenPoint(screen.Right + 20, screen.Top + (screen.Height / 2))));
+    }
+
+    [Theory]
+    // Wide and tall enough to zoom to.
+    [InlineData(60, 40, null)]
+    [InlineData(6, 40, "That box is too narrow to zoom in to")]
+    [InlineData(60, 4, "That box is too short to zoom in to")]
+    [InlineData(6, 4, "That box is too small to zoom in to")]
+    public void RefusalFor_NamesTheSideThatIsTooSmall(
+        double width,
+        double height,
+        string? expected)
+    {
+        PlotModel model = RenderedModel();
+        PlotZoomBox box = Dragged(model, width, height);
+
+        Assert.Equal(
+            expected,
+            PlotZoomRectangleReadout.RefusalFor(box, box.Screen(model.PlotArea)));
+    }
+
+    [Fact]
+    public void RefusalFor_JudgesOnlyTheSidesAZoomWouldMove()
+    {
+        PlotModel model = RenderedModel();
+        YAxis(model).IsZoomEnabled = false;
+        PlotZoomBox box = Dragged(model, width: 60, height: 2);
+
+        // Two pixels of a locked scale is a fine thing to measure and nothing the
+        // zoom would touch, so there is nothing to refuse.
+        Assert.Null(PlotZoomRectangleReadout.RefusalFor(box, box.Screen(model.PlotArea)));
+    }
+
+    [Fact]
+    public void RefusalFor_JudgesTheBoxAsItStandsWhenItIsClicked()
+    {
+        PlotModel model = RenderedModel();
+        PlotZoomBox box = Dragged(model, width: 6, height: 40);
+        Assert.NotNull(PlotZoomRectangleReadout.RefusalFor(box, box.Screen(model.PlotArea)));
+
+        // The wheel turned while the box waited, and the sliver it framed is now wide
+        // enough to zoom to. The box travels with the data, so it is the box on screen
+        // NOW that the click is answered against.
+        XAxis(model).Zoom(
+            box.HorizontalFrom - ((box.HorizontalTo - box.HorizontalFrom) * 2),
+            box.HorizontalTo + ((box.HorizontalTo - box.HorizontalFrom) * 2));
+        Render(model);
+
+        Assert.Null(PlotZoomRectangleReadout.RefusalFor(box, box.Screen(model.PlotArea)));
+    }
+
+    [Theory]
+    [InlineData(0, 0, false)]
+    [InlineData(2, 2, false)]
+    [InlineData(0, 4, true)]
+    [InlineData(40, 0, true)]
+    public void WasDrawn_TellsABoxFromAClick(double dx, double dy, bool expected)
+    {
+        var start = new ScreenPoint(120, 90);
+
+        Assert.Equal(
+            expected,
+            PlotZoomRectangleReadout.WasDrawn(start, new ScreenPoint(120 + dx, 90 + dy)));
+    }
+
+    [Fact]
+    public void HintFor_AppearsOnlyOnceTheBoxIsWaitingToBeClicked()
+    {
+        PlotModel model = RenderedModel();
+        PlotZoomBox box = Frame(model, 100, 2_000, -40, -20);
+
+        Assert.Equal(string.Empty, PlotZoomRectangleReadout.HintFor(box, pending: false));
+        Assert.Equal("click inside to zoom", PlotZoomRectangleReadout.HintFor(box, pending: true));
+    }
+
+    [Fact]
+    public void HintFor_IsLeftOutWhereNothingCanZoom()
+    {
+        PlotModel model = RenderedModel();
+        XAxis(model).IsZoomEnabled = false;
+        YAxis(model).IsZoomEnabled = false;
+        PlotZoomBox box = Frame(model, 100, 2_000, -40, -20);
+
+        // Still measured, still labelled — but not offering a click that would do
+        // nothing.
+        Assert.Equal("1.90 kHz \u00D7 20.0 dB", box.Describe(Culture));
+        Assert.Equal(string.Empty, PlotZoomRectangleReadout.HintFor(box, pending: true));
+    }
+
+    [Fact]
+    public void Describe_SaysNothingWithoutAnAxisToMeasureAgainst()
+    {
+        PlotModel model = RenderedModel();
+        XAxis(model).IsAxisVisible = false;
+        YAxis(model).IsAxisVisible = false;
+        PlotZoomBox box = Frame(model, 100, 2_000, -40, -20);
+
+        Assert.True(box.IsEmpty);
+        Assert.Equal(string.Empty, box.Describe(Culture));
+        Assert.Equal(string.Empty, PlotZoomRectangleReadout.HintFor(box, pending: true));
+    }
+
+    [Theory]
+    [InlineData("dB", "12.4 dB")]
+    [InlineData("ms", "12.4 ms")]
+    [InlineData("samples", "12.4 samples")]
+    // The unit in parentheses is what these axes are measured in; the words before it
+    // name the curve on them.
+    [InlineData("Sum loss (dB)", "12.4 dB")]
+    [InlineData("delay added to the upper channel (ms)", "12.4 ms")]
+    // A title that LEADS with the unit and then qualifies it.
+    [InlineData("ms from peak", "12.4 ms")]
+    [InlineData("dB re Main peak", "12.4 dB")]
+    // A title that is the name of the quantity rather than a unit: the number stands
+    // on its own rather than being followed by the axis's own name.
+    [InlineData("Coherence \u03B3\u00B2", "12.4")]
+    public void FormatSpan_TakesItsUnitFromTheAxisTitle(string title, string expected)
+    {
+        var axis = new LinearAxis { Position = AxisPosition.Left, Title = title };
+
+        Assert.Equal(expected, PlotZoomRectangleReadout.FormatSpan(axis, 12.4, Culture));
+    }
+
+    [Theory]
+    [InlineData(999, "999 Hz")]
+    [InlineData(1_000, "1.00 kHz")]
+    [InlineData(15_300, "15.3 kHz")]
+    public void FormatSpan_PassesFrequencySpansToKilohertzWhereRewDoes(
+        double span,
+        string expected)
+    {
+        var model = new PlotModel();
+        PlotModelStyle.AddFrequencyAxis(model);
+
+        Assert.Equal(
+            expected,
+            PlotZoomRectangleReadout.FormatSpan(model.Axes[0], span, Culture));
+    }
+
+    [Fact]
+    public void FormatSpan_ReadsAnUntitledPhaseAxisInDegrees()
+    {
+        // The phase axis carries no title at all: the key is what says degrees.
+        var phase = new LinearAxis
+        {
+            Key = PlotModelFactory.PhaseAxisKey,
+            Position = AxisPosition.Left,
+        };
+
+        Assert.Equal("45.0\u00B0", PlotZoomRectangleReadout.FormatSpan(phase, 45, Culture));
+    }
+
+    [Fact]
+    public void PlaceLabel_SitsBesideTheDraggedCornerAndOutsideTheBox()
+    {
+        var plotArea = new OxyRect(50, 50, 700, 500);
+        var box = new OxyRect(200, 200, 100, 100);
+        var text = new OxySize(80, 16);
+
+        // The drag ended at the bottom right: the label follows that corner outwards.
+        OxyRect downRight = PlotZoomRectangleReadout.PlaceLabel(
+            plotArea,
+            box,
+            new ScreenPoint(300, 300),
+            text);
+        Assert.True(downRight.Left > box.Right);
+        Assert.True(downRight.Top > box.Bottom);
+
+        // And at the top left: the other way, so the box is never covered.
+        OxyRect upLeft = PlotZoomRectangleReadout.PlaceLabel(
+            plotArea,
+            box,
+            new ScreenPoint(200, 200),
+            text);
+        Assert.True(upLeft.Right < box.Left);
+        Assert.True(upLeft.Bottom < box.Top);
+    }
+
+    [Fact]
+    public void PlaceLabel_StaysInsideThePlotAreaAtEveryCorner()
+    {
+        var plotArea = new OxyRect(50, 50, 700, 500);
+        var box = new OxyRect(60, 60, 680, 480);
+        var text = new OxySize(120, 16);
+
+        foreach (ScreenPoint corner in new[]
+        {
+            new ScreenPoint(plotArea.Left, plotArea.Top),
+            new ScreenPoint(plotArea.Right, plotArea.Top),
+            new ScreenPoint(plotArea.Left, plotArea.Bottom),
+            new ScreenPoint(plotArea.Right, plotArea.Bottom),
+        })
+        {
+            OxyRect label = PlotZoomRectangleReadout.PlaceLabel(plotArea, box, corner, text);
+
+            Assert.True(label.Left >= plotArea.Left);
+            Assert.True(label.Top >= plotArea.Top);
+            Assert.True(label.Right <= plotArea.Right);
+            Assert.True(label.Bottom <= plotArea.Bottom);
+        }
+    }
+
+    // The box a drag around a range of the data would frame, which is how a test says
+    // "the user dragged from here to there" in units it can assert on.
+    private static PlotZoomBox Frame(
+        PlotModel model,
+        double fromHz,
+        double toHz,
+        double fromDb,
+        double toDb)
+    {
+        Axis x = XAxis(model);
+        Axis y = YAxis(model);
+        return PlotZoomBox.Frame(
+            x,
+            y,
+            new ScreenPoint(x.Transform(fromHz), y.Transform(fromDb)),
+            new ScreenPoint(x.Transform(toHz), y.Transform(toDb)));
+    }
+
+    // A drag of a given size in pixels, from a point well inside the plot area.
+    private static PlotZoomBox Dragged(PlotModel model, double width, double height)
+    {
+        var start = new ScreenPoint(model.PlotArea.Left + 40, model.PlotArea.Top + 40);
+        return PlotZoomBox.Frame(
+            XAxis(model),
+            YAxis(model),
+            start,
+            new ScreenPoint(start.X + width, start.Y + height));
+    }
+
+    private static Axis XAxis(PlotModel model) =>
+        model.Axes.First(axis => axis.Key == PlotModelFactory.FrequencyAxisKey);
+
+    private static Axis YAxis(PlotModel model) =>
+        model.Axes.First(axis => axis.Key == PlotModelFactory.DecibelAxisKey);
+
+    private static PlotModel RenderedModel()
+    {
+        var model = new PlotModel();
+        PlotModelStyle.AddFrequencyAxis(model);
+        PlotModelStyle.AddDecibelAxis(model);
+        var series = new LineSeries { XAxisKey = PlotModelFactory.FrequencyAxisKey };
+        series.Points.Add(new DataPoint(20, -40));
+        series.Points.Add(new DataPoint(20_000, -60));
+        model.Series.Add(series);
+        Render(model);
+        return model;
+    }
+
+    // PlotArea and the axis transforms are computed while rendering, and the box reads
+    // both; exporting to a throwaway PNG is the cheapest way to get a laid-out model
+    // in a test.
+    private static void Render(PlotModel model)
+    {
+        var exporter = new PngExporter { Width = PlotWidth, Height = PlotHeight };
+        using var stream = new MemoryStream();
+        exporter.Export(model, stream);
+    }
+}


### PR DESCRIPTION
Ctrl + right drag drew a bare rectangle and zoomed to it the moment the button
came up. REW's box is a different instrument: its help draws the box first,
shows measurement cursors outside it, and zooms only when the shaded area is
clicked. The box is a ruler that can also zoom, not a selection that always
does. It is one here now.

The drag draws a shaded box and writes the size of the framed area beside it in
the units of the axes it is drawn over. Letting go does not move the scale: the
box stays, so the width of a suckout or the depth of a dip is read without
touching the view. A click inside zooms there; a click anywhere else, or Esc,
lets the box go and then does whatever that click would have done anyway. The
undo step moved from the press to that click, because only the click moves
anything -- a box that was only read now leaves nothing on the stack.

Both sides are measured whatever the axes allow, and only the zoom is
conditional. Over a locked scale -- the Virtual DSP phase view spans the whole
range a wrapped phase can occupy -- the box is still the rectangle that was
dragged and still reads its height in degrees, and the click then moves the
frequency axis alone. A direction the plot shows no axis for (the waterfall's
placeholder, a colour scale) is not a scale anybody reads a difference off, so a
box over it measures the other direction and spans the plot area in that one.

The box is held in axis VALUES rather than in pixels. It outlives the drag, and
the wheel can turn or the plot be panned before the click arrives; in pixels it
would then frame a different piece of the curve than the one somebody drew
around. The "too small to zoom to" refusal is judged the same way -- at the
click, against the box as it stands by then -- so a sliver that has since been
zoomed into is a good box by the time it is clicked, and REW's habit of naming
the side that is too small is kept rather than doing nothing at all.

The label is two lines: the size, and under it, dimmer and a point smaller, what
the waiting box is waiting for. No second line during the drag, none where
nothing can zoom, and none where there is nothing to measure against.

None of this, and none of the twenty gestures these graphs answer to, was
written anywhere on screen. F1 over any graph now opens Graph controls: the same
map as the REFERENCE table, on a card. Modeless, so it is read while the other
hand tries the gesture; single-instance, so F1 brings it forward rather than
stacking another; Esc or Close sends it away. The list is data, so the
controller, the card and the reference are one thing to keep true instead of
three.

That window is built in the designer with AutoScaleMode.Dpi, and its rows are
added into the designer's TableLayoutPanel in logical units -- nothing
multiplies a size by the DPI itself, which is the mistake that squares the
factor. Checked through a real scaling pass at 125% and 150%: the boxes and the
margins of the rows added in code grow with it, and nothing clips.

## A box outlives a drag, not a change of what the axes mean

Review found a hole, and it was a real one. The box was remembered as a model
reference plus two axis references and their values, and only a change of MODEL
dropped it. The Virtual DSP acoustic view keeps its model and re-arms what is in
it: one value axis object carries dB, then degrees, then a unitless impulse
scale, and the bottom axis is swapped between frequency and time in place. Draw
a box on the magnitude view, switch to impulse, and the box was still there --
drawn through an axis that had left the model, and ready to apply decibels to a
normalized impulse.

The controller already had the answer for its undo stack, which faces exactly
this: an axis identity of key, title, type and absolute limits, with a comment
naming the Virtual DSP re-arm. The zoom box simply did not use it. That
bookkeeping is now one shared thing (PlotAxisIdentities) that both the undo
stack and the box remember, and the box is dropped when the plot stops matching
what it was drawn against -- on every pointer move, before the zoom buttons' own
attach (which returns early while the model is unchanged and so never sees a
re-arm), and again in the click itself, because a view can be re-armed without
the mouse having gone anywhere.

Two smaller things from the same review. A short word in an axis title was being
read as a unit, so the impulse view's "step" axis and the correlation views' "r"
produced "0.420 step" and "0.500 r" -- units that do not exist for quantities
that are dimensionless; the rule is now a list of the units these plots are
actually measured in, plus anything a title states in parentheses, which is the
one place a unit is declared rather than guessed. And a quick double tap inside
a waiting box zoomed on the first press and opened the graph limits dialog on
the second, which arrives as a double click; the press that zooms now says so,
and that double click opens nothing.

## The box stops drawing itself when the axes stop meaning what it measured

The click could no longer act on a re-armed box, but the box was still being
DRAWN until the next mouse event -- and after a Virtual DSP view switch there
need not be one: the pointer is over the toggle, not the graph. A re-arm
repaints immediately, so the frame after Magnitude to Phase carried a shaded
rectangle labelled in decibels over a scale that had become degrees.

The annotation now answers for itself: it remembers what the axes meant when the
box was drawn and paints nothing once they stop matching. That is a condition,
not a notification, so no plot has to remember to announce a re-arm -- which is
the same trap that put the box out of step in the first place. The controller
still does the bookkeeping on the next pointer event; what changed is that
nothing is on screen in the meantime.

## Verification

Driven through the controller rather than read: after the button comes up the
axes have not moved; a click inside takes them to the framed range; Ctrl+Z puts
them back; a click outside, and a drag too small to be a box, leave the view
alone and the model without leftovers; a box drawn on one view survives neither
a pointer move nor a click once the axes under it are re-armed, with and without
a mouse event in between; the double tap was timed out rather than trusted,
since a limits dialog opening would have hung the run; and F1 opens one window,
keeps one, and opens again after Esc. Rendered both ways as well: the box draws
over the magnitude view and is gone from the very next export after the value
axis becomes degrees. 56 tests cover the arithmetic, the refusals, the label,
the axis identity and the card's contents, and the full battery is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
