### PR TITLE
Virtual DSP: the Arrival block times a low pair by its energy onsets, as the cross-side link does

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2483,11 +2483,14 @@ from. A **Δ L−R** block
 below reports each pair's inter-side state — the two sides' band-limited envelope
 arrivals with their difference (positive means the right side leads, the scene
 offset's convention), plus a **Level Δ L−R** row for the by-ear gain trim that
-finishes the centering. The arrivals are read by the same rule as the stereo
-Auto delay's [cross-side target](#auto-delay): a pair whose shared band is
-centred below 300 Hz is timed by its bands' **energy onsets** (the instant a
-tenth of the band's energy has arrived), every other pair by its first envelope
-peaks — on a slow low-frequency envelope the first peak is a coin toss, and on
+finishes the centering. The arrivals pick their instrument by the rule the
+stereo Auto delay's [cross-side target](#auto-delay) uses, applied to the row's
+own shared band (Auto delay may read a narrower band of the same pair — a pair
+that reaches the localization region is locked on its part above 300 Hz — so
+the two are the same rule, not always the same figure): a pair whose shared
+band is centred below 300 Hz is timed by its bands' **energy onsets** (the
+instant a tenth of the band's energy has arrived), every other pair by its
+first envelope peaks — on a slow low-frequency envelope the first peak is a coin toss, and on
 one measured midbass pair the peaks read a 5.6 ms split where the onsets read
 1.0 ms. Both sides need 30 dB of SNR for the onset, or the pair reads first
 peaks on both; a mono channel, with no twin to cancel the onset's bias against,

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2483,7 +2483,15 @@ from. A **Δ L−R** block
 below reports each pair's inter-side state — the two sides' band-limited envelope
 arrivals with their difference (positive means the right side leads, the scene
 offset's convention), plus a **Level Δ L−R** row for the by-ear gain trim that
-finishes the centering. Those level rows normally read the gated band level of the
+finishes the centering. The arrivals are read by the same rule as the stereo
+Auto delay's [cross-side target](#auto-delay): a pair whose shared band is
+centred below 300 Hz is timed by its bands' **energy onsets** (the instant a
+tenth of the band's energy has arrived), every other pair by its first envelope
+peaks — on a slow low-frequency envelope the first peak is a coin toss, and on
+one measured midbass pair the peaks read a 5.6 ms split where the onsets read
+1.0 ms. Both sides need 30 dB of SNR for the onset, or the pair reads first
+peaks on both; a mono channel, with no twin to cancel the onset's bias against,
+always reads its first peak. The tooltip names the instrument per row. Those level rows normally read the gated band level of the
 processed impulse responses; with the
 [hybrid](#hybrid-spatial-averages-under-the-prediction) mode on they compare the
 sides' spatial averages through their chains instead — the levels that mode draws

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2491,7 +2491,8 @@ peaks — on a slow low-frequency envelope the first peak is a coin toss, and on
 one measured midbass pair the peaks read a 5.6 ms split where the onsets read
 1.0 ms. Both sides need 30 dB of SNR for the onset, or the pair reads first
 peaks on both; a mono channel, with no twin to cancel the onset's bias against,
-always reads its first peak. The tooltip names the instrument per row. Those level rows normally read the gated band level of the
+always reads its first peak. The tooltip names the instrument per row, and says
+when a low pair is back on first peaks because a side lacks the SNR. Those level rows normally read the gated band level of the
 processed impulse responses; with the
 [hybrid](#hybrid-spatial-averages-under-the-prediction) mode on they compare the
 sides' spatial averages through their chains instead — the levels that mode draws

--- a/docs/agent/AGENT_GUIDE.md
+++ b/docs/agent/AGENT_GUIDE.md
@@ -1,6 +1,6 @@
 # Resonalyze Agent Guide
 
-Guide version 1.7 · for protocol v1 · [PROTOCOL.md](PROTOCOL.md) is the schema.
+Guide version 1.8 · for protocol v1 · [PROTOCOL.md](PROTOCOL.md) is the schema.
 
 ## 0. The rules that also travel inside every package
 
@@ -261,7 +261,10 @@ what the driver can survive there, which the measurement cannot tell you:
 **Stage.** `stereo[]` per block: `deltaMs` is left − right arrival (positive:
 the right side leads), `levelDeltaDb` is left − right. `groups[]`: each zone
 against the front. A `latched` flag means the arrival timed the room's modal
-build-up — real, but it overstates the skew.
+build-up — real, but it overstates the skew. `energyOnset` means a low pair's
+arrivals are its energy onsets, not first peaks — the instrument Auto delay
+times such a pair with; compare its `deltaMs` with the scene offset as usual,
+never with a first-peak figure from elsewhere in the package.
 
 **Target and tonal balance.** `sides[].sumVsTargetDb` is the median of the
 side's sum against the target curve; `hybridSumVsTargetDb` is the same off the

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -345,7 +345,11 @@ Every block is the panel's own read-out, unchanged. `id` is what a
 means the right side leads), `bandHz`, `levelDeltaDb` (left − right),
 `leftLatched` / `rightLatched` (the arrival timed the room's modal build-up
 rather than the direct rise — the number is real but overstates the skew),
-`levelFromSpatialAverage`.
+`energyOnset` (both arrivals are the bands' energy onsets — the instant a tenth
+of the band's energy has arrived — rather than first envelope peaks: the rule
+the stereo Auto delay's cross-side target follows for a pair whose shared band
+is centred below 300 Hz with 30 dB of SNR on both sides; false where the pair
+reads first peaks), `levelFromSpatialAverage`.
 
 `groups[]`, per zone compared against the front stage: `delayMs` (the zone's
 arrival minus the front's), `levelDb` (the zone's level minus the front's),
@@ -362,7 +366,7 @@ same chat as a second text:
 RESONALYZE_AGENT_DIAGNOSTIC_V1
 …
 BEGIN_RESONALYZE_AGENT_DIAGNOSTIC_JSON
-{ "kind": "resonalyze.agent-diagnostic", "protocolVersion": 1, "guideVersion": "1.7",
+{ "kind": "resonalyze.agent-diagnostic", "protocolVersion": 1, "guideVersion": "1.8",
   "diagnostic": "excessGroupDelay", "packageId": "…", "createdAtUtc": "…",
   "conventions": { … },
   "channels": [ { "id": "B:left", "series": { "columns": ["frequencyHz","excessGdMs"], "rows": [ … ] } }, … ] }
@@ -755,7 +759,7 @@ copied to the clipboard, pasted into the same chat:
 RESONALYZE_AGENT_PROBE_V1
 …
 BEGIN_RESONALYZE_AGENT_PROBE_JSON
-{ "kind": "resonalyze.agent-probe", "protocolVersion": 1, "guideVersion": "1.7",
+{ "kind": "resonalyze.agent-probe", "protocolVersion": 1, "guideVersion": "1.8",
   "packageId": "…", "sessionMatchesPackage": true, "createdAtUtc": "…",
   "conventions": { … },
   "probes": [

--- a/docs/agent/PROTOCOL.md
+++ b/docs/agent/PROTOCOL.md
@@ -349,7 +349,10 @@ rather than the direct rise — the number is real but overstates the skew),
 of the band's energy has arrived — rather than first envelope peaks: the rule
 the stereo Auto delay's cross-side target follows for a pair whose shared band
 is centred below 300 Hz with 30 dB of SNR on both sides; false where the pair
-reads first peaks), `levelFromSpatialAverage`.
+reads first peaks), `energyOnsetWithheld` (the band qualifies for onsets but a
+side is under the 30 dB an onset needs, so both sides read first peaks — the
+instrument that band is a coin on; treat such a `deltaMs` with the caution
+`latched` asks for), `levelFromSpatialAverage`.
 
 `groups[]`, per zone compared against the front stage: `delayMs` (the zone's
 arrival minus the front's), `levelDb` (the zone's level minus the front's),

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -4725,8 +4725,11 @@ public static class AutoAlignmentEngine
     /// sides of ONE driver pair through near-identical chains, so whatever
     /// bias the onset carries cancels in the split. The Virtual DSP arrival
     /// read-out (its L / R / Δ block) is the same comparison on the final
-    /// processed sides and reads by the same rules, so the two never
-    /// disagree about a pair. The timeline machinery
+    /// processed sides and reads by the same rules with the same detector —
+    /// on its own analysis window rather than the reprocessor's crop, which
+    /// agrees to the thousandth of a millisecond on a clean record (the
+    /// pre-front stretch integrates nothing) and can drift apart from it
+    /// only as the SNR nears the admission floor. The timeline machinery
     /// instead predicts a processed read from the bypassed front plus a chain
     /// shift measured on a reference impulse, and an energy onset is a
     /// distribution statistic that no impulse-measured shift transfers: read

--- a/dsp/AutoAlignmentEngine.cs
+++ b/dsp/AutoAlignmentEngine.cs
@@ -4723,7 +4723,10 @@ public static class AutoAlignmentEngine
     ///
     /// The LINK only, not the junction timelines: a link compares the two
     /// sides of ONE driver pair through near-identical chains, so whatever
-    /// bias the onset carries cancels in the split. The timeline machinery
+    /// bias the onset carries cancels in the split. The Virtual DSP arrival
+    /// read-out (its L / R / Δ block) is the same comparison on the final
+    /// processed sides and reads by the same rules, so the two never
+    /// disagree about a pair. The timeline machinery
     /// instead predicts a processed read from the bypassed front plus a chain
     /// shift measured on a reference impulse, and an energy onset is a
     /// distribution statistic that no impulse-measured shift transfers: read
@@ -4731,7 +4734,7 @@ public static class AutoAlignmentEngine
     /// 2.4 ms and convicted a plain BW48 80 Hz low-pass as an 18 ms modal
     /// latch (its unit tests). The peaks stay the timeline's instrument.
     /// </summary>
-    internal const double EnergyOnsetBandCenterHz = 300;
+    public const double EnergyOnsetBandCenterHz = 300;
 
     /// <summary>
     /// The SNR both sides of a link must show before its band is read by the
@@ -4758,13 +4761,13 @@ public static class AutoAlignmentEngine
     /// Thirty sits above every measured break with the delta's margin left.
     /// Field records read 45-88 dB.
     /// </summary>
-    internal const double EnergyOnsetMinimumSnrDb = 30;
+    public const double EnergyOnsetMinimumSnrDb = 30;
 
     /// <summary>
     /// Whether a link band belongs to the energy onset by its centre alone
     /// (see <see cref="EnergyOnsetBandCenterHz"/>).
     /// </summary>
-    internal static bool LinkBandReadsEnergyOnset(double bandLowHz, double bandHighHz) =>
+    public static bool LinkBandReadsEnergyOnset(double bandLowHz, double bandHighHz) =>
         Math.Sqrt(bandLowHz * bandHighHz) < EnergyOnsetBandCenterHz;
 
     /// <summary>
@@ -4774,7 +4777,7 @@ public static class AutoAlignmentEngine
     /// read of that link — both sides, their upper-half probes included — so
     /// a split never subtracts a peak from an onset.
     /// </summary>
-    internal static bool LinkReadsEnergyOnset(
+    public static bool LinkReadsEnergyOnset(
         double bandLowHz,
         double bandHighHz,
         double leftSignalToNoiseDb,
@@ -4795,7 +4798,7 @@ public static class AutoAlignmentEngine
     /// latch nor certify it; the read stays usable as a lobe pin, without the
     /// certificate, as an unmeasurable half leaves it already.
     /// </summary>
-    internal static ArrivalCertificate ClassifyLinkArrival(
+    public static ArrivalCertificate ClassifyLinkArrival(
         TimeAlignmentAnalysisResult full,
         TimeAlignmentAnalysisResult probe,
         double toleranceMs,
@@ -4811,7 +4814,7 @@ public static class AutoAlignmentEngine
     /// peak, its separation, the SNR) keep their meaning: they describe the
     /// envelope's peaks and the record, not the onset.
     /// </summary>
-    internal static TimeAlignmentAnalysisResult AsEnergyOnset(
+    public static TimeAlignmentAnalysisResult AsEnergyOnset(
         TimeAlignmentAnalysisResult read) =>
         !read.IsValid
             ? read

--- a/source/Integration/AgentBridge/AgentPackageBuilder.cs
+++ b/source/Integration/AgentBridge/AgentPackageBuilder.cs
@@ -756,7 +756,8 @@ internal static class AgentPackageBuilder
             AgentCurveSampling.Round(delta.LevelDeltaDb, 1),
             delta.LeftLatched,
             delta.RightLatched,
-            delta.LevelFromSpatialAverage);
+            delta.LevelFromSpatialAverage,
+            delta.EnergyOnset);
 
     private static AgentPackageGroup BuildGroup(VirtualCrossoverMetric.GroupDelta delta) =>
         new(

--- a/source/Integration/AgentBridge/AgentPackageBuilder.cs
+++ b/source/Integration/AgentBridge/AgentPackageBuilder.cs
@@ -757,7 +757,8 @@ internal static class AgentPackageBuilder
             delta.LeftLatched,
             delta.RightLatched,
             delta.LevelFromSpatialAverage,
-            delta.EnergyOnset);
+            delta.EnergyOnset,
+            delta.EnergyOnsetWithheld);
 
     private static AgentPackageGroup BuildGroup(VirtualCrossoverMetric.GroupDelta delta) =>
         new(

--- a/source/Integration/AgentBridge/AgentPackageModels.cs
+++ b/source/Integration/AgentBridge/AgentPackageModels.cs
@@ -260,7 +260,8 @@ internal sealed record AgentPackageStereo(
     double? LevelDeltaDb,
     bool LeftLatched,
     bool RightLatched,
-    bool LevelFromSpatialAverage);
+    bool LevelFromSpatialAverage,
+    bool EnergyOnset);
 
 internal sealed record AgentPackageGroup(
     string Zone,

--- a/source/Integration/AgentBridge/AgentPackageModels.cs
+++ b/source/Integration/AgentBridge/AgentPackageModels.cs
@@ -261,7 +261,8 @@ internal sealed record AgentPackageStereo(
     bool LeftLatched,
     bool RightLatched,
     bool LevelFromSpatialAverage,
-    bool EnergyOnset);
+    bool EnergyOnset,
+    bool EnergyOnsetWithheld);
 
 internal sealed record AgentPackageGroup(
     string Zone,

--- a/source/Integration/AgentBridge/AgentProtocol.cs
+++ b/source/Integration/AgentBridge/AgentProtocol.cs
@@ -204,7 +204,7 @@ internal static class AgentProtocol
     /// package so an assistant reading a newer guide at the URL knows which
     /// methodology the package's author expected.
     /// </summary>
-    public const string GuideVersion = "1.7";
+    public const string GuideVersion = "1.8";
 
     /// <summary>The whole clipboard text, UTF-8 bytes, before any parsing.</summary>
     public const int MaxProposalBytes = 1024 * 1024;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelState.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelState.cs
@@ -148,12 +148,17 @@ internal sealed class VirtualCrossoverChannelState
     // and the Hilbert analysis of a full-length IR is far too heavy to
     // repeat when nothing changed. The level rides in the same cache
     // entry: it is measured over the same band from the same response.
-    // Latched: the full-band envelope timed the room's modal build-up rather
-    // than the direct rise (its upper-half read lands much earlier) — the
-    // same detection the alignment engine's cross-side links run, so the
-    // read-out can mark the number instead of presenting it as a clean skew.
+    // Probe: the SAME response read in the band's upper half (from the
+    // geometric-mean frequency up), or null where the band is too narrow to
+    // cut one. The read-out grades the full read against it — the alignment
+    // engine's modal-latch detection — but the verdict is NOT cached: which
+    // instrument the pair reads by (first peaks or energy onsets, see
+    // VirtualCrossoverMetrics.ComputeStereoDeltasAsync) depends on the OTHER
+    // side's SNR too, so it is decided at assembly, per pair, from what both
+    // sides' caches hold.
     public (Complex[] ProcessedIr, double LowHz, double HighHz,
-        TimeAlignmentAnalysisResult Result, double? LevelDb, bool Latched)?
+        TimeAlignmentAnalysisResult Result, double? LevelDb,
+        TimeAlignmentAnalysisResult? Probe)?
         ArrivalCache
     { get; set; }
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
@@ -119,7 +119,12 @@ internal static class VirtualCrossoverMetric
         // band is centred below 300 Hz with 30 dB of SNR on both sides (see
         // VirtualCrossoverMetrics.ComputeStereoDeltasAsync). Both sides and
         // their latch probes read the same instrument; the legend names it.
-        bool EnergyOnset = false)
+        bool EnergyOnset = false,
+        // The band qualifies for onsets but a side sits under the SNR the
+        // onset needs, so both sides read first peaks — the instrument the
+        // band is a coin on. The row names the fallback, so a low pair back
+        // on peaks is not mistaken for a pair the onset cleared.
+        bool EnergyOnsetWithheld = false)
     {
         public double? DeltaMs => LeftMs.HasValue && RightMs.HasValue
             ? LeftMs.Value - RightMs.Value
@@ -238,7 +243,13 @@ internal static class VirtualCrossoverMetric
                     $"\u0394 {deltaText}{levelText} " +
                     $"({FrequencyText.Format(delta.LowHz)} \u2013 " +
                     $"{FrequencyText.Format(delta.HighHz)}" +
-                    (delta.EnergyOnset ? ", energy onsets" : string.Empty) + ")";
+                    (delta.EnergyOnset
+                        ? ", energy onsets"
+                        : delta.EnergyOnsetWithheld
+                            ? ", first peaks: a side is under the " +
+                                $"{AutoAlignmentEngine.EnergyOnsetMinimumSnrDb:0} dB " +
+                                "an energy onset needs"
+                            : string.Empty) + ")";
             })) +
             (deltas.Any(delta => delta.EnergyOnset)
                 ? "\r\nEnergy onsets: a pair whose shared band is centred " +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
@@ -258,9 +258,10 @@ internal static class VirtualCrossoverMetric
                     "arrived, not by its first envelope peak \u2014 a slow " +
                     "low-frequency\r\nenvelope's first hump is a coin toss " +
                     "(a fraction of a dB decides whether it peaks),\r\nand the " +
-                    "stereo Auto delay's cross-side target reads the same " +
-                    $"instant. Both sides need {AutoAlignmentEngine.EnergyOnsetMinimumSnrDb:0} dB\r\n" +
-                    "of SNR, or the pair reads first peaks."
+                    "stereo Auto delay's cross-side target picks its instrument " +
+                    "by the same rule\r\n(on the band it reads, which may be " +
+                    $"narrower). Both sides need {AutoAlignmentEngine.EnergyOnsetMinimumSnrDb:0} dB " +
+                    "of SNR,\r\nor the pair reads first peaks."
                 : string.Empty) +
             (deltas.Any(delta => delta.AnyLatched)
                 ? "\r\n~: the full-band envelope timed the room's modal " +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetric.cs
@@ -112,7 +112,14 @@ internal static class VirtualCrossoverMetric
         // responses. Timing stays on the impulse responses either way (a
         // spatial average carries no phase); only the legend changes with
         // this flag.
-        bool LevelFromSpatialAverage = false)
+        bool LevelFromSpatialAverage = false,
+        // The pair's arrivals are its bands' ENERGY ONSETS (the instant a
+        // tenth of the band's energy has arrived), not first envelope peaks:
+        // the alignment engine's cross-side link rule for a pair whose shared
+        // band is centred below 300 Hz with 30 dB of SNR on both sides (see
+        // VirtualCrossoverMetrics.ComputeStereoDeltasAsync). Both sides and
+        // their latch probes read the same instrument; the legend names it.
+        bool EnergyOnset = false)
     {
         public double? DeltaMs => LeftMs.HasValue && RightMs.HasValue
             ? LeftMs.Value - RightMs.Value
@@ -230,8 +237,20 @@ internal static class VirtualCrossoverMetric
                     $"R {Side(delta.RightMs, delta.RightLatched)} ms, " +
                     $"\u0394 {deltaText}{levelText} " +
                     $"({FrequencyText.Format(delta.LowHz)} \u2013 " +
-                    $"{FrequencyText.Format(delta.HighHz)})";
+                    $"{FrequencyText.Format(delta.HighHz)}" +
+                    (delta.EnergyOnset ? ", energy onsets" : string.Empty) + ")";
             })) +
+            (deltas.Any(delta => delta.EnergyOnset)
+                ? "\r\nEnergy onsets: a pair whose shared band is centred " +
+                    $"below {AutoAlignmentEngine.EnergyOnsetBandCenterHz:0} Hz is " +
+                    "timed by the instant a tenth\r\nof the band's energy has " +
+                    "arrived, not by its first envelope peak \u2014 a slow " +
+                    "low-frequency\r\nenvelope's first hump is a coin toss " +
+                    "(a fraction of a dB decides whether it peaks),\r\nand the " +
+                    "stereo Auto delay's cross-side target reads the same " +
+                    $"instant. Both sides need {AutoAlignmentEngine.EnergyOnsetMinimumSnrDb:0} dB\r\n" +
+                    "of SNR, or the pair reads first peaks."
+                : string.Empty) +
             (deltas.Any(delta => delta.AnyLatched)
                 ? "\r\n~: the full-band envelope timed the room's modal " +
                     "build-up, not the direct rise\r\n(its upper half reads " +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -709,8 +709,12 @@ internal sealed class VirtualCrossoverMetrics
     /// needs both sides present and unbypassed.
     ///
     /// Which instant is "the arrival" follows the alignment engine's
-    /// cross-side link, because this row IS that comparison on the final
-    /// chains: a pair whose shared band is centred below
+    /// cross-side link, because this row is that comparison on the final
+    /// chains — the selection RULE, applied to the row's own shared band;
+    /// the engine may read a narrower band of the same pair (a scene-locked
+    /// pair is timed on its part above the localization edge), so the two
+    /// share the rule, not always the figure. A pair whose shared band is
+    /// centred below
     /// <see cref="AutoAlignmentEngine.EnergyOnsetBandCenterHz"/> is timed by
     /// its bands' energy onsets, provided both sides clear
     /// <see cref="AutoAlignmentEngine.EnergyOnsetMinimumSnrDb"/>; every other
@@ -924,8 +928,16 @@ internal sealed class VirtualCrossoverMetrics
                             // A full read too weak to be reported earns no
                             // probe (the certificate would abstain anyway),
                             // and a silent band costs no second Hilbert pass.
+                            // The probe is cached beside the full read, so
+                            // it drops its envelope on the way in: the
+                            // certificate reads validity, SNR and the two
+                            // instants, and a second full-length envelope
+                            // per side per redraw is memory for nothing.
                             side.Probe = Reliable(side.Arrival.Value)
                                 ? ReadUpperHalf(side, job.LowHz, job.HighHz)
+                                    is { } probe
+                                    ? probe with { EnvelopeSamples = [] }
+                                    : null
                                 : null;
                         }
                     }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -707,6 +707,23 @@ internal sealed class VirtualCrossoverMetrics
     /// (the shared sub) has one response, so it reports that single arrival in
     /// its own band with "—" for the right side and the delta; a stereo pair
     /// needs both sides present and unbypassed.
