### PR TITLE
Virtual DSP: a Lock beside the side radios keeps the two sides' crossovers and polarity in step

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2035,7 +2035,9 @@ read-out (avg / dip per junction plus a total). The loss is a dB gap, not a
 level, so it is drawn against its own amber **Sum loss (dB)** axis on the right
 (0 dB near the top, 6 dB steps, deepening to hold a notch) that appears only
 while the curve is shown; it zooms and pans on its own, separately from the
-left dB scale.
+left dB scale. A hand check that uses it: invert one channel of a junction and
+tune its delay for the deepest null, then flip the polarity back — the deepest
+null is the best summation.
 
 The **Sum loss** selector beside the Sum toggle picks the window the loss — the
 curve and the read-out column together, so they always quote one number — is
@@ -2770,7 +2772,9 @@ unchanged. Then it places each further group against that result: one reading
 per group, and no re-tuning of anything already settled. Walked as one chain
 those groups produce junctions that do not exist, which on a car with a rear
 fill means a front midrange "handing over" to it at the midrange's own low-pass
-corner.
+corner. Set the crossovers before running it: the search reads every junction
+in the overlap around its corners, and a chain without filters has no
+junctions to read.
 
 The later groups are placed rather than searched, because there is nothing
 between them and the front stage to search: no filter hands a band from one to

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1850,7 +1850,8 @@ workflow taken to its conclusion: measure each driver once, then design the whol
 DSP setup virtually. Channels (A, B, C, …) are stereo **L/R pairs**, each side
 picking its own measurement and running its own chain. **L / R** radios switch
 which side the controls edit, **L→R** / **R→L** copy chain settings across sides
-(a dialog picks the channels and which parts travel — see below),
+(a dialog picks the channels and which parts travel — see below), **Lock** keeps
+the two sides' crossovers and polarity in step while it is on (also below),
 and a **Mono** checkbox turns a pair into a single shared driver — the typical
 one-subwoofer car layout — feeding both sides' sums. The setup grows from two up
 to twelve pairs with **Add** and **Remove** under the block list, and **+/−**
@@ -1996,6 +1997,27 @@ other side's own alignment standing. Sources are never copied: every side keeps
 its own measurement.
 **Mute**, **Bypass** and the two curve toggles are absent from the list because
 they are shared by the two sides already — there is nothing to copy.
+
+**Lock**, beside them, is for the tune that is meant to be symmetric: while it is
+ticked, a crossover or polarity change made on the side shown is written onto the
+other side of the same pair as it is made, so the crossovers stay equal without an
+**L→R** after every corner moved. It reads by difference at every autosave, and
+that sets its boundaries. Ticking it copies nothing — whatever already differed
+between the sides stays until that setting is next touched, so the two sides can
+be compared before deciding which one to type over. The crossover travels as one
+(kind and both corners): a lock that carried only the corner turned would leave
+the other side's second corner where it was, and the two crossovers unequal after
+an edit meant to equalize them. Polarity travels on its own, so moving a corner
+never flips the other side. Gain, delay, the phase angle and the PEQ are not
+locked, for the reason they start unticked in the copy dialog; mono pairs have one
+settings set and need no lock. A run that writes both sides itself — **Auto
+delay**, which decides polarity per side, or the crossover wizard — keeps its own
+answer for the hidden side: the lock is for the hand on the knob, which only
+reaches the side shown. An AI import and its undo land exactly as their rows
+say, for the same reason: the rows name their sides, and the dialog showed
+those. It is on by default, because a car tune is symmetric far
+more often than not; untick it to work one side alone. The state is not stored
+with the session, so the next opening starts symmetric again.
 
 Because every stage is linear and the measurements are loopback-referenced
 transfer IRs, multiplying each measurement by its chain and summing the results

--- a/source/Options/LiveSpectrumOpt.cs
+++ b/source/Options/LiveSpectrumOpt.cs
@@ -839,12 +839,10 @@ namespace Resonalyze.Options
             // names the loopback availability, which a static line here cannot.
             toolTip.SetToolTip(
                 signalTypeComboBox,
-                "Excitation noise played during the measurement.\r\n" +
-                "• Pink noise (periodic): one FFT-length period of exactly pink noise, looped. Deterministic and leakage-free, so the transfer function converges fastest. Recommended.\r\n" +
-                "• Pink noise: continuous random pink noise, -3 dB/octave.\r\n" +
-                "• Brown / red noise: -6 dB/octave, more low-frequency drive for subwoofer and room-mode work.\r\n" +
-                "• White noise: equal energy per hertz.\r\n" +
-                "• Silent (RTA mode only): no excitation — measures whatever the microphone hears (ambient noise or an external source).");
+                "Excitation noise. Pink (periodic): one looped FFT period,\r\n" +
+                "leakage-free — recommended. Pink: continuous. Brown: more LF\r\n" +
+                "drive. White: equal energy per hertz. Silent: RTA only, no\r\n" +
+                "excitation.");
             toolTip.SetToolTip(
                 sequenceLengthComboBox,
                 "Sets the FFT block size. Longer sequences give finer frequency resolution but slower visual updates.");

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoDelayDialog.cs
@@ -58,22 +58,14 @@ internal sealed partial class VirtualCrossoverAutoDelayDialog : Form
         toolTip.SetToolTip(radioRightHandDrive, layoutTip);
         toolTip.SetToolTip(
             numericSceneOffset,
-            "Stereo scene offset (ms).\r\n" +
-            "The far side arrives earlier by this much, pulling the image\r\n" +
-            "from the driver's axis toward the dash center: on LHD the\r\n" +
-            "right side leads, on RHD the left side does.\r\n" +
-            "Typical: 0.2–0.3 ms.\r\n" +
-            "0 = image centered on the measurement position.");
+            "Stereo scene offset (ms): the far side arrives earlier by this\r\n" +
+            "much, pulling the image toward the dash centre.\r\n" +
+            "Typical 0.2–0.3 ms; 0 = centred on the mic position.");
         toolTip.SetToolTip(
             checkBoxGains,
-            "Starting-point level balance, cut-only: channels whose band\r\n" +
-            "meaningfully reaches above 300 Hz are levelled by their\r\n" +
-            "per-octave band energy — the board to one target, left vs\r\n" +
-            "right offset by the L-R level below. Subwoofers, mono channels\r\n" +
-            "and channels without a crossover keep their gain. This is a\r\n" +
-            "starting balance, not a final tonal decision — which is why it\r\n" +
-            "is off unless you ask for it: a run then writes delays and\r\n" +
-            "polarity, and leaves every level as you set it.");
+            "Starting level balance, cut-only, for channels reaching above\r\n" +
+            "300 Hz. Subs, mono and crossover-less channels keep their\r\n" +
+            "gain. Off: a run leaves every level as you set it.");
         numericNearSideCut.ApplyToolTip(
             toolTip,
             "How much quieter the NEAR (driver's) side plays than the far\r\n" +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAutoSetupDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAutoSetupDialog.cs
@@ -499,29 +499,20 @@ internal sealed partial class VirtualCrossoverAutoSetupDialog : Form
         subElevation.ValueChanged += (_, _) => UpdatePreview();
         toolTip.SetToolTip(
             independentSlopes,
-            "Let the low-pass and high-pass of a junction take different slopes\r\n" +
-            "(they still share one crossover frequency), to compensate a driver's\r\n" +
-            "own roll-off. Off ties each DRIVER's two shoulders (its high-pass and\r\n" +
-            "low-pass) to one slope, so no driver ends up steep on one side and\r\n" +
-            "shallow on the other; different drivers may still take different\r\n" +
-            "slopes — the textbook crossover.");
+            "Let a junction's low-pass and high-pass take different slopes\r\n" +
+            "(one frequency still). Off ties each driver's two shoulders\r\n" +
+            "to one slope — the textbook crossover.");
         toolTip.SetToolTip(
             reorderBlocks,
-            "Put the channel blocks in the panel into the same order as this\r\n" +
-            "dialog: the groups one after another, and inside each the chain\r\n" +
-            "from the lowest driver up. The blocks are lettered by position, so\r\n" +
-            "the ones that move are re-lettered and take a new plot colour — and\r\n" +
-            "a tuning sheet exported before this names them by the OLD letters.\r\n" +
-            "Nothing else moves with them: sources, settings and measurements\r\n" +
-            "belong to the block.");
+            "Put the panel's blocks in this dialog's order: the groups one\r\n" +
+            "after another, each from the lowest driver up. Moved blocks are\r\n" +
+            "re-lettered and recoloured; a sheet exported before this names\r\n" +
+            "the OLD letters.");
         toolTip.SetToolTip(
             subElevation,
-            "How far the lowest driver (the sub, or the woofer/midbass when no\r\n" +
-            "sub is present) sits above the levelled midrange/tweeter. Starts at\r\n" +
-            "(and is capped by) the measured elevation — the bass at its own\r\n" +
-            "level; lower it to flatten the bottom. The midrange/tweeter are\r\n" +
-            "levelled to each other and the remaining drivers are only cut, never\r\n" +
-            "boosted, onto the resulting target.");
+            "How far the lowest driver sits above the levelled\r\n" +
+            "midrange/tweeter. Starts at, and is capped by, the measured\r\n" +
+            "elevation; lower it to flatten the bottom.");
     }
 
     // The order the wizard settled on, as Init indices, or null when the user

