### PR TITLE
The junction seed reads the polarity family its crossover sums in

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2793,6 +2793,14 @@ usable in the other. Auto delay does not correct such a driver — the same trad
 the forced polarity already makes — but neither does it move its seed half a
 period away from what the measurement plainly says.
 
+On the far side of a stereo run the crossover is not the authority: polarity is
+a property of the driver, so each far channel takes the sign its counterpart
+settled, and the family that seed is held to is therefore the one the
+**reference side** settled rather than the one the split asks for. Where the two
+agree — the ordinary case — nothing changes; where the reference side's own
+junction was decided some other way, the far side follows it, so both stages of
+that walk read the junction the same way.
+
 Where two candidates of opposite polarity still score within a fraction of a
 decibel — at a mid/tweeter junction the summation metric frequently cannot tell
 a lobe from the flipped one half a period away at all — the **direct sound's

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2699,7 +2699,9 @@ single-stage path, which is the same engine call it always took.
 **Auto delay** aligns in two stages: band-limited first arrivals, refined by a
 GCC-PHAT cross-correlation whose dominant extremum of either polarity seeds the
 junction (an inverted junction — a subwoofer against its midbass is the classic
-— seeds from the trough); then a fractional-delay search minimizing the
+— seeds from the trough), unless the junction's own crossover has already
+settled the polarity, which is the exception described under *Polarity* below;
+then a fractional-delay search minimizing the
 sum-loss metric at each junction, through a direct-sound window so late room
 reflections do not steer it. Above ~1 kHz the seeding correlation is taken on
 the two channels' **direct sound alone**: across a whole record a mid/tweeter
@@ -2773,6 +2775,19 @@ not only the flip — and only the delay is searched. A split whose filters answ
 neither way is left alone: a Butterworth 18 crosses at 90°, and two corners that
 merely meet overlap across a region instead of crossing at a point, so neither
 states a phase relation to read.
+
+Reading the polarity off the filters also settles which extremum **seeds** such
+a junction. A whitened correlation's peak and trough are one comb read under
+the two polarity assumptions — half a period apart, and which of them is taller
+measures how wide the analysed band is rather than which one is the junction's
+— so where the crossover has answered, and the direct-sound cut agrees with it,
+the seed reads that family even when the whole record's dominant extremum sits
+in the other. The cut's agreement is required, not decoration: the filters state
+how the two FILTERS relate, not how the drivers are wired, and a driver
+connected backwards behind a matched split reads strongly in the family its
+crossover forbids. Auto delay does not correct such a driver — the same trade
+the forced polarity already makes — but neither does it move its seed half a
+period away from what the measurement plainly says.
 
 Where two candidates of opposite polarity still score within a fraction of a
 decibel — at a mid/tweeter junction the summation metric frequently cannot tell

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2776,16 +2776,20 @@ neither way is left alone: a Butterworth 18 crosses at 90°, and two corners tha
 merely meet overlap across a region instead of crossing at a point, so neither
 states a phase relation to read.
 
-Reading the polarity off the filters also settles which extremum **seeds** such
-a junction. A whitened correlation's peak and trough are one comb read under
-the two polarity assumptions — half a period apart, and which of them is taller
-measures how wide the analysed band is rather than which one is the junction's
-— so where the crossover has answered, and the direct-sound cut agrees with it,
-the seed reads that family even when the whole record's dominant extremum sits
-in the other. The cut's agreement is required, not decoration: the filters state
-how the two FILTERS relate, not how the drivers are wired, and a driver
-connected backwards behind a matched split reads strongly in the family its
-crossover forbids. Auto delay does not correct such a driver — the same trade
+Reading the polarity off the filters also settles what may **seed** such a
+junction. A whitened correlation's peak and trough are one comb read under the
+two polarity assumptions — half a period apart, and which of them is taller
+measures how wide the analysed band is rather than which one is the junction's.
+So where the crossover has answered and the whole record's dominant extremum
+sits in the other family, that extremum is not a lobe the pair can be tuned to,
+and the record has nothing to say about where the permitted one is: its own
+extrema in that family are lobe crests it gives no ranking for. The
+**direct-sound cut** seeds instead, having named a lobe on the wavefronts and
+through its own trust gates. The cut's agreement with the design is required,
+not decoration: the filters state how the two FILTERS relate, not how the
+drivers are wired, and a driver connected backwards behind a matched split
+reads strongly in the family its crossover forbids while offering nothing
+usable in the other. Auto delay does not correct such a driver — the same trade
 the forced polarity already makes — but neither does it move its seed half a
 period away from what the measurement plainly says.
 

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1488,12 +1488,23 @@ public static class AutoAlignmentEngine
     /// </para>
     /// <para>
     /// Field case (2026-09-05, the reference car's 4300 Hz LR36 mid/tweeter
-    /// split): the full record's dominant extremum sat on the +0.746 ms peak
-    /// (r 0.42, in phase) while the direct cut read +0.642 ms (r 0.83) in the
-    /// inverted family the crossover sums in - the same lobe the whitened
-    /// trough named to within 2 us. The seed followed the peak, the search
-    /// settled a period late, and the tweeter came out 0.20 ms behind the lobe
-    /// the panel's own metric measures 0.24 dB better.
+    /// split): the direct cut read +0.642 ms (r 0.83) in the inverted family
+    /// the crossover sums in - the same lobe the whitened trough named, to
+    /// within 2 us - while the full record's dominant extremum sat on the
+    /// +0.746 ms peak (r 0.42, in phase). The seed followed the peak and the
+    /// search settled a period late.
+    /// </para>
+    /// <para>
+    /// What says so is the WAVEFRONT read, and only it: on the shipped tuning
+    /// the direct correlation reads 0.84 at the lobe it names against 0.57 at
+    /// the one that was applied. The summation metric happens to agree here
+    /// (0.24 dB on the in-band average, the dip unchanged) and is worth
+    /// recording, but it is not the criterion and must not be quoted as one -
+    /// at this class of junction it routinely cannot separate a lobe from its
+    /// half-period twin at all (see the DirectCoherence* constants, where the
+    /// same physics gives the direct sound the last word on polarity). A rule
+    /// resting on a fifth of a decibel of summation would be resting on
+    /// nothing; this one rests on the cut.
     /// </para>
     /// </summary>
     internal static bool SeedFamilyFollowsTheSettledPolarity(

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1285,6 +1285,10 @@ public static class AutoAlignmentEngine
         Dictionary<IAlignmentChannel, double> timeline =
             BuildArrivalTimeline(
                 byBand, pairs, log,
+                // This walk searches polarity, so the junction's own crossover
+                // is what may settle it in advance - the same rule, and the
+                // same fence, AlignChannelAtJunction forces below.
+                CrossoverSettlesJunctionPolarity,
                 out HashSet<AlignmentJunction> untrustedSeeds,
                 out Dictionary<AlignmentJunction, double> seedPartnerReach);
 
@@ -1337,20 +1341,120 @@ public static class AutoAlignmentEngine
     }
 
     /// <summary>
