### PR TITLE
Virtual DSP: a Step view draws each channel's step response and the Sum's on one scale

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1120,8 +1120,10 @@ phase and group delay, run **Auto delay...** again after adding or changing one.
 The **virtual tune is complete**; what remains is transferring it and verifying it.
 Every setting stays editable — delays, polarity, crossovers, gains — with the
 prediction redrawn immediately, in the **Magnitude**, **Phase**, **Group Delay**,
-**Impulse** and **Correlation** views. Change a parameter, look, and keep it only if the
-system actually improves. **Load / Edit… → Edit in EQ Wizard** reopens any channel
+**Impulse**, **Step** and **Correlation** views. Change a parameter, look, and keep it only if the
+system actually improves. The **Step** view is the quick polarity check: every
+driver's step and the Sum's on one scale, so a driver stepping the other way
+first, or a Sum climbing in two moves, is visible at a glance. **Load / Edit… → Edit in EQ Wizard** reopens any channel
 against its current chain. After changing a crossover, re-check that channel's PEQ;
 after changing a crossover or a bank — an all-pass included — run **Auto delay...**
 again.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2077,7 +2077,10 @@ add up to — its step is the sum of theirs, so a driver's share of the total ca
 be read off the plot. A driver in the wrong polarity steps the other way first;
 a junction whose halves arrive apart shows as a Sum that climbs in two moves.
 The Sum adds every summing channel, hidden or not, exactly the set the
-magnitude Sum adds. The running sum starts at the left edge of the drawn
+magnitude Sum adds, and the opposite side's Sum rides along beside it as a
+thin dashed translucent line on the same absolute clock, as on the magnitude
+view, so the two tunes' fronts compare without flipping the L/R selector. The
+running sum starts at the left edge of the drawn
 window, not at the record's start, so the noise before a channel's arrival does
 not float its curve; the gate is only drawn here, never applied, because a
 taper on the samples would read as a decay of the step. The Sum toggle keeps

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -126,7 +126,8 @@ remembers one range per mode, so Frequency Response and Impulse Response do not
 fight over a scale; the Time Alignment previews keep theirs across a
 reconfiguration, and the EQ Wizard and Virtual DSP graphs hold theirs until
 something changes what the axis means (loading a new wizard source, switching
-the Virtual DSP view between magnitude, phase, group delay and impulse).
+the Virtual DSP view between magnitude, phase, group delay, impulse and step —
+impulse and step share one time axis, so a toggle between those two keeps it).
 
 Axes you have **not** touched still scale themselves — the dB axis lifts its
 ceiling for a padded loopback, group delay fits its data — so the automatic
@@ -2062,10 +2063,27 @@ The acoustic plot shows raw and processed curves per channel for the active side
 redraws the same curves from the other side's measurement),
 the complex **Sum**, the **opposite side's Sum** as a dashed translucent curve,
 and the **Sum loss** curve, with a **View** row — **Magnitude**, **Phase**,