--- a/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverChannelControl.cs
@@ -566,13 +566,9 @@ public partial class VirtualCrossoverChannelControl : UserControl
         {
             toolTip.SetToolTip(
                 arrow,
-                "Move this block one place up or down the list.\r\n" +
-                "The blocks are lettered by their position, so the ones\r\n" +
-                "that move are re-lettered — and so are their colours.\r\n" +
-                "Nothing else about them changes: sources, settings and\r\n" +
-                "measurements travel with the block.\r\n" +
-                "Auto crossover can sort a whole system into crossover\r\n" +
-                "order in one go.");
+                "Move this block one place up or down. Blocks are lettered by\r\n" +
+                "position, so the ones that move are re-lettered and\r\n" +
+                "recoloured; sources and settings travel with them.");
         }
         toolTip.SetToolTip(
             buttonMute,
@@ -596,24 +592,14 @@ public partial class VirtualCrossoverChannelControl : UserControl
             "junction it pins.");
         toolTip.SetToolTip(
             comboBoxZone,
-            "Which part of the installation this block is — the fact\r\n" +
-            "the crossover corners cannot give, because Front, Rear\r\n" +
-            "and Center can play the SAME band from different places.\r\n" +
-            "Center forces Mono: it plays a signal derived from L\r\n" +
-            "and R, so it has no side.\r\n" +
-            "For now the zone only labels the block and travels with\r\n" +
-            "the project. The sum, the metric and Auto delay still\r\n" +
-            "read every channel as one chain along the spectrum;\r\n" +
-            "the grouped views and the staged alignment that act on\r\n" +
-            "the zone come next.");
+            "Which part of the installation this block is: Front, Rear or\r\n" +
+            "Center. The grouped views and Auto delay's staging follow it.\r\n" +
+            "Center forces Mono — it has no side.");
         toolTip.SetToolTip(
             labelMeasuredPolarity,
-            "Acoustic polarity read from the measured IR\r\n" +
-            "(the sign of its first significant excursion).\r\n" +
-            "Normal — the driver pushes toward the mic first.\r\n" +
-            "Inverted — it pulls first (wired in reverse).\r\n" +
-            "Unknown — no source selected.\r\n" +
-            "Independent of the Invert switch.");
+            "Acoustic polarity read from the measured IR: Normal pushes\r\n" +
+            "toward the mic first, Inverted pulls first, Unknown has no\r\n" +
+            "source. Independent of the Invert switch.");
         toolTip.SetToolTip(
             comboBoxCrossoverKind,
             "This driver's crossover role:\r\n" +
@@ -663,12 +649,9 @@ public partial class VirtualCrossoverChannelControl : UserControl
 
         toolTip.SetToolTip(
             buttonPeqMenu,
-            "This channel's parametric EQ: load it from a file\r\n" +
-            "(an EQ Wizard export or a compatible PEQ list), edit or\r\n" +
-            "create it in the EQ Wizard, or clear it. The bands add\r\n" +
-            "on top of the crossover in the processed response.\r\n" +
-            "All-pass filters (AP1/AP2) live here too, as bands of the\r\n" +
-            "bank — added or tuned in the EQ Wizard's phase view.");
+            "This channel's parametric EQ: load it from a file, edit it in\r\n" +
+            "the EQ Wizard, or clear it. All-pass filters live here too,\r\n" +
+            "as bands of the bank.");
 
         toolTip.SetToolTip(
             checkBoxShowRaw,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverGateDialog.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverGateDialog.cs
@@ -278,12 +278,9 @@ internal sealed partial class VirtualCrossoverGateDialog : Form
             "channel's placement while Auto is pressed.");
         toolTip.SetToolTip(
             checkAutoOffset,
-            "Auto places the gate automatically, following source and\r\n" +
-            "delay changes: the magnitude uses ONE window at the earliest\r\n" +
-            "arrival (so the Sum stays the exact sum of the drawn curves),\r\n" +
-            "while each phase curve is gated at its own arrival (so FDW\r\n" +
-            "keeps every channel's treble) with one common time reference.\r\n" +
-            "Release to pin one absolute window for everything instead.");
+            "Auto places the gate itself and follows source and delay\r\n" +
+            "changes: one window for the magnitude, each phase curve at\r\n" +
+            "its own arrival. Release to pin one absolute window.");
         numericLeft.ApplyToolTip(
             toolTip,
             "Tukey fade-in before the arrival, in milliseconds.\r\n" +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -1287,6 +1287,11 @@ public partial class VirtualCrossoverPanel
         }
         ApplySettingsToControl(lower);
         ApplySettingsToControl(upper);
+        // One edge, written onto both sides: the side lock takes the result as it
+        // stands. Read as a difference, a hidden side that already held the new
+        // edge would look untouched, and the shown side's whole crossover — its
+        // OTHER edge included — would be carried over the hidden side's own.
+        sideLock.Remember(channels.Select(channel => channel.Pair));
         ScheduleSave();
         RedrawAll();
 

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.AgentBridge.cs
@@ -673,6 +673,12 @@ public partial class VirtualCrossoverPanel
             int rows = toApply.Count(verdict => verdict.Operation is AgentSettingsOperation);
             summary.Add(
                 $"Applied {rows} of {proposedRows} proposed change{(proposedRows == 1 ? "" : "s")}.");
+            // The rows name their sides, and the dialog showed exactly those: the
+            // side lock takes them as written rather than carrying a row for the
+            // shown side onto the hidden one behind the dialog's back. HERE, before
+            // the engines — a junction tune saves on its own inside them, and that
+            // save would read the rows as a hand edit first.
+            sideLock.Remember(channels.Select(channel => channel.Pair));
         }
 
         bool engines = await RunAgentEngineRequests(toApply, summary, progress);
@@ -1620,6 +1626,12 @@ public partial class VirtualCrossoverPanel
         }
 
         RefreshHybridAvailability();
+        // The restored state is the record, on every side: the side lock takes it as
+        // it stands. Read as a difference it could put a side the import never
+        // touched somewhere it never was (L=A, R=B; the import wrote L=B and the
+        // lock had nothing to carry; the undo restores L=A alone, and a difference
+        // would then carry A onto R).
+        sideLock.Remember(channels.Select(channel => channel.Pair));
         ScheduleSave();
         RedrawAll();
     }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
@@ -44,6 +44,7 @@ namespace Resonalyze
             radioSideRight = new ReleaseClickRadioButton();
             buttonCopyLeftToRight = new ReleaseClickButton();
             buttonCopyRightToLeft = new ReleaseClickButton();
+            checkBoxSideLock = new ReleaseClickCheckBox();
             labelView = new Label();
             labelGroupView = new Label();
             comboBoxGroupView = new DarkComboBox();
@@ -180,6 +181,7 @@ namespace Resonalyze
             sideSelectorPanel.Controls.Add(radioSideRight);
             sideSelectorPanel.Controls.Add(buttonCopyLeftToRight);
             sideSelectorPanel.Controls.Add(buttonCopyRightToLeft);
+            sideSelectorPanel.Controls.Add(checkBoxSideLock);
             sideSelectorPanel.Location = new Point(6, 730);
             sideSelectorPanel.Name = "sideSelectorPanel";
             sideSelectorPanel.Size = new Size(347, 24);
@@ -234,7 +236,25 @@ namespace Resonalyze
             buttonCopyRightToLeft.TabIndex = 3;
             buttonCopyRightToLeft.Text = "R→L";
             buttonCopyRightToLeft.UseVisualStyleBackColor = false;