+    ///
+    /// Which instant is "the arrival" follows the alignment engine's
+    /// cross-side link, because this row IS that comparison on the final
+    /// chains: a pair whose shared band is centred below
+    /// <see cref="AutoAlignmentEngine.EnergyOnsetBandCenterHz"/> is timed by
+    /// its bands' energy onsets, provided both sides clear
+    /// <see cref="AutoAlignmentEngine.EnergyOnsetMinimumSnrDb"/>; every other
+    /// pair, and a mono channel (no twin for the onset's bias to cancel
+    /// against), by the first envelope peak. On a slow low-frequency envelope
+    /// the first peak is a coin — whether the front's hump stands as a peak
+    /// or melts into the arrival behind it turns on a fraction of a dB — and
+    /// on one measured midbass pair the row read a 5.6 ms split (the right
+    /// side's peak sat 4.7 ms into the modal build-up, and its upper half sat
+    /// on the same mode, so the latch probe passed it) where the onsets
+    /// read 1.0 ms. The instrument is decided ONCE per pair from both sides'
+    /// full-band reads and applied to both sides and their latch probes, so
+    /// a Δ never subtracts a peak from an onset.
     /// </summary>
     /// <param name="channels">
     /// EVERY channel of the project, never a pre-filtered subset. A block's