+    /// The polarity a walk has already settled a junction on before its search
+    /// begins, with the phrase that says where the answer came from.
+    /// </summary>
+    /// <remarks>
+    /// Two walks, two authorities. A walk that searches polarity asks the
+    /// junction's own crossover (<see cref="CrossoverSettlesJunctionPolarity"/>);
+    /// the stereo far-side descent does not ask it at all, because every
+    /// twinned channel inherits its counterpart's sign
+    /// (<see cref="InheritedJunctionPolarity"/>). Stage 1 must be told WHICH,
+    /// or it centres the coarse window on a family stage 2 then forbids - the
+    /// same defect one stage up.
+    /// </remarks>
+    internal readonly record struct SettledJunctionPolarity(
+        bool Inverted,
+        string Because);
+
+    /// <summary>
+    /// The polarity the junction's own filters settle, for a walk that lets
+    /// them: a matched split at or above <see cref="DirectSeedMinCrossoverHz"/>,
+    /// the same rule and the same fence stage 2 forces with (see
+    /// <see cref="ExpectsRelativeInversion"/>). Null where the filters shrug,
+    /// where the split is staggered, or below the fence.
+    /// </summary>
+    internal static SettledJunctionPolarity? CrossoverSettlesJunctionPolarity(
+        AlignmentJunction pair)
+    {
+        ArgumentNullException.ThrowIfNull(pair);
+        if (pair.CrossoverHz < DirectSeedMinCrossoverHz ||
+            ExpectsRelativeInversion(pair) is not bool inverted)
+        {
+            return null;
+        }
+
+        string sums = inverted ? "only inverted" : "in phase";
+        return new SettledJunctionPolarity(
+            inverted,
+            FormattableString.Invariant(
+                $"the matched {pair.CrossoverHz:0} Hz split sums {sums}"));
+    }
+
+    /// <summary>
+    /// The polarity a FAR-side junction will be given: not its crossover's
+    /// answer but the one the reference side already settled, because polarity
+    /// is a property of the driver and each far channel inherits its
+    /// counterpart's sign (see the inheritance in the far-side descent, and
+    /// the bridge's own for the top pair).
+    /// <para>
+    /// This is what keeps stages 1 and 2 reading one junction the same way on
+    /// that side. The far descent hands its search an inherited polarity, which
+    /// outranks the crossover rule, so a stage-1 reseat toward the SPLIT's
+    /// design could centre the window on the family the search is then
+    /// forbidden to use - precisely the alias error the reseat exists to
+    /// prevent. Where the reference side settled the pair as its crossover
+    /// asks, the two answers coincide and nothing changes; where it did not
+    /// (its own seed was untrusted, or the channel was searched jointly with a
+    /// second neighbour, and the polarity rule stood down), this follows the
+    /// side that actually decided.
+    /// </para>
+    /// <para>
+    /// Null unless BOTH channels resolve to a settled counterpart - a mono
+    /// channel is its own, a twinned one is named by the pair link, and
+    /// anything else is a channel whose polarity this walk does not inherit.
+    /// Mixed authority across one junction is not a family the seed may be held
+    /// to, and null simply leaves the seed where the record put it.
+    /// </para>
+    /// </summary>
+    internal static SettledJunctionPolarity? InheritedJunctionPolarity(
+        AlignmentJunction pair,
+        IReadOnlyCollection<IAlignmentChannel> monoChannels,
+        IReadOnlyList<StereoPairLink>? pairLinks,
+        IReadOnlyDictionary<IAlignmentChannel, AlignmentOverride> alignment)
+    {
+        ArgumentNullException.ThrowIfNull(pair);
+        ArgumentNullException.ThrowIfNull(monoChannels);
+        ArgumentNullException.ThrowIfNull(alignment);
+
+        IAlignmentChannel? Counterpart(IAlignmentChannel channel) =>
+            monoChannels.Contains(channel)
+                ? channel
+                : pairLinks?.FirstOrDefault(link => link.Right == channel)?.Left;
+
+        if (Counterpart(pair.Lower.Channel) is not { } lower ||
+            Counterpart(pair.Upper.Channel) is not { } upper)
+        {
+            return null;
+        }
+
+        // GetValueOrDefault, exactly as the descent reads it: a walk's own
+        // reference channel carries no override, which reads as "not inverted".
+        bool inverted =
+            alignment.GetValueOrDefault(lower).InvertPolarity ^
+            alignment.GetValueOrDefault(upper).InvertPolarity;
+        string settled = inverted ? "inverted" : "in phase";
+        return new SettledJunctionPolarity(
+            inverted,
+            $"the reference side settled this pair {settled} and the far side " +
+            "inherits its polarity driver by driver");
+    }
+
+    /// <summary>
     /// Whether the coarse seed must be handed to the direct-sound cut because
     /// the whitened record's dominant extremum belongs to the polarity family
-    /// the junction's own crossover cannot sum in.
+    /// this junction will not be searched in.
     /// <para>
     /// A whitened surface's peak and trough are one comb read under the two
     /// polarity assumptions: half a period apart by construction, and their
     /// |r| difference measures the analysed band's WIDTH, not which of them is
-    /// the junction's (see <see cref="PhatSeedMinRivalDominance"/>). So where a
-    /// matched split settles the polarity — the same question stage 2 forces an
-    /// answer to, behind the same frequency fence (see
-    /// <see cref="ExpectsRelativeInversion"/>) — the other family is not a lobe
-    /// this pair can be tuned to. Seeding from it centres the fine window half a
-    /// period off the lobe stage 2 will then force the polarity of, and hands
-    /// the loss search a choice between two aliases it cannot separate: at a
+    /// the junction's (see <see cref="PhatSeedMinRivalDominance"/>). So where
+    /// the polarity is already settled - by the junction's own crossover on a
+    /// walk that asks it, by the other side on one that inherits (see
+    /// <see cref="SettledJunctionPolarity"/>) - the other family is not a lobe
+    /// this pair can be tuned to. Seeding from it centres the fine window half
+    /// a period off the lobe stage 2 then holds the polarity of, and hands the
+    /// loss search a choice between two aliases it cannot separate: at a
     /// mid/tweeter junction the field pair below reads them 0.20 dB apart while
     /// the direct wavefronts read 0.84 against 0.57.
     /// </para>
@@ -1361,83 +1465,48 @@ public static class AutoAlignmentEngine
     /// and may sit several lobes apart (which is why
     /// <see cref="CorrelationAlignmentResult.PositiveOppositeNeighbor"/> exists
     /// as a separate adjacency fact), and even the ADJACENT lobe is chosen by
-    /// distance alone — on the junction below the two neighbours of the
+    /// distance alone - on the junction below the two neighbours of the
     /// dominant peak sit 0.106 and 0.110 ms out, a four-microsecond tie
     /// deciding a whole cycle. The cut has already named a lobe, on the
-    /// wavefronts, through its own trust gates, and above
+    /// wavefronts, through its own trust gates, and at or above
     /// <see cref="DirectSeedMinCrossoverHz"/> it is the better positional
-    /// witness anyway.
+    /// witness anyway. Below that frequency there is no cut and this cannot
+    /// fire at all.
     /// </para>
     /// <para>