-            // 
+            //
+            // checkBoxSideLock
+            //
+            checkBoxSideLock.Appearance = Appearance.Button;
+            checkBoxSideLock.BackColor = Color.FromArgb(46, 51, 67);
+            checkBoxSideLock.Checked = true;
+            checkBoxSideLock.CheckState = CheckState.Checked;
+            checkBoxSideLock.FlatAppearance.CheckedBackColor = Color.FromArgb(80, 100, 140);
+            checkBoxSideLock.FlatStyle = FlatStyle.Flat;
+            checkBoxSideLock.ForeColor = Color.White;
+            checkBoxSideLock.Location = new Point(239, 0);
+            checkBoxSideLock.Name = "checkBoxSideLock";
+            checkBoxSideLock.Size = new Size(56, 23);
+            checkBoxSideLock.TabIndex = 4;
+            checkBoxSideLock.Text = "Lock";
+            checkBoxSideLock.TextAlign = ContentAlignment.MiddleCenter;
+            checkBoxSideLock.UseCompatibleTextRendering = true;
+            checkBoxSideLock.UseVisualStyleBackColor = false;
+            //
             // labelView
             // 
             labelView.AutoSize = true;
@@ -795,6 +815,7 @@ namespace Resonalyze
         private ReleaseClickRadioButton radioSideRight;
         private ReleaseClickButton buttonCopyLeftToRight;
         private ReleaseClickButton buttonCopyRightToLeft;
+        private ReleaseClickCheckBox checkBoxSideLock;
         private Label labelView;
         private Label labelGroupView;
         private DarkComboBox comboBoxGroupView;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3300,19 +3300,9 @@ public partial class VirtualCrossoverPanel : UserControl
             "offered.");
         toolTip.SetToolTip(
             checkBoxSideLock,
-            "Lock the crossover and the polarity of the two sides together:\r\n" +
-            "while this is ticked, a crossover or polarity change made on\r\n" +
-            "the side shown is written onto the other side of the same\r\n" +
-            "pair as it is made. Ticking it copies nothing — whatever\r\n" +
-            "already differs stays until that setting is next touched.\r\n" +
-            "The crossover travels as one (kind and both corners),\r\n" +
-            "polarity on its own. Gain, delay, phase and the PEQ are not\r\n" +
-            "locked; mono pairs have one settings set already. A run that\r\n" +
-            "writes both sides itself (Auto delay, the crossover wizard)\r\n" +
-            "keeps its own answer for the hidden side, and an AI import\r\n" +
-            "and its undo land exactly as their rows say.\r\n" +
-            "On by default; untick it to tune one side alone. The state is\r\n" +
-            "not stored with the session, so it is on again next time.");
+            "Keep both sides' crossover and polarity in step: a change\r\n" +
+            "on the side shown is written onto the other side as it is\r\n" +
+            "made. Gain, delay, phase and PEQ are not locked.");
         toolTip.SetToolTip(
             buttonDspProcessor,
             "The processor this project is designed for: pick a model and\r\n" +

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -8705,6 +8705,11 @@ public partial class VirtualCrossoverPanel : UserControl
                 sorted.Select(channel => channels.IndexOf(channel)).ToList());
         }
 
+        // The wizard wrote both sides itself, and a proposal can carry one edge
+        // only: the side lock takes the result as it stands rather than reading a
+        // hidden side that already held that edge as untouched and carrying the
+        // shown side's other edge over its own.
+        sideLock.Remember(channels.Select(channel => channel.Pair));
         ScheduleSave();
         RedrawAll();
         if (clearedRotations > 0)

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3134,13 +3134,9 @@ public partial class VirtualCrossoverPanel : UserControl
             "playing together.");
         toolTip.SetToolTip(
             labelSumLoss,
-            "How many dB the complex sum falls short of the\r\n" +
-            "phase-blind magnitude sum (<= 0).\r\n" +
-            "0 dB means the channels are perfectly in phase.\r\n" +
-            "Tip: invert one channel and tune the delay for the\r\n" +
-            "deepest null — flipping polarity back then gives\r\n" +
-            "the best summation.\r\n" +
-            "The selector beside it picks the window it is read through.");
+            "How many dB the complex sum falls short of the magnitude sum\r\n" +
+            "(<= 0): 0 dB is perfectly in phase. The selector beside it\r\n" +
+            "picks the window it is read through.");
         toolTip.SetToolTip(
             buttonAddChannel,
             "Add a channel block to the bottom of the list.");
