### PR TITLE
The cross-side link reads the band's energy onset below 300 Hz

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -988,6 +988,24 @@ arrival, so a modal or reflected peak is not mistaken for the driver's real
 timing; the flag requires a real valley (6 dB) between the two peaks, since a
 low-frequency driver's direct sound can keep rising for milliseconds.
 
+A third instant, the **energy onset**, is reported under the delay table and
+marked `Onset` on the envelope plot: where a tenth of the band's energy has
+arrived, counting the envelope's running energy from the record's start up to
+60 ms past the strongest peak and ignoring samples 30 dB under it. It exists
+because on a slow low-frequency envelope the first peak is a coin: the direct
+front and an arrival a few milliseconds behind it merge into one climb, and
+whether the front's hump stands as a peak or melts into that climb is decided
+by a fraction of a dB — two identical midbasses read 14 and 21 ms that way,
+while their energy onsets sat 2 ms apart. The running energy is monotone, so
+it reads the front either way. It is the read the stereo
+[Auto delay](#auto-delay) uses for its cross-side links below 300 Hz, and the
+panel shows it so the figure can be checked against the two peaks; with a
+Compare record its delta prints like the table's cells. Take it as the
+alignment figure only on a band-limited low read with a clean record (the
+engine asks 40 dB of SNR): in wide bands the front is sharp and the first
+peak is the better instrument, and where a later arrival is much stronger
+than the direct sound the tenth of the energy can be reached in it.
+
 The mode recalculates when you switch into it and as you change the bandpass
 settings, and reports signal quality from the analysis envelope and the stored
 meter snapshot: a color-coded `Excellent` / `Good` / `Fair` / `Poor` **signal

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -988,8 +988,8 @@ arrival, so a modal or reflected peak is not mistaken for the driver's real
 timing; the flag requires a real valley (6 dB) between the two peaks, since a
 low-frequency driver's direct sound can keep rising for milliseconds.
 
-A third instant, the **energy onset**, is reported under the delay table and
-marked `Onset` on the envelope plot: where a tenth of the band's energy has
+A third instant, the **energy onset**, has its own row in the delay table and
+is marked `Onset` on the envelope plot: where a tenth of the band's energy has
 arrived, counting the envelope's running energy from the record's start up to
 60 ms past the strongest peak and ignoring samples 30 dB under it. It exists
 because on a slow low-frequency envelope the first peak is a coin: the direct
@@ -1014,8 +1014,18 @@ the strongest peak (a low value means the pick sits on a broad leading edge —
 normal for band-limited low-frequency drivers); peak and RMS levels in dBFS; a
 `CLIP` warning; and a `FULL SCALE` marker for a loopback reference at 0 dBFS.
 
-The measured time, distance, and sample count are clickable: click a result line
-to copy just the numeric value to the clipboard. With the bandpass window
+The **delay table** has a row per instant — `First Arrival`, `Strongest
+Peak`, `Energy onset` — and a column per unit: milliseconds, samples, meters
+at 20 °C. The row the analysis trusts most is printed bright and marked
+`◀ recommended`, the others dimmed: the energy onset on a band-limited read
+centred below 300 Hz with 40 dB of SNR (the engine's own rule for such
+bands), the first arrival otherwise, and none when a verdict above has
+disqualified the read — a near-noise record, a modal latch, a full-band read
+over detected crosstalk. The strongest peak is never the recommendation: a
+later, stronger peak is a mode or a reflection, not the driver's timing, and
+the hint under the table says which row to align from instead. Every cell is
+clickable: click it to copy just the numeric value to the clipboard (a Compare
+cell copies its value, not the delta). With the bandpass window
 enabled, a frequency-domain preview of the pass band is shown along with the
 envelope around the detected peak; selecting a [Compare](#compare) reference
 overlays its envelope there and adds a second delay-table block. Both envelopes

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2884,7 +2884,24 @@ channel where a candidate puts it.
 With stereo pairs, Auto delay tunes **both sides in one run**, and an
 **LHD / RHD** toggle says which seat you are tuning for. The driver's side is
 the reference: it aligns first, the top pair is bridged to it by band-limited
-envelope arrivals, and the far side descends junction by junction. The **scene
+envelope arrivals, and the far side descends junction by junction. Each far
+channel's search is aimed at its **cross-side target** — the delay that lands
+its band-limited arrival the scene offset ahead of its settled twin's — and
+for a pair whose shared band is centred below 300 Hz that arrival is the
+band's **energy onset** rather than its first envelope peak: the point where a
+tenth of the band's energy (counted up to 60 ms past the strongest peak,
+samples 30 dB under it ignored) has arrived. A slow low-frequency envelope
+climbs for milliseconds, and whether its first hump stands as a peak or melts
+into the arrival behind it is decided by a fraction of a dB — on one measured
+midbass pair the left dipped 0.5 dB after its hump and read 14 ms, the right
+never dipped and read 21 ms, a 7 ms split no cabin produces, which the scene
+pin then enforced. The running energy is monotone, so it reads the front
+whether or not it peaks (the same pair read 2 ms apart). The run's log names
+such a read `energy onsets`; it needs 40 dB of SNR on both sides, below which
+the pair is read by first peaks on both. The junction searches and their
+seeds keep the first arrivals: a link compares one driver pair through
+near-identical chains, where the onset's own bias cancels, which the
+front-predicting junction machinery cannot rely on. The **scene
 offset** is entered as a non-negative magnitude — how far the far side leads —
 so switching LHD/RHD never means re-entering a sign, and the level tilt is
 entered the same way, as a cut on the near side. The gain balance itself is

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1016,14 +1016,13 @@ normal for band-limited low-frequency drivers); peak and RMS levels in dBFS; a
 
 The **delay table** has a row per instant — `First Arrival`, `Strongest
 Peak`, `Energy onset` — and a column per unit: milliseconds, samples, meters
-at 20 °C. The row the analysis trusts most is printed bright and marked
-`◀ recommended`, the others dimmed: the energy onset on a band-limited read
+at 20 °C. The row the analysis trusts most is printed bright, marked `◀` and
+named under the table, the others dimmed: the energy onset on a band-limited read
 centred below 300 Hz with 40 dB of SNR (the engine's own rule for such
 bands), the first arrival otherwise, and none when a verdict above has
 disqualified the read — a near-noise record, a modal latch, a full-band read
 over detected crosstalk. The strongest peak is never the recommendation: a
-later, stronger peak is a mode or a reflection, not the driver's timing, and
-the hint under the table says which row to align from instead. Every cell is
+later, stronger peak is a mode or a reflection, not the driver's timing. Every cell is
 clickable: click it to copy just the numeric value to the clipboard (a Compare
 cell copies its value, not the delta). With the bandpass window
 enabled, a frequency-domain preview of the pass band is shown along with the

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1000,10 +1000,15 @@ while their energy onsets sat 2 ms apart. The running energy is monotone, so
 it reads the front either way. It is the read the stereo
 [Auto delay](#auto-delay) uses for its cross-side links below 300 Hz, and the
 panel shows it so the figure can be checked against the two peaks; with a
-Compare record its delta prints like the table's cells. Take it as the
-alignment figure only on a band-limited low read with a clean record (the
-engine asks 40 dB of SNR): in wide bands the front is sharp and the first
-peak is the better instrument, and where a later arrival is much stronger
+Compare record its delta prints like the table's cells. It is NOT a general
+alignment figure, and the table never recommends it: an onset is a statistic
+of how the band's energy is distributed, so its distance from the front
+depends on the response's tail and on the chain it played through (the same
+two midbass fronts read 2 ms apart through their chains and 1 ms raw). That
+bias cancels between the two sides of one driver pair through near-identical
+chains — the only case the engine reads it in — and need not cancel between a
+subwoofer and a midbass. In wide bands the front is sharp and the first peak
+is the better instrument anyway, and where a later arrival is much stronger
 than the direct sound the tenth of the energy can be reached in it.
 
 The mode recalculates when you switch into it and as you change the bandpass
@@ -1017,12 +1022,14 @@ normal for band-limited low-frequency drivers); peak and RMS levels in dBFS; a
 The **delay table** has a row per instant — `First Arrival`, `Strongest
 Peak`, `Energy onset` — and a column per unit: milliseconds, samples, meters
 at 20 °C. The row the analysis trusts most is printed bright, marked `◀` and
-named under the table, the others dimmed: the energy onset on a band-limited read
-centred below 300 Hz with 40 dB of SNR (the engine's own rule for such
-bands), the first arrival otherwise, and none when a verdict above has
-disqualified the read — a near-noise record, a modal latch, a full-band read
-over detected crosstalk. The strongest peak is never the recommendation: a
-later, stronger peak is a mode or a reflection, not the driver's timing. Every cell is
+named under the table, the others dimmed: the first arrival, unless a verdict
+above has disqualified it — a near-noise record, a modal latch, a full-band
+read over detected crosstalk — in which case no row is marked. The strongest
+peak is never the recommendation: a later, stronger peak is a mode or a
+reflection, not the driver's timing. Nor is the energy onset, for the reason
+given above: it is a figure for one driver pair's two sides, and two arbitrary
+records — a subwoofer against a midbass is the ordinary use of this panel —
+differ in the shape of their energy as well as in time. Every cell is
 clickable: click it to copy just the numeric value to the clipboard (a Compare
 cell copies its value, not the delta). With the bandpass window
 enabled, a frequency-domain preview of the pass band is shown along with the

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -4048,7 +4048,8 @@ public static class AutoAlignmentEngine
 
         // The delay that Δ-aligns this right channel to its settled left
         // counterpart — landing its arrival exactly the scene offset ahead,
-        // measured by envelope arrivals in the given band. Used as the search
+        // measured by envelope arrivals in the given band (the band's energy
+        // onset where LinkReadsEnergyOnset says so, on both sides). Used as the search
         // prior (a gentle, polarity-blind pull toward the other side's timing
         // that breaks near-ties between lobes the junction sum cannot
         // distinguish) and as the pin of a scene lock, which measures the
@@ -4123,6 +4124,27 @@ public static class AutoAlignmentEngine
                     return (null, false, false, false, false, null);
                 }
 
+                // One instrument for the whole link — both sides, full band and
+                // upper half alike — decided from the band and BOTH sides' SNR
+                // (see LinkReadsEnergyOnset), so a split never subtracts a peak
+                // from an onset.
+                bool energyOnset = LinkReadsEnergyOnset(
+                    lowHz, highHz,
+                    left.SignalToNoiseDecibels, right.SignalToNoiseDecibels);
+                if (LinkBandReadsEnergyOnset(lowHz, highHz) && !energyOnset)
+                {
+                    log.AppendLine(
+                        $"  cross-side link {rightChannel.Name}: {lowHz:0}-{highHz:0} Hz " +
+                        $"read by first peaks — the energy onset needs " +
+                        $"{EnergyOnsetMinimumSnrDb:0} dB on both sides " +
+                        $"(L {left.SignalToNoiseDecibels:0.0}, R {right.SignalToNoiseDecibels:0.0} dB)");
+                }
+                if (energyOnset)
+                {
+                    left = AsEnergyOnset(left);
+                    right = AsEnergyOnset(right);
+                }
+
                 double probeLowHz = Math.Sqrt(lowHz * highHz);
                 if (highHz <
                     probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
@@ -4138,21 +4160,24 @@ public static class AutoAlignmentEngine
                     VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
                         rightIr, rightChannel.SampleRate, probeLowHz, highHz,
                         rightSnapshot.ValidRange);