@@ -865,7 +882,7 @@ internal sealed class VirtualCrossoverMetrics
                 {
                     side.Arrival = arrival.Result;
                     side.LevelDb = arrival.LevelDb;
-                    side.Latched = arrival.Latched;
+                    side.Probe = arrival.Probe;
                     side.ArrivalFromCache = true;
                 }
             }
@@ -900,8 +917,7 @@ internal sealed class VirtualCrossoverMetrics
                             side.LevelDb = VirtualCrossoverAnalysis.MeasureBandLevelDb(
                                 side.ProcessedIr!, side.SampleRate,
                                 job.LowHz, job.HighHz);
-                            side.Latched = IsModalLatched(
-                                side, job.LowHz, job.HighHz, side.Arrival.Value);
+                            side.Probe = ReadUpperHalf(side, job.LowHz, job.HighHz);
                         }
                     }
                 }
@@ -920,7 +936,7 @@ internal sealed class VirtualCrossoverMetrics
                     {
                         side.State.ArrivalCache =
                             (side.ProcessedIr!, job.LowHz, job.HighHz,
-                                side.Arrival!.Value, side.LevelDb, side.Latched);
+                                side.Arrival!.Value, side.LevelDb, side.Probe);
                     }
                 }
             }
@@ -935,18 +951,31 @@ internal sealed class VirtualCrossoverMetrics
             {
                 TimeAlignmentAnalysisResult left = job.Left.Arrival!.Value;
                 bool leftReliable = Reliable(left);
-                double? leftMs = leftReliable
-                    ? left.FirstArrivalDelayMilliseconds
-                    : null;
                 if (job.Mono)
                 {
+                    // One response, nothing to cancel an onset's bias
+                    // against: the first peak, as the junction timelines read.
                     return new VirtualCrossoverMetric.StereoDelta(
-                        job.Channel, leftMs, null, job.LowHz, job.HighHz, null,
-                        LeftLatched: job.Left.Latched);
+                        job.Channel,
+                        leftReliable ? left.FirstArrivalDelayMilliseconds : null,
+                        null, job.LowHz, job.HighHz, null,
+                        LeftLatched: IsModalLatched(
+                            left, job.Left.Probe, job.LowHz, job.HighHz,
+                            energyOnset: false));
                 }
 
                 TimeAlignmentAnalysisResult right = job.Right.Arrival!.Value;
                 bool rightReliable = Reliable(right);