@@ -3149,12 +3145,10 @@ public partial class VirtualCrossoverPanel : UserControl
             "Drop the last channel block, with whatever is loaded in it.");
         toolTip.SetToolTip(
             buttonResetChannels,
-            "Start over: every block back to an empty default one, the list\r\n" +
-            $"back to {DefaultChannelCount} of them, and the panel's own settings —\r\n" +
-            "target level, smoothing, gate, view, scene offset — with them.\r\n" +
-            "The microphone calibration and the shared EQ target curve stay.\r\n" +
-            "Asks first, and copies the current session aside so Load session…\r\n" +
-            "brings it back — one copy, overwritten by the next reset.");
+            $"Start over: {DefaultChannelCount} empty default blocks, and the panel's own\r\n" +
+            "settings with them; calibration and the EQ target stay.\r\n" +
+            "Asks first, and copies the session aside so Load session…\r\n" +
+            "brings it back.");
         toolTip.SetToolTip(
             radioViewMagnitude,
             "Show the magnitude of the channels, the sum,\r\n" +
@@ -3171,44 +3165,19 @@ public partial class VirtualCrossoverPanel : UserControl
             "Well-aligned drivers start together.");
         toolTip.SetToolTip(
             comboBoxGroupView,
-            "Which part of the installation the plot is about — the\r\n" +
-            "curves, the Sum, the loss and the read-out all follow it.\r\n" +
-            "Blocks are sorted by their Zone.\r\n" +
-            "Front + Sub is the crossover chain, and what a front-only\r\n" +
-            "car always showed.\r\n" +
-            "Groups draws one summed line per zone instead of the\r\n" +
-            "drivers, for setting the rear fill against the front.\r\n" +
-            "A centre is drawn but never summed: it plays a signal\r\n" +
-            "synthesised from L and R, so how much of the programme\r\n" +
-            "reaches it belongs to the track, not to the tune.\r\n" +
-            "Views spanning more than one group quote no summation\r\n" +
-            "loss — with no crossover between them the sum combs\r\n" +
-            "whatever the tune — and report each group's arrival and\r\n" +
-            "level against the front instead.");
+            "Which part of the installation the plot shows; the curves, the\r\n" +
+            "Sum, the loss and the read-out follow it. Groups sums one line\r\n" +
+            "per zone. A centre is drawn but never summed.");
         toolTip.SetToolTip(
             comboBoxSmoothing,
-            "Fractional-octave smoothing of the magnitude curves —\r\n" +
-            "and of the curves the Sum loss read-out is measured from,\r\n" +
-            "so it still moves those numbers in the Phase and Impulse\r\n" +
-            "views, where the drawn traces are not smoothed at all.\r\n" +
-            "Psychoacoustic: variable 1/3 to 1/6 octave with extra peak weighting\r\n" +
-            "narrower than half its window — narrow interference nulls\r\n" +
-            "the ear barely hears drop out, peaks and broad valleys stay.\r\n" +
-            "The junction metric numbers stay unsmoothed and honest.");
+            "Fractional-octave smoothing of the magnitude curves and the\r\n" +
+            "Sum loss read. Psychoacoustic: 1/3–1/6 octave with peak\r\n" +
+            "weighting. The junction metrics stay unsmoothed.");
         toolTip.SetToolTip(
             comboBoxSumLoss,
-            "The window the Sum loss — the curve and the read-out column — is\r\n" +
-            "measured through.\r\n" +
-            "FDW-8 (default): each channel through the Junction phase block's\r\n" +
-            "8-cycle window, placed as that block places it — the loss of the\r\n" +
-            "DIRECT sound. Deeper and more sensitive to the microphone\r\n" +
-            "position than Full.\r\n" +
-            "Full: the steady-state window the magnitude curves read, one\r\n" +
-            "shared anchor — the loss of the sum the cabin hears, reflections\r\n" +
-            "included. The two families of numbers are not comparable.\r\n" +
-            "Disable: no curve; the column keeps the Full read.\r\n" +
-            "The Auto delay battery and the tuning sheet quote Full; the AI\r\n" +
-            "package carries both reads whatever is selected here.");
+            "The window the Sum loss is read through. FDW-8: the direct\r\n" +
+            "sound, as the Junction phase block reads it. Full: the\r\n" +
+            "steady-state sum the cabin hears. The two are not comparable.");
         toolTip.SetToolTip(
             radioDspGroupDelay,
             "What the lower plot shows for each channel's DSP chain:\r\n" +
@@ -3216,17 +3185,9 @@ public partial class VirtualCrossoverPanel : UserControl
             "group delay in ms, excluding the channel's bulk delay).");
         toolTip.SetToolTip(
             radioDspCorrelation,
-            "Junction correlation: the selected adjacent pair's band-limited\r\n" +
-            "cross-correlation (corr + PHAT; negative lobes = the upper\r\n" +
-            "channel inverted) and the PRIOR-FREE acoustic score — the\r\n" +
-            "dip-penalized junction loss, honestly re-gated per point — versus\r\n" +
-            "an extra delay on the upper channel, in both polarities: the comb\r\n" +
-            "of alignment lobes. Auto delay weighs this acoustics TOGETHER\r\n" +
-            "with the arrival prior and the lobe/onset/scene gates, so its\r\n" +
-            "pick may deliberately sit off this curve's deepest lobe — the\r\n" +
-            "gap to the dashed envelope-arrival marker shows that trade.\r\n" +
-            "Channels enter with their current delays: 0 ms is the alignment\r\n" +
-            "as it stands.");
+            "Junction correlation of the selected pair, and its acoustic\r\n" +
+            "score, against an extra delay on the upper channel in both\r\n" +
+            "polarities. 0 ms is the alignment as it stands.");
         toolTip.SetToolTip(
             comboBoxCorrelationPair,
             "Which adjacent channel pair the correlation view analyzes\r\n" +
@@ -3245,37 +3206,19 @@ public partial class VirtualCrossoverPanel : UserControl
             "not with the target, so retuning the shape leaves it where it is.");
         toolTip.SetToolTip(
             buttonTargetSettings,
-            "Shape the target: a parametric shape (preset, tilt, bass and\r\n" +
-            "treble shelves, presence, colour and line style) previewed live\r\n" +
-            "on this plot (which switches to the Magnitude view, the only one\r\n" +
-            "a dB shape means anything on), or a house curve of your own\r\n" +
-            "imported from a text file. Either way it is the SAME target the\r\n" +
-            "EQ Wizard equalizes towards.");
+            "Shape the target — a parametric shape or an imported house\r\n" +
+            "curve — previewed on the Magnitude view. It is the SAME target\r\n" +
+            "the EQ Wizard equalizes towards.");
         toolTip.SetToolTip(
             comboBoxCalibration,
-            "Microphone calibration applied to the magnitude curves —\r\n" +
-            "and to the curves the Sum loss read-out is measured from,\r\n" +
-            "so it still moves those numbers in the Phase and Impulse\r\n" +
-            "views, where no calibrated trace is drawn.\r\n" +
-            "The measurement is loopback-referenced, so this is\r\n" +
-            "optional. The entries are the calibrations configured in\r\n" +
-            "Record Settings; a loaded session that carries its own\r\n" +
-            "curve adds it here as '(from session)'. The selection is\r\n" +
-            "saved into the session as the curve itself, so it travels.");
+            "Microphone calibration for the magnitude curves and the Sum\r\n" +
+            "loss read. Optional — the measurement is loopback-referenced.\r\n" +
+            "Saved into the session as the curve itself.");
         toolTip.SetToolTip(
             buttonAutoDelay,
-            "Open the Auto delay dialog: align the channels in two\r\n" +
-            "stages (band-limited first arrivals, then a phase search\r\n" +
-            "that fine-tunes delays and polarity), review the proposed\r\n" +
-            "before/after table and apply or discard it. The dialog\r\n" +
-            "holds the L/R scene offset and can also balance channel\r\n" +
-            "gains (cut-only).\r\n" +
-            "With both sides loaded the run is STEREO: the left side\r\n" +
-            "aligns first, the right top driver is timed to the left\r\n" +
-            "one (honoring the L/R offset), and the right side\r\n" +
-            "descends from it — so the stereo image stays put.\r\n" +
-            "Set the crossover filters first — the search targets\r\n" +
-            "the overlap region around their corner frequencies.");
+            "Align the channels: first arrivals, then a phase search for\r\n" +
+            "delays and polarity, reviewed as before/after. Set the\r\n" +
+            "crossovers first — the search reads their overlap.");
         toolTip.SetToolTip(
             radioSideLeft,
             "Show and edit the LEFT side of every channel pair.\r\n" +
@@ -3305,23 +3248,15 @@ public partial class VirtualCrossoverPanel : UserControl
             "made. Gain, delay, phase and PEQ are not locked.");
         toolTip.SetToolTip(
             buttonDspProcessor,
-            "The processor this project is designed for: pick a model and\r\n" +
-            "its processing rate and PEQ Q convention come with it, or\r\n" +
-            "pick Custom and state them yourself.\r\n" +
-            "The processing rate is the rate every simulated filter is\r\n" +
-            "BUILT at — independent of the rate the channels were\r\n" +
-            "measured at, so a 48 kHz sound card can simulate a 96 kHz\r\n" +
-            "processor exactly, up to its own Nyquist.\r\n" +
-            "The Q convention only restates the numbers on a tuning\r\n" +
-            "sheet; it never moves a filter.");
+            "The processor this project is designed for: its processing\r\n" +
+            "rate, which every simulated filter is built at, and its PEQ Q\r\n" +
+            "convention, which only restates the tuning sheet.");
         toolTip.SetToolTip(
             buttonAi,
-            "Work with a chat assistant through the clipboard:\r\n" +
-            "Copy for AI puts the current settings, your notes and a\r\n" +
-            "diagnostic summary on the clipboard for you to paste into\r\n" +
-            "any assistant; Import AI proposal reads its reply back and\r\n" +
-            "shows every proposed change against the current value before\r\n" +
-            "anything is applied. Nothing is sent anywhere by Resonalyze.");
+            "Work with a chat assistant through the clipboard: Copy for AI\r\n" +
+            "puts the tune on it, Import AI proposal reads the reply back\r\n" +
+            "and shows every change before it is applied.\r\n" +
+            "Nothing is sent anywhere by Resonalyze.");
         toolTip.SetToolTip(
             buttonAutoSetup,
             "Crossover wizard: detect each channel's driver type from\r\n" +
@@ -3331,26 +3266,9 @@ public partial class VirtualCrossoverPanel : UserControl
             "Run Auto delay afterward to phase-align the result.");
         toolTip.SetToolTip(
             buttonPhaseGate,
-            "Configure the gate for the phase and impulse views: offset\r\n" +
-            "and Tukey fades, with an IR preview — cut the window before\r\n" +
-            "the first reflection for clean traces.\r\n" +
-            "The MAGNITUDE view deliberately ignores these durations: it\r\n" +
-            "reads a long fixed steady-state window (what the ear hears,\r\n" +
-            "cabin included — and the full depth of a bass EQ band, which\r\n" +
-            "a junction-length gate cannot contain). Only the gate's\r\n" +
-            "OFFSET carries over, saying where that window opens.\r\n" +
-            "Where the gate SITS — its offset and the detrend τ — belongs\r\n" +
-            "to the side you are viewing (L or R): their drivers arrive at\r\n" +
-            "different times, so fitting one no longer disturbs the other.\r\n" +
-            "The Tukey lengths, window mode, detrend mode and FDW cycles\r\n" +
-            "are shared, so both sides read at one resolution and method.\r\n" +
-            "The Junction phase read-out follows this gate's OFFSET and\r\n" +
-            "durations, but always reads an 8-cycle frequency-dependent\r\n" +
-            "window — the mode and FDW selectors shape a curve for the eye,\r\n" +
-            "and the settings that suit one are measurably the wrong\r\n" +
-            "instrument for a number. In the default FDW mode the numbers and\r\n" +
-            "the drawn curves are the same window; in Fixed mode they are not,\r\n" +
-            "and the plot then shows a longer window than the figures do.");
+            "Gate for the phase and impulse views: offset, fades and an IR\r\n" +
+            "preview. The magnitude view takes only the offset. Offset and\r\n" +
+            "detrend belong to the side shown; lengths and mode are shared.");
         toolTip.SetToolTip(
             buttonSessionExport,
             "Save the whole session (sources, DSP chains, gate, view)\r\n" +
@@ -3361,16 +3279,9 @@ public partial class VirtualCrossoverPanel : UserControl
             "Sources are re-resolved from history or their file paths.");
         toolTip.SetToolTip(
             buttonAudition,
-            "Render a music file through the current tune and save it\r\n" +
-            "as a WAV: the left side's summed response on channel 1,\r\n" +
-            "the right side's on channel 2. Microphone calibration can\r\n" +
-            "be applied as a linear-phase FIR baked into both sides.\r\n" +
-            "Listen through HEADPHONES only: each ear gets its side's\r\n" +
-            "measured acoustic path (drivers, cabin, capsule) at the mic\r\n" +
-            "position — not a binaural head simulation. Played through\r\n" +
-            "the same system it would convolve the car twice.\r\n" +
-            "A track at another sample rate is converted to the project's;\r\n" +
-            "the measured responses are never resampled.");
+            "Render a music file through the tune into a stereo WAV: the\r\n" +
+            "left sum on channel 1, the right on channel 2.\r\n" +
+            "Listen through HEADPHONES only.");
         // The per-channel block tooltips are applied in CreateChannel, so every
         // block — including ones added after construction — carries them.
     }

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -105,6 +105,8 @@ public partial class VirtualCrossoverPanel : UserControl
         SmoothingInverseOctaves: 12);
 
     private readonly List<VirtualCrossoverChannel> channels = new();
