### PR TITLE
An impulse response dropped on the Compare button becomes the reference

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1139,7 +1139,8 @@ measurement — the button's own **Choose file…** without the dialog. The butt
 takes only what that dialog offers, a `.json`: a sweep recording or a REW export
 is refused while it hovers there, and any other Resonalyze document (a capture, a
 session, an overlay slot) is named for what it is rather than loaded as a
-reference. Drop those elsewhere on the window to open them as the measurement.
+reference. A capture or a session dropped elsewhere on the window still opens
+where it belongs.
 
 ### Sending a measurement to REW
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -813,8 +813,11 @@ was capped, is cut when it loads.
 
 The **Compare** button overlays a second measurement on top of the current one,
 so two responses can be read side by side with the *same* analysis settings.
-Choose the reference from a file (**Choose file…**) or from a **History** entry;
-the button then shows its name, and **Clear** removes it. Compare is applied
+Choose the reference from a file (**Choose file…**) or from a **History** entry,
+or drag an impulse-response `.json` from Explorer straight onto the **Compare**
+button — the one place on the window where a dropped file becomes the reference
+rather than [the measurement](#dropping-a-file-on-the-window). The button then
+shows the reference's name, and **Clear** removes it. Compare is applied
 everywhere it is meaningful, always recomputed with the current mode's settings:
 
 - **Time Alignment** — the reference envelope is overlaid on the peak preview
@@ -1129,6 +1132,15 @@ time — the shell holds one measurement, so a drag carrying several is refused
 while it hovers, the cursor showing that no drop will happen. The same refusal
 covers a drag arriving while a sweep is running, or while a dialog is up: a file
 opened underneath one would replace the very measurement it is asking about.
+
+The one exception is the [**Compare**](#compare) button. An impulse response
+dropped on it becomes the Compare reference instead of replacing the
+measurement — the button's own **Choose file…** without the dialog. The button
+takes only what that dialog offers, a `.json`: a sweep recording or a REW export
+is refused while it hovers there, and any other Resonalyze document (a capture, a
+session, an overlay slot) is named for what it is rather than loaded as a
+reference. Drop those elsewhere on the window to open them as the measurement.
+
 ### Sending a measurement to REW
 
 **Export** imports the current measurement's loopback transfer function into a

--- a/source/Shell/DroppedFile.cs
+++ b/source/Shell/DroppedFile.cs
@@ -53,10 +53,18 @@ internal static class DroppedFile
     internal static bool HasOpenableExtension(string path)
     {
         string extension = Path.GetExtension(path);
-        return string.Equals(extension, ".json", StringComparison.OrdinalIgnoreCase) ||
+        return HasJsonExtension(path) ||
             string.Equals(extension, ".wav", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(extension, ".txt", StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// Whether the file is a <c>.json</c> — the one extension the Compare button
+    /// takes, as its own file dialog does. Answered while a drag hovers, on the same
+    /// terms as <see cref="HasOpenableExtension"/>: by the name alone.
+    /// </summary>
+    internal static bool HasJsonExtension(string path) =>
+        string.Equals(Path.GetExtension(path), ".json", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// What <paramref name="path"/> holds, or <see cref="DroppedFileKind.Unknown"/>

--- a/source/Shell/Form1.Compare.cs
+++ b/source/Shell/Form1.Compare.cs
@@ -71,16 +71,55 @@ public partial class Form1
             return;
         }
 
+        await LoadCompareFileAsync(dialog.FileName);
+    }
+
+    /// <summary>
+    /// An impulse response dropped on the Compare button from Explorer: the
+    /// button's Choose file... without the dialog, so it lands as the reference
+    /// rather than replacing the measurement the way a drop anywhere else on the
+    /// window does. The window has already checked the extension; what the file
+    /// holds is read here, once, and only an impulse response is taken — the other
+    /// documents the shell opens have no meaning as a Compare partner, and are
+    /// named for what they are rather than reported as a failed load.
+    /// </summary>
+    private async Task OpenDroppedCompareFileAsync(string path)
+    {
+        DroppedFileKind kind = DroppedFile.Classify(path);
+        if (kind == DroppedFileKind.ImpulseResponse)
+        {
+            await LoadCompareFileAsync(path);
+            return;
+        }
+
+        string what = kind switch
+        {
+            DroppedFileKind.SpatialAverageCapture => "a moving-mic capture",
+            DroppedFileKind.VirtualDspSession => "a Virtual DSP session",
+            DroppedFileKind.OverlaySlot => "an overlay slot file",
+            _ => "not a Resonalyze impulse response"
+        };
+        MessageBox.Show(
+            this,
+            $"Compare takes a Resonalyze impulse response (.json), and " +
+            $"'{Path.GetFileName(path)}' is {what}.\r\n\r\nDrop it elsewhere on " +
+            "the window to open it as the measurement instead.",
+            "Compare",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Warning);
+    }
+
+    // Shared by Choose file... and by a file dropped on the Compare button, so both
+    // install the same reference in the same way and report a bad file alike.
+    private async Task LoadCompareFileAsync(string path)
+    {
         try
         {
-            ImpulseResponseFile file = await ImpulseResponseFile.LoadAsync(dialog.FileName);
+            ImpulseResponseFile file = await ImpulseResponseFile.LoadAsync(path);
             MeasurementHistorySnapshot snapshot =
                 MeasurementHistoryService.CreateSnapshot(file);
-            compareSelection.Set(
-                Path.GetFileName(dialog.FileName),
-                dialog.FileName,
-                snapshot);
-            UpdateLastImpulseResponseDirectory(dialog.FileName);
+            compareSelection.Set(Path.GetFileName(path), path, snapshot);
+            UpdateLastImpulseResponseDirectory(path);
         }
         catch (Exception exception)
         {

--- a/source/Shell/Form1.Compare.cs
+++ b/source/Shell/Form1.Compare.cs
@@ -92,18 +92,26 @@ public partial class Form1
             return;
         }
 
+        // Where to take it instead is said only for the documents the window opens
+        // somewhere: an overlay slot is refused everywhere (the overlay panel owns
+        // those, by slot), and a file nobody recognizes has nowhere to go.
         string what = kind switch
         {
-            DroppedFileKind.SpatialAverageCapture => "a moving-mic capture",
-            DroppedFileKind.VirtualDspSession => "a Virtual DSP session",
-            DroppedFileKind.OverlaySlot => "an overlay slot file",
-            _ => "not a Resonalyze impulse response"
+            DroppedFileKind.SpatialAverageCapture =>
+                "a moving-mic capture. Drop it elsewhere on the window to open it in " +
+                "Live Spectrum",
+            DroppedFileKind.VirtualDspSession =>
+                "a Virtual DSP session. Drop it elsewhere on the window to open it in " +
+                "Virtual DSP",
+            DroppedFileKind.OverlaySlot =>
+                "an overlay slot file — this application's own storage for one slot " +
+                "of one mode, which comes back with its mode on its own",
+            _ => "not one"
         };
         MessageBox.Show(
             this,
             $"Compare takes a Resonalyze impulse response (.json), and " +
-            $"'{Path.GetFileName(path)}' is {what}.\r\n\r\nDrop it elsewhere on " +
-            "the window to open it as the measurement instead.",
+            $"'{Path.GetFileName(path)}' is {what}.",
             "Compare",
             MessageBoxButtons.OK,
             MessageBoxIcon.Warning);

--- a/source/Shell/Form1.FileDrop.cs
+++ b/source/Shell/Form1.FileDrop.cs
@@ -6,6 +6,10 @@ namespace Resonalyze;
 // the analyzers, a spatial average to the live analyzer, a session to Virtual DSP.
 // It is the Load button's own routing (see Form1.FileOperations), reached without
 // the dialog.
+//
+// The one place where WHERE the file lands does matter is the Compare button: an
+// impulse response dropped on it is the reference, not the measurement — the
+// button's own Choose file... reached without the dialog (see Form1.Compare).
 public partial class Form1
 {
     // One at a time. Two files opening at once would each install a measurement,
@@ -17,16 +21,20 @@ public partial class Form1
         FileDropTarget.Attach(this, CanOpenDroppedFiles, OpenDroppedFiles);
 
     // Answered on every drag move, so it stops at the extension: what the file
-    // holds is read once, on the drop.
-    private bool CanOpenDroppedFiles(IReadOnlyList<string> files) =>
+    // holds is read once, on the drop. The Compare button takes only what its
+    // dialog offers — a .json — so a sweep recording or a REW export hovering over
+    // it is refused there, while the rest of the window still takes it.
+    private bool CanOpenDroppedFiles(Control over, IReadOnlyList<string> files) =>
         files.Count == 1 &&
         !openingDroppedFile &&
         !expSweepMeasurement.InProgress &&
-        DroppedFile.HasOpenableExtension(files[0]);
+        (over == buttonCompare
+            ? DroppedFile.HasJsonExtension(files[0])
+            : DroppedFile.HasOpenableExtension(files[0]));
 
-    private async void OpenDroppedFiles(IReadOnlyList<string> files)
+    private async void OpenDroppedFiles(Control over, IReadOnlyList<string> files)
     {
-        if (!CanOpenDroppedFiles(files))
+        if (!CanOpenDroppedFiles(over, files))
         {
             return;
         }
@@ -34,7 +42,14 @@ public partial class Form1
         openingDroppedFile = true;
         try
         {
-            await OpenDroppedFileAsync(files[0]);
+            if (over == buttonCompare)
+            {
+                await OpenDroppedCompareFileAsync(files[0]);
+            }
+            else
+            {
+                await OpenDroppedFileAsync(files[0]);
+            }
         }
         finally
         {

--- a/source/Ui/FileDropTarget.cs
+++ b/source/Ui/FileDropTarget.cs
@@ -18,6 +18,13 @@ namespace Resonalyze.Ui;
 /// working, because a payload that is not a file drop leaves the effect exactly as the
 /// other handler left it.
 /// </para>
+/// <para>
+/// The control the pointer is over is handed to the window with the files, because
+/// where a file is dropped can be part of what the user means by it: the same
+/// impulse response dropped on the Compare button is the reference, not the
+/// measurement. That is the window's decision, not this class's — this only says
+/// which control took the drop.
+/// </para>
 /// </remarks>
 internal sealed class FileDropTarget
 {
@@ -26,13 +33,13 @@ internal sealed class FileDropTarget
     // copy of the handlers.
     private readonly HashSet<Control> registered = [];
     private readonly Control root;
-    private readonly Func<IReadOnlyList<string>, bool> accepts;
-    private readonly Action<IReadOnlyList<string>> dropped;
+    private readonly Func<Control, IReadOnlyList<string>, bool> accepts;
+    private readonly Action<Control, IReadOnlyList<string>> dropped;
 
     private FileDropTarget(
         Control root,
-        Func<IReadOnlyList<string>, bool> accepts,
-        Action<IReadOnlyList<string>> dropped)
+        Func<Control, IReadOnlyList<string>, bool> accepts,
+        Action<Control, IReadOnlyList<string>> dropped)
     {
         this.root = root;
         this.accepts = accepts;
@@ -43,14 +50,18 @@ internal sealed class FileDropTarget
     /// Makes <paramref name="root"/> and everything inside it accept dropped files.
     /// </summary>
     /// <param name="accepts">
-    /// Whether this set of files can be opened right now. Asked on every drag move, so
-    /// it must be cheap, and asked again on the drop.
+    /// Whether this set of files can be opened right now, over the control it is
+    /// hovering. Asked on every drag move, so it must be cheap, and asked again on
+    /// the drop.
     /// </param>
-    /// <param name="dropped">Opens the files. Called on the UI thread.</param>
+    /// <param name="dropped">
+    /// Opens the files, given the control they were dropped on. Called on the UI
+    /// thread.
+    /// </param>
     internal static void Attach(
         Control root,
-        Func<IReadOnlyList<string>, bool> accepts,
-        Action<IReadOnlyList<string>> dropped)
+        Func<Control, IReadOnlyList<string>, bool> accepts,
+        Action<Control, IReadOnlyList<string>> dropped)
     {
         ArgumentNullException.ThrowIfNull(root);
         ArgumentNullException.ThrowIfNull(accepts);
@@ -117,23 +128,30 @@ internal sealed class FileDropTarget
             return;
         }
 
-        e.Effect = CanAccept(files) ? DragDropEffects.Copy : DragDropEffects.None;
+        e.Effect = CanAccept(Over(sender), files)
+            ? DragDropEffects.Copy
+            : DragDropEffects.None;
     }
 
     private void HandleDragDrop(object? sender, DragEventArgs e)
     {
         IReadOnlyList<string> files = FilesOf(e.Data);
-        if (files.Count == 0 || !CanAccept(files))
+        Control over = Over(sender);
+        if (files.Count == 0 || !CanAccept(over, files))
         {
             return;
         }
 
         e.Effect = DragDropEffects.Copy;
-        dropped(files);
+        dropped(over, files);
     }
 
-    private bool CanAccept(IReadOnlyList<string> files) =>
-        IsTakingInput() && accepts(files);
+    // The control raising the event is the one under the pointer: drag events are
+    // delivered to it alone, which is the very reason every control had to register.
+    private Control Over(object? sender) => sender as Control ?? root;
+
+    private bool CanAccept(Control over, IReadOnlyList<string> files) =>
+        IsTakingInput() && accepts(over, files);
 
     /// <summary>
     /// Whether the window is taking input at all. A modal dialog — the application's

--- a/tests/Resonalyze.App.Tests/FileDropTargetTests.cs
+++ b/tests/Resonalyze.App.Tests/FileDropTargetTests.cs
@@ -157,7 +157,7 @@ public sealed class FileDropTargetTests
         FileDropTarget.Attach(
             form,
             (over, _) => over != button,
-            (over, _) => Assert.NotSame(button, over));
+            (_, _) => Assert.Fail("must not open on the refusing control"));
 
         DragEventArgs overButton = RaiseDragOver(button, Files("sweep.wav"));
         DragEventArgs overPanel = RaiseDragOver(panel, Files("sweep.wav"));

--- a/tests/Resonalyze.App.Tests/FileDropTargetTests.cs
+++ b/tests/Resonalyze.App.Tests/FileDropTargetTests.cs
@@ -11,7 +11,9 @@ namespace Resonalyze.App.Tests;
 /// every control on it has to be registered as a drop target: drag events do not
 /// bubble, and a control that never registered refuses the drag where it stands.
 /// These pin that reach, and the two things it must not do — take a drag that
-/// belongs to somebody else, or open a file while a dialog has the window.
+/// belongs to somebody else, or open a file while a dialog has the window — and
+/// that the shell is told which control the file landed on, since the Compare
+/// button reads the same file differently from the rest of the window.
 /// </summary>
 public sealed class FileDropTargetTests
 {
@@ -24,7 +26,7 @@ public sealed class FileDropTargetTests
         panel.Controls.Add(button);
         form.Controls.Add(panel);
 
-        FileDropTarget.Attach(form, _ => true, _ => { });
+        FileDropTarget.Attach(form, (_, _) => true, (_, _) => { });
 
         Assert.True(form.AllowDrop);
         Assert.True(panel.AllowDrop);
@@ -39,7 +41,7 @@ public sealed class FileDropTargetTests
         using Form form = ShownForm();
         var panel = new Panel();
         form.Controls.Add(panel);
-        FileDropTarget.Attach(form, _ => true, _ => { });
+        FileDropTarget.Attach(form, (_, _) => true, (_, _) => { });
 
         var late = new Label();
         var laterStill = new Button();
@@ -62,7 +64,7 @@ public sealed class FileDropTargetTests
         var box = new RichTextBox { Size = new Size(100, 60), ReadOnly = true };
         form.Controls.Add(box);
 
-        FileDropTarget.Attach(form, _ => true, _ => { });
+        FileDropTarget.Attach(form, (_, _) => true, (_, _) => { });
         box.CreateControl();
         DragEventArgs drag = RaiseDragOver(box, Files("measurement.json"));
 
@@ -75,7 +77,7 @@ public sealed class FileDropTargetTests
     {
         using Form form = ShownForm();
         Button button = DeepChild(form);
-        FileDropTarget.Attach(form, _ => true, _ => { });
+        FileDropTarget.Attach(form, (_, _) => true, (_, _) => { });
 
         DragEventArgs drag = RaiseDragOver(button, Files("measurement.json"));
 
@@ -87,7 +89,7 @@ public sealed class FileDropTargetTests
     {
         using Form form = ShownForm();
         Button button = DeepChild(form);
-        FileDropTarget.Attach(form, _ => false, _ => Assert.Fail("must not open"));
+        FileDropTarget.Attach(form, (_, _) => false, (_, _) => Assert.Fail("must not open"));
 
         DragEventArgs drag = RaiseDragOver(button, Files("photo.png"));
         RaiseDragDrop(button, Files("photo.png"));
@@ -103,7 +105,7 @@ public sealed class FileDropTargetTests
         // here would cancel a move the bank had already accepted.
         using Form form = ShownForm();
         Button button = DeepChild(form);
-        FileDropTarget.Attach(form, _ => true, _ => Assert.Fail("must not open"));
+        FileDropTarget.Attach(form, (_, _) => true, (_, _) => Assert.Fail("must not open"));
 
         var payload = new DataObject();
         payload.SetData("a PEQ strip");
@@ -119,11 +121,50 @@ public sealed class FileDropTargetTests
         using Form form = ShownForm();
         Button button = DeepChild(form);
         List<string>? opened = null;
-        FileDropTarget.Attach(form, _ => true, files => opened = [.. files]);
+        FileDropTarget.Attach(form, (_, _) => true, (_, files) => opened = [.. files]);
 
         RaiseDragDrop(button, Files("capture.json"));
 
         Assert.Equal(["capture.json"], opened);
+    });
+
+    [Fact]
+    public void TheControlTheFileLandedOnIsNamedWithIt() => StaTest.Run(() =>
+    {
+        // The Compare button takes the same impulse response as the reference rather
+        // than as the measurement, so the shell has to be told where a drop landed —
+        // and the control raising the event is the one under the pointer, since drag
+        // events reach no other.
+        using Form form = ShownForm();
+        Button button = DeepChild(form);
+        Control? landedOn = null;
+        FileDropTarget.Attach(form, (_, _) => true, (over, _) => landedOn = over);
+
+        RaiseDragDrop(button, Files("measurement.json"));
+
+        Assert.Same(button, landedOn);
+    });
+
+    [Fact]
+    public void AControlMayRefuseWhatTheRestOfTheWindowTakes() => StaTest.Run(() =>
+    {
+        // A sweep recording hovering over the Compare button is refused there and
+        // taken anywhere else: the answer is asked per control, on the hover as well
+        // as on the drop.
+        using Form form = ShownForm();
+        Button button = DeepChild(form);
+        Control panel = button.Parent!;
+        FileDropTarget.Attach(
+            form,
+            (over, _) => over != button,
+            (over, _) => Assert.NotSame(button, over));
+
+        DragEventArgs overButton = RaiseDragOver(button, Files("sweep.wav"));
+        DragEventArgs overPanel = RaiseDragOver(panel, Files("sweep.wav"));
+        RaiseDragDrop(button, Files("sweep.wav"));
+
+        Assert.Equal(DragDropEffects.None, overButton.Effect);
+        Assert.Equal(DragDropEffects.Copy, overPanel.Effect);
     });
 
     [Fact]
@@ -134,7 +175,7 @@ public sealed class FileDropTargetTests
         // measurement the dialog is asking about.
         using Form form = ShownForm();
         Button button = DeepChild(form);
-        FileDropTarget.Attach(form, _ => true, _ => Assert.Fail("must not open"));
+        FileDropTarget.Attach(form, (_, _) => true, (_, _) => Assert.Fail("must not open"));
         form.Enabled = false;
 
         DragEventArgs drag = RaiseDragOver(button, Files("measurement.json"));
@@ -171,7 +212,7 @@ public sealed class FileDropTargetTests
         var plot = new PlotView();
         form.Controls.AddRange([wizard, virtualDsp, timeAlignment, plot]);
 
-        FileDropTarget.Attach(form, _ => true, _ => { });
+        FileDropTarget.Attach(form, (_, _) => true, (_, _) => { });
 
         foreach (Control control in Descendants(form))
         {


### PR DESCRIPTION
## What

A `.json` impulse response dragged from Explorer onto the **Compare** button now lands as the Compare reference — the button's own **Choose file...** without the dialog — instead of replacing the measurement the way a drop anywhere else on the window does (#144).

- The button takes only what its dialog offers, a `.json`: a sweep recording or a REW export hovering over it is refused there (cursor shows it), while the rest of the window still takes it.
- Any other Resonalyze document (a moving-mic capture, a Virtual DSP session, an overlay slot) is named for what it is rather than reported as a failed load, with a pointer to drop it elsewhere on the window.
- **Choose file...** and the drop share one loader (`LoadCompareFileAsync`), so both install the reference the same way, update the dialog's last folder alike and report a bad file alike.

## How

`FileDropTarget` now hands the window the control the pointer is over along with the files, on the hover and on the drop. That is all it adds: which control took the drop is a fact it already had (drag events reach no other control, which is why every one of them had to register), and what to make of it stays the shell's decision in `Form1.FileDrop`. The one-file, no-sweep and no-dialog gates are unchanged and shared by both routes; the file's kind is still read once, on the drop, from its `format` marker.

## Tests

`FileDropTargetTests` gains two pins — the control a file landed on reaches the shell, and one control may refuse what the rest of the window takes, on the hover as well as on the drop — and the existing ones move to the new delegate shape. `DroppedFileTests` and `CompareSelectionTests` pass unchanged (41 tests in that filter).

Not verified, as in #144: a real drag out of Explorer. The handlers are exercised by raising the events the framework would raise.

## Docs

`REFERENCE.md`: a sentence in **Compare**, and a paragraph on the exception under **Dropping a file on the window**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