-    /// <paramref name="directSeed"/> — the direct-sound cut's own extremum,
-    /// already held to those gates — is REQUIRED to agree with the design, and
-    /// that is the whole guard. The filters state how the two FILTERS relate,
-    /// not how the drivers are wired, so on its own the design would overrule
-    /// an honest measurement of a driver connected backwards: such a pair reads
-    /// |r| near 1.0 in the family the crossover forbids and offers nothing
-    /// usable in the one it asks for, and moving its seed half a period would
-    /// strand the delay. Stage 2 makes that trade knowingly for the polarity it
-    /// APPLIES (a matched split's flip is not undone by Auto delay, nor its
-    /// in-phase twin corrected); the seed must not, because a position half a
-    /// period out is a lobe error everything downstream inherits.
+    /// <paramref name="directSeed"/> - the direct-sound cut's own extremum,
+    /// already held to those gates - is REQUIRED to agree with the settled
+    /// answer, and that is the whole guard. A matched split states how the two
+    /// FILTERS relate, not how the drivers are wired, so on its own it would
+    /// overrule an honest measurement of a driver connected backwards: such a
+    /// pair reads |r| near 1.0 in the family the crossover forbids and offers
+    /// nothing usable in the one it asks for, and moving its seed half a period
+    /// would strand the delay. Stage 2 makes that trade knowingly for the
+    /// polarity it APPLIES (a matched split's flip is not undone by Auto delay,
+    /// nor its in-phase twin corrected); the seed must not, because a position
+    /// half a period out is a lobe error everything downstream inherits.
     /// </para>
     /// <para>
     /// Field case (2026-09-05, the reference car's 4300 Hz LR36 mid/tweeter
     /// split): the full record's dominant extremum sat on the +0.746 ms peak
     /// (r 0.42, in phase) while the direct cut read +0.642 ms (r 0.83) in the
-    /// inverted family the crossover sums in — the same lobe the whitened
+    /// inverted family the crossover sums in - the same lobe the whitened
     /// trough named to within 2 us. The seed followed the peak, the search
     /// settled a period late, and the tweeter came out 0.20 ms behind the lobe
     /// the panel's own metric measures 0.24 dB better.
     /// </para>
     /// </summary>
-    internal static bool SeedFamilyFollowsTheCrossover(
-        bool? filterInversion,
+    internal static bool SeedFamilyFollowsTheSettledPolarity(
+        SettledJunctionPolarity? settled,
         CorrelationDelayCandidate dominant,
         CorrelationDelayCandidate? directSeed)
     {
         ArgumentNullException.ThrowIfNull(dominant);
-        return filterInversion is bool designed &&
-            dominant.InvertPolarity != designed &&
-            directSeed?.InvertPolarity == designed;
+        return settled is { } answer &&
+            dominant.InvertPolarity != answer.Inverted &&
+            directSeed?.InvertPolarity == answer.Inverted;
     }
 
-    // Stage 1: coarse offsets from band-limited first arrivals, refined by the
-    // GCC-PHAT peak where it is trustworthy. Arrivals of different drivers are
-    // only comparable inside a SHARED band — a woofer's envelope in its own low
-    // band rises milliseconds later than a tweeter's in its high band. So each
-    // adjacent pair is measured around its own crossover frequency, and the
-    // pairwise differences chain into one relative timeline. Only the
-    // differences matter downstream, so the anchor value of the first channel
-    // is arbitrary (zero).
-    /// <summary>
-    /// Whether the junction's own FILTERS ask for the two channels to be
-    /// relatively inverted — computed from the crossover settings alone, with no
-    /// measurement involved: the two chains' responses are summed across the
-    /// junction band in both relative polarities, and the inverted sum has to
-    /// win by <see cref="ExpectedInversionMarginDb"/>.
-    /// <para>
-    /// This is the piece the search could not see before. A crossover's summing
-    /// polarity is a property of its order: LR24 and LR48 sum in phase, LR12 and
-    /// LR36 sum INVERTED (their filters sit 180° apart at the corner), Butterworth
-    /// 12 likewise. Where the filters are that explicit, an inverted junction is
-    /// the crossover working as designed, and the invert preference in
-    /// <see cref="AlignmentSelection"/> — written for "a flipped driver is a
-    /// wiring fault worth several dB" — has to defend the OTHER polarity, or it
-    /// spends its 0.5 dB defending the null. Measured on the v6 cabin with the
-    /// mid/tweeter split set to LR36: on the correct alignment the in-phase sum
-    /// runs 4.8-5.8 dB below the inverted one, yet once each polarity is allowed
-    /// its own optimum delay the gap between them is only 0.28-0.49 dB, so the
-    /// undefended margin decided it — one side of the same cabin came out right
-    /// and the other wrong.
-    /// </para>
-    /// <para>
-    /// The gain, delay and polarity of each chain are neutralized first: gain
-    /// would weight one channel's filter over the other's, and delay and polarity
-    /// are exactly what the search is about to decide. What remains is the
-    /// crossover (and any PEQ, which does bend phase and belongs here).
-    /// </para>
-    /// </summary>
     private static bool? ExpectsRelativeInversion(AlignmentJunction pair)
     {
         double preferenceDb = FilterPolarityPreferenceDb(pair);
@@ -1520,13 +1589,18 @@ public static class AutoAlignmentEngine
             : double.NaN;
     }
 
+    // settledPolarity is the pass's polarity AUTHORITY, and it has no default
+    // on purpose: a caller that forgets it is a compile error rather than a
+    // walk that quietly seeds against the family its own stage 2 will hold.
     private static Dictionary<IAlignmentChannel, double> BuildArrivalTimeline(
         IReadOnlyList<AlignmentSnapshot> byBand,
         IReadOnlyList<AlignmentJunction> pairs,
         StringBuilder log,
+        Func<AlignmentJunction, SettledJunctionPolarity?> settledPolarity,
         out HashSet<AlignmentJunction> untrustedSeedJunctions,
         out Dictionary<AlignmentJunction, double> seedPartnerDistanceMs)
     {
+        ArgumentNullException.ThrowIfNull(settledPolarity);
         // Junctions whose coarse seed fell back to the arrival envelope because
         // the PHAT peak was untrusted (a low junction with too few in-band
         // periods): the coarse offset ACROSS such a junction can be a half period
@@ -1985,13 +2059,11 @@ public static class AutoAlignmentEngine
                 seed.InvertPolarity ? phat.NegativeRival : phat.PositiveRival;
             string seedLabel = seed.InvertPolarity ? "trough" : "peak";
             double seedOffsetMs = seed.DelayMs - centerLagMs;
-            // The polarity the junction's own filters settle, where they
-            // settle one at all — read here so the seed below can be held to
-            // the same answer stage 2 will force (see ExpectsRelativeInversion
-            // and the reseat further down), behind the same frequency fence.
-            bool? filterInversion = pair.CrossoverHz >= DirectSeedMinCrossoverHz
-                ? ExpectsRelativeInversion(pair)
-                : null;
+            // The polarity THIS pass will hold the junction to, whoever
+            // settles it (see SettledJunctionPolarity) - read here so the seed
+            // below can be held to the same answer, and read from the pass's
+            // own authority rather than assumed to be the crossover's.
+            SettledJunctionPolarity? settled = settledPolarity(pair);
             // Declared ahead of the trust gate below, which reads the witness
             // (a local function cannot capture a variable declared after it).
             CorrelationAlignmentResult? directPhat = null;
@@ -2341,7 +2413,7 @@ public static class AutoAlignmentEngine
             double increment;
             string seedSource;
             bool arrivalSeeded = false;
-            if (SeedFamilyFollowsTheCrossover(filterInversion, seed, directSeed))
+            if (SeedFamilyFollowsTheSettledPolarity(settled, seed, directSeed))
             {
                 // The record's dominant extremum belongs to the polarity this
                 // crossover cannot sum in, and the cut's belongs to the one it
@@ -2354,9 +2426,9 @@ public static class AutoAlignmentEngine
                 // choose a lobe. The cut named one, on the wavefronts and
                 // through its own trust gates, so the cut is the seed.
                 increment = -directSeed!.DelayMs;
-                string sums = filterInversion!.Value ? "only inverted" : "in phase";
+                string because = settled!.Value.Because;
                 seedSource = FormattableString.Invariant(
-                    $"direct-cut (the matched {pair.CrossoverHz:0} Hz split sums {sums}; the record's dominant {seedLabel} {seed.DelayMs:+0.000;-0.000} ms is the polarity it cannot sum in)");
+                    $"direct-cut ({because}; the record's dominant {seedLabel} {seed.DelayMs:+0.000;-0.000} ms is the polarity this junction will not be searched in)");
                 RecordPartnerReach(directPhat!);
             }
             else if (directSeed is { } adjudicated && trustPhat &&
@@ -3952,6 +4024,14 @@ public static class AutoAlignmentEngine
         Dictionary<IAlignmentChannel, double> rightTimeline =
             BuildArrivalTimeline(
                 rightByBand, plan.RightPairs, log,
+                // NOT the crossover here: this descent hands every twinned
+                // channel the sign its counterpart settled, which outranks the
+                // split's design (see the inheritance in AlignRight below), so
+                // the reference side is what may settle a family in advance.
+                // Reading the crossover instead would let stage 1 centre the
+                // window on a polarity stage 2 is forbidden to search.
+                pair => InheritedJunctionPolarity(
+                    pair, plan.MonoChannels, plan.PairLinks, alignment),
                 out HashSet<AlignmentJunction> rightUntrustedSeeds,
                 out Dictionary<AlignmentJunction, double> rightSeedPartnerReach);
 

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1336,6 +1336,58 @@ public static class AutoAlignmentEngine
         }
     }
 
