### PR TITLE
The energy onset is admitted from 30 dB of SNR

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2931,7 +2931,7 @@ midbass pair the left dipped 0.5 dB after its hump and read 14 ms, the right
 never dipped and read 21 ms, a 7 ms split no cabin produces, which the scene
 pin then enforced. The running energy is monotone, so it reads the front
 whether or not it peaks (the same pair read 2 ms apart). The run's log names
-such a read `energy onsets`; it needs 40 dB of SNR on both sides, below which
+such a read `energy onsets`; it needs 30 dB of SNR on both sides, below which
 the pair is read by first peaks on both. The junction searches and their
 seeds keep the first arrivals: a link compares one driver pair through
 near-identical chains, where the onset's own bias cancels, which the

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -4739,15 +4739,26 @@ public static class AutoAlignmentEngine
     /// (<see cref="TimeAlignmentAnalysis.EnergyOnsetGateDb"/>) so that the
     /// read is a property of the signal alone; the price is that noise above
     /// the gate integrates into the total, and the window ahead of the front
-    /// is ~80 ms long. A Rayleigh floor 40 dB down clears the gate in a
-    /// fraction of a percent of its samples and moves the onset by nothing
-    /// measurable; at 35 dB a fifth of them clear it and the onset drifts
-    /// tenths of a millisecond; at 20 dB the tenth is reached in the noise.
-    /// Below this the link falls back to first peaks — on BOTH sides, so the
-    /// split is still one instrument against itself. Field records read
-    /// 45-88 dB.
+    /// is ~80 ms long. Below this the link falls back to first peaks — on
+    /// BOTH sides, so the split is still one instrument against itself.
+    ///
+    /// Thirty, measured, not the forty a Rayleigh-tail estimate first put
+    /// here. The fallback is not free: on the field midbass pair the first
+    /// peaks ARE the coin, so every decibel of admission the onset does not
+    /// need hands the pair back to it. With white noise added to the right
+    /// record, its 65-200 Hz onset read 16.602 ms at 63 dB, 16.600 at 38,
+    /// 16.494 at 32.6 and 16.581 at 27.8 — never 0.11 ms off — while the
+    /// forty-dB rule sent the link to first peaks from 38 dB down and the
+    /// 4.5 ms lobe error returned (5.78 ms of L/R split against the tuned
+    /// 1.35); only under 28 dB did the witness convict the peak and the donors
+    /// take over. A chain-shaped front with a 1.4× arrival 7 ms behind it
+    /// drifts 0.05 ms at 36.6 dB and 0.03 at 30.4, where its first PEAK has
+    /// already broken to the noise; a bare band-limited delta — the thinnest
+    /// packet the band can carry — reaches the tenth in the noise at 20 dB.
+    /// Thirty sits above every measured break with the delta's margin left.
+    /// Field records read 45-88 dB.
     /// </summary>
-    internal const double EnergyOnsetMinimumSnrDb = 40;
+    internal const double EnergyOnsetMinimumSnrDb = 30;
 
     /// <summary>
     /// Whether a link band belongs to the energy onset by its centre alone
@@ -4778,7 +4789,7 @@ public static class AutoAlignmentEngine
     /// <see cref="EnergyOnsetMinimumSnrDb"/> is UNVERIFIED rather than judged.
     /// The onset decision is taken from the two FULL-band reads, and a steep
     /// low-pass or a weak upper half can leave the probe half far noisier than
-    /// the band it is cut from — between the 12 dB admission and the 40 dB an
+    /// the band it is cut from — between the 12 dB admission and the 30 dB an
     /// onset needs, exactly where the onset drifts into the noise ahead of the
     /// front. Such a probe can neither convict the clean full-band onset as a
     /// latch nor certify it; the read stays usable as a lobe pin, without the

--- a/tests/Resonalyze.Dsp.Tests/EnergyOnsetTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/EnergyOnsetTests.cs
@@ -157,9 +157,36 @@ public sealed class EnergyOnsetTests
             -0.1, 0.1);
     }
 