+                // The pair's instrument (see the summary): the link rule,
+                // from the band and BOTH full-band reads, applied to both
+                // sides and to their latch probes alike.
+                bool energyOnset = left.IsValid && right.IsValid &&
+                    AutoAlignmentEngine.LinkReadsEnergyOnset(
+                        job.LowHz, job.HighHz,
+                        left.SignalToNoiseDecibels, right.SignalToNoiseDecibels);
+                static double Arrival(TimeAlignmentAnalysisResult read, bool onset) =>
+                    (onset ? AutoAlignmentEngine.AsEnergyOnset(read) : read)
+                        .FirstArrivalDelayMilliseconds;
                 // The spatial averages' level, where the panel supplied one,
                 // outranks the point measurement AND its reliability gate: a
                 // capture is a measurement of its own, and a noisy impulse
@@ -959,58 +988,73 @@ internal sealed class VirtualCrossoverMetrics
                         : null);
                 return new VirtualCrossoverMetric.StereoDelta(
                     job.Channel,
-                    leftMs,
-                    rightReliable ? right.FirstArrivalDelayMilliseconds : null,
+                    leftReliable ? Arrival(left, energyOnset) : null,
+                    rightReliable ? Arrival(right, energyOnset) : null,
                     job.LowHz,
                     job.HighHz,
                     levelDelta,
-                    LeftLatched: job.Left.Latched,
-                    RightLatched: job.Right.Latched,
-                    LevelFromSpatialAverage: job.HybridLevelDeltaDb.HasValue);
+                    LeftLatched: IsModalLatched(
+                        left, job.Left.Probe, job.LowHz, job.HighHz, energyOnset),
+                    RightLatched: IsModalLatched(
+                        right, job.Right.Probe, job.LowHz, job.HighHz, energyOnset),
+                    LevelFromSpatialAverage: job.HybridLevelDeltaDb.HasValue,
+                    EnergyOnset: energyOnset);
             })
             .ToList();
     }
 