+    /// <summary>
+    /// Whether the coarse seed must be read from the polarity family the
+    /// junction's own crossover asks for, rather than from the dominant
+    /// extremum of the whitened surface.
+    /// <para>
+    /// A whitened surface's peak and trough are one comb read under the two
+    /// polarity assumptions: half a period apart by construction, and their
+    /// |r| difference measures the analysed band's WIDTH, not which of them is
+    /// the junction's (see <see cref="PhatSeedMinRivalDominance"/>). So where a
+    /// matched split settles the polarity — the same question stage 2 forces an
+    /// answer to, behind the same frequency fence (see
+    /// <see cref="ExpectsRelativeInversion"/>) — the other family is not a lobe
+    /// this pair can be tuned to. Seeding from it centres the fine window half a
+    /// period off the lobe stage 2 will then force the polarity of, and hands
+    /// the loss search a choice between two aliases it cannot separate: at a
+    /// mid/tweeter junction the field pair below reads them 0.20 dB apart while
+    /// the direct wavefronts read 0.84 against 0.57.
+    /// </para>
+    /// <para>
+    /// <paramref name="directSeed"/> — the direct-sound cut's own extremum,
+    /// already held to its trust gates — is REQUIRED to agree, and that is the
+    /// whole guard. The filters state how the two FILTERS relate, not how the
+    /// drivers are wired, so on its own the design would overrule an honest
+    /// measurement of a driver connected backwards: such a pair reads |r| near
+    /// 1.0 in the family the crossover forbids and offers nothing usable in the
+    /// one it asks for, and moving its seed half a period would strand the
+    /// delay. Stage 2 makes that trade knowingly for the polarity it APPLIES (a
+    /// matched split's flip is not undone by Auto delay, nor its in-phase twin
+    /// corrected); the seed must not, because a position half a period out is a
+    /// lobe error everything downstream inherits.
+    /// </para>
+    /// <para>
+    /// Field case (2026-09-05, the reference car's 4300 Hz LR36 mid/tweeter
+    /// split): the full record's dominant extremum sat on the +0.746 ms peak
+    /// (r 0.42, in phase) while the direct cut read the trough at +0.642 ms
+    /// (r 0.83) — the same lobe the whitened trough named to within 2 us — and
+    /// the crossover sums only inverted. The seed followed the peak, the search
+    /// settled a period late, and the tweeter came out 0.20 ms behind the lobe
+    /// the panel's own metric measures 0.24 dB better.
+    /// </para>
+    /// </summary>
+    internal static bool SeedFamilyFollowsTheCrossover(
+        bool? filterInversion,
+        CorrelationDelayCandidate dominant,
+        CorrelationDelayCandidate? directSeed)
+    {
+        ArgumentNullException.ThrowIfNull(dominant);
+        return filterInversion is bool designed &&
+            dominant.InvertPolarity != designed &&
+            directSeed?.InvertPolarity == designed;
+    }
+
     // Stage 1: coarse offsets from band-limited first arrivals, refined by the
     // GCC-PHAT peak where it is trustworthy. Arrivals of different drivers are
     // only comparable inside a SHARED band — a woofer's envelope in its own low
@@ -1919,6 +1971,13 @@ public static class AutoAlignmentEngine
                 seed.InvertPolarity ? phat.NegativeRival : phat.PositiveRival;
             string seedLabel = seed.InvertPolarity ? "trough" : "peak";
             double seedOffsetMs = seed.DelayMs - centerLagMs;
+            // The polarity the junction's own filters settle, where they
+            // settle one at all — read here so the seed below can be held to
+            // the same answer stage 2 will force (see ExpectsRelativeInversion
+            // and the reseat further down), behind the same frequency fence.
+            bool? filterInversion = pair.CrossoverHz >= DirectSeedMinCrossoverHz
+                ? ExpectsRelativeInversion(pair)
+                : null;
             // Declared ahead of the trust gate below, which reads the witness
             // (a local function cannot capture a variable declared after it).
             CorrelationAlignmentResult? directPhat = null;
@@ -2236,6 +2295,30 @@ public static class AutoAlignmentEngine
                 {
                     directSeed = directBest;
                 }