+    // The Lock beside the side radios; reads at every ScheduleSave, see the class.
+    private readonly VirtualCrossoverSideLock sideLock = new();
 
     // The EQ Wizard's own export machinery, reused whole so a channel's bank leaves
     // through exactly the formats, shelf/preamp rules and warnings the wizard uses.
@@ -253,6 +255,11 @@ public partial class VirtualCrossoverPanel : UserControl
         buttonResetChannels.Click += async (_, _) => await ResetChannelsAsync();
         buttonCopyLeftToRight.Click += (_, _) => CopySideSettings(fromRight: false);
         buttonCopyRightToLeft.Click += (_, _) => CopySideSettings(fromRight: true);
+        checkBoxSideLock.CheckedChanged += (_, _) => OnSideLockChanged();
+        // The designer ticks the box before this handler exists, so the lock it
+        // stands for is engaged here by hand; the pairs come under it as the
+        // project binds (BindProjectAsync hands them to Remember).
+        OnSideLockChanged();
 
         saveTimer.Tick += (_, _) => FlushProject();
         // The designer file owns Dispose; the unsaved project state and the
@@ -649,6 +656,11 @@ public partial class VirtualCrossoverPanel : UserControl
             suppressProjectEvents = false;
         }
 
+        // The blocks now hold the loaded pair objects; the lock, if it is on, starts
+        // over from them — otherwise the first edit after a load would meet an unknown
+        // pair and be recorded as its starting state instead of carried across.
+        sideLock.Remember(channels.Select(channel => channel.Pair));
+
         // Outside the suppressed block, because everything above was applied with
         // the selectors' own events silenced: the controls a view mutes (the
         // hybrid, the Sum and loss toggles, the phase and impulse radios) are
@@ -741,6 +753,10 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private void ScheduleSave()
     {
+        // Every change passes through here, so this is where the side lock reads:
+        // what moved on the shown side since the previous save goes onto the hidden
+        // one now, ahead of the redraw that follows every call and the save itself.
+        sideLock.Follow(channels.Select(channel => channel.Pair), project.ActiveSideRight);
         savePending = true;
         saveTimer.Stop();
         saveTimer.Start();
@@ -1163,6 +1179,24 @@ public partial class VirtualCrossoverPanel : UserControl
 
         ScheduleSave();
         RedrawAll();
+    }
+
+    // The Lock beside those two: engaging copies nothing — the sides are remembered
+    // as they stand and only what moves from here on is carried across, at every
+    // ScheduleSave (see VirtualCrossoverSideLock for the rules). On by default — a
+    // car tune is symmetric far more often than not — and not stored with the
+    // session: unticking it is the exception, for the one side being worked alone,
+    // and the next opening starts symmetric again.
+    private void OnSideLockChanged()
+    {
+        if (checkBoxSideLock.Checked)
+        {
+            sideLock.Engage(channels.Select(channel => channel.Pair));
+        }
+        else
+        {
+            sideLock.Release();
+        }
     }
 
     // The parts of one side's chain the dialog ticked, written onto the other side;
@@ -3264,6 +3298,21 @@ public partial class VirtualCrossoverPanel : UserControl
             "default, gain, delay, polarity and the all-pass on request.\r\n" +
             "Sources stay with their side; mono channels are not\r\n" +
             "offered.");
+        toolTip.SetToolTip(
+            checkBoxSideLock,
+            "Lock the crossover and the polarity of the two sides together:\r\n" +
+            "while this is ticked, a crossover or polarity change made on\r\n" +
+            "the side shown is written onto the other side of the same\r\n" +
+            "pair as it is made. Ticking it copies nothing — whatever\r\n" +
+            "already differs stays until that setting is next touched.\r\n" +
+            "The crossover travels as one (kind and both corners),\r\n" +
+            "polarity on its own. Gain, delay, phase and the PEQ are not\r\n" +
+            "locked; mono pairs have one settings set already. A run that\r\n" +
+            "writes both sides itself (Auto delay, the crossover wizard)\r\n" +
+            "keeps its own answer for the hidden side, and an AI import\r\n" +
+            "and its undo land exactly as their rows say.\r\n" +
+            "On by default; untick it to tune one side alone. The state is\r\n" +
+            "not stored with the session, so it is on again next time.");
         toolTip.SetToolTip(
             buttonDspProcessor,
             "The processor this project is designed for: pick a model and\r\n" +
@@ -6285,6 +6334,10 @@ public partial class VirtualCrossoverPanel : UserControl
             project.StereoLevelDifferenceDb = result.Request.LevelDifferenceDb;
         }
 
+        // The run decided polarity per side, and "keep the hidden side's" is a
+        // decision the side lock cannot see in a difference — so the lock is told to
+        // take the result as it stands rather than carry the shown side's flip over.
+        sideLock.Remember(channels.Select(channel => channel.Pair));
         ScheduleSave();
         RedrawAll();
         WriteAlignmentLog(result.Log.ToString());