-    // The alignment engine's modal-latch detection, applied to one side's
-    // read-out arrival: the SAME response measured in the band's upper half
-    // (from the geometric-mean frequency up) must agree with the full-band
-    // read to within the dispersion one direct wave packet can show — half a
-    // period at the probe's low edge. A full-band read landing far BEHIND its
-    // own upper-half read means the envelope latched onto the in-room modal
-    // build-up instead of the direct rise, and the row's L/R difference then
-    // compares different features. The probe only VOTES on the full band's
-    // honesty; its own number is never a substitute.
-    private static bool IsModalLatched(
+    // The latch probe of one side's read-out arrival: the SAME response
+    // measured in the band's upper half (from the geometric-mean frequency
+    // up), or null where the band is too narrow to cut one. Read once per
+    // processed response and cached beside the full read; the verdict is
+    // IsModalLatched, at assembly.
+    private static TimeAlignmentAnalysisResult? ReadUpperHalf(
         SideProcessJob side,
         double lowHz,
-        double highHz,
-        TimeAlignmentAnalysisResult fullBand)
+        double highHz)
     {
-        if (!fullBand.IsValid ||
-            fullBand.SignalToNoiseDecibels < AutoAlignmentEngine.MinimumArrivalSnrDb)
+        double probeLowHz = Math.Sqrt(lowHz * highHz);
+        if (highHz < probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
+        {
+            return null;
+        }
+
+        return VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
+            side.ProcessedIr!, side.SampleRate, probeLowHz, highHz,
+            side.ProcessedValidRange);
+    }
+
+    // The alignment engine's modal-latch detection, applied to one side's
+    // read-out arrival: the full-band read must agree with its upper-half
+    // probe to within the dispersion one direct wave packet can show — half
+    // a period at the probe's low edge, never under 1 ms (the link's own
+    // allowance). A full-band read landing far BEHIND its own upper-half
+    // read means the envelope latched onto the in-room modal build-up
+    // instead of the direct rise, and the row's L/R difference then compares
+    // different features. Both reads are taken with the PAIR's instrument
+    // (an onset is graded against an onset), and a probe too noisy to
+    // witness an onset abstains rather than judges — the link's
+    // certificate, verbatim. The probe only VOTES on the full band's
+    // honesty; its own number is never a substitute.
+    private static bool IsModalLatched(
+        TimeAlignmentAnalysisResult fullBand,
+        TimeAlignmentAnalysisResult? probe,
+        double lowHz,
+        double highHz,
+        bool energyOnset)
+    {
+        if (probe is not { } upperHalf)
         {
             return false;
         }
 
         double probeLowHz = Math.Sqrt(lowHz * highHz);
-        if (highHz < probeLowHz * VirtualCrossoverAnalysis.MinimumArrivalBandRatio)
-        {
-            return false;
-        }
-
-        TimeAlignmentAnalysisResult probe =
-            VirtualCrossoverAnalysis.AnalyzeBandLimitedArrival(
-                side.ProcessedIr!, side.SampleRate, probeLowHz, highHz,
-                side.ProcessedValidRange);
-        if (!probe.IsValid ||
-            probe.SignalToNoiseDecibels < AutoAlignmentEngine.MinimumArrivalSnrDb)
-        {
-            return false;
-        }
-
         double toleranceMs = Math.Max(1.0, 500.0 / probeLowHz);
-        return fullBand.FirstArrivalDelayMilliseconds
-            - probe.FirstArrivalDelayMilliseconds > toleranceMs;
+        return AutoAlignmentEngine.ClassifyLinkArrival(
+            energyOnset ? AutoAlignmentEngine.AsEnergyOnset(fullBand) : fullBand,
+            energyOnset ? AutoAlignmentEngine.AsEnergyOnset(upperHalf) : upperHalf,
+            toleranceMs,
+            energyOnset) == AutoAlignmentEngine.ArrivalCertificate.Latched;
     }
 
     /// <summary>
@@ -1146,7 +1190,7 @@ internal sealed class VirtualCrossoverMetrics
         public ValidSampleRange ProcessedValidRange { get; set; }
         public TimeAlignmentAnalysisResult? Arrival { get; set; }
         public double? LevelDb { get; set; }