+            }
+
+            if (SeedFamilyFollowsTheCrossover(filterInversion, seed, directSeed))
+            {
+                bool designedInversion = filterInversion!.Value;
+                CorrelationDelayCandidate aliased = seed;
+                seed = designedInversion ? phat.NegativeTrough : phat.PositivePeak;
+                sameSignRival =
+                    seed.InvertPolarity ? phat.NegativeRival : phat.PositiveRival;
+                seedLabel = seed.InvertPolarity ? "trough" : "peak";
+                seedOffsetMs = seed.DelayMs - centerLagMs;
+                log.AppendLine(
+                    $"  {pair.Lower.Channel.Name}/{pair.Upper.Channel.Name}: " +
+                    $"the matched {pair.CrossoverHz:0} Hz split sums " +
+                    (designedInversion ? "only inverted" : "in phase") +
+                    ", and the direct-sound cut agrees " +
+                    $"(r {directSeed!.Coefficient:+0.000;-0.000} at " +
+                    $"{directSeed.DelayMs:+0.000;-0.000} ms), so the seed reads " +
+                    $"the whitened {seedLabel} ({seed.DelayMs:+0.000;-0.000} ms, " +
+                    $"r {seed.Coefficient:+0.000;-0.000}) and not the dominant " +
+                    $"{(aliased.InvertPolarity ? "trough" : "peak")} " +
+                    $"({aliased.DelayMs:+0.000;-0.000} ms, " +
+                    $"r {aliased.Coefficient:+0.000;-0.000}) half a period from " +
+                    "it — that one is the polarity this crossover cannot sum in");
             }
 
             string? distrust = Distrust();

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -1337,9 +1337,9 @@ public static class AutoAlignmentEngine
     }
 
     /// <summary>
-    /// Whether the coarse seed must be read from the polarity family the
-    /// junction's own crossover asks for, rather than from the dominant
-    /// extremum of the whitened surface.
+    /// Whether the coarse seed must be handed to the direct-sound cut because
+    /// the whitened record's dominant extremum belongs to the polarity family
+    /// the junction's own crossover cannot sum in.
     /// <para>
     /// A whitened surface's peak and trough are one comb read under the two
     /// polarity assumptions: half a period apart by construction, and their
@@ -1355,24 +1355,38 @@ public static class AutoAlignmentEngine
     /// the direct wavefronts read 0.84 against 0.57.
     /// </para>
     /// <para>
+    /// The seed then goes to the CUT rather than to the record's best extremum
+    /// in the permitted family. The record has no statement to make about that
+    /// family's position: peak and trough are the window's strongest extrema
+    /// and may sit several lobes apart (which is why
+    /// <see cref="CorrelationAlignmentResult.PositiveOppositeNeighbor"/> exists
+    /// as a separate adjacency fact), and even the ADJACENT lobe is chosen by
+    /// distance alone — on the junction below the two neighbours of the
+    /// dominant peak sit 0.106 and 0.110 ms out, a four-microsecond tie
+    /// deciding a whole cycle. The cut has already named a lobe, on the
+    /// wavefronts, through its own trust gates, and above
+    /// <see cref="DirectSeedMinCrossoverHz"/> it is the better positional
+    /// witness anyway.
+    /// </para>
+    /// <para>
     /// <paramref name="directSeed"/> — the direct-sound cut's own extremum,
-    /// already held to its trust gates — is REQUIRED to agree, and that is the
-    /// whole guard. The filters state how the two FILTERS relate, not how the
-    /// drivers are wired, so on its own the design would overrule an honest
-    /// measurement of a driver connected backwards: such a pair reads |r| near
-    /// 1.0 in the family the crossover forbids and offers nothing usable in the
-    /// one it asks for, and moving its seed half a period would strand the
-    /// delay. Stage 2 makes that trade knowingly for the polarity it APPLIES (a
-    /// matched split's flip is not undone by Auto delay, nor its in-phase twin
-    /// corrected); the seed must not, because a position half a period out is a
-    /// lobe error everything downstream inherits.
+    /// already held to those gates — is REQUIRED to agree with the design, and
+    /// that is the whole guard. The filters state how the two FILTERS relate,
+    /// not how the drivers are wired, so on its own the design would overrule
+    /// an honest measurement of a driver connected backwards: such a pair reads
+    /// |r| near 1.0 in the family the crossover forbids and offers nothing
+    /// usable in the one it asks for, and moving its seed half a period would
+    /// strand the delay. Stage 2 makes that trade knowingly for the polarity it
+    /// APPLIES (a matched split's flip is not undone by Auto delay, nor its
+    /// in-phase twin corrected); the seed must not, because a position half a
+    /// period out is a lobe error everything downstream inherits.
     /// </para>
     /// <para>
     /// Field case (2026-09-05, the reference car's 4300 Hz LR36 mid/tweeter
     /// split): the full record's dominant extremum sat on the +0.746 ms peak
-    /// (r 0.42, in phase) while the direct cut read the trough at +0.642 ms
-    /// (r 0.83) — the same lobe the whitened trough named to within 2 us — and
-    /// the crossover sums only inverted. The seed followed the peak, the search
+    /// (r 0.42, in phase) while the direct cut read +0.642 ms (r 0.83) in the
+    /// inverted family the crossover sums in — the same lobe the whitened
+    /// trough named to within 2 us. The seed followed the peak, the search
     /// settled a period late, and the tweeter came out 0.20 ms behind the lobe
     /// the panel's own metric measures 0.24 dB better.
     /// </para>
@@ -2297,30 +2311,6 @@ public static class AutoAlignmentEngine
                 }
             }
 
-            if (SeedFamilyFollowsTheCrossover(filterInversion, seed, directSeed))
-            {
-                bool designedInversion = filterInversion!.Value;
-                CorrelationDelayCandidate aliased = seed;
-                seed = designedInversion ? phat.NegativeTrough : phat.PositivePeak;
-                sameSignRival =
-                    seed.InvertPolarity ? phat.NegativeRival : phat.PositiveRival;
-                seedLabel = seed.InvertPolarity ? "trough" : "peak";
-                seedOffsetMs = seed.DelayMs - centerLagMs;
-                log.AppendLine(
-                    $"  {pair.Lower.Channel.Name}/{pair.Upper.Channel.Name}: " +
-                    $"the matched {pair.CrossoverHz:0} Hz split sums " +
-                    (designedInversion ? "only inverted" : "in phase") +
-                    ", and the direct-sound cut agrees " +
-                    $"(r {directSeed!.Coefficient:+0.000;-0.000} at " +
-                    $"{directSeed.DelayMs:+0.000;-0.000} ms), so the seed reads " +
-                    $"the whitened {seedLabel} ({seed.DelayMs:+0.000;-0.000} ms, " +
-                    $"r {seed.Coefficient:+0.000;-0.000}) and not the dominant " +
-                    $"{(aliased.InvertPolarity ? "trough" : "peak")} " +
-                    $"({aliased.DelayMs:+0.000;-0.000} ms, " +
-                    $"r {aliased.Coefficient:+0.000;-0.000}) half a period from " +
-                    "it — that one is the polarity this crossover cannot sum in");
-            }
-
             string? distrust = Distrust();
             bool trustPhat = distrust == null;
 
@@ -2351,7 +2341,25 @@ public static class AutoAlignmentEngine
             double increment;
             string seedSource;
             bool arrivalSeeded = false;