+                if (energyOnset)
+                {
+                    leftProbe = AsEnergyOnset(leftProbe);
+                    rightProbe = AsEnergyOnset(rightProbe);
+                }
 
                 // See ClassifyArrival for the direction semantics: LATCHED
                 // poisons the read (ladder/donors), UNVERIFIED keeps it usable
                 // without the certificate, VERIFIED on both sides earns it.
                 ArrivalCertificate leftCertificate = ClassifyArrival(
                     left, leftProbe,
-                    ArrivalProbeToleranceMs(
-                        leftSnapshot, left.FirstArrivalDelayMilliseconds,
-                        leftProbe.FirstArrivalDelayMilliseconds,
+                    LinkProbeToleranceMs(
+                        leftSnapshot, left, leftProbe, energyOnset,
                         lowHz, probeLowHz, highHz));
                 ArrivalCertificate rightCertificate = ClassifyArrival(
                     right, rightProbe,
-                    ArrivalProbeToleranceMs(
-                        rightSnapshot, right.FirstArrivalDelayMilliseconds,
-                        rightProbe.FirstArrivalDelayMilliseconds,
+                    LinkProbeToleranceMs(
+                        rightSnapshot, right, rightProbe, energyOnset,
                         lowHz, probeLowHz, highHz));
                 if (leftCertificate == ArrivalCertificate.Latched ||
                     rightCertificate == ArrivalCertificate.Latched)
@@ -4318,18 +4343,34 @@ public static class AutoAlignmentEngine
                                 side.ImpulseResponse, side.Channel.SampleRate,
                                 lo, hi, side.ValidRange);
 
+                        // One instrument for the donor pair — both sides, full
+                        // band and upper half alike — decided from the band and
+                        // both sides' SNR (see LinkReadsEnergyOnset).
+                        TimeAlignmentAnalysisResult fullLeft = Read(otherLeft, lowHz2, highHz2);
+                        TimeAlignmentAnalysisResult fullRight = Read(otherRight, lowHz2, highHz2);
+                        bool energyOnset2 = LinkReadsEnergyOnset(
+                            lowHz2, highHz2,
+                            fullLeft.SignalToNoiseDecibels, fullRight.SignalToNoiseDecibels);
+
                         // A donor earns trust only if BOTH sides POSITIVELY read a
                         // clean direct arrival — full band AND its upper half
                         // valid, SNR-qualified, and agreeing. Absence of a proven
                         // latch is NOT proof of a direct read: an unmeasurable or
                         // low-SNR upper half leaves the split unverified, so skip.
-                        bool CleanDirect(AlignmentSnapshot side, out double rawMs)
+                        bool CleanDirect(
+                            AlignmentSnapshot side,
+                            TimeAlignmentAnalysisResult full,
+                            out double rawMs)
                         {
-                            TimeAlignmentAnalysisResult full = Read(side, lowHz2, highHz2);
                             TimeAlignmentAnalysisResult probe = Read(side, probeLow2, highHz2);
-                            double tolerance2 = ArrivalProbeToleranceMs(
-                                side, full.FirstArrivalDelayMilliseconds,
-                                probe.FirstArrivalDelayMilliseconds,
+                            if (energyOnset2)
+                            {
+                                full = AsEnergyOnset(full);
+                                probe = AsEnergyOnset(probe);
+                            }
+
+                            double tolerance2 = LinkProbeToleranceMs(
+                                side, full, probe, energyOnset2,
                                 lowHz2, probeLow2, highHz2);
                             rawMs = full.FirstArrivalDelayMilliseconds
                                 - alignment.GetValueOrDefault(side.Channel).DelayMs;
@@ -4342,8 +4383,8 @@ public static class AutoAlignmentEngine
                                     ArrivalCertificate.Verified;
                         }
 
-                        if (CleanDirect(otherLeft, out double rawLeft) &&
-                            CleanDirect(otherRight, out double rawRight))
+                        if (CleanDirect(otherLeft, fullLeft, out double rawLeft) &&
+                            CleanDirect(otherRight, fullRight, out double rawRight))
                         {
                             donorSplits.Add((rawRight - rawLeft,
                                 $"{other.Left.Name}/{other.Right.Name}"));
@@ -4407,6 +4448,12 @@ public static class AutoAlignmentEngine
                 $"(L arrival {arrivals.Left.FirstArrivalDelayMilliseconds:0.000}, " +
                 $"raw R {arrivals.Right.FirstArrivalDelayMilliseconds:0.000} ms " +
                 $"in {usedLowHz:0}-{usedHighHz:0} Hz" +
+                (LinkReadsEnergyOnset(
+                    usedLowHz, usedHighHz,
+                    arrivals.Left.SignalToNoiseDecibels,
+                    arrivals.Right.SignalToNoiseDecibels)
+                    ? ", energy onsets"
+                    : "") +
                 $"{(measured.Verified ? "" : "; arrival not certified by the upper-half probe — lobe pin only")})");
             return (target, !measured.Verified, false);
         }
@@ -4629,6 +4676,122 @@ public static class AutoAlignmentEngine
     /// number that times a whole side.
     /// </summary>
     public const double MinimumArrivalSnrDb = 12;
+
+    /// <summary>
+    /// Below this band CENTRE a cross-side LINK reads the ENERGY ONSET of the
+    /// band (<see cref="TimeAlignmentAnalysisResult.EnergyOnsetDelayMilliseconds"/>)
+    /// instead of its first envelope peak. In the band-limited low end the
+    /// first peak is a coin: the direct front (rise time ~1/bandwidth, 7 ms in
+    /// 65-200 Hz) and an arrival a few milliseconds behind it merge into one
+    /// climb, and whether the front's hump turns into a local maximum is
+    /// decided by a fraction of a dB — on the field midbass pair the left
+    /// dipped 0.5 dB after its hump and read 14.4 ms, the right never dipped
+    /// and read 21.3 ms, a 7 ms L/R split that no cabin geometry produces,
+    /// that the upper-half probe certified (the half sat on the same mode) and
+    /// that the scene lock then enforced. The running energy is monotone, so
+    /// the shoulder counts whether or not it peaks: the same pair read 2.2 ms
+    /// apart (1.1 ms on the raw responses, the owner's hand-tuned split).
+    /// Where the band is wide the front is sharp and the first peak is the
+    /// better instrument: on the mid and tweeter pairs the peak L/R split
+    /// holds to ±0.06 ms across their bands where the energy onset wanders
+    /// ±0.3 ms with the early-reflection structure. The rule is by band
+    /// centre, not low edge, because the coin is a matter of rise time: a
+    /// mid pair's 200-1610 Hz link band has a 0.7 ms rise and a sharp front
+    /// however low its edge sits. The centre and the decision belong to the
+    /// FULL band and to both sides: their upper-half probes are read with the
+    /// same instrument (see <see cref="LinkReadsEnergyOnset"/>), or the
+    /// certificate would compare an onset against a peak.
+    ///
+    /// The LINK only, not the junction timelines: a link compares the two
+    /// sides of ONE driver pair through near-identical chains, so whatever
+    /// bias the onset carries cancels in the split. The timeline machinery
+    /// instead predicts a processed read from the bypassed front plus a chain
+    /// shift measured on a reference impulse, and an energy onset is a
+    /// distribution statistic that no impulse-measured shift transfers: read
+    /// through it, the predictor missed a plain BW36 70-200 Hz band-pass by
+    /// 2.4 ms and convicted a plain BW48 80 Hz low-pass as an 18 ms modal
+    /// latch (its unit tests). The peaks stay the timeline's instrument.
+    /// </summary>
+    internal const double EnergyOnsetBandCenterHz = 300;
+
+    /// <summary>
+    /// The SNR both sides of a link must show before its band is read by the
+    /// energy onset. The onset's gate is fixed 30 dB under the peak
+    /// (<see cref="TimeAlignmentAnalysis.EnergyOnsetGateDb"/>) so that the
+    /// read is a property of the signal alone; the price is that noise above
+    /// the gate integrates into the total, and the window ahead of the front
+    /// is ~80 ms long. A Rayleigh floor 40 dB down clears the gate in a
+    /// fraction of a percent of its samples and moves the onset by nothing
+    /// measurable; at 35 dB a fifth of them clear it and the onset drifts
+    /// tenths of a millisecond; at 20 dB the tenth is reached in the noise.
+    /// Below this the link falls back to first peaks — on BOTH sides, so the
+    /// split is still one instrument against itself. Field records read
+    /// 45-88 dB.
+    /// </summary>
+    internal const double EnergyOnsetMinimumSnrDb = 40;
+
+    /// <summary>
+    /// Whether a link band belongs to the energy onset by its centre alone
+    /// (see <see cref="EnergyOnsetBandCenterHz"/>).
+    /// </summary>
+    internal static bool LinkBandReadsEnergyOnset(double bandLowHz, double bandHighHz) =>
+        Math.Sqrt(bandLowHz * bandHighHz) < EnergyOnsetBandCenterHz;
+
+    /// <summary>
+    /// Whether a link is read by its energy onset: the band's centre says so
+    /// AND both sides clear <see cref="EnergyOnsetMinimumSnrDb"/>. Decided
+    /// ONCE per link from both sides' full-band reads and applied to every
+    /// read of that link — both sides, their upper-half probes included — so
+    /// a split never subtracts a peak from an onset.
+    /// </summary>
+    internal static bool LinkReadsEnergyOnset(
+        double bandLowHz,
+        double bandHighHz,
+        double leftSignalToNoiseDb,
+        double rightSignalToNoiseDb) =>
+        LinkBandReadsEnergyOnset(bandLowHz, bandHighHz) &&
+        leftSignalToNoiseDb >= EnergyOnsetMinimumSnrDb &&
+        rightSignalToNoiseDb >= EnergyOnsetMinimumSnrDb;
+
+    /// <summary>
+    /// A band read restated by its energy onset: the ARRIVAL fields swapped
+    /// for <see cref="TimeAlignmentAnalysisResult.EnergyOnsetDelayMilliseconds"/>.
+    /// The peak-describing figures of the result (prominence, the strongest
+    /// peak, its separation, the SNR) keep their meaning: they describe the
+    /// envelope's peaks and the record, not the onset.
+    /// </summary>
+    internal static TimeAlignmentAnalysisResult AsEnergyOnset(
+        TimeAlignmentAnalysisResult read) =>
+        !read.IsValid
+            ? read
+            : read with
+            {
+                FirstArrivalPeakSample = read.EnergyOnsetSample,
+                FirstArrivalDelayMilliseconds = read.EnergyOnsetDelayMilliseconds
+            };
+
+    /// <summary>
+    /// The full-band-vs-upper-half tolerance for a link read. A peak read earns
+    /// the channel's own crossover smear as credit (<see cref="ArrivalProbeToleranceMs"/>,
+    /// graded against the front predictor); an energy-onset read cannot — the
+    /// predictor speaks in peaks, and grading an onset against it is grading
+    /// one instrument with another — so an energy-onset band keeps the generic
+    /// allowance: half a period at the probe's low edge, never under 1 ms.
+    /// </summary>
+    private static double LinkProbeToleranceMs(
+        AlignmentSnapshot side,
+        TimeAlignmentAnalysisResult full,
+        TimeAlignmentAnalysisResult probe,
+        bool energyOnset,
+        double bandLowHz,
+        double probeLowHz,
+        double bandHighHz) =>
+        energyOnset
+            ? Math.Max(1.0, 500.0 / probeLowHz)
+            : ArrivalProbeToleranceMs(
+                side, full.FirstArrivalDelayMilliseconds,
+                probe.FirstArrivalDelayMilliseconds,
+                bandLowHz, probeLowHz, bandHighHz);
 
     // The bridge-decision confidence bands over the weaker side's arrival
     // SNR: clean field measurements run 40-70 dB, so 30 dB still marks a

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -4731,7 +4731,7 @@ public static class AutoAlignmentEngine
     /// 2.4 ms and convicted a plain BW48 80 Hz low-pass as an 18 ms modal
     /// latch (its unit tests). The peaks stay the timeline's instrument.
     /// </summary>
-    internal const double EnergyOnsetBandCenterHz = 300;
+    public const double EnergyOnsetBandCenterHz = 300;
 
     /// <summary>
     /// The SNR both sides of a link must show before its band is read by the
@@ -4747,7 +4747,7 @@ public static class AutoAlignmentEngine
     /// split is still one instrument against itself. Field records read
     /// 45-88 dB.
     /// </summary>
-    internal const double EnergyOnsetMinimumSnrDb = 40;
+    public const double EnergyOnsetMinimumSnrDb = 40;
 
     /// <summary>
     /// Whether a link band belongs to the energy onset by its centre alone

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -4169,16 +4169,35 @@ public static class AutoAlignmentEngine
                 // See ClassifyArrival for the direction semantics: LATCHED
                 // poisons the read (ladder/donors), UNVERIFIED keeps it usable
                 // without the certificate, VERIFIED on both sides earns it.
-                ArrivalCertificate leftCertificate = ClassifyArrival(
+                ArrivalCertificate leftCertificate = ClassifyLinkArrival(
                     left, leftProbe,
                     LinkProbeToleranceMs(
                         leftSnapshot, left, leftProbe, energyOnset,
-                        lowHz, probeLowHz, highHz));
-                ArrivalCertificate rightCertificate = ClassifyArrival(
+                        lowHz, probeLowHz, highHz),
+                    energyOnset);
+                ArrivalCertificate rightCertificate = ClassifyLinkArrival(
                     right, rightProbe,
                     LinkProbeToleranceMs(
                         rightSnapshot, right, rightProbe, energyOnset,
-                        lowHz, probeLowHz, highHz));
+                        lowHz, probeLowHz, highHz),
+                    energyOnset);
+                if (energyOnset)
+                {
+                    foreach ((string name, TimeAlignmentAnalysisResult probeRead) in
+                        new[] { (link.Left.Name, leftProbe), (rightChannel.Name, rightProbe) })
+                    {
+                        if (probeRead.IsValid &&
+                            probeRead.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
+                            probeRead.SignalToNoiseDecibels < EnergyOnsetMinimumSnrDb)
+                        {
+                            log.AppendLine(
+                                $"  cross-side link {rightChannel.Name}: {name} " +
+                                $"{probeLowHz:0}-{highHz:0} Hz half at " +
+                                $"{probeRead.SignalToNoiseDecibels:0.0} dB cannot " +
+                                "witness an energy onset — read left uncertified");
+                        }
+                    }
+                }
                 if (leftCertificate == ArrivalCertificate.Latched ||
                     rightCertificate == ArrivalCertificate.Latched)
                 {
@@ -4379,7 +4398,7 @@ public static class AutoAlignmentEngine
                             // contribute no geometry).
                             return full.IsValid &&
                                 full.SignalToNoiseDecibels >= MinimumArrivalSnrDb &&
-                                ClassifyArrival(full, probe, tolerance2) ==
+                                ClassifyLinkArrival(full, probe, tolerance2, energyOnset2) ==
                                     ArrivalCertificate.Verified;
                         }
 
@@ -4752,6 +4771,27 @@ public static class AutoAlignmentEngine
         LinkBandReadsEnergyOnset(bandLowHz, bandHighHz) &&
         leftSignalToNoiseDb >= EnergyOnsetMinimumSnrDb &&
         rightSignalToNoiseDb >= EnergyOnsetMinimumSnrDb;
+
+    /// <summary>
+    /// The certificate of a link read: <see cref="ClassifyArrival"/>, except
+    /// that an energy-onset read whose upper-half probe sits under
+    /// <see cref="EnergyOnsetMinimumSnrDb"/> is UNVERIFIED rather than judged.
+    /// The onset decision is taken from the two FULL-band reads, and a steep
+    /// low-pass or a weak upper half can leave the probe half far noisier than
+    /// the band it is cut from — between the 12 dB admission and the 40 dB an
+    /// onset needs, exactly where the onset drifts into the noise ahead of the
+    /// front. Such a probe can neither convict the clean full-band onset as a
+    /// latch nor certify it; the read stays usable as a lobe pin, without the
+    /// certificate, as an unmeasurable half leaves it already.
+    /// </summary>
+    internal static ArrivalCertificate ClassifyLinkArrival(
+        TimeAlignmentAnalysisResult full,
+        TimeAlignmentAnalysisResult probe,
+        double toleranceMs,
+        bool energyOnset) =>
+        energyOnset && probe.SignalToNoiseDecibels < EnergyOnsetMinimumSnrDb
+            ? ArrivalCertificate.Unverified
+            : ClassifyArrival(full, probe, toleranceMs);
 
     /// <summary>
     /// A band read restated by its energy onset: the ARRIVAL fields swapped

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -4731,7 +4731,7 @@ public static class AutoAlignmentEngine
     /// 2.4 ms and convicted a plain BW48 80 Hz low-pass as an 18 ms modal
     /// latch (its unit tests). The peaks stay the timeline's instrument.
     /// </summary>
-    public const double EnergyOnsetBandCenterHz = 300;
+    internal const double EnergyOnsetBandCenterHz = 300;
 
     /// <summary>
     /// The SNR both sides of a link must show before its band is read by the
@@ -4747,7 +4747,7 @@ public static class AutoAlignmentEngine
     /// split is still one instrument against itself. Field records read
     /// 45-88 dB.
     /// </summary>
-    public const double EnergyOnsetMinimumSnrDb = 40;
+    internal const double EnergyOnsetMinimumSnrDb = 40;
 
     /// <summary>
     /// Whether a link band belongs to the energy onset by its centre alone