--- a/source/Tools/VirtualCrossover/VirtualCrossoverSideLock.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverSideLock.cs
@@ -1,0 +1,191 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze;
+
+/// <summary>
+/// The <b>Lock</b> beside the side radios of the Virtual DSP: while it is on, a
+/// crossover or polarity edit made on the side the controls show is written onto the
+/// other side of the same pair, so a symmetric tune stays symmetric without an L→R
+/// after every corner moved.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It works by difference rather than by hooking the editors. The panel funnels every
+/// change through its autosave, and the lock keeps a snapshot of the locked group of
+/// BOTH sides of every pair as they stood at the previous <see cref="Follow"/> (or
+/// when the pair first came under the lock). A unit that differs from its snapshot on
+/// the shown side has moved since then and is copied across — unless the hidden side
+/// moved as well in the same step. That means an automatic run wrote both sides with
+/// an answer of its own (the crossover wizard and a junction tune write both sides
+/// alike) and that answer stands; the lock is for the hand on the knob, which only
+/// ever reaches the shown side. One such answer a difference cannot see is "keep":
+/// the auto-delay decides polarity per side and may flip the shown side while leaving
+/// the hidden one as it was, so the panel hands its result to <see cref="Remember"/>
+/// before the save, and nothing of it is carried. An AI import and its undo go the
+/// same way: their rows name their sides and the dialog showed exactly those, and an
+/// undo read as a difference could carry a restored value onto a side the import
+/// never touched.
+/// </para>
+/// <para>
+/// Whatever differed between the sides when the lock was engaged keeps differing until
+/// that unit is next touched: engaging copies nothing, which is the "from the moment it
+/// is ticked" the tooltip promises, and a user whose sides disagree can still see both
+/// disagreeing before deciding which one to type over.
+/// </para>
+/// <para>
+/// Two units, deliberately. The crossover — its kind and both edges — moves as ONE: a
+/// lock that carried only the corner the user turned would leave the hidden side's
+/// other corner, or its kind, where it was, and the two crossovers unequal after an
+/// edit meant to equalize them. Polarity moves on its own, so moving a corner does not
+/// flip the other side. Gain, delay, the phase angle and the PEQ are not locked: each
+/// aligns a driver against its own side's level and geometry, the same reason the L→R
+/// dialog leaves them unticked by default.
+/// </para>
+/// </remarks>
+internal sealed class VirtualCrossoverSideLock
+{
+    // The crossover as one value, so "did it move" and "write it across" read all
+    // three fields together; the record equality is what makes a moved corner show.
+    private readonly record struct Crossover(
+        CrossoverKind Kind,
+        CrossoverEdge HighPass,
+        CrossoverEdge LowPass)
+    {
+        public static Crossover Of(VirtualCrossoverChannelSettings settings) =>
+            new(settings.CrossoverKind, settings.HighPassEdge, settings.LowPassEdge);
+
+        public void WriteTo(VirtualCrossoverChannelSettings settings)
+        {
+            settings.CrossoverKind = Kind;
+            settings.HighPassEdge = HighPass;
+            settings.LowPassEdge = LowPass;
+        }
+    }
+
+    private readonly record struct Snapshot(Crossover Crossover, bool Inverted)
+    {
+        public static Snapshot Of(VirtualCrossoverChannelSettings settings) =>
+            new(Crossover.Of(settings), settings.InvertPolarity);
+    }
+
+    // Keyed by the pair OBJECT: a loaded session binds new pair objects, which is
+    // exactly when the old snapshots stop meaning anything. The pair class has no
+    // value equality, so the default comparer is reference identity already.
+    private readonly Dictionary<
+        VirtualCrossoverChannelPairSettings, (Snapshot Left, Snapshot Right)> snapshots = new();
+
+    public bool Engaged { get; private set; }
+
+    /// <summary>
+    /// Turns the lock on over these pairs, copying nothing: the sides are remembered
+    /// as they stand, and only what moves from here on is carried across.
+    /// </summary>
+    public void Engage(IEnumerable<VirtualCrossoverChannelPairSettings> pairs)
+    {
+        Engaged = true;
+        Remember(pairs);
+    }
+
+    public void Release()
+    {
+        Engaged = false;
+        snapshots.Clear();
+    }
+
+    /// <summary>
+    /// Remembers the pairs as they stand, carrying nothing. Called after the panel
+    /// rebinds its blocks to other pair objects (a loaded session, a reset) — without
+    /// it the first edit after a load would meet an unknown pair, be recorded as its
+    /// starting state, and never be mirrored — and after a run that decided both sides
+    /// itself, whose "keep" for the hidden side a difference cannot tell from a hand
+    /// that only reached the shown one.
+    /// </summary>
+    public void Remember(IEnumerable<VirtualCrossoverChannelPairSettings> pairs)
+    {
+        snapshots.Clear();
+        if (!Engaged)
+        {
+            return;
+        }
+
+        foreach (VirtualCrossoverChannelPairSettings pair in pairs)
+        {
+            snapshots[pair] = Take(pair);
+        }
+    }
+
+    /// <summary>
+    /// Carries what moved on the shown side since the previous call onto the hidden
+    /// side of each stereo pair, and remembers both sides as they now stand. A pair
+    /// seen for the first time is only remembered; one no longer listed is forgotten.
+    /// </summary>
+    /// <returns>Whether anything was written to a hidden side.</returns>
+    public bool Follow(IEnumerable<VirtualCrossoverChannelPairSettings> pairs, bool shownRight)
+    {
+        if (!Engaged)
+        {
+            return false;
+        }
+
+        bool wrote = false;
+        var current = new Dictionary<VirtualCrossoverChannelPairSettings, (Snapshot Left, Snapshot Right)>();
+        foreach (VirtualCrossoverChannelPairSettings pair in pairs)
+        {
+            // A mono pair has one settings set, so there is nothing to keep in step;
+            // its physical right side is still remembered, so that turning Mono off
+            // later starts from what that side actually holds.
+            if (!pair.Mono && snapshots.TryGetValue(pair, out (Snapshot Left, Snapshot Right) before))
+            {
+                wrote |= Carry(pair, before, shownRight);
+            }
+
+            current[pair] = Take(pair);
+        }
+
+        snapshots.Clear();
+        foreach (KeyValuePair<VirtualCrossoverChannelPairSettings, (Snapshot Left, Snapshot Right)> entry in current)
+        {
+            snapshots[entry.Key] = entry.Value;
+        }
+
+        return wrote;
+    }
+
+    private static bool Carry(
+        VirtualCrossoverChannelPairSettings pair,
+        (Snapshot Left, Snapshot Right) before,
+        bool shownRight)
+    {
+        VirtualCrossoverChannelSettings shown = pair.SideFor(shownRight);
+        VirtualCrossoverChannelSettings hidden = pair.SideFor(!shownRight);
+        Snapshot shownBefore = shownRight ? before.Right : before.Left;
+        Snapshot hiddenBefore = shownRight ? before.Left : before.Right;
+        Snapshot shownNow = Snapshot.Of(shown);
+        Snapshot hiddenNow = Snapshot.Of(hidden);
+
+        bool wrote = false;
+        if (shownNow.Crossover != shownBefore.Crossover &&
+            hiddenNow.Crossover == hiddenBefore.Crossover &&
+            hiddenNow.Crossover != shownNow.Crossover)
+        {
+            shownNow.Crossover.WriteTo(hidden);
+            wrote = true;
+        }
+
+        if (shownNow.Inverted != shownBefore.Inverted &&
+            hiddenNow.Inverted == hiddenBefore.Inverted &&
+            hiddenNow.Inverted != shownNow.Inverted)
+        {
+            hidden.InvertPolarity = shownNow.Inverted;
+            wrote = true;
+        }
+
+        return wrote;
+    }
+
+    // The PHYSICAL sides, mono routing ignored, for the same reason the channel keeps
+    // a physical accessor: through the routed one a mono pair's right side is
+    // unreachable, and its snapshot would silently become a copy of the left.
+    private static (Snapshot Left, Snapshot Right) Take(VirtualCrossoverChannelPairSettings pair) =>
+        (Snapshot.Of(pair.Left), Snapshot.Of(pair.Right));
+}

--- a/source/Tools/VirtualCrossover/VirtualCrossoverSideLock.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverSideLock.cs
@@ -14,17 +14,19 @@ namespace Resonalyze;
 /// change through its autosave, and the lock keeps a snapshot of the locked group of
 /// BOTH sides of every pair as they stood at the previous <see cref="Follow"/> (or
 /// when the pair first came under the lock). A unit that differs from its snapshot on
-/// the shown side has moved since then and is copied across — unless the hidden side
-/// moved as well in the same step. That means an automatic run wrote both sides with
-/// an answer of its own (the crossover wizard and a junction tune write both sides
-/// alike) and that answer stands; the lock is for the hand on the knob, which only
-/// ever reaches the shown side. One such answer a difference cannot see is "keep":
-/// the auto-delay decides polarity per side and may flip the shown side while leaving
-/// the hidden one as it was, so the panel hands its result to <see cref="Remember"/>
-/// before the save, and nothing of it is carried. An AI import and its undo go the
-/// same way: their rows name their sides and the dialog showed exactly those, and an
-/// undo read as a difference could carry a restored value onto a side the import
-/// never touched.
+/// the shown side has moved since then and is copied across. The lock is for the
+/// hand on the knob, which only ever reaches the shown side; a run that writes both
+/// sides itself hands its result to <see cref="Remember"/> before the save, and
+/// nothing of it is carried. That is a rule, not a heuristic, because a difference
+/// cannot tell such a run from a hand edit: the auto-delay may flip the shown side's
+/// polarity and KEEP the hidden one; a junction tune or the crossover wizard writes
+/// one edge onto both sides, and a hidden side that already held it looks untouched
+/// while the shown side's whole crossover — its other edge included — would be
+/// carried over the hidden side's own; an AI import's rows name their sides and the
+/// dialog showed exactly those; and an undo read as a difference could carry a
+/// restored value onto a side the import never touched. (A guard that only carried
+/// when the hidden side had NOT moved in the same step was tried and failed exactly
+/// on the "already held it" case, so the panel names every such run instead.)
 /// </para>
 /// <para>
 /// Whatever differed between the sides when the lock was engaged keeps differing until
@@ -159,13 +161,11 @@ internal sealed class VirtualCrossoverSideLock
         VirtualCrossoverChannelSettings shown = pair.SideFor(shownRight);
         VirtualCrossoverChannelSettings hidden = pair.SideFor(!shownRight);
         Snapshot shownBefore = shownRight ? before.Right : before.Left;