-            if (directSeed is { } adjudicated && trustPhat &&
+            if (SeedFamilyFollowsTheCrossover(filterInversion, seed, directSeed))
+            {
+                // The record's dominant extremum belongs to the polarity this
+                // crossover cannot sum in, and the cut's belongs to the one it
+                // asks for. The record is not merely outvoted on the position
+                // — it has no statement to make about it: every extremum it
+                // offers in the permitted family is a lobe crest it gives no
+                // ranking for, and the two nearest sit on either side of the
+                // dominant one, 0.106 and 0.110 ms out on the junction that
+                // exposed this. A four-microsecond tie is not what should
+                // choose a lobe. The cut named one, on the wavefronts and
+                // through its own trust gates, so the cut is the seed.
+                increment = -directSeed!.DelayMs;
+                string sums = filterInversion!.Value ? "only inverted" : "in phase";
+                seedSource = FormattableString.Invariant(
+                    $"direct-cut (the matched {pair.CrossoverHz:0} Hz split sums {sums}; the record's dominant {seedLabel} {seed.DelayMs:+0.000;-0.000} ms is the polarity it cannot sum in)");
+                RecordPartnerReach(directPhat!);
+            }
+            else if (directSeed is { } adjudicated && trustPhat &&
                 Math.Abs(adjudicated.DelayMs - seed.DelayMs) > halfPeriodAtFcMs)
             {
                 // Two trusted extrema on different lobes: adjudicate by JOINT

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -52,6 +52,29 @@ public sealed class AutoAlignmentEngineTests
             bypassed);
     }
 
+    // A late copy of the impulse, the synthetic stand-in for a cabin
+    // reflection: far enough behind the front that the direct-sound cut never
+    // reaches it, so the full record and the cut can be made to disagree.
+    private static Complex[] WithTail(
+        Complex[] impulse, (int Samples, double Amplitude)? tail)
+    {
+        if (tail is not { } copy)
+        {
+            return impulse;
+        }
+
+        var withTail = (Complex[])impulse.Clone();
+        for (int i = 0; i < impulse.Length; i++)
+        {
+            if (impulse[i] != Complex.Zero && i + copy.Samples < impulse.Length)
+            {
+                withTail[i + copy.Samples] += impulse[i] * copy.Amplitude;
+            }
+        }
+
+        return withTail;
+    }
+
     private static Complex[] UnitImpulse(int position, double amplitude = 1.0)
     {
         var ir = new Complex[IrLength];
@@ -450,6 +473,76 @@ public sealed class AutoAlignmentEngineTests
             log.ToString());
     }
 
+    [Theory]
+    // The filters say nothing (a staggered split, a channel with no crossover,
+    // a junction under the frequency fence): the dominant extremum stands,
+    // whatever the direct cut read.
+    [InlineData(null, true, true, false)]
+    [InlineData(null, false, true, false)]
+    // The dominant extremum is already the family the crossover sums in —
+    // nothing to move.
+    [InlineData(true, true, true, false)]
+    [InlineData(false, false, false, false)]
+    // The dominant extremum is the family the crossover CANNOT sum in, and the
+    // direct-sound cut names the one it can: the record is following the
+    // cabin, and the seed follows the design and the wavefronts instead.
+    [InlineData(true, false, true, true)]
+    [InlineData(false, true, false, true)]
+    // ... but only then. With no usable direct witness, or with one that reads
+    // the same family the record does, the measurement is unopposed — a driver
+    // wired backwards behind a matched split looks exactly like this, and
+    // moving its seed half a period would strand the delay.
+    [InlineData(true, false, null, false)]
+    [InlineData(false, true, null, false)]
+    [InlineData(true, false, false, false)]
+    [InlineData(false, true, true, false)]
+    public void SeedFamilyFollowsTheCrossover_MovesOnlyOnAgreementWithTheCut(
+        bool? filterInversion,
+        bool dominantInverted,
+        bool? directInverted,
+        bool expected)
+    {
+        var dominant = new CorrelationDelayCandidate(0.5, 0.4, dominantInverted);
+        CorrelationDelayCandidate? direct = directInverted is bool inverted
+            ? new CorrelationDelayCandidate(0.4, 0.8, inverted)
+            : null;
+
+        Assert.Equal(
+            expected,
+            AutoAlignmentEngine.SeedFamilyFollowsTheCrossover(
+                filterInversion, dominant, direct));
+    }
+
+    [Fact]
+    public void Compute_MatchedOddOrderSplit_SeedsTheFamilyTheCrossoverSumsIn()
+    {
+        // The field failure this rule exists for, as a fixture. Both drivers
+        // arrive together behind a matched LR36 split, so the pair sums only
+        // inverted and the whitened TROUGH is its lobe — but each channel also
+        // carries a late cabin copy, and the two copies sit half a period
+        // apart, which grows a whitened PEAK the full record likes better. The
+        // direct-sound cut, one period of wavefront, never sees those copies
+        // and reads the trough. The seed must follow the cut and the
+        // crossover, not the record's dominant extremum: half a period is the
+        // one error the fine search below inherits whole.
+        var log = new StringBuilder();
+        Dictionary<IAlignmentChannel, AlignmentOverride> alignment =
+            RunFilteredJunction(
+                CrossoverFilterFamily.LinkwitzRiley, 36, upperCornerHz: 2_000,
+                log: log,
+                lowerTail: (240, 2.0),
+                upperTail: (228, -2.0)).Alignment;
+
+        string trace = log.ToString();
+        Assert.Contains("sums only inverted, and the direct-sound cut agrees", trace);
+        Assert.Contains("phat trough", trace);
+        Assert.DoesNotContain("phat peak", trace);
+        Assert.InRange(
+            alignment[alignment.Keys.Single(item => item.Name == "T")].DelayMs,
+            -0.12,
+            0.12);
+    }
+
     [Fact]
     public void Compute_MatchedEvenOrderSplit_KeepsInPhaseAgainstTheSumsWishes()
     {
@@ -529,7 +622,9 @@ public sealed class AutoAlignmentEngineTests
         int slopeDbPerOctave,
         double upperCornerHz,
         StringBuilder log,
-        double upperAmplitude = 1.0)
+        double upperAmplitude = 1.0,
+        (int Samples, double Amplitude)? lowerTail = null,
+        (int Samples, double Amplitude)? upperTail = null)
     {
         const double lowerCornerHz = 2_000;
         var lowPass = new DspChannelChain(Crossover: new CrossoverSpec(
@@ -539,9 +634,12 @@ public sealed class AutoAlignmentEngineTests
             CrossoverKind.HighPass,
             HighPassEdge: new CrossoverEdge(family, upperCornerHz, slopeDbPerOctave)));
 
-        AlignmentSnapshot lower = PredictableSnapshot("W", UnitImpulse(BasePosition), lowPass);
+        AlignmentSnapshot lower = PredictableSnapshot(
+            "W", WithTail(UnitImpulse(BasePosition), lowerTail), lowPass);
         AlignmentSnapshot upper = PredictableSnapshot(
-            "T", UnitImpulse(BasePosition, upperAmplitude), highPass);
+            "T",
+            WithTail(UnitImpulse(BasePosition, upperAmplitude), upperTail),
+            highPass);
         var junction = new AlignmentJunction(
             lower, upper, lowerCornerHz, lowerCornerHz / 2, lowerCornerHz * 2);
 

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -474,43 +474,193 @@ public sealed class AutoAlignmentEngineTests
     }
 
     [Theory]