--- a/dsp/TimeAlignmentAnalysis.cs
+++ b/dsp/TimeAlignmentAnalysis.cs
@@ -77,6 +77,27 @@ public readonly record struct TimeAlignmentAnalysisResult(
     bool FirstArrivalRefinedByPhat,
     double StrongestConfidence,
     bool StrongestRefinedByPhat,
+    // The band's ENERGY ONSET: where the running energy of the envelope (its
+    // square, summed from the start of the search window) first reaches
+    // <see cref="TimeAlignmentAnalysis.EnergyOnsetFraction"/> of the energy
+    // inside the window that ends <see cref="TimeAlignmentAnalysis.EnergyOnsetTailSeconds"/>
+    // after the strongest peak. Sub-sample (the crossing is interpolated
+    // inside its sample), in the same coordinates as FirstArrivalPeakSample.
+    // A DIFFERENT estimator from the first peak, for the band-limited low end
+    // where the first peak is a coin: a direct front of rise time ~1/bandwidth
+    // and an arrival a few milliseconds behind it merge into one long climb
+    // with a shoulder, and whether that shoulder turns into a local maximum
+    // is decided by a fraction of a dB. Measured on a midbass pair in
+    // 65-200 Hz: the left envelope dipped 0.5 dB after its first hump and
+    // read 14.4 ms, the right never dipped and read 21.3 ms — a 7 ms split no
+    // cabin geometry produces — while the running energy, monotone by
+    // construction, put the two onsets 2.2 ms apart (1.1 ms on the raw
+    // responses, the owner's hand-tuned split). The same idea is the Hinkley
+    // criterion of acoustic-emission onset picking and the energy-ratio
+    // detectors that won the room-impulse-response onset comparison of
+    // Defrance, Daudet and Polack (JASA 2008) over every maximum-based method.
+    double EnergyOnsetSample = 0.0,
+    double EnergyOnsetDelayMilliseconds = 0.0,
     // False when the analysis band carried no energy at all (silence, or a
     // bandpass entirely outside the measured band): with a flat-zero envelope
     // every sample "passes" the thresholds and the peak walk would fabricate a
@@ -110,6 +131,39 @@ public static class TimeAlignmentAnalysis
     // cap, which is what keeps a pathological transform bounded.
     private const double BandpassGuardCycles = 20.0;
     private const double MaxBandpassGuardSeconds = 2.0;
+
+    /// <summary>
+    /// The share of the windowed band energy at which the ENERGY ONSET is read
+    /// (see <see cref="TimeAlignmentAnalysisResult.EnergyOnsetDelayMilliseconds"/>),
+    /// and how far past the strongest peak the window that defines "all" of the
+    /// energy runs. Measured on the field midbass pair (65-200 Hz, raw and
+    /// processed responses): the L/R onset split is flat from 2 % to 15 % of
+    /// the energy (0.75-1.11 ms raw, 2.2-2.4 ms processed), then slides into
+    /// the second hump of the envelope (0.46 ms at 20 %, sign flip at 30 %) —
+    /// 10 % sits in the middle of the plateau with margin to both cliffs. The
+    /// tail bound makes the total independent of the record's reverberant
+    /// length: on those bands 99.5 % of the energy sits within 80 ms of the
+    /// front, and the onset moved by at most 0.15 ms between a whole-record
+    /// total and a 50 ms one (0.4 ms on the subwoofer's 33-130 Hz band, where
+    /// the modal tail is longest).
+    /// </summary>
+    public const double EnergyOnsetFraction = 0.10;
+    public const double EnergyOnsetTailSeconds = 0.060;
+
+    /// <summary>
+    /// The energy onset's gate: envelope samples this far under the strongest
+    /// peak contribute nothing. FIXED against the peak, never against the
+    /// record's noise: the onset must be a property of the signal alone, or
+    /// two identical drivers measured with different noise would read
+    /// different fronts (a gate at the noise floor moves up the front as the
+    /// SNR falls, and at the 12 dB admission floor it would sit on the peak
+    /// itself). What the gate is for is the noise far below the front — the
+    /// window ahead of the peak is ~80 ms long and even a quiet floor
+    /// integrates over it — so it sits where a Rayleigh floor 40 dB down
+    /// clears it in a fraction of a percent of samples, and the CONSUMER
+    /// guards the SNR: <see cref="AutoAlignmentEngine.EnergyOnsetMinimumSnrDb"/>.
+    /// </summary>
+    public const double EnergyOnsetGateDb = 30;
 
     public static TimeAlignmentAnalysisResult Analyze(
         IReadOnlyList<double> impulseResponse,
@@ -265,6 +319,10 @@ public static class TimeAlignmentAnalysis
             envelopePeakIndex, searchRotation, envelope.Length);
         int relativeStrongest = RelativeToSearchWindow(
             strongestPeakIndex, searchRotation, envelope.Length);
+        double signalToNoiseDb = SignalEnvelope.EstimatePeakConfidenceDecibels(
+            envelope, strongestPeak);
+        double energyOnsetSample = EnergyOnsetSample(
+            envelope, searchRotation, relativeStrongest, sampleRate);
         double separationMilliseconds =
             (relativeStrongest - relativeFirst) * 1000.0 / sampleRate;
         double valleyDepthDb = ValleyDepthDb(
@@ -294,6 +352,9 @@ public static class TimeAlignmentAnalysis
             strongestPeakSample = ToSignedDelaySamples(
                 strongestPeakSample,
                 envelope.Length);
+            energyOnsetSample = ToSignedDelaySamples(
+                energyOnsetSample,
+                envelope.Length);
         }
 
         return new TimeAlignmentAnalysisResult(
@@ -302,9 +363,7 @@ public static class TimeAlignmentAnalysis
             envelopePeak,
             strongestPeakIndex,
             strongestPeak,
-            SignalEnvelope.EstimatePeakConfidenceDecibels(
-                envelope,
-                strongestPeak),
+            signalToNoiseDb,
             strongestPeak > 0.0
                 ? DataHelper.AmplitudeToDecibels(envelopePeak / strongestPeak)
                 : 0.0,
@@ -317,7 +376,75 @@ public static class TimeAlignmentAnalysis
             firstArrival.Confidence,
             firstArrival.RefinedByPhat,
             strongest.Confidence,
-            strongest.RefinedByPhat);
+            strongest.RefinedByPhat,
+            energyOnsetSample,
+            energyOnsetSample * 1000.0 / sampleRate);
+    }
+
+    // The energy onset (see the result field): the running energy of the
+    // envelope, read in the SEARCH WINDOW's frame from its start, crossing
+    // EnergyOnsetFraction of the energy accumulated up to EnergyOnsetTailSeconds
+    // past the strongest peak. The crossing is interpolated inside its sample
+    // and mapped back through the window rotation. Reads the rotated frame for
+    // the same reason the separation does: a re-anchored window straddles the
+    // buffer seam, and the contiguous geometry lives around the peak.
+    //
+    // Samples under the gate (EnergyOnsetGateDb under the strongest peak)
+    // contribute nothing. Without a gate the onset is a function of how much
+    // record precedes the front: noise power is small per sample but the
+    // window in front of the peak is ~80 ms long, so at 20 dB SNR the noise
+    // ahead of a 7 ms packet holds about a fifth of the total and the tenth
+    // is reached in the noise, at the window's start. This is the Hinkley
+    // criterion's detrending in gate form — with the gate fixed to the signal,
+    // not the noise, so the read does not move with the record's SNR.
+    private static double EnergyOnsetSample(
+        IReadOnlyList<double> envelope,
+        int rotation,
+        int relativeStrongest,
+        int sampleRate)
+    {
+        int length = envelope.Count;
+        int tailSamples = (int)Math.Round(EnergyOnsetTailSeconds * sampleRate);
+        int end = Math.Min(length - 1, relativeStrongest + tailSamples);
+        double gate = envelope[(relativeStrongest + rotation) % length] *
+            Math.Pow(10.0, -EnergyOnsetGateDb / 20.0);
+        double Power(int i)
+        {
+            double value = envelope[(i + rotation) % length];
+            return value >= gate ? value * value : 0.0;
+        }
+
+        double total = 0.0;
+        for (int i = 0; i <= end; i++)
+        {
+            total += Power(i);
+        }
+
+        if (!(total > 0.0) || !double.IsFinite(total))
+        {
+            return (relativeStrongest + rotation) % length;
+        }
+
+        double target = EnergyOnsetFraction * total;
+        double previous = 0.0;
+        double running = 0.0;
+        double relative = end;
+        for (int i = 0; i <= end; i++)
+        {
+            running += Power(i);
+            if (running >= target)
+            {
+                double step = running - previous;
+                double fraction = step > 0.0 ? (target - previous) / step : 1.0;
+                relative = Math.Max(0.0, i - 1 + fraction);
+                break;
+            }
+
+            previous = running;
+        }
+
+        double original = relative + rotation;
+        return original >= length ? original - length : original;
     }
 
     /// <summary>

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -955,7 +955,10 @@ public static class VirtualCrossoverAnalysis
                     result.FirstArrivalDelayMilliseconds + startMs,
                 StrongestPeakSample = result.StrongestPeakSample + startSample,
                 StrongestDelayMilliseconds =
-                    result.StrongestDelayMilliseconds + startMs
+                    result.StrongestDelayMilliseconds + startMs,
+                EnergyOnsetSample = result.EnergyOnsetSample + startSample,
+                EnergyOnsetDelayMilliseconds =
+                    result.EnergyOnsetDelayMilliseconds + startMs
             };
         }
         return result;

--- a/source/TimeAlignment/DelayTableText.cs
+++ b/source/TimeAlignment/DelayTableText.cs
@@ -9,11 +9,15 @@ namespace Resonalyze;
 /// </summary>
 internal static class DelayTableText
 {
+    // Sized to the widest cell each column can hold with a Compare delta and
+    // one space of separation — "163.000 (+2.604)" ms (a chain latency past
+    // 100 ms) is 16 characters, "15650.3 (+116.2)" samples is 16 — so a row
+    // with every delta runs 66 characters: what the status box shows at the
+    // table font without wrapping. Wider columns wrapped the meters cell onto
+    // a second line on the field record that first showed all three rows.
     public const int MillisecondsColumn = 16;
-    // Wide enough for a Compare cell's "value (Δ)" without touching the next
-    // column: "12.345 (+0.010)" is 15 characters.
-    public const int SamplesColumn = 34;
-    public const int MetersColumn = 52;
+    public const int SamplesColumn = 33;
+    public const int MetersColumn = 50;
 
     public const string FirstArrivalLabel = "First Arrival";
     public const string StrongestPeakLabel = "Strongest Peak";
@@ -21,10 +25,11 @@ internal static class DelayTableText
 
     /// <summary>
     /// Appended after the meters cell of the row the analysis recommends for
-    /// alignment. At the END of the line on purpose: a glyph of uncertain
-    /// width ahead of the cells would shift the columns it marks.
+    /// alignment; the word itself goes on a line under the table. At the END
+    /// of the row on purpose: a glyph of uncertain width ahead of the cells
+    /// would shift the columns it marks, and a word beside it wrapped the row.
     /// </summary>
-    public const string RecommendedMarker = "  ◀ recommended";
+    public const string RecommendedMarker = " ◀";
 
     private static readonly string[] RowLabels =
         [FirstArrivalLabel, StrongestPeakLabel, EnergyOnsetLabel];

--- a/source/TimeAlignment/DelayTableText.cs
+++ b/source/TimeAlignment/DelayTableText.cs
@@ -1,25 +1,66 @@
 namespace Resonalyze;
 
 /// <summary>
-/// The fixed-column text layout of the Time Alignment delay table: formatting
-/// of its lines and cells, and the reverse cell extraction the click-to-copy
-/// feature reads back from the rendered text. Kept together (and unit-tested)
-/// because the two must agree on the column layout.
+/// The fixed-column text layout of the Time Alignment delay table: one row per
+/// instant the analysis reads (first arrival, strongest peak, energy onset),
+/// one column per unit (milliseconds, samples, meters), plus the reverse cell
+/// extraction the click-to-copy feature reads back from the rendered text.
+/// Kept together (and unit-tested) because the two must agree on the layout.
 /// </summary>
 internal static class DelayTableText
 {
-    public const int FirstColumn = 18;
-    // Wide enough for a Compare cell's "value (Δ)" without touching the
-    // Strongest Peak column.
-    public const int SecondColumn = 37;
+    public const int MillisecondsColumn = 16;
+    // Wide enough for a Compare cell's "value (Δ)" without touching the next
+    // column: "12.345 (+0.010)" is 15 characters.
+    public const int SamplesColumn = 34;
+    public const int MetersColumn = 52;
+
+    public const string FirstArrivalLabel = "First Arrival";
+    public const string StrongestPeakLabel = "Strongest Peak";
+    public const string EnergyOnsetLabel = "Energy onset";
+
+    /// <summary>
+    /// Appended after the meters cell of the row the analysis recommends for
+    /// alignment. At the END of the line on purpose: a glyph of uncertain
+    /// width ahead of the cells would shift the columns it marks.
+    /// </summary>
+    public const string RecommendedMarker = "  ◀ recommended";
+
+    private static readonly string[] RowLabels =
+        [FirstArrivalLabel, StrongestPeakLabel, EnergyOnsetLabel];
+
+    public static string FormatHeader() =>
+        "Measured delay:".PadRight(MillisecondsColumn) +
+        "ms".PadRight(SamplesColumn - MillisecondsColumn) +
+        "samples".PadRight(MetersColumn - SamplesColumn) +
+        "meters (20°C)";
 
     public static string FormatLine(
         string label,
-        string firstArrival,
-        string strongestPeak) =>
-        label.PadRight(FirstColumn) +
-        firstArrival.PadRight(SecondColumn - FirstColumn) +
-        strongestPeak;
+        string milliseconds,
+        string samples,
+        string meters) =>
+        label.PadRight(MillisecondsColumn) + FormatCells(milliseconds, samples, meters);
+
+    /// <summary>The three unit cells of a row, from the milliseconds column on.</summary>
+    public static string FormatCells(string milliseconds, string samples, string meters) =>
+        milliseconds.PadRight(SamplesColumn - MillisecondsColumn) +
+        samples.PadRight(MetersColumn - SamplesColumn) +
+        meters;
+
+    /// <summary>Whether a rendered status line is one of the table's rows.</summary>
+    public static bool IsDelayRow(string line) =>
+        RowLabels.Any(label => line.StartsWith(label, StringComparison.Ordinal));
+
+    /// <summary>
+    /// The start column of the cell a character column falls in, or null for
+    /// the label.
+    /// </summary>
+    public static int? CellAt(int column) =>
+        column >= MetersColumn ? MetersColumn
+        : column >= SamplesColumn ? SamplesColumn
+        : column >= MillisecondsColumn ? MillisecondsColumn
+        : null;
 
     /// <summary>
     /// "value" for a Source cell; "value (+delta)" for a Compare cell where a
@@ -52,7 +93,8 @@ internal static class DelayTableText
 
     /// <summary>
     /// Extracts the cell starting at <paramref name="startColumn"/> from a
-    /// rendered table line, without the Compare "(Δ)" suffix.
+    /// rendered table line, without the Compare "(Δ)" suffix and without the
+    /// recommendation marker.
     /// </summary>
     public static string GetValue(string line, int startColumn)
     {
@@ -61,10 +103,19 @@ internal static class DelayTableText
             return string.Empty;
         }
 
-        int endColumn = startColumn == FirstColumn
-            ? Math.Min(SecondColumn, line.Length)
-            : line.Length;
-        string cell = line[startColumn..endColumn].Trim();
+        int endColumn = startColumn < SamplesColumn
+            ? Math.Min(SamplesColumn, line.Length)
+            : startColumn < MetersColumn
+                ? Math.Min(MetersColumn, line.Length)
+                : line.Length;
+        string cell = line[startColumn..endColumn];
+        int markerStart = cell.IndexOf('◀');
+        if (markerStart >= 0)
+        {
+            cell = cell[..markerStart];
+        }
+
+        cell = cell.Trim();
         // Copy just the value, not the Compare "(Δ)" suffix.
         int deltaStart = cell.IndexOf(" (", StringComparison.Ordinal);
         return deltaStart >= 0 ? cell[..deltaStart] : cell;

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -94,9 +94,12 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         this.saveSettings = saveSettings;
         this.getImpulseResponseFileName = getImpulseResponseFileName;
         this.getCompareMeasurement = getCompareMeasurement;
+        // One step over the panel font, not four: the delay table is three
+        // rows of three cells with Compare deltas (66 characters with every
+        // delta), and at +4 the status box wrapped the meters cell.
         resultTableFont = new Font(
             FontFamily.GenericMonospace,
-            owner.Font.Size + 4.0f,
+            owner.Font.Size + 1.0f,
             FontStyle.Bold);
 
         sourceSummaryLabel = panel.SourceSummaryLabel;
@@ -1456,7 +1459,9 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         AppendDelayTable(result, reference, recommended);
         if (recommended is { } row)
         {
-            AppendStrongestPeakHint(result, row);
+            AppendStatusText("Recommended for alignment: ", UiPalette.TextPrimarySoft);
+            AppendStatusText(RowLabel(row) + "\r\n", UiPalette.SuccessGreen);
+            AppendStrongestPeakHint(result);
         }
     }
 