-        Snapshot hiddenBefore = shownRight ? before.Left : before.Right;
         Snapshot shownNow = Snapshot.Of(shown);
         Snapshot hiddenNow = Snapshot.Of(hidden);
 
         bool wrote = false;
         if (shownNow.Crossover != shownBefore.Crossover &&
-            hiddenNow.Crossover == hiddenBefore.Crossover &&
             hiddenNow.Crossover != shownNow.Crossover)
         {
             shownNow.Crossover.WriteTo(hidden);
@@ -173,7 +173,6 @@ internal sealed class VirtualCrossoverSideLock
         }
 
         if (shownNow.Inverted != shownBefore.Inverted &&
-            hiddenNow.Inverted == hiddenBefore.Inverted &&
             hiddenNow.Inverted != shownNow.Inverted)
         {
             hidden.InvertPolarity = shownNow.Inverted;

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSideLockTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSideLockTests.cs
@@ -153,25 +153,47 @@ public sealed class VirtualCrossoverSideLockTests
     }
 
     [Fact]
-    public void BothSidesWrittenInOneStep_KeepTheirOwnAnswers()
+    public void AnEdgeWrittenOntoBothSides_IsRememberedNotCarriedWholesale()
     {
-        // A step that moved the hidden side too is an automatic run (the crossover
-        // wizard, a junction tune, an agent proposal addressing both sides), and its
-        // answer for the hidden side is not overwritten by the shown one.
+        // A junction tune (or the crossover wizard) writes ONE edge onto both sides.
+        // The hidden side already held that edge, so as a difference it looks
+        // untouched — and a difference would then carry the shown side's whole
+        // crossover, its OTHER edge included, over the hidden side's own. The panel
+        // hands such a run to Remember instead; here is what that keeps.
         VirtualCrossoverChannelPairSettings pair = StereoPair();
-        pair.Right.InvertPolarity = true;
+        pair.Right.HighPassEdge = Bw12At100;
+        pair.Right.LowPassEdge = Lr48At3000;
         var sideLock = new VirtualCrossoverSideLock();
         sideLock.Engage([pair]);
 
-        pair.Left.InvertPolarity = true;
-        pair.Right.InvertPolarity = false;
-        pair.Right.HighPassEdge = Bw12At100;
-        pair.Left.HighPassEdge = Lr48At3000;
+        pair.Left.LowPassEdge = Lr48At3000;
+        pair.Right.LowPassEdge = Lr48At3000;
+        sideLock.Remember([pair]);
         bool wrote = sideLock.Follow([pair], shownRight: false);
 
         Assert.False(wrote);
-        Assert.False(pair.Right.InvertPolarity);
         Assert.Equal(Bw12At100, pair.Right.HighPassEdge);
+        Assert.Equal(Lr24At80, pair.Left.HighPassEdge);
+    }
+
+    [Fact]
+    public void WithoutRemember_TheSameRunWouldBeReadAsAHandEdit()
+    {
+        // The reason the panel names every such run: read as a difference, the case
+        // above carries the whole crossover. Pinned so that a guard which "detects"
+        // automatic runs is not reintroduced in place of the explicit call.
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        pair.Right.HighPassEdge = Bw12At100;
+        pair.Right.LowPassEdge = Lr48At3000;
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+
+        pair.Left.LowPassEdge = Lr48At3000;
+        pair.Right.LowPassEdge = Lr48At3000;
+        bool wrote = sideLock.Follow([pair], shownRight: false);
+
+        Assert.True(wrote);
+        Assert.Equal(Lr24At80, pair.Right.HighPassEdge);
     }
 
     [Fact]

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverSideLockTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverSideLockTests.cs
@@ -1,0 +1,291 @@
+using Resonalyze.Dsp;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// What the Lock beside the side radios carries across, and what it leaves alone.
+/// It reads by difference at every save, so the questions are all about WHICH
+/// difference: one the hand made on the shown side (carried), one already there
+/// when the lock went on (kept), one an automatic run wrote on both sides at once
+/// (kept), one made on the hidden side (kept).
+/// </summary>
+public sealed class VirtualCrossoverSideLockTests
+{
+    private static readonly CrossoverEdge Lr24At80 =
+        new(CrossoverFilterFamily.LinkwitzRiley, 80, 24);
+    private static readonly CrossoverEdge Lr24At2500 =
+        new(CrossoverFilterFamily.LinkwitzRiley, 2_500, 24);
+    private static readonly CrossoverEdge Bw12At100 =
+        new(CrossoverFilterFamily.Butterworth, 100, 12);
+    private static readonly CrossoverEdge Lr48At3000 =
+        new(CrossoverFilterFamily.LinkwitzRiley, 3_000, 48);
+
+    [Fact]
+    public void EngagingCopiesNothing_ExistingDifferencesStand()
+    {
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        pair.Right.HighPassEdge = Bw12At100;
+        pair.Right.InvertPolarity = true;
+        var sideLock = new VirtualCrossoverSideLock();
+
+        sideLock.Engage([pair]);
+        bool wrote = sideLock.Follow([pair], shownRight: false);
+
+        Assert.False(wrote);
+        Assert.Equal(Bw12At100, pair.Right.HighPassEdge);
+        Assert.True(pair.Right.InvertPolarity);
+        Assert.False(pair.Left.InvertPolarity);
+    }
+
+    [Fact]
+    public void ACornerMovedOnTheShownSide_CarriesTheWholeCrossoverAcross()
+    {
+        // The sides disagreed on the low-pass before the lock; moving the HIGH-pass
+        // on the left equalizes the whole crossover, not just the corner touched —
+        // otherwise the two crossovers would still differ after an edit meant to
+        // make them the same. Polarity is its own unit and stays.
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        pair.Right.LowPassEdge = Lr48At3000;
+        pair.Right.InvertPolarity = true;
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+
+        pair.Left.HighPassEdge = Bw12At100;
+        bool wrote = sideLock.Follow([pair], shownRight: false);
+
+        Assert.True(wrote);
+        Assert.Equal(Bw12At100, pair.Right.HighPassEdge);
+        Assert.Equal(Lr24At2500, pair.Right.LowPassEdge);
+        Assert.Equal(CrossoverKind.BandPass, pair.Right.CrossoverKind);
+        Assert.True(pair.Right.InvertPolarity);
+    }
+
+    [Fact]
+    public void APolarityFlipOnTheShownSide_CarriesOnlyThePolarity()
+    {
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        pair.Right.LowPassEdge = Lr48At3000;
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+
+        pair.Left.InvertPolarity = true;
+        bool wrote = sideLock.Follow([pair], shownRight: false);
+
+        Assert.True(wrote);
+        Assert.True(pair.Right.InvertPolarity);
+        Assert.Equal(Lr48At3000, pair.Right.LowPassEdge);
+    }
+
+    [Fact]
+    public void TheRightSideShown_CarriesOntoTheLeft()
+    {
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+
+        pair.Right.CrossoverKind = CrossoverKind.HighPass;
+        pair.Right.HighPassEdge = Bw12At100;
+        bool wrote = sideLock.Follow([pair], shownRight: true);
+
+        Assert.True(wrote);
+        Assert.Equal(CrossoverKind.HighPass, pair.Left.CrossoverKind);
+        Assert.Equal(Bw12At100, pair.Left.HighPassEdge);
+    }
+
+    [Fact]
+    public void BothUnitsMovedOnTheShownSideInOneStep_AreBothCarried()
+    {
+        // One save can hold a crossover move and a polarity flip together (a batch
+        // update of the block); the two units are read independently, so neither
+        // hides the other.
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+
+        pair.Left.HighPassEdge = Bw12At100;
+        pair.Left.InvertPolarity = true;
+        bool wrote = sideLock.Follow([pair], shownRight: false);
+
+        Assert.True(wrote);
+        Assert.Equal(Bw12At100, pair.Right.HighPassEdge);
+        Assert.True(pair.Right.InvertPolarity);
+    }
+
+    [Fact]
+    public void ACarriedChange_IsNotCarriedBackFromTheOtherSide()
+    {
+        // The write onto the hidden side is remembered in the same pass, so when
+        // the user switches to that side the lock finds nothing that moved there —
+        // a carried value is not a hand edit to bounce back.
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+
+        pair.Left.HighPassEdge = Bw12At100;
+        pair.Left.InvertPolarity = true;
+        Assert.True(sideLock.Follow([pair], shownRight: false));
+
+        Assert.False(sideLock.Follow([pair], shownRight: true));
+        Assert.Equal(Bw12At100, pair.Left.HighPassEdge);
+        Assert.Equal(Bw12At100, pair.Right.HighPassEdge);
+        Assert.True(pair.Left.InvertPolarity);
+        Assert.True(pair.Right.InvertPolarity);
+    }
+
+    [Fact]
+    public void GainDelayPhaseAndPeq_AreNotLocked()
+    {
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+
+        pair.Left.GainDb = -3;
+        pair.Left.DelayMs = 1.5;
+        pair.Left.PhaseRotationDegrees = 90;
+        pair.Left.PeqBands.Add(new PeqBand(1_000, 2.0, -4.0));
+        bool wrote = sideLock.Follow([pair], shownRight: false);
+
+        Assert.False(wrote);
+        Assert.Equal(0, pair.Right.GainDb);
+        Assert.Equal(0, pair.Right.DelayMs);
+        Assert.Equal(0, pair.Right.PhaseRotationDegrees);
+        Assert.Empty(pair.Right.PeqBands);
+    }
+
+    [Fact]
+    public void BothSidesWrittenInOneStep_KeepTheirOwnAnswers()
+    {
+        // A step that moved the hidden side too is an automatic run (the crossover
+        // wizard, a junction tune, an agent proposal addressing both sides), and its
+        // answer for the hidden side is not overwritten by the shown one.
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        pair.Right.InvertPolarity = true;
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+
+        pair.Left.InvertPolarity = true;
+        pair.Right.InvertPolarity = false;
+        pair.Right.HighPassEdge = Bw12At100;
+        pair.Left.HighPassEdge = Lr48At3000;
+        bool wrote = sideLock.Follow([pair], shownRight: false);
+
+        Assert.False(wrote);
+        Assert.False(pair.Right.InvertPolarity);
+        Assert.Equal(Bw12At100, pair.Right.HighPassEdge);
+    }
+
+    [Fact]
+    public void ARunThatKeptTheHiddenSide_IsRememberedRatherThanRead()
+    {
+        // The auto-delay may flip the shown side and decide to KEEP the hidden one —
+        // which a difference cannot tell from a hand that only reached the shown
+        // side. The panel hands such a result to Remember, and nothing is carried.
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+
+        pair.Left.InvertPolarity = true;
+        sideLock.Remember([pair]);
+        bool wrote = sideLock.Follow([pair], shownRight: false);
+
+        Assert.False(wrote);
+        Assert.False(pair.Right.InvertPolarity);
+    }
+
+    [Fact]
+    public void AChangeOnTheHiddenSide_IsAbsorbedRatherThanMirroredBack()
+    {
+        // Something wrote the hidden side alone (an L→R copy from the dialog, say)
+        // while the left was shown. It is not undone, and when the user then switches
+        // to that side it is not carried back either: it was already remembered.
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+
+        pair.Right.HighPassEdge = Bw12At100;
+        Assert.False(sideLock.Follow([pair], shownRight: false));
+        Assert.Equal(Bw12At100, pair.Right.HighPassEdge);
+        Assert.Equal(Lr24At80, pair.Left.HighPassEdge);
+
+        Assert.False(sideLock.Follow([pair], shownRight: true));
+        Assert.Equal(Lr24At80, pair.Left.HighPassEdge);
+    }
+
+    [Fact]
+    public void AMonoPair_IsLeftAlone()
+    {
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        pair.Mono = true;
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+
+        pair.Left.HighPassEdge = Bw12At100;
+        bool wrote = sideLock.Follow([pair], shownRight: false);
+
+        Assert.False(wrote);
+        Assert.Equal(Lr24At80, pair.Right.HighPassEdge);
+    }
+
+    [Fact]
+    public void APairFirstSeenAtASave_IsRememberedNotMirrored()
+    {
+        // A block added under the lock arrives at the save that added it: its state
+        // is the starting point, and nothing is carried for it until it is edited.
+        VirtualCrossoverChannelPairSettings first = StereoPair();
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([first]);
+
+        VirtualCrossoverChannelPairSettings added = StereoPair();
+        added.Left.HighPassEdge = Bw12At100;
+        Assert.False(sideLock.Follow([first, added], shownRight: false));
+        Assert.Equal(Lr24At80, added.Right.HighPassEdge);
+
+        added.Left.InvertPolarity = true;
+        Assert.True(sideLock.Follow([first, added], shownRight: false));
+        Assert.True(added.Right.InvertPolarity);
+    }
+
+    [Fact]
+    public void RebindingAfterALoad_StartsFromTheLoadedState()
+    {
+        // The panel binds new pair objects on a load. Remember takes them as
+        // loaded, so the very first edit afterwards is carried like any other.
+        VirtualCrossoverChannelPairSettings before = StereoPair();
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([before]);
+
+        VirtualCrossoverChannelPairSettings loaded = StereoPair();
+        sideLock.Remember([loaded]);
+        loaded.Left.InvertPolarity = true;
+
+        Assert.True(sideLock.Follow([loaded], shownRight: false));
+        Assert.True(loaded.Right.InvertPolarity);
+    }
+
+    [Fact]
+    public void ReleasedLock_CarriesNothing()
+    {
+        VirtualCrossoverChannelPairSettings pair = StereoPair();
+        var sideLock = new VirtualCrossoverSideLock();
+        sideLock.Engage([pair]);
+        sideLock.Release();
+
+        pair.Left.InvertPolarity = true;
+
+        Assert.False(sideLock.Follow([pair], shownRight: false));
+        Assert.False(pair.Right.InvertPolarity);
+    }
+
+    private static VirtualCrossoverChannelPairSettings StereoPair() => new()
+    {
+        Left = BandPass(),
+        Right = BandPass()
+    };
+
+    private static VirtualCrossoverChannelSettings BandPass() => new()
+    {
+        CrossoverKind = CrossoverKind.BandPass,
+        HighPassEdge = Lr24At80,
+        LowPassEdge = Lr24At2500
+    };
+}