-        public bool Latched { get; set; }
+        public TimeAlignmentAnalysisResult? Probe { get; set; }
         public bool ArrivalFromCache { get; set; }
     }
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverMetrics.cs
@@ -755,6 +755,10 @@ internal sealed class VirtualCrossoverMetrics
         Func<VirtualCrossoverChannelPairSettings, bool>? includePair = null,
         Func<VirtualCrossoverChannel, double, double, double?>? hybridLevelDeltaDb = null)
     {
+        static bool Reliable(TimeAlignmentAnalysisResult arrival) =>
+            arrival.IsValid &&
+            arrival.SignalToNoiseDecibels >= AutoAlignmentEngine.MinimumArrivalSnrDb;
+
         var jobs = new List<StereoDeltaJob>();
         int nextId = 0;
         for (int channelIndex = 0; channelIndex < channels.Count; channelIndex++)
@@ -917,7 +921,12 @@ internal sealed class VirtualCrossoverMetrics
                             side.LevelDb = VirtualCrossoverAnalysis.MeasureBandLevelDb(
                                 side.ProcessedIr!, side.SampleRate,
                                 job.LowHz, job.HighHz);
-                            side.Probe = ReadUpperHalf(side, job.LowHz, job.HighHz);
+                            // A full read too weak to be reported earns no
+                            // probe (the certificate would abstain anyway),
+                            // and a silent band costs no second Hilbert pass.
+                            side.Probe = Reliable(side.Arrival.Value)
+                                ? ReadUpperHalf(side, job.LowHz, job.HighHz)
+                                : null;
                         }
                     }
                 }
@@ -941,10 +950,6 @@ internal sealed class VirtualCrossoverMetrics
                 }
             }
         }
-
-        static bool Reliable(TimeAlignmentAnalysisResult arrival) =>
-            arrival.IsValid &&
-            arrival.SignalToNoiseDecibels >= AutoAlignmentEngine.MinimumArrivalSnrDb;
 
         return jobs
             .Select(job =>
@@ -998,7 +1003,12 @@ internal sealed class VirtualCrossoverMetrics
                     RightLatched: IsModalLatched(
                         right, job.Right.Probe, job.LowHz, job.HighHz, energyOnset),
                     LevelFromSpatialAverage: job.HybridLevelDeltaDb.HasValue,
-                    EnergyOnset: energyOnset);
+                    EnergyOnset: energyOnset,
+                    // The band asked for onsets and both sides are on the
+                    // row, yet one is under the 30 dB the onset needs: the
+                    // row is back on the coin, and must say so.
+                    EnergyOnsetWithheld: !energyOnset && leftReliable && rightReliable &&
+                        AutoAlignmentEngine.LinkBandReadsEnergyOnset(job.LowHz, job.HighHz));
             })
             .ToList();
     }

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -185,6 +185,29 @@ public sealed class VirtualCrossoverMetricTests
             ]);
 
             Assert.DoesNotContain("modal", text);
+            Assert.DoesNotContain("nergy onset", text);
+        });
+    }
+
+    [Fact]
+    public void FormatStereoDeltasDetail_NamesTheEnergyOnsetRowsAndExplainsThem()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            // The midbass pair reads its energy onsets, the mid pair its first
+            // peaks: the row says which, and the legend explains the
+            // instrument once.
+            string text = VirtualCrossoverMetric.FormatStereoDeltasDetail(
+            [
+                new VirtualCrossoverMetric.StereoDelta(
+                    "B", 16.488, 17.512, 65, 200, EnergyOnset: true),
+                new VirtualCrossoverMetric.StereoDelta("C", 16.533, 16.213, 200, 1_610)
+            ]);
+
+            Assert.Contains("B: L 16.488 / R 17.512 ms, Δ -1.024 ms (65 Hz – 200 Hz, energy onsets)", text);
+            Assert.Contains("C: L 16.533 / R 16.213 ms, Δ +0.320 ms (200 Hz – 1.61 kHz)", text);
+            Assert.Contains("Energy onsets: a pair whose shared band is centred below 300 Hz", text);
+            Assert.Contains("30 dB", text);
         });
     }
 

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricTests.cs
@@ -212,6 +212,24 @@ public sealed class VirtualCrossoverMetricTests
     }
 
     [Fact]