@@ -1627,7 +1632,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // a room mode or reflection well after the direct sound, so the two columns
     // disagree. Point the reader at the first arrival instead of the misleading
     // strongest peak.
-    private void AppendStrongestPeakHint(TimeAlignmentAnalysisResult result, DelayRow recommended)
+    private void AppendStrongestPeakHint(TimeAlignmentAnalysisResult result)
     {
         if (!result.StrongestPeakIsSeparateArrival)
         {
@@ -1636,8 +1641,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
 
         AppendStatusText(
             $"⚠ Strongest peak is ~{result.StrongestPeakSeparationMilliseconds:0.0} ms " +
-            "after first arrival — likely a room mode or reflection.\r\n" +
-            $"Use {RowLabel(recommended)} for alignment.\r\n",
+            "after first arrival — likely a room mode or reflection.\r\n",
             UiPalette.WarningAmber);
     }
 
@@ -1740,8 +1744,9 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // Rows are the instants the analysis reads, columns the units. With a
     // reference (the Compare table) every cell shows its delta against the
     // Main value in parentheses, e.g. "1.006 (+0.010)". The recommended row
-    // (see RecommendedRow) is printed bright and marked at its end; the
-    // others dimmed, so the eye lands on the figure to align from.
+    // (see RecommendedRow) is printed bright and marked at its end, and named
+    // on the line under the table; the others dimmed, so the eye lands on the
+    // figure to align from.
     private void AppendDelayTable(
         TimeAlignmentAnalysisResult result,
         TimeAlignmentAnalysisResult? reference,

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -322,7 +322,8 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             outcome.Compare,
             outcome.CompareProbe,
             outcome.CompareCrosstalk,
-            outcome.CompareWarning);
+            outcome.CompareWarning,
+            outcome.BandCenterHz);
         UpdateEnvelopePreview(
             outcome.MainResult,
             outcome.MainSource.SampleRate,
@@ -423,7 +424,10 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 compareProbe,
                 compareCrosstalk,
                 compareWarning,
-                Message: null);
+                Message: null,
+                BandCenterHz: request.BandMode == TimeAlignmentBandMode.FullBand
+                    ? null
+                    : analysisOptions.BandpassCenterHz);
         }
         catch (Exception exception)
         {
@@ -459,7 +463,11 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentArrivalProbe? CompareProbe,
         CrosstalkHeadGate? CompareCrosstalk,
         string? CompareWarning,
-        string? Message)
+        string? Message,
+        // The centre of the band the read was taken in; null for a full-band
+        // read. The recommendation reads it: below the engine's energy-onset
+        // edge the onset row is the figure to align from.
+        double? BandCenterHz = null)
     {
         public static AnalysisOutcome Failed(
             string message,
@@ -1365,21 +1373,24 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentCompareAnalysis? compareAnalysis,
         TimeAlignmentArrivalProbe? compareProbe,
         CrosstalkHeadGate? compareCrosstalk,
-        string? compareWarning)
+        string? compareWarning,
+        double? bandCenterHz)
     {
         statusTextBox.BeginUpdate();
         try
         {
             statusTextBox.Clear();
             AppendMeasurementResult(
-                bandMode, "Main", mainSource.Levels, mainResult, mainProbe, mainCrosstalk);
+                bandMode, "Main", mainSource.Levels, mainResult, mainProbe, mainCrosstalk,
+                bandCenterHz);
             AppendCompareResult(
                 bandMode,
                 mainResult,
                 compareAnalysis,
                 compareProbe,
                 compareCrosstalk,
-                compareWarning);
+                compareWarning,
+                bandCenterHz);
             statusTextBox.SelectionStart = 0;
             statusTextBox.SelectionLength = 0;
         }
@@ -1395,7 +1406,8 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentCompareAnalysis? compareAnalysis,
         TimeAlignmentArrivalProbe? compareProbe,
         CrosstalkHeadGate? compareCrosstalk,
-        string? warning)
+        string? warning,
+        double? bandCenterHz)
     {
         if (compareAnalysis == null && warning == null)
         {
@@ -1419,6 +1431,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             compareAnalysis.Value.Result,
             compareProbe,
             compareCrosstalk,
+            bandCenterHz,
             mainResult);
     }
 
@@ -1429,6 +1442,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentAnalysisResult result,
         TimeAlignmentArrivalProbe? honestyProbe,
         CrosstalkHeadGate? crosstalk,
+        double? bandCenterHz,
         TimeAlignmentAnalysisResult? reference = null)
     {
         AppendSignalQuality(title, result);
@@ -1437,12 +1451,63 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         AppendCrosstalkFlag(bandMode, crosstalk);
         AppendLevelsLine(levels);
         AppendSeparator();
-        AppendDelayTable(result, reference);
-        AppendEnergyOnsetLine(result, reference);
-        if (IsArrivalRecommendable(result, honestyProbe, bandMode, crosstalk != null))
+        DelayRow? recommended = RecommendedRow(
+            result, honestyProbe, bandMode, crosstalk != null, bandCenterHz);
+        AppendDelayTable(result, reference, recommended);
+        if (recommended is { } row)
         {
-            AppendStrongestPeakHint(result);
+            AppendStrongestPeakHint(result, row);
         }
+    }
+
+    /// <summary>The instants the delay table reports, one row each.</summary>
+    internal enum DelayRow
+    {
+        FirstArrival,
+        StrongestPeak,
+        EnergyOnset
+    }
+
+    internal static string RowLabel(DelayRow row) => row switch
+    {
+        DelayRow.FirstArrival => DelayTableText.FirstArrivalLabel,
+        DelayRow.StrongestPeak => DelayTableText.StrongestPeakLabel,
+        _ => DelayTableText.EnergyOnsetLabel
+    };
+
+    // Which row of the delay table the analysis trusts most — the one the
+    // table marks and the hint below it names. None on a near-noise record,
+    // a modal latch or a contaminated full-band read (see
+    // IsArrivalRecommendable). In a band-limited read whose band is centred
+    // below the engine's energy-onset edge, with the SNR the onset needs, the
+    // energy onset outranks the first peak for the reason the engine's
+    // cross-side links read it: on a slow low-frequency envelope the first
+    // peak is a coin. Everywhere else the first arrival is the figure, as the
+    // strongest peak never is — a later, stronger peak is a mode or a
+    // reflection, not the driver's timing.
+    internal static DelayRow? RecommendedRow(
+        TimeAlignmentAnalysisResult result,
+        TimeAlignmentArrivalProbe? honestyProbe,
+        TimeAlignmentBandMode bandMode,
+        bool crosstalkDetected,
+        double? bandCenterHz)
+    {
+        if (result.SignalToNoiseDecibels < AutoAlignmentEngine.MinimumArrivalSnrDb)
+        {
+            return null;
+        }
+
+        if (bandMode != TimeAlignmentBandMode.FullBand &&
+            bandCenterHz is { } centerHz &&
+            centerHz < AutoAlignmentEngine.EnergyOnsetBandCenterHz &&
+            result.SignalToNoiseDecibels >= AutoAlignmentEngine.EnergyOnsetMinimumSnrDb)
+        {
+            return DelayRow.EnergyOnset;
+        }
+
+        return IsArrivalRecommendable(result, honestyProbe, bandMode, crosstalkDetected)
+            ? DelayRow.FirstArrival
+            : null;
     }
 
     // Whether the First Arrival may be RECOMMENDED as the alignment figure.
@@ -1562,7 +1627,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     // a room mode or reflection well after the direct sound, so the two columns
     // disagree. Point the reader at the first arrival instead of the misleading
     // strongest peak.
-    private void AppendStrongestPeakHint(TimeAlignmentAnalysisResult result)
+    private void AppendStrongestPeakHint(TimeAlignmentAnalysisResult result, DelayRow recommended)
     {
         if (!result.StrongestPeakIsSeparateArrival)
         {
@@ -1572,7 +1637,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         AppendStatusText(
             $"⚠ Strongest peak is ~{result.StrongestPeakSeparationMilliseconds:0.0} ms " +
             "after first arrival — likely a room mode or reflection.\r\n" +
-            "Use First Arrival for alignment.\r\n",
+            $"Use {RowLabel(recommended)} for alignment.\r\n",
             UiPalette.WarningAmber);
     }
 
@@ -1672,105 +1737,81 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             resultTableFont);
     }
 
-    // When reference is supplied (the Compare table), each value shows its delta against
-    // the Source value in parentheses, e.g. "1.006 (+0.010)".
+    // Rows are the instants the analysis reads, columns the units. With a
+    // reference (the Compare table) every cell shows its delta against the
+    // Main value in parentheses, e.g. "1.006 (+0.010)". The recommended row
+    // (see RecommendedRow) is printed bright and marked at its end; the
+    // others dimmed, so the eye lands on the figure to align from.
     private void AppendDelayTable(
         TimeAlignmentAnalysisResult result,
-        TimeAlignmentAnalysisResult? reference = null)
+        TimeAlignmentAnalysisResult? reference,
+        DelayRow? recommended)
     {
-        double firstArrivalMeters = DelayMeters(result.FirstArrivalDelayMilliseconds);
-        double strongestMeters = DelayMeters(result.StrongestDelayMilliseconds);
-
-        // Header split into segments so the two peak labels carry a light colour accent
-        // matching their envelope markers, while keeping the column alignment.
         AppendStatusText(
-            "Measured delay:".PadRight(DelayTableText.FirstColumn),
+            DelayTableText.FormatHeader() + "\r\n",
             UiPalette.TextPrimarySoft,
             resultTableFont);
-        AppendStatusText(
-            "First Arrival".PadRight(DelayTableText.SecondColumn - DelayTableText.FirstColumn),
+        AppendDelayRow(
+            DelayRow.FirstArrival,
             UiPalette.TimeAlignmentFirstArrival,
-            resultTableFont);
-        AppendStatusText(
-            "Strongest Peak\r\n",
+            result.FirstArrivalDelayMilliseconds,
+            result.FirstArrivalPeakSample,
+            reference?.FirstArrivalDelayMilliseconds,
+            reference?.FirstArrivalPeakSample,
+            recommended);
+        AppendDelayRow(
+            DelayRow.StrongestPeak,
             UiPalette.TimeAlignmentStrongestPeak,
-            resultTableFont);
-        AppendStatusText(
-            FormatDelayTableLine(
-                "ms",
-                FormatValueWithDelta(
-                    result.FirstArrivalDelayMilliseconds,
-                    reference?.FirstArrivalDelayMilliseconds,
-                    "0.000"),
-                FormatValueWithDelta(
-                    result.StrongestDelayMilliseconds,
-                    reference?.StrongestDelayMilliseconds,
-                    "0.000")) + "\r\n",
-            UiPalette.TextPrimarySoft,
-            resultTableFont);
-        AppendStatusText(
-            FormatDelayTableLine(
-                "meters (20\u00B0C)",
-                FormatValueWithDelta(
-                    firstArrivalMeters,
-                    reference == null
-                        ? null
-                        : DelayMeters(reference.Value.FirstArrivalDelayMilliseconds),
-                    "0.000"),
-                FormatValueWithDelta(
-                    strongestMeters,
-                    reference == null
-                        ? null
-                        : DelayMeters(reference.Value.StrongestDelayMilliseconds),
-                    "0.000")) + "\r\n",
-            UiPalette.TextPrimarySoft,
-            resultTableFont);
-        AppendStatusText(
-            FormatDelayTableLine(
-                "samples",
-                FormatValueWithDelta(
-                    result.FirstArrivalPeakSample,
-                    reference?.FirstArrivalPeakSample,
-                    "0.0"),
-                FormatValueWithDelta(
-                    result.StrongestPeakSample,
-                    reference?.StrongestPeakSample,
-                    "0.0")) + "\r\n",
-            UiPalette.TextPrimarySoft,
-            resultTableFont);
+            result.StrongestDelayMilliseconds,
+            result.StrongestPeakSample,
+            reference?.StrongestDelayMilliseconds,
+            reference?.StrongestPeakSample,
+            recommended);
+        AppendDelayRow(
+            DelayRow.EnergyOnset,
+            UiPalette.TimeAlignmentEnergyOnset,
+            result.EnergyOnsetDelayMilliseconds,
+            result.EnergyOnsetSample,
+            reference?.EnergyOnsetDelayMilliseconds,
+            reference?.EnergyOnsetSample,
+            recommended);
     }
 