-**Impulse** and **Group delay** — and a **Sum loss** read-out (avg / dip per
+**Impulse**, **Group delay** and **Step** — and a **Sum loss** read-out (avg / dip per
 junction plus a total). **Phase** draws each processed channel's phase and the
 Sum's through the phase gate; **Impulse** promotes the gate dialog's preview to
-the main plot, every channel's processed response on one absolute timeline;
+the main plot, every channel's processed response on one absolute timeline,
+each trace normalized to its own peak; **Step** draws the same responses as
+step responses — the running sum of each processed impulse response — and the
+Sum's, over the same window and around the same gate, every curve on ONE common
+scale (the largest excursion among them) rather than each to its own peak. The
+curves keep their sizes relative to each other and to the Sum: a woofer's step
+is the big slow one, a tweeter's the small fast one, and the Sum is what they
+add up to — its step is the sum of theirs, so a driver's share of the total can
+be read off the plot. A driver in the wrong polarity steps the other way first;
+a junction whose halves arrive apart shows as a Sum that climbs in two moves.
+The Sum adds every summing channel, hidden or not, exactly the set the
+magnitude Sum adds. The running sum starts at the left edge of the drawn
+window, not at the record's start, so the noise before a channel's arrival does
+not float its curve; the gate is only drawn here, never applied, because a
+taper on the samples would read as a decay of the step. The Sum toggle keeps
+its own answer on this view, inheriting the magnitude one until it is set; the
+smoothing selector, the Sum loss selector, the hybrid, the target and the
+spatial average sit muted, as on the impulse view.
 **Group delay** draws each processed channel's group delay and the Sum's through
 that same gate and window (Fixed, or FDW with the project's cycles), placed as
 the phase curves are placed and previewed by the open **Gate…** dialog the same
@@ -2350,7 +2368,7 @@ L/R difference that is really a method difference. The two sides share ONE offse
 (the shown side's), because one analyzer session at one input gain produced every
 capture and giving each side its own would erase exactly the L/R level difference
 the captures measured. Like the target and the sum loss it
-is a magnitude toggle, greyed on the phase, group-delay and impulse views — a spatial average
+is a magnitude toggle, greyed on the phase, group-delay, impulse and step views — a spatial average
 carries no phase. The tick itself survives all of that: it says what you want
 drawn, so re-attaching a capture brings the hybrid straight back instead of
 sending you to find the checkbox again.
@@ -2411,7 +2429,7 @@ reflection tail the long window would otherwise admit; its cycle count shortens 
 window with frequency and never lengthens it, so the gate stays the outer limit and
 8 cycles are not suddenly available at 24 Hz.
 
-The gate's durations shape the **phase, group-delay and impulse views only**. The magnitude
+The gate's durations shape the **phase, group-delay, impulse and step views only**. The magnitude
 view — channels, Sum, Sum loss and the read-out built from them — deliberately
 reads a long fixed **steady-state window** (~680 ms, clamped to 32768 samples at
 high rates) that only takes the gate's OFFSET, saying where it opens. (The one

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2084,9 +2084,11 @@ running sum starts at the left edge of the drawn
 window, not at the record's start, so the noise before a channel's arrival does
 not float its curve; the gate is only drawn here, never applied, because a
 taper on the samples would read as a decay of the step. The Sum toggle keeps
-its own answer on this view, inheriting the magnitude one until it is set; the
-smoothing selector, the Sum loss selector, the hybrid, the target and the
-spatial average sit muted, as on the impulse view.
+its own answer on this view, inheriting the magnitude one until it is set. No
+loss curve is drawn here, but the Sum loss selector stays live, as on the
+impulse view: it picks the window of the read-out column, which is still
+quoted. The smoothing selector, the hybrid, the target and the spatial average
+sit muted, as on the impulse view.
 **Group delay** draws each processed channel's group delay and the Sum's through
 that same gate and window (Fixed, or FDW with the project's cycles), placed as
 the phase curves are placed and previewed by the open **Gate…** dialog the same
@@ -2102,9 +2104,11 @@ band blanks a channel's curve there, as it does in Group Delay mode. Only the
 plain group delay is drawn, no minimum/excess split — the excess of the raw
 measurement stays the AI diagnostic's — and the Sum
 toggle keeps its own answer on this view, inheriting the phase view's until it
-is set. The Sum loss selector, the hybrid, the target and the spatial average
-are magnitude toggles and sit muted here, as on the phase view; the smoothing
-selector applies, its psychoacoustic width reading as 1/12 octave on a time
+is set. The hybrid, the target and the spatial average are magnitude toggles
+and sit muted here, as on the phase view; the Sum loss selector stays live
+there and here, since the read-out column it picks the window for is still
+quoted, only its curve is magnitude-only; the smoothing selector applies, its
+psychoacoustic width reading as 1/12 octave on a time
 curve. The loss is a dB gap, not a
 level, so it is drawn against its own amber **Sum loss (dB)** axis on the right
 (0 dB near the top, 6 dB steps, deepening to hold a notch) that appears only

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2070,20 +2070,22 @@ the main plot, every channel's processed response on one absolute timeline,
 each trace normalized to its own peak; **Step** draws the same responses as
 step responses — the running sum of each processed impulse response — and the
 Sum's, over the same window and around the same gate, every curve on ONE common
-scale (the largest excursion among them) rather than each to its own peak. The
-curves keep their sizes relative to each other and to the Sum: a woofer's step
-is the big slow one, a tweeter's the small fast one, and the Sum is what they
-add up to — its step is the sum of theirs, so a driver's share of the total can
-be read off the plot. A driver in the wrong polarity steps the other way first;
-a junction whose halves arrive apart shows as a Sum that climbs in two moves.
-The Sum adds every summing channel, hidden or not, exactly the set the
-magnitude Sum adds, and the opposite side's Sum rides along beside it as a
-thin dashed translucent line on the same absolute clock, as on the magnitude
+scale (the largest excursion among them inside the window) rather than each to
+its own peak. The common scale preserves the relative transient amplitudes of
+the channel responses and their Sum: the Sum's step is the sum of theirs, so
+what each channel puts into the total's front can be seen — though a step's
+size is a matter of the channel's band and filters as much as of its level: a
+high-passed driver's step returns to zero, and it is no measure of that
+driver's share of the sound. A driver in the wrong polarity steps the other
+way first; a junction whose halves arrive apart shows as a Sum that climbs in
+two moves. The Sum adds every summing channel, hidden or not, exactly the set
+the magnitude Sum adds, and the opposite side's Sum rides along beside it as
+a thin dashed translucent line on the same absolute clock, as on the magnitude
 view, so the two tunes' fronts compare without flipping the L/R selector. The
-running sum starts at the left edge of the drawn
-window, not at the record's start, so the noise before a channel's arrival does
-not float its curve; the gate is only drawn here, never applied, because a
-taper on the samples would read as a decay of the step. The Sum toggle keeps
+running sum runs from the record's start whatever the gate is: the gate only
+frames the view and never enters the curve — the same sample reads the same
+under every gate, up to the window's scale — because a taper on the samples
+would read as a decay of the step. The Sum toggle keeps
 its own answer on this view, inheriting the magnitude one until it is set. No
 loss curve is drawn here, but the Sum loss selector stays live, as on the
 impulse view: it picks the window of the read-out column, which is still

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -312,6 +312,40 @@ public static class VirtualCrossoverAnalysis
     }
 
     /// <summary>
+    /// The step response of an impulse response over one stretch of it: the
+    /// running sum of the real samples from <paramref name="start"/>, for
+    /// <paramref name="count"/> samples, with the sum starting at zero there.
+    /// A sample past the end of the record counts as silence. Linear, so the
+    /// step of a summed response is the sum of the steps over the same stretch.
+    /// </summary>
+    /// <remarks>
+    /// Summed from the stretch's own start rather than from the record's: the
+    /// samples before a channel's arrival are noise, and their running sum would
+    /// put the whole curve on a floor that has nothing to do with the channel.
+    /// </remarks>
+    public static double[] StepResponse(Complex[] impulseResponse, int start, int count)
+    {
+        ArgumentNullException.ThrowIfNull(impulseResponse);
+        ArgumentOutOfRangeException.ThrowIfNegative(start);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        var step = new double[count];
+        double running = 0.0;
+        for (int i = 0; i < count; i++)
+        {
+            int index = start + i;
+            if (index < impulseResponse.Length)
+            {
+                running += impulseResponse[index].Real;
+            }
+
+            step[i] = running;
+        }
+
+        return step;
+    }
+
+    /// <summary>
     /// Finds the extra delay (ms) for one channel that best aligns it with the
     /// already-processed remaining channels: the delay maximizing the energy of
     /// their complex sum inside the given frequency window (the crossover

--- a/dsp/VirtualCrossoverAnalysis.cs
+++ b/dsp/VirtualCrossoverAnalysis.cs
@@ -312,16 +312,19 @@ public static class VirtualCrossoverAnalysis
     }
 
     /// <summary>
-    /// The step response of an impulse response over one stretch of it: the
-    /// running sum of the real samples from <paramref name="start"/>, for
-    /// <paramref name="count"/> samples, with the sum starting at zero there.
-    /// A sample past the end of the record counts as silence. Linear, so the
-    /// step of a summed response is the sum of the steps over the same stretch.
+    /// The step response of an impulse response — the running sum of its real
+    /// samples from the record's start — returned for one stretch of it:
+    /// <paramref name="count"/> samples from <paramref name="start"/>. A sample
+    /// past the end of the record counts as silence. Linear, so the step of a
+    /// summed response is the sum of the steps.
     /// </summary>
     /// <remarks>
-    /// Summed from the stretch's own start rather than from the record's: the
-    /// samples before a channel's arrival are noise, and their running sum would
-    /// put the whole curve on a floor that has nothing to do with the channel.
+    /// The sum always runs from the record's start, whatever stretch is asked
+    /// for: the step is a property of the response, and a reader that only
+    /// shows part of it must see the same values at the same samples whichever
+    /// part it shows. (The Virtual DSP step view's window follows the phase
+    /// gate; a sum that started at the window would change shape with a gate
+    /// that is never applied.)
     /// </remarks>
     public static double[] StepResponse(Complex[] impulseResponse, int start, int count)
     {
@@ -329,8 +332,13 @@ public static class VirtualCrossoverAnalysis
         ArgumentOutOfRangeException.ThrowIfNegative(start);
         ArgumentOutOfRangeException.ThrowIfNegative(count);
 
-        var step = new double[count];
         double running = 0.0;
+        for (int index = 0; index < start && index < impulseResponse.Length; index++)
+        {
+            running += impulseResponse[index].Real;
+        }
+
+        var step = new double[count];
         for (int i = 0; i < count; i++)
         {
             int index = start + i;

--- a/source/Options/ImpulseWindowPreview.cs
+++ b/source/Options/ImpulseWindowPreview.cs
@@ -21,11 +21,14 @@ internal enum IrPreviewSource
 }
 
 // One impulse response drawn on a gated preview: the samples on the absolute
-// timeline plus the color/title it is drawn with.
+// timeline plus the color/title it is drawn with. The stroke defaults to the
+// preview's own; the Virtual DSP step view thickens its Sum the way the other
+// views do.
 internal sealed record IrPreviewTrace(
     Complex[] Samples,
     string Title,
-    OxyColor Color);
+    OxyColor Color,
+    double Thickness = 1.2);
 
 internal static class ImpulseWindowPreview
 {
@@ -73,50 +76,24 @@ internal static class ImpulseWindowPreview
         double rightMs,
         object? seriesTag = null)
     {
-        if (traces.Count == 0 || sampleRate <= 0)
+        if (GatedDisplay.Resolve(
+                traces, sampleRate, gateOffsetMs, leftMs, plateauMs, rightMs)
+            is not { } display)
         {
             return null;
-        }
-
-        int gateOffset = MillisecondsToSamples(gateOffsetMs, sampleRate);
-        int left = MillisecondsToSamples(leftMs, sampleRate);
-        int plateau = MillisecondsToSamples(plateauMs, sampleRate);
-        int right = MillisecondsToSamples(rightMs, sampleRate);
-        int gate = Math.Max(1, left + plateau + right);
-        int gateStart = gateOffset - left;
-
-        double[] tukey = Windowing.TukeyWindow(
-            gate,
-            (double)left / gate * 2.0,
-            (double)right / gate * 2.0);
-
-        int longest = traces.Max(trace => trace.Samples.Length);
-        int context = Math.Max(gate / 8, MillisecondsToSamples(0.2, sampleRate));
-        int displayStart = Math.Max(0, gateStart - context);
-        int displayEnd = Math.Min(longest - 1, gateStart + gate + context);
-        if (displayEnd < displayStart)
-        {
-            displayEnd = displayStart;
         }
 
         foreach (IrPreviewTrace trace in traces)
         {
             double maxMagnitude = 0;
-            for (int s = displayStart; s <= displayEnd && s < trace.Samples.Length; s++)
+            for (int s = display.Start; s <= display.End && s < trace.Samples.Length; s++)
             {
                 maxMagnitude = Math.Max(maxMagnitude, Math.Abs(trace.Samples[s].Real));
             }
             double scale = maxMagnitude > 0 ? 1.0 / maxMagnitude : 1.0;
 
-            var series = new LineSeries
-            {
-                Color = trace.Color,
-                StrokeThickness = 1.2,
-                Title = trace.Title,
-                Tag = seriesTag,
-                TrackerFormatString = "{0}\n{2:0.000} ms\n{4:0.000}"
-            };
-            for (int s = displayStart; s <= displayEnd; s++)
+            LineSeries series = CreateTraceSeries(trace, seriesTag);
+            for (int s = display.Start; s <= display.End; s++)
             {
                 double value = s < trace.Samples.Length
                     ? trace.Samples[s].Real * scale
@@ -127,6 +104,143 @@ internal static class ImpulseWindowPreview
             model.Series.Add(series);
         }
 
+        AddGateOutline(model, display, sampleRate, gateOffsetMs, seriesTag);
+        return display.BoundsMs(sampleRate);
+    }
+
+    // The step view's body, the Virtual DSP's pair to the gated traces above:
+    // each trace's STEP response — the running sum of its samples from the start
+    // of the display window — over the same window, with the same gate outline.
+    // Unlike the impulse traces, every step is drawn on ONE common scale, the
+    // largest excursion among them: the curves keep their relative sizes, so a
+    // woofer's step is the big slow one, a tweeter's the small fast one, and a
+    // Sum among them is what the others add up to. Per-trace normalization
+    // would draw every driver as if it carried the whole band. The integration
+    // starts at the display window, not at the record (see
+    // VirtualCrossoverAnalysis.StepResponse), and the gate is only DRAWN: a
+    // Tukey taper applied to the samples would read as a decay of the step.
+    public static (double StartMs, double EndMs)? AddStepTraceSeries(
+        PlotModel model,
+        IReadOnlyList<IrPreviewTrace> traces,
+        int sampleRate,
+        double gateOffsetMs,
+        double leftMs,
+        double plateauMs,
+        double rightMs,
+        object? seriesTag = null)
+    {
+        if (GatedDisplay.Resolve(
+                traces, sampleRate, gateOffsetMs, leftMs, plateauMs, rightMs)
+            is not { } display)
+        {
+            return null;
+        }
+
+        int count = display.End - display.Start + 1;
+        var steps = new List<double[]>(traces.Count);
+        double largest = 0.0;
+        foreach (IrPreviewTrace trace in traces)
+        {
+            double[] step = VirtualCrossoverAnalysis.StepResponse(
+                trace.Samples, display.Start, count);
+            foreach (double value in step)
+            {
+                largest = Math.Max(largest, Math.Abs(value));
+            }
+
+            steps.Add(step);
+        }
+
+        double scale = largest > 0 ? 1.0 / largest : 1.0;
+        for (int index = 0; index < traces.Count; index++)
+        {
+            LineSeries series = CreateTraceSeries(traces[index], seriesTag);
+            double[] step = steps[index];
+            for (int i = 0; i < count; i++)
+            {
+                series.Points.Add(new DataPoint(
+                    (display.Start + i) * 1000.0 / sampleRate, step[i] * scale));
+            }
+
+            model.Series.Add(series);
+        }
+
+        AddGateOutline(model, display, sampleRate, gateOffsetMs, seriesTag);
+        return display.BoundsMs(sampleRate);
+    }
+
+    // The sample window a gated multi-trace view draws — the gate plus a
+    // context on either side — and the Tukey outline drawn inside it. One
+    // resolution for the impulse traces and the step traces, so the two views
+    // frame the same milliseconds and a toggle between them keeps the zoom.
+    private readonly record struct GatedDisplay(
+        int Start,
+        int End,
+        int GateStart,
+        int Gate,
+        double[] Tukey)
+    {
+        public static GatedDisplay? Resolve(
+            IReadOnlyList<IrPreviewTrace> traces,
+            int sampleRate,
+            double gateOffsetMs,
+            double leftMs,
+            double plateauMs,
+            double rightMs)
+        {
+            if (traces.Count == 0 || sampleRate <= 0)
+            {
+                return null;
+            }
+
+            int gateOffset = MillisecondsToSamples(gateOffsetMs, sampleRate);
+            int left = MillisecondsToSamples(leftMs, sampleRate);
+            int plateau = MillisecondsToSamples(plateauMs, sampleRate);
+            int right = MillisecondsToSamples(rightMs, sampleRate);
+            int gate = Math.Max(1, left + plateau + right);
+            int gateStart = gateOffset - left;
+
+            double[] tukey = Windowing.TukeyWindow(
+                gate,
+                (double)left / gate * 2.0,
+                (double)right / gate * 2.0);
+
+            int longest = traces.Max(trace => trace.Samples.Length);
+            int context = Math.Max(gate / 8, MillisecondsToSamples(0.2, sampleRate));
+            int displayStart = Math.Max(0, gateStart - context);
+            int displayEnd = Math.Min(longest - 1, gateStart + gate + context);
+            if (displayEnd < displayStart)
+            {
+                displayEnd = displayStart;
+            }
+
+            return new GatedDisplay(displayStart, displayEnd, gateStart, gate, tukey);
+        }
+
+        public (double StartMs, double EndMs) BoundsMs(int sampleRate) => (
+            Start * 1000.0 / sampleRate,
+            End * 1000.0 / sampleRate);
+    }
+
+    private static LineSeries CreateTraceSeries(IrPreviewTrace trace, object? seriesTag) =>
+        new()
+        {
+            Color = trace.Color,
+            StrokeThickness = trace.Thickness,
+            Title = trace.Title,
+            Tag = seriesTag,
+            TrackerFormatString = "{0}\n{2:0.000} ms\n{4:0.000}"
+        };
+
+    // The Tukey gate drawn where it sits, and a vertical mark at the gate
+    // offset (the end of the left shoulder).
+    private static void AddGateOutline(
+        PlotModel model,
+        GatedDisplay display,
+        int sampleRate,
+        double gateOffsetMs,
+        object? seriesTag)
+    {
         var windowSeries = new LineSeries
         {
             Color = OxyColor.FromArgb(127, 50, 210, 120),
@@ -135,9 +249,11 @@ internal static class ImpulseWindowPreview
             Tag = seriesTag,
             TrackerFormatString = "{0}\n{2:0.000} ms\n{4:0.000}"
         };
-        for (int s = displayStart; s <= displayEnd; s++)
+        for (int s = display.Start; s <= display.End; s++)
         {
-            double w = s >= gateStart && s < gateStart + gate ? tukey[s - gateStart] : 0.0;
+            double w = s >= display.GateStart && s < display.GateStart + display.Gate
+                ? display.Tukey[s - display.GateStart]
+                : 0.0;
             windowSeries.Points.Add(new DataPoint(s * 1000.0 / sampleRate, w));
         }
         model.Series.Add(windowSeries);
@@ -151,10 +267,6 @@ internal static class ImpulseWindowPreview
             StrokeThickness = 1.0,
             Tag = seriesTag
         });
-
-        return (
-            displayStart * 1000.0 / sampleRate,
-            displayEnd * 1000.0 / sampleRate);
     }
 
     public static void Update(

--- a/source/Options/ImpulseWindowPreview.cs
+++ b/source/Options/ImpulseWindowPreview.cs
@@ -23,12 +23,13 @@ internal enum IrPreviewSource
 // One impulse response drawn on a gated preview: the samples on the absolute
 // timeline plus the color/title it is drawn with. The stroke defaults to the
 // preview's own; the Virtual DSP step view thickens its Sum the way the other
-// views do.
+// views do, and dashes the opposite side's.
 internal sealed record IrPreviewTrace(
     Complex[] Samples,
     string Title,
     OxyColor Color,
-    double Thickness = 1.2);
+    double Thickness = 1.2,
+    LineStyle Style = LineStyle.Solid);
 
 internal static class ImpulseWindowPreview
 {
@@ -227,6 +228,7 @@ internal static class ImpulseWindowPreview
         {
             Color = trace.Color,
             StrokeThickness = trace.Thickness,
+            LineStyle = trace.Style,
             Title = trace.Title,
             Tag = seriesTag,
             TrackerFormatString = "{0}\n{2:0.000} ms\n{4:0.000}"

--- a/source/Options/ImpulseWindowPreview.cs
+++ b/source/Options/ImpulseWindowPreview.cs
@@ -110,16 +110,17 @@ internal static class ImpulseWindowPreview
     }
 
     // The step view's body, the Virtual DSP's pair to the gated traces above:
-    // each trace's STEP response — the running sum of its samples from the start
-    // of the display window — over the same window, with the same gate outline.
+    // each trace's STEP response — the running sum of its samples from the
+    // record's start — shown over the same window, with the same gate outline.
     // Unlike the impulse traces, every step is drawn on ONE common scale, the
-    // largest excursion among them: the curves keep their relative sizes, so a
-    // woofer's step is the big slow one, a tweeter's the small fast one, and a
-    // Sum among them is what the others add up to. Per-trace normalization
-    // would draw every driver as if it carried the whole band. The integration
-    // starts at the display window, not at the record (see
-    // VirtualCrossoverAnalysis.StepResponse), and the gate is only DRAWN: a
-    // Tukey taper applied to the samples would read as a decay of the step.
+    // largest excursion among them inside the window: the curves keep their
+    // relative transient amplitudes, and a Sum among them is what the others
+    // add up to. Per-trace normalization would draw every driver as if it
+    // carried the whole band. The gate only frames the view: the sum runs from
+    // the record whatever the gate is (VirtualCrossoverAnalysis.StepResponse),
+    // and a Tukey taper applied to the samples would read as a decay of the
+    // step — so the same sample reads the same under every gate, up to the
+    // window's scale.
     public static (double StartMs, double EndMs)? AddStepTraceSeries(
         PlotModel model,
         IReadOnlyList<IrPreviewTrace> traces,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverAcousticPlot.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverAcousticPlot.cs
@@ -13,7 +13,8 @@ internal enum AcousticView
     Magnitude,
     Phase,
     Impulse,
-    GroupDelay
+    GroupDelay,
+    Step
 }
 
 /// <summary>
@@ -30,9 +31,11 @@ internal sealed record AcousticCurve(
     bool OnLossAxis = false);
 
 /// <summary>
-/// The impulse view's payload: the processed traces to draw and the gate window
-/// they are gated to (the presenter draws the Tukey window and re-arms the static
-/// ms axis to the returned bounds).
+/// The payload of the two time-domain views: the processed traces to draw and
+/// the gate window they are framed by (the presenter draws the Tukey window and
+/// re-arms the static ms axis to the returned bounds). <paramref name="Step"/>
+/// draws the traces' step responses on one common scale instead of the impulse
+/// responses each on its own; the traces then include the Sum where it is on.
 /// </summary>
 internal sealed record AcousticImpulseRender(
     IReadOnlyList<IrPreviewTrace> Traces,
@@ -40,12 +43,14 @@ internal sealed record AcousticImpulseRender(
     double GateOffsetMs,
     double LeftMs,
     double PlateauMs,
-    double RightMs);
+    double RightMs,
+    bool Step = false);
 
 /// <summary>
 /// A ready-to-draw frame for the acoustic plot: the hint text plus either a set
-/// of curves (magnitude / phase) or the impulse payload. The panel prepares this
-/// from the processed channels; the presenter owns the OxyPlot mechanics.
+/// of curves (magnitude / phase / group delay) or the impulse or step payload.
+/// The panel prepares this from the processed channels; the presenter owns the
+/// OxyPlot mechanics.
 /// </summary>
 internal sealed record AcousticRender(
     string HintText,
@@ -53,13 +58,14 @@ internal sealed record AcousticRender(
     AcousticImpulseRender? Impulse);
 
 /// <summary>
-/// The Virtual DSP main (acoustic) plot: the raw/processed channel magnitudes or
-/// phases, their complex sum and the sum loss, or the gated impulse view. Owns
-/// the plot model, its four axes (the shared log-frequency axis, the magnitude/
-/// phase value axis, the right-hand sum-loss axis and the impulse-only linear ms
-/// axis), the watermark and hint annotations, the curve series and the
-/// axis-range preservation across view switches. The panel hands it a ready
-/// <see cref="AcousticRender"/>; it never builds a LineSeries itself.
+/// The Virtual DSP main (acoustic) plot: the raw/processed channel magnitudes,
+/// phases or group delays, their complex sum and the sum loss, or the gated
+/// impulse and step views. Owns the plot model, its four axes (the shared
+/// log-frequency axis, the magnitude/phase value axis, the right-hand sum-loss
+/// axis and the linear ms axis of the two time-domain views), the watermark and
+/// hint annotations, the curve series and the axis-range preservation across
+/// view switches. The panel hands it a ready <see cref="AcousticRender"/>; it
+/// never builds a LineSeries itself.
 /// </summary>
 internal sealed class VirtualCrossoverAcousticPlot
 {
@@ -193,14 +199,15 @@ internal sealed class VirtualCrossoverAcousticPlot
 
     // Magnitude, phase and group delay reuse one value axis object so pan/zoom of
     // the frequency axis survives the toggle; only the value scale and its zoom
-    // lock are re-armed. The impulse view additionally swaps the bottom axis to
-    // the linear ms one.
+    // lock are re-armed. The impulse and step views additionally swap the bottom
+    // axis to the linear ms one.
     public void ConfigureForView(AcousticView acousticView)
     {
-        if (acousticView == AcousticView.Impulse)
+        if (IsTimeDomain(acousticView))
         {
-            // Every trace is normalized to its own peak, exactly like the IR
-            // Gate preview, so the scale is unitless.
+            // The impulse traces are each normalized to their own peak, exactly
+            // like the IR Gate preview; the step traces to the largest among
+            // them. Either way the scale is unitless.
             valueAxis.Title = string.Empty;
             valueAxis.AbsoluteMinimum = -1.05;
             valueAxis.AbsoluteMaximum = 1.05;
@@ -319,10 +326,16 @@ internal sealed class VirtualCrossoverAcousticPlot
         model.InvalidatePlot(true);
     }
 
+    // The two views drawn on the ms axis: the processed impulse responses and
+    // their step responses. They share the axis object as well as the display
+    // window, so a toggle between them keeps the zoom.
+    private static bool IsTimeDomain(AcousticView acousticView) =>
+        acousticView is AcousticView.Impulse or AcousticView.Step;
+
     // Keeps exactly one bottom axis in the model: the log-frequency axis for the
-    // magnitude/phase views, the linear ms axis for the impulse view. Swapping
-    // whole axis objects (instead of reconfiguring one) preserves each view's own
-    // range across toggles.
+    // magnitude/phase/group-delay views, the linear ms axis for the impulse and
+    // step views. Swapping whole axis objects (instead of reconfiguring one)
+    // preserves each view's own range across toggles.
     private void ConfigureBottomAxis(AcousticView acousticView)
     {
         if (view.Model is not { } model)
@@ -330,9 +343,9 @@ internal sealed class VirtualCrossoverAcousticPlot
             return;
         }
 
-        bool impulse = acousticView == AcousticView.Impulse;
-        Axis wanted = impulse ? timeAxis : frequencyAxis;
-        Axis retired = impulse ? frequencyAxis : timeAxis;
+        bool timeDomain = IsTimeDomain(acousticView);
+        Axis wanted = timeDomain ? timeAxis : frequencyAxis;
+        Axis retired = timeDomain ? frequencyAxis : timeAxis;
         if (!model.Axes.Contains(wanted))
         {
             model.Axes.Remove(retired);
@@ -345,9 +358,19 @@ internal sealed class VirtualCrossoverAcousticPlot
         // The impulse view is the gate dialog's IR preview promoted to the main
         // plot: every processed channel IR on the shared absolute timeline, each
         // normalized to its own in-window peak, with the phase-gate Tukey window
-        // drawn where it sits.
-        (double StartMs, double EndMs)? window =
-            ImpulseWindowPreview.AddGatedTraceSeries(
+        // drawn where it sits. The step view draws the same traces' step
+        // responses over the same window, on one common scale.
+        (double StartMs, double EndMs)? window = impulse.Step
+            ? ImpulseWindowPreview.AddStepTraceSeries(
+                model,
+                impulse.Traces,
+                impulse.SampleRate,
+                impulse.GateOffsetMs,
+                impulse.LeftMs,
+                impulse.PlateauMs,
+                impulse.RightMs,
+                SeriesTag)
+            : ImpulseWindowPreview.AddGatedTraceSeries(
                 model,
                 impulse.Traces,
                 impulse.SampleRate,

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.Designer.cs
@@ -61,6 +61,7 @@ namespace Resonalyze
             radioViewPhase = new ReleaseClickRadioButton();
             radioViewImpulse = new ReleaseClickRadioButton();
             radioViewGroupDelay = new ReleaseClickRadioButton();
+            radioViewStep = new ReleaseClickRadioButton();
             labelSmoothing = new Label();
             comboBoxSmoothing = new DarkComboBox();
             buttonAutoDelay = new ReleaseClickButton();
@@ -272,7 +273,7 @@ namespace Resonalyze
             labelGroupView.AutoSize = true;
             labelGroupView.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             labelGroupView.ForeColor = Color.FromArgb(210, 214, 222);
-            labelGroupView.Location = new Point(947, 447);
+            labelGroupView.Location = new Point(1007, 447);
             labelGroupView.Name = "labelGroupView";
             labelGroupView.Size = new Size(40, 15);
             labelGroupView.TabIndex = 26;
@@ -282,7 +283,7 @@ namespace Resonalyze
             // 
             comboBoxGroupView.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxGroupView.ForeColor = Color.White;
-            comboBoxGroupView.Location = new Point(990, 445);
+            comboBoxGroupView.Location = new Point(1050, 445);
             comboBoxGroupView.MinimumSize = new Size(36, 19);
             comboBoxGroupView.Name = "comboBoxGroupView";
             comboBoxGroupView.Size = new Size(130, 19);
@@ -448,12 +449,24 @@ namespace Resonalyze
             radioViewGroupDelay.Text = "Group delay";
             radioViewGroupDelay.UseVisualStyleBackColor = true;
             // 
+            // radioViewStep
+            // 
+            radioViewStep.AutoSize = true;
+            radioViewStep.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            radioViewStep.ForeColor = Color.FromArgb(210, 214, 222);
+            radioViewStep.Location = new Point(331, 2);
+            radioViewStep.Name = "radioViewStep";
+            radioViewStep.Size = new Size(50, 19);
+            radioViewStep.TabIndex = 13;
+            radioViewStep.Text = "Step";
+            radioViewStep.UseVisualStyleBackColor = true;
+            // 
             // labelSmoothing
             // 
             labelSmoothing.AutoSize = true;
             labelSmoothing.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Regular, GraphicsUnit.Point, 204);
             labelSmoothing.ForeColor = Color.FromArgb(210, 214, 222);
-            labelSmoothing.Location = new Point(750, 447);
+            labelSmoothing.Location = new Point(810, 447);
             labelSmoothing.Name = "labelSmoothing";
             labelSmoothing.Size = new Size(70, 15);
             labelSmoothing.TabIndex = 10;
@@ -463,7 +476,7 @@ namespace Resonalyze
             // 
             comboBoxSmoothing.BackColor = Color.FromArgb(55, 60, 72);
             comboBoxSmoothing.ForeColor = Color.White;
-            comboBoxSmoothing.Location = new Point(824, 445);
+            comboBoxSmoothing.Location = new Point(884, 445);
             comboBoxSmoothing.MinimumSize = new Size(36, 19);
             comboBoxSmoothing.Name = "comboBoxSmoothing";
             comboBoxSmoothing.Size = new Size(100, 19);
@@ -702,11 +715,12 @@ namespace Resonalyze
             panel1.Controls.Add(radioViewMagnitude);
             panel1.Controls.Add(radioViewImpulse);
             panel1.Controls.Add(radioViewGroupDelay);
+            panel1.Controls.Add(radioViewStep);
             panel1.Controls.Add(radioViewPhase);
             panel1.CornerRadius = 4;
             panel1.Location = new Point(406, 443);
             panel1.Name = "panel1";
-            panel1.Size = new Size(331, 23);
+            panel1.Size = new Size(391, 23);
             panel1.TabIndex = 24;
             // 
             // panel2
@@ -849,6 +863,7 @@ namespace Resonalyze
         private ReleaseClickRadioButton radioViewPhase;
         private ReleaseClickRadioButton radioViewImpulse;
         private ReleaseClickRadioButton radioViewGroupDelay;
+        private ReleaseClickRadioButton radioViewStep;
         private Label labelSmoothing;
         private DarkComboBox comboBoxSmoothing;
         private ReleaseClickButton buttonAutoDelay;

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -602,17 +602,20 @@ public partial class VirtualCrossoverPanel : UserControl
             checkBoxShowTarget.Checked = project.ShowTargetCurve;
             numericTargetLevel.Value =
                 numericTargetLevel.ClampValue(project.TargetLevelDb);
-            // Impulse over group delay over phase: each newer flag is written
-            // beside the older one it falls back to in a build without it.
-            radioViewImpulse.Checked = project.ShowImpulseView;
+            // Step over impulse over group delay over phase: each newer flag is
+            // written beside the older one it falls back to in a build without it.
+            radioViewStep.Checked = project.ShowStepView;
+            radioViewImpulse.Checked =
+                !project.ShowStepView && project.ShowImpulseView;
             radioViewGroupDelay.Checked =
-                !project.ShowImpulseView && project.ShowGroupDelayView;
+                !project.ShowStepView && !project.ShowImpulseView &&
+                project.ShowGroupDelayView;
             radioViewPhase.Checked =
-                !project.ShowImpulseView && !project.ShowGroupDelayView &&
-                project.ShowPhaseView;
+                !project.ShowStepView && !project.ShowImpulseView &&
+                !project.ShowGroupDelayView && project.ShowPhaseView;
             radioViewMagnitude.Checked =
-                !project.ShowImpulseView && !project.ShowGroupDelayView &&
-                !project.ShowPhaseView;
+                !project.ShowStepView && !project.ShowImpulseView &&
+                !project.ShowGroupDelayView && !project.ShowPhaseView;
             // After the radios: the Sum is remembered per view, so which answer
             // applies is decided by the view this project opens on.
             ApplySumToggleForView();
@@ -1034,6 +1037,10 @@ public partial class VirtualCrossoverPanel : UserControl
         radioViewGroupDelay.CheckedChanged += (_, _) =>
         {
             if (radioViewGroupDelay.Checked) OnViewModeChanged();
+        };
+        radioViewStep.CheckedChanged += (_, _) =>
+        {
+            if (radioViewStep.Checked) OnViewModeChanged();
         };
         comboBoxSmoothing.SelectedIndexChanged += (_, _) => OnViewChanged();
         comboBoxSumLoss.SelectedIndexChanged += (_, _) => OnViewChanged();
@@ -1878,16 +1885,16 @@ public partial class VirtualCrossoverPanel : UserControl
     }
 
     // Each curve toggle is muted on the views that cannot draw that curve: the
-    // Sum exists on the magnitude, phase and group-delay plots but not among
-    // the impulse traces, the sum loss and the target are magnitude-only (a target is a dB
+    // Sum exists on the magnitude, phase, group-delay and step plots but not
+    // among the impulse traces, the sum loss and the target are magnitude-only (a target is a dB
     // shape — the same rule OverlayTargets.SupportsMode applies to overlay
     // targets). Fractional-octave smoothing shapes the frequency-domain curves,
-    // so it is dead in the impulse view alone. The Target... button stays live
+    // so it is dead in the impulse and step views. The Target... button stays live
     // everywhere: it switches to the view its dialog can preview on rather than
     // sitting there greyed.
     private void UpdateViewDependentControls()
     {
-        comboBoxSmoothing.Enabled = !radioViewImpulse.Checked;
+        comboBoxSmoothing.Enabled = !radioViewImpulse.Checked && !radioViewStep.Checked;
         // These two wear a fixed plot colour, so the shared helper — which
         // memorizes the colour it mutes — is safe for them.
         Ui.UiStyle.SetTextEnabledLook(
@@ -1918,6 +1925,7 @@ public partial class VirtualCrossoverPanel : UserControl
         Ui.UiStyle.SetTextEnabledLook(radioViewPhase, !groupSums, interactive: true);
         Ui.UiStyle.SetTextEnabledLook(radioViewImpulse, !groupSums, interactive: true);
         Ui.UiStyle.SetTextEnabledLook(radioViewGroupDelay, !groupSums, interactive: true);
+        Ui.UiStyle.SetTextEnabledLook(radioViewStep, !groupSums, interactive: true);
         // Magnitude-only for the same reason the loss is, and it also carries the
         // coverage answer, so it owns its own refresh.
         RefreshHybridAvailability();
@@ -1956,7 +1964,9 @@ public partial class VirtualCrossoverPanel : UserControl
                 ? project.ShowSumCurveOnPhase
                 : radioViewGroupDelay.Checked
                     ? project.ShowSumCurveOnGroupDelay
-                    : project.ShowSumCurve;
+                    : radioViewStep.Checked
+                        ? project.ShowSumCurveOnStep
+                        : project.ShowSumCurve;
         }
         finally
         {
@@ -1979,6 +1989,10 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             project.ShowSumCurveOnGroupDelay = checkBoxShowSum.Checked;
         }
+        else if (radioViewStep.Checked)
+        {
+            project.ShowSumCurveOnStep = checkBoxShowSum.Checked;
+        }
         else if (radioViewMagnitude.Checked)
         {
             project.ShowSumCurve = checkBoxShowSum.Checked;
@@ -1988,12 +2002,13 @@ public partial class VirtualCrossoverPanel : UserControl
         project.ShowHybridCurves = checkBoxHybrid.Checked;
         project.ShowTargetCurve = checkBoxShowTarget.Checked;
         project.TargetLevelDb = (double)numericTargetLevel.Value;
-        // The phase flag is written beside the group-delay one: a build that
-        // knows only the older flag opens the project on the phase view, the
-        // nearest thing it has to this one.
+        // The phase flag is written beside the group-delay one, the impulse flag
+        // beside the step one: a build that knows only the older flag opens the
+        // project on the nearest view it has.
         project.ShowPhaseView = radioViewPhase.Checked || radioViewGroupDelay.Checked;
-        project.ShowImpulseView = radioViewImpulse.Checked;
+        project.ShowImpulseView = radioViewImpulse.Checked || radioViewStep.Checked;
         project.ShowGroupDelayView = radioViewGroupDelay.Checked;
+        project.ShowStepView = radioViewStep.Checked;
         project.SetSmoothingCode(comboBoxSmoothing.SelectedItem is int value
             ? value
             : 12);
@@ -3027,6 +3042,7 @@ public partial class VirtualCrossoverPanel : UserControl
 
     private AcousticView CurrentAcousticView() =>
         radioViewImpulse.Checked ? AcousticView.Impulse
+        : radioViewStep.Checked ? AcousticView.Step
         : radioViewPhase.Checked ? AcousticView.Phase
         : radioViewGroupDelay.Checked ? AcousticView.GroupDelay
         : AcousticView.Magnitude;
@@ -3191,6 +3207,11 @@ public partial class VirtualCrossoverPanel : UserControl
             "through the phase gate: the arrival time of the energy\r\n" +
             "inside the window, in ms from the record's start.\r\n" +
             "Well-aligned drivers meet through the crossover.");
+        toolTip.SetToolTip(
+            radioViewStep,
+            "Show each processed channel's step response and the Sum's\r\n" +
+            "around the phase gate, all on one common scale.\r\n" +
+            "A driver in the wrong polarity steps the other way first.");
         toolTip.SetToolTip(
             comboBoxGroupView,
             "Which part of the installation the plot shows; the curves, the\r\n" +
@@ -3881,6 +3902,10 @@ public partial class VirtualCrossoverPanel : UserControl
         if (radioViewImpulse.Checked)
         {
             return new AcousticRender(hint, [], BuildImpulseRender(processed));
+        }
+        if (radioViewStep.Checked)
+        {
+            return new AcousticRender(hint, [], BuildStepRender(processed, summed));
         }
 
         if (VirtualCrossoverGroupViews.DrawsGroupSums(view))
@@ -7498,6 +7523,61 @@ public partial class VirtualCrossoverPanel : UserControl
             gatePreview?.LeftMs ?? project.PhaseGateLeftMs,
             gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs,
             gatePreview?.RightMs ?? project.PhaseGateRightMs);
+    }
+
+    // The step view: the impulse view's traces as step responses, on the same
+    // timeline and around the same gate, plus the Sum's. The presenter
+    // integrates and scales (ImpulseWindowPreview.AddStepTraceSeries); this
+    // decides WHICH responses go in. The shown channels set the gate offset and
+    // the window, as on the impulse view. The Sum is the sample-wise sum of the
+    // SUMMING channels' impulse responses, hidden or not — the same set the
+    // magnitude Sum adds, so this view's Sum describes the same system under the
+    // same selector — and the step of that sum is the sum of the steps by
+    // linearity, which is what lets the eye read the drivers' contributions off
+    // the total. Drawn on one common scale so the curves keep their sizes
+    // relative to each other and to the Sum: every processed response is in the
+    // one calibrated level the magnitude Sum adds them in.
+    private AcousticImpulseRender? BuildStepRender(
+        List<ProcessedChannel> processed,
+        IReadOnlyList<ProcessedChannel> summed)
+    {
+        using var _ = AppProfiler.Zone("VirtualDSP.BuildStepRender");
+        List<ProcessedChannel> shown = processed
+            .Where(item => item.Channel.Pair.ShowProcessedCurve)
+            .ToList();
+        if (shown.Count == 0)
+        {
+            return null;
+        }
+
+        int sampleRate = shown[0].SampleRate;
+        double gateOffsetMs = gatePreview?.OffsetMs
+            ?? ResolveGateOffsetMs(shown, sampleRate);
+
+        var traces = shown
+            .Select(item => new IrPreviewTrace(
+                item.ImpulseResponse,
+                item.Channel.Name,
+                item.Color))
+            .ToList();
+        if (summed.Count >= 2 && checkBoxShowSum.Checked)
+        {
+            traces.Add(new IrPreviewTrace(
+                VirtualCrossoverAnalysis.SumImpulseResponses(
+                    [.. summed.Select(item => item.ImpulseResponse)]),
+                "Sum",
+                SumColor,
+                2.4));
+        }
+
+        return new AcousticImpulseRender(
+            traces,
+            sampleRate,
+            gateOffsetMs,
+            gatePreview?.LeftMs ?? project.PhaseGateLeftMs,
+            gatePreview?.PlateauMs ?? project.PhaseGatePlateauMs,
+            gatePreview?.RightMs ?? project.PhaseGateRightMs,
+            Step: true);
     }
 
     // The gate of the side on screen. The view draws one side at a time and the two

--- a/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverPanel.cs
@@ -3718,8 +3718,11 @@ public partial class VirtualCrossoverPanel : UserControl
         // once the active side's hybrid (and therefore its offset) exists. The two
         // sides must be drawn by the same method or the comparison stops being about
         // the tunes.
+        // The step view draws it too, as the sum's step: the two tunes' fronts
+        // compare on one clock without flipping the L/R selector.
         VirtualCrossoverSideSum? oppositeSide = null;
-        if (checkBoxShowSum.Checked && radioViewMagnitude.Checked)
+        if (checkBoxShowSum.Checked &&
+            (radioViewMagnitude.Checked || radioViewStep.Checked))
         {
             oppositeSide = await metrics.ComputeSideSumAsync(
                 channels, !project.ActiveSideRight, revision, minimumChannels: 2,
@@ -3829,7 +3832,7 @@ public partial class VirtualCrossoverPanel : UserControl
         {
             acousticRender = BuildAcousticRender(
                 shown, summedChannels, groupView, magnitudes, sumCurve, drawnLoss,
-                oppositeSum, hybrid, lossDirect);
+                oppositeSum, oppositeSide, hybrid, lossDirect);
         }
 
         using (AppProfiler.Zone("VirtualDSP.AcousticPlotDraw"))
@@ -3877,6 +3880,7 @@ public partial class VirtualCrossoverPanel : UserControl
         AnalysisCurve? sumCurve,
         List<SignalPoint>? lossCurve,
         AnalysisCurve? oppositeSum,
+        VirtualCrossoverSideSum? oppositeSide,
         HybridMagnitudes? hybrid,
         bool lossDirect = false)
     {
@@ -3905,7 +3909,8 @@ public partial class VirtualCrossoverPanel : UserControl
         }
         if (radioViewStep.Checked)
         {
-            return new AcousticRender(hint, [], BuildStepRender(processed, summed));
+            return new AcousticRender(
+                hint, [], BuildStepRender(processed, summed, oppositeSide));
         }
 
         if (VirtualCrossoverGroupViews.DrawsGroupSums(view))
@@ -7536,10 +7541,15 @@ public partial class VirtualCrossoverPanel : UserControl
     // linearity, which is what lets the eye read the drivers' contributions off
     // the total. Drawn on one common scale so the curves keep their sizes
     // relative to each other and to the Sum: every processed response is in the
-    // one calibrated level the magnitude Sum adds them in.
+    // one calibrated level the magnitude Sum adds them in. The opposite side's
+    // Sum rides along as on the magnitude view — thin, dashed, translucent — so
+    // the two tunes' fronts compare on the one absolute clock; it needs the
+    // shown side's sample rate, or its samples would land on the wrong
+    // milliseconds.
     private AcousticImpulseRender? BuildStepRender(
         List<ProcessedChannel> processed,
-        IReadOnlyList<ProcessedChannel> summed)
+        IReadOnlyList<ProcessedChannel> summed,
+        VirtualCrossoverSideSum? oppositeSide)
     {
         using var _ = AppProfiler.Zone("VirtualDSP.BuildStepRender");
         List<ProcessedChannel> shown = processed
@@ -7568,6 +7578,15 @@ public partial class VirtualCrossoverPanel : UserControl
                 "Sum",
                 SumColor,
                 2.4));
+            if (oppositeSide != null && oppositeSide.SampleRate == sampleRate)
+            {
+                traces.Add(new IrPreviewTrace(
+                    oppositeSide.ImpulseResponse,
+                    $"Sum {(project.ActiveSideRight ? "L" : "R")}",
+                    OxyColor.FromAColor(110, SumColor),
+                    1.0,
+                    LineStyle.Dash));
+            }
         }
 
         return new AcousticImpulseRender(

--- a/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
+++ b/source/Tools/VirtualCrossover/VirtualCrossoverProjectFile.cs
@@ -997,6 +997,12 @@ public sealed class VirtualCrossoverProjectFile
     // ShowPhaseView beside it so a build without this flag opens the project
     // on the nearest view it has, the phase.
     public bool ShowGroupDelayView { get; set; }
+    // The main plot's step view: each processed channel's step response and
+    // the Sum's on the impulse view's timeline, on one common scale. Additive
+    // in the same way: it wins over every older flag, and the panel writes
+    // ShowImpulseView beside it so a build without this flag opens the project
+    // on the nearest view it has, the impulse.
+    public bool ShowStepView { get; set; }
 
     /// <summary>
     /// Whether the Sum is drawn on the GROUP-DELAY view. Its own answer, like the
@@ -1010,6 +1016,20 @@ public sealed class VirtualCrossoverProjectFile
     {
         get => ShowSumCurveGroupDelay ?? ShowSumCurveOnPhase;
         set => ShowSumCurveGroupDelay = value;
+    }
+
+    /// <summary>
+    /// Whether the Sum is drawn on the STEP view. Its own answer, like the
+    /// others'; a file written before the view existed carries none and inherits
+    /// the magnitude answer — the impulse view, its nearest, draws no Sum.
+    /// </summary>
+    public bool? ShowSumCurveStep { get; set; }
+
+    [JsonIgnore]
+    public bool ShowSumCurveOnStep
+    {
+        get => ShowSumCurveStep ?? ShowSumCurve;
+        set => ShowSumCurveStep = value;
     }
 
     // The EQ target curve drawn over the acoustic plot: whether it is shown, the

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverAcousticPlotZoomTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverAcousticPlotZoomTests.cs
@@ -126,6 +126,53 @@ public sealed class VirtualCrossoverAcousticPlotZoomTests
     }
 
     [Fact]
+    public void StepView_SharesTheImpulseViewsAxes_AndTheZoomBetweenThem()
+    {
+        using var view = new PlotView();
+        var plot = new VirtualCrossoverAcousticPlot(view, "hint", AcousticView.Impulse);
+        plot.Draw(Render(gateOffsetMs: 10));
+        Axis time = TimeAxis(view);
+        Axis value = ValueAxis(view);
+        time.Zoom(9.8, 10.2);
+        Update(view);
+
+        // The step view draws on the impulse view's ms axis and unitless value
+        // axis; the window is the same one, so the zoom taken on it survives.
+        plot.ConfigureForView(AcousticView.Step);
+        plot.Draw(StepRender(gateOffsetMs: 10));
+        Update(view);
+
+        Assert.Same(time, TimeAxis(view));
+        Assert.DoesNotContain(view.Model!.Axes, axis => axis is LogarithmicAxis);
+        Assert.Equal(string.Empty, value.Title);
+        Assert.Equal(-1.05, value.AbsoluteMinimum);
+        Assert.Equal(1.05, value.AbsoluteMaximum);
+        Assert.True(value.IsZoomEnabled);
+        Assert.Equal(9.8, time.ActualMinimum, 6);
+        Assert.Equal(10.2, time.ActualMaximum, 6);
+
+        // Back on the frequency views, the ms axis leaves with the step view.
+        plot.ConfigureForView(AcousticView.Magnitude);
+        Assert.Contains(view.Model!.Axes, axis => axis is LogarithmicAxis);
+        Assert.DoesNotContain(view.Model!.Axes, axis => ReferenceEquals(axis, time));
+    }
+
+    [Fact]
+    public void LossAxis_HidesOnTheStepView()
+    {
+        using var view = new PlotView();
+        var plot = new VirtualCrossoverAcousticPlot(view, "hint", AcousticView.Magnitude);
+        plot.Draw(MagnitudeRender(lossDepthDb: -10));
+        Axis loss = LossAxis(view);
+        Assert.True(loss.IsAxisVisible);
+
+        plot.ConfigureForView(AcousticView.Step);
+        Assert.False(loss.IsAxisVisible);
+        plot.Draw(StepRender(gateOffsetMs: 10));
+        Assert.False(loss.IsAxisVisible);
+    }
+
+    [Fact]
     public void LossAxis_ShowsOnlyWhileALossCurveIsDrawn()
     {
         using var view = new PlotView();
@@ -271,6 +318,19 @@ public sealed class VirtualCrossoverAcousticPlotZoomTests
             PlateauMs: 15,
             RightMs: 5);
         return new AcousticRender(string.Empty, [], impulse);
+    }
+
+    private static AcousticRender StepRender(double gateOffsetMs)
+    {
+        var step = new AcousticImpulseRender(
+            [MakeTrace("A", peakSample: 480), MakeTrace("B", peakSample: 960)],
+            SampleRate,
+            gateOffsetMs,
+            LeftMs: 0.5,
+            PlateauMs: 15,
+            RightMs: 5,
+            Step: true);
+        return new AcousticRender(string.Empty, [], step);
     }
 
     private static IrPreviewTrace MakeTrace(string title, int peakSample)

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverProjectFileTests.cs
@@ -1459,6 +1459,62 @@ public sealed class VirtualCrossoverProjectFileTests
     }
 
     [Fact]
+    public void StepView_RoundTripsWithItsOwnSumAnswer()
+    {
+        string root = CreateTemporaryDirectory();
+        try
+        {
+            // The panel writes the impulse flag beside the step one, so a build
+            // that knows only the older flag opens on the impulse view.
+            var saved = new VirtualCrossoverProjectFile
+            {
+                ShowImpulseView = true,
+                ShowStepView = true,
+                ShowSumCurve = false,
+                ShowSumCurveOnStep = true
+            };
+            saved.Save(root);
+            VirtualCrossoverProjectFile loaded =
+                VirtualCrossoverProjectFile.LoadOrDefault(root);
+
+            Assert.True(loaded.ShowStepView);
+            Assert.True(loaded.ShowImpulseView);
+            Assert.False(loaded.ShowGroupDelayView);
+            Assert.False(loaded.ShowSumCurve);
+            Assert.True(loaded.ShowSumCurveOnStep);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void StepView_AbsentFromAnOlderFile_OpensThePriorView()
+    {
+        // A file written before the view existed carries no step flag: it opens
+        // on whatever it did — the impulse view here — and the Sum on the step
+        // view inherits the magnitude answer until it is set (the impulse view,
+        // its nearest, has no Sum to inherit from).
+        var project = new VirtualCrossoverProjectFile
+        {
+            ShowImpulseView = true,
+            ShowSumCurve = false
+        };
+
+        Assert.False(project.ShowStepView);
+        Assert.Null(project.ShowSumCurveStep);
+        Assert.False(project.ShowSumCurveOnStep);
+
+        project.ShowSumCurve = true;
+        Assert.True(project.ShowSumCurveOnStep);
+
+        project.ShowSumCurveOnStep = false;
+        project.ShowSumCurve = true;
+        Assert.False(project.ShowSumCurveOnStep);
+    }
+
+    [Fact]
     public void ShowSumCurveOnPhase_OnceAnswered_StopsFollowingTheMagnitudeOne()
     {
         string root = CreateTemporaryDirectory();

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverStepViewTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverStepViewTests.cs
@@ -146,13 +146,48 @@ public sealed class VirtualCrossoverStepViewTests
     private static IrPreviewTrace Trace(string title, int sample, double amplitude) =>
         new(Delta(sample, amplitude), title, OxyColors.White);
 
+    [Fact]
+    public void TheOppositeSidesSum_RidesAlong_ThinDashedTranslucent_OnTheSameClock()
+    {
+        // As on the magnitude view: the other side's summed response beside this
+        // side's Sum, so the two tunes compare without flipping the selector. It
+        // needs the Sum on, and the shown side's sample rate.
+        using VirtualCrossoverPanel panel = Loaded();
+        var showSum = (CheckBox)Field(panel, "checkBoxShowSum");
+        List<ProcessedChannel> processed = Processed(panel);
+        VirtualCrossoverSideSum opposite = new(
+            Delta(SecondArrival + 48, 1.5), SecondArrival + 48, SampleRate, processed);
+
+        showSum.Checked = true;
+        // Named for the side it belongs to: the right side on screen, so the
+        // trace is the left's.
+        Project(panel).ActiveSideRight = true;
+        AcousticImpulseRender render = Build(panel, processed, processed, opposite)!;
+        Assert.Equal(4, render.Traces.Count);
+        IrPreviewTrace trace = render.Traces[3];
+        Assert.Equal("Sum L", trace.Title);
+        Assert.Same(opposite.ImpulseResponse, trace.Samples);
+        Assert.Equal(1.0, trace.Thickness);
+        Assert.Equal(LineStyle.Dash, trace.Style);
+        Assert.Equal(110, trace.Color.A);
+        Assert.Equal(OxyColors.White.R, trace.Color.R);
+
+        // Off with the Sum, and at another rate.
+        showSum.Checked = false;
+        Assert.Equal(2, Build(panel, processed, processed, opposite)!.Traces.Count);
+        showSum.Checked = true;
+        VirtualCrossoverSideSum otherRate = opposite with { SampleRate = 96_000 };
+        Assert.Equal(3, Build(panel, processed, processed, otherRate)!.Traces.Count);
+    }
+
     private static AcousticImpulseRender? Build(
         VirtualCrossoverPanel panel,
         List<ProcessedChannel> processed,
-        IReadOnlyList<ProcessedChannel> summed) =>
+        IReadOnlyList<ProcessedChannel> summed,
+        VirtualCrossoverSideSum? opposite = null) =>
         (AcousticImpulseRender?)panel.GetType()
             .GetMethod("BuildStepRender", Hidden)!
-            .Invoke(panel, [processed, summed]);
+            .Invoke(panel, [processed, summed, opposite]);
 
     private static List<ProcessedChannel> Processed(VirtualCrossoverPanel panel)
     {

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverStepViewTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverStepViewTests.cs
@@ -125,13 +125,47 @@ public sealed class VirtualCrossoverStepViewTests
         Assert.Equal(1.0, LastOf(stepModel, "Sum"), 9);
         Assert.Equal(2.4, Series(stepModel, "Sum").StrokeThickness);
 
-        // Before its arrival a step is flat at zero — the integration starts at
-        // the window, not at the record, and nothing before the front enters.
+        // Before its arrival a step is flat at zero: nothing before the front
+        // has entered the running sum.
         LineSeries late = Series(stepModel, "B");
         double secondMs = SecondArrival * 1_000.0 / SampleRate;
         Assert.All(
             late.Points.Where(point => point.X < secondMs - 0.05),
             point => Assert.Equal(0.0, point.Y));
+    }
+
+    [Fact]
+    public void TheGate_FramesTheView_AndNeverEntersTheCurve()
+    {
+        // The window follows the phase gate, so a gate edit moves the window;
+        // the step is a property of the response and must read the same at the
+        // same absolute time under any gate. A sum that started at the window's
+        // edge would not. Both windows hold the arrivals, so the common scale
+        // (the largest excursion inside the window) is the same too and the
+        // values compare exactly.
+        IrPreviewTrace first = Trace("A", FirstArrival, 1.0);
+        IrPreviewTrace second = Trace("B", SecondArrival, SecondAmplitude);
+        IrPreviewTrace[] traces = [first, second];
+
+        var wide = new PlotModel();
+        ImpulseWindowPreview.AddStepTraceSeries(
+            wide, traces, SampleRate, gateOffsetMs: 9, leftMs: 2, plateauMs: 30, rightMs: 10);
+        var narrow = new PlotModel();
+        ImpulseWindowPreview.AddStepTraceSeries(
+            narrow, traces, SampleRate, gateOffsetMs: 12, leftMs: 0.5, plateauMs: 12, rightMs: 3);
+
+        foreach (string title in new[] { "A", "B" })
+        {
+            Dictionary<double, double> wideByMs = Series(wide, title).Points
+                .ToDictionary(point => point.X, point => point.Y);
+            List<DataPoint> narrowPoints = Series(narrow, title).Points;
+            Assert.NotEmpty(narrowPoints);
+            Assert.All(narrowPoints, point =>
+            {
+                Assert.True(wideByMs.ContainsKey(point.X));
+                Assert.Equal(wideByMs[point.X], point.Y, 12);
+            });
+        }
     }
 
     private static double PeakOf(PlotModel model, string title) =>

--- a/tests/Resonalyze.App.Tests/VirtualCrossoverStepViewTests.cs
+++ b/tests/Resonalyze.App.Tests/VirtualCrossoverStepViewTests.cs
@@ -1,0 +1,200 @@
+using System.Numerics;
+using System.Reflection;
+using System.Windows.Forms;
+using OxyPlot;
+using OxyPlot.Series;
+using Resonalyze.Options;
+
+namespace Resonalyze.App.Tests;
+
+/// <summary>
+/// The Virtual DSP step view on synthetic channels: which responses go in (the
+/// shown channels, plus the Sum of every summing channel whether shown or
+/// not), and how the presenter draws them — every step on ONE common scale, so
+/// the curves keep their sizes relative to each other and to the Sum, where
+/// the impulse view normalizes each trace to its own peak.
+/// </summary>
+public sealed class VirtualCrossoverStepViewTests
+{
+    private const BindingFlags Hidden = BindingFlags.NonPublic | BindingFlags.Instance;
+    private const int SampleRate = 48_000;
+    private const int FirstArrival = 480;   // 10 ms.
+    private const int SecondArrival = 960;  // 20 ms.
+    private const double SecondAmplitude = 0.5;
+
+    [Fact]
+    public void ShownChannels_AndTheSum_GoIn_AsStepTraces()
+    {
+        using VirtualCrossoverPanel panel = Loaded();
+        ((CheckBox)Field(panel, "checkBoxShowSum")).Checked = true;
+        List<ProcessedChannel> processed = Processed(panel);
+
+        AcousticImpulseRender render = Build(panel, processed, processed)!;
+
+        Assert.True(render.Step);
+        Assert.Equal(SampleRate, render.SampleRate);
+        Assert.Equal(3, render.Traces.Count);
+        Assert.Equal(processed[0].Channel.Name, render.Traces[0].Title);
+        Assert.Equal(processed[1].Channel.Name, render.Traces[1].Title);
+
+        IrPreviewTrace sum = render.Traces[2];
+        Assert.Equal("Sum", sum.Title);
+        Assert.Equal(2.4, sum.Thickness);
+        Assert.Equal(1.0, sum.Samples[FirstArrival].Real);
+        Assert.Equal(SecondAmplitude, sum.Samples[SecondArrival].Real);
+    }
+
+    [Fact]
+    public void AHiddenChannel_LeavesTheTraces_ButStaysInTheSum()
+    {
+        // The Sum adds every SUMMING channel, as the magnitude Sum does — a
+        // hidden curve is hidden, not silenced.
+        using VirtualCrossoverPanel panel = Loaded();
+        ((CheckBox)Field(panel, "checkBoxShowSum")).Checked = true;
+        List<ProcessedChannel> processed = Processed(panel);
+        processed[1].Channel.Pair.ShowProcessedCurve = false;
+
+        AcousticImpulseRender render = Build(panel, processed, processed)!;
+
+        Assert.Equal(2, render.Traces.Count);
+        Assert.Equal(processed[0].Channel.Name, render.Traces[0].Title);
+        Assert.Equal("Sum", render.Traces[1].Title);
+        Assert.Equal(SecondAmplitude, render.Traces[1].Samples[SecondArrival].Real);
+    }
+
+    [Fact]
+    public void TheSum_NeedsTheToggle_AndTwoSummingChannels()
+    {
+        using VirtualCrossoverPanel panel = Loaded();
+        var showSum = (CheckBox)Field(panel, "checkBoxShowSum");
+        List<ProcessedChannel> processed = Processed(panel);
+
+        showSum.Checked = false;
+        Assert.Equal(2, Build(panel, processed, processed)!.Traces.Count);
+
+        // A centre drawn beside a stage is compared, not added: with one summing
+        // channel there is no Sum to draw.
+        showSum.Checked = true;
+        Assert.Equal(2, Build(panel, processed, [processed[0]])!.Traces.Count);
+    }
+
+    [Fact]
+    public void NothingShown_DrawsNothing()
+    {
+        using VirtualCrossoverPanel panel = Loaded();
+        ((CheckBox)Field(panel, "checkBoxShowSum")).Checked = true;
+        List<ProcessedChannel> processed = Processed(panel);
+        processed[0].Channel.Pair.ShowProcessedCurve = false;
+        processed[1].Channel.Pair.ShowProcessedCurve = false;
+
+        Assert.Null(Build(panel, processed, processed));
+    }
+
+    [Fact]
+    public void StepTraces_ShareOneScale_WhereImpulseTracesEachFillTheAxis()
+    {
+        // Two impulses of 1.0 and 0.5 and their sum. As impulses each trace is
+        // normalized to its own peak, so both read 1. As steps the three share
+        // the largest excursion — the Sum's 1.5 — so they read 2/3, 1/3 and 1:
+        // the second driver is visibly the smaller, and the Sum is what the
+        // two add up to.
+        IrPreviewTrace first = Trace("A", FirstArrival, 1.0);
+        IrPreviewTrace second = Trace("B", SecondArrival, SecondAmplitude);
+        IrPreviewTrace sum = new(
+            Dsp.VirtualCrossoverAnalysis.SumImpulseResponses([first.Samples, second.Samples]),
+            "Sum",
+            OxyColors.White,
+            2.4);
+        IrPreviewTrace[] traces = [first, second, sum];
+
+        var impulseModel = new PlotModel();
+        (double StartMs, double EndMs)? impulseWindow = ImpulseWindowPreview.AddGatedTraceSeries(
+            impulseModel, traces, SampleRate, gateOffsetMs: 10, leftMs: 0.5, plateauMs: 15, rightMs: 5);
+        var stepModel = new PlotModel();
+        (double StartMs, double EndMs)? stepWindow = ImpulseWindowPreview.AddStepTraceSeries(
+            stepModel, traces, SampleRate, gateOffsetMs: 10, leftMs: 0.5, plateauMs: 15, rightMs: 5);
+
+        // One window for both views, so a toggle between them keeps the zoom.
+        Assert.Equal(impulseWindow, stepWindow);
+
+        Assert.Equal(1.0, PeakOf(impulseModel, "A"), 9);
+        Assert.Equal(1.0, PeakOf(impulseModel, "B"), 9);
+
+        Assert.Equal(2.0 / 3.0, LastOf(stepModel, "A"), 9);
+        Assert.Equal(1.0 / 3.0, LastOf(stepModel, "B"), 9);
+        Assert.Equal(1.0, LastOf(stepModel, "Sum"), 9);
+        Assert.Equal(2.4, Series(stepModel, "Sum").StrokeThickness);
+
+        // Before its arrival a step is flat at zero — the integration starts at
+        // the window, not at the record, and nothing before the front enters.
+        LineSeries late = Series(stepModel, "B");
+        double secondMs = SecondArrival * 1_000.0 / SampleRate;
+        Assert.All(
+            late.Points.Where(point => point.X < secondMs - 0.05),
+            point => Assert.Equal(0.0, point.Y));
+    }
+
+    private static double PeakOf(PlotModel model, string title) =>
+        Series(model, title).Points.Max(point => Math.Abs(point.Y));
+
+    private static double LastOf(PlotModel model, string title) =>
+        Series(model, title).Points[^1].Y;
+
+    private static LineSeries Series(PlotModel model, string title) =>
+        model.Series.OfType<LineSeries>().Single(series => series.Title == title);
+
+    private static IrPreviewTrace Trace(string title, int sample, double amplitude) =>
+        new(Delta(sample, amplitude), title, OxyColors.White);
+
+    private static AcousticImpulseRender? Build(
+        VirtualCrossoverPanel panel,
+        List<ProcessedChannel> processed,
+        IReadOnlyList<ProcessedChannel> summed) =>
+        (AcousticImpulseRender?)panel.GetType()
+            .GetMethod("BuildStepRender", Hidden)!
+            .Invoke(panel, [processed, summed]);
+
+    private static List<ProcessedChannel> Processed(VirtualCrossoverPanel panel)
+    {
+        List<VirtualCrossoverChannel> channels = Channels(panel);
+        channels[0].Pair.ShowProcessedCurve = true;
+        channels[1].Pair.ShowProcessedCurve = true;
+        return
+        [
+            new ProcessedChannel(
+                channels[0], Delta(FirstArrival, 1.0), FirstArrival, SampleRate, OxyColors.Red),
+            new ProcessedChannel(
+                channels[1], Delta(SecondArrival, SecondAmplitude), SecondArrival, SampleRate,
+                OxyColors.Blue)
+        ];
+    }
+
+    private static Complex[] Delta(int sample, double amplitude)
+    {
+        var impulse = new Complex[8_192];
+        impulse[sample] = new Complex(amplitude, 0.0);
+        return impulse;
+    }
+
+    // A panel bound to its project's pairs, the way applying a project binds them.
+    private static VirtualCrossoverPanel Loaded()
+    {
+        var panel = new VirtualCrossoverPanel();
+        List<VirtualCrossoverChannel> channels = Channels(panel);
+        for (int index = 0; index < channels.Count; index++)
+        {
+            channels[index].Pair = Project(panel).Pairs[index];
+        }
+
+        return panel;
+    }
+
+    private static object Field(object target, string name) =>
+        target.GetType().GetField(name, Hidden)!.GetValue(target)!;
+
+    private static List<VirtualCrossoverChannel> Channels(VirtualCrossoverPanel panel) =>
+        (List<VirtualCrossoverChannel>)Field(panel, "channels");
+
+    private static VirtualCrossoverProjectFile Project(VirtualCrossoverPanel panel) =>
+        (VirtualCrossoverProjectFile)Field(panel, "project");
+}

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -464,18 +464,26 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
-    public void StepResponse_OfAnImpulse_IsAUnitStepFromTheStretchsOwnStart()
+    public void StepResponse_OfAnImpulse_IsAUnitStep_SummedFromTheRecordsStart()
     {
-        // Summed from the stretch's start, not the record's: the samples before
-        // it do not enter, and a stretch running past the record reads silence.
+        // Summed from the record's start whatever stretch is asked for: what
+        // came before the stretch is in the sum it opens on, and a stretch
+        // running past the record reads silence.
         Complex[] ir = UnitImpulse(64, 20);
         ir[5] = new Complex(3.0, 0.0);
 
         double[] step = VirtualCrossoverAnalysis.StepResponse(ir, 10, 70);
 
         Assert.Equal(70, step.Length);
-        Assert.All(step.Take(10), value => Assert.Equal(0.0, value));
-        Assert.All(step.Skip(10), value => Assert.Equal(1.0, value));
+        Assert.All(step.Take(10), value => Assert.Equal(3.0, value));
+        Assert.All(step.Skip(10), value => Assert.Equal(4.0, value));
+
+        // The same samples read the same whichever stretch holds them.
+        double[] whole = VirtualCrossoverAnalysis.StepResponse(ir, 0, 80);
+        for (int i = 0; i < step.Length; i++)
+        {
+            Assert.Equal(whole[10 + i], step[i]);
+        }
     }
 
     [Fact]
@@ -503,7 +511,7 @@ public sealed class VirtualCrossoverAnalysisTests
 
         for (int i = 0; i < sumStep.Length; i++)
         {
-            Assert.Equal(lowStep[i] + highStep[i], sumStep[i], 12);
+            Assert.Equal(lowStep[i] + highStep[i], sumStep[i], 9);
         }
 
         // The branches read as a step should: the high-pass steps up and

--- a/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
+++ b/tests/Resonalyze.Dsp.Tests/VirtualCrossoverAnalysisTests.cs
@@ -464,6 +464,57 @@ public sealed class VirtualCrossoverAnalysisTests
     }
 
     [Fact]
+    public void StepResponse_OfAnImpulse_IsAUnitStepFromTheStretchsOwnStart()
+    {
+        // Summed from the stretch's start, not the record's: the samples before
+        // it do not enter, and a stretch running past the record reads silence.
+        Complex[] ir = UnitImpulse(64, 20);
+        ir[5] = new Complex(3.0, 0.0);
+
+        double[] step = VirtualCrossoverAnalysis.StepResponse(ir, 10, 70);
+
+        Assert.Equal(70, step.Length);
+        Assert.All(step.Take(10), value => Assert.Equal(0.0, value));
+        Assert.All(step.Skip(10), value => Assert.Equal(1.0, value));
+    }
+
+    [Fact]
+    public void StepResponse_OfASum_IsTheSumOfTheSteps()
+    {
+        Complex[] low = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(4_096, 200),
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.LowPass,
+                new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 1_000, 24))),
+            SampleRate,
+            SampleRate);
+        Complex[] high = VirtualCrossoverAnalysis.ApplyChain(
+            UnitImpulse(4_096, 200),
+            new DspChannelChain(Crossover: new CrossoverSpec(
+                CrossoverKind.HighPass,
+                HighPassEdge: new CrossoverEdge(CrossoverFilterFamily.LinkwitzRiley, 1_000, 24))),
+            SampleRate,
+            SampleRate);
+        Complex[] sum = VirtualCrossoverAnalysis.SumImpulseResponses([low, high]);
+
+        double[] lowStep = VirtualCrossoverAnalysis.StepResponse(low, 150, 2_000);
+        double[] highStep = VirtualCrossoverAnalysis.StepResponse(high, 150, 2_000);
+        double[] sumStep = VirtualCrossoverAnalysis.StepResponse(sum, 150, 2_000);
+
+        for (int i = 0; i < sumStep.Length; i++)
+        {
+            Assert.Equal(lowStep[i] + highStep[i], sumStep[i], 12);
+        }
+
+        // The branches read as a step should: the high-pass steps up and
+        // returns to zero (it passes no DC), the low-pass climbs to the full
+        // step, and their sum is the all-pass reconstruction — a unit step.
+        Assert.Equal(0.0, highStep[^1], 3);
+        Assert.Equal(1.0, lowStep[^1], 3);
+        Assert.Equal(1.0, sumStep[^1], 3);
+    }
+
+    [Fact]
     public void LinkwitzRileySplit_SumsBackToTheOriginal()
     {
         // Splitting one impulse into LR24 low-pass and high-pass branches and


### PR DESCRIPTION
A fifth radio on the View row. The step response is the running sum of the processed impulse response, drawn on the impulse view's absolute ms axis around the same phase gate; the Sum is the sum of the summing channels' responses, hidden or not, the set the magnitude Sum adds. Unlike the impulse traces, every step is drawn on one common scale (the largest excursion among them), so the curves keep their sizes relative to each other and to the Sum: a woofer's step is the big slow one, a tweeter's the small fast one, and the Sum is what they add up to. The running sum starts at the drawn window's left edge, not the record's start, and the gate is drawn but never applied: a taper would read as a decay of the step.

The opposite side's Sum rides along as on the magnitude view — thin, dashed, translucent, on the one absolute clock — so the two tunes' fronts compare without flipping the L/R selector. Drawn only while the Sum is, and only at the shown side's sample rate.

**DSP.** `VirtualCrossoverAnalysis.StepResponse(ir, start, count)`: the running sum over one stretch, linear by construction (the step of a sum is the sum of the steps).

**Presenter.** `ImpulseWindowPreview` gains `AddStepTraceSeries` beside `AddGatedTraceSeries`; both resolve one `GatedDisplay` (the gate plus its context) and draw one gate outline, so a toggle between the impulse and step views keeps the zoom. `AddGatedTraceSeries` is bit-identical for the gate dialog and the impulse view. `IrPreviewTrace` carries a stroke and a line style. `AcousticView.Step` shares the impulse view's ms axis and unitless value axis.

**Panel.** `BuildStepRender(processed, summed, oppositeSide)`: the shown channels set the gate offset and the window, as on the impulse view; the Sum adds the summing set; the opposite side's summed response comes from the metrics' side sum, whose computation now runs for the step view as well. The Groups selector mutes the radio as it mutes the other non-magnitude views; smoothing is muted as on the impulse view; the Sum toggle is live.

**Project file.** `ShowStepView`, additive without a version bump; the panel writes `ShowImpulseView` beside it so an older build opens the project on the impulse view. The Sum keeps its own answer on the view (`ShowSumCurveStep`), inheriting the magnitude one until set.

**Designer.** The radio panel grows from 331 to 391 px; Smoothing and Show move 60 px right (the Show combo now ends at 1180 of 1246).

**Tests.** `VirtualCrossoverStepViewTests` (which responses go in, the common scale against the impulse view's per-trace one, the opposite side's trace and its conditions), step cases in the zoom and project-file tests, `StepResponse_*` in the DSP suite. Full non-hardware battery green.

**Docs.** REFERENCE.md describes the view and the three view lists are updated; MANUAL.md names Step as the quick polarity check. No figure shows the View row, so nothing to re-take.

Verified on the v6 session through a live-panel harness: the inverted sub's step and the Sum go negative first, the front drivers read small on the common scale, the opposite side's Sum hugs this side's (the sub is shared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