+    public void FormatStereoDeltasDetail_SaysWhenALowPairIsBackOnFirstPeaks()
+    {
+        RunWithInvariantCulture(() =>
+        {
+            string text = VirtualCrossoverMetric.FormatStereoDeltasDetail(
+            [
+                new VirtualCrossoverMetric.StereoDelta(
+                    "B", 16.628, 22.248, 65, 200, EnergyOnsetWithheld: true)
+            ]);
+
+            Assert.Contains(
+                "(65 Hz – 200 Hz, first peaks: a side is under the 30 dB an energy onset needs)",
+                text);
+            Assert.DoesNotContain("Energy onsets:", text);
+        });
+    }
+
+    [Fact]
     public void FormatStereoDeltasCompact_EmptyListRendersNothing()
     {
         Assert.Equal(

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -689,8 +689,156 @@ public sealed class VirtualCrossoverMetricsTests
         VirtualCrossoverMetric.StereoDelta delta = Assert.Single(deltas);
         Assert.True(delta.LeftLatched);
         Assert.False(delta.RightLatched);
-        // The latch flag rides in the per-side cache with the arrival.
-        Assert.True(channel.PhysicalSideState(false).ArrivalCache!.Value.Latched);
+        // The upper-half probe the verdict is graded against rides in the
+        // per-side cache with the arrival; the verdict itself is per pair.
+        Assert.NotNull(channel.PhysicalSideState(false).ArrivalCache!.Value.Probe);
+    }
+
+    // A stereo pair whose both sides play the given response through a
+    // Linkwitz-Riley 24 band-pass between lowHz and highHz — the shared
+    // band the read-out times the pair in.
+    private static VirtualCrossoverChannel BandPassPair(
+        string name, double lowHz, double highHz, Complex[] left, Complex[] right)
+    {
+        var channel = new VirtualCrossoverChannel(name);
+        foreach (bool rightSide in new[] { false, true })
+        {
+            VirtualCrossoverChannelState state = channel.PhysicalSideState(rightSide);
+            state.TransferImpulseResponse = rightSide ? right : left;
+            state.SampleRate = 48_000;
+            VirtualCrossoverChannelSettings settings = channel.SideSettings(rightSide);
+            settings.CrossoverKind = CrossoverKind.BandPass;
+            settings.HighPassEdge = new CrossoverEdge(
+                CrossoverFilterFamily.LinkwitzRiley, lowHz, 24);
+            settings.LowPassEdge = new CrossoverEdge(
+                CrossoverFilterFamily.LinkwitzRiley, highHz, 24);
+        }
+
+        return channel;
+    }
+
+    // A clean midbass-like packet: one Hann-windowed 130 Hz burst.
+    private static Complex[] MidbassPacket(double amplitude = 1.0)
+    {
+        var ir = new Complex[8_192];
+        AddBurst(ir, toneHz: 130, cycles: 4, amplitude: amplitude, startMs: 25);
+        return ir;
+    }
+
+    private static void AddNoise(Complex[] ir, double rms, int seed)
+    {
+        var random = new Random(seed);
+        for (int i = 0; i < ir.Length; i++)
+        {
+            // Box-Muller: Gaussian noise of the given RMS.
+            double u1 = 1.0 - random.NextDouble();
+            double u2 = random.NextDouble();
+            ir[i] += rms * Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(Math.Tau * u2);
+        }
+    }
+
+    [Fact]
+    public async Task ComputeStereoDeltasAsync_ReadsALowPairByItsEnergyOnsets()
+    {
+        // The pair's shared band is centred at 114 Hz, under the engine's
+        // 300 Hz rule, and both sides are clean: the row reads the bands'
+        // energy onsets — the instrument the stereo Auto delay's cross-side
+        // target uses — on BOTH sides, and says so.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        long revision = coordinator.Invalidate();
+        VirtualCrossoverChannel channel = BandPassPair(
+            "B", 65, 200, MidbassPacket(), MidbassPacket());
+
+        List<VirtualCrossoverMetric.StereoDelta> deltas =
+            await metrics.ComputeStereoDeltasAsync([channel], revision);
+
+        VirtualCrossoverMetric.StereoDelta delta = Assert.Single(deltas);
+        Assert.True(delta.EnergyOnset);
+        TimeAlignmentAnalysisResult left = channel.PhysicalSideState(false).ArrivalCache!.Value.Result;
+        TimeAlignmentAnalysisResult right = channel.PhysicalSideState(true).ArrivalCache!.Value.Result;
+        Assert.True(left.SignalToNoiseDecibels >= AutoAlignmentEngine.EnergyOnsetMinimumSnrDb);
+        Assert.Equal(left.EnergyOnsetDelayMilliseconds, delta.LeftMs!.Value, 9);
+        Assert.Equal(right.EnergyOnsetDelayMilliseconds, delta.RightMs!.Value, 9);
+        // The onset is a different instant from the first peak — on a Hann
+        // burst it leads the envelope's maximum — so the row visibly moved.
+        Assert.True(delta.LeftMs.Value < left.FirstArrivalDelayMilliseconds - 0.5);
+        Assert.False(delta.LeftLatched);
+        Assert.False(delta.RightLatched);
+    }
+
+    [Fact]
+    public async Task ComputeStereoDeltasAsync_ALowPairReadsFirstPeaksOnBothSidesWhenOneCannotWitnessAnOnset()
+    {
+        // The right record is noisy: measurable (above the 12 dB arrival
+        // floor) but under the 30 dB an energy onset needs. The link rule
+        // then reads first peaks on BOTH sides — never a peak against an
+        // onset — and the row does not claim the onset instrument.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        long revision = coordinator.Invalidate();
+        Complex[] noisy = MidbassPacket();
+        AddNoise(noisy, rms: 0.4, seed: 7);
+        VirtualCrossoverChannel channel = BandPassPair(
+            "B", 65, 200, MidbassPacket(), noisy);
+
+        List<VirtualCrossoverMetric.StereoDelta> deltas =
+            await metrics.ComputeStereoDeltasAsync([channel], revision);
+
+        VirtualCrossoverMetric.StereoDelta delta = Assert.Single(deltas);
+        TimeAlignmentAnalysisResult left = channel.PhysicalSideState(false).ArrivalCache!.Value.Result;
+        TimeAlignmentAnalysisResult right = channel.PhysicalSideState(true).ArrivalCache!.Value.Result;
+        Assert.InRange(
+            right.SignalToNoiseDecibels,
+            AutoAlignmentEngine.MinimumArrivalSnrDb,
+            AutoAlignmentEngine.EnergyOnsetMinimumSnrDb - 0.01);
+        Assert.False(delta.EnergyOnset);
+        Assert.Equal(left.FirstArrivalDelayMilliseconds, delta.LeftMs!.Value, 9);
+        Assert.Equal(right.FirstArrivalDelayMilliseconds, delta.RightMs!.Value, 9);
+    }
+
+    [Fact]
+    public async Task ComputeStereoDeltasAsync_APairCentredAboveTheOnsetRegionReadsFirstPeaks()
+    {
+        // 300–1200 Hz is centred at 600 Hz: a sharp front, where the first
+        // peak is the better instrument, as in the engine.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        long revision = coordinator.Invalidate();
+        var packet = new Complex[8_192];
+        AddBurst(packet, toneHz: 600, cycles: 4, amplitude: 1.0, startMs: 25);
+        VirtualCrossoverChannel channel = BandPassPair("C", 300, 1_200, packet, packet);
+
+        List<VirtualCrossoverMetric.StereoDelta> deltas =
+            await metrics.ComputeStereoDeltasAsync([channel], revision);
+
+        VirtualCrossoverMetric.StereoDelta delta = Assert.Single(deltas);
+        Assert.False(delta.EnergyOnset);
+        TimeAlignmentAnalysisResult left = channel.PhysicalSideState(false).ArrivalCache!.Value.Result;
+        Assert.Equal(left.FirstArrivalDelayMilliseconds, delta.LeftMs!.Value, 9);
+    }
+
+    [Fact]
+    public async Task ComputeStereoDeltasAsync_AMonoChannelReadsItsFirstPeakEvenInAnOnsetBand()
+    {
+        // A mono channel has no twin for the onset's bias to cancel against:
+        // it keeps the first peak, the junction timelines' instrument,
+        // however low its band sits.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        long revision = coordinator.Invalidate();
+        VirtualCrossoverChannel channel = BandPassPair(
+            "A", 65, 200, MidbassPacket(), MidbassPacket());
+        channel.Pair.Mono = true;
+
+        List<VirtualCrossoverMetric.StereoDelta> deltas =
+            await metrics.ComputeStereoDeltasAsync([channel], revision);
+
+        VirtualCrossoverMetric.StereoDelta delta = Assert.Single(deltas);
+        Assert.False(delta.EnergyOnset);
+        Assert.Null(delta.RightMs);
+        TimeAlignmentAnalysisResult left = channel.PhysicalSideState(false).ArrivalCache!.Value.Result;
+        Assert.Equal(left.FirstArrivalDelayMilliseconds, delta.LeftMs!.Value, 9);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverMetricsTests.cs
@@ -687,11 +687,59 @@ public sealed class VirtualCrossoverMetricsTests
             await metrics.ComputeStereoDeltasAsync([channel], revision);
 
         VirtualCrossoverMetric.StereoDelta delta = Assert.Single(deltas);
+        // 100–400 Hz is centred at 200 Hz and both records are clean, so the
+        // pair reads energy onsets — and the latch shows on that instrument
+        // too: a tenth of the full band's energy sits in the build-up, a
+        // tenth of the upper half's in the wavelet.
+        Assert.True(delta.EnergyOnset);
         Assert.True(delta.LeftLatched);
         Assert.False(delta.RightLatched);
         // The upper-half probe the verdict is graded against rides in the
         // per-side cache with the arrival; the verdict itself is per pair.
         Assert.NotNull(channel.PhysicalSideState(false).ArrivalCache!.Value.Probe);
+    }
+
+    [Fact]
+    public async Task ComputeStereoDeltasAsync_TheCoinTheFieldPairTossed_ReadsTheSameSplitByOnsets()
+    {
+        // The engine's coin, on the read-out: a front and a 1.4× arrival
+        // 8 ms behind it on the left, 7 ms on the right, through the same
+        // BW36 65 Hz / BW48 200 Hz band-pass. The first peaks read the two
+        // sides 5 ms apart (the left's hump stands as a peak, the right's
+        // melts into the arrival) for a true skew of zero; the onsets read
+        // them within 0.2 ms, and the row reads the onsets.
+        using var coordinator = new VirtualCrossoverProcessingCoordinator();
+        var metrics = new VirtualCrossoverMetrics(coordinator, (_, _, _, _, _) => EmptyMagnitude);
+        long revision = coordinator.Invalidate();
+        var channel = new VirtualCrossoverChannel("B");
+        foreach (bool rightSide in new[] { false, true })
+        {
+            var ir = new Complex[16_384];
+            ir[2_400] = Complex.One;
+            ir[2_400 + (rightSide ? 7 : 8) * 48] += 1.4;
+            VirtualCrossoverChannelState state = channel.PhysicalSideState(rightSide);
+            state.TransferImpulseResponse = ir;
+            state.SampleRate = 48_000;
+            VirtualCrossoverChannelSettings settings = channel.SideSettings(rightSide);
+            settings.CrossoverKind = CrossoverKind.BandPass;
+            settings.HighPassEdge = new CrossoverEdge(CrossoverFilterFamily.Butterworth, 65, 36);
+            settings.LowPassEdge = new CrossoverEdge(CrossoverFilterFamily.Butterworth, 200, 48);
+        }
+
+        List<VirtualCrossoverMetric.StereoDelta> deltas =
+            await metrics.ComputeStereoDeltasAsync([channel], revision);
+
+        VirtualCrossoverMetric.StereoDelta delta = Assert.Single(deltas);
+        TimeAlignmentAnalysisResult left = channel.PhysicalSideState(false).ArrivalCache!.Value.Result;
+        TimeAlignmentAnalysisResult right = channel.PhysicalSideState(true).ArrivalCache!.Value.Result;
+        // The fixture IS the coin: the peaks disagree by milliseconds.
+        Assert.True(
+            Math.Abs(left.FirstArrivalDelayMilliseconds - right.FirstArrivalDelayMilliseconds) > 3.0,
+            $"peaks split {left.FirstArrivalDelayMilliseconds - right.FirstArrivalDelayMilliseconds:0.00} ms");
+        Assert.True(delta.EnergyOnset);
+        Assert.InRange(delta.DeltaMs!.Value, -0.3, 0.3);
+        Assert.False(delta.LeftLatched);
+        Assert.False(delta.RightLatched);
     }
 
     // A stereo pair whose both sides play the given response through a
@@ -793,6 +841,9 @@ public sealed class VirtualCrossoverMetricsTests
             AutoAlignmentEngine.MinimumArrivalSnrDb,
             AutoAlignmentEngine.EnergyOnsetMinimumSnrDb - 0.01);
         Assert.False(delta.EnergyOnset);