-    // The band's energy onset (see TimeAlignmentAnalysisResult): where a tenth
-    // of the band's energy has arrived. A third instant beside the two peaks,
-    // because on a slow low-frequency envelope the first PEAK is a coin — a
-    // front's hump that a fraction of a dB turns into a shoulder hands the
-    // read to the arrival behind it — while the running energy reads the
-    // front either way. It is the figure the stereo Auto delay's cross-side
-    // links read below 300 Hz, so the panel shows it where the tuner can
-    // check it against the two peaks; with a reference (the Compare table) it
-    // carries its delta like the table's cells.
-    private void AppendEnergyOnsetLine(
-        TimeAlignmentAnalysisResult result,
-        TimeAlignmentAnalysisResult? reference)
+    private void AppendDelayRow(
+        DelayRow row,
+        Color labelColor,
+        double milliseconds,
+        double samples,
+        double? referenceMilliseconds,
+        double? referenceSamples,
+        DelayRow? recommended)
     {
-        double leadMilliseconds =
-            result.FirstArrivalDelayMilliseconds - result.EnergyOnsetDelayMilliseconds;
+        bool isRecommended = recommended == row;
+        // The label carries the row's accent (matching its envelope marker);
+        // the cells are one segment so the click-to-copy columns stay exact.
         AppendStatusText(
-            "Energy onset:".PadRight(DelayTableText.FirstColumn),
-            UiPalette.TextPrimarySoft,
+            RowLabel(row).PadRight(DelayTableText.MillisecondsColumn),
+            labelColor,
             resultTableFont);
         AppendStatusText(
-            FormatValueWithDelta(
-                result.EnergyOnsetDelayMilliseconds,
-                reference?.EnergyOnsetDelayMilliseconds,
-                "0.000") + " ms",
-            UiPalette.TimeAlignmentEnergyOnset,
+            DelayTableText.FormatCells(
+                FormatValueWithDelta(milliseconds, referenceMilliseconds, "0.000"),
+                FormatValueWithDelta(samples, referenceSamples, "0.0"),
+                FormatValueWithDelta(
+                    DelayMeters(milliseconds),
+                    referenceMilliseconds is { } referenceMs ? DelayMeters(referenceMs) : null,
+                    "0.000")),
+            isRecommended ? UiPalette.TextPrimarySoft : UiPalette.TextSecondarySoft,
             resultTableFont);
-        AppendStatusText(
-            $"  ({Math.Abs(leadMilliseconds):0.000} ms " +
-            $"{(leadMilliseconds >= 0 ? "before" : "after")} First Arrival)\r\n",
-            UiPalette.TextSecondarySoft,
-            resultTableFont);
+        if (isRecommended)
+        {
+            AppendStatusText(
+                DelayTableText.RecommendedMarker,
+                UiPalette.SuccessGreen,
+                resultTableFont);
+        }
+
+        AppendStatusText("\r\n", UiPalette.TextPrimarySoft, resultTableFont);
     }
 
     private static double DelayMeters(double delayMilliseconds) =>
@@ -1813,12 +1854,6 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             AppendStatusText(" FULL SCALE", UiPalette.TextSecondarySoft);
         }
     }
-
-    private static string FormatDelayTableLine(
-        string label,
-        string firstArrival,
-        string strongestPeak) =>
-        DelayTableText.FormatLine(label, firstArrival, strongestPeak);
 
     private void AppendStatusText(string text, Color color, Font? font = null)
     {
@@ -1866,20 +1901,16 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         }
 
         string lineText = statusTextBox.Lines[line];
-        if (!lineText.StartsWith("ms", StringComparison.Ordinal) &&
-            !lineText.StartsWith("meters", StringComparison.Ordinal) &&
-            !lineText.StartsWith("samples", StringComparison.Ordinal))
+        if (!DelayTableText.IsDelayRow(lineText))
         {
             return false;
         }
 
         int lineStart = statusTextBox.GetFirstCharIndexFromLine(line);
         int column = Math.Max(0, index - lineStart);
-        value = column >= DelayTableText.SecondColumn
-            ? GetDelayTableValue(lineText, DelayTableText.SecondColumn)
-            : column >= DelayTableText.FirstColumn
-                ? GetDelayTableValue(lineText, DelayTableText.FirstColumn)
-                : string.Empty;
+        value = DelayTableText.CellAt(column) is { } cellStart
+            ? GetDelayTableValue(lineText, cellStart)
+            : string.Empty;
         return !string.IsNullOrWhiteSpace(value);
     }
 

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -325,8 +325,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             outcome.Compare,
             outcome.CompareProbe,
             outcome.CompareCrosstalk,
-            outcome.CompareWarning,
-            outcome.BandCenterHz);
+            outcome.CompareWarning);
         UpdateEnvelopePreview(
             outcome.MainResult,
             outcome.MainSource.SampleRate,
@@ -427,10 +426,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 compareProbe,
                 compareCrosstalk,
                 compareWarning,
-                Message: null,
-                BandCenterHz: request.BandMode == TimeAlignmentBandMode.FullBand
-                    ? null
-                    : analysisOptions.BandpassCenterHz);
+                Message: null);
         }
         catch (Exception exception)
         {
@@ -466,11 +462,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentArrivalProbe? CompareProbe,
         CrosstalkHeadGate? CompareCrosstalk,
         string? CompareWarning,
-        string? Message,
-        // The centre of the band the read was taken in; null for a full-band
-        // read. The recommendation reads it: below the engine's energy-onset
-        // edge the onset row is the figure to align from.
-        double? BandCenterHz = null)
+        string? Message)
     {
         public static AnalysisOutcome Failed(
             string message,
@@ -1376,24 +1368,21 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentCompareAnalysis? compareAnalysis,
         TimeAlignmentArrivalProbe? compareProbe,
         CrosstalkHeadGate? compareCrosstalk,
-        string? compareWarning,
-        double? bandCenterHz)
+        string? compareWarning)
     {
         statusTextBox.BeginUpdate();
         try
         {
             statusTextBox.Clear();
             AppendMeasurementResult(
-                bandMode, "Main", mainSource.Levels, mainResult, mainProbe, mainCrosstalk,
-                bandCenterHz);
+                bandMode, "Main", mainSource.Levels, mainResult, mainProbe, mainCrosstalk);
             AppendCompareResult(
                 bandMode,
                 mainResult,
                 compareAnalysis,
                 compareProbe,
                 compareCrosstalk,
-                compareWarning,
-                bandCenterHz);
+                compareWarning);
             statusTextBox.SelectionStart = 0;
             statusTextBox.SelectionLength = 0;
         }
@@ -1409,8 +1398,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentCompareAnalysis? compareAnalysis,
         TimeAlignmentArrivalProbe? compareProbe,
         CrosstalkHeadGate? compareCrosstalk,
-        string? warning,
-        double? bandCenterHz)
+        string? warning)
     {
         if (compareAnalysis == null && warning == null)
         {
@@ -1434,7 +1422,6 @@ internal sealed class TimeAlignmentPanelController : IDisposable
             compareAnalysis.Value.Result,
             compareProbe,
             compareCrosstalk,
-            bandCenterHz,
             mainResult);
     }
 
@@ -1445,7 +1432,6 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         TimeAlignmentAnalysisResult result,
         TimeAlignmentArrivalProbe? honestyProbe,
         CrosstalkHeadGate? crosstalk,
-        double? bandCenterHz,
         TimeAlignmentAnalysisResult? reference = null)
     {
         AppendSignalQuality(title, result);
@@ -1455,7 +1441,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         AppendLevelsLine(levels);
         AppendSeparator();
         DelayRow? recommended = RecommendedRow(
-            result, honestyProbe, bandMode, crosstalk != null, bandCenterHz);
+            result, honestyProbe, bandMode, crosstalk != null);
         AppendDelayTable(result, reference, recommended);
         if (recommended is { } row)
         {
@@ -1481,39 +1467,28 @@ internal sealed class TimeAlignmentPanelController : IDisposable
     };
 
     // Which row of the delay table the analysis trusts most — the one the
-    // table marks and the hint below it names. None on a near-noise record,
-    // a modal latch or a contaminated full-band read (see
-    // IsArrivalRecommendable). In a band-limited read whose band is centred
-    // below the engine's energy-onset edge, with the SNR the onset needs, the
-    // energy onset outranks the first peak for the reason the engine's
-    // cross-side links read it: on a slow low-frequency envelope the first
-    // peak is a coin. Everywhere else the first arrival is the figure, as the
-    // strongest peak never is — a later, stronger peak is a mode or a
-    // reflection, not the driver's timing.
+    // table marks and names below. The first arrival when nothing has
+    // disqualified it (see IsArrivalRecommendable), otherwise none. Never the
+    // strongest peak: a later, stronger peak is a mode or a reflection, not
+    // the driver's timing. And never the energy onset, although the engine's
+    // cross-side links read it below 300 Hz: an onset is a statistic of how
+    // the band's energy is distributed, and its distance from the front
+    // depends on the response's tail and chain — on the field midbass pair
+    // the same two fronts read 2.2 ms apart through their chains and 1.1 ms
+    // raw. Between the two sides of ONE driver pair that bias cancels, which
+    // is the only case the engine reads it in; this panel cannot know what
+    // two records are (a subwoofer against a midbass is the ordinary use),
+    // and there the difference of two onsets is partly shape, not time. The
+    // onset row is shown for the tuner to read against the peaks, not
+    // recommended.
     internal static DelayRow? RecommendedRow(
         TimeAlignmentAnalysisResult result,
         TimeAlignmentArrivalProbe? honestyProbe,
         TimeAlignmentBandMode bandMode,
-        bool crosstalkDetected,
-        double? bandCenterHz)
-    {
-        if (result.SignalToNoiseDecibels < AutoAlignmentEngine.MinimumArrivalSnrDb)
-        {
-            return null;
-        }
-
-        if (bandMode != TimeAlignmentBandMode.FullBand &&
-            bandCenterHz is { } centerHz &&
-            centerHz < AutoAlignmentEngine.EnergyOnsetBandCenterHz &&
-            result.SignalToNoiseDecibels >= AutoAlignmentEngine.EnergyOnsetMinimumSnrDb)
-        {
-            return DelayRow.EnergyOnset;
-        }
-
-        return IsArrivalRecommendable(result, honestyProbe, bandMode, crosstalkDetected)
+        bool crosstalkDetected) =>
+        IsArrivalRecommendable(result, honestyProbe, bandMode, crosstalkDetected)
             ? DelayRow.FirstArrival
             : null;
-    }
 
     // Whether the First Arrival may be RECOMMENDED as the alignment figure.
     // The strongest-peak hint ends with "Use First Arrival for alignment",

--- a/source/TimeAlignment/TimeAlignmentPanelController.cs
+++ b/source/TimeAlignment/TimeAlignmentPanelController.cs
@@ -1143,7 +1143,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         return series;
     }
 
-    private static void AddMainPeakMarkers(
+    internal static void AddMainPeakMarkers(
         PlotModel model,
         TimeAlignmentAnalysisResult mainResult,
         double referenceAmplitude)
@@ -1168,9 +1168,32 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                 OxyColor.FromRgb(140, 170, 255),
                 PlotCalloutDirection.RightUp);
         }
+
+        AddCalloutMarker(
+            model,
+            "M Onset",
+            mainResult.EnergyOnsetDelayMilliseconds - mainResult.FirstArrivalDelayMilliseconds,
+            GetPeakMarkerDecibels(mainResult, referenceAmplitude, GetEnergyOnsetIndex(mainResult)),
+            OxyColor.FromRgb(96, 200, 120),
+            PlotCalloutDirection.LeftDown);
     }
 
-    private static void AddComparePeakMarkers(
+    // The envelope index of the energy onset: its sample rounded and wrapped
+    // into the (circular) envelope, since a complete record reports positions
+    // as signed delays (see TimeAlignmentAnalysisOptions.WrapPeakPositions).
+    internal static int GetEnergyOnsetIndex(TimeAlignmentAnalysisResult result)
+    {
+        int length = result.EnvelopeSamples.Length;
+        if (length == 0)
+        {
+            return 0;
+        }
+
+        long rounded = (long)Math.Round(result.EnergyOnsetSample);
+        return (int)(((rounded % length) + length) % length);
+    }
+
+    internal static void AddComparePeakMarkers(
         PlotModel model,
         TimeAlignmentAnalysisResult mainResult,
         TimeAlignmentAnalysisResult compareResult,
@@ -1236,6 +1259,29 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                     ? PlotCalloutDirection.RightUp
                     : PlotCalloutDirection.RightDown);
         }
+
+        double mainOnsetDecibels =
+            GetPeakMarkerDecibels(mainResult, referenceAmplitude, GetEnergyOnsetIndex(mainResult));
+        double compareOnsetDecibels =
+            GetPeakMarkerDecibels(compareResult, referenceAmplitude, GetEnergyOnsetIndex(compareResult));
+        AddCalloutMarker(
+            model,
+            "M Onset",
+            mainResult.EnergyOnsetDelayMilliseconds - mainResult.FirstArrivalDelayMilliseconds,
+            mainOnsetDecibels,
+            OxyColor.FromRgb(96, 200, 120),
+            mainOnsetDecibels >= compareOnsetDecibels
+                ? PlotCalloutDirection.LeftUp
+                : PlotCalloutDirection.LeftDown);
+        AddCalloutMarker(
+            model,
+            "C Onset",
+            compareResult.EnergyOnsetDelayMilliseconds - mainResult.FirstArrivalDelayMilliseconds,
+            compareOnsetDecibels,
+            OxyColor.FromArgb(145, 96, 200, 120),
+            compareOnsetDecibels > mainOnsetDecibels
+                ? PlotCalloutDirection.LeftUp
+                : PlotCalloutDirection.LeftDown);
     }
 
     private static void AddCalloutMarker(
@@ -1392,6 +1438,7 @@ internal sealed class TimeAlignmentPanelController : IDisposable
         AppendLevelsLine(levels);
         AppendSeparator();
         AppendDelayTable(result, reference);
+        AppendEnergyOnsetLine(result, reference);
         if (IsArrivalRecommendable(result, honestyProbe, bandMode, crosstalk != null))
         {
             AppendStrongestPeakHint(result);
@@ -1690,6 +1737,39 @@ internal sealed class TimeAlignmentPanelController : IDisposable
                     reference?.StrongestPeakSample,
                     "0.0")) + "\r\n",
             UiPalette.TextPrimarySoft,