-    // The filters say nothing (a staggered split, a channel with no crossover,
-    // a junction under the frequency fence): the dominant extremum stands,
-    // whatever the direct cut read.
+    // Nobody settled the polarity in advance (a staggered split, a channel
+    // with no crossover, a junction under the frequency fence, or a far-side
+    // pair whose counterparts this walk cannot resolve): the dominant extremum
+    // stands, whatever the direct cut read.
     [InlineData(null, true, true, false)]
     [InlineData(null, false, true, false)]
-    // The dominant extremum is already the family the crossover sums in —
-    // nothing to move.
+    // The dominant extremum is already the family this junction will be
+    // searched in - nothing to move.
     [InlineData(true, true, true, false)]
     [InlineData(false, false, false, false)]
-    // The dominant extremum is the family the crossover CANNOT sum in, and the
-    // direct-sound cut names the one it can: the record is following the
-    // cabin, and the seed follows the design and the wavefronts instead.
+    // The dominant extremum is the family the search will not be given, and
+    // the direct-sound cut names the one it will: the record is following the
+    // cabin, and the seed goes to the cut instead.
     [InlineData(true, false, true, true)]
     [InlineData(false, true, false, true)]
     // ... but only then. With no usable direct witness, or with one that reads
-    // the same family the record does, the measurement is unopposed — a driver
+    // the same family the record does, the measurement is unopposed - a driver
     // wired backwards behind a matched split looks exactly like this, and
     // moving its seed half a period would strand the delay.
     [InlineData(true, false, null, false)]
     [InlineData(false, true, null, false)]
     [InlineData(true, false, false, false)]
     [InlineData(false, true, true, false)]
-    public void SeedFamilyFollowsTheCrossover_MovesOnlyOnAgreementWithTheCut(
-        bool? filterInversion,
+    public void SeedFamilyFollowsTheSettledPolarity_MovesOnlyOnAgreementWithTheCut(
+        bool? settledInversion,
         bool dominantInverted,
         bool? directInverted,
         bool expected)
     {
+        AutoAlignmentEngine.SettledJunctionPolarity? settled =
+            settledInversion is bool inverted
+                ? new AutoAlignmentEngine.SettledJunctionPolarity(inverted, "because")
+                : null;
         var dominant = new CorrelationDelayCandidate(0.5, 0.4, dominantInverted);
-        CorrelationDelayCandidate? direct = directInverted is bool inverted
-            ? new CorrelationDelayCandidate(0.4, 0.8, inverted)
+        CorrelationDelayCandidate? direct = directInverted is bool cut
+            ? new CorrelationDelayCandidate(0.4, 0.8, cut)
             : null;
 
         Assert.Equal(
             expected,
-            AutoAlignmentEngine.SeedFamilyFollowsTheCrossover(
-                filterInversion, dominant, direct));
+            AutoAlignmentEngine.SeedFamilyFollowsTheSettledPolarity(
+                settled, dominant, direct));
+    }
+
+    [Theory]
+    // The matched splits stage 2 forces an answer for, at a junction the
+    // crossover dominates: stage 1 must read the same answer.
+    [InlineData(CrossoverFilterFamily.LinkwitzRiley, 36, 2_000, true)]
+    [InlineData(CrossoverFilterFamily.LinkwitzRiley, 24, 2_000, false)]
+    public void CrossoverSettlesJunctionPolarity_ReadsTheSplitAboveTheFence(
+        CrossoverFilterFamily family,
+        int slopeDbPerOctave,
+        double cornerHz,
+        bool expectInverted)
+    {
+        AutoAlignmentEngine.SettledJunctionPolarity? settled =
+            AutoAlignmentEngine.CrossoverSettlesJunctionPolarity(
+                FilteredJunction(family, slopeDbPerOctave, cornerHz));
+
+        Assert.NotNull(settled);
+        Assert.Equal(expectInverted, settled!.Value.Inverted);
+        Assert.Contains(
+            expectInverted ? "sums only inverted" : "sums in phase",
+            settled.Value.Because);
+    }
+
+    [Fact]
+    public void CrossoverSettlesJunctionPolarity_StaysOutBelowTheFence()
+    {
+        // Same matched LR36, at a corner where the cabin's modes shape the band
+        // instead of the crossover. Stage 2 does not force there and stage 1
+        // must not pre-empt it either: the archived cabins' matched Butterworth
+        // 36 splits at 70 and 180 Hz answer the polarity question by MOVING a
+        // period rather than by flipping.
+        Assert.Null(AutoAlignmentEngine.CrossoverSettlesJunctionPolarity(
+            FilteredJunction(CrossoverFilterFamily.LinkwitzRiley, 36, 180)));
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, false)]
+    public void InheritedJunctionPolarity_ReadsTheRelationTheReferenceSideSettled(
+        bool lowerReferenceInverted,
+        bool upperReferenceInverted,
+        bool expectInverted)
+    {
+        // The far side never asks its crossover: each channel takes the sign
+        // its counterpart settled, so the RELATION the far junction will be
+        // searched in is the reference side's, whatever the split asks for.
+        // The chains here say "matched LR36" — inverted by design — and three
+        // of the four cases deliberately disagree with that.
+        var lowerReference = new TestChannel("W ref", UnitImpulse(BasePosition));
+        var upperReference = new TestChannel("T ref", UnitImpulse(BasePosition));
+        AlignmentJunction far = FilteredJunction(
+            CrossoverFilterFamily.LinkwitzRiley, 36, 2_000);
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [lowerReference] = new AlignmentOverride(0.0, lowerReferenceInverted),
+            [upperReference] = new AlignmentOverride(0.0, upperReferenceInverted)
+        };
+
+        AutoAlignmentEngine.SettledJunctionPolarity? settled =
+            AutoAlignmentEngine.InheritedJunctionPolarity(
+                far,
+                [],
+                [
+                    new StereoPairLink(
+                        lowerReference, far.Lower.Channel, 100, 10_000),
+                    new StereoPairLink(
+                        upperReference, far.Upper.Channel, 100, 10_000)
+                ],
+                alignment);
+
+        Assert.NotNull(settled);
+        Assert.Equal(expectInverted, settled!.Value.Inverted);
+        Assert.Contains("the far side", settled.Value.Because);
+        // ... and it is not the crossover's answer that got through: this split
+        // sums only inverted, yet two of these cases settle in phase.
+        Assert.True(
+            AutoAlignmentEngine.CrossoverSettlesJunctionPolarity(far)
+                is { Inverted: true });
+    }
+
+    [Fact]
+    public void InheritedJunctionPolarity_TakesAMonoChannelAsItsOwnCounterpart()
+    {
+        // A shared subwoofer is one instance on both sides and carries no pair
+        // link; its settled sign IS the one the far junction will see.
+        AlignmentJunction far = FilteredJunction(
+            CrossoverFilterFamily.LinkwitzRiley, 36, 2_000);
+        var upperReference = new TestChannel("T ref", UnitImpulse(BasePosition));
+        var alignment = new Dictionary<IAlignmentChannel, AlignmentOverride>
+        {
+            [far.Lower.Channel] = new AlignmentOverride(0.0, true),
+            [upperReference] = new AlignmentOverride(0.0, false)
+        };
+
+        AutoAlignmentEngine.SettledJunctionPolarity? settled =
+            AutoAlignmentEngine.InheritedJunctionPolarity(
+                far,
+                [far.Lower.Channel],
+                [new StereoPairLink(upperReference, far.Upper.Channel, 100, 10_000)],
+                alignment);
+
+        Assert.NotNull(settled);
+        Assert.True(settled!.Value.Inverted);
+    }
+
+    [Fact]
+    public void InheritedJunctionPolarity_RefusesWhenOneSideHasNoCounterpart()
+    {
+        // Mixed authority across one junction: the searched channel would take
+        // an inherited sign and its neighbour would not, so there is no single
+        // family to hold the seed to. Null leaves the seed where the record put
+        // it — the behaviour that predates the rule.
+        AlignmentJunction far = FilteredJunction(
+            CrossoverFilterFamily.LinkwitzRiley, 36, 2_000);
+        var upperReference = new TestChannel("T ref", UnitImpulse(BasePosition));
+
+        Assert.Null(AutoAlignmentEngine.InheritedJunctionPolarity(
+            far,
+            [],
+            [new StereoPairLink(upperReference, far.Upper.Channel, 100, 10_000)],
+            new Dictionary<IAlignmentChannel, AlignmentOverride>()));
+        Assert.Null(AutoAlignmentEngine.InheritedJunctionPolarity(
+            far, [], null, new Dictionary<IAlignmentChannel, AlignmentOverride>()));
+    }
+
+    // One junction of two impulses behind a matched split, for the policies
+    // that read a pair's filters (or deliberately do not).
+    private static AlignmentJunction FilteredJunction(
+        CrossoverFilterFamily family, int slopeDbPerOctave, double cornerHz)
+    {
+        var lowPass = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.LowPass,
+            LowPassEdge: new CrossoverEdge(family, cornerHz, slopeDbPerOctave)));
+        var highPass = new DspChannelChain(Crossover: new CrossoverSpec(
+            CrossoverKind.HighPass,
+            HighPassEdge: new CrossoverEdge(family, cornerHz, slopeDbPerOctave)));
+        return new AlignmentJunction(
+            PredictableSnapshot("W", UnitImpulse(BasePosition), lowPass),
+            PredictableSnapshot("T", UnitImpulse(BasePosition), highPass),
+            cornerHz,
+            cornerHz / 2,
+            cornerHz * 2);
     }
 
     [Fact]