### PR DESCRIPTION
A Lock button-checkbox sits right of R→L, under Reset. While it is on, a crossover
or polarity change made on the side shown is written onto the other side of the
same pair as it is made, so a symmetric tune needs no L→R after every corner moved.

It reads by difference at every ScheduleSave (`VirtualCrossoverSideLock`, UI-free):
a snapshot of both sides of every pair, and what moved on the shown side since the
previous save is carried. Engaging copies nothing; what already differed stays
until that setting is next touched. The crossover travels as one (kind and both
edges), polarity on its own; gain, delay, phase and the PEQ are not locked; mono
pairs are skipped.

The lock is for the hand on the knob, which only reaches the side shown. Every
run that writes both sides itself hands its result to `Remember`, which takes
the pairs as they stand — a rule, not a guess, because a difference cannot tell
such a run from a hand edit: a load and a reset (they bind new pair objects, and
the first edit afterwards would otherwise be recorded as a starting state); the
auto-delay commit (it decides polarity per side, and "keep the hidden side" is
not a difference); a junction tune and the crossover wizard (they write one edge
onto both sides, and a hidden side that already held it looks untouched while
the shown side's whole crossover would be carried over its other edge); the AI
import right after its rows land and before the engines (the rows name their
sides and the dialog showed exactly those); and Undo AI import (read as a
difference, an undo could carry a restored value onto a side the import never
touched: L=A, R=B; the import writes L=B; the undo restores L=A alone).

On by default — a car tune is symmetric far more often than not — and not
stored with the session, so every opening starts symmetric; untick it to tune
one side alone.

REFERENCE.md documents the control. The Virtual DSP panel figure changed (Lock
added beside R→L) and wants a re-run of the screenshot tool. 15 tests pin the
rules in `VirtualCrossoverSideLockTests`, one of them the reading that goes
wrong without the explicit call.

Along the way, every tooltip in the app now says what its control does in at
most four lines. Twenty-four of them, all but one in the Virtual DSP, had grown
into reasoning that belongs to REFERENCE.md and is there already; the two facts
that were not — set the crossovers before Auto delay, and the invert-and-null
hand check for the Sum loss — are added to it, and the Zone tooltip no longer
promises grouped views and staged alignment "next".

Not done, on purpose: the hidden-side write leaves no visual trace on the side
shown (only the dashed opposite Sum moves), and a phase angle on the hidden side
keeps its number after the crossover under it was carried — the same behaviour
as the L→R dialog with Crossover ticked and Phase not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