-    // ... and below the admission the onset is NOT trusted, because at that
-    // SNR the noise ahead of the front does reach the gate and the read drifts
-    // — this is what EnergyOnsetMinimumSnrDb exists for.
+    // The admission itself, on a front shaped like the field's: a midbass
+    // front through its crossover with a 1.4× arrival 7 ms behind it, under
+    // white noise that leaves the record at ~30 dB. The onset holds within a
+    // fraction of the band's rise while the first PEAK has already broken to
+    // the noise — which is why the admission sits at 30 and not higher: every
+    // decibel above what the onset needs hands the pair back to the peaks,
+    // and on the field pair the peaks are the coin.
+    [Fact]
+    public void Analyze_EnergyOnsetHoldsAtTheAdmissionSnrOnAShapedFront()
+    {
+        double[] clean = FrontWithLaterArrival(7.0, 1.4);
+        double peak = clean.Max(Math.Abs);
+        double[] noisy = WithNoise(clean, 0.2 * peak, seed: 42);
+
+        TimeAlignmentAnalysisResult cleanRead = TimeAlignmentAnalysis.Analyze(
+            clean, SampleRate, MidbassBand);
+        TimeAlignmentAnalysisResult noisyRead = TimeAlignmentAnalysis.Analyze(
+            noisy, SampleRate, MidbassBand);
+
+        Assert.InRange(noisyRead.SignalToNoiseDecibels, 28.0, 34.0);
+        Assert.InRange(
+            noisyRead.EnergyOnsetDelayMilliseconds - cleanRead.EnergyOnsetDelayMilliseconds,
+            -0.2, 0.2);
+        Assert.True(AutoAlignmentEngine.LinkReadsEnergyOnset(
+            65, 200, cleanRead.SignalToNoiseDecibels, noisyRead.SignalToNoiseDecibels));
+    }
+
+    // ... and well below the admission the onset is NOT trusted, because at
+    // that SNR the noise ahead of the front does reach the gate and the read
+    // drifts — this is what EnergyOnsetMinimumSnrDb exists for.
     [Fact]
     public void Analyze_EnergyOnsetDriftsUnderTheAdmissionSnr_WhichTheLinkGuards()
     {
@@ -197,8 +224,9 @@ public sealed class EnergyOnsetTests
         // The SNR guard is for BOTH sides: one noisy side sends the whole link
         // back to first peaks, never one side each.
         Assert.True(AutoAlignmentEngine.LinkReadsEnergyOnset(65, 200, 60, 45));
-        Assert.False(AutoAlignmentEngine.LinkReadsEnergyOnset(65, 200, 60, 30));
-        Assert.False(AutoAlignmentEngine.LinkReadsEnergyOnset(65, 200, 30, 60));
+        Assert.True(AutoAlignmentEngine.LinkReadsEnergyOnset(65, 200, 60, 32));
+        Assert.False(AutoAlignmentEngine.LinkReadsEnergyOnset(65, 200, 60, 25));
+        Assert.False(AutoAlignmentEngine.LinkReadsEnergyOnset(65, 200, 25, 60));
         Assert.False(AutoAlignmentEngine.LinkReadsEnergyOnset(200, 1610, 60, 60));
     }
 


### PR DESCRIPTION
The energy onset's SNR admission drops from 40 to 30 dB, measured rather than estimated.

**Why.** The fallback below the admission is not free: on the field midbass pair (v6) the first peaks ARE the coin the onset was introduced against, so every decibel of admission the onset does not need hands the pair back to the wrong lobe. Probed with white noise added to the right midbass record of session-4 (the scratch harness that runs the panel's stereo Auto delay):

| noise, re peak | SNR of B R in 65-200 Hz | onset read, ms | B L − B R at 40 dB | at 30 dB |
|---|---|---|---|---|
| none | 63.5 | 16.602 | 1.87 | 1.87 |
| 3e-2 | 42.4 | 16.599 | 1.87 | 1.87 |
| 5e-2 | 38.4 | 16.600 | **5.78** (first peaks, the old defect) | 1.87 |
| 1e-1 | 32.6 | 16.494 | **5.78** | 1.85 |
| 1.5e-1 | 29.8 | — | 5.81 | 5.81 (first peaks) |
| 2e-1 | 27.8 | 16.581 | 1.67 (witness convicts the peak, donors decide) | 1.67 |

The hand-tuned split is 1.35 ms. The onset itself never moved more than 0.11 ms over the whole range; the 40 dB rule was a Rayleigh-tail estimate from the −30 dB gate and turned out 10 dB too cautious for a real packet, which carries far more energy than the bare band-limited delta the estimate was sized for. A chain-shaped synthetic front (BW36 HP 65 / BW48 LP 200 with a 1.4× arrival 7 ms behind it) drifts 0.05 ms at 36.6 dB and 0.03 at 30.4 — where its first PEAK has already broken to the noise — and the bare delta reaches the tenth in the noise at 20 dB, so 30 sits above every measured break with the delta's margin left.

**What remains.** A narrow zone, 28-30 dB on this cabin, where the link still falls back to first peaks and neither the witness nor the donors rescue it; below 28 the witness convicts the peak read and the corroborated donors decide. Preferring corroborated donors over a lone first-peak link read in the fallback zone is the follow-up already noted on #180.

**Verification.** Single-side battery byte-for-byte; stereo battery (24 archived sessions, both sides) byte-for-byte with the merged build — every archived record sits at 45 dB and above, so the archive cannot see the admission. 1518 DSP + 2415 App tests. New test: the shaped front with the later arrival under noise at ~30 dB reads its onset within 0.2 ms of the clean read and is admitted; the both-sides guard tests move to 32/25 dB. `REFERENCE.md` (stereo Auto delay) says 30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