+            resultTableFont);
+    }
+
+    // The band's energy onset (see TimeAlignmentAnalysisResult): where a tenth
+    // of the band's energy has arrived. A third instant beside the two peaks,
+    // because on a slow low-frequency envelope the first PEAK is a coin — a
+    // front's hump that a fraction of a dB turns into a shoulder hands the
+    // read to the arrival behind it — while the running energy reads the
+    // front either way. It is the figure the stereo Auto delay's cross-side
+    // links read below 300 Hz, so the panel shows it where the tuner can
+    // check it against the two peaks; with a reference (the Compare table) it
+    // carries its delta like the table's cells.
+    private void AppendEnergyOnsetLine(
+        TimeAlignmentAnalysisResult result,
+        TimeAlignmentAnalysisResult? reference)
+    {
+        double leadMilliseconds =
+            result.FirstArrivalDelayMilliseconds - result.EnergyOnsetDelayMilliseconds;
+        AppendStatusText(
+            "Energy onset:".PadRight(DelayTableText.FirstColumn),
+            UiPalette.TextPrimarySoft,
+            resultTableFont);
+        AppendStatusText(
+            FormatValueWithDelta(
+                result.EnergyOnsetDelayMilliseconds,
+                reference?.EnergyOnsetDelayMilliseconds,
+                "0.000") + " ms",
+            UiPalette.TimeAlignmentEnergyOnset,
+            resultTableFont);
+        AppendStatusText(
+            $"  ({Math.Abs(leadMilliseconds):0.000} ms " +
+            $"{(leadMilliseconds >= 0 ? "before" : "after")} First Arrival)\r\n",
+            UiPalette.TextSecondarySoft,
             resultTableFont);
     }
 

--- a/source/Ui/UiPalette.cs
+++ b/source/Ui/UiPalette.cs
@@ -97,6 +97,7 @@ internal static class UiPalette
     // strongest peak blue.
     public static Color TimeAlignmentFirstArrival => Color.FromArgb(236, 148, 148);
     public static Color TimeAlignmentStrongestPeak => Color.FromArgb(150, 180, 250);
+    public static Color TimeAlignmentEnergyOnset => Color.FromArgb(150, 220, 160);
 
     // Chrome of the OxyPlot graphs — the surface a plot is drawn on and the axis
     // furniture on top of it. OxyPlot's own defaults are a light theme (black tick

--- a/tests/Resonalyze.App.Tests/DelayTableTextTests.cs
+++ b/tests/Resonalyze.App.Tests/DelayTableTextTests.cs
@@ -7,25 +7,41 @@ public sealed class DelayTableTextTests
     [Fact]
     public void FormatLine_PadsToTheColumnLayout()
     {
-        string line = DelayTableText.FormatLine("ms", "1.006", "2.345");
+        string line = DelayTableText.FormatLine(
+            DelayTableText.FirstArrivalLabel, "1.006", "48.3", "0.345");
 
-        Assert.Equal("ms", line[..2]);
-        Assert.Equal("1.006", line[DelayTableText.FirstColumn..].TrimEnd()[..5]);
-        Assert.Equal("2.345", line[DelayTableText.SecondColumn..]);
+        Assert.StartsWith(DelayTableText.FirstArrivalLabel, line);
+        Assert.Equal("1.006", line[DelayTableText.MillisecondsColumn..].TrimEnd()[..5]);
+        Assert.Equal("48.3", line[DelayTableText.SamplesColumn..].TrimEnd()[..4]);
+        Assert.Equal("0.345", line[DelayTableText.MetersColumn..]);
     }
 
     [Fact]
-    public void GetValue_ReadsBothColumnsAndStripsDeltaSuffix()
+    public void FormatHeader_NamesTheUnitsOverTheirColumns()
+    {
+        string header = DelayTableText.FormatHeader();
+
+        Assert.StartsWith("Measured delay:", header);
+        Assert.StartsWith("ms", header[DelayTableText.MillisecondsColumn..]);
+        Assert.StartsWith("samples", header[DelayTableText.SamplesColumn..]);
+        Assert.StartsWith("meters", header[DelayTableText.MetersColumn..]);
+    }
+
+    [Fact]
+    public void GetValue_ReadsEveryColumnAndStripsTheDeltaAndTheMarker()
     {
         RunWithInvariantCulture(() =>
         {
             string line = DelayTableText.FormatLine(
-                "ms",
+                DelayTableText.EnergyOnsetLabel,
                 DelayTableText.FormatValueWithDelta(1.006, 0.996, "0.000"),
-                DelayTableText.FormatValueWithDelta(2.345, null, "0.000"));
+                DelayTableText.FormatValueWithDelta(48.3, 47.8, "0.0"),
+                DelayTableText.FormatValueWithDelta(0.345, null, "0.000")) +
+                DelayTableText.RecommendedMarker;
 
-            Assert.Equal("1.006", DelayTableText.GetValue(line, DelayTableText.FirstColumn));
-            Assert.Equal("2.345", DelayTableText.GetValue(line, DelayTableText.SecondColumn));
+            Assert.Equal("1.006", DelayTableText.GetValue(line, DelayTableText.MillisecondsColumn));
+            Assert.Equal("48.3", DelayTableText.GetValue(line, DelayTableText.SamplesColumn));
+            Assert.Equal("0.345", DelayTableText.GetValue(line, DelayTableText.MetersColumn));
         });
     }
 
@@ -34,7 +50,26 @@ public sealed class DelayTableTextTests
     {
         Assert.Equal(
             string.Empty,
-            DelayTableText.GetValue("ms", DelayTableText.FirstColumn));
+            DelayTableText.GetValue("First Arrival", DelayTableText.MillisecondsColumn));
+    }
+
+    [Fact]
+    public void IsDelayRow_RecognizesTheThreeRowsOnly()
+    {
+        Assert.True(DelayTableText.IsDelayRow("First Arrival     1.006"));
+        Assert.True(DelayTableText.IsDelayRow("Strongest Peak    1.006"));
+        Assert.True(DelayTableText.IsDelayRow("Energy onset      1.006"));
+        Assert.False(DelayTableText.IsDelayRow(DelayTableText.FormatHeader()));
+        Assert.False(DelayTableText.IsDelayRow("Arrival probe: verified"));
+    }
+
+    [Fact]
+    public void CellAt_MapsAClickColumnToItsCell()
+    {
+        Assert.Null(DelayTableText.CellAt(3));
+        Assert.Equal(DelayTableText.MillisecondsColumn, DelayTableText.CellAt(DelayTableText.MillisecondsColumn + 2));
+        Assert.Equal(DelayTableText.SamplesColumn, DelayTableText.CellAt(DelayTableText.SamplesColumn));
+        Assert.Equal(DelayTableText.MetersColumn, DelayTableText.CellAt(DelayTableText.MetersColumn + 10));
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/TimeAlignmentArrivalRecommendationTests.cs
+++ b/tests/Resonalyze.App.Tests/TimeAlignmentArrivalRecommendationTests.cs
@@ -110,63 +110,42 @@ public sealed class TimeAlignmentArrivalRecommendationTests
             crosstalkDetected: false));
     }
 
-    // Which ROW of the delay table is marked: the energy onset on a
-    // band-limited read centred below the engine edge with the SNR the onset
-    // needs, the first arrival otherwise, none where a verdict disqualified
-    // the read. The strongest peak is never the pick.
+    // Which ROW of the delay table is marked: the first arrival when it
+    // stands, none where a verdict disqualified the read. The energy onset is
+    // never the pick here, however low the band and clean the record: its
+    // bias cancels only between the two sides of one driver pair (the
+    // engine's links), and this panel cannot know what two records are.
     [Fact]
-    public void RecommendedRow_PrefersTheEnergyOnsetOnALowBandWithEnoughSnr()
+    public void RecommendedRow_IsTheFirstArrivalWhereItStands()
     {
-        Assert.Equal(
-            TimeAlignmentPanelController.DelayRow.EnergyOnset,
-            TimeAlignmentPanelController.RecommendedRow(
-                Result(snrDb: 60),
-                Probe(AutoAlignmentEngine.ArrivalCertificate.Verified),
-                TimeAlignmentBandMode.ManualBand,
-                crosstalkDetected: false,
-                bandCenterHz: 114));
-        // ... even where the first peak was convicted: the onset is what
-        // reads the front there.
-        Assert.Equal(
-            TimeAlignmentPanelController.DelayRow.EnergyOnset,
-            TimeAlignmentPanelController.RecommendedRow(
-                Result(snrDb: 60),
-                Probe(AutoAlignmentEngine.ArrivalCertificate.Latched),
-                TimeAlignmentBandMode.AutoBand,
-                crosstalkDetected: false,
-                bandCenterHz: 200));
-    }
-
-    [Fact]
-    public void RecommendedRow_FallsBackToTheFirstArrivalOutsideTheOnsetRule()
-    {
-        // A low band, but under the SNR the onset needs.
-        Assert.Equal(
-            TimeAlignmentPanelController.DelayRow.FirstArrival,
-            TimeAlignmentPanelController.RecommendedRow(
-                Result(snrDb: 30),
-                Probe(AutoAlignmentEngine.ArrivalCertificate.Verified),
-                TimeAlignmentBandMode.ManualBand,
-                crosstalkDetected: false,
-                bandCenterHz: 114));
-        // A wide band centred above the edge.
         Assert.Equal(
             TimeAlignmentPanelController.DelayRow.FirstArrival,
             TimeAlignmentPanelController.RecommendedRow(
                 Result(snrDb: 60),
                 Probe(AutoAlignmentEngine.ArrivalCertificate.Verified),
                 TimeAlignmentBandMode.ManualBand,
-                crosstalkDetected: false,
-                bandCenterHz: 1000));
-        // A full-band read has no band centre to apply the rule to.
+                crosstalkDetected: false));
         Assert.Equal(
             TimeAlignmentPanelController.DelayRow.FirstArrival,
             TimeAlignmentPanelController.RecommendedRow(
                 Result(snrDb: 60),
                 honestyProbe: null,
                 TimeAlignmentBandMode.FullBand,
-                crosstalkDetected: false,
-                bandCenterHz: null));
+                crosstalkDetected: false));
+    }
+
+    [Fact]
+    public void RecommendedRow_NeverPicksTheEnergyOnsetOrTheStrongestPeak()
+    {
+        // A clean low band — the engine's own onset case — still marks the
+        // first arrival: the table shows the onset, it does not recommend it.
+        Assert.Equal(
+            TimeAlignmentPanelController.DelayRow.FirstArrival,
+            TimeAlignmentPanelController.RecommendedRow(
+                Result(snrDb: 70),
+                Probe(AutoAlignmentEngine.ArrivalCertificate.Verified),
+                TimeAlignmentBandMode.AutoBand,
+                crosstalkDetected: false));
     }
 
     [Fact]
@@ -176,19 +155,16 @@ public sealed class TimeAlignmentArrivalRecommendationTests
             Result(snrDb: 8),
             honestyProbe: null,
             TimeAlignmentBandMode.ManualBand,
-            crosstalkDetected: false,
-            bandCenterHz: 114));
+            crosstalkDetected: false));
         Assert.Null(TimeAlignmentPanelController.RecommendedRow(
             Result(snrDb: 60),
             Probe(AutoAlignmentEngine.ArrivalCertificate.Latched),
             TimeAlignmentBandMode.ManualBand,
-            crosstalkDetected: false,
-            bandCenterHz: 1000));
+            crosstalkDetected: false));
         Assert.Null(TimeAlignmentPanelController.RecommendedRow(
             Result(snrDb: 60),
             honestyProbe: null,
             TimeAlignmentBandMode.FullBand,
-            crosstalkDetected: true,
-            bandCenterHz: null));
+            crosstalkDetected: true));
     }
 }

--- a/tests/Resonalyze.App.Tests/TimeAlignmentArrivalRecommendationTests.cs
+++ b/tests/Resonalyze.App.Tests/TimeAlignmentArrivalRecommendationTests.cs
@@ -109,4 +109,86 @@ public sealed class TimeAlignmentArrivalRecommendationTests
             TimeAlignmentBandMode.AutoBand,
             crosstalkDetected: false));
     }
+
+    // Which ROW of the delay table is marked: the energy onset on a
+    // band-limited read centred below the engine edge with the SNR the onset
+    // needs, the first arrival otherwise, none where a verdict disqualified
+    // the read. The strongest peak is never the pick.
+    [Fact]
+    public void RecommendedRow_PrefersTheEnergyOnsetOnALowBandWithEnoughSnr()
+    {
+        Assert.Equal(
+            TimeAlignmentPanelController.DelayRow.EnergyOnset,
+            TimeAlignmentPanelController.RecommendedRow(
+                Result(snrDb: 60),
+                Probe(AutoAlignmentEngine.ArrivalCertificate.Verified),
+                TimeAlignmentBandMode.ManualBand,
+                crosstalkDetected: false,
+                bandCenterHz: 114));
+        // ... even where the first peak was convicted: the onset is what
+        // reads the front there.
+        Assert.Equal(
+            TimeAlignmentPanelController.DelayRow.EnergyOnset,
+            TimeAlignmentPanelController.RecommendedRow(
+                Result(snrDb: 60),
+                Probe(AutoAlignmentEngine.ArrivalCertificate.Latched),
+                TimeAlignmentBandMode.AutoBand,
+                crosstalkDetected: false,
+                bandCenterHz: 200));
+    }
+
+    [Fact]
+    public void RecommendedRow_FallsBackToTheFirstArrivalOutsideTheOnsetRule()
+    {
+        // A low band, but under the SNR the onset needs.
+        Assert.Equal(
+            TimeAlignmentPanelController.DelayRow.FirstArrival,
+            TimeAlignmentPanelController.RecommendedRow(
+                Result(snrDb: 30),
+                Probe(AutoAlignmentEngine.ArrivalCertificate.Verified),
+                TimeAlignmentBandMode.ManualBand,
+                crosstalkDetected: false,
+                bandCenterHz: 114));
+        // A wide band centred above the edge.
+        Assert.Equal(
+            TimeAlignmentPanelController.DelayRow.FirstArrival,
+            TimeAlignmentPanelController.RecommendedRow(
+                Result(snrDb: 60),
+                Probe(AutoAlignmentEngine.ArrivalCertificate.Verified),
+                TimeAlignmentBandMode.ManualBand,
+                crosstalkDetected: false,
+                bandCenterHz: 1000));
+        // A full-band read has no band centre to apply the rule to.
+        Assert.Equal(
+            TimeAlignmentPanelController.DelayRow.FirstArrival,
+            TimeAlignmentPanelController.RecommendedRow(
+                Result(snrDb: 60),
+                honestyProbe: null,
+                TimeAlignmentBandMode.FullBand,
+                crosstalkDetected: false,
+                bandCenterHz: null));
+    }
+
+    [Fact]
+    public void RecommendedRow_IsNoneWhereAVerdictDisqualifiedTheRead()
+    {
+        Assert.Null(TimeAlignmentPanelController.RecommendedRow(
+            Result(snrDb: 8),
+            honestyProbe: null,
+            TimeAlignmentBandMode.ManualBand,
+            crosstalkDetected: false,
+            bandCenterHz: 114));
+        Assert.Null(TimeAlignmentPanelController.RecommendedRow(
+            Result(snrDb: 60),
+            Probe(AutoAlignmentEngine.ArrivalCertificate.Latched),
+            TimeAlignmentBandMode.ManualBand,
+            crosstalkDetected: false,
+            bandCenterHz: 1000));
+        Assert.Null(TimeAlignmentPanelController.RecommendedRow(
+            Result(snrDb: 60),
+            honestyProbe: null,
+            TimeAlignmentBandMode.FullBand,
+            crosstalkDetected: true,
+            bandCenterHz: null));
+    }
 }