+        // ...and the row says the onset was withheld, not that the band
+        // never asked for one.
+        Assert.True(delta.EnergyOnsetWithheld);
         Assert.Equal(left.FirstArrivalDelayMilliseconds, delta.LeftMs!.Value, 9);
         Assert.Equal(right.FirstArrivalDelayMilliseconds, delta.RightMs!.Value, 9);
     }
@@ -814,6 +865,7 @@ public sealed class VirtualCrossoverMetricsTests
 
         VirtualCrossoverMetric.StereoDelta delta = Assert.Single(deltas);
         Assert.False(delta.EnergyOnset);
+        Assert.False(delta.EnergyOnsetWithheld);
         TimeAlignmentAnalysisResult left = channel.PhysicalSideState(false).ArrivalCache!.Value.Result;
         Assert.Equal(left.FirstArrivalDelayMilliseconds, delta.LeftMs!.Value, 9);
     }


### PR DESCRIPTION

The L / R / Δ block under the sum-loss column read every pair by its first
envelope peaks. On the v6 midbass pair (65–200 Hz) that is the coin the
stereo Auto delay stopped tossing in #180: the right side's first peak sits
4.7 ms into the modal build-up, its upper half sits on the same mode, so the
latch probe passed it, and the row read L 16.63 / R 22.25 / Δ −5.62 ms
under the owner's own tune. The row is the same comparison the engine's
cross-side link makes — one driver pair through near-identical chains,
where the onset's bias cancels — so it now reads by the link's rule: a pair
whose shared band is centred below 300 Hz is timed by its bands' energy
onsets when both sides clear 30 dB of SNR, and by first peaks otherwise.
The same session now reads L 16.49 / R 17.51 / Δ −1.02 ms; the mid and
tweeter rows (centred above 300 Hz) are unchanged.

The instrument is decided once per pair from both sides' full-band reads
and applied to both sides and to their latch probes, so a Δ never subtracts
a peak from an onset. The per-side arrival cache therefore keeps the
upper-half probe instead of a latch verdict — the verdict depends on the
OTHER side's SNR — and the latch is graded by the link's certificate
(ClassifyLinkArrival on the pair's instrument; a probe too noisy to witness
an onset abstains). A mono channel keeps its first peak: it has no twin for
the onset's bias to cancel against (the sub reads 7 ms apart by the two).
The engine's link rules (LinkReadsEnergyOnset, ClassifyLinkArrival,
AsEnergyOnset and their constants) are public now — the app reads them.

The tooltip row says "energy onsets" and a legend explains the instrument;
the AI package's stereo[] rows carry energyOnset (guide 1.8); REFERENCE,
PROTOCOL and AGENT_GUIDE say the same. Tests: the onset band reads onsets on
both sides, one noisy side sends both back to peaks, a band centred above
300 Hz and a mono channel read peaks, and the legend renders.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