@@ -541,7 +691,8 @@ public sealed class AutoAlignmentEngineTests
             "direct-cut (the matched 2000 Hz split sums only inverted; " +
             "the record's dominant peak",
             trace);
-        Assert.Contains("is the polarity it cannot sum in)", trace);
+        Assert.Contains(
+            "is the polarity this junction will not be searched in)", trace);
         Assert.DoesNotContain("concurs", trace);
         Assert.InRange(
             alignment[alignment.Keys.Single(item => item.Name == "T")].DelayMs,

--- a/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/AutoAlignmentEngineTests.cs
@@ -534,9 +534,15 @@ public sealed class AutoAlignmentEngineTests
                 upperTail: (228, -2.0)).Alignment;
 
         string trace = log.ToString();
-        Assert.Contains("sums only inverted, and the direct-sound cut agrees", trace);
-        Assert.Contains("phat trough", trace);
-        Assert.DoesNotContain("phat peak", trace);
+        // The seed goes to the cut, and the log says which extremum it refused
+        // and why. "concurs" is what the defect printed: the old positions-only
+        // agreement test, reporting two readings of opposite polarity as one.
+        Assert.Contains(
+            "direct-cut (the matched 2000 Hz split sums only inverted; " +
+            "the record's dominant peak",
+            trace);
+        Assert.Contains("is the polarity it cannot sum in)", trace);
+        Assert.DoesNotContain("concurs", trace);
         Assert.InRange(
             alignment[alignment.Keys.Single(item => item.Name == "T")].DelayMs,
             -0.12,


### PR DESCRIPTION
A matched split settles a junction's summing polarity, and stage 2 has always
forced it. Stage 1 did not know. It seeded from the whitened surface's dominant
extremum of either polarity, and at the reference car's 4300 Hz LR36
mid/tweeter split that extremum was the alias half a period away: the peak at
+0.746 ms (r 0.42, in phase) while the direct-sound cut read the trough at
+0.642 ms (r 0.83) — the same lobe the whitened trough named, to within 2 us —
and the crossover sums only inverted.

A whitened surface's peak and trough are one comb read under the two polarity
assumptions. They sit half a period apart by construction, and which of them is
taller measures how wide the analysed band is rather than which one is the
junction's, so the seed's "direct-cut concurs" test — a position comparison
alone — reported agreement between two readings of OPPOSITE polarity. The
window was then centred half a period off the lobe whose polarity stage 2 went
on to force, and the loss search was handed two aliases it cannot separate: it
settled on the one 0.20 dB ahead by the dip penalty, while its own in-band
average preferred the other (-0.67 against -0.93 dB) and the panel's metric
measures that other lobe 0.24 dB better with the same dip. The tweeter came out
a period late, which is what the owner saw as a far stronger DIRECT lobe
0.21 ms earlier.

The seed now reads the family the crossover asks for — but only where the
direct-sound cut agrees with it, and that guard is the whole of the rule. The
filters state how the two FILTERS relate, not how the drivers are wired, so on
its own the design would overrule an honest measurement of a driver connected
backwards: such a pair reads |r| near 1.0 in the family its crossover forbids
and offers nothing usable in the one it asks for. Auto delay does not correct
that driver — the same trade the forced polarity already makes — and it must
not move its seed half a period either. The engine log now names the extremum
it refused and why.

The per-channel polarity read-out is deliberately not the witness here.
Measured on the reference car: it reports the tweeter inverted because the
response opens with a -0.77 precursor lobe some 40 us ahead of its +1.00 peak
lobe, while the same pair's drivers, correlated with their crossovers bypassed
across the junction band, read r +0.844 — the two cones move alike where the
junction is judged. The band-wide cut answers the question the junction asks;
the first-sample sign answers a different one.

Verification:

- The field battery over seven archived cabins (20 junctions): every judged
  row byte for byte unchanged. One log line moves, at Passat v2's C/D, where
  the reseated seed takes a different explanation path to the same result.
- The whole solution: 1499 + 2379 + 159 tests, no warnings.
- A new synthetic pins the defect end to end — two impulses behind a matched
  LR36 split plus a late cabin copy in each channel, half a period apart and
  one of them inverted, which grows exactly the field log's "seed phat
  (direct-cut concurs)" line. It fails without the fix. Eleven unit cases pin
  the policy itself, including both directions of the backwards-driver case
  the guard exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