--- a/tests/Resonalyze.App.Tests/TimeAlignmentEnergyOnsetMarkerTests.cs
+++ b/tests/Resonalyze.App.Tests/TimeAlignmentEnergyOnsetMarkerTests.cs
@@ -1,0 +1,105 @@
+using OxyPlot;
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+// The energy onset on the Time Alignment envelope plot: a third callout
+// beside the two peaks, placed where the analysis put the onset — relative to
+// the Main first arrival like every other marker — and read off the envelope
+// through the same wrap a complete record's signed positions need.
+public sealed class TimeAlignmentEnergyOnsetMarkerTests
+{
+    private const int SampleRate = 96_000;
+
+    private static TimeAlignmentAnalysisResult MakeResult(
+        int arrivalIndex,
+        int strongestIndex,
+        double onsetSample)
+    {
+        var envelope = new double[2048];
+        for (int i = 0; i < envelope.Length; i++)
+        {
+            envelope[i] =
+                0.5 * Math.Exp(-((i - arrivalIndex) * (i - arrivalIndex)) / 200.0) +
+                Math.Exp(-((i - strongestIndex) * (i - strongestIndex)) / 200.0) +
+                1e-5;
+        }
+
+        return new TimeAlignmentAnalysisResult(
+            envelope,
+            arrivalIndex,
+            envelope[arrivalIndex],
+            strongestIndex,
+            envelope[strongestIndex],
+            SignalToNoiseDecibels: 60.0,
+            FirstArrivalProminenceDecibels: -6.0,
+            FirstArrivalPeakSample: arrivalIndex,
+            FirstArrivalDelayMilliseconds: arrivalIndex * 1000.0 / SampleRate,
+            StrongestPeakSample: strongestIndex,
+            StrongestDelayMilliseconds: strongestIndex * 1000.0 / SampleRate,
+            StrongestPeakSeparationMilliseconds:
+                (strongestIndex - arrivalIndex) * 1000.0 / SampleRate,
+            StrongestPeakIsSeparateArrival: true,
+            FirstArrivalConfidence: 0.5,
+            FirstArrivalRefinedByPhat: true,
+            StrongestConfidence: 0.5,
+            StrongestRefinedByPhat: true,
+            EnergyOnsetSample: onsetSample,
+            EnergyOnsetDelayMilliseconds: onsetSample * 1000.0 / SampleRate);
+    }
+
+    [Fact]
+    public void GetEnergyOnsetIndex_RoundsAndWrapsTheSignedSample()
+    {
+        Assert.Equal(370, TimeAlignmentPanelController.GetEnergyOnsetIndex(
+            MakeResult(400, 500, 370.4)));
+        // A complete record reports a position past its midpoint as a
+        // negative delay; the envelope index wraps back into the buffer.
+        Assert.Equal(2048 - 30, TimeAlignmentPanelController.GetEnergyOnsetIndex(
+            MakeResult(400, 500, -30.0)));
+    }
+
+    [Fact]
+    public void MainMarkers_PlaceTheOnsetRelativeToTheFirstArrival()
+    {
+        TimeAlignmentAnalysisResult result = MakeResult(400, 500, 370.0);
+        var model = new PlotModel();
+
+        TimeAlignmentPanelController.AddMainPeakMarkers(
+            model, result, result.StrongestEnvelopePeak);
+
+        PlotCalloutMarkerAnnotation onset = Assert.Single(
+            model.Annotations.OfType<PlotCalloutMarkerAnnotation>(),
+            annotation => annotation.Text == "M Onset");
+        Assert.Equal((370.0 - 400.0) * 1000.0 / SampleRate, onset.AnchorPoint.X, 9);
+        Assert.Equal(
+            TimeAlignmentPanelController.GetPeakMarkerDecibels(
+                result, result.StrongestEnvelopePeak, 370),
+            onset.AnchorPoint.Y,
+            9);
+        Assert.Contains(
+            model.Annotations.OfType<PlotCalloutMarkerAnnotation>(),
+            annotation => annotation.Text == "M First");
+    }
+
+    [Fact]
+    public void CompareMarkers_PlaceBothOnsetsAgainstTheMainFirstArrival()
+    {
+        TimeAlignmentAnalysisResult main = MakeResult(400, 500, 370.0);
+        TimeAlignmentAnalysisResult compare = MakeResult(450, 550, 425.0);
+        var model = new PlotModel();
+
+        TimeAlignmentPanelController.AddComparePeakMarkers(
+            model, main, compare, main.StrongestEnvelopePeak,
+            compare.FirstArrivalDelayMilliseconds - main.FirstArrivalDelayMilliseconds);
+
+        PlotCalloutMarkerAnnotation mainOnset = Assert.Single(
+            model.Annotations.OfType<PlotCalloutMarkerAnnotation>(),
+            annotation => annotation.Text == "M Onset");
+        PlotCalloutMarkerAnnotation compareOnset = Assert.Single(
+            model.Annotations.OfType<PlotCalloutMarkerAnnotation>(),
+            annotation => annotation.Text == "C Onset");
+        Assert.Equal((370.0 - 400.0) * 1000.0 / SampleRate, mainOnset.AnchorPoint.X, 9);
+        Assert.Equal((425.0 - 400.0) * 1000.0 / SampleRate, compareOnset.AnchorPoint.X, 9);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/EnergyOnsetTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EnergyOnsetTests.cs
@@ -1,0 +1,239 @@
+using System.Numerics;
+
+namespace Resonalyze.Dsp.Tests;
+
+public sealed class EnergyOnsetTests
+{
+    private const int SampleRate = 48_000;
+
+    // The field midbass pair's band, analyzed exactly as the engine analyzes a
+    // 65-200 Hz junction or link band.
+    private static TimeAlignmentAnalysisOptions MidbassBand => new()
+    {
+        UseBandpassWindow = true,
+        BandpassCenterHz = Math.Sqrt(65.0 * 200.0),
+        BandpassPassOctaves = Math.Log2(200.0 / 65.0),
+        BandpassFadeOctaves = 1.0
+    };
+
+    private static double[] Pulses(params (double Ms, double Amplitude)[] pulses)
+    {
+        var signal = new double[16_384];
+        foreach ((double ms, double amplitude) in pulses)
+        {
+            signal[(int)Math.Round(ms * SampleRate / 1000.0)] += amplitude;
+        }
+
+        return signal;
+    }
+
+    // Deterministic Gaussian noise added to a copy of the signal.
+    private static double[] WithNoise(double[] signal, double sigma, int seed)
+    {
+        var noisy = (double[])signal.Clone();
+        var random = new Random(seed);
+        for (int i = 0; i < noisy.Length; i++)
+        {
+            double u1 = 1.0 - random.NextDouble();
+            double u2 = random.NextDouble();
+            noisy[i] += sigma * Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+        }
+
+        return noisy;
+    }
+
+    // A midbass front as the field measures it: an impulse through the pair's
+    // own crossover (BW36 high-pass 65 Hz, BW48 low-pass 200 Hz), whose band
+    // envelope climbs for milliseconds rather than peaking at once.
+    private static Complex[] MidbassFront(double atMs)
+    {
+        var impulse = new Complex[16_384];
+        impulse[(int)Math.Round(atMs * SampleRate / 1000.0)] = Complex.One;
+        return VirtualCrossoverAnalysis.ApplyChain(
+            impulse,
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.BandPass,
+                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 200, 48),
+                new CrossoverEdge(CrossoverFilterFamily.Butterworth, 65, 36))),
+            SampleRate,
+            SampleRate);
+    }
+
+    // The front plus a stronger arrival behind it (a reflection, a mode).
+    private static double[] FrontWithLaterArrival(double gapMs, double laterAmplitude)
+    {
+        Complex[] front = MidbassFront(30.0);
+        int shift = (int)Math.Round(gapMs * SampleRate / 1000.0);
+        var signal = new double[front.Length];
+        for (int i = 0; i < signal.Length; i++)
+        {
+            signal[i] = front[i].Real +
+                (i >= shift ? laterAmplitude * front[i - shift].Real : 0.0);
+        }
+
+        return signal;
+    }
+
+    [Fact]
+    public void Analyze_EnergyOnsetSitsOnTheRisingFrontOfABandLimitedPulse()
+    {
+        TimeAlignmentAnalysisResult result = TimeAlignmentAnalysis.Analyze(
+            Pulses((30.0, 1.0)), SampleRate, MidbassBand);
+
+        // A zero-phase band-limited pulse is symmetric around its centre, so
+        // the first-arrival peak sits ON the pulse and a tenth of its energy
+        // has arrived before the centre — inside the kernel's own rise, which
+        // is ~1/bandwidth (7 ms for 65-200 Hz).
+        Assert.InRange(result.FirstArrivalDelayMilliseconds, 29.5, 30.5);
+        Assert.True(result.EnergyOnsetDelayMilliseconds < result.FirstArrivalDelayMilliseconds);
+        Assert.InRange(result.EnergyOnsetDelayMilliseconds, 22.0, 30.0);
+        Assert.Equal(
+            result.EnergyOnsetDelayMilliseconds,
+            result.EnergyOnsetSample * 1000.0 / SampleRate,
+            6);
+    }
+
+    [Fact]
+    public void Analyze_EnergyOnsetFollowsThePulseWhenItMoves()
+    {
+        TimeAlignmentAnalysisResult early = TimeAlignmentAnalysis.Analyze(
+            Pulses((30.0, 1.0)), SampleRate, MidbassBand);
+        TimeAlignmentAnalysisResult late = TimeAlignmentAnalysis.Analyze(
+            Pulses((33.0, 1.0)), SampleRate, MidbassBand);
+
+        Assert.InRange(
+            late.EnergyOnsetDelayMilliseconds - early.EnergyOnsetDelayMilliseconds,
+            2.9, 3.1);
+    }
+
+    // The field coin, in the small: the same midbass front in both channels,
+    // each followed by the same stronger arrival — one 8 ms behind the front,
+    // the other 7 ms. At 8 ms the front's hump stays a local maximum of the
+    // band envelope and the first-peak read sits on the front; at 7 ms the
+    // hump melts into the climb toward the later arrival, and the first peak
+    // jumps 5 ms to that arrival. The fronts are identical, so the true split
+    // is zero: the running energy reads it within a fraction of the band's
+    // rise time, the first peak reads a split that no geometry produced.
+    [Fact]
+    public void Analyze_EnergyOnsetReadsTheFrontWhereTheFirstPeakMeltsIntoTheLaterArrival()
+    {
+        TimeAlignmentAnalysisResult humped = TimeAlignmentAnalysis.Analyze(
+            FrontWithLaterArrival(8.0, 1.4), SampleRate, MidbassBand);
+        TimeAlignmentAnalysisResult melted = TimeAlignmentAnalysis.Analyze(
+            FrontWithLaterArrival(7.0, 1.4), SampleRate, MidbassBand);
+
+        Assert.True(
+            melted.FirstArrivalDelayMilliseconds - humped.FirstArrivalDelayMilliseconds > 3.0,
+            $"the synthetic no longer reproduces the coin: first peaks {humped.FirstArrivalDelayMilliseconds:0.00} / {melted.FirstArrivalDelayMilliseconds:0.00} ms");
+        Assert.InRange(
+            Math.Abs(melted.EnergyOnsetDelayMilliseconds - humped.EnergyOnsetDelayMilliseconds),
+            0.0, 0.5);
+        // ... and the onset is a front, not the later arrival: before the
+        // front's own peak.
+        Assert.True(humped.EnergyOnsetDelayMilliseconds < humped.FirstArrivalDelayMilliseconds);
+    }
+
+    // The onset is a property of the signal, not of the record's noise: two
+    // identical drivers measured with different noise floors must read the
+    // same front. One channel is clean, the other carries a floor ~45 dB
+    // down — above the engine's admission for the onset — and 60 ms of noisy
+    // pre-roll ahead of the front, where an ungated integral would already
+    // have collected a share of the total.
+    [Fact]
+    public void Analyze_EnergyOnsetDoesNotMoveWithTheRecordsNoiseFloor()
+    {
+        double[] clean = Pulses((60.0, 1.0));
+        double[] noisy = WithNoise(clean, 0.0002, seed: 42);
+
+        TimeAlignmentAnalysisResult cleanRead = TimeAlignmentAnalysis.Analyze(
+            clean, SampleRate, MidbassBand);
+        TimeAlignmentAnalysisResult noisyRead = TimeAlignmentAnalysis.Analyze(
+            noisy, SampleRate, MidbassBand);
+
+        Assert.InRange(noisyRead.SignalToNoiseDecibels, 40.0, 60.0);
+        Assert.InRange(cleanRead.EnergyOnsetDelayMilliseconds, 52.0, 60.0);
+        Assert.InRange(
+            noisyRead.EnergyOnsetDelayMilliseconds - cleanRead.EnergyOnsetDelayMilliseconds,
+            -0.1, 0.1);
+    }
+
+    // ... and below the admission the onset is NOT trusted, because at that
+    // SNR the noise ahead of the front does reach the gate and the read drifts
+    // — this is what EnergyOnsetMinimumSnrDb exists for.
+    [Fact]
+    public void Analyze_EnergyOnsetDriftsUnderTheAdmissionSnr_WhichTheLinkGuards()
+    {
+        double[] clean = Pulses((60.0, 1.0));
+        double[] noisy = WithNoise(clean, 0.006, seed: 42);
+
+        TimeAlignmentAnalysisResult cleanRead = TimeAlignmentAnalysis.Analyze(
+            clean, SampleRate, MidbassBand);
+        TimeAlignmentAnalysisResult noisyRead = TimeAlignmentAnalysis.Analyze(
+            noisy, SampleRate, MidbassBand);
+
+        Assert.InRange(noisyRead.SignalToNoiseDecibels, 14.0, 30.0);
+        Assert.True(
+            Math.Abs(noisyRead.EnergyOnsetDelayMilliseconds - cleanRead.EnergyOnsetDelayMilliseconds) > 0.5,
+            "the low-SNR read no longer drifts; the admission floor may be revisited");
+        Assert.False(AutoAlignmentEngine.LinkReadsEnergyOnset(
+            65, 200, cleanRead.SignalToNoiseDecibels, noisyRead.SignalToNoiseDecibels));
+    }
+
+    [Fact]
+    public void LinkReadsEnergyOnset_IsDecidedByTheBandCentreAndBothSidesSnr()
+    {
+        // The field link and junction bands of the low end...
+        Assert.True(AutoAlignmentEngine.LinkBandReadsEnergyOnset(65, 200));
+        Assert.True(AutoAlignmentEngine.LinkBandReadsEnergyOnset(33, 130));
+        Assert.True(AutoAlignmentEngine.LinkBandReadsEnergyOnset(100, 400));
+        Assert.True(AutoAlignmentEngine.LinkBandReadsEnergyOnset(70, 180));
+        // ... against a mid pair's link band, whose low edge sits under the
+        // centre rule's figure but whose 0.7 ms rise makes the peak the better
+        // instrument, and the bands above the localization edge.
+        Assert.False(AutoAlignmentEngine.LinkBandReadsEnergyOnset(200, 1610));
+        Assert.False(AutoAlignmentEngine.LinkBandReadsEnergyOnset(300, 1610));
+        Assert.False(AutoAlignmentEngine.LinkBandReadsEnergyOnset(1800, 20_000));
+
+        // The SNR guard is for BOTH sides: one noisy side sends the whole link
+        // back to first peaks, never one side each.
+        Assert.True(AutoAlignmentEngine.LinkReadsEnergyOnset(65, 200, 60, 45));
+        Assert.False(AutoAlignmentEngine.LinkReadsEnergyOnset(65, 200, 60, 30));
+        Assert.False(AutoAlignmentEngine.LinkReadsEnergyOnset(65, 200, 30, 60));
+        Assert.False(AutoAlignmentEngine.LinkReadsEnergyOnset(200, 1610, 60, 60));
+    }
+
+    [Fact]
+    public void AsEnergyOnset_SwapsTheArrivalFieldsAndKeepsThePeakFigures()
+    {
+        var response = new Complex[16_384];
+        response[(int)Math.Round(30.0 * SampleRate / 1000.0)] = Complex.One;
+        response[(int)Math.Round(37.0 * SampleRate / 1000.0)] = new Complex(1.4, 0.0);
+
+        TimeAlignmentAnalysisResult plain = VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+            response, SampleRate, 65, 200);
+        TimeAlignmentAnalysisResult onset = AutoAlignmentEngine.AsEnergyOnset(plain);
+        Assert.Equal(plain.EnergyOnsetDelayMilliseconds, onset.FirstArrivalDelayMilliseconds, 9);
+        Assert.Equal(plain.EnergyOnsetSample, onset.FirstArrivalPeakSample, 9);
+        Assert.Equal(plain.StrongestDelayMilliseconds, onset.StrongestDelayMilliseconds, 9);
+        Assert.Equal(plain.SignalToNoiseDecibels, onset.SignalToNoiseDecibels, 9);
+        Assert.Equal(plain.FirstArrivalProminenceDecibels, onset.FirstArrivalProminenceDecibels, 9);
+    }
+
+    [Fact]
+    public void AnalyzeBandLimitedArrival_ReportsTheEnergyOnsetInFullRecordCoordinates()
+    {
+        var response = new Complex[16_384];
+        response[(int)Math.Round(30.0 * SampleRate / 1000.0)] = Complex.One;
+        var validRange = new ValidSampleRange(
+            (int)Math.Round(10.0 * SampleRate / 1000.0), response.Length);
+
+        TimeAlignmentAnalysisResult cropped = VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+            response, SampleRate, 65, 200, validRange);
+        TimeAlignmentAnalysisResult whole = VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+            response, SampleRate, 65, 200);
+
+        Assert.InRange(
+            cropped.EnergyOnsetDelayMilliseconds - whole.EnergyOnsetDelayMilliseconds,
+            -0.2, 0.2);
+    }
+}

--- a/tests/Resonalyze.Dsp.Tests/EnergyOnsetTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EnergyOnsetTests.cs
@@ -236,4 +236,35 @@ public sealed class EnergyOnsetTests
             cropped.EnergyOnsetDelayMilliseconds - whole.EnergyOnsetDelayMilliseconds,
             -0.2, 0.2);
     }
+
+    // The onset decision is taken from the full-band reads; the upper-half
+    // probe that certifies them can be far noisier (a steep low-pass leaves
+    // little above the corner). Under the onset admission such a probe is no
+    // witness either way: it must not convict a clean onset as a latch, nor
+    // certify it — the read stays uncertified, as with an unmeasurable half.
+    [Fact]
+    public void ClassifyLinkArrival_LeavesAnOnsetReadUncertifiedWhenItsProbeIsTooNoisy()
+    {
+        TimeAlignmentAnalysisResult full = TimeAlignmentAnalysis.Analyze(
+            Pulses((60.0, 1.0)), SampleRate, MidbassBand);
+        // A probe read that would CONVICT (it sits 10 ms ahead of the full
+        // read) but carries only 25 dB of SNR.
+        TimeAlignmentAnalysisResult noisyProbe = full with
+        {
+            FirstArrivalDelayMilliseconds = full.FirstArrivalDelayMilliseconds - 10.0,
+            SignalToNoiseDecibels = 25.0
+        };
+        TimeAlignmentAnalysisResult cleanProbe = noisyProbe with { SignalToNoiseDecibels = 60.0 };
+
+        Assert.Equal(
+            AutoAlignmentEngine.ArrivalCertificate.Latched,
+            AutoAlignmentEngine.ClassifyLinkArrival(full, cleanProbe, 1.0, energyOnset: true));
+        Assert.Equal(
+            AutoAlignmentEngine.ArrivalCertificate.Unverified,
+            AutoAlignmentEngine.ClassifyLinkArrival(full, noisyProbe, 1.0, energyOnset: true));
+        // A peak read keeps the ordinary rule: 25 dB is a measurable half.
+        Assert.Equal(
+            AutoAlignmentEngine.ArrivalCertificate.Latched,
+            AutoAlignmentEngine.ClassifyLinkArrival(full, noisyProbe, 1.0, energyOnset: false));
+    }
 }


### PR DESCRIPTION
The stereo cross-side link of a low pair reads the band's energy onset instead of its first envelope peak.

**The defect.** On the v6 cabin (session-4) Auto delay put the right midbass 4.5 ms early: its cross-side prior was locked (±2.5 ms, the lobe pin of a pair below 300 Hz) around a target built from a 6.97 ms L/R arrival split in 65-200 Hz — a split no cabin geometry produces. Both reads passed the upper-half certificate because the half sat on the same room mode. The read itself was a coin: in a 65-200 Hz band the direct front (rise time ~1/bandwidth, 7 ms) and an arrival 7 ms behind it merge into one climb with a shoulder, and whether that shoulder becomes a local maximum is decided by a fraction of a dB. The left envelope dipped 0.5 dB after its first hump and read 14.4 ms; the right never dipped and read 21.3 ms. The engine's own wide diagnostic had the right lobe (+1.93 ms, 2.3 dB better) but the lock excluded it.

**The instrument.** `TimeAlignmentAnalysisResult` gains `EnergyOnsetSample` / `EnergyOnsetDelayMilliseconds`: the point where the running energy of the band envelope (its square, from the search window's start) reaches 10 % of the energy counted up to 60 ms past the strongest peak, samples 30 dB under that peak ignored, sub-sample, in the window's rotated frame. The running energy is monotone, so the shoulder counts whether or not it peaks: the same pair reads 2.2 ms apart (1.1 ms on the raw responses — the owner's hand-tuned split). The fraction is the middle of a plateau measured on the field pair (2-15 % flat, 20 % slides into the second hump), the tail bound makes the total independent of the record's reverberant length (≤0.15 ms between a whole-record total and a 50 ms one), and the gate is fixed against the PEAK, never against the record's noise: a gate at the noise floor made the read a function of each channel's SNR (at the 12 dB admission it sat on the peak itself), so two identical drivers measured with different noise read different fronts. The same idea is the Hinkley criterion of acoustic-emission onset picking and the energy-ratio detectors that won the room-impulse-response onset comparison of Defrance, Daudet and Polack (JASA 2008) over every maximum-based method.

**Where it is read.** Only in `CrossSideTargetMs`: a link band whose centre lies below 300 Hz (`LinkBandReadsEnergyOnset`), when BOTH sides show 40 dB of SNR (`EnergyOnsetMinimumSnrDb`), is read by its energy onset on both sides, full band and upper-half probe alike (`LinkReadsEnergyOnset`, `AsEnergyOnset`), so the certificate never compares an onset against a peak and a split never subtracts one from the other; below the SNR both sides fall back to first peaks, and the log says so. Donor pairs follow the same rule per pair. The link's full-vs-half tolerance stays the generic half period for an onset band, because the predictor's smear credit speaks in peaks. The band CENTRE, not the low edge, decides: a mid pair's 200-1610 Hz link band has a 0.7 ms rise and a sharp front, and on the mid and tweeter pairs the peak L/R split holds to ±0.06 ms across their bands where the onset wanders ±0.3 ms with the early reflections. At 40 dB a Rayleigh floor clears the −30 dB gate in a fraction of a percent of its samples; at 20 dB the tenth is reached in the noise ahead of the front.

An energy-onset read whose upper-half probe sits under the 40 dB (a steep low-pass leaves little above the corner) stays UNVERIFIED rather than judged: such a probe can neither convict the clean full-band onset as a latch nor certify it, so the read keeps its lobe pin without the certificate (`ClassifyLinkArrival`; donors follow the same rule).

**Not the junction timelines.** A first version read the onset at every engine call site and failed 27 tests, three of them with a known synthetic truth: the front predictor (bypassed front plus a chain shift measured on a reference impulse) missed a plain BW36 70-200 Hz band-pass by 2.4 ms and convicted a plain BW48 80 Hz low-pass as an 18 ms modal latch — an energy onset is a distribution statistic that no impulse-measured shift transfers. A link compares one driver pair through near-identical chains, where that bias cancels; the peaks stay the timeline's instrument.

**Verification.**
- Single-side session battery (`RESONALYZE_SESSION_BATTERY=D:\hobby\AMP`, 27 rows): byte-for-byte unchanged.
- Stereo battery (a scratch harness running the panel's stereo Auto delay on all 24 archived sessions with both sides, both sides judged by the panel metric): 88 of 186 junction rows change, 46 better / 26 worse, mean +0.06 dB average and +0.07 dB dip. v6 (all four sessions): the right midbass lands in the owner's lobe (session-4: B L−B R 5.78 → 1.87 ms against the hand-tuned 1.35; right A/B −0.49/−0.95 → −0.20/−0.62 dB). Passat right B/C +1.17/+4.79 dB. Costs: v6-2 right B/C −0.50/−2.48 (its A/B +0.53/+0.98, total even), v3 and v4 right A/B 0.1-0.3 dB. No session in the archive falls under the 40 dB admission.
- 1516 DSP + 2406 App tests, 0 warnings. New `EnergyOnsetTests` (8): the coin reproduced with a chain-shaped front plus a ×1.4 arrival 8 vs 7 ms behind it (first peaks 5 ms apart, onsets 0.14 ms); identical pulses with asymmetric noise at 45 dB read the same onset within 0.1 ms; at 20 dB the read drifts and the link refuses; the band-centre and both-sides SNR rules; the swap keeps every peak figure.
- `REFERENCE.md`, stereo Auto delay: the cross-side target, the energy onset rule and its `energy onsets` log mark.

**Time Alignment.** The delay table is turned round: a row per instant — `First Arrival`, `Strongest Peak`, `Energy onset` — and a column per unit (ms, samples, meters at 20 °C), Compare deltas in every cell as before, click-to-copy following the new layout (`DelayTableText`). The row the analysis trusts most is printed bright, marked `◀` and named under the table, the others dimmed (`RecommendedRow`): the first arrival where nothing has disqualified it (near-noise, modal latch, a full-band read over detected crosstalk), none otherwise. Neither the strongest peak nor the energy onset is ever the pick: the onset is a statistic of how the band's energy is distributed, its distance from the front depends on the response's tail and chain (the same two midbass fronts read 2.2 ms apart through their chains, 1.1 ms raw), and that bias cancels only between the two sides of one driver pair — the engine's link — while this panel cannot know what two records are (a subwoofer against a midbass is its ordinary use). The onset row is shown to be read against the peaks, not recommended; the strongest-peak hint keeps its warning only. The table font drops from +4 to +1 pt over the panel font and the columns are sized to their widest realistic cells (66 characters with every Compare delta), so the three rows fit the status box without wrapping. Each record also gets an `Onset` callout on the envelope plot, placed relative to the Main first arrival like the two peak markers and read off the envelope through the complete record's signed-position wrap. Documented in the Time Alignment section of `REFERENCE.md` (the table, the recommendation, when to take the onset and when not). Tests pin the column layout and cell extraction, the recommendation rules, the index wrap and both markers' positions.

Follow-up worth its own look: on v3/v4 the witness used to convict the link and the two-pair corroborated donors decided (tight lock); now the onset read passes the certificate and disagrees with the donors by ~2.4 ms at a 0.1-0.3 dB cost — corroborated geometry may deserve the last word when it disagrees with a single link read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
